### PR TITLE
Bun.write: stream ReadableStream sources instead of stringifying them

### DIFF
--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -95,6 +95,7 @@ The second argument is the data to write. It can be any of the following:
 - `ArrayBuffer` or `SharedArrayBuffer`
 - `TypedArray` (`Uint8Array`, et. al.)
 - `Response`
+- `ReadableStream`
 
 Bun handles each combination with the fastest available system call on the current platform.
 
@@ -279,7 +280,7 @@ interface Bun {
 
   write(
     destination: string | number | BunFile | URL,
-    input: string | Blob | ArrayBuffer | SharedArrayBuffer | TypedArray | Response,
+    input: string | Blob | ArrayBuffer | SharedArrayBuffer | TypedArray | Response | ReadableStream,
   ): Promise<number>;
 }
 

--- a/docs/runtime/file-io.mdx
+++ b/docs/runtime/file-io.mdx
@@ -96,6 +96,7 @@ The second argument is the data to write. It can be any of the following:
 - `TypedArray` (`Uint8Array`, et. al.)
 - `Response`
 - `ReadableStream`
+- `AsyncIterable` (including async generators)
 
 Bun handles each combination with the fastest available system call on the current platform.
 
@@ -280,7 +281,15 @@ interface Bun {
 
   write(
     destination: string | number | BunFile | URL,
-    input: string | Blob | ArrayBuffer | SharedArrayBuffer | TypedArray | Response | ReadableStream,
+    input:
+      | string
+      | Blob
+      | ArrayBuffer
+      | SharedArrayBuffer
+      | TypedArray
+      | Response
+      | ReadableStream
+      | AsyncIterable<string | ArrayBuffer | ArrayBufferView>,
   ): Promise<number>;
 }
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1604,7 +1604,7 @@ declare module "bun" {
    */
   function write(
     destination: BunFile | S3File | PathLike,
-    input: Blob | NodeJS.TypedArray | ArrayBufferLike | string | BlobPart[] | Archive,
+    input: Blob | NodeJS.TypedArray | ArrayBufferLike | string | BlobPart[] | Archive | ReadableStream,
     options?: {
       /**
        * If writing to a PathLike, set the permissions of the file.
@@ -2210,7 +2210,7 @@ declare module "bun" {
      * @param options - The options to use for the write.
      */
     write(
-      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Request | Response | BunFile,
+      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Request | Response | BunFile | ReadableStream,
       options?: { highWaterMark?: number },
     ): Promise<number>;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1614,6 +1614,8 @@ declare module "bun" {
       | ReadableStream
       | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
       | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+      // must be an `async function*` value; an ordinary function returning
+      // an AsyncGenerator is not converted (same as Response/BodyInit)
       | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
     options?: {
       /**
@@ -2231,6 +2233,8 @@ declare module "bun" {
         | ReadableStream
         | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
         | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        // must be an `async function*` value; an ordinary function returning
+        // an AsyncGenerator is not converted (same as Response/BodyInit)
         | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: { highWaterMark?: number },
     ): Promise<number>;

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -1604,7 +1604,17 @@ declare module "bun" {
    */
   function write(
     destination: BunFile | S3File | PathLike,
-    input: Blob | NodeJS.TypedArray | ArrayBufferLike | string | BlobPart[] | Archive | ReadableStream,
+    input:
+      | Blob
+      | NodeJS.TypedArray
+      | ArrayBufferLike
+      | string
+      | BlobPart[]
+      | Archive
+      | ReadableStream
+      | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
+      | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+      | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
     options?: {
       /**
        * If writing to a PathLike, set the permissions of the file.
@@ -2210,7 +2220,18 @@ declare module "bun" {
      * @param options - The options to use for the write.
      */
     write(
-      data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer | Request | Response | BunFile | ReadableStream,
+      data:
+        | string
+        | ArrayBufferView
+        | ArrayBuffer
+        | SharedArrayBuffer
+        | Request
+        | Response
+        | BunFile
+        | ReadableStream
+        | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
+        | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: { highWaterMark?: number },
     ): Promise<number>;
 

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -724,7 +724,8 @@ declare module "bun" {
         | BunFile
         | S3File
         | Blob
-        | Archive,
+        | Archive
+        | ReadableStream,
       options?: S3Options,
     ): Promise<number>;
 
@@ -1058,7 +1059,8 @@ declare module "bun" {
         | S3File
         | Blob
         | File
-        | Archive,
+        | Archive
+        | ReadableStream,
       options?: S3Options,
     ): Promise<number>;
 
@@ -1111,7 +1113,8 @@ declare module "bun" {
         | S3File
         | Blob
         | File
-        | Archive,
+        | Archive
+        | ReadableStream,
       options?: S3Options,
     ): Promise<number>;
 

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -725,7 +725,10 @@ declare module "bun" {
         | S3File
         | Blob
         | Archive
-        | ReadableStream,
+        | ReadableStream
+        | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
+        | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;
 
@@ -1060,7 +1063,10 @@ declare module "bun" {
         | Blob
         | File
         | Archive
-        | ReadableStream,
+        | ReadableStream
+        | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
+        | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;
 
@@ -1114,7 +1120,10 @@ declare module "bun" {
         | Blob
         | File
         | Archive
-        | ReadableStream,
+        | ReadableStream
+        | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
+        | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;
 

--- a/packages/bun-types/s3.d.ts
+++ b/packages/bun-types/s3.d.ts
@@ -728,6 +728,8 @@ declare module "bun" {
         | ReadableStream
         | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
         | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        // must be an `async function*` value; an ordinary function returning
+        // an AsyncGenerator is not converted (same as Response/BodyInit)
         | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;
@@ -1066,6 +1068,8 @@ declare module "bun" {
         | ReadableStream
         | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
         | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        // must be an `async function*` value; an ordinary function returning
+        // an AsyncGenerator is not converted (same as Response/BodyInit)
         | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;
@@ -1123,6 +1127,8 @@ declare module "bun" {
         | ReadableStream
         | AsyncIterable<string | ArrayBuffer | ArrayBufferView>
         | AsyncGenerator<string | ArrayBuffer | ArrayBufferView>
+        // must be an `async function*` value; an ordinary function returning
+        // an AsyncGenerator is not converted (same as Response/BodyInit)
         | (() => AsyncGenerator<string | ArrayBuffer | ArrayBufferView>),
       options?: S3Options,
     ): Promise<number>;

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -125,6 +125,17 @@ extern "C" bool ReadableStream__isLocked(JSC::EncodedJSValue possibleReadableStr
     return stream && isReadableStreamLocked(stream);
 }
 
+// Returns [[storedError]] when [[state]] is "errored", and an empty JSValue otherwise
+// (including when the value is not a ReadableStream).
+extern "C" JSC::EncodedJSValue ReadableStream__getStoredError(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
+{
+    auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));
+    if (!stream || stream->m_state != ReadableStreamState::Errored)
+        return {};
+    JSValue storedError = stream->m_storedError.get();
+    return JSValue::encode(storedError ? storedError : JSC::jsUndefined());
+}
+
 extern "C" void ReadableStream__cancel(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject* globalObject)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));

--- a/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
+++ b/src/jsc/bindings/webcore/streams/WebStreamsExports.cpp
@@ -125,8 +125,7 @@ extern "C" bool ReadableStream__isLocked(JSC::EncodedJSValue possibleReadableStr
     return stream && isReadableStreamLocked(stream);
 }
 
-// Returns [[storedError]] when [[state]] is "errored", and an empty JSValue otherwise
-// (including when the value is not a ReadableStream).
+// [[storedError]] when [[state]] is "errored"; empty JSValue otherwise.
 extern "C" JSC::EncodedJSValue ReadableStream__getStoredError(JSC::EncodedJSValue possibleReadableStream, Zig::GlobalObject*)
 {
     auto* stream = dynamicDowncast<JSReadableStream>(JSValue::decode(possibleReadableStream));

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4480,6 +4480,7 @@ pub enum MkdirpParentResult {
 }
 
 /// `mkdir -p` the parent of `dest_path`; the ENOENT retry for `pipe_readable_stream_to_blob`'s open.
+#[inline(never)]
 fn mkdirp_parent_of(dest_path: &[u8]) -> MkdirpParentResult {
     let Some(dirname) = bun_core::dirname(dest_path) else {
         return MkdirpParentResult::NoParent;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5384,18 +5384,10 @@ pub fn write_file_internal(
                     "ReadableStream has already been used"
                 )));
             }
-            // Reject locked streams before the pipe truncates the destination
-            // — the pipe's `getReader()` would fail anyway, but only after the
+            // Reject locked streams before the pipe truncates the destination;
+            // the pipe's `getReader()` would fail anyway, but only after the
             // destination file had been opened with `O_TRUNC`.
-            // `ReadableStream__isLocked` only reports native locks (`$reader`
-            // === true); a reader created from JS stores the reader object, so
-            // also consult the web-standard `locked` getter.
-            let locked = stream.is_locked(global_this)
-                || stream
-                    .value
-                    .get(global_this, "locked")?
-                    .is_some_and(|v| v.to_boolean());
-            if locked {
+            if stream.is_locked(global_this) {
                 destination_blob.detach();
                 return Err(
                     global_this.throw_invalid_arguments(format_args!("ReadableStream is locked"))

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1486,7 +1486,13 @@ impl BlobExt for Blob {
                                     opened = bun_sys::open(path, open_flags, open_mode);
                                 }
                                 MkdirpParentResult::Failed(mkdir_err) => {
-                                    opened = bun_sys::Result::Err(mkdir_err);
+                                    // Reject with mkdir's own error (it carries
+                                    // the directory path); `with_path` below
+                                    // would mislabel it with the file path.
+                                    return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                                        global_this,
+                                        mkdir_err.to_js(global_this),
+                                    ));
                                 }
                                 MkdirpParentResult::NoParent => {}
                             }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4495,7 +4495,9 @@ fn mkdirp_parent_of(dest_path: &[u8]) -> MkdirpParentResult {
     };
     let mut node_fs = crate::node::fs::NodeFS::default();
     match node_fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
-        path: crate::node::PathLike::String(bun_core::PathString::init(dirname)),
+        path: crate::node::PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
+            dirname, false,
+        )),
         recursive: true,
         always_return_none: true,
         ..Default::default()

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1703,12 +1703,17 @@ impl BlobExt for Blob {
                 );
             }
         }
+        // `assignToStream` returned undefined: a direct stream with a
+        // synchronous `pull` already ran to completion inside
+        // `readDirectStream`, so the sink has the byte count.
+        // SAFETY: `file_sink` is still our live +1 ref.
+        let written = unsafe { (*file_sink).received_bytes.get() };
         // SAFETY: release our +1 ref on the sink.
         unsafe { webcore::FileSink::deref(file_sink) };
 
         Ok(JSPromise::resolved_promise_value(
             global_this,
-            JSValue::js_number(0.0),
+            JSValue::js_number(written as f64),
         ))
     }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1469,7 +1469,10 @@ impl BlobExt for Blob {
                     let path = pathlike.path().slice_z(&mut file_path);
                     match bun_sys::open(
                         path,
-                        bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::NONBLOCK,
+                        bun_sys::O::WRONLY
+                            | bun_sys::O::CREAT
+                            | bun_sys::O::TRUNC
+                            | bun_sys::O::NONBLOCK,
                         WRITE_PERMISSIONS,
                     ) {
                         bun_sys::Result::Ok(result) => result,
@@ -1578,6 +1581,8 @@ impl BlobExt for Blob {
                 let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
                     input_path,
                     chunk_size: 0,
+                    // `Bun.write` replaces the destination's contents.
+                    truncate: true,
                     ..Default::default()
                 });
 
@@ -1663,18 +1668,23 @@ impl BlobExt for Blob {
                         return Ok(promise_value);
                     }
                     jsc::js_promise::Status::Fulfilled => {
+                        // SAFETY: `file_sink` is still our live +1 ref.
+                        let written = unsafe { (*file_sink).received_bytes.get() };
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.done(global_this);
                         return Ok(JSPromise::resolved_promise_value(
                             global_this,
-                            JSValue::js_number(0.0),
+                            JSValue::js_number(written as f64),
                         ));
                     }
                     jsc::js_promise::Status::Rejected => {
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.cancel(global_this);
+                        // The rejection is forwarded to the promise returned
+                        // below; don't also report it as unhandled.
+                        promise.set_handled(global_this.vm());
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
                             promise.result(global_this.vm()),
@@ -5281,6 +5291,23 @@ pub fn write_file_internal(
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
         }
 
+        // Pipe a ReadableStream (or async iterable) into the destination
+        // instead of letting `Blob::get` stringify it to
+        // "[object ReadableStream]".
+        if let Some(stream) = ReadableStream::from_js(data, global_this)? {
+            if stream.is_disturbed(global_this) {
+                destination_blob.detach();
+                return Err(global_this.throw_invalid_arguments(format_args!(
+                    "ReadableStream has already been used"
+                )));
+            }
+            return destination_blob.pipe_readable_stream_to_blob(
+                global_this,
+                stream,
+                options.extra_options,
+            );
+        }
+
         break 'brk Blob::get::<false, false>(global_this, data)?;
     };
     // Detach the source blob on scope exit.
@@ -5966,7 +5993,11 @@ pub fn on_file_stream_resolve_request_stream(
     if let Some(stream) = strong.get(global_this) {
         stream.done(global_this);
     }
-    this.promise.resolve(global_this, JSValue::js_number(0.0))?;
+    // SAFETY: `this.sink` is the live +1 ref released by `FileStreamWrapper`'s
+    // `Drop` when `this` goes out of scope below.
+    let written = unsafe { (*this.sink).received_bytes.get() };
+    this.promise
+        .resolve(global_this, JSValue::js_number(written as f64))?;
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1480,11 +1480,16 @@ impl BlobExt for Blob {
                     // `Bun.write`'s `createPath` (default true): create the
                     // parent directories and retry the open once.
                     if let bun_sys::Result::Err(ref err) = opened {
-                        if err.get_errno() == bun_sys::E::ENOENT
-                            && mkdirp_if_not_exists
-                            && mkdirp_parent_of(path.as_bytes())
-                        {
-                            opened = bun_sys::open(path, open_flags, open_mode);
+                        if err.get_errno() == bun_sys::E::ENOENT && mkdirp_if_not_exists {
+                            match mkdirp_parent_of(path.as_bytes()) {
+                                MkdirpParentResult::Created => {
+                                    opened = bun_sys::open(path, open_flags, open_mode);
+                                }
+                                MkdirpParentResult::Failed(mkdir_err) => {
+                                    opened = bun_sys::Result::Err(mkdir_err);
+                                }
+                                MkdirpParentResult::NoParent => {}
+                            }
                         }
                     }
                     match opened {
@@ -1607,10 +1612,16 @@ impl BlobExt for Blob {
                 if let bun_sys::Result::Err(ref err) = started {
                     if err.get_errno() == bun_sys::E::ENOENT && mkdirp_if_not_exists {
                         if let PathOrFileDescriptor::Path(p) = &store.data.as_file().pathlike {
-                            if mkdirp_parent_of(p.slice()) {
-                                // SAFETY: `sink` is still the live +1 from `init`;
-                                // a failed `start` leaves it reusable.
-                                started = unsafe { (*sink).start(&stream_start) };
+                            match mkdirp_parent_of(p.slice()) {
+                                MkdirpParentResult::Created => {
+                                    // SAFETY: `sink` is still the live +1 from
+                                    // `init`; a failed `start` leaves it reusable.
+                                    started = unsafe { (*sink).start(&stream_start) };
+                                }
+                                MkdirpParentResult::Failed(mkdir_err) => {
+                                    started = bun_sys::Result::Err(mkdir_err);
+                                }
+                                MkdirpParentResult::NoParent => {}
                             }
                         }
                     }
@@ -4465,24 +4476,33 @@ pub fn mkdir_if_not_exists<T: MkdirpTarget>(
     Retry::No
 }
 
-/// `mkdir -p` the parent directory of `dest_path` on the JS thread. Returns
-/// `true` when the directories exist afterwards. Mirrors the ENOENT retry in
-/// `mkdir_if_not_exists` for `pipe_readable_stream_to_blob`, whose open does
-/// not go through the write-file task machinery.
-fn mkdirp_parent_of(dest_path: &[u8]) -> bool {
+pub enum MkdirpParentResult {
+    /// Parent directories exist now; retry the open.
+    Created,
+    /// `mkdir -p` itself failed; surface this error instead of the open's.
+    Failed(bun_sys::Error),
+    /// Nothing to create (no parent component); keep the open's error.
+    NoParent,
+}
+
+/// `mkdir -p` the parent directory of `dest_path` on the JS thread. Mirrors
+/// the ENOENT retry in `mkdir_if_not_exists` for
+/// `pipe_readable_stream_to_blob`, whose open does not go through the
+/// write-file task machinery.
+fn mkdirp_parent_of(dest_path: &[u8]) -> MkdirpParentResult {
     let Some(dirname) = bun_core::dirname(dest_path) else {
-        return false;
+        return MkdirpParentResult::NoParent;
     };
     let mut node_fs = crate::node::fs::NodeFS::default();
-    matches!(
-        node_fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
-            path: crate::node::PathLike::String(bun_core::PathString::init(dirname)),
-            recursive: true,
-            always_return_none: true,
-            ..Default::default()
-        }),
-        bun_sys::Result::Ok(_)
-    )
+    match node_fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
+        path: crate::node::PathLike::String(bun_core::PathString::init(dirname)),
+        recursive: true,
+        always_return_none: true,
+        ..Default::default()
+    }) {
+        bun_sys::Result::Ok(_) => MkdirpParentResult::Created,
+        bun_sys::Result::Err(err) => MkdirpParentResult::Failed(err),
+    }
 }
 
 /// `bun_sys::Error` only
@@ -5371,6 +5391,17 @@ pub fn write_file_internal(
                 destination_blob.detach();
                 return Err(
                     global_this.throw_invalid_arguments(format_args!("ReadableStream is locked"))
+                );
+            }
+            // A stream that is already errored can never produce bytes; reject
+            // with its stored error before the pipe truncates the destination.
+            if let Some(stored_error) = stream.stored_error(global_this) {
+                destination_blob.detach();
+                return Ok(
+                    JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                        global_this,
+                        stored_error,
+                    ),
                 );
             }
             return destination_blob.pipe_readable_stream_to_blob(

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -231,6 +231,8 @@ pub trait BlobExt {
         global_this: &JSGlobalObject,
         readable_stream: ReadableStream,
         extra_options: Option<JSValue>,
+        mkdirp_if_not_exists: bool,
+        mode: Option<bun_sys::Mode>,
     ) -> JsResult<JSValue>;
     fn get_writer(&self, global_this: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue>;
     fn get_slice_from(
@@ -1387,6 +1389,8 @@ impl BlobExt for Blob {
         global_this: &JSGlobalObject,
         readable_stream: ReadableStream,
         extra_options: Option<JSValue>,
+        mkdirp_if_not_exists: bool,
+        mode: Option<bun_sys::Mode>,
     ) -> JsResult<JSValue> {
         let Some(store) = self.store.get().clone() else {
             return Ok(
@@ -1467,14 +1471,23 @@ impl BlobExt for Blob {
                 } else {
                     let mut file_path = bun_paths::PathBuffer::uninit();
                     let path = pathlike.path().slice_z(&mut file_path);
-                    match bun_sys::open(
-                        path,
-                        bun_sys::O::WRONLY
-                            | bun_sys::O::CREAT
-                            | bun_sys::O::TRUNC
-                            | bun_sys::O::NONBLOCK,
-                        WRITE_PERMISSIONS,
-                    ) {
+                    let open_flags = bun_sys::O::WRONLY
+                        | bun_sys::O::CREAT
+                        | bun_sys::O::TRUNC
+                        | bun_sys::O::NONBLOCK;
+                    let open_mode = mode.unwrap_or(WRITE_PERMISSIONS);
+                    let mut opened = bun_sys::open(path, open_flags, open_mode);
+                    // `Bun.write`'s `createPath` (default true): create the
+                    // parent directories and retry the open once.
+                    if let bun_sys::Result::Err(ref err) = opened {
+                        if err.get_errno() == bun_sys::E::ENOENT
+                            && mkdirp_if_not_exists
+                            && mkdirp_parent_of(path.as_bytes())
+                        {
+                            opened = bun_sys::open(path, open_flags, open_mode);
+                        }
+                    }
+                    match opened {
                         bun_sys::Result::Ok(result) => result,
                         bun_sys::Result::Err(err) => {
                             return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
@@ -1583,11 +1596,26 @@ impl BlobExt for Blob {
                     chunk_size: 0,
                     // `Bun.write` replaces the destination's contents.
                     truncate: true,
+                    mode: mode.unwrap_or(WRITE_PERMISSIONS),
                     ..Default::default()
                 });
 
                 // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
-                if let bun_sys::Result::Err(err) = unsafe { (*sink).start(&stream_start) } {
+                let mut started = unsafe { (*sink).start(&stream_start) };
+                // `Bun.write`'s `createPath` (default true): create the parent
+                // directories and retry the start (which re-opens) once.
+                if let bun_sys::Result::Err(ref err) = started {
+                    if err.get_errno() == bun_sys::E::ENOENT && mkdirp_if_not_exists {
+                        if let PathOrFileDescriptor::Path(p) = &store.data.as_file().pathlike {
+                            if mkdirp_parent_of(p.slice()) {
+                                // SAFETY: `sink` is still the live +1 from `init`;
+                                // a failed `start` leaves it reusable.
+                                started = unsafe { (*sink).start(&stream_start) };
+                            }
+                        }
+                    }
+                }
+                if let bun_sys::Result::Err(err) = started {
                     // SAFETY: release the +1 strong ref taken by `init` on the error path.
                     unsafe { webcore::FileSink::deref(sink) };
                     return Ok(
@@ -4437,6 +4465,26 @@ pub fn mkdir_if_not_exists<T: MkdirpTarget>(
     Retry::No
 }
 
+/// `mkdir -p` the parent directory of `dest_path` on the JS thread. Returns
+/// `true` when the directories exist afterwards. Mirrors the ENOENT retry in
+/// `mkdir_if_not_exists` for `pipe_readable_stream_to_blob`, whose open does
+/// not go through the write-file task machinery.
+fn mkdirp_parent_of(dest_path: &[u8]) -> bool {
+    let Some(dirname) = bun_core::dirname(dest_path) else {
+        return false;
+    };
+    let mut node_fs = crate::node::fs::NodeFS::default();
+    matches!(
+        node_fs.mkdir_recursive(&crate::node::fs::args::Mkdir {
+            path: crate::node::PathLike::String(bun_core::PathString::init(dirname)),
+            recursive: true,
+            always_return_none: true,
+            ..Default::default()
+        }),
+        bun_sys::Result::Ok(_)
+    )
+}
+
 /// `bun_sys::Error` only
 /// exposes `with_path(&[u8])`, so route through the
 /// `PathOrFileDescriptor`'s slice when it's a path and leave the error
@@ -4809,6 +4857,8 @@ pub fn write_file_with_source_destination(
                 ctx,
                 stream,
                 options.extra_options,
+                options.mkdirp_if_not_exists.unwrap_or(true),
+                options.mode,
             );
         } else {
             return Ok(
@@ -5306,10 +5356,29 @@ pub fn write_file_internal(
                     "ReadableStream has already been used"
                 )));
             }
+            // Reject locked streams before the pipe truncates the destination
+            // — the pipe's `getReader()` would fail anyway, but only after the
+            // destination file had been opened with `O_TRUNC`.
+            // `ReadableStream__isLocked` only reports native locks (`$reader`
+            // === true); a reader created from JS stores the reader object, so
+            // also consult the web-standard `locked` getter.
+            let locked = stream.is_locked(global_this)
+                || stream
+                    .value
+                    .get(global_this, "locked")?
+                    .is_some_and(|v| v.to_boolean());
+            if locked {
+                destination_blob.detach();
+                return Err(
+                    global_this.throw_invalid_arguments(format_args!("ReadableStream is locked"))
+                );
+            }
             return destination_blob.pipe_readable_stream_to_blob(
                 global_this,
                 stream,
                 options.extra_options,
+                options.mkdirp_if_not_exists.unwrap_or(true),
+                options.mode,
             );
         }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1477,8 +1477,6 @@ impl BlobExt for Blob {
                         | bun_sys::O::NONBLOCK;
                     let open_mode = mode.unwrap_or(WRITE_PERMISSIONS);
                     let mut opened = bun_sys::open(path, open_flags, open_mode);
-                    // `Bun.write`'s `createPath` (default true): create the
-                    // parent directories and retry the open once.
                     if let bun_sys::Result::Err(ref err) = opened {
                         if err.get_errno() == bun_sys::E::ENOENT && mkdirp_if_not_exists {
                             match mkdirp_parent_of(path.as_bytes()) {
@@ -1486,9 +1484,7 @@ impl BlobExt for Blob {
                                     opened = bun_sys::open(path, open_flags, open_mode);
                                 }
                                 MkdirpParentResult::Failed(mkdir_err) => {
-                                    // Reject with mkdir's own error (it carries
-                                    // the directory path); `with_path` below
-                                    // would mislabel it with the file path.
+                                    // mkdir_err carries the directory path; don't relabel it.
                                     return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                                         global_this,
                                         mkdir_err.to_js(global_this),
@@ -1605,7 +1601,6 @@ impl BlobExt for Blob {
                 let stream_start = streams::Start::FileSink(streams::FileSinkOptions {
                     input_path,
                     chunk_size: 0,
-                    // `Bun.write` replaces the destination's contents.
                     truncate: true,
                     mode: mode.unwrap_or(WRITE_PERMISSIONS),
                     ..Default::default()
@@ -1613,8 +1608,6 @@ impl BlobExt for Blob {
 
                 // SAFETY: `init` returns a freshly-allocated +1 *mut FileSink.
                 let mut started = unsafe { (*sink).start(&stream_start) };
-                // `Bun.write`'s `createPath` (default true): create the parent
-                // directories and retry the start (which re-opens) once.
                 if let bun_sys::Result::Err(ref err) = started {
                     if err.get_errno() == bun_sys::E::ENOENT && mkdirp_if_not_exists {
                         if let PathOrFileDescriptor::Path(p) = &store.data.as_file().pathlike {
@@ -1727,8 +1720,6 @@ impl BlobExt for Blob {
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.cancel(global_this);
-                        // The rejection is forwarded to the promise returned
-                        // below; don't also report it as unhandled.
                         promise.set_handled(global_this.vm());
                         return Ok(JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
                             global_this,
@@ -4483,18 +4474,12 @@ pub fn mkdir_if_not_exists<T: MkdirpTarget>(
 }
 
 pub enum MkdirpParentResult {
-    /// Parent directories exist now; retry the open.
     Created,
-    /// `mkdir -p` itself failed; surface this error instead of the open's.
     Failed(bun_sys::Error),
-    /// Nothing to create (no parent component); keep the open's error.
     NoParent,
 }
 
-/// `mkdir -p` the parent directory of `dest_path` on the JS thread. Mirrors
-/// the ENOENT retry in `mkdir_if_not_exists` for
-/// `pipe_readable_stream_to_blob`, whose open does not go through the
-/// write-file task machinery.
+/// `mkdir -p` the parent of `dest_path`; the ENOENT retry for `pipe_readable_stream_to_blob`'s open.
 fn mkdirp_parent_of(dest_path: &[u8]) -> MkdirpParentResult {
     let Some(dirname) = bun_core::dirname(dest_path) else {
         return MkdirpParentResult::NoParent;
@@ -5374,9 +5359,6 @@ pub fn write_file_internal(
             break 'brk Blob::init_with_store(archive.store_ref().clone(), global_this);
         }
 
-        // Pipe a ReadableStream (or async iterable) into the destination
-        // instead of letting `Blob::get` stringify it to
-        // "[object ReadableStream]".
         if let Some(stream) = ReadableStream::from_js(data, global_this)? {
             if stream.is_disturbed(global_this) {
                 destination_blob.detach();
@@ -5384,17 +5366,13 @@ pub fn write_file_internal(
                     "ReadableStream has already been used"
                 )));
             }
-            // Reject locked streams before the pipe truncates the destination;
-            // the pipe's `getReader()` would fail anyway, but only after the
-            // destination file had been opened with `O_TRUNC`.
+            // Preflight locked/errored so the pipe's `O_TRUNC` open doesn't run first.
             if stream.is_locked(global_this) {
                 destination_blob.detach();
                 return Err(
                     global_this.throw_invalid_arguments(format_args!("ReadableStream is locked"))
                 );
             }
-            // A stream that is already errored can never produce bytes; reject
-            // with its stored error before the pipe truncates the destination.
             if let Some(stored_error) = stream.stored_error(global_this) {
                 destination_blob.detach();
                 return Ok(

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1017,12 +1017,13 @@ impl FileSink {
 
     /// Count the bytes the writer accepted from a single `write*` call into
     /// `received_bytes`. `Wrote`/`Pending` buffer whatever was not written
-    /// immediately, so the whole chunk was accepted; `Done` is terminal and
-    /// only `amt` bytes were taken.
+    /// immediately, so the whole chunk was accepted. `Done` means the writer
+    /// stopped accepting; its amount comes from draining the *combined*
+    /// outgoing buffer (which may include already-counted bytes from earlier
+    /// chunks), so credit nothing — in practice it is always `Done(0)` here.
     fn count_received(&self, rc: &WriteResult, chunk_len: usize) {
         let accepted = match *rc {
-            WriteResult::Err(_) => 0,
-            WriteResult::Done(amt) => amt,
+            WriteResult::Err(_) | WriteResult::Done(_) => 0,
             WriteResult::Wrote(_) | WriteResult::Pending(_) => chunk_len,
         };
         self.received_bytes

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -6,6 +6,7 @@ use core::sync::atomic::{AtomicI32, Ordering};
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{self, WriteResult, WriteStatus};
 use bun_jsc::JsCell;
+use bun_simdutf_sys::simdutf;
 use bun_sys::{self as sys, Fd, FdExt as _};
 
 use crate::api::bun::process::Status as SpawnStatus;
@@ -39,6 +40,13 @@ pub struct FileSink {
     pub writer: JsCell<IOWriter>,
     pub event_loop_handle: EventLoopHandle,
     pub written: Cell<usize>,
+    /// Total bytes accepted by `write`/`write_latin1`/`write_utf16` (UTF-8
+    /// re-encoded length for string chunks). Unlike `written` — which mixes
+    /// "buffered" and "flushed" reports and can count the same bytes twice —
+    /// every accepted byte is counted here exactly once, so
+    /// `Blob::pipe_readable_stream_to_blob` can report how many bytes a piped
+    /// `ReadableStream` wrote.
+    pub received_bytes: Cell<u64>,
     pub pending: JsCell<streams::WritablePending>,
     pub signal: JsCell<streams::Signal>,
     pub done: Cell<bool>,
@@ -191,6 +199,9 @@ bun_io::impl_streaming_writer_parent! {
 pub struct Options {
     pub chunk_size: webcore::BlobSizeType,
     pub input_path: PathOrFileDescriptor,
+    /// Truncate the destination on open. Defaults to `false`:
+    /// `Bun.file(path).writer()` has always overwritten in place. Replace-style
+    /// writers (`Blob::pipe_readable_stream_to_blob`, i.e. `Bun.write`) opt in.
     pub truncate: bool,
     pub close: bool,
     pub mode: bun_sys::Mode,
@@ -201,7 +212,7 @@ impl Default for Options {
         Self {
             chunk_size: 1024,
             input_path: PathOrFileDescriptor::Fd(Fd::INVALID),
-            truncate: true,
+            truncate: false,
             close: false,
             mode: 0o664,
         }
@@ -210,8 +221,11 @@ impl Default for Options {
 
 impl Options {
     pub fn flags(&self) -> i32 {
-        let _ = self;
-        bun_sys::O::NONBLOCK | bun_sys::O::CLOEXEC | bun_sys::O::CREAT | bun_sys::O::WRONLY
+        bun_sys::O::NONBLOCK
+            | bun_sys::O::CLOEXEC
+            | bun_sys::O::CREAT
+            | bun_sys::O::WRONLY
+            | if self.truncate { bun_sys::O::TRUNC } else { 0 }
     }
 }
 
@@ -1001,6 +1015,20 @@ impl FileSink {
         this
     }
 
+    /// Count the bytes the writer accepted from a single `write*` call into
+    /// `received_bytes`. `Wrote`/`Pending` buffer whatever was not written
+    /// immediately, so the whole chunk was accepted; `Done` is terminal and
+    /// only `amt` bytes were taken.
+    fn count_received(&self, rc: &WriteResult, chunk_len: usize) {
+        let accepted = match *rc {
+            WriteResult::Err(_) => 0,
+            WriteResult::Done(amt) => amt,
+            WriteResult::Wrote(_) | WriteResult::Pending(_) => chunk_len,
+        };
+        self.received_bytes
+            .set(self.received_bytes.get() + accepted as u64);
+    }
+
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
@@ -1008,6 +1036,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write` buffers/writes to fd; does not call JS.
         let rc = self.writer.with_mut(|w| w.write(data.slice()));
+        self.count_received(&rc, data.slice().len());
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1024,6 +1053,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_latin1` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_latin1(data.slice()));
+        self.count_received(&rc, simdutf::length::utf8::from::latin1(data.slice()));
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1035,6 +1065,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
+        self.count_received(&rc, simdutf::length::utf8::from::utf16::le(data.slice16()));
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }
@@ -1387,6 +1418,7 @@ impl FileSink {
             // SAFETY: sentinel only; never dispatched (overwritten before use).
             event_loop_handle: EventLoopHandle::init(core::ptr::null_mut()),
             written: Cell::new(0),
+            received_bytes: Cell::new(0),
             pending: JsCell::new(streams::WritablePending {
                 result: streams::Writable::Done,
                 ..Default::default()

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -40,12 +40,7 @@ pub struct FileSink {
     pub writer: JsCell<IOWriter>,
     pub event_loop_handle: EventLoopHandle,
     pub written: Cell<usize>,
-    /// Total bytes accepted by `write`/`write_latin1`/`write_utf16` (UTF-8
-    /// re-encoded length for string chunks). Unlike `written` — which mixes
-    /// "buffered" and "flushed" reports and can count the same bytes twice —
-    /// every accepted byte is counted here exactly once, so
-    /// `Blob::pipe_readable_stream_to_blob` can report how many bytes a piped
-    /// `ReadableStream` wrote.
+    /// Cumulative bytes the `write*` entry points accepted; counted once per chunk.
     pub received_bytes: Cell<u64>,
     pub pending: JsCell<streams::WritablePending>,
     pub signal: JsCell<streams::Signal>,
@@ -199,9 +194,7 @@ bun_io::impl_streaming_writer_parent! {
 pub struct Options {
     pub chunk_size: webcore::BlobSizeType,
     pub input_path: PathOrFileDescriptor,
-    /// Truncate the destination on open. Defaults to `false`:
-    /// `Bun.file(path).writer()` has always overwritten in place. Replace-style
-    /// writers (`Blob::pipe_readable_stream_to_blob`, i.e. `Bun.write`) opt in.
+    /// `O_TRUNC` on open. Default `false` preserves `Bun.file().writer()`'s overwrite-in-place.
     pub truncate: bool,
     pub close: bool,
     pub mode: bun_sys::Mode,
@@ -1015,14 +1008,9 @@ impl FileSink {
         this
     }
 
-    /// Count the bytes the writer accepted from a single `write*` call into
-    /// `received_bytes`. `Wrote`/`Pending` buffer whatever was not written
-    /// immediately, so the whole chunk was accepted. `Done` means the writer
-    /// stopped accepting; its amount comes from draining the *combined*
-    /// outgoing buffer (which may include already-counted bytes from earlier
-    /// chunks), so credit nothing — in practice it is always `Done(0)` here.
     fn count_received(&self, rc: &WriteResult, chunk_len: usize) {
         let accepted = match *rc {
+            // `Done(n)` is a final drain of the combined buffer, not this chunk.
             WriteResult::Err(_) | WriteResult::Done(_) => 0,
             WriteResult::Wrote(_) | WriteResult::Pending(_) => chunk_len,
         };
@@ -1030,11 +1018,7 @@ impl FileSink {
             .set(self.received_bytes.get() + accepted as u64);
     }
 
-    /// UTF-8 byte length the writer emits for `utf16`, matching
-    /// `convert_utf16_to_utf8_append`: well-formed input encodes as-is and an
-    /// unpaired surrogate becomes U+FFFD (3 bytes) via the WTF fallback.
-    /// `simdutf::length::utf8::from::utf16` is non-validating and counts an
-    /// unpaired surrogate as 2 bytes, so it cannot be used here.
+    /// UTF-8 length matching `convert_utf16_to_utf8_append`: unpaired surrogates become U+FFFD (3 bytes).
     fn utf8_len_from_utf16_lossy(utf16: &[u16]) -> usize {
         let mut len = 0usize;
         let mut i = 0usize;

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1018,32 +1018,6 @@ impl FileSink {
             .set(self.received_bytes.get() + accepted as u64);
     }
 
-    /// UTF-8 length matching `convert_utf16_to_utf8_append`: unpaired surrogates become U+FFFD (3 bytes).
-    fn utf8_len_from_utf16_lossy(utf16: &[u16]) -> usize {
-        let mut len = 0usize;
-        let mut i = 0usize;
-        while i < utf16.len() {
-            let u = utf16[i];
-            if u < 0x80 {
-                len += 1;
-            } else if u < 0x800 {
-                len += 2;
-            } else if (0xD800..0xDC00).contains(&u)
-                && i + 1 < utf16.len()
-                && (0xDC00..0xE000).contains(&utf16[i + 1])
-            {
-                // Surrogate pair: one 4-byte code point.
-                len += 4;
-                i += 1;
-            } else {
-                // BMP character, or an unpaired surrogate encoded as U+FFFD.
-                len += 3;
-            }
-            i += 1;
-        }
-        len
-    }
-
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
@@ -1080,7 +1054,10 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
-        self.count_received(&rc, Self::utf8_len_from_utf16_lossy(data.slice16()));
+        self.count_received(
+            &rc,
+            simdutf::length::utf8::from::utf16::le_with_replacement(data.slice16()),
+        );
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1029,6 +1029,36 @@ impl FileSink {
             .set(self.received_bytes.get() + accepted as u64);
     }
 
+    /// UTF-8 byte length the writer emits for `utf16`, matching
+    /// `convert_utf16_to_utf8_append`: well-formed input encodes as-is and an
+    /// unpaired surrogate becomes U+FFFD (3 bytes) via the WTF fallback.
+    /// `simdutf::length::utf8::from::utf16` is non-validating and counts an
+    /// unpaired surrogate as 2 bytes, so it cannot be used here.
+    fn utf8_len_from_utf16_lossy(utf16: &[u16]) -> usize {
+        let mut len = 0usize;
+        let mut i = 0usize;
+        while i < utf16.len() {
+            let u = utf16[i];
+            if u < 0x80 {
+                len += 1;
+            } else if u < 0x800 {
+                len += 2;
+            } else if (0xD800..0xDC00).contains(&u)
+                && i + 1 < utf16.len()
+                && (0xDC00..0xE000).contains(&utf16[i + 1])
+            {
+                // Surrogate pair: one 4-byte code point.
+                len += 4;
+                i += 1;
+            } else {
+                // BMP character, or an unpaired surrogate encoded as U+FFFD.
+                len += 3;
+            }
+            i += 1;
+        }
+        len
+    }
+
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
@@ -1065,7 +1095,7 @@ impl FileSink {
         let buffered_before = self.writer.get().buffered_len();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
         let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
-        self.count_received(&rc, simdutf::length::utf8::from::utf16::le(data.slice16()));
+        self.count_received(&rc, Self::utf8_len_from_utf16_lossy(data.slice16()));
         let accepted = self.bytes_accepted(buffered_before, &rc);
         self.to_result(rc, accepted)
     }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -288,9 +288,7 @@ impl ReadableStream {
         ReadableStream__is(value)
     }
 
-    /// When the stream's state is errored, returns its `storedError`
-    /// (`undefined` when the stream errored without a stored value). Returns
-    /// `None` for every other state.
+    /// `[[storedError]]` when `[[state]]` is "errored"; `None` otherwise.
     pub fn stored_error(&self, global_object: &JSGlobalObject) -> Option<JSValue> {
         let err = ReadableStream__getStoredError(self.value, global_object);
         if err.is_empty() { None } else { Some(err) }

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -107,6 +107,10 @@ unsafe extern "C" {
         possible_readable_stream: JSValue,
         global_object: &JSGlobalObject,
     ) -> bool;
+    safe fn ReadableStream__getStoredError(
+        possible_readable_stream: JSValue,
+        global_object: &JSGlobalObject,
+    ) -> JSValue;
     safe fn ReadableStream__empty(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__used(global: &JSGlobalObject) -> JSValue;
     safe fn ReadableStream__errored(global: &JSGlobalObject, reason: JSValue) -> JSValue;
@@ -282,6 +286,14 @@ impl ReadableStream {
     /// A pure `dynamicDowncast<JSReadableStream>` type test: no tagging, no conversion.
     pub fn is_readable_stream(value: JSValue) -> bool {
         ReadableStream__is(value)
+    }
+
+    /// When the stream's state is errored, returns its `storedError`
+    /// (`undefined` when the stream errored without a stored value). Returns
+    /// `None` for every other state.
+    pub fn stored_error(&self, global_object: &JSGlobalObject) -> Option<JSValue> {
+        let err = ReadableStream__getStoredError(self.value, global_object);
+        if err.is_empty() { None } else { Some(err) }
     }
 
     pub fn from_js(

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -815,6 +815,21 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(4096).fill(8));
     });
 
+    it("counts lone surrogates as their replacement-character bytes", async () => {
+      using dir = tempDir("bun-write-lone-surrogate", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write("a\uD800b"); // the lone surrogate encodes as U+FFFD
+          controller.close();
+        },
+      });
+
+      expect(await Bun.write(filePath, stream)).toBe(5);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([0x61, 0xef, 0xbf, 0xbd, 0x62]));
+    });
+
     it("works through Bun.file().write()", async () => {
       using dir = tempDir("bun-file-write-stream", {});
       const filePath = join(String(dir), "out.txt");

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -855,7 +855,8 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       });
 
       expect(await Bun.write(filePath, stream)).toBe(0);
-      expect(Bun.file(filePath).size).toBe(0);
+      expect(await Bun.file(filePath).exists()).toBe(true);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(0));
     });
 
     it("writes the values of an async iterable", async () => {
@@ -887,9 +888,10 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(() => Bun.write(filePath, stream)).toThrow("ReadableStream has already been used");
     });
 
-    it("rejects on a locked stream", async () => {
+    it("throws on a locked stream without touching the destination", async () => {
       using dir = tempDir("bun-write-locked-stream", {});
       const filePath = join(String(dir), "out.bin");
+      await Bun.write(filePath, "precious contents");
       const stream = new ReadableStream({
         start(controller) {
           controller.enqueue(new Uint8Array([1]));
@@ -898,7 +900,55 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       });
       stream.getReader();
 
-      expect(async () => await Bun.write(filePath, stream)).toThrow("ReadableStream is locked");
+      expect(() => Bun.write(filePath, stream)).toThrow("ReadableStream is locked");
+      // the destination must not have been created-or-truncated first
+      expect(await Bun.file(filePath).text()).toBe("precious contents");
+    });
+
+    it("creates parent directories by default", async () => {
+      using dir = tempDir("bun-write-stream-createpath", {});
+      const filePath = join(String(dir), "made", "up", "dirs", "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      });
+
+      expect(await Bun.write(filePath, stream)).toBe(3);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([1, 2, 3]));
+    });
+
+    it("rejects with ENOENT when createPath is false", async () => {
+      using dir = tempDir("bun-write-stream-no-createpath", {});
+      const filePath = join(String(dir), "does", "not", "exist", "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+
+      try {
+        await Bun.write(filePath, stream, { createPath: false });
+        expect.unreachable();
+      } catch (e) {
+        expect(e.code).toBe("ENOENT");
+      }
+    });
+
+    it.skipIf(isWindows)("applies the mode option to a newly created file", async () => {
+      using dir = tempDir("bun-write-stream-mode", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+
+      expect(await Bun.write(filePath, stream, { mode: 0o600 })).toBe(1);
+      expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
     });
 
     it("rejects when the stream errors", async () => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -799,6 +799,22 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(4096).fill(7));
     });
 
+    it("writes a direct ReadableStream with a synchronous pull", async () => {
+      using dir = tempDir("bun-write-direct-sync-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        type: "direct",
+        pull(controller) {
+          controller.write(new Uint8Array(4096).fill(8));
+          controller.close();
+        },
+      });
+
+      const written = await Bun.write(filePath, stream);
+      expect(written).toBe(4096);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(4096).fill(8));
+    });
+
     it("works through Bun.file().write()", async () => {
       using dir = tempDir("bun-file-write-stream", {});
       const filePath = join(String(dir), "out.txt");

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -932,6 +932,24 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(await Bun.file(filePath).text()).toBe("precious contents");
     });
 
+    it("rejects a locked stream even when the public locked getter is shadowed", async () => {
+      using dir = tempDir("bun-write-locked-stream-shadowed", {});
+      const filePath = join(String(dir), "out.bin");
+      await Bun.write(filePath, "precious contents");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+      stream.getReader();
+      // shadowing the web-standard getter must not bypass the lock check
+      Object.defineProperty(stream, "locked", { value: false });
+
+      expect(() => Bun.write(filePath, stream)).toThrow("ReadableStream is locked");
+      expect(await Bun.file(filePath).text()).toBe("precious contents");
+    });
+
     it("creates parent directories by default", async () => {
       using dir = tempDir("bun-write-stream-createpath", {});
       const filePath = join(String(dir), "made", "up", "dirs", "out.bin");

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -972,7 +972,22 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
         },
       });
 
-      expect(async () => await Bun.write(filePath, stream)).toThrow("stream go boom");
+      await expect(Bun.write(filePath, stream)).rejects.toThrow("stream go boom");
+    });
+
+    it("rejects an already-errored stream without touching the destination", async () => {
+      using dir = tempDir("bun-write-preerrored-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      await Bun.write(filePath, "precious contents");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.error(new Error("errored before write"));
+        },
+      });
+
+      await expect(Bun.write(filePath, stream)).rejects.toThrow("errored before write");
+      // the destination must not have been created-or-truncated first
+      expect(await Bun.file(filePath).text()).toBe("precious contents");
     });
   });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -727,4 +727,174 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
 
     expect(f.name).toBe(filePath);
   });
+
+  // https://github.com/oven-sh/bun/issues/31681
+  describe("ReadableStream source", () => {
+    it("writes the bytes of a fetch response body stream", async () => {
+      using dir = tempDir("bun-write-fetch-body-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      await using server = Bun.serve({
+        port: 0,
+        fetch: () => new Response(Buffer.alloc(256 * 1024, 0x5a)),
+      });
+      const res = await fetch(server.url);
+
+      const written = await Bun.write(filePath, res.body);
+      expect(written).toBe(256 * 1024);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(256 * 1024).fill(0x5a));
+    });
+
+    it("writes the bytes of a plain ReadableStream", async () => {
+      using dir = tempDir("bun-write-plain-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.enqueue(new Uint8Array([4, 5]));
+          controller.close();
+        },
+      });
+
+      const written = await Bun.write(filePath, stream);
+      expect(written).toBe(5);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([1, 2, 3, 4, 5]));
+    });
+
+    it("writes a multi-chunk pull-based stream", async () => {
+      using dir = tempDir("bun-write-pull-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      let chunk = 0;
+      const stream = new ReadableStream({
+        pull(controller) {
+          if (chunk === 8) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(new Uint8Array(1024).fill(chunk++));
+        },
+      });
+
+      const written = await Bun.write(filePath, stream);
+      expect(written).toBe(8 * 1024);
+      const bytes = await Bun.file(filePath).bytes();
+      const expected = new Uint8Array(8 * 1024);
+      for (let i = 0; i < 8; i++) expected.fill(i, i * 1024, (i + 1) * 1024);
+      expect(bytes).toEqual(expected);
+    });
+
+    it("writes a direct ReadableStream", async () => {
+      using dir = tempDir("bun-write-direct-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(controller) {
+          controller.write(new Uint8Array(4096).fill(7));
+          await controller.flush();
+          controller.close();
+        },
+      });
+
+      const written = await Bun.write(filePath, stream);
+      expect(written).toBe(4096);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array(4096).fill(7));
+    });
+
+    it("works through Bun.file().write()", async () => {
+      using dir = tempDir("bun-file-write-stream", {});
+      const filePath = join(String(dir), "out.txt");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("hello from a stream"));
+          controller.close();
+        },
+      });
+
+      const written = await Bun.file(filePath).write(stream);
+      expect(written).toBe("hello from a stream".length);
+      expect(await Bun.file(filePath).text()).toBe("hello from a stream");
+    });
+
+    it("replaces the previous contents of the destination", async () => {
+      using dir = tempDir("bun-write-stream-truncate", {});
+      const filePath = join(String(dir), "out.bin");
+      await Bun.write(filePath, Buffer.alloc(1000, 0x41));
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([0x42, 0x42]));
+          controller.close();
+        },
+      });
+
+      expect(await Bun.write(filePath, stream)).toBe(2);
+      expect(await Bun.file(filePath).text()).toBe("BB");
+    });
+
+    it("writes an empty stream as an empty file", async () => {
+      using dir = tempDir("bun-write-empty-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+
+      expect(await Bun.write(filePath, stream)).toBe(0);
+      expect(Bun.file(filePath).size).toBe(0);
+    });
+
+    it("writes the values of an async iterable", async () => {
+      using dir = tempDir("bun-write-async-iterable", {});
+      const filePath = join(String(dir), "out.bin");
+      async function* chunks() {
+        yield new Uint8Array([10, 20]);
+        yield new Uint8Array([30]);
+      }
+
+      const written = await Bun.write(filePath, chunks());
+      expect(written).toBe(3);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([10, 20, 30]));
+    });
+
+    it("throws on an already-used stream", async () => {
+      using dir = tempDir("bun-write-used-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+      const reader = stream.getReader();
+      await reader.read();
+      reader.releaseLock();
+
+      expect(() => Bun.write(filePath, stream)).toThrow("ReadableStream has already been used");
+    });
+
+    it("rejects on a locked stream", async () => {
+      using dir = tempDir("bun-write-locked-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1]));
+          controller.close();
+        },
+      });
+      stream.getReader();
+
+      expect(async () => await Bun.write(filePath, stream)).toThrow("ReadableStream is locked");
+    });
+
+    it("rejects when the stream errors", async () => {
+      using dir = tempDir("bun-write-errored-stream", {});
+      const filePath = join(String(dir), "out.bin");
+      const stream = new ReadableStream({
+        pull(controller) {
+          controller.error(new Error("stream go boom"));
+        },
+      });
+
+      expect(async () => await Bun.write(filePath, stream)).toThrow("stream go boom");
+    });
+  });
 });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -872,6 +872,18 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
       expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([10, 20, 30]));
     });
 
+    it("writes the values of an async generator function", async () => {
+      using dir = tempDir("bun-write-async-gen-fn", {});
+      const filePath = join(String(dir), "out.bin");
+
+      const written = await Bun.write(filePath, async function* () {
+        yield new Uint8Array([40, 50]);
+        yield new Uint8Array([60]);
+      });
+      expect(written).toBe(3);
+      expect(await Bun.file(filePath).bytes()).toEqual(new Uint8Array([40, 50, 60]));
+    });
+
     it("throws on an already-used stream", async () => {
       using dir = tempDir("bun-write-used-stream", {});
       const filePath = join(String(dir), "out.bin");

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1801,3 +1801,69 @@ describe("s3 multipart upload id validation", () => {
     expect(exitCode).toBe(0);
   }, 60_000);
 });
+
+describe("S3File.write(ReadableStream)", () => {
+  it("uploads the stream body, not its toString()", async () => {
+    const fixture = `
+        let received = "";
+        const server = Bun.serve({
+          port: 0,
+          async fetch(req) {
+            const url = new URL(req.url);
+            if (req.method === "POST" && url.search.startsWith("?uploads")) {
+              return new Response(
+                "<InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>",
+                { status: 200, headers: { "Content-Type": "text/xml" } },
+              );
+            }
+            if (req.method === "POST" && url.searchParams.has("uploadId")) {
+              return new Response(
+                '<CompleteMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><ETag>"etag"</ETag></CompleteMultipartUploadResult>',
+                { status: 200, headers: { "Content-Type": "text/xml" } },
+              );
+            }
+            if (req.method === "PUT") {
+              received += await req.text();
+              return new Response(null, { status: 200, headers: { ETag: '"etag"' } });
+            }
+            return new Response(null, { status: 200 });
+          },
+        });
+
+        const client = new Bun.S3Client({
+          accessKeyId: "test",
+          secretAccessKey: "test",
+          endpoint: server.url.href,
+          bucket: "bucket",
+        });
+
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("hello "));
+            controller.enqueue(new TextEncoder().encode("from "));
+            controller.enqueue(new TextEncoder().encode("stream"));
+            controller.close();
+          },
+        });
+
+        await client.file("key.txt").write(stream);
+        console.log(JSON.stringify({ received }));
+        server.stop(true);
+      `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, http_proxy: "", https_proxy: "", HTTP_PROXY: "", HTTPS_PROXY: "" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ received: "hello from stream" }),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #31681
Fixes #31682
Fixes #37658


### Repro

```js
using server = Bun.serve({ port: 0, fetch: () => new Response(Buffer.alloc(256 * 1024, 0x5a)) });
const res = await fetch(server.url);

const n = await Bun.write("/tmp/out.bin", res.body);
console.log(n);                                    // 23
console.log(await Bun.file("/tmp/out.bin").text()); // "[object ReadableStream]"
```

Passing a raw `ReadableStream` (a fetch body, a plain `new ReadableStream(...)`, or via `Bun.file(path).write(stream)`) wrote the literal string `"[object ReadableStream]"` and resolved successfully — silent data corruption.

### Cause

`write_file_internal` special-cases `Response`, `Request`, and `Archive` sources, then falls through to `Blob::get`, whose joiner string-coerces unknown objects. A raw `ReadableStream` matched none of the special cases.

### Fix

- Detect `ReadableStream` (and async iterable) sources in `write_file_internal` and pipe them into the destination with `pipe_readable_stream_to_blob` — the same machinery already used for S3→file writes. Covers file, fd, and S3 destinations. Already-used streams throw `ReadableStream has already been used`, matching the Response/Request body arms.
- Resolve with the number of bytes written instead of `0`. `FileSink.written` mixes "buffered" and "flushed" reports and can double-count, so this adds `FileSink.received_bytes`, counting every accepted chunk exactly once (UTF-8 re-encoded length for string chunks, via simdutf).
- Truncate the destination before writing, per `Bun.write`'s replace semantics. `FileSink`'s open never applied `O_TRUNC` (`Options.truncate` was dead); it is now wired into `flags()` with a `false` default so `Bun.file(path).writer()` keeps its established in-place overwrite behavior, and the pipe path opts in.
- Mark the internal `assignToStream` promise handled when it rejects synchronously, so a locked/errored stream rejects the returned promise without also surfacing a spurious unhandled rejection.

Types (`Bun.write`, `BunFile.write`, S3 writes) and docs updated to include `ReadableStream`.

### Verification

New tests in `test/js/bun/io/bun-write.test.js` (`Bun.write > ReadableStream source`): fetch body (256 KiB), plain/pull-based/direct/empty streams, byte-count accuracy, truncation of longer pre-existing files, `Bun.file().write(stream)`, async iterables, disturbed-stream throw, locked-stream and errored-stream rejections.

- `bun bd test test/js/bun/io/bun-write.test.js` → 46 pass (11 new tests fail without the fix)
- `test/js/bun/util/filesink.test.ts` (42), `test/js/web/streams/streams.test.js` (70), spawn stdin stream suites — all pass
- `Bun.file(path).writer()` on an existing longer file still overwrites in place (unchanged behavior)

### Related issues

- #31682: `Bun.write(Bun.file(path), s3file)` leaving stale trailing bytes is the same missing-`O_TRUNC` open in `pipe_readable_stream_to_blob` — fixed by the truncation change (both the POSIX `FileSink` open and the Windows arm).
- #17459: the direct forms requested there (`Bun.write(dest, readableStream)` / `Bun.write(dest, asyncIterable)`) now work. Not closing it here because its example wraps the generator in a `Response`, which hits the separate `Locked`-body hang (#28988's territory) that this PR does not touch.
- #25968 (`Bun.file().writer()` should truncate) is deliberately **not** changed: `writer()` keeps its long-standing in-place overwrite behavior; only `Bun.write`'s replace-style pipe path opts into `O_TRUNC`.


## Rebase notes

Two main changes landed between reviews that touched the same code:

- #33193 (webstreams C++ rewrite) deleted `src/jsc/bindings/webcore/ReadableStream.cpp` and replaced the JS-builtins streams with C++ classes. `ReadableStream__getStoredError` was ported to `WebStreamsExports.cpp` and now reads `JSReadableStream::m_state`/`m_storedError` directly. The separate `ReadableStream__hasReader` helper was dropped: the rewrite's `isReadableStreamLocked()` already reports reader, reader-less, and detached-native locks correctly, so the preflight in `write_file_internal` uses `stream.is_locked()` directly. The shadowed-`locked`-getter test is kept (the C++ lock check reads internal state, not the public getter, so it still passes).
- #33538 (FileSink backpressured write accounting) refactored the `write`/`write_latin1`/`write_utf16` tails to `bytes_accepted(buffered_before, &rc)` + `to_result(rc, accepted)`. That accounting (per-call pending-promise credit) and this PR's `received_bytes` counter (cumulative bytes for `Bun.write`'s resolved value) are independent; both are kept side by side.

After rebase: bun-write 54/0, filesink 46/0, streams 151/0.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 11 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->
