### PR TITLE
Truncate existing destination files in path-opened FileSinks

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1504,7 +1504,10 @@ impl BlobExt for Blob {
                     let path = pathlike.path().slice_z(&mut file_path);
                     match bun_sys::open(
                         path,
-                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
+                        bun_sys::O::WRONLY
+                            | bun_sys::O::CREAT
+                            | bun_sys::O::TRUNC
+                            | bun_sys::O::NONBLOCK,
                         WRITE_PERMISSIONS,
                     ) {
                         bun_sys::Result::Ok(result) => result,
@@ -1875,7 +1878,10 @@ impl BlobExt for Blob {
                     let mut file_path = bun_paths::PathBuffer::uninit();
                     match bun_sys::open(
                         p.slice_z(&mut file_path),
-                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
+                        bun_sys::O::WRONLY
+                            | bun_sys::O::CREAT
+                            | bun_sys::O::TRUNC
+                            | bun_sys::O::NONBLOCK,
                         WRITE_PERMISSIONS,
                     ) {
                         bun_sys::Result::Ok(result) => result,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1504,10 +1504,7 @@ impl BlobExt for Blob {
                     let path = pathlike.path().slice_z(&mut file_path);
                     match bun_sys::open(
                         path,
-                        bun_sys::O::WRONLY
-                            | bun_sys::O::CREAT
-                            | bun_sys::O::TRUNC
-                            | bun_sys::O::NONBLOCK,
+                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
                         WRITE_PERMISSIONS,
                     ) {
                         bun_sys::Result::Ok(result) => result,
@@ -1558,7 +1555,12 @@ impl BlobExt for Blob {
                 unsafe {
                     (*sink)
                         .writer
-                        .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)))
+                        .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)));
+                    // Path opens replace the destination: trim it to the bytes
+                    // written once the sink ends (`truncate_to_end_offset`).
+                    (*sink)
+                        .truncate_on_end
+                        .set(!matches!(pathlike, PathOrFileDescriptor::Fd(_)));
                 };
 
                 #[cfg(windows)]
@@ -1878,10 +1880,7 @@ impl BlobExt for Blob {
                     let mut file_path = bun_paths::PathBuffer::uninit();
                     match bun_sys::open(
                         p.slice_z(&mut file_path),
-                        bun_sys::O::WRONLY
-                            | bun_sys::O::CREAT
-                            | bun_sys::O::TRUNC
-                            | bun_sys::O::NONBLOCK,
+                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
                         WRITE_PERMISSIONS,
                     ) {
                         bun_sys::Result::Ok(result) => result,
@@ -1927,6 +1926,11 @@ impl BlobExt for Blob {
             sink_mut
                 .writer
                 .with_mut(|w| w.owns_fd = !matches!(pathlike, PathOrFileDescriptor::Fd(_)));
+            // Path opens replace the destination: trim it to the bytes written
+            // once the sink ends (`truncate_to_end_offset`).
+            sink_mut
+                .truncate_on_end
+                .set(!matches!(pathlike, PathOrFileDescriptor::Fd(_)));
 
             let start_result = sink_mut.writer.with_mut(|w| {
                 if is_stdout_or_stderr {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -65,6 +65,12 @@ pub struct FileSink {
     pub is_socket: Cell<bool>,
     pub fd: Cell<Fd>,
 
+    /// Path-opened sink with `Options.truncate` (the default): when the sink
+    /// ends, trim the destination to exactly the bytes written. Deliberately
+    /// deferred to `end()` instead of `O_TRUNC` at open so rewriting a large
+    /// file in place does not free and reallocate every block (#31682, #25968).
+    pub truncate_on_end: Cell<bool>,
+
     pub auto_flusher: JsCell<AutoFlusher>,
     pub run_pending_later: FlushPendingTask,
 
@@ -283,12 +289,8 @@ impl Default for Options {
 
 impl Options {
     pub fn flags(&self) -> i32 {
-        let mut flags =
-            bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY;
-        if self.truncate {
-            flags |= bun_sys::O::TRUNC;
-        }
-        flags
+        let _ = self;
+        bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY
     }
 }
 
@@ -739,6 +741,13 @@ impl FileSink {
             }
             sys::Result::Ok(fd) => fd,
         };
+
+        // Path opens replace the destination: trim it to the bytes written
+        // once the sink ends (see `truncate_to_end_offset`). Overwrites any
+        // previous value so re-starting the sink with an fd clears it.
+        self.truncate_on_end.set(
+            options.truncate && matches!(options.input_path, PathOrFileDescriptor::Path(_)),
+        );
 
         #[cfg(windows)]
         {
@@ -1239,6 +1248,34 @@ impl FileSink {
         self.to_result(rc)
     }
 
+    /// Deferred truncate for path-opened sinks (`Options.truncate`): trim the
+    /// destination to exactly the bytes written now that the sink is ending.
+    ///
+    /// The byte count is the fd's current offset: path opens start at offset
+    /// zero and the writer only ever writes sequentially. Bytes still buffered
+    /// at this point flush sequentially afterwards, re-extending the file, so
+    /// the final size is still exactly the total bytes written. `lseek`
+    /// failing (pipe/tty/socket) skips the truncate, matching how `O_TRUNC`
+    /// is ignored for those file types.
+    fn truncate_to_end_offset(&self) {
+        if !self.truncate_on_end.get() {
+            return;
+        }
+        self.truncate_on_end.set(false);
+
+        #[cfg(not(windows))]
+        let fd = self.writer.get().get_fd();
+        #[cfg(windows)]
+        let fd = self.fd.get();
+        if fd == Fd::INVALID {
+            return;
+        }
+
+        if let sys::Result::Ok(offset) = bun_sys::lseek(fd, 0, libc::SEEK_CUR) {
+            let _ = bun_sys::ftruncate(fd, offset);
+        }
+    }
+
     pub fn end(&self, _err: Option<sys::Error>) -> sys::Result<()> {
         if self.done.get() {
             return sys::Result::Ok(());
@@ -1249,6 +1286,7 @@ impl FileSink {
         match self.writer.with_mut(|w| w.flush()) {
             WriteResult::Done(written) => {
                 self.written.set(self.written.get() + written as usize); // @truncate
+                self.truncate_to_end_offset();
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(())
             }
@@ -1259,6 +1297,7 @@ impl FileSink {
             }
             WriteResult::Pending(written) => {
                 self.written.set(self.written.get() + written as usize); // @truncate
+                self.truncate_to_end_offset();
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();
@@ -1268,6 +1307,7 @@ impl FileSink {
             }
             WriteResult::Wrote(written) => {
                 self.written.set(self.written.get() + written as usize); // @truncate
+                self.truncate_to_end_offset();
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(())
             }
@@ -1364,6 +1404,7 @@ impl FileSink {
         match flush_result {
             WriteResult::Done(written) => {
                 self.update_ref(false);
+                self.truncate_to_end_offset();
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(JSValue::js_number(written as f64))
             }
@@ -1375,6 +1416,7 @@ impl FileSink {
             WriteResult::Pending(pending_written) => {
                 self.written
                     .set(self.written.get() + pending_written as usize); // @truncate
+                self.truncate_to_end_offset();
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();
@@ -1391,6 +1433,7 @@ impl FileSink {
                 sys::Result::Ok(unsafe { (*promise_result).to_js() })
             }
             WriteResult::Wrote(written) => {
+                self.truncate_to_end_offset();
                 self.writer.with_mut(|w| w.end());
                 sys::Result::Ok(JSValue::js_number(written as f64))
             }
@@ -1563,6 +1606,7 @@ impl FileSink {
             force_sync: Cell::new(false),
             is_socket: Cell::new(false),
             fd: Cell::new(Fd::INVALID),
+            truncate_on_end: Cell::new(false),
             auto_flusher: JsCell::new(AutoFlusher::default()),
             run_pending_later: FlushPendingTask::default(),
             readable_stream: JsCell::new(readable_stream::Strong::default()),

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -745,9 +745,8 @@ impl FileSink {
         // Path opens replace the destination: trim it to the bytes written
         // once the sink ends (see `truncate_to_end_offset`). Overwrites any
         // previous value so re-starting the sink with an fd clears it.
-        self.truncate_on_end.set(
-            options.truncate && matches!(options.input_path, PathOrFileDescriptor::Path(_)),
-        );
+        self.truncate_on_end
+            .set(options.truncate && matches!(options.input_path, PathOrFileDescriptor::Path(_)));
 
         #[cfg(windows)]
         {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -283,8 +283,12 @@ impl Default for Options {
 
 impl Options {
     pub fn flags(&self) -> i32 {
-        let _ = self;
-        bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY
+        let mut flags =
+            bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY;
+        if self.truncate {
+            flags |= bun_sys::O::TRUNC;
+        }
+        flags
     }
 }
 

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -503,6 +503,19 @@ impl FileSink {
                 return;
             }
 
+            // The post-`end()` drain has completed: no write is outstanding and
+            // no buffered data remains, so the destination offset is final.
+            // Trim path-opened sinks now, before the `writer.end()`/`close()`
+            // calls below release the fd (no-op unless `truncate_on_end` is
+            // still set — the synchronous flush arms in `end`/`end_from_js`
+            // already handled the non-pending case).
+            if (*this).done.get()
+                && !has_pending_data
+                && matches!(status, WriteStatus::Drained | WriteStatus::EndOfFile)
+            {
+                (*this).truncate_to_end_offset();
+            }
+
             if (*this).pending.get().state == streams::PendingState::Pending {
                 (*this).pending.with_mut(|p| p.consumed = amount as u64); // @truncate
 
@@ -1256,16 +1269,24 @@ impl FileSink {
     /// the final size is still exactly the total bytes written. `lseek`
     /// failing (pipe/tty/socket) skips the truncate, matching how `O_TRUNC`
     /// is ignored for those file types.
+    ///
+    /// Only call this when no write is outstanding: synchronously after
+    /// `flush()` returned `Done`/`Wrote`, or from the `on_write` completion
+    /// callback once the post-`end()` drain finishes. On Windows the in-flight
+    /// `uv_fs_write` runs on the libuv thread pool, so truncating while it is
+    /// pending would race it and could discard its bytes.
+    ///
+    /// The fd comes from the writer (its current source), not `self.fd`:
+    /// `setup()` never updates `self.fd`, so a sink re-started via
+    /// `start({path})` would otherwise hit a stale — possibly user-owned —
+    /// descriptor.
     fn truncate_to_end_offset(&self) {
         if !self.truncate_on_end.get() {
             return;
         }
         self.truncate_on_end.set(false);
 
-        #[cfg(not(windows))]
         let fd = self.writer.get().get_fd();
-        #[cfg(windows)]
-        let fd = self.fd.get();
         if fd == Fd::INVALID {
             return;
         }
@@ -1296,7 +1317,8 @@ impl FileSink {
             }
             WriteResult::Pending(written) => {
                 self.written.set(self.written.get() + written as usize); // @truncate
-                self.truncate_to_end_offset();
+                // A write is still outstanding — `on_write` truncates once the
+                // drain completes (see `truncate_to_end_offset`).
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();
@@ -1415,7 +1437,8 @@ impl FileSink {
             WriteResult::Pending(pending_written) => {
                 self.written
                     .set(self.written.get() + pending_written as usize); // @truncate
-                self.truncate_to_end_offset();
+                // A write is still outstanding — `on_write` truncates once the
+                // drain completes (see `truncate_to_end_offset`).
                 if !self.must_be_kept_alive_until_eof.get() {
                     self.must_be_kept_alive_until_eof.set(true);
                     self.ref_();

--- a/test/js/bun/s3/s3-download-truncate.test.ts
+++ b/test/js/bun/s3/s3-download-truncate.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+import fs from "node:fs";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/31682
+// Bun.write(Bun.file(path), s3file) streams through a FileSink that did not
+// open the destination with O_TRUNC, so a larger pre-existing destination
+// kept its stale tail bytes.
+test("Bun.write(Bun.file(path), s3file) truncates a larger existing destination file", async () => {
+  const OBJECT_SIZE = 1024 * 1024;
+  const objectBytes = Buffer.alloc(OBJECT_SIZE, 0xaa);
+
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      if (req.method === "HEAD") {
+        return new Response(null, {
+          status: 200,
+          headers: {
+            "Content-Length": String(OBJECT_SIZE),
+            "ETag": '"etag"',
+            "Accept-Ranges": "bytes",
+          },
+        });
+      }
+      if (req.method === "GET") {
+        const range = req.headers.get("range");
+        if (range) {
+          const match = /bytes=(\d+)-(\d+)?/.exec(range);
+          if (match) {
+            const start = Number(match[1]);
+            const end = match[2] !== undefined ? Math.min(Number(match[2]), OBJECT_SIZE - 1) : OBJECT_SIZE - 1;
+            const body = objectBytes.subarray(start, end + 1);
+            return new Response(body, {
+              status: 206,
+              headers: {
+                "Content-Range": `bytes ${start}-${end}/${OBJECT_SIZE}`,
+                "Content-Length": String(body.byteLength),
+                "ETag": '"etag"',
+              },
+            });
+          }
+        }
+        return new Response(objectBytes, {
+          status: 200,
+          headers: {
+            "Content-Length": String(OBJECT_SIZE),
+            "ETag": '"etag"',
+          },
+        });
+      }
+      return new Response("unexpected request", { status: 400 });
+    },
+  });
+
+  const dest = join(tmpdirSync(), "s3-download-truncate.bin");
+
+  // Pre-existing destination that is 4x larger than the S3 object.
+  fs.writeFileSync(dest, Buffer.alloc(4 * OBJECT_SIZE, 0xee));
+
+  // The S3 client resolves HTTP(S)_PROXY from the environment once at
+  // startup, so run the download in a child process with the proxy
+  // variables removed to guarantee it talks to the local fake endpoint.
+  const env = { ...bunEnv, S3_ENDPOINT: server.url.href, S3_DEST: dest };
+  for (const key of ["HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy"]) {
+    delete env[key];
+  }
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const s3 = new Bun.S3Client({
+        endpoint: process.env.S3_ENDPOINT,
+        bucket: "bucket",
+        accessKeyId: "test",
+        secretAccessKey: "test",
+        region: "eu-west-3",
+      });
+      await Bun.write(Bun.file(process.env.S3_DEST), s3.file("object"));
+      `,
+    ],
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(0);
+
+  const actual = fs.readFileSync(dest);
+  expect(actual.byteLength).toBe(OBJECT_SIZE);
+  expect(actual.equals(objectBytes)).toBe(true);
+});

--- a/test/js/bun/s3/s3-download-truncate.test.ts
+++ b/test/js/bun/s3/s3-download-truncate.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import fs from "node:fs";
 import { join } from "node:path";
 
@@ -54,7 +54,8 @@ test("Bun.write(Bun.file(path), s3file) truncates a larger existing destination 
     },
   });
 
-  const dest = join(tmpdirSync(), "s3-download-truncate.bin");
+  using dir = tempDir("s3-download-truncate", {});
+  const dest = join(String(dir), "s3-download-truncate.bin");
 
   // Pre-existing destination that is 4x larger than the S3 object.
   fs.writeFileSync(dest, Buffer.alloc(4 * OBJECT_SIZE, 0xee));

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -171,6 +171,19 @@ import fs from "node:fs";
 import path from "node:path";
 import util from "node:util";
 
+// https://github.com/oven-sh/bun/issues/25968
+// https://github.com/oven-sh/bun/issues/31682
+it("truncates an existing larger file when opened by path", async () => {
+  const target = path.join(tmpdirSync(), "truncate.txt");
+  fs.writeFileSync(target, Buffer.alloc(1024, "e"));
+
+  const writer = Bun.file(target).writer();
+  writer.write("short");
+  await writer.end();
+
+  expect(await Bun.file(target).text()).toBe("short");
+});
+
 it("end doesn't close when backed by a file descriptor", async () => {
   using _ = fileDescriptorLeakChecker();
   const x = tmpdirSync();


### PR DESCRIPTION
### What does this PR do?

Fixes #31682 — `Bun.write(Bun.file(path), s3file)` did not truncate a larger pre-existing destination file: the first N bytes were overwritten but the stale tail survived. Also fixes #25968 — `Bun.file(path).writer()` had the same problem.

### Repro

```js
fs.writeFileSync("/tmp/out.bin", Buffer.alloc(16 * 1024 * 1024, 0xee));
await Bun.write(Bun.file("/tmp/out.bin"), s3.file("four-mb-object"));
Bun.file("/tmp/out.bin").size; // 16777216 — expected 4194304
```

### Cause

Path destinations for `FileSink` (the sink behind `Bun.file(path).writer()` and the S3→file streaming form of `Bun.write`) were opened write-only and nothing ever truncated: `FileSink.Options` has always defaulted `truncate: true`, but the field was dead on every platform. Every other `Bun.write` form (bytes→file, file→file, Response→file) replaces the destination; only path-based FileSinks did not. The same dead field existed in the Zig implementation, so this was never correct — not a regression.

### Fix

Per review feedback, truncation is deferred to the **end** of the sink instead of `O_TRUNC` at open, so rewriting a large file in place does not free and reallocate every block:

- `FileSink` gets a `truncate_on_end` flag, set when the sink opened a **path** (with `Options.truncate`, which nothing disables). Fd-provided sinks — `Bun.stdout.writer()`, `Bun.file(fd).writer()`, subprocess stdin — never set it, so user fds are never truncated.
- When the sink ends (`end()` / `endFromJS`), it runs `ftruncate(fd, lseek(fd, 0, SEEK_CUR))` once: path opens start at offset zero and the writer only writes sequentially (`uv_fs_write(…, -1, …)` on Windows), so the current offset is exactly the bytes written. Any bytes still buffered at that point flush sequentially afterwards and re-extend the file, leaving the final size exact. The fd's offset is used rather than the `written` counter because the counter misses synchronous writes (it's why `Bun.write` resolves with 0 on this path today).
- `lseek` failing (FIFO/tty/socket) skips the truncate, matching how `O_TRUNC` is ignored for those file types.
- Flush failures (`end()` error arm) skip the truncate and reject as before.

### Verification

- `test/js/bun/s3/s3-download-truncate.test.ts` (new): fake S3 endpoint via `Bun.serve`, 4 MiB pre-existing destination, 1 MiB object — asserts the file ends up exactly the object's bytes. The download runs in a child process with `HTTP(S)_PROXY` unset because the S3 client resolves the proxy from the environment at startup. (This test caught that Windows had the same bug — its direct opens route through libuv with POSIX open semantics.)
- `test/js/bun/util/filesink.test.ts` (new case): `Bun.file(path).writer()` over a larger existing file leaves only the written bytes.

Both fail without the `src/` change (stale bytes survive) and pass with it. Full `filesink.test.ts` (43), `bun-write.test.js` (35), `streams.test.js` (70), `blob-write.test.ts`, `fs.test.ts -t createWriteStream`, `spawn-streaming-stdin` and `spawn-stdin-readable-stream` suites pass with the change on Linux; `cargo check` passes for `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc`.
