### PR TITLE
Test WebKit ThinLTO Linux builds (oven-sh/WebKit#246)

### DIFF
--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -775,19 +775,22 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   // swap is wired up, so rustc's newer-LLVM bitcode would be unreadable at
   // link time. Both halves still LTO independently when this is false — only
   // the Rust↔C++ inlining is lost.
-  // (aarch64-musl used to be gated too: LLVM's `globalopt` segfaulted on the
-  // per-crate `bun_runtime` bitcode module during the merged link, CI build
-  // #53109. That bitcode shape no longer exists — the Rust side is one fat,
-  // pre-merged module since the CARGO_PROFILE_RELEASE_LTO=fat switch — so
-  // the gate was lifted; see the deleted "globalopt-crash-aarch64-musl"
-  // workarounds.ts entry if it ever needs to come back.)
+  // musl is gated too: with the ThinLTO switch the Rust side is back to
+  // per-CGU ThinLTO-summaried bitcode (CARGO_PROFILE_RELEASE_LTO=off), and
+  // rust-lld segfaults during the aarch64-musl bun-profile link — the same
+  // failure shape as the old "globalopt-crash-aarch64-musl" workarounds.ts
+  // entry (LLVM's `globalopt` segfaulted on the per-crate `bun_runtime`
+  // bitcode module during the merged link, CI build #53109). That gate had
+  // been lifted while the Rust side was one fat pre-merged module; the
+  // bitcode shape that crashes is back, so the gate is back. C++/WebKit
+  // still ThinLTO on musl — only the Rust bitcode stays out of the link.
   // Darwin cross uses the same rust-lld swap as ELF: rustc's sysroot ships
   // `gcc-ld/ld64.lld` (rust-lld in the Mach-O flavor, built against rustc's
   // LLVM), which findRustLld() already resolves for darwin targets, so the
   // newer-LLVM bitcode rustc emits under -Clinker-plugin-lto is readable at
   // link time. Windows cross does the same with the `gcc-ld/lld-link`
   // sibling (COFF flavor) — see the wantRustLld swap below.
-  const crossLangLto = lto && !(windows && host.os === "windows");
+  const crossLangLto = lto && !(windows && host.os === "windows") && abi !== "musl";
 
   // Cross-language LTO bitcode-version skew: `-Clinker-plugin-lto` makes
   // rustc emit raw LLVM bitcode into libbun_rust.a. LLVM bitcode is

--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,8 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "963f8758c29e965471c191668d5776a1a1b014b6";
+// Testing oven-sh/WebKit#246 (Linux LTO builds switched to ThinLTO).
+export const WEBKIT_VERSION = "autobuild-preview-pr-246-499040f7";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -472,30 +472,16 @@ export const globalFlags: Flag[] = [
     // WebKit macos -lto prebuilts and rustc's -Clinker-plugin-lto bitcode are
     // both ThinLTO-summaried, so this makes the whole link one uniform
     // ThinLTO graph with cross-module importing across C++/Rust/JSC
-    // boundaries. Darwin only for now — see the -flto=full entry below.
+    // boundaries.
+    //
+    // Linux: was on -flto=full because the ThinLTO backend pipeline
+    // miscompiled JSC (DFG-tier bug, repro `bun -e 'require("axobject-query")'`)
+    // — root-caused to int32 UB in parseInt's result handling, fixed in
+    // oven-sh/WebKit#246, which also switches the linux -lto prebuilts back
+    // to ThinLTO. This branch tests that configuration end to end.
     flag: "-flto=thin",
-    when: c => c.darwin && c.lto,
+    when: c => c.unix && c.lto,
     desc: "Thin link-time optimization",
-  },
-  {
-    // Linux stays on full LTO: the LLVM 22 ThinLTO backend pipeline
-    // (rust-lld) miscompiles JavaScriptCore on linux at every opt level
-    // above --lto-O0 — a JIT-tier correctness bug plus several bundler hangs
-    // in the test suite, on both x64 and aarch64, with cross-module
-    // importing disabled, ICF ruled out, and WPD ruled out. The same
-    // bitcode through ld64.lld on darwin is fine. Full LTO uses a different
-    // (regular-LTO) pass pipeline over one merged module and has shipped
-    // green for months. Cost: the link is serial (~14 min vs ~1.5 min).
-    // Rust<->C++ cross-language inlining still happens: the Rust side emits
-    // one fat, summary-less bitcode module (CARGO_PROFILE_RELEASE_LTO=fat
-    // under -Clinker-plugin-lto — see rust.ts) that joins the same
-    // regular-LTO partition as the C++, so nothing goes through the
-    // miscompiling ThinLTO backends. Revisit ThinLTO once the bad pass is
-    // isolated — the repro is `bun -e 'require("axobject-query")'` failing
-    // in the DFG tier.
-    flag: "-flto=full",
-    when: c => c.unix && !c.darwin && c.lto,
-    desc: "Full link-time optimization (linux: ThinLTO miscompiles JSC, see comment)",
   },
   {
     // Windows (cross) uses ThinLTO like darwin: clang-cl accepts -flto=thin
@@ -535,10 +521,11 @@ export const globalFlags: Flag[] = [
     // WebKit macos/windows -lto prebuilts, so this is the configuration that
     // can't drift. Windows: -fwhole-program-vtables is never passed there
     // (see above) so 0 is already the default — kept explicit so the
-    // ThinLTO graph can't drift if that ever changes. Not linux: full LTO
-    // (no per-module summaries, so the flag is meaningless there).
+    // ThinLTO graph can't drift if that ever changes. Linux: now ThinLTO
+    // too (oven-sh/WebKit#246 builds the linux -lto prebuilts with
+    // -fno-split-lto-unit, so every module must agree on 0).
     flag: "-fno-split-lto-unit",
-    when: c => (c.darwin || c.windows) && c.lto,
+    when: c => c.lto,
     desc: "Index-based WPD: keep type metadata in the ThinLTO summaries, no regular-LTO half",
   },
 
@@ -859,21 +846,21 @@ export const linkerFlags: Flag[] = [
     // only fires for classes explicitly annotated [[clang::lto_visibility]],
     // i.e. never. A static executable that only dlopens C-ABI addons (NAPI)
     // satisfies the whole-program assumption. ld64.lld has no named option
-    // for this; -mllvm reaches the underlying cl::opt directly. Darwin only:
-    // linux is on full LTO where this was never enabled.
+    // for this; -mllvm reaches the underlying cl::opt directly.
     flag: ["-Wl,-mllvm,-whole-program-visibility"],
     when: c => c.darwin && c.lto,
     desc: "Enable index-based whole-program devirtualization at link time",
   },
   {
-    flag: ["-flto=thin", "-fwhole-program-vtables", "-fforce-emit-vtables"],
-    when: c => c.darwin && c.lto,
-    desc: "LTO at link time (matches compile-side -flto=thin)",
+    // ELF lld has the named spelling for the same visibility upgrade.
+    flag: ["-Wl,--lto-whole-program-visibility"],
+    when: c => c.unix && !c.darwin && c.lto,
+    desc: "Enable index-based whole-program devirtualization at link time (ELF)",
   },
   {
-    flag: ["-flto=full", "-fwhole-program-vtables", "-fforce-emit-vtables"],
-    when: c => c.unix && !c.darwin && c.lto,
-    desc: "LTO at link time (matches compile-side -flto=full)",
+    flag: ["-flto=thin", "-fwhole-program-vtables", "-fforce-emit-vtables"],
+    when: c => c.unix && c.lto,
+    desc: "LTO at link time (matches compile-side -flto=thin)",
   },
   {
     // Without -O at link time, clang's driver defaults LTO codegen to -O2.

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -572,22 +572,14 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     //     -fwhole-program-vtables (COFF associative-COMDAT abort) and
     //     -fno-split-lto-unit is passed explicitly, so every C/C++ module is
     //     0 and rustc's default 0 matches — pass nothing.
-    //   - linux (full LTO): the regular-LTO summary clang writes on ELF
-    //     always says EnableSplitLTOUnit=1, so every C++ module (ours and
-    //     the WebKit -lto prebuilts) carries 1. The Rust modules'
-    //     EnableSplitLTOUnit module flag must say 1 to match →
-    //     -Zsplit-lto-unit. (The flag is stamped per-CGU at module
-    //     creation, survives rustc's fat-LTO pre-merge, and is what the
-    //     rust_lto_fix step's `opt --module-summary` copies into the
-    //     regular-LTO summary it bolts onto the merged module — see
-    //     rust-lto-fix-cli.ts.)
+    //   - linux (ThinLTO since oven-sh/WebKit#246): same as darwin — the
+    //     C/C++ side passes -fno-split-lto-unit explicitly, every module is
+    //     0, and rustc's default 0 matches — pass nothing.
     //
     // (`-Clink-arg=-fuse-ld=lld` is pushed unconditionally above — under LTO
     // it doubles as making rustc's bitcode link go through the LTO-aware
     // linker our final link uses, not BFD `/usr/bin/ld`.)
     if (!cfg.darwin && !cfg.windows) {
-      rustflags.push("-Zsplit-lto-unit");
-
       // Rust functions default to carrying the `uwtable(async)` attribute.
       // When the LTO inliner inlines such a callee into one of our C++
       // callers (compiled without unwind tables), the caller inherits the
@@ -673,28 +665,14 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
     // for non-LTO release builds, where the rust .a is linked as
     // already-codegen'd machine code and still wants intra-Rust inlining.)
     //
-    //   - darwin / windows cross (ThinLTO links): `off`. Each crate's
-    //     per-CGU bitcode keeps its ThinLTO summary, so the whole link is
-    //     one uniform ThinLTO graph and cross-module importing works across
-    //     Rust↔C++/JSC. `fat` would pre-merge the crates into one
-    //     summary-less blob the thin link can't import from (and rustc's
-    //     serial pre-merge is wasted work — the linker schedules the
-    //     backends itself).
-    //   - ELF (full-LTO link — see the -flto=full entry in flags.ts): `fat`.
-    //     rustc pre-merges every crate (including the prebuilt std's
-    //     embedded bitcode) into ONE summary-less regular-LTO module, which
-    //     lld then merges into the same regular-LTO partition as the C++
-    //     `-flto=full` objects — that merge is what gives Rust↔C++
-    //     cross-language inlining under full LTO. (The merged module first
-    //     gets a regular-LTO summary bolted on by the rust_lto_fix edge —
-    //     rustLtoLinkInputs() below — because lld's EnableSplitLTOUnit
-    //     consistency check requires one.) With `off`, the per-CGU
-    //     ThinLTO-summaried modules are processed as ThinLTO partitions
-    //     instead, which (a) never exchange function bodies with the C++
-    //     regular partition (no cross-language inlining at all), and
-    //     (b) go through the LLVM 22 ThinLTO backend pipeline that
-    //     miscompiles JSC on linux.
-    env.CARGO_PROFILE_RELEASE_LTO = cfg.darwin || cfg.windows ? "off" : "fat";
+    // All platforms are ThinLTO links now (linux switched with
+    // oven-sh/WebKit#246): `off`. Each crate's per-CGU bitcode keeps its
+    // ThinLTO summary, so the whole link is one uniform ThinLTO graph and
+    // cross-module importing works across Rust↔C++/JSC. `fat` would
+    // pre-merge the crates into one summary-less blob the thin link can't
+    // import from (and rustc's serial pre-merge is wasted work — the linker
+    // schedules the backends itself).
+    env.CARGO_PROFILE_RELEASE_LTO = "off";
   } else if (cfg.asan) {
     // release-asan has `cfg.lto` forced off (config.ts), but without this
     // override Cargo.toml's `[profile.release] lto = "fat"` still applies —
@@ -881,6 +859,11 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
  */
 export function rustLtoLinkInputs(n: Ninja, cfg: Config, rustObjects: string[]): string[] {
   const rustLib = rustObjects[0];
+  // ThinLTO everywhere (linux switched with oven-sh/WebKit#246): the Rust .a
+  // keeps per-CGU ThinLTO-summaried bitcode (CARGO_PROFILE_RELEASE_LTO=off),
+  // which lld consumes directly — the regular-LTO summary fix-up below only
+  // applied to the fat pre-merged module the full-LTO linux link used.
+  if (true as boolean) return rustObjects;
   if (!cfg.crossLangLto || cfg.darwin || cfg.windows || rustLib === undefined) return rustObjects;
   assert(
     cfg.rustSysroot !== undefined && cfg.host.rustTriple !== undefined,


### PR DESCRIPTION
Tests oven-sh/WebKit#246 (Linux LTO WebKit builds switched to ThinLTO, enabled by the parseInt int32 UB fix that was miscompiling JSC under the ThinLTO backend pipeline).

- Bumps `WEBKIT_VERSION` to the preview autobuild for that PR (`autobuild-preview-pr-246-499040f7`)
- Switches bun's Linux LTO build to ThinLTO to match: `-flto=thin` + `-fno-split-lto-unit` compile and link side, `-Wl,--lto-whole-program-visibility` for index-based WPD, Rust bitcode kept per-CGU ThinLTO-summaried (`CARGO_PROFILE_RELEASE_LTO=off`) instead of the fat pre-merge, and the regular-LTO summary fix-up step disabled

Do not merge until oven-sh/WebKit#246 lands on main and this is repointed at the resulting main-branch autobuild sha.