### PR TITLE
fix(bundler): write transpiled files when using --no-bundle with --outdir

### DIFF
--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -569,7 +569,42 @@ impl BuildCommand {
                     }
                 }
 
-                break 'brk result.output_files.into_vec();
+                let mut output_files = result.output_files.into_vec();
+
+                // When transpiling without bundling (`--no-bundle`) into an output
+                // directory, `transform()` produces buffers but leaves `dest_path`
+                // empty, so the write loop below would write to "". Derive each
+                // destination path from the entry's source path with a `.js`
+                // extension (e.g. `src/a.ts` -> `src/a.js`). The write loop strips
+                // the longest common prefix of these paths before joining onto
+                // `--outdir`, so keeping the source directory layout here mirrors
+                // how the bundler computes output paths. See issue #5206.
+                if !ctx.bundler_options.outdir.is_empty() {
+                    // `root_dir` is the resolved outbase for the entry points
+                    // (computed above, mirrors the bundler). Deriving each
+                    // `dest_path` relative to it keeps the paths relative — the
+                    // write loop asserts they are not absolute — and preserves the
+                    // entry's directory layout under `--outdir`, exactly like the
+                    // bundling code path.
+                    let root_dir = &this_transpiler.options.root_dir;
+                    for output_file in output_files.iter_mut() {
+                        if !output_file.dest_path.is_empty() {
+                            continue;
+                        }
+                        let rel = bun_paths::resolve_path::relative(
+                            root_dir,
+                            output_file.src_path.text,
+                        );
+                        let ext = bun_paths::fs::PathName::find_extname(rel);
+                        let stem = &rel[..rel.len() - ext.len()];
+                        let mut dest = Vec::<u8>::with_capacity(stem.len() + 3);
+                        dest.extend_from_slice(stem);
+                        dest.extend_from_slice(b".js");
+                        output_file.dest_path = dest.into_boxed_slice();
+                    }
+                }
+
+                break 'brk output_files;
             }
 
             if ctx.bundler_options.outdir.is_empty()
@@ -783,7 +818,20 @@ impl BuildCommand {
             }
             debug_assert_eq!(all_paths.len(), output_files.len());
 
-            let from_path = resolve_path::longest_common_path(&all_paths);
+            let mut from_path = resolve_path::longest_common_path(&all_paths);
+            // `write_to_disk` strips `from_path` off each `dest_path` before joining
+            // onto the output dir. That only makes sense when the dest paths are
+            // absolute and share a real common directory. For `--no-bundle`, the
+            // dest paths are already relative (e.g. `a.js`), and
+            // `longest_common_path` returns `/` for them — `relative("/", "a.js")`
+            // would then resolve against the cwd and produce an absolute path. When
+            // the outputs are relative, there is no prefix to strip, so use ".".
+            if output_files
+                .first()
+                .is_some_and(|f| !bun_paths::is_absolute(&f.dest_path))
+            {
+                from_path = b".";
+            }
 
             let mut size_padding: usize = 0;
 

--- a/test/regression/issue/05206.test.ts
+++ b/test/regression/issue/05206.test.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/5206
+// `bun build <files> --no-bundle --outdir <dir>` used to fail with
+// `error: failed to write file ''` because the transpiled outputs never got a
+// destination path. Each entry should be transpiled in place into the outdir.
+test("bun build --no-bundle --outdir writes transpiled files", async () => {
+  using dir = tempDir("issue-05206", {
+    "a.ts": `console.log('hello world!');`,
+    "b.ts": `console.log('foo bar baz');`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "a.ts", "b.ts", "--no-bundle", "--outdir", "out"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("failed to write file");
+  expect(exitCode).toBe(0);
+
+  const aOut = await Bun.file(join(String(dir), "out", "a.js")).text();
+  const bOut = await Bun.file(join(String(dir), "out", "b.js")).text();
+  expect(aOut).toContain("console.log");
+  expect(aOut).toContain("hello world!");
+  expect(bOut).toContain("foo bar baz");
+});
+
+test("bun build --no-bundle --outdir . transpiles in place", async () => {
+  using dir = tempDir("issue-05206-inplace", {
+    "a.ts": `export const x: number = 1;`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "a.ts", "--no-bundle", "--outdir", "."],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("failed to write file");
+  expect(exitCode).toBe(0);
+
+  const out = await Bun.file(join(String(dir), "a.js")).text();
+  expect(out).toContain("export const x = 1");
+});

--- a/test/regression/issue/05206.test.ts
+++ b/test/regression/issue/05206.test.ts
@@ -23,13 +23,16 @@ test("bun build --no-bundle --outdir writes transpiled files", async () => {
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("failed to write file");
-  expect(exitCode).toBe(0);
 
   const aOut = await Bun.file(join(String(dir), "out", "a.js")).text();
   const bOut = await Bun.file(join(String(dir), "out", "b.js")).text();
   expect(aOut).toContain("console.log");
   expect(aOut).toContain("hello world!");
   expect(bOut).toContain("foo bar baz");
+
+  // Surface stderr on failure, then assert the exit code last.
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });
 
 test("bun build --no-bundle --outdir . transpiles in place", async () => {
@@ -48,8 +51,11 @@ test("bun build --no-bundle --outdir . transpiles in place", async () => {
   const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
   expect(stderr).not.toContain("failed to write file");
-  expect(exitCode).toBe(0);
 
   const out = await Bun.file(join(String(dir), "a.js")).text();
   expect(out).toContain("export const x = 1");
+
+  // Surface stderr on failure, then assert the exit code last.
+  if (exitCode !== 0) expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #5206.

`bun build <files> --no-bundle --outdir <dir>` failed with:

```
error: failed to write file ''
ENOENT: No such file or directory (open())
```

Repro:

```ts
// a.ts
console.log('hello world!');
// b.ts
console.log('foo bar baz');
```

```sh
bun build a.ts b.ts --no-bundle --outdir .
```

### Why it happened

In the `--no-bundle` (`transform_only`) path, `transform()` produces the output buffers but never assigns each `OutputFile.dest_path`. The write loop then tried to write to an empty path, producing `failed to write file ''`.

### The fix

`src/runtime/cli/build_command.rs`, two small changes:

1. **Assign `dest_path` in the transform path.** When `--outdir` is set, derive each output's `dest_path` from its source path relative to the resolved outbase (`this_transpiler.options.root_dir`), with the extension swapped to `.js` — mirroring how the bundler computes output paths. This keeps the path relative (the write loop asserts `!is_absolute`) and preserves the entry's directory layout under `--outdir`.

2. **Common-prefix fallback.** For relative destinations (`a.js`, `b.js`), `longest_common_path` returns `/`, and `write_to_disk` would then `relative("/", "a.js")` and resolve it against the cwd into an absolute path, writing files to a wrong nested location. When the destinations are already relative there is no prefix to strip, so fall back to `.`.

### Tests

Added `test/regression/issue/05206.test.ts`. Verified it **passes** with the debug build and **fails** with `USE_SYSTEM_BUN=1` (reproducing `failed to write file ''`), per the contributing guidelines.

Manually verified the produced files land correctly for: two files into `--outdir .`, into a separate `--outdir dist`, a single file, and entries in a subdirectory. The normal bundling path and `--no-bundle` stdout path are unaffected.
