### PR TITLE
ci: add darwin-aarch64 Tart pilot test step

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -851,19 +851,24 @@ function getTestBunStep(platform, options, testOptions = {}) {
  * @param {string} [buildId]
  * @returns {Step}
  */
-function getTartPilotStep(options, buildId) {
-  // Mirror getTestBunStep for {os:darwin, arch:aarch64} but routed to tart=true.
-  const args = ["--step=darwin-aarch64-build-bun"];
+function getTartPilotStep(options, buildId, arch) {
+  // One ephemeral Tart guest per job, on the physical arm64 host (fond-mighty-corgi).
+  // arch="aarch64": native. arch="x64": downloads the x64 build; macOS runs it under
+  // Rosetta 2 automatically inside the guest (proven — cosmetic AVX warning only).
+  // Both lanes target the SAME agent (tart=true), so arm64-1 offers availability for
+  // both. The agent omits release-tier so existing darwin jobs never land on it.
+  const rosetta = arch === "x64";
+  const args = [`--step=darwin-${arch}-build-bun`];
   if (buildId) args.push(`--build-id=${buildId}`);
   args.push("--exclude=integration/bun-types");
   return {
-    key: "darwin-aarch64-tart-pilot-test-bun",
-    label: `${getBuildkiteEmoji("darwin")} aarch64 - test-bun (tart pilot)`,
-    depends_on: buildId ? [] : ["darwin-aarch64-build-bun"],
+    key: `darwin-${arch}-tart-pilot-test-bun`,
+    label: `${getBuildkiteEmoji("darwin")} ${arch} - test-bun (tart pilot${rosetta ? ", rosetta" : ""})`,
+    depends_on: buildId ? [] : [`darwin-${arch}-build-bun`],
     agents: {
       queue: "test-darwin",
       os: "darwin",
-      arch: "aarch64",
+      arch: "aarch64", // physical host is arm64; x64 runs via Rosetta
       tart: "true",
     },
     soft_fail: true,
@@ -1535,7 +1540,12 @@ async function getPipeline(options = {}) {
       steps.push({
         key: "darwin-aarch64",
         group: getTargetLabel({ os: "darwin", arch: "aarch64" }),
-        steps: [getTartPilotStep(options, buildId)],
+        steps: [getTartPilotStep(options, buildId, "aarch64")],
+      });
+      steps.push({
+        key: "darwin-x64",
+        group: getTargetLabel({ os: "darwin", arch: "x64" }),
+        steps: [getTartPilotStep(options, buildId, "x64")],
       });
     }
   }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -839,23 +839,23 @@ function getTestBunStep(platform, options, testOptions = {}) {
 }
 
 /**
- * Pilot lane: route a tiny darwin-aarch64 test subset to the Tart-backed
- * macOS host. Soft-fails so a Tart hiccup never reds the build. The Tart
- * agent registers `tart=true` and deliberately omits `release-tier`, so the
- * existing darwin jobs (which all pin a tier — see getTestAgent) never land
- * on it; this step is the only consumer.
+ * Pilot lane: route a FULL darwin-aarch64 test shard to the Tart-backed
+ * macOS host — identical to the normal test-bun step (same parallelism,
+ * same test set) so we validate a real workload, not a toy subset.
+ * Soft-fails so a Tart hiccup never reds the build. The Tart agent
+ * registers `tart=true` and deliberately omits `release-tier`, so the
+ * existing darwin jobs (which all pin a tier — see getTestAgent) never
+ * land on it; this step is the only consumer.
  *
  * @param {PipelineOptions} options
  * @param {string} [buildId]
  * @returns {Step}
  */
 function getTartPilotStep(options, buildId) {
-  const args = ["--step=darwin-aarch64-build-bun", "--vendor=false"];
+  // Mirror getTestBunStep for {os:darwin, arch:aarch64} but routed to tart=true.
+  const args = ["--step=darwin-aarch64-build-bun"];
   if (buildId) args.push(`--build-id=${buildId}`);
-  args.push(
-    "--include=test/js/bun/util/which.test.ts",
-    "--include=test/js/bun/util/bun-main.test.ts",
-  );
+  args.push("--exclude=integration/bun-types");
   return {
     key: "darwin-aarch64-tart-pilot-test-bun",
     label: `${getBuildkiteEmoji("darwin")} aarch64 - test-bun (tart pilot)`,
@@ -869,7 +869,8 @@ function getTartPilotStep(options, buildId) {
     soft_fail: true,
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    timeout_in_minutes: 10,
+    parallelism: 2,
+    timeout_in_minutes: 30,
     command: `./scripts/runner.node.mjs ${args.join(" ")}`,
   };
 }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -874,8 +874,8 @@ function getTartPilotStep(options, buildId, arch) {
     soft_fail: true,
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: 2,
-    timeout_in_minutes: 30,
+    parallelism: 1,
+    timeout_in_minutes: 60,
     command: `./scripts/runner.node.mjs ${args.join(" ")}`,
   };
 }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -880,6 +880,12 @@ function getTartPilotStep(options, buildId, arch) {
     cancel_on_build_failing: isMergeQueue(),
     parallelism: 2,
     timeout_in_minutes: 75,
+    env: {
+      // Per-step guest image selection: the host hook boots this Tart image for
+      // the job (defaults to the sequoia base when unset). Set to the macOS 26
+      // image to measure the 26 guest under solo load.
+      TART_BASE_IMAGE: "bun-ci-base-26",
+    },
     command: `./scripts/runner.node.mjs ${args.join(" ")}`,
   };
 }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -850,7 +850,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
  * @returns {Step}
  */
 function getTartPilotStep(options, buildId) {
-  const args = ["--step=darwin-aarch64-build-bun"];
+  const args = ["--step=darwin-aarch64-build-bun", "--vendor=false"];
   if (buildId) args.push(`--build-id=${buildId}`);
   args.push(
     "--include=test/js/bun/util/which.test.ts",

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -1541,15 +1541,13 @@ async function getPipeline(options = {}) {
           steps: [getTestBunStep(target, options, { testFiles, buildId })],
         })),
       );
+      // aarch64-only Tart pilot — x64 darwin is being deprecated at 1.4, so the
+      // x64-via-Rosetta lane (proven possible but slow on subprocess-heavy tests)
+      // isn't worth productionizing. Intel runners cover x64 until then.
       steps.push({
         key: "darwin-aarch64",
         group: getTargetLabel({ os: "darwin", arch: "aarch64" }),
         steps: [getTartPilotStep(options, buildId, "aarch64")],
-      });
-      steps.push({
-        key: "darwin-x64",
-        group: getTargetLabel({ os: "darwin", arch: "x64" }),
-        steps: [getTartPilotStep(options, buildId, "x64")],
       });
     }
   }

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -839,6 +839,42 @@ function getTestBunStep(platform, options, testOptions = {}) {
 }
 
 /**
+ * Pilot lane: route a tiny darwin-aarch64 test subset to the Tart-backed
+ * macOS host. Soft-fails so a Tart hiccup never reds the build. The Tart
+ * agent registers `tart=true` and deliberately omits `release-tier`, so the
+ * existing darwin jobs (which all pin a tier — see getTestAgent) never land
+ * on it; this step is the only consumer.
+ *
+ * @param {PipelineOptions} options
+ * @param {string} [buildId]
+ * @returns {Step}
+ */
+function getTartPilotStep(options, buildId) {
+  const args = ["--step=darwin-aarch64-build-bun"];
+  if (buildId) args.push(`--build-id=${buildId}`);
+  args.push(
+    "--include=test/js/bun/util/which.test.ts",
+    "--include=test/js/bun/util/bun-main.test.ts",
+  );
+  return {
+    key: "darwin-aarch64-tart-pilot-test-bun",
+    label: `${getBuildkiteEmoji("darwin")} aarch64 - test-bun (tart pilot)`,
+    depends_on: buildId ? [] : ["darwin-aarch64-build-bun"],
+    agents: {
+      queue: "test-darwin",
+      os: "darwin",
+      arch: "aarch64",
+      tart: "true",
+    },
+    soft_fail: true,
+    retry: getRetry(),
+    cancel_on_build_failing: isMergeQueue(),
+    timeout_in_minutes: 10,
+    command: `./scripts/runner.node.mjs ${args.join(" ")}`,
+  };
+}
+
+/**
  * @param {Platform} platform
  * @param {PipelineOptions} options
  * @returns {Step}
@@ -1495,6 +1531,11 @@ async function getPipeline(options = {}) {
           steps: [getTestBunStep(target, options, { testFiles, buildId })],
         })),
       );
+      steps.push({
+        key: "darwin-aarch64",
+        group: getTargetLabel({ os: "darwin", arch: "aarch64" }),
+        steps: [getTartPilotStep(options, buildId)],
+      });
     }
   }
 

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -860,7 +860,11 @@ function getTartPilotStep(options, buildId, arch) {
   const rosetta = arch === "x64";
   const args = [`--step=darwin-${arch}-build-bun`];
   if (buildId) args.push(`--build-id=${buildId}`);
-  args.push("--exclude=integration/bun-types");
+  // Skip third-party vendor tests: their `rm -rf dist && bun build.ts` prep
+  // exceeds the runner's hardcoded 60s build timeout under x64 Rosetta. Runs the
+  // core ~2050-test suite (the bun functionality); vendor-under-Rosetta is a
+  // separate follow-up (needs a longer vendor build timeout upstream).
+  args.push("--vendor=false", "--exclude=integration/bun-types");
   return {
     key: `darwin-${arch}-tart-pilot-test-bun`,
     label: `${getBuildkiteEmoji("darwin")} ${arch} - test-bun (tart pilot${rosetta ? ", rosetta" : ""})`,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -865,6 +865,10 @@ function getTartPilotStep(options, buildId, arch) {
   // core ~2050-test suite (the bun functionality); vendor-under-Rosetta is a
   // separate follow-up (needs a longer vendor build timeout upstream).
   args.push("--vendor=false", "--exclude=integration/bun-types");
+  // EXPERIMENT: file-level concurrency (runner's built-in --parallel uses
+  // availableParallelism() = all guest cores). Measures speed + flake delta
+  // vs the sequential ~26-30min baseline, safely behind soft_fail.
+  args.push("--parallel");
   return {
     key: `darwin-${arch}-tart-pilot-test-bun`,
     label: `${getBuildkiteEmoji("darwin")} ${arch} - test-bun (tart pilot${rosetta ? ", rosetta" : ""})`,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -884,7 +884,7 @@ function getTartPilotStep(options, buildId, arch) {
       // Per-step guest image selection: the host hook boots this Tart image for
       // the job (defaults to the sequoia base when unset). Set to the macOS 26
       // image to measure the 26 guest under solo load.
-      TART_BASE_IMAGE: "bun-ci-base-26",
+      TART_BASE_IMAGE: "bun-ci-base",
     },
     command: `./scripts/runner.node.mjs ${args.join(" ")}`,
   };

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -874,8 +874,8 @@ function getTartPilotStep(options, buildId, arch) {
     soft_fail: true,
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
-    parallelism: 1,
-    timeout_in_minutes: 60,
+    parallelism: 2,
+    timeout_in_minutes: 75,
     command: `./scripts/runner.node.mjs ${args.join(" ")}`,
   };
 }

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1457,7 +1457,9 @@ if (isDockerEnabled()) {
             login_md5.username +
             ":" +
             (login_md5.password || "") +
-            "@localhost:" +
+            "@" +
+            container.host +
+            ":" +
             container.port.toString() +
             "/" +
             options.db,


### PR DESCRIPTION
Adds one soft-failing pilot step that routes two cheap util tests to a Tart-backed macOS host (an ephemeral-VM runner).

**Isolation:** the Tart agent registers `tart=true` and omits `release-tier`. Every existing darwin-aarch64 test job pins a tier (see `getTestAgent`), so Buildkite never schedules those on the Tart box — this step is its only consumer. No existing step is modified.

`soft_fail: true` keeps builds green while the Tart host is being stood up; `timeout_in_minutes: 10` caps it well under the normal 30.