### PR TITLE
valkey: adopt RESP payload allocation as Buffer backing store

### DIFF
--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -3,9 +3,7 @@
 //! `valkey/`; only the `JSGlobalObject`/`JSValue`-touching conversions live
 //! here so `valkey/` is JSC-free.
 
-use crate::jsc::{
-    Error as JscError, JSGlobalObject, JSValue, JsError, JsResult, bun_string_jsc,
-};
+use crate::jsc::{Error as JscError, JSGlobalObject, JSValue, JsError, JsResult, bun_string_jsc};
 use bun_valkey::valkey_protocol::{RESPValue, RedisError};
 
 // keep `protocol` referenced for sibling drafts

--- a/src/runtime/valkey_jsc/protocol_jsc.rs
+++ b/src/runtime/valkey_jsc/protocol_jsc.rs
@@ -4,7 +4,7 @@
 //! here so `valkey/` is JSC-free.
 
 use crate::jsc::{
-    ArrayBuffer, Error as JscError, JSGlobalObject, JSValue, JsError, JsResult, bun_string_jsc,
+    Error as JscError, JSGlobalObject, JSValue, JsError, JsResult, bun_string_jsc,
 };
 use bun_valkey::valkey_protocol::{RESPValue, RedisError};
 
@@ -75,12 +75,17 @@ pub struct ToJSOptions {
 
 fn valkey_str_to_js_value(
     global: &JSGlobalObject,
-    str: &[u8],
+    str: &mut Box<[u8]>,
     options: ToJSOptions,
 ) -> JsResult<JSValue> {
     if options.return_as_buffer {
-        // TODO: handle values > 4.7 GB
-        ArrayBuffer::create_buffer(global, str)
+        // The parser's payload is an owned allocation that is only converted
+        // once; adopt it as the Buffer backing store instead of copying it
+        // into a fresh ArrayBuffer.
+        Ok(JSValue::create_buffer_from_box(
+            global,
+            core::mem::take(str),
+        ))
     } else {
         bun_string_jsc::create_utf8_for_js(global, str)
     }
@@ -120,7 +125,7 @@ pub fn resp_value_to_js_with_options(
             RedisError::InvalidBlobError,
         )),
         RESPValue::VerbatimString(verbatim) => {
-            valkey_str_to_js_value(global, &verbatim.content, options)
+            valkey_str_to_js_value(global, &mut verbatim.content, options)
         }
         RESPValue::Map(entries) => {
             let js_obj = JSValue::create_empty_object_with_null_prototype(global);

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -145,3 +145,133 @@ test.concurrent("rejects a RESP simple-string reply whose line terminator never 
     }
   }
 });
+
+// Buffer-mode replies (`getBuffer` and friends) adopt the RESP parser's
+// payload allocation as the Buffer backing store instead of copying it. The
+// pointer is handed to JSC and freed by the ArrayBuffer deallocator when the
+// Buffer is collected, so an allocator mismatch or double free crashes —
+// especially under ASAN. Run a GC-heavy getBuffer workload against a mock
+// server and check both content integrity and a clean exit. Covers large,
+// pipelined, empty, null, and verbatim-string replies.
+test.concurrent("getBuffer replies survive GC with adopted backing stores intact", async () => {
+  const src = `
+    const net = require("node:net");
+
+    const CRLF = Buffer.from("\\r\\n");
+    const GET_FRAME = "*2\\r\\n$3\\r\\nGET\\r\\n$1\\r\\nk\\r\\n";
+    const replies = [];
+
+    function bulk(payload) {
+      return Buffer.concat([Buffer.from("$" + payload.length + "\\r\\n"), payload, CRLF]);
+    }
+
+    // Mock server: +OK to the HELLO handshake, then shift one queued reply
+    // per GET frame (frames may coalesce when commands are auto-pipelined).
+    let pending = "";
+    let saidHello = false;
+    const server = net.createServer(socket => {
+      socket.on("data", data => {
+        if (!saidHello) {
+          if (data.includes("HELLO")) {
+            saidHello = true;
+            socket.write("+OK\\r\\n");
+          }
+          return;
+        }
+        pending += data.toString("latin1");
+        while (pending.startsWith(GET_FRAME)) {
+          pending = pending.slice(GET_FRAME.length);
+          if (replies.length === 0) throw new Error("reply queue underflow");
+          socket.write(replies.shift());
+        }
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise((resolve, reject) => {
+      server.listen(0, "127.0.0.1", resolve);
+      server.on("error", reject);
+    });
+
+    const client = new Bun.RedisClient("redis://127.0.0.1:" + server.address().port, {
+      autoReconnect: false,
+      connectionTimeout: 5000,
+    });
+
+    function check(buf, size, seed, what) {
+      if (!(buf instanceof Uint8Array)) throw new Error(what + ": expected a Uint8Array");
+      if (buf.length !== size) throw new Error(what + ": length " + buf.length + " !== " + size);
+      for (const i of [0, size >> 1, size - 1]) {
+        if (buf[i] !== (seed & 0xff)) {
+          throw new Error(what + ": byte " + i + " is " + buf[i] + ", expected " + (seed & 0xff));
+        }
+      }
+    }
+
+    // Large payloads, sequential, collecting earlier replies while later ones
+    // are still arriving.
+    const LARGE = 1 << 20;
+    for (let i = 0; i < 4; i++) {
+      replies.push(bulk(Buffer.alloc(LARGE, i & 0xff)));
+      check(await client.getBuffer("k"), LARGE, i, "large #" + i);
+      if (i % 2 === 1) Bun.gc(true);
+    }
+
+    // Auto-pipelined batches of small payloads.
+    const SMALL = 1 << 16;
+    for (let batch = 0; batch < 5; batch++) {
+      const seeds = [];
+      for (let j = 0; j < 12; j++) {
+        const seed = batch * 12 + j;
+        seeds.push(seed);
+        replies.push(bulk(Buffer.alloc(SMALL, seed & 0xff)));
+      }
+      const bufs = await Promise.all(seeds.map(() => client.getBuffer("k")));
+      for (let j = 0; j < bufs.length; j++) {
+        check(bufs[j], SMALL, seeds[j], "batch " + batch + " #" + j);
+      }
+      Bun.gc(true);
+    }
+
+    // Zero-length reply: an empty box has no allocation to adopt or free.
+    for (let i = 0; i < 3; i++) {
+      replies.push(bulk(Buffer.alloc(0)));
+      const buf = await client.getBuffer("k");
+      if (!(buf instanceof Uint8Array) || buf.length !== 0) {
+        throw new Error("empty #" + i + ": expected a zero-length Uint8Array");
+      }
+    }
+
+    // Null bulk reply.
+    replies.push(Buffer.from("$-1\\r\\n"));
+    if ((await client.getBuffer("k")) !== null) throw new Error("expected null for $-1 reply");
+
+    // RESP3 verbatim string in buffer mode adopts verbatim.content.
+    for (let i = 0; i < 3; i++) {
+      const content = Buffer.alloc(1024, (77 + i) & 0xff);
+      const framed = Buffer.concat([Buffer.from("txt:"), content]);
+      replies.push(Buffer.concat([Buffer.from("=" + framed.length + "\\r\\n"), framed, CRLF]));
+      check(await client.getBuffer("k"), 1024, 77 + i, "verbatim #" + i);
+    }
+
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+
+    client.close();
+    server.close();
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

In buffer mode (`getBuffer` and friends), the RESP parser's owned payload (`Box<[u8]>`) was copied into a freshly allocated `ArrayBuffer` for every reply — one full-payload memcpy plus one (gigacage) allocation per reply, both unnecessary: the parser's value is converted to a JS value exactly once and then dropped.

This transfers the parser's allocation to JSC as the Buffer backing store instead (`JSValue::create_buffer_from_box`, the same adoption mechanism `Archive` and `NodeHTTPResponse` already use). String mode is unchanged (a WTF-string copy is inherent there).

Safety notes:

- Buffer mode only flows through `ValkeyCommand::resolve`, which converts a reply exactly once per promise; pub/sub delivery uses string mode. The `mem::take` leaves an empty box behind, so an (unreachable today) double conversion would produce an empty buffer, not a use-after-free.
- The deallocator (`MarkedArrayBuffer_deallocator` → default-allocator `free`) pairs with `Box`'s allocator in both release (mimalloc) and ASAN (libc) builds.
- Empty payloads take the `None`-deallocator arm (an empty `Box<[u8]>` has no backing allocation to free).

### Measured

Fixed-work benchmark (pipelined `getBuffer` of a single key, local redis 8.6.2, macOS arm64, release builds; CPU time and peak RSS for 20k × 1MB / 100k × 16KB ops):

| metric | main | this PR |
|---|---|---|
| 1MB getBuffer, CPU per op | 99-100 µs | **89-92 µs (~10% less)** |
| 1MB getBuffer, peak RSS | 380-431 MB | **~287 MB (25-33% less)** |
| 16KB getBuffer, CPU per op | 3.71 µs | 3.52 µs (~5% less) |
| string mode (any size) | — | unchanged (within noise) |

Wall-clock throughput was IO-bound at parity in this setup; the win is CPU per reply and allocation/GC pressure (one less large allocation and one less full-payload memcpy per buffer-mode reply).

### Tests

Added a regression test in `test/js/valkey/valkey-gc.test.ts` ("getBuffer replies survive GC with adopted backing stores intact"): a mock RESP server (no docker/redis dependency, so it runs on every CI lane including ASAN) drives a GC-heavy `getBuffer` workload covering large, auto-pipelined, empty, null, and RESP3 verbatim-string replies, collecting adopted buffers between replies and checking content integrity. An allocator mismatch or double free on the adopted-pointer path crashes it under ASAN. Note this guards the new free path rather than failing on main: the change is a pure perf optimization, and every spec-level observable of the resulting Buffer (contents, length, byteOffset, `.buffer` aliasing, detach/transfer semantics) is identical between the copy and adoption paths, so a fail-before test is not constructible — the only measurable differences are internal memory-accounting details, which aren't a contract a test should pin.

Also validated on the ASAN debug build against a local redis: binary/empty/1MiB round-trips, UTF-8 string mode, missing keys, and a 500-buffer GC stress dropping adopted buffers across 20 full GC cycles. The existing `test/js/valkey/` suite (including `unit/buffer-operations.test.ts`) covers buffer-mode behavior in CI.

