### PR TITLE
crypto: throw ERR_OUT_OF_RANGE for a non-integer pbkdf2 keylen

### DIFF
--- a/src/runtime/crypto/PBKDF2.rs
+++ b/src/runtime/crypto/PBKDF2.rs
@@ -93,7 +93,7 @@ impl PBKDF2 {
 
         let keylen_num = arg3.as_number();
 
-        if keylen_num.is_infinite() || keylen_num.is_nan() {
+        if keylen_num.is_infinite() || keylen_num.is_nan() || keylen_num.trunc() != keylen_num {
             return Err(global_this.throw_range_error(
                 keylen_num,
                 bun_jsc::RangeErrorOptions {

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -134,10 +134,6 @@ describe("invalid inputs", () => {
   });
 });
 
-// https://github.com/oven-sh/bun/issues/31657
-// A non-integer keylen must throw ERR_OUT_OF_RANGE ("must be an integer"),
-// matching Node's validateInt32(keylen, 'keylen', 0), instead of being
-// silently truncated to an integer.
 describe("fractional keylen throws", () => {
   for (const input of [1.5, 1.9, 2.5, 0.5, 1e-10, 2147483648.5]) {
     test(`${input}`, () => {

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -133,3 +133,40 @@ describe("invalid inputs", () => {
     );
   });
 });
+
+// https://github.com/oven-sh/bun/issues/31657
+// A non-integer keylen must throw ERR_OUT_OF_RANGE ("must be an integer"),
+// matching Node's validateInt32(keylen, 'keylen', 0), instead of being
+// silently truncated to an integer.
+describe("fractional keylen throws", () => {
+  for (const input of [1.5, 1.9, 2.5, 0.5, 1e-10, 2147483648.5]) {
+    test(`${input}`, () => {
+      const cb = jest.fn(() => {
+        expect.unreachable();
+      });
+
+      let thrown: Error & { code?: string };
+      try {
+        crypto.pbkdf2Sync("password", "salt", 1000, input, "sha256");
+        expect.unreachable();
+      } catch (e) {
+        thrown = e as Error & { code?: string };
+      }
+      expect(thrown.code).toBe("ERR_OUT_OF_RANGE");
+      expect(thrown.message).toBe(
+        `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
+      );
+
+      // The async path routes through the same validation and must throw synchronously.
+      expect(() => crypto.pbkdf2("password", "salt", 1000, input, "sha256", cb)).toThrow(
+        `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
+      );
+      expect(cb).not.toHaveBeenCalled();
+    });
+  }
+
+  test("integer keylen still succeeds", () => {
+    expect(crypto.pbkdf2Sync("password", "salt", 1, 32, "sha256").length).toBe(32);
+    expect(crypto.pbkdf2Sync("password", "salt", 1, 0, "sha256").length).toBe(0);
+  });
+});

--- a/test/js/node/crypto/pbkdf2.test.ts
+++ b/test/js/node/crypto/pbkdf2.test.ts
@@ -153,9 +153,7 @@ describe("fractional keylen throws", () => {
         thrown = e as Error & { code?: string };
       }
       expect(thrown.code).toBe("ERR_OUT_OF_RANGE");
-      expect(thrown.message).toBe(
-        `The value of "keylen" is out of range. It must be an integer. Received ${input}`,
-      );
+      expect(thrown.message).toBe(`The value of "keylen" is out of range. It must be an integer. Received ${input}`);
 
       // The async path routes through the same validation and must throw synchronously.
       expect(() => crypto.pbkdf2("password", "salt", 1000, input, "sha256", cb)).toThrow(


### PR DESCRIPTION
Fixes #31657

## Repro

```ts
import { pbkdf2Sync } from "node:crypto";
const p = keylen => pbkdf2Sync("password", "salt", 1000, keylen, "sha256");
for (const keylen of [1.5, 1.9, 2.5, 0.5, 1e-10, 32]) {
  try { console.log(`keylen=${keylen} -> length=${p(keylen).length}`); }
  catch (e) { console.log(`keylen=${keylen} -> ${e.code}: ${e.message}`); }
}
```

Before — Bun silently floored the fractional `keylen`:

```
keylen=1.5 -> length=1
keylen=0.5 -> length=0
keylen=1e-10 -> length=0
keylen=32 -> length=32
```

Node throws `ERR_OUT_OF_RANGE` ("must be an integer") for every fractional value.

## Cause

`PBKDF2::from_js` (`src/runtime/crypto/PBKDF2.rs`) validated `keylen` for non-number, infinite/NaN, and out-of-range, then did `let keylen: i32 = keylen_num as i32;` — which truncates `1.5` → `1`, `0.5` → `0`, etc. The non-integer (fractional) check was missing. Both `pbkdf2` (async) and `pbkdf2Sync` route through this `from_js`, so both were affected.

## Fix

Extend the existing integer check to also reject a `keylen` whose fractional part is non-zero (`keylen_num.trunc() != keylen_num`), reusing the same `field_name: b"keylen"`, `msg: b"an integer"` range-error path. This matches Node's `validateInt32(keylen, 'keylen', 0)`, where the integer check runs **before** the range check — so `2147483648.5` throws "must be an integer" while the integer `2147483648` still throws the "must be >= 0 and <= 2147483647" range error.

After:

```
keylen=1.5 -> ERR_OUT_OF_RANGE: The value of "keylen" is out of range. It must be an integer. Received 1.5
keylen=0.5 -> ERR_OUT_OF_RANGE: The value of "keylen" is out of range. It must be an integer. Received 0.5
keylen=1e-10 -> ERR_OUT_OF_RANGE: The value of "keylen" is out of range. It must be an integer. Received 1e-10
keylen=32 -> length=32
```

## Verification

Added a regression test to `test/js/node/crypto/pbkdf2.test.ts` covering fractional keylens (`1.5`, `1.9`, `2.5`, `0.5`, `1e-10`, `2147483648.5`) on both the sync and async paths, plus an integer-keylen success case.

- `USE_SYSTEM_BUN=1 bun test test/js/node/crypto/pbkdf2.test.ts` — new fractional tests **fail** (bug present).
- `bun bd test test/js/node/crypto/pbkdf2.test.ts` — **32 pass / 0 fail** (bug fixed).