### PR TITLE
fix(completions): correct zsh quote parity for -i flag spec

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -482,7 +482,7 @@ _bun_run_completion() {
         '--watch[Automatically restart bun'"'"'s JavaScript runtime on file change]' \
         '--no-install[Disable auto install in bun'"'"'s JavaScript runtime]' \
         '--install[Install dependencies automatically when no node_modules are present, default: "auto". "force" to ignore node_modules, fallback to install any missing]: :->install_' \
-        '-i[Automatically install dependencies and use global cache in bun'"'"'s runtime, equivalent to --install=fallback'] \
+        '-i[Automatically install dependencies and use global cache in bun'"'"'s runtime, equivalent to --install=fallback]' \
         '--prefer-offline[Skip staleness checks for packages in bun'"'"'s JavaScript runtime and resolve from disk]' \
         '--prefer-latest[Use the latest matching versions of packages in bun'"'"'s JavaScript runtime, always checking npm]' \
         '--silent[Don'"'"'t repeat the command for bun run]' \


### PR DESCRIPTION
## Summary

Fixes a one-character quoting bug in the generated zsh completion for `bun run -i`.

The `-i` argument spec in `completions/bun.zsh` closed the description string **before** the `]` (`fallback']`), while every sibling spec closes **after** the bracket (`...]'`). That leaves `_bun_run_completion` with odd single-quote parity when zsh sources the completion.

## Impact

When a shell integration snapshots and later `eval`s `typeset -f` output (for example Cursor/VS Code terminal state restore), parsing can fail at unrelated later functions and surface errors such as:

- `(eval): parse error near `/^\[[^]]+\]$/`
- `command not found: dump_zsh_state`

The bug is in the shipped completion template, so `bun completions` can regenerate a broken `~/.bun/_bun` until this is fixed upstream.

## Fix

Move the closing quote to match the other specs:

```diff
- ... equivalent to --install=fallback'] \
+ ... equivalent to --install=fallback]' \
```

## Test plan

- [x] Verified the line matches sibling specs (`--no-install`, `--install`, etc.)
- [ ] `source completions/bun.zsh` in zsh, then re-eval `_bun_run_completion` succeeds
- [ ] `bun completions` output contains `fallback]'` not `fallback']`
