### PR TITLE
Add delta updates and `bun upgrade pr <number>`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+  deltas:
+    name: Publish Delta Patches
+    runs-on: ubuntu-latest
+    needs: sign
+    # Delta patches only exist between stable releases; the daily canary
+    # refresh (schedule) has nothing to diff. The script itself skips
+    # non-stable tags, so a canary workflow_dispatch is a no-op.
+    if: ${{ github.repository_owner == 'oven-sh' && github.event_name != 'schedule' }}
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: packages/bun-release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup Bun
+        uses: ./.github/actions/setup-bun
+        with:
+          bun-version: "1.2.3"
+      - name: Install Dependencies
+        run: bun install
+      - name: Publish Delta Patches
+        run: |
+          bun upload-deltas -- "${{ env.BUN_VERSION }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   npm:
     name: Release to NPM
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # The upload step passes GITHUB_TOKEN explicitly; don't leave the
+          # checkout token in the local git config.
+          persist-credentials: false
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bsdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6709158fe6ca66c1f32eb27b4ae5997c67b0df350ae185831233af3e7a91213"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1640,7 @@ dependencies = [
  "bcrypt",
  "bitflags",
  "blake2",
+ "bsdiff",
  "bstr",
  "bun_alloc",
  "bun_analytics",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -334,6 +334,8 @@ strum = { version = "0.26", features = ["derive"] }
 hashbrown = { version = "0.15", default-features = false, features = ["inline-more", "allocator-api2"] }
 allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
 bstr = { version = "1", default-features = false, features = ["alloc"] }
+# Binary-diff patches for `bun upgrade` delta updates (pure Rust, no deps).
+bsdiff = "0.2.1"
 scopeguard = "1"
 const_format = "0.2"
 enum-map = "2"

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3604,7 +3604,7 @@
         }
       ],
       "examples": ["bun upgrade", "bun upgrade --stable", "bun upgrade pr 12345"],
-      "usage": "Usage: bun upgrade [flags]",
+      "usage": "Usage: bun upgrade [flags] [pr <number>]",
       "documentationUrl": "https://bun.com/docs/installation#upgrading",
       "dynamicCompletions": {}
     }

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3603,7 +3603,7 @@
           "type": "string"
         }
       ],
-      "examples": ["bun upgrade", "bun upgrade --stable"],
+      "examples": ["bun upgrade", "bun upgrade --stable", "bun upgrade pr 12345"],
       "usage": "Usage: bun upgrade [flags]",
       "documentationUrl": "https://bun.com/docs/installation#upgrading",
       "dynamicCompletions": {}

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3594,7 +3594,36 @@
     "upgrade": {
       "name": "upgrade",
       "description": "Upgrade Bun",
-      "flags": [],
+      "flags": [
+        {
+          "name": "canary",
+          "description": "Install the most recent canary build",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "stable",
+          "description": "Switch back to the latest stable release",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "profile",
+          "description": "Install a build with debug symbols",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        },
+        {
+          "name": "no-delta",
+          "description": "Always download the full release instead of delta patches",
+          "hasValue": false,
+          "required": false,
+          "multiple": false
+        }
+      ],
       "positionalArgs": [
         {
           "name": "flags",

--- a/completions/bun-cli.json
+++ b/completions/bun-cli.json
@@ -3601,6 +3601,18 @@
           "required": false,
           "multiple": false,
           "type": "string"
+        },
+        {
+          "name": "subcommand",
+          "required": false,
+          "multiple": false,
+          "type": "string"
+        },
+        {
+          "name": "pullRequest",
+          "required": false,
+          "multiple": false,
+          "type": "string"
         }
       ],
       "examples": ["bun upgrade", "bun upgrade --stable", "bun upgrade pr 12345"],

--- a/completions/bun.bash
+++ b/completions/bun.bash
@@ -153,7 +153,7 @@ _bun_completions() {
             COMPREPLY=( $(compgen -W "--force --no-install --help --no-git --verbose --no-package-json --open next react" -- "${cur_word}") );
             return;;
         upgrade)
-            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h") );
+            COMPREPLY=( $(compgen -W "--version --cwd --help -v -h --canary --stable --profile --no-delta pr" -- "${cur_word}") );
             return;;
         repl)
             COMPREPLY=( $(compgen -W "--help -h --eval -e --print -p --preload -r --smol --config -c --cwd --env-file --no-env-file" -- "${cur_word}") );

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -520,7 +520,10 @@ _bun_run_completion() {
 _bun_upgrade_completion() {
     _arguments -s -C \
         '1: :->cmd' \
-        '--canary[Upgrade to canary build]' &&
+        '--canary[Upgrade to canary build]' \
+        '--stable[Switch back to the latest stable release]' \
+        '--profile[Install a build with debug symbols]' \
+        '--no-delta[Always download the full release instead of delta patches]' &&
         ret=0
 
 }

--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -519,7 +519,8 @@ _bun_run_completion() {
 
 _bun_upgrade_completion() {
     _arguments -s -C \
-        '1: :->cmd' \
+        '1::subcommand:(pr)' \
+        '2::pull request number:' \
         '--canary[Upgrade to canary build]' \
         '--stable[Switch back to the latest stable release]' \
         '--profile[Install a build with debug symbols]' \

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -171,6 +171,8 @@ Once installed, the binary can upgrade itself:
 bun upgrade
 ```
 
+When upgrading between recent stable releases, `bun upgrade` downloads a small binary patch (a _delta update_) instead of the full release archive, then verifies the patched binary against the release's published checksums. If a patch isn't available, it falls back to downloading the full release. Pass `--no-delta` to always download the full release.
+
 <Tip>
 **Homebrew users** <br />
 To avoid conflicts with Homebrew, use `brew upgrade bun` instead.
@@ -179,6 +181,18 @@ To avoid conflicts with Homebrew, use `brew upgrade bun` instead.
 To avoid conflicts with Scoop, use `scoop update bun` instead.
 
 </Tip>
+
+---
+
+## Installing a Build from a Pull Request
+
+To try out a change before it's merged and released, install the CI build of any pull request in [oven-sh/bun](https://github.com/oven-sh/bun/pulls) by its number:
+
+```bash terminal icon="terminal"
+bun upgrade pr 12345
+```
+
+This replaces your current `bun` binary with the pull request's build for your platform. To switch back, run `bun upgrade` (or `bun upgrade --canary`).
 
 ---
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -186,10 +186,12 @@ To avoid conflicts with Scoop, use `scoop update bun` instead.
 
 ## Installing a Build from a Pull Request
 
-To try out a change before it's merged and released, install the CI build of any pull request in [oven-sh/bun](https://github.com/oven-sh/bun/pulls) by its number:
+To try out a change before it's merged and released, install the CI build of any pull request in [oven-sh/bun](https://github.com/oven-sh/bun/pulls). The pull request can be given as a plain number, a `#`-prefixed number, or the pull request's URL:
 
 ```bash terminal icon="terminal"
 bun upgrade pr 12345
+bun upgrade pr "#12345"
+bun upgrade pr https://github.com/oven-sh/bun/pull/12345
 ```
 
 This replaces your current `bun` binary with the pull request's build for your platform. To switch back, run `bun upgrade` (or `bun upgrade --canary`).

--- a/packages/bun-release/package.json
+++ b/packages/bun-release/package.json
@@ -17,6 +17,7 @@
     "get-version": "bun scripts/get-version.ts",
     "upload-npm": "bun scripts/upload-npm.ts",
     "upload-assets": "bun scripts/upload-assets.ts",
+    "upload-deltas": "bun scripts/upload-deltas.ts",
     "upload-s3": "bun scripts/upload-s3.ts"
   }
 }

--- a/packages/bun-release/scripts/upload-deltas.ts
+++ b/packages/bun-release/scripts/upload-deltas.ts
@@ -165,7 +165,10 @@ for (const asset of targets) {
     const oldBinary = await extractBinary(previousAsset.browser_download_url, previousAsset.name);
     const newBinary = await extractBinary(asset.browser_download_url, asset.name);
     if (!oldBinary || !newBinary) {
-      warn("Skipping", base, "(no binary found in the archive)\n");
+      // Both archives exist, so a missing binary means the standard layout
+      // changed; that must fail the job, not silently skip the platform.
+      warn("No binary found in the", base, "archives\n");
+      failures++;
       continue;
     }
 

--- a/packages/bun-release/scripts/upload-deltas.ts
+++ b/packages/bun-release/scripts/upload-deltas.ts
@@ -1,0 +1,209 @@
+import JSZip from "jszip";
+import { spawnSync } from "node:child_process";
+import { error, log, warn } from "../src/console";
+import { fetch } from "../src/fetch";
+import { chmod, exists, hash, join, rm, tmp, write } from "../src/fs";
+import { getRelease, github, uploadAsset } from "../src/github";
+
+// Publishes the delta-update assets that `bun upgrade` consumes:
+//
+//   bun-<target>.from-<prev>.bsdiff            zstd-compressed bsdiff patch
+//   bun-<target>.from-<prev>.bsdiff.sha256sum  checksum of the patch
+//   bun-<target>.sha256sum                     checksum of the uncompressed binary
+//
+// Each release gets one patch per target, from its immediate predecessor;
+// `bun upgrade` chains patches when it is more than one release behind. The
+// previous release also gets a `bun-<target>.sha256sum` (if missing) so
+// binaries installed from it can verify themselves before patching.
+
+const [tag] = process.argv.slice(2);
+
+if (!tag) {
+  error("Invalid arguments: [tag]");
+  process.exit(1);
+}
+
+function parseStableVersion(tagName: string): [number, number, number] | null {
+  const match = /^bun-v(\d+)\.(\d+)\.(\d+)$/.exec(tagName);
+  if (!match) {
+    return null;
+  }
+  return [parseInt(match[1]), parseInt(match[2]), parseInt(match[3])];
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  return a[0] - b[0] || a[1] - b[1] || a[2] - b[2];
+}
+
+const release = await getRelease(tag);
+const version = parseStableVersion(release.tag_name);
+if (!version) {
+  log("Skipping delta patches for non-stable release:", release.tag_name, "\n");
+  process.exit(0);
+}
+
+// Find the immediate predecessor among stable releases.
+const releases = await github("GET /repos/{owner}/{repo}/releases", {
+  per_page: 100,
+});
+let previous: { tag_name: string; version: [number, number, number] } | undefined;
+for (const { tag_name } of releases) {
+  const candidate = parseStableVersion(tag_name);
+  if (!candidate || compareVersions(candidate, version) >= 0) {
+    continue;
+  }
+  if (!previous || compareVersions(candidate, previous.version) > 0) {
+    previous = { tag_name, version: candidate };
+  }
+}
+if (!previous) {
+  log("No previous stable release found, skipping delta patches\n");
+  process.exit(0);
+}
+const previousRelease = await getRelease(previous.tag_name);
+const previousVersion = previous.tag_name.replace(/^bun-v/, "");
+log("Release:", release.tag_name, "\n");
+log("Previous:", previousRelease.tag_name, "\n");
+
+// Patches are published for the standard binaries only (not -profile, which
+// `bun upgrade` always downloads in full).
+function isDeltaTarget(name: string): boolean {
+  return /^bun-[a-z0-9-]+\.zip$/.test(name) && !name.includes("-profile") && !name.includes("-asan");
+}
+
+async function extractBinary(url: string, assetName: string): Promise<Buffer | null> {
+  const response = await fetch(url);
+  const zip = await JSZip.loadAsync(await response.arrayBuffer());
+  const folder = assetName.replace(/\.zip$/, "");
+  const file = zip.file(`${folder}/bun`) ?? zip.file(`${folder}/bun.exe`);
+  if (!file) {
+    return null;
+  }
+  return file.async("nodebuffer");
+}
+
+// The freshly-released binary generates the patches (via its
+// `bun:internal-for-testing` bindings), so this script does not depend on
+// the runner's installed version of Bun.
+const cwd = tmp();
+const generator = join(cwd, "bun");
+{
+  const hostAsset = release.assets.find(({ name }) => name === "bun-linux-x64.zip");
+  if (!hostAsset) {
+    error("Release has no bun-linux-x64.zip to generate patches with");
+    process.exit(1);
+  }
+  const binary = await extractBinary(hostAsset.browser_download_url, hostAsset.name);
+  if (!binary) {
+    error("bun-linux-x64.zip does not contain a bun binary");
+    process.exit(1);
+  }
+  write(generator, binary);
+  chmod(generator, 0o755);
+}
+
+function createDeltaPatch(oldPath: string, newPath: string, patchPath: string): boolean {
+  const { status, stderr } = spawnSync(
+    generator,
+    [
+      "-e",
+      `const { upgrade_test_helpers } = require("bun:internal-for-testing");
+       const fs = require("node:fs");
+       try {
+         fs.writeFileSync(
+           process.env.DELTA_OUT,
+           upgrade_test_helpers.createDeltaPatch(
+             fs.readFileSync(process.env.DELTA_OLD),
+             fs.readFileSync(process.env.DELTA_NEW),
+           ),
+         );
+       } catch (cause) {
+         console.error(cause?.message ?? cause);
+         process.exit(1);
+       }`,
+    ],
+    {
+      env: {
+        ...process.env,
+        // Release builds only read BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING when
+        // BUN_GARBAGE_COLLECTOR_LEVEL is also present (a startup optimization
+        // that skips obscure env lookups); "0" leaves GC behavior unchanged.
+        BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+        BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+        DELTA_OLD: oldPath,
+        DELTA_NEW: newPath,
+        DELTA_OUT: patchPath,
+      },
+      stdio: ["ignore", "inherit", "pipe"],
+    },
+  );
+  if (status !== 0) {
+    warn("Failed to generate patch:", stderr?.toString() ?? `exit code ${status}`);
+    return false;
+  }
+  // Don't trust the exit code alone: verify a non-empty patch was written.
+  if (!exists(patchPath) || Bun.file(patchPath).size === 0) {
+    warn("Failed to generate patch: no output was written");
+    return false;
+  }
+  return true;
+}
+
+const targets = release.assets.filter(({ name }) => isDeltaTarget(name));
+log("Targets:\n", ...targets.map(({ name }) => `- ${name}\n`));
+
+let failures = 0;
+for (const asset of targets) {
+  const base = asset.name.replace(/\.zip$/, "");
+  const previousAsset = previousRelease.assets.find(({ name }) => name === asset.name);
+  if (!previousAsset) {
+    log("Skipping", base, "(not present in the previous release)\n");
+    continue;
+  }
+
+  try {
+    const oldBinary = await extractBinary(previousAsset.browser_download_url, previousAsset.name);
+    const newBinary = await extractBinary(asset.browser_download_url, asset.name);
+    if (!oldBinary || !newBinary) {
+      warn("Skipping", base, "(no binary found in the archive)\n");
+      continue;
+    }
+
+    const oldPath = join(cwd, `${base}-old`);
+    const newPath = join(cwd, `${base}-new`);
+    const patchName = `${base}.from-${previousVersion}.bsdiff`;
+    const patchPath = join(cwd, patchName);
+    write(oldPath, oldBinary);
+    write(newPath, newBinary);
+
+    log("Generating", patchName, "\n");
+    if (!createDeltaPatch(oldPath, newPath, patchPath)) {
+      failures++;
+      continue;
+    }
+
+    const patchHash = hash(patchPath);
+    log("Uploading", patchName, `(${patchHash})\n`);
+    await uploadAsset(tag, patchName, new Blob([await Bun.file(patchPath).arrayBuffer()]));
+    await uploadAsset(tag, `${patchName}.sha256sum`, new Blob([`${patchHash}  ${patchName}\n`]));
+    await uploadAsset(tag, `${base}.sha256sum`, new Blob([`${hash(newBinary)}  ${base}\n`]));
+
+    // Let binaries installed from the previous release verify themselves.
+    if (!previousRelease.assets.some(({ name }) => name === `${base}.sha256sum`)) {
+      await uploadAsset(previous.tag_name, `${base}.sha256sum`, new Blob([`${hash(oldBinary)}  ${base}\n`]));
+    }
+
+    rm(oldPath);
+    rm(newPath);
+    rm(patchPath);
+  } catch (cause) {
+    warn("Failed to publish a delta patch for", base, "\n", cause);
+    failures++;
+  }
+}
+
+if (failures > 0) {
+  error(`Failed to publish ${failures} delta patch(es)`);
+  process.exit(1);
+}
+log("Done\n");

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -108,6 +108,10 @@ export const crash_handler = $rust("crash_handler.rs", "js_bindings.generate") a
 export const upgrade_test_helpers = $rust("upgrade_command.rs", "upgrade_js_bindings.generate") as {
   openTempDirWithoutSharingDelete: () => void;
   closeTempDirHandle: () => void;
+  /** Create a `bun upgrade` delta patch that transforms `oldData` into `newData`. */
+  createDeltaPatch: (oldData: Uint8Array, newData: Uint8Array) => Buffer;
+  /** Apply a delta patch created by `createDeltaPatch`. */
+  applyDeltaPatch: (oldData: Uint8Array, patch: Uint8Array) => Buffer;
 };
 
 export const install_test_helpers = $rust("install_binding.rs", "bun_install_js_bindings.generate") as {

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -22,6 +22,7 @@ bytemuck = "1"
 thiserror.workspace = true
 strum.workspace = true
 bstr.workspace = true
+bsdiff.workspace = true
 scopeguard.workspace = true
 const_format.workspace = true
 enum-map.workspace = true

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -2119,6 +2119,12 @@ Learn more: <magenta>https://bun.com/docs/cli/bun-create<r>
   <d>{}<r>
   <b><green>bun upgrade<r> <cyan>--{}<r>
 
+  <d>Install the build from a GitHub pull request<r>
+  <b><green>bun upgrade<r> <cyan>pr 12345<r>
+
+<b>Flags:<r>
+  <cyan>--no-delta<r>  Always download the full release instead of delta patches
+
 Full documentation is available at <magenta>https://bun.com/docs/installation#upgrading<r>
 ",
                     latest,

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -2109,7 +2109,7 @@ Learn more: <magenta>https://bun.com/docs/cli/bun-create<r>
 
                 pretty!(
                     "\
-<b>Usage<r>: <b><green>bun upgrade<r> <cyan>[flags]<r>
+<b>Usage<r>: <b><green>bun upgrade<r> <cyan>[flags] [pr \\<number\\>]<r>
   Upgrade Bun
 
 <b>Examples:<r>

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -2123,6 +2123,9 @@ Learn more: <magenta>https://bun.com/docs/cli/bun-create<r>
   <b><green>bun upgrade<r> <cyan>pr 12345<r>
 
 <b>Flags:<r>
+  <cyan>--canary<r>    Install the most recent canary build
+  <cyan>--stable<r>    Switch back to the latest stable release
+  <cyan>--profile<r>   Install a build with debug symbols
   <cyan>--no-delta<r>  Always download the full release instead of delta patches
 
 Full documentation is available at <magenta>https://bun.com/docs/installation#upgrading<r>

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -534,12 +534,64 @@ impl UpgradeCommand {
         }
     };
 
+    /// Parse a pull request number from `1234`, `#1234`, or a GitHub pull
+    /// request URL like `https://github.com/oven-sh/bun/pull/1234`.
+    fn parse_pr_number(arg: &[u8]) -> Option<u64> {
+        let mut digits = arg;
+        if strings::has_prefix_comptime(digits, b"https://")
+            || strings::has_prefix_comptime(digits, b"http://")
+        {
+            let i = strings::index_of(digits, b"/pull/")?;
+            digits = &digits[i as usize + b"/pull/".len()..];
+            if let Some(end) = digits.iter().position(|c| !c.is_ascii_digit()) {
+                digits = &digits[..end];
+            }
+        } else if let Some(rest) = digits.strip_prefix(b"#") {
+            digits = rest;
+        }
+
+        if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+            return None;
+        }
+        core::str::from_utf8(digits)
+            .ok()?
+            .parse::<u64>()
+            .ok()
+            .filter(|n| *n > 0)
+    }
+
     #[cold]
     pub fn exec(ctx: Command::Context) -> crate::Result<()> {
         let args = bun_core::argv();
+        let mut pr_number: Option<u64> = None;
         if args.len() > 2 {
-            for arg in args.iter().skip(2) {
-                if !strings::contains(arg, b"--") {
+            let mut positionals = args
+                .iter()
+                .skip(2)
+                .filter(|arg| !strings::contains(arg, b"--"));
+            if let Some(first) = positionals.next() {
+                if first == b"pr".as_slice() {
+                    let Some(arg) = positionals.next() else {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r><d>:<r> Expected a pull request number.\n<blue>note<r><d>:<r> Usage: <b>bun upgrade pr \\<number\\><r>"
+                        );
+                        Global::exit(1);
+                    };
+                    let Some(number) = Self::parse_pr_number(arg) else {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r><d>:<r> Invalid pull request number: <b>{}<r>\n<blue>note<r><d>:<r> Usage: <b>bun upgrade pr \\<number\\><r>",
+                            bstr::BStr::new(arg)
+                        );
+                        Global::exit(1);
+                    };
+                    if positionals.next().is_some() {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error<r><d>:<r> Unexpected extra arguments.\n<blue>note<r><d>:<r> Usage: <b>bun upgrade pr \\<number\\><r>"
+                        );
+                        Global::exit(1);
+                    }
+                    pr_number = Some(number);
+                } else {
                     bun_core::pretty_error!(
                         "<r><red>error<r><d>:<r> This command updates Bun itself, and does not take package names.\n<blue>note<r><d>:<r> Use `bun update"
                     );
@@ -552,7 +604,7 @@ impl UpgradeCommand {
             }
         }
 
-        if let Err(err) = Self::_exec(ctx) {
+        if let Err(err) = Self::_exec(ctx, pr_number) {
             bun_core::pretty_errorln!(
                 "<r>Bun upgrade failed with error: <red><b>{}<r>\n\n<cyan>Please upgrade manually<r>:\n  <b>{}<r>\n\n",
                 err.name(),
@@ -563,7 +615,7 @@ impl UpgradeCommand {
         Ok(())
     }
 
-    fn _exec(ctx: Command::Context) -> crate::Result<()> {
+    fn _exec(ctx: Command::Context, pr_number: Option<u64>) -> crate::Result<()> {
         HTTP::http_thread::init(&Default::default());
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.
@@ -574,21 +626,32 @@ impl UpgradeCommand {
         };
         env_loader.load_process()?;
 
-        let use_canary: bool = 'brk: {
-            let default_use_canary = Environment::IS_CANARY;
+        let is_pr = pr_number.is_some();
 
-            if default_use_canary && argv_contains(b"--stable") {
-                break 'brk false;
-            }
+        let use_canary: bool = !is_pr
+            && 'brk: {
+                let default_use_canary = Environment::IS_CANARY;
 
-            break 'brk (env_loader.map.get(b"BUN_CANARY").unwrap_or(b"0") == b"1")
-                || argv_contains(b"--canary")
-                || default_use_canary;
-        };
+                if default_use_canary && argv_contains(b"--stable") {
+                    break 'brk false;
+                }
+
+                break 'brk (env_loader.map.get(b"BUN_CANARY").unwrap_or(b"0") == b"1")
+                    || argv_contains(b"--canary")
+                    || default_use_canary;
+            };
 
         let use_profile = argv_contains(b"--profile");
 
-        let mut version: Version = if !use_canary {
+        let mut pr_build_title: Option<Box<[u8]>> = None;
+        let mut pr_zip_sha1: Option<Box<[u8]>> = None;
+
+        let mut version: Version = if let Some(number) = pr_number {
+            let pr_build = Self::fetch_pr_build(&mut env_loader, number, use_profile)?;
+            pr_build_title = Some(pr_build.title);
+            pr_zip_sha1 = pr_build.zip_sha1;
+            pr_build.version
+        } else if !use_canary {
             // `Progress::start` returns `&mut Node` borrowing `refresher`;
             // leak the Progress and use raw pointers so we can pass both
             // `&mut refresher` and `&mut progress` to `get_latest_version`.
@@ -665,85 +728,125 @@ impl UpgradeCommand {
             }
         };
 
+        // Try a delta upgrade first: download binary patches between
+        // consecutive stable releases instead of the full archive. Any
+        // failure falls back to the regular zip download below.
+        let delta_binary: Option<Vec<u8>> =
+            if !use_canary && !is_pr && !use_profile && !argv_contains(b"--no-delta") {
+                match version.name() {
+                    Some(target) => Self::try_delta_upgrade(&mut env_loader, &target, version.size),
+                    None => None,
+                }
+            } else {
+                None
+            };
+
         let zip_url_bytes = core::mem::take(&mut version.zip_url);
         let zip_url = URL::parse(&zip_url_bytes);
         let http_proxy = env_loader.get_http_proxy_for(&zip_url);
 
         {
-            let refresher: *mut Progress::Progress =
-                bun_core::heap::into_raw(Box::new(Progress::Progress::default()));
-            // SAFETY: refresher is a fresh leaked allocation.
-            let progress: *mut Progress::Node =
-                unsafe { (*refresher).start(b"Downloading", version.size as usize) };
-            // SAFETY: see above.
-            unsafe { (*progress).unit = Progress::Unit::Bytes };
-            // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
-            unsafe { (*refresher).refresh() };
-            // Store in the process-lifetime CLI arena.
-            let zip_file_buffer: &'static mut MutableString = crate::cli::cli_arena()
-                .alloc(MutableString::init(version.size.max(1024) as usize)?);
+            let bytes: &[u8] = if delta_binary.is_some() {
+                // The new binary was reconstructed from delta patches; no
+                // archive download is needed.
+                b""
+            } else {
+                let refresher: *mut Progress::Progress =
+                    bun_core::heap::into_raw(Box::new(Progress::Progress::default()));
+                // SAFETY: refresher is a fresh leaked allocation.
+                let progress: *mut Progress::Node =
+                    unsafe { (*refresher).start(b"Downloading", version.size as usize) };
+                // SAFETY: see above.
+                unsafe { (*progress).unit = Progress::Unit::Bytes };
+                // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
+                unsafe { (*refresher).refresh() };
+                // Store in the process-lifetime CLI arena.
+                let zip_file_buffer: &'static mut MutableString = crate::cli::cli_arena()
+                    .alloc(MutableString::init(version.size.max(1024) as usize)?);
 
-            let mut async_http = Box::new(HTTP::AsyncHTTP::init_sync(
-                HTTP::Method::GET,
-                zip_url,
-                headers::EntryList::default(),
-                b"",
-                std::ptr::from_mut::<MutableString>(zip_file_buffer),
-                b"",
-                http_proxy,
-                None,
-                HTTP::FetchRedirect::Follow,
-            ));
-            // `progress` is intentionally leaked (process-lifetime), so the
-            // untracked NonNull stored in `progress_node` can never dangle.
-            async_http.client.progress_node =
-                Some(NonNull::new(progress).expect("leaked Box is non-null"));
-            async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
+                let mut async_http = Box::new(HTTP::AsyncHTTP::init_sync(
+                    HTTP::Method::GET,
+                    zip_url,
+                    headers::EntryList::default(),
+                    b"",
+                    std::ptr::from_mut::<MutableString>(zip_file_buffer),
+                    b"",
+                    http_proxy,
+                    None,
+                    HTTP::FetchRedirect::Follow,
+                ));
+                // `progress` is intentionally leaked (process-lifetime), so the
+                // untracked NonNull stored in `progress_node` can never dangle.
+                async_http.client.progress_node =
+                    Some(NonNull::new(progress).expect("leaked Box is non-null"));
+                async_http.client.flags.reject_unauthorized =
+                    env_loader.get_tls_reject_unauthorized();
 
-            let response = async_http.send_sync()?;
+                let response = async_http.send_sync()?;
 
-            match response.status_code {
-                404 => {
-                    if use_canary {
+                match response.status_code {
+                    404 => {
+                        if use_canary {
+                            bun_core::pretty_errorln!(
+                                "<r><red>error:<r> Canary builds are not available for this platform yet\n\n   Release: <cyan>https://github.com/oven-sh/bun/releases/tag/canary<r>\n  Filename: <b>{}<r>\n",
+                                Version::ZIP_FILENAME
+                            );
+                            Global::exit(1);
+                        }
+
+                        return Err(crate::Error::HTTP404);
+                    }
+                    403 => return Err(crate::Error::HTTPForbidden),
+                    429 => return Err(crate::Error::HTTPTooManyRequests),
+                    // PR artifacts download from Buildkite, not GitHub.
+                    499..=599 if is_pr => return Err(crate::Error::HTTPServerError),
+                    499..=599 => return Err(crate::Error::GitHubIsDown),
+                    200 => {}
+                    _ => return Err(crate::Error::HTTPError),
+                }
+
+                let bytes = zip_file_buffer.slice();
+
+                // SAFETY: refresher/progress are leaked allocations.
+                unsafe { (*progress).end() };
+                // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
+                unsafe { (*refresher).refresh() };
+
+                if bytes.is_empty() {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> Failed to download the latest version of Bun. Received empty content"
+                    );
+                    Global::exit(1);
+                }
+
+                if let Some(expected_sha1) = pr_zip_sha1.as_deref() {
+                    let actual = Self::sha1_hex(bytes);
+                    if actual.as_bytes() != expected_sha1 {
                         bun_core::pretty_errorln!(
-                            "<r><red>error:<r> Canary builds are not available for this platform yet\n\n   Release: <cyan>https://github.com/oven-sh/bun/releases/tag/canary<r>\n  Filename: <b>{}<r>\n",
-                            Version::ZIP_FILENAME
+                            "<r><red>error:<r> The downloaded artifact failed checksum verification.\n  Expected: <b>{}<r>\n    Actual: <b>{}<r>",
+                            bstr::BStr::new(expected_sha1),
+                            actual
                         );
                         Global::exit(1);
                     }
-
-                    return Err(crate::Error::HTTP404);
                 }
-                403 => return Err(crate::Error::HTTPForbidden),
-                429 => return Err(crate::Error::HTTPTooManyRequests),
-                499..=599 => return Err(crate::Error::GitHubIsDown),
-                200 => {}
-                _ => return Err(crate::Error::HTTPError),
-            }
 
-            let bytes = zip_file_buffer.slice();
+                // The digest describes the release archive, so it only applies
+                // to a downloaded one. Delta upgrades verify every patch and
+                // the reconstructed binary against their own checksums.
+                if version.digest.tag.is_supported() && !version.digest.verify(bytes) {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> The file downloaded from {} did not match the checksum reported by the GitHub API for this release.\n<r>note: run <b>bun upgrade<r> again to retry the download",
+                        bstr::BStr::new(&zip_url_bytes)
+                    );
+                    Global::exit(1);
+                }
 
-            // SAFETY: refresher/progress are leaked allocations.
-            unsafe { (*progress).end() };
-            // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
-            unsafe { (*refresher).refresh() };
-
-            if bytes.is_empty() {
-                bun_core::pretty_errorln!(
-                    "<r><red>error:<r> Failed to download the latest version of Bun. Received empty content"
-                );
-                Global::exit(1);
-            }
-
-            if version.digest.tag.is_supported() && !version.digest.verify(bytes) {
-                bun_core::pretty_errorln!(
-                    "<r><red>error:<r> The file downloaded from {} did not match the checksum reported by the GitHub API for this release.\n<r>note: run <b>bun upgrade<r> again to retry the download",
-                    bstr::BStr::new(&zip_url_bytes)
-                );
-                Global::exit(1);
-            }
+                bytes
+            };
 
             let version_name = version.name().unwrap();
+            let mut pr_revision: Option<Box<[u8]>> = None;
 
             if version_name.is_empty()
                 || version_name.as_slice() == b"."
@@ -815,113 +918,152 @@ impl UpgradeCommand {
                 Self::EXE_SUBPATH.as_bytes()
             };
 
-            let zip_file = match save_dir.open_file(
-                tmpname.as_bytes(),
-                sys::O::WRONLY | sys::O::CREAT | sys::O::TRUNC,
-                0o644,
-            ) {
-                Ok(f) => f,
-                Err(err) => {
+            if let Some(patched) = delta_binary.as_deref() {
+                // The patched executable was reconstructed in memory; write it
+                // into the staging directory at the same path the archive
+                // would have been extracted to.
+                // SAFETY: literal ends with NUL.
+                let folder_z: &ZStr = ZStr::from_static(
+                    const_format::concatcp!(Version::FOLDER_NAME, "\0").as_bytes(),
+                );
+                if let Err(err) = sys::mkdirat(&save_dir, folder_z, 0o755) {
                     bun_core::pretty_errorln!(
-                        "<r><red>error:<r> Failed to open temp file {}",
+                        "<r><red>error:<r> Failed to create staging directory {}",
                         bstr::BStr::new(err.name())
                     );
                     Global::exit(1);
                 }
-            };
 
-            {
-                if let Err(err) = zip_file.write_all(bytes) {
-                    let _ = sys::unlinkat(&save_dir, tmpname);
+                let exe_file = match save_dir.open_file(
+                    exe,
+                    sys::O::WRONLY | sys::O::CREAT | sys::O::TRUNC,
+                    0o755,
+                ) {
+                    Ok(f) => f,
+                    Err(err) => {
+                        bun_core::pretty_errorln!(
+                            "<r><red>error:<r> Failed to open temp file {}",
+                            bstr::BStr::new(err.name())
+                        );
+                        Global::exit(1);
+                    }
+                };
+                if let Err(err) = exe_file.write_all(patched) {
                     bun_core::pretty_errorln!(
                         "<r><red>error:<r> Failed to write to temp file {}",
                         bstr::BStr::new(err.name())
                     );
                     Global::exit(1);
                 }
-                let _ = zip_file.close();
-            }
-
-            {
-                scopeguard::defer! {
-                    let _ = sys::unlinkat(&save_dir, tmpname);
-                }
-
-                #[cfg(unix)]
-                {
-                    let mut unzip_path_buf = PathBuffer::uninit();
-                    let Some(unzip_exe) = which(
-                        &mut unzip_path_buf,
-                        env_loader.map.get(b"PATH").unwrap_or(b""),
-                        filesystem.top_level_dir,
-                        b"unzip",
-                    ) else {
-                        let _ = sys::unlinkat(&save_dir, tmpname);
+                let _ = exe_file.close();
+            } else {
+                let zip_file = match save_dir.open_file(
+                    tmpname.as_bytes(),
+                    sys::O::WRONLY | sys::O::CREAT | sys::O::TRUNC,
+                    0o644,
+                ) {
+                    Ok(f) => f,
+                    Err(err) => {
                         bun_core::pretty_errorln!(
-                            "<r><red>error:<r> Failed to locate \"unzip\" in PATH. bun upgrade needs \"unzip\" to work."
+                            "<r><red>error:<r> Failed to open temp file {}",
+                            bstr::BStr::new(err.name())
                         );
                         Global::exit(1);
-                    };
+                    }
+                };
 
-                    // We could just embed libz2
-                    // however, we want to be sure that xattrs are preserved
-                    // xattrs are used for codesigning
-                    // it'd be easy to mess that up
-                    let unzip_argv: [&[u8]; 4] =
-                        [unzip_exe.as_bytes(), b"-q", b"-o", tmpname.as_bytes()];
+                {
+                    if let Err(err) = zip_file.write_all(bytes) {
+                        let _ = sys::unlinkat(&save_dir, tmpname);
+                        bun_core::pretty_errorln!(
+                            "<r><red>error:<r> Failed to write to temp file {}",
+                            bstr::BStr::new(err.name())
+                        );
+                        Global::exit(1);
+                    }
+                    let _ = zip_file.close();
+                }
 
-                    let unzip_result = match spawn_sync::spawn(&spawn_sync::Options {
-                        argv: build_argv(&unzip_argv),
-                        envp: None,
-                        cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
-                        stdin: spawn_sync::SyncStdio::Inherit,
-                        stdout: spawn_sync::SyncStdio::Inherit,
-                        stderr: spawn_sync::SyncStdio::Inherit,
-                        #[cfg(windows)]
-                        windows: spawn_windows_options(),
-                        ..Default::default()
-                    }) {
-                        Ok(Ok(r)) => r,
-                        Ok(Err(err)) => {
+                {
+                    scopeguard::defer! {
+                        let _ = sys::unlinkat(&save_dir, tmpname);
+                    }
+
+                    #[cfg(unix)]
+                    {
+                        let mut unzip_path_buf = PathBuffer::uninit();
+                        let Some(unzip_exe) = which(
+                            &mut unzip_path_buf,
+                            env_loader.map.get(b"PATH").unwrap_or(b""),
+                            filesystem.top_level_dir,
+                            b"unzip",
+                        ) else {
                             let _ = sys::unlinkat(&save_dir, tmpname);
                             bun_core::pretty_errorln!(
-                                "<r><red>error:<r> Failed to spawn unzip due to {}.",
-                                bstr::BStr::new(err.name())
+                                "<r><red>error:<r> Failed to locate \"unzip\" in PATH. bun upgrade needs \"unzip\" to work."
                             );
                             Global::exit(1);
-                        }
-                        Err(err) => {
-                            let _ = sys::unlinkat(&save_dir, tmpname);
-                            bun_core::pretty_errorln!(
-                                "<r><red>error:<r> Failed to spawn unzip due to {}.",
-                                err.name()
-                            );
-                            Global::exit(1);
-                        }
-                    };
+                        };
 
-                    match unzip_result.status {
-                        Status::Exited(e) if e.code == 0 => {}
-                        Status::Exited(e) => {
-                            bun_core::pretty_errorln!(
-                                "<r><red>Unzip failed<r> (exit code: {})",
-                                e.code
-                            );
-                            let _ = sys::unlinkat(&save_dir, tmpname);
-                            Global::exit(1);
-                        }
-                        other => {
-                            bun_core::pretty_errorln!("<r><red>Unzip failed<r> ({})", other);
-                            let _ = sys::unlinkat(&save_dir, tmpname);
-                            Global::exit(1);
+                        // We could just embed libz2
+                        // however, we want to be sure that xattrs are preserved
+                        // xattrs are used for codesigning
+                        // it'd be easy to mess that up
+                        let unzip_argv: [&[u8]; 4] =
+                            [unzip_exe.as_bytes(), b"-q", b"-o", tmpname.as_bytes()];
+
+                        let unzip_result = match spawn_sync::spawn(&spawn_sync::Options {
+                            argv: build_argv(&unzip_argv),
+                            envp: None,
+                            cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
+                            stdin: spawn_sync::SyncStdio::Inherit,
+                            stdout: spawn_sync::SyncStdio::Inherit,
+                            stderr: spawn_sync::SyncStdio::Inherit,
+                            #[cfg(windows)]
+                            windows: spawn_windows_options(),
+                            ..Default::default()
+                        }) {
+                            Ok(Ok(r)) => r,
+                            Ok(Err(err)) => {
+                                let _ = sys::unlinkat(&save_dir, tmpname);
+                                bun_core::pretty_errorln!(
+                                    "<r><red>error:<r> Failed to spawn unzip due to {}.",
+                                    bstr::BStr::new(err.name())
+                                );
+                                Global::exit(1);
+                            }
+                            Err(err) => {
+                                let _ = sys::unlinkat(&save_dir, tmpname);
+                                bun_core::pretty_errorln!(
+                                    "<r><red>error:<r> Failed to spawn unzip due to {}.",
+                                    err.name()
+                                );
+                                Global::exit(1);
+                            }
+                        };
+
+                        match unzip_result.status {
+                            Status::Exited(e) if e.code == 0 => {}
+                            Status::Exited(e) => {
+                                bun_core::pretty_errorln!(
+                                    "<r><red>Unzip failed<r> (exit code: {})",
+                                    e.code
+                                );
+                                let _ = sys::unlinkat(&save_dir, tmpname);
+                                Global::exit(1);
+                            }
+                            other => {
+                                bun_core::pretty_errorln!("<r><red>Unzip failed<r> ({})", other);
+                                let _ = sys::unlinkat(&save_dir, tmpname);
+                                Global::exit(1);
+                            }
                         }
                     }
-                }
-                #[cfg(windows)]
-                {
-                    // Run a powershell script to unzip the file
-                    let mut unzip_script = Vec::new();
-                    write!(
+                    #[cfg(windows)]
+                    {
+                        // Run a powershell script to unzip the file
+                        let mut unzip_script = Vec::new();
+                        write!(
                         &mut unzip_script,
                         "$global:ProgressPreference='SilentlyContinue';Expand-Archive -Path \"{}\" \"{}\" -Force",
                         bun_fmt::escape_powershell(bstr::BStr::new(tmpname.as_bytes())),
@@ -929,23 +1071,24 @@ impl UpgradeCommand {
                     )
                     .expect("oom");
 
-                    let mut buf = PathBuffer::uninit();
-                    // Separate fallback buffer — borrowck holds `buf` for the lifetime
-                    // of `which`'s returned `Option<&ZStr>` even across the `None` arm.
-                    let mut buf2 = PathBuffer::uninit();
-                    let powershell_path: &ZStr = match which(
-                        &mut buf,
-                        bun_core::env_var::PATH.get().unwrap_or(b""),
-                        b"",
-                        b"powershell",
-                    ) {
-                        Some(p) => p,
-                        None => {
-                            let system_root = bun_core::env_var::SYSTEMROOT
-                                .get()
-                                .unwrap_or(b"C:\\Windows");
-                            let hardcoded_system_powershell =
-                                bun_paths::join_abs_string_buf_z::<bun_paths::platform::Windows>(
+                        let mut buf = PathBuffer::uninit();
+                        // Separate fallback buffer — borrowck holds `buf` for the lifetime
+                        // of `which`'s returned `Option<&ZStr>` even across the `None` arm.
+                        let mut buf2 = PathBuffer::uninit();
+                        let powershell_path: &ZStr = match which(
+                            &mut buf,
+                            bun_core::env_var::PATH.get().unwrap_or(b""),
+                            b"",
+                            b"powershell",
+                        ) {
+                            Some(p) => p,
+                            None => {
+                                let system_root = bun_core::env_var::SYSTEMROOT
+                                    .get()
+                                    .unwrap_or(b"C:\\Windows");
+                                let hardcoded_system_powershell = bun_paths::join_abs_string_buf_z::<
+                                    bun_paths::platform::Windows,
+                                >(
                                     system_root,
                                     &mut buf2[..],
                                     &[
@@ -953,62 +1096,63 @@ impl UpgradeCommand {
                                         b"System32\\WindowsPowerShell\\v1.0\\powershell.exe",
                                     ],
                                 );
-                            if !sys::exists(hardcoded_system_powershell.as_bytes()) {
+                                if !sys::exists(hardcoded_system_powershell.as_bytes()) {
+                                    bun_core::pretty_errorln!(
+                                        "<r><red>error:<r> Failed to unzip {} due to PowerShell not being installed.",
+                                        bstr::BStr::new(tmpname.as_bytes())
+                                    );
+                                    Global::exit(1);
+                                }
+                                hardcoded_system_powershell
+                            }
+                        };
+
+                        let unzip_argv: [&[u8]; 6] = [
+                            powershell_path.as_bytes(),
+                            b"-NoProfile",
+                            b"-ExecutionPolicy",
+                            b"Bypass",
+                            b"-Command",
+                            &unzip_script,
+                        ];
+
+                        let spawn_res = spawn_sync::spawn(&spawn_sync::Options {
+                            argv: build_argv(&unzip_argv),
+                            envp: None,
+                            cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
+                            stderr: spawn_sync::SyncStdio::Inherit,
+                            stdout: spawn_sync::SyncStdio::Inherit,
+                            stdin: spawn_sync::SyncStdio::Inherit,
+                            #[cfg(windows)]
+                            windows: spawn_windows_options(),
+                            ..Default::default()
+                        });
+                        let spawn_res = match spawn_res {
+                            Ok(r) => r,
+                            Err(err) => {
                                 bun_core::pretty_errorln!(
-                                    "<r><red>error:<r> Failed to unzip {} due to PowerShell not being installed.",
-                                    bstr::BStr::new(tmpname.as_bytes())
+                                    "<r><red>error:<r> Failed to spawn Expand-Archive on {} due to error {}",
+                                    bstr::BStr::new(tmpname.as_bytes()),
+                                    err.name()
                                 );
                                 Global::exit(1);
                             }
-                            hardcoded_system_powershell
-                        }
-                    };
-
-                    let unzip_argv: [&[u8]; 6] = [
-                        powershell_path.as_bytes(),
-                        b"-NoProfile",
-                        b"-ExecutionPolicy",
-                        b"Bypass",
-                        b"-Command",
-                        &unzip_script,
-                    ];
-
-                    let spawn_res = spawn_sync::spawn(&spawn_sync::Options {
-                        argv: build_argv(&unzip_argv),
-                        envp: None,
-                        cwd: Box::<[u8]>::from(&tmpdir_path_buf[..tmpdir_path_len]),
-                        stderr: spawn_sync::SyncStdio::Inherit,
-                        stdout: spawn_sync::SyncStdio::Inherit,
-                        stdin: spawn_sync::SyncStdio::Inherit,
-                        #[cfg(windows)]
-                        windows: spawn_windows_options(),
-                        ..Default::default()
-                    });
-                    let spawn_res = match spawn_res {
-                        Ok(r) => r,
-                        Err(err) => {
+                        };
+                        if let Err(err) = spawn_res {
                             bun_core::pretty_errorln!(
-                                "<r><red>error:<r> Failed to spawn Expand-Archive on {} due to error {}",
+                                "<r><red>error:<r> Failed to run Expand-Archive on {} due to error {}",
                                 bstr::BStr::new(tmpname.as_bytes()),
-                                err.name()
+                                bstr::BStr::new(err.name())
                             );
                             Global::exit(1);
                         }
-                    };
-                    if let Err(err) = spawn_res {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error:<r> Failed to run Expand-Archive on {} due to error {}",
-                            bstr::BStr::new(tmpname.as_bytes()),
-                            bstr::BStr::new(err.name())
-                        );
-                        Global::exit(1);
                     }
                 }
             }
             {
                 let verify_argv: [&[u8]; 2] = [
                     exe,
-                    if use_canary {
+                    if use_canary || is_pr {
                         b"--revision"
                     } else {
                         b"--version"
@@ -1089,6 +1233,13 @@ impl UpgradeCommand {
                     if let Some(i) = strings::index_of_char(version_string, b'+') {
                         version.tag = version_string[(i as usize + 1)..].into();
                     }
+                } else if is_pr {
+                    // PR builds report an arbitrary in-development version;
+                    // a successful exit is all the verification we can do.
+                    pr_revision = Some(Box::<[u8]>::from(bun_core::trim(
+                        result.stdout.as_slice(),
+                        b" \n\r\t",
+                    )));
                 } else {
                     let mut version_string = result.stdout.as_slice();
                     if let Some(i) = strings::index_of_char(version_string, b' ') {
@@ -1368,7 +1519,15 @@ impl UpgradeCommand {
 
             Output::print_start_end(ctx.start_time, bun_core::time::nano_timestamp());
 
-            if use_canary {
+            if let Some(number) = pr_number {
+                bun_core::pretty_errorln!(
+                    "<r> Upgraded.\n\n<b><green>Installed a build of Bun from pull request #{}<r>\n\n     Title: <b>{}<r>\n  Revision: <b>{}<r>\n       PR: <cyan>https://github.com/oven-sh/bun/pull/{}<r>\n\nTo switch back to the latest stable release:\n\n  <b><cyan>bun upgrade<r>\n",
+                    number,
+                    bstr::BStr::new(pr_build_title.as_deref().unwrap_or(b"")),
+                    bstr::BStr::new(pr_revision.as_deref().unwrap_or(b"unknown")),
+                    number
+                );
+            } else if use_canary {
                 bun_core::pretty_errorln!(
                     "<r> Upgraded.\n\n<b><green>Welcome to Bun's latest canary build!<r>\n\nReport any bugs:\n\n    https://github.com/oven-sh/bun/issues\n\nChangelog:\n\n    https://github.com/oven-sh/bun/compare/{}...{}\n",
                     Environment::GIT_SHA_SHORT,
@@ -1408,6 +1567,785 @@ impl UpgradeCommand {
 
         Ok(())
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // HTTP helpers
+
+    /// Build the `Accept` (+ optional `Authorization`) headers for GitHub
+    /// API requests, honoring `GITHUB_TOKEN` / `GITHUB_ACCESS_TOKEN`.
+    fn github_api_headers(env_loader: &DotEnv::Loader) -> (headers::EntryList, &'static [u8]) {
+        let mut headers_buf: Vec<u8> = Self::DEFAULT_GITHUB_HEADERS.to_vec();
+
+        let mut header_entries: headers::EntryList = headers::EntryList::default();
+        let accept = headers::Entry {
+            name: HTTP::ETag::StringPointer {
+                offset: 0,
+                length: u32::try_from(b"Accept".len()).expect("int cast"),
+            },
+            value: HTTP::ETag::StringPointer {
+                offset: u32::try_from(b"Accept".len()).expect("int cast"),
+                length: u32::try_from(b"application/vnd.github.v3+json".len()).expect("int cast"),
+            },
+        };
+        header_entries.append(accept).expect("oom");
+
+        if let Some(access_token) = env_loader
+            .map
+            .get(b"GITHUB_TOKEN")
+            .or_else(|| env_loader.map.get(b"GITHUB_ACCESS_TOKEN"))
+        {
+            if !access_token.is_empty() {
+                let offset = u32::try_from(headers_buf.len()).expect("int cast");
+                write!(
+                    &mut headers_buf,
+                    "AuthorizationBearer {}",
+                    bstr::BStr::new(access_token),
+                )
+                .expect("oom");
+                header_entries
+                    .append(headers::Entry {
+                        name: HTTP::ETag::StringPointer {
+                            offset,
+                            length: u32::try_from(b"Authorization".len()).expect("int cast"),
+                        },
+                        value: HTTP::ETag::StringPointer {
+                            offset: offset
+                                + u32::try_from(b"Authorization".len()).expect("int cast"),
+                            length: u32::try_from(b"Bearer ".len() + access_token.len())
+                                .expect("int cast"),
+                        },
+                    })
+                    .expect("oom");
+            }
+        }
+
+        (header_entries, crate::cli::cli_dupe(&headers_buf))
+    }
+
+    /// Synchronously GET `url_bytes`, following redirects. Returns the
+    /// response body when the server answers 200.
+    fn http_get_sync(
+        env_loader: &mut DotEnv::Loader,
+        url_bytes: &[u8],
+        github_auth: bool,
+    ) -> crate::Result<&'static [u8]> {
+        // `AsyncHTTP::init_sync` wants `URL<'static>` / `&'static [u8]`; back
+        // the buffers in the process-lifetime CLI arena.
+        let url_buf: &'static [u8] = crate::cli::cli_dupe(url_bytes);
+        let url = URL::parse(url_buf);
+
+        let (header_entries, headers_buf) = if github_auth {
+            Self::github_api_headers(env_loader)
+        } else {
+            (headers::EntryList::default(), &b""[..])
+        };
+
+        let http_proxy = env_loader.get_http_proxy_for(&url);
+
+        let response_body: &'static mut MutableString =
+            crate::cli::cli_arena().alloc(MutableString::init(2048)?);
+
+        // ensure very stable memory address
+        let mut async_http = Box::new(HTTP::AsyncHTTP::init_sync(
+            HTTP::Method::GET,
+            url,
+            header_entries,
+            headers_buf,
+            std::ptr::from_mut::<MutableString>(response_body),
+            b"",
+            http_proxy,
+            None,
+            HTTP::FetchRedirect::Follow,
+        ));
+        async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
+
+        let response = async_http.send_sync()?;
+
+        match response.status_code {
+            200 => Ok(response_body.list.as_slice()),
+            404 => Err(crate::Error::HTTP404),
+            403 => Err(crate::Error::HTTPForbidden),
+            429 => Err(crate::Error::HTTPTooManyRequests),
+            // This helper also talks to non-GitHub hosts (Buildkite), so
+            // only blame GitHub when the request actually went there.
+            499..=599 if github_auth => Err(crate::Error::GitHubIsDown),
+            499..=599 => Err(crate::Error::HTTPServerError),
+            _ => Err(crate::Error::HTTPError),
+        }
+    }
+
+    fn parse_json_response(bytes: &'static [u8]) -> Option<bun_ast::Expr> {
+        let mut log = bun_ast::Log::init();
+        let source = bun_ast::Source::init_path_string(b"response.json", bytes);
+        bun_ast::initialize_store();
+        let bump: &'static Bump = crate::cli::cli_arena();
+        let expr = JSON::parse_utf8(&source, &mut log, bump).ok()?;
+        if log.errors > 0 {
+            return None;
+        }
+        Some(expr)
+    }
+
+    /// Owned copy of the string literal at `expr[name]`, if present.
+    fn json_string_property(expr: &bun_ast::Expr, name: &[u8]) -> Option<Vec<u8>> {
+        let query = expr.as_property(name)?;
+        Some(query.expr.as_utf8_string_literal()?.to_vec())
+    }
+
+    /// `scheme://host[:port]` prefix of `url`, without any path/query/fragment.
+    fn url_origin(url: &[u8]) -> &[u8] {
+        let scheme_end = match strings::index_of(url, b"://") {
+            Some(i) => i as usize + b"://".len(),
+            None => 0,
+        };
+        let mut end = url.len();
+        for (i, c) in url[scheme_end..].iter().enumerate() {
+            if *c == b'/' || *c == b'?' || *c == b'#' {
+                end = scheme_end + i;
+                break;
+            }
+        }
+        &url[..end]
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use bun_sha_hmac::sha;
+        let mut digest = [0u8; sha::SHA256::DIGEST];
+        let mut hasher = sha::SHA256::init();
+        hasher.update(bytes);
+        hasher.r#final(&mut digest);
+        bun_fmt::bytes_to_hex_lower_string(&digest)
+    }
+
+    fn sha1_hex(bytes: &[u8]) -> String {
+        use bun_sha_hmac::sha;
+        let mut digest = [0u8; sha::SHA1::DIGEST];
+        let mut hasher = sha::SHA1::init();
+        hasher.update(bytes);
+        hasher.r#final(&mut digest);
+        bun_fmt::bytes_to_hex_lower_string(&digest)
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Delta upgrades
+
+    const RELEASES_DOWNLOAD_BASE: &'static str = "https://github.com/oven-sh/bun/releases/download";
+
+    /// zstd frame magic number — delta patches are zstd-compressed bsdiff
+    /// streams. Raw bsdiff patches are accepted as well.
+    const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+    /// Upper bound on the decompressed size of a delta patch, to reject
+    /// pathological inputs (the raw bsdiff stream can exceed the size of the
+    /// new binary, so this is intentionally generous).
+    const MAX_PATCH_SIZE: usize = 2 * 1024 * 1024 * 1024;
+
+    /// The release version this build was cut from, without the `-debug`
+    /// suffix that debug builds append to `Bun.version`.
+    fn current_release_version() -> &'static [u8] {
+        let version = Global::package_json_version.as_bytes();
+        version.strip_suffix(b"-debug").unwrap_or(version)
+    }
+
+    /// Base URL that release assets (delta patches and checksums) are
+    /// downloaded from. Overridable so tests can serve fixtures.
+    fn releases_download_base(env_loader: &DotEnv::Loader) -> Vec<u8> {
+        let base: &[u8] = match env_loader.map.get(b"BUN_UPGRADE_TESTING_RELEASE_URL") {
+            Some(url) if !url.is_empty() => url,
+            _ => Self::RELEASES_DOWNLOAD_BASE.as_bytes(),
+        };
+        base.strip_suffix(b"/").unwrap_or(base).to_vec()
+    }
+
+    fn parse_version_component(digits: &[u8]) -> Option<u64> {
+        if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+            return None;
+        }
+        core::str::from_utf8(digits).ok()?.parse::<u64>().ok()
+    }
+
+    /// Parse a plain `major.minor.patch` version. Pre-release or build
+    /// metadata (canary, debug, …) disqualifies a version from delta
+    /// upgrades, so anything else returns `None`.
+    fn parse_stable_version(bytes: &[u8]) -> Option<(u64, u64, u64)> {
+        let mut parts = bytes.split(|c| *c == b'.');
+        let major = Self::parse_version_component(parts.next()?)?;
+        let minor = Self::parse_version_component(parts.next()?)?;
+        let patch = Self::parse_version_component(parts.next()?)?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some((major, minor, patch))
+    }
+
+    /// Build the chain of consecutive `(from, to)` versions between
+    /// `current` and `target`. Each release publishes a delta patch from its
+    /// immediate predecessor, so multi-step upgrades chain patches:
+    /// 1.2.10 -> 1.2.12 applies the 1.2.10->1.2.11 patch, then the
+    /// 1.2.11->1.2.12 patch.
+    ///
+    /// Supports same-minor patch chains and a single minor-version jump
+    /// (e.g. 1.2.13 -> 1.3.0 -> 1.3.1); capped at 3 steps. Returns an empty
+    /// chain when the versions aren't eligible for delta upgrade.
+    fn build_delta_chain(current: &[u8], target: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let Some((current_major, current_minor, current_patch)) =
+            Self::parse_stable_version(current)
+        else {
+            return Vec::new();
+        };
+        let Some((target_major, target_minor, target_patch)) = Self::parse_stable_version(target)
+        else {
+            return Vec::new();
+        };
+        if current_major != target_major {
+            return Vec::new();
+        }
+
+        fn format_version(major: u64, minor: u64, patch: u64) -> Vec<u8> {
+            let mut out = Vec::new();
+            write!(&mut out, "{}.{}.{}", major, minor, patch).expect("oom");
+            out
+        }
+
+        let mut chain = Vec::new();
+
+        if current_minor == target_minor {
+            // Same minor: chain through consecutive patch versions.
+            let diff = target_patch.saturating_sub(current_patch);
+            if diff == 0 || diff > 3 {
+                return Vec::new();
+            }
+            for i in 0..diff {
+                chain.push((
+                    format_version(current_major, current_minor, current_patch + i),
+                    format_version(current_major, current_minor, current_patch + i + 1),
+                ));
+            }
+        } else if target_minor == current_minor + 1 {
+            // Cross-minor: the first step jumps to target_minor.0, the rest
+            // chain through its patch versions.
+            chain.push((
+                current.to_vec(),
+                format_version(target_major, target_minor, 0),
+            ));
+            for i in 0..target_patch {
+                chain.push((
+                    format_version(target_major, target_minor, i),
+                    format_version(target_major, target_minor, i + 1),
+                ));
+            }
+            if chain.len() > 3 {
+                return Vec::new();
+            }
+        }
+
+        chain
+    }
+
+    /// Parse the `<hex sha256>  <filename>` format of `.sha256sum` release
+    /// assets (a bare hash is accepted too).
+    fn parse_sha256sum(body: &[u8]) -> Option<Vec<u8>> {
+        let hash = body
+            .split(|c: &u8| c.is_ascii_whitespace())
+            .find(|token| !token.is_empty())?;
+        if hash.len() != 64 || !hash.iter().all(u8::is_ascii_hexdigit) {
+            return None;
+        }
+        Some(hash.to_ascii_lowercase())
+    }
+
+    /// Apply a delta patch (zstd-compressed bsdiff stream) to `old`,
+    /// producing the new binary.
+    pub(crate) fn apply_delta_patch(
+        old: &[u8],
+        patch_data: &[u8],
+    ) -> Result<Vec<u8>, &'static str> {
+        let decompressed;
+        let raw_patch: &[u8] = if patch_data.starts_with(&Self::ZSTD_MAGIC) {
+            if bun_zstd::get_decompressed_size(patch_data) > Self::MAX_PATCH_SIZE {
+                return Err("patch is too large");
+            }
+            decompressed =
+                bun_zstd::decompress_alloc(patch_data).map_err(|_| "failed to decompress patch")?;
+            if decompressed.len() > Self::MAX_PATCH_SIZE {
+                return Err("patch is too large");
+            }
+            &decompressed
+        } else {
+            patch_data
+        };
+
+        let mut new = Vec::new();
+        let mut reader = raw_patch;
+        bsdiff::patch(old, &mut reader, &mut new).map_err(|_| "patch did not apply")?;
+        if new.is_empty() {
+            return Err("patch produced an empty file");
+        }
+        Ok(new)
+    }
+
+    /// Create a delta patch that transforms `old` into `new` — the inverse
+    /// of [`Self::apply_delta_patch`]. Used by the release tooling (via
+    /// `bun:internal-for-testing`) to publish patch assets.
+    pub(crate) fn create_delta_patch(old: &[u8], new: &[u8]) -> Result<Vec<u8>, &'static str> {
+        let mut raw = Vec::new();
+        bsdiff::diff(old, new, &mut raw).map_err(|_| "failed to compute binary diff")?;
+
+        let mut compressed = vec![0u8; bun_zstd::compress_bound(raw.len())];
+        match bun_zstd::compress(&mut compressed, &raw, Some(19)) {
+            bun_zstd::Result::Success(size) => {
+                compressed.truncate(size);
+                Ok(compressed)
+            }
+            _ => Err("failed to compress binary diff"),
+        }
+    }
+
+    /// Fetch `<url>.sha256sum` and return the expected hash, if valid.
+    fn fetch_sha256(env_loader: &mut DotEnv::Loader, url: &[u8]) -> Option<Vec<u8>> {
+        let mut checksum_url = url.to_vec();
+        checksum_url.extend_from_slice(b".sha256sum");
+        Self::parse_sha256sum(Self::http_get_sync(env_loader, &checksum_url, false).ok()?)
+    }
+
+    /// Attempt to reconstruct the target release's binary by downloading and
+    /// applying bsdiff patches between consecutive releases, instead of
+    /// downloading the whole archive.
+    ///
+    /// Tries the direct `target.from-current` patch first (each release
+    /// publishes a patch from its immediate predecessor, which covers the
+    /// common "one release behind" case even when version numbers were
+    /// skipped), then falls back to chaining per-version patches. Returns
+    /// `None` on any failure so the caller downloads the full archive.
+    fn try_delta_upgrade(
+        env_loader: &mut DotEnv::Loader,
+        target_version: &[u8],
+        full_download_size: u32,
+    ) -> Option<Vec<u8>> {
+        let current_version = Self::current_release_version();
+
+        let chain = Self::build_delta_chain(current_version, target_version);
+        if chain.is_empty() {
+            return None;
+        }
+
+        let base = Self::releases_download_base(env_loader);
+
+        // Verify the on-disk binary matches its release checksum before
+        // patching anything; modified binaries can't be patched. Releases
+        // that predate delta support have no checksum asset, so failures
+        // here are silent.
+        let expected_current = {
+            let mut url = Vec::new();
+            write!(
+                &mut url,
+                "{}/bun-v{}/{}",
+                bstr::BStr::new(&base),
+                bstr::BStr::new(current_version),
+                Version::FOLDER_NAME,
+            )
+            .expect("oom");
+            Self::fetch_sha256(env_loader, &url)?
+        };
+
+        let current_exe = bun_core::self_exe_path().ok()?;
+        let mut original: Vec<u8> = sys::File::open(current_exe, sys::O::RDONLY, 0)
+            .and_then(|file| file.read_to_end())
+            .ok()?;
+        if Self::sha256_hex(&original).as_bytes() != expected_current {
+            return None;
+        }
+
+        let mut candidates: Vec<Vec<(Vec<u8>, Vec<u8>)>> =
+            vec![vec![(current_version.to_vec(), target_version.to_vec())]];
+        if chain.len() > 1 {
+            candidates.push(chain);
+        }
+
+        bun_core::pretty_errorln!("<r><d>Attempting delta upgrade<r>");
+        Output::flush();
+
+        let candidate_count = candidates.len();
+        'candidates: for (candidate, chain) in candidates.iter().enumerate() {
+            // The last candidate can take the buffer instead of copying it.
+            let mut binary = if candidate + 1 == candidate_count {
+                core::mem::take(&mut original)
+            } else {
+                original.clone()
+            };
+            let mut downloaded: usize = 0;
+            let total_steps = chain.len();
+
+            for (step, (from, to)) in chain.iter().enumerate() {
+                let mut patch_url = Vec::new();
+                write!(
+                    &mut patch_url,
+                    "{}/bun-v{}/{}.from-{}.bsdiff",
+                    bstr::BStr::new(&base),
+                    bstr::BStr::new(to),
+                    Version::FOLDER_NAME,
+                    bstr::BStr::new(from),
+                )
+                .expect("oom");
+
+                bun_core::pretty_errorln!(
+                    "<r><d>Downloading patch {}/{} (v{} -> v{})<r>",
+                    step + 1,
+                    total_steps,
+                    bstr::BStr::new(from),
+                    bstr::BStr::new(to),
+                );
+                Output::flush();
+
+                let Ok(patch) = Self::http_get_sync(env_loader, &patch_url, false) else {
+                    continue 'candidates;
+                };
+                downloaded += patch.len();
+
+                let Some(expected_patch) = Self::fetch_sha256(env_loader, &patch_url) else {
+                    continue 'candidates;
+                };
+                if Self::sha256_hex(patch).as_bytes() != expected_patch {
+                    continue 'candidates;
+                }
+
+                binary = match Self::apply_delta_patch(&binary, patch) {
+                    Ok(patched) => patched,
+                    Err(_) => continue 'candidates,
+                };
+
+                let expected_binary = {
+                    let mut url = Vec::new();
+                    write!(
+                        &mut url,
+                        "{}/bun-v{}/{}",
+                        bstr::BStr::new(&base),
+                        bstr::BStr::new(to),
+                        Version::FOLDER_NAME,
+                    )
+                    .expect("oom");
+                    let Some(expected) = Self::fetch_sha256(env_loader, &url) else {
+                        continue 'candidates;
+                    };
+                    expected
+                };
+                if Self::sha256_hex(&binary).as_bytes() != expected_binary {
+                    continue 'candidates;
+                }
+            }
+
+            if full_download_size > 0 {
+                bun_core::pretty_errorln!(
+                    "<r><green>Delta upgrade verified<r> <d>— downloaded {} instead of {}<r>",
+                    bun_fmt::bytes(downloaded),
+                    bun_fmt::bytes(full_download_size as usize),
+                );
+            } else {
+                bun_core::pretty_errorln!(
+                    "<r><green>Delta upgrade verified<r> <d>— downloaded {}<r>",
+                    bun_fmt::bytes(downloaded),
+                );
+            }
+            Output::flush();
+
+            return Some(binary);
+        }
+
+        bun_core::pretty_errorln!(
+            "<r><d>Delta upgrade unavailable, downloading the full release<r>"
+        );
+        Output::flush();
+        None
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Installing builds from pull requests
+
+    /// Locate the Buildkite build for a pull request's latest commit and
+    /// resolve the download URL of this platform's build artifact.
+    ///
+    /// PR builds are uploaded as public Buildkite artifacts, so — unlike
+    /// GitHub Actions artifacts — no authentication is needed. The build is
+    /// discovered through the `buildkite/bun` commit status, and artifacts
+    /// are listed via Buildkite's browser-facing JSON endpoints.
+    fn fetch_pr_build(
+        env_loader: &mut DotEnv::Loader,
+        pr_number: u64,
+        use_profile: bool,
+    ) -> crate::Result<PrBuild> {
+        // Incase they're using a GitHub proxy in e.g. China
+        let api_domain: Vec<u8> = match env_loader.map.get(b"GITHUB_API_DOMAIN") {
+            Some(domain) if !domain.is_empty() => domain.to_vec(),
+            _ => b"api.github.com".to_vec(),
+        };
+
+        bun_core::pretty_errorln!(
+            "<r><d>Looking up pull request <b>#{}<r><d>...<r>",
+            pr_number
+        );
+        Output::flush();
+
+        let pull_body = {
+            let mut url = Vec::new();
+            write!(
+                &mut url,
+                "https://{}/repos/oven-sh/bun/pulls/{}",
+                bstr::BStr::new(&api_domain),
+                pr_number,
+            )
+            .expect("oom");
+            match Self::http_get_sync(env_loader, &url, true) {
+                Ok(body) => body,
+                Err(crate::Error::HTTP404) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> Pull request <b>#{}<r> was not found in oven-sh/bun",
+                        pr_number
+                    );
+                    Global::exit(1);
+                }
+                Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> Failed to look up pull request #{} (code: {})",
+                        pr_number,
+                        err.name()
+                    );
+                    Global::exit(1);
+                }
+            }
+        };
+        let Some(pull) = Self::parse_json_response(pull_body) else {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> Failed to parse the GitHub API response for PR #{}",
+                pr_number
+            );
+            Global::exit(1);
+        };
+
+        let title: Box<[u8]> = Self::json_string_property(&pull, b"title")
+            .unwrap_or_default()
+            .into();
+        let state: Vec<u8> =
+            Self::json_string_property(&pull, b"state").unwrap_or_else(|| b"unknown".to_vec());
+        let Some(head_sha) = pull
+            .as_property(b"head")
+            .and_then(|p| Self::json_string_property(&p.expr, b"sha"))
+        else {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> The GitHub API response for PR #{} is missing the head commit",
+                pr_number
+            );
+            Global::exit(1);
+        };
+
+        bun_core::pretty_errorln!(
+            "<r>PR <b>#{}<r><d>:<r> {} <d>({})<r>",
+            pr_number,
+            bstr::BStr::new(&title),
+            bstr::BStr::new(&state),
+        );
+        Output::flush();
+
+        // Find the Buildkite build for the latest commit through its commit
+        // status.
+        let statuses_body = {
+            let mut url = Vec::new();
+            write!(
+                &mut url,
+                "https://{}/repos/oven-sh/bun/commits/{}/statuses?per_page=100",
+                bstr::BStr::new(&api_domain),
+                bstr::BStr::new(&head_sha),
+            )
+            .expect("oom");
+            match Self::http_get_sync(env_loader, &url, true) {
+                Ok(body) => body,
+                Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> Failed to fetch the CI statuses for PR #{} (code: {})",
+                        pr_number,
+                        err.name()
+                    );
+                    Global::exit(1);
+                }
+            }
+        };
+
+        let mut build_url: Option<Vec<u8>> = None;
+        if let Some(statuses) = Self::parse_json_response(statuses_body) {
+            if let Some(statuses) = statuses.data.e_array() {
+                // Statuses are listed newest-first; take the most recent
+                // Buildkite build.
+                for status in statuses.items.slice() {
+                    let Some(context) = Self::json_string_property(status, b"context") else {
+                        continue;
+                    };
+                    if context != b"buildkite/bun" {
+                        continue;
+                    }
+                    if let Some(target_url) = Self::json_string_property(status, b"target_url") {
+                        if !target_url.is_empty() {
+                            build_url = Some(target_url);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        let Some(build_url_owned) = build_url else {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> No CI build was found for the latest commit of PR <b>#{}<r>.\n\nCI may not have started yet:\n\n  <cyan>https://github.com/oven-sh/bun/pull/{}<r>\n",
+                pr_number,
+                pr_number
+            );
+            Global::exit(1);
+        };
+        let mut build_url: &[u8] = &build_url_owned;
+        if let Some(i) = build_url.iter().position(|c| *c == b'#' || *c == b'?') {
+            build_url = &build_url[..i];
+        }
+        let build_url = build_url.strip_suffix(b"/").unwrap_or(build_url);
+        let origin: Vec<u8> = Self::url_origin(build_url).to_vec();
+
+        bun_core::pretty_errorln!("<r><d>Finding build artifacts...<r>");
+        Output::flush();
+
+        let build_body = {
+            let mut url = build_url.to_vec();
+            url.extend_from_slice(b".json");
+            match Self::http_get_sync(env_loader, &url, false) {
+                Ok(body) => body,
+                Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> Failed to fetch the CI build for PR #{} (code: {})",
+                        pr_number,
+                        err.name()
+                    );
+                    Global::exit(1);
+                }
+            }
+        };
+        let Some(build) = Self::parse_json_response(build_body) else {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> Failed to parse the CI build info for PR #{}",
+                pr_number
+            );
+            Global::exit(1);
+        };
+
+        let jobs_prop = build.as_property(b"jobs");
+        let jobs_array = jobs_prop.and_then(|p| p.expr.data.e_array());
+        let mut jobs: &[bun_ast::Expr] = match &jobs_array {
+            Some(array) => array.items.slice(),
+            None => &[],
+        };
+
+        // Buildkite's frontend stopped inlining jobs in the build response;
+        // fall back to the paginated jobs endpoint.
+        let fallback_jobs_array;
+        if jobs.is_empty() {
+            let mut url = build_url.to_vec();
+            url.extend_from_slice(b"/data/jobs");
+            fallback_jobs_array = Self::http_get_sync(env_loader, &url, false)
+                .ok()
+                .and_then(Self::parse_json_response)
+                .and_then(|expr| expr.as_property(b"records"))
+                .and_then(|p| p.expr.data.e_array());
+            if let Some(array) = &fallback_jobs_array {
+                jobs = array.items.slice();
+            }
+        }
+
+        let artifact_name: &[u8] = if use_profile {
+            Version::PROFILE_ZIP_FILENAME.as_bytes()
+        } else {
+            Version::ZIP_FILENAME.as_bytes()
+        };
+
+        for job in jobs {
+            let Some(step_key) = Self::json_string_property(job, b"step_key") else {
+                continue;
+            };
+            if !strings::contains(&step_key, b"build-bun") {
+                continue;
+            }
+            let Some(base_path) = Self::json_string_property(job, b"base_path") else {
+                continue;
+            };
+            if base_path.is_empty() {
+                continue;
+            }
+
+            let mut artifacts_url = origin.clone();
+            artifacts_url.extend_from_slice(&base_path);
+            artifacts_url.extend_from_slice(b"/artifacts");
+            let Ok(artifacts_body) = Self::http_get_sync(env_loader, &artifacts_url, false) else {
+                continue;
+            };
+            let Some(artifacts) = Self::parse_json_response(artifacts_body) else {
+                continue;
+            };
+            let Some(artifacts) = artifacts.data.e_array() else {
+                continue;
+            };
+
+            for artifact in artifacts.items.slice() {
+                let Some(file_name) = Self::json_string_property(artifact, b"file_name") else {
+                    continue;
+                };
+                if file_name != artifact_name {
+                    continue;
+                }
+                let Some(artifact_url) = Self::json_string_property(artifact, b"url") else {
+                    continue;
+                };
+                if artifact_url.is_empty() {
+                    continue;
+                }
+
+                let zip_url: Vec<u8> = if strings::has_prefix_comptime(&artifact_url, b"http") {
+                    artifact_url
+                } else {
+                    // Always followed by `return`, so `origin` can be taken.
+                    let mut absolute = origin;
+                    absolute.extend_from_slice(&artifact_url);
+                    absolute
+                };
+
+                let zip_sha1: Option<Box<[u8]>> = Self::json_string_property(artifact, b"sha1sum")
+                    .filter(|hash| hash.len() == 40 && hash.iter().all(u8::is_ascii_hexdigit))
+                    .map(|hash| hash.to_ascii_lowercase().into());
+
+                let mut tag = Vec::new();
+                write!(&mut tag, "pr-{}", pr_number).expect("oom");
+
+                return Ok(PrBuild {
+                    version: Version {
+                        tag: tag.into(),
+                        zip_url: zip_url.into(),
+                        size: 0,
+                        buf: MutableString::init_empty(),
+                    },
+                    title,
+                    zip_sha1,
+                });
+            }
+        }
+
+        bun_core::pretty_errorln!(
+            "<r><red>error:<r> Could not find a <b>{}<r> build artifact for PR <b>#{}<r>.\n\nThe build may still be running, or this platform isn't built in PR CI:\n\n  <cyan>{}<r>\n",
+            bstr::BStr::new(artifact_name),
+            pr_number,
+            bstr::BStr::new(build_url),
+        );
+        Global::exit(1);
+    }
+}
+
+/// A pull request's build artifact, resolved by [`UpgradeCommand::fetch_pr_build`].
+struct PrBuild {
+    version: Version,
+    title: Box<[u8]>,
+    /// Buildkite's recorded checksum of the artifact, when present.
+    zip_sha1: Option<Box<[u8]>>,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1423,7 +2361,7 @@ pub mod upgrade_js_bindings {
     static TEMPDIR_FD: bun_core::RacyCell<Option<sys::Fd>> = bun_core::RacyCell::new(None);
 
     pub fn generate(global: &JSGlobalObject) -> JSValue {
-        let obj = JSValue::create_empty_object(global, 2);
+        let obj = JSValue::create_empty_object(global, 4);
         obj.put(
             global,
             b"openTempDirWithoutSharingDelete",
@@ -1448,7 +2386,82 @@ pub mod upgrade_js_bindings {
                 Default::default(),
             ),
         );
+        obj.put(
+            global,
+            b"createDeltaPatch",
+            jsc::JSFunction::create(
+                global,
+                b"createDeltaPatch",
+                __jsc_host_js_create_delta_patch,
+                2,
+                Default::default(),
+            ),
+        );
+        obj.put(
+            global,
+            b"applyDeltaPatch",
+            jsc::JSFunction::create(
+                global,
+                b"applyDeltaPatch",
+                __jsc_host_js_apply_delta_patch,
+                2,
+                Default::default(),
+            ),
+        );
         obj
+    }
+
+    fn delta_patch_arguments(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<(crate::node::StringOrBuffer, crate::node::StringOrBuffer)> {
+        let arguments = frame.arguments();
+        let (Some(first), Some(second)) = (arguments.first(), arguments.get(1)) else {
+            return Err(
+                global.throw_invalid_arguments(format_args!("Expected two buffer arguments"))
+            );
+        };
+        let (Some(first), Some(second)) = (
+            crate::node::StringOrBuffer::from_js(global, *first)?,
+            crate::node::StringOrBuffer::from_js(global, *second)?,
+        ) else {
+            return Err(
+                global.throw_invalid_arguments(format_args!("Expected two buffer arguments"))
+            );
+        };
+        Ok((first, second))
+    }
+
+    /// Create a delta patch transforming `old` into `new` — the format that
+    /// `bun upgrade` downloads from release assets. Used by the release
+    /// tooling to publish patches, and by tests.
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_create_delta_patch(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let (old, new) = delta_patch_arguments(global, frame)?;
+        match UpgradeCommand::create_delta_patch(old.slice(), new.slice()) {
+            Ok(patch) => Ok(JSValue::create_buffer(global, patch.leak())),
+            Err(message) => Err(global
+                .err(jsc::ErrCode::INVALID_ARG_VALUE, format_args!("{}", message))
+                .throw()),
+        }
+    }
+
+    /// Apply a delta patch created by `createDeltaPatch`.
+    #[bun_jsc::host_fn]
+    pub(crate) fn js_apply_delta_patch(
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let (old, patch) = delta_patch_arguments(global, frame)?;
+        match UpgradeCommand::apply_delta_patch(old.slice(), patch.slice()) {
+            Ok(new) => Ok(JSValue::create_buffer(global, new.leak())),
+            Err(message) => Err(global
+                .err(jsc::ErrCode::INVALID_ARG_VALUE, format_args!("{}", message))
+                .throw()),
+        }
     }
 
     /// For testing upgrades when the temp directory has an open handle without FILE_SHARE_DELETE.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -541,8 +541,11 @@ impl UpgradeCommand {
         if strings::has_prefix_comptime(digits, b"https://")
             || strings::has_prefix_comptime(digits, b"http://")
         {
-            let i = strings::index_of(digits, b"/pull/")?;
-            digits = &digits[i as usize + b"/pull/".len()..];
+            // The number is looked up in oven-sh/bun, so a URL naming any
+            // other repository must be rejected, not reinterpreted.
+            const PULL_PATH: &[u8] = b"github.com/oven-sh/bun/pull/";
+            let i = strings::index_of(digits, PULL_PATH)?;
+            digits = &digits[i as usize + PULL_PATH.len()..];
             if let Some(end) = digits.iter().position(|c| !c.is_ascii_digit()) {
                 digits = &digits[..end];
             }
@@ -2321,7 +2324,9 @@ impl UpgradeCommand {
                 let zip_url: Vec<u8> = if strings::has_prefix_comptime(&artifact_url, b"http") {
                     // An absolute artifact URL must stay on the build's own
                     // origin; anything else doesn't belong to this CI build.
-                    if !strings::starts_with(&artifact_url, &origin) {
+                    // Compare origins exactly (a prefix check would accept
+                    // lookalike hosts such as `https://example.com.evil`).
+                    if Self::url_origin(&artifact_url) != origin.as_slice() {
                         continue;
                     }
                     artifact_url

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -568,7 +568,7 @@ impl UpgradeCommand {
             let mut positionals = args
                 .iter()
                 .skip(2)
-                .filter(|arg| !strings::contains(arg, b"--"));
+                .filter(|arg| !strings::has_prefix_comptime(arg, b"--"));
             if let Some(first) = positionals.next() {
                 if first == b"pr".as_slice() {
                     let Some(arg) = positionals.next() else {
@@ -644,12 +644,12 @@ impl UpgradeCommand {
         let use_profile = argv_contains(b"--profile");
 
         let mut pr_build_title: Option<Box<[u8]>> = None;
-        let mut pr_zip_sha1: Option<Box<[u8]>> = None;
+        let mut pr_checksum: Option<PrArtifactChecksum> = None;
 
         let mut version: Version = if let Some(number) = pr_number {
             let pr_build = Self::fetch_pr_build(&mut env_loader, number, use_profile)?;
             pr_build_title = Some(pr_build.title);
-            pr_zip_sha1 = pr_build.zip_sha1;
+            pr_checksum = Some(pr_build.zip_checksum);
             pr_build.version
         } else if !use_canary {
             // `Progress::start` returns `&mut Node` borrowing `refresher`;
@@ -819,12 +819,17 @@ impl UpgradeCommand {
                     Global::exit(1);
                 }
 
-                if let Some(expected_sha1) = pr_zip_sha1.as_deref() {
-                    let actual = Self::sha1_hex(bytes);
-                    if actual.as_bytes() != expected_sha1 {
+                if let Some(checksum) = &pr_checksum {
+                    let (expected, actual) = match checksum {
+                        PrArtifactChecksum::Sha256(expected) => {
+                            (&**expected, Self::sha256_hex(bytes))
+                        }
+                        PrArtifactChecksum::Sha1(expected) => (&**expected, Self::sha1_hex(bytes)),
+                    };
+                    if actual.as_bytes() != expected {
                         bun_core::pretty_errorln!(
                             "<r><red>error:<r> The downloaded artifact failed checksum verification.\n  Expected: <b>{}<r>\n    Actual: <b>{}<r>",
-                            bstr::BStr::new(expected_sha1),
+                            bstr::BStr::new(expected),
                             actual
                         );
                         Global::exit(1);
@@ -2310,9 +2315,26 @@ impl UpgradeCommand {
                     absolute
                 };
 
-                let zip_sha1: Option<Box<[u8]>> = Self::json_string_property(artifact, b"sha1sum")
-                    .filter(|hash| hash.len() == 40 && hash.iter().all(u8::is_ascii_hexdigit))
-                    .map(|hash| hash.to_ascii_lowercase().into());
+                // Buildkite records checksums for every artifact; refuse to
+                // install one that can't be verified after download.
+                let zip_checksum = Self::json_string_property(artifact, b"sha256sum")
+                    .filter(|hash| hash.len() == 64 && hash.iter().all(u8::is_ascii_hexdigit))
+                    .map(|hash| PrArtifactChecksum::Sha256(hash.to_ascii_lowercase().into()))
+                    .or_else(|| {
+                        Self::json_string_property(artifact, b"sha1sum")
+                            .filter(|hash| {
+                                hash.len() == 40 && hash.iter().all(u8::is_ascii_hexdigit)
+                            })
+                            .map(|hash| PrArtifactChecksum::Sha1(hash.to_ascii_lowercase().into()))
+                    });
+                let Some(zip_checksum) = zip_checksum else {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error:<r> The <b>{}<r> artifact for PR <b>#{}<r> has no usable checksum; refusing to install it.",
+                        bstr::BStr::new(&file_name),
+                        pr_number,
+                    );
+                    Global::exit(1);
+                };
 
                 let mut tag = Vec::new();
                 write!(&mut tag, "pr-{}", pr_number).expect("oom");
@@ -2325,7 +2347,7 @@ impl UpgradeCommand {
                         buf: MutableString::init_empty(),
                     },
                     title,
-                    zip_sha1,
+                    zip_checksum,
                 });
             }
         }
@@ -2344,8 +2366,15 @@ impl UpgradeCommand {
 struct PrBuild {
     version: Version,
     title: Box<[u8]>,
-    /// Buildkite's recorded checksum of the artifact, when present.
-    zip_sha1: Option<Box<[u8]>>,
+    /// Buildkite's recorded checksum of the artifact.
+    zip_checksum: PrArtifactChecksum,
+}
+
+/// Buildkite's recorded checksum of a build artifact, as a lowercase hex
+/// string. Newer responses carry sha256; older ones only sha1.
+enum PrArtifactChecksum {
+    Sha256(Box<[u8]>),
+    Sha1(Box<[u8]>),
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -2370,6 +2370,9 @@ impl UpgradeCommand {
                         zip_url: zip_url.into(),
                         size: 0,
                         buf: MutableString::init_empty(),
+                        // CI artifacts are verified against the checksum
+                        // Buildkite records for them, not a release digest.
+                        digest: Integrity::default(),
                     },
                     title,
                     zip_checksum,

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -1736,6 +1736,10 @@ impl UpgradeCommand {
 
     const RELEASES_DOWNLOAD_BASE: &'static str = "https://github.com/oven-sh/bun/releases/download";
 
+    /// Where `buildkite/bun` commit statuses are expected to point; builds
+    /// anywhere else are not Bun's CI.
+    const BUILDKITE_BUILDS_PREFIX: &'static str = "https://buildkite.com/bun/bun/builds/";
+
     /// zstd frame magic number — delta patches are zstd-compressed bsdiff
     /// streams. Raw bsdiff patches are accepted as well.
     const ZSTD_MAGIC: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
@@ -2174,6 +2178,14 @@ impl UpgradeCommand {
             }
         };
 
+        // Only follow links into Bun's own Buildkite pipeline: a status whose
+        // target points anywhere else is not the CI build (fail closed).
+        let allowed_build_prefix: Vec<u8> =
+            match env_loader.map.get(b"BUN_UPGRADE_TESTING_BUILDKITE_URL") {
+                Some(url) if !url.is_empty() => url.to_vec(),
+                _ => Self::BUILDKITE_BUILDS_PREFIX.as_bytes().to_vec(),
+            };
+
         let mut build_url: Option<Vec<u8>> = None;
         if let Some(statuses) = Self::parse_json_response(statuses_body) {
             if let Some(statuses) = statuses.data.e_array() {
@@ -2187,7 +2199,7 @@ impl UpgradeCommand {
                         continue;
                     }
                     if let Some(target_url) = Self::json_string_property(status, b"target_url") {
-                        if !target_url.is_empty() {
+                        if strings::starts_with(&target_url, &allowed_build_prefix) {
                             build_url = Some(target_url);
                             break;
                         }
@@ -2307,6 +2319,11 @@ impl UpgradeCommand {
                 }
 
                 let zip_url: Vec<u8> = if strings::has_prefix_comptime(&artifact_url, b"http") {
+                    // An absolute artifact URL must stay on the build's own
+                    // origin; anything else doesn't belong to this CI build.
+                    if !strings::starts_with(&artifact_url, &origin) {
+                        continue;
+                    }
                     artifact_url
                 } else {
                     // Always followed by `return`, so `origin` can be taken.

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -541,11 +541,14 @@ impl UpgradeCommand {
         if strings::has_prefix_comptime(digits, b"https://")
             || strings::has_prefix_comptime(digits, b"http://")
         {
-            // The number is looked up in oven-sh/bun, so a URL naming any
-            // other repository must be rejected, not reinterpreted.
-            const PULL_PATH: &[u8] = b"github.com/oven-sh/bun/pull/";
-            let i = strings::index_of(digits, PULL_PATH)?;
-            digits = &digits[i as usize + PULL_PATH.len()..];
+            // The number is looked up in oven-sh/bun, so only the canonical
+            // oven-sh/bun pull request URL is accepted; a URL naming any
+            // other location must be rejected, not reinterpreted.
+            digits = digits
+                .strip_prefix(b"https://github.com/oven-sh/bun/pull/".as_slice())
+                .or_else(|| {
+                    digits.strip_prefix(b"http://github.com/oven-sh/bun/pull/".as_slice())
+                })?;
             if let Some(end) = digits.iter().position(|c| !c.is_ascii_digit()) {
                 digits = &digits[..end];
             }

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -276,6 +276,8 @@ pub enum Error {
     lcovCoverageError,
     #[error("HTTP404")]
     HTTP404,
+    #[error("HTTPServerError")]
+    HTTPServerError,
     #[error("GitHubIsDown")]
     GitHubIsDown,
     #[error("UpgradeFailedMissingExecutable")]
@@ -734,6 +736,7 @@ impl Error {
             Self::JUnitReportFailed => "JUnitReportFailed",
             Self::lcovCoverageError => "lcovCoverageError",
             Self::HTTP404 => "HTTP404",
+            Self::HTTPServerError => "HTTPServerError",
             Self::GitHubIsDown => "GitHubIsDown",
             Self::UpgradeFailedMissingExecutable => "UpgradeFailedMissingExecutable",
             Self::UpgradeFailedBecauseOfMissingExecutableDir => {

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -945,6 +945,9 @@ it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build"
       ...env,
       NODE_TLS_REJECT_UNAUTHORIZED: "0",
       GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      // Build links are pinned to Bun's Buildkite pipeline; point the pin at
+      // the mock server.
+      BUN_UPGRADE_TESTING_BUILDKITE_URL: `https://${server.hostname}:${server.port}/bun/bun/builds/`,
       BUN_TMPDIR: String(staging),
       ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
     },

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -467,7 +467,8 @@ it.skipIf(isWindows)("delta upgrade applies binary patches instead of downloadin
   const { current, target } = releaseVersions();
   const tagName = `bun-v${target}`;
 
-  const cwd = tmpdirSync();
+  using cwdDir = tempDir("bun-upgrade-cwd", {});
+  const cwd = String(cwdDir);
   const execPath = join(cwd, basename(bunExe()));
   await copyFile(bunExe(), execPath);
 
@@ -553,7 +554,8 @@ it("delta upgrade falls back to the full download when the patch fails verificat
   const { current, target } = releaseVersions();
   const tagName = `bun-v${target}`;
 
-  const cwd = tmpdirSync();
+  using cwdDir = tempDir("bun-upgrade-cwd", {});
+  const cwd = String(cwdDir);
   const execPath = join(cwd, basename(bunExe()));
   await copyFile(bunExe(), execPath);
 
@@ -630,11 +632,124 @@ it("delta upgrade falls back to the full download when the patch fails verificat
   expect(exitCode).toBe(1);
 });
 
+it.skipIf(isWindows)("delta upgrade chains through intermediate releases", async () => {
+  // Two releases behind: current -> middle -> target. No direct
+  // target.from-current patch exists, so the chain is used, verifying the
+  // intermediate binary's checksum along the way.
+  const { current, target: middle } = releaseVersions();
+  const [major, minor, patch] = middle.split(".").map(Number);
+  const target = `${major}.${minor}.${patch + 1}`;
+  const tagName = `bun-v${target}`;
+
+  using cwdDir = tempDir("bun-upgrade-cwd", {});
+  const cwd = String(cwdDir);
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  const middleBinary = new TextEncoder().encode(`#!/bin/sh\necho ${middle}\n`);
+  const targetBinary = new TextEncoder().encode(`#!/bin/sh\necho ${target}\n`);
+  const middlePatch = craftReplacementPatch(middleBinary);
+  const targetPatch = craftReplacementPatch(targetBinary);
+  const currentExeSha = await sha256HexOfFile(execPath);
+
+  const requests: string[] = [];
+  using server = Bun.serve({
+    tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname.startsWith("/releases/")) {
+        return new Response("this is not a real zip archive");
+      }
+      if (pathname.includes(`/bun-v${target}/`) && pathname.includes(`.from-${current}.bsdiff`)) {
+        // The direct patch doesn't exist; only per-release patches do.
+        return new Response("not found", { status: 404 });
+      }
+      if (pathname.includes(`/bun-v${middle}/`)) {
+        if (pathname.endsWith(".bsdiff.sha256sum")) {
+          return new Response(`${sha256Hex(middlePatch)}  patch.bsdiff\n`);
+        }
+        if (pathname.endsWith(`.from-${current}.bsdiff`)) {
+          return new Response(middlePatch);
+        }
+        if (pathname.endsWith(".sha256sum")) {
+          return new Response(`${sha256Hex(middleBinary)}  bun\n`);
+        }
+      }
+      if (pathname.includes(`/bun-v${target}/`)) {
+        if (pathname.endsWith(".bsdiff.sha256sum")) {
+          return new Response(`${sha256Hex(targetPatch)}  patch.bsdiff\n`);
+        }
+        if (pathname.endsWith(`.from-${middle}.bsdiff`)) {
+          return new Response(targetPatch);
+        }
+        if (pathname.endsWith(".sha256sum")) {
+          return new Response(`${sha256Hex(targetBinary)}  bun\n`);
+        }
+      }
+      if (pathname.includes(`/bun-v${current}/`) && pathname.endsWith(".sha256sum")) {
+        return new Response(`${currentExeSha}  bun\n`);
+      }
+      return new Response(
+        JSON.stringify({
+          tag_name: tagName,
+          assets: allPlatformAssetNames().map(name => ({
+            url: "foo",
+            content_type: "application/zip",
+            name: `${name}.zip`,
+            browser_download_url: `https://${server.hostname}:${server.port}/releases/${tagName}/${name}.zip`,
+          })),
+        }),
+      );
+    },
+  });
+
+  using staging = tempDir("bun-upgrade-delta-chain", {});
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", "--stable"],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      BUN_UPGRADE_TESTING_RELEASE_URL: `https://${server.hostname}:${server.port}`,
+      BUN_TMPDIR: String(staging),
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // The direct patch 404s, then the two-step chain applies.
+  expect(stderr).toContain("Attempting delta upgrade");
+  expect(stderr).toContain("Downloading patch 1/2");
+  expect(stderr).toContain("Downloading patch 2/2");
+  expect(stderr).toContain("Delta upgrade verified");
+  expect(stderr).not.toContain("error:");
+
+  // The direct patch was tried first, then both chain patches; the archive
+  // was never downloaded.
+  expect(requests.some(p => p.includes(`/bun-v${target}/`) && p.includes(`.from-${current}.bsdiff`))).toBe(true);
+  expect(requests.some(p => p.includes(`/bun-v${middle}/`) && p.endsWith(`.from-${current}.bsdiff`))).toBe(true);
+  expect(requests.some(p => p.includes(`/bun-v${target}/`) && p.endsWith(`.from-${middle}.bsdiff`))).toBe(true);
+  expect(requests.some(p => p.startsWith("/releases/"))).toBe(false);
+
+  // The final chained binary was installed.
+  expect(await Bun.file(execPath).text()).toBe(`#!/bin/sh\necho ${target}\n`);
+
+  expect(exitCode).toBe(0);
+});
+
 it("delta upgrade is skipped with --no-delta", async () => {
   const { target } = releaseVersions();
   const tagName = `bun-v${target}`;
 
-  const cwd = tmpdirSync();
+  using cwdDir = tempDir("bun-upgrade-cwd", {});
+  const cwd = String(cwdDir);
   const execPath = join(cwd, basename(bunExe()));
   await copyFile(bunExe(), execPath);
 
@@ -761,10 +876,12 @@ it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build"
     );
   }
 
-  const cwd = tmpdirSync();
+  using cwdDir = tempDir("bun-upgrade-cwd", {});
+  const cwd = String(cwdDir);
   const execPath = join(cwd, basename(bunExe()));
   await copyFile(bunExe(), execPath);
 
+  const artifactDownloads: string[] = [];
   using server = Bun.serve({
     tls,
     port: 0,
@@ -798,15 +915,18 @@ it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build"
         });
       }
       if (pathname === "/bun/bun/builds/4242/jobs/build/artifacts") {
+        // Real Buildkite responses carry both checksums.
         return Response.json(
           [...zips.entries()].map(([name, data]) => ({
             file_name: name,
             url: `/artifacts/${name}`,
+            sha256sum: sha256Hex(data),
             sha1sum: sha1Hex(data),
           })),
         );
       }
       if (pathname.startsWith("/artifacts/")) {
+        artifactDownloads.push(pathname);
         const zip = zips.get(pathname.slice("/artifacts/".length));
         if (zip) return new Response(zip);
       }
@@ -837,17 +957,55 @@ it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build"
   expect(stderr).toContain(`Installed a build of Bun from pull request #${prNumber}`);
   expect(stderr).not.toContain("error:");
 
+  // Exactly one artifact was downloaded, and it was this platform's.
+  const os = process.platform === "darwin" ? "darwin" : "linux";
+  const arch = process.arch === "arm64" ? "aarch64" : "x64";
+  expect(artifactDownloads).toHaveLength(1);
+  expect(artifactDownloads[0]).toStartWith(`/artifacts/bun-${os}-${arch}`);
+
   // The pull request's build was installed over the executable.
   expect(await Bun.file(execPath).text()).toBe(script);
 
   expect(exitCode).toBe(0);
 });
 
+// `#1234` and pull request URLs are accepted too; a 404 from the mocked
+// GitHub API proves the number was parsed out of each spelling (the error
+// echoes it back) without running a full install.
+describe.concurrent("bun upgrade pr argument spellings", () => {
+  it.each(["#4321", "https://github.com/oven-sh/bun/pull/4321"])("accepts %s", async spelling => {
+    using cwd = tempDir("bun-upgrade-pr-spelling", {});
+    using server = Bun.serve({
+      tls,
+      port: 0,
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade", "pr", spelling],
+      cwd: String(cwd),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      },
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Pull request #4321 was not found");
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe.concurrent("bun upgrade pr argument validation", () => {
   it("requires a pull request number", async () => {
+    using cwd = tempDir("bun-upgrade-pr-args", {});
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "pr"],
-      cwd: tmpdirSync(),
+      cwd: String(cwd),
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
@@ -860,9 +1018,10 @@ describe.concurrent("bun upgrade pr argument validation", () => {
   });
 
   it("rejects a non-numeric pull request number", async () => {
+    using cwd = tempDir("bun-upgrade-pr-args", {});
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "pr", "not-a-number"],
-      cwd: tmpdirSync(),
+      cwd: String(cwd),
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",
@@ -875,9 +1034,10 @@ describe.concurrent("bun upgrade pr argument validation", () => {
   });
 
   it("rejects extra arguments after the pull request number", async () => {
+    using cwd = tempDir("bun-upgrade-pr-args", {});
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "pr", "123", "456"],
-      cwd: tmpdirSync(),
+      cwd: String(cwd),
       stdout: null,
       stdin: "pipe",
       stderr: "pipe",

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -367,7 +367,6 @@ it("verifies the downloaded release archive against the digest reported by the r
   expect(matched.exitCode).toBe(1);
 });
 
-
 // ── Delta upgrades ─────────────────────────────────────────────────────────
 
 /** Every release asset name, so the mock matches whichever target runs the test. */
@@ -507,6 +506,10 @@ it.skipIf(isWindows)("delta upgrade applies binary patches instead of downloadin
             url: "foo",
             content_type: "application/zip",
             name: `${name}.zip`,
+            // Real releases report a digest for the archive. It describes the
+            // archive the delta path never downloads, so it must not be
+            // checked against the reconstructed binary.
+            digest: `sha256:${Buffer.alloc(32, 0xab).toString("hex")}`,
             browser_download_url: `https://${server.hostname}:${server.port}/releases/${tagName}/${name}.zip`,
           })),
         }),

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1044,6 +1044,10 @@ describe.concurrent("bun upgrade pr argument spellings", () => {
           ...env,
           NODE_TLS_REJECT_UNAUTHORIZED: "0",
           GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+          // The lookup reaches the HTTP path, which intentionally leaks
+          // process-lifetime allocations (CLI arena); leak detection is not
+          // what this asserts.
+          ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
         },
       });
 

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -667,7 +667,9 @@ it.skipIf(isWindows).each(chainLayouts)("delta upgrade chains through $label", a
   const middleBinary = new TextEncoder().encode(`#!/bin/sh\necho ${middle}\n`);
   const targetBinary = new TextEncoder().encode(`#!/bin/sh\necho ${target}\n`);
   const middlePatch = craftReplacementPatch(middleBinary);
-  const targetPatch = craftReplacementPatch(targetBinary);
+  // A real diff against the intermediate binary: the second hop only
+  // produces the target if the first hop produced exactly `middleBinary`.
+  const targetPatch = createDeltaPatch(middleBinary, targetBinary);
   const currentExeSha = await sha256HexOfFile(execPath);
 
   const requests: string[] = [];
@@ -749,10 +751,14 @@ it.skipIf(isWindows).each(chainLayouts)("delta upgrade chains through $label", a
   expect(stderr).toContain("Delta upgrade verified");
   expect(stderr).not.toContain("error:");
 
-  // The direct patch was tried first, then both chain patches; the archive
-  // was never downloaded.
+  // The direct patch was tried first, then both chain patches; the
+  // intermediate binary's checksum was verified; the archive was never
+  // downloaded.
   expect(requests.some(p => p.includes(`/bun-v${target}/`) && p.includes(`.from-${current}.bsdiff`))).toBe(true);
   expect(requests.some(p => p.includes(`/bun-v${middle}/`) && p.endsWith(`.from-${current}.bsdiff`))).toBe(true);
+  expect(
+    requests.some(p => p.includes(`/bun-v${middle}/`) && p.endsWith(".sha256sum") && !p.endsWith(".bsdiff.sha256sum")),
+  ).toBe(true);
   expect(requests.some(p => p.includes(`/bun-v${target}/`) && p.endsWith(`.from-${middle}.bsdiff`))).toBe(true);
   expect(requests.some(p => p.startsWith("/releases/"))).toBe(false);
 
@@ -1062,10 +1068,15 @@ describe.concurrent("bun upgrade pr argument validation", () => {
     expect(exitCode).toBe(1);
   });
 
-  // Wrong-repo URLs are rejected: the number is looked up in oven-sh/bun,
-  // so reinterpreting another repository's PR URL would install a build the
-  // user never named.
-  it.each(["not-a-number", "https://github.com/acme/widget/pull/123"])("rejects %s", async arg => {
+  // Non-canonical URLs are rejected: the number is looked up in oven-sh/bun,
+  // so reinterpreting another repository's PR URL (or a URL merely
+  // containing the oven-sh/bun pull path) would install a build the user
+  // never named.
+  it.each([
+    "not-a-number",
+    "https://github.com/acme/widget/pull/123",
+    "https://evil.example/github.com/oven-sh/bun/pull/123",
+  ])("rejects %s", async arg => {
     using cwd = tempDir("bun-upgrade-pr-args", {});
     await using proc = spawn({
       cmd: [bunExe(), "upgrade", "pr", arg],

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1,11 +1,11 @@
 import { spawn } from "bun";
 import { upgrade_test_helpers } from "bun:internal-for-testing";
 import { describe, expect, it, setDefaultTimeout } from "bun:test";
-import { bunExe, bunEnv as env, tempDir, tls, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, isWindows, tempDir, tls, tmpdirSync } from "harness";
 import { existsSync, statSync } from "node:fs";
 import { copyFile } from "node:fs/promises";
 import { basename, join } from "path";
-const { openTempDirWithoutSharingDelete, closeTempDirHandle } = upgrade_test_helpers;
+const { openTempDirWithoutSharingDelete, closeTempDirHandle, createDeltaPatch, applyDeltaPatch } = upgrade_test_helpers;
 
 setDefaultTimeout(1000 * 60 * 5);
 
@@ -365,4 +365,527 @@ it("verifies the downloaded release archive against the digest reported by the r
   expect(matched.stderr).toContain("9.9.8");
   expect(matched.stderr).not.toContain("did not match the checksum reported by the GitHub API for this release");
   expect(matched.exitCode).toBe(1);
+});
+
+
+// ── Delta upgrades ─────────────────────────────────────────────────────────
+
+/** Every release asset name, so the mock matches whichever target runs the test. */
+function allPlatformAssetNames(): string[] {
+  const names: string[] = [];
+  for (const os of ["windows", "linux", "darwin"]) {
+    for (const arch of ["x64", "aarch64"]) {
+      for (const abi of ["", "-musl"]) {
+        for (const cpu of ["", "-baseline"]) {
+          names.push(`bun-${os}-${arch}${abi}${cpu}`);
+        }
+      }
+    }
+  }
+  return names;
+}
+
+function sha256Hex(data: Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(data).digest("hex");
+}
+
+function sha1Hex(data: Uint8Array): string {
+  return new Bun.CryptoHasher("sha1").update(data).digest("hex");
+}
+
+async function sha256HexOfFile(path: string): Promise<string> {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for await (const chunk of Bun.file(path).stream()) {
+    hasher.update(chunk);
+  }
+  return hasher.digest("hex");
+}
+
+/**
+ * Craft a minimal delta patch that replaces the old file with `newData`,
+ * without diffing the (huge) old binary: a single bsdiff control block with
+ * zero diff bytes, `newData.length` extra bytes, and zero seek — wrapped in
+ * zstd like published patches are.
+ */
+function craftReplacementPatch(newData: Uint8Array): Uint8Array {
+  const raw = new Uint8Array(24 + newData.length);
+  const control = new DataView(raw.buffer, 0, 24);
+  control.setBigUint64(0, 0n, true); // diff ("mix") length
+  control.setBigUint64(8, BigInt(newData.length), true); // extra ("copy") length
+  control.setBigUint64(16, 0n, true); // seek
+  raw.set(newData, 24);
+  return Bun.zstdCompressSync(raw);
+}
+
+/** The running build's version, with the `-debug` suffix of debug builds removed. */
+function releaseVersions(): { current: string; target: string } {
+  const current = Bun.version.replace(/-debug$/, "");
+  const [major, minor, patch] = current.split(".").map(Number);
+  return { current, target: `${major}.${minor}.${patch + 1}` };
+}
+
+describe.concurrent("delta patches", () => {
+  it("roundtrips through createDeltaPatch and applyDeltaPatch", () => {
+    const old = new Uint8Array(256 * 1024);
+    for (let i = 0; i < old.length; i++) old[i] = (i * 31 + 7) & 0xff;
+
+    // A mostly-identical file: flip a few ranges and append a tail.
+    const updated = new Uint8Array(old.length + 512);
+    updated.set(old);
+    for (let i = 1000; i < 1300; i++) updated[i] ^= 0x5a;
+    for (let i = old.length; i < updated.length; i++) updated[i] = 0x42;
+
+    const patch = createDeltaPatch(old, updated);
+    // zstd frame magic — patches are published zstd-compressed.
+    expect(Array.from(patch.subarray(0, 4))).toEqual([0x28, 0xb5, 0x2f, 0xfd]);
+    // A patch between mostly-identical files must be much smaller than the file.
+    expect(patch.length).toBeLessThan(updated.length / 4);
+
+    const applied = applyDeltaPatch(old, patch);
+    expect(applied.equals(Buffer.from(updated))).toBe(true);
+  });
+
+  it("applies a patch to an empty file", () => {
+    const old = new Uint8Array(0);
+    const updated = new TextEncoder().encode("#!/bin/sh\necho hello\n");
+    const patch = createDeltaPatch(old, updated);
+    const applied = applyDeltaPatch(old, patch);
+    expect(applied.equals(Buffer.from(updated))).toBe(true);
+  });
+
+  it("rejects a truncated patch", () => {
+    const old = new Uint8Array(1024).fill(3);
+    const updated = new Uint8Array(1024).fill(4);
+    const patch = createDeltaPatch(old, updated);
+    expect(() => applyDeltaPatch(old, patch.subarray(0, 8))).toThrow();
+  });
+});
+
+// The upgraded "binary" is a shell script, which can't be spawned as an
+// executable on Windows, so the happy paths are POSIX-only.
+it.skipIf(isWindows)("delta upgrade applies binary patches instead of downloading the archive", async () => {
+  const { current, target } = releaseVersions();
+  const tagName = `bun-v${target}`;
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  const newBinary = new TextEncoder().encode(`#!/bin/sh\necho ${target}\n`);
+  const patch = craftReplacementPatch(newBinary);
+  const currentExeSha = await sha256HexOfFile(execPath);
+
+  const requests: string[] = [];
+  using server = Bun.serve({
+    tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname.startsWith("/releases/")) {
+        // The delta path never downloads the archive; serve garbage so a
+        // fallback would fail loudly.
+        return new Response("this is not a real zip archive");
+      }
+      if (pathname.endsWith(".bsdiff.sha256sum")) {
+        return new Response(`${sha256Hex(patch)}  patch.bsdiff\n`);
+      }
+      if (pathname.endsWith(".bsdiff")) {
+        return new Response(patch);
+      }
+      if (pathname.endsWith(".sha256sum")) {
+        // Binary checksums: the current version's is the copied executable,
+        // the target version's is the patched result.
+        const sha = pathname.startsWith(`/bun-v${current}/`) ? currentExeSha : sha256Hex(newBinary);
+        return new Response(`${sha}  bun\n`);
+      }
+      return new Response(
+        JSON.stringify({
+          tag_name: tagName,
+          assets: allPlatformAssetNames().map(name => ({
+            url: "foo",
+            content_type: "application/zip",
+            name: `${name}.zip`,
+            browser_download_url: `https://${server.hostname}:${server.port}/releases/${tagName}/${name}.zip`,
+          })),
+        }),
+      );
+    },
+  });
+
+  using staging = tempDir("bun-upgrade-delta", {});
+  await using proc = Bun.spawn({
+    // --stable forces the GitHub-release code path even on canary/debug builds.
+    cmd: [execPath, "upgrade", "--stable"],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      BUN_UPGRADE_TESTING_RELEASE_URL: `https://${server.hostname}:${server.port}`,
+      BUN_TMPDIR: String(staging),
+      // The CLI intentionally leaks process-lifetime allocations (progress
+      // bars, download buffers); leak detection is not what this asserts.
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Attempting delta upgrade");
+  expect(stderr).toContain("Delta upgrade verified");
+  expect(stderr).not.toContain("error:");
+
+  // The patched binary was installed over the executable.
+  expect(await Bun.file(execPath).text()).toBe(`#!/bin/sh\necho ${target}\n`);
+
+  // The patch was downloaded; the archive never was.
+  expect(requests.some(pathname => pathname.endsWith(".bsdiff"))).toBe(true);
+  expect(requests.some(pathname => pathname.startsWith("/releases/"))).toBe(false);
+
+  expect(exitCode).toBe(0);
+});
+
+it("delta upgrade falls back to the full download when the patch fails verification", async () => {
+  const { current, target } = releaseVersions();
+  const tagName = `bun-v${target}`;
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  const newBinary = new TextEncoder().encode(`#!/bin/sh\necho ${target}\n`);
+  const patch = craftReplacementPatch(newBinary);
+  const currentExeSha = await sha256HexOfFile(execPath);
+
+  const requests: string[] = [];
+  using server = Bun.serve({
+    tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname.startsWith("/releases/")) {
+        // The fallback archive is bogus, so the upgrade fails at unpacking —
+        // after the delta attempt.
+        return new Response("this is not a real zip archive");
+      }
+      if (pathname.endsWith(".bsdiff.sha256sum")) {
+        // Wrong checksum: the delta attempt must be abandoned.
+        return new Response(`${sha256Hex(new TextEncoder().encode("not the patch"))}  patch.bsdiff\n`);
+      }
+      if (pathname.endsWith(".bsdiff")) {
+        return new Response(patch);
+      }
+      if (pathname.endsWith(".sha256sum")) {
+        const sha = pathname.startsWith(`/bun-v${current}/`) ? currentExeSha : sha256Hex(newBinary);
+        return new Response(`${sha}  bun\n`);
+      }
+      return new Response(
+        JSON.stringify({
+          tag_name: tagName,
+          assets: allPlatformAssetNames().map(name => ({
+            url: "foo",
+            content_type: "application/zip",
+            name: `${name}.zip`,
+            browser_download_url: `https://${server.hostname}:${server.port}/releases/${tagName}/${name}.zip`,
+          })),
+        }),
+      );
+    },
+  });
+
+  using staging = tempDir("bun-upgrade-delta-fallback", {});
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", "--stable"],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      BUN_UPGRADE_TESTING_RELEASE_URL: `https://${server.hostname}:${server.port}`,
+      BUN_TMPDIR: String(staging),
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("Attempting delta upgrade");
+  expect(stderr).toContain("Delta upgrade unavailable");
+
+  // The full archive was downloaded after the delta attempt failed.
+  const patchRequest = requests.findIndex(pathname => pathname.endsWith(".bsdiff"));
+  const archiveRequest = requests.findIndex(pathname => pathname.startsWith("/releases/"));
+  expect(patchRequest).toBeGreaterThanOrEqual(0);
+  expect(archiveRequest).toBeGreaterThan(patchRequest);
+
+  // The bogus archive must not be installed; the upgrade fails cleanly.
+  expect(exitCode).toBe(1);
+});
+
+it("delta upgrade is skipped with --no-delta", async () => {
+  const { target } = releaseVersions();
+  const tagName = `bun-v${target}`;
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  const requests: string[] = [];
+  using server = Bun.serve({
+    tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+      requests.push(pathname);
+      if (pathname.startsWith("/releases/")) {
+        return new Response("this is not a real zip archive");
+      }
+      return new Response(
+        JSON.stringify({
+          tag_name: tagName,
+          assets: allPlatformAssetNames().map(name => ({
+            url: "foo",
+            content_type: "application/zip",
+            name: `${name}.zip`,
+            browser_download_url: `https://${server.hostname}:${server.port}/releases/${tagName}/${name}.zip`,
+          })),
+        }),
+      );
+    },
+  });
+
+  using staging = tempDir("bun-upgrade-no-delta", {});
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", "--stable", "--no-delta"],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      BUN_UPGRADE_TESTING_RELEASE_URL: `https://${server.hostname}:${server.port}`,
+      BUN_TMPDIR: String(staging),
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  // No delta request was made; the archive was downloaded directly.
+  expect(stderr).not.toContain("Attempting delta upgrade");
+  expect(requests.some(pathname => pathname.endsWith(".bsdiff"))).toBe(false);
+  expect(requests.some(pathname => pathname.startsWith("/releases/"))).toBe(true);
+  expect(exitCode).toBe(1);
+});
+
+// ── Installing builds from pull requests ───────────────────────────────────
+
+/** Minimal store-only (uncompressed) zip archive with unix file modes. */
+function storeZip(entries: Record<string, { data: Uint8Array; mode?: number }>): Uint8Array {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  const centrals: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const [name, { data, mode = 0o644 }] of Object.entries(entries)) {
+    const nameBytes = encoder.encode(name);
+    const crc = Bun.hash.crc32(data);
+
+    const local = new Uint8Array(30 + nameBytes.length + data.length);
+    const localView = new DataView(local.buffer);
+    localView.setUint32(0, 0x04034b50, true); // local file header signature
+    localView.setUint16(4, 20, true); // version needed
+    localView.setUint16(8, 0, true); // method: store
+    localView.setUint32(14, crc, true);
+    localView.setUint32(18, data.length, true); // compressed size
+    localView.setUint32(22, data.length, true); // uncompressed size
+    localView.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(data, 30 + nameBytes.length);
+    chunks.push(local);
+
+    const central = new Uint8Array(46 + nameBytes.length);
+    const centralView = new DataView(central.buffer);
+    centralView.setUint32(0, 0x02014b50, true); // central directory signature
+    centralView.setUint16(4, (3 << 8) | 20, true); // made by: unix
+    centralView.setUint16(6, 20, true); // version needed
+    centralView.setUint16(10, 0, true); // method: store
+    centralView.setUint32(16, crc, true);
+    centralView.setUint32(20, data.length, true);
+    centralView.setUint32(24, data.length, true);
+    centralView.setUint16(28, nameBytes.length, true);
+    centralView.setUint32(38, ((0o100000 | mode) << 16) >>> 0, true); // unix mode
+    centralView.setUint32(42, offset, true); // local header offset
+    central.set(nameBytes, 46);
+    centrals.push(central);
+
+    offset += local.length;
+  }
+
+  const centralSize = centrals.reduce((total, chunk) => total + chunk.length, 0);
+  const eocd = new Uint8Array(22);
+  const eocdView = new DataView(eocd.buffer);
+  eocdView.setUint32(0, 0x06054b50, true); // end of central directory signature
+  eocdView.setUint16(8, centrals.length, true);
+  eocdView.setUint16(10, centrals.length, true);
+  eocdView.setUint32(12, centralSize, true);
+  eocdView.setUint32(16, offset, true);
+
+  return Buffer.concat([...chunks, ...centrals, eocd]);
+}
+
+it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build", async () => {
+  const prNumber = 12345;
+  const prTitle = "fix: make something faster";
+  const headSha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+  const script = `#!/bin/sh\necho 1.2.3-pr+${headSha.slice(0, 9)}\n`;
+
+  // One artifact zip per platform so the test passes on any target.
+  const zips = new Map<string, Uint8Array>();
+  for (const name of allPlatformAssetNames()) {
+    zips.set(
+      `${name}.zip`,
+      storeZip({
+        [`${name}/bun`]: { data: new TextEncoder().encode(script), mode: 0o755 },
+      }),
+    );
+  }
+
+  const cwd = tmpdirSync();
+  const execPath = join(cwd, basename(bunExe()));
+  await copyFile(bunExe(), execPath);
+
+  using server = Bun.serve({
+    tls,
+    port: 0,
+    async fetch(req) {
+      const { pathname } = new URL(req.url);
+
+      if (pathname === `/repos/oven-sh/bun/pulls/${prNumber}`) {
+        return Response.json({
+          title: prTitle,
+          state: "open",
+          head: { sha: headSha },
+        });
+      }
+      if (pathname === `/repos/oven-sh/bun/commits/${headSha}/statuses`) {
+        return Response.json([
+          { context: "some-other-ci", state: "success", target_url: "https://example.com/nope" },
+          {
+            context: "buildkite/bun",
+            state: "success",
+            target_url: `https://${server.hostname}:${server.port}/bun/bun/builds/4242#annotation`,
+          },
+        ]);
+      }
+      if (pathname === "/bun/bun/builds/4242.json") {
+        return Response.json({
+          state: "passed",
+          jobs: [
+            { step_key: "linux-x64-test-bun", base_path: "/bun/bun/builds/4242/jobs/test" },
+            { step_key: "build-bun", base_path: "/bun/bun/builds/4242/jobs/build" },
+          ],
+        });
+      }
+      if (pathname === "/bun/bun/builds/4242/jobs/build/artifacts") {
+        return Response.json(
+          [...zips.entries()].map(([name, data]) => ({
+            file_name: name,
+            url: `/artifacts/${name}`,
+            sha1sum: sha1Hex(data),
+          })),
+        );
+      }
+      if (pathname.startsWith("/artifacts/")) {
+        const zip = zips.get(pathname.slice("/artifacts/".length));
+        if (zip) return new Response(zip);
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  using staging = tempDir("bun-upgrade-pr", {});
+  await using proc = Bun.spawn({
+    cmd: [execPath, "upgrade", "pr", String(prNumber)],
+    cwd,
+    stdout: null,
+    stdin: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      NODE_TLS_REJECT_UNAUTHORIZED: "0",
+      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+      BUN_TMPDIR: String(staging),
+      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+    },
+  });
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain(`PR #${prNumber}`);
+  expect(stderr).toContain(prTitle);
+  expect(stderr).toContain(`Installed a build of Bun from pull request #${prNumber}`);
+  expect(stderr).not.toContain("error:");
+
+  // The pull request's build was installed over the executable.
+  expect(await Bun.file(execPath).text()).toBe(script);
+
+  expect(exitCode).toBe(0);
+});
+
+describe.concurrent("bun upgrade pr argument validation", () => {
+  it("requires a pull request number", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade", "pr"],
+      cwd: tmpdirSync(),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Expected a pull request number");
+    expect(exitCode).toBe(1);
+  });
+
+  it("rejects a non-numeric pull request number", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade", "pr", "not-a-number"],
+      cwd: tmpdirSync(),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Invalid pull request number");
+    expect(exitCode).toBe(1);
+  });
+
+  it("rejects extra arguments after the pull request number", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "upgrade", "pr", "123", "456"],
+      cwd: tmpdirSync(),
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("Unexpected extra arguments");
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -632,13 +632,31 @@ it("delta upgrade falls back to the full download when the patch fails verificat
   expect(exitCode).toBe(1);
 });
 
-it.skipIf(isWindows)("delta upgrade chains through intermediate releases", async () => {
-  // Two releases behind: current -> middle -> target. No direct
-  // target.from-current patch exists, so the chain is used, verifying the
-  // intermediate binary's checksum along the way.
-  const { current, target: middle } = releaseVersions();
-  const [major, minor, patch] = middle.split(".").map(Number);
-  const target = `${major}.${minor}.${patch + 1}`;
+// Two releases behind: current -> middle -> target. No direct
+// target.from-current patch exists, so the chain is used, verifying the
+// intermediate binary's checksum along the way.
+const chainLayouts = [
+  {
+    label: "consecutive patch releases",
+    versions() {
+      const { current, target: middle } = releaseVersions();
+      const [major, minor, patch] = middle.split(".").map(Number);
+      return { current, middle, target: `${major}.${minor}.${patch + 1}` };
+    },
+  },
+  {
+    label: "a minor version bump",
+    versions() {
+      // The chain crosses the minor boundary via the new minor's .0 release.
+      const { current } = releaseVersions();
+      const [major, minor] = current.split(".").map(Number);
+      return { current, middle: `${major}.${minor + 1}.0`, target: `${major}.${minor + 1}.1` };
+    },
+  },
+];
+
+it.skipIf(isWindows).each(chainLayouts)("delta upgrade chains through $label", async ({ versions }) => {
+  const { current, middle, target } = versions();
   const tagName = `bun-v${target}`;
 
   using cwdDir = tempDir("bun-upgrade-cwd", {});
@@ -859,118 +877,142 @@ function storeZip(entries: Record<string, { data: Uint8Array; mode?: number }>):
   return Buffer.concat([...chunks, ...centrals, eocd]);
 }
 
-it.skipIf(isWindows)("bun upgrade pr <number> installs the pull request's build", async () => {
-  const prNumber = 12345;
-  const prTitle = "fix: make something faster";
-  const headSha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
-  const script = `#!/bin/sh\necho 1.2.3-pr+${headSha.slice(0, 9)}\n`;
+const prInstallVariants = [
+  { label: "", flags: [] as string[], exeName: "bun" },
+  { label: " with --profile", flags: ["--profile"], exeName: "bun-profile" },
+];
 
-  // One artifact zip per platform so the test passes on any target.
-  const zips = new Map<string, Uint8Array>();
-  for (const name of allPlatformAssetNames()) {
-    zips.set(
-      `${name}.zip`,
-      storeZip({
-        [`${name}/bun`]: { data: new TextEncoder().encode(script), mode: 0o755 },
-      }),
-    );
-  }
+it.skipIf(isWindows).each(prInstallVariants)(
+  "bun upgrade pr <number> installs the pull request's build$label",
+  async ({ flags, exeName }) => {
+    const prNumber = 12345;
+    const prTitle = "fix: make something faster";
+    const headSha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+    const scriptFor = (exe: string) => `#!/bin/sh\necho ${exe} 1.2.3-pr+${headSha.slice(0, 9)}\n`;
 
-  using cwdDir = tempDir("bun-upgrade-cwd", {});
-  const cwd = String(cwdDir);
-  const execPath = join(cwd, basename(bunExe()));
-  await copyFile(bunExe(), execPath);
-
-  const artifactDownloads: string[] = [];
-  using server = Bun.serve({
-    tls,
-    port: 0,
-    async fetch(req) {
-      const { pathname } = new URL(req.url);
-
-      if (pathname === `/repos/oven-sh/bun/pulls/${prNumber}`) {
-        return Response.json({
-          title: prTitle,
-          state: "open",
-          head: { sha: headSha },
-        });
-      }
-      if (pathname === `/repos/oven-sh/bun/commits/${headSha}/statuses`) {
-        return Response.json([
-          { context: "some-other-ci", state: "success", target_url: "https://example.com/nope" },
-          {
-            context: "buildkite/bun",
-            state: "success",
-            target_url: `https://${server.hostname}:${server.port}/bun/bun/builds/4242#annotation`,
-          },
-        ]);
-      }
-      if (pathname === "/bun/bun/builds/4242.json") {
-        return Response.json({
-          state: "passed",
-          jobs: [
-            { step_key: "linux-x64-test-bun", base_path: "/bun/bun/builds/4242/jobs/test" },
-            { step_key: "build-bun", base_path: "/bun/bun/builds/4242/jobs/build" },
-          ],
-        });
-      }
-      if (pathname === "/bun/bun/builds/4242/jobs/build/artifacts") {
-        // Real Buildkite responses carry both checksums.
-        return Response.json(
-          [...zips.entries()].map(([name, data]) => ({
-            file_name: name,
-            url: `/artifacts/${name}`,
-            sha256sum: sha256Hex(data),
-            sha1sum: sha1Hex(data),
-          })),
+    // Standard and -profile artifact zips for every platform, so the test
+    // passes on any target and proves the requested flavor gets picked.
+    const zips = new Map<string, Uint8Array>();
+    for (const name of allPlatformAssetNames()) {
+      for (const [folder, exe] of [
+        [name, "bun"],
+        [`${name}-profile`, "bun-profile"],
+      ] as const) {
+        zips.set(
+          `${folder}.zip`,
+          storeZip({
+            [`${folder}/${exe}`]: { data: new TextEncoder().encode(scriptFor(exe)), mode: 0o755 },
+          }),
         );
       }
-      if (pathname.startsWith("/artifacts/")) {
-        artifactDownloads.push(pathname);
-        const zip = zips.get(pathname.slice("/artifacts/".length));
-        if (zip) return new Response(zip);
-      }
-      return new Response("not found", { status: 404 });
-    },
-  });
+    }
 
-  using staging = tempDir("bun-upgrade-pr", {});
-  await using proc = Bun.spawn({
-    cmd: [execPath, "upgrade", "pr", String(prNumber)],
-    cwd,
-    stdout: null,
-    stdin: "pipe",
-    stderr: "pipe",
-    env: {
-      ...env,
-      NODE_TLS_REJECT_UNAUTHORIZED: "0",
-      GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
-      // Build links are pinned to Bun's Buildkite pipeline; point the pin at
-      // the mock server.
-      BUN_UPGRADE_TESTING_BUILDKITE_URL: `https://${server.hostname}:${server.port}/bun/bun/builds/`,
-      BUN_TMPDIR: String(staging),
-      ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
-    },
-  });
+    using cwdDir = tempDir("bun-upgrade-cwd", {});
+    const cwd = String(cwdDir);
+    const execPath = join(cwd, basename(bunExe()));
+    await copyFile(bunExe(), execPath);
 
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const artifactDownloads: string[] = [];
+    using server = Bun.serve({
+      tls,
+      port: 0,
+      async fetch(req) {
+        const { pathname } = new URL(req.url);
 
-  expect(stderr).toContain(`PR #${prNumber}`);
-  expect(stderr).toContain(prTitle);
-  expect(stderr).toContain(`Installed a build of Bun from pull request #${prNumber}`);
-  expect(stderr).not.toContain("error:");
+        if (pathname === `/repos/oven-sh/bun/pulls/${prNumber}`) {
+          return Response.json({
+            title: prTitle,
+            state: "open",
+            head: { sha: headSha },
+          });
+        }
+        if (pathname === `/repos/oven-sh/bun/commits/${headSha}/statuses`) {
+          return Response.json([
+            { context: "some-other-ci", state: "success", target_url: "https://example.com/nope" },
+            {
+              context: "buildkite/bun",
+              state: "success",
+              target_url: `https://${server.hostname}:${server.port}/bun/bun/builds/4242#annotation`,
+            },
+          ]);
+        }
+        if (pathname === "/bun/bun/builds/4242.json") {
+          return Response.json({
+            state: "passed",
+            jobs: [
+              { step_key: "linux-x64-test-bun", base_path: "/bun/bun/builds/4242/jobs/test" },
+              { step_key: "build-bun", base_path: "/bun/bun/builds/4242/jobs/build" },
+            ],
+          });
+        }
+        if (pathname === "/bun/bun/builds/4242/jobs/build/artifacts") {
+          // Real Buildkite responses carry both checksums. Each artifact is
+          // listed twice: first a decoy on a lookalike origin (must be
+          // skipped: the build's origin is a prefix of it, but not equal),
+          // then the real entry. The profile variant uses absolute
+          // same-origin URLs and the standard variant relative ones, so both
+          // accepted URL forms stay covered.
+          const origin = `https://${server.hostname}:${server.port}`;
+          return Response.json(
+            [...zips.entries()].flatMap(([name, data]) => {
+              const entry = { file_name: name, sha256sum: sha256Hex(data), sha1sum: sha1Hex(data) };
+              return [
+                { ...entry, url: `${origin}.attacker.example/artifacts/${name}` },
+                { ...entry, url: exeName === "bun-profile" ? `${origin}/artifacts/${name}` : `/artifacts/${name}` },
+              ];
+            }),
+          );
+        }
+        if (pathname.startsWith("/artifacts/")) {
+          artifactDownloads.push(pathname);
+          const zip = zips.get(pathname.slice("/artifacts/".length));
+          if (zip) return new Response(zip);
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
 
-  // Exactly one artifact was downloaded, and it was this platform's.
-  const os = process.platform === "darwin" ? "darwin" : "linux";
-  const arch = process.arch === "arm64" ? "aarch64" : "x64";
-  expect(artifactDownloads).toHaveLength(1);
-  expect(artifactDownloads[0]).toStartWith(`/artifacts/bun-${os}-${arch}`);
+    using staging = tempDir("bun-upgrade-pr", {});
+    await using proc = Bun.spawn({
+      cmd: [execPath, "upgrade", "pr", String(prNumber), ...flags],
+      cwd,
+      stdout: null,
+      stdin: "pipe",
+      stderr: "pipe",
+      env: {
+        ...env,
+        NODE_TLS_REJECT_UNAUTHORIZED: "0",
+        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        // Build links are pinned to Bun's Buildkite pipeline; point the pin at
+        // the mock server.
+        BUN_UPGRADE_TESTING_BUILDKITE_URL: `https://${server.hostname}:${server.port}/bun/bun/builds/`,
+        BUN_TMPDIR: String(staging),
+        ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+      },
+    });
 
-  // The pull request's build was installed over the executable.
-  expect(await Bun.file(execPath).text()).toBe(script);
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
 
-  expect(exitCode).toBe(0);
-});
+    expect(stderr).toContain(`PR #${prNumber}`);
+    expect(stderr).toContain(prTitle);
+    expect(stderr).toContain(`Installed a build of Bun from pull request #${prNumber}`);
+    expect(stderr).not.toContain("error:");
+
+    // Exactly one artifact was downloaded: this platform's, in the requested
+    // flavor.
+    const os = process.platform === "darwin" ? "darwin" : "linux";
+    const arch = process.arch === "arm64" ? "aarch64" : "x64";
+    expect(artifactDownloads).toHaveLength(1);
+    expect(artifactDownloads[0]).toStartWith(`/artifacts/bun-${os}-${arch}`);
+    expect(artifactDownloads[0].endsWith("-profile.zip")).toBe(exeName === "bun-profile");
+
+    // The pull request's build (of the requested flavor) was installed over
+    // the executable.
+    expect(await Bun.file(execPath).text()).toBe(scriptFor(exeName));
+
+    expect(exitCode).toBe(0);
+  },
+);
 
 // `#1234` and pull request URLs are accepted too; a 404 from the mocked
 // GitHub API proves the number was parsed out of each spelling (the error
@@ -1020,10 +1062,13 @@ describe.concurrent("bun upgrade pr argument validation", () => {
     expect(exitCode).toBe(1);
   });
 
-  it("rejects a non-numeric pull request number", async () => {
+  // Wrong-repo URLs are rejected: the number is looked up in oven-sh/bun,
+  // so reinterpreting another repository's PR URL would install a build the
+  // user never named.
+  it.each(["not-a-number", "https://github.com/acme/widget/pull/123"])("rejects %s", async arg => {
     using cwd = tempDir("bun-upgrade-pr-args", {});
     await using proc = spawn({
-      cmd: [bunExe(), "upgrade", "pr", "not-a-number"],
+      cmd: [bunExe(), "upgrade", "pr", arg],
       cwd: String(cwd),
       stdout: null,
       stdin: "pipe",

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -1024,31 +1024,34 @@ it.skipIf(isWindows).each(prInstallVariants)(
 // GitHub API proves the number was parsed out of each spelling (the error
 // echoes it back) without running a full install.
 describe.concurrent("bun upgrade pr argument spellings", () => {
-  it.each(["#4321", "https://github.com/oven-sh/bun/pull/4321"])("accepts %s", async spelling => {
-    using cwd = tempDir("bun-upgrade-pr-spelling", {});
-    using server = Bun.serve({
-      tls,
-      port: 0,
-      fetch: () => new Response("not found", { status: 404 }),
-    });
+  it.each(["#4321", "https://github.com/oven-sh/bun/pull/4321", "http://github.com/oven-sh/bun/pull/4321"])(
+    "accepts %s",
+    async spelling => {
+      using cwd = tempDir("bun-upgrade-pr-spelling", {});
+      using server = Bun.serve({
+        tls,
+        port: 0,
+        fetch: () => new Response("not found", { status: 404 }),
+      });
 
-    await using proc = spawn({
-      cmd: [bunExe(), "upgrade", "pr", spelling],
-      cwd: String(cwd),
-      stdout: null,
-      stdin: "pipe",
-      stderr: "pipe",
-      env: {
-        ...env,
-        NODE_TLS_REJECT_UNAUTHORIZED: "0",
-        GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
-      },
-    });
+      await using proc = spawn({
+        cmd: [bunExe(), "upgrade", "pr", spelling],
+        cwd: String(cwd),
+        stdout: null,
+        stdin: "pipe",
+        stderr: "pipe",
+        env: {
+          ...env,
+          NODE_TLS_REJECT_UNAUTHORIZED: "0",
+          GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
+        },
+      });
 
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("Pull request #4321 was not found");
-    expect(exitCode).toBe(1);
-  });
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Pull request #4321 was not found");
+      expect(exitCode).toBe(1);
+    },
+  );
 });
 
 describe.concurrent("bun upgrade pr argument validation", () => {


### PR DESCRIPTION
### What does this PR do?

Two additions to `bun upgrade`:

**1. Delta updates.** When upgrading between recent stable releases, `bun upgrade` now downloads a small binary patch instead of the full release archive:

- Patches are zstd-compressed [bsdiff](https://crates.io/crates/bsdiff) streams published as release assets, named `bun-<target>.from-<prev>.bsdiff` with `.sha256sum` sidecars, plus a `bun-<target>.sha256sum` checksum of each release's uncompressed binary.
- Before patching, the on-disk binary is verified against its release's published checksum (modified/canary/debug binaries silently fall back). Each patch and each intermediate result is checksum-verified too.
- Each release carries one patch from its immediate predecessor; upgrades that are 2–3 releases behind chain patches. The direct `target.from-current` patch is tried first, which also covers skipped version numbers.
- Any miss (missing asset, checksum mismatch, patch failure) falls back to the normal full download. `--no-delta` skips the attempt entirely.
- The release workflow gains a `deltas` job (`packages/bun-release/scripts/upload-deltas.ts`) that publishes the patch + checksum assets on each stable release, generating patches with the freshly released binary itself (via `bun:internal-for-testing`), and backfills the previous release's binary checksum so deltas activate with the very next release.

**2. `bun upgrade pr <number>`** installs the CI build of a pull request (accepts `1234`, `#1234`, or a PR URL):

- Resolves the PR via the GitHub API, finds the `buildkite/bun` commit status of its latest commit, lists the build's artifacts through Buildkite's public endpoints, and downloads this platform's `bun-<triplet>.zip` — no `gh` CLI or authentication required, since Bun's PR artifacts are public.
- The artifact is verified against Buildkite's recorded sha1 and installed through the existing staging → verify → replace flow. `--profile` picks the profile build.

Also updates `bun upgrade --help`, shell completions, and the installation docs.

### How did you verify your code works?

- `test/cli/install/bun-upgrade.test.ts` gains 10 tests (all pass with the debug build, fail on unpatched bun):
  - patch create/apply roundtrip, empty-base patch, truncated-patch rejection (via `bun:internal-for-testing` bindings)
  - end-to-end delta upgrade against a mock release server: binary patched, checksums verified, archive endpoint never hit
  - checksum-mismatch fallback: delta attempt abandoned, full archive downloaded afterwards
  - `--no-delta` skips the delta attempt
  - end-to-end `bun upgrade pr` against a mock GitHub + Buildkite server (real zip artifact, sha1-verified, binary replaced)
  - `pr` argument validation (missing / non-numeric / extra arguments)
- Smoke-tested against the live APIs: `BUN_DRY_RUN=1 bun-debug upgrade pr 31707` resolves the PR, finds build 59882, locates `bun-linux-x64.zip`, and starts the download (the sandbox blocks s3.amazonaws.com, so the download itself was exercised through the mock-server test); `BUN_DRY_RUN=1 bun-debug upgrade --stable` still performs a full real upgrade cycle with the delta code silently skipping (no checksum assets exist on current releases yet).
- `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-upgrade.test.ts

<!-- robobun:evidence:end -->