### PR TITLE
test: fix crash when a failing matcher formats its diff near the stack limit

### DIFF
--- a/src/runtime/test_runner/diff_format.rs
+++ b/src/runtime/test_runner/diff_format.rs
@@ -53,6 +53,10 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 &mut received_buf,
                 fmt_options,
             ); // TODO:
+            // Pretty-printing runs user JS and may leave a pending exception
+            // (e.g. a stack overflow). This is a best-effort diff, so clear it;
+            // otherwise the next JS call observes the stale exception and asserts.
+            let _ = global_this.clear_exception_except_termination();
 
             let _ = JestPrettyFormat::format(
                 MessageLevel::Debug,
@@ -62,6 +66,7 @@ impl<'a> fmt::Display for DiffFormatter<'a> {
                 &mut expected_buf,
                 fmt_options,
             ); // TODO:
+            let _ = global_this.clear_exception_except_termination();
         }
 
         let mut received_slice: &[u8] = received_buf.as_slice();

--- a/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
+++ b/test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts
@@ -19,3 +19,31 @@ test("expect does not crash when value has Symbol.toPrimitive returning a Symbol
 
   expect(exitCode).toBe(0);
 });
+
+test("expect does not crash when a failing matcher formats the diff near the stack limit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      let ran = false;
+      function deep() {
+        try {
+          deep();
+        } catch {
+          if (!ran) {
+            ran = true;
+            try { Bun.jest().expect(new Map([[1, 2]])).toEqual(new Map()); } catch {}
+          }
+        }
+      }
+      deep();
+    `,
+    ],
+    env: bunEnv,
+  });
+
+  const exitCode = await proc.exited;
+
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

A failing `toEqual` / `toStrictEqual` could abort the process with:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Maximum call stack size exceeded.
!exception() || m_vm.hasPendingTerminationException()
.../JavaScriptCore/ExceptionScope.h(63) : void JSC::ExceptionScope::assertNoExceptionExceptTermination()
```

## Why

When a matcher fails, `DiffFormatter` renders the diff by pretty-printing the
*received* and *expected* values in two sequential passes
(`JestPrettyFormat::format`). Pretty-printing runs user-observable JS (property
access, `toString`, iteration, …), which can raise an exception — in the fuzzer
repro a stack overflow when the values are formatted while the stack is already
near exhausted.

Each pretty-print result is intentionally discarded (the diff is best-effort),
but the pending JS exception was left on the VM. A stack-overflow `RangeError`
is *not* a termination exception, so the second pretty-print's JSC calls
observed the stale pending exception and tripped
`assertNoExceptionExceptTermination`, aborting the process.

## Fix

Clear any pending non-termination exception after each pretty-print pass in
`DiffFormatter`, matching the best-effort intent of the surrounding code (the
format results are already discarded). Real worker-termination exceptions are
preserved via `clear_exception_except_termination`.

## Test

`test/js/bun/test/expect-symbol-toPrimitive-crash.test.ts` gains a case that
drives `toEqual` to fail while the stack is near its limit and asserts the
process exits cleanly. It aborts before this change and passes after.