### PR TITLE
node:path: fix win32 drive-relative resolve on non-Windows hosts

### DIFF
--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3128,13 +3128,19 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
             {
                 // Translated from the following JS code:
                 //   path = `${resolvedDevice}\\`;
-                buf_size = resolved_device_len;
-                memmove(&mut buf2[0..buf_size], &tmp_buf[0..resolved_device_len]);
-                buf_offset = buf_size;
-                buf_size += 1;
-                buf2[buf_offset] = T::from_u8(CHAR_BACKWARD_SLASH);
-                path_ptr = buf2.as_ptr();
-                path_len = buf_size;
+                //
+                // Built in tmp_buf, NOT buf2: resolvedTail lives at
+                // buf2[0..resolved_tail_len], and writing the fallback there
+                // clobbered it (in JS this is a fresh string). tmp_buf already
+                // holds the device at [0..resolved_device_len]; the discarded
+                // env path/cwd bytes after it are dead, so only the separator
+                // needs appending. The device is always a 2-char drive (`X:`)
+                // here — a UNC device comes from an absolute path, which
+                // breaks out of the loop before this fallback runs — so this
+                // stays well within tmp_buf.
+                tmp_buf[resolved_device_len] = T::from_u8(CHAR_BACKWARD_SLASH);
+                path_ptr = tmp_buf.as_ptr();
+                path_len = resolved_device_len + 1;
             }
         }
 

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -3097,8 +3097,14 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
                 path_len = ep_len;
             } else {
                 // cwd is limited to MAX_PATH_BYTES.
-                cwd_len = get_cwd_t(&mut tmp_buf[..])?.len();
-                path_ptr = tmp_buf.as_ptr();
+                // Write the cwd *after* tmp_buf[0..resolved_device_len] so the
+                // resolved device survives: the drive-mismatch check below and
+                // the final assembly both read it from tmp_buf. On a non-Windows
+                // host the cwd is a POSIX path, so overwriting from index 0
+                // replaced the device with the cwd's first bytes (and panicked
+                // when the cwd was shorter than 3 bytes, e.g. "/").
+                cwd_len = get_cwd_t(&mut tmp_buf[resolved_device_len..])?.len();
+                path_ptr = tmp_buf[resolved_device_len..].as_ptr();
                 path_len = cwd_len;
                 // We must set envPath here so that it doesn't hit the null check just below.
                 env_path_len = Some(cwd_len);
@@ -3112,8 +3118,12 @@ pub(crate) fn resolve_windows_t<'a, T: PathCharCwd>(
             //     (StringPrototypeToLowerCase(StringPrototypeSlice(path, 0, 2)) !==
             //     StringPrototypeToLowerCase(resolvedDevice) &&
             //     StringPrototypeCharCodeAt(path, 2) === CHAR_BACKWARD_SLASH)) {
+            //
+            // `path_len > 2` mirrors JS `charCodeAt(2)` returning NaN for short
+            // strings (NaN !== CHAR_BACKWARD_SLASH).
             if env_path_len.is_none()
-                || (path!()[2] == T::from_u8(CHAR_BACKWARD_SLASH)
+                || (path_len > 2
+                    && path!()[2] == T::from_u8(CHAR_BACKWARD_SLASH)
                     && !eql_ignore_case_t(&path!()[0..2], &tmp_buf[0..resolved_device_len]))
             {
                 // Translated from the following JS code:

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";
+import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 // import fixtures from "./common/fixtures.js";
 
@@ -147,6 +148,47 @@ describe("path.resolve", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // When the cwd has a backslash at index 2 and doesn't start with the
+  // requested drive, Node's drive-mismatch check decides the cwd lives on
+  // another device and falls back to `path = `${resolvedDevice}\``, built as a
+  // fresh JS string. The port built it inside the shared buffer that already
+  // held resolvedTail, clobbering the user's path segments (e.g. `C:\C:`
+  // instead of `C:\foo`). On POSIX this requires a cwd like `/r\…` — a
+  // backslash-named directory at the filesystem root — so it only runs as
+  // root on Linux; on Windows the same branch is hit by any cross-drive cwd.
+  test.skipIf(isWindows || !isLinux || process.getuid() !== 0)(
+    "win32 drive-relative input falls back to the drive root when the cwd does not live on the drive",
+    async () => {
+      const weirdCwd = `/r\\resolve-drive-mismatch-${Math.random().toString(36).slice(2)}`;
+      mkdirSync(weirdCwd);
+      try {
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `const p = require("path");
+             console.log(JSON.stringify([
+               p.win32.resolve("C:foo"),
+               p.win32.resolve("C:"),
+               p.win32.resolve("D:a", "b"),
+               p.win32.toNamespacedPath("C:foo"),
+             ]));`,
+          ],
+          env: bunEnv,
+          cwd: weirdCwd,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(JSON.parse(stdout.trim())).toEqual(["C:\\foo", "C:\\", "D:\\a\\b", "\\\\?\\C:\\foo"]);
+        expect(stderr).toBe("");
+        expect(exitCode).toBe(0);
+      } finally {
+        rmSync(weirdCwd, { recursive: true, force: true });
+      }
+    },
+  );
 
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {
     expect(() => {

--- a/test/js/node/path/resolve.test.js
+++ b/test/js/node/path/resolve.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import assert from "node:assert";
 // import child from "node:child_process";
 import path from "node:path";
@@ -109,6 +109,43 @@ describe("path.resolve", () => {
     expect(path.win32.resolve("//server/share", "C:relative")).toBe(path.win32.resolve("C:relative"));
     expect(path.win32.resolve("//server/share", "C:")).toBe(path.win32.resolve("C:"));
     expect(path.win32.resolve("//a/b", "//c/d", "C:foo")).toBe(path.win32.resolve("C:foo"));
+  });
+
+  // On a non-Windows host there is no per-drive cwd, so Node falls back to
+  // process.cwd() and (since a POSIX cwd never has a backslash at index 2)
+  // keeps it as the resolved tail under the requested drive.
+  test.skipIf(isWindows)("win32 drive-relative input on a non-Windows host preserves the drive letter", () => {
+    // Node: `${drive}\` + cwd-with-forward-slashes-normalized + `\` + tail
+    const cwdTail = process.cwd().slice(1).replaceAll("/", "\\");
+    expect(path.win32.resolve("C:foo")).toBe(`C:\\${cwdTail}\\foo`);
+    expect(path.win32.resolve("c:bar/baz")).toBe(`c:\\${cwdTail}\\bar\\baz`);
+    expect(path.win32.resolve("D:")).toBe(`D:\\${cwdTail}`);
+    expect(path.win32.toNamespacedPath("C:foo")).toBe(`\\\\?\\C:\\${cwdTail}\\foo`);
+  });
+
+  test.skipIf(isWindows)("win32 drive-relative input does not panic when cwd is /", async () => {
+    // Spawn with cwd "/" so the POSIX cwd is shorter than 3 bytes — this
+    // previously panicked indexing path[2] in the drive-mismatch check.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const p = require("path");
+         console.log(JSON.stringify([
+           p.win32.resolve("C:foo"),
+           p.win32.resolve("c:bar/baz"),
+           p.win32.toNamespacedPath("C:foo"),
+         ]));`,
+      ],
+      env: bunEnv,
+      cwd: "/",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim())).toEqual(["C:\\foo", "c:\\bar\\baz", "\\\\?\\C:\\foo"]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 
   test("undefined argument are ignored if absolute path comes first (reverse loop through args)", () => {


### PR DESCRIPTION
On a non-Windows host, `path.win32.resolve()` / `path.win32.toNamespacedPath()` corrupted the drive letter for drive-relative inputs, and panicked (index out of bounds) when the process cwd was `/`:

- `path.win32.resolve("C:foo")` → `"/U\Users\…\foo"` (the `C:` replaced by the first 2 bytes of the POSIX cwd) — Node returns `"C:\Users\…\foo"`.
- with cwd `/`: `path.win32.resolve("C:foo")` → `panic: index out of bounds: the len is 1 but the index is 2` — Node returns `"C:\foo"`.

In `resolve_windows_t`, the non-Windows fallback ran `get_cwd_t` into `tmp_buf[..]`, **overwriting the drive prefix** already stored at `tmp_buf[0..resolved_device_len]`, and then indexed `path[2]` without a length guard. Fix: write the cwd into `tmp_buf[resolved_device_len..]` so the drive survives, and guard the index with `path_len > 2` (mirroring JS `charCodeAt(2)` returning NaN on a short string).

Review caught a second aliasing bug in the same else-block, which the first fix made reachable via the cwd fallback: the `path = `${resolvedDevice}\`` drive-mismatch fallback (cwd does not live on the requested drive — any cross-drive cwd on Windows with `=X:` unset, or a POSIX cwd with a literal `\` at index 2) built the fallback inside `buf2`, where `resolvedTail` already lives, clobbering the user's path segments: `resolve("D:foo")` → `"D:\D:"` instead of Node's `"D:\foo"`. Fixed by appending the separator to the device already sitting in `tmp_buf` instead (in JS this is a fresh string, so it can't alias).

Now matches Node byte-for-byte for drive-relative inputs and no longer panics on cwd `/`; `path.posix.*` and absolute `path.win32` inputs unchanged. Shared with Zig (not a port regression); `USE_SYSTEM_BUN` shows the same corruption. The pre-existing `getenv_w("=X:")`-hit aliasing on real Windows (also flagged in review, identical in `path.zig`) is left for a follow-up.

Fixes #31182
