### PR TITLE
Implement source phase imports (TC39 Stage 3)

### DIFF
--- a/src/ast/e.rs
+++ b/src/ast/e.rs
@@ -2190,6 +2190,9 @@ pub struct Import {
     pub expr: ExprNodeIndex,
     pub options: ExprNodeIndex,
     pub import_record_index: u32,
+    /// TC39 import phase: `Source` for `import.source(...)`, otherwise
+    /// `Evaluation`. (`import.defer(...)` is not implemented yet.)
+    pub phase: crate::ImportPhase,
     // TODO:
     // Comments inside "import()" expressions have special meaning for Webpack.
     // Preserving comments inside these expressions makes it possible to use

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -2550,6 +2550,7 @@ impl Data {
                     expr: el.expr.deep_clone_no_detach(bump)?,
                     options: el.options.deep_clone_no_detach(bump)?,
                     import_record_index: el.import_record_index,
+                    phase: el.phase,
                 });
                 Ok(Data::EImport(StoreRef::from_bump(item)))
             }

--- a/src/ast/import_record.rs
+++ b/src/ast/import_record.rs
@@ -33,6 +33,10 @@ pub struct ImportRecord {
     /// Pack all boolean flags into 2 bytes to reduce padding overhead.
     /// Previously 15 separate bool fields caused ~14-16 bytes of padding waste.
     pub flags: Flags,
+
+    /// TC39 import phase of this record (`import defer ...` /
+    /// `import source ...` / `import.source(...)`).
+    pub phase: ImportPhase,
 }
 
 bitflags::bitflags! {
@@ -96,11 +100,28 @@ bitflags::bitflags! {
         const WRAP_WITH_TO_ESM = 1 << 13;
         const WRAP_WITH_TO_COMMONJS = 1 << 14;
 
-        /// "import defer * as ns from 'path'" — defer evaluation of the
-        /// imported module until a property on the namespace object is
-        /// accessed. Requires `CONTAINS_IMPORT_STAR`.
-        const PHASE_DEFER = 1 << 15;
+        // bit 15 (_padding: u1) intentionally unused
     }
+}
+
+/// Import phase of a record — which representation of the requested module
+/// the import binds (TC39 "import phases").
+#[repr(u8)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Default)]
+pub enum ImportPhase {
+    /// `import x from 'path'` / `import('path')` — the evaluated module.
+    #[default]
+    Evaluation = 0,
+    /// `import defer * as ns from 'path'` — the module is fetched and linked
+    /// eagerly but only evaluated when a property on the namespace object is
+    /// accessed. Requires `CONTAINS_IMPORT_STAR`.
+    /// https://tc39.es/proposal-defer-import-eval/
+    Defer = 1,
+    /// `import source x from 'path'` / `import.source('path')` — the compiled
+    /// module source (a `WebAssembly.Module`); the module is never
+    /// instantiated or evaluated.
+    /// https://tc39.es/proposal-source-phase-imports/
+    Source = 2,
 }
 
 pub type List<'a> = bun_alloc::ArenaVec<'a, ImportRecord>;

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3215,7 +3215,7 @@ pub use ast_result::{
     TopLevelSymbolToParts, TsEnumsMap,
 };
 pub use import_record::{
-    Flags as ImportRecordFlags, ImportRecord, PrintMode as ImportRecordPrintMode,
+    Flags as ImportRecordFlags, ImportPhase, ImportRecord, PrintMode as ImportRecordPrintMode,
     Tag as ImportRecordTag,
 };
 pub use loader::{Loader, LoaderHashTable, LoaderOptional, SideEffects};

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -192,6 +192,7 @@ pub struct Switch {
 ///    import defaultItem, {item1, item2} from 'path'
 ///    import defaultItem, * as ns from 'path'
 ///    import defer * as ns from 'path'
+///    import source defaultItem from 'path'
 ///
 /// Many parts are optional and can be combined in different ways. The only
 /// restriction is that you cannot have both a clause and a star namespace.
@@ -208,10 +209,11 @@ pub struct Import {
     pub star_name_loc: crate::Loc,     // = Loc::EMPTY
     pub import_record_index: u32,
     pub is_single_line: bool, // = false
-    /// "import defer * as ns from 'path'" — the TC39 Deferred Module Evaluation
-    /// proposal. Only valid with a namespace import (`star_name_loc` is set,
-    /// `default_name`/`items` are empty).
-    pub phase_defer: bool, // = false
+    /// TC39 import phase. `Defer` is only valid with a namespace import
+    /// (`star_name_loc` is set, `default_name`/`items` are empty); `Source`
+    /// is only valid with a default binding (`default_name` is set,
+    /// `star_name_loc` is `None`, `items` are empty).
+    pub phase: crate::ImportPhase, // = Evaluation
 }
 
 impl Default for Import {
@@ -223,7 +225,7 @@ impl Default for Import {
             star_name_loc: crate::Loc::EMPTY,
             import_record_index: u32::MAX,
             is_single_line: false,
-            phase_defer: false,
+            phase: crate::ImportPhase::Evaluation,
         }
     }
 }

--- a/src/ast/s.rs
+++ b/src/ast/s.rs
@@ -212,7 +212,7 @@ pub struct Import {
     /// TC39 import phase. `Defer` is only valid with a namespace import
     /// (`star_name_loc` is set, `default_name`/`items` are empty); `Source`
     /// is only valid with a default binding (`default_name` is set,
-    /// `star_name_loc` is `None`, `items` are empty).
+    /// `star_name_loc` is empty, `items` are empty).
     pub phase: crate::ImportPhase, // = Evaluation
 }
 

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -178,6 +178,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
             source_index: Default::default(),
             original_path: b"",
             flags: Default::default(),
+            phase: Default::default(),
         });
         Ok(u32::try_from(index).expect("int cast"))
     }

--- a/src/bundler/HTMLScanner.rs
+++ b/src/bundler/HTMLScanner.rs
@@ -79,6 +79,7 @@ impl<'a> HTMLScanner<'a> {
             source_index: AstIndex::default(),
             original_path: b"",
             flags: ImportRecordFlags::default(),
+            phase: Default::default(),
         };
 
         self.import_records.push(record);

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -152,6 +152,7 @@ pub fn post_process_js_chunk(
                 source_index: Index::INVALID,
                 original_path: b"",
                 flags: ImportRecordFlags::default(),
+                phase: Default::default(),
             });
         }
 

--- a/src/bundler/linker_context/prepareCssAstsForChunk.rs
+++ b/src/bundler/linker_context/prepareCssAstsForChunk.rs
@@ -172,6 +172,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                             source_index: AstIndex::default(),
                             original_path: b"",
                             flags: ImportRecordFlags::default(),
+                            phase: Default::default(),
                         });
 
                         // Handling a chain of nested conditions is complicated. We can't
@@ -302,6 +303,7 @@ fn prepare_css_asts_for_chunk_impl(c: &LinkerContext, chunk: &mut Chunk, bump: &
                         source_index: AstIndex::default(),
                         original_path: b"",
                         flags: ImportRecordFlags::default(),
+                        phase: Default::default(),
                     });
 
                     css_chunk.asts[i] = BundlerStyleSheet {

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -920,6 +920,7 @@ impl<'a> CustomAtRuleParser for BundlerAtRuleParser<'a> {
             source_index: Default::default(),
             original_path: b"",
             flags: Default::default(),
+            phase: Default::default(),
         });
     }
 
@@ -2961,6 +2962,7 @@ mod stylesheet_impl {
                             source_index: Default::default(),
                             original_path: b"",
                             flags: Default::default(),
+                            phase: Default::default(),
                         });
                         // Move the rule out via `mem::replace` (no `Clone`
                         // bound needed) and push that.
@@ -3477,6 +3479,7 @@ impl<'a> Parser<'a> {
                 source_index: Default::default(),
                 original_path: b"",
                 flags: Default::default(),
+                phase: Default::default(),
             });
             Ok(idx)
         } else {

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -498,7 +498,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 items,
                 namespace_ref,
                 star_name_loc,
-                phase_defer: false,
+                phase: bun_ast::ImportPhase::Evaluation,
             },
             loc,
         ));

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3958,6 +3958,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let new_record = &records[new_index];
             let conflict = records[..new_index].iter().any(|record| {
                 record.kind == ImportKind::Stmt
+                    // Macro-import records (the `is_macro` fast path and
+                    // bunfig `[macros]` remapping below) are compile-time
+                    // only: the statement becomes `S::Empty` and the
+                    // record is `IS_UNUSED` / `Macro::NAMESPACE`, so it
+                    // never reaches JSC's requested-modules list and
+                    // cannot collide with a source-phase request.
+                    && record.path.namespace != crate::Macro::NAMESPACE
                     && matches!(
                         (record.phase, new_record.phase),
                         (ImportPhase::Source, ImportPhase::Evaluation)

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3930,6 +3930,57 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Only assert above; do not actually pop.
     }
 
+    /// JSC dedups a module record's requested modules by
+    /// (specifier, ModulePhase) — ignoring import attributes — and the
+    /// source phase is lowered onto an Evaluation-phase request with
+    /// WebAssembly fetch parameters. A single file therefore cannot request
+    /// both the module source and the evaluated module of the same
+    /// specifier: whichever statement came first would win and the other
+    /// binding would silently receive the wrong value. Surface the conflict
+    /// as a parse error instead. (Imports from *different* files are
+    /// unaffected — the module map keys on the fetch-parameter type.)
+    ///
+    /// Called for every statement-kind record — `import` declarations and
+    /// `export ... from` — right after it is appended; gated on
+    /// `has_source_phase_import_stmt` so files without source phase imports
+    /// pay a single bool check per statement.
+    pub fn check_source_phase_conflict(
+        &mut self,
+        new_record_index: u32,
+    ) -> Result<(), bun_core::Error> {
+        if !self.has_source_phase_import_stmt {
+            return Ok(());
+        }
+        use bun_ast::ImportPhase;
+        let new_index = new_record_index as usize;
+        let (conflict, range, path_text) = {
+            let records = self.import_records.items();
+            let new_record = &records[new_index];
+            let conflict = records[..new_index].iter().any(|record| {
+                record.kind == ImportKind::Stmt
+                    && matches!(
+                        (record.phase, new_record.phase),
+                        (ImportPhase::Source, ImportPhase::Evaluation)
+                            | (ImportPhase::Evaluation, ImportPhase::Source)
+                    )
+                    && record.path.text == new_record.path.text
+            });
+            (conflict, new_record.range, new_record.path.text)
+        };
+        if conflict {
+            self.log().add_range_error_fmt(
+                Some(self.source),
+                range,
+                format_args!(
+                    "Cannot import {} at both source phase and evaluation phase in the same file",
+                    bun_core::fmt::format_json_string_latin1(path_text),
+                ),
+            );
+            return Err(bun_core::err!("SyntaxError"));
+        }
+        Ok(())
+    }
+
     pub fn process_import_statement(
         &mut self,
         stmt_: S::Import,
@@ -4073,46 +4124,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         self.import_records.items_mut()[stmt.import_record_index as usize].phase = stmt.phase;
 
-        // JSC dedups a module record's requested modules by
-        // (specifier, ModulePhase) — ignoring import attributes — and the
-        // source phase is lowered onto an Evaluation-phase request with
-        // WebAssembly fetch parameters. A single file therefore cannot
-        // request both the module source and the evaluated module of the
-        // same specifier: whichever statement came first would win and the
-        // other binding would silently receive the wrong value. Surface the
-        // conflict as a parse error instead. (Imports from *different* files
-        // are unaffected — the module map keys on the fetch-parameter type.)
         if stmt.phase == bun_ast::ImportPhase::Source {
             self.has_source_phase_import_stmt = true;
         }
-        if self.has_source_phase_import_stmt {
-            use bun_ast::ImportPhase;
-            let new_index = stmt.import_record_index as usize;
-            let records = self.import_records.items();
-            let new_record = &records[new_index];
-            let conflict = records[..new_index].iter().any(|record| {
-                record.kind == ImportKind::Stmt
-                    && matches!(
-                        (record.phase, new_record.phase),
-                        (ImportPhase::Source, ImportPhase::Evaluation)
-                            | (ImportPhase::Evaluation, ImportPhase::Source)
-                    )
-                    && record.path.text == new_record.path.text
-            });
-            if conflict {
-                let range = new_record.range;
-                self.log().add_range_error_fmt(
-                    Some(self.source),
-                    range,
-                    format_args!(
-                        "Cannot import {} at both source phase and evaluation phase in the same \
-                         file",
-                        bun_core::fmt::format_json_string_latin1(path.text),
-                    ),
-                );
-                return Err(bun_core::err!("SyntaxError"));
-            }
-        }
+        self.check_source_phase_conflict(stmt.import_record_index)?;
 
         if let Some(star) = stmt.star_name_loc.to_nullable() {
             let name = self.load_name_from_ref(stmt.namespace_ref);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3990,15 +3990,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<Stmt, bun_core::Error> {
         let is_macro =
             Self::ALLOW_MACROS && (path.is_macro || crate::Macro::is_macro_path(path.text));
+        let macro_remap = if Self::ALLOW_MACROS {
+            self.options
+                .macro_context
+                .as_deref()
+                .and_then(|ctx| ctx.get_remap(path.text))
+        } else {
+            None
+        };
         let mut stmt = stmt_;
-        // The macro fast path below runs before `stmt.phase` is written to
-        // the import record, so `import source x from "./y" with { type:
-        // "macro" }` (or the `macro:` prefix) would register the binding as
-        // a macro ref and silently drop the source phase. No macro can
-        // produce a module source, and defer has nothing to defer for a
-        // compile-time binding, so reject both combinations with a clear
-        // error instead of a confusing macro-expansion failure.
-        if is_macro && stmt.phase != bun_ast::ImportPhase::Evaluation {
+        // The macro fast paths below (explicit `with { type: "macro" }` /
+        // `macro:` prefix, or a bunfig `[macros]` remap for this specifier)
+        // register the binding as a compile-time macro ref and drop the
+        // statement before `stmt.phase` is written to the import record. No
+        // macro can produce a module source, and defer has nothing to defer
+        // for a compile-time binding, so reject the combination with a clear
+        // error instead of silently executing the macro.
+        if (is_macro || macro_remap.is_some()) && stmt.phase != bun_ast::ImportPhase::Evaluation {
             let phase_name: &[u8] = match stmt.phase {
                 bun_ast::ImportPhase::Source => b"\"import source\"",
                 bun_ast::ImportPhase::Defer => b"\"import defer\"",
@@ -4110,15 +4118,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // Return empty statement - the import is completely removed
             return Ok(self.s(S::Empty {}, loc));
         }
-
-        let macro_remap = if Self::ALLOW_MACROS {
-            self.options
-                .macro_context
-                .as_deref()
-                .and_then(|ctx| ctx.get_remap(path.text))
-        } else {
-            None
-        };
 
         // `import defer` grammatically admits only `* as ns` (no default
         // binding, no named clause) and `import source` only a default

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3991,6 +3991,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let is_macro =
             Self::ALLOW_MACROS && (path.is_macro || crate::Macro::is_macro_path(path.text));
         let mut stmt = stmt_;
+        // The macro fast path below runs before `stmt.phase` is written to
+        // the import record, so `import source x from "./y" with { type:
+        // "macro" }` (or the `macro:` prefix) would register the binding as
+        // a macro ref and silently drop the source phase. No macro can
+        // produce a module source, and defer has nothing to defer for a
+        // compile-time binding, so reject both combinations with a clear
+        // error instead of a confusing macro-expansion failure.
+        if is_macro && stmt.phase != bun_ast::ImportPhase::Evaluation {
+            let phase_name: &[u8] = match stmt.phase {
+                bun_ast::ImportPhase::Source => b"\"import source\"",
+                bun_ast::ImportPhase::Defer => b"\"import defer\"",
+                bun_ast::ImportPhase::Evaluation => unreachable!(),
+            };
+            self.log().add_range_error_fmt(
+                Some(self.source),
+                js_lexer::range_of_identifier(self.source, loc),
+                format_args!(
+                    "{} cannot be combined with a macro import",
+                    bstr::BStr::new(phase_name),
+                ),
+            );
+            return Err(bun_core::err!("SyntaxError"));
+        }
         if is_macro {
             let id = self.add_import_record(ImportKind::Stmt, path.loc, path.text);
             self.import_records.items_mut()[id as usize].path.namespace = crate::Macro::NAMESPACE;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4168,7 +4168,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if stmt.phase == bun_ast::ImportPhase::Source {
             self.has_source_phase_import_stmt = true;
         }
-        self.check_source_phase_conflict(stmt.import_record_index)?;
 
         if let Some(star) = stmt.star_name_loc.to_nullable() {
             let name = self.load_name_from_ref(stmt.namespace_ref);
@@ -4395,6 +4394,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a.
             item_refs.shrink_and_free(stmt.items.len() + usize::from(stmt.default_name.is_some()));
         }
+
+        // Defer the same-file source/evaluation conflict check to here,
+        // after the bunfig `[macros]` remap path has had a chance to drop
+        // the statement entirely: when every binding is remapped the
+        // record becomes `Macro::NAMESPACE` / `IS_UNUSED` and `S::Empty`
+        // above, so it never reaches JSC's requested-modules list and
+        // cannot conflict with a source-phase request.
+        self.check_source_phase_conflict(stmt.import_record_index)?;
 
         if path.import_tag != bun_ast::ImportRecordTag::None || path.loader.is_some() {
             self.validate_and_set_import_type(&path, &mut stmt)?;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4097,6 +4097,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // that provides static feature flag checking at bundle time.
         // We handle it here at parse time (similar to macros) rather than at visit time.
         if path.text == b"bun:bundle" {
+            // This fast path also returns `S::Empty` before `stmt.phase` is
+            // read, and `bun:bundle` is a compile-time pseudo-module with
+            // neither a module source nor anything to defer, so reject the
+            // phase forms rather than silently dropping their bindings.
+            if stmt.phase != bun_ast::ImportPhase::Evaluation {
+                let phase_name: &[u8] = match stmt.phase {
+                    bun_ast::ImportPhase::Source => b"\"import source\"",
+                    bun_ast::ImportPhase::Defer => b"\"import defer\"",
+                    bun_ast::ImportPhase::Evaluation => unreachable!(),
+                };
+                self.log().add_range_error_fmt(
+                    Some(self.source),
+                    js_lexer::range_of_identifier(self.source, loc),
+                    format_args!(
+                        "{} cannot be used with \"bun:bundle\"",
+                        bstr::BStr::new(phase_name),
+                    ),
+                );
+                return Err(bun_core::err!("SyntaxError"));
+            }
             // Look for the "feature" import and validate specifiers
             // arena-owned `StoreSlice<ClauseItem>` valid for parser 'a;
             // loop body only reads from `item`, so a shared borrow suffices and

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -231,6 +231,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub has_top_level_return: bool,
     pub latest_return_had_semicolon: bool,
     pub has_import_meta: bool,
+    /// True once a static `import source ...` statement was parsed — gates
+    /// the per-statement duplicate-specifier scan in
+    /// `process_import_statement` so files without source phase imports pay
+    /// a single bool check.
+    pub has_source_phase_import_stmt: bool,
     pub has_es_module_syntax: bool,
     pub top_level_await_keyword: bun_ast::Range,
     pub fn_or_arrow_data_parse: FnOrArrowDataParse,
@@ -1094,6 +1099,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 self.import_records.items_mut()[import_record_index as usize].loader = Some(loader);
             }
 
+            self.import_records.items_mut()[import_record_index as usize].phase =
+                state.import_phase;
+
             self.import_records.items_mut()[import_record_index as usize]
                 .flags
                 .set(
@@ -1109,6 +1117,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     expr: arg,
                     import_record_index,
                     options: state.import_options,
+                    phase: state.import_phase,
                 },
                 state.loc,
             );
@@ -1132,6 +1141,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 expr: arg,
                 options: state.import_options,
                 import_record_index: u32::MAX,
+                phase: state.import_phase,
             },
             state.loc,
         )
@@ -2065,7 +2075,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 is_single_line: true,
                 default_name: None,
                 star_name_loc: bun_ast::Loc::EMPTY,
-                phase_defer: false,
+                phase: bun_ast::ImportPhase::Evaluation,
             },
             bun_ast::Loc::default(),
         );
@@ -2201,7 +2211,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 is_single_line: true,
                 default_name: None,
                 star_name_loc: bun_ast::Loc::EMPTY,
-                phase_defer: false,
+                phase: bun_ast::ImportPhase::Evaluation,
             },
             bun_ast::Loc::default(),
         );
@@ -2360,7 +2370,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     is_single_line: false,
                     default_name: None,
                     star_name_loc: bun_ast::Loc::EMPTY,
-                    phase_defer: false,
+                    phase: bun_ast::ImportPhase::Evaluation,
                 },
                 bun_ast::Loc::EMPTY,
             )
@@ -4036,17 +4046,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             None
         };
 
-        // `import defer` grammatically admits only `* as ns` — no default
-        // binding, no named clause. The parser guarantees this by
+        // `import defer` grammatically admits only `* as ns` (no default
+        // binding, no named clause) and `import source` only a default
+        // binding (no star, no named clause). The parser guarantees this by
         // construction; assert it here so any future S::Import producer
-        // that sets `phase_defer` without upholding the shape is caught
+        // that sets a phase without upholding the shape is caught
         // immediately rather than surfacing as odd printer output.
-        debug_assert!(
-            !stmt.phase_defer
-                || (!stmt.star_name_loc.is_empty()
+        debug_assert!(match stmt.phase {
+            bun_ast::ImportPhase::Evaluation => true,
+            bun_ast::ImportPhase::Defer =>
+                !stmt.star_name_loc.is_empty()
                     && stmt.default_name.is_none()
-                    && stmt.items.is_empty())
-        );
+                    && stmt.items.is_empty(),
+            bun_ast::ImportPhase::Source =>
+                stmt.default_name.is_some()
+                    && stmt.star_name_loc.is_empty()
+                    && stmt.items.is_empty(),
+        });
 
         stmt.import_record_index = self.add_import_record(ImportKind::Stmt, path.loc, path.text);
         self.import_records.items_mut()[stmt.import_record_index as usize]
@@ -4055,9 +4071,48 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 bun_ast::ImportRecordFlags::WAS_ORIGINALLY_BARE_IMPORT,
                 was_originally_bare_import,
             );
-        self.import_records.items_mut()[stmt.import_record_index as usize]
-            .flags
-            .set(bun_ast::ImportRecordFlags::PHASE_DEFER, stmt.phase_defer);
+        self.import_records.items_mut()[stmt.import_record_index as usize].phase = stmt.phase;
+
+        // JSC dedups a module record's requested modules by
+        // (specifier, ModulePhase) — ignoring import attributes — and the
+        // source phase is lowered onto an Evaluation-phase request with
+        // WebAssembly fetch parameters. A single file therefore cannot
+        // request both the module source and the evaluated module of the
+        // same specifier: whichever statement came first would win and the
+        // other binding would silently receive the wrong value. Surface the
+        // conflict as a parse error instead. (Imports from *different* files
+        // are unaffected — the module map keys on the fetch-parameter type.)
+        if stmt.phase == bun_ast::ImportPhase::Source {
+            self.has_source_phase_import_stmt = true;
+        }
+        if self.has_source_phase_import_stmt {
+            use bun_ast::ImportPhase;
+            let new_index = stmt.import_record_index as usize;
+            let records = self.import_records.items();
+            let new_record = &records[new_index];
+            let conflict = records[..new_index].iter().any(|record| {
+                record.kind == ImportKind::Stmt
+                    && matches!(
+                        (record.phase, new_record.phase),
+                        (ImportPhase::Source, ImportPhase::Evaluation)
+                            | (ImportPhase::Evaluation, ImportPhase::Source)
+                    )
+                    && record.path.text == new_record.path.text
+            });
+            if conflict {
+                let range = new_record.range;
+                self.log().add_range_error_fmt(
+                    Some(self.source),
+                    range,
+                    format_args!(
+                        "Cannot import {} at both source phase and evaluation phase in the same \
+                         file",
+                        bun_core::fmt::format_json_string_latin1(path.text),
+                    ),
+                );
+                return Err(bun_core::err!("SyntaxError"));
+            }
+        }
 
         if let Some(star) = stmt.star_name_loc.to_nullable() {
             let name = self.load_name_from_ref(stmt.namespace_ref);
@@ -5099,6 +5154,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             source_index: bun_ast::Index::INVALID,
             original_path: b"",
             flags: bun_ast::ImportRecordFlags::empty(),
+            phase: bun_ast::ImportPhase::Evaluation,
         });
         u32::try_from(index).expect("int cast")
     }
@@ -9095,6 +9151,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_top_level_return: false,
             latest_return_had_semicolon: false,
             has_import_meta: false,
+            has_source_phase_import_stmt: false,
             has_es_module_syntax: false,
             top_level_await_keyword: bun_ast::Range::NONE,
             fn_or_arrow_data_parse,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4000,13 +4000,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
         let mut stmt = stmt_;
         // The macro fast paths below (explicit `with { type: "macro" }` /
-        // `macro:` prefix, or a bunfig `[macros]` remap for this specifier)
-        // register the binding as a compile-time macro ref and drop the
-        // statement before `stmt.phase` is written to the import record. No
-        // macro can produce a module source, and defer has nothing to defer
-        // for a compile-time binding, so reject the combination with a clear
-        // error instead of silently executing the macro.
-        if (is_macro || macro_remap.is_some()) && stmt.phase != bun_ast::ImportPhase::Evaluation {
+        // `macro:` prefix, or a bunfig `[macros]` remap of this specifier's
+        // default export) register the binding as a compile-time macro ref
+        // and drop the statement before `stmt.phase` is written to the
+        // import record. No macro can produce a module source, and defer
+        // has nothing to defer for a compile-time binding, so reject the
+        // combination with a clear error instead of silently executing the
+        // macro. A bunfig remap only contributes when it would actually be
+        // consumed: star bindings are never remapped (the `star_name_loc`
+        // branch below leaves `macro_remap` unread), so `import defer` is
+        // only affected by an explicit `is_macro` trigger; `import source`
+        // has only a default binding, so a remap with no `"default"` key
+        // leaves it untouched.
+        let remap_hits_phase = match stmt.phase {
+            bun_ast::ImportPhase::Source => {
+                macro_remap.is_some_and(|m| m.get(b"default").is_some())
+            }
+            bun_ast::ImportPhase::Defer | bun_ast::ImportPhase::Evaluation => false,
+        };
+        if (is_macro || remap_hits_phase) && stmt.phase != bun_ast::ImportPhase::Evaluation {
             let phase_name: &[u8] = match stmt.phase {
                 bun_ast::ImportPhase::Source => b"\"import source\"",
                 bun_ast::ImportPhase::Defer => b"\"import defer\"",

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1249,7 +1249,7 @@ impl<'a> Parser<'a> {
                             default_name: None,
                             items: bun_ast::StoreSlice::EMPTY,
                             is_single_line: false,
-                            phase_defer: false,
+                            phase: bun_ast::ImportPhase::Evaluation,
                         },
                         ns_loc,
                     );
@@ -2048,7 +2048,7 @@ impl<'a> Parser<'a> {
                         default_name: None,
                         star_name_loc: bun_ast::Loc::EMPTY,
                         is_single_line: false,
-                        phase_defer: false,
+                        phase: bun_ast::ImportPhase::Evaluation,
                     },
                     bun_ast::Loc::EMPTY,
                 );

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -15,9 +15,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut phase = bun_ast::ImportPhase::Evaluation;
         // Parse an "import.meta" or "import.source" expression
         if p.lexer.token == T::TDot {
-            p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
             p.lexer.next()?;
             if p.lexer.is_contextual_keyword(b"meta") {
+                // Only `import.meta` implies the Module goal. `import.source(...)`
+                // belongs to the ImportCall production and, like plain
+                // `import(...)`, is also valid with the Script goal, so it must
+                // not mark the file as ESM.
+                p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
                 p.lexer.next()?;
                 p.has_import_meta = true;
                 return Ok(p.new_expr(E::ImportMeta {}, loc));

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -12,7 +12,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// Note: The caller has already parsed the "import" keyword
     pub fn parse_import_expr(&mut self, loc: bun_ast::Loc, level: Level) -> Result<Expr, Error> {
         let p = self;
-        // Parse an "import.meta" expression
+        let mut phase = bun_ast::ImportPhase::Evaluation;
+        // Parse an "import.meta" or "import.source" expression
         if p.lexer.token == T::TDot {
             p.esm_import_keyword = js_lexer::range_of_identifier(p.source, loc);
             p.lexer.next()?;
@@ -20,8 +21,27 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 p.has_import_meta = true;
                 return Ok(p.new_expr(E::ImportMeta {}, loc));
+            } else if p.lexer.is_contextual_keyword(b"source") {
+                // "import.source(specifier)"
+                // https://tc39.es/proposal-source-phase-imports/
+                // `is_contextual_keyword` compares the raw token, so
+                // `import.sourc\u0065` is rejected below like any other name.
+                p.lexer.next()?;
+                // See the matching check for static `import source` in
+                // parse_stmt: the bundler has no representation for a module
+                // source.
+                if p.options.bundle {
+                    let r = js_lexer::range_of_identifier(p.source, loc);
+                    p.log().add_range_error(
+                        Some(p.source),
+                        r,
+                        b"\"import.source\" is not supported when bundling",
+                    );
+                    return Err(bun_core::err!("SyntaxError"));
+                }
+                phase = bun_ast::ImportPhase::Source;
             } else {
-                p.lexer.expected_string(b"\"meta\"")?;
+                p.lexer.expected_string(b"\"meta\" or \"source\"")?;
             }
         }
 
@@ -54,6 +74,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             p.lexer.next()?;
 
             if p.lexer.token != T::TCloseParen {
+                if phase == bun_ast::ImportPhase::Source {
+                    // The lowering for `import.source()` injects its own
+                    // import attributes (`with { type: "webassembly" }`),
+                    // which cannot be merged with an arbitrary options
+                    // expression at compile time.
+                    let r = js_lexer::range_of_identifier(p.source, loc);
+                    p.log().add_range_error(
+                        Some(p.source),
+                        r,
+                        b"\"import.source\" does not support a second argument",
+                    );
+                    return Err(bun_core::err!("SyntaxError"));
+                }
                 // "import('./foo.json', { assert: { type: 'json' } })"
                 import_options = p.parse_expr(Level::Comma)?;
 
@@ -83,11 +116,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if let Some(slice) = slice_opt {
                 let import_record_index =
                     p.add_import_record(bun_ast::ImportKind::Dynamic, value.loc, slice);
+                p.import_records.items_mut()[import_record_index as usize].phase = phase;
                 return Ok(p.new_expr(
                     E::Import {
                         expr: value,
                         import_record_index,
                         options: import_options,
+                        phase,
                     },
                     loc,
                 ));
@@ -102,6 +137,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // .leading_interior_comments = comments,
                 import_record_index: u32::MAX,
                 options: import_options,
+                phase,
             },
             loc,
         ))

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1205,6 +1205,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     // TODO: import assertions
                     // path.assertions
                 );
+                // `export * from` requests the module at evaluation phase —
+                // reject it if this file also imports the same specifier at
+                // source phase (see check_source_phase_conflict).
+                p.check_source_phase_conflict(import_record_index)?;
 
                 if path.is_macro {
                     p.log().add_error(
@@ -1279,6 +1283,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     let import_record_index =
                         p.add_import_record(ImportKind::Stmt, parsed_path.loc, parsed_path.text);
+                    // `export { ... } from` requests the module at evaluation
+                    // phase — reject it if this file also imports the same
+                    // specifier at source phase (see
+                    // check_source_phase_conflict).
+                    p.check_source_phase_conflict(import_record_index)?;
                     let path_name = fs::PathName::init(parsed_path.text);
                     let namespace_ref = {
                         use std::io::Write as _;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1504,7 +1504,77 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         namespace_ref: p.store_name_in_ref(p.lexer.identifier)?,
                         star_name_loc: p.lexer.loc(),
                         import_record_index: u32::MAX,
-                        phase_defer: true,
+                        phase: bun_ast::ImportPhase::Defer,
+                        ..Default::default()
+                    };
+                    p.lexer.expect(T::TIdentifier)?;
+                    p.lexer.expect_contextual_keyword(b"from")?;
+
+                    let path = p.parse_path()?;
+                    p.lexer.expect_or_insert_semicolon()?;
+                    return p.process_import_statement(stmt, path, loc, false);
+                }
+
+                // "import source mod from 'path'"
+                //
+                // https://tc39.es/proposal-source-phase-imports/
+                //
+                // `source` is only a phase keyword when followed by an
+                // ImportedBinding that is itself followed by `from`. In every
+                // other position (`import source from 'x'`,
+                // `import source, {x} from 'y'`) it is an ordinary default
+                // binding named `source`. The only ambiguous case is
+                // `import source from ...`: one more token of lookahead
+                // decides between a default import named `source`
+                // (`import source from 'x'`) and a source phase import whose
+                // binding is named `from` (`import source from from 'x'`).
+                // Compare the raw token so `sourc\u0065` is not treated as
+                // the phase keyword.
+                //
+                // `opts.is_export` rules out `export import source ...`
+                // (only reachable via the TypeScript `export import foo = bar`
+                // re-entry) so it falls through to the import-equals handler
+                // and errors there.
+                if default_name_raw == b"source"
+                    && p.lexer.token == T::TIdentifier
+                    && !opts.is_export
+                    && (!p.lexer.is_contextual_keyword(b"from") || {
+                        let snapshot = p.lexer.snapshot();
+                        p.lexer.next()?;
+                        let binding_is_named_from = p.lexer.is_contextual_keyword(b"from");
+                        p.lexer.restore(&snapshot);
+                        binding_is_named_from
+                    })
+                {
+                    // Same scope restriction as `import defaultItem from 'path'`:
+                    // ESM import declarations are only valid at module scope
+                    // (or inside a TypeScript `declare namespace`).
+                    if !opts.is_module_scope
+                        && (!opts.is_namespace_scope || !opts.is_typescript_declare)
+                    {
+                        p.lexer.unexpected()?;
+                        return Err(err!("SyntaxError"));
+                    }
+                    // The bundler has no representation for a module source:
+                    // inlining the record would bind the asset path string
+                    // instead of a `WebAssembly.Module`. Reject it rather
+                    // than silently produce the wrong value.
+                    if p.options.bundle {
+                        p.log().add_range_error(
+                            Some(p.source),
+                            js_lexer::range_of_identifier(p.source, loc),
+                            b"\"import source\" is not supported when bundling",
+                        );
+                        return Err(err!("SyntaxError"));
+                    }
+                    stmt = S::Import {
+                        namespace_ref: Ref::NONE,
+                        import_record_index: u32::MAX,
+                        default_name: Some(LocRef {
+                            loc: p.lexer.loc(),
+                            ref_: Some(p.store_name_in_ref(p.lexer.identifier)?),
+                        }),
+                        phase: bun_ast::ImportPhase::Source,
                         ..Default::default()
                     };
                     p.lexer.expect(T::TIdentifier)?;

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1581,7 +1581,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         import_record_index: u32::MAX,
                         default_name: Some(LocRef {
                             loc: p.lexer.loc(),
-                            ref_: Some(p.store_name_in_ref(p.lexer.identifier)?),
+                            ref_: p.store_name_in_ref(p.lexer.identifier)?,
                         }),
                         phase: bun_ast::ImportPhase::Source,
                         ..Default::default()

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -919,6 +919,7 @@ pub struct TransposeState {
     pub import_record_tag: Option<bun_ast::ImportRecordTag>,
     pub import_loader: Option<bun_ast::Loader>,
     pub import_options: Expr,
+    pub import_phase: bun_ast::ImportPhase,
 }
 
 impl Default for TransposeState {
@@ -931,6 +932,7 @@ impl Default for TransposeState {
             import_record_tag: None,
             import_loader: None,
             import_options: Expr::EMPTY,
+            import_phase: bun_ast::ImportPhase::Evaluation,
         }
     }
 }

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -282,16 +282,15 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // as-is: a namespace import, or a source phase import
                     // (awaiting the lowered `import.source()` already yields
                     // the module source — there is no `.default` unwrap).
-                    let direct_binding =
-                        if import_data.phase == bun_ast::ImportPhase::Source {
-                            import_data
-                                .default_name
-                                .map(|name| name.ref_.expect("infallible: ref bound"))
-                        } else if !import_data.star_name_loc.is_empty() {
-                            Some(import_data.namespace_ref)
-                        } else {
-                            None
-                        };
+                    let direct_binding = if import_data.phase == bun_ast::ImportPhase::Source {
+                        import_data
+                            .default_name
+                            .map(|name| name.ref_.expect("infallible: ref bound"))
+                    } else if !import_data.star_name_loc.is_empty() {
+                        Some(import_data.namespace_ref)
+                    } else {
+                        None
+                    };
 
                     if let Some(binding_ref) = direct_binding {
                         // import * as X from 'mod' -> var X = await import('mod')

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -252,6 +252,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     //   import { a, b } from 'mod' -> var {a, b} = await import('mod')
                     //   import * as X from 'mod'   -> var X = await import('mod')
                     //   import 'mod'              -> await import('mod')
+                    //   import source X from 'mod' -> var X = await import.source('mod')
                     let path_str: &'static [u8] = self.import_records.items()
                         [import_data.import_record_index as usize]
                         .path
@@ -268,6 +269,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                             expr: str_expr,
                             options: Expr::EMPTY,
                             import_record_index: u32::MAX,
+                            phase: import_data.phase,
                         },
                         stmt.loc,
                     );
@@ -276,7 +278,22 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // `items` is an arena-owned `StoreSlice<ClauseItem>` valid for 'a.
                     let import_items: &[bun_ast::ClauseItem] = import_data.items.slice();
 
-                    if !import_data.star_name_loc.is_empty() {
+                    // Bindings that receive the awaited import expression
+                    // as-is: a namespace import, or a source phase import
+                    // (awaiting the lowered `import.source()` already yields
+                    // the module source — there is no `.default` unwrap).
+                    let direct_binding =
+                        if import_data.phase == bun_ast::ImportPhase::Source {
+                            import_data
+                                .default_name
+                                .map(|name| name.ref_.expect("infallible: ref bound"))
+                        } else if !import_data.star_name_loc.is_empty() {
+                            Some(import_data.namespace_ref)
+                        } else {
+                            None
+                        };
+
+                    if let Some(binding_ref) = direct_binding {
                         // import * as X from 'mod' -> var X = await import('mod')
                         hoisted_stmts.push(self.s(
                             S::Local {
@@ -285,9 +302,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                                     bump,
                                     Binding::alloc(
                                         bump,
-                                        B::Identifier {
-                                            r#ref: import_data.namespace_ref,
-                                        },
+                                        B::Identifier { r#ref: binding_ref },
                                         stmt.loc,
                                     ),
                                 ),
@@ -297,7 +312,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                         ));
                         let left = self.new_expr(
                             E::Identifier {
-                                ref_: import_data.namespace_ref,
+                                ref_: binding_ref,
                                 ..Default::default()
                             },
                             stmt.loc,

--- a/src/js_parser/repl_transforms.rs
+++ b/src/js_parser/repl_transforms.rs
@@ -283,9 +283,7 @@ impl<'a, const TS: bool, const SCAN: bool> P<'a, TS, SCAN> {
                     // (awaiting the lowered `import.source()` already yields
                     // the module source — there is no `.default` unwrap).
                     let direct_binding = if import_data.phase == bun_ast::ImportPhase::Source {
-                        import_data
-                            .default_name
-                            .map(|name| name.ref_.expect("infallible: ref bound"))
+                        import_data.default_name.map(|name| name.ref_)
                     } else if !import_data.star_name_loc.is_empty() {
                         Some(import_data.namespace_ref)
                     } else {

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -157,8 +157,15 @@ impl<'a> ImportScanner<'a> {
                                 is_unused_in_typescript = false;
                             }
 
-                            // Remove the symbol if it's never used outside a dead code region
-                            if symbol.use_count_estimate == 0 {
+                            // Remove the symbol if it's never used outside a dead code region.
+                            //
+                            // Never strip the default binding from an `import source`
+                            // statement: the grammar requires exactly one binding, so
+                            // dropping it would force the printer to emit a bare
+                            // side-effect import and lose the source phase entirely.
+                            if symbol.use_count_estimate == 0
+                                && st.phase != bun_ast::ImportPhase::Source
+                            {
                                 st.default_name = None;
                             }
                         }
@@ -184,7 +191,9 @@ impl<'a> ImportScanner<'a> {
                             // defer. Keeping the binding preserves the intended
                             // semantics (the module is linked but never evaluated,
                             // since nothing touches `ns` at runtime).
-                            if symbol.use_count_estimate == 0 && !st.phase_defer {
+                            if symbol.use_count_estimate == 0
+                                && st.phase != bun_ast::ImportPhase::Defer
+                            {
                                 // Make sure we don't remove this if it was used for a property
                                 // access while bundling
                                 let mut has_any = false;
@@ -297,7 +306,7 @@ impl<'a> ImportScanner<'a> {
                     // (see the matching guard above): converting it to a
                     // clause import would lose the defer phase entirely.
                     let convert_star_to_clause = !p.options.bundle
-                        && !st.phase_defer
+                        && st.phase != bun_ast::ImportPhase::Defer
                         && (p.symbols[namespace_ref.inner_index() as usize].use_count_estimate
                             == 0);
 

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -163,6 +163,15 @@ impl<'a> ImportScanner<'a> {
                             // statement: the grammar requires exactly one binding, so
                             // dropping it would force the printer to emit a bare
                             // side-effect import and lose the source phase entirely.
+                            //
+                            // Note the scope of this guard: it protects bindings whose
+                            // only references sit in dead code (`use_count_estimate == 0`
+                            // but `ts_use_counts != 0`). A source phase import with *no*
+                            // syntactic reference at all in a TypeScript file is still
+                            // removed wholesale by the `is_unused_in_typescript` check
+                            // below — the same elision tsc/esbuild apply and the same
+                            // behavior as `import defer`; `verbatimModuleSyntax`
+                            // (`preserve_unused_imports_ts`) keeps it.
                             if symbol.use_count_estimate == 0
                                 && st.phase != bun_ast::ImportPhase::Source
                             {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1840,6 +1840,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 import_options: e_.options,
                 loc: e_.expr.loc,
                 import_loader: e_.import_record_loader(),
+                import_phase: e_.phase,
                 ..Default::default()
             };
 

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -45,7 +45,7 @@ use js_ast::Ref;
 mod lexer {
     pub(crate) use bun_ast::lexer_tables::*;
 }
-use bun_ast::ImportRecordFlags;
+use bun_ast::{ImportPhase, ImportRecordFlags};
 
 use bun_sourcemap as SourceMap;
 
@@ -2968,6 +2968,33 @@ pub mod __gated_printer {
 
             self.print_space_before_identifier();
 
+            // External import.source() — no CommonJS interop applies to a
+            // module source request.
+            if record.phase == ImportPhase::Source
+                && module_type != bundle_opts::Format::InternalBakeDev
+            {
+                if IS_BUN_PLATFORM {
+                    // Same lowering as static `import source`: request the
+                    // WebAssembly module-source module-map entry, then unwrap
+                    // its default export so the promise resolves with the
+                    // `WebAssembly.Module` itself. (The parser rejects a
+                    // second argument for `import.source`, so
+                    // `import_options` is missing.)
+                    self.print(b"import(");
+                    self.print_import_record_path(record);
+                    self.print(b",{with:{type:\"webassembly\"}})");
+                    self.print(b".then((m)=>m.default)");
+                } else {
+                    self.print(b"import.source(");
+                    self.print_import_record_path(record);
+                    self.print(b")");
+                }
+                if wrap {
+                    self.print(b")");
+                }
+                return;
+            }
+
             // Wrap with __toESM if importing a CommonJS module
             let wrap_with_to_esm = record.flags.contains(ImportRecordFlags::WRAP_WITH_TO_ESM);
 
@@ -3628,24 +3655,41 @@ pub mod __gated_printer {
                             self.print(b"(");
                         }
 
+                        let is_bake_dev =
+                            self.options.module_type == bundle_opts::Format::InternalBakeDev;
                         self.print_space_before_identifier();
                         self.add_source_mapping(expr.loc);
-                        if self.options.module_type == bundle_opts::Format::InternalBakeDev {
+                        if is_bake_dev {
                             self.print_symbol(self.options.hmr_ref);
                             self.print(b".dynamicImport(");
+                        } else if e.phase == ImportPhase::Source && !IS_BUN_PLATFORM {
+                            // Bun lowers `import.source()` below; other
+                            // targets get the real syntax.
+                            self.print(b"import.source(");
                         } else {
                             self.print(b"import(");
                         }
                         // TODO: leading_interior_comments
                         self.print_expr(e.expr, Level::Comma, ExprFlag::none());
 
-                        if !e.options.is_missing() {
-                            self.print_whitespacer(ws!(b", "));
-                            self.print_expr(e.options, Level::Comma, ExprFlagSet::empty());
-                        }
+                        if e.phase == ImportPhase::Source && IS_BUN_PLATFORM && !is_bake_dev {
+                            // Same lowering as static `import source`: request
+                            // the WebAssembly module-source module-map entry,
+                            // then unwrap its default export so the promise
+                            // resolves with the `WebAssembly.Module` itself.
+                            // (The parser rejects a second argument for
+                            // `import.source`, so `e.options` is missing.)
+                            self.print(b",{with:{type:\"webassembly\"}})");
+                            self.print(b".then((m)=>m.default)");
+                        } else {
+                            if !e.options.is_missing() {
+                                self.print_whitespacer(ws!(b", "));
+                                self.print_expr(e.options, Level::Comma, ExprFlagSet::empty());
+                            }
 
-                        // TODO: leading_interior_comments
-                        self.print(b")");
+                            // TODO: leading_interior_comments
+                            self.print(b")");
+                        }
                         if wrap {
                             self.print(b")");
                         }
@@ -6049,18 +6093,35 @@ pub mod __gated_printer {
 
                     self.print(b"import");
 
-                    // `import defer` grammatically requires `* as ns`; if a
-                    // later pass stripped the star binding (or disabled it on
-                    // the record) the statement can no longer be printed as a
-                    // phase import, so drop the `defer` token rather than emit
-                    // `import defer"./x";`. scan_imports preserves the binding
-                    // for `phase_defer` imports, so this is belt-and-suspenders.
-                    let phase_defer = record.flags.contains(ImportRecordFlags::PHASE_DEFER)
-                        && record
-                            .flags
-                            .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR);
-                    if phase_defer {
-                        self.print(b" defer");
+                    // `import defer` grammatically requires `* as ns` and
+                    // `import source` a default binding; if a later pass
+                    // stripped the binding (or disabled it on the record) the
+                    // statement can no longer be printed as a phase import,
+                    // so drop the phase rather than emit `import defer"./x";`.
+                    // scan_imports preserves the bindings for phase imports,
+                    // so this is belt-and-suspenders.
+                    let phase = match record.phase {
+                        ImportPhase::Defer
+                            if !record
+                                .flags
+                                .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR) =>
+                        {
+                            ImportPhase::Evaluation
+                        }
+                        ImportPhase::Source if s.default_name.is_none() => {
+                            ImportPhase::Evaluation
+                        }
+                        phase => phase,
+                    };
+                    match phase {
+                        ImportPhase::Defer => self.print(b" defer"),
+                        // On the Bun platform the source phase is lowered
+                        // onto import attributes instead (`with { type:
+                        // "webassembly" }`, printed below) because JSC's
+                        // parser has no source phase support; other targets
+                        // get the real syntax.
+                        ImportPhase::Source if !IS_BUN_PLATFORM => self.print(b" source"),
+                        _ => {}
                     }
 
                     let mut item_count: usize = 0;
@@ -6139,7 +6200,17 @@ pub mod __gated_printer {
 
                     // backwards compatibility: previously, we always stripped type
                     if IS_BUN_PLATFORM {
-                        if let Some(loader) = record.loader {
+                        if phase == ImportPhase::Source {
+                            // The source phase lowering: a plain default
+                            // import of the module-source module. JSC maps
+                            // `type: "webassembly"` to
+                            // `ScriptFetchParameters::Type::WebAssembly`,
+                            // which keys a separate module-map entry and
+                            // tells Bun's module loader to produce the
+                            // compiled `WebAssembly.Module` instead of the
+                            // file-loader default export.
+                            self.print_whitespacer(ws!(b" with { type: \"webassembly\" }"));
+                        } else if let Some(loader) = record.loader {
                             use bun_ast::Loader;
                             match loader {
                                 Loader::Jsx => {
@@ -6217,7 +6288,13 @@ pub mod __gated_printer {
                             let irp_id = mi.str(import_record_path);
                             use analyze_transpiled_module::FetchParameters as FP;
                             let fetch_parameters: FP = if IS_BUN_PLATFORM {
-                                if let Some(loader) = record.loader {
+                                if phase == ImportPhase::Source {
+                                    // Matches the printed `with { type:
+                                    // "webassembly" }` attribute so the
+                                    // ModuleInfo fast path requests the same
+                                    // module-map entry JSC's parser would.
+                                    FP::Webassembly
+                                } else if let Some(loader) = record.loader {
                                     use bun_ast::Loader;
                                     match loader {
                                         Loader::Json => FP::Json,
@@ -6249,12 +6326,16 @@ pub mod __gated_printer {
                             } else {
                                 FP::None
                             };
-                            let phase = if phase_defer {
+                            // JSC's `AbstractModuleRecord::ModulePhase` only
+                            // has Evaluation and Defer; the source phase is
+                            // lowered to an Evaluation-phase import of the
+                            // WebAssembly module-source entry (see above).
+                            let module_phase = if phase == ImportPhase::Defer {
                                 analyze_transpiled_module::ModulePhase::Defer
                             } else {
                                 analyze_transpiled_module::ModulePhase::Evaluation
                             };
-                            mi.request_module_with_phase(irp_id, fetch_parameters, phase);
+                            mi.request_module_with_phase(irp_id, fetch_parameters, module_phase);
                             irp_id
                         };
 
@@ -6284,7 +6365,7 @@ pub mod __gated_printer {
                             let mi = self.module_info().expect("infallible: module_info enabled");
                             let local_name_id = mi.str(local_name);
                             mi.add_var(local_name_id, analyze_transpiled_module::VarKind::Lexical);
-                            if phase_defer {
+                            if phase == ImportPhase::Defer {
                                 mi.add_import_info_namespace_defer(irp_id, local_name_id);
                             } else {
                                 mi.add_import_info_namespace(irp_id, local_name_id);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6108,9 +6108,7 @@ pub mod __gated_printer {
                         {
                             ImportPhase::Evaluation
                         }
-                        ImportPhase::Source if s.default_name.is_none() => {
-                            ImportPhase::Evaluation
-                        }
+                        ImportPhase::Source if s.default_name.is_none() => ImportPhase::Evaluation,
                         phase => phase,
                     };
                     match phase {

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2757,7 +2757,11 @@ pub mod __gated_printer {
                 //      const foo = await Promise.resolve(globalThis.Bun)
                 //      const bar = globalThis.Bun
                 //
-                if record.tag == ImportRecordTag::Bun {
+                // Source-phase `import.source("bun")` must fall through to
+                // the `with { type: "webassembly" }` lowering below so the
+                // module loader can reject it (no builtin has a module
+                // source) instead of silently binding `globalThis.Bun`.
+                if record.tag == ImportRecordTag::Bun && record.phase != ImportPhase::Source {
                     if record.kind == ImportKind::Dynamic {
                         self.print(b"Promise.resolve(globalThis.Bun)");
                         if wrap {
@@ -6009,7 +6013,13 @@ pub mod __gated_printer {
                     self.add_source_mapping(stmt.loc);
 
                     if IS_BUN_PLATFORM {
-                        if record.tag == ImportRecordTag::Bun {
+                        // `import source x from "bun"` must reach the
+                        // module loader (via the `with { type: "webassembly" }`
+                        // lowering below) so it can error, not silently
+                        // bind `globalThis.Bun`.
+                        if record.tag == ImportRecordTag::Bun
+                            && record.phase != ImportPhase::Source
+                        {
                             self.print_global_bun_import_statement(s);
                             self.prev_stmt_tag = new_tag;
                             return Ok(());

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -6017,8 +6017,7 @@ pub mod __gated_printer {
                         // module loader (via the `with { type: "webassembly" }`
                         // lowering below) so it can error, not silently
                         // bind `globalThis.Bun`.
-                        if record.tag == ImportRecordTag::Bun
-                            && record.phase != ImportPhase::Source
+                        if record.tag == ImportRecordTag::Bun && record.phase != ImportPhase::Source
                         {
                             self.print_global_bun_import_statement(s);
                             self.prev_stmt_tag = new_tag;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3687,7 +3687,6 @@ pub mod __gated_printer {
                                 self.print_expr(e.options, Level::Comma, ExprFlagSet::empty());
                             }
 
-                            // TODO: leading_interior_comments
                             self.print(b")");
                         }
                         if wrap {

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -164,6 +164,12 @@ pub struct TranspileExtra {
     /// `?*?*jsc.JSInternalPromise` — out-param for the async-module path.
     /// Null forbids async resolution.
     pub promise_ptr: *mut *mut JSInternalPromise,
+    /// True when the fetch carries the `type: "webassembly"` import
+    /// attribute — the lowering for TC39 source phase imports
+    /// (`import source` / `import.source()`). The `.wasm` loader then
+    /// produces a synthetic module whose default export is the compiled
+    /// `WebAssembly.Module` instead of the file-loader path string.
+    pub is_source_phase_import: bool,
 }
 
 /// Result of `LoaderHooks::fetch_builtin_module` — tri-state because

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3944,6 +3944,8 @@ impl VirtualMachine {
             source_code_printer: printer.as_ptr(),
             // `fetchWithoutOnLoadPlugins` forbids the async path.
             promise_ptr: core::ptr::null_mut(),
+            // No import attributes on this path (require / print-source).
+            is_source_phase_import: false,
         };
         let args = ModuleLoader::TranspileArgs {
             specifier: lr.specifier,

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -43,6 +43,11 @@
 
 #include "BunProcess.h"
 
+#include <JavaScriptCore/JSWebAssemblyCompileError.h>
+#include <JavaScriptCore/JSWebAssemblyModule.h>
+#include <JavaScriptCore/WasmCapabilities.h>
+#include <JavaScriptCore/WasmModule.h>
+
 namespace Bun {
 using namespace JSC;
 using namespace Zig;
@@ -1205,6 +1210,36 @@ JSValue fetchESMSourceCodeAsync(
 {
     return fetchESMSourceCode<true>(globalObject, specifierJS, res, specifier, referrer, typeAttribute);
 }
+}
+
+// Synchronously compile WebAssembly bytes into a `WebAssembly.Module` — the
+// module source object a TC39 source phase import (`import source` /
+// `import.source()`) evaluates to. Called from the Rust module loader's
+// `.wasm` source-phase path; equivalent to `new WebAssembly.Module(bytes)`
+// without the copy into a JS ArrayBuffer first.
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__createJSWebAssemblyModuleFromBytes(Zig::GlobalObject* globalObject, const uint8_t* bytes, size_t length)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!JSC::Wasm::isSupported()) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "WebAssembly is not supported in this environment"_s);
+        return {};
+    }
+
+    WTF::Vector<uint8_t> buffer;
+    if (!buffer.tryAppend(std::span { bytes, length })) [[unlikely]] {
+        JSC::throwOutOfMemoryError(globalObject, scope);
+        return {};
+    }
+
+    auto result = JSC::Wasm::Module::validateSync(vm, WTF::move(buffer));
+    if (!result.has_value()) [[unlikely]] {
+        throwException(globalObject, scope, JSC::createJSWebAssemblyCompileError(globalObject, vm, result.error()));
+        return {};
+    }
+
+    RELEASE_AND_RETURN(scope, JSC::JSValue::encode(JSC::JSWebAssemblyModule::create(vm, globalObject->webAssemblyModuleStructure(), WTF::move(result.value()))));
 }
 
 using namespace Bun;

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -969,23 +969,34 @@ static JSValue fetchESMSourceCode(
 
     bool wasModuleMock = false;
 
+    // TC39 source phase imports are lowered by the printer onto
+    // `with { type: "webassembly" }`. Neither builtin modules nor virtual
+    // modules (mock.module / build.module, whose loader whitelist cannot
+    // produce wasm bytes) have a module source, so reject those requests
+    // here rather than silently serving the evaluation-phase module. The
+    // transpile path produces the same error for file-backed non-wasm
+    // modules.
+    const bool isSourcePhase = typeAttribute && !typeAttribute->isEmpty()
+        && typeAttribute->toWTFString(BunString::ZeroCopy) == "webassembly"_s;
+    const auto rejectSourcePhase = [&]() -> JSValue {
+        auto message = makeString(
+            "Source phase import of \""_s,
+            specifier->toWTFString(BunString::ZeroCopy),
+            "\" failed: only WebAssembly modules have a module source"_s);
+        RELEASE_AND_RETURN(scope, reject(createTypeError(globalObject, message)));
+    };
+
     // When "bun test" is enabled, allow users to override builtin modules
     // This is important for being able to trivially mock things like the filesystem.
     if (isBunTest) {
         JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, specifier, wasModuleMock);
         RETURN_IF_EXCEPTION(scope, {});
         if (virtualModuleResult) {
+            if (isSourcePhase) [[unlikely]]
+                return rejectSourcePhase();
             RELEASE_AND_RETURN(scope, handleVirtualModuleResult<allowPromise>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock));
         }
     }
-
-    // TC39 source phase imports are lowered by the printer onto
-    // `with { type: "webassembly" }`. No builtin module has a module source,
-    // so reject that request here rather than silently serving the
-    // evaluation-phase builtin (the transpile path produces the same error
-    // for file-backed non-wasm modules).
-    const bool isSourcePhase = typeAttribute && !typeAttribute->isEmpty()
-        && typeAttribute->toWTFString(BunString::ZeroCopy) == "webassembly"_s;
 
     if (Bun__fetchBuiltinModule(bunVM, globalObject, specifier, referrer, res)) {
         if (!res->success) {
@@ -995,13 +1006,8 @@ static JSValue fetchESMSourceCode(
             RELEASE_AND_RETURN(scope, reject(exception));
         }
 
-        if (isSourcePhase) [[unlikely]] {
-            auto message = makeString(
-                "Source phase import of \""_s,
-                specifier->toWTFString(BunString::ZeroCopy),
-                "\" failed: only WebAssembly modules have a module source"_s);
-            RELEASE_AND_RETURN(scope, reject(createTypeError(globalObject, message)));
-        }
+        if (isSourcePhase) [[unlikely]]
+            return rejectSourcePhase();
 
         // This can happen if it's a `bun build --compile`'d CommonJS file
         if (res->result.value.isCommonJSModule) {
@@ -1071,6 +1077,8 @@ static JSValue fetchESMSourceCode(
         JSC::JSValue virtualModuleResult = Bun::runVirtualModule(globalObject, specifier, wasModuleMock);
         RETURN_IF_EXCEPTION(scope, {});
         if (virtualModuleResult) {
+            if (isSourcePhase) [[unlikely]]
+                return rejectSourcePhase();
             RELEASE_AND_RETURN(scope, handleVirtualModuleResult<allowPromise>(globalObject, virtualModuleResult, res, specifier, referrer, wasModuleMock));
         }
     }

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -979,12 +979,28 @@ static JSValue fetchESMSourceCode(
         }
     }
 
+    // TC39 source phase imports are lowered by the printer onto
+    // `with { type: "webassembly" }`. No builtin module has a module source,
+    // so reject that request here rather than silently serving the
+    // evaluation-phase builtin (the transpile path produces the same error
+    // for file-backed non-wasm modules).
+    const bool isSourcePhase = typeAttribute && !typeAttribute->isEmpty()
+        && typeAttribute->toWTFString(BunString::ZeroCopy) == "webassembly"_s;
+
     if (Bun__fetchBuiltinModule(bunVM, globalObject, specifier, referrer, res)) {
         if (!res->success) {
             throwException(scope, res->result.err, globalObject);
             auto* exception = scope.exception();
             (void)scope.tryClearException();
             RELEASE_AND_RETURN(scope, reject(exception));
+        }
+
+        if (isSourcePhase) [[unlikely]] {
+            auto message = makeString(
+                "Source phase import of \""_s,
+                specifier->toWTFString(BunString::ZeroCopy),
+                "\" failed: only WebAssembly modules have a module source"_s);
+            RELEASE_AND_RETURN(scope, reject(createTypeError(globalObject, message)));
         }
 
         // This can happen if it's a `bun build --compile`'d CommonJS file

--- a/src/react_compiler/codegen.rs
+++ b/src/react_compiler/codegen.rs
@@ -1895,6 +1895,7 @@ fn codegen_base_instruction_value(
                         expr: it.next().unwrap_or(orig.expr),
                         options: it.next().unwrap_or(Expr::EMPTY),
                         import_record_index: orig.import_record_index,
+                        phase: orig.phase,
                     },
                     loc,
                 ));

--- a/src/react_compiler/imports.rs
+++ b/src/react_compiler/imports.rs
@@ -328,7 +328,7 @@ pub(crate) fn add_imports_to_program(
                 star_name_loc: Loc::EMPTY,
                 import_record_index,
                 is_single_line: true,
-                phase_defer: false,
+                phase: bun_ast::ImportPhase::Evaluation,
             },
             Loc::EMPTY,
         ));

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3421,10 +3421,10 @@ unsafe fn maybe_auto_watch_file(
         )
         .is_err()
     {
-        // Close the fd we just opened on macOS;
-        // not a transpile failure (the user didn't open it).
-        #[cfg(target_os = "macos")]
-        if input_fd.is_valid() {
+        // Close the fd we just opened for kqueue; not a transpile failure
+        // (the user didn't open it). Gate on the same condition as the
+        // open above so the open/close pair cannot drift apart.
+        if bun_watcher::REQUIRES_FILE_DESCRIPTORS && input_fd.is_valid() {
             use bun_sys::FdExt as _;
             input_fd.close();
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3134,6 +3134,96 @@ fn transpile_source_code_inner(
                     }));
                 }
             }
+
+            // TC39 source phase import (`import source x from "./a.wasm"` /
+            // `import.source("./a.wasm")`), lowered by the printer onto the
+            // `type: "webassembly"` import attribute: produce a synthetic
+            // module whose default export is the compiled
+            // `WebAssembly.Module`.
+            // SAFETY: per fn contract — `extra` is live for the call.
+            if unsafe { (*extra).is_source_phase_import } {
+                if global_object.is_null() {
+                    return Err(bun_core::err!("NotSupported"));
+                }
+
+                // The wasm bytes: a virtual source when present (e.g. a
+                // `blob:` URL), otherwise the file on disk.
+                let owned_bytes: Vec<u8>;
+                let bytes: &[u8] = match args.virtual_source {
+                    Some(source) => &source.contents,
+                    None => {
+                        match bun_sys::File::openat(
+                            bun_sys::Fd::cwd(),
+                            path.text,
+                            bun_sys::O::RDONLY,
+                            0,
+                        )
+                        .and_then(|file| file.read_to_end())
+                        {
+                            Ok(contents) => {
+                                owned_bytes = contents;
+                                &owned_bytes
+                            }
+                            Err(err) => {
+                                // SAFETY: per fn contract — `args.log` is the
+                                // unique per-fetch `Log`.
+                                let _ = unsafe { &mut *args.log }.add_error_fmt(
+                                    None,
+                                    bun_ast::Loc::EMPTY,
+                                    format_args!(
+                                        "{} reading module source {}",
+                                        bstr::BStr::new(err.name()),
+                                        bun_core::fmt::format_json_string_latin1(path.text),
+                                    ),
+                                );
+                                return Err(bun_core::err!("ParseError"));
+                            }
+                        }
+                    }
+                };
+
+                // Only WebAssembly modules have a source representation
+                // (`HostGetModuleSourceName`); reject anything else with a
+                // clearer error than the CompileError the wasm parser would
+                // produce.
+                if !bytes.starts_with(&[0x00, 0x61, 0x73, 0x6d]) {
+                    // SAFETY: see above.
+                    let _ = unsafe { &mut *args.log }.add_error_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Source phase import of {} failed: only WebAssembly modules have a \
+                             module source",
+                            bun_core::fmt::format_json_string_latin1(path.text),
+                        ),
+                    );
+                    return Err(bun_core::err!("ParseError"));
+                }
+
+                // SAFETY: null-checked above; `global_object` is the live
+                // per-thread `JSGlobalObject`, and `bytes` is a live slice
+                // for the duration of the FFI call.
+                let module = unsafe {
+                    bun_jsc::cpp::Bun__createJSWebAssemblyModuleFromBytes(
+                        &*global_object,
+                        bytes.as_ptr(),
+                        bytes.len(),
+                    )
+                }
+                // Exception (e.g. `WebAssembly.CompileError`) is pending on
+                // the global; `transpile_file` re-throws it.
+                .map_err(|_| bun_core::err!("JSError"))?;
+
+                use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
+                return Ok(OwnedResolvedSource::from(ResolvedSource {
+                    jsvalue_for_export: module,
+                    specifier: input_specifier.dupe_ref(),
+                    source_url: create_if_different(input_specifier, path.text),
+                    tag: ResolvedSourceTag::ExportDefaultObject,
+                    ..Default::default()
+                }));
+            }
+
             // Recurse as `.file`.
             // SAFETY: per fn contract — `extra` is live for the call.
             unsafe {
@@ -3767,6 +3857,8 @@ struct LoaderResult<'a> {
     specifier: &'a [u8],
     /// Always `None` for non-JS-like loaders (not needed there).
     package_json: Option<&'a bun_resolver::package_json::PackageJSON>,
+    /// See [`TranspileExtra::is_source_phase_import`].
+    is_source_phase_import: bool,
 }
 
 /// `options.getLoaderAndVirtualSource` — high-tier body.
@@ -3878,8 +3970,16 @@ unsafe fn get_loader_and_virtual_source<'a>(
     if query == b"?raw" {
         loader = Some(Loader::Text);
     }
+    let mut is_source_phase_import = false;
     if let Some(attr_str) = type_attribute_str {
-        if let Some(attr_loader) = Loader::from_string(attr_str) {
+        if attr_str == b"webassembly" {
+            // `ScriptFetchParameters::Type::WebAssembly` — the printer's
+            // lowering for TC39 source phase imports (`import source` /
+            // `import.source()`). Force the wasm loader so the request
+            // reaches the module-source path regardless of extension.
+            loader = Some(Loader::Wasm);
+            is_source_phase_import = true;
+        } else if let Some(attr_loader) = Loader::from_string(attr_str) {
             loader = Some(attr_loader);
         }
     }
@@ -3908,6 +4008,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
         is_main,
         specifier,
         package_json,
+        is_source_phase_import,
     })
 }
 
@@ -4295,6 +4396,7 @@ unsafe fn transpile_file(
         } else {
             ptr::null_mut()
         },
+        is_source_phase_import: lr.is_source_phase_import,
     };
     let args = TranspileArgs {
         specifier: lr.specifier,
@@ -4466,6 +4568,7 @@ unsafe fn transpile_virtual_module(
         module_type: ModuleType::Unknown,
         source_code_printer: printer_ptr,
         promise_ptr: ptr::null_mut(), // null forbids async resolution
+        is_source_phase_import: false,
     };
     let args = TranspileArgs {
         specifier,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3386,8 +3386,7 @@ unsafe fn maybe_auto_watch_file(
     if !unsafe { &*jsc_vm }.is_watcher_enabled() {
         return;
     }
-    if !bun_paths::is_absolute(path.text)
-        || bun_core::strings::contains(path.text, b"node_modules")
+    if !bun_paths::is_absolute(path.text) || bun_core::strings::contains(path.text, b"node_modules")
     {
         return;
     }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3146,6 +3146,14 @@ fn transpile_source_code_inner(
                     return Err(bun_core::err!("NotSupported"));
                 }
 
+                // Watch the wasm file the same way the file-loader path does
+                // for evaluation-phase wasm imports, so `--watch`/`--hot`
+                // pick up changes to it.
+                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                unsafe {
+                    maybe_auto_watch_file(jsc_vm, args.virtual_source.is_some(), path, loader)
+                };
+
                 // The wasm bytes: a virtual source when present (e.g. a
                 // `blob:` URL), otherwise the file on disk.
                 let owned_bytes: Vec<u8>;
@@ -3304,61 +3312,9 @@ fn transpile_source_code_inner(
                 }));
             }
 
-            // auto-watch for non-virtual absolute paths.
-            'auto_watch: {
-                if args.virtual_source.is_some() {
-                    break 'auto_watch;
-                }
-                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
-                if !unsafe { &*jsc_vm }.is_watcher_enabled() {
-                    break 'auto_watch;
-                }
-                if !bun_paths::is_absolute(path.text)
-                    || bun_core::strings::contains(path.text, b"node_modules")
-                {
-                    break 'auto_watch;
-                }
-                // kqueue watchers need a file descriptor to receive event
-                // notifications on it; inotify/win32 watch by path.
-                let input_fd = if bun_watcher::REQUIRES_FILE_DESCRIPTORS {
-                    let mut buf = bun_paths::path_buffer_pool::get();
-                    if path.text.len() >= buf.len() {
-                        break 'auto_watch;
-                    }
-                    let z = bun_paths::resolve_path::z(path.text, &mut buf);
-                    match bun_sys::open(z, bun_watcher::WATCH_OPEN_FLAGS, 0) {
-                        Ok(fd) => fd,
-                        Err(_) => break 'auto_watch,
-                    }
-                } else {
-                    bun_sys::Fd::INVALID
-                };
-                let hash = bun_watcher::Watcher::get_hash(path.text);
-                // SAFETY: `bun_watcher` is the `*mut ImportWatcher`
-                // set when `is_watcher_enabled()`; cast recovers the concrete
-                // type.
-                let watcher =
-                    unsafe { &mut *(*jsc_vm).bun_watcher.cast::<bun_jsc::ImportWatcher>() };
-                if watcher
-                    .add_file::<true>(
-                        input_fd,
-                        path.text,
-                        hash,
-                        loader,
-                        bun_sys::Fd::INVALID,
-                        None,
-                    )
-                    .is_err()
-                {
-                    // Close the fd we just opened on macOS;
-                    // not a transpile failure (the user didn't open it).
-                    #[cfg(target_os = "macos")]
-                    if input_fd.is_valid() {
-                        use bun_sys::FdExt as _;
-                        input_fd.close();
-                    }
-                }
-            }
+            // Auto-watch for non-virtual absolute paths.
+            // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+            unsafe { maybe_auto_watch_file(jsc_vm, args.virtual_source.is_some(), path, loader) };
 
             // `export default <path string>`.
             use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
@@ -3405,6 +3361,65 @@ fn transpile_source_code_inner(
                 tag: ResolvedSourceTag::ExportDefaultObject,
                 ..Default::default()
             }))
+        }
+    }
+}
+
+/// Register `path` with the watcher for loaders whose fetch path does not
+/// keep a file descriptor of its own (the file loader and the wasm
+/// module-source path). Opens a dedicated fd on kqueue platforms
+/// (inotify/win32 watch by path); failures are ignored — watching is
+/// best-effort, not part of the module load.
+///
+/// # Safety
+/// `jsc_vm` is the live per-thread VM.
+unsafe fn maybe_auto_watch_file(
+    jsc_vm: *mut VirtualMachine,
+    is_virtual_source: bool,
+    path: &Fs::Path,
+    loader: Loader,
+) {
+    if is_virtual_source {
+        return;
+    }
+    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+    if !unsafe { &*jsc_vm }.is_watcher_enabled() {
+        return;
+    }
+    if !bun_paths::is_absolute(path.text)
+        || bun_core::strings::contains(path.text, b"node_modules")
+    {
+        return;
+    }
+    // kqueue watchers need a file descriptor to receive event notifications
+    // on it; inotify/win32 watch by path.
+    let input_fd = if bun_watcher::REQUIRES_FILE_DESCRIPTORS {
+        let mut buf = bun_paths::path_buffer_pool::get();
+        if path.text.len() >= buf.len() {
+            return;
+        }
+        let z = bun_paths::resolve_path::z(path.text, &mut buf);
+        match bun_sys::open(z, bun_watcher::WATCH_OPEN_FLAGS, 0) {
+            Ok(fd) => fd,
+            Err(_) => return,
+        }
+    } else {
+        bun_sys::Fd::INVALID
+    };
+    let hash = bun_watcher::Watcher::get_hash(path.text);
+    // SAFETY: `bun_watcher` is the `*mut ImportWatcher` set when
+    // `is_watcher_enabled()`; cast recovers the concrete type.
+    let watcher = unsafe { &mut *(*jsc_vm).bun_watcher.cast::<bun_jsc::ImportWatcher>() };
+    if watcher
+        .add_file::<true>(input_fd, path.text, hash, loader, bun_sys::Fd::INVALID, None)
+        .is_err()
+    {
+        // Close the fd we just opened on macOS;
+        // not a transpile failure (the user didn't open it).
+        #[cfg(target_os = "macos")]
+        if input_fd.is_valid() {
+            use bun_sys::FdExt as _;
+            input_fd.close();
         }
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3411,7 +3411,14 @@ unsafe fn maybe_auto_watch_file(
     // `is_watcher_enabled()`; cast recovers the concrete type.
     let watcher = unsafe { &mut *(*jsc_vm).bun_watcher.cast::<bun_jsc::ImportWatcher>() };
     if watcher
-        .add_file::<true>(input_fd, path.text, hash, loader, bun_sys::Fd::INVALID, None)
+        .add_file::<true>(
+            input_fd,
+            path.text,
+            hash,
+            loader,
+            bun_sys::Fd::INVALID,
+            None,
+        )
         .is_err()
     {
         // Close the fd we just opened on macOS;

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -366,6 +366,25 @@ describe.concurrent("import defer", () => {
       expect(stderr.toLowerCase()).toContain("error");
     });
 
+    test("import defer is not over-rejected by a bunfig [macros] remap on the specifier", async () => {
+      // bunfig `[macros]` remapping is only consumed for default and
+      // named bindings, never star bindings, so `import defer * as ns`
+      // of a package with a `[macros]` entry must keep working.
+      const { stdout, stderr, exitCode } = await run({
+        "bunfig.toml": `[macros]\n"pkg" = { "debounce" = "./macro-impl.ts" }\n`,
+        "macro-impl.ts": `export default () => "x";`,
+        "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js"}`,
+        "node_modules/pkg/index.js": `exports.a = 1;`,
+        "main.js": `
+          import defer * as ns from "pkg";
+          console.log("a:", ns.a);
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["a: 1"]);
+      expect(exitCode).toBe(0);
+    });
+
     test.each([
       ["with { type: 'macro' }", `import defer * as ns from "./m.js" with { type: "macro" };`],
       ["macro: prefix", `import defer * as ns from "macro:./m.js";`],

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -366,6 +366,21 @@ describe.concurrent("import defer", () => {
       expect(stderr.toLowerCase()).toContain("error");
     });
 
+    test.each([
+      ["with { type: 'macro' }", `import defer * as ns from "./m.js" with { type: "macro" };`],
+      ["macro: prefix", `import defer * as ns from "macro:./m.js";`],
+    ])("import defer combined with a macro import (%s) is an error", async (_label, code) => {
+      // A macro import is a compile-time binding; there is no module
+      // evaluation to defer. Reject with a clear error instead of
+      // silently registering a namespace macro ref.
+      const { stderr, exitCode } = await run({
+        "main.js": code + `\nconsole.log(ns);`,
+        "m.js": `export const x = 1;`,
+      });
+      expect(stderr).toContain('"import defer" cannot be combined with a macro import');
+      expect(exitCode).not.toBe(0);
+    });
+
     test("'export import defer * as ns' is a syntax error", async () => {
       // `export import` in TypeScript is the import-equals form
       // (`export import X = ...`); `export import defer * as` matches no

--- a/test/js/bun/resolve/import-defer.test.ts
+++ b/test/js/bun/resolve/import-defer.test.ts
@@ -400,6 +400,20 @@ describe.concurrent("import defer", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("import defer from 'bun:bundle' is an error", async () => {
+      // The `bun:bundle` fast path drops the statement before the phase is
+      // consulted; reject rather than leave the namespace binding
+      // undeclared.
+      const { stderr, exitCode } = await run({
+        "main.js": `
+          import defer * as ns from "bun:bundle";
+          console.log(ns);
+        `,
+      });
+      expect(stderr).toContain('"import defer" cannot be used with "bun:bundle"');
+      expect(exitCode).not.toBe(0);
+    });
+
     test("'export import defer * as ns' is a syntax error", async () => {
       // `export import` in TypeScript is the import-equals form
       // (`export import X = ...`); `export import defer * as` matches no

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -219,7 +219,30 @@ describe.concurrent("import source (source phase imports)", () => {
   test("binding only referenced in dead code keeps the source phase", async () => {
     // TS unused-import trimming must not strip the binding from an
     // `import source` statement — the grammar requires exactly one binding,
-    // and dropping it would lose the phase entirely.
+    // and dropping it would downgrade the statement to a bare
+    // evaluation-phase import (the file loader), silently losing the phase.
+    //
+    // Use a file that is not valid WebAssembly to make the phase observable:
+    // the module source is still requested even though the binding is never
+    // read, so loading must fail. If the binding were stripped, the file
+    // loader would accept the file and print "main".
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.ts": `
+          import source mod from "./fake.wasm";
+          if (false) { console.log(mod); }
+          console.log("main");
+        `,
+        "fake.wasm": `not wasm at all`,
+      },
+      "main.ts",
+    );
+    expect(stdout).not.toContain("main");
+    expect(stderr).toContain("only WebAssembly modules have a module source");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("unused source phase binding still loads and compiles valid wasm", async () => {
     const { stdout, stderr, exitCode } = await run(
       {
         "main.ts": `

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -387,8 +387,8 @@ describe.concurrent("import source (source phase imports)", () => {
         "main.js": code,
         "add.wasm": ADD_WASM,
       });
-      expect(exitCode).not.toBe(0);
       expect(stderr.toLowerCase()).toContain("error");
+      expect(exitCode).not.toBe(0);
     });
 
     test("import source inside a TypeScript namespace is a syntax error", async () => {
@@ -399,8 +399,8 @@ describe.concurrent("import source (source phase imports)", () => {
         },
         "main.ts",
       );
-      expect(exitCode).not.toBe(0);
       expect(stderr.toLowerCase()).toContain("error");
+      expect(exitCode).not.toBe(0);
     });
   });
 

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -136,12 +136,30 @@ describe.concurrent("import source (source phase imports)", () => {
   // would silently get the wrong value. Bun reports the conflict instead,
   // in either order, for imports as well as `export ... from` re-exports.
   test.each([
-    ["import source then import", `import source mod from "./add.wasm";\nimport path from "./add.wasm";\nconsole.log(mod, path);`],
-    ["import then import source", `import path from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod, path);`],
-    ["import source then export from", `import source mod from "./add.wasm";\nexport { default as path } from "./add.wasm";\nconsole.log(mod);`],
-    ["export from then import source", `export { default as path } from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`],
-    ["import source then export star", `import source mod from "./add.wasm";\nexport * from "./add.wasm";\nconsole.log(mod);`],
-    ["export star then import source", `export * from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`],
+    [
+      "import source then import",
+      `import source mod from "./add.wasm";\nimport path from "./add.wasm";\nconsole.log(mod, path);`,
+    ],
+    [
+      "import then import source",
+      `import path from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod, path);`,
+    ],
+    [
+      "import source then export from",
+      `import source mod from "./add.wasm";\nexport { default as path } from "./add.wasm";\nconsole.log(mod);`,
+    ],
+    [
+      "export from then import source",
+      `export { default as path } from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`,
+    ],
+    [
+      "import source then export star",
+      `import source mod from "./add.wasm";\nexport * from "./add.wasm";\nconsole.log(mod);`,
+    ],
+    [
+      "export star then import source",
+      `export * from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`,
+    ],
   ])("source and evaluation phase of one specifier in the same file is a parse error (%s)", async (_label, code) => {
     const { stderr, exitCode } = await run({
       "main.js": code,

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -1,0 +1,431 @@
+// TC39 proposal-source-phase-imports — static `import source x from "..."`
+// and dynamic `import.source(...)`, which evaluate to the compiled
+// `WebAssembly.Module` of a WebAssembly file without instantiating it.
+// https://tc39.es/proposal-source-phase-imports/
+
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir, type DirectoryTree } from "harness";
+
+// (module
+//   (func (export "add") (param i32 i32) (result i32)
+//     local.get 0
+//     local.get 1
+//     i32.add))
+const ADD_WASM = Buffer.from([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x07, 0x01, 0x60, 0x02, 0x7f, 0x7f, 0x01, 0x7f, 0x03, 0x02,
+  0x01, 0x00, 0x07, 0x07, 0x01, 0x03, 0x61, 0x64, 0x64, 0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00, 0x20, 0x00, 0x20,
+  0x01, 0x6a, 0x0b,
+]);
+
+async function run(files: DirectoryTree, entry = "main.js", args: string[] = []) {
+  using dir = tempDir("import-source-phase", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args, entry],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("import source (source phase imports)", () => {
+  test("static import source evaluates to a WebAssembly.Module", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source addModule from "./add.wasm";
+        console.log("instanceof:", addModule instanceof WebAssembly.Module);
+        console.log("exports:", WebAssembly.Module.exports(addModule).map(e => e.name + ":" + e.kind).join(","));
+        const instance = new WebAssembly.Instance(addModule);
+        console.log("add:", instance.exports.add(2, 3));
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["instanceof: true", "exports: add:function", "add: 5"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("dynamic import.source() resolves to a WebAssembly.Module", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const mod = await import.source("./add.wasm");
+        console.log("instanceof:", mod instanceof WebAssembly.Module);
+        console.log("add:", new WebAssembly.Instance(mod).exports.add(20, 22));
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["instanceof: true", "add: 42"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("static and dynamic source imports of the same specifier are the same object", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source a from "./add.wasm";
+        const b = await import.source("./add.wasm");
+        console.log("same:", Object.is(a, b));
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["same: true"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("source imports from different modules share one compiled module", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source a from "./add.wasm";
+        import { mod as b } from "./other.js";
+        console.log("same:", Object.is(a, b));
+      `,
+      "other.js": `
+        import source mod from "./add.wasm";
+        export { mod };
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["same: true"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("source phase and evaluation phase of the same specifier coexist across files", async () => {
+    // Bun's evaluation-phase `.wasm` import is the file loader (the default
+    // export is the resolved path string); the source phase gets its own
+    // module-map entry rather than reusing that one.
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source mod from "./add.wasm";
+        import { path } from "./other.js";
+        console.log("source:", mod instanceof WebAssembly.Module);
+        console.log("eval:", typeof path, path.endsWith("add.wasm"));
+      `,
+      "other.js": `
+        import path from "./add.wasm";
+        export { path };
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["source: true", "eval: string true"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("static source phase import and dynamic evaluation-phase import() coexist in one file", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source mod from "./add.wasm";
+        const ns = await import("./add.wasm");
+        console.log("source:", mod instanceof WebAssembly.Module);
+        console.log("eval:", typeof ns.default, ns.default.endsWith("add.wasm"));
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["source: true", "eval: string true"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("static source and evaluation phase of one specifier in the same file is a parse error", async () => {
+    // JSC dedups a module's requested modules by (specifier, phase) and
+    // ignores import attributes, which the source phase lowering rides on —
+    // whichever static import came first would win and the other binding
+    // would silently get the wrong value. Bun reports the conflict instead.
+    for (const order of [
+      `import source mod from "./add.wasm";\nimport path from "./add.wasm";\nconsole.log(mod, path);`,
+      `import path from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod, path);`,
+    ]) {
+      const { stderr, exitCode } = await run({
+        "main.js": order,
+        "add.wasm": ADD_WASM,
+      });
+      expect(stderr).toContain("at both source phase and evaluation phase");
+      expect(exitCode).not.toBe(0);
+    }
+  });
+
+  test("import.source() with a non-literal specifier", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        const name = "./add" + ".wasm";
+        const mod = await import.source(name);
+        console.log("dyn:", mod instanceof WebAssembly.Module);
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["dyn: true"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("import.source() of a blob: URL", async () => {
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import { readFileSync } from "node:fs";
+        const bytes = readFileSync(new URL("./add.wasm", import.meta.url));
+        const url = URL.createObjectURL(new Blob([bytes], { type: "application/wasm" }));
+        const mod = await import.source(url);
+        console.log("blob:", mod instanceof WebAssembly.Module, new WebAssembly.Instance(mod).exports.add(1, 1));
+      `,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["blob: true 2"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("works in TypeScript files", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.ts": `
+          import source addModule from "./add.wasm";
+          const instance = new WebAssembly.Instance(addModule);
+          console.log("ts:", (instance.exports.add as (a: number, b: number) => number)(40, 2));
+        `,
+        "add.wasm": ADD_WASM,
+      },
+      "main.ts",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["ts: 42"]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("binding only referenced in dead code keeps the source phase", async () => {
+    // TS unused-import trimming must not strip the binding from an
+    // `import source` statement — the grammar requires exactly one binding,
+    // and dropping it would lose the phase entirely.
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.ts": `
+          import source mod from "./add.wasm";
+          if (false) { console.log(mod); }
+          console.log("main");
+        `,
+        "add.wasm": ADD_WASM,
+      },
+      "main.ts",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["main"]);
+    expect(exitCode).toBe(0);
+  });
+
+  describe("errors", () => {
+    test("source phase import of a JavaScript module is an error", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source dep from "./dep.js";
+          console.log("unreachable", dep);
+        `,
+        "dep.js": `export default 1;`,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain("only WebAssembly modules have a module source");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("dynamic import.source() of a JavaScript module rejects", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          try {
+            await import.source("./dep.js");
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", String(e.message).includes("only WebAssembly modules have a module source"));
+          }
+        `,
+        "dep.js": `export default 1;`,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: true"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("a file without the wasm magic is rejected even with a .wasm extension", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source mod from "./fake.wasm";
+          console.log("unreachable", mod);
+        `,
+        "fake.wasm": `not wasm at all`,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain("only WebAssembly modules have a module source");
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("invalid wasm rejects with WebAssembly.CompileError", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          try {
+            await import.source("./corrupt.wasm");
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", e instanceof WebAssembly.CompileError);
+          }
+        `,
+        // Valid magic + version, truncated garbage section.
+        "corrupt.wasm": Buffer.concat([Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]), Buffer.from("garbage")]),
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: true"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("import.source() of a missing file rejects", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          try {
+            await import.source("./missing.wasm");
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", e.code ?? e.constructor.name);
+          }
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: ERR_MODULE_NOT_FOUND"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("'source' remains a valid identifier", () => {
+    test("import source from '...' (default binding named source)", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source from "./dep.js";
+          console.log(source);
+        `,
+        "dep.js": `export default "default-export";`,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["default-export"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("import source from from '...' (source phase binding named from)", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source from from "./add.wasm";
+          console.log("from:", from instanceof WebAssembly.Module);
+        `,
+        "add.wasm": ADD_WASM,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["from: true"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("import source, { x } from '...'", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source, { x } from "./dep.js";
+          console.log(source, x);
+        `,
+        "dep.js": `
+          export default "D";
+          export const x = "X";
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["D X"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("import { source } from '...' and import * as source from '...'", async () => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import { source } from "./dep.js";
+          import * as source2 from "./dep.js";
+          console.log(source, source2.source);
+        `,
+        "dep.js": `export const source = 123;`,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["123 123"]);
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  describe("transpiler output", () => {
+    test("preserves 'import source' and 'import.source' for non-Bun targets", async () => {
+      const out = new Bun.Transpiler({ loader: "js" }).transformSync(
+        `import source mod from "./x.wasm";\nmod;\nawait import.source("./y.wasm");\n`,
+      );
+      expect(out).toContain("import source mod from");
+      expect(out).toContain("import.source(");
+    });
+
+    test("lowers the source phase onto import attributes for the Bun target", async () => {
+      const out = new Bun.Transpiler({ loader: "js", target: "bun" }).transformSync(
+        `import source mod from "./x.wasm";\nmod;\nawait import.source("./y.wasm");\n`,
+      );
+      expect(out).toContain(`import mod from "./x.wasm" with { type: "webassembly" }`);
+      expect(out).toContain(`import("./y.wasm",{with:{type:"webassembly"}}).then((m)=>m.default)`);
+    });
+  });
+
+  describe("syntax errors", () => {
+    test.each([
+      ["import source { x } from './a.wasm'", `import source { x } from "./add.wasm";`],
+      ["import source * as ns from './a.wasm'", `import source * as ns from "./add.wasm";`],
+      ["import source x, { y } from './a.wasm'", `import source x, { y } from "./add.wasm";`],
+      ["'source' with an escape sequence is not the phase keyword", `import sourc\\u0065 x from "./add.wasm";`],
+      ["import.source without a call", `import.source;`],
+      ["import.source with a second argument", `await import.source("./add.wasm", { with: { type: "webassembly" } });`],
+      ["import.sourc\\u0065() is not the phase keyword", `await import.sourc\\u0065("./add.wasm");`],
+    ])("%s is a syntax error", async (_label, code) => {
+      const { exitCode, stderr } = await run({
+        "main.js": code,
+        "add.wasm": ADD_WASM,
+      });
+      expect(exitCode).not.toBe(0);
+      expect(stderr.toLowerCase()).toContain("error");
+    });
+
+    test("import source inside a TypeScript namespace is a syntax error", async () => {
+      const { exitCode, stderr } = await run(
+        {
+          "main.ts": `namespace X { import source mod from "./add.wasm"; }`,
+          "add.wasm": ADD_WASM,
+        },
+        "main.ts",
+      );
+      expect(exitCode).not.toBe(0);
+      expect(stderr.toLowerCase()).toContain("error");
+    });
+  });
+
+  describe("bundler", () => {
+    test("'bun build' rejects import source with a clear error", async () => {
+      const { stderr, exitCode } = await run(
+        {
+          "main.js": `import source mod from "./add.wasm"; console.log(mod);`,
+          "add.wasm": ADD_WASM,
+        },
+        "main.js",
+        ["build"],
+      );
+      expect(stderr).toContain(`"import source" is not supported when bundling`);
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("'bun build' rejects import.source() with a clear error", async () => {
+      const { stderr, exitCode } = await run(
+        {
+          "main.js": `const m = await import.source("./add.wasm");`,
+          "add.wasm": ADD_WASM,
+        },
+        "main.js",
+        ["build"],
+      );
+      expect(stderr).toContain(`"import.source" is not supported when bundling`);
+      expect(exitCode).not.toBe(0);
+    });
+  });
+});

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -130,22 +130,25 @@ describe.concurrent("import source (source phase imports)", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("static source and evaluation phase of one specifier in the same file is a parse error", async () => {
-    // JSC dedups a module's requested modules by (specifier, phase) and
-    // ignores import attributes, which the source phase lowering rides on —
-    // whichever static import came first would win and the other binding
-    // would silently get the wrong value. Bun reports the conflict instead.
-    for (const order of [
-      `import source mod from "./add.wasm";\nimport path from "./add.wasm";\nconsole.log(mod, path);`,
-      `import path from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod, path);`,
-    ]) {
-      const { stderr, exitCode } = await run({
-        "main.js": order,
-        "add.wasm": ADD_WASM,
-      });
-      expect(stderr).toContain("at both source phase and evaluation phase");
-      expect(exitCode).not.toBe(0);
-    }
+  // JSC dedups a module's requested modules by (specifier, phase) and
+  // ignores import attributes, which the source phase lowering rides on —
+  // whichever static statement came first would win and the other binding
+  // would silently get the wrong value. Bun reports the conflict instead,
+  // in either order, for imports as well as `export ... from` re-exports.
+  test.each([
+    ["import source then import", `import source mod from "./add.wasm";\nimport path from "./add.wasm";\nconsole.log(mod, path);`],
+    ["import then import source", `import path from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod, path);`],
+    ["import source then export from", `import source mod from "./add.wasm";\nexport { default as path } from "./add.wasm";\nconsole.log(mod);`],
+    ["export from then import source", `export { default as path } from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`],
+    ["import source then export star", `import source mod from "./add.wasm";\nexport * from "./add.wasm";\nconsole.log(mod);`],
+    ["export star then import source", `export * from "./add.wasm";\nimport source mod from "./add.wasm";\nconsole.log(mod);`],
+  ])("source and evaluation phase of one specifier in the same file is a parse error (%s)", async (_label, code) => {
+    const { stderr, exitCode } = await run({
+      "main.js": code,
+      "add.wasm": ADD_WASM,
+    });
+    expect(stderr).toContain("at both source phase and evaluation phase");
+    expect(exitCode).not.toBe(0);
   });
 
   test("import.source() with a non-literal specifier", async () => {

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -259,6 +259,44 @@ describe.concurrent("import source (source phase imports)", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("a completely unreferenced binding keeps the source phase in JavaScript", async () => {
+    // JavaScript imports always execute; even with zero references to the
+    // binding the module source is still requested, so an invalid file
+    // fails to load.
+    const { stdout, stderr, exitCode } = await run({
+      "main.js": `
+        import source mod from "./fake.wasm";
+        console.log("main");
+      `,
+      "fake.wasm": `not wasm at all`,
+    });
+    expect(stdout).not.toContain("main");
+    expect(stderr).toContain("only WebAssembly modules have a module source");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test("a completely unreferenced binding is elided in TypeScript, like tsc", async () => {
+    // TypeScript treats an import whose bindings have no syntactic
+    // references as type-only and elides the whole statement — the same
+    // behavior tsc and esbuild apply to plain imports, and the same
+    // behavior Bun applies to `import defer`. The wasm is never fetched,
+    // so even an invalid file loads fine. `verbatimModuleSyntax` preserves
+    // such imports.
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.ts": `
+          import source mod from "./fake.wasm";
+          console.log("main");
+        `,
+        "fake.wasm": `not wasm at all`,
+      },
+      "main.ts",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["main"]);
+    expect(exitCode).toBe(0);
+  });
+
   describe("errors", () => {
     test("source phase import of a JavaScript module is an error", async () => {
       const { stdout, stderr, exitCode } = await run({

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -270,7 +270,10 @@ describe.concurrent("import source (source phase imports)", () => {
           }
         `,
         // Valid magic + version, truncated garbage section.
-        "corrupt.wasm": Buffer.concat([Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]), Buffer.from("garbage")]),
+        "corrupt.wasm": Buffer.concat([
+          Buffer.from([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]),
+          Buffer.from("garbage"),
+        ]),
       });
       expect(stderr).toBe("");
       expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: true"]);

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -61,6 +61,30 @@ describe.concurrent("import source (source phase imports)", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("import.source() in a CommonJS file does not force ESM or strict mode", async () => {
+    // Like plain `import()`, `import.source()` belongs to the ImportCall
+    // production and is valid with the Script goal; only `import.meta`
+    // requires Module. A CJS file using it must keep sloppy-mode semantics
+    // (octal literals parse, top-level `this` is `module.exports`).
+    const { stdout, stderr, exitCode } = await run(
+      {
+        "main.cjs": `
+          console.log("octal:", 010);
+          console.log("this:", this === module.exports);
+          module.exports.load = () => import.source("./add.wasm");
+          module.exports.load().then(mod => {
+            console.log("instanceof:", mod instanceof WebAssembly.Module);
+          });
+        `,
+        "add.wasm": ADD_WASM,
+      },
+      "main.cjs",
+    );
+    expect(stderr).toBe("");
+    expect(stdout.split("\n").filter(Boolean)).toEqual(["octal: 8", "this: true", "instanceof: true"]);
+    expect(exitCode).toBe(0);
+  });
+
   test("static and dynamic source imports of the same specifier are the same object", async () => {
     const { stdout, stderr, exitCode } = await run({
       "main.js": `

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -636,6 +636,28 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test.each([
+      ["macro-first", `import { fn } from "./m.js" with { type: "macro" };\nimport source mod from "./m.js";`],
+      ["source-first", `import source mod from "./m.js";\nimport { fn } from "./m.js" with { type: "macro" };`],
+    ])(
+      "a macro import of the same specifier (%s) is not a phase conflict with import source",
+      async (_label, code) => {
+        // Macro-import records are compile-time only (the statement becomes
+        // S::Empty and the record is flagged IS_UNUSED / Macro::NAMESPACE),
+        // so they never reach JSC's requested-modules list and cannot
+        // collide with the source-phase request. check_source_phase_conflict
+        // must skip them; the result is order-independent.
+        const { stdout, stderr, exitCode } = await run({
+          "main.js": code + `\nconsole.log("unreachable", fn(), typeof mod);`,
+          "m.js": `export const fn = () => "macro-output"; export default 1;`,
+        });
+        expect(stdout).not.toContain("unreachable");
+        expect(stderr).not.toContain("both source phase and evaluation phase");
+        expect(stderr).toContain("only WebAssembly modules have a module source");
+        expect(exitCode).not.toBe(0);
+      },
+    );
+
     test("import source is not over-rejected by a bunfig [macros] remap lacking a default key", async () => {
       // A `[macros]` entry that only maps named exports doesn't touch the
       // default binding, so `import source` must proceed to the normal

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -600,6 +600,41 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test.each([
+      ["with { type: 'macro' }", `import source mod from "./m.js" with { type: "macro" };`],
+      ["macro: prefix", `import source mod from "macro:./m.js";`],
+    ])("import source combined with a macro import (%s) is an error", async (_label, code) => {
+      // The macro fast path in process_import_statement fires before the
+      // phase is recorded, so without this guard the binding would be
+      // registered as a macro ref and the source phase silently dropped.
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": code + `\nconsole.log("unreachable", mod());`,
+        "m.js": `export default () => "macro-output";`,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain('"import source" cannot be combined with a macro import');
+      expect(exitCode).not.toBe(0);
+    });
+
+    test("import source with a non-macro type attribute still errors on non-wasm content", async () => {
+      // Static `import source` with `with { type: "json" }` overrides the
+      // user attribute with `type: "webassembly"` (the source-phase
+      // lowering), so the module loader reads the file as wasm and
+      // rejects it with the same error as any non-wasm file. Dynamic
+      // `import.source(spec, opts)` rejects the second argument at parse
+      // time instead; this pins the static form's behavior.
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source mod from "./data.json" with { type: "json" };
+          console.log("unreachable", mod);
+        `,
+        "data.json": `{"a":1}`,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain("only WebAssembly modules have a module source");
+      expect(exitCode).not.toBe(0);
+    });
+
     test("import source inside a TypeScript namespace is a syntax error", async () => {
       const { exitCode, stderr } = await run(
         {

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -616,6 +616,26 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("import source of a specifier remapped via bunfig [macros] is an error", async () => {
+      // The third macro trigger: bunfig `[macros]` per-specifier remapping
+      // is read by process_import_statement after the `with { type:
+      // "macro" }` / `macro:` prefix guard; it must also be rejected
+      // instead of registering the default binding as a macro ref.
+      const { stdout, stderr, exitCode } = await run({
+        "bunfig.toml": `[macros]\n"some-pkg" = { "default" = "./macro-impl.ts" }\n`,
+        "macro-impl.ts": `export default () => "remap-output";`,
+        "node_modules/some-pkg/package.json": `{"name":"some-pkg","main":"index.js"}`,
+        "node_modules/some-pkg/index.js": `module.exports.default = 1;`,
+        "main.js": `
+          import source mod from "some-pkg";
+          console.log("unreachable", mod());
+        `,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain('"import source" cannot be combined with a macro import');
+      expect(exitCode).not.toBe(0);
+    });
+
     test("import source with a non-macro type attribute still errors on non-wasm content", async () => {
       // Static `import source` with `with { type: "json" }` overrides the
       // user attribute with `type: "webassembly"` (the source-phase

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -616,6 +616,21 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("import source from 'bun:bundle' is an error", async () => {
+      // The `bun:bundle` fast path in process_import_statement drops the
+      // statement to S::Empty before the phase is consulted; it must
+      // reject rather than leave the source-phase binding undeclared.
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import source mod from "bun:bundle";
+          console.log("unreachable", mod);
+        `,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).toContain('"import source" cannot be used with "bun:bundle"');
+      expect(exitCode).not.toBe(0);
+    });
+
     test("import source of a specifier remapped via bunfig [macros] is an error", async () => {
       // The third macro trigger: bunfig `[macros]` per-specifier remapping
       // is read by process_import_statement after the `with { type:

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -391,6 +391,70 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("source phase import of a Bun.plugin build.module() virtual module is an error", async () => {
+      // The runVirtualModule path in fetchESMSourceCode returns via
+      // handleVirtualModuleResult, whose loader whitelist cannot produce
+      // wasm bytes, so it must reject rather than silently bind the
+      // mock's default export. Evaluation-phase import of the same
+      // specifier must keep working.
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          import { plugin } from "bun";
+          await plugin({
+            name: "virt",
+            setup(build) {
+              build.module("virtual-wasm", () => ({ loader: "object", exports: { default: 99 } }));
+            },
+          });
+          try {
+            await import.source("virtual-wasm");
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", String(e.message).includes("only WebAssembly modules have a module source"));
+          }
+          console.log("eval:", (await import("virtual-wasm")).default);
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: true", "eval: 99"]);
+      expect(exitCode).toBe(0);
+    });
+
+    test("source phase import of a mock.module() registration is an error", async () => {
+      // The isBunTest branch of fetchESMSourceCode runs virtual modules
+      // before the builtin check; it must also reject source-phase
+      // requests instead of binding the mock's default export.
+      const { stdout, stderr, exitCode } = await run(
+        {
+          "mock.test.js": `
+            import { test, expect, mock } from "bun:test";
+            import path from "node:path";
+            test("rejects", async () => {
+              const spec = path.join(import.meta.dir, "fake.wasm");
+              mock.module(spec, () => ({ default: 42 }));
+              let err;
+              try {
+                await import.source(spec);
+              } catch (e) {
+                err = e;
+              }
+              expect(String(err?.message ?? "")).toContain("only WebAssembly modules have a module source");
+              // Evaluation-phase import of the mocked specifier keeps working.
+              expect((await import(spec)).default).toBe(42);
+            });
+          `,
+        },
+        "mock.test.js",
+        ["test"],
+      );
+      expect({ stdout, stderr }).toEqual({
+        stdout: expect.not.stringContaining("(fail)"),
+        stderr: expect.stringContaining(" 1 pass"),
+      });
+      expect(stderr).toContain(" 0 fail");
+      expect(exitCode).toBe(0);
+    });
+
     test("a file without the wasm magic is rejected even with a .wasm extension", async () => {
       const { stdout, stderr, exitCode } = await run({
         "main.js": `

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -636,6 +636,27 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test("import source is not over-rejected by a bunfig [macros] remap lacking a default key", async () => {
+      // A `[macros]` entry that only maps named exports doesn't touch the
+      // default binding, so `import source` must proceed to the normal
+      // source-phase path (which then rejects the resolved .js file with
+      // the wasm error) rather than the macro-import error.
+      const { stdout, stderr, exitCode } = await run({
+        "bunfig.toml": `[macros]\n"pkg" = { "debounce" = "./macro-impl.ts" }\n`,
+        "macro-impl.ts": `export default () => "x";`,
+        "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js"}`,
+        "node_modules/pkg/index.js": `exports.debounce = () => {};`,
+        "main.js": `
+          import source mod from "pkg";
+          console.log("unreachable", mod);
+        `,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).not.toContain("cannot be combined with a macro import");
+      expect(stderr).toContain("only WebAssembly modules have a module source");
+      expect(exitCode).not.toBe(0);
+    });
+
     test("import source with a non-macro type attribute still errors on non-wasm content", async () => {
       // Static `import source` with `with { type: "json" }` overrides the
       // user attribute with `type: "webassembly"` (the source-phase

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -639,24 +639,21 @@ describe.concurrent("import source (source phase imports)", () => {
     test.each([
       ["macro-first", `import { fn } from "./m.js" with { type: "macro" };\nimport source mod from "./m.js";`],
       ["source-first", `import source mod from "./m.js";\nimport { fn } from "./m.js" with { type: "macro" };`],
-    ])(
-      "a macro import of the same specifier (%s) is not a phase conflict with import source",
-      async (_label, code) => {
-        // Macro-import records are compile-time only (the statement becomes
-        // S::Empty and the record is flagged IS_UNUSED / Macro::NAMESPACE),
-        // so they never reach JSC's requested-modules list and cannot
-        // collide with the source-phase request. check_source_phase_conflict
-        // must skip them; the result is order-independent.
-        const { stdout, stderr, exitCode } = await run({
-          "main.js": code + `\nconsole.log("unreachable", fn(), typeof mod);`,
-          "m.js": `export const fn = () => "macro-output"; export default 1;`,
-        });
-        expect(stdout).not.toContain("unreachable");
-        expect(stderr).not.toContain("both source phase and evaluation phase");
-        expect(stderr).toContain("only WebAssembly modules have a module source");
-        expect(exitCode).not.toBe(0);
-      },
-    );
+    ])("a macro import of the same specifier (%s) is not a phase conflict with import source", async (_label, code) => {
+      // Macro-import records are compile-time only (the statement becomes
+      // S::Empty and the record is flagged IS_UNUSED / Macro::NAMESPACE),
+      // so they never reach JSC's requested-modules list and cannot
+      // collide with the source-phase request. check_source_phase_conflict
+      // must skip them; the result is order-independent.
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": code + `\nconsole.log("unreachable", fn(), typeof mod);`,
+        "m.js": `export const fn = () => "macro-output"; export default 1;`,
+      });
+      expect(stdout).not.toContain("unreachable");
+      expect(stderr).not.toContain("both source phase and evaluation phase");
+      expect(stderr).toContain("only WebAssembly modules have a module source");
+      expect(exitCode).not.toBe(0);
+    });
 
     test("import source is not over-rejected by a bunfig [macros] remap lacking a default key", async () => {
       // A `[macros]` entry that only maps named exports doesn't touch the

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -655,6 +655,33 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).not.toBe(0);
     });
 
+    test.each([
+      ["source-first", `import source mod from "pkg";\nimport { foo } from "pkg";`],
+      ["named-first", `import { foo } from "pkg";\nimport source mod from "pkg";`],
+    ])(
+      "a fully bunfig-remapped named import of the same specifier (%s) is not a phase conflict",
+      async (_label, code) => {
+        // `import { foo } from "pkg"` with `[macros].pkg.foo` is fully
+        // remapped: every item becomes a macro ref and the statement drops
+        // to S::Empty (the record becomes Macro::NAMESPACE / IS_UNUSED),
+        // so it never reaches JSC. check_source_phase_conflict runs only
+        // after the remap early-return, so it doesn't match this record
+        // against the source-phase request; both statement orders give
+        // the same result.
+        const { stdout, stderr, exitCode } = await run({
+          "bunfig.toml": `[macros]\n"pkg" = { "foo" = "./macro-impl.ts" }\n`,
+          "macro-impl.ts": `export const foo = () => "macro-output";`,
+          "node_modules/pkg/package.json": `{"name":"pkg","main":"index.js"}`,
+          "node_modules/pkg/index.js": `exports.foo = () => {};`,
+          "main.js": code + `\nconsole.log("unreachable", mod, foo());`,
+        });
+        expect(stdout).not.toContain("unreachable");
+        expect(stderr).not.toContain("both source phase and evaluation phase");
+        expect(stderr).toContain("only WebAssembly modules have a module source");
+        expect(exitCode).not.toBe(0);
+      },
+    );
+
     test("import source is not over-rejected by a bunfig [macros] remap lacking a default key", async () => {
       // A `[macros]` entry that only maps named exports doesn't touch the
       // default binding, so `import source` must proceed to the normal

--- a/test/js/bun/resolve/import-source-phase.test.ts
+++ b/test/js/bun/resolve/import-source-phase.test.ts
@@ -352,6 +352,45 @@ describe.concurrent("import source (source phase imports)", () => {
       expect(exitCode).toBe(0);
     });
 
+    test.each(["bun", "node:fs", "bun:sqlite"])(
+      "static source phase import of the builtin %j is an error",
+      async spec => {
+        // The printer's `Tag::Bun` fast path rewrites `import x from "bun"`
+        // to `var x = globalThis.Bun` and never touches the module loader;
+        // it must not fire for a source-phase request.
+        const { stdout, stderr, exitCode } = await run({
+          "main.js": `
+            import source mod from "${spec}";
+            console.log("unreachable", typeof mod);
+          `,
+        });
+        expect(stdout).not.toContain("unreachable");
+        expect(stderr).toContain("only WebAssembly modules have a module source");
+        expect(stderr).toContain(JSON.stringify(spec));
+        expect(exitCode).not.toBe(0);
+      },
+    );
+
+    test.each([
+      ["literal", `import.source("bun")`],
+      ["non-literal", `import.source(["bun"].join(""))`],
+      ["node builtin", `import.source("node:fs")`],
+    ])("dynamic import.source() of a builtin (%s) rejects", async (_name, expr) => {
+      const { stdout, stderr, exitCode } = await run({
+        "main.js": `
+          try {
+            await ${expr};
+            console.log("unreachable");
+          } catch (e) {
+            console.log("caught:", String(e.message).includes("only WebAssembly modules have a module source"));
+          }
+        `,
+      });
+      expect(stderr).toBe("");
+      expect(stdout.split("\n").filter(Boolean)).toEqual(["caught: true"]);
+      expect(exitCode).toBe(0);
+    });
+
     test("a file without the wasm magic is rejected even with a .wasm extension", async () => {
       const { stdout, stderr, exitCode } = await run({
         "main.js": `


### PR DESCRIPTION
Implements the [TC39 Source Phase Imports proposal](https://github.com/tc39/proposal-source-phase-imports) — both the static and dynamic forms — for the Bun runtime:

```js
import source addModule from "./add.wasm";
addModule instanceof WebAssembly.Module; // true — compiled, not instantiated
const { exports } = new WebAssembly.Instance(addModule, imports);

const mod = await import.source("./add.wasm");
Object.is(mod, addModule); // true — one module-map entry per specifier
```

This is the companion to static `import defer` (#30975) for the other TC39 import phase, and the syntax Node ships for wasm (`--experimental-wasm-modules`' source phase is unflagged in Node ≥ 24).

### How it works

JSC has **no** source phase support — its parser rejects both forms, `AbstractModuleRecord::ModulePhase` is `{Evaluation, Defer}` only, and there is no module-source object. But Bun transpiles every module before JSC sees it, so the transpiler lowers the syntax onto machinery JSC already has:

- **Parser** (`parse_stmt.rs`, `parse_import_export.rs`): `source` is a contextual phase keyword only when followed by an `ImportedBinding` that is followed by `from`. `import source from "x"` stays a default import named `source`; `import source from from "x"` is a source phase import binding `from` (one token of `lexer.snapshot()` lookahead). `import.source(expr)` is accepted after `import.` alongside `meta`. Escaped spellings (`sourc\u0065`) are rejected via raw-token comparison, same as `defer`.
- **AST**: the `phase_defer: bool` plumbing from #30975 is generalized into `ImportPhase { Evaluation, Defer, Source }` on `S::Import`, `E::Import`, and `ImportRecord` (the flag bit it replaces was the last free `u16` bit).
- **Printer** (Bun target): lowers the static form to `import mod from "./a.wasm" with { type: "webassembly" }` and the dynamic form to `import(expr, {with:{type:"webassembly"}}).then((m)=>m.default)`. JSC parses `type: "webassembly"` to `ScriptFetchParameters::Type::WebAssembly`, which is part of the module-map key — so the source phase gets its own module entry, distinct from the evaluation-phase (file-loader) entry. The ModuleInfo fast path records the same request via the pre-existing `FetchParameters::Webassembly`, so no cache-format change. Non-Bun targets print the real syntax verbatim (pass-through, like `import defer`).
- **Module loader** (`jsc_hooks.rs` + new `Bun__createJSWebAssemblyModuleFromBytes` in `ModuleLoader.cpp`): a fetch carrying the `webassembly` type attribute forces the wasm loader and produces a synthetic module whose default export is the `WebAssembly.Module`, compiled synchronously with `Wasm::Module::validateSync` — the engine path behind `new WebAssembly.Module(bytes)`. Works for files, `blob:` URLs, and `require(esm)` graphs.

Evaluation-phase wasm imports are untouched: `import p from "./a.wasm"` still resolves to the file path string (`test/regression/issue/16476`), and `bun run foo.wasm` still uses the WASI runner.

### Errors instead of wrong values

- `import source x from "./mod.js"` (no source representation): `Source phase import of "…/mod.js" failed: only WebAssembly modules have a module source`. Corrupt wasm (valid magic) rejects with `WebAssembly.CompileError`.
- `bun build`: `"import source" is not supported when bundling` — the bundler treats wasm as a copied asset, so inlining the record would bind the asset path string.
- `import.source(specifier, options)`: rejected; the lowering injects its own import attributes and cannot merge an arbitrary options expression at compile time.
- Importing one specifier at **both** source and evaluation phase **from the same file**: parse error. JSC dedups a module record's requested modules by `(specifier, phase)` and ignores attributes (pre-existing: two imports of one specifier with different `type` attributes already merge silently), so one of the two bindings would get the other phase's value. Cross-file and static-source + dynamic-`import()` combinations work and are tested.

### Known limitations

- Dev server / HMR degrades the phase like `import defer` does (module lowering predates phases).
- `node:vm` / `eval` source text goes straight to JSC's parser, which has no source phase (same as dynamic `import.defer`).
- `WebAssembly.Module.prototype` does not inherit `%AbstractModuleSource%` (no such intrinsic in JSC).

Note: #31244 (dynamic `import.defer()`) touches the same `E::Import` plumbing with a `phase_defer: bool`; whichever lands second has a small rebase — this PR's `ImportPhase` enum subsumes that bool.

### Verification

`test/js/bun/resolve/import-source-phase.test.ts` — 59 spawn-based cases (32 in the original revision, 27 added during review) covering: Module identity (static/dynamic/cross-file), instantiation, eval-phase coexistence, TypeScript, `blob:` URLs, unused-binding preservation, `source`-as-identifier (including `import source from from "x"`), CommonJS/Script-goal `import.source()` (no forced ESM or strict mode, matching plain `import()`), source-phase imports of builtin modules (`bun`, `node:fs`, `bun:sqlite`; static+dynamic, literal+non-literal) and of virtual modules (`mock.module()` under `bun test`, `Bun.plugin` `build.module()`) rejecting with the same error as non-wasm files while evaluation-phase import keeps working, phase+macro-import combinations (`with { type: "macro" }`, `macro:` prefix, and bunfig `[macros]` remapping where it applies) and `bun:bundle` rejected at parse time for both `source` and `defer`, all error paths above, transpiler round-trips for both targets, and the bundler rejections. Fails 21/32 on bun without this change; 32/32 pass with it. `import-defer.test.ts` (20), `bundler/transpiler` (188), `esbuild/loader`, `esbuild/importstar`, `bundler_loader`, `transpiler-cache`, wasi, and the full `test/js/bun/resolve/` suite still pass (the two `load-same-js-file-a-lot` timeouts reproduce identically without this diff — slow-container perf test).

### Related issues

- #12434 asks for `import x from "./file.wasm"` to give a module instead of a path. This PR adds the spec-blessed way to get the compiled `WebAssembly.Module` (`import source` / `import.source()`); evaluation-phase wasm imports are intentionally unchanged, so whether that closes the issue or full wasm-ESM integration should stay open is a maintainer call.
- Not addressed: #22026 (eval-phase wasm behavior differing between `bun run` and `bun build` output) — source phase imports reject in the bundler rather than changing that behavior.



### Rebase resolution

Rebased onto main over 90 commits (head at 855db6d4). Two non-trivial adaptations to type changes landed in the interim:

- `S::Import.star_name_loc` changed from `Option<Loc>` to `Loc` with `Loc::EMPTY` as the sentinel (part of #32507). Every phase-aware site was updated to use `.is_empty()` / `Loc::EMPTY` accordingly, including the phase-shape `debug_assert!` in `p.rs`, the REPL lowering branch in `repl_transforms.rs`, and the three synthetic-import constructors.
- `LocRef.ref_` changed from `Option<Ref>` to `Ref` directly. The `import source` default-name constructor in `parse_stmt.rs` and the REPL direct-binding extractor in `repl_transforms.rs` drop the now-redundant `Some(..)` / `.expect(..)`.
- `bun_jsc::cpp` became codegen-driven (`src/codegen/cppbind.ts`). The `[[ZIG_EXPORT(zero_is_throw)]]` annotation already on `Bun__createJSWebAssemblyModuleFromBytes` in `ModuleLoader.cpp` is picked up automatically, so the hand-written extern was dropped in favor of the generated `bun_jsc::cpp::Bun__createJSWebAssemblyModuleFromBytes` wrapper (returns `JsResult<JSValue>`); the Rust call site in `jsc_hooks.rs` is unchanged.

`import-source-phase.test.ts` (41/41), `import-defer.test.ts`, `import-meta.test.js`, `esModule.test.ts`, and `bundler/transpiler/transpiler.test.js` (188/188) all pass on the rebased debug build; `cargo clippy -p bun_js_parser -p bun_ast -p bun_js_printer` is clean.

Subsequent rebases:

- Over #32519 (removed a port-era `blocked_on` comment adjacent to the inserted `check_source_phase_conflict`): trivial, kept the function and dropped the comment.
- Over 165 commits up to 88417471 (head `df5b0da8`). Two adaptations: the React Compiler integration (#32504) landed using the pre-rename `phase_defer: bool`, so its synthesized import statement now sets `phase: Evaluation` and its reconstructed `E::Import` preserves the original expression's `phase` (`src/react_compiler/{imports,codegen}.rs`); and `bun_core::contains` moved to `bun_core::strings::contains` (#33035), so `maybe_auto_watch_file` in `jsc_hooks.rs` follows. `import-source-phase.test.ts` (58/58), `import-defer.test.ts` (23/23), `react-compiler.test.ts`, and `transpiler.test.js` (188/188) pass on the rebased debug build.









