### PR TITLE
fix(dns): handle UTF-16 strings in lookupService address and resolve record type

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -5041,7 +5041,7 @@ impl Resolver {
                     break 'brk RecordType::DEFAULT;
                 }
                 // TODO(port): phf custom hasher — Zig used getWithEql with ZigString.eqlComptime
-                match RECORD_TYPE_MAP.get(record_type_str.get_zig_string(global_this).slice()) {
+                match RECORD_TYPE_MAP.get(record_type_str.to_slice(global_this).slice()) {
                     Some(r) => *r,
                     None => {
                         return Err(global_this.throw_invalid_argument_property_value(
@@ -5994,8 +5994,8 @@ impl Resolver {
                 "non-empty string",
             ));
         }
-        let addr_zigstr = addr_str.get_zig_string(global_this);
-        let addr_s = addr_zigstr.slice();
+        let addr_slice = addr_str.to_slice(global_this);
+        let addr_s = addr_slice.slice();
 
         let port_value = arguments.ptr[1];
         let port: u16 = port_value.to_port_number(global_this)?;

--- a/test/js/bun/dns/resolve-dns.test.ts
+++ b/test/js/bun/dns/resolve-dns.test.ts
@@ -194,4 +194,41 @@ describe("dns", () => {
       expect(() => dns.setServers([[4, "8.8.8.8", 53]])).not.toThrow();
     });
   });
+
+  describe("UTF-16 string arguments", () => {
+    // Builds a JSString backed by a 16-bit (UTF-16) buffer even though the
+    // contents are plain ASCII. Passing such strings used to hit a debug
+    // assertion (ZigString::slice() on UTF-16 string) instead of being
+    // transcoded.
+    const utf16 = (s: string) =>
+      new TextDecoder("utf-16le").decode(new Uint8Array([...s].flatMap(c => [c.charCodeAt(0), 0])));
+
+    test("lookupService() with a UTF-16 invalid address throws TypeError", () => {
+      // @ts-expect-error
+      expect(() => Bun.dns.lookupService(utf16("1,2,3"), 443)).toThrow(
+        `The "address" argument is invalid. Received type string ('1,2,3')`,
+      );
+    });
+
+    test("lookupService() with a UTF-16 valid address does not crash", async () => {
+      // The reverse lookup result is environment-dependent; the assertion is
+      // that the address parses (no synchronous throw) and nothing panics.
+      // @ts-expect-error
+      await Bun.dns.lookupService(utf16("127.0.0.1"), 443).catch(() => {});
+    });
+
+    test("resolve() with a UTF-16 record type does not crash", async () => {
+      // A valid record type must be accepted (no synchronous throw); the
+      // query result itself is environment-dependent.
+      // @ts-expect-error
+      await Bun.dns.resolve(utf16("localhost"), utf16("AAAA")).catch(() => {});
+    });
+
+    test("resolve() with a UTF-16 invalid record type throws TypeError", () => {
+      // @ts-expect-error
+      expect(() => Bun.dns.resolve("localhost", utf16("BOGUS"))).toThrow(
+        `The property "record" is invalid. Expected one of: A, AAAA, ANY, CAA, CNAME, MX, NS, PTR, SOA, SRV, TXT, received type string ('BOGUS')`,
+      );
+    });
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes a crash found by fuzzing (fingerprint: `panic: ZigString::slice() on UTF-16 string; use to_slice()`).

`Bun.dns.lookupService` read its address argument — and `Bun.dns.resolve` its record-type argument — via `ZigString::slice()`, which requires an 8-bit string. Any JSString backed by a 16-bit buffer (e.g. output of `toLocaleString`, `toLocaleUpperCase`, or `TextDecoder("utf-16le")`, even when the contents are plain ASCII) tripped the debug assertion; in release builds the UTF-16 buffer would be misread as bytes.

```js
Bun.dns.lookupService([127,0,0,1].toLocaleString(), 443); // panicked
Bun.dns.resolve("localhost", "AAAA".toLocaleUpperCase()); // panicked
```

Both sites now use `JSString::to_slice()`, which transcodes UTF-16 to UTF-8:

- a 16-bit `"127.0.0.1"` address parses and resolves like its 8-bit equivalent
- an invalid address still throws the proper `TypeError`
- a 16-bit `"AAAA"` record type matches the record-type table (restoring the original `getWithEql`/`eqlComptime` semantics the port lost)
- an invalid record type still throws the proper `TypeError`

### How did you verify your code works?

- The fuzzer repro now exits cleanly; invalid inputs produce JS `TypeError`s instead of panicking.
- Added regression tests in `test/js/bun/dns/resolve-dns.test.ts` covering all four cases; they panic on an unfixed debug build and pass with this change.