### PR TITLE
parser: fix "Scope mismatch while visiting" panic from macro tagged templates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
 name = "bun_bin"
 version = "0.0.0"
 dependencies = [
+ "bstr",
  "bun_alloc",
  "bun_core",
  "bun_crash_handler",

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -707,9 +707,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let expr = *e;
         let _ = in_;
         let mut e_ = expr.data.e_template().expect("infallible: variant checked");
-        if let Some(tag) = e_.tag {
+        if e_.tag.is_some() {
             p.visit_expr(e_.tag.as_mut().unwrap());
+        }
 
+        // Visit the interpolation values before the macro dispatch below: its
+        // early-return paths (dead code, macros disabled, node_modules, macro
+        // failure) replace the whole expression without visiting the parts,
+        // which would leave the scopes recorded during the parse pass for any
+        // arrows/functions inside them unconsumed and trip "Scope mismatch
+        // while visiting" on the next scope push. Mirrors e_call, which visits
+        // its arguments before macro handling.
+        // `Template.parts` is arena-owned (Zig: `[]E.TemplatePart`).
+        for part in e_.parts_mut().iter_mut() {
+            p.visit_expr(&mut part.value);
+        }
+
+        if let Some(tag) = e_.tag {
             if Self::ALLOW_MACROS {
                 let ref_ = match &e_.tag.unwrap().data {
                     Data::EImportIdentifier(ident) => Some(ident.ref_),
@@ -795,11 +809,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
             }
-        }
-
-        // `Template.parts` is arena-owned (Zig: `[]E.TemplatePart`).
-        for part in e_.parts_mut().iter_mut() {
-            p.visit_expr(&mut part.value);
         }
 
         // When mangling, inline string values into the template literal. Note that

--- a/test/bundler/transpiler/scope-mismatch-panic.test.ts
+++ b/test/bundler/transpiler/scope-mismatch-panic.test.ts
@@ -147,6 +147,91 @@ describe("TypeScript 'declare' statements discard scopes of dropped statements",
   });
 });
 
+describe("macro tagged templates visit their interpolations", () => {
+  // When a tagged template's tag resolves to a macro import, the macro dispatch
+  // replaces the whole expression (dead code, macros disabled, or the macro call
+  // failing) without visiting the template parts. Scopes recorded during the parse
+  // pass for arrows/functions inside the interpolations were then never consumed by
+  // the visit pass, panicking with "Scope mismatch while visiting" on the next scope.
+  const macroFile = `export function mac(...args: any[]) { return "from-macro"; }`;
+
+  test.concurrent("tagged template macro with arrow interpolation reports the macro error", async () => {
+    using dir = tempDir("macro-template-scope", {
+      "macro.ts": macroFile,
+      "index.ts": `
+import { mac } from './macro.ts' with { type: 'macro' };
+const r = mac\`a\${() => { let q = 1; }}b\`;
+function g() { { let y = 1; } }
+g();`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // Must fail with the intended transpiler error, not a scope mismatch panic.
+    expect(stderr).not.toContain("Scope mismatch");
+    expect(stderr).toContain("template literal macro invocations are not supported");
+    expect(exitCode).not.toBe(0);
+  });
+
+  test.concurrent("tagged template macro with arrow interpolation in dead code is erased", async () => {
+    using dir = tempDir("macro-template-scope-dead", {
+      "macro.ts": macroFile,
+      "index.ts": `
+import { mac } from './macro.ts' with { type: 'macro' };
+false && mac\`a\${() => { let q = 1; }}b\`;
+function g() { { let y = 2; console.log("ran", y); } }
+g();`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Scope mismatch");
+    expect(stdout).toBe("ran 2\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("member-expression macro tag with function interpolation reports the macro error", async () => {
+    using dir = tempDir("macro-template-scope-ns", {
+      "macro.ts": macroFile,
+      "index.ts": `
+import * as macros from './macro.ts' with { type: 'macro' };
+macros.mac\`x\${function inner() { let z = 3; }}y\`;
+class C { m() { { let w = 4; } } }
+new C().m();`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Scope mismatch");
+    expect(stderr).toContain("template literal macro invocations are not supported");
+    expect(exitCode).not.toBe(0);
+  });
+});
+
 describe("dropped TypeScript class members discard scopes", () => {
   // Decorators and computed keys are parsed before the parser knows whether the class
   // member they belong to will be kept. When the member is then dropped (an overload


### PR DESCRIPTION
### Repro

```ts
// macro.ts
export function mac(...args: any[]) { return "x"; }

// index.ts
import { mac } from './macro.ts' with { type: 'macro' };
mac`a${() => { let q = 1; }}b`;
function g() { { let y = 1; } }
```

```
$ bun index.ts
panic: Scope mismatch while visiting
```

Any tagged-template macro invocation whose interpolations contain a scope-creating expression (arrow, function, class) panics instead of reporting the intended `template literal macro invocations are not supported` error. The dead-code variant (`false && mac`…`` `), the macros-disabled path, and the node_modules path crash the same way. Panics on release builds (kind mismatch) and debug builds (loc mismatch); same structure existed in the Zig-era `visitExpr.zig`, so this predates the Rust port. Crash signature matches Sentry [BUN-3BYK](https://bun-p9.sentry.io/issues/7504990169/) (`Scope mismatch while visiting`, also seen in Zig-era releases).

### Cause

The parser records every scope pushed during the parse pass in `scopes_in_order`; the visit pass replays them in the same order and panics on divergence. In `e_template` (`src/js_parser/visit/visit_expr.rs`), when the tag resolves to a macro ref, **every** dispatch outcome returns before the `for part in e_.parts_mut()` visit loop:

- `is_control_flow_dead` → replaced with `undefined`
- `no_macros` → error + `undefined`
- `node_modules` → error + `undefined`
- `macro_context.call(...)` failure → plain `return` (and template invocations currently always fail with `template literal macro invocations are not supported`, `src/js_parser_jsc/Macro.rs`)

The scopes recorded for arrows/functions inside the interpolations are never consumed, so the next scope the visit pass pushes reads a stale entry and trips the `Scope mismatch while visiting` check. Same bug family as #31231 / #31340 / #31533 (constructs dropped without consuming/discarding their recorded scopes).

### Fix

Visit the template parts right after visiting the tag, **before** the macro dispatch — the same ordering `e_call` uses (arguments are visited before its macro handling). All dispatch paths may then freely replace the expression: the parts' scope entries have already been consumed. The fall-through case no longer re-visits parts.

Also syncs `Cargo.lock` with `bun_bin`'s manifest (`bstr` was added to `Cargo.toml` in 90f334a46b without the lock update; any local cargo invocation regenerates this line).

### Verification

- 3 new tests in `test/bundler/transpiler/scope-mismatch-panic.test.ts` (live tag, dead-flow, namespace-member tag). All three panic without the fix and pass with it.
- `test/bundler/transpiler/{scope-mismatch-panic,macro-test,transpiler,template-literal}.test.ts` and `test/bundler/bundler_string.test.ts` all pass.

Note: #30545 (tagged-template macro support, feature) inserts a parts visit before the macro *call*, which would cover the live path but not the dead-flow / macros-disabled / node_modules returns. This fix is independent and minimal; #30545 rebases on top by dropping its duplicate visit loop (its fold-flag wrapper can stay).
