### PR TITLE
fix(transpiler): force production JSX runtime when NODE_ENV=production

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -615,6 +615,12 @@ impl<'a> Transpiler<'a> {
         } else if is_production {
             self.options.set_production(true);
             self.resolver.opts.set_production(true);
+            // Mirror the development branch: force the production environment so
+            // the bundler's per-file JSX dev/prod selection (which keys off
+            // `force_node_env`) picks the production runtime even when a
+            // tsconfig set `jsx: "react-jsx"` (automatic runtime). See #23959.
+            self.options.force_node_env = options::ForceNodeEnv::Production;
+            self.resolver.opts.force_node_env = options::ForceNodeEnv::Production;
         }
         Ok(())
     }

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -29,7 +29,7 @@ test("bun build respects NODE_ENV=production for automatic JSX runtime (#23959)"
   expect(stdout).not.toContain("jsxDEV");
 
   // Surface stderr on failure, then assert the exit code last.
-  if (result.exitCode !== 0) console.error(stderr);
+  if (result.exitCode !== 0) expect(stderr).toBe("");
   expect(result.exitCode).toBe(0);
 });
 
@@ -54,8 +54,8 @@ test("bun build keeps the development JSX runtime by default (#23959)", () => {
   const stderr = result.stderr.toString();
 
   expect(stdout).toContain("react/jsx-dev-runtime");
-  expect(stdout).not.toContain('"react/jsx-runtime"');
+  expect(stdout).not.toContain("react/jsx-runtime");
 
-  if (result.exitCode !== 0) console.error(stderr);
+  if (result.exitCode !== 0) expect(stderr).toBe("");
   expect(result.exitCode).toBe(0);
 });

--- a/test/regression/issue/23959.test.ts
+++ b/test/regression/issue/23959.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test";
+import { bunExe, bunEnv, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/23959
+// With `NODE_ENV=production`, `bun build` must emit the production automatic
+// runtime (`react/jsx-runtime`, `jsx(...)`) even when a tsconfig sets
+// `jsx: "react-jsx"`. It regressed to always emitting the development runtime
+// (`react/jsx-dev-runtime`, `jsxDEV(...)`).
+test("bun build respects NODE_ENV=production for automatic JSX runtime (#23959)", () => {
+  using dir = tempDir("23959", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+    "test.tsx": `console.log(<div>Hello</div>);`,
+  });
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "build", "test.tsx", "--external", "react"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+
+  // Production: must use the production runtime, never the dev one.
+  expect(stdout).toContain("react/jsx-runtime");
+  expect(stdout).not.toContain("react/jsx-dev-runtime");
+  expect(stdout).not.toContain("jsxDEV");
+
+  // Surface stderr on failure, then assert the exit code last.
+  if (result.exitCode !== 0) console.error(stderr);
+  expect(result.exitCode).toBe(0);
+});
+
+// Counterpart: without NODE_ENV=production, the automatic runtime stays in
+// development mode (this is the existing, intended behavior — guards against
+// "fixing" #23959 by forcing production unconditionally).
+test("bun build keeps the development JSX runtime by default (#23959)", () => {
+  using dir = tempDir("23959-dev", {
+    "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "react-jsx" } }),
+    "test.tsx": `console.log(<div>Hello</div>);`,
+  });
+
+  const result = Bun.spawnSync({
+    cmd: [bunExe(), "build", "test.tsx", "--external", "react"],
+    env: { ...bunEnv, NODE_ENV: undefined },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+
+  expect(stdout).toContain("react/jsx-dev-runtime");
+  expect(stdout).not.toContain('"react/jsx-runtime"');
+
+  if (result.exitCode !== 0) console.error(stderr);
+  expect(result.exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #23959.

With `NODE_ENV=production`, `bun build` emitted the **development** JSX runtime (`react/jsx-dev-runtime`, `jsxDEV(...)`) instead of the production one (`react/jsx-runtime`, `jsx(...)`) when a `tsconfig.json` set `jsx: "react-jsx"`.

Repro:

```tsx
// test.tsx
console.log(<div>Hello</div>);
```
```jsonc
// tsconfig.json
{ "compilerOptions": { "jsx": "react-jsx" } }
```
```sh
NODE_ENV=production bun build test.tsx
# before: imports react/jsx-dev-runtime, emits jsxDEV(...)
# after:  imports react/jsx-runtime, emits jsx(...)
```

### Root cause

When `NODE_ENV=production`, the transpiler called `set_production(true)` but never set `force_node_env = Production` (the `is_development` branch *does* set `force_node_env = Development`). The bundler's per-file JSX dev/prod selection switches on `force_node_env`, so the `Unspecified` arm fell through to the file's `jsx.development` — which is `true` for the automatic runtime selected by `jsx: "react-jsx"` — and produced the development runtime in a production build.

### The fix

In `src/bundler/transpiler.rs`, set `force_node_env = Production` in the `is_production` branch, mirroring the existing `is_development` branch. Production builds now select the production JSX runtime regardless of the tsconfig automatic-runtime setting.

The runtime mapping (`RUNTIME_MAP`) is intentionally **left unchanged**: `react-jsx` stays the automatic runtime, so without `NODE_ENV=production` it still emits the development runtime — preserving the behavior asserted by `test/bundler/bundler_jsx.test.ts > jsx/sideEffectsTrueTsconfigAutomatic`.

### Tests

Added `test/regression/issue/23959.test.ts` with two cases:
- `NODE_ENV=production` + `jsx: "react-jsx"` → must emit `react/jsx-runtime` (the fix).
- No `NODE_ENV` + `jsx: "react-jsx"` → still emits `react/jsx-dev-runtime` (guards against over-forcing production).

Verified the new test passes with the build and fails with `USE_SYSTEM_BUN=1`, and the full `test/bundler/bundler_jsx.test.ts` suite passes (no regression).
