### PR TITLE
Validate VLQ accumulation and size math in standalone sourcemap embedding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
 name = "bun_bin"
 version = "0.0.0"
 dependencies = [
+ "bstr",
  "bun_alloc",
  "bun_core",
  "bun_crash_handler",

--- a/src/sourcemap/InternalSourceMap.rs
+++ b/src/sourcemap/InternalSourceMap.rs
@@ -1310,6 +1310,18 @@ impl From<FromVlqError> for bun_core::Error {
 /// (`name_index`) is decoded but discarded; nothing in the stack-trace remap
 /// path reads it.
 pub fn from_vlq(vlq: &[u8], input_line_count_hint: u32) -> Result<Box<[u8]>, FromVlqError> {
+    /// Accumulate a VLQ delta into an absolute value. Like `Mapping::parse`,
+    /// reject streams whose absolute value overflows `i32` or goes negative —
+    /// both make the mapping meaningless, and unchecked garbage here would
+    /// flow into every downstream size/index computation.
+    #[inline]
+    fn accumulate(absolute: i32, delta: i32) -> Result<i32, FromVlqError> {
+        absolute
+            .checked_add(delta)
+            .filter(|v| *v >= 0)
+            .ok_or(FromVlqError::InvalidSourceMap)
+    }
+
     let mut builder = Builder::init();
 
     let mut generated_column: i32 = 0;
@@ -1335,7 +1347,7 @@ pub fn from_vlq(vlq: &[u8], input_line_count_hint: u32) -> Result<Box<[u8]>, Fro
         if gc.start == 0 {
             return Err(FromVlqError::InvalidSourceMap);
         }
-        generated_column += gc.value;
+        generated_column = accumulate(generated_column, gc.value)?;
         remain = &remain[gc.start as usize..];
 
         if remain.is_empty() || remain[0] == b',' || remain[0] == b';' {
@@ -1349,21 +1361,21 @@ pub fn from_vlq(vlq: &[u8], input_line_count_hint: u32) -> Result<Box<[u8]>, Fro
         if si.start == 0 {
             return Err(FromVlqError::InvalidSourceMap);
         }
-        source_index += si.value;
+        source_index = accumulate(source_index, si.value)?;
         remain = &remain[si.start as usize..];
 
         let ol = vlq_decode(remain, 0);
         if ol.start == 0 {
             return Err(FromVlqError::InvalidSourceMap);
         }
-        original_line += ol.value;
+        original_line = accumulate(original_line, ol.value)?;
         remain = &remain[ol.start as usize..];
 
         let oc = vlq_decode(remain, 0);
         if oc.start == 0 {
             return Err(FromVlqError::InvalidSourceMap);
         }
-        original_column += oc.value;
+        original_column = accumulate(original_column, oc.value)?;
         remain = &remain[oc.start as usize..];
 
         if !remain.is_empty() && remain[0] != b',' && remain[0] != b';' {

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -2287,12 +2287,11 @@ pub(crate) fn serialize_json_source_map_for_standalone(
     let map_blob =
         SourceMap::InternalSourceMap::from_vlq(map_vlq, 0).map_err(|_| err!("InvalidSourceMap"))?;
 
+    // Every offset/length in the serialized map is a u32 `StringPointer`;
+    // anything that cannot be represented is a build error, not a crash.
+    let map_blob_len_u32 = u32::try_from(map_blob.len()).map_err(|_| err!("SourceMapTooLarge"))?;
     header_list.extend_from_slice(&u32::to_le_bytes(sources_paths.items.len_u32()));
-    header_list.extend_from_slice(
-        &u32::try_from(map_blob.len())
-            .expect("int cast")
-            .to_le_bytes(),
-    );
+    header_list.extend_from_slice(&map_blob_len_u32.to_le_bytes());
 
     let string_payload_start_location = size_of::<u32>()
         + size_of::<u32>()
@@ -2310,8 +2309,10 @@ pub(crate) fn serialize_json_source_map_for_standalone(
         string_payload.extend_from_slice(decoded);
 
         let slice = StringPointer {
-            offset: u32::try_from(offset + string_payload_start_location).expect("int cast"),
-            length: u32::try_from(string_payload.len() - offset).expect("int cast"),
+            offset: u32::try_from(offset + string_payload_start_location)
+                .map_err(|_| err!("SourceMapTooLarge"))?,
+            length: u32::try_from(string_payload.len() - offset)
+                .map_err(|_| err!("SourceMapTooLarge"))?,
         };
         header_list.extend_from_slice(&slice.offset.to_le_bytes());
         header_list.extend_from_slice(&slice.length.to_le_bytes());
@@ -2327,6 +2328,13 @@ pub(crate) fn serialize_json_source_map_for_standalone(
         let offset = string_payload.len();
 
         let bound = bun_zstd::compress_bound(utf8.len());
+        // `ZSTD_compressBound` returns an *error code* (a value near
+        // `usize::MAX`) when the input size exceeds `ZSTD_MAX_INPUT_SIZE`;
+        // feeding that to `Vec::reserve` below would abort with a capacity
+        // overflow instead of failing the build.
+        if bun_zstd::is_error(bound) {
+            return Err(err!("SourceMapTooLarge"));
+        }
         // SAFETY: zstd writes only into the spare slice and reports the byte
         // count on success; on error we commit 0 and `Output::panic` diverges.
         unsafe {
@@ -2344,8 +2352,10 @@ pub(crate) fn serialize_json_source_map_for_standalone(
         };
 
         let slice = StringPointer {
-            offset: u32::try_from(offset + string_payload_start_location).expect("int cast"),
-            length: u32::try_from(string_payload.len() - offset).expect("int cast"),
+            offset: u32::try_from(offset + string_payload_start_location)
+                .map_err(|_| err!("SourceMapTooLarge"))?,
+            length: u32::try_from(string_payload.len() - offset)
+                .map_err(|_| err!("SourceMapTooLarge"))?,
         };
         header_list.extend_from_slice(&slice.offset.to_le_bytes());
         header_list.extend_from_slice(&slice.length.to_le_bytes());

--- a/src/zstd/lib.rs
+++ b/src/zstd/lib.rs
@@ -219,6 +219,15 @@ pub fn compress_bound(src_size: usize) -> usize {
     c::ZSTD_compressBound(src_size)
 }
 
+/// `ZSTD_isError` — true when a `size_t` return value (including from
+/// [`compress_bound`], see zstd.h: "ZSTD_compressBound() itself can fail, if
+/// `srcSize >= ZSTD_MAX_INPUT_SIZE`") is an error code rather than a size.
+/// Error codes are near `usize::MAX`, so treating one as a size requests an
+/// absurd allocation.
+pub fn is_error(code: usize) -> bool {
+    c::ZSTD_isError(code) != 0
+}
+
 /// ZSTD_decompress() :
 /// `compressedSize` : must be the _exact_ size of some number of compressed and/or skippable frames.
 /// `dstCapacity` is an upper bound of originalSize to regenerate.

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -176,6 +176,56 @@ function buildSyntheticVLQ(): string {
 
 // --- Tests ---
 
+describe("InternalSourceMap.fromVLQ validation", () => {
+  // fromVLQ accumulates relative VLQ deltas into absolute i32 values. A
+  // malformed/hostile mappings string can drive an accumulator negative or
+  // overflow it; both must be rejected as an invalid source map (matching
+  // Mapping.parse) instead of panicking in debug builds or carrying wrapped
+  // garbage into the serialized blob in release builds.
+  //
+  // "+/////D" encodes +2147483647 (i32::MAX); "D" encodes -1.
+  const INT32_MAX_VLQ = "+/////D";
+  const invalid: Record<string, string> = {
+    "generated column overflows i32": `${INT32_MAX_VLQ},${INT32_MAX_VLQ}`,
+    "negative absolute generated column": "D",
+    "negative absolute source index": "ADAA",
+    "negative absolute original line": "AADA",
+    "negative absolute original column": "AAAD",
+    "source index overflows i32": `A${INT32_MAX_VLQ}AA,A${INT32_MAX_VLQ}AA`,
+    "original line overflows i32": `AA${INT32_MAX_VLQ}A,AA${INT32_MAX_VLQ}A`,
+    "original column overflows i32": `AAA${INT32_MAX_VLQ},AAA${INT32_MAX_VLQ}`,
+  };
+
+  for (const [name, vlq] of Object.entries(invalid)) {
+    test(name, () => {
+      expect(() => internalSourceMap.fromVLQ(vlq)).toThrow("invalid VLQ input");
+    });
+  }
+
+  test("negative deltas with non-negative absolutes are still accepted", () => {
+    // gen col 5 → 2 (delta -3), original line 4 → 1 (delta -3): legal,
+    // out-of-order mappings exist in real maps.
+    const vlq = [
+      encodeVLQ(5) + encodeVLQ(0) + encodeVLQ(4) + encodeVLQ(7),
+      encodeVLQ(-3) + encodeVLQ(0) + encodeVLQ(-3) + encodeVLQ(-7),
+    ].join(",");
+    const blob = internalSourceMap.fromVLQ(vlq);
+    expect(blob.byteLength).toBeGreaterThan(32);
+    expect(decodeMappings(internalSourceMap.toVLQ(blob))).toEqual([
+      { genLine: 0, genCol: 5, srcIdx: 0, origLine: 4, origCol: 7 },
+      { genLine: 0, genCol: 2, srcIdx: 0, origLine: 1, origCol: 0 },
+    ]);
+  });
+
+  test("i32::MAX absolutes are accepted (boundary)", () => {
+    const vlq = `${INT32_MAX_VLQ}A${INT32_MAX_VLQ}${INT32_MAX_VLQ}`;
+    const blob = internalSourceMap.fromVLQ(vlq);
+    expect(decodeMappings(internalSourceMap.toVLQ(blob))).toEqual([
+      { genLine: 0, genCol: 2147483647, srcIdx: 0, origLine: 2147483647, origCol: 2147483647 },
+    ]);
+  });
+});
+
 describe("InternalSourceMap round-trip", () => {
   test("synthetic: fromVLQ → toVLQ preserves all 4-field positions; names dropped, 1-field skipped", () => {
     const vlqIn = buildSyntheticVLQ();

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -197,7 +197,7 @@ describe("InternalSourceMap.fromVLQ validation", () => {
   };
 
   for (const [name, vlq] of Object.entries(invalid)) {
-    test(name, async () => {
+    test.concurrent(name, async () => {
       // Run fromVLQ in a child process: on a build without the validation,
       // the debug-mode i32 overflow trap aborts the whole process, which must
       // not take down the test runner (and must still be recorded as a

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -197,8 +197,33 @@ describe("InternalSourceMap.fromVLQ validation", () => {
   };
 
   for (const [name, vlq] of Object.entries(invalid)) {
-    test(name, () => {
-      expect(() => internalSourceMap.fromVLQ(vlq)).toThrow("invalid VLQ input");
+    test(name, async () => {
+      // Run fromVLQ in a child process: on a build without the validation,
+      // the debug-mode i32 overflow trap aborts the whole process, which must
+      // not take down the test runner (and must still be recorded as a
+      // failure here).
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const { internalSourceMap } = require("bun:internal-for-testing");
+           try {
+             internalSourceMap.fromVLQ(${JSON.stringify(vlq)});
+             console.log("FROMVLQ_RETURNED_A_BLOB");
+           } catch (e) {
+             console.log("FROMVLQ_THREW: " + e.message);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "ignore",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      // Must reject the mappings as invalid — not return a blob built from
+      // wrapped/negative garbage, and not crash.
+      expect(stdout).toContain("FROMVLQ_THREW: InternalSourceMap.fromVLQ: invalid VLQ input");
+      expect(stdout).not.toContain("FROMVLQ_RETURNED_A_BLOB");
+      expect(exitCode).toBe(0);
     });
   }
 


### PR DESCRIPTION
### What

Fixes the crash class behind Sentry BUN-3BAJ (`core::num::overflowing_mul` — layout overflow growing a buffer in `StandaloneModuleGraph::serialize_json_source_map_for_standalone` during `bun build --compile` with sourcemaps).

### Cause

Three unvalidated trust boundaries in the standalone sourcemap embedding path:

1. **`InternalSourceMap::from_vlq`** accumulates VLQ deltas into absolute `i32` values (`generated_column += gc.value`, same for `source_index` / `original_line` / `original_column`) with **unchecked arithmetic**. Its sibling parser `Mapping::parse` validates every accumulated value (`< 0` → "Invalid … value" parse failure); `from_vlq` — used only by `--compile` — skips all of those checks. A malformed/extreme mappings string panics debug builds with "attempt to add with overflow" and silently wraps negative/garbage values into the serialized blob in release builds.
2. **`serialize_json_source_map_for_standalone`** fed `ZSTD_compressBound(utf8.len())` straight into `Vec::reserve`. Per zstd's documented contract, `ZSTD_compressBound` **can itself fail**, returning an error code near `usize::MAX` — which turns the reserve into the reported capacity-overflow abort (`finish_grow → layout_array → repeat_packed → checked_mul → overflowing_mul`).
3. The u32 `StringPointer` offset/length casts used `expect("int cast")`, so a sourcemap payload the format cannot represent aborted the process instead of failing the build.

The Zig sibling returned `error.OutOfMemory` from fallible allocation here; the port's infallible paths turned the same conditions into process aborts.

### Fix

- `from_vlq`: checked accumulation; i32 overflow or a negative absolute value is rejected as `InvalidSourceMap`, matching `Mapping::parse`.
- `serialize_json_source_map_for_standalone`: validate the `compress_bound` result via the new `bun_zstd::is_error`, and replace the `expect("int cast")` aborts with a `SourceMapTooLarge` build error (surfaces as `failed to create executable: SourceMapTooLarge`).

### Verification

New tests in `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` drive `fromVLQ` with mappings whose accumulators overflow i32 or go negative, plus non-regression guards (negative deltas with valid absolutes, `i32::MAX` boundary):

- unfixed bun: 8 failures — `fromVLQ` returns blobs containing wrapped garbage (debug builds panic outright on the overflow cases)
- with fix: all 13 pass; full `test/js/bun/sourcemap/`, `bun-build-compile-sourcemap.test.ts`, and `compile-sourcemap-internal.test.ts` pass; `--compile --sourcemap` end-to-end smoke (incl. `--bytecode` and fullstack) unaffected

The `Cargo.lock` hunk re-syncs `bstr` in `bun_bin`'s dependencies, missed by #31668.