### PR TITLE
net: emit 'close' when a backpressured socket's peer dies

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -164,6 +164,37 @@ function endNT(socket, callback, err) {
 function emitCloseNT(self, hasError) {
   self.emit("close", hasError);
 }
+// The native layer reported the connection closed. The socket is built with
+// `autoDestroy: true`, but autoDestroy only runs `_destroy` (which emits
+// `'close'`) once *both* halves of the Duplex finish. When the fd is gone but
+// the writable still holds backpressure that can never reach the dead peer,
+// that half never finishes: the socket lingers as a zombie (`destroyed`
+// false), `'close'` never fires, `server._connections` never decrements so
+// `server.close()` hangs, and a peer that keeps the fd hot spins the loop.
+//
+// Force the teardown only when there is nothing left to read
+// (`readableLength === 0`): a reader that is intentionally deferring
+// `read()` with data still buffered (test-net-socket-close-after-end.js) must
+// be allowed to consume it and emit `'end'` before `'close'`, as Node does.
+// Defer via `setImmediate` so everything already scheduled on the nextTick
+// queue runs first — the pending `'end'` from `push(null)`+`read(0)`, and the
+// "write EBADF" `_write` delivers via nextTick for a write that races the
+// close (test-net-socket-write-after-close.js). In the common clean case the
+// socket has auto-destroyed by then and this is a no-op. No error is passed:
+// real read errors already surface through the dedicated error paths, and
+// the passive peer close that lands here is benign.
+function destroyAfterClose(self) {
+  if (!self.destroyed && self.readableLength === 0) {
+    setImmediate(() => {
+      // Re-check `kclosed`: a user can call `socket.connect()` from inside
+      // `'close'` (which on the detached-handle path drains on nextTick
+      // before this setImmediate), and `initSocketHandle` clears `kclosed`
+      // — without this guard the fallback would tear down the fresh
+      // connection.
+      if (!self.destroyed && self[kclosed]) self.destroy();
+    });
+  }
+}
 function detachSocket(self) {
   if (!self) self = this;
   self._handle = null;
@@ -261,6 +292,7 @@ const SocketHandlers: SocketHandler = {
     detachSocket(self);
     SocketEmitEndNT(self, err);
     self.data = null;
+    destroyAfterClose(self);
   },
   data(socket, buffer) {
     const { data: self } = socket;
@@ -518,6 +550,11 @@ function SocketEmitEndNT(self, _err?) {
     }
     self[kended] = true;
     self.push(null);
+    // Kick the readable so a paused stream with nothing buffered still
+    // schedules `'end'` (matching the `push(null); read(0)` pair
+    // `SocketHandlers2.close` already does); without this a paused socket
+    // whose peer cleanly closed stalls before autoDestroy.
+    self.read(0);
   } else if (_err && !self.destroyed) {
     // An error excluded from the synthesis above (teardown noise, or no
     // listener attached): nothing more is coming, but the socket still has to
@@ -527,8 +564,13 @@ function SocketEmitEndNT(self, _err?) {
   }
   // A write that was waiting on the native drain can never complete once the
   // socket is gone - fail it so 'finish'/destroy are not stuck behind it.
+  // Gate on `kclosed` (set by the close handlers before reaching here) as
+  // well, so a clean close that lands with no error still flushes — otherwise
+  // a paused reader with buffered data plus a backpressured write leaves
+  // `kWriting` set and autoDestroy can never fire even after the reader
+  // drains.
   const pendingWrite = self[kwriteCallback];
-  if (pendingWrite && (self.destroyed || _err)) {
+  if (pendingWrite && (self.destroyed || _err || self[kclosed])) {
     self[kwriteCallback] = null;
     pendingWrite(_err ?? $ERR_SOCKET_CLOSED());
   }
@@ -702,6 +744,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
         SocketEmitEndNT(data, err);
         data.data = null;
         socket[owner_symbol] = null;
+        destroyAfterClose(data);
       }
     }
   },
@@ -1097,6 +1140,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       self[kwriteCallback] = null;
       pendingWrite($ERR_SOCKET_CLOSED());
     }
+    destroyAfterClose(self);
   },
   handshake(socket, success, verifyError) {
     $debug("Bun.Socket handshake");

--- a/test/js/node/net/node-hup-backpressure-peer-fixture.js
+++ b/test/js/node/net/node-hup-backpressure-peer-fixture.js
@@ -1,0 +1,13 @@
+// Peer side of the "busy-loop on half-closed UDS" regression. Connects to the
+// survivor's UDS and pauses (never reads) so the survivor's writes pile up into
+// backpressure. Prints CONNECTED, then sits idle until the test SIGKILLs it.
+const net = require("node:net");
+
+const sockPath = process.env.UDS_PATH;
+
+const client = net.connect(sockPath, () => {
+  console.log("CONNECTED");
+});
+// Never consume — let the survivor's writes create backpressure.
+client.pause();
+client.on("error", () => {});

--- a/test/js/node/net/node-hup-backpressure-survivor-fixture.js
+++ b/test/js/node/net/node-hup-backpressure-survivor-fixture.js
@@ -1,0 +1,57 @@
+// Survivor side of the "busy-loop on half-closed UDS" regression
+// (see node-net.test.ts "should emit close ... when a backpressured peer is killed").
+//
+// Listens on a UDS, and on connect immediately floods the peer with data so the
+// kernel send buffer fills and µSockets marks the socket backpressured
+// (last_write_failed). The test then SIGKILLs the peer. The survivor must
+// receive a single 'close' and exit 0. Before the fix, 'close' never fired and
+// this process hung forever (spinning on the half-closed fd).
+const net = require("node:net");
+
+const sockPath = process.env.UDS_PATH;
+
+// Watchdog: if 'close' never arrives, fail loudly instead of hanging forever.
+const watchdog = setTimeout(() => {
+  console.error("survivor: timed out waiting for close");
+  process.exit(3);
+}, 15_000);
+
+let closeCount = 0;
+
+const server = net.createServer(socket => {
+  console.log("ACCEPTED");
+
+  const big = Buffer.alloc(8 * 1024 * 1024, 0x41);
+  const pump = () => {
+    // Write until the kernel applies backpressure.
+    while (socket.write(big)) {}
+  };
+  socket.on("drain", pump);
+  pump();
+
+  socket.on("data", () => {});
+  socket.on("end", () => {});
+  socket.on("error", () => {});
+  socket.on("close", () => {
+    closeCount++;
+    clearTimeout(watchdog);
+    server.close();
+    // Give a tick to catch any erroneous second 'close', then report.
+    setImmediate(() => {
+      if (closeCount !== 1) {
+        console.error(`survivor: expected exactly one close, got ${closeCount}`);
+        process.exit(4);
+      }
+      process.exit(0);
+    });
+  });
+});
+
+server.on("error", err => {
+  console.error("survivor: server error", err);
+  process.exit(5);
+});
+
+server.listen(sockPath, () => {
+  console.log("LISTENING");
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -773,6 +773,106 @@ it("should not hang after destroy", async () => {
   }
 }, 120_000);
 
+it.skipIf(isWindows)(
+  "should emit 'close' exactly once when a backpressured UDS peer is killed",
+  async () => {
+    // Regression: a node:net socket with pending write-backpressure toward a
+    // peer that is SIGKILLed never emitted 'close' and the process spun /
+    // hung forever on the half-closed fd. Both sides talk over a Unix domain
+    // socket; the survivor floods the peer (backpressure), we kill the peer,
+    // and the survivor must get a single 'close' and exit 0.
+    const udsPath = join(tmpdirSync(), `hup-${randomUUID()}.sock`);
+
+    // Reads stdout until `needle` appears; rejects if the stream ends first.
+    const waitForLine = async (proc: Bun.Subprocess<"ignore", "pipe", "inherit">, needle: string) => {
+      const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+      const decoder = new TextDecoder();
+      let buf = "";
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (value) buf += decoder.decode(value, { stream: true });
+          if (buf.includes(needle)) return;
+          if (done) throw new Error(`process exited before printing "${needle}" (saw: ${JSON.stringify(buf)})`);
+        }
+      } finally {
+        reader.releaseLock();
+      }
+    };
+
+    await using survivor = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "node-hup-backpressure-survivor-fixture.js")],
+      env: { ...bunEnv, UDS_PATH: udsPath },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    await waitForLine(survivor, "LISTENING");
+
+    await using peer = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "node-hup-backpressure-peer-fixture.js")],
+      env: { ...bunEnv, UDS_PATH: udsPath },
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+    // Survivor prints ACCEPTED once it has a connected socket and has begun
+    // flooding the peer, i.e. backpressure is building.
+    await waitForLine(survivor, "ACCEPTED");
+
+    // Kill the peer hard, mid-backpressure. This is the race the bug hit.
+    peer.kill("SIGKILL");
+
+    // Fail loudly on a hang instead of letting the test time out with no info.
+    const watchdog = setTimeout(() => survivor.kill("SIGKILL"), 20_000);
+    const exitCode = await survivor.exited;
+    clearTimeout(watchdog);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
+
+it.skipIf(isWindows)(
+  "emits 'close' and lets server.close() complete when a paused socket's peer ends",
+  async () => {
+    // A paused (or never-read) server socket never consumes the EOF its peer's
+    // FIN pushes, so autoDestroy never runs: the socket lingers as a zombie,
+    // 'close' never fires, and server.close() hangs because _connections never
+    // decrements. Same root cause as the backpressure case, different stuck half.
+    const udsPath = join(tmpdirSync(), `hup-paused-${randomUUID()}.sock`);
+
+    const { promise: serverSocketClosed, resolve: onServerSocketClose } = Promise.withResolvers<void>();
+    const { promise: paused, resolve: onPaused } = Promise.withResolvers<void>();
+
+    const server = createServer(socket => {
+      socket.on("error", () => {});
+      socket.on("close", () => onServerSocketClose());
+      socket.on("data", () => {
+        socket.pause(); // stop reading — the peer's FIN/EOF will never be consumed
+        onPaused();
+      });
+    });
+
+    try {
+      await new Promise<void>(resolve => server.listen(udsPath, () => resolve()));
+
+      const client = connect(udsPath, () => client.write("hello"));
+      client.on("error", () => {});
+
+      await paused;
+      client.end(); // peer FIN arrives while the server socket is paused
+
+      // The server socket must transition to closed...
+      await serverSocketClosed;
+      // ...and server.close() must complete rather than hang on a zombie.
+      await new Promise<void>((resolve, reject) => server.close(err => (err ? reject(err) : resolve())));
+    } finally {
+      server.close();
+    }
+  },
+  30_000,
+);
+
 it("should trigger error when aborted even if connection failed #13126", async () => {
   const signal = AbortSignal.timeout(100);
   const socket = createConnection({


### PR DESCRIPTION
## Symptom

A `node:net` socket whose peer disappears while the socket still has a *stuck half* never emits `'close'`. The process hangs forever (spinning on the half-closed fd when the peer keeps it hot), and `server.close()` never completes. Calling `socket.destroy()` from JS immediately clears it.

Two stuck-half shapes trigger it:

1. **Write backpressure toward a dead peer.** The survivor has unflushed outbound data when the peer is `SIGKILL`ed. A race: most peer kills deliver `'close'` normally. (The originally reported case, `node:net` over a Unix domain socket, both accepted and connecting sockets, macOS + Linux.)
2. **A paused readable with nothing buffered.** The peer sends FIN; the socket's readable is paused so the queued EOF is never consumed. This is the `server.close()` / process-exit hang behind several Express/Supertest/proxy reports.

## Cause

A `net.Socket` is a `Duplex` constructed with `{ emitClose: false, autoDestroy: true }`, so `'close'` is emitted only from `_destroy`, and autoDestroy only runs `_destroy` once **both** halves of the Duplex finish.

When the native layer reports the connection closed, `SocketEmitEndNT` ends the readable half with `push(null)`, but:
- a **paused readable with nothing buffered** never schedules `'end'` from that alone (`read(0)` is what kicks it, and `SocketEmitEndNT` wasn't calling it), so the readable half never finishes;
- a **writable holding backpressure** toward a dead peer can never flush, so the writable half never finishes.

Either way autoDestroy waits forever, `_destroy` never runs, `'close'` is never emitted, and `server._connections` never decrements (so `server.close()` hangs).

## Fix

Two small changes in `src/js/node/net.ts`:

- **`SocketEmitEndNT` follows `push(null)` with `read(0)`** (the same pair `SocketHandlers2.close` already does), so a paused stream with nothing buffered schedules `'end'` and can auto-destroy instead of stalling.

- **`destroyAfterClose()`** in the three native close handlers forces the teardown: when there is nothing left to read (`readableLength === 0`) and the socket is not already destroyed, schedule `destroy()` on `setImmediate`. Deferring past the nextTick queue lets the pending `'end'` and any `"write EBADF"` callback `_write` scheduled for a write that raced the close fire first (`test-net-socket-close-after-end.js`, `test-net-socket-write-after-close.js`). Readers with data still buffered are left alone so they can consume it and emit `'end'` before `'close'`, as Node does. No error is passed: real read errors already surface through `SocketEmitEndNT`'s dedicated error paths (from #31155), and the passive peer close that lands here is benign (a post-response RST, a keep-alive idle close).

## Verification

Two regression tests in `test/js/node/net/node-net.test.ts`:
- backpressure: two Bun processes over a UDS; the survivor floods the peer, the peer is `SIGKILL`ed mid-flight, and the survivor must receive `'close'` and exit;
- paused readable: a paused server socket whose peer ends must fire `'close'` (after `'end'`) and let `server.close()` complete.

```
USE_SYSTEM_BUN=1 bun test test/js/node/net/node-net.test.ts -t "UDS peer"       → hangs, fails
USE_SYSTEM_BUN=1 bun test test/js/node/net/node-net.test.ts -t "paused socket"  → hangs, fails
bun bd test test/js/node/net/node-net.test.ts -t "UDS peer"                     → passes (~3s)
bun bd test test/js/node/net/node-net.test.ts -t "paused socket"                → passes (~0.5s)
```

All 141 `test-net-*` Node parallel tests pass under `bun bd` (ASAN), including `test-net-socket-close-after-end.js` and `test-net-socket-write-after-close.js` which earlier iterations of this PR regressed. `node-net-server.test.ts` (18/18), the http/tls parallel tests that previous CI runs flagged (`test-https-eof-for-eom`, `test-http-1.0-keep-alive`, `test-tls-wrap-econnreset-socket`, `test-tls-reuse-host-from-socket`, …), and `regression/issue/12117` all pass.

Rebased onto #31155, which substantially reworked these close handlers (ECONNRESET-shaped destroy in `SocketEmitEndNT`, `kwriteCallback` flush). Those changes are kept; `destroyAfterClose` sits after them as the stuck-writable fallback they leave open. This also covers the net-level fix of #28350 / #28732 (server.close() hang on a paused socket), with the `readableLength`/`setImmediate` guard so `'end'`-before-`'close'` ordering is preserved. Happy to rebase/defer however a maintainer prefers.

Fixes #24808
