### PR TITLE
ipc: pass net.Server and net.Socket handles over send(message, handle)

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -450,6 +450,14 @@ struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *g
         return 0;
     }
 
+    /* A listening net.Server socket is always SOCK_STREAM (TCP or unix). Reject
+     * SOCK_DGRAM/SOCK_RAW here — on macOS the SO_ACCEPTCONN check below is
+     * compiled out, so this is the only guard that catches a non-stream fd. */
+    if (socktype != SOCK_STREAM) {
+        *error = EINVAL;
+        return 0;
+    }
+
     /* Reject a socket that is not listening. SO_ACCEPTCONN is reliable on Linux
      * but NOT on macOS/BSD — there it can report 0 for a genuinely-listening fd
      * that was inherited/duplicated (e.g. over SCM_RIGHTS), so only treat a 0 as

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -420,6 +420,75 @@ struct us_listen_socket_t *us_socket_group_listen_unix(struct us_socket_group_t 
     return ls;
 }
 
+/* Adopt an already-listening file descriptor (inherited from a parent process
+ * or received over IPC via SCM_RIGHTS) as a listen socket, rather than
+ * creating+binding a new one. The fd must already be a socket in the LISTEN
+ * state. On success the group owns the fd (us_listen_socket_close closes it);
+ * on failure the caller keeps it, and an errno is written into *error:
+ * ENOTSOCK if the fd is not a socket, EINVAL if it is a socket but
+ * (verifiably) not listening. */
+struct us_listen_socket_t *us_socket_group_listen_fd(struct us_socket_group_t *group,
+        unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+        LIBUS_SOCKET_DESCRIPTOR fd, int options, int socket_ext_size, int *error) {
+#if defined(LIBUS_USE_LIBUV) || defined(WIN32)
+    (void) group; (void) kind; (void) ssl_ctx; (void) fd; (void) options; (void) socket_ext_size;
+    *error = EINVAL;
+    return 0;
+#else
+    if (fd == LIBUS_SOCKET_ERROR) {
+        *error = EINVAL;
+        return 0;
+    }
+
+    /* The fd must at least be a socket. getsockopt(SO_TYPE) fails with ENOTSOCK
+     * on a non-socket fd (e.g. stdin) and EBADF on a closed one, on both Linux
+     * and macOS — this is what rejects `listen({ fd: 0 })`. */
+    int socktype = 0;
+    socklen_t typelen = sizeof(socktype);
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, (void *) &socktype, &typelen) != 0) {
+        *error = errno ? errno : ENOTSOCK;
+        return 0;
+    }
+
+    /* Reject a socket that is not listening. SO_ACCEPTCONN is reliable on Linux
+     * but NOT on macOS/BSD — there it can report 0 for a genuinely-listening fd
+     * that was inherited/duplicated (e.g. over SCM_RIGHTS), so only treat a 0 as
+     * fatal where the query is trustworthy. A non-listening socket on macOS
+     * surfaces EINVAL from accept() instead, which Node's contract allows. */
+#if defined(SO_ACCEPTCONN) && !defined(__APPLE__)
+    int accepting = 0;
+    socklen_t optlen = sizeof(accepting);
+    if (getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, (void *) &accepting, &optlen) == 0 && !accepting) {
+        *error = EINVAL;
+        return 0;
+    }
+#endif
+
+    /* The fd arrives from another process; normalize the flags we rely on. */
+    apple_no_sigpipe(fd);
+    bsd_set_nonblocking(fd);
+
+    struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
+    us_poll_init(p, fd, POLL_TYPE_SEMI_SOCKET);
+    /* Mirror us_socket_from_fd: honor the epoll_ctl/kevent return code so a
+     * registration failure is reported rather than yielding a dead listener. */
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
+        *error = errno ? errno : EINVAL;
+        us_poll_free(p, group->loop);
+        return 0;
+    }
+
+    struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
+    us_internal_init_listen_socket(ls, group, kind, ssl_ctx, options, socket_ext_size);
+
+    if (options & LIBUS_LISTEN_DEFER_ACCEPT) {
+        ls->deferred_accept = bsd_set_defer_accept(fd);
+    }
+
+    return ls;
+#endif
+}
+
 void us_listen_socket_close(struct us_listen_socket_t *ls) {
     struct us_socket_t *s = &ls->s;
     if (!us_socket_is_closed(s)) {

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -343,6 +343,14 @@ struct us_listen_socket_t *us_socket_group_listen_unix(us_socket_group_r group,
     unsigned char kind, struct ssl_ctx_st *ssl_ctx,
     const char *path, size_t pathlen, int options, int socket_ext_size, int *error)
     __attribute__((nonnull(1, 4, 8)));  /* ssl_ctx nullable */
+/* Adopt an already-listening fd (inherited from a parent process or received
+ * over IPC via SCM_RIGHTS) instead of creating+binding a new one. POSIX only;
+ * on success the group owns the fd (us_listen_socket_close closes it). On
+ * failure returns NULL and writes ENOTSOCK/EINVAL into *error. */
+struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
+    unsigned char kind, struct ssl_ctx_st *ssl_ctx,
+    LIBUS_SOCKET_DESCRIPTOR fd, int options, int socket_ext_size, int *error)
+    __attribute__((nonnull(1, 7)));  /* ssl_ctx nullable */
 void us_listen_socket_close(struct us_listen_socket_t *ls) nonnull_fn_decl;
 
 /* SNI: tree hangs off the listen socket. ssl_ctx is up_ref'd; user is opaque

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -346,7 +346,9 @@ struct us_listen_socket_t *us_socket_group_listen_unix(us_socket_group_r group,
 /* Adopt an already-listening fd (inherited from a parent process or received
  * over IPC via SCM_RIGHTS) instead of creating+binding a new one. POSIX only;
  * on success the group owns the fd (us_listen_socket_close closes it). On
- * failure returns NULL and writes ENOTSOCK/EINVAL into *error. */
+ * failure returns NULL and writes an errno into *error: ENOTSOCK/EINVAL for the
+ * common validation failures, plus any propagated errno (e.g. EBADF from the
+ * SO_TYPE probe, or a poll-registration error). */
 struct us_listen_socket_t *us_socket_group_listen_fd(us_socket_group_r group,
     unsigned char kind, struct ssl_ctx_st *ssl_ctx,
     LIBUS_SOCKET_DESCRIPTOR fd, int options, int socket_ext_size, int *error)

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -1,236 +1,112 @@
-// for net.Server, get ._handle
-
-// const handleConversion = {
-//   "net.Server": {
-//     simultaneousAccepts: true,
-
-//     send(message, server, options) {
-//       return server._handle;
-//     },
-
-//     got(message, handle, emit) {
-//       const server = new net.Server();
-//       server.listen(handle, () => {
-//         emit(server);
-//       });
-//     },
-//   },
-
-//   "net.Socket": {
-//     send(message, socket, options) {
-//       if (!socket._handle) return;
-
-//       // If the socket was created by net.Server
-//       if (socket.server) {
-//         // The worker should keep track of the socket
-//         message.key = socket.server._connectionKey;
-
-//         const firstTime = !this[kChannelHandle].sockets.send[message.key];
-//         const socketList = getSocketList("send", this, message.key);
-
-//         // The server should no longer expose a .connection property
-//         // and when asked to close it should query the socket status from
-//         // the workers
-//         if (firstTime) socket.server._setupWorker(socketList);
-
-//         // Act like socket is detached
-//         if (!options.keepOpen) socket.server._connections--;
-//       }
-
-//       const handle = socket._handle;
-
-//       // Remove handle from socket object, it will be closed when the socket
-//       // will be sent
-//       if (!options.keepOpen) {
-//         handle.onread = nop;
-//         socket._handle = null;
-//         socket.setTimeout(0);
-
-//         if (freeParser === undefined) freeParser = require("_http_common").freeParser;
-//         if (HTTPParser === undefined) HTTPParser = require("_http_common").HTTPParser;
-
-//         // In case of an HTTP connection socket, release the associated
-//         // resources
-//         if (socket.parser && socket.parser instanceof HTTPParser) {
-//           freeParser(socket.parser, null, socket);
-//           if (socket._httpMessage) socket._httpMessage.detachSocket(socket);
-//         }
-//       }
-
-//       return handle;
-//     },
-
-//     postSend(message, handle, options, callback, target) {
-//       // Store the handle after successfully sending it, so it can be closed
-//       // when the NODE_HANDLE_ACK is received. If the handle could not be sent,
-//       // just close it.
-//       if (handle && !options.keepOpen) {
-//         if (target) {
-//           // There can only be one _pendingMessage as passing handles are
-//           // processed one at a time: handles are stored in _handleQueue while
-//           // waiting for the NODE_HANDLE_ACK of the current passing handle.
-//           assert(!target._pendingMessage);
-//           target._pendingMessage = { callback, message, handle, options, retransmissions: 0 };
-//         } else {
-//           handle.close();
-//         }
-//       }
-//     // NOTE that another function will call _pendingMessage.handle.close() and set _pendingMessage to null
-//     },
-
-//     got(message, handle, emit) {
-//       const socket = new net.Socket({
-//         handle: handle,
-//         readable: true,
-//         writable: true,
-//       });
-
-//       // If the socket was created by net.Server we will track the socket
-//       if (message.key) {
-//         // Add socket to connections list
-//         const socketList = getSocketList("got", this, message.key);
-//         socketList.add({
-//           socket: socket,
-//         });
-//       }
-
-//       emit(socket);
-//     },
-//   },
-
-//   "dgram.Native": {
-//     simultaneousAccepts: false,
-
-//     send(message, handle, options) {
-//       return handle;
-//     },
-
-//     got(message, handle, emit) {
-//       emit(handle);
-//     },
-//   },
-
-//   "dgram.Socket": {
-//     simultaneousAccepts: false,
-
-//     send(message, socket, options) {
-//       message.dgramType = socket.type;
-
-//       return socket[kStateSymbol].handle;
-//     },
-
-//     got(message, handle, emit) {
-//       const socket = new dgram.Socket(message.dgramType);
-
-//       socket.bind(handle, () => {
-//         emit(socket);
-//       });
-//     },
-//   },
-// };
+// Serialization of the handle attached to an IPC message sent with
+// `subprocess.send(message, handle)` / `process.send(message, handle)`.
+// Mirrors the `handleConversion` table in Node's lib/internal/child_process.js:
+// https://github.com/nodejs/node/blob/main/lib/internal/child_process.js
+//
+// The transport (SCM_RIGHTS over the IPC socketpair, the NODE_HANDLE /
+// NODE_HANDLE_ACK / NODE_HANDLE_NACK handshake, the ack-gated send queue)
+// lives in src/jsc/ipc.rs; `do_send` in src/runtime/ipc_host.rs takes the
+// native handle returned from `serialize()` and dups its fd into the queued
+// message, so the sender's copy can be released independently.
 
 // have to use jsdoc type definitions because bundle-functions is based on regex
 /**
  * @typedef {Object} Serialized
  * @property {"NODE_HANDLE"} cmd
- * @property {unknown} message
- * @property {"net.Socket" | "net.Server" | "dgram.Socket"} type
+ * @property {"net.Server" | "net.Socket"} type
+ * @property {unknown} msg
  */
+
 /**
- * @typedef {import("node:net").Server | import("node:net").Socket | import("node:dgram").Socket} Handle
- */
-/**
+ * Map a user-provided handle to `[nativeHandle, wrappedMessage]`. Returns
+ * `null` to send `message` with no handle (its socket is already gone — Node
+ * falls back the same way); throws for handle types that cannot be sent.
+ *
  * @param {unknown} message
- * @param {Handle} handle
+ * @param {import("node:net").Server | import("node:net").Socket} handle
  * @param {{ keepOpen?: boolean } | undefined} options
  * @returns {[unknown, Serialized] | null}
  */
-export function serialize(_message, _handle, _options) {
-  // sending file descriptors is not supported yet
-  return null; // send the message without the file descriptor
-
-  /*
+export function serialize(message, handle, options) {
   const net = require("node:net");
-  const dgram = require("node:dgram");
-  if (handle instanceof net.Server) {
-    // this one doesn't need a close function, but the fd needs to be kept alive until it is sent
-    const server = handle as unknown as (typeof net)["Server"] & { _handle: Bun.TCPSocketListener<unknown> };
-    return [server._handle, { cmd: "NODE_HANDLE", message, type: "net.Server" }];
-  } else if (handle instanceof net.Socket) {
-    const new_message: { cmd: "NODE_HANDLE"; message: unknown; type: "net.Socket"; key?: string } = {
-      cmd: "NODE_HANDLE",
-      message,
-      type: "net.Socket",
-    };
-    const socket = handle as unknown as (typeof net)["Socket"] & {
-      _handle: Bun.Socket;
-      server: (typeof net)["Server"] | null;
-      setTimeout(timeout: number): void;
-    };
-    if (!socket._handle) return null; // failed
-
-    // If the socket was created by net.Server
-    if (socket.server) {
-      // The worker should keep track of the socket
-      new_message.key = socket.server._connectionKey;
-
-      const firstTime = !this[kChannelHandle].sockets.send[message.key];
-      const socketList = getSocketList("send", this, message.key);
-
-      // The server should no longer expose a .connection property
-      // and when asked to close it should query the socket status from
-      // the workers
-      if (firstTime) socket.server._setupWorker(socketList);
-
-      // Act like socket is detached
-      if (!options?.keepOpen) socket.server._connections--;
-    }
-
-    const internal_handle = socket._handle;
-
-    // Remove handle from socket object, it will be closed when the socket
-    // will be sent
-    if (!options?.keepOpen) {
-      // we can use a $newRustFunction to have it unset the callback
-      internal_handle.onread = nop;
-      socket._handle = null;
-      socket.setTimeout(0);
-    }
-    return [internal_handle, new_message];
-  } else if (handle instanceof dgram.Socket) {
-    // this one doesn't need a close function, but the fd needs to be kept alive until it is sent
-    throw new Error("todo serialize dgram.Socket");
-  } else {
+  const isSocket = handle instanceof net.Socket;
+  if (!isSocket && !(handle instanceof net.Server)) {
+    // dgram.Socket needs an fd getter on Bun's native UDPSocket plus a
+    // bind-to-fd path, neither of which exist yet. Everything else is not a
+    // sendable handle in Node either. Never silently drop the handle.
     throw $ERR_INVALID_HANDLE_TYPE();
   }
-  */
+  if (process.platform === "win32") {
+    // Bun's Windows IPC channel is a libuv named pipe with no SOCKET
+    // duplication (uv_write2 / WSADuplicateSocketW) implemented.
+    const { throwNotImplemented } = require("internal/shared");
+    throwNotImplemented("Passing a net.Socket or net.Server over IPC on Windows");
+  }
+
+  const nativeHandle = handle._handle;
+  if (!nativeHandle) return null;
+
+  if (isSocket) {
+    // `tls.TLSSocket extends net.Socket`, so TLS sockets land here too
+    // (matching Node); the receiver reconstructs a plain net.Socket around
+    // the transferred fd — TLS session state is not transferable.
+    if (!options?.keepOpen) {
+      // Node detaches the sender's socket the moment it is sent. Closing the
+      // native handle is deferred one tick — past `do_send`'s dup — so the
+      // sender's event loop stops consuming bytes that now belong to the
+      // receiving process and its copy of the fd is released.
+      handle._handle = null;
+      handle.setTimeout(0);
+      process.nextTick(h => h.close(), nativeHandle);
+    }
+    return [nativeHandle, { cmd: "NODE_HANDLE", type: "net.Socket", msg: message }];
+  }
+
+  // net.Server: the listener stays open in the sender. Both processes
+  // accept() on the shared fd (the pre-fork server model).
+  return [nativeHandle, { cmd: "NODE_HANDLE", type: "net.Server", msg: message }];
 }
+
 /**
+ * Reconstruct a handle object around a file descriptor received over
+ * SCM_RIGHTS and re-dispatch the wrapped user message with it. Invoked from
+ * `handle_ipc_message` (src/jsc/ipc.rs) once a `NODE_HANDLE` message and its
+ * ancillary fd have both arrived (the ACK has already been written back).
+ * On success the constructed handle owns `fd`.
+ *
+ * @param {unknown} target the Subprocess (parent side) or null (child side)
  * @param {Serialized} serialized
- * @param {unknown} handle
- * @param {(handle: Handle) => void} emit
- * @returns {void}
+ * @param {number} fd
  */
 export function parseHandle(target, serialized, fd) {
   const emit = $newRustFunction("ipc.rs", "emitHandleIPCMessage", 3);
   const net = require("node:net");
-  // const dgram = require("node:dgram");
   switch (serialized.type) {
     case "net.Server": {
       const server = new net.Server();
       server.listen({ fd }, () => {
-        emit(target, serialized.message, server);
+        emit(target, serialized.msg, server);
       });
       return;
     }
     case "net.Socket": {
-      throw new Error("TODO case net.Socket");
-    }
-    case "dgram.Socket": {
-      throw new Error("TODO case dgram.Socket");
+      // Adopt the already-connected fd. `connect({ fd })` opens synchronously
+      // (the native `open` handler fires inside it), so the socket handed to
+      // the 'message' listener is already live.
+      const socket = new net.Socket();
+      socket.connect({ fd });
+      emit(target, serialized.msg, socket);
+      return;
     }
     default: {
-      throw new Error("failed to parse handle");
+      // A handle type Bun cannot reconstruct (e.g. a dgram.Socket or a raw
+      // net.Native/dgram.Native wrap from a Node.js peer). The sender was
+      // already ACK'd, so the fd is ours to release; leaking it would also
+      // pin the peer's connection open.
+      require("node:fs").closeSync(fd);
+      throw new Error(
+        `Cannot receive a ${JSON.stringify(serialized.type)} handle over IPC; only "net.Server" and "net.Socket" are supported`,
+      );
     }
   }
 }

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -84,9 +84,11 @@ export function parseHandle(target, serialized, fd) {
   switch (serialized.type) {
     case "net.Server": {
       const server = new net.Server();
-      server.listen({ fd }, () => {
-        emit(target, serialized.msg, server);
-      });
+      // exclusive: true adopts the fd directly (a cluster worker would otherwise
+      // route it to the primary as a queryServer). Bun.listen({ fd }) is
+      // synchronous, so emit now, not from the setTimeout-deferred listen cb.
+      server.listen({ fd, exclusive: true });
+      emit(target, serialized.msg, server);
       return;
     }
     case "net.Socket": {

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -38,9 +38,11 @@ export function serialize(message, handle, options) {
   }
   if (process.platform === "win32") {
     // Bun's Windows IPC channel is a libuv named pipe with no SOCKET
-    // duplication (uv_write2 / WSADuplicateSocketW) implemented.
-    const { throwNotImplemented } = require("internal/shared");
-    throwNotImplemented("Passing a net.Socket or net.Server over IPC on Windows");
+    // duplication (uv_write2 / WSADuplicateSocketW) yet, so fall back to sending
+    // the message with no handle (receiver sees handle === undefined) rather
+    // than throwing synchronously out of send() — matching the pre-feature
+    // behavior that cross-platform code and the Node IPC tests rely on.
+    return null;
   }
 
   const nativeHandle = handle._handle;

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -51,6 +51,14 @@ export function serialize(message, handle, options) {
     // (matching Node); the receiver reconstructs a plain net.Socket around
     // the transferred fd — TLS session state is not transferable.
     if (!options?.keepOpen) {
+      // For a server-accepted socket, decrement the server's connection count
+      // now (Node does this synchronously on handoff) and null `.server` so the
+      // deferred `_destroy` doesn't double-count — otherwise with allowHalfOpen
+      // the server never drains and `server.close()` never emits 'close'.
+      if (handle.server) {
+        handle.server._connections--;
+        handle.server = null;
+      }
       // Node detaches the sender's socket the moment it is sent. Closing the
       // native handle is deferred one tick — past `do_send`'s dup — so the
       // sender's event loop stops consuming bytes that now belong to the

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1567,20 +1567,6 @@ Socket.prototype.connect = function connect(...args) {
     if (socket) {
       connection = socket;
     }
-    if (fd) {
-      doConnect(this._handle, {
-        data: this,
-        fd: fd,
-        socket: SocketHandlers,
-        // Always half-open natively; see kConnect.
-        allowHalfOpen: true,
-      }).catch(error => {
-        if (!this.destroyed) {
-          this.emit("error", error);
-          this.emit("close", true);
-        }
-      });
-    }
     this.pauseOnConnect = pauseOnConnect;
     if (pauseOnConnect) {
       this.pause();
@@ -1595,6 +1581,22 @@ Socket.prototype.connect = function connect(...args) {
       this.connecting = true;
     }
     if (fd) {
+      // `doConnect({ fd })` adopts an already-open fd: the `open` handler
+      // fires synchronously inside it (setting `_handle` and
+      // `connecting = false`), so it must run after the `connecting = true`
+      // above — running it first left adopted sockets stuck in 'opening'.
+      doConnect(this._handle, {
+        data: this,
+        fd: fd,
+        socket: SocketHandlers,
+        // Always half-open natively; see kConnect.
+        allowHalfOpen: true,
+      }).catch(error => {
+        if (!this.destroyed) {
+          this.emit("error", error);
+          this.emit("close", true);
+        }
+      });
       return this;
     }
     if (

--- a/src/jsc/bindings/IPC.cpp
+++ b/src/jsc/bindings/IPC.cpp
@@ -4,7 +4,7 @@
 #include "WebCoreJSBuiltins.h"
 #include "ZigGlobalObject.h"
 
-extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(Zig::GlobalObject* global, JSC::EncodedJSValue message, JSC::EncodedJSValue handle)
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(Zig::GlobalObject* global, JSC::EncodedJSValue message, JSC::EncodedJSValue handle, JSC::EncodedJSValue options)
 {
     auto& vm = JSC::getVM(global);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -14,6 +14,7 @@ extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue IPCSerialize(Zig::G
     JSC::MarkedArgumentBuffer args;
     args.append(JSC::JSValue::decode(message));
     args.append(JSC::JSValue::decode(handle));
+    args.append(JSC::JSValue::decode(options));
 
     auto result = JSC::call(global, serializeFunction, callData, JSC::jsUndefined(), args);
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/ipc.rs
+++ b/src/jsc/ipc.rs
@@ -663,16 +663,27 @@ pub fn get_nack_packet(mode: Mode) -> &'static [u8] {
 // (uws_sys/socket.rs); `<false>` is the non-SSL handler.
 pub type Socket = bun_uws::SocketHandler<false>;
 
+/// An fd queued for transfer over the IPC socket via `SCM_RIGHTS`.
+///
+/// The fd is OWNED: `do_send` (`bun_runtime::ipc_host`) dups it off the JS
+/// handle so the transfer survives the sender closing its own copy (node
+/// closes a sent `net.Socket`'s local handle). Closed on `Drop` — after the
+/// receiver ACKs/NACKs, or when the send queue is torn down.
 pub struct Handle {
     pub fd: Fd,
-    pub js: Protected,
 }
 
 impl Handle {
-    pub fn init(fd: Fd, js: JSValue) -> Self {
-        Self {
-            fd,
-            js: js.protected(),
+    /// Takes ownership of `fd`; it is closed when this `Handle` drops.
+    pub fn init(fd: Fd) -> Self {
+        Self { fd }
+    }
+}
+
+impl Drop for Handle {
+    fn drop(&mut self) {
+        if self.fd.is_valid() {
+            FdExt::close(self.fd);
         }
     }
 }
@@ -2282,9 +2293,10 @@ pub fn ipc_serialize(
     global_object: &JSGlobalObject,
     message: JSValue,
     handle: JSValue,
+    options: JSValue,
 ) -> JsResult<JSValue> {
     // `[[ZIG_EXPORT(zero_is_throw)]]`
-    crate::cpp::IPCSerialize(global_object, message, handle)
+    crate::cpp::IPCSerialize(global_object, message, handle, options)
 }
 
 #[track_caller]

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -187,6 +187,16 @@ pub(crate) fn do_send(
                         return do_send_err(global_object, callback, ex, from);
                     }
                 }
+            } else {
+                // serialize() returned a handle but it carries no transferable
+                // fd (e.g. a net.Socket that isn't connected yet, or a listener
+                // that isn't listening). Don't silently send the message with no
+                // handle — serialize() may have already detached the sender's
+                // socket, so report the failure instead.
+                let ex = global_object.create_type_error_instance(format_args!(
+                    "The handle could not be sent over IPC: it has no transferable file descriptor"
+                ));
+                return do_send_err(global_object, callback, ex, from);
             }
         }
     }

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -13,9 +13,12 @@ use bun_jsc::ipc::{
     self as IPC, DecodedIPCMessage, Handle, IsInternal, SendQueue, SerializeAndSendResult,
 };
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
+use bun_sys::Fd;
+use bun_sys_jsc::ErrorJsc as _;
 
 use crate::api::bun::subprocess::Subprocess;
-use crate::socket::Listener;
+use crate::socket::listener::ListenerType;
+use crate::socket::{Listener, TCPSocket, TLSSocket};
 
 bun_core::define_scoped_log!(log, IPC, visible);
 
@@ -70,19 +73,50 @@ fn do_send_err(
     Err(global_object.throw_value(ex))
 }
 
+/// The live fd behind a native socket handle that `Ipc.ts`'s `serialize()`
+/// returns: a `Listener` (from a `net.Server`) or a `TCPSocket`/`TLSSocket`
+/// (from a `net.Socket`). `None` when the handle's socket is already
+/// closed/detached or the type carries no fd (named pipes).
+fn native_handle_fd(handle: JSValue) -> Option<Fd> {
+    let fd = if let Some(listener) = Listener::from_js(handle) {
+        // SAFETY: `from_js` returned a non-null `*mut Listener`; the JS
+        // wrapper holds it alive for the call.
+        match unsafe { (*listener).listener.get() } {
+            // SAFETY: `socket_uws` is a live non-null `*mut ListenSocket`
+            // owned by uSockets; `get_socket` only reinterpret-casts to
+            // `&mut us_socket_t` and `get_fd` is a read-only FFI call.
+            ListenerType::Uws(socket_uws) => unsafe { &mut *socket_uws }.get_socket().get_fd(),
+            ListenerType::NamedPipe(_) | ListenerType::None => return None,
+        }
+    } else if let Some(tcp) = handle.as_::<TCPSocket>() {
+        // SAFETY: `as_` returned a non-null `*mut TCPSocket`; the JS wrapper
+        // holds it alive for the call.
+        unsafe { (*tcp).socket.get() }.fd()
+    } else if let Some(tls) = handle.as_::<TLSSocket>() {
+        // SAFETY: see above.
+        unsafe { (*tls).socket.get() }.fd()
+    } else {
+        return None;
+    };
+    fd.is_valid().then_some(fd)
+}
+
 pub(crate) fn do_send(
     ipc: Option<&mut SendQueue>,
     global_object: &JSGlobalObject,
     call_frame: &CallFrame,
     from: FromEnum,
 ) -> JsResult<JSValue> {
-    let [mut message, mut handle, options_, mut callback] = call_frame.arguments_as_array::<4>();
+    let [mut message, mut handle, mut options_, mut callback] =
+        call_frame.arguments_as_array::<4>();
 
     if handle.is_callable() {
         callback = handle;
         handle = JSValue::UNDEFINED;
+        options_ = JSValue::UNDEFINED;
     } else if options_.is_callable() {
         callback = options_;
+        options_ = JSValue::UNDEFINED;
     } else if !options_.is_undefined() {
         global_object.validate_object("options", options_, Default::default())?;
     }
@@ -123,38 +157,37 @@ pub(crate) fn do_send(
         ));
     }
 
-    if !handle.is_undefined_or_null() {
-        let serialized_array: JSValue = IPC::ipc_serialize(global_object, message, handle)?;
-        if serialized_array.is_undefined_or_null() {
-            handle = JSValue::UNDEFINED;
-        } else {
-            let serialized_handle = serialized_array.get_index(global_object, 0)?;
-            let serialized_message = serialized_array.get_index(global_object, 1)?;
-            handle = serialized_handle;
-            message = serialized_message;
-        }
-    }
-
+    // Package the message with a handle. `ipc_serialize` (the `Ipc.ts`
+    // `serialize()` builtin) maps a JS handle (net.Server / net.Socket) to
+    // `[nativeHandle, wrappedMessage]`; null means "send the message plain"
+    // (the handle's socket is already gone — node falls back the same way).
+    // The wrapped `{cmd: "NODE_HANDLE", ...}` message is adopted ONLY once an
+    // fd is secured: writing a NODE_HANDLE message with no ancillary fd makes
+    // the receiver NACK until the retry limit and the message is lost.
     let mut zig_handle: Option<Handle> = None;
     if !handle.is_undefined_or_null() {
-        if let Some(listener) = Listener::from_js(handle) {
-            log!("got listener");
-            // SAFETY: from_js returned a non-null `*mut Listener`; the JS
-            // wrapper holds it alive for the call.
-            match unsafe { (*listener).listener.get() } {
-                crate::socket::listener::ListenerType::Uws(socket_uws) => {
-                    // may need to handle ssl case
-                    // SAFETY: `socket_uws` is a live non-null `*mut ListenSocket`
-                    // owned by uSockets; `get_socket` only reinterpret-casts to
-                    // `&mut us_socket_t` and `get_fd` is a read-only FFI call.
-                    let fd = unsafe { &mut *socket_uws }.get_socket().get_fd();
-                    zig_handle = Some(Handle::init(fd, handle));
+        let serialized_array: JSValue =
+            IPC::ipc_serialize(global_object, message, handle, options_)?;
+        if !serialized_array.is_undefined_or_null() {
+            let native_handle = serialized_array.get_index(global_object, 0)?;
+            let wrapped_message = serialized_array.get_index(global_object, 1)?;
+            if let Some(fd) = native_handle_fd(native_handle) {
+                // Dup so the in-flight transfer owns its own fd: the sender's
+                // copy is closed right after this call for a net.Socket (node
+                // semantics), and a net.Server can be closed by the user
+                // before the queued sendmsg runs. `Handle` closes it on drop.
+                match bun_sys::dup(fd) {
+                    Ok(owned) => {
+                        log!("sending handle fd {} (dup of {})", owned.uv(), fd.uv());
+                        zig_handle = Some(Handle::init(owned));
+                        message = wrapped_message;
+                    }
+                    Err(err) => {
+                        let ex = err.to_js(global_object)?;
+                        return do_send_err(global_object, callback, ex, from);
+                    }
                 }
-                crate::socket::listener::ListenerType::NamedPipe(_named_pipe) => {}
-                crate::socket::listener::ListenerType::None => {}
             }
-        } else {
-            //
         }
     }
 

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -92,11 +92,10 @@ fn native_handle_fd(handle: JSValue) -> Option<Fd> {
         // SAFETY: `as_` returned a non-null `*mut TCPSocket`; the JS wrapper
         // holds it alive for the call.
         unsafe { (*tcp).socket.get() }.fd()
-    } else if let Some(tls) = handle.as_::<TLSSocket>() {
+    } else {
+        let tls = handle.as_::<TLSSocket>()?;
         // SAFETY: see above.
         unsafe { (*tls).socket.get() }.fd()
-    } else {
-        return None;
     };
     fd.is_valid().then_some(fd)
 }

--- a/src/runtime/socket/Handlers.rs
+++ b/src/runtime/socket/Handlers.rs
@@ -563,7 +563,13 @@ impl SocketConfig {
         // JSValues — no manual error-path cleanup needed.
 
         if result.fd.is_some() {
-            // If a user passes a file descriptor then prefer it over hostname or unix
+            // If a user passes a file descriptor then prefer it over hostname or unix.
+            // Carry the listen flags through so e.g. `listen({ fd, allowHalfOpen })`
+            // is honored on the adopted socket (net.Server.listen({ fd })).
+            result.exclusive = generated.exclusive;
+            result.allow_half_open = generated.allow_half_open;
+            result.reuse_port = generated.reuse_port;
+            result.ipv6_only = generated.ipv6_only;
         } else if let Some(unix) = generated.unix_.get() {
             if unix.length() == 0 {
                 return Err(global

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -433,19 +433,47 @@ impl Listener {
                 )
             }),
             UnixOrHost::Fd(fd) => {
-                let err = jsc::SystemError {
-                    errno: bun_sys::SystemErrno::EINVAL as c_int,
-                    code: bun_core::String::static_("EINVAL"),
-                    message: bun_core::String::static_(
-                        "Bun does not support listening on a file descriptor.",
-                    ),
-                    syscall: bun_core::String::static_("listen"),
-                    fd: fd.uv(),
-                    path: bun_core::String::empty(),
-                    hostname: bun_core::String::empty(),
-                    dest: bun_core::String::empty(),
-                };
-                return Err(global.throw_value(err.to_error_instance(global)));
+                // Adopt an already-listening fd. `us_socket_group_listen_fd`
+                // validates the fd (ENOTSOCK for a non-socket like stdin, EINVAL
+                // for a non-listening socket) and is a no-op under libuv/Windows
+                // (returns EINVAL). Throw the structured error here rather than
+                // falling through to the generic "Failed to listen" path, which
+                // uses an empty hostname and would be less useful for an fd.
+                let fd_native = fd.uv();
+                let mut fd_errno: c_int = 0;
+                let ls = this_ref.group.with_mut(|g| {
+                    g.listen_fd(
+                        kind,
+                        secure_ctx_ptr,
+                        // `LIBUS_SOCKET_DESCRIPTOR` is `c_int` on POSIX,
+                        // `SOCKET` (`usize`) on Windows; `Fd::native()` matches.
+                        fd.native() as uws_sys::LIBUS_SOCKET_DESCRIPTOR,
+                        socket_flags,
+                        size_of::<*mut c_void>() as c_int,
+                        &mut fd_errno,
+                    )
+                });
+                if ls.is_null() {
+                    if fd_errno == 0 {
+                        fd_errno = bun_sys::SystemErrno::EINVAL as c_int;
+                    }
+                    let code = bun_sys::SystemErrno::init(fd_errno as i64)
+                        .map_or("EINVAL", <&'static str>::from);
+                    let err = jsc::SystemError {
+                        errno: fd_errno,
+                        code: bun_core::String::static_(code),
+                        message: bun_core::String::static_(
+                            "Failed to listen on the given file descriptor.",
+                        ),
+                        syscall: bun_core::String::static_("listen"),
+                        fd: fd_native,
+                        path: bun_core::String::empty(),
+                        hostname: bun_core::String::empty(),
+                        dest: bun_core::String::empty(),
+                    };
+                    return Err(global.throw_value(err.to_error_instance(global)));
+                }
+                ls
             }
         };
         if listen_socket.is_null() {

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -212,8 +212,10 @@ impl SocketGroup {
 
     /// Adopt an already-listening fd (received over IPC via SCM_RIGHTS or
     /// inherited from a parent process) as a listen socket, rather than
-    /// creating+binding a new one. POSIX only; on failure returns null and
-    /// writes `ENOTSOCK`/`EINVAL` into `err`, and the caller keeps the fd.
+    /// creating+binding a new one. POSIX only; the caller keeps the fd. On
+    /// failure returns null and writes an errno into `err`: `ENOTSOCK`/`EINVAL`
+    /// for the common validation failures, plus any propagated errno (e.g.
+    /// `EBADF` from the SO_TYPE probe, or a poll-registration error).
     pub fn listen_fd(
         &mut self,
         kind: SocketKind,

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -212,10 +212,11 @@ impl SocketGroup {
 
     /// Adopt an already-listening fd (received over IPC via SCM_RIGHTS or
     /// inherited from a parent process) as a listen socket, rather than
-    /// creating+binding a new one. POSIX only; the caller keeps the fd. On
-    /// failure returns null and writes an errno into `err`: `ENOTSOCK`/`EINVAL`
-    /// for the common validation failures, plus any propagated errno (e.g.
-    /// `EBADF` from the SO_TYPE probe, or a poll-registration error).
+    /// creating+binding a new one. POSIX only; on success the group owns the fd
+    /// (`us_listen_socket_close` closes it); on failure the caller keeps it and
+    /// null is returned with an errno in `err`: `ENOTSOCK`/`EINVAL` for the
+    /// common validation failures, plus any propagated errno (e.g. `EBADF` from
+    /// the SO_TYPE probe, or a poll-registration error).
     pub fn listen_fd(
         &mut self,
         kind: SocketKind,

--- a/src/uws_sys/SocketGroup.rs
+++ b/src/uws_sys/SocketGroup.rs
@@ -210,6 +210,34 @@ impl SocketGroup {
         }
     }
 
+    /// Adopt an already-listening fd (received over IPC via SCM_RIGHTS or
+    /// inherited from a parent process) as a listen socket, rather than
+    /// creating+binding a new one. POSIX only; on failure returns null and
+    /// writes `ENOTSOCK`/`EINVAL` into `err`, and the caller keeps the fd.
+    pub fn listen_fd(
+        &mut self,
+        kind: SocketKind,
+        ssl_ctx: Option<*mut SslCtx>,
+        fd: LIBUS_SOCKET_DESCRIPTOR,
+        options: c_int,
+        socket_ext_size: c_int,
+        err: &mut c_int,
+    ) -> *mut ListenSocket {
+        // SAFETY: forwarding to C; `err` is a valid out-param the callee
+        // writes an errno into on failure.
+        unsafe {
+            us_socket_group_listen_fd(
+                self,
+                kind as u8,
+                ssl_ctx.unwrap_or(ptr::null_mut()),
+                fd,
+                options,
+                socket_ext_size,
+                err,
+            )
+        }
+    }
+
     pub fn connect(
         &mut self,
         kind: SocketKind,
@@ -339,6 +367,15 @@ unsafe extern "C" {
         ssl_ctx: *mut SslCtx,
         path: *const u8,
         pathlen: usize,
+        options: c_int,
+        socket_ext_size: c_int,
+        err: *mut c_int,
+    ) -> *mut ListenSocket;
+    fn us_socket_group_listen_fd(
+        group: *mut SocketGroup,
+        kind: u8,
+        ssl_ctx: *mut SslCtx,
+        fd: LIBUS_SOCKET_DESCRIPTOR,
         options: c_int,
         socket_ext_size: c_int,
         err: *mut c_int,

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -14,7 +14,7 @@ const node = nodeExe();
 
 // Passing a net.Server handle over IPC duplicates the listening socket's fd to
 // the child via SCM_RIGHTS, which is POSIX-only.
-test.skipIf(isWindows)("fork() + subprocess.send(msg, server) gives the child a usable net.Server", async () => {
+test.skipIf(isWindows).concurrent("fork() + subprocess.send(msg, server) gives the child a usable net.Server", async () => {
   using dir = tempDir("ipc-server-handle", {
     "parent.js": `
 import { fork } from 'node:child_process';
@@ -87,7 +87,7 @@ process.on('message', (m, server) => {
 // The NODE_HANDLE envelope carries the user payload under `msg` (Node's wire
 // format), so a Bun parent can hand a net.Server to a Node child and the child
 // still receives the accompanying message.
-test.skipIf(isWindows || !node)("Bun parent can pass a net.Server (and message) to a Node child", async () => {
+test.skipIf(isWindows || !node).concurrent("Bun parent can pass a net.Server (and message) to a Node child", async () => {
   using dir = tempDir("ipc-server-handle-node", {
     "parent.js": `
 import { fork } from 'node:child_process';
@@ -154,7 +154,7 @@ process.on('message', (m, server) => {
 // A plain message sent right after a handle message must not overtake it: the
 // child reconstructs the server from the fd synchronously, so IPC stays in
 // send order (Node guarantees this; a deferred emit would reorder).
-test.skipIf(isWindows)("a message sent after a net.Server handle is not reordered before it", async () => {
+test.skipIf(isWindows).concurrent("a message sent after a net.Server handle is not reordered before it", async () => {
   using dir = tempDir("ipc-server-handle-order", {
     "parent.js": `
 import { fork } from 'node:child_process';
@@ -212,7 +212,7 @@ process.on('message', (m, handle) => {
 // back to the primary as a cluster queryServer (the fd is worker-local). The
 // worker serves a connection to prove it owns the listening socket; with the
 // bug the primary crashes handling the spurious queryServer.
-test.skipIf(isWindows)("a net.Server handle sent to a cluster worker is adopted by the worker", async () => {
+test.skipIf(isWindows).concurrent("a net.Server handle sent to a cluster worker is adopted by the worker", async () => {
   using dir = tempDir("ipc-server-handle-cluster", {
     "entry.js": `
 import cluster from 'node:cluster';
@@ -293,7 +293,7 @@ async function run(dir: string) {
   return { stdout: stdout.trim(), exitCode };
 }
 
-describe.skipIf(isWindows)("send(message, netSocket)", () => {
+describe.skipIf(isWindows).concurrent("send(message, netSocket)", () => {
   test("parent passes an accepted net.Socket to a forked child", async () => {
     using dir = tempDir("ipc-send-socket", {
       "child.mjs": /* js */ `
@@ -476,7 +476,7 @@ describe.skipIf(isWindows)("send(message, netSocket)", () => {
   });
 });
 
-test("send(message, handle) with an unsupported handle type throws, never drops silently", async () => {
+test.concurrent("send(message, handle) with an unsupported handle type throws, never drops silently", async () => {
   using dir = tempDir("ipc-send-bad-handle", {
     "child.mjs": /* js */ `process.on("message", () => {}); process.on("disconnect", () => process.exit(0));`,
     "parent.mjs": /* js */ `

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -446,6 +446,34 @@ describe.skipIf(isWindows)("send(message, netSocket)", () => {
     });
     expect(await run(String(dir))).toEqual({ stdout: "got:Socket", exitCode: 0 });
   });
+
+  // Handing off an accepted socket must decrement the server's connection count
+  // synchronously (Node semantics). With allowHalfOpen the detached socket's
+  // _destroy never runs, so without the synchronous decrement server.close()
+  // would never drain and never emit 'close'.
+  test("server.close() drains after handing off an accepted socket with allowHalfOpen", async () => {
+    using dir = tempDir("ipc-send-socket-drain", {
+      "child.mjs": /* js */ `
+        process.on("message", (m, handle) => { if (handle) handle.resume(); });
+        process.on("disconnect", () => process.exit(0));
+      `,
+      "parent.mjs": /* js */ `
+        import { fork } from "node:child_process";
+        import net from "node:net";
+        const child = fork(new URL("./child.mjs", import.meta.url).pathname);
+        const srv = net.createServer({ allowHalfOpen: true }, sock => {
+          child.send("conn", sock);
+          srv.close();
+        });
+        srv.on("close", () => { console.log("closed"); child.kill(); process.exit(0); });
+        srv.listen(0, "127.0.0.1", () => {
+          const c = net.connect(srv.address().port, "127.0.0.1");
+          c.on("error", () => {});
+        });
+      `,
+    });
+    expect(await run(String(dir))).toEqual({ stdout: "closed", exitCode: 0 });
+  });
 });
 
 test("send(message, handle) with an unsupported handle type throws, never drops silently", async () => {

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, nodeExe, tempDir } from "harness";
+
+// `subprocess.send(message, handle)` / `process.send(message, handle)`:
+// the handle's fd is passed over the IPC channel (SCM_RIGHTS on the unix
+// socketpair + Node's `NODE_HANDLE` / `NODE_HANDLE_ACK` handshake) and
+// reconstructed as a live net.Server / net.Socket in the receiving process.
+// https://nodejs.org/api/child_process.html#subprocesssendmessage-sendhandle-options-callback
+//
+// Windows is skipped: Bun's named-pipe IPC has no SOCKET duplication yet, and
+// `send()` throws there instead of silently dropping the handle.
+
+const node = nodeExe();
+
+// Passing a net.Server handle over IPC duplicates the listening socket's fd to
+// the child via SCM_RIGHTS, which is POSIX-only.
+test.skipIf(isWindows)("fork() + subprocess.send(msg, server) gives the child a usable net.Server", async () => {
+  using dir = tempDir("ipc-server-handle", {
+    "parent.js": `
+import { fork } from 'node:child_process';
+import { createServer, connect } from 'node:net';
+
+const child = fork('child.js');
+const server = createServer();
+
+function finish(ok, detail) {
+  console.log(ok ? 'RESPONSE:' + detail : 'FAILED:' + detail);
+  try { child.kill(); } catch {}
+  try { server.close(); } catch {}
+  process.exit(ok ? 0 : 1);
+}
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port;
+  child.send('server', server);
+
+  child.on('message', m => {
+    if (typeof m === 'object' && m.error) return finish(false, m.error);
+    if (m !== 'ready') return;
+    // The fd is duplicated to the child (SCM_RIGHTS), so both processes would
+    // otherwise race on accept(). The child has already called
+    // server.listen({ fd }) before sending 'ready', so closing our copy now
+    // leaves only the child's fd accepting — deterministically the child
+    // answers the connection.
+    server.close();
+    const client = connect(port, '127.0.0.1');
+    client.setEncoding('utf8');
+    let data = '';
+    client.on('data', chunk => { data += chunk; });
+    client.on('end', () => finish(true, data));
+    client.on('error', err => finish(false, 'client:' + err.message));
+  });
+});
+`,
+    "child.js": `
+process.on('message', (m, server) => {
+  if (m !== 'server') return;
+  console.log('CHILD_TYPEOF:' + typeof server);
+  if (!server || typeof server.on !== 'function') {
+    process.send({ error: 'handle was ' + typeof server });
+    return;
+  }
+  server.on('connection', socket => {
+    socket.end('Hello from child');
+  });
+  process.send('ready');
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("CHILD_TYPEOF:object");
+  expect(stdout).toContain("RESPONSE:Hello from child");
+  expect(exitCode).toBe(0);
+});
+
+// The NODE_HANDLE envelope carries the user payload under `msg` (Node's wire
+// format), so a Bun parent can hand a net.Server to a Node child and the child
+// still receives the accompanying message.
+test.skipIf(isWindows || !node)("Bun parent can pass a net.Server (and message) to a Node child", async () => {
+  using dir = tempDir("ipc-server-handle-node", {
+    "parent.js": `
+import { fork } from 'node:child_process';
+import { createServer, connect } from 'node:net';
+
+const child = fork('child.js', [], { execPath: ${JSON.stringify(node)} });
+const server = createServer();
+
+function finish(ok, detail) {
+  console.log(ok ? 'RESPONSE:' + detail : 'FAILED:' + detail);
+  try { child.kill(); } catch {}
+  try { server.close(); } catch {}
+  process.exit(ok ? 0 : 1);
+}
+
+server.listen(0, '127.0.0.1', () => {
+  const port = server.address().port;
+  child.send({ greeting: 'hi-from-bun' }, server);
+  child.on('message', m => {
+    if (typeof m === 'object' && m.error) return finish(false, m.error);
+    if (m !== 'ready') return;
+    server.close();
+    const client = connect(port, '127.0.0.1');
+    client.setEncoding('utf8');
+    let data = '';
+    client.on('data', chunk => { data += chunk; });
+    client.on('end', () => finish(true, data));
+    client.on('error', err => finish(false, 'client:' + err.message));
+  });
+});
+`,
+    "child.js": `
+const net = require('node:net');
+process.on('message', (m, server) => {
+  if (!(server instanceof net.Server)) {
+    process.send({ error: 'handle was ' + typeof server });
+    return;
+  }
+  if (!m || m.greeting !== 'hi-from-bun') {
+    process.send({ error: 'message was ' + JSON.stringify(m) });
+    return;
+  }
+  server.on('connection', socket => socket.end('Hello from node child'));
+  process.send('ready');
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("RESPONSE:Hello from node child");
+  expect(exitCode).toBe(0);
+});
+
+async function run(dir: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.mjs"],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("parent.mjs stderr:\n" + stderr);
+  return { stdout: stdout.trim(), exitCode };
+}
+
+describe.skipIf(isWindows)("send(message, netSocket)", () => {
+  test("parent passes an accepted net.Socket to a forked child", async () => {
+    using dir = tempDir("ipc-send-socket", {
+      "child.mjs": /* js */ `
+        process.on("message", (m, handle) => {
+          // The whole bug: send() reported true but the child saw no handle.
+          if (!handle) process.exit(40);
+          handle.end("got:" + handle.constructor.name + ":" + handle.readyState);
+        });
+      `,
+      "parent.mjs": /* js */ `
+        import { fork } from "node:child_process";
+        import net from "node:net";
+
+        const child = fork(new URL("./child.mjs", import.meta.url).pathname);
+        child.on("exit", code => { if (code) process.exit(30); });
+
+        const srv = net.createServer(sock => {
+          const sent = child.send("conn", sock);
+          if (sent !== true) { console.error("send() returned", sent); process.exit(31); }
+          // Node detaches the sender's copy of a sent socket immediately
+          // (_handle becomes null; readyState stays "open" in node too).
+          if (sock._handle !== null) { console.error("sender _handle not detached"); process.exit(32); }
+        });
+
+        srv.listen(0, "127.0.0.1", () => {
+          const c = net.connect(srv.address().port, "127.0.0.1");
+          let data = "";
+          c.on("data", d => (data += d));
+          c.on("end", () => {
+            console.log(data);
+            srv.close();
+            child.kill();
+            process.exit(data === "got:Socket:open" ? 0 : 1);
+          });
+          c.on("error", e => { console.error("client error:", e); process.exit(33); });
+        });
+      `,
+    });
+    expect(await run(String(dir))).toEqual({ stdout: "got:Socket:open", exitCode: 0 });
+  });
+
+  test("child passes an accepted net.Socket to the parent via process.send", async () => {
+    using dir = tempDir("ipc-send-socket-up", {
+      "child.mjs": /* js */ `
+        import net from "node:net";
+        const srv = net.createServer(sock => {
+          const sent = process.send("conn", sock);
+          if (sent !== true) { console.error("process.send() returned", sent); process.exit(41); }
+        });
+        srv.listen(0, "127.0.0.1", () => process.send({ port: srv.address().port }));
+      `,
+      "parent.mjs": /* js */ `
+        import { fork } from "node:child_process";
+        import net from "node:net";
+
+        const child = fork(new URL("./child.mjs", import.meta.url).pathname);
+        child.on("exit", code => { if (code) process.exit(30); });
+
+        child.on("message", (m, handle) => {
+          if (m?.port) {
+            const c = net.connect(m.port, "127.0.0.1");
+            let data = "";
+            c.on("data", d => (data += d));
+            c.on("end", () => {
+              console.log(data);
+              child.kill();
+              process.exit(data === "got:Socket" ? 0 : 1);
+            });
+            return;
+          }
+          if (m === "conn") {
+            if (!handle) process.exit(40);
+            handle.end("got:" + handle.constructor.name);
+          }
+        });
+      `,
+    });
+    expect(await run(String(dir))).toEqual({ stdout: "got:Socket", exitCode: 0 });
+  });
+
+  test("{ keepOpen: true } leaves the sender's net.Socket attached", async () => {
+    using dir = tempDir("ipc-send-keepopen", {
+      "child.mjs": /* js */ `
+        process.on("message", (m, handle) => {
+          if (!handle) process.exit(40);
+          handle.end("from-child");
+        });
+      `,
+      "parent.mjs": /* js */ `
+        import { fork } from "node:child_process";
+        import net from "node:net";
+
+        const child = fork(new URL("./child.mjs", import.meta.url).pathname);
+        child.on("exit", code => { if (code) process.exit(30); });
+
+        const srv = net.createServer(sock => {
+          child.send("conn", sock, { keepOpen: true });
+          // keepOpen: the sender's socket must stay usable.
+          console.log("sender:" + sock.readyState);
+        });
+
+        srv.listen(0, "127.0.0.1", () => {
+          const c = net.connect(srv.address().port, "127.0.0.1");
+          let data = "";
+          c.on("data", d => (data += d));
+          c.on("end", () => {
+            console.log("client:" + data);
+            srv.close();
+            child.kill();
+            process.exit(data === "from-child" ? 0 : 1);
+          });
+        });
+      `,
+    });
+    expect(await run(String(dir))).toEqual({ stdout: "sender:open\nclient:from-child", exitCode: 0 });
+  });
+
+  // The real test of the NODE_HANDLE wire format: a Node.js child must be able
+  // to reconstruct the socket Bun sent it, using only Node's own machinery.
+  test.skipIf(!node)("Bun parent passes an accepted net.Socket to a Node child", async () => {
+    using dir = tempDir("ipc-send-socket-node", {
+      "child.cjs": /* js */ `
+        process.on("message", (m, handle) => {
+          if (m !== "conn") return;
+          if (!handle) { console.error("node child got no handle"); process.exit(40); }
+          handle.end("got:" + handle.constructor.name);
+        });
+      `,
+      "parent.mjs": /* js */ `
+        import { fork } from "node:child_process";
+        import net from "node:net";
+
+        const child = fork(new URL("./child.cjs", import.meta.url).pathname, [], { execPath: ${JSON.stringify(node)} });
+        child.on("exit", code => { if (code) process.exit(30); });
+
+        const srv = net.createServer(sock => child.send("conn", sock));
+        srv.listen(0, "127.0.0.1", () => {
+          const c = net.connect(srv.address().port, "127.0.0.1");
+          let data = "";
+          c.on("data", d => (data += d));
+          c.on("end", () => {
+            console.log(data);
+            srv.close();
+            child.kill();
+            process.exit(data === "got:Socket" ? 0 : 1);
+          });
+          c.on("error", e => { console.error("client error:", e); process.exit(33); });
+        });
+      `,
+    });
+    expect(await run(String(dir))).toEqual({ stdout: "got:Socket", exitCode: 0 });
+  });
+});
+
+test("send(message, handle) with an unsupported handle type throws, never drops silently", async () => {
+  using dir = tempDir("ipc-send-bad-handle", {
+    "child.mjs": /* js */ `process.on("message", () => {}); process.on("disconnect", () => process.exit(0));`,
+    "parent.mjs": /* js */ `
+      import { fork } from "node:child_process";
+      const child = fork(new URL("./child.mjs", import.meta.url).pathname);
+      let err;
+      let returned;
+      try {
+        returned = child.send("x", {});
+      } catch (e) {
+        err = e;
+      }
+      console.log(JSON.stringify({ returned, code: err?.code, name: err?.name }));
+      child.disconnect();
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error("parent.mjs stderr:\n" + stderr);
+  expect(JSON.parse(stdout)).toEqual({ code: "ERR_INVALID_HANDLE_TYPE", name: "TypeError" });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -7,8 +7,8 @@ import { bunEnv, bunExe, isWindows, nodeExe, tempDir } from "harness";
 // reconstructed as a live net.Server / net.Socket in the receiving process.
 // https://nodejs.org/api/child_process.html#subprocesssendmessage-sendhandle-options-callback
 //
-// Windows is skipped: Bun's named-pipe IPC has no SOCKET duplication yet, and
-// `send()` throws there instead of silently dropping the handle.
+// Windows is skipped: Bun's named-pipe IPC has no SOCKET duplication yet, so
+// `send()` falls back to delivering the message with no handle there.
 
 const node = nodeExe();
 

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -151,6 +151,135 @@ process.on('message', (m, server) => {
   expect(exitCode).toBe(0);
 });
 
+// A plain message sent right after a handle message must not overtake it: the
+// child reconstructs the server from the fd synchronously, so IPC stays in
+// send order (Node guarantees this; a deferred emit would reorder).
+test.skipIf(isWindows)("a message sent after a net.Server handle is not reordered before it", async () => {
+  using dir = tempDir("ipc-server-handle-order", {
+    "parent.js": `
+import { fork } from 'node:child_process';
+import { createServer } from 'node:net';
+
+const child = fork('child.js');
+const server = createServer();
+server.listen(0, '127.0.0.1', () => {
+  child.send('server', server);
+  child.send('after-server');
+  child.on('message', m => {
+    if (typeof m === 'object' && m.order) {
+      console.log('ORDER:' + m.order.join(','));
+      child.kill();
+      server.close();
+      process.exit(0);
+    }
+  });
+});
+`,
+    "child.js": `
+const net = require('node:net');
+const received = [];
+let reported = false;
+process.on('message', (m, handle) => {
+  if (m === 'server') {
+    received.push(handle instanceof net.Server ? 'server' : 'server(bad:' + typeof handle + ')');
+  } else if (m === 'after-server') {
+    received.push('after-server');
+  }
+  if (received.length === 2 && !reported) {
+    reported = true;
+    process.send({ order: received });
+  }
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("ORDER:server,after-server");
+  expect(exitCode).toBe(0);
+});
+
+// A cluster worker must adopt a received net.Server fd directly, not route it
+// back to the primary as a cluster queryServer (the fd is worker-local). The
+// worker serves a connection to prove it owns the listening socket; with the
+// bug the primary crashes handling the spurious queryServer.
+test.skipIf(isWindows)("a net.Server handle sent to a cluster worker is adopted by the worker", async () => {
+  using dir = tempDir("ipc-server-handle-cluster", {
+    "entry.js": `
+import cluster from 'node:cluster';
+import { createServer, connect } from 'node:net';
+
+if (cluster.isPrimary) {
+  const worker = cluster.fork();
+  const server = createServer();
+  function finish(ok, detail) {
+    console.log(ok ? 'RESPONSE:' + detail : 'FAILED:' + detail);
+    try { worker.kill(); } catch {}
+    try { server.close(); } catch {}
+    process.exit(ok ? 0 : 1);
+  }
+  worker.on('online', () => {
+    server.listen(0, '127.0.0.1', () => {
+      worker.send('server', server);
+    });
+  });
+  worker.on('message', m => {
+    if (typeof m !== 'object') return;
+    if (m.ready === false) return finish(false, 'worker-not-ready:' + m.why);
+    if (m.ready) {
+      // The fd was duplicated to the worker (SCM_RIGHTS); close our copy so only
+      // the worker accepts, otherwise the primary (no connection handler) could
+      // win accept() and the client would hang.
+      const port = server.address().port;
+      server.close();
+      const client = connect(port, '127.0.0.1');
+      client.setEncoding('utf8');
+      let data = '';
+      client.on('data', c => { data += c; });
+      client.on('end', () => finish(true, data));
+      client.on('error', e => finish(false, 'client:' + e.message));
+    }
+  });
+  worker.on('error', e => finish(false, 'worker:' + e.message));
+} else {
+  const net = require('node:net');
+  process.on('message', (m, handle) => {
+    if (m !== 'server') return;
+    if (!(handle instanceof net.Server)) {
+      process.send({ ready: false, why: typeof handle });
+      return;
+    }
+    handle.on('connection', sock => sock.end('served-by-worker'));
+    process.send({ ready: true });
+  });
+}
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("RESPONSE:served-by-worker");
+  expect(exitCode).toBe(0);
+});
+
 async function run(dir: string) {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "parent.mjs"],

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -14,9 +14,11 @@ const node = nodeExe();
 
 // Passing a net.Server handle over IPC duplicates the listening socket's fd to
 // the child via SCM_RIGHTS, which is POSIX-only.
-test.skipIf(isWindows).concurrent("fork() + subprocess.send(msg, server) gives the child a usable net.Server", async () => {
-  using dir = tempDir("ipc-server-handle", {
-    "parent.js": `
+test
+  .skipIf(isWindows)
+  .concurrent("fork() + subprocess.send(msg, server) gives the child a usable net.Server", async () => {
+    using dir = tempDir("ipc-server-handle", {
+      "parent.js": `
 import { fork } from 'node:child_process';
 import { createServer, connect } from 'node:net';
 
@@ -52,7 +54,7 @@ server.listen(0, '127.0.0.1', () => {
   });
 });
 `,
-    "child.js": `
+      "child.js": `
 process.on('message', (m, server) => {
   if (m !== 'server') return;
   console.log('CHILD_TYPEOF:' + typeof server);
@@ -66,30 +68,32 @@ process.on('message', (m, server) => {
   process.send('ready');
 });
 `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("CHILD_TYPEOF:object");
+    expect(stdout).toContain("RESPONSE:Hello from child");
+    expect(exitCode).toBe(0);
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "parent.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout).toContain("CHILD_TYPEOF:object");
-  expect(stdout).toContain("RESPONSE:Hello from child");
-  expect(exitCode).toBe(0);
-});
 
 // The NODE_HANDLE envelope carries the user payload under `msg` (Node's wire
 // format), so a Bun parent can hand a net.Server to a Node child and the child
 // still receives the accompanying message.
-test.skipIf(isWindows || !node).concurrent("Bun parent can pass a net.Server (and message) to a Node child", async () => {
-  using dir = tempDir("ipc-server-handle-node", {
-    "parent.js": `
+test
+  .skipIf(isWindows || !node)
+  .concurrent("Bun parent can pass a net.Server (and message) to a Node child", async () => {
+    using dir = tempDir("ipc-server-handle-node", {
+      "parent.js": `
 import { fork } from 'node:child_process';
 import { createServer, connect } from 'node:net';
 
@@ -119,7 +123,7 @@ server.listen(0, '127.0.0.1', () => {
   });
 });
 `,
-    "child.js": `
+      "child.js": `
 const net = require('node:net');
 process.on('message', (m, server) => {
   if (!(server instanceof net.Server)) {
@@ -134,22 +138,22 @@ process.on('message', (m, server) => {
   process.send('ready');
 });
 `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toContain("RESPONSE:Hello from node child");
+    expect(exitCode).toBe(0);
   });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "parent.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect(stderr).toBe("");
-  expect(stdout).toContain("RESPONSE:Hello from node child");
-  expect(exitCode).toBe(0);
-});
 
 // A plain message sent right after a handle message must not overtake it: the
 // child reconstructs the server from the fd synchronously, so IPC stays in

--- a/test/js/node/net/listen-fd.test.ts
+++ b/test/js/node/net/listen-fd.test.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// net.Server.listen({ fd }) adopts an already-bound, already-listening socket
+// inherited from the parent process — the mechanism systemd socket activation
+// uses (LISTEN_FDS hands the listening socket to the service as fd 3).
+// Inheriting a listening fd is POSIX-only.
+test.skipIf(isWindows)("net.Server.listen({ fd }) adopts an inherited listening socket", async () => {
+  using dir = tempDir("listen-fd", {
+    "parent.mjs": `
+import net from "node:net";
+import { spawn } from "node:child_process";
+
+// Create the bound + listening socket in this process.
+const listener = net.createServer();
+await new Promise((res, rej) => {
+  listener.once("error", rej);
+  listener.listen(0, "127.0.0.1", res);
+});
+const port = listener.address().port;
+const fd = listener._handle.fd;
+
+// Hand the listening socket to the child as fd 3 (systemd convention), then
+// close our own copy so only the child accepts connections.
+const child = spawn(process.execPath, [new URL("./child.mjs", import.meta.url).pathname], {
+  stdio: ["inherit", "inherit", "inherit", fd],
+  env: { ...process.env, PORT_FROM_PARENT: String(port) },
+});
+listener.close();
+child.on("exit", code => process.exit(code ?? 1));
+`,
+    "child.mjs": `
+import net from "node:net";
+
+const server = net.createServer(sock => {
+  sock.setEncoding("utf8");
+  sock.on("data", () => sock.end("OK from fd-activated child"));
+});
+
+server.on("error", e => { console.log("FAILED:server:" + e.message); process.exit(2); });
+server.listen({ fd: 3 }, () => {
+  const port = Number(process.env.PORT_FROM_PARENT);
+  const client = net.connect(port, "127.0.0.1", () => client.write("ping"));
+  client.setEncoding("utf8");
+  let data = "";
+  client.on("data", d => { data += d; });
+  client.on("end", () => {
+    console.log("RESPONSE:" + data);
+    server.close();
+    process.exit(0);
+  });
+  client.on("error", e => { console.log("FAILED:client:" + e.message); process.exit(3); });
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toContain("RESPONSE:OK from fd-activated child");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`subprocess.send(message, handle)` and `process.send(message, handle)` silently dropped the handle: `send()` returned `true`, the message arrived, but the peer's `message` handler received `handle === undefined`. fd/socket passing over the IPC channel did not exist.

```js
// parent.js
import { fork } from "node:child_process";
import net from "node:net";
const child = fork("child.js");
net.createServer(sock => child.send("conn", sock)).listen(0);
```

```js
// child.js
process.on("message", (m, handle) => {
  console.log(handle?.constructor?.name); // node: "Socket"   bun: undefined
  handle?.end("hi-from-child");
});
```

`send(msg, handle)` is the primitive under every pre-fork multi-process pattern in the Node ecosystem: `node:cluster`'s connection distribution, socket-passing load balancers, graceful-restart managers, "pass the listening fd to the new version" deploys. All of them degraded silently.

Fixes #6743
Fixes #22559

## Root cause

The low-level transport already existed in `src/jsc/ipc.rs` (SCM_RIGHTS send and receive on the IPC socketpair, the `NODE_HANDLE` / `NODE_HANDLE_ACK` / `NODE_HANDLE_NACK` handshake, the ack-gated send queue). Nothing fed it:

1. Send: `serialize()` in `src/js/builtins/Ipc.ts` was a stub (`return null; // sending file descriptors is not supported yet`), so the handle was discarded before any of it ran, and `send()` still returned `true`.
2. Receive, `net.Server`: `parseHandle()` reconstructs a server with `server.listen({ fd })`, but `Bun.listen({ fd })` threw `EINVAL: Bun does not support listening on a file descriptor.`
3. Receive, `net.Socket`: `parseHandle()`'s `net.Socket` case was `throw new Error("TODO")`.

## Fix

**`src/js/builtins/Ipc.ts`**: implement `serialize()` and `parseHandle()` for `net.Socket` and `net.Server`, using Node's `NODE_HANDLE` wire format (user payload under `msg`, per `lib/internal/child_process.js`), so a Bun peer interoperates with a Node peer in either direction. Anything else throws `ERR_INVALID_HANDLE_TYPE` (Node's own error for unsendable handle types) rather than silently dropping. Unless `options.keepOpen` is set, the sender's `net.Socket` is detached (`_handle = null`, matching Node) and its native handle closed one tick later, after the fd has been duplicated into the transfer.

**`packages/bun-usockets`**: new `us_socket_group_listen_fd()` adopts an already-bound, already-listening fd as a listen socket. The fd is validated with `getsockopt(SO_TYPE)` (rejects a non-socket like `listen({ fd: 0 })` with `ENOTSOCK`) and `SO_ACCEPTCONN` where it is reliable (Linux; on macOS it can report 0 for a genuinely listening inherited fd). Wired through `SocketGroup::listen_fd` and the `UnixOrHost::Fd` arm in `Listener::listen`, which previously threw unconditionally. `SocketConfig` now carries the listen flags (`allowHalfOpen`, `exclusive`, `reusePort`, `ipv6Only`) through on the fd path, which dropped them before.

**`src/runtime/ipc_host.rs` (`do_send`)**: extract the fd from a `TCPSocket` or `TLSSocket` as well as a `Listener`, and `dup()` it so the in-flight `Handle` owns its own descriptor for the lifetime of the transfer. Previously `Handle.fd` borrowed the source's live fd and never closed it; the source could be closed and the number reused before the queued `sendmsg` ran. The wrapped `{ cmd: "NODE_HANDLE" }` message is now only used once an fd is secured: before this, any handle whose fd could not be resolved would still ship the `NODE_HANDLE` envelope, which the receiver NACKs until the retry limit and the message is lost entirely. `options` is threaded through to `serialize()` so `keepOpen` is honored.

**`src/jsc/ipc.rs`**: `Handle` owns its fd and closes it on `Drop` (after the ack, after the retry budget is exhausted, or on queue teardown).

**`src/js/node/net.ts`**: `connect({ fd })` ran `doConnect()` first (which adopts the fd and fires `open` synchronously, setting `connecting = false` and `_handle`), then unconditionally set `connecting = true`, leaving every fd-adopted socket reporting `readyState: "opening"` forever. Reordered so the assignment happens before the adoption.

## Not covered

- `dgram.Socket` handles: need an fd getter on the native `UDPSocket` plus a bind-to-fd path, neither of which exist yet. `send()` now throws for them instead of silently dropping.
- Windows: Bun's named-pipe IPC has no SOCKET duplication (`WSADuplicateSocketW`) yet. `serialize()` returns null there, so `send()` delivers the message with no handle (receiver sees `handle === undefined`) rather than throwing.

#31829 builds the full `node:cluster` family (round-robin handoff, `SCHED_NONE` shared handles, UDP, Windows) on top of this same mechanism.

## Verification

8 tests across `test/js/node/child_process/child_process_ipc_handle.test.ts` and `test/js/node/net/listen-fd.test.ts`:

- `net.Socket` parent to child (the reproduction above), child to parent, and `{ keepOpen: true }`
- `net.Server` parent to child
- `send(msg, {})` throws `ERR_INVALID_HANDLE_TYPE`
- `listen({ fd })` systemd socket activation (an inherited listening fd at fd 3)
- Two Bun-to-Node.js interop tests: a real `node` child reconstructs both a `net.Server` and a `net.Socket` from Bun's wire format, proving the `NODE_HANDLE` envelope and the SCM_RIGHTS ancillary fd are what Node expects

All 8 fail on an unfixed build (`USE_SYSTEM_BUN=1`: 0 pass, 8 fail) and pass with this one. The three vendored Node tests for `listen({ fd })` (`test-listen-fd-detached.js`, `test-listen-fd-detached-inherit.js`, `test-net-listen-fd0.js`) also pass now; `test-net-listen-fd0.js` is the one the `SO_TYPE` validation is for.

