### PR TITLE
Fix panic when FilePoll unregister fails on macOS

### DIFF
--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -30,18 +30,17 @@ fn loop_sub_active(loop_: &mut Loop, value: u32) {
 
 bun_core::declare_scope!(KeepAlive, visible);
 
-// TODO(port): bun_sys::syslog — macro not exported from bun_sys yet.
-// Local no-op shim so debug log call sites compile. All call sites live in
-// `#[cfg(not(windows))] impl FilePoll`, so gate the definition to match.
 #[cfg(not(windows))]
-macro_rules! syslog {
-    ($($arg:tt)*) => {{ let _ = ::core::format_args!($($arg)*); }};
-}
+use bun_sys::syslog;
 
 /// Local port of `Maybe(T).errnoSys` (Zig: src/runtime/node.zig). `bun_sys`
 /// does not yet expose this helper on `Result<T>`; once it does, drop this and
 /// call `sys::Result::<()>::errno_sys` directly.
-#[cfg(not(windows))]
+///
+/// Decodes the -1-sentinel *return-code* convention (the thread-local errno is
+/// only read when `rc` is the all-ones failure value). Do NOT feed it a value
+/// that already is an errno — use [`kevent_change_error`] for those.
+#[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 #[inline]
 fn errno_sys<R>(rc: R, syscall: sys::Tag) -> Option<sys::Result<()>>
 where
@@ -51,6 +50,22 @@ where
         sys::E::SUCCESS => None,
         e => Some(sys::Result::Err(sys::Error::from_code(e, syscall))),
     }
+}
+
+/// Error for a kevent changelist entry that came back with `EV_ERROR` set:
+/// the kernel stores the errno *value* in `data`. That is not the -1-sentinel
+/// return-code convention `errno_sys` decodes — feeding `data` through it
+/// yields `None` for every real errno. `EV_DELETE` reports EBADF/ENOENT here
+/// when the knote is already gone (e.g. the fd was closed while the poll was
+/// still registered, which removes its kevents); the deinit path tolerates
+/// that race by discarding the returned error.
+#[cfg(any(target_os = "macos", all(test, not(windows))))]
+#[inline]
+fn kevent_change_error(data: i64) -> sys::Result<()> {
+    sys::Result::Err(sys::Error::from_code(
+        sys::SystemErrno::init(data).unwrap_or(sys::E::EINVAL),
+        sys::Tag::kevent,
+    ))
 }
 
 pub use crate::{EventLoopCtx, EventLoopCtxKind, EventLoopKind, OpaqueCallback};
@@ -804,7 +819,7 @@ impl FilePoll {
             // with EV_ERROR set in flags and the system error in data. xnu ORs
             // EV_ERROR into the existing action bits, so test the bit.
             if (changelist[0].flags & EV::ERROR) != 0 && changelist[0].data != 0 {
-                return errno_sys(changelist[0].data, sys::Tag::kevent).unwrap();
+                return kevent_change_error(changelist[0].data);
                 // Otherwise, -1 will be returned, and errno will be set to
                 // indicate the error condition.
             }
@@ -1112,10 +1127,10 @@ impl FilePoll {
             // which change failed. xnu ORs EV_ERROR into the existing action
             // bits (EV_DELETE|EV_ERROR = 0x4002), so test the bit, not equality.
             if rc >= 1 && (changelist[0].flags & EV::ERROR) != 0 && changelist[0].data != 0 {
-                return errno_sys(changelist[0].data, sys::Tag::kevent).unwrap();
+                return kevent_change_error(changelist[0].data);
             }
             if rc >= 2 && (changelist[1].flags & EV::ERROR) != 0 && changelist[1].data != 0 {
-                return errno_sys(changelist[1].data, sys::Tag::kevent).unwrap();
+                return kevent_change_error(changelist[1].data);
             }
         }
         #[cfg(target_os = "freebsd")]
@@ -1560,5 +1575,31 @@ pub use crate::closer::Closer;
 pub use crate::waker::KEventWaker;
 #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
 pub use crate::waker::Waker;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// kevent `EV_ERROR` entries carry the errno value itself in `data`.
+    /// These used to be round-tripped through `errno_sys`, which decodes the
+    /// -1-sentinel return-code convention and therefore returned `None` for
+    /// every real errno — panicking at the `.unwrap()` call sites whenever an
+    /// `EV_DELETE` failed (e.g. EBADF/ENOENT from a pipe fd closed while its
+    /// `FilePoll` was still registered).
+    #[cfg(not(windows))]
+    #[test]
+    fn kevent_change_error_decodes_errno_value_not_return_code() {
+        let err = kevent_change_error(sys::E::EBADF as i64).unwrap_err();
+        assert_eq!(err.get_errno(), sys::E::EBADF);
+        assert_eq!(err.syscall, sys::Tag::kevent);
+
+        let err = kevent_change_error(sys::E::ENOENT as i64).unwrap_err();
+        assert_eq!(err.get_errno(), sys::E::ENOENT);
+
+        // Out-of-range data must not panic either.
+        let err = kevent_change_error(i64::MAX).unwrap_err();
+        assert_eq!(err.get_errno(), sys::E::EINVAL);
+    }
+}
 
 // ported from: src/aio/posix_event_loop.zig

--- a/test/js/bun/spawn/spawn-pipe-stale-fd-unregister.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-stale-fd-unregister.test.ts
@@ -1,0 +1,106 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// FilePoll::unregister builds its error from the kevent changelist: with
+// KEVENT_FLAG_ERROR_EVENTS, a failed EV_DELETE comes back as an eventlist
+// entry with EV_ERROR set and the errno *value* in `data`. That value used to
+// be fed through `errno_sys`, which decodes the -1-sentinel return-code
+// convention and therefore returned `None` for every real errno — so the
+// `.unwrap()` at the call site panicked whenever deregistration failed.
+//
+// Deregistration legitimately fails when the polled fd is closed while the
+// poll is still registered: close() removes the fd's kevents, so the forced
+// EV_DELETE during PipeReader teardown reports ENOENT/EBADF. That is a
+// tolerated race (the deinit path discards the error); it must not abort.
+//
+// The fixture makes the race deterministic. Bun.spawn({stdout: "pipe"})
+// registers a FilePoll on the parent's read end of the stdout socketpair at
+// spawn time (no dup — the polled fd is discoverable via /proc/self/fd //
+// /dev/fd). Closing that fd behind the runtime's back drops the kernel-side
+// registration, so cancelling the stream force-unregisters a stale FilePoll.
+// Only macOS reaches the buggy kevent path (Linux's epoll branch decodes the
+// epoll_ctl return code, which is the convention `errno_sys` expects), so the
+// test can only fail on an unfixed build there; it still runs on Linux, where
+// it exercises the EPOLL_CTL_DEL-on-stale-fd teardown.
+test.skipIf(isWindows)("FilePoll teardown tolerates an fd closed while still registered", async () => {
+  using dir = tempDir("spawn-pipe-stale-fd", {
+    "fixture.js": `
+import { closeSync, constants, fstatSync, openSync, readdirSync } from "node:fs";
+
+function pipeFds() {
+  const dir = process.platform === "linux" ? "/proc/self/fd" : "/dev/fd";
+  const out = new Map();
+  for (const name of readdirSync(dir)) {
+    const fd = Number(name);
+    if (!Number.isInteger(fd)) continue;
+    try {
+      const st = fstatSync(fd);
+      if (st.isFIFO() || st.isSocket()) out.set(fd, st.ino);
+    } catch {
+      // closed between readdir and fstat (e.g. readdir's own dir fd)
+    }
+  }
+  return out;
+}
+
+const before = pipeFds();
+const proc = Bun.spawn({
+  cmd: ["sleep", "120"],
+  stdin: "ignore",
+  stdout: "pipe",
+  stderr: "ignore",
+});
+
+try {
+  // Transfers the live BufferedReader (and its registered FilePoll) into a
+  // ReadableStream source; the pending read keeps it polling.
+  const reader = proc.stdout.getReader();
+  const pending = reader.read();
+  await new Promise(resolve => setImmediate(resolve));
+
+  // Only stdout is piped, so exactly one new pipe/socket fd exists: the
+  // parent's read end of the stdout socketpair, which is what the FilePoll
+  // is registered on.
+  const candidates = [...pipeFds()].filter(([fd, ino]) => before.get(fd) !== ino).map(([fd]) => fd);
+  if (candidates.length !== 1) {
+    throw new Error("expected exactly one new pipe fd, got [" + candidates.join(", ") + "]");
+  }
+  const stdoutFd = candidates[0];
+
+  // Closing the polled fd removes its kevents/epoll registration in the
+  // kernel; the FilePoll's later EV_DELETE / EPOLL_CTL_DEL now fails with
+  // ENOENT/EBADF.
+  closeSync(stdoutFd);
+  // Re-occupy the fd number (lowest free fd) so the reader's own deferred
+  // close() of it hits a live descriptor instead of EBADF.
+  const shield = openSync("/dev/null", constants.O_RDONLY);
+  if (shield !== stdoutFd) throw new Error("fd number was not reused: " + stdoutFd + " vs " + shield);
+
+  // Teardown force-unregisters the stale FilePoll. Stream-level rejections
+  // are fine; a runtime panic (abort) is what this test guards against.
+  await reader.cancel().catch(() => {});
+  await pending.catch(() => {});
+  console.log("OK");
+} finally {
+  proc.kill();
+  await proc.exited;
+}
+process.exit(0);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const stderrLines = stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+  expect(stderrLines).toEqual([]);
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes Sentry crash BUN-38SJ: `Option::unwrap()` panic in `FilePoll::unregister_with_fd_impl` while a `PosixBufferedReader` tears down a subprocess pipe (`read_pipe` → `close_without_reporting` → `PollOrFd::close_impl` → `deinit_force_unregister` → `unregister`). macOS only, 1.4 canary.

### Cause

With `KEVENT_FLAG_ERROR_EVENTS`, kevent reports a failed changelist entry by writing it back to the eventlist with `EV_ERROR` set in `flags` and the errno **value** in `data` (e.g. ENOENT=2, EBADF=9). Those `data` values were fed through `errno_sys`, which decodes the **-1-sentinel return-code** convention: it reads the thread-local errno only when `rc` is the all-ones failure value and returns `None` otherwise. A positive errno value is never `-1`, so `errno_sys(data, …)` returned `None` for every real error and the `.unwrap()` at the `EV_ERROR` call sites panicked.

The panic fires whenever an `EV_DELETE` fails, which is a legitimate race on the teardown path: `close()` removes an fd's kevents, so a `FilePoll` force-unregistered after its fd was closed out from under it gets EBADF/ENOENT. libuv tolerates exactly these two errnos when deleting kevents, and every `unregister` caller in-tree already discards the returned error (`let _ = self.unregister(…)` in `deinit_possibly_defer` etc.) — the only bad outcome was the unwrap.

Why the Zig original never crashed here: it tested `changelist[0].flags == EV.ERROR` (strict equality), but xnu ORs `EV_ERROR` into the existing action bits (`EV_DELETE|EV_ERROR` = 0x4002), so the check never fired and changelist errors were silently swallowed. The port fixed the flag test ("test the bit, not equality"), which made the path live with the broken errno round-trip behind it.

### Fix

`src/io/posix_event_loop.rs`:

- Add `kevent_change_error(data)`, which builds the `sys::Error` from the errno value via the checked `SystemErrno::init` (EINVAL fallback for out-of-range data, so the never-happens case can't panic either), and use it at all three `EV_ERROR` sites (unregister ×2 — the live crash; register ×1 — latent, its `data` stays 0 because it passes `nevents=0`).
- Narrow `errno_sys` to linux/android/freebsd, the platforms that still use the return-code convention (macOS no longer references it; `-D dead-code` enforces this), and document the convention it decodes.
- Replace the local no-op `syslog!` shim with the real `bun_sys::syslog` per the shim's own TODO (the macro is exported now). This is the Zig original's `const log = bun.sys.syslog;` — debug builds now log FilePoll register/unregister under `BUN_DEBUG_SYS=1`, which is how the regression fixture below was validated.

### Test

- `test/js/bun/spawn/spawn-pipe-stale-fd-unregister.test.ts` makes the race deterministic: `Bun.spawn({stdout: "pipe"})` registers a `FilePoll` on the parent's read end of the stdout socketpair at spawn (used as-is, no dup, so it's discoverable via `/proc/self/fd` // `/dev/fd`). The fixture closes that fd behind the runtime's back (kernel drops the kevent/epoll registration), re-occupies the fd number with `/dev/null` so the reader's own deferred `close()` stays valid, then cancels the stream — teardown force-unregisters the stale poll. Debug logs confirm the sequence: `register: FilePoll(…) readable (11[socket:…])` at spawn, then `unregister: FilePoll(…) readable (11[/dev/null])` at cancel.

  **Gate note:** the buggy code is inside `#[cfg(target_os = "macos")]` — only the kevent path feeds an errno value into `errno_sys`; Linux's epoll branch decodes the `epoll_ctl` return code, which is the convention `errno_sys` expects and always handled the same race correctly. So the test can only fail-before on macOS (where the unfixed build aborts with the unwrap panic); on Linux it passes both with and without the patch while still exercising the EPOLL_CTL_DEL-on-stale-fd teardown. Same situation as the darwin-only statfs64 fix (753f1c4620).

- In-crate unit test `kevent_change_error_decodes_errno_value_not_return_code` pins the decode behavior. `cargo test -p bun_io` doesn't link on Linux (pre-existing: `bun_windows_sys`' `#[link]` directives leak into test binaries), but it runs under `cargo miri test -p bun_io kevent_change_error` — passes with the fix, and panics exactly like the crash signature if the old `errno_sys(data, …).unwrap()` expression is substituted back.

### Verification

- `cargo check -p bun_io` on x86_64-linux, aarch64-apple-darwin, x86_64-pc-windows-msvc
- `cargo clippy -p bun_io --all-targets` clean on linux + darwin targets
- `cargo miri test -p bun_io kevent_change_error` passes
- `bun bd test test/js/bun/spawn/spawn-pipe-stale-fd-unregister.test.ts` (debug+ASAN) passes; also `spawn-pipe-read-error-leak.test.ts`, `process-stdin-stale-hup.test.ts`, `spawn-streaming-stdout.test.ts`, and a partial `spawn.test.ts` run (35 tests, 0 failures)