### PR TITLE
fix(File): set Symbol.toStringTag to "File"

### DIFF
--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -87,8 +87,13 @@ public:
             return JSValue::encode(JSC::jsUndefined());
         }
 
-        return JSValue::encode(
-            WebCore::JSBlob::create(vm, globalObject, structure, ptr));
+        auto* object = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+        // File and Blob share a prototype, so File instances would otherwise
+        // inherit Blob's `Symbol.toStringTag`. Give each File instance its own
+        // "File" tag (matching Node and JSS3File's approach) so
+        // `Object.prototype.toString.call(file)` is "[object File]". See #14102.
+        object->putDirect(vm, vm.propertyNames->toStringTagSymbol, jsOwnedString(vm, "File"_s), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::ReadOnly);
+        return JSValue::encode(object);
     }
 
     static JSC_HOST_CALL_ATTRIBUTES EncodedJSValue call(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)

--- a/test/regression/issue/14102.test.ts
+++ b/test/regression/issue/14102.test.ts
@@ -1,0 +1,25 @@
+// https://github.com/oven-sh/bun/issues/14102
+// `new File(...)[Symbol.toStringTag]` returns "Blob" instead of "File"
+import { test, expect } from "bun:test";
+
+test("File[Symbol.toStringTag] is 'File', Blob stays 'Blob' (#14102)", () => {
+  const file = new File(["x"], "a.txt");
+  const blob = new Blob(["x"]);
+
+  // File should have its own toStringTag
+  expect(file[Symbol.toStringTag]).toBe("File");
+  expect(Object.prototype.toString.call(file)).toBe("[object File]");
+
+  // Blob should be unaffected
+  expect(blob[Symbol.toStringTag]).toBe("Blob");
+  expect(Object.prototype.toString.call(blob)).toBe("[object Blob]");
+
+  // instanceof checks
+  expect(file instanceof File).toBe(true);
+  expect(file instanceof Blob).toBe(true);
+
+  // The tag must be non-enumerable (per spec) so it does not leak into spreads.
+  const desc = Object.getOwnPropertyDescriptor(file, Symbol.toStringTag);
+  expect(desc?.enumerable).toBe(false);
+  expect(Object.getOwnPropertySymbols({ ...file })).not.toContain(Symbol.toStringTag);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #14102.

`new File(...)` reported the wrong `Symbol.toStringTag`:

```js
const file = new File(["Hello"], "file.txt");
file[Symbol.toStringTag];                       // before: "Blob"  → after: "File"
Object.prototype.toString.call(file);           // before: "[object Blob]" → after: "[object File]"
```

This diverges from Node and breaks `fetch`/`form-data`-style packages that branch on the tag (an instance is initially treated as a `Blob`).

### Root cause

`File` and `Blob` share the same prototype object (`File.prototype === Blob.prototype`), so `File` instances inherit Blob's `Symbol.toStringTag`. Renaming it on the shared prototype is not an option (it would rename `Blob` too).

### The fix

In `src/jsc/bindings/JSDOMFile.cpp`, give each `File` instance its own `Symbol.toStringTag` of `"File"` at construction time — the same approach `JSS3File` already uses. The property is defined **non-enumerable and non-writable** (matching the WebIDL `Symbol.toStringTag` descriptor: `{ configurable: true, enumerable: false, writable: false }`) so it does not leak into object spreads. `Blob` is unaffected; `instanceof File` / `instanceof Blob` and `file.name` are unchanged.

### Tests

Added `test/regression/issue/14102.test.ts`:
- `new File(...)[Symbol.toStringTag] === "File"` and `Object.prototype.toString.call(file) === "[object File]"`
- `new Blob(...)` still reports `"Blob"` / `"[object Blob]"`
- `instanceof File` / `instanceof Blob` still true
- the tag is non-enumerable and does not appear in `{ ...file }`

Verified the test passes with the build and fails with `USE_SYSTEM_BUN=1`.
