### PR TITLE
install: don't panic when downloading a package whose patch was removed

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1522,6 +1522,15 @@ impl<'a> PackageInstaller<'a> {
                         path: self.node_modules.path.clone(),
                         dependency_id,
                     });
+                // When the patch is being removed, its entry is no longer in
+                // `lockfile.patched_dependencies` (only in
+                // `patched_dependencies_to_remove`), so there is no patch to
+                // apply after download — fetch the package unpatched.
+                let download_patch_hash = if remove_patch {
+                    None
+                } else {
+                    patch_name_and_version_hash
+                };
                 match resolution.tag {
                     resolution::Tag::Git => {
                         package_manager::enqueue_git_for_checkout(
@@ -1530,7 +1539,7 @@ impl<'a> PackageInstaller<'a> {
                             alias.slice(string_buf!()),
                             resolution,
                             context,
-                            patch_name_and_version_hash,
+                            download_patch_hash,
                         );
                     }
                     resolution::Tag::Github => {
@@ -1542,7 +1551,7 @@ impl<'a> PackageInstaller<'a> {
                             package_id,
                             &url,
                             context,
-                            patch_name_and_version_hash,
+                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1568,7 +1577,7 @@ impl<'a> PackageInstaller<'a> {
                             package_id,
                             resolution.remote_tarball().slice(string_buf!()),
                             context,
-                            patch_name_and_version_hash,
+                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),
@@ -1600,7 +1609,7 @@ impl<'a> PackageInstaller<'a> {
                             npm.version,
                             npm.url.slice(string_buf!()),
                             context,
-                            patch_name_and_version_hash,
+                            download_patch_hash,
                         ) {
                             Ok(()) => {}
                             Err(ForTarballError::OutOfMemory) => bun_core::out_of_memory(),

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1733,6 +1733,18 @@ fn enqueue_git_clone(
     // slot already claimed would leave a claimed-but-uninit `Task` (which carries
     // `Log`/`Box<PatchTask>` drop glue) for the next `put()` to drop. With
     // `get_init` the slot is claimed only after the value is fully constructed.
+    //
+    // The patched-dependency entry can be missing (or its hash not yet
+    // computed) when install state went stale — e.g. the patch was removed
+    // from package.json, leaving the hash only in
+    // `patched_dependencies_to_remove`. Install the package unpatched instead
+    // of panicking.
+    let patch = patch_name_and_version_hash.and_then(|h| {
+        Some((
+            h,
+            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+        ))
+    });
     let value = Task::Task {
         // `this` is a live `&mut PackageManager`; the task is owned by
         // `this.preallocated_resolve_tasks` and never outlives the manager.
@@ -1761,7 +1773,7 @@ fn enqueue_git_clone(
             }),
         },
         id: task_id,
-        apply_patch_task: if let Some(h) = patch_name_and_version_hash {
+        apply_patch_task: if let Some((h, patch_hash)) = patch {
             let dep = dependency;
             let pkg_id = match this
                 .lockfile
@@ -1772,13 +1784,6 @@ fn enqueue_git_clone(
                 PackageIndexEntry::Id(p) => *p,
                 PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
             };
-            let patch_hash = this
-                .lockfile
-                .patched_dependencies
-                .get(&h)
-                .unwrap()
-                .patchfile_hash()
-                .unwrap();
             let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
             // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
             let mut pt = unsafe { bun_core::heap::take(pt) };
@@ -1806,6 +1811,17 @@ pub fn enqueue_git_checkout(
     // if patched then we need to do apply step after network task is done
     patch_name_and_version_hash: Option<u64>,
 ) -> *mut ThreadPool::Task {
+    // The patched-dependency entry can be missing (or its hash not yet
+    // computed) when install state went stale — e.g. the patch was removed
+    // from package.json, leaving the hash only in
+    // `patched_dependencies_to_remove`. Install the package unpatched instead
+    // of panicking.
+    let patch = patch_name_and_version_hash.and_then(|h| {
+        Some((
+            h,
+            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+        ))
+    });
     // SAFETY: `this` is a live `&mut PackageManager`.
     let task_value = unsafe {
         Task::Task {
@@ -1838,7 +1854,7 @@ pub fn enqueue_git_checkout(
                     env: crate::repository::SharedEnv::get(this.env_mut()),
                 }),
             },
-            apply_patch_task: if let Some(h) = patch_name_and_version_hash {
+            apply_patch_task: if let Some((h, patch_hash)) = patch {
                 let dep_name_hash =
                     this.lockfile.buffers.dependencies[dependency_id as usize].name_hash;
                 let pkg_id = match this
@@ -1850,13 +1866,6 @@ pub fn enqueue_git_checkout(
                     PackageIndexEntry::Id(p) => *p,
                     PackageIndexEntry::Ids(ps) => ps[0], // TODO is this correct
                 };
-                let patch_hash = this
-                    .lockfile
-                    .patched_dependencies
-                    .get(&h)
-                    .unwrap()
-                    .patchfile_hash()
-                    .unwrap();
                 let pt = PatchTask::new_apply_patch_hash(this, pkg_id, patch_hash, h);
                 // SAFETY: `pt` is fresh from `heap::alloc`; reclaim ownership.
                 let mut pt = bun_core::heap::take(pt);

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1742,7 +1742,10 @@ fn enqueue_git_clone(
     let patch = patch_name_and_version_hash.and_then(|h| {
         Some((
             h,
-            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+            this.lockfile
+                .patched_dependencies
+                .get(&h)?
+                .patchfile_hash()?,
         ))
     });
     let value = Task::Task {
@@ -1819,7 +1822,10 @@ pub fn enqueue_git_checkout(
     let patch = patch_name_and_version_hash.and_then(|h| {
         Some((
             h,
-            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+            this.lockfile
+                .patched_dependencies
+                .get(&h)?
+                .patchfile_hash()?,
         ))
     });
     // SAFETY: `this` is a live `&mut PackageManager`.

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1800,14 +1800,18 @@ pub fn generate_network_task_for_tarball<'a>(
     // first; the immutable `pkg_name`/`scope` borrows are taken afterwards and
     // live only through `for_tarball`, leaving `this` free for the streaming
     // tail.
-    let apply_patch_task = if let Some(h) = patch_name_and_version_hash {
-        let patch_hash = this
-            .lockfile
-            .patched_dependencies
-            .get(&h)
-            .unwrap()
-            .patchfile_hash()
-            .unwrap();
+    // The patched-dependency entry can be missing (or its hash not yet
+    // computed) when install state went stale — e.g. the patch was removed
+    // from package.json, leaving the hash only in
+    // `patched_dependencies_to_remove`. Install the package unpatched instead
+    // of panicking.
+    let patch = patch_name_and_version_hash.and_then(|h| {
+        Some((
+            h,
+            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+        ))
+    });
+    let apply_patch_task = if let Some((h, patch_hash)) = patch {
         let task: *mut PatchTask =
             PatchTask::new_apply_patch_hash(this, package.meta.id, patch_hash, h);
         // SAFETY: `task` is a fresh non-null `heap::alloc` from

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1808,7 +1808,10 @@ pub fn generate_network_task_for_tarball<'a>(
     let patch = patch_name_and_version_hash.and_then(|h| {
         Some((
             h,
-            this.lockfile.patched_dependencies.get(&h)?.patchfile_hash()?,
+            this.lockfile
+                .patched_dependencies
+                .get(&h)?
+                .patchfile_hash()?,
         ))
     });
     let apply_patch_task = if let Some((h, patch_hash)) = patch {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -942,3 +942,84 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
     });
   });
 });
+
+describe("removing a patched dependency", () => {
+  // A patch that only adds a new file applies cleanly to any package contents.
+  const isOddNewFilePatch = `diff --git a/bun-patch-test.txt b/bun-patch-test.txt
+new file mode 100644
+index 0000000000000000000000000000000000000000..2f9a147b6e5d17254f1bfce0d4e109a24a42dcab
+--- /dev/null
++++ b/bun-patch-test.txt
+@@ -0,0 +1 @@
++patched
+`;
+
+  test("install with an empty cache downloads the package unpatched", async () => {
+    const filedir = tempDirWithFiles("patch-remove", {
+      "package.json": JSON.stringify({
+        name: "remove-patch-test",
+        dependencies: {
+          "is-odd": "3.0.1",
+        },
+        patchedDependencies: {
+          "is-odd@3.0.1": "patches/is-odd@3.0.1.patch",
+        },
+      }),
+      patches: {
+        "is-odd@3.0.1.patch": isOddNewFilePatch,
+      },
+    });
+
+    // First install: bun.lock records the patched dependency and the patch is applied.
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: filedir,
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(filedir, "cache-with-patch") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(true);
+    expect(await Bun.file(join(filedir, "bun.lock")).text()).toContain("patchedDependencies");
+
+    // Remove the patch from package.json (bun.lock still references it) and
+    // install again with an empty cache so the package has to be downloaded.
+    await Bun.write(
+      join(filedir, "package.json"),
+      JSON.stringify({
+        name: "remove-patch-test",
+        dependencies: {
+          "is-odd": "3.0.1",
+        },
+      }),
+    );
+
+    // This used to panic with `called Option::unwrap() on a None value` while
+    // creating the download task: the patch entry had already been moved out of
+    // `lockfile.patched_dependencies` into the to-remove list.
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: filedir,
+        env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(filedir, "cache-empty") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).not.toContain("error:");
+      expect(exitCode).toBe(0);
+    }
+
+    // The package is reinstalled without the patch.
+    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "package.json")).json()).toMatchObject({
+      name: "is-odd",
+      version: "3.0.1",
+    });
+    expect(await Bun.file(join(filedir, "node_modules", "is-odd", "bun-patch-test.txt")).exists()).toBe(false);
+    expect(await Bun.file(join(filedir, "bun.lock")).text()).not.toContain("patchedDependencies");
+  });
+});


### PR DESCRIPTION
### Crash

`bun install` panics with `called Option::unwrap() on a None value` in `generate_network_task_for_tarball` (src/install/PackageManager/runTasks.rs). Crash telemetry: 13 crashes over 14 days across 9 consecutive canary builds (Sentry BUN-3BZF).

### Repro

1. Install a project that uses `patchedDependencies`:
   ```json
   {
     "dependencies": { "is-odd": "3.0.1" },
     "patchedDependencies": { "is-odd@3.0.1": "patches/is-odd@3.0.1.patch" }
   }
   ```
2. Delete the `patchedDependencies` entry from package.json (keep `bun.lock`).
3. Run `bun install` with an empty install cache (fresh machine / pruned cache).

```
panic: called `Option::unwrap()` on a `None` value
```

### Cause

When a patch entry exists in `bun.lock` but not in package.json, `install_with_manager` moves its hash into `patched_dependencies_to_remove` and **deletes it from `lockfile.patched_dependencies`**.

The hoisted installer (`install_package_with_name_and_resolution`) then sets `remove_patch = true` — which correctly forces a reinstall — but still passed the now-dangling `patch_name_and_version_hash` to the download/checkout enqueues. If the unpatched package is missing from the cache, `generate_network_task_for_tarball` does `lockfile.patched_dependencies.get(&h).unwrap()` on the entry that was just removed and panics. The same unwrap chain exists in `enqueue_git_clone` / `enqueue_git_checkout` for git dependencies.

The isolated installer already handles this correctly: its `PatchInfo::name_and_version_hash()` returns `None` for the `Remove` case.

### Fix

- `PackageInstaller.rs`: when `remove_patch` is set, pass no patch hash to the git/github/remote-tarball/npm download enqueues — there is no patch to apply after download; the package is fetched unpatched. This matches the isolated installer's semantics.
- `runTasks.rs` / `PackageManagerEnqueue.rs`: the three apply-patch-task constructors now look the entry up fallibly and skip creating the apply task when the entry (or its computed hash) is missing, instead of `.unwrap()`ing state that user-driven lockfile/package.json divergence can invalidate.

### Verification

New test in `test/cli/install/bun-install-patch.test.ts` (`removing a patched dependency > install with an empty cache downloads the package unpatched`) reproduces the full sequence. Without the fix the second install dies with the unwrap panic (exit 132); with the fix it exits 0, reinstalls the package unpatched, and drops `patchedDependencies` from `bun.lock`. All 18 tests in the file and all 26 in `bun-patch.test.ts` pass with the fix.
