### PR TITLE
Don't define `self` on the main thread

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3000,16 +3000,23 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     // ----- Public Properties -----
 
-    // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
-    putDirectAccessor(
-        this,
-        builtinNames.selfPublicName(),
-        JSC::GetterSetter::create(
-            vm,
+    // `self` is a member of WindowOrWorkerGlobalScope. Node.js only exposes it
+    // in Worker threads, never on the main thread, and isomorphic libraries use
+    // `typeof self === "object"` to sniff a browser/worker environment. Defining
+    // it on the main thread makes those libraries take the browser code path.
+    // Match Node: expose `self` everywhere except the main thread.
+    if (!scriptExecutionContext()->isMainThread()) {
+        // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
+        putDirectAccessor(
             this,
-            JSFunction::create(vm, this, 0, "get"_s, functionGetSelf, ImplementationVisibility::Public),
-            JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
-        PropertyAttribute::Accessor | 0);
+            builtinNames.selfPublicName(),
+            JSC::GetterSetter::create(
+                vm,
+                this,
+                JSFunction::create(vm, this, 0, "get"_s, functionGetSelf, ImplementationVisibility::Public),
+                JSFunction::create(vm, this, 0, "set"_s, functionSetSelf, ImplementationVisibility::Public)),
+            PropertyAttribute::Accessor | 0);
+    }
 
     // TODO: this should be usable on the lookup table. it crashed las time i tried it
     putDirectCustomAccessor(vm, JSC::Identifier::fromString(vm, "onmessage"_s), JSC::CustomGetterSetter::create(vm, globalOnMessage, setGlobalOnMessage), 0);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3000,12 +3000,16 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
 
     // ----- Public Properties -----
 
-    // `self` is a member of WindowOrWorkerGlobalScope. Node.js only exposes it
-    // in Worker threads, never on the main thread, and isomorphic libraries use
-    // `typeof self === "object"` to sniff a browser/worker environment. Defining
-    // it on the main thread makes those libraries take the browser code path.
-    // Match Node: expose `self` everywhere except the main thread.
-    if (!scriptExecutionContext()->isMainThread()) {
+    // `self` is a member of WindowOrWorkerGlobalScope — the Web spec defines it
+    // in Windows and Workers. Node.js never defines it (not on the main thread
+    // nor in worker_threads). Isomorphic libraries use `typeof self === "object"`
+    // to sniff a browser/worker environment, so defining it on the main thread
+    // (which is neither a Window nor a Worker) makes them take the browser code
+    // path. Expose `self` only off the main thread: Workers keep it for Web
+    // Worker spec compatibility, the main thread matches Node by not having it.
+    // `WTF::isMainThread()` checks the actual thread, so globals derived on the
+    // main thread (e.g. a ShadowRealm) also don't get `self`.
+    if (!WTF::isMainThread()) {
         // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
         putDirectAccessor(
             this,

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3007,9 +3007,15 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     // (which is neither a Window nor a Worker) makes them take the browser code
     // path. Expose `self` only off the main thread: Workers keep it for Web
     // Worker spec compatibility, the main thread matches Node by not having it.
-    // `WTF::isMainThread()` checks the actual thread, so globals derived on the
-    // main thread (e.g. a ShadowRealm) also don't get `self`.
-    if (!WTF::isMainThread()) {
+    //
+    // Use the same notion of "main thread" as `Bun.isMainThread`
+    // (`ScriptExecutionContext::isMainThread()`, i.e. execution-context id 1).
+    // Internal code such as `node:worker_threads` gates global `self` reads on
+    // `!Bun.isMainThread`, so the two checks must agree — using `WTF::isMainThread`
+    // here instead would diverge for a main-thread ShadowRealm (context id > 1
+    // but on the main OS thread), where `fakeParentPort()` would then read an
+    // undefined `self`. A ShadowRealm getting `self` is harmless.
+    if (!scriptExecutionContext()->isMainThread()) {
         // a direct accessor (uses js functions for get and set) cannot be on the lookup table. i think.
         putDirectAccessor(
             this,

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -190,13 +190,13 @@ it("globals are deletable", () => {
   expect(exitCode).toBe(0);
 });
 
-it("self is a getter", () => {
-  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "self");
-  expect(descriptor.get).toBeInstanceOf(Function);
-  expect(descriptor.set).toBeInstanceOf(Function);
-  expect(descriptor.enumerable).toBe(true);
-  expect(descriptor.configurable).toBe(true);
-  expect(globalThis.self).toBe(globalThis);
+it("self is not defined on the main thread (matches Node.js)", () => {
+  // `self` is a WindowOrWorkerGlobalScope member. Node.js only exposes it in
+  // Worker threads, never on the main thread, and isomorphic libraries sniff
+  // `typeof self === "object"` to detect a browser/worker. Match Node here.
+  expect("self" in globalThis).toBe(false);
+  expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toBeUndefined();
+  expect(typeof self).toBe("undefined");
 });
 
 it("errors thrown by native code should be TypeError", async () => {

--- a/test/js/bun/globals.test.js
+++ b/test/js/bun/globals.test.js
@@ -191,8 +191,8 @@ it("globals are deletable", () => {
 });
 
 it("self is not defined on the main thread (matches Node.js)", () => {
-  // `self` is a WindowOrWorkerGlobalScope member. Node.js only exposes it in
-  // Worker threads, never on the main thread, and isomorphic libraries sniff
+  // `self` is a WindowOrWorkerGlobalScope member. Node.js never defines it, and
+  // the main thread is neither a Window nor a Worker. Isomorphic libraries sniff
   // `typeof self === "object"` to detect a browser/worker. Match Node here.
   expect("self" in globalThis).toBe(false);
   expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toBeUndefined();

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -308,18 +308,56 @@ test("confirm (no) windows newline", async () => {
   expect(await proc.stderr.text()).toBe("No\n");
 });
 
+test("self is not defined on the main thread (matches Node.js)", () => {
+  // Node.js only exposes `self` in Worker threads, not on the main thread.
+  // Isomorphic libraries sniff `typeof self === "object"` to detect a
+  // browser/worker environment; defining it on the main thread makes them
+  // take the browser code path instead of the Node fallback.
+  // See https://github.com/oven-sh/bun/issues/31713
+  expect("self" in globalThis).toBe(false);
+  expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toBeUndefined();
+  expect(typeof self).toBe("undefined");
+});
+
+test("self is defined inside a Worker (matches Node.js and the Web spec)", async () => {
+  const { Worker } = await import("node:worker_threads");
+  const worker = new Worker(
+    `
+      const { parentPort } = require("node:worker_threads");
+      parentPort.postMessage({
+        hasSelf: "self" in globalThis,
+        typeofSelf: typeof self,
+        selfIsGlobalThis: typeof self === "object" ? self === globalThis : null,
+      });
+    `,
+    { eval: true },
+  );
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    worker.on("message", resolve);
+    worker.on("error", reject);
+    const result = await promise;
+    expect(result).toEqual({
+      hasSelf: true,
+      typeofSelf: "object",
+      selfIsGlobalThis: true,
+    });
+  } finally {
+    await worker.terminate();
+  }
+});
+
 test("globalThis.self = 123 works", () => {
-  expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toMatchObject({
-    configurable: true,
-    enumerable: true,
-    get: expect.any(Function),
-    set: expect.any(Function),
-  });
+  const hadSelf = Object.hasOwn(globalThis, "self");
   const original = Object.getOwnPropertyDescriptor(globalThis, "self");
   try {
     globalThis.self = 123;
     expect(globalThis.self).toBe(123);
   } finally {
-    Object.defineProperty(globalThis, "self", original);
+    if (hadSelf) {
+      Object.defineProperty(globalThis, "self", original);
+    } else {
+      delete globalThis.self;
+    }
   }
 });

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -350,6 +350,29 @@ test("self is defined inside a Worker (Web Worker spec)", async () => {
   }
 });
 
+test("node:worker_threads imports in a main-thread ShadowRealm", async () => {
+  // The `self` gate must use the same notion of "main thread" as
+  // `Bun.isMainThread`. A ShadowRealm runs on the main OS thread but has its own
+  // execution-context id (> 1), so `Bun.isMainThread` is false there. worker_threads
+  // builds `fakeParentPort()` when `!Bun.isMainThread`, reading the global `self`;
+  // if the gate disagreed, `self` would be undefined and the import would throw.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const realm = new ShadowRealm();
+       const isMainThread = await realm.importValue("node:worker_threads", "isMainThread");
+       console.log("ok:" + isMainThread);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok:false");
+  expect(exitCode).toBe(0);
+});
+
 test("globalThis.self = 123 works", () => {
   const hadSelf = Object.hasOwn(globalThis, "self");
   const original = Object.getOwnPropertyDescriptor(globalThis, "self");

--- a/test/js/web/web-globals.test.js
+++ b/test/js/web/web-globals.test.js
@@ -1,6 +1,8 @@
 import { spawn } from "bun";
 import { expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, isMacOS, isWindows, withoutAggressiveGC } from "harness";
+// Aliased so it doesn't shadow the global Web `Worker` asserted in the "exists" test.
+import { Worker as NodeWorker } from "node:worker_threads";
 
 test("exists", () => {
   expect(typeof URL !== "undefined").toBe(true);
@@ -309,19 +311,20 @@ test("confirm (no) windows newline", async () => {
 });
 
 test("self is not defined on the main thread (matches Node.js)", () => {
-  // Node.js only exposes `self` in Worker threads, not on the main thread.
-  // Isomorphic libraries sniff `typeof self === "object"` to detect a
-  // browser/worker environment; defining it on the main thread makes them
-  // take the browser code path instead of the Node fallback.
-  // See https://github.com/oven-sh/bun/issues/31713
+  // `self` is a WindowOrWorkerGlobalScope member. Node.js never defines it, and
+  // the main thread is neither a Window nor a Worker. Isomorphic libraries sniff
+  // `typeof self === "object"` to detect a browser/worker environment; defining
+  // it on the main thread makes them take the browser code path instead of the
+  // Node fallback. See https://github.com/oven-sh/bun/issues/31713
   expect("self" in globalThis).toBe(false);
   expect(Object.getOwnPropertyDescriptor(globalThis, "self")).toBeUndefined();
   expect(typeof self).toBe("undefined");
 });
 
-test("self is defined inside a Worker (matches Node.js and the Web spec)", async () => {
-  const { Worker } = await import("node:worker_threads");
-  const worker = new Worker(
+test("self is defined inside a Worker (Web Worker spec)", async () => {
+  // Per the Web spec, `self` is defined in WorkerGlobalScope. Bun keeps it in
+  // workers (Node does not define it there, but browsers do).
+  const worker = new NodeWorker(
     `
       const { parentPort } = require("node:worker_threads");
       parentPort.postMessage({


### PR DESCRIPTION
Fixes #31713

## Repro

With `canvas`, `jsdom`, and `paper` installed:

```js
// script 2 — importSVG
import paper from "paper";
import { createCanvas } from "canvas";
const canvas = createCanvas(10, 10);
paper.setup(canvas);
paper.project.importSVG(`<svg xmlns="http://www.w3.org/2000/svg"><path d='M 10 10 L 100 100' /></svg>`);
```

Before (Bun), matching the issue exactly:

```
error: TypeError: undefined is not a constructor (evaluating 'new self.DOMParser()')
      at onError (.../paper/dist/paper-full.js:15645:15)
```

`exportSVG` threw `TypeError: undefined is not an object (evaluating 'document.createElementNS')`, and the bare `new paper.Path()` script never exited. Node runs all three cleanly.

## Cause

`self` is a member of `WindowOrWorkerGlobalScope`. Node.js exposes it **only in Worker threads**, never on the main thread (`'self' in globalThis` is `false` there). Bun defined `self` on **every** global object — main thread included — as a getter returning `globalThis`.

`paper.js` (like most isomorphic libraries) decides between a real browser DOM and its bundled jsdom fallback with a `typeof self === 'object'` sniff:

```js
}.call(this, typeof self === 'object' ? self : null);
// ...
self = self || require('./node/self.js'); // jsdom fallback
var window = self.window, document = self.document;
```

- **Node**: `self` is undefined on the main thread → paper passes `null` → loads jsdom → `window`/`document`/`DOMParser` all work.
- **Bun (before)**: `self` is defined → paper uses `self.window` / `self.document` (both `undefined`) and never loads jsdom → every DOM operation fails. The same mis-detection left `paper.agent.node` falsy, so paper's auto-update render loop stayed on and the process hung.

The accessor was installed unconditionally in `GlobalObject::addBuiltinGlobals`, which runs for both the main thread and workers.

## Fix

Install the `self` accessor only when the global object is **not** the main thread, using `ScriptExecutionContext::isMainThread()` (main thread has execution-context identifier `1`; workers get a generated id `> 1`). Workers keep `self` — matching both Node and the Web spec — while the main thread no longer has it.

This makes isomorphic libraries take the Node fallback path on Bun's main thread, exactly as they do on Node.

## Verification

New/updated tests:

- `test/js/web/web-globals.test.js`
  - `self is not defined on the main thread (matches Node.js)` — `"self" in globalThis === false`, `typeof self === "undefined"`.
  - `self is defined inside a Worker (matches Node.js and the Web spec)` — spawns a worker and asserts `self === globalThis` there.
  - `globalThis.self = 123 works` — assignment still works.
- `test/js/bun/globals.test.js` — `self is not defined on the main thread`.

Gate:

- `USE_SYSTEM_BUN=1 bun test test/js/web/web-globals.test.js -t "self is not defined on the main thread"` → **fails** (`"self" in globalThis` is `true`).
- `bun bd test test/js/web/web-globals.test.js -t "self"` → **all pass**, including the worker test.

Manually confirmed paper.js scripts 1–3 from the issue now run and exit cleanly (importSVG returns a `Group`, exportSVG returns 297 chars), matching Node's output.

No behavioral break from removing main-thread `self`: every global-`self` read in the codebase is either inside a worker (still defined), an assignment (`globalThis.self = …`, still works), or a guarded `typeof self === "object"` feature-detection that now correctly falls through to the Node/`globalThis` branch.