### PR TITLE
install: use a bitset for Lockfile.exact_pinned instead of Vec<bool>

### DIFF
--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1639,6 +1639,11 @@ impl DynamicBitSet {
         self.unmanaged.is_set(index)
     }
 
+    /// Like `is_set`, but returns `out_of_bounds` for indices past the end.
+    pub fn is_set_allow_out_of_bound(&self, index: usize, out_of_bounds: bool) -> bool {
+        self.unmanaged.is_set_allow_out_of_bound(index, out_of_bounds)
+    }
+
     /// Returns the total number of set bits in this bit set.
     pub fn count(&self) -> usize {
         self.unmanaged.count()

--- a/src/collections/bit_set.rs
+++ b/src/collections/bit_set.rs
@@ -1641,7 +1641,8 @@ impl DynamicBitSet {
 
     /// Like `is_set`, but returns `out_of_bounds` for indices past the end.
     pub fn is_set_allow_out_of_bound(&self, index: usize, out_of_bounds: bool) -> bool {
-        self.unmanaged.is_set_allow_out_of_bound(index, out_of_bounds)
+        self.unmanaged
+            .is_set_allow_out_of_bound(index, out_of_bounds)
     }
 
     /// Returns the total number of set bits in this bit set.

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -219,7 +219,7 @@ pub struct Lockfile {
     /// exact pin is a deliberate choice, not an artifact of which manifest
     /// happened to land first. Runtime-only — never serialised; sized lazily
     /// in `mark_exact_pin`.
-    pub exact_pinned: Vec<bool>,
+    pub exact_pinned: DynamicBitSet,
 }
 
 /// Zig: `Lockfile.Package.List` — `MultiArrayList(Package)`.
@@ -2125,7 +2125,7 @@ impl Lockfile {
             // session-appended, so the order-independence guard in
             // `get_package_id` applies from id 0.
             loaded_package_count: 0,
-            exact_pinned: Vec::new(),
+            exact_pinned: DynamicBitSet::default(),
         }
     }
 
@@ -2142,10 +2142,10 @@ impl Lockfile {
     #[inline]
     pub fn mark_exact_pin(&mut self, id: PackageID) {
         let i = id as usize;
-        if self.exact_pinned.len() <= i {
-            self.exact_pinned.resize(i + 1, false);
+        if self.exact_pinned.bit_length() <= i {
+            bun_core::handle_oom(self.exact_pinned.resize(i + 1, false));
         }
-        self.exact_pinned[i] = true;
+        self.exact_pinned.set(i);
     }
 
     pub fn get_package_id(
@@ -2184,7 +2184,7 @@ impl Lockfile {
         let buf = self.buffers.string_bytes.as_slice();
 
         let loaded_watermark = self.loaded_package_count;
-        let exact_pinned = self.exact_pinned.as_slice();
+        let exact_pinned = &self.exact_pinned;
         let try_satisfies_dedupe = |id: PackageID| -> bool {
             let existing = &resolutions[id as usize];
             if existing.tag != ResolutionTag::Npm {
@@ -2212,7 +2212,8 @@ impl Lockfile {
             // flake: a wide range (`*`, `>=X`) collapsing onto a sibling's
             // *range-resolved* lower major depending on whose manifest landed
             // first ("text lockfile is hoisted").
-            if id >= loaded_watermark && !exact_pinned.get(id as usize).copied().unwrap_or(false) {
+            if id >= loaded_watermark && !exact_pinned.is_set_allow_out_of_bound(id as usize, false)
+            {
                 if let Some(floor) = resolved_npm_floor {
                     if existing_ver.order(floor, buf, buf) == Ordering::Less
                         && existing_ver.major != floor.major


### PR DESCRIPTION
Replaces the runtime-only `Lockfile.exact_pinned: Vec<bool>` with `bun_collections::DynamicBitSet`, which packs the same per-package flag 8x denser and is already used throughout `bun_install`.

- `mark_exact_pin` keeps the lazy-sizing behavior (`resize(i + 1, false)` then `set(i)`), with OOM handled via `bun_core::handle_oom` since `DynamicBitSet::resize` is fallible.
- `get_package_id`'s order-independence guard now uses `is_set_allow_out_of_bound(id, false)`, matching the old `.get().copied().unwrap_or(false)` semantics for ids past the end.
- Adds an `is_set_allow_out_of_bound` delegate on `DynamicBitSet` — `DynamicBitSetUnmanaged` already had it, the managed wrapper just didn't expose it.

No behavior change.

Tested: `bun bd test test/cli/install/bun-install-registry.test.ts -t "dragon test"` (8 pass — includes "dragon test 2", which exercises the exact-pin dedupe path) and `test/cli/install/lockfile-only.test.ts` (2 pass).