### PR TITLE
dotenv: restore skipping non-regular env files

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -965,7 +965,7 @@ impl<'a> Loader<'a> {
 /// memo slot they write — those stay in the callers. Only the shared read
 /// tail is factored here.
 enum ReadEnvFile {
-    /// Zero-length — caller marks the slot and returns.
+    /// Zero-length or non-regular file — caller marks the slot and returns.
     Empty,
     /// Recoverable read errno (ENOMEM/EPIPE/EACCES/EISDIR) — caller prints
     /// (unless `quiet`), marks the slot, and returns.
@@ -975,6 +975,11 @@ enum ReadEnvFile {
 }
 
 fn read_env_file_contents(file: &bun_sys::File) -> crate::Result<ReadEnvFile> {
+    #[cfg(not(windows))]
+    if bun_sys::kind_from_mode(file.stat()?.st_mode as bun_sys::Mode) != bun_sys::FileKind::File {
+        // `read_to_end` uses `pread(2)`, which fails with ESPIPE for FIFOs.
+        return Ok(ReadEnvFile::Empty);
+    }
     match file.read_to_end() {
         Ok(buf) if buf.is_empty() => Ok(ReadEnvFile::Empty),
         Ok(buf) => Ok(ReadEnvFile::Bytes(buf)),

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -12,6 +12,7 @@ import {
   isWindows,
   tempDirWithFiles,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import path from "path";
 
 function bunRunWithoutTrim(file: string, env?: Record<string, string>) {
@@ -592,6 +593,30 @@ describe("--env-file", () => {
   test("should ignore a file that doesn't exist", () => {
     const res = bunRun(["--env-file=.env.nonexisting"]);
     expect(res.stdout).toBe("");
+  });
+
+  test.skipIf(isWindows)("should ignore a FIFO", async () => {
+    const fifoPath = path.join(dir, ".env.fifo");
+    mkfifo(fifoPath);
+    // Keep a read+write handle open so the loader's read-only open doesn't block.
+    const fd = fs.openSync(fifoPath, "r+");
+    try {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), `--env-file=${fifoPath}`, "-e", "console.log('hello')"],
+        cwd: dir,
+        env: {
+          ...bunEnv,
+          NODE_ENV: undefined,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode }).toMatchObject({ stdout: "hello\n", exitCode: 0 });
+    } finally {
+      fs.closeSync(fd);
+    }
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Restore the non-regular-file guard that was present before the dotenv loader moved from Zig to Rust.

The Rust loader now checks the already-open env-file handle with `fstat(2)` and skips it unless it is a regular file. This applies to explicit `--env-file` inputs and the shared default env-file read path.

### Why?

On Unix, `bun_sys::File::read_to_end()` reads with `pread(2)`. Calling it on a FIFO returns `ESPIPE`, which is not handled as a recoverable dotenv read error, so the error propagates out of startup.

The previous loader skipped non-regular files before reading them; the Rust port omitted that guard. This is separate from the old-kernel `statx` failure: current `main` already uses the Rust `fstat` path for regular env files, while this PR restores the missing non-regular-file behavior.

### Testing

- Added a non-Windows regression test that keeps a FIFO open, passes it via `--env-file`, and verifies that the child reaches user code and exits successfully.
- Reproduced on Linux `3.10.0-1160.el7.x86_64` with `1.4.0-canary.1+be77b6528` (the PR base): a regular `.env` loads successfully, while `--env-file=<fifo>` exits 1 with no output before this patch.
- `git diff --check`, Prettier, and `cargo fmt --check` pass locally.
- A local native build could not start because the available Clang is 21.0.0 and the repository requires Clang 21.1.x. The fork Buildkite run requires maintainer approval.