### PR TITLE
webcore: snapshot shared buffers before sink writes

### DIFF
--- a/src/runtime/webcore/ResumableSink.rs
+++ b/src/runtime/webcore/ResumableSink.rs
@@ -126,6 +126,33 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
         // Dereferenced as `&mut` because impls mutate (detachSink, deref, etc.).
         unsafe { (*ctx).write_request_data(bytes) }
     }
+
+    /// Push `bytes` to the context, fold the backpressure result into `status`,
+    /// and return the JS-visible "wants more" boolean (`false` while paused, and
+    /// `false` once the context will take no more data).
+    #[inline]
+    fn dispatch_write(&mut self, bytes: &[u8]) -> JSValue {
+        scoped_log!(ResumableSink, "jsWrite {}", bytes.len());
+        match Self::on_write(self.context, bytes) {
+            ResumableSinkBackpressure::Backpressure => {
+                scoped_log!(ResumableSink, "paused");
+                self.status = Status::Paused;
+            }
+            ResumableSinkBackpressure::Done => {
+                // The context will take no more data (e.g. an aborted FetchTasklet
+                // or a dropped stream buffer). Report `false` so JS stops pushing
+                // chunks. Status is left as-is: `Status::Done` is the onEnd-fired
+                // terminal state set by `js_end`/`cancel`, and forcing it here
+                // would make a later `.end()` a no-op via `is_detached()` and skip
+                // `on_end`.
+                return JSValue::from(false);
+            }
+            ResumableSinkBackpressure::WantMore => {
+                self.status = Status::Started;
+            }
+        }
+        JSValue::from(self.status != Status::Paused)
+    }
     #[inline]
     fn on_end(ctx: *mut Context, err: Option<JSValue>) {
         // SAFETY: see on_write.
@@ -320,26 +347,35 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
         }
 
         let buffer = args[0];
+
+        // Shared or resizable JS backing stores are not stable enough to form a
+        // Rust `&[u8]`: another agent can mutate (or the owner resize) the bytes
+        // while the sink reads them. Snapshot into owned bytes (the copy runs in
+        // C++) before Rust forms a slice, then consume the owned payload
+        // synchronously. Fixed unshared input keeps the borrowed `StringOrBuffer`
+        // fast path. Mirrors `JSSink::js_write` — `ResumableSink` backs the S3
+        // upload writer, which routes through here rather than `JSSink`.
+        if let Some(array_buffer) = buffer.as_array_buffer(global_this) {
+            if (array_buffer.shared || array_buffer.resizable)
+                && !array_buffer.is_detached()
+                && array_buffer.byte_len > 0
+            {
+                buffer.ensure_still_alive();
+                let owned = crate::webcore::sink::snapshot_shared_array_buffer_bytes(
+                    global_this,
+                    &array_buffer,
+                )?;
+                return Ok(this.dispatch_write(&owned));
+            }
+        }
+
         let Some(sb) = StringOrBuffer::from_js(global_this, buffer)? else {
             return Err(global_this.throw_invalid_arguments(format_args!(
                 "ResumableSink.write requires a string or buffer"
             )));
         };
 
-        let bytes = sb.slice();
-        scoped_log!(ResumableSink, "jsWrite {}", bytes.len());
-        match Self::on_write(this.context, bytes) {
-            ResumableSinkBackpressure::Backpressure => {
-                scoped_log!(ResumableSink, "paused");
-                this.status = Status::Paused;
-            }
-            ResumableSinkBackpressure::Done => {}
-            ResumableSinkBackpressure::WantMore => {
-                this.status = Status::Started;
-            }
-        }
-
-        Ok(JSValue::from(this.status != Status::Paused))
+        Ok(this.dispatch_write(sb.slice()))
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -883,6 +883,19 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
         }
 
         if let Some(buffer) = arg.as_array_buffer(global) {
+            // Shared/resizable JS backing stores are not stable enough for a Rust
+            // `&[u8]`: another agent can mutate (or the owner resize) the bytes
+            // while the sink reads them. Snapshot into owned bytes before Rust
+            // forms a slice; the copy runs in C++, and the sink consumes the
+            // owned payload synchronously. Fixed unshared input keeps the
+            // borrowed fast path.
+            if (buffer.shared || buffer.resizable) && !buffer.is_detached() && buffer.byte_len > 0 {
+                let owned = snapshot_shared_array_buffer_bytes(global, &buffer)?;
+                return Ok(this
+                    .sink
+                    .write_bytes(&streams::Result::Owned(owned))
+                    .to_js(global));
+            }
             let slice = buffer.slice();
             if slice.is_empty() {
                 return Ok(JSValue::js_number(0.0));
@@ -1209,4 +1222,49 @@ pub extern "C" fn Bun__onSinkDestroyed(ptr_value: *mut c_void, sink_ptr: *mut c_
         return;
     }
     bun_core::debug_warn!("Unknown sink type");
+}
+
+/// Copy a `SharedArrayBuffer`, growable `SharedArrayBuffer`, or resizable
+/// `ArrayBuffer` into owned bytes so a sink write never reads JS backing storage
+/// another agent can mutate through a Rust `&[u8]`. The copy is performed in C++
+/// (`Bun__createArrayBufferForCopy`) into a fresh non-shared buffer, so Rust only
+/// borrows stable, unshared memory before copying it into the returned `Vec`.
+pub(crate) fn snapshot_shared_array_buffer_bytes(
+    global: &JSGlobalObject,
+    buffer: &bun_jsc::ArrayBuffer,
+) -> bun_jsc::JsResult<Vec<u8>> {
+    let copy = bun_jsc::from_js_host_call(global, || {
+        // SAFETY: `Bun__createArrayBufferForCopy` copies `byte_len` bytes from
+        // `buffer.ptr` into a fresh, non-shared ArrayBuffer. Callers only reach
+        // this helper for a live, non-detached buffer with `byte_len > 0`
+        // (checked in `js_write`), so `ptr`/`byte_len` name a valid readable
+        // region and `global` is a live JSGlobalObject.
+        unsafe { Bun__createArrayBufferForCopy(global, buffer.ptr.cast(), buffer.byte_len) }
+    })?;
+    let copy_buffer = copy.as_array_buffer(global).ok_or_else(|| {
+        global.throw_invalid_arguments(format_args!(
+            "Failed to snapshot shared ArrayBuffer for sink write"
+        ))
+    })?;
+    // The snapshot only removes the aliasing hazard if the copy is itself a fixed,
+    // non-shared buffer of the requested length. If the C++ copy contract is ever
+    // violated, error out rather than fall back to reading shared/short input.
+    if copy_buffer.is_detached()
+        || copy_buffer.shared
+        || copy_buffer.resizable
+        || copy_buffer.byte_len != buffer.byte_len
+    {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "snapshot of shared ArrayBuffer did not produce a stable copy"
+        )));
+    }
+    Ok(copy_buffer.byte_slice().to_vec())
+}
+
+unsafe extern "C" {
+    fn Bun__createArrayBufferForCopy(
+        global: *const JSGlobalObject,
+        ptr: *const c_void,
+        len: usize,
+    ) -> JSValue;
 }

--- a/test/js/bun/s3/s3.test.ts
+++ b/test/js/bun/s3/s3.test.ts
@@ -1801,3 +1801,70 @@ describe("s3 multipart upload id validation", () => {
     expect(exitCode).toBe(0);
   }, 60_000);
 });
+
+describe.concurrent("shared/resizable writer input (stable bytes)", () => {
+  // S3File.writer().write() routes through ResumableSink, which snapshots
+  // shared/resizable backing stores before the sink reads them, so the uploaded
+  // body is exactly the view range (not the 0xff guard bytes). The production
+  // guard is `(buffer.shared || buffer.resizable)`; cover both branches against
+  // a local fake S3 endpoint.
+  const offset = 13;
+  const bytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+
+  function sabView() {
+    const sab = new SharedArrayBuffer(offset + bytes.length + 4);
+    const all = new Uint8Array(sab);
+    all.fill(0xff);
+    all.set(bytes, offset);
+    return new Uint8Array(sab, offset, bytes.length);
+  }
+
+  // Resizable (but non-shared) ArrayBuffer hits the same snapshot branch as a SAB.
+  function resizableView() {
+    const ab = new ArrayBuffer(offset + bytes.length + 4, { maxByteLength: offset + bytes.length + 16 });
+    const all = new Uint8Array(ab);
+    all.fill(0xff);
+    all.set(bytes, offset);
+    return new Uint8Array(ab, offset, bytes.length);
+  }
+
+  async function uploadView(view: Uint8Array) {
+    const received: { method: string; body: Uint8Array }[] = [];
+    const server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        received.push({ method: req.method, body: new Uint8Array(await req.arrayBuffer()) });
+        return new Response("", { status: 200, headers: { etag: '"sink"', "content-length": "0" } });
+      },
+    });
+    try {
+      const client = new S3Client({
+        accessKeyId: "test",
+        secretAccessKey: "test",
+        region: "us-east-1",
+        bucket: "bucket",
+        endpoint: server.url.href,
+      });
+      const writer = client.file("sink-sab-object").writer();
+      const wrote = await writer.write(view);
+      await writer.end();
+      return { wrote, put: received.find(r => r.method === "PUT") };
+    } finally {
+      server.stop(true);
+    }
+  }
+
+  it("S3 writer uploads a nonzero-offset Uint8Array(SAB) view", async () => {
+    const { wrote, put } = await uploadView(sabView());
+    expect(wrote).toBe(bytes.length);
+    expect(put).toBeDefined();
+    expect(Array.from(put!.body)).toEqual(bytes);
+  });
+
+  it("S3 writer uploads a nonzero-offset Uint8Array(resizable ArrayBuffer) view", async () => {
+    const { wrote, put } = await uploadView(resizableView());
+    expect(wrote).toBe(bytes.length);
+    expect(put).toBeDefined();
+    expect(Array.from(put!.body)).toEqual(bytes);
+  });
+});

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -62,3 +62,62 @@ describe("ArrayBufferSink", () => {
     });
   }
 });
+
+describe("ArrayBufferSink shared/resizable input (stable bytes)", () => {
+  // Shared and resizable backing stores are snapshotted before the sink reads
+  // them, so the written bytes are exactly the requested view range. The 0xff
+  // guard bytes around the view must never appear in the output.
+  function sabView(offset: number, bytes: number[]) {
+    const sab = new SharedArrayBuffer(offset + bytes.length + 4);
+    const all = new Uint8Array(sab);
+    all.fill(0xff);
+    all.set(bytes, offset);
+    return new Uint8Array(sab, offset, bytes.length);
+  }
+
+  // A resizable (but non-shared) ArrayBuffer hits the same snapshot branch as a
+  // SharedArrayBuffer: the production guard is `(buffer.shared || buffer.resizable)`.
+  function resizableView(offset: number, bytes: number[]) {
+    const ab = new ArrayBuffer(offset + bytes.length + 4, {
+      maxByteLength: offset + bytes.length + 16,
+    });
+    const all = new Uint8Array(ab);
+    all.fill(0xff);
+    all.set(bytes, offset);
+    return new Uint8Array(ab, offset, bytes.length);
+  }
+
+  it("writes a nonzero-offset Uint8Array(SAB) view", () => {
+    const sink = new ArrayBufferSink();
+    const wrote = sink.write(sabView(9, [1, 2, 3, 4, 5]));
+    const out = new Uint8Array(sink.end());
+    expect(wrote).toBe(5);
+    expect(Array.from(out)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("writes a raw SharedArrayBuffer", () => {
+    const sab = new SharedArrayBuffer(4);
+    new Uint8Array(sab).set([10, 20, 30, 40]);
+    const sink = new ArrayBufferSink();
+    const wrote = sink.write(sab);
+    const out = new Uint8Array(sink.end());
+    expect(wrote).toBe(4);
+    expect(Array.from(out)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("accepts a zero-length SharedArrayBuffer view", () => {
+    const sink = new ArrayBufferSink();
+    const wrote = sink.write(new Uint8Array(new SharedArrayBuffer(8), 4, 0));
+    const out = new Uint8Array(sink.end());
+    expect(wrote).toBe(0);
+    expect(out.byteLength).toBe(0);
+  });
+
+  it("writes a nonzero-offset Uint8Array(resizable ArrayBuffer) view", () => {
+    const sink = new ArrayBufferSink();
+    const wrote = sink.write(resizableView(7, [11, 22, 33, 44]));
+    const out = new Uint8Array(sink.end());
+    expect(wrote).toBe(4);
+    expect(Array.from(out)).toEqual([11, 22, 33, 44]);
+  });
+});

--- a/test/js/bun/util/filesink.test.ts
+++ b/test/js/bun/util/filesink.test.ts
@@ -1,6 +1,6 @@
 import { createSocketPair, fileSinkInternals } from "bun:internal-for-testing";
 import { describe, expect, it } from "bun:test";
-import { fileDescriptorLeakChecker, isPosix, isWindows, tmpdirSync } from "harness";
+import { fileDescriptorLeakChecker, isPosix, isWindows, tempDir, tmpdirSync } from "harness";
 import { mkfifo } from "mkfifo";
 import { join } from "node:path";
 
@@ -307,4 +307,33 @@ it.skipIf(!isPosix)("writing after end() fails during flush does not crash", asy
   expect(() => writer.flush()).not.toThrow();
   await Promise.resolve(writer.end()).catch(() => {});
   await 1;
+});
+
+// Shared and resizable backing stores both hit the snapshot branch; the
+// production guard is `(buffer.shared || buffer.resizable)`. Only the view's
+// range (not the 0xff guard bytes) is written to the file.
+it.each([
+  ["SharedArrayBuffer", (offset: number, len: number) => new Uint8Array(new SharedArrayBuffer(offset + len + 4))],
+  [
+    "resizable ArrayBuffer",
+    (offset: number, len: number) =>
+      new Uint8Array(new ArrayBuffer(offset + len + 4, { maxByteLength: offset + len + 16 })),
+  ],
+] as const)("FileSink writes a nonzero-offset %s view (stable bytes)", async (_label, makeBacking) => {
+  const offset = 11;
+  const bytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const all = makeBacking(offset, bytes.length);
+  all.fill(0xff);
+  all.set(bytes, offset);
+  const view = new Uint8Array(all.buffer, offset, bytes.length);
+
+  using dir = tempDir("filesink-sab", {});
+  const path = join(String(dir), "filesink-sab-view.bin");
+  const writer = Bun.file(path).writer();
+  const wrote = await writer.write(view);
+  await writer.end();
+
+  const out = new Uint8Array(await Bun.file(path).arrayBuffer());
+  expect(wrote).toBe(bytes.length);
+  expect(Array.from(out)).toEqual(bytes);
 });


### PR DESCRIPTION
## What this does

A sink `.write()` accepts a `SharedArrayBuffer`-backed or resizable chunk from safe JS. `JSSink::js_write` (`ArrayBufferSink`, `FileSink`) and `ResumableSink::js_write` (S3, fetch) read it as a Rust `&[u8]` via `byte_slice()`, but another agent can mutate that backing store mid-read. That is undefined behavior under Rust's aliasing rules.

**Fix:** shared/resizable chunks are copied in C++ (`Bun__createArrayBufferForCopy`) to a fresh non-shared buffer and read as owned bytes. Fixed unshared chunks keep the borrowed fast path.

## Verification

Behavior-preserving: tests pass on old code by design; the real change is the removed `&[u8]`.

| Check | Result |
| --- | --- |
| `arraybuffersink` / `filesink` / `s3` tests | exact view range (SAB + resizable) |
| `fmt`, `clippy` | clean |

## Review map

- `Sink.rs`, `ResumableSink.rs`: snapshot/validate shared input; fast path for fixed-unshared
- `arraybuffersink` / `filesink` / `s3` tests: SAB and resizable coverage
