### PR TITLE
test: build docker test services instead of bind-mounting their config

### DIFF
--- a/test/docker/Dockerfile.autobahn
+++ b/test/docker/Dockerfile.autobahn
@@ -1,0 +1,2 @@
+FROM crossbario/autobahn-testsuite
+COPY config/fuzzingserver.json /config/fuzzingserver.json

--- a/test/docker/Dockerfile.autobahn
+++ b/test/docker/Dockerfile.autobahn
@@ -1,2 +1,2 @@
-FROM crossbario/autobahn-testsuite
+FROM crossbario/autobahn-testsuite:25.10.1
 COPY config/fuzzingserver.json /config/fuzzingserver.json

--- a/test/docker/Dockerfile.postgres-auth
+++ b/test/docker/Dockerfile.postgres-auth
@@ -1,0 +1,3 @@
+FROM postgres:15
+COPY init-scripts/postgres-auth/ /docker-entrypoint-initdb.d/
+COPY config/pg_hba_auth.conf /etc/postgresql/pg_hba.conf

--- a/test/docker/Dockerfile.postgres-plain
+++ b/test/docker/Dockerfile.postgres-plain
@@ -1,0 +1,2 @@
+FROM postgres:15
+COPY init-scripts/postgres/ /docker-entrypoint-initdb.d/

--- a/test/docker/Dockerfile.squid
+++ b/test/docker/Dockerfile.squid
@@ -1,0 +1,2 @@
+FROM ubuntu/squid:5.2-22.04_beta
+COPY config/squid.conf /etc/squid/squid.conf

--- a/test/docker/README.md
+++ b/test/docker/README.md
@@ -66,7 +66,10 @@ const postgres = await dockerCompose.ensure("postgres_plain");
 ```yaml
 services:
   postgres_plain:
-    image: postgres:15
+    build:                # build a local image so init scripts are baked in
+      context: .          # (bind mounts don't resolve against a remote/sidecar daemon)
+      dockerfile: Dockerfile.postgres-plain
+    image: bun-postgres-plain:local
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
     ports:
@@ -168,6 +171,10 @@ test("wait for service to be healthy", async () => {
 ```
 test/docker/
 ├── docker-compose.yml       # Service definitions
+├── Dockerfile.postgres-plain # postgres_plain image (bakes in init-scripts)
+├── Dockerfile.postgres-auth  # postgres_auth image (init-scripts + pg_hba)
+├── Dockerfile.autobahn       # autobahn image (fuzzingserver.json)
+├── Dockerfile.squid          # squid image (squid.conf)
 ├── index.ts                # TypeScript API
 ├── prepare-ci.sh          # CI/CD setup script
 ├── README.md              # This file

--- a/test/docker/docker-compose.yml
+++ b/test/docker/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   # PostgreSQL Services
   postgres_plain:
-    image: postgres:15
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres-plain
+    image: bun-postgres-plain:local
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_USER: postgres
-    volumes:
-      - ./init-scripts/postgres:/docker-entrypoint-initdb.d:ro
     ports:
       - target: 5432
         published: 0
@@ -49,13 +50,13 @@ services:
       start_interval: 1s
 
   postgres_auth:
-    image: postgres:15
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres-auth
+    image: bun-postgres-auth:local
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_USER: postgres
-    volumes:
-      - ./init-scripts/postgres-auth:/docker-entrypoint-initdb.d:ro
-      - ./config/pg_hba_auth.conf:/etc/postgresql/pg_hba.conf:ro
     ports:
       - target: 5432
         published: 0
@@ -205,9 +206,10 @@ services:
   # because it validates the Host header against its configured listening port.
   # Dynamic port mapping causes "port X does not match server listening port 9002" errors.
   autobahn:
-    image: crossbario/autobahn-testsuite
-    volumes:
-      - ./config/fuzzingserver.json:/config/fuzzingserver.json:ro
+    build:
+      context: .
+      dockerfile: Dockerfile.autobahn
+    image: bun-autobahn:local
     command: wstest -m fuzzingserver -s /config/fuzzingserver.json
     ports:
       - target: 9002
@@ -226,9 +228,10 @@ services:
 
   # Squid proxy for WebSocket proxy testing
   squid:
-    image: ubuntu/squid:5.2-22.04_beta
-    volumes:
-      - ./config/squid.conf:/etc/squid/squid.conf:ro
+    build:
+      context: .
+      dockerfile: Dockerfile.squid
+    image: bun-squid:local
     ports:
       - target: 3128
         published: 0

--- a/test/docker/index.ts
+++ b/test/docker/index.ts
@@ -120,12 +120,12 @@ class DockerComposeHelper {
   }
 
   private async doUp(service: ServiceName): Promise<void> {
-    // Build the service if needed (for services like mysql_tls, postgres_tls that need building)
-    if (service === "mysql_tls" || service === "redis_unified" || service === "postgres_tls") {
-      const buildResult = await this.exec(["build", service]);
-      if (buildResult.exitCode !== 0) {
-        throw new Error(`Failed to build service ${service}: ${buildResult.stderr}`);
-      }
+    // Pre-build the service (a no-op for image-only services) so build time
+    // doesn't eat into the `up --wait` timeout below. CI pre-bakes everything
+    // via buildServices(); this covers local dev where that wasn't run.
+    const buildResult = await this.exec(["build", service]);
+    if (buildResult.exitCode !== 0) {
+      throw new Error(`Failed to build service ${service}: ${buildResult.stderr}`);
     }
 
     // Start the service and wait for it to be healthy.
@@ -404,10 +404,10 @@ class DockerComposeHelper {
    * Build all services that need building - useful for CI
    */
   async buildServices(): Promise<void> {
-    // One `compose build` with all services — buildkit parallelizes them.
-    const servicesToBuild = ["postgres_tls", "mysql_tls", "redis_unified"];
-    console.log(`Building ${servicesToBuild.join(", ")}...`);
-    const { exitCode, stderr } = await this.exec(["build", ...servicesToBuild]);
+    // Bare `compose build` builds every service that has a `build:` section,
+    // so there's no hardcoded list to keep in sync as services are converted.
+    console.log("Building all services with a build section...");
+    const { exitCode, stderr } = await this.exec(["build"]);
     if (exitCode !== 0) {
       throw new Error(`Failed to build services: ${stderr}`);
     }


### PR DESCRIPTION
## What this does

Converts the four `test/docker` services that bind-mounted local files — `postgres_plain`, `postgres_auth`, `autobahn`, `squid` — to **build their own images** (a small Dockerfile that `COPY`s the init-scripts/config in) instead of `image:` + `volumes:` bind mounts.

## Why

Bind mounts resolve on the **Docker daemon's** filesystem, not the client's. The darwin CI runners are moving to a **sidecar-Docker model** (the daemon runs in a separate Linux VM, reached over `DOCKER_HOST` — Apple Silicon can't run accelerated Docker inside a macOS guest). In that model the bind-mounted `./init-scripts` / `./config` files don't exist on the daemon side, so they **silently don't apply** — e.g. the Postgres init scripts never run and the `bun_sql_test` role is missing, which then looks like a confusing test failure rather than a setup problem.

`docker build`'s context, by contrast, **ships to the daemon**, so baking the files into the image works against both a local daemon and a remote/sidecar one.

This follows the pattern the repo already uses for its TLS services (`postgres_tls`, `mysql_tls`, `redis_unified` are all `build:`-based).

## Changes
- New `Dockerfile.postgres-plain`, `Dockerfile.postgres-auth`, `Dockerfile.autobahn`, `Dockerfile.squid` (each `FROM` the stock image + `COPY` the scripts/config).
- The four services now use `build:` + a `bun-*:local` image tag; their `volumes:` bind mounts are removed.

## Compatibility
- **Local dev unchanged in behavior** — `docker compose up` just builds the image on first run (cached after), then runs identically. Init scripts/config are baked in rather than mounted.
- Minor DX note: editing a baked config now needs a `docker compose build` to pick up (same as the existing TLS services).

## Verification
Ran the real compose against an actual Linux Docker sidecar VM (Tart) over `DOCKER_HOST`:
- `docker compose config` valid; all four images **build** (context shipped to the remote daemon).
- `postgres_plain` + `postgres_auth` come up **healthy**, and the baked init scripts run → **`bun_sql_test` role present on both** (the exact thing that was silently missing with bind mounts).

## Context
Second piece of the darwin Tart-runner migration; pairs with #31731 (the `BUN_DOCKER_TEST_HOST` host indirection).