### PR TITLE
Update upgrade-webkit instructions for the current build system

### DIFF
--- a/.claude/commands/upgrade-webkit.md
+++ b/.claude/commands/upgrade-webkit.md
@@ -1,26 +1,41 @@
-Upgrade Bun's Webkit fork to the latest upstream version of Webkit.
+---
+description: Upgrade Bun's WebKit fork to the latest upstream version of WebKit
+---
+
+Upgrade Bun's WebKit fork (vendor/WebKit = oven-sh/WebKit) to the latest upstream WebKit.
+
+Two modes — pick from ARGUMENTS:
+
+- **Direct (default)**: push the merge straight to oven-sh/WebKit main. Confirm with the user before pushing.
+- **Preview** (when ARGUMENTS contains `preview` or `pr`): never push to main. Open a PR on oven-sh/WebKit and use its auto-built preview release instead.
 
 To do that:
 
-- cd vendor/WebKit
+- cd vendor/WebKit (must be a real clone with an `upstream` remote pointing at WebKit/WebKit)
 - git fetch upstream
-- git merge upstream main
-- Fix the merge conflicts
-- bun build.ts debug
-- While it compiles, in another task review the JSC commits between the last version of Webkit and the new version. Write up a summary of the webkit changes in a file called "webkit-changes.md"
-- bun run build:local (build a build of Bun with the new Webkit, make sure it compiles)
-- After making sure it compiles, run some code to make sure things work. something like ./build/debug-local/bun-debug --print '42' should be all you need
-- cd vendor/WebKit
-- git commit -am "Upgrade Webkit to the latest version"
-- git push
-- get the commit SHA in the vendor/WebKit directory of your new commit
-- cd ../../ (back to bun)
-- Update WEBKIT_VERSION in cmake/tools/SetupWebKit.cmake to the commit SHA of your new commit
-- git checkout -b bun/webkit-upgrade-<commit-sha>
+- OLD_BASE=$(git merge-base origin/main upstream/main) — save this for the changelog
+- Preview mode: create a working branch (e.g. `bun/upgrade-to-<upstream-short-sha>`) instead of staying on main
+- git merge upstream/main
+- Fix the merge conflicts (preserve the fork's Bun-specific changes)
+- bun run jsc:build:debug — from the bun repo root, builds just JSC
+- While it compiles, in another task review the JSC commits between $OLD_BASE and upstream/main (Source/JavaScriptCore, Source/WTF, Source/bmalloc). Write up a summary in a file called "webkit-changes.md"
+- bun run build:local — full Bun build against the local WebKit (reuses the JSC build above)
+- After it compiles, run some code to make sure things work: `bun run build:local -p '42'`
+- Publish the new WebKit:
+  - Direct: cd vendor/WebKit, commit, `git push origin main`. The push triggers a release tagged `autobuild-<full-sha>`.
+  - Preview: push the branch and open a PR on oven-sh/WebKit. CI publishes a prerelease tagged `autobuild-preview-pr-<PR#>-<first-8-chars-of-head-sha>`. (Auto-triggers only for authors with write access; otherwise `gh workflow run build-preview.yml --repo oven-sh/WebKit -f pr_number=<N>`.)
+- Wait until the release exists: `gh release view <tag> --repo oven-sh/WebKit`. It is created only after ALL platform builds succeed (takes a while). Bun's CI downloads prebuilts from it, so don't open the bun PR before it's up.
+- cd back to bun and update WEBKIT_VERSION in scripts/build/deps/webkit.ts:
+  - Direct: the new vendor/WebKit commit sha
+  - Preview: the full preview tag (`autobuild-preview-pr-...`)
+- git checkout -b claude/webkit-upgrade-<sha> (branch must start with `claude/` for CI)
 - commit + push (without adding the webkit-changes.md file)
-- create PR titled "Upgrade Webkit to the <commit-sha>", paste your webkit-changes.md into the PR description
+- create a PR titled "Upgrade WebKit to <upstream-short-sha>", paste webkit-changes.md into the description
+  - Preview mode: also note in the description that WEBKIT_VERSION points at a preview build and must be bumped to the merge-commit's `autobuild-<sha>` after the oven-sh/WebKit PR merges — do that bump before merging the bun PR
 - delete the webkit-changes.md file
 
 Things to check for a successful upgrade:
-- Did JSType in vendor/WebKit/Source/JavaScriptCore have any recent changes? Does the enum values align with whats present in src/jsc/bindings/JSType.zig?
-- Were there any changes to the webcore code generator? If there are C++ compilation errors, check for differences in some of the generated code in like vendor/WebKit/source/WebCore/bindings/scripts/test/JS/
+
+- Did Source/JavaScriptCore/runtime/JSType.h change? The enum values must align with Bun's mirror in src/jsc/JSType.rs (src/jsc/JSType.zig is a non-compiled porting reference, not the live code).
+- Were there any changes to the WebCore code generator? If there are C++ compilation errors, check for differences in the generated reference code in vendor/WebKit/Source/WebCore/bindings/scripts/test/JS/
+- If the merge touched the fork's .github/workflows, the release tarball names must still match prebuiltSuffix() in scripts/build/deps/webkit.ts


### PR DESCRIPTION
## Summary
- Fix outdated references in `.claude/commands/upgrade-webkit.md`: `WEBKIT_VERSION` now lives in `scripts/build/deps/webkit.ts` (not `cmake/tools/SetupWebKit.cmake`), and the JSType mirror to check is `src/jsc/JSType.rs` (not `src/jsc/bindings/JSType.zig`)
- Update build/verify steps to the current commands (`bun run jsc:build:debug`, `bun run build:local -p '42'`) and the `claude/`-prefixed branch naming required by CI
- Add a **preview mode**: instead of pushing the upstream merge directly to oven-sh/WebKit `main`, open a PR on the fork, wait for its `autobuild-preview-pr-<N>-<sha>` prerelease, point Bun's `WEBKIT_VERSION` at that tag, and swap to the merge-commit autobuild before merging the Bun PR
- Document that the bun-side PR must wait for the WebKit release to exist (it is only published after all platform builds succeed)

## Test plan
- [ ] Verify all file paths referenced in the instructions exist in the repo (`scripts/build/deps/webkit.ts`, `src/jsc/JSType.rs`, `vendor/WebKit/Source/WebCore/bindings/scripts/test/JS/`)
- [ ] Verify the referenced package scripts exist (`jsc:build:debug`, `build:local`)
- [ ] Dry-read the preview flow against `oven-sh/WebKit`'s `.github/workflows/build-preview.yml` tag format