### PR TITLE
Record the running CLI command in crash report trace strings

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -559,6 +559,14 @@ mod draft {
         pub fn is_main_thread() -> bool {
             MAIN_THREAD_ID.load(Ordering::Relaxed) == bun_threading::current_thread_id()
         }
+
+        /// Zig: `Cli.cmd = command` (cli.zig `createContextData`). `bun_runtime`
+        /// stores `Command.Tag.char()` here at dispatch so crash-report trace
+        /// strings encode which subcommand was running instead of `_` (pre-init).
+        pub fn set_cmd_char(c: u8) {
+            CMD_CHAR.store(c, Ordering::Relaxed);
+        }
+
         pub(crate) fn cmd_char() -> Option<u8> {
             match CMD_CHAR.load(Ordering::Relaxed) {
                 0 => None,

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1162,8 +1162,12 @@ pub mod command {
         log: &mut bun_ast::Log,
     ) -> Result<&'static mut ContextData, bun_core::Error> {
         // SAFETY: single-threaded CLI startup — no other thread exists yet.
-        // `CMD` is read by crash-reporter / debug logging only.
+        // `CMD` is read by debug logging only.
         unsafe { CMD.write(Some(cmd)) };
+        // The crash handler can't read `CMD` (lower-tier crate); mirror the
+        // one-byte command tag into its `cli_state` so crash-report trace
+        // strings encode the running subcommand (Zig: `Cli.cmd = command`).
+        bun_crash_handler::cli_state::set_cmd_char(cmd.char());
 
         let ctx = write_context_no_parse(log);
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -1162,7 +1162,7 @@ pub mod command {
         log: &mut bun_ast::Log,
     ) -> Result<&'static mut ContextData, bun_core::Error> {
         // SAFETY: single-threaded CLI startup — no other thread exists yet.
-        // `CMD` is read by debug logging only.
+        // `CMD` is read by debug logging and `run_command` (feedback dispatch).
         unsafe { CMD.write(Some(cmd)) };
         // The crash handler can't read `CMD` (lower-tier crate); mirror the
         // one-byte command tag into its `cli_state` so crash-report trace

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -11,10 +11,13 @@ describe.concurrent("crash report command character", () => {
   //   {base}/{version}/{platform char}{command char}{remainder}
   // Expected characters must stay in sync with `Command.Tag.char()`
   // (src/options_types/command_tag.rs) and bun.report's decoder.
-  async function commandCharFromCrash(args: string[], cwd?: string): Promise<string> {
+  async function commandCharFromCrash(args: string[]): Promise<string> {
     using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
     const base = new URL(server.url).origin;
 
+    // No cwd override: on Windows the crash reporter spawns a detached child
+    // that inherits the crashing process's cwd, which would keep a tempDir
+    // cwd alive past the test and make its cleanup fail with EBUSY.
     await using proc = Bun.spawn({
       cmd: [bunExe(), ...args],
       env: mergeWindowEnvs([
@@ -24,7 +27,6 @@ describe.concurrent("crash report command character", () => {
           BUN_ENABLE_CRASH_REPORTING: "1",
         },
       ]),
-      cwd,
       stdio: ["ignore", "pipe", "pipe"],
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
@@ -54,6 +56,7 @@ describe.concurrent("crash report command character", () => {
         crash_handler.panic();
       `,
     });
-    expect(await commandCharFromCrash(["test", "crash.fixture.test.js"], String(dir))).toBe("t");
+    const testFile = path.join(String(dir), "crash.fixture.test.js");
+    expect(await commandCharFromCrash(["test", testFile])).toBe("t");
   });
 });

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, mergeWindowEnvs, tempDir } from "harness";
+import path from "path";
+
+// NOTE: kept separate from run-crash-handler.test.ts on purpose — that file
+// is skip-listed in test/expectations.txt (its segfault-reporter test is
+// broken), so anything added there never runs in CI.
+describe.concurrent("crash report command character", () => {
+  // Crash while a given subcommand is running and return the command
+  // character from the trace string printed to stderr:
+  //   {base}/{version}/{platform char}{command char}{remainder}
+  // Expected characters must stay in sync with `Command.Tag.char()`
+  // (src/options_types/command_tag.rs) and bun.report's decoder.
+  async function commandCharFromCrash(args: string[], cwd?: string): Promise<string> {
+    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
+    const base = new URL(server.url).origin;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: base,
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+
+    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
+    expect(trace).not.toBeNull();
+    const payload = new URL(trace![0]).pathname.split("/")[2];
+    expect(payload.length).toBeGreaterThan(2);
+    return payload[1];
+  }
+
+  const fixture = path.join(import.meta.dir, "fixture-crash.js");
+
+  test("bun <script> encodes AutoCommand", async () => {
+    expect(await commandCharFromCrash([fixture, "panic"])).toBe("a");
+  });
+
+  test("bun run <script> encodes RunCommand", async () => {
+    expect(await commandCharFromCrash(["run", fixture, "panic"])).toBe("r");
+  });
+
+  test("bun test encodes TestCommand", async () => {
+    using dir = tempDir("crash-report-cmd-char", {
+      "crash.fixture.test.js": `
+        import { crash_handler } from "bun:internal-for-testing";
+        crash_handler.panic();
+      `,
+    });
+    expect(await commandCharFromCrash(["test", "crash.fixture.test.js"], String(dir))).toBe("t");
+  });
+});

--- a/test/cli/run/crash-report-command-char.test.ts
+++ b/test/cli/run/crash-report-command-char.test.ts
@@ -22,8 +22,6 @@ describe.concurrent("crash report command character", () => {
         {
           BUN_CRASH_REPORT_URL: base,
           BUN_ENABLE_CRASH_REPORTING: "1",
-          GITHUB_ACTIONS: undefined,
-          CI: undefined,
         },
       ]),
       cwd,

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs, tempDir } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -74,6 +74,61 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
 
   expect(proc.exited).resolves.not.toBe(0);
   expect(sent).toBe(false);
+});
+
+describe.concurrent("crash report command character", () => {
+  // Crash while a given subcommand is running and return the command
+  // character from the trace string printed to stderr:
+  //   {base}/{version}/{platform char}{command char}{remainder}
+  // Expected characters must stay in sync with `Command.Tag.char()`
+  // (src/options_types/command_tag.rs) and bun.report's decoder.
+  async function commandCharFromCrash(args: string[], cwd?: string): Promise<string> {
+    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
+    const base = new URL(server.url).origin;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), ...args],
+      env: mergeWindowEnvs([
+        bunEnv,
+        {
+          BUN_CRASH_REPORT_URL: base,
+          BUN_ENABLE_CRASH_REPORTING: "1",
+          GITHUB_ACTIONS: undefined,
+          CI: undefined,
+        },
+      ]),
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).not.toBe(0);
+
+    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
+    expect(trace).not.toBeNull();
+    const payload = new URL(trace![0]).pathname.split("/")[2];
+    expect(payload.length).toBeGreaterThan(2);
+    return payload[1];
+  }
+
+  const fixture = path.join(import.meta.dir, "fixture-crash.js");
+
+  test("bun <script> encodes AutoCommand", async () => {
+    expect(await commandCharFromCrash([fixture, "panic"])).toBe("a");
+  });
+
+  test("bun run <script> encodes RunCommand", async () => {
+    expect(await commandCharFromCrash(["run", fixture, "panic"])).toBe("r");
+  });
+
+  test("bun test encodes TestCommand", async () => {
+    using dir = tempDir("crash-report-cmd-char", {
+      "crash.fixture.test.js": `
+        import { crash_handler } from "bun:internal-for-testing";
+        crash_handler.panic();
+      `,
+    });
+    expect(await commandCharFromCrash(["test", "crash.fixture.test.js"], String(dir))).toBe("t");
+  });
 });
 
 describe("automatic crash reporter", () => {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -74,61 +74,6 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
 
   expect(proc.exited).resolves.not.toBe(0);
   expect(sent).toBe(false);
-});
-
-describe.concurrent("crash report command character", () => {
-  // Crash while a given subcommand is running and return the command
-  // character from the trace string printed to stderr:
-  //   {base}/{version}/{platform char}{command char}{remainder}
-  // Expected characters must stay in sync with `Command.Tag.char()`
-  // (src/options_types/command_tag.rs) and bun.report's decoder.
-  async function commandCharFromCrash(args: string[], cwd?: string): Promise<string> {
-    using server = Bun.serve({ port: 0, fetch: () => new Response("OK") });
-    const base = new URL(server.url).origin;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), ...args],
-      env: mergeWindowEnvs([
-        bunEnv,
-        {
-          BUN_CRASH_REPORT_URL: base,
-          BUN_ENABLE_CRASH_REPORTING: "1",
-          GITHUB_ACTIONS: undefined,
-          CI: undefined,
-        },
-      ]),
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(exitCode).not.toBe(0);
-
-    const trace = stderr.match(new RegExp(`${base.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}/\\S+`));
-    expect(trace).not.toBeNull();
-    const payload = new URL(trace![0]).pathname.split("/")[2];
-    expect(payload.length).toBeGreaterThan(2);
-    return payload[1];
-  }
-
-  const fixture = path.join(import.meta.dir, "fixture-crash.js");
-
-  test("bun <script> encodes AutoCommand", async () => {
-    expect(await commandCharFromCrash([fixture, "panic"])).toBe("a");
-  });
-
-  test("bun run <script> encodes RunCommand", async () => {
-    expect(await commandCharFromCrash(["run", fixture, "panic"])).toBe("r");
-  });
-
-  test("bun test encodes TestCommand", async () => {
-    using dir = tempDir("crash-report-cmd-char", {
-      "crash.fixture.test.js": `
-        import { crash_handler } from "bun:internal-for-testing";
-        crash_handler.panic();
-      `,
-    });
-    expect(await commandCharFromCrash(["test", "crash.fixture.test.js"], String(dir))).toBe("t");
-  });
 });
 
 describe("automatic crash reporter", () => {


### PR DESCRIPTION
### What

Crash reports from Rust-port builds always encode `_` ("pre-init") as the command character — 206 of 213 crashes on 1.4.0-canary are tagged `(pre-init)`, including crashes that are demonstrably mid-`bun install`. On Zig builds this dimension worked (`InstallCommand`, `AutoCommand`, …).

### Repro

```
BUN_CRASH_REPORT_URL=http://localhost:<port> BUN_ENABLE_CRASH_REPORTING=1 \
  bun test/cli/run/fixture-crash.js panic
```

stderr trace string before: `http://…/1.4.0/l_2561eb8f…` — the byte after the platform char is `_` for every subcommand.

### Cause

The port has the storage and the reader but the setter was never ported:

- `cli_state::CMD_CHAR` (`src/crash_handler/lib.rs`) is declared with a `cmd_char()` getter consumed by the trace-string encoder, but no `set_cmd_char` exists and nothing in the tree stores to it.
- `bun_runtime::cli::CMD` *is* written at dispatch (`create_context_data`, the port of Zig's `Cli.cmd = command`), but the crash handler is a lower-tier crate and can't read it — `cli_state` exists precisely so `bun_runtime` can mirror the value down, like the adjacent `set_main_thread_id` already does.

### Fix

- Add `cli_state::set_cmd_char(u8)`.
- Call it from `create_context_data` with `cmd.char()` — the single dispatch point every subcommand funnels through, matching Zig's write site. `Tag::char()` was already ported byte-for-byte from `Command.Tag.char()` (kept in sync with bun.report's decoder).

After: `http://…/1.4.0/la2561eb8f…` (`a` = AutoCommand); bun.report can again pick the per-command issue template and Sentry's command facet works for Rust builds.

Also syncs `Cargo.lock` with the `bstr` dependency added to `bun_bin` in 90f334a46b (lockfile wasn't regenerated in that commit).

### Verification

New tests in `test/cli/run/crash-report-command-char.test.ts` self-host the report URL, crash under three different subcommands via the debug crash hooks, and decode the command byte from the trace string: `bun <file>` → `a`, `bun run <file>` → `r`, `bun test` → `t`. All three fail with `_` before the fix and pass after.

The tests live in their own file (rather than `run-crash-handler.test.ts`) because that file is skip-listed in `test/expectations.txt` — its pre-existing segfault-reporter test is broken — so anything added there is silently skipped on every CI lane.
