### PR TITLE
Fix `--watch` reload panic when the executable has been deleted or replaced

### DIFF
--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4432,11 +4432,28 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         envp.push(core::ptr::null());
 
         // we must clone selfExePath in case argv[0] was not an absolute path
-        let exec_path = self_exe_path().expect("unreachable").as_ptr();
+        let exe = self_exe_path().expect("unreachable");
+        let exec_path = exe.as_ptr();
 
         libc::execve(exec_path, newargv.as_ptr().cast(), envp.as_ptr().cast());
         // execve only returns on error.
-        let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+        #[allow(unused_mut)]
+        let mut errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+
+        // Linux: `/proc/self/exe` reads as "<path> (deleted)" once the running
+        // binary has been unlinked. If it was atomically replaced (`bun
+        // upgrade`, a package reinstall, a rebuild), a fresh executable lives
+        // at the original path — retry with the suffix stripped so the reload
+        // lands on the replacement instead of failing.
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        if errno == libc::ENOENT {
+            if let Some(trimmed) = exe.as_bytes().strip_suffix(b" (deleted)") {
+                let trimmed = ZBox::from_bytes(trimmed);
+                libc::execve(trimmed.as_ptr(), newargv.as_ptr().cast(), envp.as_ptr().cast());
+                errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+            }
+        }
+
         if may_return {
             crate::output::pretty_errorln(format_args!(
                 "error: Failed to reload process: errno {}",
@@ -4444,7 +4461,28 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
             ));
             return;
         }
-        panic!("Unexpected error while reloading: errno {}", errno);
+        // The executable can legitimately be gone or unrunnable by the time a
+        // reload fires: deleted or replaced by `bun upgrade`, a package
+        // reinstall, or a rebuild while `--watch` is running. That's an
+        // environment problem, not a Bun bug, so report it and exit instead of
+        // emitting a crash report. Anything else still panics.
+        if matches!(
+            errno,
+            libc::ENOENT | libc::ENOTDIR | libc::EACCES | libc::ETXTBSY | libc::ENOEXEC
+        ) {
+            let name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
+            let detail = crate::result::coreutils_error_map::get(errno).unwrap_or("unknown error");
+            crate::output::err_generic(
+                "Failed to reload process: {} ({}) while executing \"{}\". The executable may have been deleted or replaced while Bun was running.",
+                (name, detail, bstr::BStr::new(exe.as_bytes())),
+            );
+            crate::Global::exit(1);
+        }
+        let errno_name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
+        panic!(
+            "Unexpected error while reloading: errno {} {}",
+            errno, errno_name
+        );
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4449,7 +4449,11 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         if errno == libc::ENOENT {
             if let Some(trimmed) = exe.as_bytes().strip_suffix(b" (deleted)") {
                 let trimmed = ZBox::from_bytes(trimmed);
-                libc::execve(trimmed.as_ptr(), newargv.as_ptr().cast(), envp.as_ptr().cast());
+                libc::execve(
+                    trimmed.as_ptr(),
+                    newargv.as_ptr().cast(),
+                    envp.as_ptr().cast(),
+                );
                 errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
             }
         }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4439,6 +4439,10 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         // execve only returns on error.
         #[allow(unused_mut)]
         let mut errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+        // The path whose exec attempt produced `errno`; the Linux retry below
+        // updates both together so the error message stays accurate.
+        #[allow(unused_mut)]
+        let mut attempted = exe.as_bytes();
 
         // Linux: `/proc/self/exe` reads as "<path> (deleted)" once the running
         // binary has been unlinked. If it was atomically replaced (`bun
@@ -4448,13 +4452,14 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
         #[cfg(any(target_os = "linux", target_os = "android"))]
         if errno == libc::ENOENT {
             if let Some(trimmed) = exe.as_bytes().strip_suffix(b" (deleted)") {
-                let trimmed = ZBox::from_bytes(trimmed);
+                let trimmed_z = ZBox::from_bytes(trimmed);
                 libc::execve(
-                    trimmed.as_ptr(),
+                    trimmed_z.as_ptr(),
                     newargv.as_ptr().cast(),
                     envp.as_ptr().cast(),
                 );
                 errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(-1);
+                attempted = trimmed;
             }
         }
 
@@ -4478,7 +4483,7 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
             let detail = crate::result::coreutils_error_map::get(errno).unwrap_or("unknown error");
             crate::output::err_generic(
                 "Failed to reload process: {} ({}) while executing \"{}\". The executable may have been deleted or replaced while Bun was running.",
-                (name, detail, bstr::BStr::new(exe.as_bytes())),
+                (name, detail, bstr::BStr::new(attempted)),
             );
             crate::Global::exit(1);
         }

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4463,11 +4463,13 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
             }
         }
 
+        let name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
+        let detail = crate::result::coreutils_error_map::get(errno).unwrap_or("unknown error");
         if may_return {
-            crate::output::pretty_errorln(format_args!(
-                "error: Failed to reload process: errno {}",
-                errno
-            ));
+            crate::output::err_generic(
+                "Failed to reload process: {} ({}) while executing \"{}\"",
+                (name, detail, bstr::BStr::new(attempted)),
+            );
             return;
         }
         // The executable can legitimately be gone or unrunnable by the time a
@@ -4479,19 +4481,13 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
             errno,
             libc::ENOENT | libc::ENOTDIR | libc::EACCES | libc::ETXTBSY | libc::ENOEXEC
         ) {
-            let name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
-            let detail = crate::result::coreutils_error_map::get(errno).unwrap_or("unknown error");
             crate::output::err_generic(
                 "Failed to reload process: {} ({}) while executing \"{}\". The executable may have been deleted or replaced while Bun was running.",
                 (name, detail, bstr::BStr::new(attempted)),
             );
             crate::Global::exit(1);
         }
-        let errno_name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
-        panic!(
-            "Unexpected error while reloading: errno {} {}",
-            errno, errno_name
-        );
+        panic!("Unexpected error while reloading: errno {} {}", errno, name);
     }
 
     #[cfg(not(any(unix, windows)))]

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4463,7 +4463,7 @@ pub fn reload_process(clear_terminal: bool, may_return: bool) {
             }
         }
 
-        let name = crate::result::system_errno_name(errno).unwrap_or("EUNKNOWN");
+        let name = crate::ErrnoNames::SYS.name(errno).unwrap_or("EUNKNOWN");
         let detail = crate::result::coreutils_error_map::get(errno).unwrap_or("unknown error");
         if may_return {
             crate::output::err_generic(

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -2,7 +2,7 @@ import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, expect, it } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
-import { readdirSync, rmSync } from "node:fs";
+import { chmodSync, copyFileSync, linkSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -407,4 +407,123 @@ it.skipIf(isWindows)(
     await watchee.exited;
   },
   30000,
+);
+
+// The executable can be deleted or replaced while `--watch` is running (bun
+// upgrade, a package reinstall, a rebuild). The re-exec reload must then fail
+// with a clean error instead of "panic: Unexpected error while reloading".
+// Windows reloads through a watcher-manager parent process instead of exec,
+// so this scenario does not apply there.
+it.skipIf(isWindows)(
+  "should exit with a clean error when the executable is gone at reload time",
+  async () => {
+    using dir = tempDir("watch-exe-gone", {
+      "app/entry.js": "console.log('VERSION_1');",
+    });
+    // A private copy of the executable that the test can delete. It lives
+    // outside the watched directory so deleting it does not itself count as a
+    // file change. Hardlink when possible to avoid copying large debug
+    // builds; fall back to a real copy across filesystems.
+    const exeCopy = join(String(dir), "bun-copy");
+    try {
+      linkSync(bunExe(), exeCopy);
+    } catch {
+      copyFileSync(bunExe(), exeCopy);
+      chmodSync(exeCopy, 0o755);
+    }
+
+    await using proc = spawn({
+      cmd: [exeCopy, "--watch", "entry.js"],
+      cwd: join(String(dir), "app"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    // Wait for the initial run to finish; the entry file is registered with
+    // the watcher before it executes, so a change written after this output
+    // is guaranteed to trigger a reload.
+    const firstRun = Promise.withResolvers<void>();
+    const stdoutDone = (async () => {
+      let output = "";
+      const decoder = new TextDecoder();
+      for await (const chunk of proc.stdout) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("VERSION_1")) firstRun.resolve();
+      }
+    })();
+    await firstRun.promise;
+
+    // Delete the executable out from under the process, then trigger a reload.
+    rmSync(exeCopy);
+    writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    await stdoutDone;
+    expect(stderr).toContain("Failed to reload process");
+    expect(stderr).toContain("ENOENT");
+    expect(exitCode).toBe(1);
+  },
+  30_000,
+);
+
+// On Linux, a deleted-then-recreated executable (how upgrades and package
+// reinstalls land) makes `/proc/self/exe` read "<path> (deleted)" while a
+// fresh binary sits at the original path. The reload must pick up the
+// replacement instead of crashing.
+it.skipIf(isWindows)(
+  "should reload into the replacement when the executable is replaced",
+  async () => {
+    using dir = tempDir("watch-exe-replaced", {
+      "app/entry.js": "console.log('VERSION_1');",
+    });
+    const exeCopy = join(String(dir), "bun-copy");
+    const installExe = () => {
+      try {
+        linkSync(bunExe(), exeCopy);
+      } catch {
+        copyFileSync(bunExe(), exeCopy);
+        chmodSync(exeCopy, 0o755);
+      }
+    };
+    installExe();
+
+    await using proc = spawn({
+      cmd: [exeCopy, "--watch", "entry.js"],
+      cwd: join(String(dir), "app"),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const firstRun = Promise.withResolvers<void>();
+    const secondRun = Promise.withResolvers<void>();
+    const stdoutDone = (async () => {
+      let output = "";
+      const decoder = new TextDecoder();
+      for await (const chunk of proc.stdout) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("VERSION_1")) firstRun.resolve();
+        if (output.includes("VERSION_2")) secondRun.resolve();
+      }
+    })();
+    await firstRun.promise;
+
+    // Replace the executable (delete + recreate, same path, new inode), then
+    // trigger a reload. The reload re-execs and must land on the replacement.
+    rmSync(exeCopy);
+    installExe();
+    writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
+
+    const result = await Promise.race([
+      secondRun.promise.then(() => "reloaded" as const),
+      proc.exited.then(code => `exited with code ${code} before reloading` as const),
+    ]);
+    expect(result).toBe("reloaded");
+    proc.kill();
+    await Promise.all([proc.exited, stdoutDone]);
+  },
+  30_000,
 );

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -414,116 +414,108 @@ it.skipIf(isWindows)(
 // with a clean error instead of "panic: Unexpected error while reloading".
 // Windows reloads through a watcher-manager parent process instead of exec,
 // so this scenario does not apply there.
-it.skipIf(isWindows)(
-  "should exit with a clean error when the executable is gone at reload time",
-  async () => {
-    using dir = tempDir("watch-exe-gone", {
-      "app/entry.js": "console.log('VERSION_1');",
-    });
-    // A private copy of the executable that the test can delete. It lives
-    // outside the watched directory so deleting it does not itself count as a
-    // file change. Hardlink when possible to avoid copying large debug
-    // builds; fall back to a real copy across filesystems.
-    const exeCopy = join(String(dir), "bun-copy");
+it.skipIf(isWindows)("should exit with a clean error when the executable is gone at reload time", async () => {
+  using dir = tempDir("watch-exe-gone", {
+    "app/entry.js": "console.log('VERSION_1');",
+  });
+  // A private copy of the executable that the test can delete. It lives
+  // outside the watched directory so deleting it does not itself count as a
+  // file change. Hardlink when possible to avoid copying large debug
+  // builds; fall back to a real copy across filesystems.
+  const exeCopy = join(String(dir), "bun-copy");
+  try {
+    linkSync(bunExe(), exeCopy);
+  } catch {
+    copyFileSync(bunExe(), exeCopy);
+    chmodSync(exeCopy, 0o755);
+  }
+
+  await using proc = spawn({
+    cmd: [exeCopy, "--watch", "entry.js"],
+    cwd: join(String(dir), "app"),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  // Wait for the initial run to finish; the entry file is registered with
+  // the watcher before it executes, so a change written after this output
+  // is guaranteed to trigger a reload.
+  const firstRun = Promise.withResolvers<void>();
+  const stdoutDone = (async () => {
+    let output = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stdout) {
+      output += decoder.decode(chunk, { stream: true });
+      if (output.includes("VERSION_1")) firstRun.resolve();
+    }
+  })();
+  await firstRun.promise;
+
+  // Delete the executable out from under the process, then trigger a reload.
+  rmSync(exeCopy);
+  writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  await stdoutDone;
+  expect(stderr).toContain("Failed to reload process");
+  expect(stderr).toContain("ENOENT");
+  expect(exitCode).toBe(1);
+});
+
+// On Linux, a deleted-then-recreated executable (how upgrades and package
+// reinstalls land) makes `/proc/self/exe` read "<path> (deleted)" while a
+// fresh binary sits at the original path. The reload must pick up the
+// replacement instead of crashing.
+it.skipIf(isWindows)("should reload into the replacement when the executable is replaced", async () => {
+  using dir = tempDir("watch-exe-replaced", {
+    "app/entry.js": "console.log('VERSION_1');",
+  });
+  const exeCopy = join(String(dir), "bun-copy");
+  const installExe = () => {
     try {
       linkSync(bunExe(), exeCopy);
     } catch {
       copyFileSync(bunExe(), exeCopy);
       chmodSync(exeCopy, 0o755);
     }
+  };
+  installExe();
 
-    await using proc = spawn({
-      cmd: [exeCopy, "--watch", "entry.js"],
-      cwd: join(String(dir), "app"),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-    });
+  await using proc = spawn({
+    cmd: [exeCopy, "--watch", "entry.js"],
+    cwd: join(String(dir), "app"),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
 
-    // Wait for the initial run to finish; the entry file is registered with
-    // the watcher before it executes, so a change written after this output
-    // is guaranteed to trigger a reload.
-    const firstRun = Promise.withResolvers<void>();
-    const stdoutDone = (async () => {
-      let output = "";
-      const decoder = new TextDecoder();
-      for await (const chunk of proc.stdout) {
-        output += decoder.decode(chunk, { stream: true });
-        if (output.includes("VERSION_1")) firstRun.resolve();
-      }
-    })();
-    await firstRun.promise;
+  const firstRun = Promise.withResolvers<void>();
+  const secondRun = Promise.withResolvers<void>();
+  const stdoutDone = (async () => {
+    let output = "";
+    const decoder = new TextDecoder();
+    for await (const chunk of proc.stdout) {
+      output += decoder.decode(chunk, { stream: true });
+      if (output.includes("VERSION_1")) firstRun.resolve();
+      if (output.includes("VERSION_2")) secondRun.resolve();
+    }
+  })();
+  await firstRun.promise;
 
-    // Delete the executable out from under the process, then trigger a reload.
-    rmSync(exeCopy);
-    writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
+  // Replace the executable (delete + recreate, same path, new inode), then
+  // trigger a reload. The reload re-execs and must land on the replacement.
+  rmSync(exeCopy);
+  installExe();
+  writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    await stdoutDone;
-    expect(stderr).toContain("Failed to reload process");
-    expect(stderr).toContain("ENOENT");
-    expect(exitCode).toBe(1);
-  },
-  30_000,
-);
-
-// On Linux, a deleted-then-recreated executable (how upgrades and package
-// reinstalls land) makes `/proc/self/exe` read "<path> (deleted)" while a
-// fresh binary sits at the original path. The reload must pick up the
-// replacement instead of crashing.
-it.skipIf(isWindows)(
-  "should reload into the replacement when the executable is replaced",
-  async () => {
-    using dir = tempDir("watch-exe-replaced", {
-      "app/entry.js": "console.log('VERSION_1');",
-    });
-    const exeCopy = join(String(dir), "bun-copy");
-    const installExe = () => {
-      try {
-        linkSync(bunExe(), exeCopy);
-      } catch {
-        copyFileSync(bunExe(), exeCopy);
-        chmodSync(exeCopy, 0o755);
-      }
-    };
-    installExe();
-
-    await using proc = spawn({
-      cmd: [exeCopy, "--watch", "entry.js"],
-      cwd: join(String(dir), "app"),
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
-    });
-
-    const firstRun = Promise.withResolvers<void>();
-    const secondRun = Promise.withResolvers<void>();
-    const stdoutDone = (async () => {
-      let output = "";
-      const decoder = new TextDecoder();
-      for await (const chunk of proc.stdout) {
-        output += decoder.decode(chunk, { stream: true });
-        if (output.includes("VERSION_1")) firstRun.resolve();
-        if (output.includes("VERSION_2")) secondRun.resolve();
-      }
-    })();
-    await firstRun.promise;
-
-    // Replace the executable (delete + recreate, same path, new inode), then
-    // trigger a reload. The reload re-execs and must land on the replacement.
-    rmSync(exeCopy);
-    installExe();
-    writeFileSync(join(String(dir), "app", "entry.js"), "console.log('VERSION_2');");
-
-    const result = await Promise.race([
-      secondRun.promise.then(() => "reloaded" as const),
-      proc.exited.then(code => `exited with code ${code} before reloading` as const),
-    ]);
-    expect(result).toBe("reloaded");
-    proc.kill();
-    await Promise.all([proc.exited, stdoutDone]);
-  },
-  30_000,
-);
+  const result = await Promise.race([
+    secondRun.promise.then(() => "reloaded" as const),
+    proc.exited.then(code => `exited with code ${code} before reloading` as const),
+  ]);
+  expect(result).toBe("reloaded");
+  proc.kill();
+  await Promise.all([proc.exited, stdoutDone]);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes the long-standing crash `panic: Unexpected error while reloading: errno 2` (163+ reports across 1.3.x stables, still firing on 1.4 canary).

`--watch` (and `bun build --watch`, `bun test --watch`, and crash auto-reload under `--hot`) reloads by re-exec'ing the process: `reload_process()` calls `execve(self_exe_path, ...)`. If the running executable was deleted or replaced in the meantime — `bun upgrade`, a package reinstall that recreates `node_modules`, a rebuild of a local binary — `execve` fails with `ENOENT` and Bun panicked with a full crash report, even though nothing is wrong with Bun or the user's code.

**Repro** (Linux/macOS):

```bash
cp $(which bun) /tmp/bun-copy
echo 'console.log("hi")' > /tmp/entry.js
/tmp/bun-copy --watch /tmp/entry.js &
sleep 1 && rm /tmp/bun-copy          # delete the binary out from under the watcher
echo 'console.log("hi2")' > /tmp/entry.js   # trigger a reload
# => panic: Unexpected error while reloading: errno 2
# => oh no: Bun has crashed. ... (exit 132)
```

### Fix (`src/bun_core/util.rs`, `reload_process`)

1. **Replaced binary → reload seamlessly.** On Linux, `/proc/self/exe` reads `"<path> (deleted)"` once the running binary has been unlinked, so even when a fresh executable sits at the original path (atomic replace / delete+recreate), the exec failed. Retry once with the ` (deleted)` suffix stripped so the reload lands on the replacement.
2. **Gone/unrunnable binary → clean error, no crash report.** For the expected exec failures (`ENOENT`, `ENOTDIR`, `EACCES`, `ETXTBSY`, `ENOEXEC`) print a one-line error and exit with code 1:
   ```
   error: Failed to reload process: ENOENT (No such file or directory) while executing "/tmp/bun-copy (deleted)". The executable may have been deleted or replaced while Bun was running.
   ```
3. **Genuinely unexpected errnos still panic**, now including the errno name in the message for easier triage.

Windows is unaffected (reloads go through the watcher-manager parent process, not exec).

### How did you verify your code works?

Two tests in `test/cli/watch/watch.test.ts` (POSIX-only):

- *executable is gone at reload time*: delete the binary, touch the entry → expects the clean `Failed to reload process` + `ENOENT` message and exit code 1. On an unfixed build this fails with the `errno 2` panic and exit 132.
- *executable is replaced*: delete + recreate the binary at the same path, touch the entry → expects the reload to land on the replacement (second run output observed). On an unfixed build the process panics instead of reloading.

Verified failing with `USE_SYSTEM_BUN=1 bun test test/cli/watch/watch.test.ts` and passing with `bun bd test test/cli/watch/watch.test.ts` (all 4 tests in the file, plus `test/cli/hot/hot.test.ts`, `test/cli/hot/watch.test.ts`, `test/cli/hot/watch-many-dirs.test.ts`, `test/cli/watch/watcher-trace.test.ts`). `bun run rust:check-all` passes on all 10 target combos; clippy clean.

The `Cargo.lock` line is pre-existing drift from 90f334a46b (`bstr` added to `bun_bin/Cargo.toml` without the lockfile update); any cargo invocation regenerates it.