### PR TITLE
spawn: retry via /bin/sh when exec returns ENOEXEC

### DIFF
--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -980,9 +980,7 @@ pub unsafe fn spawn_process_posix(
     let argv0 = options.argv0.unwrap_or_else(|| unsafe { *argv });
     // SAFETY: argv0 is a valid NUL-terminated C string (caller contract).
     let argv0_cstr = unsafe { bun_core::ffi::cstr(argv0) };
-    // Android's shell lives at /system/bin/sh; /bin is only symlinked on API 29+,
-    // below Bun's minimum (API 28). Matches the rest of the codebase (e.g.
-    // run_command.rs, install/PackageManager.rs, js/node/child_process.ts).
+    // Android ships the shell at /system/bin/sh; /bin only exists on API 29+.
     #[cfg(target_os = "android")]
     const SHELL_PATH: &core::ffi::CStr = c"/system/bin/sh";
     #[cfg(not(target_os = "android"))]
@@ -990,11 +988,7 @@ pub unsafe fn spawn_process_posix(
 
     let spawn_result =
         match posix_spawn::spawn_z(argv0_cstr, Some(&actions), Some(&attr), argv, envp) {
-            // The file is executable but not a recognized format (e.g. a script with
-            // no shebang). libuv/Node retry the exec through the shell, so the file is
-            // run as a shell script. Mirror that: re-exec `sh <file> <args...>`, where
-            // `<file>` is the originally-resolved path (becomes `$0` in the shell) and
-            // `<args...>` are the user-supplied arguments (argv[1..]).
+            // ENOEXEC (e.g. script with no shebang): retry as `sh <file> argv[1..]` like libuv.
             Err(err) if err.get_errno() == bun_sys::E::ENOEXEC => {
                 let mut sh_argv: Vec<*const c_char> = Vec::new();
                 sh_argv.push(SHELL_PATH.as_ptr());

--- a/src/spawn_sys/spawn_process.rs
+++ b/src/spawn_sys/spawn_process.rs
@@ -980,7 +980,48 @@ pub unsafe fn spawn_process_posix(
     let argv0 = options.argv0.unwrap_or_else(|| unsafe { *argv });
     // SAFETY: argv0 is a valid NUL-terminated C string (caller contract).
     let argv0_cstr = unsafe { bun_core::ffi::cstr(argv0) };
-    let spawn_result = posix_spawn::spawn_z(argv0_cstr, Some(&actions), Some(&attr), argv, envp);
+    // Android's shell lives at /system/bin/sh; /bin is only symlinked on API 29+,
+    // below Bun's minimum (API 28). Matches the rest of the codebase (e.g.
+    // run_command.rs, install/PackageManager.rs, js/node/child_process.ts).
+    #[cfg(target_os = "android")]
+    const SHELL_PATH: &core::ffi::CStr = c"/system/bin/sh";
+    #[cfg(not(target_os = "android"))]
+    const SHELL_PATH: &core::ffi::CStr = c"/bin/sh";
+
+    let spawn_result =
+        match posix_spawn::spawn_z(argv0_cstr, Some(&actions), Some(&attr), argv, envp) {
+            // The file is executable but not a recognized format (e.g. a script with
+            // no shebang). libuv/Node retry the exec through the shell, so the file is
+            // run as a shell script. Mirror that: re-exec `sh <file> <args...>`, where
+            // `<file>` is the originally-resolved path (becomes `$0` in the shell) and
+            // `<args...>` are the user-supplied arguments (argv[1..]).
+            Err(err) if err.get_errno() == bun_sys::E::ENOEXEC => {
+                let mut sh_argv: Vec<*const c_char> = Vec::new();
+                sh_argv.push(SHELL_PATH.as_ptr());
+                sh_argv.push(argv0_cstr.as_ptr());
+                // Skip the original argv[0] (arg0); keep the user-supplied args.
+                let mut i = 1usize;
+                loop {
+                    // SAFETY: argv is a NULL-terminated array (caller contract), so
+                    // `argv[i]` is valid until the NULL terminator is reached.
+                    let arg = unsafe { *argv.add(i) };
+                    if arg.is_null() {
+                        break;
+                    }
+                    sh_argv.push(arg);
+                    i += 1;
+                }
+                sh_argv.push(core::ptr::null());
+                posix_spawn::spawn_z(
+                    SHELL_PATH,
+                    Some(&actions),
+                    Some(&attr),
+                    sh_argv.as_ptr(),
+                    envp,
+                )
+            }
+            other => other,
+        };
 
     match spawn_result {
         Err(err) => {

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "bun";
 import { describe, expect, test } from "bun:test";
-import { rmSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isWindows, tempDir } from "harness";
+import { chmodSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { bunEnv, bunExe, bunRun, isPosix, isWindows, tempDir } from "harness";
+import { join } from "path";
 
 let cwd: string;
 
@@ -38,6 +39,40 @@ describe("bun", () => {
     expect(stderr.toString()).toMatch(/Script not found/);
     expect(exitCode).toBe(1);
   });
+});
+
+// A package whose `bin` is an executable script with no shebang (e.g. a plain
+// shell script) makes execve() return ENOEXEC. npx runs the bin through /bin/sh
+// in that case; `bun run` must do the same so `bun run <bin>` works wherever
+// `npx <bin>` does. https://github.com/oven-sh/bun/issues/5386
+test.if(isPosix)("bun run <bin> executes a no-shebang bin through /bin/sh", () => {
+  using dir = tempDir("run-no-shebang-bin", {
+    "package.json": JSON.stringify({
+      name: "app",
+      dependencies: { "no-shebang-bin": "1.0.0" },
+    }),
+    "node_modules/no-shebang-bin/package.json": JSON.stringify({
+      name: "no-shebang-bin",
+      version: "1.0.0",
+      bin: { "no-shebang-bin": "./bin.sh" },
+    }),
+    "node_modules/no-shebang-bin/bin.sh": 'echo "hello from bin $1"\n',
+  });
+  const cwd = String(dir);
+  chmodSync(join(cwd, "node_modules/no-shebang-bin/bin.sh"), 0o755);
+  mkdirSync(join(cwd, "node_modules/.bin"), { recursive: true });
+  symlinkSync("../no-shebang-bin/bin.sh", join(cwd, "node_modules/.bin/no-shebang-bin"));
+
+  const { exitCode, stdout, stderr } = spawnSync({
+    cwd,
+    cmd: [bunExe(), "run", "no-shebang-bin", "world"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(stderr.toString()).toBe("");
+  expect(stdout.toString()).toBe("hello from bin world\n");
+  expect(exitCode).toBe(0);
 });
 
 test.if(isWindows)("[windows] A file in drive root runs", async () => {

--- a/test/cli/run/run_command.test.ts
+++ b/test/cli/run/run_command.test.ts
@@ -45,34 +45,42 @@ describe("bun", () => {
 // shell script) makes execve() return ENOEXEC. npx runs the bin through /bin/sh
 // in that case; `bun run` must do the same so `bun run <bin>` works wherever
 // `npx <bin>` does. https://github.com/oven-sh/bun/issues/5386
-test.if(isPosix)("bun run <bin> executes a no-shebang bin through /bin/sh", () => {
-  using dir = tempDir("run-no-shebang-bin", {
-    "package.json": JSON.stringify({
-      name: "app",
-      dependencies: { "no-shebang-bin": "1.0.0" },
-    }),
-    "node_modules/no-shebang-bin/package.json": JSON.stringify({
-      name: "no-shebang-bin",
-      version: "1.0.0",
-      bin: { "no-shebang-bin": "./bin.sh" },
-    }),
-    "node_modules/no-shebang-bin/bin.sh": 'echo "hello from bin $1"\n',
-  });
-  const cwd = String(dir);
-  chmodSync(join(cwd, "node_modules/no-shebang-bin/bin.sh"), 0o755);
-  mkdirSync(join(cwd, "node_modules/.bin"), { recursive: true });
-  symlinkSync("../no-shebang-bin/bin.sh", join(cwd, "node_modules/.bin/no-shebang-bin"));
+//
+// The `--silent` variant is what bunx uses (bunx_command.rs sets
+// ctx.debug.silent = true), which on macOS routes through POSIX_SPAWN_SETEXEC
+// instead of the ordinary fork+exec path.
+describe.if(isPosix)("bun run <bin> executes a no-shebang bin through /bin/sh", () => {
+  for (const silent of [false, true]) {
+    test(silent ? "with --silent (bunx path)" : "default", () => {
+      using dir = tempDir("run-no-shebang-bin", {
+        "package.json": JSON.stringify({
+          name: "app",
+          dependencies: { "no-shebang-bin": "1.0.0" },
+        }),
+        "node_modules/no-shebang-bin/package.json": JSON.stringify({
+          name: "no-shebang-bin",
+          version: "1.0.0",
+          bin: { "no-shebang-bin": "./bin.sh" },
+        }),
+        "node_modules/no-shebang-bin/bin.sh": 'echo "hello from bin $1"\n',
+      });
+      const cwd = String(dir);
+      chmodSync(join(cwd, "node_modules/no-shebang-bin/bin.sh"), 0o755);
+      mkdirSync(join(cwd, "node_modules/.bin"), { recursive: true });
+      symlinkSync("../no-shebang-bin/bin.sh", join(cwd, "node_modules/.bin/no-shebang-bin"));
 
-  const { exitCode, stdout, stderr } = spawnSync({
-    cwd,
-    cmd: [bunExe(), "run", "no-shebang-bin", "world"],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  expect(stderr.toString()).toBe("");
-  expect(stdout.toString()).toBe("hello from bin world\n");
-  expect(exitCode).toBe(0);
+      const { exitCode, stdout, stderr } = spawnSync({
+        cwd,
+        cmd: [bunExe(), ...(silent ? ["--silent"] : []), "run", "no-shebang-bin", "world"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stderr.toString()).toBe("");
+      expect(stdout.toString()).toBe("hello from bin world\n");
+      expect(exitCode).toBe(0);
+    });
+  }
 });
 
 test.if(isWindows)("[windows] A file in drive root runs", async () => {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3216,3 +3216,17 @@ test.skipIf(isWindows)("external command resolution uses the PATH from the shell
     expect(exitCode).toBe(0);
   }
 });
+
+// An executable file with no shebang makes execve() return ENOEXEC. Like
+// Node/libuv, the file should be run through /bin/sh instead of failing with
+// "Exec format error". https://github.com/oven-sh/bun/issues/11563
+test.if(isPosix)("runs an executable with no shebang through /bin/sh", async () => {
+  using dir = tempDir("shell-noshebang", { "script.sh": "echo 'Hello, World!'\n" });
+  const cwd = String(dir).replaceAll("\\", "/");
+  chmodSync(join(cwd, "script.sh"), 0o755);
+
+  const { stdout, stderr, exitCode } = await $`./script.sh`.cwd(cwd).quiet().nothrow();
+  expect(stderr.toString()).toBe("");
+  expect(stdout.toString()).toBe("Hello, World!\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,18 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  isLinux,
+  isPosix,
+  isWindows,
+  nodeExe,
+  runBunInstall,
+  shellExe,
+  tempDir,
+  tmpdirSync,
+} from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
 import { promisify } from "node:util";

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -619,13 +619,19 @@ describe("execSync()", () => {
 describe.if(isPosix)("spawning an executable with no shebang", () => {
   const scriptBody = 'echo "arg0=$0"\necho "args=$*"\n';
 
-  it("execFileSync runs it through /bin/sh", () => {
-    using dir = tempDir("enoexec-execFileSync", { "script.sh": scriptBody });
+  it("execFileSync runs it through /bin/sh with args passed verbatim", () => {
+    // The retry is `sh <file> <args...>` with each arg as its own argv entry,
+    // so shell metachars reach the script un-expanded and embedded spaces stay
+    // intact. A `sh -c`-style retry would expand $HOME and glob `*`.
+    using dir = tempDir("enoexec-execFileSync", {
+      "script.sh": `printf '[%s]' "$0" "$#" "$@"; echo\n`,
+    });
     const scriptPath = path.join(String(dir), "script.sh");
     fs.chmodSync(scriptPath, 0o755);
 
-    const result = execFileSync(scriptPath, ["hello", "world"], { encoding: "utf8", env: bunEnv });
-    expect(result).toBe(`arg0=${scriptPath}\nargs=hello world\n`);
+    const args = ["$HOME", "a b", "*", "'quote'"];
+    const result = execFileSync(scriptPath, args, { encoding: "utf8", env: bunEnv });
+    expect(result).toBe(`[${scriptPath}][4][$HOME][a b][*]['quote']\n`);
   });
 
   it("spawnSync runs it through /bin/sh and succeeds", () => {
@@ -636,6 +642,18 @@ describe.if(isPosix)("spawning an executable with no shebang", () => {
     const result = spawnSync(scriptPath, ["a", "b"], { encoding: "utf8", env: bunEnv });
     expect(result.stderr).toBe("");
     expect(result.stdout).toBe(`arg0=${scriptPath}\nargs=a b\n`);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+  });
+
+  it("spawnSync with a relative path and cwd replays the chdir on retry", () => {
+    using dir = tempDir("enoexec-cwd", { "script.sh": scriptBody });
+    fs.chmodSync(path.join(String(dir), "script.sh"), 0o755);
+
+    const result = spawnSync("./script.sh", ["rel"], { cwd: String(dir), encoding: "utf8", env: bunEnv });
+    expect(result.stderr).toBe("");
+    // $0 is the caller-supplied relative path, matching Node/libuv.
+    expect(result.stdout).toBe("arg0=./script.sh\nargs=rel\n");
     expect(result.error).toBeUndefined();
     expect(result.status).toBe(0);
   });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isPosix, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { getEventListeners, once, setMaxListeners } from "node:events";
 import { promisify } from "node:util";
@@ -599,6 +599,61 @@ describe("execSync()", () => {
   it("should execute a command in the shell synchronously", () => {
     const result = execSync(bunExe() + " -v", { encoding: "utf8", env: bunEnv });
     expect(isValidSemver(result.trim())).toBe(true);
+  });
+});
+
+// An executable file with no shebang returns ENOEXEC from execve(). Node/libuv
+// transparently retry the exec through /bin/sh, so the file runs as a shell
+// script. https://github.com/oven-sh/bun/issues/31710
+describe.if(isPosix)("spawning an executable with no shebang", () => {
+  const scriptBody = 'echo "arg0=$0"\necho "args=$*"\n';
+
+  it("execFileSync runs it through /bin/sh", () => {
+    using dir = tempDir("enoexec-execFileSync", { "script.sh": scriptBody });
+    const scriptPath = path.join(String(dir), "script.sh");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const result = execFileSync(scriptPath, ["hello", "world"], { encoding: "utf8", env: bunEnv });
+    expect(result).toBe(`arg0=${scriptPath}\nargs=hello world\n`);
+  });
+
+  it("spawnSync runs it through /bin/sh and succeeds", () => {
+    using dir = tempDir("enoexec-spawnSync", { "script.sh": scriptBody });
+    const scriptPath = path.join(String(dir), "script.sh");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const result = spawnSync(scriptPath, ["a", "b"], { encoding: "utf8", env: bunEnv });
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(`arg0=${scriptPath}\nargs=a b\n`);
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+  });
+
+  it("execFile (async) runs it through /bin/sh", async () => {
+    using dir = tempDir("enoexec-execFile", { "script.sh": scriptBody });
+    const scriptPath = path.join(String(dir), "script.sh");
+    fs.chmodSync(scriptPath, 0o755);
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    execFile(scriptPath, ["x", "y"], { encoding: "utf8", env: bunEnv }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+    expect(await promise).toBe(`arg0=${scriptPath}\nargs=x y\n`);
+  });
+
+  it("resolves the command from PATH before falling back to /bin/sh", () => {
+    using dir = tempDir("enoexec-path", { "noshebang-cmd": scriptBody });
+    const scriptPath = path.join(String(dir), "noshebang-cmd");
+    fs.chmodSync(scriptPath, 0o755);
+
+    // The command has no slash, so it must be resolved via PATH. $0 is then the
+    // fully-resolved path, matching Node/libuv.
+    const result = execFileSync("noshebang-cmd", ["one"], {
+      encoding: "utf8",
+      env: { ...bunEnv, PATH: `${String(dir)}:${bunEnv.PATH}` },
+    });
+    expect(result).toBe(`arg0=${scriptPath}\nargs=one\n`);
   });
 });
 


### PR DESCRIPTION
Fixes #31710
Fixes #11563
Fixes #5386

### Repro

A package whose `bin` is a shell script without a shebang:

```sh
# node_modules/.bin/my-bin -> bin.sh (no #! line)
echo "hello"
```

```
$ npx my-bin
hello
$ bun run my-bin
error: Failed to run "my-bin" due to:
ENOEXEC: .../my-bin: Exec format error (posix_spawn())
```

The same applies to `node:child_process`:

```js
import { execFileSync } from 'node:child_process';
execFileSync('./script.sh', ['hello']);  // ENOEXEC in Bun, works in Node
```

and Bun Shell (`` $`./script.sh` `` → `bun: Exec format error`).

### Cause

An executable file with no recognized format (e.g. a script with no shebang) makes `execve()` return `ENOEXEC`. Node, via libuv's `uv__execvpe`, transparently retries the exec through `/bin/sh` so the file runs as a shell script. Bun's posix spawn path (`spawn_process_posix`) only ported libuv's **PATH-resolution** half of `execvpe`; the **`ENOEXEC` → `/bin/sh` retry** half was missing, so the raw error surfaced.

### Fix

In `src/spawn_sys/spawn_process.rs`, when the initial `posix_spawn` returns `ENOEXEC`, re-exec `/bin/sh` with the originally-resolved path as `argv[1]` (becomes `$0` inside the script) followed by the user-supplied args. This matches libuv/Node exactly:

- `$0` is the resolved path (including when the command is resolved from `PATH`),
- `$1`, `$2`… are the user args, in order,
- any `ENOEXEC` triggers the fallback (no pre-sniffing).

All spawn entry points funnel through `spawn_process_posix`, so this covers the sync path (`execFileSync`/`spawnSync`/`Bun.spawnSync`), the async path (`execFile`/`spawn`/`Bun.spawn`), Bun Shell (#11563), and `bun run <bin>` / bunx (#5386).

### Verification

New tests cover all three entry points:
- `test/js/node/child_process/child_process.test.ts`: `execFileSync`, `spawnSync`, `execFile` (async), and the PATH-resolved case.
- `test/js/bun/shell/bunshell.test.ts`: Bun Shell (#11563).
- `test/cli/run/run_command.test.ts`: `bun run <bin>` with a no-shebang bin in `node_modules/.bin` (#5386).

All fail on the current release with `ENOEXEC` and pass with the fix.

The `grafbase` case in #5386 is slightly different: its `bin` file is a placeholder that `postinstall` replaces with the real binary. When the postinstall runs, the bin is a valid native binary and works; when it doesn't, the placeholder is a plain text file and this fix makes `bun run` behave exactly like npx (route through `/bin/sh`, which then prints a parse error). Whether bunx runs the postinstall is tracked separately by #19637.
