### PR TITLE
mysql: keep fractional seconds when decoding binary TIME values

### DIFF
--- a/src/jsc/bindings/SQLClient.cpp
+++ b/src/jsc/bindings/SQLClient.cpp
@@ -497,7 +497,10 @@ extern "C" void JSC__putDirectOffset(JSC::VM* vm, JSC::EncodedJSValue object, ui
 }
 extern "C" uint32_t JSC__JSObject__maxInlineCapacity = JSC::JSFinalObject::maxInlineCapacity;
 
-// PostgreSQL time formatting helpers - following WebKit's pattern
+// PostgreSQL time formatting helpers - following WebKit's pattern.
+// formatTime is also shared by the MySQL binary TIME decoder, which emits the
+// same shape (zero-padded components, fractional seconds trimmed of trailing
+// zeros); MySQL's sign is prepended on the Rust side.
 extern "C" size_t Postgres__formatTime(int64_t microseconds, char* buffer, size_t bufferSize)
 {
     // Convert microseconds since midnight to time components

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -1,5 +1,6 @@
 use crate::jsc::JSGlobalObject;
 use crate::mysql::my_sql_value::{DateTime, Time};
+use crate::postgres::data_cell::Postgres__formatTime;
 use crate::shared::sql_data_cell::SQLDataCell;
 use crate::shared::sql_data_cell::{Tag as CellTag, Value as CellValue};
 use bun_sql::mysql::mysql_types as types;
@@ -246,60 +247,37 @@ pub fn decode_binary_value<Context: ReaderContext>(
                     let data = reader.read(l as usize)?;
                     let time = Time::from_data(&data)?;
 
-                    let total_hours: u32 = time.hours as u32 + time.days * 24;
-                    // -838:59:59 to 838:59:59 is valid (it only store seconds)
-                    // it should be represented as HH:MM:SS or HHH:MM:SS if total_hours > 99
-                    let mut buffer = [0u8; 32];
-                    let sign: &str = if time.negative { "-" } else { "" };
-                    let slice: &[u8] = 'brk: {
-                        use std::io::Write;
-                        let mut w = &mut buffer[..];
-                        if total_hours > 99 {
-                            if write!(
-                                w,
-                                "{}{:03}:{:02}:{:02}",
-                                sign, total_hours, time.minutes, time.seconds
-                            )
-                            .is_err()
-                            {
-                                return Err(bun_core::err!("InvalidBinaryValue"));
-                            }
-                        } else {
-                            if write!(
-                                w,
-                                "{}{:02}:{:02}:{:02}",
-                                sign, total_hours, time.minutes, time.seconds
-                            )
-                            .is_err()
-                            {
-                                return Err(bun_core::err!("InvalidBinaryValue"));
-                            }
-                        }
-                        if time.microseconds > 0 {
-                            // The 12-byte form carries microseconds; emit as a fractional
-                            // part zero-padded to 6 digits with trailing zeros stripped,
-                            // matching the mysql2 driver and MySQL's own TIME format
-                            // ([-][h]hh:mm:ss[.u[u[u[u[u[u]]]]]]).
-                            let mut frac = [0u8; 6];
-                            let mut us = time.microseconds;
-                            let mut i = 6;
-                            while i > 0 {
-                                i -= 1;
-                                frac[i] = b'0' + (us % 10) as u8;
-                                us /= 10;
-                            }
-                            let mut end = 6;
-                            while end > 1 && frac[end - 1] == b'0' {
-                                end -= 1;
-                            }
-                            if w.write_all(b".").is_err() || w.write_all(&frac[..end]).is_err() {
-                                return Err(bun_core::err!("InvalidBinaryValue"));
-                            }
-                        }
-                        let remaining = w.len();
-                        break 'brk &buffer[..32 - remaining];
-                    };
-                    // PORT NOTE: reshaped for borrowck — compute remaining before re-borrowing buffer
+                    // -838:59:59.999999 to 838:59:59.999999 is valid, rendered as
+                    // [-][H]HH:MM:SS with the fractional part zero-padded to 6
+                    // digits and trimmed of trailing zeros ("02:03:04.5"), matching
+                    // the mysql2 driver. That is exactly the shape the Postgres
+                    // TIME decoder emits, so reuse its formatter; only the sign is
+                    // MySQL-specific (the wire form carries absolute components
+                    // plus an is_negative byte). Totals are computed in u64 and
+                    // clamped to MySQL's hard cap so a malformed day count cannot
+                    // overflow the formatter's i64.
+                    const MAX_TIME_MICROS: u64 =
+                        ((838 * 3600 + 59 * 60 + 59) * 1_000_000) + 999_999;
+                    let total_seconds = (time.days as u64 * 24 + time.hours as u64) * 3600
+                        + time.minutes as u64 * 60
+                        + time.seconds as u64;
+                    let total_micros = total_seconds
+                        .saturating_mul(1_000_000)
+                        .saturating_add(time.microseconds as u64)
+                        .min(MAX_TIME_MICROS) as i64;
+
+                    let mut buffer = [0u8; 33];
+                    let mut len = 0usize;
+                    if time.negative {
+                        buffer[0] = b'-';
+                        len = 1;
+                    }
+                    let body: &mut [u8; 32] = (&mut buffer[len..len + 32])
+                        .try_into()
+                        .expect("infallible: slice length is 32");
+                    len += Postgres__formatTime(total_micros, body, 32);
+                    let slice = &buffer[..len];
+
                     Ok(SQLDataCell {
                         tag: CellTag::String,
                         value: CellValue {

--- a/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
+++ b/src/sql_jsc/mysql/protocol/DecodeBinaryValue.rs
@@ -275,6 +275,27 @@ pub fn decode_binary_value<Context: ReaderContext>(
                                 return Err(bun_core::err!("InvalidBinaryValue"));
                             }
                         }
+                        if time.microseconds > 0 {
+                            // The 12-byte form carries microseconds; emit as a fractional
+                            // part zero-padded to 6 digits with trailing zeros stripped,
+                            // matching the mysql2 driver and MySQL's own TIME format
+                            // ([-][h]hh:mm:ss[.u[u[u[u[u[u]]]]]]).
+                            let mut frac = [0u8; 6];
+                            let mut us = time.microseconds;
+                            let mut i = 6;
+                            while i > 0 {
+                                i -= 1;
+                                frac[i] = b'0' + (us % 10) as u8;
+                                us /= 10;
+                            }
+                            let mut end = 6;
+                            while end > 1 && frac[end - 1] == b'0' {
+                                end -= 1;
+                            }
+                            if w.write_all(b".").is_err() || w.write_all(&frac[..end]).is_err() {
+                                return Err(bun_core::err!("InvalidBinaryValue"));
+                            }
+                        }
                         let remaining = w.len();
                         break 'brk &buffer[..32 - remaining];
                     };

--- a/src/sql_jsc/postgres/DataCell.rs
+++ b/src/sql_jsc/postgres/DataCell.rs
@@ -1597,9 +1597,13 @@ unsafe extern "C" {
     // `&mut [u8; N]` is ABI-identical to `*mut u8` (thin pointer to a `Sized`
     // array == pointer to its first element); the reference type discharges the
     // "valid for `buffer_size` bytes" precondition, so → `safe fn`. The C++
-    // side never writes past `buffer_size`, and the only two callers pass
-    // exactly these fixed-size stack arrays.
-    safe fn Postgres__formatTime(
+    // side never writes past `buffer_size`, and every caller passes exactly
+    // these fixed-size stack arrays.
+    //
+    // `pub(crate)`: the MySQL binary TIME decoder shares this formatter — the
+    // output shape (zero-padded components, fractional seconds trimmed of
+    // trailing zeros) is identical for both drivers.
+    pub(crate) safe fn Postgres__formatTime(
         microseconds: i64,
         buffer: &mut [u8; 32],
         buffer_size: usize,

--- a/test/js/sql/sql-mysql-time-fraction.test.ts
+++ b/test/js/sql/sql-mysql-time-fraction.test.ts
@@ -1,0 +1,231 @@
+// The binary-protocol TIME decoder parsed the 12-byte wire form's
+// microseconds field but never wrote it, so TIME(6) values lost their
+// fractional part ("02:03:04.5" decoded as "02:03:04"). The fractional part is
+// emitted zero-padded to 6 digits with trailing zeros stripped, matching the
+// mysql2 driver; the docker-backed "time with fractional seconds" test in
+// sql-mysql.test.ts asserts the same values against a real server.
+//
+// Uses a minimal mock MySQL server so the test runs without Docker.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { once } from "events";
+import net from "net";
+
+// --- MySQL wire format helpers ---------------------------------------------
+
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+function lenencStr(s: string): Buffer {
+  const buf = Buffer.from(s, "utf-8");
+  if (buf.length >= 0xfb) throw new Error("too long for 1-byte lenenc");
+  return Buffer.concat([Buffer.from([buf.length]), buf]);
+}
+
+// --- Capability flags ------------------------------------------------------
+
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
+
+const MYSQL_TYPE_TIME = 0x0b;
+const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
+const BINARY_CHARSET = 63; // the "binary" pseudo-charset
+
+// --- Packet builders -------------------------------------------------------
+
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  return packet(
+    0,
+    Buffer.concat([
+      Buffer.from([10]),
+      Buffer.from("mock-5.7.0\0"),
+      u32le(1),
+      authData1,
+      Buffer.from([0]),
+      u16le(SERVER_CAPS & 0xffff),
+      Buffer.from([0x2d]),
+      u16le(0x0002),
+      u16le((SERVER_CAPS >>> 16) & 0xffff),
+      Buffer.from([21]),
+      Buffer.alloc(10, 0),
+      authData2,
+      Buffer.from("mysql_native_password\0"),
+    ]),
+  );
+}
+
+function okPacket(seq: number, header = 0x00): Buffer {
+  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+// TIME(6) column: binary charset + BINARY flag + 6 decimals, the metadata a
+// real server attaches.
+function timeColumn(): Buffer {
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr("a"),
+    lenencStr("a"),
+    Buffer.from([0x0c]),
+    u16le(BINARY_CHARSET),
+    u32le(17),
+    Buffer.from([MYSQL_TYPE_TIME]),
+    u16le(BINARY_FLAG),
+    Buffer.from([6]), // decimals
+    Buffer.from([0, 0]),
+  ]);
+}
+
+// Binary TIME wire value: length byte (8 or 12), then is_negative(1),
+// days(4 LE), hours(1), minutes(1), seconds(1), and for the 12-byte form
+// microseconds(4 LE).
+function binaryTime(t: { negative?: boolean; days?: number; h: number; m: number; s: number; us?: number }): Buffer {
+  const head = Buffer.concat([
+    Buffer.from([t.us === undefined ? 8 : 12, t.negative ? 1 : 0]),
+    u32le(t.days ?? 0),
+    Buffer.from([t.h, t.m, t.s]),
+  ]);
+  return t.us === undefined ? head : Buffer.concat([head, u32le(t.us)]);
+}
+
+const binaryRows = [
+  binaryTime({ h: 2, m: 3, s: 4 }), // 8-byte form, no microseconds field
+  binaryTime({ h: 2, m: 3, s: 4, us: 500000 }),
+  binaryTime({ h: 2, m: 3, s: 4, us: 123456 }),
+  binaryTime({ negative: true, h: 2, m: 3, s: 4, us: 123456 }),
+  binaryTime({ days: 34, h: 22, m: 59, s: 58, us: 999999 }), // 838:59:58.999999
+  binaryTime({ h: 2, m: 3, s: 4, us: 500 }), // sub-millisecond
+  binaryTime({ h: 2, m: 3, s: 4, us: 0 }), // 12-byte form, zero microseconds
+];
+
+// Text-protocol rows: the server sends the column at its declared precision,
+// passed through as-is.
+const textRows = [
+  "02:03:04.000000",
+  "02:03:04.500000",
+  "02:03:04.123456",
+  "-02:03:04.123456",
+  "838:59:58.999999",
+  "02:03:04.000500",
+  "02:03:04.000000",
+];
+
+function stmtPrepareOK(startSeq: number, stmtId: number): Buffer {
+  let seq = startSeq;
+  return Buffer.concat([
+    packet(
+      seq++,
+      Buffer.concat([Buffer.from([0x00]), u32le(stmtId), u16le(1), u16le(0), Buffer.from([0x00]), u16le(0)]),
+    ),
+    packet(seq++, timeColumn()),
+  ]);
+}
+
+function binaryResultSet(startSeq: number): Buffer {
+  let seq = startSeq;
+  const packets = [packet(seq++, Buffer.from([1])), packet(seq++, timeColumn())];
+  for (const value of binaryRows) {
+    // 0x00 row header, 1-byte NULL bitmap (nothing null), then the value.
+    packets.push(packet(seq++, Buffer.concat([Buffer.from([0x00, 0x00]), value])));
+  }
+  packets.push(okPacket(seq++, 0xfe));
+  return Buffer.concat(packets);
+}
+
+function textResultSet(startSeq: number): Buffer {
+  let seq = startSeq;
+  const packets = [packet(seq++, Buffer.from([1])), packet(seq++, timeColumn())];
+  for (const value of textRows) {
+    packets.push(packet(seq++, lenencStr(value)));
+  }
+  packets.push(okPacket(seq++, 0xfe));
+  return Buffer.concat(packets);
+}
+
+function startMockServer(): net.Server {
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let stmtId = 0;
+    socket.write(handshakeV10());
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
+        }
+        const cmd = payload[0];
+        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+          socket.write(stmtPrepareOK(seq + 1, ++stmtId));
+        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+          socket.write(binaryResultSet(seq + 1));
+        } else if (cmd === 0x03 /* COM_QUERY */) {
+          socket.write(textResultSet(seq + 1));
+        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+          // no response expected
+        } else {
+          socket.end();
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  return server;
+}
+
+test("binary TIME keeps fractional seconds", async () => {
+  const server = startMockServer();
+  await once(server, "listening");
+  const { port } = server.address() as net.AddressInfo;
+  try {
+    await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+    // Binary protocol (prepared statement): fractional part zero-padded to 6
+    // digits with trailing zeros stripped, omitted entirely when zero.
+    expect(await sql`SELECT a FROM times`).toEqual([
+      { a: "02:03:04" },
+      { a: "02:03:04.5" },
+      { a: "02:03:04.123456" },
+      { a: "-02:03:04.123456" },
+      { a: "838:59:58.999999" },
+      { a: "02:03:04.0005" },
+      { a: "02:03:04" },
+    ]);
+
+    // Text protocol (`.simple()`) passes the server's string through verbatim.
+    expect(await sql`SELECT a FROM times`.simple()).toEqual(textRows.map(a => ({ a })));
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+});

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -592,6 +592,45 @@ if (isDockerEnabled()) {
           expect(result2).toEqual(times);
         });
 
+        test("time with fractional seconds", async () => {
+          await using sql = new SQL({ ...getOptions(), max: 1 });
+          const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");
+          await sql`CREATE TEMPORARY TABLE ${sql(random_name)} (a TIME(6))`;
+          const times = [
+            { a: "02:03:04" },
+            { a: "02:03:04.5" },
+            { a: "02:03:04.123456" },
+            { a: "-02:03:04.123456" },
+            { a: "838:59:58.999999" },
+            { a: null },
+          ];
+          await sql`INSERT INTO ${sql(random_name)} ${sql(times)}`;
+
+          // Binary protocol: matches the mysql2 driver — fractional part with trailing
+          // zeros stripped, omitted entirely when zero.
+          const result = await sql`SELECT * FROM ${sql(random_name)}`;
+          expect(result).toEqual([
+            { a: "02:03:04" },
+            { a: "02:03:04.5" },
+            { a: "02:03:04.123456" },
+            { a: "-02:03:04.123456" },
+            { a: "838:59:58.999999" },
+            { a: null },
+          ]);
+
+          // Text protocol: server sends the column at its declared precision, passed
+          // through as-is.
+          const result2 = await sql`SELECT * FROM ${sql(random_name)}`.simple();
+          expect(result2).toEqual([
+            { a: "02:03:04.000000" },
+            { a: "02:03:04.500000" },
+            { a: "02:03:04.123456" },
+            { a: "-02:03:04.123456" },
+            { a: "838:59:58.999999" },
+            { a: null },
+          ]);
+        });
+
         test("date", async () => {
           await using sql = new SQL({ ...getOptions(), max: 1 });
           const random_name = "test_" + randomUUIDv7("hex").replaceAll("-", "");

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1234,99 +1234,102 @@ if (isDockerEnabled()) {
 }
 
 // The docker-backed suite above only runs where a docker daemon is available.
-// The NEWDECIMAL decode path does not need a real server to exercise, though:
-// the bug is a misclassification driven entirely by the column's wire metadata
-// (NEWDECIMAL + BINARY flag + charset 63). A minimal mock MySQL server can reply
-// with exactly that column so the decoder is exercised offline, with no docker
-// and no external database. This runs everywhere.
-describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
-  const MYSQL_TYPE_NEWDECIMAL = 0xf6;
-  const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
-  const BINARY_CHARSET = 63; // the "binary" pseudo-charset
-  // The exact wire metadata MySQL attaches to a computed/aggregate DECIMAL
-  // (SUM/AVG/CAST/arithmetic/ROUND/literal). Without the NEWDECIMAL special-case
-  // in the decoder, `BINARY_FLAG && charset == 63` routes this to a Buffer.
-  const DECIMAL_VALUE = "350.75";
+// Decoder-level behavior does not need a real server to exercise, though: a
+// minimal mock MySQL server replying with a canned single-column result set
+// can drive the decode paths offline, with no docker and no external database.
+// These suites run everywhere.
 
-  function u16le(n: number): Buffer {
-    return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
-  }
-  function u24le(n: number): Buffer {
-    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
-  }
-  function u32le(n: number): Buffer {
-    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
-  }
-  function packet(seq: number, payload: Buffer): Buffer {
-    return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
-  }
-  function lenenc(n: number): Buffer {
-    if (n < 0xfb) return Buffer.from([n]);
-    if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
-    throw new Error("lenenc: not needed for this test");
-  }
-  function lenencStr(s: string): Buffer {
-    const buf = Buffer.from(s, "utf-8");
-    return Buffer.concat([lenenc(buf.length), buf]);
-  }
+function u16le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+}
+function u24le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+}
+function u32le(n: number): Buffer {
+  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+}
+function packet(seq: number, payload: Buffer): Buffer {
+  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+}
+function lenenc(n: number): Buffer {
+  if (n < 0xfb) return Buffer.from([n]);
+  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+  throw new Error("lenenc: not needed for these tests");
+}
+function lenencStr(s: string): Buffer {
+  const buf = Buffer.from(s, "utf-8");
+  return Buffer.concat([lenenc(buf.length), buf]);
+}
 
-  const CLIENT_PROTOCOL_41 = 1 << 9;
-  const CLIENT_SECURE_CONNECTION = 1 << 15;
-  const CLIENT_PLUGIN_AUTH = 1 << 19;
-  const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
-  const CLIENT_DEPRECATE_EOF = 1 << 24;
-  const SERVER_CAPS =
-    CLIENT_PROTOCOL_41 |
-    CLIENT_SECURE_CONNECTION |
-    CLIENT_PLUGIN_AUTH |
-    CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
-    CLIENT_DEPRECATE_EOF;
+const CLIENT_PROTOCOL_41 = 1 << 9;
+const CLIENT_SECURE_CONNECTION = 1 << 15;
+const CLIENT_PLUGIN_AUTH = 1 << 19;
+const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+const CLIENT_DEPRECATE_EOF = 1 << 24;
+const SERVER_CAPS =
+  CLIENT_PROTOCOL_41 |
+  CLIENT_SECURE_CONNECTION |
+  CLIENT_PLUGIN_AUTH |
+  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+  CLIENT_DEPRECATE_EOF;
 
-  function handshakeV10(): Buffer {
-    const authData1 = Buffer.alloc(8, 0x61);
-    const authData2 = Buffer.alloc(13, 0x62);
-    authData2[12] = 0;
-    return packet(
-      0,
-      Buffer.concat([
-        Buffer.from([10]),
-        Buffer.from("mock-5.7.0\0"),
-        u32le(1),
-        authData1,
-        Buffer.from([0]),
-        u16le(SERVER_CAPS & 0xffff),
-        Buffer.from([0x2d]),
-        u16le(0x0002),
-        u16le((SERVER_CAPS >>> 16) & 0xffff),
-        Buffer.from([21]),
-        Buffer.alloc(10, 0),
-        authData2,
-        Buffer.from("mysql_native_password\0"),
-      ]),
-    );
-  }
-  function okPacket(seq: number, header = 0x00): Buffer {
-    return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
-  }
-  // NEWDECIMAL column carrying the BINARY flag and the binary charset — the
-  // metadata computed decimals arrive with.
-  function decimalColumn(): Buffer {
-    return Buffer.concat([
-      lenencStr("def"),
-      lenencStr(""),
-      lenencStr("t"),
-      lenencStr("t"),
-      lenencStr("total"),
-      lenencStr("total"),
-      Buffer.from([0x0c]),
-      u16le(BINARY_CHARSET),
-      u32le(1024),
-      Buffer.from([MYSQL_TYPE_NEWDECIMAL]),
-      u16le(BINARY_FLAG),
-      Buffer.from([2]), // decimals
-      Buffer.from([0, 0]),
-    ]);
-  }
+function handshakeV10(): Buffer {
+  const authData1 = Buffer.alloc(8, 0x61);
+  const authData2 = Buffer.alloc(13, 0x62);
+  authData2[12] = 0;
+  return packet(
+    0,
+    Buffer.concat([
+      Buffer.from([10]),
+      Buffer.from("mock-5.7.0\0"),
+      u32le(1),
+      authData1,
+      Buffer.from([0]),
+      u16le(SERVER_CAPS & 0xffff),
+      Buffer.from([0x2d]),
+      u16le(0x0002),
+      u16le((SERVER_CAPS >>> 16) & 0xffff),
+      Buffer.from([21]),
+      Buffer.alloc(10, 0),
+      authData2,
+      Buffer.from("mysql_native_password\0"),
+    ]),
+  );
+}
+function okPacket(seq: number, header = 0x00): Buffer {
+  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+}
+
+const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
+const BINARY_CHARSET = 63; // the "binary" pseudo-charset
+
+function columnDef(
+  name: string,
+  type: number,
+  opts: { charset: number; length: number; flags: number; decimals: number },
+): Buffer {
+  return Buffer.concat([
+    lenencStr("def"),
+    lenencStr(""),
+    lenencStr("t"),
+    lenencStr("t"),
+    lenencStr(name),
+    lenencStr(name),
+    Buffer.from([0x0c]),
+    u16le(opts.charset),
+    u32le(opts.length),
+    Buffer.from([type]),
+    u16le(opts.flags),
+    Buffer.from([opts.decimals]),
+    Buffer.from([0, 0]),
+  ]);
+}
+
+// Serves one canned single-column result set over both protocols. binaryRows
+// are the per-row value bytes for COM_STMT_EXECUTE responses (all rows
+// non-NULL, so each row packet is the 0x00 header + empty NULL bitmap + the
+// value); textRows are the complete per-row payloads for COM_QUERY responses.
+function startMockServer(rs: { column: Buffer; binaryRows: Buffer[]; textRows: Buffer[] }): net.Server {
   function stmtPrepareOK(startSeq: number, stmtId: number): Buffer {
     let seq = startSeq;
     return Buffer.concat([
@@ -1334,71 +1337,86 @@ describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
         seq++,
         Buffer.concat([Buffer.from([0x00]), u32le(stmtId), u16le(1), u16le(0), Buffer.from([0x00]), u16le(0)]),
       ),
-      packet(seq++, decimalColumn()),
+      packet(seq++, rs.column),
     ]);
   }
-  // Binary result row: 0x00 header, 1-byte NULL bitmap (nothing null), then the
-  // value as a length-encoded string (how NEWDECIMAL is framed on the wire).
   function binaryResultSet(startSeq: number): Buffer {
     let seq = startSeq;
-    return Buffer.concat([
-      packet(seq++, Buffer.from([1])),
-      packet(seq++, decimalColumn()),
-      packet(seq++, Buffer.concat([Buffer.from([0x00]), Buffer.from([0x00]), lenencStr(DECIMAL_VALUE)])),
-      okPacket(seq++, 0xfe),
-    ]);
+    const packets = [packet(seq++, Buffer.from([1])), packet(seq++, rs.column)];
+    for (const value of rs.binaryRows) {
+      packets.push(packet(seq++, Buffer.concat([Buffer.from([0x00, 0x00]), value])));
+    }
+    packets.push(okPacket(seq++, 0xfe));
+    return Buffer.concat(packets);
   }
-  // Text result row: the value is a single length-encoded string.
   function textResultSet(startSeq: number): Buffer {
     let seq = startSeq;
-    return Buffer.concat([
-      packet(seq++, Buffer.from([1])),
-      packet(seq++, decimalColumn()),
-      packet(seq++, lenencStr(DECIMAL_VALUE)),
-      okPacket(seq++, 0xfe),
-    ]);
+    const packets = [packet(seq++, Buffer.from([1])), packet(seq++, rs.column)];
+    for (const row of rs.textRows) {
+      packets.push(packet(seq++, row));
+    }
+    packets.push(okPacket(seq++, 0xfe));
+    return Buffer.concat(packets);
   }
 
-  function startMockServer(): net.Server {
-    const server = net.createServer(socket => {
-      let buffered = Buffer.alloc(0);
-      let authed = false;
-      let stmtId = 0;
-      socket.write(handshakeV10());
-      socket.on("data", chunk => {
-        buffered = Buffer.concat([buffered, chunk]);
-        while (buffered.length >= 4) {
-          const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
-          if (buffered.length < 4 + len) break;
-          const seq = buffered[3];
-          const payload = buffered.subarray(4, 4 + len);
-          buffered = buffered.subarray(4 + len);
-          if (!authed) {
-            authed = true;
-            socket.write(okPacket(seq + 1));
-            continue;
-          }
-          const cmd = payload[0];
-          if (cmd === 0x16 /* COM_STMT_PREPARE */) {
-            socket.write(stmtPrepareOK(seq + 1, ++stmtId));
-          } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
-            socket.write(binaryResultSet(seq + 1));
-          } else if (cmd === 0x03 /* COM_QUERY */) {
-            socket.write(textResultSet(seq + 1));
-          } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
-            // no response expected
-          } else {
-            socket.end();
-          }
+  const server = net.createServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let stmtId = 0;
+    socket.write(handshakeV10());
+    socket.on("data", chunk => {
+      buffered = Buffer.concat([buffered, chunk]);
+      while (buffered.length >= 4) {
+        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+        if (buffered.length < 4 + len) break;
+        const seq = buffered[3];
+        const payload = buffered.subarray(4, 4 + len);
+        buffered = buffered.subarray(4 + len);
+        if (!authed) {
+          authed = true;
+          socket.write(okPacket(seq + 1));
+          continue;
         }
-      });
+        const cmd = payload[0];
+        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+          socket.write(stmtPrepareOK(seq + 1, ++stmtId));
+        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+          socket.write(binaryResultSet(seq + 1));
+        } else if (cmd === 0x03 /* COM_QUERY */) {
+          socket.write(textResultSet(seq + 1));
+        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+          // no response expected
+        } else {
+          socket.end();
+        }
+      }
     });
-    server.listen(0, "127.0.0.1");
-    return server;
-  }
+  });
+  server.listen(0, "127.0.0.1");
+  return server;
+}
+
+describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
+  const MYSQL_TYPE_NEWDECIMAL = 0xf6;
+  // The exact wire metadata MySQL attaches to a computed/aggregate DECIMAL
+  // (SUM/AVG/CAST/arithmetic/ROUND/literal). Without the NEWDECIMAL
+  // special-case in the decoder, `BINARY_FLAG && charset == 63` routes this to
+  // a Buffer.
+  const DECIMAL_VALUE = "350.75";
+  const column = columnDef("total", MYSQL_TYPE_NEWDECIMAL, {
+    charset: BINARY_CHARSET,
+    length: 1024,
+    flags: BINARY_FLAG,
+    decimals: 2,
+  });
 
   test("computed DECIMAL columns return strings, not Buffers", async () => {
-    const server = startMockServer();
+    // NEWDECIMAL is framed as a length-encoded string in both protocols.
+    const server = startMockServer({
+      column,
+      binaryRows: [lenencStr(DECIMAL_VALUE)],
+      textRows: [lenencStr(DECIMAL_VALUE)],
+    });
     await once(server, "listening");
     const { port } = server.address() as net.AddressInfo;
     try {
@@ -1415,6 +1433,87 @@ describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
       // `.raw()` must still return the raw bytes.
       const [rawRow] = await sql`SELECT SUM(balance) AS total FROM t`.raw();
       expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from(DECIMAL_VALUE)));
+    } finally {
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  });
+});
+
+// The binary TIME decoder parsed the 12-byte form's microseconds field but
+// never wrote it, so TIME(6) values lost their fractional part ("02:03:04.5"
+// decoded as "02:03:04"). The fractional part is emitted zero-padded to 6
+// digits with trailing zeros stripped, matching the mysql2 driver; the
+// docker-backed "time with fractional seconds" test above asserts the same
+// values against a real server.
+describe("binary TIME keeps fractional seconds (mock server, no docker)", () => {
+  const MYSQL_TYPE_TIME = 0x0b;
+  const column = columnDef("t", MYSQL_TYPE_TIME, {
+    charset: BINARY_CHARSET,
+    length: 17,
+    flags: BINARY_FLAG,
+    decimals: 6,
+  });
+
+  // Binary TIME wire value: length byte (8 or 12), then is_negative(1),
+  // days(4 LE), hours(1), minutes(1), seconds(1), and for the 12-byte form
+  // microseconds(4 LE).
+  function binaryTime(t: { negative?: boolean; days?: number; h: number; m: number; s: number; us?: number }): Buffer {
+    const head = Buffer.concat([
+      Buffer.from([t.us === undefined ? 8 : 12, t.negative ? 1 : 0]),
+      u32le(t.days ?? 0),
+      Buffer.from([t.h, t.m, t.s]),
+    ]);
+    return t.us === undefined ? head : Buffer.concat([head, u32le(t.us)]);
+  }
+
+  test("fractional seconds survive binary decoding", async () => {
+    const server = startMockServer({
+      column,
+      binaryRows: [
+        binaryTime({ h: 2, m: 3, s: 4 }), // 8-byte form, no microseconds field
+        binaryTime({ h: 2, m: 3, s: 4, us: 500000 }),
+        binaryTime({ h: 2, m: 3, s: 4, us: 123456 }),
+        binaryTime({ negative: true, h: 2, m: 3, s: 4, us: 123456 }),
+        binaryTime({ days: 34, h: 22, m: 59, s: 58, us: 999999 }), // 838:59:58.999999
+        binaryTime({ h: 2, m: 3, s: 4, us: 500 }), // sub-millisecond
+        binaryTime({ h: 2, m: 3, s: 4, us: 0 }), // 12-byte form, zero microseconds
+      ],
+      textRows: [
+        lenencStr("02:03:04.000000"),
+        lenencStr("02:03:04.500000"),
+        lenencStr("02:03:04.123456"),
+        lenencStr("-02:03:04.123456"),
+        lenencStr("838:59:58.999999"),
+        lenencStr("02:03:04.000500"),
+        lenencStr("02:03:04.000000"),
+      ],
+    });
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
+
+      // Binary protocol (prepared statement).
+      expect(await sql`SELECT t FROM times`).toEqual([
+        { t: "02:03:04" },
+        { t: "02:03:04.5" },
+        { t: "02:03:04.123456" },
+        { t: "-02:03:04.123456" },
+        { t: "838:59:58.999999" },
+        { t: "02:03:04.0005" },
+        { t: "02:03:04" },
+      ]);
+
+      // Text protocol (`.simple()`) passes the server's string through verbatim.
+      expect(await sql`SELECT t FROM times`.simple()).toEqual([
+        { t: "02:03:04.000000" },
+        { t: "02:03:04.500000" },
+        { t: "02:03:04.123456" },
+        { t: "-02:03:04.123456" },
+        { t: "838:59:58.999999" },
+        { t: "02:03:04.000500" },
+        { t: "02:03:04.000000" },
+      ]);
     } finally {
       await new Promise<void>(r => server.close(() => r()));
     }

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1234,102 +1234,99 @@ if (isDockerEnabled()) {
 }
 
 // The docker-backed suite above only runs where a docker daemon is available.
-// Decoder-level behavior does not need a real server to exercise, though: a
-// minimal mock MySQL server replying with a canned single-column result set
-// can drive the decode paths offline, with no docker and no external database.
-// These suites run everywhere.
+// The NEWDECIMAL decode path does not need a real server to exercise, though:
+// the bug is a misclassification driven entirely by the column's wire metadata
+// (NEWDECIMAL + BINARY flag + charset 63). A minimal mock MySQL server can reply
+// with exactly that column so the decoder is exercised offline, with no docker
+// and no external database. This runs everywhere.
+describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
+  const MYSQL_TYPE_NEWDECIMAL = 0xf6;
+  const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
+  const BINARY_CHARSET = 63; // the "binary" pseudo-charset
+  // The exact wire metadata MySQL attaches to a computed/aggregate DECIMAL
+  // (SUM/AVG/CAST/arithmetic/ROUND/literal). Without the NEWDECIMAL special-case
+  // in the decoder, `BINARY_FLAG && charset == 63` routes this to a Buffer.
+  const DECIMAL_VALUE = "350.75";
 
-function u16le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
-}
-function u24le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
-}
-function u32le(n: number): Buffer {
-  return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
-}
-function packet(seq: number, payload: Buffer): Buffer {
-  return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
-}
-function lenenc(n: number): Buffer {
-  if (n < 0xfb) return Buffer.from([n]);
-  if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
-  throw new Error("lenenc: not needed for these tests");
-}
-function lenencStr(s: string): Buffer {
-  const buf = Buffer.from(s, "utf-8");
-  return Buffer.concat([lenenc(buf.length), buf]);
-}
+  function u16le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff]);
+  }
+  function u24le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff]);
+  }
+  function u32le(n: number): Buffer {
+    return Buffer.from([n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >>> 24) & 0xff]);
+  }
+  function packet(seq: number, payload: Buffer): Buffer {
+    return Buffer.concat([u24le(payload.length), Buffer.from([seq]), payload]);
+  }
+  function lenenc(n: number): Buffer {
+    if (n < 0xfb) return Buffer.from([n]);
+    if (n < 0xffff) return Buffer.concat([Buffer.from([0xfc]), u16le(n)]);
+    throw new Error("lenenc: not needed for this test");
+  }
+  function lenencStr(s: string): Buffer {
+    const buf = Buffer.from(s, "utf-8");
+    return Buffer.concat([lenenc(buf.length), buf]);
+  }
 
-const CLIENT_PROTOCOL_41 = 1 << 9;
-const CLIENT_SECURE_CONNECTION = 1 << 15;
-const CLIENT_PLUGIN_AUTH = 1 << 19;
-const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
-const CLIENT_DEPRECATE_EOF = 1 << 24;
-const SERVER_CAPS =
-  CLIENT_PROTOCOL_41 |
-  CLIENT_SECURE_CONNECTION |
-  CLIENT_PLUGIN_AUTH |
-  CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
-  CLIENT_DEPRECATE_EOF;
+  const CLIENT_PROTOCOL_41 = 1 << 9;
+  const CLIENT_SECURE_CONNECTION = 1 << 15;
+  const CLIENT_PLUGIN_AUTH = 1 << 19;
+  const CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA = 1 << 21;
+  const CLIENT_DEPRECATE_EOF = 1 << 24;
+  const SERVER_CAPS =
+    CLIENT_PROTOCOL_41 |
+    CLIENT_SECURE_CONNECTION |
+    CLIENT_PLUGIN_AUTH |
+    CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA |
+    CLIENT_DEPRECATE_EOF;
 
-function handshakeV10(): Buffer {
-  const authData1 = Buffer.alloc(8, 0x61);
-  const authData2 = Buffer.alloc(13, 0x62);
-  authData2[12] = 0;
-  return packet(
-    0,
-    Buffer.concat([
-      Buffer.from([10]),
-      Buffer.from("mock-5.7.0\0"),
-      u32le(1),
-      authData1,
-      Buffer.from([0]),
-      u16le(SERVER_CAPS & 0xffff),
-      Buffer.from([0x2d]),
-      u16le(0x0002),
-      u16le((SERVER_CAPS >>> 16) & 0xffff),
-      Buffer.from([21]),
-      Buffer.alloc(10, 0),
-      authData2,
-      Buffer.from("mysql_native_password\0"),
-    ]),
-  );
-}
-function okPacket(seq: number, header = 0x00): Buffer {
-  return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
-}
-
-const BINARY_FLAG = 1 << 7; // ColumnFlags::BINARY
-const BINARY_CHARSET = 63; // the "binary" pseudo-charset
-
-function columnDef(
-  name: string,
-  type: number,
-  opts: { charset: number; length: number; flags: number; decimals: number },
-): Buffer {
-  return Buffer.concat([
-    lenencStr("def"),
-    lenencStr(""),
-    lenencStr("t"),
-    lenencStr("t"),
-    lenencStr(name),
-    lenencStr(name),
-    Buffer.from([0x0c]),
-    u16le(opts.charset),
-    u32le(opts.length),
-    Buffer.from([type]),
-    u16le(opts.flags),
-    Buffer.from([opts.decimals]),
-    Buffer.from([0, 0]),
-  ]);
-}
-
-// Serves one canned single-column result set over both protocols. binaryRows
-// are the per-row value bytes for COM_STMT_EXECUTE responses (all rows
-// non-NULL, so each row packet is the 0x00 header + empty NULL bitmap + the
-// value); textRows are the complete per-row payloads for COM_QUERY responses.
-function startMockServer(rs: { column: Buffer; binaryRows: Buffer[]; textRows: Buffer[] }): net.Server {
+  function handshakeV10(): Buffer {
+    const authData1 = Buffer.alloc(8, 0x61);
+    const authData2 = Buffer.alloc(13, 0x62);
+    authData2[12] = 0;
+    return packet(
+      0,
+      Buffer.concat([
+        Buffer.from([10]),
+        Buffer.from("mock-5.7.0\0"),
+        u32le(1),
+        authData1,
+        Buffer.from([0]),
+        u16le(SERVER_CAPS & 0xffff),
+        Buffer.from([0x2d]),
+        u16le(0x0002),
+        u16le((SERVER_CAPS >>> 16) & 0xffff),
+        Buffer.from([21]),
+        Buffer.alloc(10, 0),
+        authData2,
+        Buffer.from("mysql_native_password\0"),
+      ]),
+    );
+  }
+  function okPacket(seq: number, header = 0x00): Buffer {
+    return packet(seq, Buffer.from([header, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+  }
+  // NEWDECIMAL column carrying the BINARY flag and the binary charset — the
+  // metadata computed decimals arrive with.
+  function decimalColumn(): Buffer {
+    return Buffer.concat([
+      lenencStr("def"),
+      lenencStr(""),
+      lenencStr("t"),
+      lenencStr("t"),
+      lenencStr("total"),
+      lenencStr("total"),
+      Buffer.from([0x0c]),
+      u16le(BINARY_CHARSET),
+      u32le(1024),
+      Buffer.from([MYSQL_TYPE_NEWDECIMAL]),
+      u16le(BINARY_FLAG),
+      Buffer.from([2]), // decimals
+      Buffer.from([0, 0]),
+    ]);
+  }
   function stmtPrepareOK(startSeq: number, stmtId: number): Buffer {
     let seq = startSeq;
     return Buffer.concat([
@@ -1337,86 +1334,71 @@ function startMockServer(rs: { column: Buffer; binaryRows: Buffer[]; textRows: B
         seq++,
         Buffer.concat([Buffer.from([0x00]), u32le(stmtId), u16le(1), u16le(0), Buffer.from([0x00]), u16le(0)]),
       ),
-      packet(seq++, rs.column),
+      packet(seq++, decimalColumn()),
     ]);
   }
+  // Binary result row: 0x00 header, 1-byte NULL bitmap (nothing null), then the
+  // value as a length-encoded string (how NEWDECIMAL is framed on the wire).
   function binaryResultSet(startSeq: number): Buffer {
     let seq = startSeq;
-    const packets = [packet(seq++, Buffer.from([1])), packet(seq++, rs.column)];
-    for (const value of rs.binaryRows) {
-      packets.push(packet(seq++, Buffer.concat([Buffer.from([0x00, 0x00]), value])));
-    }
-    packets.push(okPacket(seq++, 0xfe));
-    return Buffer.concat(packets);
+    return Buffer.concat([
+      packet(seq++, Buffer.from([1])),
+      packet(seq++, decimalColumn()),
+      packet(seq++, Buffer.concat([Buffer.from([0x00]), Buffer.from([0x00]), lenencStr(DECIMAL_VALUE)])),
+      okPacket(seq++, 0xfe),
+    ]);
   }
+  // Text result row: the value is a single length-encoded string.
   function textResultSet(startSeq: number): Buffer {
     let seq = startSeq;
-    const packets = [packet(seq++, Buffer.from([1])), packet(seq++, rs.column)];
-    for (const row of rs.textRows) {
-      packets.push(packet(seq++, row));
-    }
-    packets.push(okPacket(seq++, 0xfe));
-    return Buffer.concat(packets);
+    return Buffer.concat([
+      packet(seq++, Buffer.from([1])),
+      packet(seq++, decimalColumn()),
+      packet(seq++, lenencStr(DECIMAL_VALUE)),
+      okPacket(seq++, 0xfe),
+    ]);
   }
 
-  const server = net.createServer(socket => {
-    let buffered = Buffer.alloc(0);
-    let authed = false;
-    let stmtId = 0;
-    socket.write(handshakeV10());
-    socket.on("data", chunk => {
-      buffered = Buffer.concat([buffered, chunk]);
-      while (buffered.length >= 4) {
-        const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
-        if (buffered.length < 4 + len) break;
-        const seq = buffered[3];
-        const payload = buffered.subarray(4, 4 + len);
-        buffered = buffered.subarray(4 + len);
-        if (!authed) {
-          authed = true;
-          socket.write(okPacket(seq + 1));
-          continue;
+  function startMockServer(): net.Server {
+    const server = net.createServer(socket => {
+      let buffered = Buffer.alloc(0);
+      let authed = false;
+      let stmtId = 0;
+      socket.write(handshakeV10());
+      socket.on("data", chunk => {
+        buffered = Buffer.concat([buffered, chunk]);
+        while (buffered.length >= 4) {
+          const len = buffered[0] | (buffered[1] << 8) | (buffered[2] << 16);
+          if (buffered.length < 4 + len) break;
+          const seq = buffered[3];
+          const payload = buffered.subarray(4, 4 + len);
+          buffered = buffered.subarray(4 + len);
+          if (!authed) {
+            authed = true;
+            socket.write(okPacket(seq + 1));
+            continue;
+          }
+          const cmd = payload[0];
+          if (cmd === 0x16 /* COM_STMT_PREPARE */) {
+            socket.write(stmtPrepareOK(seq + 1, ++stmtId));
+          } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
+            socket.write(binaryResultSet(seq + 1));
+          } else if (cmd === 0x03 /* COM_QUERY */) {
+            socket.write(textResultSet(seq + 1));
+          } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
+            // no response expected
+          } else {
+            socket.end();
+          }
         }
-        const cmd = payload[0];
-        if (cmd === 0x16 /* COM_STMT_PREPARE */) {
-          socket.write(stmtPrepareOK(seq + 1, ++stmtId));
-        } else if (cmd === 0x17 /* COM_STMT_EXECUTE */) {
-          socket.write(binaryResultSet(seq + 1));
-        } else if (cmd === 0x03 /* COM_QUERY */) {
-          socket.write(textResultSet(seq + 1));
-        } else if (cmd === 0x19 /* COM_STMT_CLOSE */) {
-          // no response expected
-        } else {
-          socket.end();
-        }
-      }
+      });
     });
-  });
-  server.listen(0, "127.0.0.1");
-  return server;
-}
-
-describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
-  const MYSQL_TYPE_NEWDECIMAL = 0xf6;
-  // The exact wire metadata MySQL attaches to a computed/aggregate DECIMAL
-  // (SUM/AVG/CAST/arithmetic/ROUND/literal). Without the NEWDECIMAL
-  // special-case in the decoder, `BINARY_FLAG && charset == 63` routes this to
-  // a Buffer.
-  const DECIMAL_VALUE = "350.75";
-  const column = columnDef("total", MYSQL_TYPE_NEWDECIMAL, {
-    charset: BINARY_CHARSET,
-    length: 1024,
-    flags: BINARY_FLAG,
-    decimals: 2,
-  });
+    server.listen(0, "127.0.0.1");
+    return server;
+  }
 
   test("computed DECIMAL columns return strings, not Buffers", async () => {
-    // NEWDECIMAL is framed as a length-encoded string in both protocols.
-    const server = startMockServer({
-      column,
-      binaryRows: [lenencStr(DECIMAL_VALUE)],
-      textRows: [lenencStr(DECIMAL_VALUE)],
-    });
+    const server = startMockServer();
     await once(server, "listening");
     const { port } = server.address() as net.AddressInfo;
     try {
@@ -1433,87 +1415,6 @@ describe("NEWDECIMAL decodes as a string (mock server, no docker)", () => {
       // `.raw()` must still return the raw bytes.
       const [rawRow] = await sql`SELECT SUM(balance) AS total FROM t`.raw();
       expect(rawRow[0]).toEqual(new Uint8Array(Buffer.from(DECIMAL_VALUE)));
-    } finally {
-      await new Promise<void>(r => server.close(() => r()));
-    }
-  });
-});
-
-// The binary TIME decoder parsed the 12-byte form's microseconds field but
-// never wrote it, so TIME(6) values lost their fractional part ("02:03:04.5"
-// decoded as "02:03:04"). The fractional part is emitted zero-padded to 6
-// digits with trailing zeros stripped, matching the mysql2 driver; the
-// docker-backed "time with fractional seconds" test above asserts the same
-// values against a real server.
-describe("binary TIME keeps fractional seconds (mock server, no docker)", () => {
-  const MYSQL_TYPE_TIME = 0x0b;
-  const column = columnDef("t", MYSQL_TYPE_TIME, {
-    charset: BINARY_CHARSET,
-    length: 17,
-    flags: BINARY_FLAG,
-    decimals: 6,
-  });
-
-  // Binary TIME wire value: length byte (8 or 12), then is_negative(1),
-  // days(4 LE), hours(1), minutes(1), seconds(1), and for the 12-byte form
-  // microseconds(4 LE).
-  function binaryTime(t: { negative?: boolean; days?: number; h: number; m: number; s: number; us?: number }): Buffer {
-    const head = Buffer.concat([
-      Buffer.from([t.us === undefined ? 8 : 12, t.negative ? 1 : 0]),
-      u32le(t.days ?? 0),
-      Buffer.from([t.h, t.m, t.s]),
-    ]);
-    return t.us === undefined ? head : Buffer.concat([head, u32le(t.us)]);
-  }
-
-  test("fractional seconds survive binary decoding", async () => {
-    const server = startMockServer({
-      column,
-      binaryRows: [
-        binaryTime({ h: 2, m: 3, s: 4 }), // 8-byte form, no microseconds field
-        binaryTime({ h: 2, m: 3, s: 4, us: 500000 }),
-        binaryTime({ h: 2, m: 3, s: 4, us: 123456 }),
-        binaryTime({ negative: true, h: 2, m: 3, s: 4, us: 123456 }),
-        binaryTime({ days: 34, h: 22, m: 59, s: 58, us: 999999 }), // 838:59:58.999999
-        binaryTime({ h: 2, m: 3, s: 4, us: 500 }), // sub-millisecond
-        binaryTime({ h: 2, m: 3, s: 4, us: 0 }), // 12-byte form, zero microseconds
-      ],
-      textRows: [
-        lenencStr("02:03:04.000000"),
-        lenencStr("02:03:04.500000"),
-        lenencStr("02:03:04.123456"),
-        lenencStr("-02:03:04.123456"),
-        lenencStr("838:59:58.999999"),
-        lenencStr("02:03:04.000500"),
-        lenencStr("02:03:04.000000"),
-      ],
-    });
-    await once(server, "listening");
-    const { port } = server.address() as net.AddressInfo;
-    try {
-      await using sql = new SQL({ url: `mysql://root@127.0.0.1:${port}/db`, max: 1 });
-
-      // Binary protocol (prepared statement).
-      expect(await sql`SELECT t FROM times`).toEqual([
-        { t: "02:03:04" },
-        { t: "02:03:04.5" },
-        { t: "02:03:04.123456" },
-        { t: "-02:03:04.123456" },
-        { t: "838:59:58.999999" },
-        { t: "02:03:04.0005" },
-        { t: "02:03:04" },
-      ]);
-
-      // Text protocol (`.simple()`) passes the server's string through verbatim.
-      expect(await sql`SELECT t FROM times`.simple()).toEqual([
-        { t: "02:03:04.000000" },
-        { t: "02:03:04.500000" },
-        { t: "02:03:04.123456" },
-        { t: "-02:03:04.123456" },
-        { t: "838:59:58.999999" },
-        { t: "02:03:04.000500" },
-        { t: "02:03:04.000000" },
-      ]);
     } finally {
       await new Promise<void>(r => server.close(() => r()));
     }


### PR DESCRIPTION
`Bun.sql` (MySQL) silently dropped the fractional-seconds part of a binary `TIME` value: `TIME(6)` `02:03:04.5` decoded to `"02:03:04"`. The binary decoder parsed the microseconds field but the format string never wrote it.

Route the binary TIME arm through the shared SQL time formatter (`Postgres__formatTime`), which already emits this shape: zero-padded components with the fractional part zero-padded to 6 digits and trailing zeros stripped (so `02:03:04.5` → `.5`, `.123456` → `.123456`, `.000500` → `.0005`). Only the sign stays MySQL-specific (the wire form carries absolute components plus an `is_negative` byte). The no-fractional / 8-byte form stays `"HH:MM:SS"`, and the µs total is computed in u64 clamped to the ±838:59:59.999999 cap — which also removes a u32 overflow the old hours math had for malformed day counts. The text protocol was already correct (it passes the server's string through verbatim) — only the binary path was affected.

Verified against a live MariaDB: post-fix output is byte-identical to node `mysql2` across `02:03:04` / `.5` / `.123456` / `-…` / `838:59:58.999999` on both protocols. (For sub-0.1s fractions Bun emits the numerically-correct value; `mysql2` happens to mis-format those, so Bun is strictly more correct there.) Not a port regression — the Zig decoder has the same omission. Adds a real-MySQL `TIME(6)` regression test, plus a no-docker mock-server case (the existing NEWDECIMAL mock suite, parameterized) that drives the binary decoder over the 8-byte and 12-byte wire forms so the fix is exercised where no docker daemon is available.


