### PR TITLE
markdown: snapshot resizable ArrayBuffer input before option getters run

### DIFF
--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -50,12 +50,49 @@ impl PinnedView {
     fn slice(&self) -> &[u8] {
         self.0.byte_slice()
     }
+
+    /// A non-shared resizable ArrayBuffer can `resize()`/shrink its backing
+    /// store out from under a borrowed `&[u8]`. Pinning prevents detach but
+    /// not resize (see array_buffer.rs:28-30, JSValue.rs as_pinned_arraybuffer),
+    /// so input from such a buffer must be snapshotted before any JS reentry.
+    #[inline]
+    fn is_non_shared_resizable(&self) -> bool {
+        self.0.resizable && !self.0.shared
+    }
 }
 
 impl Drop for PinnedView {
     fn drop(&mut self) {
         self.0.unpin();
     }
+}
+
+/// Copy the submitted bytes into owned storage when (and only when) the input is
+/// backed by a non-shared resizable ArrayBuffer, before any option getter,
+/// callback, or component extraction can run JS that resizes the backing store.
+/// Returns `None` for string, fixed Buffer/TypedArray, and SharedArrayBuffer
+/// input, all of which keep the existing pinned fast path (no copy).
+#[inline]
+fn snapshot_resizable_markdown_input(pinned: &Option<PinnedView>) -> Option<Box<[u8]>> {
+    pinned
+        .as_ref()
+        .filter(|p| p.is_non_shared_resizable())
+        .map(|p| Box::<[u8]>::from(p.slice()))
+}
+
+/// The bytes the parser/renderer should read: the owned snapshot if one was
+/// taken (resizable RAB input), otherwise the pinned view (fixed buffers) or the
+/// `StringOrBuffer`'s own bytes (string input).
+#[inline]
+fn markdown_input_slice<'a>(
+    buffer: &'a StringOrBuffer,
+    pinned: &'a Option<PinnedView>,
+    snapshot: Option<&'a [u8]>,
+) -> &'a [u8] {
+    snapshot.unwrap_or_else(|| match pinned {
+        Some(pinned) => pinned.slice(),
+        None => buffer.slice(),
+    })
 }
 
 pub(crate) fn create(global_this: &JSGlobalObject) -> JSValue {
@@ -90,10 +127,8 @@ pub fn render_to_ansi(global_this: &JSGlobalObject, callframe: &CallFrame) -> Js
     };
 
     let pinned = PinnedView::pin(global_this, &buffer)?;
-    let input: &[u8] = match &pinned {
-        Some(p) => p.slice(),
-        None => buffer.slice(),
-    };
+    let input_snapshot = snapshot_resizable_markdown_input(&pinned);
+    let input = markdown_input_slice(&buffer, &pinned, input_snapshot.as_deref());
 
     let mut theme = md::AnsiTheme {
         colors: true,
@@ -164,10 +199,8 @@ pub(crate) fn render_to_html(
     };
 
     let pinned = PinnedView::pin(global_this, &buffer)?;
-    let input: &[u8] = match &pinned {
-        Some(p) => p.slice(),
-        None => buffer.slice(),
-    };
+    let input_snapshot = snapshot_resizable_markdown_input(&pinned);
+    let input = markdown_input_slice(&buffer, &pinned, input_snapshot.as_deref());
 
     let options = parse_options(global_this, opts_value)?;
 
@@ -276,10 +309,8 @@ pub(crate) fn render(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsR
     };
 
     let pinned = PinnedView::pin(global_this, &buffer)?;
-    let input: &[u8] = match &pinned {
-        Some(p) => p.slice(),
-        None => buffer.slice(),
-    };
+    let input_snapshot = snapshot_resizable_markdown_input(&pinned);
+    let input = markdown_input_slice(&buffer, &pinned, input_snapshot.as_deref());
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;
@@ -380,10 +411,8 @@ fn render_ast(
     };
 
     let pinned = PinnedView::pin(global_this, &buffer)?;
-    let input: &[u8] = match &pinned {
-        Some(p) => p.slice(),
-        None => buffer.slice(),
-    };
+    let input_snapshot = snapshot_resizable_markdown_input(&pinned);
+    let input = markdown_input_slice(&buffer, &pinned, input_snapshot.as_deref());
 
     // Parse parser options from 3rd argument
     let options = parse_options(global_this, opts_value)?;

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -1122,3 +1122,91 @@ describe("pathological autolink opener inputs", () => {
     );
   }, 90_000);
 });
+
+// A non-shared resizable ArrayBuffer can shrink its backing store from a JS
+// getter that runs *after* Bun.markdown has formed a Rust &[u8] over it but
+// *before* the parser reads it (options getters, render callbacks, react
+// components all run user JS at that point). Pinning prevents detach but not
+// resize, so the input must be snapshotted up front. Each test resizes the
+// backing buffer to 0 from a getter and asserts the *submitted* bytes were
+// still parsed (and that the resize really happened).
+describe("resizable ArrayBuffer input across JS reentry", () => {
+  function makeView() {
+    const text = Buffer.from("# hello\n\nworld\n");
+    const rab = new ArrayBuffer(text.length, { maxByteLength: 1024 });
+    const view = new Uint8Array(rab);
+    view.set(text);
+    return { rab, view };
+  }
+
+  test("html snapshots input before option getters can resize", () => {
+    const { rab, view } = makeView();
+    const html = Markdown.html(view, {
+      get autolinks() {
+        rab.resize(0);
+        return false;
+      },
+    });
+    expect(rab.byteLength).toBe(0);
+    expect(html).toContain("<h1>hello</h1>");
+    expect(html).toContain("world");
+  });
+
+  test("ansi snapshots input before theme getters can resize", () => {
+    const { rab, view } = makeView();
+    const ansi = Markdown.ansi(view, {
+      get colors() {
+        rab.resize(0);
+        return false;
+      },
+    });
+    expect(rab.byteLength).toBe(0);
+    expect(ansi).toContain("hello");
+    expect(ansi).toContain("world");
+  });
+
+  test("render snapshots input before callback getters can resize", () => {
+    const { rab, view } = makeView();
+    const rendered = Markdown.render(view, {
+      get heading() {
+        rab.resize(0);
+        return (children: string, { level }: any) => `<h${level}>${children}</h${level}>`;
+      },
+      paragraph: (children: string) => `<p>${children}</p>`,
+    });
+    expect(rab.byteLength).toBe(0);
+    expect(rendered).toContain("<h1>hello</h1>");
+    expect(rendered).toContain("<p>world</p>");
+  });
+
+  test("react snapshots input before option getters can resize", () => {
+    const { rab, view } = makeView();
+    const element = Markdown.react(view, undefined, {
+      reactVersion: 18,
+      get headings() {
+        rab.resize(0);
+        return false;
+      },
+    });
+    const rendered = renderToString(element);
+    expect(rab.byteLength).toBe(0);
+    expect(rendered).toContain("hello");
+    expect(rendered).toContain("world");
+  });
+
+  // A non-shared resizable ArrayBuffer can also be grown, which may reallocate
+  // and move the backing store (same UB class as shrink). The snapshot is taken
+  // before reentry, so the original input still renders.
+  test("html snapshots input before a getter grows the buffer", () => {
+    const { rab, view } = makeView();
+    const html = Markdown.html(view, {
+      get autolinks() {
+        rab.resize(rab.maxByteLength);
+        return false;
+      },
+    });
+    expect(rab.byteLength).toBe(rab.maxByteLength);
+    expect(html).toContain("<h1>hello</h1>");
+    expect(html).toContain("world");
+  });
+});


### PR DESCRIPTION
## What this does

`Bun.markdown.html` / `.ansi` / `.render` / `.react` accept a resizable `ArrayBuffer`-backed input. Bun forms a Rust `&[u8]` over it, then reads an options getter or render callback that can run safe JS and resize the backing before the parser consumes the slice, leaving a stale pointer/length. That is undefined behavior under Rust's lifetime rules.

**Fix:** resizable inputs are snapshotted into owned bytes before any getter or callback runs, so the parser never holds a slice whose backing can move. Fixed inputs keep the borrowed fast path.

## Verification

Live repro: the tests crash (SEGV) on old code and pass with the fix. `md-edge-cases` resizes the input from a getter (shrink and grow) and asserts the submitted bytes still parse. `fmt` clean.

## Review map

- `MarkdownObject.rs`: snapshot resizable input before option/callback/component reads; borrowed fast path for fixed input
- `md-edge-cases.test.ts`: getter-reentry coverage for html, ansi, render, react
