### PR TITLE
Add JIT-tier regression tests for int32-boundary parseInt/Map/switch values; fix local WebKit LTO flags

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -254,7 +254,17 @@ export const webkit: Dependency = {
     // PIE-default distros — without it the driver still passes -pie and the
     // -fno-pic probe object fails R_X86_64_32S relocation, killing FindThreads.
     if (cfg.unix && cfg.abi !== "android") optFlags.push("-fno-pic", "-fno-pie", "-no-pie");
-    if (cfg.lto) optFlags.push("-flto=thin");
+    // Match the flags oven-sh/WebKit's artifact builders use for the -lto
+    // prebuilts (Dockerfile ARG LTO_FLAG on Linux, applied to both C and
+    // C++) — the final bun link uses -fwhole-program-vtables, which requires
+    // every bitcode module to have been compiled with -fsplit-lto-unit
+    // (implied by -fwhole-program-vtables) or the link fails with
+    // "inconsistent LTO Unit splitting". The gate mirrors the link-side
+    // predicate in flags.ts (unix && !darwin), which includes FreeBSD.
+    if (cfg.lto) {
+      if (cfg.unix && !cfg.darwin) optFlags.push("-flto=full", "-fwhole-program-vtables", "-fforce-emit-vtables");
+      else optFlags.push("-flto=thin");
+    }
     if (cfg.pgoGenerate) optFlags.push(`-fprofile-generate=${cfg.pgoGenerate}`);
     if (cfg.pgoUse) {
       optFlags.push(

--- a/test/js/bun/jsc/parseint-jit-int32-overflow.test.ts
+++ b/test/js/bun/jsc/parseint-jit-int32-overflow.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// parseInt results at or above 2^31 must stay exact after the call site
+// tiers up to the DFG/FTL.
+//
+// Regression test for a miscompile in official Linux release builds: the
+// DFG's parseIntResult() (oven-sh/WebKit Source/JavaScriptCore/dfg/
+// DFGOperations.cpp) did `static_cast<int>(input)` on out-of-range doubles
+// — undefined behavior — and the LLVM 22 LTO backend folded the int32
+// overflow guard into a bare integrality test. parseInt("80000000", 16)
+// then returned -2147483648 once the function got hot, and stayed wrong
+// for the life of the process. Lower tiers were unaffected, so the flip
+// only appeared after JIT warmup.
+//
+// Only LTO release builds can exhibit the fold (debug/asan builds pass by
+// construction); CI's release lanes exercise it. See oven-sh/WebKit#245.
+test.concurrent("parseInt keeps values >= 2^31 exact after JIT warmup", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      function hex(s) { return parseInt(s, 16); }
+      function dec(s) { return parseInt(s); }
+      for (let i = 0; i < 200_000; i++) {
+        let v = hex("80000000");
+        if (v !== 2147483648) throw new Error(\`iter \${i}: parseInt("80000000", 16) === \${v}\`);
+        v = hex("ffffffff");
+        if (v !== 4294967295) throw new Error(\`iter \${i}: parseInt("ffffffff", 16) === \${v}\`);
+        v = hex("-80000001");
+        if (v !== -2147483649) throw new Error(\`iter \${i}: parseInt("-80000001", 16) === \${v}\`);
+        v = dec("2147483648");
+        if (v !== 2147483648) throw new Error(\`iter \${i}: parseInt("2147483648") === \${v}\`);
+      }
+      console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, BUN_JSC_jitPolicyScale: "0.001" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});
+
+// Same undefined-behavior class, sibling call sites (issue #31080 reported
+// the Map variant against an older canary): Map key normalization and
+// switch-immediate dispatch both compare a truncated double against the
+// original value to decide the int32 fast path.
+test.concurrent("Map keys and switch scrutinees >= 2^31 are not wrapped to int32", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      // Map key normalization (issue #31080): keys outside int32 range and
+      // ±Infinity were all replaced with -2147483648.
+      function mapRoundtrip(k) { return [...new Map([[k, 1]]).keys()][0]; }
+      // switch on a double outside int32 range must not match any int32 case.
+      // The case set is dense (range 3) so tryTableSwitch() compiles it to
+      // op_switch_imm with a jump table — the path slow_path_switch_imm
+      // handles. A raw static_cast<int32_t> there converts 2^31 and 2^32 to
+      // INT32_MIN (cvttsd2si's sentinel), matching the first case if the
+      // range check was folded away.
+      function denseSwitch(x) {
+        switch (x) {
+          case -2147483648: return "int32-min";
+          case -2147483647: return "int32-min+1";
+          case -2147483646: return "int32-min+2";
+          case -2147483645: return "int32-min+3";
+          default: return "default";
+        }
+      }
+      // 5k iterations: tier-up with this jitPolicyScale happens within the
+      // first few hundred calls; kept low because Map allocations are slow
+      // on debug/ASAN builds and the default per-test timeout applies.
+      for (let i = 0; i < 5_000; i++) {
+        let k = mapRoundtrip(2 ** 31);
+        if (k !== 2 ** 31) throw new Error(\`iter \${i}: Map key 2^31 became \${k}\`);
+        k = mapRoundtrip(Infinity);
+        if (k !== Infinity) throw new Error(\`iter \${i}: Map key Infinity became \${k}\`);
+        if (new Map([[2 ** 31, 1]]).has(2 ** 32)) throw new Error(\`iter \${i}: has(2^32) true for 2^31 key\`);
+        if (new Map([[-(2 ** 31), 1]]).has(2 ** 31)) throw new Error(\`iter \${i}: has(2^31) true for -(2^31) key\`);
+        let s = denseSwitch(2 ** 31);
+        if (s !== "default") throw new Error(\`iter \${i}: switch(2^31) matched \${s}\`);
+        s = denseSwitch(4294967296);
+        if (s !== "default") throw new Error(\`iter \${i}: switch(2^32) matched \${s}\`);
+        s = denseSwitch(-2147483648);
+        if (s !== "int32-min") throw new Error(\`iter \${i}: switch(-2^31) matched \${s}\`);
+      }
+      console.log("ok");
+      `,
+    ],
+    env: { ...bunEnv, BUN_JSC_jitPolicyScale: "0.001" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What this PR is now

**Regression tests** for the int32-boundary JIT miscompiles, plus a **local-build LTO flag fix**. The JSC source fixes landed in oven-sh/WebKit#244 and reached main via the WebKit upgrade in #31724 — this PR was rebased accordingly (it previously pinned preview artifacts of the equivalent oven-sh/WebKit#245, now superseded).

## The bug being guarded

On official Linux x64 release builds (`--lto=on`), values at or above 2^31 came back as sign-wrapped int32s once the call site tiered up to the DFG:

```js
function f(s) { return parseInt(s, 16) }
// after ~10k hot calls on 1.4 canary (≤ e75a55dab):
f("80000000") === -2147483648   // expected 2147483648; wrong for the life of the process
```

Same failure mode for Map keys (#31080: `2**31`, even `±Infinity` → `-2147483648`) and switch-immediate dispatch. Fresh processes replayed clean — lower tiers box through hardened paths — making this miserable to track down downstream.

**Root cause**: JSC had out-of-range `double`→`int` casts (undefined behavior) in round-trip checks deciding int32 boxing/dispatch (`parseIntResult`, `slow_path_switch_imm`, and friends). The Linux release pipeline ships JSC as LTO bitcode whose final optimization runs in rust-lld — rustc 1.97's **LLVM 22**, newer than the clang 21 that produced the bitcode — and LLVM 22's InstCombine legally folds `(double)(int)x == x` into a bare integrality test, deleting the overflow guard. Verified by disassembly (`vroundsd`+unguarded `vcvttsd2si` in the shipped artifact vs. the intact check from lld-21 on identical bitcode). x86-64 only (aarch64's `fcvtzs` round-trip survives the fold), LTO only, JIT-tier only — exactly the reported symptom matrix.

## Changes

- `test/js/bun/jsc/parseint-jit-int32-overflow.test.ts` — two concurrent tests spawning bun with a small `jitPolicyScale`, hammering parseInt (hex/decimal/negative/Infinity-overflow), Map key normalization (keys ≥ 2^31, ±Infinity, `has()` probes), and a dense `op_switch_imm` jump table with out-of-range scrutinees. They fail in ~130 ms on the last broken canary and exercise the real failure mode on CI's Linux x64 release (LTO) lanes; debug builds pass by construction.
- `scripts/build/deps/webkit.ts` — forward the artifact builders' LTO flags (`-flto=full -fwhole-program-vtables -fforce-emit-vtables`, per the oven-sh/WebKit Dockerfile, C and C++ alike) to **local** Linux/FreeBSD WebKit builds. With plain `-flto=thin`, `--webkit=local --lto=on` fails to link with `inconsistent LTO Unit splitting` (bun-profile links with `-fwhole-program-vtables`). This is how the fix was validated end-to-end before prebuilt artifacts existed.

## Verification

| binary | result |
|---|---|
| official canary `e75a55dab` (pre-#31724) | parseInt repro fails @ ~22k iters; regression test **fails in ~130 ms** |
| `--lto=on` @ current main pin (`6d586e29`, includes oven-sh/WebKit#244) | parseInt repro clean through 2M iters; both tests pass |
| `--lto=on` @ patched local WebKit (pre-artifact validation) | clean through 10M iters incl. forced FTL; guard visibly restored in disassembly |
| `bun bd` (debug/ASAN) | both tests pass (5.4 s) |

Fixes #31080
