### PR TITLE
sql: share the wall-clock datetime text parser between MySQL and Postgres

### DIFF
--- a/src/sql_jsc/lib.rs
+++ b/src/sql_jsc/lib.rs
@@ -23,6 +23,8 @@ pub mod shared {
     #[path = "CachedStructure.rs"]
     pub mod cached_structure;
 
+    pub mod datetime_text;
+
     #[path = "ObjectIterator.rs"]
     pub mod object_iterator;
 

--- a/src/sql_jsc/mysql/MySQLValue.rs
+++ b/src/sql_jsc/mysql/MySQLValue.rs
@@ -571,72 +571,26 @@ impl DateTime {
     /// malformed input, so the caller surfaces `Invalid Date` — matching what
     /// the previous `Date.parse` path produced for those.
     pub fn from_text(text: &[u8]) -> Option<DateTime> {
-        fn parse_u(bytes: &[u8]) -> Option<u32> {
-            if bytes.is_empty() {
-                return None;
-            }
-            let mut n: u32 = 0;
-            for &c in bytes {
-                if !c.is_ascii_digit() {
-                    return None;
-                }
-                n = n.checked_mul(10)?.checked_add(u32::from(c - b'0'))?;
-            }
-            Some(n)
-        }
-
-        if text.len() < 10 || text[4] != b'-' || text[7] != b'-' {
-            return None;
-        }
-        let year = u16::try_from(parse_u(&text[0..4])?).ok()?;
-        let month = u8::try_from(parse_u(&text[5..7])?).ok()?;
-        let day = u8::try_from(parse_u(&text[8..10])?).ok()?;
-        if month < 1 || month > 12 || day < 1 || day > days_in_month(year, month) {
-            return None;
-        }
-
-        let mut result = DateTime {
-            year,
-            month,
-            day,
-            ..Default::default()
-        };
-        if text.len() == 10 {
-            return Some(result);
-        }
-
-        // Either "YYYY-MM-DD HH:MM:SS" or the ISO "YYYY-MM-DDTHH:MM:SS".
-        if text.len() < 19
-            || (text[10] != b' ' && text[10] != b'T')
-            || text[13] != b':'
-            || text[16] != b':'
+        let parsed = crate::shared::datetime_text::parse_mysql(text)?;
+        if parsed.month < 1
+            || parsed.month > 12
+            || parsed.day < 1
+            || parsed.day > days_in_month(parsed.year, parsed.month)
+            || parsed.hour > 23
+            || parsed.minute > 59
+            || parsed.second > 59
         {
             return None;
         }
-        result.hour = u8::try_from(parse_u(&text[11..13])?).ok()?;
-        result.minute = u8::try_from(parse_u(&text[14..16])?).ok()?;
-        result.second = u8::try_from(parse_u(&text[17..19])?).ok()?;
-        if result.hour > 23 || result.minute > 59 || result.second > 59 {
-            return None;
-        }
-
-        if text.len() == 19 {
-            return Some(result);
-        }
-        if text[19] != b'.' {
-            return None;
-        }
-        // Fractional seconds: up to 6 digits, right-padded to microseconds.
-        let frac = &text[20..];
-        if frac.is_empty() || frac.len() > 6 {
-            return None;
-        }
-        let mut micro = parse_u(frac)?;
-        for _ in 0..(6 - frac.len()) {
-            micro *= 10;
-        }
-        result.microsecond = micro;
-        Some(result)
+        Some(DateTime {
+            year: parsed.year,
+            month: parsed.month,
+            day: parsed.day,
+            hour: parsed.hour,
+            minute: parsed.minute,
+            second: parsed.second,
+            microsecond: parsed.microsecond,
+        })
     }
 
     pub fn to_binary(&self, field_type: FieldType, buffer: &mut [u8]) -> u8 {

--- a/src/sql_jsc/postgres/types/date.rs
+++ b/src/sql_jsc/postgres/types/date.rs
@@ -28,57 +28,19 @@ pub fn from_binary(bytes: &[u8]) -> f64 {
 /// `Date.parse`. `timestamptz` and `date` already decode correctly via
 /// `Date.parse` and must NOT be routed here.
 pub fn timestamp_text_to_ms_utc(global_object: &JSGlobalObject, bytes: &[u8]) -> Option<f64> {
-    fn parse_u(bytes: &[u8]) -> Option<i32> {
-        if bytes.is_empty() {
-            return None;
-        }
-        let mut n: i32 = 0;
-        for &c in bytes {
-            if !c.is_ascii_digit() {
-                return None;
-            }
-            n = n.checked_mul(10)?.checked_add(i32::from(c - b'0'))?;
-        }
-        Some(n)
-    }
-
-    if bytes.len() < 19
-        || bytes[4] != b'-'
-        || bytes[7] != b'-'
-        || bytes[10] != b' '
-        || bytes[13] != b':'
-        || bytes[16] != b':'
-    {
-        return None;
-    }
-    let year = parse_u(&bytes[0..4])?;
-    let month = parse_u(&bytes[5..7])?;
-    let day = parse_u(&bytes[8..10])?;
-    let hour = parse_u(&bytes[11..13])?;
-    let minute = parse_u(&bytes[14..16])?;
-    let second = parse_u(&bytes[17..19])?;
-
-    let millisecond = if bytes.len() > 19 {
-        if bytes[19] != b'.' {
-            return None;
-        }
-        let frac = &bytes[20..];
-        if frac.is_empty() || frac.len() > 6 || !frac.iter().all(u8::is_ascii_digit) {
-            return None;
-        }
-        // Fractional seconds → milliseconds (JS Date is ms-precision, like the
-        // binary path's f64 truncation).
-        let mut micro = parse_u(frac)?;
-        for _ in 0..(6 - frac.len()) {
-            micro *= 10;
-        }
-        micro / 1000
-    } else {
-        0
-    };
-
+    let parsed = crate::shared::datetime_text::parse_postgres_timestamp(bytes)?;
     global_object
-        .gregorian_date_time_to_ms_utc(year, month, day, hour, minute, second, millisecond)
+        .gregorian_date_time_to_ms_utc(
+            i32::from(parsed.year),
+            i32::from(parsed.month),
+            i32::from(parsed.day),
+            i32::from(parsed.hour),
+            i32::from(parsed.minute),
+            i32::from(parsed.second),
+            // Fractional seconds → milliseconds (JS Date is ms-precision, like
+            // the binary path's f64 truncation).
+            (parsed.microsecond / 1000) as i32,
+        )
         .ok()
 }
 

--- a/src/sql_jsc/shared/datetime_text.rs
+++ b/src/sql_jsc/shared/datetime_text.rs
@@ -1,0 +1,94 @@
+//! Shared parser for the wall-clock date/time text both SQL drivers receive
+//! over their text protocols: `YYYY-MM-DD[ |T]HH:MM:SS[.ffffff]`.
+//!
+//! The text carries no timezone, so callers convert the parsed components with
+//! UTC arithmetic to match their binary protocol paths. Routing these strings
+//! through JS `Date.parse` instead would read the wall-clock as *local* time
+//! and shift the value by the host's UTC offset.
+//!
+//! Only the structural form is validated here (digit positions, separators,
+//! fraction length). Calendar/range validation is the caller's job: MySQL
+//! rejects impossible dates itself (`DateTime::from_text`), while Postgres
+//! delegates to `gregorian_date_time_to_ms_utc`.
+
+/// Components of a parsed wall-clock timestamp.
+#[derive(Default, Clone, Copy)]
+pub struct DateTimeText {
+    pub year: u16,
+    pub month: u8,
+    pub day: u8,
+    pub hour: u8,
+    pub minute: u8,
+    pub second: u8,
+    /// Fractional seconds right-padded to microseconds (`.5` → 500_000).
+    pub microsecond: u32,
+}
+
+/// MySQL DATE/DATETIME/TIMESTAMP text. Accepts the 10-byte date-only form
+/// (`YYYY-MM-DD`) and either `' '` or `'T'` as the date/time separator.
+pub fn parse_mysql(text: &[u8]) -> Option<DateTimeText> {
+    parse(text, true, true)
+}
+
+/// Postgres `timestamp` (WITHOUT TIME ZONE) text. Requires the full
+/// `YYYY-MM-DD HH:MM:SS[.ffffff]` shape — anything else (date-only, `'T'`
+/// separator, `infinity`, BC dates, 5+ digit years) returns `None` so the
+/// caller can fall back to `Date.parse`.
+pub fn parse_postgres_timestamp(text: &[u8]) -> Option<DateTimeText> {
+    parse(text, false, false)
+}
+
+fn parse(text: &[u8], allow_date_only: bool, allow_t_separator: bool) -> Option<DateTimeText> {
+    fn parse_u(bytes: &[u8]) -> Option<u32> {
+        if bytes.is_empty() {
+            return None;
+        }
+        let mut n: u32 = 0;
+        for &c in bytes {
+            if !c.is_ascii_digit() {
+                return None;
+            }
+            n = n.checked_mul(10)?.checked_add(u32::from(c - b'0'))?;
+        }
+        Some(n)
+    }
+
+    if text.len() < 10 || text[4] != b'-' || text[7] != b'-' {
+        return None;
+    }
+    let mut result = DateTimeText {
+        year: u16::try_from(parse_u(&text[0..4])?).ok()?,
+        month: u8::try_from(parse_u(&text[5..7])?).ok()?,
+        day: u8::try_from(parse_u(&text[8..10])?).ok()?,
+        ..Default::default()
+    };
+    if text.len() == 10 {
+        return if allow_date_only { Some(result) } else { None };
+    }
+
+    let separator_ok = text[10] == b' ' || (allow_t_separator && text[10] == b'T');
+    if text.len() < 19 || !separator_ok || text[13] != b':' || text[16] != b':' {
+        return None;
+    }
+    result.hour = u8::try_from(parse_u(&text[11..13])?).ok()?;
+    result.minute = u8::try_from(parse_u(&text[14..16])?).ok()?;
+    result.second = u8::try_from(parse_u(&text[17..19])?).ok()?;
+
+    if text.len() == 19 {
+        return Some(result);
+    }
+    if text[19] != b'.' {
+        return None;
+    }
+    // Fractional seconds: up to 6 digits, right-padded to microseconds.
+    let frac = &text[20..];
+    if frac.is_empty() || frac.len() > 6 {
+        return None;
+    }
+    let mut micro = parse_u(frac)?;
+    for _ in 0..(6 - frac.len()) {
+        micro *= 10;
+    }
+    result.microsecond = micro;
+    Some(result)
+}

--- a/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
@@ -42,6 +42,44 @@ function assertRoundTrip(stdout: string, stderr: string, TZ: string) {
   expect(stdout).toMatch(TZ === "Etc/UTC" ? /offsetMin=0\b/ : /offsetMin=-?[1-9]/);
 }
 
+// Text-protocol decode against a mock MySQL server — runs everywhere (no
+// Docker / live server needed). The mock sends wall-clock DATE/DATETIME text
+// (`2024-06-15 12:34:56`, zero dates, impossible calendar dates) and the
+// decoded epoch-ms must match the UTC interpretation of those components in
+// every process timezone.
+import { COLUMNS } from "./sql-mysql-datetime-text-mock-fixture.ts";
+
+describe.each(TIMEZONES)("text protocol via mock server, TZ=%s", TZ => {
+  test("DATE/DATETIME text decodes as UTC", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "sql-mysql-datetime-text-mock-fixture.ts")],
+      env: { ...bunEnv, TZ },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Surface mock-server / client errors, not just a JSON parse failure.
+    // (ASAN emits a harmless interposition warning.)
+    const diagnostics = stderr
+      .split(/\r?\n/)
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(diagnostics).toBe("");
+
+    const out = JSON.parse(stdout) as { tz: string; offsetMin: number; values: Record<string, string> };
+    expect(out.values).toEqual(Object.fromEntries(COLUMNS.map(col => [col.name, String(col.expected)])));
+    // The child must actually have adopted the injected timezone — otherwise
+    // the non-UTC runs degenerate into the UTC case and prove nothing.
+    if (TZ === "Etc/UTC") {
+      expect(out.offsetMin).toBe(0);
+    } else {
+      expect(out.offsetMin).not.toBe(0);
+    }
+    expect(exitCode).toBe(0);
+  });
+});
+
 if (isDockerEnabled()) {
   // CI: run against the docker-compose MySQL service.
   describeWithContainer("mysql", { image: "mysql_plain" }, container => {

--- a/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
@@ -60,12 +60,7 @@ describe.each(TIMEZONES)("text protocol via mock server, TZ=%s", TZ => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     // Surface mock-server / client errors, not just a JSON parse failure.
-    // (ASAN emits a harmless interposition warning.)
-    const diagnostics = stderr
-      .split(/\r?\n/)
-      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-      .join("\n");
-    expect(diagnostics).toBe("");
+    expect(stderr).toBe("");
 
     const out = JSON.parse(stdout) as { tz: string; offsetMin: number; values: Record<string, string> };
     expect(out.values).toEqual(Object.fromEntries(COLUMNS.map(col => [col.name, String(col.expected)])));

--- a/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
@@ -27,12 +27,8 @@ function assertRoundTrip(stdout: string, stderr: string, TZ: string) {
   // On a round-trip mismatch the fixture writes `FAIL TZ=… offsetMin=…` plus the
   // per-row `diffMin` breakdown to stderr, then exits 1. Assert it's empty so a
   // CI failure surfaces *which* dates drifted and by how much, not just a bare
-  // "CONNECTED" vs "OK" mismatch. (ASAN emits a harmless interposition warning.)
-  const diagnostics = stderr
-    .split(/\r?\n/)
-    .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
-    .join("\n");
-  expect(diagnostics).toBe("");
+  // "CONNECTED" vs "OK" mismatch.
+  expect(stderr).toBe("");
   // "OK TZ=<tz>" only prints when all three Dates round-trip to the same instant.
   expect(stdout).toContain(`OK TZ=${TZ}`);
   // And the child runtime must actually have adopted the injected timezone —

--- a/test/js/sql/sql-mysql-datetime-text-mock-fixture.ts
+++ b/test/js/sql/sql-mysql-datetime-text-mock-fixture.ts
@@ -1,0 +1,197 @@
+// Fixture: decode MySQL text-protocol DATE/DATETIME values through a minimal
+// mock MySQL server (no Docker / live server needed) and print the resulting
+// epoch-ms values as JSON.
+//
+// The text protocol sends dates as wall-clock strings with no timezone
+// (`2024-06-15 12:34:56`). The decoder must treat those components as UTC —
+// the same convention the binary protocol and the encode path use — so the
+// printed values must be identical regardless of this process's TZ.
+//
+// Spawned by sql-mysql-datetime-roundtrip.test.ts under several TZ values.
+
+import { SQL } from "bun";
+import { once } from "events";
+import net from "net";
+
+// --- MySQL wire format helpers (mirrors sql-mysql-raw-length-prefix.test.ts) ---
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+function lenenc(n: number): Buffer {
+  if (n < 0xfb) return Buffer.from([n]);
+  throw new Error("lenenc: only the 1-byte form is needed for this fixture");
+}
+function lenencStr(s: string): Buffer {
+  const buf = Buffer.from(s, "utf-8");
+  return Buffer.concat([lenenc(buf.length), buf]);
+}
+
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+const MYSQL_TYPE_DATE = 0x0a;
+const MYSQL_TYPE_DATETIME = 0x0c;
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  const payload = Buffer.concat([
+    Buffer.from([10]), // protocol version
+    Buffer.from("mock-5.7.0\0"),
+    u32le(1), // connection id
+    authData1,
+    Buffer.from([0]), // filler
+    u16le(SERVER_CAPS & 0xffff),
+    Buffer.from([0x2d]), // utf8mb4_general_ci
+    u16le(0x0002), // SERVER_STATUS_AUTOCOMMIT
+    u16le((SERVER_CAPS >>> 16) & 0xffff),
+    Buffer.from([21]), // length of auth-plugin-data
+    Buffer.alloc(10, 0), // reserved
+    authData2,
+    Buffer.from("mysql_native_password\0"),
+  ]);
+  return packet(0, payload);
+}
+
+function okPacket(seq: number): Buffer {
+  return packet(seq, Buffer.from([0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+function columnDefinition(name: string, type: number): Buffer {
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr(name),
+    lenencStr(name),
+    Buffer.from([0x0c]), // fixed-length-fields length = 12
+    u16le(33), // utf8_general_ci
+    u32le(32), // column_length (display width)
+    Buffer.from([type]),
+    u16le(0), // flags
+    Buffer.from([0]), // decimals
+    Buffer.from([0, 0]), // reserved
+  ]);
+}
+
+// The columns this fixture serves, with the wall-clock text the mock server
+// sends and the UTC instant (or NaN) the decoder must produce for it.
+export const COLUMNS: { name: string; type: number; text: string; expected: number }[] = [
+  {
+    name: "dt",
+    type: MYSQL_TYPE_DATETIME,
+    text: "2024-06-15 12:34:56",
+    expected: Date.UTC(2024, 5, 15, 12, 34, 56),
+  },
+  {
+    name: "dt_frac",
+    type: MYSQL_TYPE_DATETIME,
+    text: "2024-06-15 12:34:56.123456",
+    expected: Date.UTC(2024, 5, 15, 12, 34, 56, 123),
+  },
+  {
+    name: "d",
+    type: MYSQL_TYPE_DATE,
+    text: "2024-06-15",
+    expected: Date.UTC(2024, 5, 15),
+  },
+  {
+    name: "zero_date",
+    type: MYSQL_TYPE_DATETIME,
+    text: "0000-00-00 00:00:00",
+    expected: NaN,
+  },
+  {
+    name: "impossible_date",
+    type: MYSQL_TYPE_DATETIME,
+    text: "2024-02-31 00:00:00",
+    expected: NaN,
+  },
+];
+
+// Text-protocol result set: one row whose cells are the COLUMNS texts.
+function textResultSet(startSeq: number): Buffer {
+  const packets: Buffer[] = [];
+  let seq = startSeq;
+  packets.push(packet(seq++, Buffer.from([COLUMNS.length])));
+  for (const col of COLUMNS) {
+    packets.push(packet(seq++, columnDefinition(col.name, col.type)));
+  }
+  packets.push(packet(seq++, Buffer.concat(COLUMNS.map(col => lenencStr(col.text)))));
+  // OK packet closing the result set (CLIENT_DEPRECATE_EOF, header 0xfe).
+  packets.push(packet(seq++, Buffer.from([0xfe, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00])));
+  return Buffer.concat(packets);
+}
+
+if (import.meta.main) {
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+
+    socket.write(handshakeV10());
+
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
+        }
+
+        if (payload[0] === 0x03 /* COM_QUERY */) {
+          socket.write(textResultSet(seq + 1));
+        } else {
+          // COM_QUIT / anything else — close.
+          socket.end();
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+    // `.simple()` forces the text protocol → ResultSet text decode → DateTime::from_text.
+    const rows = (await sql`SELECT * FROM t`.simple()) as Record<string, Date>[];
+    console.log(
+      JSON.stringify({
+        tz: process.env.TZ,
+        offsetMin: new Date(Date.UTC(2024, 5, 15, 12, 34, 56)).getTimezoneOffset(),
+        // NaN is not representable in JSON; stringify getTime() instead.
+        values: Object.fromEntries(COLUMNS.map(col => [col.name, String(rows[0][col.name]?.getTime())])),
+      }),
+    );
+  } finally {
+    server.close();
+  }
+}


### PR DESCRIPTION
Follow-up to #31212.

## What this does

#31212 fixed naive `DATETIME`/`TIMESTAMP` text decoding to be UTC, but introduced two near-identical hand-rolled parsers for the `YYYY-MM-DD HH:MM:SS[.ffffff]` wall-clock format:

- `DateTime::from_text` in `src/sql_jsc/mysql/MySQLValue.rs`
- `timestamp_text_to_ms_utc` in `src/sql_jsc/postgres/types/date.rs`

Both had the same digit accumulator, the same separator validation, and the same fractional-second padding. This PR extracts the structural parsing into one shared module, `src/sql_jsc/shared/datetime_text.rs`, and reduces both call sites to thin wrappers.

No existing helper could be reused instead: the workspace has no date crates, and the only WTF date function exposed to Rust (`parse_date`) is JS `Date.parse` — the local-time behavior #31212 exists to avoid.

## What stays driver-specific (deliberately)

- **MySQL** (`parse_mysql`): accepts the 10-byte date-only form and a `T` separator, validates calendar dates (`days_in_month`) and h/m/s ranges, keeps microsecond precision.
- **Postgres** (`parse_postgres_timestamp`): requires the full `YYYY-MM-DD HH:MM:SS` shape — anything else returns `None` so the caller falls back to `Date.parse` (`infinity`, BC dates, 5+ digit years); no range validation (delegated to `gregorianDateTimeToMS`); millisecond precision.

Public signatures of both wrapped functions are unchanged, so no call sites move.

## New test coverage

The existing roundtrip tests skip their assertions when no real MySQL/Postgres server is reachable, which left the text-protocol date decode path untested without Docker. This PR adds a mock-MySQL-server test (same approach as `sql-mysql-raw-length-prefix.test.ts`) that exercises text-protocol `DATE`/`DATETIME` decode across `Etc/UTC` / `America/New_York` / `Asia/Tokyo`, including zero dates and impossible calendar dates.

## How we know it works

This is a **behavior-preserving refactor**, so there is deliberately no test that fails without it on a current build: any Bun that already includes #31212 decodes these dates identically before and after this change. The tests pin the #31212 semantics as regression coverage that now runs without Docker. (On builds predating #31212 — e.g. the 1.4.0 release — the mock-server tests fail: text dates are read as local time, and `2024-02-31` wraps to March 2 instead of Invalid Date.)

- **Equivalence check**: the shared parser was differential-fuzzed against byte-for-byte copies of both removed hand-rolled parsers — 2.6M structured, truncated, corrupted, and fully random inputs; zero divergence in accept/reject or in any parsed component, for both the MySQL and the Postgres wrapper.
- `bun bd test test/js/sql/sql-mysql-datetime-roundtrip.test.ts` → 6 pass in all three timezones, including the live-server round-trip path against a local MySQL-compatible server (which exercises `assertRoundTrip`, not just the mock path).
- Full SQL suite (`sql-mysql-mediumint`, `sql-mysql-raw-length-prefix`, `sql-mysql-bind-oob`, both datetime roundtrip files) passes with this change.
- The CI docker lanes run the real-server roundtrip tests, which assert binary/text agreement for both drivers across the same three timezones.
