### PR TITLE
Fix type confusion in generated class custom setters

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -1128,7 +1128,11 @@ JSC_DEFINE_CUSTOM_SETTER(${symbolName(typeName, name)}SetterWrap, (JSGlobalObjec
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    ${className(typeName)}* thisObject = uncheckedDowncast<${className(typeName)}>(JSValue::decode(encodedThisValue));
+    ${className(typeName)}* thisObject = dynamicDowncast<${className(typeName)}>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        throwDOMAttributeSetterTypeError(lexicalGlobalObject, throwScope, ${className(typeName)}::info(), attributeName);
+        return false;
+    }
     JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
     thisObject->${cacheName}.set(vm, thisObject, JSValue::decode(encodedValue));
     RELEASE_AND_RETURN(throwScope, true);
@@ -1229,7 +1233,11 @@ JSC_DEFINE_CUSTOM_SETTER(${symbolName(typeName, name)}SetterWrap, (JSGlobalObjec
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     auto throwScope = DECLARE_THROW_SCOPE(vm);
-    ${className(typeName)}* thisObject = uncheckedDowncast<${className(typeName)}>(JSValue::decode(encodedThisValue));
+    ${className(typeName)}* thisObject = dynamicDowncast<${className(typeName)}>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        throwDOMAttributeSetterTypeError(lexicalGlobalObject, throwScope, ${className(typeName)}::info(), attributeName);
+        return false;
+    }
     JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
     bool result = ${symbolName(typeName, proto[name].setter || proto[name].accessor.setter)}(thisObject->wrapped(),${
       !!proto[name].this ? " encodedThisValue, " : ""

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -43,6 +43,69 @@ test.concurrent("RedisClient survives GC after a command throws during argument 
   expect(exitCode).toBe(0);
 });
 
+// Fuzzer found heap corruption (zapped cell during GC marking) when a custom
+// setter on a generated class was invoked with a receiver that is not an
+// instance of that class (e.g. through a Proxy wrapping the instance, or an
+// extracted setter function). The generated setter wrapper downcast the
+// receiver without a type check and wrote an internal field into whatever
+// object the receiver happened to be.
+test.concurrent("custom setter with a foreign receiver throws instead of corrupting the heap", async () => {
+  const src = `
+    const client = new Bun.RedisClient();
+
+    // Receiver is a Proxy wrapping the instance.
+    try {
+      const proxy = new Proxy(client, {});
+      proxy.onconnect = function () {};
+      throw new Error("expected TypeError");
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;
+    }
+
+    // Receiver is a plain object with the instance on its prototype chain.
+    try {
+      Object.create(client).onconnect = function () {};
+      throw new Error("expected TypeError");
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;
+    }
+
+    // Extracted setter function called with a foreign this value.
+    const desc = Object.getOwnPropertyDescriptor(Bun.RedisClient.prototype, "onconnect");
+    for (const thisValue of [{}, null, 42, new Proxy(client, {})]) {
+      try {
+        desc.set.call(thisValue, function () {});
+        throw new Error("expected TypeError");
+      } catch (e) {
+        if (!(e instanceof TypeError)) throw e;
+      }
+    }
+
+    // Setting on a real instance still works.
+    const fn = function () {};
+    client.onconnect = fn;
+    if (client.onconnect !== fn) throw new Error("expected onconnect to be set");
+
+    Bun.gc(true);
+    await 1;
+    Bun.gc(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("RedisClient survives GC across many short-lived instances", async () => {
   const src = `
     for (let i = 0; i < 1000; i++) {


### PR DESCRIPTION
### What does this PR do?

Fixes a heap-corruption type confusion found by fuzzing (fingerprint `89cfe3a29be2ad36`): a zapped cell crash during GC marking after setting `onconnect` on a `Proxy` wrapping a `Bun.RedisClient`.

The custom setter wrappers emitted by `generate-classes.ts` downcast the incoming `this` value with `uncheckedDowncast` — no type check. But JSC invokes `CustomAccessor` setters with the **put receiver**, not the slot base (`JSObject::putInlineSlow` passes `slot.thisValue()`), and `JSCustomSetterFunction` (the function materialized by `Object.getOwnPropertyDescriptor(proto, name).set`) passes whatever `this` it is called with. Unlike the getter path, JSC performs no `DOMAttribute` receiver check before calling a custom setter, so the wrapper can run with a receiver of any type:

```js
const client = new Bun.RedisClient();
new Proxy(client, {}).onconnect = fn;                    // receiver = proxy
Object.create(client).onconnect = fn;                    // receiver = plain object
Object.getOwnPropertyDescriptor(Bun.RedisClient.prototype, "onconnect")
  .set.call({}, fn);                                     // this = anything, even null/42
```

The wrapper then treated that foreign object as a `JSRedisClient` and stored a `WriteBarrier` JSValue at the class's inline member offset — out-of-bounds / overlapping writes into an unrelated cell, which the GC later trips over (`reportZappedCellAndCrash` in `SlotVisitor::appendToMarkStack`). This affects every generated class with a custom or writable cached setter (`RedisClient`, `PostgresSQLConnection`, sockets' `data`, node `Timeout` internals, `FileSink` callbacks, HTMLRewriter element setters, ...).

### Fix

In both generated setter wrapper variants, replace `uncheckedDowncast` with `dynamicDowncast` and throw on mismatch via JSC's `throwDOMAttributeSetterTypeError` — producing the same `TypeError: The RedisClient.onconnect setter can only be used on instances of RedisClient` message JSC already throws for the corresponding getters (and matching WebCore binding behavior for DOM attributes). Setters invoked on real instances (including through internal JS like `handle.ondata = ...`) are unaffected.

### How did you verify your code works?

- The fuzzer repro and minimized variants now exit cleanly (or throw a proper `TypeError`) under the ASAN debug build instead of aborting in GC.
- Added a regression test in `test/js/valkey/valkey-gc.test.ts` covering the proxy receiver, prototype-chain receiver, and extracted-setter paths plus normal instance usage; it fails (subprocess crash) on the previous build and passes with the fix.
- Ran zlib (`onerror`), node http (`ondata`/`onabort`), HTMLRewriter, FileSink, socket, and timer suites against the debug build — no new failures.

🤖 Generated by fuzzing infrastructure