### PR TITLE
base64: encode URL-safe via simdutf directly instead of the WTF C++ shim

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -141,17 +141,17 @@ pub(crate) fn simdutf_encode_len_url_safe(source_len: usize) -> usize {
 /// * `-` and `_` are used instead of `+` and `/`
 ///
 /// See the documentation for simdutf's `binary_to_base64` function for more details (simdutf_impl.h).
-pub(crate) fn simdutf_encode_url_safe(destination: &mut [u8], source: &[u8]) -> usize {
-    simdutf::base64::encode(source, destination, true)
+pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
+    simdutf::base64::encode(source, dest, true)
 }
 
-/// `simdutf_encode_url_safe` into a freshly-allocated `Vec<u8>` sized exactly via
+/// `encode_url_safe` into a freshly-allocated `Vec<u8>` sized exactly via
 /// `simdutf_encode_len_url_safe` (simdutf computes the exact no-padding length, so
 /// the trailing `truncate` is a no-op kept for symmetry with `encode_alloc`).
 pub fn simdutf_encode_url_safe_alloc(source: &[u8]) -> Vec<u8> {
     let len = simdutf_encode_len_url_safe(source.len());
     let mut destination = vec![0u8; len];
-    let encoded_len = simdutf_encode_url_safe(&mut destination, source);
+    let encoded_len = encode_url_safe(&mut destination, source);
     destination.truncate(encoded_len);
     destination
 }
@@ -198,23 +198,6 @@ pub(crate) const fn url_safe_encode_len_from_size(n: usize) -> usize {
 #[inline]
 pub const fn url_safe_encode_len(source: &[u8]) -> usize {
     url_safe_encode_len_from_size(source.len())
-}
-
-// TODO(port): move to base64_sys
-unsafe extern "C" {
-    fn WTF__base64URLEncode(
-        input: *const u8,
-        input_len: usize,
-        output: *mut u8,
-        output_len: usize,
-    ) -> usize;
-}
-
-pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
-    // TODO(port): bun.jsc.markBinding(@src()) — debug-only binding marker, no Rust equivalent yet
-    // SAFETY: WTF__base64URLEncode reads `input_len` bytes from `input` and writes at most
-    // `output_len` bytes to `output`; both slices are valid for those lengths.
-    unsafe { WTF__base64URLEncode(source.as_ptr(), source.len(), dest.as_mut_ptr(), dest.len()) }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1027,7 +1010,7 @@ pub fn wyhash_url_safe<'a>(
     let slice_to_write: &mut [u8] =
         bump.alloc_slice_fill_default(encode_len + usize::from(at_start));
 
-    let base64_encoded_hash_len = simdutf_encode_url_safe(slice_to_write, &h_bytes);
+    let base64_encoded_hash_len = encode_url_safe(slice_to_write, &h_bytes);
 
     let base64_encoded_hash = &slice_to_write[0..base64_encoded_hash_len];
 

--- a/test/js/bun/util/base64-url-safe-encode.test.ts
+++ b/test/js/bun/util/base64-url-safe-encode.test.ts
@@ -22,8 +22,7 @@ function base64UrlReference(bytes: Uint8Array): string {
     out += URL_SAFE_ALPHABET[(n >> 18) & 63] + URL_SAFE_ALPHABET[(n >> 12) & 63];
   } else if (remainder === 2) {
     const n = (bytes[i] << 16) | (bytes[i + 1] << 8);
-    out +=
-      URL_SAFE_ALPHABET[(n >> 18) & 63] + URL_SAFE_ALPHABET[(n >> 12) & 63] + URL_SAFE_ALPHABET[(n >> 6) & 63];
+    out += URL_SAFE_ALPHABET[(n >> 18) & 63] + URL_SAFE_ALPHABET[(n >> 12) & 63] + URL_SAFE_ALPHABET[(n >> 6) & 63];
   }
   return out;
 }

--- a/test/js/bun/util/base64-url-safe-encode.test.ts
+++ b/test/js/bun/util/base64-url-safe-encode.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+
+// Scalar RFC 4648 §5 base64url reference (no padding), independent of any
+// native base64 implementation. `bun_base64::encode_url_safe` (simdutf's
+// base64_url mode) must agree with this for every input.
+const URL_SAFE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+function base64UrlReference(bytes: Uint8Array): string {
+  let out = "";
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out +=
+      URL_SAFE_ALPHABET[(n >> 18) & 63] +
+      URL_SAFE_ALPHABET[(n >> 12) & 63] +
+      URL_SAFE_ALPHABET[(n >> 6) & 63] +
+      URL_SAFE_ALPHABET[n & 63];
+  }
+  const remainder = bytes.length - i;
+  if (remainder === 1) {
+    const n = bytes[i] << 16;
+    out += URL_SAFE_ALPHABET[(n >> 18) & 63] + URL_SAFE_ALPHABET[(n >> 12) & 63];
+  } else if (remainder === 2) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out +=
+      URL_SAFE_ALPHABET[(n >> 18) & 63] + URL_SAFE_ALPHABET[(n >> 12) & 63] + URL_SAFE_ALPHABET[(n >> 6) & 63];
+  }
+  return out;
+}
+
+// Deterministic pseudo-random bytes so failures reproduce.
+function fillDeterministic(bytes: Uint8Array): Uint8Array {
+  let state = 0x12345678;
+  for (let i = 0; i < bytes.length; i++) {
+    // xorshift32
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    bytes[i] = state & 0xff;
+  }
+  return bytes;
+}
+
+describe("URL-safe base64 encoding", () => {
+  test("Buffer.prototype.toString('base64url') reference vectors", () => {
+    expect(Buffer.alloc(0).toString("base64url")).toBe("");
+    expect(Buffer.from("A").toString("base64url")).toBe("QQ");
+    expect(Buffer.from("Man").toString("base64url")).toBe("TWFu");
+    // No padding, unlike toString("base64")
+    expect(Buffer.from("Woman").toString("base64")).toBe("V29tYW4=");
+    expect(Buffer.from("Woman").toString("base64url")).toBe("V29tYW4");
+    // '-' and '_' where the standard alphabet has '+' and '/'
+    const bytes = Buffer.from([0xff, 0xff, 0xbe, 0xff, 0xef, 0xbf, 0xfb, 0xef, 0xff]);
+    expect(bytes.toString("base64")).toBe("//++/++/++//");
+    expect(bytes.toString("base64url")).toBe("__--_--_--__");
+  });
+
+  test("matches the scalar reference for every length 0..=513", () => {
+    // Covers all three mod-3 phases many times over with pseudo-random bytes.
+    const bytes = fillDeterministic(new Uint8Array(513));
+    for (let len = 0; len <= bytes.length; len++) {
+      const slice = bytes.subarray(0, len);
+      expect(Buffer.from(slice).toString("base64url")).toBe(base64UrlReference(slice));
+    }
+  });
+
+  test("large inputs whose encoding exceeds 32 KiB are byte-exact", () => {
+    // Buffer.toString("base64url") switches to an external-string strategy for
+    // outputs >= 32 KiB; both branches must produce identical bytes.
+    for (const len of [32 * 1024, 32 * 1024 + 1, 32 * 1024 + 2]) {
+      const bytes = fillDeterministic(new Uint8Array(len));
+      expect(Buffer.from(bytes).toString("base64url")).toBe(base64UrlReference(bytes));
+    }
+  });
+
+  test("node:crypto Hash.digest('base64url')", () => {
+    const raw = createHash("sha256").update("bun").digest();
+    expect(createHash("sha256").update("bun").digest("base64url")).toBe(base64UrlReference(raw));
+  });
+
+  test("Bun.CryptoHasher digest('base64url')", () => {
+    const raw = new Bun.CryptoHasher("sha256").update("bun").digest();
+    expect(new Bun.CryptoHasher("sha256").update("bun").digest("base64url")).toBe(
+      base64UrlReference(new Uint8Array(raw)),
+    );
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Ports #25428 to the Rust rewrite: removes the FFI boundary crossing in `bun_base64::encode_url_safe` — Rust → simdutf directly instead of Rust → C++ (`WTF__base64URLEncode`) → simdutf.

The C++ shim is a one-liner that forwards to `simdutf::binary_to_base64(..., simdutf::base64_url)` and ignores its destination-length parameter, so calling `simdutf::base64::encode(source, dest, true)` through `bun_simdutf_sys` is the exact same simdutf entry point with the same option — behavior is identical by construction. This also resolves the `TODO(port): move to base64_sys` left on the extern block.

While here, the crate-private `simdutf_encode_url_safe` (which already did the direct call for `simdutf_encode_url_safe_alloc` and `wyhash_url_safe`) became an exact duplicate of the fixed `encode_url_safe`, so the two are consolidated into one public function.

The C++ `WTF__base64URLEncode` itself stays: `Bun::base64URLEncodeToString` (WebCrypto JWK export) still calls it internally.

#25428 stalled because its new test referenced `Bun.unsafe.base64.encodeURLSafe`, which isn't a real API, and failed in CI. This PR adds the test #25428 intended, through real APIs instead.

### How did you verify your code works?

- New `test/js/bun/util/base64-url-safe-encode.test.ts` pins URL-safe encoding against an independent scalar RFC 4648 §5 reference across the JS surfaces that route through `encode_url_safe`: the #25428 reference vectors (no padding, `-`/`_` alphabet), `Buffer.toString('base64url')` for every input length 0–513 and for >32 KiB outputs (the external-string branch), plus `node:crypto` `Hash.digest('base64url')` and `Bun.CryptoHasher.digest('base64url')` (the `simdutf_encode_url_safe_alloc` path)
- `cargo check -p bun_base64` and `cargo test -p bun_base64` pass
- `bun bd test test/js/node/buffer.test.js -t base64` — 62 pass
- `bun bd test test/js/bun/util/csrf.test.ts` and `bun bd test test/bundler/css/css-modules.test.ts` — 24 + 3 pass, covering the remaining `encode_url_safe` consumers (CSRF tokens, CSS-modules hash); the proxy-auth consumer is covered by the existing round-trip assertions in `test/js/bun/http/proxy.test.ts`
