### PR TITLE
Report OutOfMemory crashes from infallible allocation failure

### DIFF
--- a/src/crash_handler/handle_oom.rs
+++ b/src/crash_handler/handle_oom.rs
@@ -25,11 +25,12 @@ use bun_core::Error;
 /// let thing = match allocate_thing() { Ok(v) => v, Err(err) => bun::handle_oom(err) };
 /// ```
 ///
-/// In Rust, `Vec`/`Box` allocation already aborts on OOM via the
-/// global allocator's `handle_alloc_error`. Per PORTING.md §Allocators,
-/// callsites of `bun.handleOom(expr)` translate to bare `expr`. This function
-/// remains for the residual cases where a `Result<T, AllocError>` is threaded
-/// explicitly.
+/// In Rust, `Vec`/`Box` allocation failure goes through the global
+/// allocator's `handle_alloc_error`, which the alloc-error hook installed by
+/// `install_hooks()` routes into the same `bun::out_of_memory()` crash report
+/// as this function. Per PORTING.md §Allocators, callsites of
+/// `bun.handleOom(expr)` translate to bare `expr`. This function remains for
+/// the residual cases where a `Result<T, AllocError>` is threaded explicitly.
 pub fn handle_oom<A: HandleOom>(error_union_or_set: A) -> A::Output {
     error_union_or_set.handle_oom()
 }

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -20,6 +20,9 @@
 // builds only. Declaring the feature where neither is compiled (Windows
 // release) trips `unused_features`.
 #![cfg_attr(any(not(windows), debug_assertions), feature(core_intrinsics))]
+// `std::alloc::set_alloc_error_hook` — routes infallible-allocation failure
+// (`handle_alloc_error`) into the crash handler. See `alloc_error_hook`.
+#![feature(alloc_error_hook)]
 #![allow(internal_features)]
 #![allow(nonstandard_style, static_mut_refs, unexpected_cfgs)]
 #![warn(unused_must_use)]
@@ -48,6 +51,26 @@ pub(crate) fn out_of_memory() -> ! {
 #[doc(hidden)]
 #[unsafe(no_mangle)]
 pub(crate) extern "Rust" fn __bun_crash_handler_out_of_memory() -> ! {
+    out_of_memory()
+}
+
+/// Alloc-error hook registered by `install_hooks()`. Infallible allocations
+/// (`Vec`/`Box`/`String` growth) report failure through
+/// `std::alloc::handle_alloc_error`, which calls this hook. Without it, std's
+/// default hook prints "memory allocation of N bytes failed" and aborts —
+/// no OOM message, no trace string, no crash report. Routing into
+/// `out_of_memory()` gives those failures the same `CrashReason::OutOfMemory`
+/// report as the explicit `Result<_, AllocError>` path (`bun_core::handle_oom`),
+/// matching Zig, where every failed allocation bubbled to `bun.outOfMemory()`.
+///
+/// Runs under memory pressure, so it must not allocate: the body is a single
+/// diverging call, and the crash handler itself writes through stack buffers
+/// and raw stderr. If the report path does hit a second OOM, the
+/// `PANIC_STAGE` re-entry guard in `crash_handler()` aborts instead of
+/// looping.
+#[cold]
+#[inline(never)]
+fn alloc_error_hook(_layout: core::alloc::Layout) {
     out_of_memory()
 }
 
@@ -1774,6 +1797,11 @@ mod draft {
         // this hook, a bare `panic!` would print the std
         // default hook + unwind with no trace string and no upload.
         std::panic::set_hook(Box::new(rust_panic_hook));
+        // Route infallible-allocation failure (`handle_alloc_error`) through
+        // the same `CrashReason::OutOfMemory` path as `bun_core::handle_oom`;
+        // std's default hook would print "memory allocation of N bytes failed"
+        // and abort with no trace string and no report.
+        std::alloc::set_alloc_error_hook(crate::alloc_error_hook);
     }
 
     /// `std::panic` hook: emit the same trace-string + auto-report as the fatal

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -102,6 +102,7 @@ export const crash_handler = $zig("crash_handler.zig", "js_bindings.generate") a
   panic: () => void;
   rootError: () => void;
   outOfMemory: () => void;
+  infallibleOutOfMemory: () => void;
   raiseIgnoringPanicHandler: () => void;
 };
 

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -12,7 +12,6 @@ pub mod js_bindings {
     use super::*;
 
     pub fn generate(global: &JSGlobalObject) -> JSValue {
-        let obj = JSValue::create_empty_object(global, 8);
         // `#[bun_jsc::host_fn]` emits an `extern "C"` shim named `__jsc_host_<fn>`; that
         // shim is the `JSHostFn` value passed to `JSFunction::create`.
         const ENTRIES: &[(&str, bun_jsc::JSHostFn)] = &[
@@ -35,6 +34,7 @@ pub mod js_bindings {
                 __jsc_host_js_raise_ignoring_panic_handler,
             ),
         ];
+        let obj = JSValue::create_empty_object(global, ENTRIES.len());
         for &(name, func) in ENTRIES {
             obj.put(
                 global,

--- a/src/runtime/api/crash_handler_jsc.rs
+++ b/src/runtime/api/crash_handler_jsc.rs
@@ -27,6 +27,10 @@ pub mod js_bindings {
             ("rootError", __jsc_host_js_root_error),
             ("outOfMemory", __jsc_host_js_out_of_memory),
             (
+                "infallibleOutOfMemory",
+                __jsc_host_js_infallible_out_of_memory,
+            ),
+            (
                 "raiseIgnoringPanicHandler",
                 __jsc_host_js_raise_ignoring_panic_handler,
             ),
@@ -111,6 +115,25 @@ pub mod js_bindings {
     ) -> JsResult<JSValue> {
         crash_handler::suppress_core_dumps_if_necessary();
         bun_core::out_of_memory();
+    }
+
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_infallible_out_of_memory(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        crash_handler::suppress_core_dumps_if_necessary();
+        // Unlike `outOfMemory` above (the explicit `bun_core::out_of_memory()`
+        // entry), this exercises the global-allocator path: a reservation no
+        // 64-bit address space can satisfy makes the allocator return null, and
+        // `Vec` growth reports it via `std::alloc::handle_alloc_error`, which
+        // reaches the alloc-error hook installed by `crash_handler::init()`.
+        // Under ASAN, the interceptor hard-errors on impossible sizes instead
+        // of returning null unless `ASAN_OPTIONS=allocator_may_return_null=1`
+        // is set (the crash-handler test sets it).
+        let v = Vec::<u8>::with_capacity(1usize << 61);
+        core::hint::black_box(&v);
+        Ok(JSValue::UNDEFINED)
     }
 
     #[bun_jsc::host_fn]

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -11,5 +11,5 @@ const approach = process.argv[2];
 if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
-  console.error("usage: bun fixture-crash.js <segfault|panic|rootError|outOfMemory|raiseIgnoringPanicHandler>");
+  console.error("usage: bun fixture-crash.js <segfault|panic|rootError|outOfMemory|infallibleOutOfMemory|raiseIgnoringPanicHandler>");
 }

--- a/test/cli/run/fixture-crash.js
+++ b/test/cli/run/fixture-crash.js
@@ -12,4 +12,5 @@ if (approach in crash_handler) {
   crash_handler[approach]();
 } else {
   console.error("usage: bun fixture-crash.js <segfault|panic|rootError|outOfMemory|infallibleOutOfMemory|raiseIgnoringPanicHandler>");
+  process.exit(1);
 }

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -123,7 +123,11 @@ test("raise ignoring panic handler does not trigger the panic handler", async ()
 });
 
 describe("automatic crash reporter", () => {
-  for (const approach of ["panic", "segfault", "outOfMemory"]) {
+  // "outOfMemory" is the explicit `Result<_, AllocError>` path;
+  // "infallibleOutOfMemory" is ordinary `Vec`/`Box` growth failing inside the
+  // global allocator (`handle_alloc_error` → alloc-error hook). Both must
+  // produce the same OutOfMemory crash report.
+  for (const approach of ["panic", "segfault", "outOfMemory", "infallibleOutOfMemory"]) {
     test(`${approach} should report`, async () => {
       let sent = false;
       const resolve_handler = Promise.withResolvers();
@@ -149,6 +153,14 @@ describe("automatic crash reporter", () => {
             GITHUB_ACTIONS: undefined,
             CI: undefined,
           },
+          approach === "infallibleOutOfMemory"
+            ? {
+                // ASAN's interceptor hard-errors on impossible allocation
+                // sizes; let it return null so the failure reaches Rust's
+                // `handle_alloc_error` like a real OOM would. No-op without ASAN.
+                ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+              }
+            : {},
         ]),
         stdio: ["ignore", "pipe", "pipe"],
       });
@@ -156,16 +168,17 @@ describe("automatic crash reporter", () => {
       const stderr = await proc.stderr.text();
       console.log(stderr);
 
-      await resolve_handler.promise;
-
       expect(exitCode).not.toBe(0);
       expect(stderr).toContain(server.url.toString());
-      if (approach !== "outOfMemory") {
-        expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
-      } else {
+      if (approach === "outOfMemory" || approach === "infallibleOutOfMemory") {
         expect(stderr.toLowerCase()).toContain("out of memory");
         expect(stderr.toLowerCase()).not.toContain("panic");
+      } else {
+        expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
       }
+
+      // Wait for the report to arrive (resolves the moment the POST is heard).
+      await resolve_handler.promise;
       expect(sent).toBe(true);
     });
   }


### PR DESCRIPTION
### Problem

Out-of-memory crashes from ordinary (infallible) allocations are invisible: zero `OutOfMemory`-typed crash reports come from Rust builds, while Zig stable builds report thousands. In Zig, every failed allocation returned `error.OutOfMemory` and bubbled to `bun.outOfMemory()` → `CrashReason::OutOfMemory` → auto-report. In the Rust port, only explicit `Result<_, AllocError>` paths go through `bun_core::handle_oom`; plain `Vec`/`Box`/`String` growth failure goes to the global allocator's `handle_alloc_error`, whose std default hook prints:

```
memory allocation of 2305843009213693952 bytes failed
```

and calls `abort()` — SIGABRT (exit 134), no "Bun ran out of memory" message, no trace string, no report URL, no upload. Since the vast majority of allocations are the infallible kind, effectively all real-world OOMs vanish from telemetry. The POSIX crash handler only registers `SIGSEGV/SIGILL/SIGBUS/SIGFPE`, so nothing downstream catches it either (and by SIGABRT time the OOM context would be gone anyway).

### Fix

`install_hooks()` — where `std::panic::set_hook` is already wired — now also registers `std::alloc::set_alloc_error_hook` (nightly API; the workspace is pinned to nightly). The hook routes into the existing `out_of_memory()` → `crash_handler(CrashReason::OutOfMemory, …)` path, so infallible allocation failure produces the same report as the explicit `AllocError` path and Zig:

```
oh no: Bun has run out of memory.

To send a redacted crash report to Bun's team,
please file a GitHub issue using the link below:

 https://bun.report/1.4.0/…
```

The hook runs under memory pressure, so it must not allocate: its body is a single diverging call, and the crash handler itself writes through stack buffers and raw stderr. A second OOM inside the report path hits the existing `PANIC_STAGE` re-entry guard and aborts instead of looping. This also covers the in-tree direct `handle_alloc_error` callers (`VirtualMachine.rs`, `analyze_transpiled_module.rs`).

(`-Zoom=panic` was considered and rejected: it would type these as `Panic` instead of `OutOfMemory`; registering SIGABRT was rejected because the OOM context is gone by signal time.)

### Test

New `crash_handler.infallibleOutOfMemory` binding in `bun:internal-for-testing` performs a real `Vec::with_capacity(1 << 61)` — a reservation no 64-bit address space can satisfy — so the failure travels the genuine route: global allocator returns null → `RawVec` → `handle_alloc_error` → hook → report. Wired into the existing `automatic crash reporter` matrix in `test/cli/run/run-crash-handler.test.ts`, which asserts the OOM message, the report URL, and the POST arriving at a self-hosted report server. Under ASAN the child gets `ASAN_OPTIONS=allocator_may_return_null=1` so the interceptor returns null instead of hard-erroring before Rust sees the failure.

Verified on the ASAN debug build: test fails without the src changes (fixture reports the approach as unknown, process exits 0 with no report) and passes with them; the other crash-reporter approaches (`panic`, `segfault`, `outOfMemory`) are unaffected.

`Cargo.lock`: syncs the `bstr` dependency `bun_bin` gained in #31668 (lockfile wasn't regenerated there; any cargo invocation reproduces this hunk).