### PR TITLE
crash handler: evaluate stack-trim anchors in the capturing frame

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -99,10 +99,15 @@ impl StoredTrace {
     /// Capture the current call stack starting at `begin` (or the caller's return addr).
     pub fn capture(begin: Option<usize>) -> StoredTrace {
         let mut stored = StoredTrace::EMPTY;
-        let n = crate::capture_stack_trace(
-            begin.unwrap_or_else(crate::return_address),
-            &mut stored.data,
-        );
+        // Not `unwrap_or_else`: the default trim anchor must be read from this
+        // frame. Evaluated lazily, `return_address()` inlines into the closure
+        // and reads its popped frame, so the anchor matches no captured frame
+        // and the capture machinery is never trimmed.
+        let begin = match begin {
+            Some(addr) => addr,
+            None => crate::return_address(),
+        };
+        let n = crate::capture_stack_trace(begin, &mut stored.data);
         stored.index = n;
         // Trim trailing nulls (matches Zig loop).
         for (i, &addr) in stored.data[..n].iter().enumerate() {

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -3244,6 +3244,12 @@ pub fn capture_stack_trace(begin: usize, addrs: &mut [usize]) -> usize {
 /// and `[fp + PC_OFFSET]` is the caller's saved return address. Used as the
 /// `first_address` trim point for `capture_current` (which falls back to the
 /// full trace if it doesn't match).
+///
+/// Always call this directly from the frame you want anchored. Passing it as
+/// a callback (e.g. `unwrap_or_else(return_address)`) inlines it into the
+/// closure instead, which reads the closure's frame — popped again before any
+/// capture runs — so the returned PC matches no captured frame and the trim
+/// silently degrades to the full untrimmed trace.
 #[inline(always)]
 pub fn return_address() -> usize {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -1528,6 +1528,16 @@ mod draft {
         error_return_trace: Option<&StackTrace>,
         begin_addr: Option<usize>,
     ) -> ! {
+        // Not `unwrap_or_else(debug::return_address)`: the default trim anchor
+        // must be read from *this* function's frame. Evaluated lazily, the
+        // `#[inline(always)]` intrinsic reads the closure's frame instead,
+        // which is popped before the capture walks the stack — the anchor then
+        // matches no captured frame and the capture/handler frames survive the
+        // trim, burying the real crash site in every report.
+        let begin_addr = match begin_addr {
+            Some(addr) => addr,
+            None => debug::return_address(),
+        };
         crash_handler(
             if msg == b"reached unreachable code" {
                 CrashReason::Unreachable
@@ -1538,7 +1548,7 @@ mod draft {
             },
             match error_return_trace {
                 Some(ert) if ert.index > 0 => TraceSeed::ErrorReturn(ert),
-                _ => TraceSeed::BeginAddr(begin_addr.unwrap_or_else(debug::return_address)),
+                _ => TraceSeed::BeginAddr(begin_addr),
             },
         );
     }
@@ -1939,11 +1949,14 @@ mod draft {
         limits: bun_core::DumpStackTraceOptions,
     ) {
         Output::flush();
+        // Not `unwrap_or_else`: the default trim anchor must be read from this
+        // frame, not from a closure's popped frame (see `panic_impl`).
+        let first_address = match first_address {
+            Some(addr) => addr,
+            None => debug::return_address(),
+        };
         let mut addrs: [usize; 32] = [0; 32];
-        let n = debug::capture_stack_trace(
-            first_address.unwrap_or_else(debug::return_address),
-            &mut addrs,
-        );
+        let n = debug::capture_stack_trace(first_address, &mut addrs);
         let n = n.min(limits.frame_count);
         if !Environment::SHOW_CRASH_TRACE {
             // debug symbols aren't available, lets print a tracestring
@@ -3270,11 +3283,14 @@ mod draft {
     }
 
     pub fn dump_current_stack_trace(first_address: Option<usize>, limits: WriteStackTraceLimits) {
+        // Not `unwrap_or_else`: the default trim anchor must be read from this
+        // frame, not from a closure's popped frame (see `panic_impl`).
+        let first_address = match first_address {
+            Some(addr) => addr,
+            None => debug::return_address(),
+        };
         let mut addrs: [usize; 32] = [0; 32];
-        let n = debug::capture_stack_trace(
-            first_address.unwrap_or_else(debug::return_address),
-            &mut addrs,
-        );
+        let n = debug::capture_stack_trace(first_address, &mut addrs);
         let stack = StackTrace {
             index: n,
             instruction_addresses: &addrs,

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,8 +1,41 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
+
+// On Linux, debug builds symbolize crash traces by spawning llvm-symbolizer;
+// without it the fallback printer has no Rust symbol names to assert on.
+const hasSymbolizer = !!(Bun.which("llvm-symbolizer") || Bun.which("llvm-symbolizer-21"));
+
+test.if(isDebug && isLinux && hasSymbolizer)(
+  "crash trace starts at the crash site, not inside the crash handler",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic"],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    // The panic header goes to stderr; the symbolized frames are printed by
+    // llvm-symbolizer, which is spawned with inherited stdio, so they land on
+    // stdout.
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain("panic(main thread): invoked crashByPanic() handler");
+    expect(exitCode).not.toBe(0);
+
+    // The innermost frame of the trace must be the code that crashed (the
+    // js_panic test hook)...
+    const firstFrame = stdout.split("\n").find(line => line.trim().length > 0);
+    expect(firstFrame ?? "<no frames printed>").toContain("js_panic");
+
+    // ...not the capture machinery. A mismatched trim anchor used to leave
+    // `capture_stack_trace` → `crash_handler` → `panic_impl` as the innermost
+    // frames of every report, burying the real crash site.
+    expect(stdout).not.toContain("capture_stack_trace");
+  },
+  60_000, // symbolizing the debug binary takes several seconds
+);
 
 test.if(process.platform === "darwin")("macOS has the assumed image offset", () => {
   // If this fails, then https://bun.report will be incorrect and the stack


### PR DESCRIPTION
### Problem

Crash traces could keep the crash handler's own capture machinery as the innermost frames, burying the real crash site. On a debug build, `bun fixture-crash.js panic` printed:

```
panic(main thread): invoked crashByPanic() handler
bun_core::capture_stack_trace            ← innermost
bun_crash_handler::debug::capture_stack_trace
bun_crash_handler::draft::crash_handler
bun_crash_handler::draft::panic_impl
bun_runtime::api::crash_handler_jsc::js_bindings::js_panic   ← real crash site, buried 5 deep
```

This is the remaining instance of the bug family #31163 fixed for signal-delivered faults (the "`Bun__captureStackTrace`" Sentry grouping problem): paths that seed the capture with a `BeginAddr` trim anchor instead of a fault context.

### Cause

Four sites computed the default anchor lazily:

```rust
begin_addr.unwrap_or_else(debug::return_address)
```

`return_address()` is an `#[inline(always)]` frame-pointer read standing in for Zig's `@returnAddress()`. Passed as a callback, it inlines into the closure and reads the **closure's** frame — popped again before the capture walks the stack — so the anchor is a PC in a dead frame, `capture_current` finds no matching frame to trim at, and it falls back to the full untrimmed trace. Release builds usually escape because the inliner collapses the closure into the caller; debug builds hit it on every capture, and the release behavior is an optimizer accident either way.

Affected: `panic_impl` (crash reports, e.g. unsupported-libuv-function panics), `dump_current_stack_trace`, `dump_current_stack_trace_from_core` (advisory dumps: EBADF warnings, ref-count leak reports), and `StoredTrace::capture`.

### Fix

Evaluate the default anchor in the capturing function's own frame:

```rust
let begin_addr = match begin_addr {
    Some(addr) => addr,
    None => debug::return_address(),
};
```

(`match` rather than `unwrap_or(...)` because `clippy::or_fun_call` is deny — and its suggestion, `unwrap_or_else`, is exactly the bug.) Also documents the hazard on `bun_core::return_address()` so new call sites don't reintroduce it.

After the fix the same forced panic starts at the crash site:

```
panic(main thread): invoked crashByPanic() handler
bun_runtime::api::crash_handler_jsc::js_bindings::js_panic   ← innermost
```

### Verification

- New test in `test/cli/run/run-crash-handler.test.ts` forces a panic and asserts the innermost symbolized frame is the crash site (`js_panic`) and that no `capture_stack_trace` frames survive. Fails on main (`Received: "bun_core::capture_stack_trace"`), passes with the fix.
- Real signal path (regression check on #31163, non-ASAN debug build, forced SIGSEGV through `handle_segfault_posix`): frame 0 is the exact faulting instruction (`core::ptr::write_unaligned` inlined in `js_segfault`), no handler/altstack frames in the trace — the ucontext-seeded walk is position-based, so crashes inside symbol-named lookalikes (user `Error.captureStackTrace` paths) keep their frames.
- `outOfMemory`, `segfault`, and `panic` reporter tests still pass; clippy clean.
