### PR TITLE
css: bound nested prefixed-rule serialization when nesting is preserved

### DIFF
--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -134,11 +134,11 @@ pub struct Printer<'a> {
     pub targets: Targets,
     pub vendor_prefix: css::VendorPrefix,
     /// True while nested rules are being re-serialized for a non-final vendor
-    /// prefix pass of an ancestor style rule (when nesting is compiled away).
-    /// Nested style rules that carry their own vendor prefixes override
-    /// `vendor_prefix`, so their output is identical in every ancestor pass;
-    /// they are skipped while this is set and emitted once in the final pass,
-    /// keeping the output linear in nesting depth instead of exponential.
+    /// prefix pass of an ancestor style rule (whether nesting is preserved or
+    /// compiled away). Nested style rules that carry their own vendor prefixes
+    /// override `vendor_prefix`, so their output is identical in every ancestor
+    /// pass; they are skipped while this is set and emitted once in the final
+    /// pass, keeping the output linear in nesting depth instead of exponential.
     pub skip_prefixed_nested_rules: bool,
     pub in_calc: bool,
     pub css_module: Option<css::CssModule<'a>>,

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -121,7 +121,39 @@ impl<R> StyleRule<R> {
 
         let len =
             self.declarations.declarations.len() + self.declarations.important_declarations.len();
-        let has_declarations = supports_nesting || len > 0 || self.rules.v.len() == 0;
+
+        // This rule is serialized once per vendor prefix, and each pass
+        // re-serializes the nested rules. Nested style rules that carry their
+        // own vendor prefixes override `dest.vendor_prefix`, so they produce
+        // identical output in every pass; mark non-final passes so they are
+        // skipped and emitted only in the final pass. Otherwise they would be
+        // duplicated once per ancestor prefix, which grows exponentially with
+        // nesting depth. This applies whether nesting is preserved or compiled
+        // away — the prefix loop in `to_css` re-serializes the nested rules
+        // either way.
+        let saved_skip = dest.skip_prefixed_nested_rules;
+        let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
+        // Whether any nested rule is emitted in this pass; if not, don't write
+        // the separator between the declarations and the nested rules, or the
+        // wrapper block when there are no own declarations either (nothing
+        // would go inside it).
+        let has_nested_output = !skip_prefixed_nested
+            || self.rules.v.iter().any(|rule| {
+                !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
+            });
+
+        // With nesting preserved the nested rules are written inside this
+        // rule's block, so a non-final prefix pass that emits neither its own
+        // declarations nor any nested rule would otherwise print an empty
+        // `selector{}`. Suppress the wrapper in that case (matching how an
+        // entirely empty rule is dropped). The nesting-compiled-away branch
+        // writes nested rules after the block, so its `has_declarations` is
+        // unchanged.
+        let has_declarations = if supports_nesting {
+            len > 0 || has_nested_output || self.rules.v.len() == 0
+        } else {
+            len > 0 || self.rules.v.len() == 0
+        };
 
         if has_declarations {
             //   #[cfg(feature = "sourcemap")]
@@ -192,7 +224,13 @@ impl<R> StyleRule<R> {
 
                     dest.newline()?;
                     decl.to_css(dest, important)?;
-                    if i != len - 1 || !dest.minify || (supports_nesting && self.rules.v.len() > 0)
+                    // Keep the trailing `;` before nested rules, but only when a
+                    // nested rule is actually emitted in this pass — otherwise
+                    // (all nested rules deferred to the final pass) nothing
+                    // follows and the `;` is redundant.
+                    if i != len - 1
+                        || !dest.minify
+                        || (supports_nesting && self.rules.v.len() > 0 && has_nested_output)
                     {
                         dest.write_char(b';')?;
                     }
@@ -226,25 +264,6 @@ impl<R> StyleRule<R> {
             }
             Ok(())
         }
-
-        // This rule is serialized once per vendor prefix, and each pass
-        // re-serializes the nested rules. Nested style rules that carry their
-        // own vendor prefixes override `dest.vendor_prefix`, so they produce
-        // identical output in every pass; mark non-final passes so they are
-        // skipped and emitted only in the final pass. Otherwise they would be
-        // duplicated once per ancestor prefix, which grows exponentially with
-        // nesting depth. This applies whether nesting is preserved or compiled
-        // away — the prefix loop in `to_css` re-serializes the nested rules
-        // either way.
-        let saved_skip = dest.skip_prefixed_nested_rules;
-        let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
-        // Whether any nested rule is emitted in this pass; if not, don't write
-        // the separator between the declarations and the nested rules (nothing
-        // would follow it).
-        let has_nested_output = !skip_prefixed_nested
-            || self.rules.v.iter().any(|rule| {
-                !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
-            });
 
         // Write nested rules after the parent.
         if supports_nesting {

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -136,11 +136,13 @@ impl<R> StyleRule<R> {
         // Whether any nested rule is emitted in this pass; if not, don't write
         // the separator between the declarations and the nested rules, or the
         // wrapper block when there are no own declarations either (nothing
-        // would go inside it).
-        let has_nested_output = !skip_prefixed_nested
-            || self.rules.v.iter().any(|rule| {
-                !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
-            });
+        // would go inside it). `Ignored` rules never emit; prefixed rules are
+        // deferred to the final pass, so they only emit when
+        // `skip_prefixed_nested` is false.
+        let has_nested_output = self.rules.v.iter().any(|rule| {
+            !matches!(rule, CssRule::Ignored)
+                && (!skip_prefixed_nested || !rule.is_deferred_to_final_prefix_pass())
+        });
 
         // With nesting preserved the nested rules are written inside this
         // rule's block, so a non-final prefix pass that emits neither its own

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -134,9 +134,8 @@ impl<R> StyleRule<R> {
         let saved_skip = dest.skip_prefixed_nested_rules;
         let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
         // Whether any nested rule is emitted in this pass; if not, don't write
-        // the separator between the declarations and the nested rules, or the
-        // wrapper block when there are no own declarations either (nothing
-        // would go inside it). `Ignored` rules never emit; prefixed rules are
+        // the separator between the declarations and the nested rules (nothing
+        // would follow it). `Ignored` rules never emit; prefixed rules are
         // deferred to the final pass, so they only emit when
         // `skip_prefixed_nested` is false.
         let has_nested_output = self.rules.v.iter().any(|rule| {
@@ -144,18 +143,7 @@ impl<R> StyleRule<R> {
                 && (!skip_prefixed_nested || !rule.is_deferred_to_final_prefix_pass())
         });
 
-        // With nesting preserved the nested rules are written inside this
-        // rule's block, so a non-final prefix pass that emits neither its own
-        // declarations nor any nested rule would otherwise print an empty
-        // `selector{}`. Suppress the wrapper in that case (matching how an
-        // entirely empty rule is dropped). The nesting-compiled-away branch
-        // writes nested rules after the block, so its `has_declarations` is
-        // unchanged.
-        let has_declarations = if supports_nesting {
-            len > 0 || has_nested_output || self.rules.v.len() == 0
-        } else {
-            len > 0 || self.rules.v.len() == 0
-        };
+        let has_declarations = supports_nesting || len > 0 || self.rules.v.len() == 0;
 
         if has_declarations {
             //   #[cfg(feature = "sourcemap")]

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -227,29 +227,36 @@ impl<R> StyleRule<R> {
             Ok(())
         }
 
+        // This rule is serialized once per vendor prefix, and each pass
+        // re-serializes the nested rules. Nested style rules that carry their
+        // own vendor prefixes override `dest.vendor_prefix`, so they produce
+        // identical output in every pass; mark non-final passes so they are
+        // skipped and emitted only in the final pass. Otherwise they would be
+        // duplicated once per ancestor prefix, which grows exponentially with
+        // nesting depth. This applies whether nesting is preserved or compiled
+        // away — the prefix loop in `to_css` re-serializes the nested rules
+        // either way.
+        let saved_skip = dest.skip_prefixed_nested_rules;
+        let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
+        // Whether any nested rule is emitted in this pass; if not, don't write
+        // the separator between the declarations and the nested rules (nothing
+        // would follow it).
+        let has_nested_output = !skip_prefixed_nested
+            || self.rules.v.iter().any(|rule| {
+                !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
+            });
+
         // Write nested rules after the parent.
         if supports_nesting {
-            helpers_newline(self, dest, supports_nesting, len)?;
-            self.rules.to_css(dest)?;
+            if has_nested_output {
+                helpers_newline(self, dest, supports_nesting, len)?;
+            }
+            dest.skip_prefixed_nested_rules = skip_prefixed_nested;
+            let result = self.rules.to_css(dest);
+            dest.skip_prefixed_nested_rules = saved_skip;
+            result?;
             helpers_end(dest, has_declarations)?;
         } else {
-            // This rule is serialized once per vendor prefix, and each pass
-            // re-serializes the nested rules. Nested style rules that carry
-            // their own vendor prefixes override `dest.vendor_prefix`, so they
-            // produce identical output in every pass; mark non-final passes so
-            // they are skipped and emitted only in the final pass. Otherwise
-            // they would be duplicated once per ancestor prefix, which grows
-            // exponentially with nesting depth.
-            let saved_skip = dest.skip_prefixed_nested_rules;
-            let skip_prefixed_nested = saved_skip || !is_final_prefix_pass;
-            // Whether any nested rule is emitted in this pass; if not, don't
-            // write the separator between the declarations and the nested
-            // rules (nothing would follow it).
-            let has_nested_output = !skip_prefixed_nested
-                || self.rules.v.iter().any(|rule| {
-                    !matches!(rule, CssRule::Ignored) && !rule.is_deferred_to_final_prefix_pass()
-                });
-
             helpers_end(dest, has_declarations)?;
             if has_nested_output {
                 helpers_newline(self, dest, supports_nesting, len)?;

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -87,6 +87,52 @@ test("pretty-printed output has no dangling separators when the rule has declara
   );
 });
 
+// The same exponential blow-up happens when nesting is *preserved* (no browser
+// targets set). The vendor prefix comes from the selector (e.g.
+// `:placeholder-shown`, `:-webkit-autofill`), independent of targets, so
+// `StyleRule::to_css` still serializes the rule once per prefix and each pass
+// re-serializes the nested rules. Before the fix the guard that defers prefixed
+// nested rules only covered the nesting-compiled-away branch, leaving this path
+// unbounded: a ~1 KB stylesheet of ~20 nested levels hung the minifier for 25s+
+// (fuzzer signature `hang:css:…serialize_dimension|…TokenList::To…`).
+//
+// Each level here carries a vendor prefix (`:-webkit-autofill` -> none +
+// `-webkit-`), so output grew ~4x per nesting level. With the fix the prefixed
+// nested rules are emitted once, in the ancestor's final pass, and output stays
+// linear.
+// The selector list from the fuzzer input: `:placeholder-shown` expands to an
+// unprefixed + a prefixed variant, so each nesting level's rule is serialized
+// twice. Each nested level carries the same prefix set, so before the fix the
+// leaf rule was duplicated once per ancestor pass (2^depth copies).
+const prefixedSelector = ".foo:placeholder-shown .bar, .foo:-webkit-autofill spective";
+
+function nestedPrefixed(depth: number, innermost: string): string {
+  return `${prefixedSelector} {\n`.repeat(depth) + innermost + "\n" + "}\n".repeat(depth);
+}
+
+test("nesting-preserved (no targets) prefixed rules stay linear in depth", () => {
+  // No third argument => no browser targets => nesting is preserved. Before the
+  // fix this was ~2^depth copies of the leaf rule (tens of MB at depth 18, hung
+  // the minifier for 25s+ at depth 20). The leaf declaration must appear once
+  // per distinct prefix variant (2) regardless of nesting depth.
+  const depth = 24;
+  const output = minifyTest(nestedPrefixed(depth, "color: red;"), "");
+  expect(output.length).toBeLessThan(10_000);
+  expect(output.split("color:red").length - 1).toBe(2);
+});
+
+test("nesting-preserved prefixed rule emits each prefix variant once", () => {
+  // Two nested levels: the leaf rule appears once per distinct ancestor prefix
+  // variant (2), not once per combination of ancestor passes (4 before the fix).
+  const output = minifyTest(nestedPrefixed(2, "color: red;"), "");
+  expect(output).toBe(
+    ".foo:placeholder-shown .bar,.foo:-webkit-autofill spective{}" +
+      ".foo:placeholder-shown .bar,.foo:autofill spective{" +
+      "& .foo:placeholder-shown .bar,& .foo:-webkit-autofill spective{color:red}" +
+      "& .foo:placeholder-shown .bar,& .foo:autofill spective{color:red}}",
+  );
+});
+
 test("bun build --target=browser does not blow up on deeply nested prefixed selectors", async () => {
   // Mirrors the fuzzer input: deeply nested `:fullscreen` blocks. The default
   // browser targets (safari 14) require the `-webkit-` prefix for

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -120,15 +120,41 @@ test("nesting-preserved (no targets) prefixed rules stay linear in depth", () =>
 test("nesting-preserved prefixed rule emits each prefix variant once", () => {
   // Two nested levels: the leaf rule appears once per distinct ancestor prefix
   // variant (2), not once per combination of ancestor passes (4 before the fix).
-  // The non-final (`-webkit-autofill`) pass of the outer rule has no own
-  // declarations and its only nested rule is deferred to the final pass, so it
-  // emits nothing — no empty `selector{}` wrapper.
+  // The non-final (`-webkit-`) pass of the outer rule has no declarations of its
+  // own (its prefixed nested rule is deferred to the final pass), so it emits an
+  // empty `selector{}` — a minor cosmetic artifact, but valid CSS. Suppressing
+  // it would require skipping the rule's prelude, which drops the `&` nesting
+  // context the deferred child relies on and reintroduces the blow-up, so the
+  // empty block is kept intentionally.
   const output = minifyTest(nestedPrefixed(2, "color: red;"), "");
   expect(output).toBe(
-    ".foo:placeholder-shown .bar,.foo:autofill spective{" +
+    ".foo:placeholder-shown .bar,.foo:-webkit-autofill spective{}" +
+      ".foo:placeholder-shown .bar,.foo:autofill spective{" +
       "& .foo:placeholder-shown .bar,& .foo:-webkit-autofill spective{color:red}" +
       "& .foo:placeholder-shown .bar,& .foo:autofill spective{color:red}}",
   );
+});
+
+test("nesting-preserved blow-up stays bounded with unprefixed intermediate rules", () => {
+  // A nested chain that alternates a prefixed selector list with an unprefixed
+  // intermediate (`.wrapper`). The unprefixed rule is not deferred, so it is
+  // re-serialized in every ancestor prefix pass, but the prefixed rules inside
+  // it still collapse to two variants per level rather than multiplying across
+  // ancestor passes. The leaf declaration must appear a bounded number of times
+  // regardless of depth — without the deferral this grows exponentially.
+  const leaf = ".a:placeholder-shown, .a:-webkit-autofill";
+  const build = (depth: number) => {
+    let css = "";
+    for (let i = 0; i < depth; i++) css += `${i % 2 === 0 ? leaf : ".wrapper"} {\n`;
+    return css + "color: red;\n" + "}\n".repeat(depth);
+  };
+  const shallow = minifyTest(build(4), "");
+  const deep = minifyTest(build(20), "");
+  const shallowReds = shallow.split("color:red").length - 1;
+  const deepReds = deep.split("color:red").length - 1;
+  // Bounded: the leaf-declaration count does not grow with nesting depth.
+  expect(deepReds).toBe(shallowReds);
+  expect(deep.length).toBeLessThan(10_000);
 });
 
 test("bun build --target=browser does not blow up on deeply nested prefixed selectors", async () => {

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -96,14 +96,10 @@ test("pretty-printed output has no dangling separators when the rule has declara
 // unbounded: a ~1 KB stylesheet of ~20 nested levels hung the minifier for 25s+
 // (fuzzer signature `hang:css:…serialize_dimension|…TokenList::To…`).
 //
-// Each level here carries a vendor prefix (`:-webkit-autofill` -> none +
-// `-webkit-`), so output grew ~4x per nesting level. With the fix the prefixed
-// nested rules are emitted once, in the ancestor's final pass, and output stays
-// linear.
-// The selector list from the fuzzer input: `:placeholder-shown` expands to an
-// unprefixed + a prefixed variant, so each nesting level's rule is serialized
-// twice. Each nested level carries the same prefix set, so before the fix the
-// leaf rule was duplicated once per ancestor pass (2^depth copies).
+// The selector list `:placeholder-shown`/`:-webkit-autofill` expands to an
+// unprefixed + a prefixed variant, so each nesting level is serialized twice and
+// output grew ~4x per level. With the fix the prefixed nested rules are emitted
+// once, in the ancestor's final pass, and output stays linear.
 const prefixedSelector = ".foo:placeholder-shown .bar, .foo:-webkit-autofill spective";
 
 function nestedPrefixed(depth: number, innermost: string): string {
@@ -124,10 +120,12 @@ test("nesting-preserved (no targets) prefixed rules stay linear in depth", () =>
 test("nesting-preserved prefixed rule emits each prefix variant once", () => {
   // Two nested levels: the leaf rule appears once per distinct ancestor prefix
   // variant (2), not once per combination of ancestor passes (4 before the fix).
+  // The non-final (`-webkit-autofill`) pass of the outer rule has no own
+  // declarations and its only nested rule is deferred to the final pass, so it
+  // emits nothing — no empty `selector{}` wrapper.
   const output = minifyTest(nestedPrefixed(2, "color: red;"), "");
   expect(output).toBe(
-    ".foo:placeholder-shown .bar,.foo:-webkit-autofill spective{}" +
-      ".foo:placeholder-shown .bar,.foo:autofill spective{" +
+    ".foo:placeholder-shown .bar,.foo:autofill spective{" +
       "& .foo:placeholder-shown .bar,& .foo:-webkit-autofill spective{color:red}" +
       "& .foo:placeholder-shown .bar,& .foo:autofill spective{color:red}}",
   );


### PR DESCRIPTION
## What does this PR do?

Fixes a hang in the CSS minifier found by fuzzing: a ~8 KB stylesheet of deeply nested rules whose selectors carry vendor prefixes makes the printer re-serialize nested rules exponentially — 25s+ on the original input, unbounded as nesting deepens.

Fuzzer signature: `hang:css:_RN…serialize_dimension|_RN…properties6custom…To…` (the sampler lands in `serialize_dimension` at the bottom of one recursion level; the real work is the exponential re-serialization in `StyleRule::to_css`).

```js
// before: hangs for 25s+; after: ~50ms
const sel = ".foo:placeholder-shown .bar, .foo:-webkit-autofill spective";
const css = `${sel} {`.repeat(20) + "color: red;" + "}".repeat(20);
require("bun:internal-for-testing").cssInternals.minifyTest(css, "");
```

## Cause

A style rule whose selector needs vendor prefixes (e.g. `:placeholder-shown`, `:-webkit-autofill`) is serialized once per prefix in `StyleRule::to_css`, and **each prefix pass re-serializes all of its nested rules**. A nested rule that carries its own vendor prefixes overrides `dest.vendor_prefix` with its own prefix loop, so its output is byte-for-byte identical in every ancestor pass — each nesting level multiplies the output.

PR #31270 fixed this for the branch where **CSS nesting is compiled away for older targets** by deferring prefixed nested rules to the ancestor's final prefix pass (`Printer::skip_prefixed_nested_rules`). But it left the **nesting-preserved** branch (`supports_nesting == true`) unguarded.

When no browser targets are set, nesting is always preserved (`should_compile_same(Nesting)` is false), yet the prefix loop in `to_css` still runs — the prefix comes from the *selector*, independent of targets. So the unguarded branch is exactly the path the fuzz input (which sets no targets) takes. Output grew ~4× per nesting level (the selector list `:placeholder-shown` expands to two prefix variants, re-emitted once per ancestor pass): 32 KB at depth 8, 8 MB at depth 16, 33 MB at depth 18, hang at depth 20.

With old targets set, a later selector-expansion cap (#31277) already errors out cleanly at 65536 selectors — so only the no-targets / nesting-preserved path was unbounded.

## Fix

Hoist the skip-pass bookkeeping out of the `else` branch so **both** branches defer prefixed nested rules to the ancestor's final prefix pass. The nesting-preserved branch now sets `skip_prefixed_nested_rules` around its nested `to_css` call, mirroring the existing logic.

Output is semantically unchanged — the same set of rules is emitted, just without the exact duplicates — and grows linearly with nesting depth instead of exponentially.

## Verification

- Original 8342-byte fuzz input: **30s+ hang → ~50ms**.
- Output is now linear in depth: depth-100 nesting → 12 KB, constant ~255ms (was 4^N; depth-20 hung before).
- New tests in `test/js/bun/css/nested-vendor-prefix-duplication.test.ts`:
  - depth-24 nested prefixed rules stay under 10 KB and emit the leaf declaration exactly twice (once per prefix variant) — this test hangs on the unfixed build.
  - exact minified output for a 2-level case (leaf rule appears once per prefix variant, not once per combination of ancestor passes).
- All existing tests in that file (from #31270) still pass, including the pretty-print separator checks — output remains well-formed.
- `test/js/bun/css/css.test.ts` (1087 pass), `color.test.ts`, `test/bundler/css` (166 pass), and the other nesting/selector/printer test files all pass.