### PR TITLE
http: combine duplicate response/request headers with ", " per the Fetch spec

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1973,8 +1973,8 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
             } else {
                 // the case where we do not need to clone the name
                 // when the header name is already present in the list
-                // we don't have that information here, so map.setUncommonHeaderCloneName exists
-                map.setUncommonHeaderCloneName(nameView, value);
+                // we don't have that information here, so map.addUncommonHeaderCloneName exists
+                map.addUncommonHeaderCloneName(nameView, value);
             }
         }
 
@@ -2003,7 +2003,7 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromUWS(void* arg1)
         if (WebCore::findHTTPHeaderName(nameView, name)) {
             map.add(name, WTF::move(value));
         } else {
-            map.setUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
         }
     }
     headers->setInternalHeaders(WTF::move(map));
@@ -2028,7 +2028,7 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromH3(void* arg1)
         if (WebCore::findHTTPHeaderName(nameView, hn)) {
             map.add(hn, WTF::move(value));
         } else {
-            map.setUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
+            map.addUncommonHeader(nameView.toString().isolatedCopy(), WTF::move(value));
         }
     });
     headers->setInternalHeaders(WTF::move(map));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1954,14 +1954,19 @@ WebCore::FetchHeaders* WebCore__FetchHeaders__createFromPicoHeaders_(const void*
 
         for (size_t j = 0; j < end; j++) {
             PicoHTTPHeader header = pico_headers.ptr[j];
-            if (header.value.len == 0 || header.name.len == 0)
+            // picohttpparser reports obs-fold continuation lines with an empty
+            // name; skip those. Empty *values* must flow through so duplicate
+            // headers combine per the Fetch spec ("a, , c") and a lone empty
+            // header is still visible to JS, matching the uWS/H3 paths.
+            if (header.name.len == 0)
                 continue;
 
             StringView nameView = StringView(std::span { reinterpret_cast<const char*>(header.name.ptr), header.name.len });
 
             std::span<Latin1Character> data;
             auto value = String::createUninitialized(header.value.len, data);
-            memcpy(data.data(), header.value.ptr, header.value.len);
+            if (header.value.len > 0)
+                memcpy(data.data(), header.value.ptr, header.value.len);
 
             HTTPHeaderName name;
 

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.cpp
@@ -177,7 +177,18 @@ void HTTPHeaderMap::setUncommonHeader(const String& name, const String& value)
         m_uncommonHeaders[index].value = value;
 }
 
-void HTTPHeaderMap::setUncommonHeaderCloneName(const StringView name, const String& value)
+void HTTPHeaderMap::addUncommonHeader(const String& name, const String& value)
+{
+    auto index = m_uncommonHeaders.findIf([&](auto& header) {
+        return equalIgnoringASCIICase(header.key, name);
+    });
+    if (index == notFound)
+        m_uncommonHeaders.append(UncommonHeader { name, value });
+    else
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
+}
+
+void HTTPHeaderMap::addUncommonHeaderCloneName(const StringView name, const String& value)
 {
     auto index = m_uncommonHeaders.findIf([&](auto& header) {
         return equalIgnoringASCIICase(header.key, name);
@@ -188,7 +199,7 @@ void HTTPHeaderMap::setUncommonHeaderCloneName(const StringView name, const Stri
         memcpy(ptr.data(), name.span8().data(), name.length());
         m_uncommonHeaders.append(UncommonHeader { nameCopy, value });
     } else
-        m_uncommonHeaders[index].value = value;
+        m_uncommonHeaders[index].value = makeString(m_uncommonHeaders[index].value, ", "_s, value);
 }
 
 void HTTPHeaderMap::add(const String& name, const String& value)

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -270,7 +270,8 @@ public:
     template<class Encoder> void encode(Encoder &) const;
     template<class Decoder> [[nodiscard]] static bool decode(Decoder &, HTTPHeaderMap &);
     void setUncommonHeader(const String &name, const String &value);
-    void setUncommonHeaderCloneName(const StringView name, const String &value);
+    void addUncommonHeader(const String &name, const String &value);
+    void addUncommonHeaderCloneName(const StringView name, const String &value);
 
 private:
     WEBCORE_EXPORT String getUncommonHeader(const StringView name) const;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2173,6 +2173,57 @@ it.concurrent("#6462", async () => {
   ]);
 });
 
+it.concurrent("combines duplicate request headers per the Fetch spec", async () => {
+  // WHATWG Fetch requires repeated header fields to be combined with ", " when
+  // read via Headers.get(). Previously Bun.serve overwrote duplicate non-common
+  // request header names with the last value, dropping earlier values.
+  let seen: Record<string, string | null> = {};
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      seen = {
+        xdup: req.headers.get("x-dup"),
+        xonce: req.headers.get("x-once"),
+        accept: req.headers.get("accept"),
+      };
+      return new Response("ok");
+    },
+  });
+
+  const { promise, resolve } = Promise.withResolvers<void>();
+  await Bun.connect({
+    port: server.port,
+    hostname: server.hostname,
+    socket: {
+      open(socket) {
+        socket.write(
+          "GET / HTTP/1.1\r\n" +
+            `Host: ${server.hostname}\r\n` +
+            "X-Dup: first\r\n" +
+            "X-Dup: second\r\n" +
+            "X-Dup: third\r\n" +
+            "X-Once: only\r\n" +
+            "Accept: text/html\r\n" +
+            "Accept: application/json\r\n" +
+            "Connection: close\r\n" +
+            "\r\n",
+        );
+      },
+      data() {},
+      close() {
+        resolve();
+      },
+    },
+  });
+  await promise;
+
+  expect(seen).toEqual({
+    xdup: "first, second, third",
+    xonce: "only",
+    accept: "text/html, application/json",
+  });
+});
+
 it.concurrent("#6583", async () => {
   const callback = mock();
   using server = Bun.serve({

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2184,6 +2184,8 @@ it.concurrent("combines duplicate request headers per the Fetch spec", async () 
       seen = {
         xdup: req.headers.get("x-dup"),
         xonce: req.headers.get("x-once"),
+        xgap: req.headers.get("x-gap"),
+        xempty: req.headers.get("x-empty"),
         accept: req.headers.get("accept"),
       };
       return new Response("ok");
@@ -2203,6 +2205,10 @@ it.concurrent("combines duplicate request headers per the Fetch spec", async () 
             "X-Dup: second\r\n" +
             "X-Dup: third\r\n" +
             "X-Once: only\r\n" +
+            "X-Gap: a\r\n" +
+            "X-Gap:\r\n" +
+            "X-Gap: c\r\n" +
+            "X-Empty:\r\n" +
             "Accept: text/html\r\n" +
             "Accept: application/json\r\n" +
             "Connection: close\r\n" +
@@ -2220,6 +2226,10 @@ it.concurrent("combines duplicate request headers per the Fetch spec", async () 
   expect(seen).toEqual({
     xdup: "first, second, third",
     xonce: "only",
+    // the combine step has no empty-value exception, and a lone empty header
+    // is still visible — Node reports "a, , c" and "", not "a, c" and null
+    xgap: "a, , c",
+    xempty: "",
     accept: "text/html, application/json",
   });
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2559,6 +2559,10 @@ it("combines duplicate response headers per the Fetch spec", async () => {
           "X-Dup: second\r\n" +
           "X-Dup: third\r\n" +
           "X-Once: only\r\n" +
+          "X-Gap: a\r\n" +
+          "X-Gap:\r\n" +
+          "X-Gap: c\r\n" +
+          "X-Empty:\r\n" +
           "Accept: text/html\r\n" +
           "Accept: application/json\r\n" +
           "Set-Cookie: a=1\r\n" +
@@ -2576,6 +2580,10 @@ it("combines duplicate response headers per the Fetch spec", async () => {
   expect(await res.text()).toBe("ok");
   expect(res.headers.get("x-dup")).toBe("first, second, third");
   expect(res.headers.get("x-once")).toBe("only");
+  // the combine step has no empty-value exception, and a lone empty header is
+  // still visible — undici returns "a, , c" and "" here, not "a, c" and null
+  expect(res.headers.get("x-gap")).toBe("a, , c");
+  expect(res.headers.get("x-empty")).toBe("");
   expect(res.headers.get("accept")).toBe("text/html, application/json");
   expect(res.headers.getSetCookie()).toEqual(["a=1", "b=2"]);
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2545,6 +2545,41 @@ it("rejects a response with an unparseable Content-Length instead of treating it
   expect(await ok.text()).toBe("hello");
 });
 
+it("combines duplicate response headers per the Fetch spec", async () => {
+  // WHATWG Fetch requires repeated header fields to be combined with ", " when
+  // read via Headers.get(), except Set-Cookie which is stored as separate
+  // values exposed by getSetCookie(). Previously Bun overwrote duplicate
+  // non-common header names with the last value, dropping earlier values.
+  await using server = net.createServer(socket => {
+    socket.once("data", () => {
+      socket.end(
+        "HTTP/1.1 200 OK\r\n" +
+          "Content-Length: 2\r\n" +
+          "X-Dup: first\r\n" +
+          "X-Dup: second\r\n" +
+          "X-Dup: third\r\n" +
+          "X-Once: only\r\n" +
+          "Accept: text/html\r\n" +
+          "Accept: application/json\r\n" +
+          "Set-Cookie: a=1\r\n" +
+          "Set-Cookie: b=2\r\n" +
+          "Connection: close\r\n" +
+          "\r\n" +
+          "ok",
+      );
+    });
+  });
+  await once(server.listen(0, "localhost"), "listening");
+  const { port } = server.address() as AddressInfo;
+
+  const res = await fetch(`http://localhost:${port}/`);
+  expect(await res.text()).toBe("ok");
+  expect(res.headers.get("x-dup")).toBe("first, second, third");
+  expect(res.headers.get("x-once")).toBe("only");
+  expect(res.headers.get("accept")).toBe("text/html, application/json");
+  expect(res.headers.getSetCookie()).toEqual(["a=1", "b=2"]);
+});
+
 it("drops a custom Host header when following a cross-origin redirect", async () => {
   // A per-request Host override must not survive a change of origin: the
   // follow-up request's Host header (and the TLS SNI / certificate identity

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2569,10 +2569,10 @@ it("combines duplicate response headers per the Fetch spec", async () => {
       );
     });
   });
-  await once(server.listen(0, "localhost"), "listening");
+  await once(server.listen(0, "127.0.0.1"), "listening");
   const { port } = server.address() as AddressInfo;
 
-  const res = await fetch(`http://localhost:${port}/`);
+  const res = await fetch(`http://127.0.0.1:${port}/`);
   expect(await res.text()).toBe("ok");
   expect(res.headers.get("x-dup")).toBe("first, second, third");
   expect(res.headers.get("x-once")).toBe("only");


### PR DESCRIPTION
Duplicate non-common HTTP headers silently collapsed to the **last** value — on both `fetch()` response parsing and `Bun.serve` request parsing — so earlier values were dropped. The WHATWG Fetch "combine" step requires joining duplicates with `, `; Node/undici do. (e.g. two `X-Dup: first` / `X-Dup: second` → Bun returned `"second"`, Node returns `"first, second"`.)

`HTTPHeaderMap`'s uncommon-header setter overwrote on duplicate; the comma-join only existed for common headers (`add()`). Add `addUncommonHeader` / `addUncommonHeaderCloneName` that combine with `makeString(existing, ", ", value)` (mirroring `add()`), and switch the three wire-protocol parsers (picohttpparser fetch response, uWS HTTP/1 request, HTTP/3 request) to them. The plain `setUncommonHeader` (overwrite) is kept — it backs `Headers.set()`, which must overwrite.

`Set-Cookie` is unaffected: it's a *common* header with its own separate-values list (`getSetCookie()`), so it never goes through the uncommon path — verified it still returns separate values. `Headers.set()` (overwrite) and `Headers.append()` (combine) semantics unchanged.

Matches Node/undici on fetch + serve (combine uncommon, separate Set-Cookie, common headers already combined). Not a port regression — the C++ header map predates the Rust port; `USE_SYSTEM_BUN` shows the same last-wins loss.


---

Follow-up from review: the pico (fetch response) path also skipped headers with **empty values** before the combine step, so `X-Dup: a` / `X-Dup:` / `X-Dup: c` read `"a, c"` from `fetch()` while `Bun.serve` (uWS/H3, which never skipped empties) reads `"a, , c"` — the spec's combine step has no empty-value exception. Now only `name.len == 0` is skipped (picohttpparser obs-fold continuations); empty values flow through like the other parsers. Matches undici/Node: `"a, , c"`, a lone empty header reads `""` instead of `null`, and an empty `Set-Cookie` appears in `getSetCookie()`. Both tests cover these cases.
