### PR TITLE
test: let the docker test helper target a remote Docker host

### DIFF
--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -159,6 +159,10 @@ class DockerComposeHelper {
     return parseInt(match[1], 10);
   }
 
+  private get testHost(): string {
+    return process.env.BUN_DOCKER_TEST_HOST || "127.0.0.1";
+  }
+
   async waitForPort(port: number, timeout: number = 10000): Promise<void> {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
@@ -170,7 +174,7 @@ class DockerComposeHelper {
             resolve();
           });
           socket.once("error", reject);
-          socket.connect(port, "127.0.0.1");
+          socket.connect(port, this.testHost);
         });
         return;
       } catch {
@@ -197,7 +201,7 @@ class DockerComposeHelper {
     }
 
     const info: ServiceInfo = {
-      host: "127.0.0.1",
+      host: this.testHost,
       ports: {},
     };
 


### PR DESCRIPTION
## What this does

`test/docker/index.ts` (`DockerComposeHelper`) hardcoded `127.0.0.1` for both the port-readiness probe and the `host` it returns from `ensure()`. This adds a `BUN_DOCKER_TEST_HOST` env var (default `127.0.0.1`) and routes both through it.

## Why

The darwin CI runners are moving to an **ephemeral-VM model** — Tart on Apple Silicon, where each test job runs in a fresh macOS VM and Docker runs in a **separate Linux sidecar VM** (Apple Silicon can't run accelerated Docker inside a macOS guest, so the daemon lives next door). In that setup the container ports are published on the **sidecar's** address, not `localhost`, so the test process needs to connect there.

This is the first, self-contained piece of that migration. On its own it's a no-op for everyone today.

## Backward compatible

- `BUN_DOCKER_TEST_HOST` unset → `127.0.0.1`, exactly as before. Local dev and the current bare-metal agents are unaffected.
- The sidecar path sets `BUN_DOCKER_TEST_HOST=<sidecar-ip>` alongside `DOCKER_HOST=tcp://<sidecar-ip>:2375` (which points the `docker` CLI at the same daemon).

## Verification

Ran the real `ensure("postgres_plain")` against an actual Linux Docker sidecar VM (Tart) from a macOS host, with `BUN_DOCKER_TEST_HOST` + `DOCKER_HOST` set:

```
ENSURE_HOST 192.168.64.2
HOST_HONORS_ENV true      # ensure() returns the configured host, not 127.0.0.1
CONNECT_OK true           # a bun SQL connection through that host succeeds
```

## What's next (not in this PR)

The follow-up changes that complete the sidecar model: switching bind-mounted init-scripts/configs to `build:`/`COPY` (bind mounts don't cross to a remote daemon; `docker build` context does — already validated), plus the CI pipeline wiring. This PR is just the host indirection that everything else builds on.