### PR TITLE
Re-sync `$pkg` overrides after `bun update` (no args)

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -626,6 +626,27 @@ pub fn install_with_manager(
         root = *manager.lockfile.packages.get(0);
     }
 
+    // `bun update` bumps a root dep's resolved version and rewrites
+    // package.json's range *after* resolution. Re-sync any `$name`
+    // self-referencing override with the dep it mirrors so the saved
+    // lockfile stays consistent with the package.json it is written next
+    // to — otherwise the next `bun install --frozen-lockfile` reports the
+    // override as changed. No-op unless `OverrideMap::self_referential`
+    // is non-empty and the referenced dep is one `bun update` is bumping.
+    // See issue #31748.
+    if manager.subcommand == Subcommand::Update && manager.lockfile.packages.len() > 0 {
+        // SAFETY: `mgr` is the sole provenance root;
+        // `refresh_self_referential_overrides` reborrows `(*mgr).lockfile`
+        // and reads disjoint `manager` fields through the `&mut *mgr` arg.
+        // No other live `&mut` to `*mgr` exists across the call.
+        let mgr: *mut PackageManager = manager;
+        unsafe {
+            (*mgr)
+                .lockfile
+                .refresh_self_referential_overrides(&mut *mgr)?;
+        }
+    }
+
     if manager.lockfile.packages.len() > 0 {
         for request in &manager.update_requests {
             // prevent redundant errors

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -690,6 +690,158 @@ impl Lockfile {
         dep.behavior.is_bundled() || !dep.behavior.is_enabled(features)
     }
 
+    /// Re-sync `$name` self-referencing overrides with the root dep they
+    /// mirror after `bun update` bumps it. Called from `install_with_manager`
+    /// once `clean_with_logger` has produced the lockfile that will be saved.
+    ///
+    /// `"overrides": { "vite": "$vite" }` stores a *clone* of the root `vite`
+    /// dep captured when `package.json` was parsed. `bun update` resolves a
+    /// newer version and rewrites `package.json`'s range *after* resolution,
+    /// so the stored override keeps the pre-bump literal and the saved
+    /// lockfile no longer matches the `package.json` written next to it —
+    /// the next `bun install --frozen-lockfile` reports the override as
+    /// changed. See issue #31748.
+    ///
+    /// Only overrides whose referenced root dep is actually being updated
+    /// (`manager.updating_packages.contains_key(dep_name)`) are touched, so
+    /// untouched deps and user-authored literal overrides
+    /// (`"overrides": { "vite": "1.0.0" }` — not listed in
+    /// `OverrideMap::self_referential`) are left alone.
+    pub fn refresh_self_referential_overrides(
+        &mut self,
+        manager: &mut PackageManager,
+    ) -> Result<(), AllocError> {
+        if self.overrides.self_referential.count() == 0 {
+            return Ok(());
+        }
+
+        let workspace_package_id = manager
+            .root_package_id
+            .get(self, manager.workspace_name_hash);
+        let root_deps_list = self.packages.items_dependencies()[workspace_package_id as usize];
+        let root_resolutions_list =
+            self.packages.items_resolutions()[workspace_package_id as usize];
+
+        // Pass 1: collect (override_key_hash, new_literal_bytes) so the read
+        // of root deps + resolutions doesn't overlap the `StringBuilder`'s
+        // mutable borrow of `buffers.string_bytes`.
+        let mut rewrites: Vec<(PackageNameHash, Vec<u8>)> = Vec::new();
+        {
+            let string_buf = self.buffers.string_bytes.as_slice();
+            let root_deps = root_deps_list.get(self.buffers.dependencies.as_slice());
+            let root_resolution_ids =
+                root_resolutions_list.get(self.buffers.resolutions.as_slice());
+            let resolutions = self.packages.items_resolution();
+            let packages_len = self.packages.len();
+
+            debug_assert_eq!(root_deps.len(), root_resolution_ids.len());
+            for (&override_key_hash, &ref_name_hash) in self
+                .overrides
+                .self_referential
+                .keys()
+                .iter()
+                .zip(self.overrides.self_referential.values())
+            {
+                let Some(override_dep) = self.overrides.map.get(&override_key_hash) else {
+                    continue;
+                };
+
+                // Locate the referenced root dep's resolved npm version.
+                let mut resolved: Option<&Semver::Version> = None;
+                for (dep, &package_id) in root_deps.iter().zip(root_resolution_ids) {
+                    if dep.name_hash != ref_name_hash {
+                        continue;
+                    }
+                    // Only re-sync when this root dep's range is being
+                    // rewritten in package.json (i.e. it's one of the
+                    // packages `bun update` is bumping). If the root dep
+                    // wasn't updated, the override already matches package.json.
+                    if !manager
+                        .updating_packages
+                        .contains_key(dep.name.slice(string_buf))
+                    {
+                        break;
+                    }
+                    if package_id == invalid_package_id || package_id as usize >= packages_len {
+                        break;
+                    }
+                    let resolution = &resolutions[package_id as usize];
+                    if resolution.tag == ResolutionTag::Npm {
+                        resolved = Some(&resolution.npm().version);
+                    }
+                    break;
+                }
+                let Some(resolved_version) = resolved else {
+                    continue;
+                };
+
+                // Scope: only handle plain npm semver. The pin-style logic
+                // below (`which_version_is_pinned` + `^`/`~`/exact prefix)
+                // assumes a `1.2.3`-shaped literal. For `npm:foo@…` aliases
+                // and `catalog:default` references — both of which can show
+                // up in a `$`-ref override as clones of the root dep —
+                // `which_version_is_pinned` falls into the default branch
+                // on the leading `n` / `c`, returns `Patch`, and we'd write
+                // a bare semver, stripping the `npm:foo@` / `catalog:`
+                // prefix and breaking the next install. Leave those alone;
+                // they remain a known limitation tracked in the PR comment.
+                let existing_literal = override_dep.version.literal.slice(string_buf);
+                let trimmed = strings::trim(existing_literal, &strings::WHITESPACE_CHARS);
+                if trimmed.starts_with(b"npm:") || trimmed.starts_with(b"catalog:") {
+                    continue;
+                }
+
+                // Preserve the override's existing pin style (`^`/`~`/exact)
+                // so the new literal matches what `PackageJSONEditor` writes
+                // into `package.json` for the bumped dep.
+                let pinned = Semver::Version::which_version_is_pinned(existing_literal);
+                let version_fmt = resolved_version.fmt(string_buf);
+                let mut new_literal: Vec<u8> = Vec::new();
+                let _ = match pinned {
+                    Semver::PinnedVersion::Patch => write!(&mut new_literal, "{}", version_fmt),
+                    Semver::PinnedVersion::Minor => write!(&mut new_literal, "~{}", version_fmt),
+                    Semver::PinnedVersion::Major => write!(&mut new_literal, "^{}", version_fmt),
+                };
+
+                if new_literal.as_slice() != existing_literal {
+                    rewrites.push((override_key_hash, new_literal));
+                }
+            }
+        }
+
+        if rewrites.is_empty() {
+            return Ok(());
+        }
+
+        let mut string_builder = string_builder!(self);
+        for (_, literal) in &rewrites {
+            string_builder.count(literal);
+        }
+        string_builder.allocate()?;
+
+        for (override_key_hash, literal) in &rewrites {
+            let Some(override_dep) = self.overrides.map.get_mut(override_key_hash) else {
+                continue;
+            };
+            let external = string_builder.append::<ExternalString>(literal);
+            let sliced = external
+                .value
+                .sliced(string_builder.string_bytes.as_slice());
+            override_dep.version = dependency::parse(
+                override_dep.name,
+                override_dep.name_hash,
+                sliced.slice,
+                &sliced,
+                None,
+                &mut *manager,
+            )
+            .unwrap_or_default();
+        }
+        string_builder.clamp();
+
+        Ok(())
+    }
+
     fn preprocess_update_requests(
         old: &mut Lockfile,
         manager: &mut PackageManager,

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -23,6 +23,13 @@ declare_scope!(OverrideMap, visible);
 pub struct OverrideMap {
     // `ArrayHashMap` defaults to identity hashing for integer keys.
     pub(crate) map: ArrayHashMap<PackageNameHash, Dependency>,
+    /// Tracks which `map` entries were created from `"$pkg"`-style
+    /// self-references so `bun update` can refresh them when the
+    /// referenced root dep bumps without disturbing user-authored literal
+    /// overrides. Key = override entry's name hash (same as `map` key),
+    /// value = name hash of the referenced root dep (`pkg` in `"$pkg"`).
+    /// Not serialized — re-derived from package.json on every parse.
+    pub(crate) self_referential: ArrayHashMap<PackageNameHash, PackageNameHash>,
 }
 
 impl OverrideMap {
@@ -91,6 +98,17 @@ impl OverrideMap {
         for (k, v) in self.map.keys().iter().zip(self.map.values()) {
             new.map
                 .put_assume_capacity(*k, v.clone_in(pm, old_string_bytes, new_builder)?);
+        }
+
+        new.self_referential
+            .ensure_total_capacity(self.self_referential.count())?;
+        for (k, v) in self
+            .self_referential
+            .keys()
+            .iter()
+            .zip(self.self_referential.values())
+        {
+            new.self_referential.put_assume_capacity(*k, *v);
         }
 
         Ok(new)
@@ -262,7 +280,7 @@ impl OverrideMap {
                 return Ok(());
             }
 
-            if let Some(version) = parse_override_value(
+            if let Some(parsed) = parse_override_value(
                 "override",
                 lockfile_dependencies,
                 pm,
@@ -274,7 +292,11 @@ impl OverrideMap {
                 version_str,
                 builder,
             )? {
-                self.map.put_assume_capacity(name_hash, version);
+                if let Some(ref_name_hash) = parsed.ref_name_hash {
+                    self.self_referential
+                        .put(name_hash, ref_name_hash)?;
+                }
+                self.map.put_assume_capacity(name_hash, parsed.dep);
             }
             Ok(())
         })
@@ -364,7 +386,7 @@ impl OverrideMap {
                 return Ok(());
             }
 
-            if let Some(version) = parse_override_value(
+            if let Some(parsed) = parse_override_value(
                 "resolution",
                 lockfile_dependencies,
                 pm,
@@ -377,11 +399,25 @@ impl OverrideMap {
                 builder,
             )? {
                 let name_hash = SemverBuilder::string_hash(k);
-                self.map.put_assume_capacity(name_hash, version);
+                if let Some(ref_name_hash) = parsed.ref_name_hash {
+                    self.self_referential
+                        .put(name_hash, ref_name_hash)?;
+                }
+                self.map.put_assume_capacity(name_hash, parsed.dep);
             }
             Ok(())
         })
     }
+}
+
+/// Returned by [`parse_override_value`]: the cloned/parsed dependency plus,
+/// for `"$pkg"`-style values, the referenced root dep's `name_hash`. Callers
+/// record the latter in [`OverrideMap::self_referential`] so a later
+/// `bun update` can refresh just these entries without touching user-authored
+/// literal overrides. See issue #31748.
+pub struct ParsedOverride {
+    pub dep: Dependency,
+    pub ref_name_hash: Option<PackageNameHash>,
 }
 
 // `field` is only used in warning-message
@@ -400,7 +436,7 @@ pub(crate) fn parse_override_value(
     key: &[u8],
     value: &[u8],
     builder: &mut StringBuilder,
-) -> Result<Option<Dependency>, Error> {
+) -> Result<Option<ParsedOverride>, Error> {
     if value.is_empty() {
         log.add_warning_fmt(Some(source), loc, format_args!("Missing {} value", field));
         return Ok(None);
@@ -420,7 +456,10 @@ pub(crate) fn parse_override_value(
                 .name
                 .eql(ref_name_str, builder.string_bytes.as_slice(), ref_name)
             {
-                return Ok(Some(dep.clone()));
+                return Ok(Some(ParsedOverride {
+                    dep: dep.clone(),
+                    ref_name_hash: Some(dep.name_hash),
+                }));
             }
         }
         log.add_warning_fmt(
@@ -465,10 +504,13 @@ pub(crate) fn parse_override_value(
         }
     };
 
-    Ok(Some(Dependency {
-        name,
-        name_hash,
-        version,
-        behavior: Behavior::default(),
+    Ok(Some(ParsedOverride {
+        dep: Dependency {
+            name,
+            name_hash,
+            version,
+            behavior: Behavior::default(),
+        },
+        ref_name_hash: None,
     }))
 }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -4952,6 +4952,227 @@ test("name from manifest is scoped and url encoded", async () => {
 });
 
 describe("update", () => {
+  // Regression test for https://github.com/oven-sh/bun/issues/31748
+  // `bun update` (no args) used to leave the lockfile's root-workspace
+  // dependency snapshot out of sync with the package.json caret ranges it
+  // itself just wrote, so the very next `bun install --frozen-lockfile`
+  // failed. The trigger is a self-referencing override (`"$pkg"`) on a
+  // package that's also a transitive of another root dep.
+  test("no-args leaves lockfile in sync with package.json (regression #31748)", async () => {
+    // The bug is at the in-memory `Dependency.version.literal` level and
+    // affects both lockfile formats. We force text via `--save-text-lockfile`
+    // only so the second regression test below can grep the lockfile text
+    // (suite default is binary).
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "1.0.0",
+          "one-range-dep": "1.0.0",
+        },
+        overrides: {
+          "no-deps": "$no-deps",
+        },
+      }),
+    );
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+    expect(await exists(join(packageDir, "bun.lock"))).toBe(true);
+
+    // Loosen the no-deps range so `bun update` has room to bump it.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "^1.0.0",
+          "one-range-dep": "1.0.0",
+        },
+        overrides: {
+          "no-deps": "$no-deps",
+        },
+      }),
+    );
+
+    await runBunUpdate(env, packageDir);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    expect(await file(packageJson).json()).toEqual({
+      name: "foo",
+      dependencies: {
+        "no-deps": "^1.1.0",
+        "one-range-dep": "1.0.0",
+      },
+      overrides: {
+        "no-deps": "$no-deps",
+      },
+    });
+
+    // The fix: `bun install --frozen-lockfile` immediately after `bun update`
+    // must succeed. Pre-fix this errored: "lockfile had changes, but lockfile
+    // is frozen". `runBunInstall` asserts no "error:" in stderr and exit 0.
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
+  });
+
+  // Companion to the regression test above: a user-authored LITERAL override
+  // (not a "$pkg" reference) on one root dep must NOT be silently rewritten
+  // by `bun update` of a different root dep. An earlier draft of the #31748
+  // fix blindly cloned the root dep into every matching override entry; this
+  // test guards against that.
+  test("no-args preserves literal override that differs from root literal (regression #31748)", async () => {
+    // The literal override is on the SAME dep being bumped, with a literal
+    // that differs from the root dep's literal:
+    //
+    //   deps.no-deps        = "^1.0.0"     → root lockfile literal "^1.0.0"
+    //   overrides.no-deps   = "^1.0.1"     → override lockfile literal "^1.0.1"
+    //
+    // After `bun update`, root no-deps bumps to "^1.1.0". A naive override
+    // propagation that copies root.version into every matching override
+    // would clobber the override literal to "^1.1.0", diverging from
+    // package.json's "^1.0.1" and failing the final --frozen-lockfile check.
+    // The fix's "match pre-update root literal" heuristic skips this case.
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "^1.0.0",
+        },
+        overrides: {
+          "no-deps": "^1.0.1",
+        },
+      }),
+    );
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+    expect(await exists(join(packageDir, "bun.lock"))).toBe(true);
+
+    await runBunUpdate(env, packageDir);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    // The literal override stays exactly as the user wrote it (would have been
+    // clobbered to "^1.1.0" by the naive draft of the fix).
+    expect(await file(packageJson).json()).toEqual({
+      name: "foo",
+      dependencies: {
+        "no-deps": "^1.1.0",
+      },
+      overrides: {
+        "no-deps": "^1.0.1",
+      },
+    });
+
+    // Lockfile's overrides section must also keep the user's literal range.
+    // Pre-fix naive propagation clobbered this to root's "^1.1.0", which is
+    // why we assert directly rather than relying on `--frozen-lockfile` alone.
+    const lockfileText = await file(join(packageDir, "bun.lock")).text();
+    const overridesMatch = lockfileText.match(/"overrides":\s*\{[^}]*"no-deps":\s*"([^"]+)"/);
+    expect(overridesMatch?.[1]).toBe("^1.0.1");
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
+  });
+
+  // Sharper variant: deps and overrides use the EXACT SAME literal string
+  // (`^1.0.0` in both). The previous heuristic ("override literal matches
+  // pre-update root literal → treat as $-ref") misfired here and tracked the
+  // root after `bun update`. With the explicit `OverrideMap.self_referential`
+  // marker, a literal override is never confused with a `$`-ref.
+  test("no-args preserves literal override that coincides with root literal (regression #31748)", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          "no-deps": "^1.0.0",
+        },
+        overrides: {
+          // Literal coincides with the deps literal — only the explicit
+          // `self_referential` marker can distinguish this from `"$no-deps"`.
+          "no-deps": "^1.0.0",
+        },
+      }),
+    );
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    await runBunUpdate(env, packageDir);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    // deps bumps to ^1.1.0; override stays at ^1.0.0 because it was a literal.
+    expect(await file(packageJson).json()).toEqual({
+      name: "foo",
+      dependencies: {
+        "no-deps": "^1.1.0",
+      },
+      overrides: {
+        "no-deps": "^1.0.0",
+      },
+    });
+
+    const lockfileText = await file(join(packageDir, "bun.lock")).text();
+    const overridesMatch = lockfileText.match(/"overrides":\s*\{[^}]*"no-deps":\s*"([^"]+)"/);
+    expect(overridesMatch?.[1]).toBe("^1.0.0");
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
+  });
+
+  // Guards a regression introduced by the e4a94e7c refactor that dropped the
+  // alias filter from the root-dep mutation pass. The refresh path was then
+  // willing to rewrite an aliased $-ref override (`"a1": "$a1"` where
+  // `"a1": "npm:no-deps@^1"`), but `which_version_is_pinned` on the cloned
+  // alias literal `"npm:no-deps@^1.0.0"` returns `Patch` (leading `n` hits
+  // the default branch), so the override would have been overwritten with a
+  // bare `"1.1.0"` — stripping the `npm:foo@` prefix and the alias semantics.
+  // Same regression existed in the closed #31754 PR.
+  test("no-args leaves aliased \\$-ref overrides untouched (regression #31748)", async () => {
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        dependencies: {
+          // npm-alias spec on root: "a1" points at no-deps.
+          "a1": "npm:no-deps@^1.0.0",
+        },
+        overrides: {
+          // $-ref override on the alias. Pre-fix this would get rewritten
+          // to "1.1.0" (or similar) after bun update.
+          "a1": "$a1",
+        },
+      }),
+    );
+
+    await runBunInstall(env, packageDir, { saveTextLockfile: true });
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+    expect(await exists(join(packageDir, "bun.lock"))).toBe(true);
+
+    await runBunUpdate(env, packageDir);
+    assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+
+    // package.json should bump the alias spec to the new version.
+    expect(await file(packageJson).json()).toEqual({
+      name: "foo",
+      dependencies: {
+        "a1": "npm:no-deps@^1.1.0",
+      },
+      overrides: {
+        "a1": "$a1",
+      },
+    });
+
+    // The override entry in bun.lock must remain a full alias spec — it is
+    // a clone of the root alias dep, so the literal includes the `npm:foo@`
+    // prefix. Bare `"1.1.0"` here would mean the refresh stripped the alias.
+    const lockfileText = await file(join(packageDir, "bun.lock")).text();
+    const overridesMatch = lockfileText.match(/"overrides":\s*\{[^}]*"a1":\s*"([^"]+)"/);
+    expect(overridesMatch?.[1]).toMatch(/^npm:no-deps@/);
+
+    await runBunInstall(env, packageDir, { frozenLockfile: true, savesLockfile: false });
+  });
+
   test("duplicate peer dependency (one package is invalid_package_id)", async () => {
     await write(
       packageJson,


### PR DESCRIPTION
Fixes #31748 (auto-closed as a duplicate of the still-open #13388).

`"overrides": { "pkg": "$pkg" }` is stored in the lockfile as a clone of the root `pkg` dep, captured when `package.json` is parsed. `bun update` with no args resolves a newer version and rewrites `package.json`'s range *after* resolution, so the cloned override keeps the pre-bump literal. The saved lockfile no longer matches the `package.json` written next to it, and the very next `bun install --frozen-lockfile` fails with `lockfile had changes, but lockfile is frozen`.

The fix is `Lockfile::refresh_self_referential_overrides` in `src/install/lockfile.rs`, called from `install_with_manager` once `clean_with_logger` has produced the lockfile that will be saved, and only for `Subcommand::Update`. It rewrites the literal of each `$`-ref override from the referenced root dep's resolved npm version, preserving the existing pin style (`^`/`~`/exact).

To know which entries are `$`-refs, `OverrideMap` now records them explicitly in `self_referential` as they are parsed (`parse_override_value` returns the referenced dep's name hash alongside the cloned dep). An earlier draft inferred this by comparing the override literal against the pre-update root literal, which misidentifies a user-authored literal override that happens to spell the same range. The map is not serialized — it is re-derived from `package.json` on every parse.

`npm:foo@…` aliases and `catalog:` references are skipped: their literals are not `1.2.3`-shaped, so `which_version_is_pinned` returns `Patch` on the leading `n`/`c` and the rewrite would strip the prefix. Those keep the existing behavior.

Four tests in `test/cli/install/bun-install-registry.test.ts`. The first reproduces the bug and fails on unpatched main with the exact `lockfile had changes, but lockfile is frozen` error; the other three are negative-contract guards that fail only if the fix over-reaches — a literal override that differs from the root literal, a literal override that coincides with it, and a `$`-ref on an npm alias. Full file: 233 pass, 5 todo, 0 fail.
