### PR TITLE
Bun.file().slice(): enforce the slice window on unknown-size sources (chardev over-read + stream hang)

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -670,6 +670,9 @@ impl PosixBufferedReader {
                                     ReadState::Progress
                                 },
                             );
+                            if parent.is_done() {
+                                return;
+                            }
                         } else {
                             parent
                                 ._buffer
@@ -886,15 +889,18 @@ impl PosixBufferedReader {
                                 // Once HUP is set the kernel
                                 // returns the remaining bytes then 0, so
                                 // draining to `bytes_read == 0` is bounded.
-                                if !parent.vtable.on_read_chunk(
+                                let keep_reading = parent.vtable.on_read_chunk(
                                     &event_loop.pipe_read_buffer_mut()[..head_start],
                                     if received_hup {
                                         ReadState::Eof
                                     } else {
                                         ReadState::Progress
                                     },
-                                ) && !received_hup
-                                {
+                                );
+                                // `on_read_chunk` may close the reader
+                                // (sliced window satisfied); `fd` is stale
+                                // after that even on HUP.
+                                if parent.is_done() || (!keep_reading && !received_hup) {
                                     return;
                                 }
                                 head_start = 0;
@@ -935,15 +941,15 @@ impl PosixBufferedReader {
                 }
 
                 if head_start > 0 {
-                    if !parent.vtable.on_read_chunk(
+                    let keep_reading = parent.vtable.on_read_chunk(
                         &event_loop.pipe_read_buffer_mut()[..head_start],
                         if received_hup {
                             ReadState::Eof
                         } else {
                             ReadState::Progress
                         },
-                    ) && !received_hup
-                    {
+                    );
+                    if parent.is_done() || (!keep_reading && !received_hup) {
                         return;
                     }
                 }

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -897,9 +897,6 @@ impl PosixBufferedReader {
                                         ReadState::Progress
                                     },
                                 );
-                                // `on_read_chunk` may close the reader
-                                // (sliced window satisfied); `fd` is stale
-                                // after that even on HUP.
                                 if parent.is_done() || (!keep_reading && !received_hup) {
                                     return;
                                 }

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -610,9 +610,7 @@ impl FileReader {
                 let total_readed = self.total_readed.get();
                 if total_readed >= max_size {
                     if !self.reader().is_done() {
-                        // Clear first: on Windows the chunk lives in the
-                        // reader buffer and would otherwise reach
-                        // `consume_reader_buffer` via `on_reader_done`.
+                        // Drop past-window bytes before close() or they reach consume_reader_buffer.
                         self.reader().buffer().clear();
                         self.reader().close();
                     }
@@ -624,9 +622,7 @@ impl FileReader {
                 }
                 self.total_readed.set(total_readed + len);
 
-                // Reaching `max_size` is this stream's EOF: close so a
-                // chardev / file past the window doesn't keep the consumer
-                // pending on a read that is never re-armed.
+                // Reaching `max_size` is this stream's EOF.
                 if total_readed + len >= max_size {
                     close = true;
                     has_more = false;

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -609,6 +609,13 @@ impl FileReader {
             if let Some(max_size) = self.max_size {
                 let total_readed = self.total_readed.get();
                 if total_readed >= max_size {
+                    if !self.reader().is_done() {
+                        // Clear first: on Windows the chunk lives in the
+                        // reader buffer and would otherwise reach
+                        // `consume_reader_buffer` via `on_reader_done`.
+                        self.reader().buffer().clear();
+                        self.reader().close();
+                    }
                     return false;
                 }
                 let len = (max_size - total_readed).min(buf.len());
@@ -617,7 +624,10 @@ impl FileReader {
                 }
                 self.total_readed.set(total_readed + len);
 
-                if buf.is_empty() {
+                // Reaching `max_size` is this stream's EOF: close so a
+                // chardev / file past the window doesn't keep the consumer
+                // pending on a read that is never re-armed.
+                if total_readed + len >= max_size {
                     close = true;
                     has_more = false;
                 }
@@ -713,7 +723,7 @@ impl FileReader {
                     break 'pending false;
                 }
 
-                let was_done = self.reader().is_done();
+                let was_done = self.reader().is_done() || close;
 
                 if pending_buf.len() >= buf.len() {
                     pending_buf[0..buf.len()].copy_from_slice(buf);
@@ -738,7 +748,7 @@ impl FileReader {
 
                 // SAFETY: see `reader_buffer` decl — tight deref.
                 if is_slice_in_vec_capacity(buf, unsafe { &*reader_buffer }) {
-                    if self.reader().is_done() {
+                    if was_done {
                         // SAFETY: see `reader_buffer` decl.
                         debug_assert_eq!(buf.as_ptr(), unsafe { (*reader_buffer).as_ptr() });
                         // SAFETY: see `reader_buffer` decl — tight deref, no `&mut` held across.
@@ -760,7 +770,7 @@ impl FileReader {
 
                 if !is_slice_in_vec_capacity(buf, self.buffered.get()) {
                     self.pending.with_mut(|p| {
-                        p.result = if self.reader().is_done() {
+                        p.result = if was_done {
                             streams::Result::TemporaryAndDone(bun_ptr::RawSlice::new(buf))
                         } else {
                             streams::Result::Temporary(bun_ptr::RawSlice::new(buf))
@@ -774,7 +784,7 @@ impl FileReader {
                 buffered.truncate(buf.len()); // shrinkRetainingCapacity
 
                 self.pending.with_mut(|p| {
-                    p.result = if self.reader().is_done() {
+                    p.result = if was_done {
                         streams::Result::OwnedAndDone(Vec::<u8>::move_from_list(buffered))
                     } else {
                         streams::Result::Owned(Vec::<u8>::move_from_list(buffered))
@@ -812,11 +822,13 @@ impl FileReader {
         // For pipes, we have to keep pulling or the other process will block.
         // SAFETY: see `reader_buffer` decl.
         let reader_buffer_len = unsafe { (*reader_buffer).len() };
-        let ret = !matches!(
-            self.read_inside_on_pull.get(),
-            ReadDuringJSOnPullResult::Temporary(_)
-        ) && !(self.buffered.get().len() + reader_buffer_len >= self.highwater_mark
-            && !self.reader_is_pollable());
+        let ret = !close
+            && !matches!(
+                self.read_inside_on_pull.get(),
+                ReadDuringJSOnPullResult::Temporary(_)
+            )
+            && !(self.buffered.get().len() + reader_buffer_len >= self.highwater_mark
+                && !self.reader_is_pollable());
         close_if_needed!();
         ret
     }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -804,6 +804,7 @@ impl ReadFile {
             // held as a safe `&mut [u8]` across the `&mut self` call.
             let mut buffer = core::mem::take(&mut self.buffer);
             while self.state.load(Ordering::Relaxed) == ClosingState::Running as u8 {
+                self.read_off = buffer.len() as SizeType;
                 let (use_stack, buf) = Self::remaining_buffer(
                     &mut buffer,
                     &mut stack_buffer,
@@ -843,6 +844,7 @@ impl ReadFile {
                     //   be Blob.max_size which is an impossibly large
                     //   amount to read.
                     if !self.read_eof && buffer.len() >= self.max_length as usize {
+                        buffer.truncate(self.max_length as usize);
                         break;
                     }
 

--- a/test/js/bun/util/bun-file.test.ts
+++ b/test/js/bun/util/bun-file.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import fsPromises from "fs/promises";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 test("delete() and stat() should work with unicode paths", async () => {
@@ -154,4 +154,89 @@ test("Bun.file().json() with UTF-8 BOM does not free an interior pointer", async
     emptyErr: "Unexpected end of JSON input",
   });
   expect(exitCode).toBe(0);
+});
+
+// Bun.file(<chardev>).slice(a, b): the slice window must be enforced on
+// sources whose stat size is unknown (character devices). Previously the
+// buffered consumers rounded up to the internal read-chunk quantum and
+// .stream() delivered the window but never closed.
+describe.skipIf(!isPosix)("Bun.file().slice() on a character device", () => {
+  const cases = [
+    [0, 1],
+    [0, 100_000],
+    [0, 999_999],
+    [0, 1_000_000],
+    [500_000, 1_500_000],
+  ] as const;
+
+  test.concurrent.each(cases)(".arrayBuffer()/.bytes()/.text() return exactly the window [%i, %i)", async (a, b) => {
+    const want = b - a;
+    const sl = Bun.file("/dev/zero").slice(a, b);
+    expect(sl.size).toBe(want);
+
+    const buf = await sl.arrayBuffer();
+    expect(buf.byteLength).toBe(want);
+
+    const bytes = await Bun.file("/dev/zero").slice(a, b).bytes();
+    expect(bytes.byteLength).toBe(want);
+
+    const text = await Bun.file("/dev/zero").slice(a, b).text();
+    expect(text.length).toBe(want);
+  });
+
+  test.concurrent("buffered read returns the window's contents", async () => {
+    const bytes = await Bun.file("/dev/zero").slice(0, 100_000).bytes();
+    expect(bytes.byteLength).toBe(100_000);
+    expect(Buffer.from(bytes.buffer).equals(Buffer.alloc(100_000))).toBe(true);
+  });
+
+  test.concurrent("/dev/urandom .bytes() returns exactly the slice length", async () => {
+    const bytes = await Bun.file("/dev/urandom").slice(0, 999_999).bytes();
+    expect(bytes.byteLength).toBe(999_999);
+  });
+
+  test.concurrent.each(cases)(".stream() delivers exactly the window [%i, %i) and then closes", async (a, b) => {
+    const want = b - a;
+    let got = 0;
+    for await (const chunk of Bun.file("/dev/zero").slice(a, b).stream()) {
+      got += chunk.byteLength;
+    }
+    expect(got).toBe(want);
+  });
+
+  test.concurrent(".stream() getReader().read() resolves done after the window", async () => {
+    const reader = Bun.file("/dev/zero").slice(0, 1_000_000).stream().getReader();
+    let got = 0;
+    while (true) {
+      const r = await reader.read();
+      if (r.done) break;
+      got += r.value.byteLength;
+    }
+    expect(got).toBe(1_000_000);
+  });
+});
+
+// Same slice-window exhaustion applies to regular files larger than the
+// streaming read buffer: the window is satisfied mid-read instead of at EOF,
+// so the reader must close itself (https://github.com/oven-sh/bun/issues/31675).
+test.concurrent("Bun.file().slice(start, end).stream() resolves on a file larger than the read buffer", async () => {
+  const size = 1024 * 1024;
+  const data = Buffer.alloc(size);
+  for (let i = 0; i < size; i++) data[i] = i % 251;
+  using dir = tempDir("bun-file-slice-stream", { "data.bin": data });
+  const p = join(String(dir), "data.bin");
+
+  const small = Buffer.from(await Bun.file(p).slice(100, 1124).stream().bytes());
+  expect(small.equals(data.subarray(100, 1124))).toBe(true);
+
+  const spanStart = 1000;
+  const spanEnd = spanStart + 600 * 1024;
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of Bun.file(p).slice(spanStart, spanEnd).stream()) {
+    chunks.push(chunk);
+  }
+  expect(Buffer.concat(chunks).equals(data.subarray(spanStart, spanEnd))).toBe(true);
+
+  const empty = await Bun.file(p).slice(500, 500).stream().bytes();
+  expect(empty.byteLength).toBe(0);
 });


### PR DESCRIPTION
### What

`Bun.file(path).slice(start, end)` does not enforce the slice window when the underlying source's stat size is unknown, and the same slice's consumers disagree with each other:

```js
// character device
const sl = Bun.file("/dev/zero").slice(0, 1_000_000);
sl.size;                         // 1000000
(await sl.arrayBuffer()).byteLength;   // 1048576  (over-read, rounded up to the read-chunk quantum)
(await sl.text()).length;              // 1048576
for await (const c of sl.stream()) {}  // delivers exactly 1000000 bytes, then never closes

// regular file larger than the streaming read buffer
await Bun.write("/tmp/data.bin", Buffer.alloc(1024 * 1024, 0x42));
await Bun.file("/tmp/data.bin").slice(100, 1124).stream().bytes();  // never resolves
```

Observed sizes from the buffered consumers: `slice(0, 500_000)` returns 524_288, `slice(0, 999_999)` returns 1_048_576, `slice(0, 3_000_000)` returns 4_194_304. So `.size` (and by extension Content-Length framing) understates the delivered bytes, and "give me N random bytes from `/dev/urandom`" hands back N rounded up.

Fixes #31675
Fixes #18192

### Why

Two independent paths:

**Buffered read over-read** (`src/runtime/webcore/blob/read_file.rs`): the POSIX `do_read_loop` passes `self.read_off` to `remaining_buffer()` as "bytes read so far", but never increments it (Windows `ReadFileUV` does). So each read is capped at `max_length` rather than `max_length - bytes_read_so_far`; the `Vec` capacity doubles, the 64 KB stack read fills the spare, and the loop breaks at `buffer.len() >= max_length` without truncating. For regular files this does not bite because the initial allocation is `stat.st_size + 16` and the first read is exact; for `could_block` sources the initial allocation is 4 KB and the loop keeps reading.

**Stream hang** (`src/runtime/webcore/FileReader.rs`): `on_read_chunk` caps the stream at `max_size`, but the chunk that satisfies the window was truncated and delivered as a non-final chunk (`has_more` / `close` stay unset because the `if buf.is_empty()` branch is dead code after the `total_readed >= max_size` guard). The next chunk then hit `total_readed >= max_size` and returned `false`, which stops the `read_with_fn` drain loop without calling `done()` or closing the reader. Regular files are not pollable so nothing re-arms a read, and `/dev/zero` just keeps producing on the next pull; the pending read promise leaks and the consumer hangs.

### How

- `read_file.rs`: keep `read_off` in sync with `buffer.len()` so `remaining_buffer()` computes the actual remaining window, and truncate to `max_length` at the `>=` break.
- `FileReader.rs`: treat reaching `max_size` as this stream's EOF. Set `close = true` / `has_more = false` when the window is satisfied, fold `close` into `was_done` so the pending path yields `*AndDone`, return `false` from the fallthrough `ret`, and close the reader on the already-exhausted early return.
- `PipeReader.rs`: stop the posix drain loops when `on_read_chunk` finished the reader; the captured `fd` is stale after the callback closes it.

### Verification

New tests in `test/js/bun/util/bun-file.test.ts` cover the `/dev/zero` and `/dev/urandom` slice windows across `.arrayBuffer()` / `.bytes()` / `.text()` / `.stream()` / `getReader().read()`, plus a 1 MiB regular file (window inside the first chunk, spanning multiple chunks, and empty). On `main` the buffered-read cases fail with the rounded-up byte counts and every `.stream()` case times out; with the fix they pass in about 6 seconds.

Supersedes #27213 (same logic applied to the pre-port `FileReader.zig`).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 13 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (6a5e98a03)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [326.80ms]
(pass) writer.end() should not close the fd if it does not own the fd [982.81ms]
(pass) Bun.file() read errors include async stack frames [31.44ms]
(pass) Bun.write() errors include async stack frames [35.81ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [21.55ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [740.78ms]
173 |     const want = b - a;
174 |     const sl = Bun.file("/dev/zero").slice(a, b);
175 |     expect(sl.size).toBe(want);
176 | 
177 |     const buf = await sl.arrayBuffer();
178 |     expect(buf.byteLength).toBe(want);
                                 ^
error: expect(received).toBe(expected)

Expected: 100000
Received: 131072

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-file.test.ts:178:28)
173 |     const want = b - a;
174 |     const sl = Bun.file("/dev/zero").slice(a, b);
175 |     expec
... (truncated)

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [5.44ms]
(pass) writer.end() should not close the fd if it does not own the fd [4.98ms]
(pass) Bun.file() read errors include async stack frames [0.76ms]
(pass) Bun.write() errors include async stack frames [2.48ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [0.39ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [385.53ms]
173 |     const want = b - a;
174 |     const sl = Bun.file("/dev/zero").slice(a, b);
175 |     expect(sl.size).toBe(want);
176 | 
177 |     const buf = await sl.arrayBuffer();
178 |     expect(buf.byteLength).toBe(want);
                                 ^
error: expect(received).toBe(expected)

Expected: 100000
Received: 131072

      at <anonymous> (/workspace/bun/test/js/bun/util/bun-file.test.ts:178:28)
184 |     expect(text.length).toBe(want);
185 |   });
186 | 
187 |   test.concurrent("buffered read returns the window's contents", async () => {
188 |     const bytes = await Bun.file("/dev/zero").slice(0, 100_000).bytes();
189 |     expect(bytes.byteLength).toBe(1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/bun-file.test.ts
bun test v1.4.0 (6a5e98a03)

test/js/bun/util/bun-file.test.ts:
(pass) delete() and stat() should work with unicode paths [244.36ms]
(pass) writer.end() should not close the fd if it does not own the fd [795.13ms]
(pass) Bun.file() read errors include async stack frames [27.83ms]
(pass) Bun.write() errors include async stack frames [37.36ms]
(pass) Bun.file().arrayBuffer() errors include async stack frames [19.69ms]
(pass) Bun.file().json() with UTF-8 BOM does not free an interior pointer [868.46ms]
(pass) Bun.file().slice() on a character device > .arrayBuffer()/.bytes()/.text() return exactly the window [0, 1) [52.69ms]
(pass) Bun.file().slice() on a character device > .arrayBuffer()/.bytes()/.text() return exactly the window [0, 100000) [42.80ms]
(pass) Bun.file().slice() on a character device > .arrayBuffer()/.bytes()/.text() return exactly the window [0, 999999) [49.92ms]
(pass) Bun.file().slice() on a character device > .stream() delivers exactly the window [0, 1) and then closes [21.88ms]
(pass)
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     6a5e98a03b
  features     baseline

22 deps, 108 codegen, 1171 objects in 4804ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1234] fetch tinycc
[tinycc] up to date
[2/1234] gen ErrorCode+*.h
[3/1234] gen bindgenv2
[4/1234] gen .bind.ts → GeneratedBindings.cpp
[5/1234] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[6/1234] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[7/1234] fetch zlib
[zlib] up to date
[8/1234] fetch picohttpparser
[picohttpparser] up to date
[9/1234] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[10/1234] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[11/1234] subst deps/zlib/zconf.h
[12/1234] subst deps/zlib/zlib.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/io/PipeReader.rs                  | 15 +++---
 src/runtime/webcore/FileReader.rs     | 28 +++++++----
 src/runtime/webcore/blob/read_file.rs |  2 +
 test/js/bun/util/bun-file.test.ts     | 89 ++++++++++++++++++++++++++++++++++-
 4 files changed, 116 insertions(+), 18 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 13

<details><summary>evidence per changed file</summary>

```
file                                   reads  edits  tests
src/io/PipeReader.rs                      11      4      3
src/runtime/webcore/FileReader.rs          7     10      4
src/runtime/webcore/blob/read_file.rs      0      0      1
test/js/bun/util/bun-file.test.ts          0      0      1
```

</details>

<!-- robobun:evidence:end -->