### PR TITLE
image: add composite(), .pixels(), and raw pixel input

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -155,6 +155,7 @@ Rules and behavior:
 - Repeat `composite()` calls **replace** the layer set rather than appending, matching sharp.
 - Overlay bytes are copied when `composite()` is called, so it's safe to mutate or reuse a passed buffer afterwards.
 - Each overlay decode is subject to the same `maxPixels` guard as the base image.
+- JPEG overlays follow the base `Image`'s `autoOrient` setting (default `true`): EXIF orientation is applied to the overlay before placement and the oversized rule, so a portrait-shot photo blends upright. Construct the base with `autoOrient: false` to blend overlays in their stored orientation.
 - Blending happens in premultiplied-alpha space and always uses a deterministic portable integer kernel — regardless of `Bun.Image.backend`, blended output is byte-identical across Linux, macOS, and Windows.
 
 ### Deviations from sharp

--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -149,7 +149,7 @@ Each layer accepts:
 
 Rules and behavior:
 
-- For a `Bun.file()` / `Bun.s3()` source, pass `await file.bytes()` or the path string — `Blob` values and fd/S3-backed `Image` overlays throw.
+- An `Image` created from a path-backed `Bun.file()` works as an overlay — it resolves to its path, read at blend time. For `Bun.s3()` / fd-backed sources, pass `await file.bytes()` or the path string — raw `Blob` values and fd/S3-backed `Image` overlays throw.
 - An `Image` overlay contributes its **input** bytes; its chained ops are not applied. Encode first (e.g. `await img.png().bytes()`) to transform an overlay. A raw-pixel-sourced `Image` (constructed with a `raw` descriptor) works directly — its pixel buffer is blended as-is, no encode round-trip needed.
 - An overlay must be **no larger than the base** in either dimension — an oversized overlay rejects the terminal with an error, matching sharp.
 - Repeat `composite()` calls **replace** the layer set rather than appending, matching sharp.

--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -3,7 +3,7 @@ title: Image
 description: Decode, transform, and encode images with a fast native pipeline
 ---
 
-`Bun.Image` is a chainable image pipeline for decoding, resizing, rotating, and re-encoding JPEG, PNG, WebP, HEIC, and AVIF — built on libjpeg-turbo, spng, libwebp, and SIMD geometry kernels, with zero npm dependencies and no native addon build step.
+`Bun.Image` is a chainable image pipeline for decoding, resizing, rotating, compositing, and re-encoding JPEG, PNG, WebP, HEIC, and AVIF — built on libjpeg-turbo, spng, libwebp, and SIMD geometry kernels, with zero npm dependencies and no native addon build step.
 
 ```ts
 await Bun.file("photo.jpg").image().resize(400, 400, { fit: "inside" }).webp({ quality: 80 }).write("thumb.webp");
@@ -40,6 +40,22 @@ new Bun.Image(input, {
   autoOrient: true,
 });
 ```
+
+### Raw RGBA input
+
+To re-ingest pixels you've produced or mutated yourself — for example from `.pixels()` (see [Terminals](#terminals)) — pass a `raw` descriptor in the options. This bypasses format sniffing entirely; the bytes are treated as a decoded pixel buffer:
+
+```ts
+const img = new Bun.Image(data, {
+  raw: {
+    width: 256,
+    height: 256,
+    channels: 4, // 4 = RGBA, or 3 = RGB (expanded to RGBA on ingest)
+  },
+});
+```
+
+All three fields are required. `data.length` must be exactly `width × height × channels` and both dimensions must be non-zero — anything else throws at construction time with a clear error. Whatever the input channel count, the pipeline operates on (and `.pixels()` returns) 4-channel RGBA.
 
 ## Metadata
 
@@ -97,6 +113,57 @@ img.modulate({
 });
 ```
 
+## Composite
+
+`composite()` overlays other images onto the base — watermarks, logos, badges, collages. It takes an ordered array of layers, blended bottom-to-top:
+
+```ts
+await Bun.file("photo.jpg")
+  .image()
+  .resize(1200)
+  .composite([
+    { image: "logo.png", gravity: "southeast" },
+    { image: watermarkBytes, top: 20, left: 20, opacity: 0.5 },
+  ])
+  .jpeg({ quality: 85 })
+  .write("out.jpg");
+```
+
+Like sharp, composite runs as the **last** pipeline stage — after `resize`, `rotate`, `modulate`, and the rest. So `top`/`left` coordinates are in the final post-resize space, and overlays are **not** scaled by the base's `resize()`. To transform an overlay first, run its own pipeline to bytes and pass the result:
+
+```ts
+const logo = await Bun.file("logo.png").image().resize(120).png().bytes();
+img.composite([{ image: logo, gravity: "southeast" }]);
+```
+
+Each layer accepts:
+
+| Option          | Default    | Behavior                                                                                                                                                                                                                        |
+| --------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`         | _required_ | The overlay: an `Image`, a path string, or encoded bytes (`Buffer` / `TypedArray` / `ArrayBuffer`). Unlike the constructor, `Blob` is not accepted — see below                                                                  |
+| `top`, `left`   | —          | Pixel offset of the overlay's top-left corner. Set both or neither; overrides `gravity`. Negative values are allowed — pixels falling outside the base are clipped                                                              |
+| `gravity`       | `"centre"` | Placement when `top`/`left` aren't given: `"centre"` (the `"center"` spelling also works) or one of the 8 compass points (`"north"`, `"northeast"`, `"east"`, `"southeast"`, `"south"`, `"southwest"`, `"west"`, `"northwest"`) |
+| `blend`         | `"over"`   | Blend mode. Currently only Porter–Duff `"over"` (source-over) is supported                                                                                                                                                      |
+| `opacity`       | `1`        | `0`–`1`; multiplies the overlay's alpha before blending. **Bun extension** — see deviations below                                                                                                                               |
+| `premultiplied` | `false`    | Set `true` if the overlay's RGB channels are already premultiplied by alpha, to skip the premultiply pass                                                                                                                       |
+
+Rules and behavior:
+
+- For a `Bun.file()` / `Bun.s3()` source, pass `await file.bytes()` or the path string — `Blob` values and fd/S3-backed `Image` overlays throw.
+- An `Image` overlay contributes its **input** bytes; its chained ops are not applied. Encode first (e.g. `await img.png().bytes()`) to transform an overlay. A raw-pixel-sourced `Image` (constructed with a `raw` descriptor) works directly — its pixel buffer is blended as-is, no encode round-trip needed.
+- An overlay must be **no larger than the base** in either dimension — an oversized overlay rejects the terminal with an error, matching sharp.
+- Repeat `composite()` calls **replace** the layer set rather than appending, matching sharp.
+- Overlay bytes are copied when `composite()` is called, so it's safe to mutate or reuse a passed buffer afterwards.
+- Each overlay decode is subject to the same `maxPixels` guard as the base image.
+- Blending happens in premultiplied-alpha space and always uses a deterministic portable integer kernel — regardless of `Bun.Image.backend`, blended output is byte-identical across Linux, macOS, and Windows.
+
+### Deviations from sharp
+
+- **Per-layer `opacity` is a Bun extension.** Sharp has no per-layer opacity — sharp users emulate it by extracting raw pixels and multiplying the alpha channel by hand. Bun exposes it directly: the overlay's alpha is multiplied by `opacity` before the blend.
+- **No ICC color management during compositing.** Layers are blended as decoded RGBA8 without converting embedded ICC profiles to a common colorspace (libvips composites in sRGB by default). If the base and an overlay carry different color profiles, the numeric channel values are blended as-is — convert the images to a common profile yourself before compositing if you need color-managed results.
+
+Also currently unsupported: `{ text }` and SVG overlay inputs, animated (multi-frame) composites, `tile`, and blend modes beyond `"over"`.
+
 ## Output formats
 
 Calling a format method sets the encode target; without one, the source format is reused.
@@ -123,11 +190,30 @@ await img.buffer(); // Buffer
 await img.blob(); // Blob with .type set to the output MIME
 await img.toBase64(); // string
 await img.dataurl(); // "data:image/png;base64,…"
+await img.pixels(); // { data: Uint8Array, width, height, channels: 4 }
 await img.write("out.webp"); // number (bytes written)
 await img.write(Bun.s3("bucket/out.webp"));
 ```
 
 `.write()` accepts the same destinations as `Bun.write` — a path string, `Bun.file()`, `Bun.s3()`, or an fd. If you didn't chain a format method and the destination is a path string, the extension picks one (`.jpg`/`.png`/`.webp`/`.heic`/`.avif`).
+
+### Raw pixel output
+
+`.pixels()` skips the encode step entirely and resolves the decoded pixel buffer — the equivalent of sharp's `.raw().toBuffer({ resolveWithObject: true })`:
+
+```ts
+const { data, width, height, channels } = await Bun.file("photo.jpg").image().resize(256).pixels();
+// data: Uint8Array of width × height × 4 bytes — 8-bit RGBA, row-major, no row padding
+// channels: always 4
+```
+
+The buffer reflects the image **after** every chained op (resize, rotate, modulate, composite), and is always 4-channel RGBA8 regardless of the source format. The result is a valid `raw` descriptor, so mutated pixels round-trip straight back through the constructor:
+
+```ts
+const px = await new Bun.Image(src).pixels();
+for (let i = 3; i < px.data.length; i += 4) px.data[i] = (px.data[i] * 0.5) | 0; // halve alpha
+const png = await new Bun.Image(px.data, { raw: px }).png().bytes();
+```
 
 ## Placeholders
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -8205,6 +8205,8 @@ declare module "bun" {
      *   exceed `maxPixels`, or a path-backed input is over the 256 MiB cap.
      * - `ERR_IMAGE_DECODE_FAILED` / `ERR_IMAGE_ENCODE_FAILED` — codec error.
      * - `ERR_IMAGE_UNKNOWN_FORMAT` — input bytes didn't match any sniffer.
+     * - `ERR_IMAGE_COMPOSITE_OVERSIZED` — a composite overlay is larger than
+     *   the base in either dimension.
      * - `ERR_INVALID_STATE` — the input ArrayBuffer was transferred between
      *   construction and the terminal call.
      * - File-backed inputs surface the underlying syscall code (`ENOENT`,
@@ -8216,6 +8218,7 @@ declare module "bun" {
       | "ERR_IMAGE_DECODE_FAILED"
       | "ERR_IMAGE_ENCODE_FAILED"
       | "ERR_IMAGE_UNKNOWN_FORMAT"
+      | "ERR_IMAGE_COMPOSITE_OVERSIZED"
       | "ERR_INVALID_STATE";
 
     /**
@@ -8250,6 +8253,123 @@ declare module "bun" {
        * @default true
        */
       autoOrient?: boolean;
+      /**
+       * Treat `input` as raw, tightly-packed pixel data instead of an encoded
+       * image. Format sniffing and decoding are skipped; `input` must be the
+       * pixel buffer (`ArrayBuffer`/`TypedArray`) and its byte length must be
+       * exactly `width × height × channels` — anything else throws at
+       * construction. Round-trips with the `pixels()` terminal:
+       *
+       * ```ts
+       * const px = await new Bun.Image("photo.jpg").pixels();
+       * // ...mutate px.data...
+       * const out = await new Bun.Image(px.data, { raw: px }).png().bytes();
+       * ```
+       */
+      raw?: RawOptions;
+    }
+
+    /**
+     * Describes the layout of a raw pixel buffer passed to the `Bun.Image`
+     * constructor via {@link ConstructorOptions.raw}. The `pixels()` terminal
+     * resolves to a compatible shape, so its result can be passed back
+     * directly.
+     */
+    interface RawOptions {
+      /** Width of the raw pixel buffer, in pixels. Must be at least 1. */
+      width: number;
+      /** Height of the raw pixel buffer, in pixels. Must be at least 1. */
+      height: number;
+      /**
+       * Channels per pixel in the input buffer. `3` (RGB) is expanded to
+       * RGBA on ingest; the pipeline always operates on 4-channel RGBA.
+       */
+      channels: 3 | 4;
+    }
+
+    /**
+     * Where a composite layer is placed on the base image when `top`/`left`
+     * are not given: the centre or one of the 8 compass points. Both the
+     * `"centre"` and `"center"` spellings are accepted.
+     */
+    type Gravity =
+      | "centre"
+      | "center"
+      | "north"
+      | "northeast"
+      | "east"
+      | "southeast"
+      | "south"
+      | "southwest"
+      | "west"
+      | "northwest";
+
+    /**
+     * Blend mode for `composite()`. Only Porter-Duff `"over"`
+     * (source-over) is currently supported.
+     */
+    type Blend = "over";
+
+    /** One overlay in a `composite()` call. Layers apply bottom-to-top. */
+    interface CompositeLayerOptions {
+      /**
+       * The overlay — another `Bun.Image` (including one constructed from a
+       * `raw` pixel descriptor, whose buffer is blended directly), a path
+       * string or `data:` URL, or encoded bytes as
+       * `ArrayBuffer`/`TypedArray`. For a `Blob`/`Bun.file` source, pass
+       * `await blob.bytes()` or the path string instead. Decoded with the
+       * same `maxPixels` guard as the base. Must be the same size as the
+       * base or smaller in both dimensions, in final (post-`resize`)
+       * coordinates.
+       */
+      image: Image | string | ArrayBuffer | NodeJS.TypedArray;
+      /**
+       * Pixel offset of the overlay's top edge from the base's top edge.
+       * `top` and `left` must be given together; together they override
+       * `gravity`. Negative values are allowed — the overlay is clipped
+       * against the base.
+       */
+      top?: number;
+      /**
+       * Pixel offset of the overlay's left edge from the base's left edge.
+       * See {@link top}.
+       */
+      left?: number;
+      /**
+       * Placement when `top`/`left` are omitted.
+       * @default "centre"
+       */
+      gravity?: Gravity;
+      /**
+       * How the overlay is blended onto the image below it.
+       * @default "over"
+       */
+      blend?: Blend;
+      /**
+       * Multiply the overlay's alpha by this factor (`0`–`1`) before
+       * blending. `1` leaves it unchanged. Not in sharp — there you'd
+       * hand-roll this with raw pixel math.
+       * @default 1
+       */
+      opacity?: number;
+      /**
+       * Set to `true` if the overlay's pixel data already has premultiplied
+       * alpha, to skip the premultiply pass before blending.
+       * @default false
+       */
+      premultiplied?: boolean;
+    }
+
+    /** Result of the `pixels()` terminal — raw post-pipeline RGBA. */
+    interface Pixels {
+      /** Tightly-packed RGBA bytes, `width × height × 4` long. */
+      data: Uint8Array;
+      /** Width of the pixel buffer, in pixels. */
+      width: number;
+      /** Height of the pixel buffer, in pixels. */
+      height: number;
+      /** Always `4` — the pipeline operates in RGBA. */
+      channels: 4;
     }
 
     interface ResizeOptions {
@@ -8275,7 +8395,12 @@ declare module "bun" {
     interface Metadata {
       width: number;
       height: number;
-      format: Format;
+      /**
+       * The sniffed container format of the source, or `"raw"` when the
+       * image was constructed from raw pixels via
+       * {@link ConstructorOptions.raw}.
+       */
+      format: Format | "raw";
     }
   }
 
@@ -8286,11 +8411,12 @@ declare module "bun" {
    *
    * The constructor and every chainable method only *record* settings; the
    * decode → transform → encode pipeline runs on a worker thread when a
-   * terminal (`bytes`, `buffer`, `blob`, `toBase64`, `metadata`) is awaited.
+   * terminal (`bytes`, `buffer`, `blob`, `toBase64`, `metadata`, `pixels`)
+   * is awaited.
    *
    * Chainables overwrite (calling `.resize()` twice keeps the second). Order
    * of execution is fixed regardless of call order:
-   * `autoOrient → rotate → flip/flop → resize → modulate`.
+   * `autoOrient → rotate → flip/flop → resize → modulate → composite`.
    *
    * The source ICC colour profile (Display P3, Adobe RGB, Jpegli XYB, etc.)
    * is preserved through re-encode to JPEG, PNG, and WebP so non-sRGB
@@ -8353,6 +8479,29 @@ declare module "bun" {
     flop(): this;
     /** Adjust brightness/saturation. */
     modulate(options: Image.ModulateOptions): this;
+    /**
+     * Overlay images onto this one, bottom-to-top. Compositing runs as the
+     * **last** pipeline stage (after `modulate`), so `top`/`left`/`gravity`
+     * are in final, post-`resize` coordinates and overlays are not affected
+     * by the base's `resize()`.
+     *
+     * Each layer is decoded, alpha-blended at the resolved position, then
+     * the next layer applies on top. Calling `composite()` again *replaces*
+     * the previous layer list, like every other chainable.
+     *
+     * Layers are blended in raw RGBA without ICC profile conversion; only
+     * the base image's colour profile is carried through to the output.
+     *
+     * @example
+     * ```ts
+     * await new Bun.Image("photo.jpg")
+     *   .resize(1200, 800)
+     *   .composite([{ image: "logo.png", gravity: "southeast", opacity: 0.5 }])
+     *   .webp({ quality: 80 })
+     *   .write("out.webp");
+     * ```
+     */
+    composite(layers: Image.CompositeLayerOptions[]): this;
 
     /** Set output format to JPEG. */
     jpeg(options?: {
@@ -8431,6 +8580,15 @@ declare module "bun" {
     toBase64(): Promise<string>;
     /** Decode just enough to read width/height/format. */
     metadata(): Promise<Image.Metadata>;
+    /**
+     * Run the pipeline and return the raw, post-pipeline RGBA pixels instead
+     * of encoding — the equivalent of sharp's `.raw().toBuffer()`. `data` is
+     * tightly packed, `width × height × 4` bytes, `channels` is always `4`.
+     *
+     * The result round-trips through the constructor's `raw` option:
+     * `new Bun.Image(px.data, { raw: px })`.
+     */
+    pixels(): Promise<Image.Pixels>;
 
     /** Populated after the first awaited terminal; `-1` before. */
     readonly width: number;

--- a/scripts/build/unified.ts
+++ b/scripts/build/unified.ts
@@ -132,6 +132,8 @@ const noUnify: readonly string[] = [
   // image_resize.cpp: it must expand its own per-ISA namespaces so
   // HWY_EXPORT(HashLong) resolves the N_AVX2/N_AVX3/etc. variants.
   "src/jsc/bindings/xxhash3.cpp",
+  // Fourth highway TU — same foreach_target.h include-guard reason.
+  "src/jsc/bindings/image_composite.cpp",
   // Declares its own minimal CGRect/kCFStringEncodingUTF8/kCFNumberDoubleType
   // so it doesn't pull a CoreGraphics load command; bundled with files that
   // include the real CF headers those names become ambiguous.

--- a/scripts/verify-baseline-static/allowlist-aarch64.txt
+++ b/scripts/verify-baseline-static/allowlist-aarch64.txt
@@ -228,13 +228,14 @@ adler32_arm_neon_dotprod  [DotProd]
 
 
 # ----------------------------------------------------------------------------
-# Bun.Image highway kernels (image_resize.cpp). Gate: HWY_DYNAMIC_DISPATCH ->
-# hwy::SupportedTargets() via getauxval(AT_HWCAP). Same gate as the
-# highway_strings.cpp block above.
-# (5 symbols)
+# Bun.Image highway kernels (image_resize.cpp, image_composite.cpp).
+# Gate: HWY_DYNAMIC_DISPATCH -> hwy::SupportedTargets() via
+# getauxval(AT_HWCAP). Same gate as the highway_strings.cpp block above.
+# (6 symbols)
 # ----------------------------------------------------------------------------
 _ZN9bun_image10N_SVE2_128L12ModulateImplEPhmff                                [SVE]
 _ZN9bun_image10N_SVE2_128L13Rotate180ImplEPKhmmPh                             [SVE]
+_ZN9bun_image10N_SVE2_128L17CompositeOverImplEPhjjPKhjjllji                   [SVE]
 _ZN9bun_image10N_SVE2_128L8VertPassEPKhmmPhmPKNS_4SpanEPKsm                   [SVE]
 _ZN9bun_image10N_SVE2_128L9FlipHImplEPKhmmPh                                  [SVE]
 _ZN9bun_image10N_SVE2_128L9HorizPassEPKhmmPhmPKNS_4SpanEPKsm                  [SVE]

--- a/scripts/verify-baseline-static/allowlist-x64-windows.txt
+++ b/scripts/verify-baseline-static/allowlist-x64-windows.txt
@@ -928,10 +928,12 @@ bun::xxh3::N_AVX10_2::HashLong    [AVX, AVX2, AVX512DQ, AVX512F, BMI2]
 
 
 # ----------------------------------------------------------------------------
-# Bun.Image highway kernels (image_resize.cpp). Gate: HWY_DYNAMIC_DISPATCH ->
-# hwy::SupportedTargets() via CPUID. Same gate as the highway_strings block.
-# (40 symbols; PDB demangles these to bun_image::N_*::*)
+# Bun.Image highway kernels (image_resize.cpp, image_composite.cpp).
+# Gate: HWY_DYNAMIC_DISPATCH -> hwy::SupportedTargets() via CPUID. Same gate
+# as the highway_strings block.
+# (45 symbols; PDB demangles these to bun_image::N_*::*)
 # ----------------------------------------------------------------------------
+bun_image::N_AVX2::CompositeOverImpl  [AVX, AVX2, BMI1, BMI2]
 bun_image::N_AVX2::FlipHImpl  [AVX, AVX2]
 bun_image::N_AVX2::HorizPass  [AVX, AVX2, FMA]
 bun_image::N_AVX2::ModulateImpl  [AVX, AVX2, FMA]
@@ -940,6 +942,7 @@ bun_image::N_AVX2::Rotate180Impl  [AVX, AVX2]
 bun_image::N_AVX2::Rotate270Impl  [AVX]
 bun_image::N_AVX2::Rotate90Impl  [AVX]
 bun_image::N_AVX2::VertPass  [AVX, AVX2, BMI1, FMA]
+bun_image::N_AVX3::CompositeOverImpl  [AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun_image::N_AVX3::FlipHImpl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3::HorizPass  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3::ModulateImpl  [AVX, AVX512DQ, AVX512F, AVX512VL]
@@ -948,6 +951,7 @@ bun_image::N_AVX3::Rotate180Impl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3::Rotate270Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3::Rotate90Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3::VertPass  [AVX, AVX512BW, AVX512F, AVX512VL, BMI1, FMA]
+bun_image::N_AVX3_DL::CompositeOverImpl  [AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun_image::N_AVX3_DL::FlipHImpl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3_DL::HorizPass  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL, AVX512_VNNI]
 bun_image::N_AVX3_DL::ModulateImpl  [AVX, AVX512DQ, AVX512F, AVX512VL]
@@ -956,6 +960,7 @@ bun_image::N_AVX3_DL::Rotate180Impl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3_DL::Rotate270Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3_DL::Rotate90Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3_DL::VertPass  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
+bun_image::N_AVX3_SPR::CompositeOverImpl  [AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun_image::N_AVX3_SPR::FlipHImpl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3_SPR::HorizPass  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL, AVX512_VNNI]
 bun_image::N_AVX3_SPR::ModulateImpl  [AVX, AVX512DQ, AVX512F, AVX512VL]
@@ -964,6 +969,7 @@ bun_image::N_AVX3_SPR::Rotate180Impl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3_SPR::Rotate270Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3_SPR::Rotate90Impl  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 bun_image::N_AVX3_SPR::VertPass  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
+bun_image::N_AVX3_ZEN4::CompositeOverImpl  [AVX2, AVX512BW, AVX512DQ, AVX512F, AVX512VL, BMI1, BMI2]
 bun_image::N_AVX3_ZEN4::FlipHImpl  [AVX, AVX2, AVX512F]
 bun_image::N_AVX3_ZEN4::HorizPass  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL, AVX512_VNNI]
 bun_image::N_AVX3_ZEN4::ModulateImpl  [AVX, AVX512DQ, AVX512F, AVX512VL]

--- a/scripts/verify-baseline-static/allowlist-x64.txt
+++ b/scripts/verify-baseline-static/allowlist-x64.txt
@@ -904,14 +904,16 @@ _RNvNt<rust-hash>12blake2b_simd4avx214compress1_loop  [AVX, AVX2]
 
 
 # ----------------------------------------------------------------------------
-# Bun.Image highway kernels (image_resize.cpp). Gate: HWY_DYNAMIC_DISPATCH ->
-# hwy::SupportedTargets() via CPUID. Same gate as the highway_strings block.
-# (40 symbols; union of glibc + musl LTO outcomes)
+# Bun.Image highway kernels (image_resize.cpp, image_composite.cpp).
+# Gate: HWY_DYNAMIC_DISPATCH -> hwy::SupportedTargets() via CPUID. Same gate
+# as the highway_strings block.
+# (45 symbols; union of glibc + musl LTO outcomes)
 # ----------------------------------------------------------------------------
 _ZN9bun_image10N_AVX3_SPRL12ModulateImplEPhmff  [AVX, AVX512F]
 _ZN9bun_image10N_AVX3_SPRL12Rotate90ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 _ZN9bun_image10N_AVX3_SPRL13Rotate180ImplEPKhmmPh  [AVX, AVX2, AVX512F]
 _ZN9bun_image10N_AVX3_SPRL13Rotate270ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
+_ZN9bun_image10N_AVX3_SPRL17CompositeOverImplEPhjjPKhjjllji  [AVX, AVX2, AVX512F, AVX512VL, BMI1, BMI2]
 _ZN9bun_image10N_AVX3_SPRL18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image10N_AVX3_SPRL8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
 _ZN9bun_image10N_AVX3_SPRL9FlipHImplEPKhmmPh  [AVX, AVX2, AVX512F]
@@ -920,6 +922,7 @@ _ZN9bun_image11N_AVX3_ZEN4L12ModulateImplEPhmff  [AVX, AVX512F]
 _ZN9bun_image11N_AVX3_ZEN4L12Rotate90ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 _ZN9bun_image11N_AVX3_ZEN4L13Rotate180ImplEPKhmmPh  [AVX, AVX2, AVX512F]
 _ZN9bun_image11N_AVX3_ZEN4L13Rotate270ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
+_ZN9bun_image11N_AVX3_ZEN4L17CompositeOverImplEPhjjPKhjjllji  [AVX, AVX2, AVX512F, AVX512VL, BMI1, BMI2]
 _ZN9bun_image11N_AVX3_ZEN4L18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image11N_AVX3_ZEN4L8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
 _ZN9bun_image11N_AVX3_ZEN4L9FlipHImplEPKhmmPh  [AVX, AVX2, AVX512F]
@@ -928,6 +931,7 @@ _ZN9bun_image6N_AVX2L12ModulateImplEPhmff  [AVX, AVX2, FMA]
 _ZN9bun_image6N_AVX2L12Rotate90ImplEPKhmmPh  [AVX]
 _ZN9bun_image6N_AVX2L13Rotate180ImplEPKhmmPh  [AVX, AVX2]
 _ZN9bun_image6N_AVX2L13Rotate270ImplEPKhmmPh  [AVX]
+_ZN9bun_image6N_AVX2L17CompositeOverImplEPhjjPKhjjllji  [AVX, AVX2, BMI1, BMI2]
 _ZN9bun_image6N_AVX2L18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image6N_AVX2L8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX2, BMI1, FMA]
 _ZN9bun_image6N_AVX2L9FlipHImplEPKhmmPh  [AVX, AVX2]
@@ -936,6 +940,7 @@ _ZN9bun_image6N_AVX3L12ModulateImplEPhmff  [AVX, AVX512F]
 _ZN9bun_image6N_AVX3L12Rotate90ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 _ZN9bun_image6N_AVX3L13Rotate180ImplEPKhmmPh  [AVX, AVX2, AVX512F]
 _ZN9bun_image6N_AVX3L13Rotate270ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
+_ZN9bun_image6N_AVX3L17CompositeOverImplEPhjjPKhjjllji  [AVX, AVX2, AVX512F, AVX512VL, BMI1, BMI2]
 _ZN9bun_image6N_AVX3L18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image6N_AVX3L8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX512BW, AVX512F, AVX512VL, BMI1, FMA]
 _ZN9bun_image6N_AVX3L9FlipHImplEPKhmmPh  [AVX, AVX2, AVX512F]
@@ -944,6 +949,7 @@ _ZN9bun_image9N_AVX3_DLL12ModulateImplEPhmff  [AVX, AVX512F]
 _ZN9bun_image9N_AVX3_DLL12Rotate90ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
 _ZN9bun_image9N_AVX3_DLL13Rotate180ImplEPKhmmPh  [AVX, AVX2, AVX512F]
 _ZN9bun_image9N_AVX3_DLL13Rotate270ImplEPKhmmPh  [AVX, AVX2, AVX512DQ, AVX512F, AVX512VL]
+_ZN9bun_image9N_AVX3_DLL17CompositeOverImplEPhjjPKhjjllji  [AVX, AVX2, AVX512F, AVX512VL, BMI1, BMI2]
 _ZN9bun_image9N_AVX3_DLL18NearestPaletteImplEPKhjiiii  [AVX]
 _ZN9bun_image9N_AVX3_DLL8VertPassEPKhmmPhmPKNS_4SpanEPKsm  [AVX, AVX512BW, AVX512F, AVX512VL, AVX512_VNNI, BMI1, FMA]
 _ZN9bun_image9N_AVX3_DLL9FlipHImplEPKhmmPh  [AVX, AVX2, AVX512F]

--- a/src/jsc/bindings/image_composite.cpp
+++ b/src/jsc/bindings/image_composite.cpp
@@ -53,10 +53,11 @@ namespace HWY_NAMESPACE {
 
 namespace hn = hwy::HWY_NAMESPACE;
 
-// ⌊t/65025⌋ for t ≤ 33,228,287 (< 2^25.99): (t · 33818121) >> 41.
-// M = ⌈2^41/65025⌉ = 33818121; M·65025 − 2^41 = 23,021 ≤ 2^(41−26) ⇒ exact
-// over the range (Granlund-Montgomery), brute-force-verified end-to-end
-// against the u64 reference for all 65536 (sa·op) products × c/d grids.
+// ⌊t/65025⌋ for t ≤ 33,228,287 (< 2^25): (t · 33818121) >> 41.
+// M = ⌈2^41/65025⌉ = 33818121; e = M·65025 − 2^41 = 62,473 < 2^(41−25) ⇒
+// e·t < 2^41 over the range, so the shifted product never crosses a quotient
+// boundary (Granlund-Montgomery). Brute-force-verified end-to-end against
+// the u64 reference for all 65536 (sa·op) products × c/d grids.
 constexpr uint64_t kDivM = 33818121;
 constexpr int kDivS = 41;
 

--- a/src/jsc/bindings/image_composite.cpp
+++ b/src/jsc/bindings/image_composite.cpp
@@ -1,0 +1,203 @@
+// Bun.Image composite (Porter-Duff `over`) kernel.
+//
+// Same Highway runtime-dispatch shell as image_resize.cpp: re-included once
+// per target ISA via foreach_target.h, with the HWY_ONCE block exporting one
+// plain C entry point that HWY_DYNAMIC_DISPATCH-es to the best variant.
+//
+// Blends one RGBA8 overlay onto the base in premultiplied-alpha space the way
+// libvips composites (composite.cpp): premultiply both sides (the overlay
+// pass is skipped when the caller says its pixels already are), scale the
+// overlay by the layer opacity, accumulate `aR = aA + aB·(1−aA)`,
+// `cR = cA + cB·(1−aA)`, then unpremultiply back to straight RGBA8.
+//
+// ── Exactness contract ──────────────────────────────────────────────────────
+// All math is exact 255-denominator fixed point: alphas carry denominator
+// 255², premultiplied colours 255³/255⁴, and the only rounding is the final
+// `round-half-up(num/den)` per channel. Rounding any intermediate to 8 bits
+// would put up to half an LSB of premultiplied error over a tiny `aR` and
+// blow up in the unpremultiply (e.g. a (53,122,71,2) overlay at opacity 0.7
+// over a transparent base must stay (53,122,71,1), not collapse to 0/255 per
+// channel). Integer-only ⇒ output is byte-identical on every platform/ISA
+// (docs/runtime/image.mdx "byte-identical" guarantee — no FMA, no
+// float-rounding divergence), and identical between the SIMD and scalar
+// paths below (test/js/bun/image/image-kernels.test.ts sweeps the seam).
+//
+// ── Two paths ───────────────────────────────────────────────────────────────
+// Opaque base pixel (da == 255, the watermark-on-photo case): `aR` collapses
+// to the constant 255·65025, so the per-channel quotient reduces to
+//   out = ⌊(n_ps + d·(65025 − w) + 32512) / 65025⌋,  w = sa·op ≤ 65025
+// (divide both sides of the general quotient by 255; the +32512 vs
+// +⌊8290687/255⌋ bias difference can never bridge an integer boundary, so
+// the rounded result is identical). Constant divisor ⇒ SIMD via a
+// Granlund-Montgomery multiply: ⌊t/65025⌋ == (t·33818121) >> 41 — exact for
+// every t ≤ 33,228,287, brute-force-verified over the full range (the path's
+// max is 2·255·65025 + 32512 = 33,195,262). One pixel per iteration, RGBA in
+// 4 u32 lanes (same FixedTag<.,4> shape image_resize.cpp uses, universal on
+// 128-bit targets).
+//
+// Non-opaque base pixel: `aR` varies per pixel, so the quotient needs a real
+// division — scalar u64, exact, identical formula.
+
+// clang-format off
+#undef HWY_TARGET_INCLUDE
+#define HWY_TARGET_INCLUDE "image_composite.cpp"
+#include <hwy/foreach_target.h>
+#include <hwy/highway.h>
+// clang-format on
+
+#include <cstdint>
+
+HWY_BEFORE_NAMESPACE();
+namespace bun_image {
+namespace HWY_NAMESPACE {
+
+namespace hn = hwy::HWY_NAMESPACE;
+
+// ⌊t/65025⌋ for t ≤ 33,228,287 (< 2^25.99): (t · 33818121) >> 41.
+// M = ⌈2^41/65025⌉ = 33818121; M·65025 − 2^41 = 23,021 ≤ 2^(41−26) ⇒ exact
+// over the range (Granlund-Montgomery), brute-force-verified end-to-end
+// against the u64 reference for all 65536 (sa·op) products × c/d grids.
+constexpr uint64_t kDivM = 33818121;
+constexpr int kDivS = 41;
+
+// One pixel: Porter-Duff over, general (any base alpha). Exact u64
+// fixed-point; the single rounding is round-half-up via +den/2 then floor.
+static HWY_INLINE void BlendPixelScalar(uint8_t* HWY_RESTRICT d, const uint8_t* HWY_RESTRICT s,
+    uint64_t opacity, bool premultiplied)
+{
+    constexpr uint64_t D2 = 255 * 255;
+    const uint64_t sa = s[3];
+    // Source alpha (denom 255²) and premultiplied colour (denom 255³), both
+    // scaled by the layer opacity. Straight input premultiplies here
+    // (×alpha); already-premultiplied input keeps its colour and only
+    // rescales the denominator (×255) so both paths agree.
+    const uint64_t n_as = sa * opacity;
+    const uint64_t cmul = premultiplied ? opacity * 255 : sa * opacity;
+    const uint64_t n_psr = s[0] * cmul;
+    const uint64_t n_psg = s[1] * cmul;
+    const uint64_t n_psb = s[2] * cmul;
+    // Fully transparent overlay pixel ⇒ identity. (For straight input,
+    // `n_as == 0` already implies zero premultiplied colour.)
+    if ((n_as | n_psr | n_psg | n_psb) == 0) return;
+    const uint64_t da = d[3];
+    const uint64_t inv = D2 - n_as; // 1 − aA, denom 255²
+    // aR = aA + aB·(1−aA), denom 255³. `n_as ≤ 255²` ⇒ `n_ar ≤ 255³`, so the
+    // rounded byte below never exceeds 255.
+    const uint64_t n_ar = n_as * 255 + da * inv;
+    const auto blend1 = [&](uint64_t n_ps, uint64_t dc) -> uint8_t {
+        // cR = cA + cB·(1−aA) in premultiplied space (denom 255⁴), then
+        // unpremultiply with one round-half-up division: 255·cR/aR =
+        // n_pr/n_ar exactly. Clamp: a hostile `premultiplied: true` layer
+        // can claim colour > alpha.
+        const uint64_t n_pr = n_ps * 255 + dc * da * inv;
+        if (n_ar == 0) return 0;
+        const uint64_t q = (n_pr + n_ar / 2) / n_ar;
+        return static_cast<uint8_t>(q > 255 ? 255 : q);
+    };
+    d[0] = blend1(n_psr, d[0]);
+    d[1] = blend1(n_psg, d[1]);
+    d[2] = blend1(n_psb, d[2]);
+    d[3] = static_cast<uint8_t>((n_ar + D2 / 2) / D2);
+}
+
+static void CompositeOverImpl(uint8_t* HWY_RESTRICT base, uint32_t bw, uint32_t bh,
+    const uint8_t* HWY_RESTRICT overlay, uint32_t ow, uint32_t oh,
+    int64_t left, int64_t top, uint32_t opacity, int32_t premultiplied)
+{
+    // Clip the overlay to the base — offsets may be negative or overhang.
+    const int64_t x0 = left > 0 ? left : 0;
+    const int64_t y0 = top > 0 ? top : 0;
+    const int64_t x1 = (left + static_cast<int64_t>(ow)) < static_cast<int64_t>(bw)
+        ? left + static_cast<int64_t>(ow)
+        : static_cast<int64_t>(bw);
+    const int64_t y1 = (top + static_cast<int64_t>(oh)) < static_cast<int64_t>(bh)
+        ? top + static_cast<int64_t>(oh)
+        : static_cast<int64_t>(bh);
+    if (x0 >= x1 || y0 >= y1 || opacity == 0) return;
+
+    // i32 lanes (not u32): every intermediate is ≤ 33,195,262 < 2^31, and the
+    // i32 flavours of Mul/MulEven/DemoteTo are the universally-supported set
+    // (same FixedTag<.,4>-per-pixel shape image_resize.cpp uses).
+    using D32 = hn::FixedTag<int32_t, 4>;
+    const D32 di32;
+    const hn::Rebind<uint8_t, D32> du8; // 4× u8 ⇄ 4× i32
+
+    const auto vop = hn::Set(di32, static_cast<int32_t>(opacity));
+    // Premultiplied input keeps its colour and only rescales the denominator:
+    // n_ps = c·op·255 instead of c·sa·op (both ≤ 255³, exact in i32).
+    const auto vpremul = hn::Set(di32, static_cast<int32_t>(opacity * 255));
+    const auto vd2 = hn::Set(di32, 255 * 255);
+    const auto vbias = hn::Set(di32, 32512); // ⌊65025/2⌋, round-half-up
+    const auto v255 = hn::Set(di32, 255);
+    const auto vmagic = hn::Set(di32, static_cast<int32_t>(kDivM));
+    // Lane 3 is alpha: the colour formula in that lane is garbage (bounded —
+    // sa·sa·op ≤ 255³ — so no overflow, just meaningless); an opaque base
+    // stays opaque, so patch the lane to 255 before the demote.
+    const auto alpha_lane = hn::Eq(hn::Iota(di32, 0), hn::Set(di32, 3));
+
+    const size_t span = static_cast<size_t>(x1 - x0);
+    const uint8_t* srow0 = overlay + ((static_cast<size_t>(y0 - top) * ow) + static_cast<size_t>(x0 - left)) * 4;
+    uint8_t* drow0 = base + ((static_cast<size_t>(y0) * bw) + static_cast<size_t>(x0)) * 4;
+    const bool premul = premultiplied != 0;
+
+    for (int64_t y = y0; y < y1; y++, srow0 += static_cast<size_t>(ow) * 4, drow0 += static_cast<size_t>(bw) * 4) {
+        const uint8_t* sp = srow0;
+        uint8_t* dp = drow0;
+        for (size_t i = 0; i < span; i++, sp += 4, dp += 4) {
+            if (dp[3] != 255) {
+                // General path: variable aR ⇒ real division. Rare in the
+                // watermark case; exact and shared with the tail/edge cases.
+                BlendPixelScalar(dp, sp, opacity, premul);
+                continue;
+            }
+            // Opaque-base SIMD path: one pixel across 4 i32 lanes.
+            const auto vs = hn::PromoteTo(di32, hn::LoadU(du8, sp)); // [c_r c_g c_b sa]
+            const auto vd = hn::PromoteTo(di32, hn::LoadU(du8, dp)); // [d_r d_g d_b 255]
+            const auto vsa = hn::Broadcast<3>(vs);
+            const auto vw = hn::Mul(vsa, vop); // sa·op ≤ 65025
+            // n_ps per colour lane; ≤ 255·65025.
+            const auto vnps = premul ? hn::Mul(vs, vpremul) : hn::Mul(vs, vw);
+            const auto vinv = hn::Sub(vd2, vw); // 65025 − w
+            // t = n_ps + d·inv + 32512 ≤ 2·255·65025 + 32512 < 2^25.99.
+            const auto vt = hn::Add(hn::Add(vnps, hn::Mul(vd, vinv)), vbias);
+            // ⌊t/65025⌋ via (t·M) >> 41: 32×32→64 widening MulEven/MulOdd
+            // (PMULDQ/SMULL — universal), shift, then OR the odd results
+            // (each i64's low i32, value < 512) back up one i32 lane.
+            const auto qe = hn::ShiftRight<kDivS>(hn::MulEven(vt, vmagic));
+            const auto qo = hn::ShiftRight<kDivS>(hn::MulOdd(vt, vmagic));
+            const auto q32 = hn::Or(hn::BitCast(di32, qe),
+                hn::ShiftLeftLanes<1>(hn::BitCast(di32, qo)));
+            // Clamp (hostile premultiplied colour > alpha ⇒ q ≤ 510), then
+            // force the alpha lane to 255.
+            const auto out = hn::IfThenElse(alpha_lane, v255, hn::Min(q32, v255));
+            hn::StoreU(hn::DemoteTo(du8, out), du8, dp);
+        }
+    }
+}
+
+} // namespace HWY_NAMESPACE
+} // namespace bun_image
+HWY_AFTER_NAMESPACE();
+
+#if HWY_ONCE
+namespace bun_image {
+
+HWY_EXPORT(CompositeOverImpl);
+
+extern "C" {
+
+// In-place Porter-Duff `over` of `overlay` (ow×oh RGBA8) onto `base`
+// (bw×bh RGBA8) at (left, top). `opacity` is the per-layer alpha multiplier
+// in 1/255 steps (0..=255); `premultiplied` ≠ 0 skips the overlay
+// premultiply pass. Negative/overhanging offsets clip to the intersection.
+void bun_image_composite_over_rgba8(uint8_t* base, uint32_t bw, uint32_t bh,
+    const uint8_t* overlay, uint32_t ow, uint32_t oh,
+    int64_t left, int64_t top, uint32_t opacity, int32_t premultiplied)
+{
+    HWY_DYNAMIC_DISPATCH(CompositeOverImpl)(base, bw, bh, overlay, ow, oh, left, top, opacity, premultiplied);
+}
+
+} // extern "C"
+
+} // namespace bun_image
+#endif // HWY_ONCE

--- a/src/runtime/image/Image.classes.ts
+++ b/src/runtime/image/Image.classes.ts
@@ -18,7 +18,11 @@ export default [
     // pinned for the task's duration — so the slice stays valid off-thread.
     // (No `hasPendingActivity` polling; the JSRef upgrade/downgrade is
     //  explicit at schedule/then.)
-    values: ["sourceJS"],
+    // `compositeJS` roots the JS array of overlay inputs passed to
+    // `.composite()` across the async task — the layer bytes are copied at
+    // call time, but rooting the descriptors keeps `Image` overlay inputs
+    // (and their borrowed ArrayBuffers) reachable for the wrapper's lifetime.
+    values: ["sourceJS", "compositeJS"],
     configurable: false,
     JSType: "0b11101110",
     klass: {
@@ -41,6 +45,10 @@ export default [
       flip: { fn: "doFlip", length: 0 },
       flop: { fn: "doFlop", length: 0 },
       modulate: { fn: "doModulate", length: 1 },
+      // Record overlay layers (bottom-to-top); blended after every other
+      // pipeline stage, in final post-resize coordinate space. Repeat calls
+      // replace the layer list (Sharp semantics).
+      composite: { fn: "doComposite", length: 1 },
       // Chainable output-format setters (Sharp-style); the encode happens
       // when a terminal below is awaited.
       jpeg: { fn: "doFormatJpeg", length: 1 },
@@ -64,6 +72,10 @@ export default [
       // <img src> / blurDataURL.
       placeholder: { fn: "doPlaceholder", length: 0, async: true },
       metadata: { fn: "doMetadata", length: 0, async: true },
+      // Post-pipeline RGBA8 pixels as `{data: Uint8Array, width, height,
+      // channels: 4}` — the `.raw().toBuffer({resolveWithObject: true})`
+      // equivalent, minus the encode round-trip.
+      pixels: { fn: "doPixels", length: 0, async: true },
 
       // Read-only after a pipeline has run; -1 before.
       width: { getter: "getWidth" },

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1168,9 +1168,9 @@ impl Image {
                     unsafe { &*std::ptr::from_ref::<[u8]>(ab.byte_slice()) }
                 }),
             Source::Owned(b) => Some(b.as_slice()),
-            // Raw bytes have no header to probe — `do_metadata` (this fn's
-            // only caller) answers raw sources from the descriptor before
-            // calling here.
+            // Raw bytes have no header to probe — callers (`do_metadata`,
+            // the composite-overlay path) answer raw sources from the
+            // constructor descriptor before calling here.
             Source::Raw { .. } => None,
             Source::Path(_) | Source::Blob(_) => None,
         }
@@ -1750,8 +1750,8 @@ impl Image {
                 "{}",
                 bstr::BStr::new(error_message(e).as_bytes())
             ))),
-            TaskResult::ErrWithCode { msg, .. } => {
-                Err(global.throw(format_args!("{}", bstr::BStr::new(msg.as_bytes()))))
+            TaskResult::ErrWithCode { code, msg } => {
+                Err(global.throw_value(error_with_code(global, code, msg)))
             }
             // Preserve errno/path/syscall instead of flattening to DecodeFailed.
             TaskResult::IoErr(e) => Err(global.throw_value(e.to_js(global))),
@@ -2625,9 +2625,22 @@ impl<'a> PipelineTask<'a> {
                         }
                         CompositeInput::Raw { .. } => unreachable!(),
                     };
-                    decoded_overlay =
+                    let mut dec =
                         codecs::decode(bytes, self.max_pixels, codecs::DecodeHint::default())
                             .map_err(TaskResult::Err)?;
+                    // Overlays follow the pipeline's EXIF policy, same as the
+                    // base at the top of `run()` — a portrait-shot JPEG
+                    // watermark blends upright when `autoOrient` (default) is
+                    // on, and the oversized rule below sees the upright dims.
+                    if self.auto_orient
+                        && codecs::Format::sniff(bytes) == Some(codecs::Format::Jpeg)
+                    {
+                        let orient = exif::read_jpeg(bytes);
+                        if orient != exif::Orientation::Normal {
+                            apply_orientation(&mut dec, orient).map_err(TaskResult::Err)?;
+                        }
+                    }
+                    decoded_overlay = dec;
                     (
                         &decoded_overlay.rgba,
                         decoded_overlay.width,

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -428,8 +428,13 @@ impl Image {
         // for the `.js_buffer` path, which a Blob never produces. The only
         // reason `source_from_js` takes `this_value` at all is to set that slot
         // for ArrayBuffer inputs — pass `.zero` and assert below.
-        img.source
-            .set(source_from_js(global, blob_value, JSValue::ZERO, None, img.max_pixels)?);
+        img.source.set(source_from_js(
+            global,
+            blob_value,
+            JSValue::ZERO,
+            None,
+            img.max_pixels,
+        )?);
         debug_assert!(!matches!(img.source.get(), Source::JsBuffer));
         Ok(img.to_js(global))
     }
@@ -481,8 +486,13 @@ fn from_input_js(
     // duplicated source bytes are handled by `Box` Drop on `?`.
     apply_options(&mut img, global, options)?;
     let raw = raw_from_options(global, options)?;
-    img.source
-        .set(source_from_js(global, input, this_value, raw, img.max_pixels)?);
+    img.source.set(source_from_js(
+        global,
+        input,
+        this_value,
+        raw,
+        img.max_pixels,
+    )?);
     // Raw dims are constructor-known — let `.width`/`.height` answer
     // immediately, the way they would after the first awaited terminal.
     if let Source::Raw { width, height, .. } = img.source.get() {
@@ -542,9 +552,9 @@ fn raw_from_options(global: &JSGlobalObject, opt: JSValue) -> JsResult<Option<Ra
             v.as_number() as u8
         }
         _ => {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Image: raw.channels must be 3 or 4",
-            )));
+            return Err(
+                global.throw_invalid_arguments(format_args!("Image: raw.channels must be 3 or 4",))
+            );
         }
     };
     Ok(Some(RawOptions {
@@ -731,12 +741,14 @@ fn composite_input_from_js(
         // Reuse the constructor's path / data:-URL handling. The string arms
         // never touch `this_value` (only ArrayBuffer inputs cache into the
         // wrapper's sourceJS slot), so ZERO is safe here.
-        return Ok(match source_from_js(global, value, JSValue::ZERO, None, max_pixels)? {
-            Source::Owned(b) => CompositeInput::Owned(b),
-            Source::Path(p) => CompositeInput::Path(p),
-            // A string input only ever resolves to bytes or a path.
-            Source::JsBuffer | Source::Blob(_) | Source::Raw { .. } => unreachable!(),
-        });
+        return Ok(
+            match source_from_js(global, value, JSValue::ZERO, None, max_pixels)? {
+                Source::Owned(b) => CompositeInput::Owned(b),
+                Source::Path(p) => CompositeInput::Path(p),
+                // A string input only ever resolves to bytes or a path.
+                Source::JsBuffer | Source::Blob(_) | Source::Raw { .. } => unreachable!(),
+            },
+        );
     }
     if let Some(ab) = value.as_array_buffer(global) {
         // Copied on the JS thread right now, so resizable/shared buffers are
@@ -1738,10 +1750,9 @@ impl Image {
                 "{}",
                 bstr::BStr::new(error_message(e).as_bytes())
             ))),
-            TaskResult::ErrWithCode { msg, .. } => Err(global.throw(format_args!(
-                "{}",
-                bstr::BStr::new(msg.as_bytes())
-            ))),
+            TaskResult::ErrWithCode { msg, .. } => {
+                Err(global.throw(format_args!("{}", bstr::BStr::new(msg.as_bytes()))))
+            }
             // Preserve errno/path/syscall instead of flattening to DecodeFailed.
             TaskResult::IoErr(e) => Err(global.throw_value(e.to_js(global))),
             // `kind` above is always `Kind::Encode` — `run()` can't produce these.

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -768,9 +768,24 @@ fn composite_input_from_js(
             },
             Source::Owned(b) => Ok(CompositeInput::Owned(b.clone())),
             Source::Path(p) => Ok(CompositeInput::Path(p.clone())),
-            Source::Blob(_) => Err(global.throw_invalid_arguments(format_args!(
-                "composite: fd/S3-backed Bun.file overlay — pass `await file.bytes()` or a path string"
-            ))),
+            // A path-backed `Bun.file()` Image resolves like a path string —
+            // the worker reads it at blend time (same store inspection as the
+            // sync `new Response(image)` path in `encode_for_body`). fd/S3
+            // Blobs have no bytes until an async read; refuse those.
+            Source::Blob(strong) => {
+                if let Some(blob) = strong.get().as_class_ref::<Blob>() {
+                    if let Some(store) = blob.store.get() {
+                        if let blob_store::Data::File(file) = &store.data {
+                            if let PathOrFileDescriptor::Path(path) = &file.pathlike {
+                                return Ok(CompositeInput::Path(ZBox::from_bytes(path.slice())));
+                            }
+                        }
+                    }
+                }
+                Err(global.throw_invalid_arguments(format_args!(
+                    "composite: fd/S3-backed Bun.file overlay — pass `await file.bytes()` or a path string"
+                )))
+            }
             // Raw pixels skip the worker's decode: copy them (same call-time
             // contract as every other overlay input) with their dims.
             Source::Raw {

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1382,6 +1382,7 @@ impl Image {
                 source: JsCell::new(Source::Owned(bytes)),
                 ..Default::default()
             });
+            img.refresh_reported_size();
             return Ok(img.to_js(global));
         }
         #[cfg(not(any(target_os = "macos", windows)))]

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -79,6 +79,11 @@ pub struct Image {
     /// collect the wrapper without polling `hasPendingActivity` every cycle.
     this_ref: JsCell<JsRef>,
     pending_tasks: Cell<u32>,
+    /// Overlays recorded by `.composite([...])`. Kept outside `Pipeline` so it
+    /// stays `Copy` (the Cell get/modify/set pattern); cloned into each
+    /// `PipelineTask` at schedule time so chained calls between schedule and
+    /// completion don't race the worker. Repeat `.composite()` calls replace.
+    composite_layers: JsCell<Vec<CompositeLayer>>,
 }
 
 impl Default for Image {
@@ -92,6 +97,7 @@ impl Default for Image {
             last_height: Cell::new(-1),
             this_ref: JsCell::new(JsRef::empty()),
             pending_tasks: Cell::new(0),
+            composite_layers: JsCell::new(Vec::new()),
         }
     }
 }
@@ -120,6 +126,17 @@ pub enum Source {
     /// task off the resulting Promise. After the first read completes the
     /// source is swapped to `.owned` so subsequent terminals reuse the bytes.
     Blob(Strong),
+    /// Raw RGBA8 pixels from the `{raw: {width, height, channels}}`
+    /// constructor option (Sharp's raw-input descriptor). Validated
+    /// (`len == width × height × channels`, dims ≥ 1) and copied — with
+    /// 3-channel input expanded to RGBA — at construction, so the worker
+    /// uses the bytes as the decoded frame directly: no `Format::sniff`,
+    /// no decode, no EXIF/ICC (raw pixels carry no container metadata).
+    Raw {
+        rgba: Vec<u8>,
+        width: u32,
+        height: u32,
+    },
 }
 
 // `Source::deinit` in Zig only frees owned fields — `Vec<u8>`, `ZString`, and
@@ -226,6 +243,108 @@ impl Default for Modulate {
     }
 }
 
+/// One overlay recorded by `.composite([...])`. Layers live beside `Pipeline`
+/// (not inside it) so `Pipeline` keeps its `Copy` snapshot semantics; each
+/// scheduled task gets its own clone of the layer list.
+#[derive(Clone)]
+pub struct CompositeLayer {
+    pub input: CompositeInput,
+    /// Explicit `(left, top)` placement. Overrides `gravity` when set
+    /// (Sharp requires both-or-neither). Negative offsets are allowed and
+    /// clip at blend time.
+    pub position: Option<(i32, i32)>,
+    /// Placement when `position` is `None`. Sharp's default is centre.
+    pub gravity: Gravity,
+    pub blend: BlendMode,
+    /// Per-layer alpha multiplier in `0.0..=1.0`; `1.0` = identity. Bun
+    /// extension — Sharp has no per-layer opacity.
+    pub opacity: f32,
+    /// Overlay pixels are already alpha-premultiplied, so the premultiply
+    /// pass before blending is skipped.
+    pub premultiplied: bool,
+}
+
+/// Overlay bytes for one composite layer. Mirrors `Source` minus the
+/// JS-backed variants: buffer inputs are copied at `.composite()` call time
+/// (one memcpy per overlay) so a task never has to pin more than the base's
+/// ArrayBuffer across the WorkPool roundtrip.
+#[derive(Clone)]
+pub enum CompositeInput {
+    /// Encoded overlay bytes, copied from the JS input at call time.
+    Owned(Vec<u8>),
+    /// Owned, NUL-terminated path. Read on the worker thread with the same
+    /// guards as a `Source::Path` base.
+    Path(ZBox),
+    /// Decoded RGBA8, copied from a raw-pixel-sourced `Image` overlay
+    /// (`Source::Raw`) at call time. Already validated by that Image's
+    /// constructor (`len == w×h×4`, dims ≥ 1), so the worker skips the
+    /// sniff/decode entirely and blends these bytes as-is.
+    Raw {
+        rgba: Vec<u8>,
+        width: u32,
+        height: u32,
+    },
+}
+
+/// Overlay placement when no explicit `top`/`left` is given. Matches Sharp's
+/// gravity set: centre plus the 8 compass points.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum Gravity {
+    #[default]
+    Centre,
+    North,
+    Northeast,
+    East,
+    Southeast,
+    South,
+    Southwest,
+    West,
+    Northwest,
+}
+
+/// Compositing operator. v1 ships Porter-Duff `over` only; an enum so
+/// further modes slot in without re-shaping the task snapshot.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq, Default)]
+pub enum BlendMode {
+    #[default]
+    Over,
+}
+
+static GRAVITY_MAP: phf::Map<&'static [u8], Gravity> = phf::phf_map! {
+    b"centre" => Gravity::Centre,
+    // Sharp accepts both spellings.
+    b"center" => Gravity::Centre,
+    b"north" => Gravity::North,
+    b"northeast" => Gravity::Northeast,
+    b"east" => Gravity::East,
+    b"southeast" => Gravity::Southeast,
+    b"south" => Gravity::South,
+    b"southwest" => Gravity::Southwest,
+    b"west" => Gravity::West,
+    b"northwest" => Gravity::Northwest,
+};
+impl jsc::FromJsEnum for Gravity {
+    fn from_js_value(v: JSValue, global: &JSGlobalObject, prop: &'static str) -> JsResult<Self> {
+        v.to_enum_from_map(
+            global,
+            prop,
+            &GRAVITY_MAP,
+            "'centre', 'north', 'northeast', 'east', 'southeast', 'south', 'southwest', 'west' or 'northwest'",
+        )
+    }
+}
+
+static BLEND_MAP: phf::Map<&'static [u8], BlendMode> = phf::phf_map! {
+    b"over" => BlendMode::Over,
+};
+impl jsc::FromJsEnum for BlendMode {
+    fn from_js_value(v: JSValue, global: &JSGlobalObject, prop: &'static str) -> JsResult<Self> {
+        v.to_enum_from_map(global, prop, &BLEND_MAP, "'over'")
+    }
+}
+
 /// `@intFromFloat` is safety-checked UB on NaN/±Inf/out-of-range; every
 /// number we read from JS goes through this so hostile input throws/clamps
 /// instead of aborting. NaN → lo, ±Inf → the matching bound; bounds are f64
@@ -295,13 +414,22 @@ impl Image {
         let mut img = Box::<Image>::default();
         // errdefer img.finalize() — `Box` drops on `?` automatically.
         apply_options(&mut img, global, options)?;
+        // `{raw}` requires the pixel bytes in hand at construction so the
+        // length/dims contract can be checked synchronously; a Blob receiver
+        // (file/S3/fd) doesn't have them yet. Throw rather than silently
+        // sniffing pixel data as an encoded image.
+        if raw_from_options(global, options)?.is_some() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Image: the `raw` option requires the pixel bytes as an ArrayBuffer or TypedArray input",
+            )));
+        }
         // For Blob receivers `source_from_js` either dupes (in-memory blob) or
         // creates a Strong (file/S3); the cached `sourceJS` slot is only used
         // for the `.js_buffer` path, which a Blob never produces. The only
         // reason `source_from_js` takes `this_value` at all is to set that slot
         // for ArrayBuffer inputs — pass `.zero` and assert below.
         img.source
-            .set(source_from_js(global, blob_value, JSValue::ZERO)?);
+            .set(source_from_js(global, blob_value, JSValue::ZERO, None, img.max_pixels)?);
         debug_assert!(!matches!(img.source.get(), Source::JsBuffer));
         Ok(img.to_js(global))
     }
@@ -318,13 +446,25 @@ impl Image {
     pub fn estimated_size(&self) -> usize {
         // Only the bytes WE own. .js_buffer is the caller's ArrayBuffer (already
         // counted via the cached value slot); the worker's RGBA scratch is
-        // task-scoped and freed before any GC could observe it.
+        // task-scoped and freed before any GC could observe it. Composite
+        // overlay bytes ARE ours — copied at `.composite()` call time.
         mem::size_of::<Image>()
             + match self.source.get() {
                 Source::JsBuffer | Source::Blob(_) => 0,
                 Source::Owned(b) => b.len(),
                 Source::Path(p) => p.len(),
+                Source::Raw { rgba, .. } => rgba.len(),
             }
+            + self
+                .composite_layers
+                .get()
+                .iter()
+                .map(|l| match &l.input {
+                    CompositeInput::Owned(b) => b.len(),
+                    CompositeInput::Path(p) => p.len(),
+                    CompositeInput::Raw { rgba, .. } => rgba.len(),
+                })
+                .sum::<usize>()
     }
 }
 
@@ -335,10 +475,22 @@ fn from_input_js(
     this_value: JSValue,
 ) -> JsResult<Box<Image>> {
     let mut img = Box::<Image>::default();
-    // `opt.get` can throw (Proxy/getter); without this the heap-allocated
-    // *Image and the duplicated source bytes leak. (Handled by `Box` Drop on `?`.)
-    img.source.set(source_from_js(global, input, this_value)?);
+    // Options first: `{raw}` decides how `input` is interpreted, and the raw
+    // dims are guarded against `maxPixels` during source construction.
+    // `opt.get` can throw (Proxy/getter); the heap-allocated *Image and any
+    // duplicated source bytes are handled by `Box` Drop on `?`.
     apply_options(&mut img, global, options)?;
+    let raw = raw_from_options(global, options)?;
+    img.source
+        .set(source_from_js(global, input, this_value, raw, img.max_pixels)?);
+    // Raw dims are constructor-known — let `.width`/`.height` answer
+    // immediately, the way they would after the first awaited terminal.
+    if let Source::Raw { width, height, .. } = img.source.get() {
+        img.last_width
+            .set(i32::try_from(*width).expect("validated ≤ i32::MAX"));
+        img.last_height
+            .set(i32::try_from(*height).expect("validated ≤ i32::MAX"));
+    }
     Ok(img)
 }
 
@@ -357,11 +509,143 @@ fn apply_options(img: &mut Image, global: &JSGlobalObject, opt: JSValue) -> JsRe
     Ok(())
 }
 
+/// Parsed `{raw: {width, height, channels}}` constructor option — Sharp's
+/// raw-input descriptor. Presence switches the constructor into raw-pixel
+/// mode: the input is treated as an already-decoded pixel buffer instead of
+/// an encoded image (see `Source::Raw`).
+struct RawOptions {
+    width: u32,
+    height: u32,
+    /// 3 (RGB, expanded to RGBA on ingest) or 4 (RGBA).
+    channels: u8,
+}
+
+fn raw_from_options(global: &JSGlobalObject, opt: JSValue) -> JsResult<Option<RawOptions>> {
+    if !opt.is_object() {
+        return Ok(None);
+    }
+    let Some(raw) = opt.get(global, "raw")? else {
+        return Ok(None);
+    };
+    if raw.is_null() {
+        return Ok(None);
+    }
+    if !raw.is_object() {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Image: `raw` must be an object: {{width, height, channels}}",
+        )));
+    }
+    let width = raw_dim(global, raw, "width")?;
+    let height = raw_dim(global, raw, "height")?;
+    let channels = match raw.get(global, "channels")? {
+        Some(v) if v.is_number() && (v.as_number() == 3.0 || v.as_number() == 4.0) => {
+            v.as_number() as u8
+        }
+        _ => {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Image: raw.channels must be 3 or 4",
+            )));
+        }
+    };
+    Ok(Some(RawOptions {
+        width,
+        height,
+        channels,
+    }))
+}
+
+/// One raw dimension: a positive integer that fits the i32 range the rest of
+/// the pipeline assumes (`last_width`/`last_height`, kernel args). `0`,
+/// fractions, NaN/±Inf and non-numbers all throw — a wrong dimension would
+/// silently re-stride the whole pixel grid, so no `coerce_int` clamping here.
+fn raw_dim(global: &JSGlobalObject, raw: JSValue, name: &str) -> JsResult<u32> {
+    if let Some(v) = raw.get(global, name)? {
+        if v.is_number() {
+            let x = v.as_number();
+            if x.is_finite() && x.fract() == 0.0 && x >= 1.0 && x <= f64::from(i32::MAX) {
+                return Ok(x as u32);
+            }
+        }
+    }
+    Err(global.throw_invalid_arguments(format_args!(
+        "Image: raw.{name} must be an integer between 1 and 2147483647",
+    )))
+}
+
+/// Build `Source::Raw` from user-supplied pixel bytes: enforce the exact
+/// `len == width × height × channels` contract plus the `maxPixels` guard,
+/// and expand 3-channel RGB to the pipeline's RGBA (opaque alpha). Copying
+/// here — on the JS thread, at construction — is what lets the worker treat
+/// the bytes as the decoded frame with no JS buffer pinned across the
+/// WorkPool roundtrip, and surfaces every validation error synchronously.
+fn raw_source_from_bytes(
+    global: &JSGlobalObject,
+    bytes: &[u8],
+    raw: &RawOptions,
+    max_pixels: u64,
+) -> JsResult<Source> {
+    let (w, h) = (raw.width, raw.height);
+    // Same decompression-bomb cap the decoders apply via `codecs::guard`,
+    // checked before any allocation. u64 mul cannot overflow two u32 factors.
+    if (w as u64) * (h as u64) > max_pixels {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Image: raw dimensions ({w} × {h}) exceed maxPixels",
+        )));
+    }
+    let expected = (w as u64) * (h as u64) * u64::from(raw.channels);
+    if bytes.len() as u64 != expected {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "Image: raw input is {} bytes; width × height × channels = {w} × {h} × {} requires exactly {expected}",
+            bytes.len(),
+            raw.channels,
+        )));
+    }
+    let rgba = if raw.channels == 4 {
+        bytes.to_vec()
+    } else {
+        // RGB → RGBA: pre-fill with 0xFF so alpha is opaque, then overwrite
+        // the colour bytes of each pixel.
+        let mut out = vec![0xFFu8; (w as usize) * (h as usize) * 4];
+        for (dst, src) in out.chunks_exact_mut(4).zip(bytes.chunks_exact(3)) {
+            dst[..3].copy_from_slice(src);
+        }
+        out
+    };
+    Ok(Source::Raw {
+        rgba,
+        width: w,
+        height: h,
+    })
+}
+
 fn source_from_js(
     global: &JSGlobalObject,
     value: JSValue,
     this_value: JSValue,
+    raw: Option<RawOptions>,
+    max_pixels: u64,
 ) -> JsResult<Source> {
+    // `{raw}` mode: `value` IS the pixel buffer. Validate and copy on the JS
+    // thread right now — errors surface at construction, and a later detach
+    // of the JS buffer can't affect us — expanding 3-channel RGB to RGBA.
+    // `Format::sniff` never sees these bytes (raw pixels can start with any
+    // byte pattern, including a JPEG SOI).
+    if let Some(r) = raw {
+        let Some(ab) = value.as_array_buffer(global) else {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Image: the `raw` option requires the pixel bytes as an ArrayBuffer or TypedArray input",
+            )));
+        };
+        // Same rejection as the encoded path below — we copy synchronously,
+        // but a growable/shared buffer mutating mid-copy still has no sane
+        // semantics, and `buf.slice()` is the documented workaround.
+        if ab.resizable || ab.shared {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Image(): resizable / shared ArrayBuffer is not supported; pass a fixed-length view (e.g. buf.slice())",
+            )));
+        }
+        return raw_source_from_bytes(global, ab.byte_slice(), &r, max_pixels);
+    }
     // String → file path or data:/base64 URL. Everything else → bytes.
     if value.is_string() {
         let str = bun_core::OwnedString::new(value.to_bun_string(global)?);
@@ -432,6 +716,91 @@ fn source_from_js(
     Err(global.throw_invalid_arguments(format_args!(
         "Image() input must be a path string, data: URL, ArrayBuffer, TypedArray or Blob",
     )))
+}
+
+/// Resolve one `.composite()` overlay's `image` value to bytes the layer
+/// owns. v1 contract: copy at call time (one memcpy per overlay) so nothing
+/// JS-side has to stay alive or be pinned across the async task; path
+/// strings are duped and read on the worker like a path-sourced base.
+fn composite_input_from_js(
+    global: &JSGlobalObject,
+    value: JSValue,
+    max_pixels: u64,
+) -> JsResult<CompositeInput> {
+    if value.is_string() {
+        // Reuse the constructor's path / data:-URL handling. The string arms
+        // never touch `this_value` (only ArrayBuffer inputs cache into the
+        // wrapper's sourceJS slot), so ZERO is safe here.
+        return Ok(match source_from_js(global, value, JSValue::ZERO, None, max_pixels)? {
+            Source::Owned(b) => CompositeInput::Owned(b),
+            Source::Path(p) => CompositeInput::Path(p),
+            // A string input only ever resolves to bytes or a path.
+            Source::JsBuffer | Source::Blob(_) | Source::Raw { .. } => unreachable!(),
+        });
+    }
+    if let Some(ab) = value.as_array_buffer(global) {
+        // Copied on the JS thread right now, so resizable/shared buffers are
+        // fine here — there's no TOCTOU window, unlike the borrowed base
+        // source that `source_from_js` has to reject.
+        return Ok(CompositeInput::Owned(ab.byte_slice().to_vec()));
+    }
+    if let Some(other) = value.as_class_ref::<Image>() {
+        // Snapshot the other Image's *input* bytes. Its pipeline ops are NOT
+        // applied — same as Sharp, where an overlay is its input file.
+        return match other.source.get() {
+            Source::JsBuffer => match other.js_thread_bytes(value, global) {
+                Some(b) => Ok(CompositeInput::Owned(b.to_vec())),
+                None => Err(global.throw_invalid_arguments(format_args!(
+                    "composite: overlay Image's source ArrayBuffer was detached"
+                ))),
+            },
+            Source::Owned(b) => Ok(CompositeInput::Owned(b.clone())),
+            Source::Path(p) => Ok(CompositeInput::Path(p.clone())),
+            Source::Blob(_) => Err(global.throw_invalid_arguments(format_args!(
+                "composite: fd/S3-backed Bun.file overlay — pass `await file.bytes()` or a path string"
+            ))),
+            // Raw pixels skip the worker's decode: copy them (same call-time
+            // contract as every other overlay input) with their dims.
+            Source::Raw {
+                rgba,
+                width,
+                height,
+            } => Ok(CompositeInput::Raw {
+                rgba: rgba.clone(),
+                width: *width,
+                height: *height,
+            }),
+        };
+    }
+    Err(global.throw_invalid_arguments(format_args!(
+        "composite: `image` must be an Image, ArrayBuffer, TypedArray, path string or data: URL"
+    )))
+}
+
+/// `top`/`left` for one composite layer: absent / undefined / null ⇒ `None`;
+/// anything else must be a number. Negatives are allowed — they clip at
+/// blend time rather than throwing (Sharp passes them through unclamped).
+fn composite_offset(
+    global: &JSGlobalObject,
+    item: JSValue,
+    name: &'static str,
+) -> JsResult<Option<i32>> {
+    match item.get(global, name)? {
+        Some(v) if !v.is_undefined_or_null() => {
+            if !v.is_number() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "composite: `{name}` must be a number"
+                )));
+            }
+            Ok(Some(coerce_int!(
+                i32,
+                v.as_number(),
+                f64::from(i32::MIN),
+                f64::from(i32::MAX)
+            )))
+        }
+        _ => Ok(None),
+    }
 }
 
 // ───────────────────────────── chainable ops ────────────────────────────────
@@ -545,6 +914,105 @@ impl Image {
             }
         }
         self.update_pipeline(|p| p.modulate = Some(m));
+        Ok(callframe.this())
+    }
+
+    /// Sharp-compatible `.composite(layers)` — records the overlay list and
+    /// copies each overlay's bytes NOW (see `composite_input_from_js`); the
+    /// decode → blend work runs as the last pipeline stage when a terminal
+    /// is awaited. A repeat call REPLACES the recorded list, the same
+    /// slot-overwrite semantics as every other chainable op (and Sharp).
+    #[bun_jsc::host_fn(method)]
+    pub fn do_composite(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let args = callframe.arguments();
+        if args.len() < 1 || !args[0].is_array() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "composite(layers) expects an array of overlay objects"
+            )));
+        }
+        let list = args[0];
+        // `is_array` above ⇒ a real JS Array, whose length fits u32.
+        let len = u32::try_from(list.get_length(global)?).expect("int cast");
+        // Cap the pre-allocation, not the layer count — a hostile
+        // `new Array(4e9)` must not reserve gigabytes before the per-item
+        // validation below ever runs (its holes throw at i=0 anyway).
+        let mut layers: Vec<CompositeLayer> = Vec::with_capacity(len.min(64) as usize);
+        for i in 0..len {
+            let item = list.get_index(global, i)?;
+            if !item.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "composite: layer {i} must be an object with an `image` property"
+                )));
+            }
+            let input = match item.get(global, "image")? {
+                Some(v) if !v.is_undefined_or_null() => v,
+                _ => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "composite: layer {i} is missing `image`"
+                    )));
+                }
+            };
+            let input = composite_input_from_js(global, input, self.max_pixels)?;
+
+            // Explicit placement comes as a pair and overrides gravity.
+            let top = composite_offset(global, item, "top")?;
+            let left = composite_offset(global, item, "left")?;
+            let position = match (left, top) {
+                (Some(left), Some(top)) => Some((left, top)),
+                (None, None) => None,
+                _ => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "composite: layer {i} must set both `top` and `left`, or neither"
+                    )));
+                }
+            };
+
+            let gravity = item
+                .get_optional_enum::<Gravity>(global, "gravity")?
+                .unwrap_or_default();
+            let blend = item
+                .get_optional_enum::<BlendMode>(global, "blend")?
+                .unwrap_or_default();
+
+            let mut opacity: f32 = 1.0;
+            if let Some(v) = item.get(global, "opacity")? {
+                if v.is_number() {
+                    let x = v.as_number();
+                    // Same non-finite policy as `.modulate()`: identity, so
+                    // NaN/±Inf never reach the blend kernel.
+                    opacity = if x.is_finite() {
+                        x.clamp(0.0, 1.0) as f32
+                    } else {
+                        1.0
+                    };
+                }
+            }
+            let premultiplied = match item.get(global, "premultiplied")? {
+                Some(v) => v.to_boolean(),
+                None => false,
+            };
+
+            layers.push(CompositeLayer {
+                input,
+                position,
+                gravity,
+                blend,
+                opacity,
+                premultiplied,
+            });
+        }
+        self.composite_layers.set(layers);
+        // Root the user's overlay array in the wrapper's `compositeJS` cached
+        // slot (GC-visited via WriteBarrier, like `sourceJS`). The owned byte
+        // copies above already make the worker safe; this keeps the overlay
+        // *descriptors* — `Image` inputs and their borrowed ArrayBuffers —
+        // reachable across the async task for as long as the wrapper is.
+        // Replaced wholesale on each call, matching the layer-list overwrite.
+        js::composite_js_set_cached(callframe.this(), global, list);
         Ok(callframe.this())
     }
 
@@ -688,6 +1156,10 @@ impl Image {
                     unsafe { &*std::ptr::from_ref::<[u8]>(ab.byte_slice()) }
                 }),
             Source::Owned(b) => Some(b.as_slice()),
+            // Raw bytes have no header to probe — `do_metadata` (this fn's
+            // only caller) answers raw sources from the descriptor before
+            // calling here.
+            Source::Raw { .. } => None,
             Source::Path(_) | Source::Blob(_) => None,
         }
     }
@@ -776,6 +1248,18 @@ impl Image {
             }),
             Source::Path(p) => Ok(Input {
                 path: Some(std::ptr::from_ref::<ZStr>(p.as_zstr())),
+                ..Default::default()
+            }),
+            // SAFETY: same contract as `Owned` — the constructor-built Vec
+            // outlives the task because `this_ref` is held Strong while
+            // pending_tasks > 0 (see `schedule()`).
+            Source::Raw {
+                rgba,
+                width,
+                height,
+            } => Ok(Input {
+                bytes: bun_ptr::RawSlice::new(rgba.as_slice()),
+                raw: Some((*width, *height)),
                 ..Default::default()
             }),
             // schedule() peels this off before pin_for_task is reached.
@@ -904,6 +1388,26 @@ impl Image {
 impl Image {
     #[bun_jsc::host_fn(method)]
     pub fn do_metadata(&self, global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        // Raw sources have no header: dims come from the constructor
+        // descriptor and there's no container format to sniff. Copy the dims
+        // out so no `&Source` borrow is held across the JS calls below.
+        let raw_dims = match self.source.get() {
+            Source::Raw { width, height, .. } => Some((*width, *height)),
+            _ => None,
+        };
+        if let Some((w, h)) = raw_dims {
+            self.last_width.set(i32::try_from(w).expect("int cast"));
+            self.last_height.set(i32::try_from(h).expect("int cast"));
+            let obj = JSValue::create_empty_object(global, 3);
+            obj.put(global, b"width", JSValue::js_number(f64::from(w)));
+            obj.put(global, b"height", JSValue::js_number(f64::from(h)));
+            obj.put(
+                global,
+                b"format",
+                jsc::bun_string_jsc::create_utf8_for_js(global, b"raw")?,
+            );
+            return Ok(JSPromise::resolved_promise_value(global, obj));
+        }
         // Header-only probe is a few dozen byte reads — when the bytes are already
         // in memory it's cheaper to do it inline than to bounce off the WorkPool
         // (~0.4 ms roundtrip). Path-backed sources still go async for the file I/O.
@@ -947,6 +1451,16 @@ impl Image {
             Kind::Metadata,
             Deliver::Uint8Array,
         )
+    }
+
+    /// `.pixels()` — resolve the post-pipeline RGBA8 buffer as
+    /// `{data: Uint8Array, width, height, channels: 4}`. Sharp's
+    /// `.raw().toBuffer({resolveWithObject: true})` equivalent, minus the
+    /// encode round-trip; chained format setters are ignored because nothing
+    /// is encoded.
+    #[bun_jsc::host_fn(method)]
+    pub fn do_pixels(&self, global: &JSGlobalObject, cf: &CallFrame) -> JsResult<JSValue> {
+        self.schedule(global, cf.this(), Kind::Raw, Deliver::Uint8Array)
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1106,6 +1620,8 @@ impl Image {
             // Struct copy — the worker reads its own snapshot so further chained
             // calls on the JS side between schedule and completion don't race.
             pipeline: self.pipeline.get(),
+            // Same snapshot contract for the (non-`Copy`) overlay list.
+            layers: self.composite_layers.get().clone(),
             input,
             kind,
             deliver,
@@ -1192,6 +1708,7 @@ impl Image {
             image: std::ptr::from_ref::<Image>(self),
             global,
             pipeline: self.pipeline.get(),
+            layers: self.composite_layers.get().clone(),
             input,
             kind: Kind::Encode(self.pipeline.get().output),
             deliver: Deliver::Uint8Array,
@@ -1208,6 +1725,9 @@ impl Image {
         );
         // Zig `defer input.release()` (see PORT NOTE above).
         mem::take(&mut task.input).release();
+        // `ManuallyDrop` suppresses field Drops (see PORT NOTE above) — the
+        // layer snapshot owns heap buffers, so free it explicitly.
+        drop(mem::take(&mut task.layers));
         match result {
             TaskResult::Encoded { out, format, w, h } => {
                 self.last_width.set(i32::try_from(w).expect("int cast"));
@@ -1218,9 +1738,14 @@ impl Image {
                 "{}",
                 bstr::BStr::new(error_message(e).as_bytes())
             ))),
+            TaskResult::ErrWithCode { msg, .. } => Err(global.throw(format_args!(
+                "{}",
+                bstr::BStr::new(msg.as_bytes())
+            ))),
             // Preserve errno/path/syscall instead of flattening to DecodeFailed.
             TaskResult::IoErr(e) => Err(global.throw_value(e.to_js(global))),
-            TaskResult::Meta { .. } => unreachable!(),
+            // `kind` above is always `Kind::Encode` — `run()` can't produce these.
+            TaskResult::Meta { .. } | TaskResult::Raw { .. } => unreachable!(),
         }
     }
 }
@@ -1391,6 +1916,11 @@ pub struct PipelineTask<'a> {
     image: *const Image,
     global: &'a JSGlobalObject,
     pipeline: Pipeline,
+    /// Clone of `image.composite_layers` taken at schedule time — same
+    /// snapshot contract as `pipeline`, just `Clone` instead of `Copy`. The
+    /// overlay bytes are owned (`Vec<u8>`/`ZBox`), so the worker never touches
+    /// JS-side memory for them.
+    layers: Vec<CompositeLayer>,
     input: Input,
     kind: Kind,
     deliver: Deliver,
@@ -1412,6 +1942,10 @@ pub struct Input {
     pinned: JSValue,
     /// Our own dupe of a FastTypedArray's bytes — freed in `then()`.
     copied: Option<Vec<u8>>,
+    /// `Some((width, height))` when `bytes` holds a raw RGBA8 frame from a
+    /// `Source::Raw` input. `run()` then uses the bytes as the decoded frame
+    /// directly — no sniff/probe/decode, no EXIF, no ICC.
+    raw: Option<(u32, u32)>,
 }
 
 impl Default for Input {
@@ -1421,6 +1955,7 @@ impl Default for Input {
             path: None,
             pinned: JSValue::ZERO,
             copied: None,
+            raw: None,
         }
     }
 }
@@ -1462,6 +1997,10 @@ pub enum Kind {
     /// `None` ⇒ re-encode in the source format (resolved after decode).
     Encode(Option<codecs::EncodeOptions>),
     Metadata,
+    /// `.pixels()` — decode → apply pipeline → hand the post-pipeline RGBA8
+    /// buffer to JS as `{data, width, height, channels: 4}` without encoding.
+    /// Raw is post-pipeline, same as Sharp's `.raw()`.
+    Raw,
     /// `.placeholder()` — decode → box-resize ≤100 → ThumbHash → render
     /// → PNG → `data:` URL. The whole chain runs on the worker; the
     /// hash itself never crosses the JS boundary unless we add an
@@ -1482,7 +2021,21 @@ pub enum TaskResult {
         h: u32,
         format: codecs::Format,
     },
+    /// Post-pipeline RGBA8 pixels, taken straight out of `codecs::Decoded`
+    /// (global allocator) — no encode step.
+    Raw {
+        rgba: Vec<u8>,
+        w: u32,
+        h: u32,
+    },
     Err(codecs::Error),
+    /// Errors with no `codecs::Error` analogue (e.g. an oversized composite
+    /// overlay) — carries its own `.code`/message instead of borrowing one of
+    /// the codec error's fixed strings.
+    ErrWithCode {
+        code: &'static ZStr,
+        msg: &'static ZStr,
+    },
     IoErr(sys::Error),
 }
 
@@ -1559,7 +2112,7 @@ impl<'a> PipelineTask<'a> {
         // IHDR/SOF/VP8 header; we used to decode the full RGBA buffer first
         // (~70× slower on a 1920×1080 PNG). EXIF orientation only swaps the
         // reported dims, no pixels involved.
-        if matches!(self.kind, Kind::Metadata) {
+        if matches!(self.kind, Kind::Metadata) && self.input.raw.is_none() {
             match codecs::probe(input, self.max_pixels) {
                 Ok(p) => {
                     let mut w = p.width;
@@ -1587,42 +2140,68 @@ impl<'a> PipelineTask<'a> {
             }
         }
 
-        // Decode-time downscale hint. The IDCT picker constrains in *stored*
-        // axes, so any 90/270 rotate that runs before resize — explicit OR
-        // EXIF auto-orient — needs the hint axes swapped, otherwise one axis
-        // can be over-shrunk and then upscaled, throwing away detail.
-        // (flip/flop are pure mirrors that never change w/h, so the hint
-        //  stays valid through them.)
-        let hint: codecs::DecodeHint = if let Some(r) = self.pipeline.resize {
-            let mut tw = r.w;
-            // r.h==0 means "preserve aspect" — constrain on width only.
-            let mut th = if r.h != 0 { r.h } else { r.w };
-            let swap_explicit = self.pipeline.rotate == 90 || self.pipeline.rotate == 270;
-            let swap_exif = self.auto_orient && {
-                let t = exif::read_jpeg(input).transform();
-                t.rotate == 90 || t.rotate == 270
-            };
-            if swap_explicit != swap_exif {
-                mem::swap(&mut tw, &mut th);
-            }
-            codecs::DecodeHint {
-                target_w: tw,
-                target_h: th,
-            }
+        let (mut decoded, src_format) = if let Some((w, h)) = self.input.raw {
+            // Raw RGBA8 source: the constructor validated `len == w×h×ch`,
+            // rejected 0-dims and expanded 3-channel input, so these bytes
+            // ARE the decoded frame. `Format::sniff` must not run — raw
+            // pixels can start with any byte pattern (including a JPEG SOI,
+            // which would route them through the EXIF parsing below) — and a
+            // raw buffer carries no ICC profile. The copy gives this task its
+            // own mutable frame; the source Vec stays intact for later
+            // terminals.
+            (
+                codecs::Decoded {
+                    rgba: input.to_vec(),
+                    width: w,
+                    height: h,
+                    icc_profile: None,
+                },
+                // No source container to "re-encode in the source format";
+                // the no-format-chained fallback below emits PNG, same as
+                // the decode-only formats.
+                codecs::Format::Png,
+            )
         } else {
-            codecs::DecodeHint::default()
-        };
+            // Decode-time downscale hint. The IDCT picker constrains in *stored*
+            // axes, so any 90/270 rotate that runs before resize — explicit OR
+            // EXIF auto-orient — needs the hint axes swapped, otherwise one axis
+            // can be over-shrunk and then upscaled, throwing away detail.
+            // (flip/flop are pure mirrors that never change w/h, so the hint
+            //  stays valid through them.)
+            let hint: codecs::DecodeHint = if let Some(r) = self.pipeline.resize {
+                let mut tw = r.w;
+                // r.h==0 means "preserve aspect" — constrain on width only.
+                let mut th = if r.h != 0 { r.h } else { r.w };
+                let swap_explicit = self.pipeline.rotate == 90 || self.pipeline.rotate == 270;
+                let swap_exif = self.auto_orient && {
+                    let t = exif::read_jpeg(input).transform();
+                    t.rotate == 90 || t.rotate == 270
+                };
+                if swap_explicit != swap_exif {
+                    mem::swap(&mut tw, &mut th);
+                }
+                codecs::DecodeHint {
+                    target_w: tw,
+                    target_h: th,
+                }
+            } else {
+                codecs::DecodeHint::default()
+            };
 
-        let mut decoded = match codecs::decode(input, self.max_pixels, hint) {
-            Ok(d) => d,
-            Err(e) => {
-                self.result = TaskResult::Err(e);
-                return;
-            }
-        };
-        // `defer decoded.deinit()` — `codecs::Decoded` Drop frees rgba/icc.
+            let decoded = match codecs::decode(input, self.max_pixels, hint) {
+                Ok(d) => d,
+                Err(e) => {
+                    self.result = TaskResult::Err(e);
+                    return;
+                }
+            };
+            // `defer decoded.deinit()` — `codecs::Decoded` Drop frees rgba/icc.
 
-        let src_format = codecs::Format::sniff(input).unwrap_or(codecs::Format::Png);
+            (
+                decoded,
+                codecs::Format::sniff(input).unwrap_or(codecs::Format::Png),
+            )
+        };
 
         // EXIF auto-orient: applied BEFORE any user op so resize targets and
         // metadata report the visually-upright dimensions, the way Sharp does.
@@ -1637,7 +2216,9 @@ impl<'a> PipelineTask<'a> {
         }
 
         if matches!(self.kind, Kind::Metadata) {
-            // Reached only for HEIC/AVIF (probe fell through).
+            // Reached only for HEIC/AVIF (probe fell through) — raw sources
+            // never schedule Metadata (`do_metadata` answers them on the JS
+            // thread from the constructor descriptor).
             self.result = TaskResult::Meta {
                 w: decoded.width,
                 h: decoded.height,
@@ -1656,6 +2237,27 @@ impl<'a> PipelineTask<'a> {
 
         if let Err(e) = self.apply_pipeline(&mut decoded) {
             self.result = TaskResult::Err(e);
+            return;
+        }
+
+        // Composite is the LAST pipeline stage (after modulate) — Sharp also
+        // runs it after every base op (pipeline.cc:640–740), so overlay
+        // coordinates are in final post-resize space and `.pixels()` sees the
+        // blended result.
+        if let Err(r) = self.apply_composite(&mut decoded) {
+            self.result = r;
+            return;
+        }
+
+        // `.pixels()` — the decoded RGBA buffer IS the output; skip the encode
+        // block entirely. Raw is post-pipeline (rotate/flip/resize/modulate
+        // already applied above), matching Sharp's `.raw()`.
+        if matches!(self.kind, Kind::Raw) {
+            self.result = TaskResult::Raw {
+                rgba: mem::take(&mut decoded.rgba),
+                w: decoded.width,
+                h: decoded.height,
+            };
             return;
         }
 
@@ -1721,7 +2323,9 @@ impl<'a> PipelineTask<'a> {
         // Stash final dims here (JS thread) — `run()` is on a WorkPool thread
         // so writing `self.image.*` there would race the synchronous getters.
         match &self.result {
-            TaskResult::Encoded { w, h, .. } | TaskResult::Meta { w, h, .. } => {
+            TaskResult::Encoded { w, h, .. }
+            | TaskResult::Meta { w, h, .. }
+            | TaskResult::Raw { w, h, .. } => {
                 image.last_width.set(i32::try_from(*w).expect("int cast"));
                 image.last_height.set(i32::try_from(*h).expect("int cast"));
             }
@@ -1881,7 +2485,39 @@ impl<'a> PipelineTask<'a> {
                 obj.put(global, b"format", fmt_js);
                 promise.resolve(global, obj)?;
             }
+            TaskResult::Raw { rgba, w, h } => {
+                // Hand the post-pipeline RGBA buffer to JS without a copy:
+                // wrap the Vec's allocation as a Uint8Array whose finalizer is
+                // the matching global-allocator free (same handoff as the
+                // `Encoded` arm above; ownership transfers to JS, so suppress
+                // the codec `Drop`).
+                let out = mem::ManuallyDrop::new(codecs::Encoded::from_owned(rgba));
+                // SAFETY: `out.bytes` is a non-null fat pointer into a live
+                // allocation; valid until `out.free` runs. Mutability is for
+                // the `from_bytes` signature only — JS takes ownership.
+                let mut_slice = unsafe {
+                    core::slice::from_raw_parts_mut(
+                        out.bytes.as_ptr().cast::<u8>(),
+                        out.bytes.len(),
+                    )
+                };
+                let data = match ArrayBuffer::from_bytes(mut_slice, jsc::JSType::Uint8Array)
+                    .to_js_with_context(global, core::ptr::null_mut(), Some(out.free))
+                {
+                    Ok(v) => v,
+                    Err(_) => return promise.reject(global, Err(jsc::JsError::Thrown)),
+                };
+                let obj = JSValue::create_empty_object(global, 4);
+                obj.put(global, b"data", data);
+                obj.put(global, b"width", JSValue::js_number(f64::from(w)));
+                obj.put(global, b"height", JSValue::js_number(f64::from(h)));
+                obj.put(global, b"channels", JSValue::js_number(4.0));
+                promise.resolve(global, obj)?;
+            }
             TaskResult::Err(e) => promise.reject(global, Ok(reject_error(global, e)))?,
+            TaskResult::ErrWithCode { code, msg } => {
+                promise.reject(global, Ok(error_with_code(global, code, msg)))?;
+            }
             TaskResult::IoErr(e) => promise.reject(global, Ok(e.to_js(global)))?,
         }
         Ok(())
@@ -1934,6 +2570,88 @@ impl<'a> PipelineTask<'a> {
         }
         if let Some(m) = p.modulate {
             codecs::modulate(&mut d.rgba, m.brightness, m.saturation);
+        }
+        Ok(())
+    }
+
+    /// Composite stage — the last pipeline op. Layers blend bottom-to-top,
+    /// strictly one at a time: decode overlay → enforce overlay ≤ base →
+    /// resolve placement → blend → drop the overlay before the next decode,
+    /// so peak memory stays base + one overlay (libvips' n-ary composite is
+    /// sequential pairwise accumulation, so per-layer blending is
+    /// mathematically identical).
+    ///
+    /// Errors carry a full `TaskResult` so a path-sourced overlay keeps
+    /// errno/path fidelity (`IoErr`) instead of flattening to `DecodeFailed`.
+    fn apply_composite(&self, d: &mut codecs::Decoded) -> Result<(), TaskResult> {
+        for layer in &self.layers {
+            // Resolve the layer to (rgba, w, h). Encoded inputs decode here
+            // with the same `max_pixels` guard as the base, applied per
+            // overlay, so a decompression-bomb overlay is rejected before
+            // its RGBA buffer is allocated (no decode hint — overlays are
+            // never resized). Raw inputs were validated at construction;
+            // re-check the *pixel-count* guard against THIS image's
+            // `max_pixels` (the overlay Image's own limit may differ).
+            let decoded_overlay: codecs::Decoded;
+            let (overlay_rgba, ow, oh): (&[u8], u32, u32) = match &layer.input {
+                CompositeInput::Raw {
+                    rgba,
+                    width,
+                    height,
+                } => {
+                    if u64::from(*width) * u64::from(*height) > self.max_pixels {
+                        return Err(TaskResult::Err(codecs::Error::TooManyPixels));
+                    }
+                    (rgba, *width, *height)
+                }
+                input => {
+                    let file_bytes: Vec<u8>;
+                    let bytes: &[u8] = match input {
+                        CompositeInput::Owned(b) => b,
+                        CompositeInput::Path(p) => {
+                            file_bytes = read_overlay_file(p.as_zstr())?;
+                            &file_bytes
+                        }
+                        CompositeInput::Raw { .. } => unreachable!(),
+                    };
+                    decoded_overlay =
+                        codecs::decode(bytes, self.max_pixels, codecs::DecodeHint::default())
+                            .map_err(TaskResult::Err)?;
+                    (
+                        &decoded_overlay.rgba,
+                        decoded_overlay.width,
+                        decoded_overlay.height,
+                    )
+                }
+            };
+            // Sharp's rule (pipeline.cc:669): the overlay must fit the base.
+            if ow > d.width || oh > d.height {
+                return Err(TaskResult::ErrWithCode {
+                    code: zstr!("ERR_IMAGE_COMPOSITE_OVERSIZED"),
+                    msg: zstr!("Image to composite must have same dimensions or smaller"),
+                });
+            }
+            // Explicit top/left override gravity and may be negative (clipped
+            // at blend time); gravity placement is always in-bounds because
+            // overlay ≤ base was just enforced.
+            let (left, top) = match layer.position {
+                Some((l, t)) => (i64::from(l), i64::from(t)),
+                None => resolve_gravity(layer.gravity, d.width, d.height, ow, oh),
+            };
+            match layer.blend {
+                BlendMode::Over => codecs::composite_over(
+                    &mut d.rgba,
+                    d.width,
+                    d.height,
+                    overlay_rgba,
+                    ow,
+                    oh,
+                    left,
+                    top,
+                    opacity_q255(layer.opacity),
+                    layer.premultiplied,
+                ),
+            }
         }
         Ok(())
     }
@@ -2005,6 +2723,74 @@ fn resolve_resize(r: Resize, sw: u32, sh: u32) -> (u32, u32) {
         return (sw, sh);
     }
     (w, h)
+}
+
+/// Read an overlay path with the same hardening as a `Source::Path` base in
+/// `run()`: O_NONBLOCK open (a FIFO with no writer must not park the WorkPool
+/// thread), `!S_ISREG` → ENODEV (`/dev/zero` would pread forever), and the
+/// encoded-size cap before reading anything.
+fn read_overlay_file(p: &ZStr) -> Result<Vec<u8>, TaskResult> {
+    #[cfg(unix)]
+    let oflags = sys::O::RDONLY | sys::O::NONBLOCK;
+    #[cfg(not(unix))]
+    let oflags = sys::O::RDONLY;
+    let file = match sys::File::openat(sys::Fd::cwd(), p, oflags, 0) {
+        sys::Result::Ok(f) => f,
+        sys::Result::Err(e) => return Err(TaskResult::IoErr(e.with_path(p.as_bytes()))),
+    };
+    let st = match file.stat() {
+        sys::Result::Ok(s) => s,
+        sys::Result::Err(e) => return Err(TaskResult::IoErr(e.with_path(p.as_bytes()))),
+    };
+    if !sys::S::ISREG(st.st_mode as _) {
+        return Err(TaskResult::IoErr(sys::Error {
+            errno: sys::E::ENODEV as _,
+            syscall: sys::Tag::read,
+            path: p.as_bytes().to_vec().into_boxed_slice(),
+            ..Default::default()
+        }));
+    }
+    if u64::try_from(st.st_size.max(0)).expect("int cast") > MAX_INPUT_FILE_BYTES {
+        return Err(TaskResult::Err(codecs::Error::TooManyPixels));
+    }
+    match file.read_to_end() {
+        Ok(bytes) => Ok(bytes),
+        Err(e) => Err(TaskResult::IoErr(e.with_path(p.as_bytes()))),
+    }
+}
+
+/// Sharp's `CalculateCrop` placement math (common.cc): centre rounds toward
+/// the bottom-right via the `+1`; the compass points sit flush against their
+/// edge. Overlay ≤ base is enforced before this is called, so every result
+/// is in-bounds — only explicit `top`/`left` can place an overlay partially
+/// (or wholly) outside the base.
+fn resolve_gravity(g: Gravity, bw: u32, bh: u32, ow: u32, oh: u32) -> (i64, i64) {
+    let (bw, bh) = (i64::from(bw), i64::from(bh));
+    let (ow, oh) = (i64::from(ow), i64::from(oh));
+    let cx = (bw - ow + 1) / 2;
+    let cy = (bh - oh + 1) / 2;
+    match g {
+        Gravity::Centre => (cx, cy),
+        Gravity::North => (cx, 0),
+        Gravity::Northeast => (bw - ow, 0),
+        Gravity::East => (bw - ow, cy),
+        Gravity::Southeast => (bw - ow, bh - oh),
+        Gravity::South => (cx, bh - oh),
+        Gravity::Southwest => (0, bh - oh),
+        Gravity::West => (0, cy),
+        Gravity::Northwest => (0, 0),
+    }
+}
+
+/// Map an opacity in `0.0..=1.0` to `0..=255` (1/255 steps) so the per-layer
+/// multiply in the blend kernel is pure integer math. This is the *only*
+/// quantisation in the blend — the kernel is exact rational arithmetic over
+/// denominator 255ⁿ until its single final rounding back to bytes. Parse time
+/// already clamps, but the layer struct is `pub`, so clamp again rather than
+/// trust it.
+#[inline]
+fn opacity_q255(opacity: f32) -> u32 {
+    (f64::from(opacity).clamp(0.0, 1.0) * 255.0).round() as u32
 }
 
 fn apply_orientation(

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -84,6 +84,14 @@ pub struct Image {
     /// `PipelineTask` at schedule time so chained calls between schedule and
     /// completion don't race the worker. Repeat `.composite()` calls replace.
     composite_layers: JsCell<Vec<CompositeLayer>>,
+    /// Byte total for `estimated_size()`. `estimatedSize` is called from
+    /// JSC's concurrent GC marker threads ("Called from any thread"), so it
+    /// must not walk `source`/`composite_layers` heap structures the JS
+    /// thread can drop mid-iteration (`.composite()` replaces the layer
+    /// Vec). Recomputed on the JS thread at every mutation site and read as
+    /// a single word from the GC thread — the same `reported_estimated_size`
+    /// convention Request/Response/Blob use.
+    reported_estimated_size: Cell<usize>,
 }
 
 impl Default for Image {
@@ -98,6 +106,7 @@ impl Default for Image {
             this_ref: JsCell::new(JsRef::empty()),
             pending_tasks: Cell::new(0),
             composite_layers: JsCell::new(Vec::new()),
+            reported_estimated_size: Cell::new(mem::size_of::<Image>()),
         }
     }
 }
@@ -435,6 +444,7 @@ impl Image {
             None,
             img.max_pixels,
         )?);
+        img.refresh_reported_size();
         debug_assert!(!matches!(img.source.get(), Source::JsBuffer));
         Ok(img.to_js(global))
     }
@@ -449,11 +459,19 @@ impl Image {
     }
 
     pub fn estimated_size(&self) -> usize {
+        // GC-thread-safe single-word read; see `reported_estimated_size`.
+        self.reported_estimated_size.get()
+    }
+
+    /// Recompute `reported_estimated_size`. JS thread only — it walks the
+    /// `source`/`composite_layers` heap structures, so call it after every
+    /// `source.set` / `composite_layers.set`.
+    fn refresh_reported_size(&self) {
         // Only the bytes WE own. .js_buffer is the caller's ArrayBuffer (already
         // counted via the cached value slot); the worker's RGBA scratch is
         // task-scoped and freed before any GC could observe it. Composite
         // overlay bytes ARE ours — copied at `.composite()` call time.
-        mem::size_of::<Image>()
+        let size = mem::size_of::<Image>()
             + match self.source.get() {
                 Source::JsBuffer | Source::Blob(_) => 0,
                 Source::Owned(b) => b.len(),
@@ -469,7 +487,8 @@ impl Image {
                     CompositeInput::Path(p) => p.len(),
                     CompositeInput::Raw { rgba, .. } => rgba.len(),
                 })
-                .sum::<usize>()
+                .sum::<usize>();
+        self.reported_estimated_size.set(size);
     }
 }
 
@@ -493,6 +512,7 @@ fn from_input_js(
         raw,
         img.max_pixels,
     )?);
+    img.refresh_reported_size();
     // Raw dims are constructor-known — let `.width`/`.height` answer
     // immediately, the way they would after the first awaited terminal.
     if let Source::Raw { width, height, .. } = img.source.get() {
@@ -1033,6 +1053,7 @@ impl Image {
             });
         }
         self.composite_layers.set(layers);
+        self.refresh_reported_size();
         // Root the user's overlay array in the wrapper's `compositeJS` cached
         // slot (GC-visited via WriteBarrier, like `sourceJS`). The owned byte
         // copies above already make the worker safe; this keeps the overlay
@@ -1709,6 +1730,7 @@ impl Image {
                         let p = ZBox::from_bytes(path.slice());
                         // `Source::Blob`'s `Strong` Drop releases the JS ref.
                         self.source.set(Source::Path(p));
+                        self.refresh_reported_size();
                     } else {
                         return Err(global.throw(format_args!("{REFUSE}")));
                     }
@@ -1873,6 +1895,7 @@ impl<'a> BlobReadChain<'a> {
                 // on the already-swapped source.
                 if matches!(image.source.get(), Source::Blob(_)) {
                     image.source.set(Source::Owned(bytes));
+                    image.refresh_reported_size();
                 } else {
                     drop(bytes);
                 }

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -648,6 +648,18 @@ unsafe extern "C" {
     fn bun_image_rotate_rgba8(src: *const u8, w: i32, h: i32, dst: *mut u8, deg: i32);
     fn bun_image_flip_rgba8(src: *const u8, w: i32, h: i32, dst: *mut u8, horiz: i32);
     fn bun_image_modulate_rgba8(buf: *mut u8, len: usize, brightness: f32, saturation: f32);
+    fn bun_image_composite_over_rgba8(
+        base: *mut u8,
+        bw: u32,
+        bh: u32,
+        overlay: *const u8,
+        ow: u32,
+        oh: u32,
+        left: i64,
+        top: i64,
+        opacity: u32,
+        premultiplied: i32,
+    );
 }
 
 /// In-place brightness/saturation. brightness multiplies V (so 1.0 is
@@ -656,6 +668,48 @@ unsafe extern "C" {
 pub(crate) fn modulate(rgba: &mut [u8], brightness: f32, saturation: f32) {
     // SAFETY: ptr+len from a valid slice; C++ kernel writes within bounds.
     unsafe { bun_image_modulate_rgba8(rgba.as_mut_ptr(), rgba.len(), brightness, saturation) }
+}
+
+/// In-place Porter-Duff `over` of one RGBA8 overlay onto `base` at
+/// (`left`, `top`), in premultiplied-alpha space the way libvips composites.
+/// `opacity` is a per-layer alpha multiplier in 1/255 steps (0..=255);
+/// `premultiplied` skips the kernel's premultiply pass for overlays whose
+/// pixels already are. Offsets may be negative or overhang — the kernel clips
+/// to the intersection. Exact integer math throughout: byte-identical on
+/// every platform/ISA (the docs' byte-identical guarantee), see
+/// image_composite.cpp for the fixed-point derivation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn composite_over(
+    base: &mut [u8],
+    bw: u32,
+    bh: u32,
+    overlay: &[u8],
+    ow: u32,
+    oh: u32,
+    left: i64,
+    top: i64,
+    opacity: u32,
+    premultiplied: bool,
+) {
+    debug_assert!(base.len() == (bw as usize) * (bh as usize) * 4);
+    debug_assert!(overlay.len() == (ow as usize) * (oh as usize) * 4);
+    // SAFETY: ptr+len pairs from valid slices whose dims the debug_asserts
+    // pin; the kernel clips (left, top, ow, oh) against (bw, bh) and writes
+    // only within the intersection.
+    unsafe {
+        bun_image_composite_over_rgba8(
+            base.as_mut_ptr(),
+            bw,
+            bh,
+            overlay.as_ptr(),
+            ow,
+            oh,
+            left,
+            top,
+            opacity,
+            i32::from(premultiplied),
+        )
+    }
 }
 
 pub(crate) fn resize(

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -58,6 +58,6 @@ pub mod thumbhash;
 #[path = "Image.rs"]
 pub mod image_body;
 pub use image_body::{
-    AsyncImageTask, Deliver, Fit, Image, Input, Kind, Modulate, Pipeline, PipelineTask, Resize,
-    Source, TaskResult,
+    AsyncImageTask, BlendMode, CompositeInput, CompositeLayer, Deliver, Fit, Gravity, Image,
+    Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source, TaskResult,
 };

--- a/src/runtime/image/mod.rs
+++ b/src/runtime/image/mod.rs
@@ -58,6 +58,6 @@ pub mod thumbhash;
 #[path = "Image.rs"]
 pub mod image_body;
 pub use image_body::{
-    AsyncImageTask, BlendMode, CompositeInput, CompositeLayer, Deliver, Fit, Gravity, Image,
-    Input, Kind, Modulate, Pipeline, PipelineTask, Resize, Source, TaskResult,
+    AsyncImageTask, BlendMode, CompositeInput, CompositeLayer, Deliver, Fit, Gravity, Image, Input,
+    Kind, Modulate, Pipeline, PipelineTask, Resize, Source, TaskResult,
 };

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -305,3 +305,162 @@ describe("Floyd–Steinberg dither", () => {
     }
   });
 });
+
+describe("composite over-blend kernel", () => {
+  // Reference implementation of the kernel's exact 255-denominator
+  // fixed-point Porter-Duff `over` (image_composite.cpp) in plain JS Number
+  // arithmetic. Every intermediate is an integer below 2^53, so doubles
+  // represent it exactly and Math.floor reproduces the integer divisions
+  // bit-for-bit. The kernel splits into a SIMD path (opaque base pixel) and
+  // a scalar path (everything else); this reference is path-agnostic, so
+  // sweeping base alphas across both paths proves they agree with each
+  // other AND with the spec.
+  function refOver(
+    base: Uint8Array,
+    bw: number,
+    bh: number,
+    ov: Uint8Array,
+    ow: number,
+    oh: number,
+    left: number,
+    top: number,
+    op: number, // 0..=255
+    premul: boolean,
+  ): void {
+    const D2 = 65025;
+    if (op === 0) return;
+    const x0 = Math.max(left, 0);
+    const y0 = Math.max(top, 0);
+    const x1 = Math.min(left + ow, bw);
+    const y1 = Math.min(top + oh, bh);
+    for (let y = y0; y < y1; y++) {
+      for (let x = x0; x < x1; x++) {
+        const si = ((y - top) * ow + (x - left)) * 4;
+        const di = (y * bw + x) * 4;
+        const sa = ov[si + 3];
+        const n_as = sa * op;
+        const cmul = premul ? op * 255 : sa * op;
+        const n_psr = ov[si] * cmul;
+        const n_psg = ov[si + 1] * cmul;
+        const n_psb = ov[si + 2] * cmul;
+        if ((n_as | n_psr | n_psg | n_psb) === 0) continue;
+        const da = base[di + 3];
+        const inv = D2 - n_as;
+        const n_ar = n_as * 255 + da * inv;
+        const blend1 = (n_ps: number, d: number) => {
+          const n_pr = n_ps * 255 + d * da * inv;
+          if (n_ar === 0) return 0;
+          return Math.min(Math.floor((n_pr + Math.floor(n_ar / 2)) / n_ar), 255);
+        };
+        base[di] = blend1(n_psr, base[di]);
+        base[di + 1] = blend1(n_psg, base[di + 1]);
+        base[di + 2] = blend1(n_psb, base[di + 2]);
+        base[di + 3] = Math.floor((n_ar + 32512) / D2);
+      }
+    }
+  }
+
+  // 67 wide (odd, prime) exercises the row tail; the alpha layout exercises
+  // the SIMD↔scalar seam: rows 0–7 fully opaque (SIMD path), rows 8–15 a
+  // mixed alpha pattern that sprinkles 255s between partials so the kernel
+  // flips between paths mid-row.
+  const BW = 67;
+  const BH = 16;
+  function makeBase(): Uint8Array {
+    const px = new Uint8Array(BW * BH * 4);
+    for (let y = 0; y < BH; y++) {
+      for (let x = 0; x < BW; x++) {
+        const i = (y * BW + x) * 4;
+        px[i] = (x * 3) & 255;
+        px[i + 1] = (y * 17 + 11) & 255;
+        px[i + 2] = (x ^ (y * 29)) & 255;
+        px[i + 3] = y < 8 ? 255 : (x * 4 + y) & 255;
+      }
+    }
+    return px;
+  }
+  // Overlay alphas sweep the full 0..255 range (including exact 0 and 255
+  // runs at the start of rows) with varied colours; for the premultiplied
+  // sweep the colours are clamped to ≤ alpha so the input is well-formed,
+  // and a dedicated case covers hostile colour > alpha.
+  const OW = 61;
+  const OH = 12;
+  function makeOverlay(premulWellFormed: boolean): Uint8Array {
+    const px = new Uint8Array(OW * OH * 4);
+    for (let y = 0; y < OH; y++) {
+      for (let x = 0; x < OW; x++) {
+        const i = (y * OW + x) * 4;
+        const a = x < 4 ? (x % 2 ? 255 : 0) : (x * 5 + y * 23) & 255;
+        let r = (x * 7) & 255;
+        let g = (y * 31 + 5) & 255;
+        let b = (x * 13 + y * 3) & 255;
+        if (premulWellFormed) {
+          r = Math.min(r, a);
+          g = Math.min(g, a);
+          b = Math.min(b, a);
+        }
+        px[i] = r;
+        px[i + 1] = g;
+        px[i + 2] = b;
+        px[i + 3] = a;
+      }
+    }
+    return px;
+  }
+
+  async function runKernel(
+    base: Uint8Array,
+    ov: Uint8Array,
+    left: number,
+    top: number,
+    op255: number,
+    premultiplied: boolean,
+  ): Promise<Uint8Array> {
+    const overlay = new Bun.Image(ov, { raw: { width: OW, height: OH, channels: 4 } });
+    const out = await new Bun.Image(base, { raw: { width: BW, height: BH, channels: 4 } })
+      .composite([{ image: overlay, left, top, opacity: op255 / 255, premultiplied }])
+      .pixels();
+    return out.data;
+  }
+
+  test.each([
+    [255, false],
+    [254, false],
+    [128, false],
+    [1, false],
+    [255, true],
+    [128, true],
+  ] as const)("kernel matches the exact fixed-point reference (opacity %d/255, premultiplied: %s)", async (op255, premul) => {
+    const ov = makeOverlay(premul);
+    // Negative offsets clip on two edges; the overlay also overhangs nothing
+    // on the right, leaving untouched base columns to verify as identity.
+    const got = await runKernel(makeBase(), ov, -3, -2, op255, premul);
+    const want = makeBase();
+    refOver(want, BW, BH, ov, OW, OH, -3, -2, op255, premul);
+    expect(Buffer.compare(Buffer.from(got), Buffer.from(want))).toBe(0);
+  });
+
+  test("hostile premultiplied input (colour > alpha) clamps identically in both paths", async () => {
+    // All-partial alphas with full-bright colours: every unpremultiply wants
+    // to exceed 255 and must clamp — on the opaque-base SIMD rows AND the
+    // mixed scalar rows.
+    const ov = new Uint8Array(OW * OH * 4);
+    for (let i = 0; i < OW * OH; i++) {
+      ov[i * 4] = 255;
+      ov[i * 4 + 1] = 200;
+      ov[i * 4 + 2] = 255;
+      ov[i * 4 + 3] = (i * 11) & 127; // 0..127, never 255
+    }
+    const got = await runKernel(makeBase(), ov, 0, 0, 255, true);
+    const want = makeBase();
+    refOver(want, BW, BH, ov, OW, OH, 0, 0, 255, true);
+    expect(Buffer.compare(Buffer.from(got), Buffer.from(want))).toBe(0);
+  });
+
+  test("kernel output is identical across repeat runs (deterministic dispatch)", async () => {
+    const ov = makeOverlay(false);
+    const a = await runKernel(makeBase(), ov, 5, 3, 200, false);
+    const b = await runKernel(makeBase(), ov, 5, 3, 200, false);
+    expect(Buffer.compare(Buffer.from(a), Buffer.from(b))).toBe(0);
+  });
+});

--- a/test/js/bun/image/image-kernels.test.ts
+++ b/test/js/bun/image/image-kernels.test.ts
@@ -430,15 +430,18 @@ describe("composite over-blend kernel", () => {
     [1, false],
     [255, true],
     [128, true],
-  ] as const)("kernel matches the exact fixed-point reference (opacity %d/255, premultiplied: %s)", async (op255, premul) => {
-    const ov = makeOverlay(premul);
-    // Negative offsets clip on two edges; the overlay also overhangs nothing
-    // on the right, leaving untouched base columns to verify as identity.
-    const got = await runKernel(makeBase(), ov, -3, -2, op255, premul);
-    const want = makeBase();
-    refOver(want, BW, BH, ov, OW, OH, -3, -2, op255, premul);
-    expect(Buffer.compare(Buffer.from(got), Buffer.from(want))).toBe(0);
-  });
+  ] as const)(
+    "kernel matches the exact fixed-point reference (opacity %d/255, premultiplied: %s)",
+    async (op255, premul) => {
+      const ov = makeOverlay(premul);
+      // Negative offsets clip on two edges; the overlay also overhangs nothing
+      // on the right, leaving untouched base columns to verify as identity.
+      const got = await runKernel(makeBase(), ov, -3, -2, op255, premul);
+      const want = makeBase();
+      refOver(want, BW, BH, ov, OW, OH, -3, -2, op255, premul);
+      expect(Buffer.compare(Buffer.from(got), Buffer.from(want))).toBe(0);
+    },
+  );
 
   test("hostile premultiplied input (colour > alpha) clamps identically in both paths", async () => {
     // All-partial alphas with full-bright colours: every unpremultiply wants

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1849,6 +1849,11 @@ describe("composite()", () => {
     await Bun.write(p, solidPng(2, 2, GREEN));
     ({ data } = await compositePixels(base, [{ image: p }]));
     expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+    // path-backed Bun.file() Image — resolves to its path like a path string
+    ({ data } = await compositePixels(base, [{ image: new Bun.Image(Bun.file(p)) }]));
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+    ({ data } = await compositePixels(base, [{ image: Bun.file(p).image() }]));
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
   });
 
   test("JPEG overlay EXIF orientation follows the base's autoOrient", async () => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1088,6 +1088,136 @@ describe("Bun.Image", () => {
       expect(buf[1]).toBe(0xd8);
     });
   });
+
+  describe("raw pixel I/O", () => {
+    test(".pixels() returns decoded RGBA8 {data, width, height, channels: 4}", async () => {
+      const out = await new Bun.Image(cornersPng).pixels();
+      expect(out.width).toBe(4);
+      expect(out.height).toBe(3);
+      expect(out.channels).toBe(4);
+      expect(out.data).toBeInstanceOf(Uint8Array);
+      expect(out.data.length).toBe(4 * 3 * 4);
+      for (let y = 0; y < 3; y++)
+        for (let x = 0; x < 4; x++) expect(rgbaAt(out.data, 4, x, y)).toEqual(cornerPattern(x, y));
+    });
+
+    test(".pixels() is post-pipeline: ops apply before extraction", async () => {
+      // flop is an exact pixel permutation — no resampling jitter to tolerate.
+      const flopped = await new Bun.Image(cornersPng).flop().pixels();
+      expect([flopped.width, flopped.height, flopped.channels]).toEqual([4, 3, 4]);
+      for (let y = 0; y < 3; y++)
+        for (let x = 0; x < 4; x++) expect(rgbaAt(flopped.data, 4, x, y)).toEqual(cornerPattern(3 - x, y));
+
+      // rotate(90) CW swaps the reported dims (same corner mapping as the
+      // encode-path rotate test above).
+      const rot = await new Bun.Image(cornersPng).rotate(90).pixels();
+      expect([rot.width, rot.height]).toEqual([3, 4]);
+      expect(rgbaAt(rot.data, 3, 2, 0)).toEqual([255, 0, 0, 255]); // red
+      expect(rgbaAt(rot.data, 3, 0, 0)).toEqual([0, 0, 255, 255]); // blue
+      expect(rgbaAt(rot.data, 3, 0, 3)).toEqual([255, 255, 255, 255]); // white
+
+      // resize updates dims and the buffer size together.
+      const small = await new Bun.Image(gradientPng).resize(8, 8).pixels();
+      expect([small.width, small.height, small.data.length]).toEqual([8, 8, 8 * 8 * 4]);
+    });
+
+    test(".pixels() agrees with the PNG encode path byte-for-byte", async () => {
+      const img = new Bun.Image(gradientPng).resize(8, 8);
+      const viaPixels = await img.pixels();
+      const viaPng = decodePngRaw(await new Bun.Image(gradientPng).resize(8, 8).png().bytes());
+      expect(Uint8Array.from(viaPixels.data)).toEqual(Uint8Array.from(viaPng.data));
+    });
+
+    test("raw RGBA input round-trips through .pixels() byte-for-byte", async () => {
+      const w = 5;
+      const h = 4;
+      const src = new Uint8Array(w * h * 4);
+      for (let i = 0; i < src.length; i++) src[i] = (i * 7 + 3) & 255;
+      const out = await new Bun.Image(src, { raw: { width: w, height: h, channels: 4 } }).pixels();
+      expect(out.width).toBe(w);
+      expect(out.height).toBe(h);
+      expect(out.channels).toBe(4);
+      expect(Uint8Array.from(out.data)).toEqual(src);
+    });
+
+    test("raw input feeds the normal encode pipeline (raw → PNG → exact pixels)", async () => {
+      const w = 4;
+      const h = 3;
+      const src = new Uint8Array(w * h * 4);
+      for (let y = 0; y < h; y++) for (let x = 0; x < w; x++) src.set(cornerPattern(x, y), (y * w + x) * 4);
+      const png = await new Bun.Image(src, { raw: { width: w, height: h, channels: 4 } }).png().bytes();
+      const back = decodePngRaw(png);
+      expect([back.w, back.h]).toEqual([w, h]);
+      expect(Uint8Array.from(back.data)).toEqual(src);
+      // Pipeline ops work on raw sources too: flop then read back.
+      const flopped = await new Bun.Image(src, { raw: { width: w, height: h, channels: 4 } }).flop().pixels();
+      for (let y = 0; y < h; y++)
+        for (let x = 0; x < w; x++) expect(rgbaAt(flopped.data, w, x, y)).toEqual(cornerPattern(w - 1 - x, y));
+    });
+
+    test("raw input with channels: 3 expands to RGBA with opaque alpha", async () => {
+      const w = 3;
+      const h = 2;
+      const rgb = new Uint8Array(w * h * 3);
+      for (let i = 0; i < rgb.length; i++) rgb[i] = (i * 11 + 5) & 255;
+      const out = await new Bun.Image(rgb, { raw: { width: w, height: h, channels: 3 } }).pixels();
+      expect(out.width).toBe(w);
+      expect(out.height).toBe(h);
+      expect(out.channels).toBe(4);
+      expect(out.data.length).toBe(w * h * 4);
+      for (let p = 0; p < w * h; p++) {
+        expect(out.data[p * 4]).toBe(rgb[p * 3]);
+        expect(out.data[p * 4 + 1]).toBe(rgb[p * 3 + 1]);
+        expect(out.data[p * 4 + 2]).toBe(rgb[p * 3 + 2]);
+        expect(out.data[p * 4 + 3]).toBe(255);
+      }
+    });
+
+    test("raw input validates length and dimensions at constructor time", () => {
+      const buf = new Uint8Array(2 * 2 * 4);
+      // data.length must equal width*height*channels.
+      expect(() => new Bun.Image(buf, { raw: { width: 3, height: 2, channels: 4 } })).toThrow();
+      expect(() => new Bun.Image(buf.subarray(0, 15), { raw: { width: 2, height: 2, channels: 4 } })).toThrow();
+      expect(() => new Bun.Image(buf, { raw: { width: 2, height: 2, channels: 3 } })).toThrow();
+      // Zero dimensions are rejected even when the length product matches.
+      expect(() => new Bun.Image(new Uint8Array(0), { raw: { width: 0, height: 0, channels: 4 } })).toThrow();
+      expect(() => new Bun.Image(new Uint8Array(0), { raw: { width: 0, height: 2, channels: 4 } })).toThrow();
+      expect(() => new Bun.Image(new Uint8Array(0), { raw: { width: 2, height: 0, channels: 4 } })).toThrow();
+    });
+
+    test("raw input validates the descriptor and the input kind", () => {
+      const buf = new Uint8Array(2 * 2 * 4);
+      // channels must be exactly 3 or 4.
+      expect(() => new Bun.Image(buf, { raw: { width: 2, height: 2, channels: 2 as any } })).toThrow(/channels/);
+      expect(() => new Bun.Image(buf, { raw: { width: 4, height: 2, channels: 1 as any } })).toThrow(/channels/);
+      expect(() => new Bun.Image(buf, { raw: { width: 2, height: 2 } as any })).toThrow(/channels/);
+      // Dimensions must be positive integers.
+      expect(() => new Bun.Image(buf, { raw: { width: 1.5, height: 2, channels: 4 } })).toThrow(/width/);
+      expect(() => new Bun.Image(buf, { raw: { width: 2, height: NaN, channels: 4 } })).toThrow(/height/);
+      expect(() => new Bun.Image(buf, { raw: { width: -2, height: 2, channels: 4 } })).toThrow(/width/);
+      // `raw` only makes sense for in-memory pixel bytes — paths, data: URLs
+      // and Blobs throw instead of silently sniffing pixel data.
+      expect(() => new Bun.Image("some/file.bin" as any, { raw: { width: 2, height: 2, channels: 4 } })).toThrow(
+        /ArrayBuffer or TypedArray/,
+      );
+      expect(() => new Bun.Image(new Blob([buf]) as any, { raw: { width: 2, height: 2, channels: 4 } })).toThrow(
+        /ArrayBuffer or TypedArray/,
+      );
+      // The error names the actual vs expected byte count.
+      expect(() => new Bun.Image(buf, { raw: { width: 3, height: 2, channels: 4 } })).toThrow(/16 bytes.*24/);
+    });
+
+    test("raw sources answer metadata() and width/height from the descriptor", async () => {
+      const w = 6;
+      const h = 2;
+      const img = new Bun.Image(new Uint8Array(w * h * 4), { raw: { width: w, height: h, channels: 4 } });
+      // Dims are constructor-known for raw sources — no terminal needed.
+      expect([img.width, img.height]).toEqual([w, h]);
+      // No container was sniffed (a raw buffer could even start with a JPEG
+      // SOI), so format reports "raw".
+      expect(await img.metadata()).toEqual({ width: w, height: h, format: "raw" });
+    });
+  });
 });
 
 describe("decode-only formats (BMP / TIFF / GIF)", () => {
@@ -1441,6 +1571,402 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
       await expect(new Bun.Image(tiff).png().bytes()).rejects.toMatchObject({ code: "ERR_IMAGE_FORMAT_UNSUPPORTED" });
     });
   }
+});
+
+// ─── composite() ────────────────────────────────────────────────────────────
+// Sharp-compatible layering. Layers blend bottom-to-top into the base AFTER
+// all other pipeline ops (final-canvas coordinates), in premultiplied-alpha
+// space (Porter-Duff `over` in v1). Placement is explicit top/left (negatives
+// clip, never error) or gravity using sharp's CalculateCrop math. The overlay
+// must be ≤ the base in both dimensions. Inputs are hand-rolled PNGs and the
+// output is read back through our own PNG decoder, so these tests depend on
+// composite() alone — verified against hand-computed Porter-Duff vectors, not
+// the sharp fixture file (fixtures/sharp-reference.bin stays untouched).
+
+describe("composite()", () => {
+  type RGBA = [number, number, number, number];
+  const BLACK: RGBA = [0, 0, 0, 255];
+  const RED: RGBA = [255, 0, 0, 255];
+  const GREEN: RGBA = [0, 255, 0, 255];
+  const HALF_BLUE: RGBA = [0, 0, 255, 128];
+
+  const solidPng = (w: number, h: number, rgba: RGBA) => makePng(w, h, () => rgba);
+
+  function compositeBytes(base: Uint8Array, layers: any[]): Promise<Uint8Array> {
+    return new Bun.Image(base).composite(layers).png().bytes();
+  }
+  async function compositePixels(base: Uint8Array, layers: any[]): Promise<{ w: number; h: number; data: Uint8Array }> {
+    return decodePngRaw(await compositeBytes(base, layers));
+  }
+
+  // Float-exact Porter-Duff `over` in premultiplied space, rounded once at the
+  // end. The shipped kernel is integer fixed-point (the byte-identical-output
+  // guarantee forbids ISA-dependent float paths), so blended channels may sit
+  // a couple of LSB from this reference; channels with no fractional part
+  // (alpha 0/255 inputs) must match it exactly.
+  function overRef(src: RGBA, dst: RGBA): RGBA {
+    const sa = src[3] / 255;
+    const da = dst[3] / 255;
+    const oa = sa + da * (1 - sa);
+    if (oa === 0) return [0, 0, 0, 0];
+    const ch = (s: number, d: number) => Math.round((((s / 255) * sa + (d / 255) * da * (1 - sa)) / oa) * 255);
+    return [ch(src[0], dst[0]), ch(src[1], dst[1]), ch(src[2], dst[2]), Math.round(oa * 255)];
+  }
+
+  // Assert the whole canvas: `inner` colour inside the rect, `outer` outside.
+  function expectRect(
+    data: Uint8Array,
+    w: number,
+    h: number,
+    rect: { left: number; top: number; w: number; h: number },
+    inner: RGBA,
+    outer: RGBA,
+  ) {
+    const mismatches: Array<{ x: number; y: number; got: number[]; want: RGBA }> = [];
+    for (let y = 0; y < h; y++) {
+      for (let x = 0; x < w; x++) {
+        const inside = x >= rect.left && x < rect.left + rect.w && y >= rect.top && y < rect.top + rect.h;
+        const want = inside ? inner : outer;
+        const got = rgbaAt(data, w, x, y);
+        if (got[0] !== want[0] || got[1] !== want[1] || got[2] !== want[2] || got[3] !== want[3]) {
+          mismatches.push({ x, y, got: [...got], want });
+        }
+      }
+    }
+    expect(mismatches).toEqual([]);
+  }
+
+  // ── over blend ──────────────────────────────────────────────────────────
+
+  test("over: 50%-alpha blue over opaque red matches the hand-computed Porter-Duff vector", async () => {
+    const { w, h, data } = await compositePixels(solidPng(4, 4, RED), [{ image: solidPng(4, 4, HALF_BLUE) }]);
+    expect([w, h]).toEqual([4, 4]);
+    for (let i = 0; i < data.length; i += 4) {
+      // aA = 128/255: r = 255·(1−aA) = 127.0 and b = 255·aA = 128.0 in exact
+      // arithmetic → (126..127, 0, 127..128, 255) depending on whether the
+      // fixed-point kernel floors ((255·127)>>8 = 126) or divides by 255 with
+      // round-half-up (127). Green and alpha admit no rounding at all.
+      expect(data[i]).toBeGreaterThanOrEqual(126);
+      expect(data[i]).toBeLessThanOrEqual(127);
+      expect(data[i + 1]).toBe(0);
+      expect(data[i + 2]).toBeGreaterThanOrEqual(127);
+      expect(data[i + 2]).toBeLessThanOrEqual(128);
+      expect(data[i + 3]).toBe(255);
+    }
+    // A full-cover solid-over-solid blend has no positional dependence.
+    for (let i = 4; i < data.length; i++) expect(data[i]).toBe(data[i % 4]);
+  });
+
+  test("over: opaque overlay replaces base pixels exactly", async () => {
+    const overlay = makePng(3, 3, (x, y) => [x * 40, y * 40, (x ^ y) * 30, 255]);
+    const { data } = await compositePixels(solidPng(3, 3, RED), [{ image: overlay }]);
+    expect([...data]).toEqual([...decodePngRaw(overlay).data]);
+  });
+
+  test("over: zero-alpha overlay is a pixel-exact no-op (its RGB must not bleed through)", async () => {
+    const base = makePng(3, 3, (x, y) => [x * 50, y * 50, 200, 255]);
+    const { data } = await compositePixels(base, [{ image: solidPng(3, 3, [255, 255, 0, 0]) }]);
+    expect([...data]).toEqual([...decodePngRaw(base).data]);
+  });
+
+  test("over blend tracks the premultiplied Porter-Duff reference across alpha combinations", async () => {
+    const cases: Array<{ src: RGBA; dst: RGBA }> = [
+      { src: [255, 255, 255, 64], dst: [0, 0, 0, 255] }, // quarter-white over black
+      { src: [200, 40, 90, 200], dst: [10, 250, 60, 255] }, // arbitrary colours, opaque base
+      { src: [50, 100, 150, 1], dst: [200, 60, 20, 255] }, // near-transparent overlay
+      // Semi-transparent BASE: separates correct premultiplied `over` from a
+      // naive straight-alpha lerp (which would put g≈155 here, not ≈96).
+      { src: [255, 0, 0, 100], dst: [0, 255, 0, 100] },
+      { src: [0, 0, 255, 128], dst: [255, 0, 0, 0] }, // fully transparent base
+    ];
+    for (const { src, dst } of cases) {
+      const { data } = await compositePixels(solidPng(2, 2, dst), [{ image: solidPng(2, 2, src) }]);
+      const got = [...rgbaAt(data, 2, 0, 0)];
+      const ref = overRef(src, dst);
+      // Result alpha: one rounding step. RGB: premultiply + blend + (when the
+      // result is non-opaque) an unpremultiply that amplifies intermediate
+      // rounding — hence the wider window there.
+      const rgbTol = ref[3] === 255 ? 2 : 3;
+      for (let c = 0; c < 4; c++) {
+        const tol = c === 3 ? 1 : rgbTol;
+        if (Math.abs(got[c] - ref[c]) > tol) {
+          expect({ src, dst, got }).toEqual({ src, dst, got: ref }); // readable failure
+        }
+      }
+    }
+  });
+
+  // ── gravity placement (sharp CalculateCrop math) ──────────────────────────
+
+  // 8×6 base, 3×3 overlay: both deltas are odd, so the `+1` in sharp's
+  // centring formula left=(inW−outW+1)/2 is load-bearing (3, not 2).
+  const gravityCases: Array<[string, number, number]> = [
+    ["centre", 3, 2],
+    ["center", 3, 2], // US-spelling alias
+    ["north", 3, 0],
+    ["northeast", 5, 0],
+    ["east", 5, 2],
+    ["southeast", 5, 3],
+    ["south", 3, 3],
+    ["southwest", 0, 3],
+    ["west", 0, 2],
+    ["northwest", 0, 0],
+  ];
+  test.each(gravityCases)(
+    "gravity '%s' places a 3×3 overlay on an 8×6 base at (%i, %i)",
+    async (gravity, left, top) => {
+      const { w, h, data } = await compositePixels(solidPng(8, 6, BLACK), [{ image: solidPng(3, 3, GREEN), gravity }]);
+      expect([w, h]).toEqual([8, 6]);
+      expectRect(data, 8, 6, { left, top, w: 3, h: 3 }, GREEN, BLACK);
+    },
+  );
+
+  test("default placement (no gravity, no top/left) is centre", async () => {
+    const { data } = await compositePixels(solidPng(8, 6, BLACK), [{ image: solidPng(3, 3, GREEN) }]);
+    expectRect(data, 8, 6, { left: 3, top: 2, w: 3, h: 3 }, GREEN, BLACK);
+  });
+
+  test("explicit top/left override gravity", async () => {
+    const { data } = await compositePixels(solidPng(8, 6, BLACK), [
+      { image: solidPng(3, 3, GREEN), gravity: "southeast", left: 1, top: 0 },
+    ]);
+    expectRect(data, 8, 6, { left: 1, top: 0, w: 3, h: 3 }, GREEN, BLACK);
+  });
+
+  // ── offset clipping ───────────────────────────────────────────────────────
+
+  test("negative top/left clip the overlay instead of erroring", async () => {
+    // Overlay pixel (ox,oy) lands at (left+ox, top+oy); with left=−2, top=−1
+    // only the ox=2, oy∈{1,2} column survives → green at (0,0) and (0,1).
+    const { data } = await compositePixels(solidPng(4, 4, RED), [{ image: solidPng(3, 3, GREEN), left: -2, top: -1 }]);
+    expectRect(data, 4, 4, { left: 0, top: 0, w: 1, h: 2 }, GREEN, RED);
+  });
+
+  test("offsets past the bottom-right edge clip", async () => {
+    const { data } = await compositePixels(solidPng(4, 4, RED), [{ image: solidPng(3, 3, GREEN), left: 2, top: 3 }]);
+    expectRect(data, 4, 4, { left: 2, top: 3, w: 2, h: 1 }, GREEN, RED);
+  });
+
+  test("a fully off-canvas overlay leaves the base untouched", async () => {
+    const base = makePng(4, 4, (x, y) => [x * 60, y * 60, 0, 255]);
+    const { data } = await compositePixels(base, [{ image: solidPng(3, 3, GREEN), left: -3, top: 0 }]);
+    expect([...data]).toEqual([...decodePngRaw(base).data]);
+  });
+
+  // ── oversized overlay rejection ───────────────────────────────────────────
+
+  test("an overlay larger than the base rejects with a clear error", async () => {
+    const base = solidPng(4, 4, BLACK);
+    for (const [ow, oh] of [
+      [5, 4], // wider only
+      [4, 6], // taller only
+      [9, 9], // both
+    ] as const) {
+      await expect(compositeBytes(base, [{ image: solidPng(ow, oh, GREEN) }])).rejects.toThrow(
+        /smaller|larger|exceed|dimension|fit|size/i,
+      );
+    }
+    // Boundary: exactly base-sized is allowed.
+    const { data } = await compositePixels(base, [{ image: solidPng(4, 4, GREEN) }]);
+    expect([...rgbaAt(data, 4, 0, 0)]).toEqual(GREEN);
+  });
+
+  // ── layer list semantics ──────────────────────────────────────────────────
+
+  test("repeat .composite() replaces the layer set (sharp semantics) and is chainable", async () => {
+    const img = new Bun.Image(solidPng(2, 2, BLACK));
+    expect(img.composite([{ image: solidPng(2, 2, RED) }])).toBe(img); // records + returns this
+    img.composite([{ image: solidPng(2, 2, HALF_BLUE) }]); // replaces, not appends
+    const { data } = decodePngRaw(await img.png().bytes());
+    // Half-blue over BLACK: had the red layer survived, r would be ≈127.
+    expect(data[0]).toBe(0);
+    expect(data[1]).toBe(0);
+    expect(data[2]).toBeGreaterThanOrEqual(127);
+    expect(data[2]).toBeLessThanOrEqual(128);
+    expect(data[3]).toBe(255);
+  });
+
+  test("layers in a single call stack bottom-to-top", async () => {
+    const base = solidPng(2, 2, BLACK);
+    const red = solidPng(2, 2, RED);
+    const halfBlue = solidPng(2, 2, HALF_BLUE);
+    // red (bottom) then half-blue (top) → red shows through at ≈half strength
+    let { data } = await compositePixels(base, [{ image: red }, { image: halfBlue }]);
+    expect(data[0]).toBeGreaterThanOrEqual(126);
+    expect(data[0]).toBeLessThanOrEqual(127);
+    expect(data[2]).toBeGreaterThanOrEqual(127);
+    expect(data[2]).toBeLessThanOrEqual(128);
+    // reversed: opaque red on top hides the blue completely
+    ({ data } = await compositePixels(base, [{ image: halfBlue }, { image: red }]));
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(RED);
+  });
+
+  // ── pipeline position & input forms ───────────────────────────────────────
+
+  test("composite runs after resize (final-canvas coordinates)", async () => {
+    // The 3×3 overlay would not fit the raw 2×2 base — it must be placed on
+    // the post-resize 8×8 canvas, exactly like sharp.
+    const { w, h, data } = decodePngRaw(
+      await new Bun.Image(solidPng(2, 2, BLACK))
+        .resize(8, 8)
+        .composite([{ image: solidPng(3, 3, GREEN), gravity: "northwest" }])
+        .png()
+        .bytes(),
+    );
+    expect([w, h]).toEqual([8, 8]);
+    expectRect(data, 8, 8, { left: 0, top: 0, w: 3, h: 3 }, GREEN, BLACK);
+  });
+
+  test("overlay accepts a Bun.Image instance and a file path", async () => {
+    const base = solidPng(2, 2, BLACK);
+    // Bun.Image instance
+    let { data } = await compositePixels(base, [{ image: new Bun.Image(solidPng(2, 2, GREEN)) }]);
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+    // path string
+    using dir = tempDir("image-composite-path", {});
+    const p = join(String(dir), "overlay.png");
+    await Bun.write(p, solidPng(2, 2, GREEN));
+    ({ data } = await compositePixels(base, [{ image: p }]));
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+  });
+
+  // ── raw-pixel-sourced Image overlays ─────────────────────────────────────
+  // A `new Bun.Image(buf, {raw})` overlay blends its pixel buffer directly —
+  // no encode round-trip, no sniff/decode on the worker.
+
+  test("raw-sourced Image overlay blends byte-identically to the same pixels PNG-encoded", async () => {
+    const w = 5;
+    const h = 4;
+    const px = new Uint8Array(w * h * 4);
+    for (let i = 0; i < w * h; i++) {
+      px[i * 4 + 0] = (i * 37) & 0xff;
+      px[i * 4 + 1] = (i * 91) & 0xff;
+      px[i * 4 + 2] = (i * 53) & 0xff;
+      px[i * 4 + 3] = (i * 29) & 0xff; // includes 0 and partial alphas
+    }
+    const base = makePng(8, 8, (x, y) => [x * 30, y * 30, 128, 255]);
+    const encoded = await new Bun.Image(px, { raw: { width: w, height: h, channels: 4 } }).png().bytes();
+    const viaRaw = await compositePixels(base, [
+      { image: new Bun.Image(px, { raw: { width: w, height: h, channels: 4 } }), top: 1, left: 2, opacity: 0.7 },
+    ]);
+    const viaPng = await compositePixels(base, [{ image: encoded, top: 1, left: 2, opacity: 0.7 }]);
+    expect([...viaRaw.data]).toEqual([...viaPng.data]);
+  });
+
+  test("raw-sourced overlay with channels: 3 blends as opaque RGB", async () => {
+    const rgb = new Uint8Array([255, 0, 0, 0, 255, 0, 0, 0, 255, 9, 9, 9]);
+    const overlay = new Bun.Image(rgb, { raw: { width: 2, height: 2, channels: 3 } });
+    const { data } = await compositePixels(solidPng(2, 2, BLACK), [{ image: overlay, top: 0, left: 0 }]);
+    expect([...data]).toEqual([255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 9, 9, 9, 255]);
+  });
+
+  test("raw-sourced overlay still enforces the oversized rule and the base's maxPixels", async () => {
+    const big = new Uint8Array(4 * 4 * 4).fill(255);
+    const overlay = new Bun.Image(big, { raw: { width: 4, height: 4, channels: 4 } });
+    // larger than the 2×2 base in both dimensions
+    await expect(compositeBytes(solidPng(2, 2, BLACK), [{ image: overlay }])).rejects.toThrow(
+      /same dimensions or smaller/,
+    );
+    // The base's maxPixels caps the overlay's pixel count even though the
+    // raw buffer was validated by ITS OWN constructor (whose roomier default
+    // cap accepted 8×9). The pixel-count guard fires before the dims rule,
+    // mirroring the decode path where maxPixels is checked pre-allocation.
+    const base = new Bun.Image(solidPng(8, 8, BLACK), { maxPixels: 8 * 8 });
+    const wide = new Uint8Array(8 * 9 * 4).fill(255);
+    const overLimit = new Bun.Image(wide, { raw: { width: 8, height: 9, channels: 4 } });
+    await expect(
+      base
+        .composite([{ image: overLimit }])
+        .png()
+        .bytes(),
+    ).rejects.toThrow(/TooManyPixels|pixel/i);
+    // sanity: a within-cap raw overlay (smaller than the base in both dims) works
+    const ok = new Bun.Image(big, { raw: { width: 4, height: 4, channels: 4 } });
+    await base
+      .composite([{ image: ok }])
+      .png()
+      .bytes();
+  });
+
+  // ── opacity (Bun extension) ──────────────────────────────────────────────
+  // Sharp has no per-layer opacity, so there is no fixture to diff against —
+  // these are hand-computed vectors. opacity scales the premultiplied overlay
+  // (colour AND alpha) before the `over` accumulate, so opaque-red-at-0.5
+  // must equal the 50%-alpha-red blend, not a straight RGB lerp.
+
+  test("opacity 0.5: opaque red over opaque green matches the hand-computed vector", async () => {
+    const { data } = await compositePixels(solidPng(2, 2, GREEN), [{ image: solidPng(2, 2, RED), opacity: 0.5 }]);
+    // Effective source alpha 255·0.5 → 128: r = 128·255/255 = 128 and
+    // g = 255·(127/255) = 127 in exact arithmetic. Allow ±1 on the blended
+    // channels for fixed-point rounding-mode changes; b and the opaque result
+    // alpha admit no rounding at all.
+    for (let y = 0; y < 2; y++) {
+      for (let x = 0; x < 2; x++) {
+        const [r, g, b, a] = rgbaAt(data, 2, x, y);
+        expect(Math.abs(r - 128)).toBeLessThanOrEqual(1);
+        expect(Math.abs(g - 127)).toBeLessThanOrEqual(1);
+        expect(b).toBe(0);
+        expect(a).toBe(255);
+      }
+    }
+  });
+
+  test("opacity 0 leaves the base pixel-exact", async () => {
+    const base = makePng(3, 3, (x, y) => [x * 50, y * 50, 200, 255]);
+    const { data } = await compositePixels(base, [{ image: solidPng(3, 3, RED), opacity: 0 }]);
+    expect([...data]).toEqual([...decodePngRaw(base).data]);
+  });
+
+  test("out-of-range and non-finite opacity clamp instead of erroring", async () => {
+    const base = solidPng(2, 2, GREEN);
+    const overlay = solidPng(2, 2, RED);
+    // > 1 clamps to 1; NaN/Infinity take the same identity policy as
+    // .modulate() — all three behave as full-strength overlay.
+    for (const opacity of [2, NaN, Infinity]) {
+      const { data } = await compositePixels(base, [{ image: overlay, opacity }]);
+      expect([...rgbaAt(data, 2, 0, 0)]).toEqual(RED);
+    }
+    // < 0 clamps to 0: base untouched.
+    const { data } = await compositePixels(base, [{ image: overlay, opacity: -1 }]);
+    expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+  });
+
+  // ── premultiplied input ──────────────────────────────────────────────────
+
+  test("premultiplied: true skips the premultiply pass — [128,0,0,128] ≡ straight [255,0,0,128]", async () => {
+    const base = solidPng(2, 2, GREEN);
+    const straight = await compositePixels(base, [{ image: solidPng(2, 2, [255, 0, 0, 128]) }]);
+    const prem = await compositePixels(base, [{ image: solidPng(2, 2, [128, 0, 0, 128]), premultiplied: true }]);
+    expect([...prem.data]).toEqual([...straight.data]);
+    // Sanity: blending actually happened (the result is not the bare base) …
+    expect([...rgbaAt(straight.data, 2, 0, 0)]).not.toEqual(GREEN);
+    // … and the flag is load-bearing: without it the same bytes premultiply
+    // AGAIN (128·128/255 ≈ 64), landing visibly darker.
+    const twice = await compositePixels(base, [{ image: solidPng(2, 2, [128, 0, 0, 128]) }]);
+    expect(rgbaAt(twice.data, 2, 0, 0)[0]).toBeLessThan(rgbaAt(prem.data, 2, 0, 0)[0]);
+  });
+
+  // ── argument validation (composite() parses eagerly, so all throws are
+  // synchronous — no terminal needed) ──────────────────────────────────────
+
+  test("composite() validates its arguments synchronously", () => {
+    const img = (): any => new Bun.Image(solidPng(2, 2, BLACK));
+    const overlay = solidPng(2, 2, GREEN);
+    // non-array argument
+    expect(() => img().composite({ image: overlay })).toThrow(/array/);
+    expect(() => img().composite()).toThrow(/array/);
+    // non-object layer
+    expect(() => img().composite([42])).toThrow(/object/);
+    // missing / null `image`
+    expect(() => img().composite([{}])).toThrow(/image/);
+    expect(() => img().composite([{ image: null }])).toThrow(/image/);
+    // top/left are both-or-neither (sharp semantics)
+    expect(() => img().composite([{ image: overlay, top: 1 }])).toThrow(/both/);
+    expect(() => img().composite([{ image: overlay, left: 1 }])).toThrow(/both/);
+    // unknown gravity / blend names
+    expect(() => img().composite([{ image: overlay, gravity: "middle" }])).toThrow(/gravity/);
+    expect(() => img().composite([{ image: overlay, blend: "multiply" }])).toThrow(/over/);
+  });
 });
 
 describe("Bun.Image clipboard statics", () => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1771,6 +1771,27 @@ describe("composite()", () => {
     expect([...rgbaAt(data, 4, 0, 0)]).toEqual(GREEN);
   });
 
+  test("oversized overlay error carries .code on both the async terminal and the sync Response path", async () => {
+    const make = () => new Bun.Image(solidPng(2, 2, BLACK)).composite([{ image: solidPng(3, 3, GREEN) }]);
+    // async terminal rejection
+    await expect(make().png().bytes()).rejects.toMatchObject({
+      code: "ERR_IMAGE_COMPOSITE_OVERSIZED",
+      message: expect.stringMatching(/same dimensions or smaller/),
+    });
+    // `new Response(image)` encodes synchronously on the JS thread — the same
+    // error, including `.code`, must surface there too.
+    let caught: any = null;
+    try {
+      new Response(make());
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toMatchObject({
+      code: "ERR_IMAGE_COMPOSITE_OVERSIZED",
+      message: expect.stringMatching(/same dimensions or smaller/),
+    });
+  });
+
   // ── layer list semantics ──────────────────────────────────────────────────
 
   test("repeat .composite() replaces the layer set (sharp semantics) and is chainable", async () => {
@@ -1828,6 +1849,38 @@ describe("composite()", () => {
     await Bun.write(p, solidPng(2, 2, GREEN));
     ({ data } = await compositePixels(base, [{ image: p }]));
     expect([...rgbaAt(data, 2, 0, 0)]).toEqual(GREEN);
+  });
+
+  test("JPEG overlay EXIF orientation follows the base's autoOrient", async () => {
+    // 4×2 black JPEG with a spliced APP1 Orientation=6 (90° CW) — the same
+    // splice as the metadata EXIF test. Upright it is 2 wide × 4 tall.
+    const jpg = await new Bun.Image(solidPng(4, 2, BLACK)).jpeg({ quality: 95 }).bytes();
+    // prettier-ignore
+    const tiff = new Uint8Array([
+      0x4d, 0x4d, 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, // header
+      0x00, 0x01,                                     // 1 entry
+      0x01, 0x12, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x06, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,                         // next IFD = 0
+    ]);
+    const exif = Buffer.concat([Buffer.from("Exif\0\0"), tiff]);
+    const seglen = exif.length + 2;
+    const app1 = Buffer.concat([Buffer.from([0xff, 0xe1, seglen >> 8, seglen & 255]), exif]);
+    const withExif = Buffer.concat([jpg.subarray(0, 2), app1, jpg.subarray(2)]);
+
+    const base = solidPng(6, 6, [255, 255, 255, 255]);
+    // autoOrient (default): blends upright — dark inside the 2×4 rect only.
+    const on = await compositePixels(base, [{ image: withExif, top: 0, left: 0 }]);
+    expect(rgbaAt(on.data, 6, 1, 3)[0]).toBeLessThan(80); // inside upright rect
+    expect(rgbaAt(on.data, 6, 3, 1)[0]).toBeGreaterThan(200); // outside it
+    // autoOrient: false on the base: stored orientation (4 wide × 2 tall).
+    const off = decodePngRaw(
+      await new Bun.Image(base, { autoOrient: false })
+        .composite([{ image: withExif, top: 0, left: 0 }])
+        .png()
+        .bytes(),
+    );
+    expect(rgbaAt(off.data, 6, 3, 1)[0]).toBeLessThan(80);
+    expect(rgbaAt(off.data, 6, 1, 3)[0]).toBeGreaterThan(200);
   });
 
   // ── raw-pixel-sourced Image overlays ─────────────────────────────────────


### PR DESCRIPTION
### What does this PR do?

Adds the two most-requested missing pieces for watermarking/overlay workflows in `Bun.Image`:

**Raw pixel I/O** (closes #30622)
- `img.pixels()` — async terminal returning the post-pipeline decoded RGBA8 as `{ data: Uint8Array, width, height, channels: 4 }`, no encode round-trip.
- `new Bun.Image(buf, { raw: { width, height, channels: 3 | 4 } })` — ingests raw pixels directly (3-channel input expands to RGBA). Length is validated against `width * height * channels` at construction.

**`composite()`** (the core of #30628)
- Sharp-shaped layer array, applied as the last pipeline stage (after resize/modulate, in final post-resize coordinates — same order as sharp):
  ```ts
  const out = await new Bun.Image(photo)
    .resize(1200)
    .composite([{ image: watermark, gravity: "southeast", opacity: 0.5 }])
    .jpeg()
    .bytes();
  ```
- v1 surface: blend `"over"`, `top`/`left` placement (both-or-neither, override gravity, negative offsets clip), `gravity` (centre + 8 compass points, sharp's CalculateCrop math), `premultiplied` inputs, and per-layer `opacity` (a documented deviation — sharp has no per-layer opacity and users hand-roll it through `.raw()`).
- Overlays accept `Image` instances (including raw-sourced ones, blended without re-encoding), encoded buffers/typed arrays, and path strings. Repeat `.composite()` calls replace, matching sharp. Overlays must be ≤ the base in both dimensions (sharp's rule) and are decoded under the same `maxPixels` guard as the base.
- Out of scope for v1 (documented): `{ text }`/SVG overlay inputs, animated composites, `tile`, blend modes beyond `"over"`, and ICC conversion before blending.

### Implementation

The blend kernel is a Highway TU (`src/jsc/bindings/image_composite.cpp`) with per-ISA runtime dispatch, same shell as `image_resize.cpp`. All math is exact 255-denominator fixed point — premultiply, `aR = aA + aB(1-aA)`, `cR = cA + cB(1-aA)`, unpremultiply — with a single round-half-up division per channel:

- **Opaque-base pixels** (the watermark-on-photo case): the denominator collapses to a constant, so the per-channel quotient becomes a Granlund-Montgomery multiply, `floor(t/65025) == (t * 33818121) >> 41`, computed across 4 i32 lanes per pixel with widening `MulEven`/`MulOdd` (PMULDQ/SMULL — universal on 128-bit targets). The constant is brute-force-verified exact over the kernel's full input range; notably the folklore `(y + (y>>8) + 1) >> 8` divide-by-255 trick is *not* exact in this range (first failure at 65535), which is why it's a magic multiply.
- **Non-opaque-base pixels**: exact scalar u64 path, same formula.

Integer-only math means output is byte-identical across platforms and ISAs (keeping the docs' byte-identical guarantee), and identical between the SIMD and scalar paths.

Raw-sourced overlays add a `CompositeInput::Raw` variant that copies the already-validated pixel buffer at call time and skips the worker's sniff/decode entirely.

### How did you verify your code works?

- `bun bd test test/js/bun/image/` — 271 pass / 0 fail across all 4 files.
- New differential suite in `image-kernels.test.ts`: an exact fixed-point reference implementation in JS, swept across the SIMD/scalar seam — mixed-alpha rows, odd (67px) widths for tail handling, two-edge clipping, hostile premultiplied colour > alpha, 6 opacity/premultiplied combos — byte-for-byte equal in all cases.
- Composite tests pin hand-computed Porter-Duff vectors (e.g. 50%-alpha blue over opaque red → exactly (127, 0, 128, 255)); gravity placement matches sharp's CalculateCrop; raw-sourced overlays blend byte-identically to the same pixels PNG-encoded.
- All new tests fail under `USE_SYSTEM_BUN=1` (composite/pixels don't exist there) and pass on this build.
- `bun-types` declaration tests pass (same pass/fail profile as main).

Closes #30622. Implements the core of #30628 (additional blend modes can follow as a separate PR).