### PR TITLE
bake: don't free the VM or bundle state while dev server parse tasks are in flight

### DIFF
--- a/packages/bun-uws/src/Loop.h
+++ b/packages/bun-uws/src/Loop.h
@@ -133,6 +133,14 @@ public:
         }
     }
 
+    /* Keep the lazily-created loop alive past thread exit (a deliberate
+     * leak): disarms the thread_local LoopCleaner so its destructor — which
+     * runs via __cxa_thread_atexit regardless of how the thread returns —
+     * does not us_loop_free() a loop that other threads may still wake up. */
+    static void leakLoopAtThreadExit() {
+        getLazyLoop().cleanMe = false;
+    }
+
     /* Freeing the default loop should be done once */
     void free() {
         LoopData *loopData = (LoopData *) us_loop_ext((us_loop_t *) this);

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -318,6 +318,21 @@ pub struct VirtualMachine {
     pub has_started_debugger: bool,
     pub has_terminated: bool,
 
+    /// Number of Bake `DevServer` bundles currently in flight on this VM.
+    /// Incremented by `DevServer::start_async_bundle`, decremented when
+    /// `finalize_bundle` clears `current_bundle`. Same-thread only (the
+    /// `DevServer` lives on this VM's thread), hence `Cell`; zero-valid for
+    /// the `alloc_zeroed` init.
+    ///
+    /// Read by `WebWorker::shutdown`: a nonzero count means ParseTasks on the
+    /// shared `WorkPool` still hold pointers into this VM — the bundle's
+    /// `AnyEventLoop::Js` handle points at `self.event_loop` (a value field
+    /// of this struct) and result enqueues go through
+    /// `EventLoop::enqueue_task_concurrent`. Those tasks can be neither
+    /// cancelled nor waited for once the event loop stops draining, so the VM
+    /// must be leaked rather than freed while this is nonzero.
+    pub pending_async_bundles: core::cell::Cell<u32>,
+
     #[cfg(debug_assertions)]
     pub debug_thread_id: std::thread::ThreadId,
     #[cfg(not(debug_assertions))]

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -316,7 +316,12 @@ pub struct VirtualMachine {
 
     pub debugger: Option<Box<crate::debugger::Debugger>>,
     pub has_started_debugger: bool,
-    pub has_terminated: bool,
+    /// `AtomicBool` (not `bool`): stored on the VM's own thread
+    /// (`destroy()`, and `WebWorker::shutdown`'s leak-the-VM branch) while
+    /// WorkPool threads concurrently read it through `&VirtualMachine` in
+    /// `EventLoop::enqueue_task_concurrent{,_batch}` to drop enqueues onto a
+    /// terminated VM. Zero-valid for the `alloc_zeroed` init.
+    pub has_terminated: core::sync::atomic::AtomicBool,
 
     /// Number of Bake `DevServer` bundles currently in flight on this VM.
     /// Incremented by `DevServer::start_async_bundle`, decremented when
@@ -4469,7 +4474,8 @@ impl VirtualMachine {
             // once on the same thread; `self` is the live per-thread VM.
             unsafe { (hooks.deinit_runtime_state)(std::ptr::from_mut(self), state) };
         }
-        self.has_terminated = true;
+        self.has_terminated
+            .store(true, core::sync::atomic::Ordering::Release);
     }
     /// Note: takes the concrete
     /// `bun_core::io::Writer` since every call site passes

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4419,6 +4419,14 @@ impl VirtualMachine {
     }
     /// Worker-thread teardown.
     pub fn destroy(&mut self) {
+        // Publish the terminal flag before tearing the event loops down so a
+        // concurrent `EventLoop::enqueue_task_concurrent{,_batch}` (which
+        // no-ops once this is set) can't push into — and wake — a
+        // partially-deinitialized loop. Nothing drains the queue past this
+        // point anyway, so rejecting late producers loses no work.
+        self.has_terminated
+            .store(true, core::sync::atomic::Ordering::Release);
+
         self.regular_event_loop.deinit();
         self.macro_event_loop.deinit();
 
@@ -4474,8 +4482,6 @@ impl VirtualMachine {
             // once on the same thread; `self` is the live per-thread VM.
             unsafe { (hooks.deinit_runtime_state)(std::ptr::from_mut(self), state) };
         }
-        self.has_terminated
-            .store(true, core::sync::atomic::Ordering::Release);
     }
     /// Note: takes the concrete
     /// `bun_core::io::Writer` since every call site passes

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1039,11 +1039,18 @@ impl EventLoop {
     /// `task` must be a live `ConcurrentTaskItem` that the queue may take
     /// ownership of via its intrusive `next` link. All callers pass a
     /// freshly-allocated or struct-embedded task — never null.
+    ///
+    /// A terminated VM never drains its queue again, so the enqueue is
+    /// dropped (and the task intentionally leaked — its ownership contract
+    /// has no deallocation callback). This is reachable when a worker is
+    /// torn down while a Bake DevServer bundle is still in flight:
+    /// `WebWorker::shutdown` leaks the VM and sets `has_terminated`, and the
+    /// bundle's straggler ParseTask completions land here afterwards. (Zig
+    /// debug-paniced on this state; that turned a legitimate
+    /// terminate-mid-bundle into an abort.)
     pub fn enqueue_task_concurrent(&self, task: core::ptr::NonNull<ConcurrentTaskItem>) {
-        if cfg!(debug_assertions) {
-            if self.vm_ref().has_terminated {
-                panic!("EventLoop.enqueueTaskConcurrent: VM has terminated");
-            }
+        if self.vm_ref().has_terminated {
+            return;
         }
         self.concurrent_tasks.push(task);
         self.wakeup();
@@ -1200,10 +1207,11 @@ impl EventLoop {
         &self,
         batch: bun_threading::unbounded_queue::Batch<ConcurrentTaskItem>,
     ) {
-        if cfg!(debug_assertions) {
-            if self.vm_ref().has_terminated {
-                panic!("EventLoop.enqueueTaskConcurrent: VM has terminated");
-            }
+        // See `enqueue_task_concurrent`: a terminated VM never drains its
+        // queue again; drop the enqueue (leaking the batch) instead of
+        // pushing into — and waking — a torn-down loop.
+        if self.vm_ref().has_terminated {
+            return;
         }
         // Panic on an empty batch; `push_batch`'s first line is
         // `set_next(last, null)`, so a null `last` would be UB, not a clean fail.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1049,7 +1049,11 @@ impl EventLoop {
     /// debug-paniced on this state; that turned a legitimate
     /// terminate-mid-bundle into an abort.)
     pub fn enqueue_task_concurrent(&self, task: core::ptr::NonNull<ConcurrentTaskItem>) {
-        if self.vm_ref().has_terminated {
+        if self
+            .vm_ref()
+            .has_terminated
+            .load(core::sync::atomic::Ordering::Acquire)
+        {
             return;
         }
         self.concurrent_tasks.push(task);
@@ -1210,7 +1214,11 @@ impl EventLoop {
         // See `enqueue_task_concurrent`: a terminated VM never drains its
         // queue again; drop the enqueue (leaking the batch) instead of
         // pushing into — and waking — a torn-down loop.
-        if self.vm_ref().has_terminated {
+        if self
+            .vm_ref()
+            .has_terminated
+            .load(core::sync::atomic::Ordering::Acquire)
+        {
             return;
         }
         // Panic on an empty batch; `push_batch`'s first line is

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1282,6 +1282,36 @@ impl WebWorker {
             // SAFETY: loop owned by this thread's VM; no concurrent access.
             unsafe { (*loop_).internal_loop_data.jsc_vm = core::ptr::null_mut() };
         }
+        // A Bake DevServer bundle may still be in flight on the shared
+        // `WorkPool`. Its ParseTasks hold pointers into this VM: the bundle's
+        // `AnyEventLoop::Js` handle points at `vm.event_loop` (a value field
+        // of the VM box), result enqueues go through
+        // `EventLoop::enqueue_task_concurrent`, and the resolver reads the
+        // worker env. Those tasks can be neither cancelled nor waited for —
+        // the loop above stopped draining, so the bundle completion that
+        // would decrement `pending_async_bundles` can never run. Freeing the
+        // VM / env / uws loop here is a use-after-free on the pool threads
+        // (observed as segfaults inside parser codegen, e.g.
+        // `generate_react_refresh_import_hmr`); leak them instead — the same
+        // doctrine as Zig's DevServer `.current_bundle` teardown arm
+        // ("impossible to de-initialize this state correctly").
+        // `has_terminated` turns the stragglers' enqueues into no-ops (see
+        // `EventLoop::enqueue_task_concurrent`).
+        if !vm_ptr.is_null()
+            // SAFETY: vm_ptr valid; sole owner (unpublished under vm_lock).
+            && unsafe { &*vm_ptr }.pending_async_bundles.get() > 0
+        {
+            log!(
+                "[{}] leaking the VM: a dev server bundle is still in flight",
+                self.execution_context_id
+            );
+            // SAFETY: vm_ptr valid; sole owner. Flag write (the VM is leaked,
+            // not `destroy()`ed) so concurrent enqueues bail out.
+            unsafe { (*vm_ptr).has_terminated = true };
+            virtual_machine::VMHolder::set_vm(None);
+            let _ = core::mem::ManuallyDrop::new(arena.take());
+            return;
+        }
         if !vm_ptr.is_null() {
             // SAFETY: vm_ptr valid; sole owner.
             // Must precede Loop.shutdown so uv_close isn't called twice on the

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1197,6 +1197,8 @@ impl WebWorker {
 
         // Snapshot everything we'll need after `this` may be freed (step 4).
         let cpp_worker = self.cpp_worker;
+        // For the leak-the-VM log in step 5 — `self.*` must not be read there.
+        let execution_context_id = self.execution_context_id;
         // worker-thread only field; no other thread reads `arena`.
         let mut arena = self.arena.replace(None);
         let env_loader = self.worker_env_loader.replace(core::ptr::null_mut());
@@ -1303,11 +1305,15 @@ impl WebWorker {
         {
             log!(
                 "[{}] leaking the VM: a dev server bundle is still in flight",
-                self.execution_context_id
+                execution_context_id
             );
-            // SAFETY: vm_ptr valid; sole owner. Flag write (the VM is leaked,
-            // not `destroy()`ed) so concurrent enqueues bail out.
-            unsafe { (*vm_ptr).has_terminated = true };
+            // SAFETY: vm_ptr valid; sole owner. Flag store (the VM is leaked,
+            // not `destroy()`ed) so concurrent enqueues bail out; `Release`
+            // pairs with the `Acquire` loads in
+            // `EventLoop::enqueue_task_concurrent{,_batch}`.
+            unsafe { &*vm_ptr }
+                .has_terminated
+                .store(true, core::sync::atomic::Ordering::Release);
             virtual_machine::VMHolder::set_vm(None);
             let _ = core::mem::ManuallyDrop::new(arena.take());
             return;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1314,6 +1314,14 @@ impl WebWorker {
             unsafe { &*vm_ptr }
                 .has_terminated
                 .store(true, core::sync::atomic::Ordering::Release);
+            // Early-returning skips `bun_uws::on_thread_exit()` below, but
+            // that alone does NOT leak the loop: the C++ `thread_local
+            // LoopCleaner` destructor still runs at thread exit (via
+            // `__cxa_thread_atexit`, independent of the unwind-free return
+            // path) and would `us_loop_free()` it — under a straggler that
+            // loaded `has_terminated == false` and is about to `wakeup()`
+            // this loop. Disarm it explicitly.
+            bun_uws::leak_loop_on_thread_exit();
             virtual_machine::VMHolder::set_vm(None);
             let _ = core::mem::ManuallyDrop::new(arena.take());
             return;
@@ -1369,12 +1377,12 @@ impl WebWorker {
         }
         bun_core::delete_all_pools_for_thread_exit();
         // Free this thread's lazily-created uWS loop and its 512 KiB recv
-        // buffer. The C++ thread_local `~LoopCleaner` does not fire here:
-        // we return normally and
-        // unwinding never crosses the `extern "C"` frame, so the destructor is
-        // skipped on glibc; under BUN_DESTRUCT_VM_ON_EXIT it would also gate
-        // on `!bun_is_exiting()`. Everything that registers polls on the loop
-        // (gc_controller, sockets, timers) has been deinit'd above.
+        // buffer. This nulls `getLazyLoop().loop`, so the C++ `thread_local
+        // ~LoopCleaner` — which DOES run at thread exit via
+        // `__cxa_thread_atexit` (see c-bindings.cpp `shared_header_buffer_get`
+        // note), independent of this unwind-free return path — becomes a
+        // no-op instead of double-freeing. Everything that registers polls on
+        // the loop (gc_controller, sockets, timers) has been deinit'd above.
         bun_uws::on_thread_exit();
         drop(arena.take());
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1176,8 +1176,20 @@ impl Drop for DevServer {
 
         // The map's `Drop` runs `SerializedFailure::drop` for each value.
 
-        if self.current_bundle.is_some() {
-            debug_assert!(false); // impossible to de-initialize this state correctly.
+        // An async bundle may still be in flight: its ParseTasks on the shared
+        // `WorkPool` hold pointers into `bv2`, the bundle heap, and the
+        // `AstAllocState`, and they can be neither cancelled nor waited for
+        // here (the event loop that would drain their completions is tearing
+        // down). Zig deliberately leaked this state (DevServer.zig `deinit`,
+        // `.current_bundle` arm: "impossible to de-initialize this state
+        // correctly"); letting the field drop instead frees mi-heaps under a
+        // running parse — observed as scattered segfaults inside parser
+        // codegen (e.g. `generate_react_refresh_import_hmr`). Leak it.
+        // `VirtualMachine::pending_async_bundles` intentionally stays nonzero
+        // so a worker-thread teardown leaks the VM too (`WebWorker::shutdown`).
+        if let Some(bundle) = self.current_bundle.take() {
+            debug_log!("deinit with an in-flight bundle; leaking it");
+            let _ = ::core::mem::ManuallyDrop::new(bundle);
         }
 
         {
@@ -3387,6 +3399,16 @@ impl DevServer {
             promise: ::core::mem::take(&mut self.next_bundle.promise),
             resolution_failure_entries: Default::default(),
         });
+        // Tasks for this bundle are now queued on the shared `WorkPool`, each
+        // holding pointers into `bv2`/`heap` and this VM's event loop. Keep
+        // the VM's in-flight count in sync so a forced teardown
+        // (`WebWorker::shutdown`) knows it must leak the VM instead of
+        // freeing it under those tasks; `finalize_bundle` decrements.
+        {
+            let vm = self.vm();
+            vm.pending_async_bundles
+                .set(vm.pending_async_bundles.get() + 1);
+        }
 
         self.next_bundle.promise = DeferredPromise::default();
         self.next_bundle.requests = deferred_request::List::default();
@@ -3887,6 +3909,14 @@ pub(super) fn finalize_bundle(
         bv2.deinit_without_freeing_arena();
         if let Some(cb) = &mut dev.current_bundle {
             cb.promise.deinit_idempotently();
+        }
+        // The bundle ran to completion (`pending_items == 0`), so no task on
+        // the `WorkPool` references it anymore — releasing the VM's in-flight
+        // count makes a later teardown free the VM normally again.
+        {
+            let vm = dev.vm();
+            vm.pending_async_bundles
+                .set(vm.pending_async_bundles.get().saturating_sub(1));
         }
         // Drops `CurrentBundle.heap` (the arena `bv2.graph.heap` borrows).
         dev.current_bundle = None;

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1187,10 +1187,13 @@ impl Drop for DevServer {
         // codegen (e.g. `generate_react_refresh_import_hmr`). Leak it.
         // `VirtualMachine::pending_async_bundles` intentionally stays nonzero
         // so a worker-thread teardown leaks the VM too (`WebWorker::shutdown`).
-        if let Some(bundle) = self.current_bundle.take() {
+        let bundle_in_flight = if let Some(bundle) = self.current_bundle.take() {
             debug_log!("deinit with an in-flight bundle; leaking it");
             let _ = ::core::mem::ManuallyDrop::new(bundle);
-        }
+            true
+        } else {
+            false
+        };
 
         {
             let mut r = self.next_bundle.requests.first;
@@ -1234,12 +1237,21 @@ impl Drop for DevServer {
             .server_components
             .as_ref()
             .is_some_and(|sc| sc.separate_ssr_graph);
-        // SAFETY: each transpiler is initialized exactly once in `init()`.
-        unsafe {
-            self.server_transpiler.assume_init_drop();
-            self.client_transpiler.assume_init_drop();
-            if separate_ssr_graph {
-                self.ssr_transpiler.assume_init_drop();
+        // A leaked in-flight `bv2` holds `&mut` borrows of these inline
+        // transpilers (see `CurrentBundle::bv2`), and straggler ParseTasks
+        // read them (`ctx.transpiler().options`, worker transpiler clones) —
+        // don't run their destructors out from under those tasks. This only
+        // preserves the transpilers' heap-side state; keeping the *inline
+        // storage* alive requires the owner to leak the whole `Box<DevServer>`
+        // (`DevServer::drop_or_leak`), which every drop site goes through.
+        if !bundle_in_flight {
+            // SAFETY: each transpiler is initialized exactly once in `init()`.
+            unsafe {
+                self.server_transpiler.assume_init_drop();
+                self.client_transpiler.assume_init_drop();
+                if separate_ssr_graph {
+                    self.ssr_transpiler.assume_init_drop();
+                }
             }
         }
 
@@ -1268,6 +1280,33 @@ impl Drop for DevServer {
 }
 
 impl DevServer {
+    /// `true` while an async bundle is running on the shared `WorkPool`. Its
+    /// ParseTasks borrow the transpilers stored inline in this box (see
+    /// `CurrentBundle::bv2`), so the `Box<DevServer>` must not be freed while
+    /// this holds.
+    #[inline]
+    pub fn has_in_flight_bundle(&self) -> bool {
+        self.current_bundle.is_some()
+    }
+
+    /// Drop `dev`, or — when an async bundle is still in flight — leak the
+    /// whole box. The bundle's ParseTasks on the shared `WorkPool` hold
+    /// `&mut` borrows of the transpilers stored *inline* in the `DevServer`
+    /// allocation (`CurrentBundle::bv2` doc) plus the watcher and the
+    /// `dev_server` handle; they can be neither cancelled nor waited for, so
+    /// freeing the box would dangle all of them (same UAF class as freeing
+    /// the bundle heap). Normally unreachable: `start_async_bundle` refs the
+    /// server (`on_pending_request`) for every bundle, which gates
+    /// `deinit_if_we_can` — this is the backstop for forced teardowns.
+    pub fn drop_or_leak(dev: Box<DevServer>) {
+        if dev.has_in_flight_bundle() {
+            debug_log!("leaking the DevServer: a bundle is still in flight");
+            let _ = Box::leak(dev);
+        } else {
+            drop(dev);
+        }
+    }
+
     /// Everything is `Box`/`Vec` on the global mimalloc, so this just
     /// returns the default `StdAllocator`. Kept for the few call sites
     /// that still want a `StdAllocator` handle.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -309,6 +309,14 @@ impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
     fn drop(&mut self) {
         // The remaining owned fields (config, base_url, h3_alt_svc, dev_server,
         // user_routes, all_closed_promise, on_clienterror) drop automatically.
+        //
+        // ...except `dev_server`, which must be leaked instead of dropped when
+        // an async bundle is still in flight on the shared WorkPool (its
+        // ParseTasks borrow the transpilers stored inline in the box — see
+        // `DevServer::drop_or_leak`).
+        if let Some(dev) = self.dev_server.take() {
+            crate::bake::DevServer::DevServer::drop_or_leak(dev);
+        }
         if let Some(p) = self.plugins.take() {
             // SAFETY: `plugins` carries the `heap::alloc` provenance from
             // `ServePlugins::init`; this releases the server's counted ref.
@@ -1680,7 +1688,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     // S012: `NewApp<SSL>` is a ZST opaque — safe `*mut → &mut` deref.
                     bun_opaque::opaque_deref_mut(app).clear_routes();
                 }
-                drop(dev); // dev.deinit()
+                // dev.deinit(); leaks instead if a bundle is still in flight
+                // (its WorkPool tasks borrow the box — see `drop_or_leak`).
+                crate::bake::DevServer::DevServer::drop_or_leak(dev);
             }
 
             // Only free the memory if the JS reference has been freed too.

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -102,7 +102,7 @@ pub struct SocketAddress {
     pub is_ipv6: bool,
 }
 
-pub use bun_uws_sys::loop_::on_thread_exit;
+pub use bun_uws_sys::loop_::{leak_loop_on_thread_exit, on_thread_exit};
 
 /// # Safety
 /// `filename` and `error_msg` must be valid NUL-terminated C strings.

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -663,10 +663,21 @@ pub use c::{us_loop_run, us_wakeup_loop};
 unsafe extern "C" {
     // safe: no args; clears the C side's thread-local loop pointer — no preconditions.
     safe fn bun_clear_loop_at_thread_exit();
+    // safe: no args; flips a thread-local bool — no preconditions.
+    safe fn bun_leak_loop_at_thread_exit();
 }
 
 /// Clears the C side's thread-local loop pointer. Call when a thread that ran
 /// a uws loop (e.g. a Worker thread) exits.
 pub fn on_thread_exit() {
     bun_clear_loop_at_thread_exit()
+}
+
+/// Deliberately leak this thread's lazily-created uWS loop: disarm the C++
+/// `thread_local LoopCleaner` whose destructor runs at thread exit (via
+/// `__cxa_thread_atexit` — independent of how the thread returns) and would
+/// otherwise `us_loop_free()` it. For teardown paths where other threads may
+/// still `wakeup()` the loop after this thread is gone.
+pub fn leak_loop_on_thread_exit() {
+    bun_leak_loop_at_thread_exit()
 }

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1934,5 +1934,12 @@ __attribute__((callback (corker, ctx)))
       uWS::Loop::clearLoopAtThreadExit();
   }
 
+  // Deliberately leak this thread's loop instead (see Loop.h
+  // leakLoopAtThreadExit): used when other threads may still wake the loop
+  // after this thread exits.
+  extern "C" void bun_leak_loop_at_thread_exit() {
+      uWS::Loop::leakLoopAtThreadExit();
+  }
+
 #pragma clang attribute pop
 }

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -33,7 +33,9 @@ test.skipIf(!isASAN)(
           // A bundler macro spins up a JSC VM on the worker-pool thread
           // mid-parse, keeping parse tasks in flight long enough that some
           // reliably outlive the worker's teardown.
-          i % 2 === 0 ? `import { buildTag } from "./mac.ts" with { type: "macro" };\nconst TAG${i} = buildTag(${i});` : ""
+          i % 2 === 0
+            ? `import { buildTag } from "./mac.ts" with { type: "macro" };\nconst TAG${i} = buildTag(${i});`
+            : ""
         }
         export function Inner${i}() {
           const [count, setCount] = useState(${i});

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,4 +1,4 @@
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
@@ -11,3 +11,140 @@ test("dev server deinitializes itself", () => {
   expect(result.signalCode).toBeUndefined();
   expect(result.exitCode).toBe(0);
 });
+
+// Terminating a worker while its dev server still has a bundle in flight used
+// to free the VirtualMachine (and the bundle state reachable from it) while
+// ParseTasks were still running on the shared WorkPool. The stragglers then
+// dereferenced the freed VM / bundle heap — observed in production as
+// scattered segfaults inside parser codegen (react-refresh import generation).
+// The UAF is only reliably detectable under ASAN; release builds corrupt
+// silently, so this test is ASAN-only.
+test.skipIf(!isASAN)(
+  "worker terminate during an in-flight dev server bundle does not use-after-free",
+  async () => {
+    const components: Record<string, string> = {};
+    const imports: string[] = [];
+    const elements: string[] = [];
+    for (let i = 0; i < 24; i++) {
+      components[`Comp${i}.tsx`] = `
+        import { useState, useEffect, useMemo } from "react";
+        import { useCustom${i} } from "./hooks${i % 4}";
+        ${
+          // A bundler macro spins up a JSC VM on the worker-pool thread
+          // mid-parse, keeping parse tasks in flight long enough that some
+          // reliably outlive the worker's teardown.
+          i % 2 === 0 ? `import { buildTag } from "./mac.ts" with { type: "macro" };\nconst TAG${i} = buildTag(${i});` : ""
+        }
+        export function Inner${i}() {
+          const [count, setCount] = useState(${i});
+          const [other] = useState({ a: ${i} });
+          const memo = useMemo(() => count * ${i + 1}, [count]);
+          const custom = useCustom${i}();
+          useEffect(() => { setCount(c => c); }, []);
+          return <div onClick={() => setCount(count + 1)}>{count}{memo}{custom}{other.a}</div>;
+        }
+        export const Inline${i} = () => {
+          const [v] = useState(${i});
+          return <span>{v}</span>;
+        };
+        export default function Comp${i}() {
+          const [v, setV] = useState("x${i}");
+          return <p onMouseOver={() => setV(v + "!")}>{v}<Inner${i} /><Inline${i} /></p>;
+        }
+      `;
+      imports.push(`import Comp${i} from "./Comp${i}";`);
+      elements.push(`<Comp${i} />`);
+    }
+    for (let j = 0; j < 4; j++) {
+      let hooks = `import { useState } from "react";\n`;
+      for (let i = j; i < 24; i += 4) {
+        hooks += `export function useCustom${i}() { const [v] = useState(${i}); return v; }\n`;
+      }
+      components[`hooks${j}.tsx`] = hooks;
+    }
+    components["mac.ts"] = `
+      export function buildTag(n: number) {
+        return "tag-" + n;
+      }
+    `;
+
+    using dir = tempDir("bake-worker-terminate", {
+      ...components,
+      "node_modules/react/package.json": JSON.stringify({ name: "react", version: "0.0.1", main: "index.js" }),
+      "node_modules/react/index.js": `
+        exports.useState = (v) => [v, () => {}];
+        exports.useEffect = () => {};
+        exports.useMemo = (f) => f();
+      `,
+      "node_modules/react/jsx-dev-runtime.js": `
+        exports.jsxDEV = (t, p) => ({ t, p });
+        exports.Fragment = "Fragment";
+      `,
+      "node_modules/react-refresh/package.json": JSON.stringify({
+        name: "react-refresh",
+        version: "0.0.1",
+        main: "runtime.js",
+      }),
+      "node_modules/react-refresh/runtime.js": `
+        exports.performReactRefresh = () => {};
+        exports.injectIntoGlobalHook = () => {};
+        exports.isLikelyComponentType = () => true;
+        exports.register = () => {};
+        exports.createSignatureFunctionForTransform = () => function (fn) { return fn; };
+      `,
+      "index.html": `<!DOCTYPE html><html><head></head><body><div id="root"></div><script type="module" src="./App.tsx"></script></body></html>`,
+      "App.tsx": `
+        ${imports.join("\n")}
+        export function App() {
+          return <main>${elements.join("")}</main>;
+        }
+        console.log(App);
+      `,
+      "worker-server.ts": `
+        // @ts-ignore
+        import html from "./index.html";
+        const server = Bun.serve({
+          routes: { "/": html },
+          fetch() {
+            return new Response("fallback");
+          },
+          hostname: "127.0.0.1",
+          port: 0,
+        });
+        postMessage({ port: server.port });
+      `,
+      "terminate-fixture.ts": `
+        // Sweep the terminate() timing so at least one iteration lands while
+        // the dev server's bundle still has parse tasks in flight.
+        for (let i = 0; i < 10; i++) {
+          const worker = new Worker(new URL("./worker-server.ts", import.meta.url).href);
+          const port = await new Promise(resolve => {
+            worker.onmessage = e => resolve(e.data.port);
+          });
+          // Kick off the bundle; the response never arrives once the worker
+          // is terminated, so don't await it.
+          fetch(\`http://127.0.0.1:\${port}/\`, { signal: AbortSignal.timeout(10_000) }).catch(() => {});
+          await Bun.sleep(25 + i * 10);
+          await worker.terminate();
+          console.log("terminated", i);
+        }
+        console.log("survived all");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), path.join(String(dir), "terminate-fixture.ts")],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("AddressSanitizer");
+    expect(stdout).toContain("survived all");
+    expect(exitCode).toBe(0);
+  },
+  240_000,
+);

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -136,7 +136,17 @@ test.skipIf(!isASAN)(
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(String(dir), "terminate-fixture.ts")],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // The fix under test *deliberately leaks* the worker VM and bundle
+        // state when a dev server bundle is still in flight at terminate()
+        // (its WorkPool tasks can be neither cancelled nor awaited, so
+        // leaking is the only sound teardown). LeakSanitizer would report
+        // those intentional leaks at child exit; this test is about
+        // use-after-free, which ASAN proper still detects with leak
+        // detection off.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -144,7 +144,10 @@ test.skipIf(!isASAN)(
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).not.toContain("AddressSanitizer");
+    // The only stderr a passing run produces is the dev server's
+    // bundle-progress lines (bundles that finish before the terminate());
+    // anything else — e.g. an AddressSanitizer report — is a failure.
+    expect(stderr.replace(/^Bundled page in .+$/gm, "").trim()).toBe("");
     expect(stdout).toContain("survived all");
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
Fixes a use-after-free behind a cluster of Sentry crash reports (BUN-3EA0, BUN-3EA2, BUN-3EA5, BUN-3EAK): four distinct memory-death signatures (segfaults in `deref_mut`, `EString::init`, `baby_vec::drop`, and `RawVecInner::try_allocate_in`), all with `generate_react_refresh_import_hmr` on the stack — i.e. scattered crashes inside the dev server's parser codegen.

## Root cause

Tearing down a VM or DevServer while its async bundle still has ParseTasks running on the shared `WorkPool` frees memory those tasks dereference:

- `WebWorker::shutdown` deallocates the `VirtualMachine` box. The bundle's `AnyEventLoop::Js` handle points at `vm.event_loop`, a **value field of that box**, so a straggler ParseTask's result enqueue reads freed memory:
  ```
  heap-use-after-free READ of size 8 (thread "Bun Pool 4")
    EventLoop::vm_ref            src/jsc/event_loop.rs:1111
    EventLoop::enqueue_task_concurrent
    ParseTask::run_from_thread_pool   src/bundler/ParseTask.rs:2891
  freed by thread (Worker):
    WebWorker::shutdown          src/jsc/web_worker.rs:1348
  ```
- `Drop for DevServer` let `current_bundle`'s automatic field drop free the `BundleV2`, the bundle mi-heap (which arena-owns the `ParseTask`s themselves), and the `AstAllocState`. The Zig implementation deliberately **leaked** this state (`DevServer.zig` deinit, `.current_bundle` arm: *"impossible to de-initialize this state correctly"*); the Rust port kept only the debug assert and freed anyway.

In release builds the stray reads/writes land in recycled mimalloc blocks and surface later as unrelated-looking segfaults in allocation-heavy code — the react-refresh import codegen is the biggest allocation burst at the end of every dev-server JSX parse, which is why all four crash signatures cluster in that frame.

These straggler tasks can be neither cancelled (no cancellation mechanism exists) nor waited for (the event loop that would drain their completions has stopped, so the completion that ends the bundle can never run). The only sound teardown is the one Zig chose: leak.

## Fix

- `VirtualMachine::pending_async_bundles`: new same-thread counter, incremented by `DevServer::start_async_bundle`, decremented when `finalize_bundle` clears `current_bundle`.
- `WebWorker::shutdown`: when the counter is nonzero, leak the VM (and the env loader/map, uws loop, and worker arena that the stragglers also reach) instead of freeing them, and set `has_terminated` so straggler enqueues bail out.
- `Drop for DevServer`: leak `current_bundle` (Zig parity) instead of dropping it.
- `EventLoop::enqueue_task_concurrent{,_batch}`: a terminated VM never drains its queue again, so the enqueue is now a no-op (previously a debug-only panic, which turned a legitimate terminate-mid-bundle into an abort).

## Reproduction / verification

`worker.terminate()` while the worker's dev server (`Bun.serve` with an HTML route) is mid-bundle reproduces the UAF deterministically under ASAN. The new regression test in `test/bake/deinitialization.test.ts` sweeps the terminate timing against a bundle of 24 JSX components (hooks + a bundler macro, mirroring the react-refresh transform the production crashes went through):

- before the fix: 3/3 runs fail with the ASAN `heap-use-after-free` above
- after the fix: 3/3 runs pass

Also verified: `test/bake/dev/react-spa.test.ts`, `test/bake/dev/hot.test.ts`, `test/bake/dev/stress.test.ts`, `test/regression/issue/25716.test.ts` (Bun.build reactFastRefresh), and a 30-revision dev-server rebuild stress loop — all clean on the fixed build. The test is `skipIf(!isASAN)` since release builds corrupt silently.