### PR TITLE
fix(win32): restore console input mode after a child inherits the console

### DIFF
--- a/src/runtime/api/bun/process.zig
+++ b/src/runtime/api/bun/process.zig
@@ -230,6 +230,13 @@ pub const Process = struct {
     ref_count: RefCount,
     exit_handler: ProcessExitHandler = ProcessExitHandler{},
     sync: bool = false,
+    /// Windows only: the console input mode captured at spawn time when this
+    /// child inherited our console stdin, so we can restore it after the child
+    /// exits. A child can switch the shared console input buffer back to cooked
+    /// mode and libuv's cached tty mode keeps us from re-applying raw mode. null
+    /// when stdin was not an inherited console (the common case) or on POSIX.
+    /// See WindowsConsoleInGuard.
+    windows_console_in_mode: ?u32 = null,
     event_loop: jsc.EventLoopHandle,
 
     pub fn memoryCost(_: *const Process) usize {
@@ -294,6 +301,14 @@ pub const Process = struct {
 
         if (this.hasExited()) {
             this.detach();
+            // A child that inherited our console stdin may have switched the
+            // shared console input buffer back to cooked mode. Put back the mode
+            // we captured at spawn so an interactive parent (e.g. a TUI in raw
+            // mode) keeps receiving raw keystrokes instead of cooked, echoed,
+            // line-buffered input. No-op unless we snapshotted a mode for this
+            // child. See WindowsConsoleInGuard.
+            WindowsConsoleInGuard.restore(this.windows_console_in_mode);
+            this.windows_console_in_mode = null;
         }
 
         exit_handler.call(this, status, rusage);
@@ -1668,6 +1683,46 @@ pub fn spawnProcessPosix(
     unreachable;
 }
 
+/// Windows: a child that inherits our console stdin can switch the shared
+/// console input buffer back to cooked mode (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT)
+/// — cmd.exe, PowerShell, git, node, python and many CRTs reconfigure CONIN$ on
+/// startup. libuv's uv_tty_set_mode caches the last mode it applied and
+/// early-returns when asked for that same mode:
+///
+///     if ((int)mode == tty->tty.rd.mode.mode) return 0;   // no SetConsoleMode
+///
+/// so once the OS mode is changed out from under it, libuv never re-applies it,
+/// and a subsequent setRawMode(true) from JS is a no-op. The user-visible result
+/// is a TUI that keeps rendering while its stdin is cooked: keystrokes echo and
+/// line-buffer instead of reaching the app. We mirror what the POSIX path does
+/// via bun_restore_stdio: snapshot the console input mode before handing the
+/// console to the child and restore it when the child exits.
+const WindowsConsoleInGuard = struct {
+    /// Returns the current console input mode iff `stdin` is an inherited
+    /// console handle, otherwise null. GetConsoleMode only succeeds on a real
+    /// console handle, so a redirected (pipe/file) stdin returns null and the
+    /// guard is skipped.
+    fn snapshot(stdin: WindowsSpawnOptions.Stdio) ?u32 {
+        if (comptime Environment.isWindows) {
+            if (stdin != .inherit) return null;
+            const handle = std.os.windows.peb().ProcessParameters.hStdInput;
+            var mode: bun.windows.DWORD = undefined;
+            if (bun.c.GetConsoleMode(handle, &mode) == 0) return null;
+            return mode;
+        }
+        return null;
+    }
+
+    /// Restore a mode captured by `snapshot`. No-op when `saved` is null.
+    fn restore(saved: ?u32) void {
+        if (comptime Environment.isWindows) {
+            const mode = saved orelse return;
+            const handle = std.os.windows.peb().ProcessParameters.hStdInput;
+            _ = bun.c.SetConsoleMode(handle, mode);
+        }
+    }
+};
+
 pub fn spawnProcessWindows(
     options: *const WindowsSpawnOptions,
     argv: [*:null]?[*:0]const u8,
@@ -1861,6 +1916,10 @@ pub fn spawnProcessWindows(
         .event_loop = options.windows.loop,
         .pid = 0,
     });
+    // Capture the console input mode before uv_spawn so it reflects our mode,
+    // not whatever the child sets. Restored in Process.onExit when the child
+    // exits. See WindowsConsoleInGuard.
+    process.windows_console_in_mode = WindowsConsoleInGuard.snapshot(options.stdin);
 
     defer {
         if (failed) {

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -131,7 +131,66 @@ pub struct Process {
     pub ref_count: bun_ptr::ThreadSafeRefCount<Process>,
     pub exit_handler: ProcessExitHandler,
     pub sync: bool,
+    /// Windows only: the console input mode captured at spawn time when this
+    /// child inherited our console stdin, so we can restore it after the child
+    /// exits. A child can switch the shared console input buffer back to cooked
+    /// mode (`ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT`) and libuv's cached tty
+    /// mode keeps us from re-applying raw mode. `None` when stdin was not an
+    /// inherited console (the common case). See `windows_console_in_snapshot`
+    /// and `windows_console_in_restore`.
+    #[cfg(windows)]
+    pub windows_console_in_mode: Option<u32>,
     pub event_loop: EventLoopHandle,
+}
+
+/// Windows: a child that inherits our console stdin can switch the shared
+/// console input buffer back to cooked mode (`ENABLE_LINE_INPUT |
+/// ENABLE_ECHO_INPUT`) — cmd.exe, PowerShell, git, node, python and many CRTs
+/// reconfigure `CONIN$` on startup. libuv's `uv_tty_set_mode` caches the last
+/// mode it applied and early-returns when asked for that same mode:
+///
+/// ```c
+/// if ((int)mode == tty->tty.rd.mode.mode) return 0;   // no SetConsoleMode
+/// ```
+///
+/// so once the OS mode is changed out from under it, libuv never re-applies it
+/// and a subsequent `setRawMode(true)` from JS is a no-op — a TUI keeps
+/// rendering while its stdin is cooked, echoed and line-buffered. We mirror the
+/// POSIX `bun_restore_stdio` path: snapshot the console input mode before
+/// handing the console to the child, and restore it when the child exits.
+///
+/// Returns the current console input mode iff `stdin` is an inherited console
+/// handle, otherwise `None`. `GetConsoleMode` only succeeds on a real console
+/// handle, so a redirected (pipe/file) stdin returns `None` and the guard is
+/// skipped for free.
+#[cfg(windows)]
+fn windows_console_in_snapshot(stdin: &WindowsStdio) -> Option<u32> {
+    if !matches!(stdin, WindowsStdio::Inherit) {
+        return None;
+    }
+    let handle = Fd::stdin().native();
+    let mut mode: u32 = 0;
+    // SAFETY: `handle` is the process stdin handle (valid for the process
+    // lifetime); `&mut mode` coerces to the `*mut DWORD` out-param. The call is
+    // side-effect free and returns 0 for a non-console handle.
+    if unsafe { bun_sys::windows::GetConsoleMode(handle, &mut mode) } == 0 {
+        return None;
+    }
+    Some(mode)
+}
+
+/// Restore a console input mode captured by [`windows_console_in_snapshot`].
+/// No-op when `saved` is `None`. Restoring the exact prior mode keeps libuv's
+/// cached tty value consistent with the OS rather than fighting the cache.
+#[cfg(windows)]
+fn windows_console_in_restore(saved: Option<u32>) {
+    let Some(mode) = saved else { return };
+    // SAFETY: stdin handle is valid for the process lifetime. Restore is
+    // best-effort — an error (e.g. handle no longer a console) is ignored,
+    // matching `bun_restore_stdio`.
+    unsafe {
+        let _ = bun_sys::windows::SetConsoleMode(Fd::stdin().native(), mode);
+    }
 }
 
 impl Drop for Process {
@@ -282,6 +341,17 @@ impl Process {
         self.status = status.clone();
         if self.has_exited() {
             self.detach();
+            // A child that inherited our console stdin may have switched the
+            // shared console input buffer back to cooked mode. Put back the mode
+            // we captured at spawn so an interactive parent (e.g. a TUI in raw
+            // mode) keeps receiving raw keystrokes instead of cooked, echoed,
+            // line-buffered input. No-op unless we snapshotted a mode for this
+            // child.
+            #[cfg(windows)]
+            {
+                windows_console_in_restore(self.windows_console_in_mode);
+                self.windows_console_in_mode = None;
+            }
         }
         call_exit_handler(&exit_handler, self, status, rusage);
     }
@@ -2120,6 +2190,9 @@ mod spawn_process_body {
             poller: Poller::Detached,
             exit_handler: ProcessExitHandler::default(),
             sync: false,
+            // Captured before uv_spawn below so it reflects our mode, not
+            // whatever the child sets. Restored in `Process::on_exit`.
+            windows_console_in_mode: windows_console_in_snapshot(&options.stdin),
         }));
 
         // defer if failed: process.close(); process.deref(); — handled at error sites

--- a/test/regression/issue/25663.test.ts
+++ b/test/regression/issue/25663.test.ts
@@ -1,0 +1,156 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDirWithFiles } from "harness";
+import { join } from "path";
+
+// Regression test for https://github.com/oven-sh/bun/issues/25663 (the Windows
+// console raw-mode problem; this is the restore-after-child-exit half).
+//
+// On Windows, a child spawned with an inherited console stdin
+// can switch the shared console input buffer back to cooked mode
+// (ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT). libuv's uv_tty_set_mode caches the
+// last mode it applied and early-returns for the same mode, so it never
+// re-applies raw mode and an interactive TUI is left with cooked, echoed,
+// line-buffered stdin. spawnProcessWindows now snapshots the console input mode
+// before the child runs and restores it on exit (windows_console_in_snapshot /
+// windows_console_in_restore in src/spawn/process.rs; WindowsConsoleInGuard in
+// the src/runtime/api/bun/process.zig porting reference).
+//
+// IMPORTANT: the cooking child must be a *non-Bun* process. Bun restores its own
+// console mode on exit (Bun__restoreWindowsStdio in src/bun_core/output.rs), so
+// a Bun child self-heals and would mask the bug — making the test pass with or
+// without the fix. We use a PowerShell P/Invoke that cooks the shared buffer and
+// exits without restoring, exactly like cmd.exe / PowerShell / git / node do in
+// the wild.
+//
+// We need a real console to observe this, so the scenario runs inside a
+// Bun.Terminal (ConPTY). process.stdin.isRaw only reflects libuv's cache — the
+// exact thing that is wrong here — so the parent reads the *actual* console mode
+// via bun:ffi GetConsoleMode instead.
+
+// PowerShell cooker: switch the shared console input buffer to cooked mode and
+// write "<before> <after>" so the parent can confirm the cook actually landed
+// (otherwise the test could pass vacuously if the child never cooked).
+const COOKER_PS1 = String.raw`
+param([string]$OutFile)
+$sig = @"
+using System;
+using System.Runtime.InteropServices;
+public class K {
+  [DllImport("kernel32.dll")] public static extern bool SetConsoleMode(IntPtr h, uint m);
+  [DllImport("kernel32.dll")] public static extern bool GetConsoleMode(IntPtr h, out uint m);
+  [DllImport("kernel32.dll")] public static extern IntPtr GetStdHandle(int n);
+}
+"@
+Add-Type -TypeDefinition $sig
+$h = [K]::GetStdHandle(-10)
+[uint32]$before = 0; [void][K]::GetConsoleMode($h, [ref]$before)
+[void][K]::SetConsoleMode($h, (0x1 -bor 0x2 -bor 0x4))
+[uint32]$aft = 0; [void][K]::GetConsoleMode($h, [ref]$aft)
+"$before $aft" | Set-Content -Path $OutFile -Encoding ascii
+`;
+
+// Parent role — runs inside the ConPTY so there is a real console.
+const PARENT = /* ts */ `
+import { dlopen, FFIType, ptr } from "bun:ffi";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const k32 = dlopen("kernel32.dll", {
+  GetStdHandle: { args: [FFIType.u32], returns: FFIType.ptr },
+  GetConsoleMode: { args: [FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
+});
+
+const STD_INPUT_HANDLE = 0xfffffff6; // (DWORD)-10
+const ENABLE_LINE_INPUT = 0x0002;
+const stdinHandle = k32.symbols.GetStdHandle(STD_INPUT_HANDLE);
+
+function consoleMode(): number | null {
+  const buf = new Uint32Array(1);
+  if (k32.symbols.GetConsoleMode(stdinHandle, ptr(buf)) === 0) return null;
+  return buf[0];
+}
+
+const dir = dirname(import.meta.path);
+const cooker = join(dir, "cook.ps1");
+const outFile = join(dir, "cook.out");
+
+const initial = consoleMode();
+if (initial === null) {
+  // No real console (ConPTY unavailable) — report so the test can skip rather
+  // than assert on a meaningless value.
+  console.log("RESULT:" + JSON.stringify({ error: "stdin is not a console" }));
+  process.exit(0);
+}
+
+process.stdin.setRawMode(true);
+const rawMode = consoleMode() ?? 0;
+
+// Spawn a non-Bun child that inherits this console and cooks it.
+Bun.spawnSync({
+  cmd: ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", cooker, "-OutFile", outFile],
+  stdio: ["inherit", "inherit", "inherit"],
+  env: process.env,
+});
+
+const afterChild = consoleMode() ?? 0;
+
+// Did the child actually cook the shared buffer? (precondition guard so the
+// assertion below can't pass vacuously.)
+let childCooked = false;
+try {
+  const parts = readFileSync(outFile, "utf8").trim().split(/\\s+/);
+  childCooked = (Number(parts[1]) & ENABLE_LINE_INPUT) !== 0;
+} catch {}
+
+console.log(
+  "RESULT:" +
+    JSON.stringify({
+      rawHasLineInput: (rawMode & ENABLE_LINE_INPUT) !== 0,
+      childCooked,
+      afterHasLineInput: (afterChild & ENABLE_LINE_INPUT) !== 0,
+    }),
+);
+`;
+
+test.if(isWindows)("console raw mode is restored after a non-Bun child cooks the console", async () => {
+  const dir = tempDirWithFiles("win32-console-restore", {
+    "parent.ts": PARENT,
+    "cook.ps1": COOKER_PS1,
+  });
+
+  let output = "";
+  const { promise: gotResult, resolve } = Promise.withResolvers<void>();
+
+  await using terminal = new Bun.Terminal({
+    cols: 200,
+    data(_term, data) {
+      output += Buffer.from(data).toString("latin1");
+      if (output.includes("RESULT:")) resolve();
+    },
+  });
+
+  const proc = Bun.spawn({
+    cmd: [bunExe(), join(dir, "parent.ts")],
+    env: bunEnv,
+    terminal,
+  });
+
+  await Promise.race([gotResult, proc.exited]);
+  await proc.exited;
+
+  const line = output.split(/\r?\n/).find(l => l.includes("RESULT:"));
+  expect(line, `expected a RESULT line, got:\n${output}`).toBeDefined();
+  const result = JSON.parse(line!.slice(line!.indexOf("RESULT:") + "RESULT:".length));
+
+  // If ConPTY isn't available the scenario can't run; don't assert on noise.
+  if (result.error) return;
+
+  // setRawMode(true) must really clear line input on the OS console...
+  expect(result.rawHasLineInput).toBe(false);
+  // ...the non-Bun child must actually have cooked the shared buffer (otherwise
+  // this test would pass vacuously)...
+  expect(result.childCooked).toBe(true);
+  // ...and raw mode must still be in effect after the child cooked and exited.
+  // Without the fix the child's cooked mode leaks and this assertion fails.
+  expect(result.afterHasLineInput).toBe(false);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a Windows-only bug where an interactive TUI loses raw input after it spawns a child that inherits the console.

**Symptom:** a TUI (Ink/readline app — e.g. Claude Code, OpenCode) keeps rendering, but after a tool/child runs, keystrokes echo and line-buffer as if the parent shell took over; the session looks "stuck" until the terminal is killed.

**Root cause.** `process.stdin.setRawMode(true)` → `Source__setRawModeStdin` → `tty.setMode(.vt)` → libuv `uv_tty_set_mode(RAW_VT)`. A child spawned with inherited console stdin (cmd.exe, PowerShell, git, node, python, and many CRTs reconfigure `CONIN$` on startup) switches the shared console input buffer back to cooked mode (`ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT`). libuv caches the last mode it set and early-returns for the same mode, **never re-querying the OS**:

```c
// libuv src/win/tty.c — uv_tty_set_mode
if ((int)mode == tty->tty.rd.mode.mode) {
  return 0;            // no SetConsoleMode call
}
```

So once the child cooks the console, libuv still believes stdin is raw and a subsequent `setRawMode(true)` from JS is a no-op. The Windows spawn path does no console save/restore (only ConPTY), and the only Windows console restore is wired to the Ctrl+C handler — nothing puts the parent's mode back after a normal child exit.

Now that the default `stdio` is `.inherit`, more spawns hand the child the real console, widening the impact.

**Fix.** Mirror what the parent-process restore already does (`Bun__restoreWindowsStdio` / the POSIX `bun_restore_stdio`), but per-spawn: when `stdin == .inherit`, snapshot `GetConsoleMode(stdin)` (which only succeeds on a real console handle, so redirected stdin is skipped for free) before `uv_spawn`, store it on the `Process`, and `SetConsoleMode` it back in `Process.onExit`. This restores the exact prior mode, so libuv's cached value stays consistent with the OS — no fighting the cache. POSIX and the ConPTY path are unaffected.

The runtime spawn implementation has been ported from Zig to Rust, so the **compiled** fix lives in `src/spawn/process.rs` (`windows_console_in_snapshot` / `windows_console_in_restore`, with a `windows_console_in_mode: Option<u32>` field on `Process`). The change is mirrored into the `src/runtime/api/bun/process.zig` porting reference (`WindowsConsoleInGuard`), which is no longer compiled but kept in sync for behavior reference.

### How did you verify your code works?

Added a Windows regression test: `test/regression/issue/25663.test.ts`. It runs the scenario inside a `Bun.Terminal` (ConPTY) so there is a real console: it puts stdin in raw mode, spawns an inherited-stdio child that switches the shared console input buffer back to cooked mode, then reads the **actual OS console mode** via `bun:ffi` `GetConsoleMode` after the child exits (`process.stdin.isRaw` only reflects libuv's cache, which is the value that is wrong here). It asserts stdin is still raw after the child exits; without this change the child's cooked mode leaks (`ENABLE_LINE_INPUT` stays set) and that assertion fails.

**The cooking child must be a non-Bun process.** Bun restores its own console mode on exit (`Bun__restoreWindowsStdio` in `src/bun_core/output.rs`), so a Bun child self-heals and masks the bug — making the test pass with or without the fix. The test therefore spawns a **PowerShell P/Invoke** that switches the shared `CONIN$` to cooked mode and exits without restoring (exactly what cmd.exe / PowerShell / git / node / python do in the wild). It also asserts the child *actually* cooked the buffer (a precondition guard, so the test can't pass vacuously).

Verified by building `bun-debug` on Windows and toggling the restore: with the fix the test passes (the child cooks the buffer, and raw mode is restored on its exit); with the restore disabled the cooked mode leaks and the test fails — i.e. the test genuinely reproduces the bug.

Manual repro (Windows): run any Ink/readline TUI that holds raw mode, have it spawn a console-aware child with inherited stdin (e.g. `cmd /c ver`), then inspect `GetConsoleMode(stdin)` — without this change it comes back with `ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT` set and keystrokes stop reaching the app; with it, raw mode is restored.

### Related issues

This is **one half of a two-part Windows console-mode problem**, and the other half is already on file:

- **Related to #25663** — *Windows: `setRawMode(true)` overwrites console mode flags instead of preserving them.* That issue is the **enter-raw-mode** half: calling `setRawMode(true)` replaces the console mode with a fixed flag set, wiping out pre-existing flags such as `ENABLE_MOUSE_INPUT` / `ENABLE_EXTENDED_FLAGS`. It was closed with the conclusion that the root cause lives in libuv's `uv_tty_set_mode` (`src/win/tty.c`), which writes a fixed flag set instead of preserving the prior mode — i.e. the fix for that half belongs in libuv. This PR fixes the **complementary restore half**: putting the console mode back after a child inherits and cooks it. The two are independent — a libuv fix for #25663 still would not restore the parent's mode after a normal child exit, and this PR's restore is correct regardless of which flags `setRawMode` happened to leave set. Neither change alone round-trips the console mode across a spawn.

- **#25876** (*fix(win32): SIGINT instantly killing app + CTRL+C input in raw mode*) targeted only the **Ctrl+C / SIGINT** trigger — restoring console state on the signal path. It was closed without being merged, and even as designed it covered only the signal half; it does nothing for the **normal child-exit** path fixed here. Complementary, not competing — different files, different triggers.

### Upstream libuv relationship

The analysis above surfaces two genuine libuv Windows defects in `uv_tty_set_mode` (`src/win/tty.c`). Both are already open upstream; this PR is intentionally independent of either being fixed:

- **libuv/libuv#1292** (draft fix: **libuv/libuv#5156**) - *tty: internal mode state does not account for changes outside of libuv.* This is the cache early-return quoted above (`if ((int)mode == tty->tty.rd.mode.mode) return 0;`): libuv trusts its cached mode and skips `SetConsoleMode`, so a `setRawMode(true)` becomes a silent no-op once a child has changed the real console mode behind libuv's back. **This PR sidesteps it** rather than depending on a fix: by restoring the *exact prior mode* on child exit, libuv's cached value stays consistent with the OS, so the stale-cache no-op is never reached. The draft PR addresses the libuv side directly by validating the cached mode against the live console before short-circuiting.

- **libuv/libuv#4979** (draft fix: **libuv/libuv#5155**) - *Windows: `uv_tty_set_mode()` may be overwriting console mode flags.* `uv_tty_set_mode` writes a fixed flag set for RAW (`flags = ENABLE_WINDOW_INPUT`) without first reading the current mode, dropping pre-existing flags such as `ENABLE_MOUSE_INPUT` / `ENABLE_EXTENDED_FLAGS`. This is the upstream home of #25663 (filed when #25663 was closed as a libuv-side bug). It is orthogonal to this PR: it concerns which flags are set on *entering* raw mode, not restoring the mode after a child exits.

Note these are libuv defects, not things this PR fixes: even if both were resolved upstream, libuv still would not restore the parent's console mode after a normal child exit — that policy belongs to the consumer, which is what this PR implements (mirroring the existing parent-process `Bun__restoreWindowsStdio` / POSIX `bun_restore_stdio`).
