### PR TITLE
Fix OOB panic in redacting JS highlighter when `${}` ends the input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
 name = "bun_bin"
 version = "0.0.0"
 dependencies = [
+ "bstr",
  "bun_alloc",
  "bun_core",
  "bun_crash_handler",

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1866,7 +1866,15 @@ impl Display for QuickAndDirtyJavaScriptSyntaxHighlighter<'_> {
                         text = &text[1..];
                     }
 
-                    if !text.is_empty() && (text[0] == b'=' || text[0] == b':') {
+                    // A redacted keyword followed by nothing but whitespace:
+                    // the loop above consumed the rest of the input, so there
+                    // is no value left to redact (`text[0]` below would be out
+                    // of bounds).
+                    if text.is_empty() {
+                        return Ok(());
+                    }
+
+                    if text[0] == b'=' || text[0] == b':' {
                         writer.write_char(text[0] as char)?;
                         text = &text[1..];
                         while !text.is_empty() && text[0].is_ascii_whitespace() {

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2021,6 +2021,14 @@ impl Display for QuickAndDirtyJavaScriptSyntaxHighlighter<'_> {
                             continue;
                         } else if self.opts.redact_sensitive_information {
                             'try_redact: {
+                                // `i == 0` happens when a `${...}` interpolation ended
+                                // exactly at the end of the input: the scan loop above
+                                // resets `i` to 0 and exits with `text` empty, so there
+                                // is no quoted content to inspect (`text[1..0]` would
+                                // be out of range).
+                                if i == 0 {
+                                    break 'try_redact;
+                                }
                                 let mut inner = &text[1..i];
                                 if !inner.is_empty() && inner[inner.len() - 1] == char_ {
                                     inner = &inner[..inner.len() - 1];

--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -944,7 +944,13 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                         text = text[1..];
                     }
 
-                    if (text.len > 0 and (text[0] == '=' or text[0] == ':')) {
+                    // A redacted keyword followed by nothing but whitespace:
+                    // the loop above consumed the rest of the input, so there
+                    // is no value left to redact (`text[0]` below would be out
+                    // of bounds).
+                    if (text.len == 0) return;
+
+                    if (text[0] == '=' or text[0] == ':') {
                         try writer.writeByte(text[0]);
                         text = text[1..];
                         while (text.len > 0 and std.ascii.isWhitespace(text[0])) {

--- a/src/bun_core/fmt.zig
+++ b/src/bun_core/fmt.zig
@@ -1066,6 +1066,12 @@ pub const QuickAndDirtyJavaScriptSyntaxHighlighter = struct {
                             continue;
                         } else if (this.opts.redact_sensitive_information) {
                             try_redact: {
+                                // `i == 0` happens when a `${...}` interpolation ended
+                                // exactly at the end of the input: the scan loop above
+                                // resets `i` to 0 and exits with `text` empty, so there
+                                // is no quoted content to inspect (`text[1..0]` would
+                                // be out of range).
+                                if (i == 0) break :try_redact;
                                 var inner = text[1..i];
                                 if (inner.len > 0 and inner[inner.len - 1] == char) {
                                     inner = inner[0 .. inner.len - 1];

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -10,6 +10,7 @@
 const fmtBinding = $bindgenFn("fmt_jsc.bind.ts", "fmtString");
 
 export const highlightJavaScript = (code: string) => fmtBinding(code, "highlight-javascript");
+export const highlightJavaScriptRedacted = (code: string) => fmtBinding(code, "highlight-javascript-redacted");
 export const escapePowershell = (code: string) => fmtBinding(code, "escape-powershell");
 
 export const canonicalizeIP = $newCppFunction("NodeTLS.cpp", "Bun__canonicalizeIP", 1);

--- a/src/jsc/fmt_jsc.bind.ts
+++ b/src/jsc/fmt_jsc.bind.ts
@@ -2,7 +2,7 @@ import { fn, t } from "bindgen";
 
 const implNamespace = "js_bindings";
 
-export const Formatter = t.stringEnum("highlight-javascript", "escape-powershell");
+export const Formatter = t.stringEnum("highlight-javascript", "highlight-javascript-redacted", "escape-powershell");
 
 export const fmtString = fn({
   implNamespace,

--- a/src/jsc/fmt_jsc.rs
+++ b/src/jsc/fmt_jsc.rs
@@ -21,6 +21,7 @@ pub mod js_bindings {
     pub enum Formatter {
         EscapePowershell = 0,
         HighlightJavascript = 1,
+        HighlightJavascriptRedacted = 2,
     }
 
     /// Internal function for testing in highlighter.test.ts
@@ -40,6 +41,17 @@ pub mod js_bindings {
                         enable_colors: true,
                         check_for_unhighlighted_write: false,
                         ..Default::default()
+                    },
+                );
+                write!(writer, "{}", formatter).map_err(|_| global.throw_out_of_memory())?;
+            }
+            Formatter::HighlightJavascriptRedacted => {
+                let formatter = fmt::fmt_javascript(
+                    code,
+                    fmt::HighlighterOptions {
+                        enable_colors: true,
+                        check_for_unhighlighted_write: false,
+                        redact_sensitive_information: true,
                     },
                 );
                 write!(writer, "{}", formatter).map_err(|_| global.throw_out_of_memory())?;

--- a/test/js/bun/util/highlighter.test.ts
+++ b/test/js/bun/util/highlighter.test.ts
@@ -34,6 +34,19 @@ test.each([
   expect(typeof highlighterRedacted(input)).toBe("string");
 });
 
+// A redacted keyword followed by nothing but whitespace used to drain `text`
+// in the whitespace-skip loop and then index `text[0]` on an empty slice
+// (index out of bounds: the len is 0 but the index is 0).
+test.each([
+  "token ", // redacted keyword, trailing space
+  "email\n", // redacted keyword, trailing newline
+  "_auth\t", // redacted keyword, trailing tab
+  "_password  ", // redacted keyword, several trailing spaces
+  "x token = ", // value also drained after the separator
+])("redacting highlighter handles redacted keyword at end of input for %p", input => {
+  expect(typeof highlighterRedacted(input)).toBe("string");
+});
+
 test("redacting highlighter still redacts values", () => {
   const out = highlighterRedacted('_authToken = "npm_123456"');
   expect(out).not.toContain("npm_123456");

--- a/test/js/bun/util/highlighter.test.ts
+++ b/test/js/bun/util/highlighter.test.ts
@@ -1,5 +1,8 @@
-import { highlightJavaScript as highlighter } from "bun:internal-for-testing";
+import * as internalForTesting from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const { highlightJavaScript: highlighter, highlightJavaScriptRedacted: highlighterRedacted } = internalForTesting;
 
 test("highlighter", () => {
   expect(highlighter("`can do ${123} ${'123'} ${`123`}`").length).toBeLessThan(150);
@@ -16,4 +19,44 @@ test.each([
   "`${\\}", // backslash escaping the closing brace, nothing after
 ])("highlighter does not read past end of input for %p", input => {
   expect(typeof highlighter(input)).toBe("string");
+});
+
+// A `${...}` interpolation ending exactly at the end of the input exits the
+// string scan with `i == 0` and `text` fully consumed; the redacting
+// highlighter then sliced `text[1..0]` (range start index 1 out of range for
+// slice of length 0).
+test.each([
+  "`${}", // empty interpolation, nothing after
+  "`${0}", // interpolation with content, nothing after
+  "`a${bc}", // text before the interpolation
+  "`${x}${y}", // two interpolations back to back
+])("redacting highlighter handles `${}` at end of input for %p", input => {
+  expect(typeof highlighterRedacted(input)).toBe("string");
+});
+
+test("redacting highlighter still redacts values", () => {
+  const out = highlighterRedacted('_authToken = "npm_123456"');
+  expect(out).not.toContain("npm_123456");
+  expect(out).toContain("*");
+});
+
+// End-to-end: an error in bunfig.toml whose source line ends with an
+// unterminated template interpolation is printed through the redacting syntax
+// highlighter. This used to panic while printing the error message.
+test("bunfig error on a line ending in `${}` does not crash", async () => {
+  using dir = tempDir("bunfig-highlighter", {
+    "bunfig.toml": "logLevel = 3 # `${}\n",
+    "index.js": `console.log("hi");`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.js"],
+    env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("expected string");
+  expect(stdout).toContain("hi");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Crash

Sentry groups BUN-3C97 / BUN-3AA5 report a panic inside
`QuickAndDirtyJavaScriptSyntaxHighlighter::fmt` (`src/bun_core/fmt.rs`) while printing an
error message:

```
panic: range end index 5 out of range for slice of length 4
```

Investigating that signature turned up **three** bugs in the highlighter's scan loop — one
already fixed, two still live on main and fixed here:

1. **The Sentry signature itself** (`end 5 / len 4`) matches #31434 exactly: a trailing `\`
   inside an unterminated `` `${ `` (the 4 bytes `` `${\ ``) pushed the cursor to 5. That was
   fixed by #31435 (May 26); the reported events predate the fix reaching canary users.
2. **`${...}` ending the input** (still crashing on current canary): when a template
   interpolation ends *exactly* at the end of the input, the string-scan loop exits with
   `i == 0` and `text` fully consumed. The `redact_sensitive_information` branch then slices
   `text[1..i]` → `&[][1..0]`:

   ```
   panic: range start index 1 out of range for slice of length 0
   ```
3. **Redacted keyword followed by only whitespace** (found in review): after a
   `RedactedKeyword` (`token`, `email`, `_auth`, …), the whitespace-skip loop can drain
   `text` to empty, and control falls through to `match text[0]`:

   ```
   panic: index out of bounds: the len is 0 but the index is 0
   ```

### Repro (current canary, 1.4.0-canary.1)

```sh
printf 'logLevel = 3 # `${}\n' > bunfig.toml
echo 'console.log("hi")' > index.js
FORCE_COLOR=1 bun run index.js   # crashes, exit 132
```

The bunfig type error is printed with `redact_sensitive_information: true` and the offending
source line highlighted; the line ends with `` `${} ``, so the highlighter panics *while
printing the error message* — the user sees a crash report instead of their config error.
Same shape is reachable from `.npmrc` error printing (also redacting). Bug 3 reproduces with
`highlightJavaScriptRedacted("token ")` via the testing binding.

### Fix

- Guard the `i == 0` case before forming the `inner` slice in the redact branch; `i == 0`
  can only happen via the interpolation sub-path with an empty remainder, so there is no
  quoted content to inspect.
- Hoist the emptiness check to right after the whitespace-skip loop; the existing check
  inside the `=`/`:` branch only fired when a separator was present.
- Both mirrored into the `.zig` porting reference.

Also exposes the redacting highlighter options through the `bun:internal-for-testing` fmt
binding (`highlight-javascript-redacted`) so tests can drive the redact code path directly,
matching how #31435 tests the non-redacting options.

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/highlighter.test.ts` → the end-to-end test
  crashes with `panic: range start index 1 out of range for slice of length 0` (exit 132),
  matching the live bug; the redacted-binding tests fail (binding doesn't exist yet).
- `bun bd test test/js/bun/util/highlighter.test.ts` → 16 pass, 0 fail.
- Fuzzed the patched highlighter through the real binary in both modes (plain + redacting):
  - exhaustive over all inputs of length ≤ 5 from a 24-char alphabet covering every token
    class the scanner dispatches on (backtick/quotes, `${`/`}`, `\`, digits, identifier
    chars, `/*`, `//`, newlines, `=`/`:`, and 2-, 3- and 4-byte UTF-8 chars) — ~8.3M inputs;
  - keyword-gated paths: every `RedactedKeyword` and the `prev_keyword`-setting syntax
    keywords as prefixes (optionally inside `` `${ ``), × exhaustive tails of length ≤ 3
    (alphabet + `\t`) × keyword-not-at-start variants, plus ~1M keyword-prefixed random
    inputs up to 33 chars;
  - ~2.1M additional seeded-random inputs of length 5–30.

  No panics remain.
