### PR TITLE
napi: implement statically-implementable libuv functions on POSIX

### DIFF
--- a/src/jsc/bindings/libuv/generate_uv_posix_stubs.ts
+++ b/src/jsc/bindings/libuv/generate_uv_posix_stubs.ts
@@ -290,7 +290,7 @@ const final_contents = `// GENERATED CODE - DO NOT MODIFY BY HAND
 #include "uv-posix-polyfills.h"
 
 
-#if OS(LINUX) || OS(DARWIN)
+#if OS(LINUX) || OS(DARWIN) || OS(FREEBSD)
 ${parts.map(([stub, _]) => stub).join("\n\n")}
 #endif
 

--- a/src/jsc/bindings/libuv/generate_uv_posix_stubs_constants.ts
+++ b/src/jsc/bindings/libuv/generate_uv_posix_stubs_constants.ts
@@ -30,15 +30,22 @@ export const symbols = [
   "uv_check_stop",
   "uv_clock_gettime",
   "uv_close",
-  "uv_cond_broadcast",
-  "uv_cond_destroy",
-  "uv_cond_init",
-  "uv_cond_signal",
-  "uv_cond_timedwait",
-  "uv_cond_wait",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_broadcast",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_destroy",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_init",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_signal",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_timedwait",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cond_wait",
   "uv_cpu_info",
   "uv_cpumask_size",
-  "uv_cwd",
+  // Defined in uv-posix-polyfills.c
+  // "uv_cwd",
   "uv_default_loop",
   "uv_disable_stdio_inheritance",
   "uv_dlclose",
@@ -50,7 +57,8 @@ export const symbols = [
   "uv_exepath",
   "uv_fileno",
   "uv_free_cpu_info",
-  "uv_free_interface_addresses",
+  // Defined in uv-posix-polyfills.c
+  // "uv_free_interface_addresses",
   "uv_freeaddrinfo",
   "uv_fs_access",
   "uv_fs_chmod",
@@ -107,7 +115,8 @@ export const symbols = [
   "uv_get_available_memory",
   "uv_get_constrained_memory",
   "uv_get_free_memory",
-  "uv_get_osfhandle",
+  // Defined in uv-posix-polyfills.c
+  // "uv_get_osfhandle",
   "uv_get_process_title",
   "uv_get_total_memory",
   "uv_getaddrinfo",
@@ -130,14 +139,22 @@ export const symbols = [
   "uv_idle_stop",
   "uv_if_indextoiid",
   "uv_if_indextoname",
-  "uv_inet_ntop",
-  "uv_inet_pton",
-  "uv_interface_addresses",
-  "uv_ip4_addr",
-  "uv_ip4_name",
-  "uv_ip6_addr",
-  "uv_ip6_name",
-  "uv_ip_name",
+  // Defined in uv-posix-polyfills.c
+  // "uv_inet_ntop",
+  // Defined in uv-posix-polyfills.c
+  // "uv_inet_pton",
+  // Defined in uv-posix-polyfills.c
+  // "uv_interface_addresses",
+  // Defined in uv-posix-polyfills.c
+  // "uv_ip4_addr",
+  // Defined in uv-posix-polyfills.c
+  // "uv_ip4_name",
+  // Defined in uv-posix-polyfills.c
+  // "uv_ip6_addr",
+  // Defined in uv-posix-polyfills.c
+  // "uv_ip6_name",
+  // Defined in uv-posix-polyfills.c
+  // "uv_ip_name",
   "uv_is_active",
   "uv_is_closing",
   "uv_is_readable",
@@ -172,7 +189,8 @@ export const symbols = [
   "uv_now",
   // Defined in uv-posix-polyfills.cpp
   // "uv_once",
-  "uv_open_osfhandle",
+  // Defined in uv-posix-polyfills.c
+  // "uv_open_osfhandle",
   "uv_os_environ",
   "uv_os_free_environ",
   "uv_os_free_group",
@@ -231,19 +249,32 @@ export const symbols = [
   "uv_req_type_name",
   "uv_resident_set_memory",
   "uv_run",
-  "uv_rwlock_destroy",
-  "uv_rwlock_init",
-  "uv_rwlock_rdlock",
-  "uv_rwlock_rdunlock",
-  "uv_rwlock_tryrdlock",
-  "uv_rwlock_trywrlock",
-  "uv_rwlock_wrlock",
-  "uv_rwlock_wrunlock",
-  "uv_sem_destroy",
-  "uv_sem_init",
-  "uv_sem_post",
-  "uv_sem_trywait",
-  "uv_sem_wait",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_destroy",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_init",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_rdlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_rdunlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_tryrdlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_trywrlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_wrlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_rwlock_wrunlock",
+  // Defined in uv-posix-polyfills.c
+  // "uv_sem_destroy",
+  // Defined in uv-posix-polyfills.c
+  // "uv_sem_init",
+  // Defined in uv-posix-polyfills.c
+  // "uv_sem_post",
+  // Defined in uv-posix-polyfills.c
+  // "uv_sem_trywait",
+  // Defined in uv-posix-polyfills.c
+  // "uv_sem_wait",
   "uv_send_buffer_size",
   "uv_set_process_title",
   "uv_setup_args",
@@ -274,13 +305,15 @@ export const symbols = [
   "uv_thread_create",
   "uv_thread_create_ex",
   "uv_thread_detach",
-  "uv_thread_equal",
+  // Defined in uv-posix-polyfills.c
+  // "uv_thread_equal",
   "uv_thread_getaffinity",
   "uv_thread_getcpu",
   "uv_thread_getname",
   "uv_thread_getpriority",
   "uv_thread_join",
-  "uv_thread_self",
+  // Defined in uv-posix-polyfills.c
+  // "uv_thread_self",
   "uv_thread_setaffinity",
   "uv_thread_setname",
   "uv_thread_setpriority",
@@ -328,8 +361,10 @@ export const symbols = [
   "uv_uptime",
   "uv_utf16_length_as_wtf8",
   "uv_utf16_to_wtf8",
-  "uv_version",
-  "uv_version_string",
+  // Defined in uv-posix-polyfills.c
+  // "uv_version",
+  // Defined in uv-posix-polyfills.c
+  // "uv_version_string",
   "uv_walk",
   "uv_write",
   "uv_write2",

--- a/src/jsc/bindings/uv-posix-polyfills.c
+++ b/src/jsc/bindings/uv-posix-polyfills.c
@@ -138,4 +138,1058 @@ UV_EXTERN void uv_mutex_unlock(uv_mutex_t* mutex)
         abort();
 }
 
+// ---------------------------------------------------------------------------
+// Everything below is copy-pasted from libuv at the commit recorded in
+// libuv/README.md (the same commit the headers in libuv/ were copied from),
+// with two adaptations:
+// - uv__malloc/uv__calloc/uv__free are replaced with calloc/free
+// - the glibc < 2.21 custom-semaphore workaround in uv_sem_* is omitted
+//   (https://sourceware.org/bugzilla/show_bug.cgi?id=12674 was fixed in 2015;
+//   every glibc Bun runs on is newer)
+// Do not "improve" these: prebuilt N-API addons expect libuv's exact
+// documented semantics.
+// ---------------------------------------------------------------------------
+
+#include <ifaddrs.h>
+#include <limits.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+
+#if defined(__linux__)
+#include <linux/if_packet.h>
+#else
+#include <net/if_dl.h>
+#endif
+
+#if defined(PATH_MAX)
+#define UV__PATH_MAX PATH_MAX
+#else
+#define UV__PATH_MAX 8192
+#endif
+
+#define UV__NANOSEC ((uint64_t)1e9)
+
+#define UV__ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+#define UV__EXCLUDE_IFPHYS 0
+#define UV__EXCLUDE_IFADDR 1
+
+#define UV__INET_ADDRSTRLEN 16
+#define UV__INET6_ADDRSTRLEN 46
+
+// Copied from libuv src/version.c
+#define UV__STRINGIFY(v) UV__STRINGIFY_HELPER(v)
+#define UV__STRINGIFY_HELPER(v) #v
+
+#define UV__VERSION_STRING_BASE     \
+    UV__STRINGIFY(UV_VERSION_MAJOR) \
+    "." UV__STRINGIFY(UV_VERSION_MINOR) "." UV__STRINGIFY(UV_VERSION_PATCH)
+
+#if UV_VERSION_IS_RELEASE
+#define UV__VERSION_STRING UV__VERSION_STRING_BASE
+#else
+#define UV__VERSION_STRING UV__VERSION_STRING_BASE "-" UV_VERSION_SUFFIX
+#endif
+
+UV_EXTERN unsigned int uv_version(void)
+{
+    return UV_VERSION_HEX;
+}
+
+UV_EXTERN const char* uv_version_string(void)
+{
+    return UV__VERSION_STRING;
+}
+
+// Copied from libuv src/unix/core.c
+UV_EXTERN int uv_cwd(char* buffer, size_t* size)
+{
+    char scratch[1 + UV__PATH_MAX];
+
+    if (buffer == NULL || size == NULL || *size == 0)
+        return UV_EINVAL;
+
+    /* Try to read directly into the user's buffer first... */
+    if (getcwd(buffer, *size) != NULL)
+        goto fixup;
+
+    if (errno != ERANGE)
+        return UV__ERR(errno);
+
+    /* ...or into scratch space if the user's buffer is too small
+     * so we can report how much space to provide on the next try.
+     */
+    if (getcwd(scratch, sizeof(scratch)) == NULL)
+        return UV__ERR(errno);
+
+    buffer = scratch;
+
+fixup:
+
+    *size = strlen(buffer);
+
+    if (*size > 1 && buffer[*size - 1] == '/') {
+        *size -= 1;
+        buffer[*size] = '\0';
+    }
+
+    if (buffer == scratch) {
+        *size += 1;
+        return UV_ENOBUFS;
+    }
+
+    return 0;
+}
+
+// Copied from libuv src/unix/core.c
+UV_EXTERN uv_os_fd_t uv_get_osfhandle(int fd)
+{
+    return fd;
+}
+
+// Copied from libuv src/unix/core.c
+UV_EXTERN int uv_open_osfhandle(uv_os_fd_t os_fd)
+{
+    return os_fd;
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN uv_thread_t uv_thread_self(void)
+{
+    return pthread_self();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2)
+{
+    return pthread_equal(*t1, *t2);
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_rwlock_init(uv_rwlock_t* rwlock)
+{
+    return UV__ERR(pthread_rwlock_init(rwlock, NULL));
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_rwlock_destroy(uv_rwlock_t* rwlock)
+{
+    if (pthread_rwlock_destroy(rwlock))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_rwlock_rdlock(uv_rwlock_t* rwlock)
+{
+    if (pthread_rwlock_rdlock(rwlock))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock)
+{
+    int err;
+
+    err = pthread_rwlock_tryrdlock(rwlock);
+    if (err) {
+        if (err != EBUSY && err != EAGAIN)
+            abort();
+        return UV_EBUSY;
+    }
+
+    return 0;
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_rwlock_rdunlock(uv_rwlock_t* rwlock)
+{
+    if (pthread_rwlock_unlock(rwlock))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_rwlock_wrlock(uv_rwlock_t* rwlock)
+{
+    if (pthread_rwlock_wrlock(rwlock))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_rwlock_trywrlock(uv_rwlock_t* rwlock)
+{
+    int err;
+
+    err = pthread_rwlock_trywrlock(rwlock);
+    if (err) {
+        if (err != EBUSY && err != EAGAIN)
+            abort();
+        return UV_EBUSY;
+    }
+
+    return 0;
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_rwlock_wrunlock(uv_rwlock_t* rwlock)
+{
+    if (pthread_rwlock_unlock(rwlock))
+        abort();
+}
+
+#if defined(__APPLE__) && defined(__MACH__)
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_sem_init(uv_sem_t* sem, unsigned int value)
+{
+    kern_return_t err;
+
+    err = semaphore_create(mach_task_self(), sem, SYNC_POLICY_FIFO, value);
+    if (err == KERN_SUCCESS)
+        return 0;
+    if (err == KERN_INVALID_ARGUMENT)
+        return UV_EINVAL;
+    if (err == KERN_RESOURCE_SHORTAGE)
+        return UV_ENOMEM;
+
+    abort();
+    return UV_EINVAL; /* Satisfy the compiler. */
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_sem_destroy(uv_sem_t* sem)
+{
+    if (semaphore_destroy(mach_task_self(), *sem))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_sem_post(uv_sem_t* sem)
+{
+    if (semaphore_signal(*sem))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_sem_wait(uv_sem_t* sem)
+{
+    int r;
+
+    do
+        r = semaphore_wait(*sem);
+    while (r == KERN_ABORTED);
+
+    if (r != KERN_SUCCESS)
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_sem_trywait(uv_sem_t* sem)
+{
+    mach_timespec_t interval;
+    kern_return_t err;
+
+    interval.tv_sec = 0;
+    interval.tv_nsec = 0;
+
+    err = semaphore_timedwait(*sem, interval);
+    if (err == KERN_SUCCESS)
+        return 0;
+    if (err == KERN_OPERATION_TIMED_OUT)
+        return UV_EAGAIN;
+
+    abort();
+    return UV_EINVAL; /* Satisfy the compiler. */
+}
+
+#else /* !(defined(__APPLE__) && defined(__MACH__)) */
+
+// Copied from libuv src/unix/thread.c (uv__sem_init; see note at the top of
+// this section about the omitted glibc < 2.21 workaround)
+UV_EXTERN int uv_sem_init(uv_sem_t* sem, unsigned int value)
+{
+    if (sem_init(sem, 0, value))
+        return UV__ERR(errno);
+    return 0;
+}
+
+// Copied from libuv src/unix/thread.c (uv__sem_destroy)
+UV_EXTERN void uv_sem_destroy(uv_sem_t* sem)
+{
+    if (sem_destroy(sem))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c (uv__sem_post)
+UV_EXTERN void uv_sem_post(uv_sem_t* sem)
+{
+    if (sem_post(sem))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c (uv__sem_wait)
+UV_EXTERN void uv_sem_wait(uv_sem_t* sem)
+{
+    int r;
+
+    do
+        r = sem_wait(sem);
+    while (r == -1 && errno == EINTR);
+
+    if (r)
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c (uv__sem_trywait)
+UV_EXTERN int uv_sem_trywait(uv_sem_t* sem)
+{
+    int r;
+
+    do
+        r = sem_trywait(sem);
+    while (r == -1 && errno == EINTR);
+
+    if (r) {
+        if (errno == EAGAIN)
+            return UV_EAGAIN;
+        abort();
+    }
+
+    return 0;
+}
+
+#endif /* defined(__APPLE__) && defined(__MACH__) */
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_cond_init(uv_cond_t* cond)
+{
+#if defined(__APPLE__) && defined(__MACH__)
+    return UV__ERR(pthread_cond_init(cond, NULL));
+#else
+    pthread_condattr_t attr;
+    int err;
+
+    err = pthread_condattr_init(&attr);
+    if (err)
+        return UV__ERR(err);
+
+    err = pthread_condattr_setclock(&attr, CLOCK_MONOTONIC);
+    if (err)
+        goto error2;
+
+    err = pthread_cond_init(cond, &attr);
+    if (err)
+        goto error2;
+
+    err = pthread_condattr_destroy(&attr);
+    if (err)
+        goto error;
+
+    return 0;
+
+error:
+    pthread_cond_destroy(cond);
+error2:
+    pthread_condattr_destroy(&attr);
+    return UV__ERR(err);
+#endif
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_cond_destroy(uv_cond_t* cond)
+{
+#if defined(__APPLE__) && defined(__MACH__)
+    /* It has been reported that destroying condition variables that have been
+     * signalled but not waited on can sometimes result in application crashes.
+     * See https://codereview.chromium.org/1323293005.
+     */
+    pthread_mutex_t mutex;
+    struct timespec ts;
+    int err;
+
+    if (pthread_mutex_init(&mutex, NULL))
+        abort();
+
+    if (pthread_mutex_lock(&mutex))
+        abort();
+
+    ts.tv_sec = 0;
+    ts.tv_nsec = 1;
+
+    err = pthread_cond_timedwait_relative_np(cond, &mutex, &ts);
+    if (err != 0 && err != ETIMEDOUT)
+        abort();
+
+    if (pthread_mutex_unlock(&mutex))
+        abort();
+
+    if (pthread_mutex_destroy(&mutex))
+        abort();
+#endif /* defined(__APPLE__) && defined(__MACH__) */
+
+    if (pthread_cond_destroy(cond))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_cond_signal(uv_cond_t* cond)
+{
+    if (pthread_cond_signal(cond))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_cond_broadcast(uv_cond_t* cond)
+{
+    if (pthread_cond_broadcast(cond))
+        abort();
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex)
+{
+#if defined(__APPLE__) && defined(__MACH__)
+    int r;
+
+    errno = 0;
+    r = pthread_cond_wait(cond, mutex);
+
+    /* Workaround for a bug in OS X at least up to 13.6
+     * See https://github.com/libuv/libuv/issues/4165
+     */
+    if (r == EINVAL)
+        if (errno == EBUSY)
+            return;
+
+    if (r)
+        abort();
+#else
+    if (pthread_cond_wait(cond, mutex))
+        abort();
+#endif
+}
+
+// Copied from libuv src/unix/thread.c
+UV_EXTERN int uv_cond_timedwait(uv_cond_t* cond, uv_mutex_t* mutex, uint64_t timeout)
+{
+    int r;
+    struct timespec ts;
+
+#if defined(__APPLE__) && defined(__MACH__)
+    ts.tv_sec = timeout / UV__NANOSEC;
+    ts.tv_nsec = timeout % UV__NANOSEC;
+    r = pthread_cond_timedwait_relative_np(cond, mutex, &ts);
+#else
+    timeout += uv__hrtime(UV_CLOCK_PRECISE);
+    ts.tv_sec = timeout / UV__NANOSEC;
+    ts.tv_nsec = timeout % UV__NANOSEC;
+    r = pthread_cond_timedwait(cond, mutex, &ts);
+#endif
+
+    if (r == 0)
+        return 0;
+
+    if (r == ETIMEDOUT)
+        return UV_ETIMEDOUT;
+
+    abort();
+    return UV_EINVAL; /* Satisfy the compiler. */
+}
+
+// Copied from libuv src/inet.c (uv__strscpy from src/strscpy.c)
+static ssize_t uv__strscpy(char* d, const char* s, size_t n)
+{
+    size_t i;
+
+    for (i = 0; i < n; i++)
+        if ('\0' == (d[i] = s[i]))
+            return i > SSIZE_MAX ? UV_E2BIG : (ssize_t)i;
+
+    if (i == 0)
+        return 0;
+
+    d[--i] = '\0';
+
+    return UV_E2BIG;
+}
+
+// Copied from libuv src/inet.c
+static int uv__inet_ntop4(const unsigned char* src, char* dst, size_t size)
+{
+    static const char fmt[] = "%u.%u.%u.%u";
+    char tmp[UV__INET_ADDRSTRLEN];
+    int l;
+
+    l = snprintf(tmp, sizeof(tmp), fmt, src[0], src[1], src[2], src[3]);
+    if (l <= 0 || (size_t)l >= size) {
+        return UV_ENOSPC;
+    }
+    uv__strscpy(dst, tmp, size);
+    return 0;
+}
+
+// Copied from libuv src/inet.c
+static int uv__inet_ntop6(const unsigned char* src, char* dst, size_t size)
+{
+    /*
+     * Note that int32_t and int16_t need only be "at least" large enough
+     * to contain a value of the specified size.  On some systems, like
+     * Crays, there is no such thing as an integer variable with 16 bits.
+     * Keep this in mind if you think this function should have been coded
+     * to use pointer overlays.  All the world's not a VAX.
+     */
+    char tmp[UV__INET6_ADDRSTRLEN], *tp;
+    struct {
+        int base, len;
+    } best, cur;
+    unsigned int words[sizeof(struct in6_addr) / sizeof(uint16_t)];
+    int i;
+
+    /*
+     * Preprocess:
+     *  Copy the input (bytewise) array into a wordwise array.
+     *  Find the longest run of 0x00's in src[] for :: shorthanding.
+     */
+    memset(words, '\0', sizeof words);
+    for (i = 0; i < (int)sizeof(struct in6_addr); i++)
+        words[i / 2] |= (src[i] << ((1 - (i % 2)) << 3));
+    best.base = -1;
+    best.len = 0;
+    cur.base = -1;
+    cur.len = 0;
+    for (i = 0; i < (int)UV__ARRAY_SIZE(words); i++) {
+        if (words[i] == 0) {
+            if (cur.base == -1)
+                cur.base = i, cur.len = 1;
+            else
+                cur.len++;
+        } else {
+            if (cur.base != -1) {
+                if (best.base == -1 || cur.len > best.len)
+                    best = cur;
+                cur.base = -1;
+            }
+        }
+    }
+    if (cur.base != -1) {
+        if (best.base == -1 || cur.len > best.len)
+            best = cur;
+    }
+    if (best.base != -1 && best.len < 2)
+        best.base = -1;
+
+    /*
+     * Format the result.
+     */
+    tp = tmp;
+    for (i = 0; i < (int)UV__ARRAY_SIZE(words); i++) {
+        /* Are we inside the best run of 0x00's? */
+        if (best.base != -1 && i >= best.base && i < (best.base + best.len)) {
+            if (i == best.base)
+                *tp++ = ':';
+            continue;
+        }
+        /* Are we following an initial run of 0x00s or any real hex? */
+        if (i != 0)
+            *tp++ = ':';
+        /* Is this address an encapsulated IPv4? */
+        if (i == 6 && best.base == 0 && (best.len == 6 || (best.len == 7 && words[7] != 0x0001) || (best.len == 5 && words[5] == 0xffff))) {
+            int err = uv__inet_ntop4(src + 12, tp, sizeof tmp - (tp - tmp));
+            if (err)
+                return err;
+            tp += strlen(tp);
+            break;
+        }
+        tp += snprintf(tp, sizeof tmp - (tp - tmp), "%x", words[i]);
+    }
+    /* Was it a trailing run of 0x00's? */
+    if (best.base != -1 && (best.base + best.len) == UV__ARRAY_SIZE(words))
+        *tp++ = ':';
+    *tp++ = '\0';
+    if ((size_t)(tp - tmp) > size)
+        return UV_ENOSPC;
+    uv__strscpy(dst, tmp, size);
+    return 0;
+}
+
+// Copied from libuv src/inet.c
+UV_EXTERN int uv_inet_ntop(int af, const void* src, char* dst, size_t size)
+{
+    switch (af) {
+    case AF_INET:
+        return (uv__inet_ntop4(src, dst, size));
+    case AF_INET6:
+        return (uv__inet_ntop6(src, dst, size));
+    default:
+        return UV_EAFNOSUPPORT;
+    }
+    /* NOTREACHED */
+}
+
+// Copied from libuv src/inet.c
+static int uv__inet_pton4(const char* src, unsigned char* dst)
+{
+    static const char digits[] = "0123456789";
+    int saw_digit, octets, ch;
+    unsigned char tmp[sizeof(struct in_addr)], *tp;
+
+    saw_digit = 0;
+    octets = 0;
+    *(tp = tmp) = 0;
+    while ((ch = *src++) != '\0') {
+        const char* pch;
+
+        if ((pch = strchr(digits, ch)) != NULL) {
+            unsigned int nw = *tp * 10 + (pch - digits);
+
+            if (saw_digit && *tp == 0)
+                return UV_EINVAL;
+            if (nw > 255)
+                return UV_EINVAL;
+            *tp = nw;
+            if (!saw_digit) {
+                if (++octets > 4)
+                    return UV_EINVAL;
+                saw_digit = 1;
+            }
+        } else if (ch == '.' && saw_digit) {
+            if (octets == 4)
+                return UV_EINVAL;
+            *++tp = 0;
+            saw_digit = 0;
+        } else
+            return UV_EINVAL;
+    }
+    if (octets < 4)
+        return UV_EINVAL;
+    memcpy(dst, tmp, sizeof(struct in_addr));
+    return 0;
+}
+
+// Copied from libuv src/inet.c
+static int uv__inet_pton6(const char* src, unsigned char* dst)
+{
+    static const char xdigits_l[] = "0123456789abcdef",
+                      xdigits_u[] = "0123456789ABCDEF";
+    unsigned char tmp[sizeof(struct in6_addr)], *tp, *endp, *colonp;
+    const char *xdigits, *curtok;
+    int ch, seen_xdigits;
+    unsigned int val;
+
+    memset((tp = tmp), '\0', sizeof tmp);
+    endp = tp + sizeof tmp;
+    colonp = NULL;
+    /* Leading :: requires some special handling. */
+    if (*src == ':')
+        if (*++src != ':')
+            return UV_EINVAL;
+    curtok = src;
+    seen_xdigits = 0;
+    val = 0;
+    while ((ch = *src++) != '\0') {
+        const char* pch;
+
+        if ((pch = strchr((xdigits = xdigits_l), ch)) == NULL)
+            pch = strchr((xdigits = xdigits_u), ch);
+        if (pch != NULL) {
+            val <<= 4;
+            val |= (pch - xdigits);
+            if (++seen_xdigits > 4)
+                return UV_EINVAL;
+            continue;
+        }
+        if (ch == ':') {
+            curtok = src;
+            if (!seen_xdigits) {
+                if (colonp)
+                    return UV_EINVAL;
+                colonp = tp;
+                continue;
+            } else if (*src == '\0') {
+                return UV_EINVAL;
+            }
+            if (tp + sizeof(uint16_t) > endp)
+                return UV_EINVAL;
+            *tp++ = (unsigned char)(val >> 8) & 0xff;
+            *tp++ = (unsigned char)val & 0xff;
+            seen_xdigits = 0;
+            val = 0;
+            continue;
+        }
+        if (ch == '.' && ((tp + sizeof(struct in_addr)) <= endp)) {
+            int err = uv__inet_pton4(curtok, tp);
+            if (err == 0) {
+                tp += sizeof(struct in_addr);
+                seen_xdigits = 0;
+                break; /*%< '\0' was seen by inet_pton4(). */
+            }
+        }
+        return UV_EINVAL;
+    }
+    if (seen_xdigits) {
+        if (tp + sizeof(uint16_t) > endp)
+            return UV_EINVAL;
+        *tp++ = (unsigned char)(val >> 8) & 0xff;
+        *tp++ = (unsigned char)val & 0xff;
+    }
+    if (colonp != NULL) {
+        /*
+         * Since some memmove()'s erroneously fail to handle
+         * overlapping regions, we'll do the shift by hand.
+         */
+        const int n = tp - colonp;
+        int i;
+
+        if (tp == endp)
+            return UV_EINVAL;
+        for (i = 1; i <= n; i++) {
+            endp[-i] = colonp[n - i];
+            colonp[n - i] = 0;
+        }
+        tp = endp;
+    }
+    if (tp != endp)
+        return UV_EINVAL;
+    memcpy(dst, tmp, sizeof tmp);
+    return 0;
+}
+
+// Copied from libuv src/inet.c
+UV_EXTERN int uv_inet_pton(int af, const char* src, void* dst)
+{
+    if (src == NULL || dst == NULL)
+        return UV_EINVAL;
+
+    switch (af) {
+    case AF_INET:
+        return (uv__inet_pton4(src, dst));
+    case AF_INET6: {
+        int len;
+        char tmp[UV__INET6_ADDRSTRLEN], *s, *p;
+        s = (char*)src;
+        p = strchr(src, '%');
+        if (p != NULL) {
+            s = tmp;
+            len = p - src;
+            if (len > UV__INET6_ADDRSTRLEN - 1)
+                return UV_EINVAL;
+            memcpy(s, src, len);
+            s[len] = '\0';
+        }
+        return uv__inet_pton6(s, dst);
+    }
+    default:
+        return UV_EAFNOSUPPORT;
+    }
+    /* NOTREACHED */
+}
+
+// Copied from libuv src/uv-common.c
+UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr)
+{
+    memset(addr, 0, sizeof(*addr));
+    addr->sin_family = AF_INET;
+    addr->sin_port = htons(port);
+#ifdef SIN6_LEN
+    addr->sin_len = sizeof(*addr);
+#endif
+    return uv_inet_pton(AF_INET, ip, &(addr->sin_addr.s_addr));
+}
+
+// Copied from libuv src/uv-common.c
+UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr)
+{
+    char address_part[40];
+    size_t address_part_size;
+    const char* zone_index;
+
+    memset(addr, 0, sizeof(*addr));
+    addr->sin6_family = AF_INET6;
+    addr->sin6_port = htons(port);
+#ifdef SIN6_LEN
+    addr->sin6_len = sizeof(*addr);
+#endif
+
+    zone_index = strchr(ip, '%');
+    if (zone_index != NULL) {
+        address_part_size = zone_index - ip;
+        if (address_part_size >= sizeof(address_part))
+            address_part_size = sizeof(address_part) - 1;
+
+        memcpy(address_part, ip, address_part_size);
+        address_part[address_part_size] = '\0';
+        ip = address_part;
+
+        zone_index++; /* skip '%' */
+        /* NOTE: unknown interface (id=0) is silently ignored */
+        addr->sin6_scope_id = if_nametoindex(zone_index);
+    }
+
+    return uv_inet_pton(AF_INET6, ip, &addr->sin6_addr);
+}
+
+// Copied from libuv src/uv-common.c
+UV_EXTERN int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size)
+{
+    return uv_inet_ntop(AF_INET, &src->sin_addr, dst, size);
+}
+
+// Copied from libuv src/uv-common.c
+UV_EXTERN int uv_ip6_name(const struct sockaddr_in6* src, char* dst, size_t size)
+{
+    return uv_inet_ntop(AF_INET6, &src->sin6_addr, dst, size);
+}
+
+// Copied from libuv src/uv-common.c
+UV_EXTERN int uv_ip_name(const struct sockaddr* src, char* dst, size_t size)
+{
+    switch (src->sa_family) {
+    case AF_INET:
+        return uv_inet_ntop(AF_INET, &((struct sockaddr_in*)src)->sin_addr,
+            dst, size);
+    case AF_INET6:
+        return uv_inet_ntop(AF_INET6, &((struct sockaddr_in6*)src)->sin6_addr,
+            dst, size);
+    default:
+        return UV_EAFNOSUPPORT;
+    }
+}
+
+#if defined(__linux__)
+
+// Copied from libuv src/unix/linux.c
+static int uv__ifaddr_exclude(struct ifaddrs* ent, int exclude_type)
+{
+    if (!((ent->ifa_flags & IFF_UP) && (ent->ifa_flags & IFF_RUNNING)))
+        return 1;
+    if (ent->ifa_addr == NULL)
+        return 1;
+    /*
+     * On Linux getifaddrs returns information related to the raw underlying
+     * devices. We're not interested in this information yet.
+     */
+    if (ent->ifa_addr->sa_family == PF_PACKET)
+        return exclude_type;
+    return !exclude_type;
+}
+
+// Copied from libuv src/unix/linux.c, plus the NULL ifa_netmask check from
+// src/unix/bsd-ifaddrs.c (point-to-point interfaces may not have one)
+UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses, int* count)
+{
+    uv_interface_address_t* address;
+    struct sockaddr_ll* sll;
+    struct ifaddrs* addrs;
+    struct ifaddrs* ent;
+    size_t namelen;
+    char* name;
+    int i;
+
+    *count = 0;
+    *addresses = NULL;
+
+    if (getifaddrs(&addrs))
+        return UV__ERR(errno);
+
+    /* Count the number of interfaces */
+    namelen = 0;
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
+            continue;
+
+        namelen += strlen(ent->ifa_name) + 1;
+        (*count)++;
+    }
+
+    if (*count == 0) {
+        freeifaddrs(addrs);
+        return 0;
+    }
+
+    /* Make sure the memory is initiallized to zero using calloc() */
+    *addresses = calloc(1, *count * sizeof(**addresses) + namelen);
+    if (*addresses == NULL) {
+        freeifaddrs(addrs);
+        return UV_ENOMEM;
+    }
+
+    name = (char*)&(*addresses)[*count];
+    address = *addresses;
+
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
+            continue;
+
+        namelen = strlen(ent->ifa_name) + 1;
+        address->name = memcpy(name, ent->ifa_name, namelen);
+        name += namelen;
+
+        if (ent->ifa_addr->sa_family == AF_INET6) {
+            address->address.address6 = *((struct sockaddr_in6*)ent->ifa_addr);
+        } else {
+            address->address.address4 = *((struct sockaddr_in*)ent->ifa_addr);
+        }
+
+        if (ent->ifa_netmask == NULL) {
+            memset(&address->netmask, 0, sizeof(address->netmask));
+        } else if (ent->ifa_netmask->sa_family == AF_INET6) {
+            address->netmask.netmask6 = *((struct sockaddr_in6*)ent->ifa_netmask);
+        } else {
+            address->netmask.netmask4 = *((struct sockaddr_in*)ent->ifa_netmask);
+        }
+
+        address->is_internal = !!(ent->ifa_flags & IFF_LOOPBACK);
+
+        address++;
+    }
+
+    /* Fill in physical addresses for each interface */
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFPHYS))
+            continue;
+
+        address = *addresses;
+
+        for (i = 0; i < (*count); i++) {
+            size_t namelen = strlen(ent->ifa_name);
+            /* Alias interface share the same physical address */
+            if (strncmp(address->name, ent->ifa_name, namelen) == 0 && (address->name[namelen] == 0 || address->name[namelen] == ':')) {
+                sll = (struct sockaddr_ll*)ent->ifa_addr;
+                memcpy(address->phys_addr, sll->sll_addr, sizeof(address->phys_addr));
+            }
+            address++;
+        }
+    }
+
+    freeifaddrs(addrs);
+
+    return 0;
+}
+
+#else /* !defined(__linux__) */
+
+// Copied from libuv src/unix/bsd-ifaddrs.c
+static int uv__ifaddr_exclude(struct ifaddrs* ent, int exclude_type)
+{
+    if (!((ent->ifa_flags & IFF_UP) && (ent->ifa_flags & IFF_RUNNING)))
+        return 1;
+    if (ent->ifa_addr == NULL)
+        return 1;
+    /*
+     * If `exclude_type` is `UV__EXCLUDE_IFPHYS`, return whether `sa_family`
+     * equals `AF_LINK`. Otherwise, the result depends on the operating
+     * system with `AF_LINK` or `PF_INET`.
+     */
+    if (exclude_type == UV__EXCLUDE_IFPHYS)
+        return (ent->ifa_addr->sa_family != AF_LINK);
+    /*
+     * On BSD getifaddrs returns information related to the raw underlying
+     * devices. We're not interested in this information.
+     */
+    if (ent->ifa_addr->sa_family == AF_LINK)
+        return 1;
+    return 0;
+}
+
+// Copied from libuv src/unix/bsd-ifaddrs.c
+UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses, int* count)
+{
+    uv_interface_address_t* address;
+    struct ifaddrs* addrs;
+    struct ifaddrs* ent;
+    size_t namelen;
+    char* name;
+
+    *count = 0;
+    *addresses = NULL;
+
+    if (getifaddrs(&addrs) != 0)
+        return UV__ERR(errno);
+
+    /* Count the number of interfaces */
+    namelen = 0;
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
+            continue;
+        namelen += strlen(ent->ifa_name) + 1;
+        (*count)++;
+    }
+
+    if (*count == 0) {
+        freeifaddrs(addrs);
+        return 0;
+    }
+
+    /* Make sure the memory is initiallized to zero using calloc() */
+    *addresses = calloc(1, *count * sizeof(**addresses) + namelen);
+    if (*addresses == NULL) {
+        freeifaddrs(addrs);
+        return UV_ENOMEM;
+    }
+
+    name = (char*)&(*addresses)[*count];
+    address = *addresses;
+
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFADDR))
+            continue;
+
+        namelen = strlen(ent->ifa_name) + 1;
+        address->name = memcpy(name, ent->ifa_name, namelen);
+        name += namelen;
+
+        if (ent->ifa_addr->sa_family == AF_INET6) {
+            address->address.address6 = *((struct sockaddr_in6*)ent->ifa_addr);
+        } else {
+            address->address.address4 = *((struct sockaddr_in*)ent->ifa_addr);
+        }
+
+        if (ent->ifa_netmask == NULL) {
+            memset(&address->netmask, 0, sizeof(address->netmask));
+        } else if (ent->ifa_netmask->sa_family == AF_INET6) {
+            address->netmask.netmask6 = *((struct sockaddr_in6*)ent->ifa_netmask);
+        } else {
+            address->netmask.netmask4 = *((struct sockaddr_in*)ent->ifa_netmask);
+        }
+
+        address->is_internal = !!(ent->ifa_flags & IFF_LOOPBACK);
+
+        address++;
+    }
+
+    /* Fill in physical addresses for each interface */
+    for (ent = addrs; ent != NULL; ent = ent->ifa_next) {
+        int i;
+
+        if (uv__ifaddr_exclude(ent, UV__EXCLUDE_IFPHYS))
+            continue;
+
+        address = *addresses;
+
+        for (i = 0; i < *count; i++) {
+            if (strcmp(address->name, ent->ifa_name) == 0) {
+                struct sockaddr_dl* sa_addr;
+                sa_addr = (struct sockaddr_dl*)(ent->ifa_addr);
+                memcpy(address->phys_addr, LLADDR(sa_addr), sizeof(address->phys_addr));
+            }
+            address++;
+        }
+    }
+
+    freeifaddrs(addrs);
+
+    return 0;
+}
+
+#endif /* defined(__linux__) */
+
+// Copied from libuv src/unix/linux.c
+UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
+    int count)
+{
+    free(addresses);
+}
+
 #endif

--- a/src/jsc/bindings/uv-posix-stubs.c
+++ b/src/jsc/bindings/uv-posix-stubs.c
@@ -106,44 +106,6 @@ UV_EXTERN void uv_close(uv_handle_t* handle, uv_close_cb close_cb)
     __builtin_unreachable();
 }
 
-UV_EXTERN void uv_cond_broadcast(uv_cond_t* cond)
-{
-    __bun_throw_not_implemented("uv_cond_broadcast");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_cond_destroy(uv_cond_t* cond)
-{
-    __bun_throw_not_implemented("uv_cond_destroy");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_cond_init(uv_cond_t* cond)
-{
-    __bun_throw_not_implemented("uv_cond_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_cond_signal(uv_cond_t* cond)
-{
-    __bun_throw_not_implemented("uv_cond_signal");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_cond_timedwait(uv_cond_t* cond,
-    uv_mutex_t* mutex,
-    uint64_t timeout)
-{
-    __bun_throw_not_implemented("uv_cond_timedwait");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex)
-{
-    __bun_throw_not_implemented("uv_cond_wait");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count)
 {
     __bun_throw_not_implemented("uv_cpu_info");
@@ -153,12 +115,6 @@ UV_EXTERN int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count)
 UV_EXTERN int uv_cpumask_size(void)
 {
     __bun_throw_not_implemented("uv_cpumask_size");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_cwd(char* buffer, size_t* size)
-{
-    __bun_throw_not_implemented("uv_cwd");
     __builtin_unreachable();
 }
 
@@ -225,13 +181,6 @@ UV_EXTERN int uv_fileno(const uv_handle_t* handle, uv_os_fd_t* fd)
 UV_EXTERN void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count)
 {
     __bun_throw_not_implemented("uv_free_cpu_info");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_free_interface_addresses(uv_interface_address_t* addresses,
-    int count)
-{
-    __bun_throw_not_implemented("uv_free_interface_addresses");
     __builtin_unreachable();
 }
 
@@ -725,12 +674,6 @@ UV_EXTERN uint64_t uv_get_free_memory(void)
     __builtin_unreachable();
 }
 
-UV_EXTERN uv_os_fd_t uv_get_osfhandle(int fd)
-{
-    __bun_throw_not_implemented("uv_get_osfhandle");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_get_process_title(char* buffer, size_t size)
 {
     __bun_throw_not_implemented("uv_get_process_title");
@@ -861,55 +804,6 @@ UV_EXTERN int uv_if_indextoname(unsigned int ifindex,
     size_t* size)
 {
     __bun_throw_not_implemented("uv_if_indextoname");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_inet_ntop(int af, const void* src, char* dst, size_t size)
-{
-    __bun_throw_not_implemented("uv_inet_ntop");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_inet_pton(int af, const char* src, void* dst)
-{
-    __bun_throw_not_implemented("uv_inet_pton");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_interface_addresses(uv_interface_address_t** addresses,
-    int* count)
-{
-    __bun_throw_not_implemented("uv_interface_addresses");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_ip4_addr(const char* ip, int port, struct sockaddr_in* addr)
-{
-    __bun_throw_not_implemented("uv_ip4_addr");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_ip4_name(const struct sockaddr_in* src, char* dst, size_t size)
-{
-    __bun_throw_not_implemented("uv_ip4_name");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_ip6_addr(const char* ip, int port, struct sockaddr_in6* addr)
-{
-    __bun_throw_not_implemented("uv_ip6_addr");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_ip6_name(const struct sockaddr_in6* src, char* dst, size_t size)
-{
-    __bun_throw_not_implemented("uv_ip6_name");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_ip_name(const struct sockaddr* src, char* dst, size_t size)
-{
-    __bun_throw_not_implemented("uv_ip_name");
     __builtin_unreachable();
 }
 
@@ -1060,12 +954,6 @@ UV_EXTERN int uv_metrics_info(uv_loop_t* loop, uv_metrics_t* metrics)
 UV_EXTERN uint64_t uv_now(const uv_loop_t*)
 {
     __bun_throw_not_implemented("uv_now");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_open_osfhandle(uv_os_fd_t os_fd)
-{
-    __bun_throw_not_implemented("uv_open_osfhandle");
     __builtin_unreachable();
 }
 
@@ -1423,84 +1311,6 @@ UV_EXTERN int uv_run(uv_loop_t*, uv_run_mode mode)
     __builtin_unreachable();
 }
 
-UV_EXTERN void uv_rwlock_destroy(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_destroy");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_rwlock_init(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_rwlock_rdlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_rdlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_rwlock_rdunlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_rdunlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_rwlock_tryrdlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_tryrdlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_rwlock_trywrlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_trywrlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_rwlock_wrlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_wrlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_rwlock_wrunlock(uv_rwlock_t* rwlock)
-{
-    __bun_throw_not_implemented("uv_rwlock_wrunlock");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_sem_destroy(uv_sem_t* sem)
-{
-    __bun_throw_not_implemented("uv_sem_destroy");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_sem_init(uv_sem_t* sem, unsigned int value)
-{
-    __bun_throw_not_implemented("uv_sem_init");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_sem_post(uv_sem_t* sem)
-{
-    __bun_throw_not_implemented("uv_sem_post");
-    __builtin_unreachable();
-}
-
-UV_EXTERN int uv_sem_trywait(uv_sem_t* sem)
-{
-    __bun_throw_not_implemented("uv_sem_trywait");
-    __builtin_unreachable();
-}
-
-UV_EXTERN void uv_sem_wait(uv_sem_t* sem)
-{
-    __bun_throw_not_implemented("uv_sem_wait");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_send_buffer_size(uv_handle_t* handle, int* value)
 {
     __bun_throw_not_implemented("uv_send_buffer_size");
@@ -1707,12 +1517,6 @@ UV_EXTERN int uv_thread_detach(uv_thread_t* tid)
     __builtin_unreachable();
 }
 
-UV_EXTERN int uv_thread_equal(const uv_thread_t* t1, const uv_thread_t* t2)
-{
-    __bun_throw_not_implemented("uv_thread_equal");
-    __builtin_unreachable();
-}
-
 UV_EXTERN int uv_thread_getaffinity(uv_thread_t* tid,
     char* cpumask,
     size_t mask_size)
@@ -1742,12 +1546,6 @@ UV_EXTERN int uv_thread_getpriority(uv_thread_t tid, int* priority)
 UV_EXTERN int uv_thread_join(uv_thread_t* tid)
 {
     __bun_throw_not_implemented("uv_thread_join");
-    __builtin_unreachable();
-}
-
-UV_EXTERN uv_thread_t uv_thread_self(void)
-{
-    __bun_throw_not_implemented("uv_thread_self");
     __builtin_unreachable();
 }
 
@@ -2062,18 +1860,6 @@ UV_EXTERN int uv_utf16_to_wtf8(const uint16_t* utf16,
     size_t* wtf8_len_ptr)
 {
     __bun_throw_not_implemented("uv_utf16_to_wtf8");
-    __builtin_unreachable();
-}
-
-UV_EXTERN unsigned int uv_version(void)
-{
-    __bun_throw_not_implemented("uv_version");
-    __builtin_unreachable();
-}
-
-UV_EXTERN const char* uv_version_string(void)
-{
-    __bun_throw_not_implemented("uv_version_string");
     __builtin_unreachable();
 }
 

--- a/test/napi/uv-stub-stuff/plugin.c
+++ b/test/napi/uv-stub-stuff/plugin.c
@@ -164,51 +164,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     return NULL;
   }
 
-  if (strcmp(buffer, "uv_cond_broadcast") == 0) {
-    uv_cond_t *arg0 = {0};
-
-    uv_cond_broadcast(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cond_destroy") == 0) {
-    uv_cond_t *arg0 = {0};
-
-    uv_cond_destroy(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cond_init") == 0) {
-    uv_cond_t *arg0 = {0};
-
-    uv_cond_init(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cond_signal") == 0) {
-    uv_cond_t *arg0 = {0};
-
-    uv_cond_signal(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cond_timedwait") == 0) {
-    uv_cond_t *arg0 = {0};
-    uv_mutex_t *arg1 = {0};
-    uint64_t arg2 = {0};
-
-    uv_cond_timedwait(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cond_wait") == 0) {
-    uv_cond_t *arg0 = {0};
-    uv_mutex_t *arg1 = {0};
-
-    uv_cond_wait(arg0, arg1);
-    return NULL;
-  }
-
   if (strcmp(buffer, "uv_cpu_info") == 0) {
     uv_cpu_info_t **arg0 = NULL;
     int *arg1 = {0};
@@ -220,14 +175,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
   if (strcmp(buffer, "uv_cpumask_size") == 0) {
 
     uv_cpumask_size();
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_cwd") == 0) {
-    char *arg0 = {0};
-    size_t *arg1 = {0};
-
-    uv_cwd(arg0, arg1);
     return NULL;
   }
 
@@ -311,14 +258,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     int arg1 = {0};
 
     uv_free_cpu_info(arg0, arg1);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_free_interface_addresses") == 0) {
-    uv_interface_address_t *arg0 = {0};
-    int arg1 = {0};
-
-    uv_free_interface_addresses(arg0, arg1);
     return NULL;
   }
 
@@ -867,13 +806,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     return NULL;
   }
 
-  if (strcmp(buffer, "uv_get_osfhandle") == 0) {
-    int arg0 = {0};
-
-    uv_get_osfhandle(arg0);
-    return NULL;
-  }
-
   if (strcmp(buffer, "uv_get_process_title") == 0) {
     char *arg0 = {0};
     size_t arg1 = {0};
@@ -1020,78 +952,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     size_t *arg2 = {0};
 
     uv_if_indextoname(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_inet_ntop") == 0) {
-    int arg0 = {0};
-    const void *arg1 = {0};
-    char *arg2 = {0};
-    size_t arg3 = {0};
-
-    uv_inet_ntop(arg0, arg1, arg2, arg3);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_inet_pton") == 0) {
-    int arg0 = {0};
-    const char *arg1 = {0};
-    void *arg2 = {0};
-
-    uv_inet_pton(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_interface_addresses") == 0) {
-    uv_interface_address_t **arg0 = NULL;
-    int *arg1 = {0};
-
-    uv_interface_addresses(arg0, arg1);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_ip4_addr") == 0) {
-    const char *arg0 = {0};
-    int arg1 = {0};
-    struct sockaddr_in *arg2 = {0};
-
-    uv_ip4_addr(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_ip4_name") == 0) {
-    const struct sockaddr_in *arg0 = {0};
-    char *arg1 = {0};
-    size_t arg2 = {0};
-
-    uv_ip4_name(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_ip6_addr") == 0) {
-    const char *arg0 = {0};
-    int arg1 = {0};
-    struct sockaddr_in6 *arg2 = {0};
-
-    uv_ip6_addr(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_ip6_name") == 0) {
-    const struct sockaddr_in6 *arg0 = {0};
-    char *arg1 = {0};
-    size_t arg2 = {0};
-
-    uv_ip6_name(arg0, arg1, arg2);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_ip_name") == 0) {
-    const struct sockaddr *arg0 = {0};
-    char *arg1 = {0};
-    size_t arg2 = {0};
-
-    uv_ip_name(arg0, arg1, arg2);
     return NULL;
   }
 
@@ -1271,13 +1131,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     const uv_loop_t *arg0 = {0};
 
     uv_now(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_open_osfhandle") == 0) {
-    uv_os_fd_t arg0 = {0};
-
-    uv_open_osfhandle(arg0);
     return NULL;
   }
 
@@ -1721,98 +1574,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     return NULL;
   }
 
-  if (strcmp(buffer, "uv_rwlock_destroy") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_destroy(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_init") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_init(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_rdlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_rdlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_rdunlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_rdunlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_tryrdlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_tryrdlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_trywrlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_trywrlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_wrlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_wrlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_rwlock_wrunlock") == 0) {
-    uv_rwlock_t *arg0 = {0};
-
-    uv_rwlock_wrunlock(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_sem_destroy") == 0) {
-    uv_sem_t *arg0 = {0};
-
-    uv_sem_destroy(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_sem_init") == 0) {
-    uv_sem_t *arg0 = {0};
-    unsigned int arg1 = {0};
-
-    uv_sem_init(arg0, arg1);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_sem_post") == 0) {
-    uv_sem_t *arg0 = {0};
-
-    uv_sem_post(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_sem_trywait") == 0) {
-    uv_sem_t *arg0 = {0};
-
-    uv_sem_trywait(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_sem_wait") == 0) {
-    uv_sem_t *arg0 = {0};
-
-    uv_sem_wait(arg0);
-    return NULL;
-  }
-
   if (strcmp(buffer, "uv_send_buffer_size") == 0) {
     uv_handle_t *arg0 = {0};
     int *arg1 = {0};
@@ -2059,14 +1820,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     return NULL;
   }
 
-  if (strcmp(buffer, "uv_thread_equal") == 0) {
-    const uv_thread_t *arg0 = {0};
-    const uv_thread_t *arg1 = {0};
-
-    uv_thread_equal(arg0, arg1);
-    return NULL;
-  }
-
   if (strcmp(buffer, "uv_thread_getaffinity") == 0) {
     uv_thread_t *arg0 = {0};
     char *arg1 = {0};
@@ -2086,12 +1839,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     uv_thread_t *arg0 = {0};
 
     uv_thread_join(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_thread_self") == 0) {
-
-    uv_thread_self();
     return NULL;
   }
 
@@ -2424,18 +2171,6 @@ napi_value call_uv_func(napi_env env, napi_callback_info info) {
     double *arg0 = {0};
 
     uv_uptime(arg0);
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_version") == 0) {
-
-    uv_version();
-    return NULL;
-  }
-
-  if (strcmp(buffer, "uv_version_string") == 0) {
-
-    uv_version_string();
     return NULL;
   }
 

--- a/test/napi/uv-stub-stuff/uv_impl.c
+++ b/test/napi/uv-stub-stuff/uv_impl.c
@@ -1,8 +1,12 @@
 #include <node_api.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #include <uv.h>
 
@@ -131,6 +135,463 @@ static napi_value test_hrtime(napi_env env, napi_callback_info info) {
   return obj;
 }
 
+static void set_int32(napi_env env, napi_value obj, const char *name,
+                      int32_t value) {
+  napi_value v;
+  napi_create_int32(env, value, &v);
+  napi_set_named_property(env, obj, name, v);
+}
+
+static void set_uint32(napi_env env, napi_value obj, const char *name,
+                       uint32_t value) {
+  napi_value v;
+  napi_create_uint32(env, value, &v);
+  napi_set_named_property(env, obj, name, v);
+}
+
+static void set_bool(napi_env env, napi_value obj, const char *name,
+                     bool value) {
+  napi_value v;
+  napi_get_boolean(env, value, &v);
+  napi_set_named_property(env, obj, name, v);
+}
+
+static void set_string(napi_env env, napi_value obj, const char *name,
+                       const char *value) {
+  napi_value v;
+  napi_create_string_utf8(env, value, NAPI_AUTO_LENGTH, &v);
+  napi_set_named_property(env, obj, name, v);
+}
+
+// Test uv_version and uv_version_string
+static napi_value test_version(napi_env env, napi_callback_info info) {
+  napi_value obj;
+  napi_create_object(env, &obj);
+
+  set_uint32(env, obj, "version", uv_version());
+  set_string(env, obj, "versionString", uv_version_string());
+  set_uint32(env, obj, "major", UV_VERSION_MAJOR);
+  set_uint32(env, obj, "minor", UV_VERSION_MINOR);
+  set_uint32(env, obj, "patch", UV_VERSION_PATCH);
+
+  return obj;
+}
+
+// Test uv_cwd
+static napi_value test_cwd(napi_env env, napi_callback_info info) {
+  char big[4096];
+  size_t big_size = sizeof(big);
+  int rc_big = uv_cwd(big, &big_size);
+
+  char small[1];
+  size_t small_size = sizeof(small);
+  int rc_small = uv_cwd(small, &small_size);
+
+  int rc_invalid = uv_cwd(NULL, NULL);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+
+  set_int32(env, obj, "rcBig", rc_big);
+  if (rc_big == 0) {
+    set_string(env, obj, "cwd", big);
+    set_uint32(env, obj, "bigSize", (uint32_t)big_size);
+  }
+  set_int32(env, obj, "rcSmall", rc_small);
+  set_uint32(env, obj, "smallSize", (uint32_t)small_size);
+  set_int32(env, obj, "rcInvalid", rc_invalid);
+
+  return obj;
+}
+
+// Test uv_get_osfhandle and uv_open_osfhandle (identity on POSIX)
+static napi_value test_osfhandle(napi_env env, napi_callback_info info) {
+  bool ok = uv_get_osfhandle(0) == 0 && uv_get_osfhandle(42) == 42 &&
+            uv_open_osfhandle((uv_os_fd_t)37) == 37;
+
+  napi_value ret;
+  napi_get_boolean(env, ok, &ret);
+  return ret;
+}
+
+// Test uv_thread_self and uv_thread_equal
+static void *thread_self_worker(void *arg) {
+  *(uv_thread_t *)arg = uv_thread_self();
+  return NULL;
+}
+
+static napi_value test_thread_self(napi_env env, napi_callback_info info) {
+  uv_thread_t self = uv_thread_self();
+  uv_thread_t self_again = uv_thread_self();
+  pthread_t raw_self = pthread_self();
+
+  uv_thread_t other;
+  pthread_t t;
+  if (pthread_create(&t, NULL, thread_self_worker, &other) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+  pthread_join(t, NULL);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_bool(env, obj, "selfEqualsSelf",
+           uv_thread_equal(&self, &self_again) != 0);
+  set_bool(env, obj, "selfMatchesPthread", pthread_equal(self, raw_self) != 0);
+  set_bool(env, obj, "otherThreadDiffers", uv_thread_equal(&self, &other) == 0);
+  return obj;
+}
+
+// Test uv_ip4_addr, uv_ip4_name, uv_ip_name
+static napi_value test_ip4(napi_env env, napi_callback_info info) {
+  struct sockaddr_in addr;
+  int rc = uv_ip4_addr("127.0.0.1", 8080, &addr);
+
+  char name[64] = {0};
+  int name_rc = uv_ip4_name(&addr, name, sizeof(name));
+
+  char generic_name[64] = {0};
+  int generic_rc =
+      uv_ip_name((const struct sockaddr *)&addr, generic_name, sizeof(generic_name));
+
+  struct sockaddr_in bogus;
+  int invalid_octet_rc = uv_ip4_addr("999.1.2.3", 80, &bogus);
+  int invalid_string_rc = uv_ip4_addr("not an ip", 80, &bogus);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "rc", rc);
+  set_bool(env, obj, "familyOk", addr.sin_family == AF_INET);
+  set_uint32(env, obj, "port", ntohs(addr.sin_port));
+  set_uint32(env, obj, "addrRaw", ntohl(addr.sin_addr.s_addr));
+  set_int32(env, obj, "nameRc", name_rc);
+  set_string(env, obj, "name", name);
+  set_int32(env, obj, "genericRc", generic_rc);
+  set_string(env, obj, "genericName", generic_name);
+  set_int32(env, obj, "invalidOctetRc", invalid_octet_rc);
+  set_int32(env, obj, "invalidStringRc", invalid_string_rc);
+  return obj;
+}
+
+// Test uv_ip6_addr, uv_ip6_name
+static napi_value test_ip6(napi_env env, napi_callback_info info) {
+  struct sockaddr_in6 addr;
+  int rc = uv_ip6_addr("::1", 9090, &addr);
+
+  char name[64] = {0};
+  int name_rc = uv_ip6_name(&addr, name, sizeof(name));
+
+  struct sockaddr_in6 addr2;
+  int rc2 = uv_ip6_addr("2001:db8:85a3::8a2e:370:7334", 443, &addr2);
+  char name2[64] = {0};
+  int name2_rc = uv_ip6_name(&addr2, name2, sizeof(name2));
+
+  struct sockaddr_in6 bogus;
+  int invalid_rc = uv_ip6_addr("not an ip", 1, &bogus);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "rc", rc);
+  set_bool(env, obj, "familyOk", addr.sin6_family == AF_INET6);
+  set_uint32(env, obj, "port", ntohs(addr.sin6_port));
+  set_bool(env, obj, "isLoopback", IN6_IS_ADDR_LOOPBACK(&addr.sin6_addr));
+  set_int32(env, obj, "nameRc", name_rc);
+  set_string(env, obj, "name", name);
+  set_int32(env, obj, "rc2", rc2);
+  set_int32(env, obj, "name2Rc", name2_rc);
+  set_string(env, obj, "name2", name2);
+  set_int32(env, obj, "invalidRc", invalid_rc);
+  return obj;
+}
+
+// Test uv_inet_pton and uv_inet_ntop
+static napi_value test_inet(napi_env env, napi_callback_info info) {
+  unsigned char buf4[4] = {0};
+  int pton4_rc = uv_inet_pton(AF_INET, "192.168.100.200", buf4);
+  bool bytes_ok =
+      buf4[0] == 192 && buf4[1] == 168 && buf4[2] == 100 && buf4[3] == 200;
+  char round4[64] = {0};
+  int ntop4_rc = uv_inet_ntop(AF_INET, buf4, round4, sizeof(round4));
+
+  unsigned char buf16[16] = {0};
+  int pton6_rc = uv_inet_pton(AF_INET6, "2001:db8::ff00:42:8329", buf16);
+  char round6[64] = {0};
+  int ntop6_rc = uv_inet_ntop(AF_INET6, buf16, round6, sizeof(round6));
+
+  char tiny[2];
+  int nospc_rc = uv_inet_ntop(AF_INET, buf4, tiny, sizeof(tiny));
+  int einval_rc = uv_inet_pton(AF_INET, NULL, buf4);
+  int eafnosupport_rc = uv_inet_pton(12345, "x", buf4);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "pton4Rc", pton4_rc);
+  set_bool(env, obj, "bytesOk", bytes_ok);
+  set_int32(env, obj, "ntop4Rc", ntop4_rc);
+  set_string(env, obj, "round4", round4);
+  set_int32(env, obj, "pton6Rc", pton6_rc);
+  set_int32(env, obj, "ntop6Rc", ntop6_rc);
+  set_string(env, obj, "round6", round6);
+  set_int32(env, obj, "nospcRc", nospc_rc);
+  set_int32(env, obj, "einvalRc", einval_rc);
+  set_int32(env, obj, "eafnosupportRc", eafnosupport_rc);
+  return obj;
+}
+
+// Test uv_cond_init/wait/signal/broadcast/destroy
+typedef struct {
+  uv_mutex_t mutex;
+  uv_cond_t cond;
+  int flag;
+  int woken;
+} cond_ctx_t;
+
+static void *cond_waiter(void *arg) {
+  cond_ctx_t *ctx = arg;
+  uv_mutex_lock(&ctx->mutex);
+  while (!ctx->flag)
+    uv_cond_wait(&ctx->cond, &ctx->mutex);
+  ctx->woken++;
+  uv_mutex_unlock(&ctx->mutex);
+  return NULL;
+}
+
+static napi_value test_cond_signal(napi_env env, napi_callback_info info) {
+  cond_ctx_t ctx = {0};
+  if (uv_mutex_init(&ctx.mutex) != 0 || uv_cond_init(&ctx.cond) != 0) {
+    napi_throw_error(env, NULL, "init failed");
+    return NULL;
+  }
+
+  pthread_t t;
+  if (pthread_create(&t, NULL, cond_waiter, &ctx) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+
+  uv_mutex_lock(&ctx.mutex);
+  ctx.flag = 1;
+  uv_cond_signal(&ctx.cond);
+  uv_mutex_unlock(&ctx.mutex);
+
+  pthread_join(t, NULL);
+
+  int woken = ctx.woken;
+  uv_cond_destroy(&ctx.cond);
+  uv_mutex_destroy(&ctx.mutex);
+
+  napi_value ret;
+  napi_create_int32(env, woken, &ret);
+  return ret;
+}
+
+static napi_value test_cond_broadcast(napi_env env, napi_callback_info info) {
+  cond_ctx_t ctx = {0};
+  if (uv_mutex_init(&ctx.mutex) != 0 || uv_cond_init(&ctx.cond) != 0) {
+    napi_throw_error(env, NULL, "init failed");
+    return NULL;
+  }
+
+  pthread_t t1, t2;
+  if (pthread_create(&t1, NULL, cond_waiter, &ctx) != 0 ||
+      pthread_create(&t2, NULL, cond_waiter, &ctx) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+
+  uv_mutex_lock(&ctx.mutex);
+  ctx.flag = 1;
+  uv_cond_broadcast(&ctx.cond);
+  uv_mutex_unlock(&ctx.mutex);
+
+  pthread_join(t1, NULL);
+  pthread_join(t2, NULL);
+
+  int woken = ctx.woken;
+  uv_cond_destroy(&ctx.cond);
+  uv_mutex_destroy(&ctx.mutex);
+
+  napi_value ret;
+  napi_create_int32(env, woken, &ret);
+  return ret;
+}
+
+// Test uv_cond_timedwait timing out. The timeout is relative nanoseconds;
+// on Linux the implementation adds it to the monotonic clock, so a clock
+// mismatch would make this return immediately (elapsedMs ~ 0).
+static napi_value test_cond_timedwait(napi_env env, napi_callback_info info) {
+  uv_mutex_t mutex;
+  uv_cond_t cond;
+  if (uv_mutex_init(&mutex) != 0 || uv_cond_init(&cond) != 0) {
+    napi_throw_error(env, NULL, "init failed");
+    return NULL;
+  }
+
+  const uint64_t timeout_ns = 20 * 1000 * 1000; // 20ms
+  uv_mutex_lock(&mutex);
+  uint64_t start = uv_hrtime();
+  int rc = 0;
+  // pthread_cond_timedwait may wake spuriously (rc == 0); retry until the
+  // timeout actually elapses.
+  for (int i = 0; i < 100; i++) {
+    rc = uv_cond_timedwait(&cond, &mutex, timeout_ns);
+    if (rc != 0)
+      break;
+  }
+  uint64_t elapsed = uv_hrtime() - start;
+  uv_mutex_unlock(&mutex);
+
+  uv_cond_destroy(&cond);
+  uv_mutex_destroy(&mutex);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "rc", rc);
+  set_uint32(env, obj, "elapsedMs", (uint32_t)(elapsed / 1000000));
+  return obj;
+}
+
+// Test uv_sem_init/post/wait/trywait/destroy
+static void *sem_poster(void *arg) {
+  uv_sem_post((uv_sem_t *)arg);
+  return NULL;
+}
+
+static napi_value test_sem(napi_env env, napi_callback_info info) {
+  uv_sem_t sem;
+  if (uv_sem_init(&sem, 2) != 0) {
+    napi_throw_error(env, NULL, "uv_sem_init failed");
+    return NULL;
+  }
+
+  int try1 = uv_sem_trywait(&sem);
+  int try2 = uv_sem_trywait(&sem);
+  int try_empty = uv_sem_trywait(&sem);
+  uv_sem_post(&sem);
+  int try_after_post = uv_sem_trywait(&sem);
+
+  // Cross-thread: semaphore is at 0; uv_sem_wait blocks until the other
+  // thread posts.
+  pthread_t t;
+  if (pthread_create(&t, NULL, sem_poster, &sem) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+  uv_sem_wait(&sem);
+  pthread_join(t, NULL);
+
+  uv_sem_destroy(&sem);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "try1", try1);
+  set_int32(env, obj, "try2", try2);
+  set_int32(env, obj, "tryEmpty", try_empty);
+  set_int32(env, obj, "tryAfterPost", try_after_post);
+  return obj;
+}
+
+// Test uv_rwlock_*
+typedef struct {
+  uv_rwlock_t lock;
+  int tryrd_rc;
+  int trywr_rc;
+} rwlock_ctx_t;
+
+static void *rwlock_try_worker(void *arg) {
+  rwlock_ctx_t *ctx = arg;
+  ctx->tryrd_rc = uv_rwlock_tryrdlock(&ctx->lock);
+  if (ctx->tryrd_rc == 0)
+    uv_rwlock_rdunlock(&ctx->lock);
+  ctx->trywr_rc = uv_rwlock_trywrlock(&ctx->lock);
+  if (ctx->trywr_rc == 0)
+    uv_rwlock_wrunlock(&ctx->lock);
+  return NULL;
+}
+
+static napi_value test_rwlock(napi_env env, napi_callback_info info) {
+  rwlock_ctx_t ctx = {0};
+  if (uv_rwlock_init(&ctx.lock) != 0) {
+    napi_throw_error(env, NULL, "uv_rwlock_init failed");
+    return NULL;
+  }
+
+  // Two concurrent readers are allowed.
+  uv_rwlock_rdlock(&ctx.lock);
+  int second_reader_rc = uv_rwlock_tryrdlock(&ctx.lock);
+  if (second_reader_rc == 0)
+    uv_rwlock_rdunlock(&ctx.lock);
+  uv_rwlock_rdunlock(&ctx.lock);
+
+  // While a writer holds the lock, try* from another thread fails with
+  // UV_EBUSY.
+  uv_rwlock_wrlock(&ctx.lock);
+  pthread_t t;
+  if (pthread_create(&t, NULL, rwlock_try_worker, &ctx) != 0) {
+    napi_throw_error(env, NULL, "pthread_create failed");
+    return NULL;
+  }
+  pthread_join(t, NULL);
+  uv_rwlock_wrunlock(&ctx.lock);
+
+  int wr_after_unlock_rc = uv_rwlock_trywrlock(&ctx.lock);
+  if (wr_after_unlock_rc == 0)
+    uv_rwlock_wrunlock(&ctx.lock);
+
+  uv_rwlock_destroy(&ctx.lock);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "secondReaderRc", second_reader_rc);
+  set_int32(env, obj, "tryrdWhileWriterRc", ctx.tryrd_rc);
+  set_int32(env, obj, "trywrWhileWriterRc", ctx.trywr_rc);
+  set_int32(env, obj, "trywrAfterUnlockRc", wr_after_unlock_rc);
+  return obj;
+}
+
+// Test uv_interface_addresses / uv_free_interface_addresses
+static napi_value test_interface_addresses(napi_env env,
+                                           napi_callback_info info) {
+  uv_interface_address_t *addresses = NULL;
+  int count = 0;
+  int rc = uv_interface_addresses(&addresses, &count);
+
+  napi_value obj;
+  napi_create_object(env, &obj);
+  set_int32(env, obj, "rc", rc);
+  set_int32(env, obj, "count", count);
+
+  napi_value arr;
+  napi_create_array(env, &arr);
+  if (rc == 0) {
+    for (int i = 0; i < count; i++) {
+      napi_value entry;
+      napi_create_object(env, &entry);
+
+      set_string(env, entry, "name", addresses[i].name);
+      set_bool(env, entry, "isInternal", addresses[i].is_internal != 0);
+
+      int family = addresses[i].address.address4.sin_family;
+      set_string(env, entry, "family",
+                 family == AF_INET    ? "ipv4"
+                 : family == AF_INET6 ? "ipv6"
+                                      : "other");
+
+      char ip[64] = {0};
+      int ip_rc = uv_ip_name((const struct sockaddr *)&addresses[i].address,
+                             ip, sizeof(ip));
+      set_int32(env, entry, "addressRc", ip_rc);
+      set_string(env, entry, "address", ip);
+
+      napi_set_element(env, arr, i, entry);
+    }
+    uv_free_interface_addresses(addresses, count);
+  }
+  napi_set_named_property(env, obj, "interfaces", arr);
+
+  return obj;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   // Register all test functions
   napi_value fn;
@@ -152,6 +613,58 @@ napi_value Init(napi_env env, napi_value exports) {
 
   napi_create_function(env, NULL, 0, test_hrtime, NULL, &fn);
   napi_set_named_property(env, exports, "testHrtime", fn);
+
+  napi_create_function(env, NULL, 0, test_version, NULL, &fn);
+  napi_set_named_property(env, exports, "testVersion", fn);
+
+  napi_create_function(env, NULL, 0, test_cwd, NULL, &fn);
+  napi_set_named_property(env, exports, "testCwd", fn);
+
+  napi_create_function(env, NULL, 0, test_osfhandle, NULL, &fn);
+  napi_set_named_property(env, exports, "testOsfhandle", fn);
+
+  napi_create_function(env, NULL, 0, test_thread_self, NULL, &fn);
+  napi_set_named_property(env, exports, "testThreadSelf", fn);
+
+  napi_create_function(env, NULL, 0, test_ip4, NULL, &fn);
+  napi_set_named_property(env, exports, "testIp4", fn);
+
+  napi_create_function(env, NULL, 0, test_ip6, NULL, &fn);
+  napi_set_named_property(env, exports, "testIp6", fn);
+
+  napi_create_function(env, NULL, 0, test_inet, NULL, &fn);
+  napi_set_named_property(env, exports, "testInet", fn);
+
+  napi_create_function(env, NULL, 0, test_cond_signal, NULL, &fn);
+  napi_set_named_property(env, exports, "testCondSignal", fn);
+
+  napi_create_function(env, NULL, 0, test_cond_broadcast, NULL, &fn);
+  napi_set_named_property(env, exports, "testCondBroadcast", fn);
+
+  napi_create_function(env, NULL, 0, test_cond_timedwait, NULL, &fn);
+  napi_set_named_property(env, exports, "testCondTimedwait", fn);
+
+  napi_create_function(env, NULL, 0, test_sem, NULL, &fn);
+  napi_set_named_property(env, exports, "testSem", fn);
+
+  napi_create_function(env, NULL, 0, test_rwlock, NULL, &fn);
+  napi_set_named_property(env, exports, "testRwlock", fn);
+
+  napi_create_function(env, NULL, 0, test_interface_addresses, NULL, &fn);
+  napi_set_named_property(env, exports, "testInterfaceAddresses", fn);
+
+  // Expose the UV_* error codes so the JS side can assert exact return
+  // values (they are -errno and differ between Linux and macOS).
+  napi_value constants;
+  napi_create_object(env, &constants);
+  set_int32(env, constants, "UV_EINVAL", UV_EINVAL);
+  set_int32(env, constants, "UV_ENOBUFS", UV_ENOBUFS);
+  set_int32(env, constants, "UV_EAGAIN", UV_EAGAIN);
+  set_int32(env, constants, "UV_EBUSY", UV_EBUSY);
+  set_int32(env, constants, "UV_ETIMEDOUT", UV_ETIMEDOUT);
+  set_int32(env, constants, "UV_EAFNOSUPPORT", UV_EAFNOSUPPORT);
+  set_int32(env, constants, "UV_ENOSPC", UV_ENOSPC);
+  napi_set_named_property(env, exports, "constants", constants);
 
   return exports;
 }

--- a/test/napi/uv.test.ts
+++ b/test/napi/uv.test.ts
@@ -57,7 +57,9 @@ describe.if(!isWindows)("uv stubs", () => {
     await Bun.$`${bunExe()} i && ${bunExe()} build:napi`.env(bunEnv).cwd(tempdir);
 
     nativeModule = require(path.join(tempdir, "./build/Release/uv_test.node"));
-  });
+    // Building the addon with node-gyp takes much longer than the default
+    // per-test timeout.
+  }, 300_000);
 
   afterEach(() => {
     process.chdir(cwd);
@@ -89,6 +91,140 @@ describe.if(!isWindows)("uv stubs", () => {
     expect(nativeModule.testUvOnce()).toBe(1);
     expect(nativeModule.testUvOnce()).toBe(1);
     expect(nativeModule.testUvOnce()).toBe(1);
+  });
+
+  test("uv_version and uv_version_string", () => {
+    const r = nativeModule.testVersion();
+    expect(r.major).toBe(1);
+    expect(r.version).toBe((r.major << 16) | (r.minor << 8) | r.patch);
+    expect(r.versionString).toStartWith(`${r.major}.${r.minor}.${r.patch}`);
+  });
+
+  test("uv_cwd", () => {
+    const r = nativeModule.testCwd();
+    const cwdByteLength = Buffer.byteLength(r.cwd);
+    expect(r.rcBig).toBe(0);
+    expect(r.cwd).toBe(process.cwd());
+    expect(r.bigSize).toBe(cwdByteLength);
+    // A too-small buffer reports UV_ENOBUFS and the required size (including
+    // the NUL terminator).
+    expect(r.rcSmall).toBe(nativeModule.constants.UV_ENOBUFS);
+    expect(r.smallSize).toBe(cwdByteLength + 1);
+    expect(r.rcInvalid).toBe(nativeModule.constants.UV_EINVAL);
+  });
+
+  test("uv_get_osfhandle and uv_open_osfhandle", () => {
+    expect(nativeModule.testOsfhandle()).toBe(true);
+  });
+
+  test("uv_thread_self and uv_thread_equal", () => {
+    expect(nativeModule.testThreadSelf()).toEqual({
+      selfEqualsSelf: true,
+      selfMatchesPthread: true,
+      otherThreadDiffers: true,
+    });
+  });
+
+  test("uv_ip4_addr, uv_ip4_name, uv_ip_name", () => {
+    const { UV_EINVAL } = nativeModule.constants;
+    expect(nativeModule.testIp4()).toEqual({
+      rc: 0,
+      familyOk: true,
+      port: 8080,
+      addrRaw: 0x7f000001,
+      nameRc: 0,
+      name: "127.0.0.1",
+      genericRc: 0,
+      genericName: "127.0.0.1",
+      invalidOctetRc: UV_EINVAL,
+      invalidStringRc: UV_EINVAL,
+    });
+  });
+
+  test("uv_ip6_addr, uv_ip6_name", () => {
+    expect(nativeModule.testIp6()).toEqual({
+      rc: 0,
+      familyOk: true,
+      port: 9090,
+      isLoopback: true,
+      nameRc: 0,
+      name: "::1",
+      rc2: 0,
+      name2Rc: 0,
+      name2: "2001:db8:85a3::8a2e:370:7334",
+      invalidRc: nativeModule.constants.UV_EINVAL,
+    });
+  });
+
+  test("uv_inet_pton and uv_inet_ntop", () => {
+    const { UV_ENOSPC, UV_EINVAL, UV_EAFNOSUPPORT } = nativeModule.constants;
+    expect(nativeModule.testInet()).toEqual({
+      pton4Rc: 0,
+      bytesOk: true,
+      ntop4Rc: 0,
+      round4: "192.168.100.200",
+      pton6Rc: 0,
+      ntop6Rc: 0,
+      round6: "2001:db8::ff00:42:8329",
+      nospcRc: UV_ENOSPC,
+      einvalRc: UV_EINVAL,
+      eafnosupportRc: UV_EAFNOSUPPORT,
+    });
+  });
+
+  test("uv_cond wait/signal", () => {
+    expect(nativeModule.testCondSignal()).toBe(1);
+  });
+
+  test("uv_cond broadcast", () => {
+    expect(nativeModule.testCondBroadcast()).toBe(2);
+  });
+
+  test("uv_cond_timedwait times out", () => {
+    const r = nativeModule.testCondTimedwait();
+    expect(r.rc).toBe(nativeModule.constants.UV_ETIMEDOUT);
+    // 20ms requested; anything way below means the deadline computation used
+    // the wrong clock.
+    expect(r.elapsedMs).toBeGreaterThanOrEqual(10);
+  });
+
+  test("uv_sem", () => {
+    const { UV_EAGAIN } = nativeModule.constants;
+    // testSem also exercises a blocking uv_sem_wait satisfied by uv_sem_post
+    // from another thread; returning at all proves it woke up.
+    expect(nativeModule.testSem()).toEqual({
+      try1: 0,
+      try2: 0,
+      tryEmpty: UV_EAGAIN,
+      tryAfterPost: 0,
+    });
+  });
+
+  test("uv_rwlock", () => {
+    const { UV_EBUSY } = nativeModule.constants;
+    expect(nativeModule.testRwlock()).toEqual({
+      secondReaderRc: 0,
+      tryrdWhileWriterRc: UV_EBUSY,
+      trywrWhileWriterRc: UV_EBUSY,
+      trywrAfterUnlockRc: 0,
+    });
+  });
+
+  test("uv_interface_addresses", () => {
+    const r = nativeModule.testInterfaceAddresses();
+    expect(r.rc).toBe(0);
+    expect(r.interfaces).toHaveLength(r.count);
+    expect(r.count).toBeGreaterThanOrEqual(1);
+    for (const iface of r.interfaces) {
+      expect(iface.name.length).toBeGreaterThan(0);
+      expect(["ipv4", "ipv6"]).toContain(iface.family);
+      expect(iface.addressRc).toBe(0);
+      expect(iface.address.length).toBeGreaterThan(0);
+    }
+    // Every environment we test in has a loopback interface up.
+    const internal = r.interfaces.filter((iface: any) => iface.isInternal);
+    expect(internal.length).toBeGreaterThanOrEqual(1);
+    expect(internal.some((iface: any) => iface.address === "127.0.0.1" || iface.address === "::1")).toBe(true);
   });
 
   test("hrtime", () => {


### PR DESCRIPTION
## What

On Linux/macOS/FreeBSD, every exported `uv_*` symbol is a generated panic stub — any prebuilt N-API addon that calls one kills the process with `panic: unsupported uv function: <name>`. (On Windows bun links real libuv, so the same addons work.) By crash-report frequency this is dominated by `uv_version_string`, `uv_cwd`, `uv_cond_init`, `uv_interface_addresses`, `uv_thread_self`, `uv_get_osfhandle`, `uv_ip6_addr`, with the loop-coupled functions (`uv_default_loop`, `uv_async_init`, `uv_timer_init`, …) next.

This implements the statically-implementable subset — pure functions over libc/pthread with **no event-loop dependency** — in `src/jsc/bindings/uv-posix-polyfills.c`, alongside the existing `uv_mutex_*`/`uv_once`/`uv_hrtime` polyfills:

- `uv_version`, `uv_version_string`
- `uv_cwd`
- `uv_get_osfhandle`, `uv_open_osfhandle` (identity on POSIX)
- `uv_thread_self`, `uv_thread_equal`
- `uv_inet_ntop`, `uv_inet_pton`
- `uv_ip4_addr`, `uv_ip6_addr`, `uv_ip4_name`, `uv_ip6_name`, `uv_ip_name`
- `uv_cond_init/destroy/signal/broadcast/wait/timedwait`
- `uv_sem_init/destroy/post/wait/trywait`
- `uv_rwlock_init/destroy/rdlock/tryrdlock/rdunlock/wrlock/trywrlock/wrunlock`
- `uv_interface_addresses`, `uv_free_interface_addresses`

All implementations are **copied from libuv at the exact commit the bundled headers come from** (v1.51.0, `bb706f5` — see `src/jsc/bindings/libuv/README.md`), so semantics match what prebuilt addons expect, including the platform quirks libuv carries (mach semaphores + `pthread_cond_timedwait_relative_np` on macOS, `CLOCK_MONOTONIC` condattr on Linux, the macOS `pthread_cond_wait` EBUSY workaround, `UV_ENOBUFS`+required-size contract of `uv_cwd`, zone-index handling in `uv_ip6_addr`). Two deliberate adaptations, noted in a comment: `uv__malloc/uv__calloc/uv__free` → libc `calloc`/`free`, and the glibc < 2.21 custom-semaphore workaround is omitted (every glibc bun runs on is newer).

The **loop-coupled** functions intentionally remain crashing stubs: `napi_get_uv_event_loop` on POSIX hands out bun's own `EventLoop*`, not a `uv_loop_t`, so silently no-op'ing `uv_async_init`/`uv_timer_start` would turn clean crashes into hangs and memory corruption. That surface tracks in #18546.

## How

- Implemented symbols are commented out of the `symbols` list in `src/jsc/bindings/libuv/generate_uv_posix_stubs_constants.ts` (same pattern as the existing `uv_mutex_*` entries), and `bun uv-posix-stubs` regenerated `uv-posix-stubs.c` + `test/napi/uv-stub-stuff/plugin.c` — both diffs are pure deletions.
- The generator template emitted `#if OS(LINUX) || OS(DARWIN)` while the checked-in stubs file has `|| OS(FREEBSD)`; fixed the template so regeneration no longer drops FreeBSD.
- The exported symbol set is unchanged (stubs already exported these names), so no linker-script/`symbols.txt` changes.

## Tests

Extended the existing `test/napi/uv-stub-stuff/uv_impl.c` addon + `test/napi/uv.test.ts` with 13 new tests covering every implemented function, asserting exact libuv semantics (exact `UV_*` error codes exported from the addon since they're `-errno` and platform-dependent):

- version hex ↔ version string consistency
- `uv_cwd` == `process.cwd()`, plus the `UV_ENOBUFS` + required-size and `UV_EINVAL` contracts
- osfhandle identity; `uv_thread_self`/`uv_thread_equal` vs `pthread_self` and vs another thread
- ip4/ip6/inet round-trips (`127.0.0.1`, `::1`, `2001:db8:…` canonicalization), invalid-input `UV_EINVAL`, `UV_ENOSPC`, `UV_EAFNOSUPPORT`
- cond: cross-thread wait/signal, broadcast waking two waiters, `timedwait` returning `UV_ETIMEDOUT` after actually waiting (catches wrong-clock bugs)
- sem: counting + `UV_EAGAIN` + blocking `uv_sem_wait` satisfied by `uv_sem_post` from another thread
- rwlock: shared readers, `UV_EBUSY` for try-acquire against a held write lock (from a second thread)
- `uv_interface_addresses`: loopback present + internal, addresses render via `uv_ip_name`, proper free

`test/napi/uv_stub.test.ts` (all remaining stubs must still crash) still passes — ran to completion locally, including the regenerated `plugin.c` and the `good_plugin` no-crash test.

Verification:
- `USE_SYSTEM_BUN=1 bun test test/napi/uv.test.ts` → **fails** (`panic: unsupported uv function: uv_version`)
- `bun bd test test/napi/uv.test.ts` → **19 pass**

## Related

Also related: #28900 (maintainer PR from April, “47 simple libuv functions”) — overlaps this PR on version/osfhandle/rwlock/thread_self+equal and additionally has buf_init/strerror/err_name/key_*/handle+req accessors, but **misses** cwd/cond/sem/inet/ip/interface_addresses (the crash-telemetry bulk). It predates the repo restructure (paths are `src/bun.js/bindings/...`) so it needs a rework to land; if it's revived, whichever lands second drops the duplicated functions during rebase.

Overlaps with #29261 (`uv_thread_*` family for the ffi-napi crash in #29260) on `uv_thread_self`/`uv_thread_equal` only; that PR additionally adds `uv_thread_create/create_ex/join/detach`, which this PR does not touch. Whichever lands second needs a trivial rebase of `uv-posix-polyfills.c`/`uv-posix-stubs.c`/the constants list.

### On the suggested auto-close lines (#29223, #14369)

Tested both against this branch — **neither is fully fixed**, so no `Fixes` lines:

- #29223 (ffi-napi): the crash moves from `uv_thread_self` to `uv_async_init`, hit at `import "ffi-napi"` time (same wall #29261 documents). Unblocked only by the loop-coupled surface (#18546).
- #14369 (hyperdht / udx-native): `uv_interface_addresses` itself now works, but `udx-native` crashes next on `uv_timer_init`. Also #18546.

This PR is progress toward both, not a fix for either.
