### PR TITLE
Fix pending exception when `Bun.plugin` target coercion throws

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,8 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,23 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that throws while being converted to a string", () => {
+    let setupCalled = false;
+    const opts = {
+      setup: () => {
+        setupCalled = true;
+      },
+      target: {
+        [Symbol.toPrimitive]: () => ({}),
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("Symbol.toPrimitive returned an object");
+    expect(setupCalled).toBe(false);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a missing exception check in `setupBunPlugin` (`Bun.plugin()`), found by fuzzing.

When the plugin options object has a `target` property whose string coercion throws — e.g. an object whose `Symbol.toPrimitive` returns an object — `toStringOrNull()` returns `null` with a pending exception. The code treated the `null` as "no valid string, skip validation" and continued on to build the builder object and invoke the plugin's `setup()` function with the exception still pending. In debug builds this trips `ExceptionScope::assertNoException()` and aborts:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Symbol.toPrimitive returned an object
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

Repro:

```js
Bun.plugin({
  setup: () => {},
  target: { [Symbol.toPrimitive]: () => ({}) },
});
```

The fix adds `RETURN_IF_EXCEPTION` after the `toStringOrNull()` and `JSString::value()` calls so the exception propagates to the caller as a normal catchable `TypeError`, matching the pattern used elsewhere in the bindings (e.g. `JSBuffer.cpp`, `ErrorCode.cpp`).

### How did you verify your code works?

- Reproduced the assertion failure with a debug (ASAN) build before the fix; after the fix the same script throws a catchable `TypeError` and exits cleanly.
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` (`errors > handles 'target' that throws while being converted to a string`). It aborts with the assertion on an unfixed debug build and passes with the fix.
- `bun bd test test/js/bun/plugin/plugins.test.ts`, `test/js/bun/plugin/plugin-namespace-drive-letter.test.ts`, and `test/bundler/bundler_plugin.test.ts` all pass.