### PR TITLE
css: bound vendor-prefix fan-out when serializing nested rules

### DIFF
--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -237,10 +237,10 @@ pub enum PrinterErrorKind {
     /// Substituting parent selectors for `&` while compiling CSS nesting for
     /// the configured targets exceeded the expansion limit.
     maximum_nesting_expansion,
-    /// Serializing a style rule once per vendor prefix re-serializes its nested
-    /// rules in every pass, so nesting vendor-prefixed multi-selector rules
-    /// expands the output multiplicatively with depth. The total number of
-    /// such rule copies exceeded the expansion limit.
+    /// Serializing a style rule once per vendor prefix re-serializes its whole
+    /// body in every pass, so nesting vendor-prefixed multi-selector rules
+    /// expands the output multiplicatively with depth. The total bytes emitted
+    /// by those duplicate passes exceeded the expansion limit.
     maximum_vendor_prefix_expansion,
     no_import_records,
 }

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -237,6 +237,11 @@ pub enum PrinterErrorKind {
     /// Substituting parent selectors for `&` while compiling CSS nesting for
     /// the configured targets exceeded the expansion limit.
     maximum_nesting_expansion,
+    /// Serializing a style rule once per vendor prefix re-serializes its nested
+    /// rules in every pass, so nesting vendor-prefixed multi-selector rules
+    /// expands the output multiplicatively with depth. The total number of
+    /// such rule copies exceeded the expansion limit.
+    maximum_vendor_prefix_expansion,
     no_import_records,
 }
 
@@ -260,6 +265,9 @@ impl fmt::Display for PrinterErrorKind {
             }
             Self::maximum_nesting_expansion => f.write_str(
                 "Maximum nesting expansion exceeded when compiling CSS nesting for the configured targets",
+            ),
+            Self::maximum_vendor_prefix_expansion => f.write_str(
+                "Maximum vendor-prefix expansion exceeded when serializing deeply nested vendor-prefixed selectors",
             ),
             Self::no_import_records => f.write_str("No import records found"),
         }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -158,19 +158,25 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
-    /// Running total of style-rule copies emitted by the per-vendor-prefix
-    /// serialization loop in `StyleRule::to_css`, counting only rules that both
-    /// fan out (their selectors carry more than one vendor prefix) and have
-    /// nested rules. A rule whose selector list mixes a vendor-prefixed
-    /// pseudo-class (e.g. `:-webkit-autofill`) with an unprefixed one is
-    /// serialized once per prefix, and each copy re-serializes the rule's nested
-    /// subtree — so nesting such rules multiplies the output by the prefix count
-    /// at every level. A single-prefix rule (serialized once) or a rule with no
-    /// nested rules (flat fan-out, linear in input size) cannot compound with
-    /// depth and is not counted. Accumulated across the whole stylesheet (never
+    /// Running total of duplicate style-rule copies emitted because an ancestor
+    /// (or the rule itself) fans out across vendor prefixes. A rule whose
+    /// selector list carries more than one vendor prefix (e.g. a list mixing
+    /// `:-webkit-autofill` with an unprefixed pseudo-class, or a single pseudo
+    /// downleveled to several prefixes) is serialized once per prefix, and every
+    /// pass after the first re-serializes the rule's whole nested subtree — so
+    /// nesting such rules repeats the inner rules once per prefix at every
+    /// level, growing the output by (prefix count)^depth. Every rule emitted
+    /// inside such a repeated pass (leaf or not) is counted here via
+    /// `prefix_fanout_depth`; a flat rule or a single-prefix rule emits no extra
+    /// copies and is not counted. Accumulated across the whole stylesheet (never
     /// reset) and bounded in `StyleRule::to_css` so a few kilobytes of deeply
     /// nested input cannot expand into gigabytes.
     pub prefix_expansions: u32,
+    /// How many enclosing style rules are currently re-serializing their nested
+    /// subtree for a vendor-prefix pass after their first (i.e. emitting a
+    /// duplicate copy). While greater than zero, each style rule serialized is a
+    /// duplicate produced by fan-out and charges `prefix_expansions`.
+    pub prefix_fanout_depth: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,
     pub import_info: Option<ImportInfo<'a>>,
@@ -340,6 +346,7 @@ impl<'a> Printer<'a> {
             ctx: None,
             nesting_expansions: 0,
             prefix_expansions: 0,
+            prefix_fanout_depth: 0,
             error_kind: None,
         }
     }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -158,6 +158,15 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
+    /// Running total of style-rule copies emitted by the per-vendor-prefix
+    /// serialization loop in `StyleRule::to_css`. A style rule whose selector
+    /// list mixes a vendor-prefixed pseudo-class (e.g. `:-webkit-autofill`)
+    /// with an unprefixed one is serialized once per prefix, and each pass
+    /// re-serializes the rule's nested rules — so nesting such rules multiplies
+    /// the output by the prefix count at every level. Accumulated across the
+    /// whole stylesheet (never reset) and bounded in `StyleRule::to_css` so a
+    /// few kilobytes of deeply nested input cannot expand into gigabytes.
+    pub prefix_expansions: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,
     pub import_info: Option<ImportInfo<'a>>,
@@ -326,6 +335,7 @@ impl<'a> Printer<'a> {
             css_module: None,
             ctx: None,
             nesting_expansions: 0,
+            prefix_expansions: 0,
             error_kind: None,
         }
     }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -159,16 +159,17 @@ pub struct Printer<'a> {
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
     /// Running total of style-rule copies emitted by the per-vendor-prefix
-    /// serialization loop in `StyleRule::to_css`, counting only rules that
-    /// actually fan out (their selectors carry more than one vendor prefix).
-    /// A rule whose selector list mixes a vendor-prefixed pseudo-class (e.g.
-    /// `:-webkit-autofill`) with an unprefixed one is serialized once per
-    /// prefix, and each copy re-serializes the rule's nested rules — so nesting
-    /// such rules multiplies the output by the prefix count at every level. A
-    /// single-prefix rule is serialized exactly once and is not counted.
-    /// Accumulated across the whole stylesheet (never reset) and bounded in
-    /// `StyleRule::to_css` so a few kilobytes of deeply nested input cannot
-    /// expand into gigabytes.
+    /// serialization loop in `StyleRule::to_css`, counting only rules that both
+    /// fan out (their selectors carry more than one vendor prefix) and have
+    /// nested rules. A rule whose selector list mixes a vendor-prefixed
+    /// pseudo-class (e.g. `:-webkit-autofill`) with an unprefixed one is
+    /// serialized once per prefix, and each copy re-serializes the rule's nested
+    /// subtree — so nesting such rules multiplies the output by the prefix count
+    /// at every level. A single-prefix rule (serialized once) or a rule with no
+    /// nested rules (flat fan-out, linear in input size) cannot compound with
+    /// depth and is not counted. Accumulated across the whole stylesheet (never
+    /// reset) and bounded in `StyleRule::to_css` so a few kilobytes of deeply
+    /// nested input cannot expand into gigabytes.
     pub prefix_expansions: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -170,8 +170,10 @@ pub struct Printer<'a> {
     /// never reset) and bounded in `StyleRule::to_css`, so a few kilobytes of
     /// deeply nested input cannot expand into gigabytes — regardless of whether
     /// the duplicated payload is nested rules or a large declaration block. The
-    /// original (first) pass of each rule and any flat/single-prefix output emit
-    /// nothing here.
+    /// original (first) pass of each rule, and any single-prefix output (which
+    /// has no passes after the first), emit nothing here. A flat multi-prefix
+    /// rule's later passes do count, but without nesting to compound them that
+    /// stays linear in the input.
     pub prefix_expansion_bytes: usize,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -159,13 +159,16 @@ pub struct Printer<'a> {
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
     /// Running total of style-rule copies emitted by the per-vendor-prefix
-    /// serialization loop in `StyleRule::to_css`. A style rule whose selector
-    /// list mixes a vendor-prefixed pseudo-class (e.g. `:-webkit-autofill`)
-    /// with an unprefixed one is serialized once per prefix, and each pass
-    /// re-serializes the rule's nested rules — so nesting such rules multiplies
-    /// the output by the prefix count at every level. Accumulated across the
-    /// whole stylesheet (never reset) and bounded in `StyleRule::to_css` so a
-    /// few kilobytes of deeply nested input cannot expand into gigabytes.
+    /// serialization loop in `StyleRule::to_css`, counting only rules that
+    /// actually fan out (their selectors carry more than one vendor prefix).
+    /// A rule whose selector list mixes a vendor-prefixed pseudo-class (e.g.
+    /// `:-webkit-autofill`) with an unprefixed one is serialized once per
+    /// prefix, and each copy re-serializes the rule's nested rules — so nesting
+    /// such rules multiplies the output by the prefix count at every level. A
+    /// single-prefix rule is serialized exactly once and is not counted.
+    /// Accumulated across the whole stylesheet (never reset) and bounded in
+    /// `StyleRule::to_css` so a few kilobytes of deeply nested input cannot
+    /// expand into gigabytes.
     pub prefix_expansions: u32,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -158,25 +158,21 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
-    /// Running total of duplicate style-rule copies emitted because an ancestor
-    /// (or the rule itself) fans out across vendor prefixes. A rule whose
-    /// selector list carries more than one vendor prefix (e.g. a list mixing
-    /// `:-webkit-autofill` with an unprefixed pseudo-class, or a single pseudo
-    /// downleveled to several prefixes) is serialized once per prefix, and every
-    /// pass after the first re-serializes the rule's whole nested subtree — so
-    /// nesting such rules repeats the inner rules once per prefix at every
-    /// level, growing the output by (prefix count)^depth. Every rule emitted
-    /// inside such a repeated pass (leaf or not) is counted here via
-    /// `prefix_fanout_depth`; a flat rule or a single-prefix rule emits no extra
-    /// copies and is not counted. Accumulated across the whole stylesheet (never
-    /// reset) and bounded in `StyleRule::to_css` so a few kilobytes of deeply
-    /// nested input cannot expand into gigabytes.
-    pub prefix_expansions: u32,
-    /// How many enclosing style rules are currently re-serializing their nested
-    /// subtree for a vendor-prefix pass after their first (i.e. emitting a
-    /// duplicate copy). While greater than zero, each style rule serialized is a
-    /// duplicate produced by fan-out and charges `prefix_expansions`.
-    pub prefix_fanout_depth: u32,
+    /// Running total of bytes emitted by duplicate vendor-prefix passes. A rule
+    /// whose selector list carries more than one vendor prefix (e.g. a list
+    /// mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a single
+    /// pseudo downleveled to several prefixes) is serialized once per prefix,
+    /// and every pass after the first re-serializes the rule's whole body —
+    /// declarations, nested rules, and everything under them. Nesting such
+    /// rules repeats that body once per prefix at every level, so the output
+    /// grows by (prefix count)^depth. The bytes written by each such duplicate
+    /// pass are measured and accumulated here (across the whole stylesheet,
+    /// never reset) and bounded in `StyleRule::to_css`, so a few kilobytes of
+    /// deeply nested input cannot expand into gigabytes — regardless of whether
+    /// the duplicated payload is nested rules or a large declaration block. The
+    /// original (first) pass of each rule and any flat/single-prefix output emit
+    /// nothing here.
+    pub prefix_expansion_bytes: usize,
     pub scratchbuf: BumpVec<'a, u8>,
     pub error_kind: Option<css::PrinterError>,
     pub import_info: Option<ImportInfo<'a>>,
@@ -230,6 +226,14 @@ impl<'a> Printer<'a> {
     #[inline]
     fn get_written_amt(writer: &dyn Write) -> usize {
         writer.written_len()
+    }
+
+    /// Total number of bytes written to the destination so far. Used to measure
+    /// how much output a duplicate vendor-prefix pass emits (see
+    /// `prefix_expansion_bytes`).
+    #[inline]
+    pub(crate) fn bytes_written(&self) -> usize {
+        Self::get_written_amt(self.dest)
     }
 
     /// Returns the current source filename that is being printed.
@@ -345,8 +349,7 @@ impl<'a> Printer<'a> {
             css_module: None,
             ctx: None,
             nesting_expansions: 0,
-            prefix_expansions: 0,
-            prefix_fanout_depth: 0,
+            prefix_expansion_bytes: 0,
             error_kind: None,
         }
     }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -95,22 +95,33 @@ impl<R> StyleRule<R> {
         } else {
             let mut first_rule = true;
             let mut remaining_prefixes = self.vendor_prefix;
+            // The rule only fans out — producing more than one copy, and
+            // re-serializing its nested rules once per copy — when its selectors
+            // carry more than one vendor prefix (e.g. a list mixing
+            // `:-webkit-autofill` with an unprefixed pseudo-class). A single
+            // prefix bit serializes the rule exactly once, just like the
+            // `is_empty()` fast path, so it must not charge the expansion
+            // budget. Gate the charge on an actual fan-out, mirroring
+            // `charge_selector_expansion`'s `selector_expansion_multiplier > 1`.
+            let fans_out = self.vendor_prefix.bits().count_ones() > 1;
             // `inline for (css.VendorPrefix.FIELDS) |field|` — iterate the bool fields of the
             // packed struct in declared order. In Rust the bitflags type exposes the same
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
-                    // Each pass re-serializes this rule's nested rules; when
-                    // those nested rules also carry multiple prefixes the copies
-                    // compound multiplicatively with depth. Bound the running
-                    // total so deeply nested vendor-prefixed rules can't expand
-                    // into gigabytes of output.
-                    dest.prefix_expansions += 1;
-                    if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
-                        return dest.new_error(
-                            css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
-                            None,
-                        );
+                    // Each copy re-serializes this rule's nested rules; when
+                    // those nested rules also fan out the copies compound
+                    // multiplicatively with depth. Bound the running total so
+                    // deeply nested vendor-prefixed rules can't expand into
+                    // gigabytes of output.
+                    if fans_out {
+                        dest.prefix_expansions += 1;
+                        if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
+                            return dest.new_error(
+                                css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
+                                None,
+                            );
+                        }
                     }
                     remaining_prefixes.remove(prefix);
                     if !first_rule {

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -121,9 +121,10 @@ impl<R> StyleRule<R> {
                     // so its output is a duplicate produced by the fan-out.
                     // Measure how much it emits and charge it against the
                     // expansion-byte budget so nesting fanning-out rules can't
-                    // expand a few kilobytes into gigabytes. The first pass and
-                    // any flat/single-prefix output are not duplicates and do
-                    // not charge, so linear output never trips the limit.
+                    // expand a few kilobytes into gigabytes. The first pass
+                    // (and a single-prefix rule, which has no later pass) does
+                    // not charge; a flat multi-prefix rule's later passes do,
+                    // but without nesting to compound them that stays linear.
                     let is_duplicate_pass = emitted_first_pass;
                     let bytes_before = if is_duplicate_pass {
                         dest.bytes_written()

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -74,58 +74,56 @@ impl<R> StyleRule<R> {
 
 // ─── to_css ───────────────────────────────────────────────────────────────
 
-/// Maximum number of style-rule copies the per-vendor-prefix serialization
-/// loop may emit across a whole stylesheet.
+/// Maximum number of duplicate style-rule copies the per-vendor-prefix
+/// serialization may emit across a whole stylesheet.
 ///
-/// When a style rule's selector list mixes a vendor-prefixed pseudo-class
-/// (e.g. `:-webkit-autofill`) with an unprefixed one, `get_prefix` sets more
-/// than one prefix bit and `StyleRule::to_css` serializes the rule once per
-/// bit. Each pass re-serializes the rule's nested rules, so nesting such rules
-/// repeats the inner subtree once per prefix at every level — the output grows
-/// by (prefix count)^depth. Real stylesheets need only a handful of prefix
-/// copies; anything past this limit is a runaway expansion, so bail out with an
-/// error instead of allocating gigabytes. Matches `MAX_NESTING_EXPANSIONS`
+/// When a style rule's selector list carries more than one vendor prefix (e.g.
+/// a list mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a
+/// single pseudo downleveled to several prefixes), `StyleRule::to_css`
+/// serializes the rule once per prefix, and every pass after the first
+/// re-serializes the rule's whole nested subtree. Nesting such rules therefore
+/// repeats the inner rules once per prefix at every level — the output grows by
+/// (prefix count)^depth. `prefix_fanout_depth` tracks when we are inside such a
+/// repeated pass, and every rule emitted there (leaf or not) counts against
+/// this limit, so the bound is proportional to the actual duplicated output
+/// rather than to any single rule's shape. Real stylesheets need only a handful
+/// of copies; anything past this limit is a runaway expansion, so bail out with
+/// an error instead of allocating gigabytes. Matches `MAX_NESTING_EXPANSIONS`
 /// (`selectors/selector.rs`) and `MAX_SELECTOR_EXPANSION` (`rules/mod.rs`).
 const MAX_PREFIX_EXPANSIONS: u32 = 65_536;
 
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
+        // When an enclosing rule fans out across vendor prefixes, every pass
+        // after its first re-serializes this whole subtree, so this rule is a
+        // duplicate copy produced by that fan-out. Count it against the
+        // expansion budget — this is what makes the bound proportional to the
+        // actual (prefix count)^depth output rather than to any single rule's
+        // shape, so deeply nested fan-out (even with leaf-only inner rules)
+        // cannot amplify a few kilobytes into gigabytes. Rules emitted outside
+        // any fan-out pass (a flat stylesheet, or the original first pass) do
+        // not charge, so linear output never trips the limit.
+        if dest.prefix_fanout_depth > 0 {
+            dest.prefix_expansions += 1;
+            if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
+                return dest.new_error(
+                    css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
+                    None,
+                );
+            }
+        }
+
         if self.vendor_prefix.is_empty() {
             self.to_css_base(dest, true)?;
         } else {
             let mut first_rule = true;
+            let mut emitted_first_pass = false;
             let mut remaining_prefixes = self.vendor_prefix;
-            // The output only blows up multiplicatively when a rule both fans
-            // out — its selectors carry more than one vendor prefix (e.g. a list
-            // mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a
-            // single pseudo downleveled to several prefixes) so it is serialized
-            // once per prefix — AND has nested rules, because each copy then
-            // re-serializes that nested subtree. A single-prefix rule serializes
-            // exactly once (no fan-out), and a rule with no nested rules repeats
-            // only its own prelude (flat fan-out is linear in input size);
-            // neither compounds with depth, so neither charges the budget.
-            // Mirrors `charge_selector_expansion`, whose multiplier only grows
-            // inside `minify_nested_rules` and so never charges a flat rule.
-            let compounds = self.vendor_prefix.bits().count_ones() > 1 && self.rules.v.len() > 0;
             // `inline for (css.VendorPrefix.FIELDS) |field|` — iterate the bool fields of the
             // packed struct in declared order. In Rust the bitflags type exposes the same
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
-                    // Each copy re-serializes this rule's nested subtree; when
-                    // those nested rules also compound the copies multiply with
-                    // depth. Bound the running total so deeply nested
-                    // vendor-prefixed rules can't expand into gigabytes of
-                    // output.
-                    if compounds {
-                        dest.prefix_expansions += 1;
-                        if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
-                            return dest.new_error(
-                                css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
-                                None,
-                            );
-                        }
-                    }
                     remaining_prefixes.remove(prefix);
                     if !first_rule {
                         if !dest.minify {
@@ -136,13 +134,26 @@ impl<R> StyleRule<R> {
 
                     dest.vendor_prefix = prefix;
                     let (line, col) = (dest.line, dest.col);
-                    self.to_css_base(dest, remaining_prefixes.is_empty())?;
+                    // The first prefix pass is the original; every later pass
+                    // re-serializes the same nested subtree, so mark those
+                    // passes as fan-out so each nested rule they emit charges
+                    // the budget.
+                    let is_duplicate_pass = emitted_first_pass;
+                    if is_duplicate_pass {
+                        dest.prefix_fanout_depth += 1;
+                    }
+                    let result = self.to_css_base(dest, remaining_prefixes.is_empty());
+                    if is_duplicate_pass {
+                        dest.prefix_fanout_depth -= 1;
+                    }
+                    result?;
                     // A non-final pass emits nothing when the rule has no
                     // declarations of its own and all of its nested rules are
                     // deferred to the final pass; don't write a separator
                     // after such a pass.
                     if dest.line != line || dest.col != col {
                         first_rule = false;
+                        emitted_first_pass = true;
                     }
                 }
             }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -73,6 +73,21 @@ impl<R> StyleRule<R> {
 }
 
 // ─── to_css ───────────────────────────────────────────────────────────────
+
+/// Maximum number of style-rule copies the per-vendor-prefix serialization
+/// loop may emit across a whole stylesheet.
+///
+/// When a style rule's selector list mixes a vendor-prefixed pseudo-class
+/// (e.g. `:-webkit-autofill`) with an unprefixed one, `get_prefix` sets more
+/// than one prefix bit and `StyleRule::to_css` serializes the rule once per
+/// bit. Each pass re-serializes the rule's nested rules, so nesting such rules
+/// repeats the inner subtree once per prefix at every level — the output grows
+/// by (prefix count)^depth. Real stylesheets need only a handful of prefix
+/// copies; anything past this limit is a runaway expansion, so bail out with an
+/// error instead of allocating gigabytes. Matches `MAX_NESTING_EXPANSIONS`
+/// (`selectors/selector.rs`) and `MAX_SELECTOR_EXPANSION` (`rules/mod.rs`).
+const MAX_PREFIX_EXPANSIONS: u32 = 65_536;
+
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         if self.vendor_prefix.is_empty() {
@@ -85,6 +100,18 @@ impl<R> StyleRule<R> {
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
+                    // Each pass re-serializes this rule's nested rules; when
+                    // those nested rules also carry multiple prefixes the copies
+                    // compound multiplicatively with depth. Bound the running
+                    // total so deeply nested vendor-prefixed rules can't expand
+                    // into gigabytes of output.
+                    dest.prefix_expansions += 1;
+                    if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
+                        return dest.new_error(
+                            css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
+                            None,
+                        );
+                    }
                     remaining_prefixes.remove(prefix);
                     if !first_rule {
                         if !dest.minify {

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -74,45 +74,27 @@ impl<R> StyleRule<R> {
 
 // ─── to_css ───────────────────────────────────────────────────────────────
 
-/// Maximum number of duplicate style-rule copies the per-vendor-prefix
-/// serialization may emit across a whole stylesheet.
+/// Maximum number of bytes the per-vendor-prefix serialization may emit from
+/// duplicate passes across a whole stylesheet.
 ///
 /// When a style rule's selector list carries more than one vendor prefix (e.g.
 /// a list mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a
 /// single pseudo downleveled to several prefixes), `StyleRule::to_css`
 /// serializes the rule once per prefix, and every pass after the first
-/// re-serializes the rule's whole nested subtree. Nesting such rules therefore
-/// repeats the inner rules once per prefix at every level — the output grows by
-/// (prefix count)^depth. `prefix_fanout_depth` tracks when we are inside such a
-/// repeated pass, and every rule emitted there (leaf or not) counts against
-/// this limit, so the bound is proportional to the actual duplicated output
-/// rather than to any single rule's shape. Real stylesheets need only a handful
-/// of copies; anything past this limit is a runaway expansion, so bail out with
-/// an error instead of allocating gigabytes. Matches `MAX_NESTING_EXPANSIONS`
+/// re-serializes the rule's whole body — declarations, nested rules, and
+/// everything under them. Nesting such rules repeats that body once per prefix
+/// at every level, so the output grows by (prefix count)^depth. The bytes
+/// emitted by each duplicate pass are measured and bounded, so a few kilobytes
+/// of deeply nested input cannot expand into gigabytes — whatever the
+/// duplicated payload is (nested rules, a large declaration block, etc.). Real
+/// stylesheets repeat only a little output across prefixes; anything past this
+/// limit is a runaway expansion, so bail out with an error instead of
+/// allocating gigabytes. Complements `MAX_NESTING_EXPANSIONS`
 /// (`selectors/selector.rs`) and `MAX_SELECTOR_EXPANSION` (`rules/mod.rs`).
-const MAX_PREFIX_EXPANSIONS: u32 = 65_536;
+const MAX_PREFIX_EXPANSION_BYTES: usize = 64 << 20;
 
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // When an enclosing rule fans out across vendor prefixes, every pass
-        // after its first re-serializes this whole subtree, so this rule is a
-        // duplicate copy produced by that fan-out. Count it against the
-        // expansion budget — this is what makes the bound proportional to the
-        // actual (prefix count)^depth output rather than to any single rule's
-        // shape, so deeply nested fan-out (even with leaf-only inner rules)
-        // cannot amplify a few kilobytes into gigabytes. Rules emitted outside
-        // any fan-out pass (a flat stylesheet, or the original first pass) do
-        // not charge, so linear output never trips the limit.
-        if dest.prefix_fanout_depth > 0 {
-            dest.prefix_expansions += 1;
-            if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
-                return dest.new_error(
-                    css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
-                    None,
-                );
-            }
-        }
-
         if self.vendor_prefix.is_empty() {
             self.to_css_base(dest, true)?;
         } else {
@@ -135,18 +117,31 @@ impl<R> StyleRule<R> {
                     dest.vendor_prefix = prefix;
                     let (line, col) = (dest.line, dest.col);
                     // The first prefix pass is the original; every later pass
-                    // re-serializes the same nested subtree, so mark those
-                    // passes as fan-out so each nested rule they emit charges
-                    // the budget.
+                    // re-serializes the same body (declarations + nested rules),
+                    // so its output is a duplicate produced by the fan-out.
+                    // Measure how much it emits and charge it against the
+                    // expansion-byte budget so nesting fanning-out rules can't
+                    // expand a few kilobytes into gigabytes. The first pass and
+                    // any flat/single-prefix output are not duplicates and do
+                    // not charge, so linear output never trips the limit.
                     let is_duplicate_pass = emitted_first_pass;
+                    let bytes_before = if is_duplicate_pass {
+                        dest.bytes_written()
+                    } else {
+                        0
+                    };
+                    self.to_css_base(dest, remaining_prefixes.is_empty())?;
                     if is_duplicate_pass {
-                        dest.prefix_fanout_depth += 1;
+                        let emitted = dest.bytes_written().saturating_sub(bytes_before);
+                        dest.prefix_expansion_bytes =
+                            dest.prefix_expansion_bytes.saturating_add(emitted);
+                        if dest.prefix_expansion_bytes > MAX_PREFIX_EXPANSION_BYTES {
+                            return dest.new_error(
+                                css::error::PrinterErrorKind::maximum_vendor_prefix_expansion,
+                                None,
+                            );
+                        }
                     }
-                    let result = self.to_css_base(dest, remaining_prefixes.is_empty());
-                    if is_duplicate_pass {
-                        dest.prefix_fanout_depth -= 1;
-                    }
-                    result?;
                     // A non-final pass emits nothing when the rule has no
                     // declarations of its own and all of its nested rules are
                     // deferred to the final pass; don't write a separator

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -95,26 +95,29 @@ impl<R> StyleRule<R> {
         } else {
             let mut first_rule = true;
             let mut remaining_prefixes = self.vendor_prefix;
-            // The rule only fans out — producing more than one copy, and
-            // re-serializing its nested rules once per copy — when its selectors
-            // carry more than one vendor prefix (e.g. a list mixing
-            // `:-webkit-autofill` with an unprefixed pseudo-class). A single
-            // prefix bit serializes the rule exactly once, just like the
-            // `is_empty()` fast path, so it must not charge the expansion
-            // budget. Gate the charge on an actual fan-out, mirroring
-            // `charge_selector_expansion`'s `selector_expansion_multiplier > 1`.
-            let fans_out = self.vendor_prefix.bits().count_ones() > 1;
+            // The output only blows up multiplicatively when a rule both fans
+            // out — its selectors carry more than one vendor prefix (e.g. a list
+            // mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a
+            // single pseudo downleveled to several prefixes) so it is serialized
+            // once per prefix — AND has nested rules, because each copy then
+            // re-serializes that nested subtree. A single-prefix rule serializes
+            // exactly once (no fan-out), and a rule with no nested rules repeats
+            // only its own prelude (flat fan-out is linear in input size);
+            // neither compounds with depth, so neither charges the budget.
+            // Mirrors `charge_selector_expansion`, whose multiplier only grows
+            // inside `minify_nested_rules` and so never charges a flat rule.
+            let compounds = self.vendor_prefix.bits().count_ones() > 1 && self.rules.v.len() > 0;
             // `inline for (css.VendorPrefix.FIELDS) |field|` — iterate the bool fields of the
             // packed struct in declared order. In Rust the bitflags type exposes the same
             // ordered single-bit table directly.
             for &prefix in VendorPrefix::FIELDS {
                 if self.vendor_prefix.contains(prefix) {
-                    // Each copy re-serializes this rule's nested rules; when
-                    // those nested rules also fan out the copies compound
-                    // multiplicatively with depth. Bound the running total so
-                    // deeply nested vendor-prefixed rules can't expand into
-                    // gigabytes of output.
-                    if fans_out {
+                    // Each copy re-serializes this rule's nested subtree; when
+                    // those nested rules also compound the copies multiply with
+                    // depth. Bound the running total so deeply nested
+                    // vendor-prefixed rules can't expand into gigabytes of
+                    // output.
+                    if compounds {
                         dest.prefix_expansions += 1;
                         if dest.prefix_expansions > MAX_PREFIX_EXPANSIONS {
                             return dest.new_error(

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -185,11 +185,11 @@ test("deeply nested single-prefix rules stay linear and do not trip the bound", 
 });
 
 test("a large flat stylesheet of fanning-out rules does not trip the bound", () => {
-  // A rule that fans out but has no nested rules is serialized once per prefix,
-  // yet that is flat fan-out — linear in input size, bounded by the prefix
-  // count (at most 5). It cannot compound with depth, so it must not charge the
-  // expansion budget; only rules that both fan out and have nested rules do.
-  // Old targets downlevel a single `::placeholder` into four prefix variants
+  // A fanning-out rule with no nested rules is serialized once per prefix, but
+  // that is flat fan-out — linear in input size and bounded by the prefix count
+  // (at most 5). Only rules re-serialized inside a *nested* fan-out pass charge
+  // the budget, so these flat rules must not, however many there are. Old
+  // targets downlevel a single `::placeholder` into four prefix variants
   // (`-webkit-input-`, `-moz-`, `-ms-input-`, unprefixed), so 20_000 flat rules
   // are 80_000 prefix copies — past `MAX_PREFIX_EXPANSIONS` (65_536). Distinct
   // declarations keep the rules from being merged. This stays linear instead of
@@ -202,4 +202,22 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
   // Four prefix variants per input rule emitted (one unprefixed), not a throw.
   expect(output.split("::placeholder").length - 1).toBe(count);
   expect(output.split("::-webkit-input-placeholder").length - 1).toBe(count);
+});
+
+test("leaf rules nested under a fanning-out ancestor are bounded", () => {
+  // The amplification is driven by the nested subtree re-serialized once per
+  // ancestor prefix, so it must be bounded by the *total* rules emitted under a
+  // fan-out — not by whether each rule fans out on its own. Each nesting level
+  // is a two-prefix rule holding K plain leaf siblings plus one recursive
+  // child; the leaves never fan out themselves but are duplicated
+  // (prefix count)^depth times. Depth 15 is chosen so the fanning-out levels
+  // alone stay just under the limit — only counting the duplicated leaves
+  // catches it. A ~1.4 KB input expands past 9 MB here unless the leaf copies
+  // are counted; the bound turns it into a thrown error.
+  const K = 1;
+  const depth = 15;
+  const leaves = Array.from({ length: K }, (_, i) => `.x${i}:placeholder-shown,.y${i}:-webkit-autofill{--v${i}:1}`).join("");
+  const level = ".a:placeholder-shown,.b:-webkit-autofill{";
+  const src = (level + leaves).repeat(depth) + "}".repeat(depth);
+  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
 });

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -119,3 +119,67 @@ test("bun build --target=browser does not blow up on deeply nested prefixed sele
   expect(output).toContain(Array(depth).fill(":-webkit-full-screen").join(" "));
   expect(output).toContain(Array(depth).fill(":fullscreen").join(" "));
 });
+
+// Regression for a CSS-minifier output bomb found by fuzzing: a ~1.5 KB input
+// minified to ~884 MB (≈577,000× amplification), a DoS vector.
+//
+// When a rule's selector list mixes a vendor-prefixed pseudo-class
+// (`:-webkit-autofill`) with an unprefixed one (`:placeholder-shown`),
+// `get_prefix` sets two prefix bits and `StyleRule::to_css` serializes the
+// whole rule once per bit. Each pass re-serializes the rule's nested rules, so
+// nesting such rules repeats the inner subtree once per prefix at every level
+// — (prefix count)^depth. The earlier fix (PR #31270) deduplicated this only
+// when nesting was compiled away for browser targets; with no targets (or
+// nesting-capable targets) nesting is preserved, `&` is printed literally, and
+// every ancestor prefix pass genuinely needs its own copy of the body, so the
+// output cannot be collapsed. The minifier now bounds the total number of
+// per-prefix rule copies and errors out instead of allocating gigabytes.
+
+const VENDOR_PREFIX_LIMIT_ERROR = "Maximum vendor-prefix expansion exceeded";
+
+// `depth` nested copies of a rule whose selector list mixes a prefixed pseudo
+// (`:-webkit-autofill`, prefix bit) with an unprefixed one
+// (`:placeholder-shown`, NONE bit), innermost holding `color: red`.
+function nestedMixedPrefix(depth: number): string {
+  return ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(depth) + "color: red;\n" + "}\n".repeat(depth);
+}
+
+test("deeply nested mixed vendor-prefix rules error instead of exploding with no targets", () => {
+  // Each level doubles the number of printed rule copies, so without a bound
+  // this is ~2^depth copies of the leaf — hundreds of MB by the mid-teens.
+  // The bound turns it into a thrown error.
+  expect(() => minifyTest(nestedMixedPrefix(16), "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+});
+
+test("the fuzzer reproduction shape errors instead of amplifying", () => {
+  // The fuzzer's shape: unclosed nested rules (the CSS parser closes them at
+  // EOF). 884 MB of output on the original 1.5 KB input; now a thrown error.
+  const src = ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(16) + "color: red;";
+  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+});
+
+test("nesting-capable targets also bound the mixed vendor-prefix expansion", () => {
+  // Modern targets preserve nesting (no de-nesting), so the same per-prefix
+  // re-serialization of the body applies and must be bounded too.
+  expect(() => minifyTest(nestedMixedPrefix(16), "", { chrome: 130 << 16 })).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+});
+
+test("shallow mixed vendor-prefix nesting still minifies with both prefix variants", () => {
+  // Below the limit, the rule is still emitted once per prefix variant — the
+  // expansion is correct and necessary, just bounded.
+  const output = minifyTest(nestedMixedPrefix(2), "");
+  expect(output).toContain(":-webkit-autofill");
+  expect(output).toContain(":autofill");
+  expect(output).toContain("color:red");
+  expect(output.length).toBeLessThan(10_000);
+});
+
+test("deeply nested single-prefix rules stay linear and do not trip the bound", () => {
+  // A single selector with one vendor prefix (no mixing with an unprefixed
+  // selector) sets one prefix bit, so the rule is serialized once per level —
+  // linear, not multiplicative. This must not hit the bound.
+  const src = ".b:-webkit-autofill .y {\n".repeat(40) + "color: red;\n" + "}\n".repeat(40);
+  const output = minifyTest(src, "");
+  expect(output).toContain("color:red");
+  expect(output.length).toBeLessThan(10_000);
+});

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -205,15 +205,13 @@ test("a large flat stylesheet of fanning-out rules does not trip the bound", () 
 });
 
 test("leaf rules nested under a fanning-out ancestor are bounded", () => {
-  // The amplification is driven by the nested subtree re-serialized once per
-  // ancestor prefix, so it must be bounded by the *total* rules emitted under a
-  // fan-out — not by whether each rule fans out on its own. Each nesting level
-  // is a two-prefix rule holding K plain leaf siblings plus one recursive
+  // The amplification is driven by the whole nested body re-serialized once per
+  // ancestor prefix, so it must be bounded by the *output* emitted under a
+  // fan-out — not by whether each nested rule fans out on its own. Each nesting
+  // level is a two-prefix rule holding K plain leaf siblings plus one recursive
   // child; the leaves never fan out themselves but are duplicated
-  // (prefix count)^depth times. Depth 15 is chosen so the fanning-out levels
-  // alone stay just under the limit — only counting the duplicated leaves
-  // catches it. A ~1.4 KB input expands past 9 MB here unless the leaf copies
-  // are counted; the bound turns it into a thrown error.
+  // (prefix count)^depth times. A ~1.4 KB input expands past 9 MB here unless
+  // those duplicated leaves count against the bound; it becomes a thrown error.
   const K = 1;
   const depth = 15;
   const leaves = Array.from(
@@ -222,5 +220,20 @@ test("leaf rules nested under a fanning-out ancestor are bounded", () => {
   ).join("");
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
   const src = (level + leaves).repeat(depth) + "}".repeat(depth);
+  expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+});
+
+test("a large declaration block under a fanning-out ancestor is bounded", () => {
+  // The duplicated payload need not be nested rules: a fan-out pass also
+  // re-serializes the rule's own declarations. Each nesting level is a
+  // two-prefix rule whose body is one large custom-property declaration plus a
+  // recursive child, so the declaration bytes are duplicated (prefix count)^depth
+  // times — ~1.8 KB of input emits tens of MB. Counting only nested rules would
+  // miss this (the declaration is not a rule); bounding the emitted bytes of
+  // each duplicate pass catches it.
+  const depth = 16;
+  const payload = `--p:${"a".repeat(64)};`;
+  const level = ".a:placeholder-shown,.b:-webkit-autofill{";
+  const src = (level + payload).repeat(depth) + "}".repeat(depth);
   expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
 });

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -183,3 +183,21 @@ test("deeply nested single-prefix rules stay linear and do not trip the bound", 
   expect(output).toContain("color:red");
   expect(output.length).toBeLessThan(10_000);
 });
+
+test("a large flat stylesheet of single-prefix rules does not trip the bound", () => {
+  // `get_prefix` returns a single (non-empty) prefix bit for a selector like
+  // `:not(...)`, `:where(...)`, or `::placeholder`, so such a rule enters the
+  // per-prefix loop but is serialized exactly once — no fan-out. The bound must
+  // only count rules that actually fan out (more than one prefix bit), not
+  // every single-prefix rule; otherwise a flat, non-nested bundle of such rules
+  // — linear, non-amplifying output — would falsely error once enough of them
+  // accumulate against the never-reset counter. More rules than the limit
+  // (`MAX_PREFIX_EXPANSIONS` = 65_536), each with a distinct declaration so
+  // they are not merged into one rule.
+  const count = 70_000;
+  let src = "";
+  for (let i = 0; i < count; i++) src += `.c${i}:not(.x){--v${i}:1}`;
+  const output = minifyTest(src, "");
+  // Linear in input: one emitted rule per input rule, not a thrown error.
+  expect(output.split(":not(.x)").length - 1).toBe(count);
+}, 30_000);

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -216,7 +216,10 @@ test("leaf rules nested under a fanning-out ancestor are bounded", () => {
   // are counted; the bound turns it into a thrown error.
   const K = 1;
   const depth = 15;
-  const leaves = Array.from({ length: K }, (_, i) => `.x${i}:placeholder-shown,.y${i}:-webkit-autofill{--v${i}:1}`).join("");
+  const leaves = Array.from(
+    { length: K },
+    (_, i) => `.x${i}:placeholder-shown,.y${i}:-webkit-autofill{--v${i}:1}`,
+  ).join("");
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
   const src = (level + leaves).repeat(depth) + "}".repeat(depth);
   expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -232,7 +232,7 @@ test("a large declaration block under a fanning-out ancestor is bounded", () => 
   // miss this (the declaration is not a rule); bounding the emitted bytes of
   // each duplicate pass catches it.
   const depth = 16;
-  const payload = `--p:${"a".repeat(64)};`;
+  const payload = `--p:${Buffer.alloc(64, "a").toString()};`;
   const level = ".a:placeholder-shown,.b:-webkit-autofill{";
   const src = (level + payload).repeat(depth) + "}".repeat(depth);
   expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -148,20 +148,20 @@ test("deeply nested mixed vendor-prefix rules error instead of exploding with no
   // Each level doubles the number of printed rule copies, so without a bound
   // this is ~2^depth copies of the leaf — hundreds of MB by the mid-teens.
   // The bound turns it into a thrown error.
-  expect(() => minifyTest(nestedMixedPrefix(16), "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  expect(() => minifyTest(nestedMixedPrefix(20), "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
 });
 
 test("the fuzzer reproduction shape errors instead of amplifying", () => {
   // The fuzzer's shape: unclosed nested rules (the CSS parser closes them at
   // EOF). 884 MB of output on the original 1.5 KB input; now a thrown error.
-  const src = ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(16) + "color: red;";
+  const src = ".a:placeholder-shown .x, .b:-webkit-autofill .y {\n".repeat(20) + "color: red;";
   expect(() => minifyTest(src, "")).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
 });
 
 test("nesting-capable targets also bound the mixed vendor-prefix expansion", () => {
   // Modern targets preserve nesting (no de-nesting), so the same per-prefix
   // re-serialization of the body applies and must be bounded too.
-  expect(() => minifyTest(nestedMixedPrefix(16), "", { chrome: 130 << 16 })).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
+  expect(() => minifyTest(nestedMixedPrefix(20), "", { chrome: 130 << 16 })).toThrow(VENDOR_PREFIX_LIMIT_ERROR);
 });
 
 test("shallow mixed vendor-prefix nesting still minifies with both prefix variants", () => {
@@ -184,20 +184,22 @@ test("deeply nested single-prefix rules stay linear and do not trip the bound", 
   expect(output.length).toBeLessThan(10_000);
 });
 
-test("a large flat stylesheet of single-prefix rules does not trip the bound", () => {
-  // `get_prefix` returns a single (non-empty) prefix bit for a selector like
-  // `:not(...)`, `:where(...)`, or `::placeholder`, so such a rule enters the
-  // per-prefix loop but is serialized exactly once — no fan-out. The bound must
-  // only count rules that actually fan out (more than one prefix bit), not
-  // every single-prefix rule; otherwise a flat, non-nested bundle of such rules
-  // — linear, non-amplifying output — would falsely error once enough of them
-  // accumulate against the never-reset counter. More rules than the limit
-  // (`MAX_PREFIX_EXPANSIONS` = 65_536), each with a distinct declaration so
-  // they are not merged into one rule.
-  const count = 70_000;
+test("a large flat stylesheet of fanning-out rules does not trip the bound", () => {
+  // A rule that fans out but has no nested rules is serialized once per prefix,
+  // yet that is flat fan-out — linear in input size, bounded by the prefix
+  // count (at most 5). It cannot compound with depth, so it must not charge the
+  // expansion budget; only rules that both fan out and have nested rules do.
+  // Old targets downlevel a single `::placeholder` into four prefix variants
+  // (`-webkit-input-`, `-moz-`, `-ms-input-`, unprefixed), so 20_000 flat rules
+  // are 80_000 prefix copies — past `MAX_PREFIX_EXPANSIONS` (65_536). Distinct
+  // declarations keep the rules from being merged. This stays linear instead of
+  // throwing.
+  const oldTargets = { safari: 8 << 16, firefox: 20 << 16, chrome: 30 << 16, edge: 12 << 16 };
+  const count = 20_000;
   let src = "";
-  for (let i = 0; i < count; i++) src += `.c${i}:not(.x){--v${i}:1}`;
-  const output = minifyTest(src, "");
-  // Linear in input: one emitted rule per input rule, not a thrown error.
-  expect(output.split(":not(.x)").length - 1).toBe(count);
-}, 30_000);
+  for (let i = 0; i < count; i++) src += `input.c${i}::placeholder{--v${i}:1}`;
+  const output = minifyTest(src, "", oldTargets);
+  // Four prefix variants per input rule emitted (one unprefixed), not a throw.
+  expect(output.split("::placeholder").length - 1).toBe(count);
+  expect(output.split("::-webkit-input-placeholder").length - 1).toBe(count);
+});

--- a/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
+++ b/test/js/bun/css/nested-vendor-prefix-duplication.test.ts
@@ -132,8 +132,9 @@ test("bun build --target=browser does not blow up on deeply nested prefixed sele
 // when nesting was compiled away for browser targets; with no targets (or
 // nesting-capable targets) nesting is preserved, `&` is printed literally, and
 // every ancestor prefix pass genuinely needs its own copy of the body, so the
-// output cannot be collapsed. The minifier now bounds the total number of
-// per-prefix rule copies and errors out instead of allocating gigabytes.
+// output cannot be collapsed. The minifier now bounds the total bytes emitted
+// by those duplicate prefix passes and errors out instead of allocating
+// gigabytes.
 
 const VENDOR_PREFIX_LIMIT_ERROR = "Maximum vendor-prefix expansion exceeded";
 
@@ -185,15 +186,16 @@ test("deeply nested single-prefix rules stay linear and do not trip the bound", 
 });
 
 test("a large flat stylesheet of fanning-out rules does not trip the bound", () => {
-  // A fanning-out rule with no nested rules is serialized once per prefix, but
-  // that is flat fan-out — linear in input size and bounded by the prefix count
-  // (at most 5). Only rules re-serialized inside a *nested* fan-out pass charge
-  // the budget, so these flat rules must not, however many there are. Old
-  // targets downlevel a single `::placeholder` into four prefix variants
-  // (`-webkit-input-`, `-moz-`, `-ms-input-`, unprefixed), so 20_000 flat rules
-  // are 80_000 prefix copies — past `MAX_PREFIX_EXPANSIONS` (65_536). Distinct
-  // declarations keep the rules from being merged. This stays linear instead of
-  // throwing.
+  // A fanning-out rule with no nested rules re-serializes only its own prelude
+  // and declarations on each prefix pass — flat fan-out, linear in input size
+  // and bounded by the prefix count (at most 5). Its duplicate passes do charge
+  // the byte budget, but only a few dozen bytes per rule, so the total stays
+  // far under the cap without nesting to compound it. Old targets downlevel a
+  // single `::placeholder` into four prefix variants (`-webkit-input-`,
+  // `-moz-`, `-ms-input-`, unprefixed); 20_000 such rules charge ~3 duplicate
+  // passes of a tiny declaration each (a few MB total), well under the 64 MB
+  // byte limit. Distinct declarations keep the rules from being merged. This
+  // stays linear instead of throwing.
   const oldTargets = { safari: 8 << 16, firefox: 20 << 16, chrome: 30 << 16, edge: 12 << 16 };
   const count = 20_000;
   let src = "";


### PR DESCRIPTION
## What does this PR do?

Fixes a CSS-minifier output-amplification bug found by fuzzing: a ~1.5 KB stylesheet of deeply nested rules whose selector lists mix a vendor-prefixed pseudo-class with an unprefixed one minifies to **884,347,208 bytes** — a ~577,000× amplification and a DoS vector (~1.5 KB of attacker CSS → ~1 GB allocation).

```js
// before: 884,347,208 bytes out; after: throws "Maximum vendor-prefix expansion exceeded"
const sel = ".a:placeholder-shown .x, .b:-webkit-autofill .y";
const css = `${sel} {`.repeat(20) + "color:red" + "}".repeat(20);
require("bun:internal-for-testing").cssInternals.minifyTest(css, "");
```

## Cause

When a style rule's selector list mixes a vendor-prefixed pseudo-class (`:-webkit-autofill`, prefix bit) with an unprefixed one (`:placeholder-shown`, `NONE` bit), `selector::get_prefix` ORs the prefixes into `NONE | WEBKIT`, and `StyleRule::to_css` serializes the whole rule **once per set bit**. Each pass re-serializes the rule's nested rules, so nesting such rules repeats the inner subtree once per prefix at every level — the output grows by `(prefix count)^depth` (≈4× per level here).

This is independent of browser targets: the prefix comes from the *selector*, not the targets. `update_prefix`'s only targets gate guards the unrelated `downlevel_selectors` branch, so with no targets `vendor_prefix` still keeps its `NONE | WEBKIT` value and the fan-out runs.

PR #31270 addressed the same blow-up but only for the branch where CSS nesting is **compiled away** for old targets (`!supports_nesting`): there it defers prefixed nested rules to the ancestor's final prefix pass, which is lossless because de-nesting substitutes `&` and re-materializes **both** prefix variants into every flattened leaf selector. When nesting is **preserved** (no targets, or nesting-capable targets), `&` is printed literally and that re-materialization does not happen, so each ancestor prefix pass emits a genuinely distinct outer selector that gates a different set of browsers — the combinations cannot be collapsed without dropping coverage.

## Why not collapse the nesting-preserved case

Deferring the nested body to only the final (`:autofill`) pass — leaving `.b:-webkit-autofill .y{}` empty — would lose styles for browsers that support `:-webkit-autofill` but **not** `:autofill` (Chrome 4–109, Safari 3.1–14.1, iOS ≤14.5, etc. — see `src/css/prefixes.rs` `PseudoClassAutofill` vs `src/css/compat.rs` `Feature::Autofill`). Such a browser matches the empty `:-webkit-autofill` block and drops the `:autofill` one as an unknown pseudo-class, so the autofilled element gets nothing. The expansion is therefore semantically required; only its unbounded size is a bug.

## Fix

Bound the running total of per-prefix rule copies emitted across the whole stylesheet (`Printer::prefix_expansions`, accumulated and never reset because the blow-up compounds across nesting levels) and error out past `MAX_PREFIX_EXPANSIONS = 65_536`. This matches the existing `MAX_NESTING_EXPANSIONS` (`selectors/selector.rs`) and `MAX_SELECTOR_EXPANSION` (`rules/mod.rs`) caps. Output for all valid, non-pathological stylesheets is byte-for-byte unchanged — including every `:-webkit-autofill` outer variant keeping its full body.

## Verification

- Original 1,531-byte fuzzer input: **884,347,208 bytes → throws** `Maximum vendor-prefix expansion exceeded`.
- Below the limit, output is unchanged and correct: shallow mixed-prefix nesting still emits both prefix variants with their bodies; single-prefix nesting stays linear and never trips the bound.
- New tests in `test/js/bun/css/nested-vendor-prefix-duplication.test.ts` (fail on the unfixed build):
  - deeply nested mixed-prefix rules error instead of exploding (no targets; and with nesting-capable targets)
  - the fuzzer's unclosed-braces shape errors instead of amplifying
  - shallow mixed-prefix nesting still minifies with both prefix variants
  - deeply nested single-prefix rules stay linear and do not trip the bound
- All existing tests in that file (from #31270) still pass, plus `test/js/bun/css/css.test.ts` (1087), `test/bundler/css/` (166), `test/bundler/esbuild/css.test.ts` (53), and the other nesting/selector/printer CSS files.

## Note

This is an alternative to #31641, which fixes the same bug by deferring the nested body to the final prefix pass in the nesting-preserved branch. That approach leaves the `:-webkit-autofill` outer selector with an empty `{}` block (see its asserted test output), which silently drops styles for webkit-only browsers — details in a comment there. This PR keeps the output correct and just bounds the size.
