### PR TITLE
node:async_hooks: assign AsyncResource a unique asyncId

### DIFF
--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -414,24 +414,7 @@ export function initializeNextTickQueue(
       // node fires one TickObject init per process.nextTick() call, at
       // construction time (before the callback runs).
       const asyncHooksTick = require("internal/async_hooks_tick");
-      const asyncId = asyncHooksTick.newAsyncId();
-      // Snapshot: enable()/disable() from inside a hook must not affect the
-      // in-flight dispatch (node stages such mutations in tmp_array until
-      // the emit completes).
-      const hooks = tickInitHooks.slice();
-      for (let i = 0; i < hooks.length; i++) {
-        try {
-          hooks[i](asyncId, "TickObject", 0, tock);
-        } catch (err) {
-          // node: a throwing init hook is fatal (fatalError: print + exit 1),
-          // never surfaced to the process.nextTick() caller. console is a
-          // user-mutable global, so shield the print; exit regardless.
-          try {
-            console.error(typeof err?.stack === "string" ? err.stack : err);
-          } catch {}
-          process.exit(1);
-        }
-      }
+      asyncHooksTick.emitInit(asyncHooksTick.newAsyncId(), "TickObject", 0, tock);
     }
     queue.push(tock);
     $putInternalField(nextTickQueue, 0, 1);

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -412,9 +412,10 @@ export function initializeNextTickQueue(
     };
     if (tickInitHooks.length !== 0) {
       // node fires one TickObject init per process.nextTick() call, at
-      // construction time (before the callback runs).
+      // construction time (before the callback runs), with the current
+      // execution async id as the trigger.
       const asyncHooksTick = require("internal/async_hooks_tick");
-      asyncHooksTick.emitInit(asyncHooksTick.newAsyncId(), "TickObject", 0, tock);
+      asyncHooksTick.emitInit(asyncHooksTick.newAsyncId(), "TickObject", asyncHooksTick.executionAsyncId(), tock);
     }
     queue.push(tock);
     $putInternalField(nextTickQueue, 0, 1);

--- a/src/js/internal/async_hooks_tick.ts
+++ b/src/js/internal/async_hooks_tick.ts
@@ -6,10 +6,27 @@
 const tickInitHooks = [];
 let nextAsyncId = 1;
 
+// Current scope's execution/trigger async ids: 1/0 at the root like Node.
+// AsyncResource.runInAsyncScope (node/async_hooks.ts) swaps in the resource's
+// ids; other async boundaries don't update them. Lives here so both `init`
+// emitters can report them.
+let currentExecutionAsyncId = 1;
+let currentTriggerAsyncId = 0;
+
 export default {
   tickInitHooks,
   newAsyncId() {
     return ++nextAsyncId;
+  },
+  executionAsyncId() {
+    return currentExecutionAsyncId;
+  },
+  triggerAsyncId() {
+    return currentTriggerAsyncId;
+  },
+  setCurrentAsyncIds(executionAsyncId, triggerAsyncId) {
+    currentExecutionAsyncId = executionAsyncId;
+    currentTriggerAsyncId = triggerAsyncId;
   },
   emitInit(asyncId, type, triggerAsyncId, resource) {
     // .slice(): enable()/disable() from inside a hook must not affect the

--- a/src/js/internal/async_hooks_tick.ts
+++ b/src/js/internal/async_hooks_tick.ts
@@ -1,14 +1,8 @@
-// Bridge between node:async_hooks createHook() and the places that emit
-// `init` events: the process.nextTick queue (builtins/ProcessObjectInternals.ts)
-// and the AsyncResource constructor (node/async_hooks.ts). Enabled `init`
-// hooks are pushed into `tickInitHooks` so emitters pay only an array-length
-// check when no hook is enabled.
-//
-// The array identity must stay stable (push/splice only, never reassign):
-// the nextTick closure captures it once at setup.
-//
-// Currently TickObject and AsyncResource `init` events are delivered;
-// promise, timer and native resource events are still unimplemented.
+// Bridge between node:async_hooks createHook() and the `init` emitters:
+// process.nextTick (builtins/ProcessObjectInternals.ts) and the AsyncResource
+// constructor. Emitters gate on tickInitHooks.length, so the hot paths pay
+// nothing when no hook is enabled. The array identity must stay stable
+// (push/splice only, never reassign): the nextTick closure captures it once.
 const tickInitHooks = [];
 let nextAsyncId = 1;
 
@@ -18,17 +12,15 @@ export default {
     return ++nextAsyncId;
   },
   emitInit(asyncId, type, triggerAsyncId, resource) {
-    // Snapshot: enable()/disable() from inside a hook must not affect the
-    // in-flight dispatch (node stages such mutations in tmp_array until
-    // the emit completes).
+    // .slice(): enable()/disable() from inside a hook must not affect the
+    // in-flight dispatch (node's tmp_array staging).
     const hooks = tickInitHooks.slice();
     for (let i = 0; i < hooks.length; i++) {
       try {
         hooks[i](asyncId, type, triggerAsyncId, resource);
       } catch (err) {
-        // node: a throwing init hook is fatal (fatalError: print + exit 1),
-        // never surfaced to the emitter's caller. console is a user-mutable
-        // global, so shield the print; exit regardless.
+        // node: a throwing init hook is fatal (print + exit 1), never
+        // surfaced to the emitter's caller.
         try {
           console.error(typeof err?.stack === "string" ? err.stack : err);
         } catch {}

--- a/src/js/internal/async_hooks_tick.ts
+++ b/src/js/internal/async_hooks_tick.ts
@@ -1,14 +1,14 @@
-// Bridge between node:async_hooks createHook() and the process.nextTick
-// queue (builtins/ProcessObjectInternals.ts). Enabled `init` hooks are pushed
-// into `tickInitHooks` so the nextTick hot path pays only an array-length
+// Bridge between node:async_hooks createHook() and the places that emit
+// `init` events: the process.nextTick queue (builtins/ProcessObjectInternals.ts)
+// and the AsyncResource constructor (node/async_hooks.ts). Enabled `init`
+// hooks are pushed into `tickInitHooks` so emitters pay only an array-length
 // check when no hook is enabled.
 //
 // The array identity must stay stable (push/splice only, never reassign):
 // the nextTick closure captures it once at setup.
 //
-// Currently only TickObject `init` events are delivered (enough for
-// console.log/stream.write tick-coalescing tests); promise, timer and native
-// resource events are still unimplemented.
+// Currently TickObject and AsyncResource `init` events are delivered;
+// promise, timer and native resource events are still unimplemented.
 const tickInitHooks = [];
 let nextAsyncId = 1;
 
@@ -16,5 +16,24 @@ export default {
   tickInitHooks,
   newAsyncId() {
     return ++nextAsyncId;
+  },
+  emitInit(asyncId, type, triggerAsyncId, resource) {
+    // Snapshot: enable()/disable() from inside a hook must not affect the
+    // in-flight dispatch (node stages such mutations in tmp_array until
+    // the emit completes).
+    const hooks = tickInitHooks.slice();
+    for (let i = 0; i < hooks.length; i++) {
+      try {
+        hooks[i](asyncId, type, triggerAsyncId, resource);
+      } catch (err) {
+        // node: a throwing init hook is fatal (fatalError: print + exit 1),
+        // never surfaced to the emitter's caller. console is a user-mutable
+        // global, so shield the print; exit regardless.
+        try {
+          console.error(typeof err?.stack === "string" ? err.stack : err);
+        } catch {}
+        process.exit(1);
+      }
+    }
   },
 };

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -354,12 +354,9 @@ if (IS_BUN_DEVELOPMENT) {
   };
 }
 
-// The execution/trigger async ids of the current scope. Node reports
-// executionAsyncId() === 1 (root) and triggerAsyncId() === 0 at the top
-// level. AsyncResource.prototype.runInAsyncScope swaps these to the
-// resource's ids for the duration of the callback, keeping the invariant
-// that inside a scope `executionAsyncId() === resource.asyncId()`. Promise,
-// timer and native resource boundaries still do not update them.
+// Current scope's execution/trigger async ids: 1/0 at the root like Node.
+// runInAsyncScope swaps in the resource's ids so `executionAsyncId() ===
+// resource.asyncId()` inside a scope; other async boundaries don't update them.
 let currentExecutionAsyncId = 1;
 let currentTriggerAsyncId = 0;
 
@@ -372,9 +369,7 @@ class AsyncResource {
   constructor(type, opts?) {
     validateString(type, "type");
 
-    // Node defaults to getDefaultTriggerAsyncId() (the current execution
-    // async id): 1 at the top level, or the enclosing resource's id inside a
-    // runInAsyncScope.
+    // Node defaults to getDefaultTriggerAsyncId(), the current execution async id.
     let triggerAsyncId =
       typeof opts === "number"
         ? opts

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -354,17 +354,33 @@ if (IS_BUN_DEVELOPMENT) {
   };
 }
 
+// The execution/trigger async ids of the current scope. Node reports
+// executionAsyncId() === 1 (root) and triggerAsyncId() === 0 at the top
+// level. AsyncResource.prototype.runInAsyncScope swaps these to the
+// resource's ids for the duration of the callback, keeping the invariant
+// that inside a scope `executionAsyncId() === resource.asyncId()`. Promise,
+// timer and native resource boundaries still do not update them.
+let currentExecutionAsyncId = 1;
+let currentTriggerAsyncId = 0;
+
 class AsyncResource {
   type;
   #snapshot;
+  #asyncId;
   #triggerAsyncId;
 
   constructor(type, opts?) {
     validateString(type, "type");
 
-    // Node defaults to getDefaultTriggerAsyncId() (the current execution async
-    // id); Bun does not track async ids, so its executionAsyncId() is 0.
-    let triggerAsyncId = typeof opts === "number" ? opts : opts?.triggerAsyncId === undefined ? 0 : opts.triggerAsyncId;
+    // Node defaults to getDefaultTriggerAsyncId() (the current execution
+    // async id): 1 at the top level, or the enclosing resource's id inside a
+    // runInAsyncScope.
+    let triggerAsyncId =
+      typeof opts === "number"
+        ? opts
+        : opts?.triggerAsyncId === undefined
+          ? currentExecutionAsyncId
+          : opts.triggerAsyncId;
     if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < -1) {
       throw $ERR_INVALID_ASYNC_ID("triggerAsyncId", triggerAsyncId);
     }
@@ -375,7 +391,12 @@ class AsyncResource {
     setAsyncHooksEnabled(true);
     this.type = type;
     this.#snapshot = get();
+    const asyncHooksTick = require("internal/async_hooks_tick");
+    this.#asyncId = asyncHooksTick.newAsyncId();
     this.#triggerAsyncId = triggerAsyncId;
+    if (asyncHooksTick.tickInitHooks.length !== 0) {
+      asyncHooksTick.emitInit(this.#asyncId, type, triggerAsyncId, this);
+    }
   }
 
   emitBefore() {
@@ -387,7 +408,7 @@ class AsyncResource {
   }
 
   asyncId() {
-    return 0;
+    return this.#asyncId;
   }
 
   triggerAsyncId() {
@@ -395,16 +416,22 @@ class AsyncResource {
   }
 
   emitDestroy() {
-    //
+    return this;
   }
 
   runInAsyncScope(fn, thisArg, ...args) {
     var prev = get();
+    const prevExecutionAsyncId = currentExecutionAsyncId;
+    const prevTriggerAsyncId = currentTriggerAsyncId;
     set(this.#snapshot);
+    currentExecutionAsyncId = this.#asyncId;
+    currentTriggerAsyncId = this.#triggerAsyncId;
     try {
       return fn.$apply(thisArg, args);
     } finally {
       set(prev);
+      currentExecutionAsyncId = prevExecutionAsyncId;
+      currentTriggerAsyncId = prevTriggerAsyncId;
     }
   }
 
@@ -534,15 +561,15 @@ function createHook(hook) {
 }
 
 const executionAsyncIdNotImpl = createWarning(
-  "async_hooks.executionAsyncId/triggerAsyncId are not implemented in Bun. It will return 0 every time.",
+  "async_hooks.executionAsyncId/triggerAsyncId are only partially implemented in Bun. They track AsyncResource.runInAsyncScope but not other async boundaries.",
 );
 function executionAsyncId() {
   executionAsyncIdNotImpl();
-  return 0;
+  return currentExecutionAsyncId;
 }
 
 function triggerAsyncId() {
-  return 0;
+  return currentTriggerAsyncId;
 }
 
 const executionAsyncResourceWarning = createWarning(

--- a/src/js/node/async_hooks.ts
+++ b/src/js/node/async_hooks.ts
@@ -354,11 +354,11 @@ if (IS_BUN_DEVELOPMENT) {
   };
 }
 
-// Current scope's execution/trigger async ids: 1/0 at the root like Node.
-// runInAsyncScope swaps in the resource's ids so `executionAsyncId() ===
-// resource.asyncId()` inside a scope; other async boundaries don't update them.
-let currentExecutionAsyncId = 1;
-let currentTriggerAsyncId = 0;
+// The current execution/trigger async ids live in internal/async_hooks_tick
+// so the TickObject init emitter can report them too. runInAsyncScope swaps
+// in the resource's ids so `executionAsyncId() === resource.asyncId()` inside
+// a scope; other async boundaries don't update them.
+const asyncHooksTick = require("internal/async_hooks_tick");
 
 class AsyncResource {
   type;
@@ -374,7 +374,7 @@ class AsyncResource {
       typeof opts === "number"
         ? opts
         : opts?.triggerAsyncId === undefined
-          ? currentExecutionAsyncId
+          ? asyncHooksTick.executionAsyncId()
           : opts.triggerAsyncId;
     if (!Number.isSafeInteger(triggerAsyncId) || triggerAsyncId < -1) {
       throw $ERR_INVALID_ASYNC_ID("triggerAsyncId", triggerAsyncId);
@@ -386,7 +386,6 @@ class AsyncResource {
     setAsyncHooksEnabled(true);
     this.type = type;
     this.#snapshot = get();
-    const asyncHooksTick = require("internal/async_hooks_tick");
     this.#asyncId = asyncHooksTick.newAsyncId();
     this.#triggerAsyncId = triggerAsyncId;
     if (asyncHooksTick.tickInitHooks.length !== 0) {
@@ -416,17 +415,15 @@ class AsyncResource {
 
   runInAsyncScope(fn, thisArg, ...args) {
     var prev = get();
-    const prevExecutionAsyncId = currentExecutionAsyncId;
-    const prevTriggerAsyncId = currentTriggerAsyncId;
+    const prevExecutionAsyncId = asyncHooksTick.executionAsyncId();
+    const prevTriggerAsyncId = asyncHooksTick.triggerAsyncId();
     set(this.#snapshot);
-    currentExecutionAsyncId = this.#asyncId;
-    currentTriggerAsyncId = this.#triggerAsyncId;
+    asyncHooksTick.setCurrentAsyncIds(this.#asyncId, this.#triggerAsyncId);
     try {
       return fn.$apply(thisArg, args);
     } finally {
       set(prev);
-      currentExecutionAsyncId = prevExecutionAsyncId;
-      currentTriggerAsyncId = prevTriggerAsyncId;
+      asyncHooksTick.setCurrentAsyncIds(prevExecutionAsyncId, prevTriggerAsyncId);
     }
   }
 
@@ -520,8 +517,6 @@ function createHook(hook) {
   return {
     enable() {
       if (init !== undefined && enabledInit === undefined) {
-        // init is delivered for TickObject resources (process.nextTick);
-        // other resource types are still unimplemented.
         // Per-instance wrapper: two hooks registered with the same init
         // function must stay independently removable (removal is by
         // identity, and removing the other instance's entry would reorder
@@ -560,11 +555,11 @@ const executionAsyncIdNotImpl = createWarning(
 );
 function executionAsyncId() {
   executionAsyncIdNotImpl();
-  return currentExecutionAsyncId;
+  return asyncHooksTick.executionAsyncId();
 }
 
 function triggerAsyncId() {
-  return currentTriggerAsyncId;
+  return asyncHooksTick.triggerAsyncId();
 }
 
 const executionAsyncResourceWarning = createWarning(

--- a/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
+++ b/test/js/node/async_hooks/EventEmitterAsyncResource.test.ts
@@ -8,13 +8,14 @@ describe("EventEmitterAsyncResource", () => {
     expect(ee).toBeInstanceOf(EventEmitterAsyncResource);
     expect(ee).toBeInstanceOf(EventEmitter);
   });
-  // triggerAsyncId echoes the constructor option like Node; Bun's default execution async id is 0.
+  // triggerAsyncId echoes the constructor option like Node; the default is the
+  // current executionAsyncId(), which is 1 at the top level.
   test("triggerAsyncId reflects the option", () => {
     expect(new EventEmitterAsyncResource({ name: "x", triggerAsyncId: 7 }).triggerAsyncId).toBe(7);
-    expect(new EventEmitterAsyncResource({ name: "x" }).triggerAsyncId).toBe(0);
+    expect(new EventEmitterAsyncResource({ name: "x" }).triggerAsyncId).toBe(1);
     expect(new AsyncResource("x", { triggerAsyncId: 7 }).triggerAsyncId()).toBe(7);
     expect(new AsyncResource("x", 7).triggerAsyncId()).toBe(7);
-    expect(new AsyncResource("x").triggerAsyncId()).toBe(0);
+    expect(new AsyncResource("x").triggerAsyncId()).toBe(1);
     let err;
     try {
       new EventEmitterAsyncResource({ name: "x", triggerAsyncId: -2 });

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { AsyncLocalStorage, AsyncResource } from "async_hooks";
+import { AsyncLocalStorage, AsyncResource, createHook, executionAsyncId, triggerAsyncId } from "async_hooks";
 
 test("node async_hooks.AsyncLocalStorage enable disable", async done => {
   const asyncLocalStorage = new AsyncLocalStorage<Map<string, any>>();
@@ -86,4 +86,79 @@ test("AsyncResource.bind", () => {
     fn = AsyncResource.bind(() => localStorage.getStore());
   });
   expect(fn()).toBe(true);
+});
+
+// https://github.com/oven-sh/bun/issues/31709
+test("AsyncResource.prototype.asyncId returns a unique, monotonically increasing id", () => {
+  const a = new AsyncResource("MY_ASYNC_RESOURCE");
+  const b = new AsyncResource("MY_ASYNC_RESOURCE");
+
+  // Each resource gets a positive integer id (0 was the old stub value).
+  expect(a.asyncId()).toBeGreaterThan(0);
+  expect(Number.isSafeInteger(a.asyncId())).toBe(true);
+
+  // Ids are unique and increase for later resources.
+  expect(b.asyncId()).toBeGreaterThan(a.asyncId());
+
+  // asyncId() is stable across calls, including after emitDestroy().
+  const id = a.asyncId();
+  a.emitDestroy();
+  expect(a.asyncId()).toBe(id);
+  expect(a.asyncId()).toBe(id);
+});
+
+test("AsyncResource.prototype.emitDestroy returns the resource", () => {
+  const a = new AsyncResource("T");
+  expect(a.emitDestroy()).toBe(a);
+  // Repeated calls keep returning the resource.
+  expect(a.emitDestroy()).toBe(a);
+});
+
+test("runInAsyncScope makes executionAsyncId()/triggerAsyncId() match the resource", () => {
+  const a = new AsyncResource("foobar");
+
+  // At the top level Node reports executionAsyncId() === 1 (root).
+  const outerExecutionId = executionAsyncId();
+  expect(outerExecutionId).toBe(1);
+
+  a.runInAsyncScope(() => {
+    // Inside the scope, the free functions report the resource's (non-zero) ids.
+    expect(executionAsyncId()).toBeGreaterThan(1);
+    expect(executionAsyncId()).toBe(a.asyncId());
+    expect(triggerAsyncId()).toBe(a.triggerAsyncId());
+
+    // A resource created inside the scope inherits the current executionAsyncId()
+    // as its triggerAsyncId, whether or not an options object is passed.
+    const b = new AsyncResource("bar");
+    const c = new AsyncResource("baz", {});
+    expect(b.triggerAsyncId()).toBe(a.asyncId());
+    expect(c.triggerAsyncId()).toBe(a.asyncId());
+
+    // Nesting restores correctly on exit.
+    b.runInAsyncScope(() => {
+      expect(executionAsyncId()).toBe(b.asyncId());
+      expect(triggerAsyncId()).toBe(b.triggerAsyncId());
+    });
+    expect(executionAsyncId()).toBe(a.asyncId());
+  });
+
+  // Restored to the outer value once the scope exits.
+  expect(executionAsyncId()).toBe(outerExecutionId);
+});
+
+test("createHook init fires for AsyncResource construction", () => {
+  const events: Array<{ asyncId: number; type: string; triggerAsyncId: number; resource: unknown }> = [];
+  const hook = createHook({
+    init(asyncId, type, triggerAsyncId, resource) {
+      if (type === "MY_HOOKED_RESOURCE") events.push({ asyncId, type, triggerAsyncId, resource });
+    },
+  }).enable();
+  try {
+    const a = new AsyncResource("MY_HOOKED_RESOURCE");
+    expect(events).toEqual([
+      { asyncId: a.asyncId(), type: "MY_HOOKED_RESOURCE", triggerAsyncId: a.triggerAsyncId(), resource: a },
+    ]);
+  } finally {
+    hook.disable();
+  }
 });

--- a/test/js/node/async_hooks/async_hooks.node.test.ts
+++ b/test/js/node/async_hooks/async_hooks.node.test.ts
@@ -162,3 +162,27 @@ test("createHook init fires for AsyncResource construction", () => {
     hook.disable();
   }
 });
+
+test("TickObject init receives the current executionAsyncId as its triggerAsyncId", async () => {
+  const triggers: number[] = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const hook = createHook({
+    init(asyncId, type, triggerAsyncId, resource) {
+      // Match our tick exactly; the runtime may schedule unrelated ticks.
+      if (type === "TickObject" && (resource as { callback?: unknown })?.callback === resolve) {
+        triggers.push(triggerAsyncId);
+      }
+    },
+  }).enable();
+  try {
+    const a = new AsyncResource("T");
+    expect(a.asyncId()).toBeGreaterThan(1);
+    a.runInAsyncScope(() => {
+      process.nextTick(resolve);
+    });
+    await promise;
+    expect(triggers).toEqual([a.asyncId()]);
+  } finally {
+    hook.disable();
+  }
+});


### PR DESCRIPTION
Fixes #31709

### Problem

- `AsyncResource.prototype.asyncId()` was a hardcoded `return 0` stub, and `emitDestroy()` returned `undefined`. Node assigns each resource a unique, monotonically increasing async id and returns the resource from `emitDestroy()`.
- Repro from the issue: `new AsyncResource("MY_ASYNC_RESOURCE").asyncId()` prints `0` in Bun, `2` in Node.
- The free `executionAsyncId()` / `triggerAsyncId()` were also `0` stubs, and `test-async-hooks-recursive-stack-runInAsyncScope.js` only passed because both sides of its `asyncId() === executionAsyncId()` assertion were equally stubbed.

### Fix

- Assign `AsyncResource` ids from the shared counter in `internal/async_hooks_tick` (the one `process.nextTick` already uses for TickObject ids), so ids stay unique across resource kinds.
- Emit `createHook` `init` events for `AsyncResource` construction through a shared `emitInit` helper; the nextTick path now uses the same helper instead of its own inlined loop.
- Track the current execution/trigger async id across `runInAsyncScope` (1/0 at the root, matching Node) and return them from `executionAsyncId()` / `triggerAsyncId()`, so `executionAsyncId() === resource.asyncId()` holds inside a scope.
- Default `triggerAsyncId` to the current `executionAsyncId()` in all constructor forms (no opts, `{}`, object without the field), matching Node's `getDefaultTriggerAsyncId()`.
- `emitDestroy()` returns `this`.

### Verification

- New tests in `test/js/node/async_hooks/async_hooks.node.test.ts`: id uniqueness/monotonicity/stability, `emitDestroy` return value, the `runInAsyncScope` id invariant with nesting, and `createHook` init firing for `AsyncResource`. All fail on the unfixed binary and pass with this change.
- `test/js/node/async_hooks/EventEmitterAsyncResource.test.ts`: default `triggerAsyncId` expectation updated from `0` to `1` (Node's root execution id).
- Node reference tests pass: `test-async-hooks-recursive-stack-runInAsyncScope.js` (now passes for the right reason), `test-asyncresource-bind.js`, `test-async-hooks-asyncresource-constructor.js`, `test-eventemitter-asyncresource.js`, `test-stream-finished-bindAsyncResource-path.js`, `test-stream-writable-samecb-singletick.js`, `test-emit-after-uncaught-exception.js`.
- Full `test/js/node/async_hooks/` suite and `process-nexttick` tests pass.

### Background

- An async id is the number Node gives every async resource so `async_hooks` consumers can correlate `init`/`before`/`after`/`destroy` events; `executionAsyncId()` names the resource whose callback is currently running, and `triggerAsyncId()` names the resource that caused it to be created. Ids `0` and `1` are reserved (unset and root).
- `runInAsyncScope(fn)` runs `fn` as if it were a callback of that resource, so inside it `executionAsyncId()` must equal the resource's own id; Bun implements this by saving/restoring two module-level variables around the call, with no cost on other paths.
- Bun's `createHook` only delivers `init` for TickObject (process.nextTick) and now AsyncResource; promise, timer, and native resource events remain unimplemented, and the one-time warning says so.

<details>
<summary>Rebase notes (conflicts with main resolved)</summary>

The PR was rebased after main independently reworked the same areas. Superseded parts of the original diff were dropped:

- `EventEmitterAsyncResource` in `events.ts` was rewritten on main with delegating `asyncId`/`triggerAsyncId` getters over a private `#asyncResource`, which is what earlier revisions of this PR added. This PR no longer touches `events.ts`; the getters now surface real ids automatically.
- main added a real `createHook` with a `tickInitHooks` registry and a shared id counter for TickObject events (`internal/async_hooks_tick`). Instead of a second module-level counter, this PR reuses that counter for `AsyncResource` ids (a comment on main explicitly deferred wiring `AsyncResource` up to it) and extracts the init-dispatch loop into `emitInit` so both emitters share it.
- `AsyncResource.bind` on main gained Node's `length`/receiver semantics; unchanged here.

Original (pre-rebase) verification table against Node v24: `new AsyncResource("T").asyncId()` → 2, second resource → 3, `triggerAsyncId()` default → 1, `{ triggerAsyncId: 42 }` → 42, numeric opts `7` → 7, `a.emitDestroy() === a` → true, id stable after destroy → true.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 6 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/EventEmitterAsyncResource.test.ts test/js/node/async_hooks/async_hooks.node.test.ts
bun test v1.4.0 (07d38c171)

test/js/node/async_hooks/async_hooks.node.test.ts:
(pass) node async_hooks.AsyncLocalStorage enable disable [205.66ms]
(pass) node async_hooks.AsyncLocalStorage enable disable multiple times [37.55ms]
(pass) AsyncResource.prototype.bind [32.62ms]
(pass) AsyncResource.bind [18.08ms]
92 | test("AsyncResource.prototype.asyncId returns a unique, monotonically increasing id", () => {
93 |   const a = new AsyncResource("MY_ASYNC_RESOURCE");
94 |   const b = new AsyncResource("MY_ASYNC_RESOURCE");
95 | 
96 |   // Each resource gets a positive integer id (0 was the old stub value).
97 |   expect(a.asyncId()).toBeGreaterThan(0);
                           ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 0
Received: 0

      at <anonymous> (/workspace/bun/test/js/node/async_hooks/async_hooks.node.test.ts:97:23)
(fail) AsyncResource.prototype.asyncId returns a unique, monotonically increasing id
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (005c65502)

test/js/node/async_hooks/async_hooks.node.test.ts:
(pass) node async_hooks.AsyncLocalStorage enable disable [0.83ms]
(pass) node async_hooks.AsyncLocalStorage enable disable multiple times [0.26ms]
(pass) AsyncResource.prototype.bind [0.27ms]
(pass) AsyncResource.bind [0.07ms]
(pass) AsyncResource.prototype.asyncId returns a unique, monotonically increasing id [0.05ms]
(pass) AsyncResource.prototype.emitDestroy returns the resource [0.02ms]
(pass) runInAsyncScope makes executionAsyncId()/triggerAsyncId() match the resource [0.18ms]
(pass) createHook init fires for AsyncResource construction [0.31ms]
179 |     expect(a.asyncId()).toBeGreaterThan(1);
180 |     a.runInAsyncScope(() => {
181 |       process.nextTick(resolve);
182 |     });
183 |     await promise;
184 |     expect(triggers).toEqual([a.asyncId()]);
                           ^
error: expect(received).toEqual(expected)

  [
-   11,
+   0,
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/node/async_hooks/async_hooks.node.test.ts:184:22)
(fail) TickObject init receives the current executionAsyncId as its triggerAsyncId [0.37ms]

test/js
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/async_hooks/EventEmitterAsyncResource.test.ts test/js/node/async_hooks/async_hooks.node.test.ts
bun test v1.4.0 (07d38c171)

test/js/node/async_hooks/async_hooks.node.test.ts:
(pass) node async_hooks.AsyncLocalStorage enable disable [248.32ms]
(pass) node async_hooks.AsyncLocalStorage enable disable multiple times [41.02ms]
(pass) AsyncResource.prototype.bind [41.34ms]
(pass) AsyncResource.bind [17.81ms]
(pass) AsyncResource.prototype.asyncId returns a unique, monotonically increasing id [7.97ms]
(pass) AsyncResource.prototype.emitDestroy returns the resource [3.29ms]
(pass) runInAsyncScope makes executionAsyncId()/triggerAsyncId() match the resource [24.94ms]
(pass) createHook init fires for AsyncResource construction [31.28ms]
(pass) TickObject init receives the current executionAsyncId as its triggerAsyncId [19.95ms]

test/js/node/async_hooks/EventEmitterAsyncResource.test.ts:
(pass) EventEmitterAsyncResource > is an EventEmitter [26.99ms]
(pass) EventEmitterAsyncResource > triggerAsyncId reflects the option [19.44ms]
(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 917ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen cpp.rs (cppbind)
[2/22] gen JS modules (bundle-modules)
Preprocess modules (15394ms)
Bundle modules (279ms)
Postprocesss modules (482ms)
Bundle Functions (1427ms)
Generate Code (41ms)

[17.66s] Bundled "src/js" for production
  2632 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[2/10] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/car
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/builtins/ProcessObjectInternals.ts          |  22 +----
 src/js/internal/async_hooks_tick.ts                |  50 +++++++---
 src/js/node/async_hooks.ts                         |  37 ++++++--
 .../async_hooks/EventEmitterAsyncResource.test.ts  |   7 +-
 test/js/node/async_hooks/async_hooks.node.test.ts  | 101 ++++++++++++++++++++-
 5 files changed, 173 insertions(+), 44 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/builtins/ProcessObjectInternals.ts                     2      3     19
src/js/internal/async_hooks_tick.ts                           3      4     19
src/js/node/async_hooks.ts                                   10     16     19
…t/js/node/async_hooks/EventEmitterAsyncResource.test.ts      3      4     10
test/js/node/async_hooks/async_hooks.node.test.ts             6     10     17
```

</details>

**root cause** · written by the author bot

Bun's AsyncResource stubbed out async id tracking, so the constructor never generated an id and asyncId() and triggerAsyncId() always returned 0, unlike Node where each resource gets a unique monotonic id. The fix adds a module-level id generator starting at 2, has the AsyncResource constructor store its generated async id and the caller's trigger id in private fields, and makes the instance methods return those stored values. The current execution and trigger ids now live in shared internal state that runInAsyncScope swaps in, so executionAsyncId() and async_hooks init events report consis…

<!-- robobun:evidence:end -->