### PR TITLE
Allow napi_delete_reference to be called from finalizers during GC

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1236,12 +1236,20 @@ extern "C" napi_status napi_reference_ref(napi_env env, napi_ref ref,
 
 extern "C" napi_status napi_delete_reference(napi_env env, napi_ref ref)
 {
-    NAPI_PREAMBLE(env);
-    NAPI_CHECK_ENV_NOT_IN_GC(env);
+    // This function must be callable from finalizers that run while the
+    // garbage collector is sweeping: deleting the reference returned by
+    // napi_wrap is documented to be done from the finalize callback, and
+    // node-addon-api's ObjectWrap destructor relies on that. Node declares
+    // napi_delete_reference with node_api_basic_env and deliberately omits
+    // both CHECK_ENV_NOT_IN_GC and the pending-exception check, so we must
+    // not use NAPI_CHECK_ENV_NOT_IN_GC or the throw-scope preamble here.
+    // Deleting the NapiRef mid-sweep is safe: its WeakImpl is already in the
+    // Finalized state, so clearing it only marks it Deallocated.
+    NAPI_PREAMBLE_NO_THROW_SCOPE(env);
     NAPI_CHECK_ARG(env, ref);
     NapiRef* napiRef = toJS(ref);
     delete napiRef;
-    NAPI_RETURN_SUCCESS(env);
+    return napi_clear_last_error(env);
 }
 
 extern "C" napi_status napi_is_detached_arraybuffer(napi_env env,

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -324,7 +324,7 @@ public:
                 fprintf(stderr, "Use `node_api_post_finalizer` from inside of the finalizer to work around this issue.\n");
                 fprintf(stderr, "It schedules the call as a new task in the event loop.\n");
                 fflush(stderr);
-                NAPI_ABORT("napi_reference_unref");
+                NAPI_ABORT("A Node-API function that may affect GC state was called from a finalizer during garbage collection");
             }
         }
     }

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -263,5 +263,16 @@
                 "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
             ],
         },
+        {
+            "target_name": "test_delete_ref_in_finalizer_experimental",
+            "sources": ["test_delete_ref_in_finalizer_experimental.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/test_delete_ref_in_finalizer_experimental.c
+++ b/test/napi/napi-app/test_delete_ref_in_finalizer_experimental.c
@@ -1,0 +1,162 @@
+// Test that napi_delete_reference can be called from a finalizer that runs
+// while the garbage collector is sweeping, in a module built with the
+// experimental Node-API version (experimental modules run finalizers
+// synchronously from GC instead of deferring them).
+//
+// Node.js explicitly allows this: napi_delete_reference takes
+// node_api_basic_env and performs no GC-access check, because deleting the
+// reference returned by napi_wrap is documented to be done from the finalize
+// callback (node-addon-api's ObjectWrap destructor does exactly this).
+//
+// Bun used to abort here with the message "napi_reference_unref".
+
+#define NAPI_EXPERIMENTAL
+
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define NODE_API_CALL(env, call)                                               \
+  do {                                                                         \
+    napi_status status = (call);                                               \
+    if (status != napi_ok) {                                                   \
+      const napi_extended_error_info *error_info = NULL;                       \
+      napi_get_last_error_info((env), &error_info);                            \
+      const char *err_message = error_info->error_message;                     \
+      bool is_pending;                                                         \
+      napi_is_exception_pending((env), &is_pending);                           \
+      if (!is_pending) {                                                       \
+        const char *message =                                                  \
+            (err_message == NULL) ? "empty error message" : err_message;       \
+        napi_throw_error((env), NULL, message);                                \
+      }                                                                        \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
+
+typedef struct {
+  napi_ref ref;
+} RefHolder;
+
+static int finalize_count = 0;
+static int delete_ok_count = 0;
+
+static void finalize_delete_own_ref(napi_env env, void *data, void *hint) {
+  (void)hint;
+  RefHolder *holder = (RefHolder *)data;
+  finalize_count++;
+
+  if (holder && holder->ref) {
+    // Deleting the reference from its own finalize callback is the documented
+    // way to clean up the napi_ref created by napi_wrap/napi_add_finalizer.
+    // This must work even though the finalizer runs during garbage
+    // collection.
+    napi_status status = napi_delete_reference(env, holder->ref);
+    if (status == napi_ok) {
+      delete_ok_count++;
+    } else {
+      fprintf(stderr, "napi_delete_reference returned status %d\n",
+              (int)status);
+    }
+  }
+
+  free(holder);
+}
+
+// Create `count` objects wrapped with napi_wrap; each finalize callback
+// deletes the reference napi_wrap returned (the node-addon-api ObjectWrap
+// pattern).
+static napi_value create_wrapped(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+
+  uint32_t count = 0;
+  NODE_API_CALL(env, napi_get_value_uint32(env, argv[0], &count));
+
+  for (uint32_t i = 0; i < count; i++) {
+    napi_value obj;
+    NODE_API_CALL(env, napi_create_object(env, &obj));
+
+    RefHolder *holder = (RefHolder *)malloc(sizeof(RefHolder));
+    holder->ref = NULL;
+    NODE_API_CALL(env, napi_wrap(env, obj, holder, finalize_delete_own_ref,
+                                 NULL, &holder->ref));
+  }
+
+  napi_value undefined;
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+  return undefined;
+}
+
+// Create `count` objects with napi_add_finalizer; each finalize callback
+// deletes the reference napi_add_finalizer returned.
+static napi_value create_with_finalizer(napi_env env,
+                                        napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  NODE_API_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+
+  uint32_t count = 0;
+  NODE_API_CALL(env, napi_get_value_uint32(env, argv[0], &count));
+
+  for (uint32_t i = 0; i < count; i++) {
+    napi_value obj;
+    NODE_API_CALL(env, napi_create_object(env, &obj));
+
+    RefHolder *holder = (RefHolder *)malloc(sizeof(RefHolder));
+    holder->ref = NULL;
+    NODE_API_CALL(env, napi_add_finalizer(env, obj, holder,
+                                          finalize_delete_own_ref, NULL,
+                                          &holder->ref));
+  }
+
+  napi_value undefined;
+  NODE_API_CALL(env, napi_get_undefined(env, &undefined));
+  return undefined;
+}
+
+static napi_value get_stats(napi_env env, napi_callback_info info) {
+  (void)info;
+  napi_value result;
+  NODE_API_CALL(env, napi_create_object(env, &result));
+
+  napi_value finalizers_called;
+  NODE_API_CALL(env, napi_create_int32(env, finalize_count,
+                                       &finalizers_called));
+  NODE_API_CALL(env, napi_set_named_property(env, result, "finalizersCalled",
+                                             finalizers_called));
+
+  napi_value deletes_succeeded;
+  NODE_API_CALL(env, napi_create_int32(env, delete_ok_count,
+                                       &deletes_succeeded));
+  NODE_API_CALL(env, napi_set_named_property(env, result, "deletesSucceeded",
+                                             deletes_succeeded));
+
+  return result;
+}
+
+static napi_value init(napi_env env, napi_value exports) {
+  napi_value fn;
+
+  NODE_API_CALL(env, napi_create_function(env, "createWrapped",
+                                          NAPI_AUTO_LENGTH, create_wrapped,
+                                          NULL, &fn));
+  NODE_API_CALL(env,
+                napi_set_named_property(env, exports, "createWrapped", fn));
+
+  NODE_API_CALL(env, napi_create_function(env, "createWithFinalizer",
+                                          NAPI_AUTO_LENGTH,
+                                          create_with_finalizer, NULL, &fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports,
+                                             "createWithFinalizer", fn));
+
+  NODE_API_CALL(env, napi_create_function(env, "getStats", NAPI_AUTO_LENGTH,
+                                          get_stats, NULL, &fn));
+  NODE_API_CALL(env, napi_set_named_property(env, exports, "getStats", fn));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/test/napi/napi-finalizer-delete-ref.test.ts
+++ b/test/napi/napi-finalizer-delete-ref.test.ts
@@ -1,21 +1,35 @@
 import { spawn, spawnSync } from "bun";
 import { beforeAll, expect, it } from "bun:test";
+import { existsSync } from "fs";
 import { bunEnv, bunExe } from "harness";
 import { join } from "path";
 
+const addonPath = join(__dirname, "napi-app/build/Debug/test_delete_ref_in_finalizer_experimental.node");
+
 beforeAll(() => {
-  // build the native addons in napi-app (cached once napi.test.ts or a
-  // previous run has built them)
-  const install = spawnSync({
-    cmd: [bunExe(), "install", "--verbose"],
-    cwd: join(__dirname, "napi-app"),
-    stderr: "inherit",
-    env: bunEnv,
-    stdout: "inherit",
-    stdin: "inherit",
-  });
-  if (!install.success) {
-    throw new Error("building napi-app addons failed");
+  // Build the native addons in napi-app, but only if the one this test needs
+  // is missing (napi.test.ts or a previous run usually has built it already).
+  // The addon doesn't link against bun, so an existing binary stays valid
+  // across bun builds; skipping the install avoids re-running the node-gyp
+  // rebuild, which is slow and occasionally flaky under resource pressure.
+  if (existsSync(addonPath)) {
+    return;
+  }
+  for (let attempt = 0; ; attempt++) {
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: join(__dirname, "napi-app"),
+      stderr: "inherit",
+      env: bunEnv,
+      stdout: "inherit",
+      stdin: "inherit",
+    });
+    if (install.success && existsSync(addonPath)) {
+      return;
+    }
+    if (attempt >= 1) {
+      throw new Error("building napi-app addons failed");
+    }
   }
 }, 300_000);
 

--- a/test/napi/napi-finalizer-delete-ref.test.ts
+++ b/test/napi/napi-finalizer-delete-ref.test.ts
@@ -19,19 +19,17 @@ beforeAll(() => {
   }
 }, 300_000);
 
-it(
-  "napi_delete_reference can be called from finalizers during GC in experimental modules",
-  async () => {
-    // Finalizers in NAPI_VERSION_EXPERIMENTAL modules run synchronously while
-    // the garbage collector is sweeping. Unlike napi_reference_unref (which
-    // really is forbidden there, see "napi_reference_unref is blocked from
-    // finalizers in experimental modules" in napi.test.ts), Node.js still
-    // allows napi_delete_reference during GC: it takes node_api_basic_env,
-    // and deleting the reference returned by napi_wrap is documented to be
-    // done from the finalize callback (node-addon-api's ObjectWrap destructor
-    // does exactly this). Bun used to abort with a "napi_reference_unref"
-    // panic.
-    const code = `
+it("napi_delete_reference can be called from finalizers during GC in experimental modules", async () => {
+  // Finalizers in NAPI_VERSION_EXPERIMENTAL modules run synchronously while
+  // the garbage collector is sweeping. Unlike napi_reference_unref (which
+  // really is forbidden there, see "napi_reference_unref is blocked from
+  // finalizers in experimental modules" in napi.test.ts), Node.js still
+  // allows napi_delete_reference during GC: it takes node_api_basic_env,
+  // and deleting the reference returned by napi_wrap is documented to be
+  // done from the finalize callback (node-addon-api's ObjectWrap destructor
+  // does exactly this). Bun used to abort with a "napi_reference_unref"
+  // panic.
+  const code = `
       const addon = require(${JSON.stringify(
         join(__dirname, "napi-app/build/Debug/test_delete_ref_in_finalizer_experimental.node"),
       )});
@@ -53,23 +51,21 @@ it(
       }
       console.log("SUCCESS");
     `;
-    const { BUN_INSPECT_CONNECT_TO: _, ASAN_OPTIONS, ...rest } = bunEnv;
-    await using proc = spawn({
-      cmd: [bunExe(), "-e", code],
-      env: {
-        ...rest,
-        // If the GC check wrongly fires, die with a plain abort instead of
-        // hanging in the crash reporter / ASAN symbolizer.
-        BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1",
-        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("FATAL ERROR");
-    expect(stdout).toContain("SUCCESS");
-    expect(exitCode).toBe(0);
-  },
-  30_000,
-);
+  const { BUN_INSPECT_CONNECT_TO: _, ASAN_OPTIONS, ...rest } = bunEnv;
+  await using proc = spawn({
+    cmd: [bunExe(), "-e", code],
+    env: {
+      ...rest,
+      // If the GC check wrongly fires, die with a plain abort instead of
+      // hanging in the crash reporter / ASAN symbolizer.
+      BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1",
+      ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("FATAL ERROR");
+  expect(stdout).toContain("SUCCESS");
+  expect(exitCode).toBe(0);
+}, 30_000);

--- a/test/napi/napi-finalizer-delete-ref.test.ts
+++ b/test/napi/napi-finalizer-delete-ref.test.ts
@@ -1,0 +1,75 @@
+import { spawn, spawnSync } from "bun";
+import { beforeAll, expect, it } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "path";
+
+beforeAll(() => {
+  // build the native addons in napi-app (cached once napi.test.ts or a
+  // previous run has built them)
+  const install = spawnSync({
+    cmd: [bunExe(), "install", "--verbose"],
+    cwd: join(__dirname, "napi-app"),
+    stderr: "inherit",
+    env: bunEnv,
+    stdout: "inherit",
+    stdin: "inherit",
+  });
+  if (!install.success) {
+    throw new Error("building napi-app addons failed");
+  }
+}, 300_000);
+
+it(
+  "napi_delete_reference can be called from finalizers during GC in experimental modules",
+  async () => {
+    // Finalizers in NAPI_VERSION_EXPERIMENTAL modules run synchronously while
+    // the garbage collector is sweeping. Unlike napi_reference_unref (which
+    // really is forbidden there, see "napi_reference_unref is blocked from
+    // finalizers in experimental modules" in napi.test.ts), Node.js still
+    // allows napi_delete_reference during GC: it takes node_api_basic_env,
+    // and deleting the reference returned by napi_wrap is documented to be
+    // done from the finalize callback (node-addon-api's ObjectWrap destructor
+    // does exactly this). Bun used to abort with a "napi_reference_unref"
+    // panic.
+    const code = `
+      const addon = require(${JSON.stringify(
+        join(__dirname, "napi-app/build/Debug/test_delete_ref_in_finalizer_experimental.node"),
+      )});
+      function makeGarbage() {
+        addon.createWrapped(50);
+        addon.createWithFinalizer(50);
+      }
+      makeGarbage();
+      Bun.gc(true);
+      Bun.gc(true);
+      const stats = addon.getStats();
+      if (stats.finalizersCalled === 0) {
+        throw new Error("test bug: no finalizers ran during Bun.gc");
+      }
+      if (stats.deletesSucceeded !== stats.finalizersCalled) {
+        throw new Error(
+          \`napi_delete_reference failed in \${stats.finalizersCalled - stats.deletesSucceeded} of \${stats.finalizersCalled} finalizers\`,
+        );
+      }
+      console.log("SUCCESS");
+    `;
+    const { BUN_INSPECT_CONNECT_TO: _, ASAN_OPTIONS, ...rest } = bunEnv;
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", code],
+      env: {
+        ...rest,
+        // If the GC check wrongly fires, die with a plain abort instead of
+        // hanging in the crash reporter / ASAN symbolizer.
+        BUN_INTERNAL_SUPPRESS_CRASH_ON_NAPI_ABORT: "1",
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=1:symbolize=0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("FATAL ERROR");
+    expect(stdout).toContain("SUCCESS");
+    expect(exitCode).toBe(0);
+  },
+  30_000,
+);

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -75,6 +75,7 @@ test/js/third_party/prisma/prisma.test.ts
 test/js/third_party/remix/remix.test.ts
 test/js/third_party/resvg/bbox.test.js
 test/js/third_party/rollup-v4/rollup-v4.test.ts
+test/napi/napi-finalizer-delete-ref.test.ts
 test/napi/uv.test.ts
 test/napi/uv_stub.test.ts
 test/napi/node-napi-tests/test/js-native-api/2_function_arguments/do.test.ts


### PR DESCRIPTION
## What does this PR do?

Fixes the `napi_reference_unref` panic (Sentry BUN-39FR, 11 crashes/14d on 1.4.0-canary, also present on 1.3.x stable) that fires when a NAPI addon's finalize callback calls `napi_delete_reference` on its own reference while the garbage collector is sweeping.

### Reproduction

A module built with the experimental Node-API version runs its finalizers synchronously from the weak-handle sweep (`MarkedBlock::Handle::sweep` → `WeakSet::sweep` → `WeakBlock::finalize` → `NapiRefWeakHandleOwner::finalize`). If such a finalizer calls `napi_delete_reference` — e.g. node-addon-api's `ObjectWrap` destructor deleting the ref returned by `napi_wrap`, which is exactly the two addon frames in the crash stacks — Bun aborted:

```
FATAL ERROR: Finalizer is calling a function that may affect GC state.
...
panic(main thread): napi_reference_unref
```

Reproduced on Linux with `Bun.gc(true)` (→ `collectNow(Sync)` → `sweepSynchronously()`), which enters the same `SweepingScope` as the incremental sweeper timer seen in the wild — the all-Windows telemetry is population skew, not a platform difference; the guard is shared C++.

### Cause

1. `napi_delete_reference` used `NAPI_CHECK_ENV_NOT_IN_GC`. Node.js deliberately does not: it declares the function with `node_api_basic_env` and plain `CHECK_ENV`, because deleting the `napi_wrap` reference from its finalize callback is the *documented* cleanup pattern ("For a napi_reference returned from `napi_wrap`, this must be called in the finalizer." — node/src/js_native_api_v8.cc).
2. The abort message in `NapiEnv::checkGC()` was hardcoded to `napi_reference_unref` regardless of which API tripped the check, which is why the crash reports blame the wrong function.

### Fix

- `napi_delete_reference` no longer performs the GC-access check, and uses `NAPI_PREAMBLE_NO_THROW_SCOPE` + `napi_clear_last_error` to match Node's "omit NAPI_PREAMBLE, calls here cannot throw" semantics (it must also work with a pending exception). Deleting the `NapiRef` mid-sweep is safe: its `WeakImpl` is already in the `Finalized` state, so `Weak::clear()` only marks it `Deallocated` — the same pattern `NapiRefSelfDeletingWeakHandleOwner` already uses.
- `checkGC()` aborts with an accurate message. `napi_reference_unref` (and other non-basic functions) remain blocked from in-GC finalizers, matching Node — the existing `napi_reference_unref is blocked from finalizers in experimental modules` test still covers that.

### Verification

New addon `test/napi/napi-app/test_delete_ref_in_finalizer_experimental.c` (`NAPI_EXPERIMENTAL`) wraps objects with `napi_wrap`/`napi_add_finalizer` whose finalizers delete their own ref, driven by `test/napi/napi-finalizer-delete-ref.test.ts`:

- without the fix: `panic(main thread): napi_reference_unref` — the exact production signature
- with the fix: all 100 finalizers run during the sweep and every `napi_delete_reference` succeeds; full `test/napi/napi.test.ts` suite still passes