### PR TITLE
install: re-sync self-referencing overrides after `bun update`

### DIFF
--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -632,6 +632,25 @@ pub fn install_with_manager(
         root = *manager.lockfile.packages.get(0);
     }
 
+    // `bun update` bumps a direct dependency's resolved version and rewrites
+    // package.json's range *after* resolution. Re-sync any `$name`
+    // self-referencing override with the direct dependency it mirrors so the
+    // saved lockfile stays consistent with the package.json it is written next
+    // to (otherwise the next `bun install --frozen-lockfile` reports the
+    // override as changed). No-op unless self-referencing overrides exist and
+    // the referenced dependency is one `bun update` is bumping.
+    if manager.subcommand == Subcommand::Update && manager.lockfile.packages.len() > 0 {
+        let mgr: *mut PackageManager = manager;
+        // SAFETY: `mgr` is the sole provenance root; `refresh_self_referential_overrides`
+        // reborrows `(*mgr).lockfile` and reads disjoint `manager` fields through the
+        // `&mut *mgr` arg. No other live `&mut` to `*mgr` exists across the call.
+        unsafe {
+            (*mgr)
+                .lockfile
+                .refresh_self_referential_overrides(&mut *mgr)?;
+        }
+    }
+
     if manager.lockfile.packages.len() > 0 {
         for request in &manager.update_requests {
             // prevent redundant errors

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -891,6 +891,141 @@ impl Lockfile {
         Ok(())
     }
 
+    /// Re-sync `$name` self-referencing overrides with the direct dependency
+    /// they mirror.
+    ///
+    /// `"overrides": { "vite": "$vite" }` stores a clone of the `vite` direct
+    /// dependency taken when package.json was parsed. `bun update` resolves a
+    /// newer version and rewrites package.json's range (e.g. `^7.3.3` ->
+    /// `^7.3.5`) *after* resolution, so the stored override keeps the pre-bump
+    /// range and the saved lockfile no longer matches the package.json it was
+    /// written next to — the next `bun install --frozen-lockfile` then reports
+    /// the override as changed.
+    ///
+    /// This rewrites each self-referencing override (whose referenced
+    /// dependency `bun update` is bumping) to that dependency's resolved
+    /// version, preserving the override's pin style (`^`/`~`/exact) so the
+    /// result matches the range `PackageJSONEditor` writes into package.json
+    /// for the same dependency.
+    pub fn refresh_self_referential_overrides(
+        &mut self,
+        manager: &mut PackageManager,
+    ) -> Result<(), AllocError> {
+        if self.overrides.self_referential.count() == 0 {
+            return Ok(());
+        }
+
+        let workspace_package_id = manager
+            .root_package_id
+            .get(self, manager.workspace_name_hash);
+
+        let root_deps_list = self.packages.items_dependencies()[workspace_package_id as usize];
+        let root_resolutions_list =
+            self.packages.items_resolutions()[workspace_package_id as usize];
+
+        // Collect the (override key hash -> resolved version literal) rewrites
+        // first so the read of the direct dependency's resolution doesn't
+        // overlap the `StringBuilder`'s mutable borrow of `buffers.string_bytes`.
+        let mut rewrites: Vec<(PackageNameHash, Vec<u8>)> = Vec::new();
+        {
+            let string_buf = self.buffers.string_bytes.as_slice();
+            let root_deps = root_deps_list.get(self.buffers.dependencies.as_slice());
+            let root_resolution_ids = root_resolutions_list.get(self.buffers.resolutions.as_slice());
+            let resolutions = self.packages.items_resolution();
+            let packages_len = self.packages.len();
+
+            debug_assert_eq!(root_deps.len(), root_resolution_ids.len());
+            for (&override_key_hash, &ref_name_hash) in self
+                .overrides
+                .self_referential
+                .keys()
+                .iter()
+                .zip(self.overrides.self_referential.values())
+            {
+                let Some(override_dep) = self.overrides.map.get(&override_key_hash) else {
+                    continue;
+                };
+
+                // Find the referenced direct dependency's resolved npm version.
+                let mut resolved: Option<&Semver::Version> = None;
+                for (dep, &package_id) in root_deps.iter().zip(root_resolution_ids) {
+                    if dep.name_hash != ref_name_hash {
+                        continue;
+                    }
+                    // Only re-sync when this direct dependency's range is being
+                    // rewritten in package.json (i.e. it is one of the packages
+                    // `bun update` is bumping). A self-referencing override
+                    // mirrors the dependency's range literal, not its resolved
+                    // version, so for a dependency whose range is left untouched
+                    // the override already matches package.json and must not be
+                    // rewritten to its resolved version.
+                    if !manager
+                        .updating_packages
+                        .contains_key(dep.name.slice(string_buf))
+                    {
+                        break;
+                    }
+                    if package_id == invalid_package_id || package_id as usize >= packages_len {
+                        break;
+                    }
+                    let resolution = &resolutions[package_id as usize];
+                    if resolution.tag == ResolutionTag::Npm {
+                        resolved = Some(&resolution.npm().version);
+                    }
+                    break;
+                }
+                let Some(resolved_version) = resolved else {
+                    continue;
+                };
+
+                // Preserve the override's existing pin style (`^`/`~`/exact).
+                let existing_literal = override_dep.version.literal.slice(string_buf);
+                let pinned = Semver::Version::which_version_is_pinned(existing_literal);
+                let version_fmt = resolved_version.fmt(string_buf);
+                let mut new_literal: Vec<u8> = Vec::new();
+                let _ = match pinned {
+                    Semver::PinnedVersion::Patch => write!(&mut new_literal, "{}", version_fmt),
+                    Semver::PinnedVersion::Minor => write!(&mut new_literal, "~{}", version_fmt),
+                    Semver::PinnedVersion::Major => write!(&mut new_literal, "^{}", version_fmt),
+                };
+
+                if new_literal.as_slice() != existing_literal {
+                    rewrites.push((override_key_hash, new_literal));
+                }
+            }
+        }
+
+        if rewrites.is_empty() {
+            return Ok(());
+        }
+
+        let mut string_builder = string_builder!(self);
+        for (_, literal) in &rewrites {
+            string_builder.count(literal);
+        }
+        string_builder.allocate()?;
+
+        for (override_key_hash, literal) in &rewrites {
+            let Some(override_dep) = self.overrides.map.get_mut(override_key_hash) else {
+                continue;
+            };
+            let external = string_builder.append::<ExternalString>(literal);
+            let sliced = external.value.sliced(string_builder.string_bytes.as_slice());
+            override_dep.version = dependency::parse(
+                override_dep.name,
+                override_dep.name_hash,
+                sliced.slice,
+                &sliced,
+                None,
+                &mut *manager,
+            )
+            .unwrap_or_default();
+        }
+        string_builder.clamp();
+
+        Ok(())
+    }
+
     pub fn clean(
         &mut self,
         manager: &mut PackageManager,

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -930,7 +930,8 @@ impl Lockfile {
         {
             let string_buf = self.buffers.string_bytes.as_slice();
             let root_deps = root_deps_list.get(self.buffers.dependencies.as_slice());
-            let root_resolution_ids = root_resolutions_list.get(self.buffers.resolutions.as_slice());
+            let root_resolution_ids =
+                root_resolutions_list.get(self.buffers.resolutions.as_slice());
             let resolutions = self.packages.items_resolution();
             let packages_len = self.packages.len();
 
@@ -1010,7 +1011,9 @@ impl Lockfile {
                 continue;
             };
             let external = string_builder.append::<ExternalString>(literal);
-            let sliced = external.value.sliced(string_builder.string_bytes.as_slice());
+            let sliced = external
+                .value
+                .sliced(string_builder.string_bytes.as_slice());
             override_dep.version = dependency::parse(
                 override_dep.name,
                 override_dep.name_hash,

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -25,6 +25,16 @@ pub struct OverrideMap {
     // Zig used ArrayIdentityContext.U64 (identity hash on u64 key); the Rust
     // `ArrayHashMap` defaults to identity hashing for integer keys.
     pub map: ArrayHashMap<PackageNameHash, Dependency>,
+
+    /// Overrides defined as a `$name` reference to a direct dependency's spec
+    /// (`"overrides": { "vite": "$vite" }`). Maps the override key's name hash
+    /// to the referenced direct dependency's name hash so the stored value can
+    /// be re-synced with the direct dependency after `bun update` bumps it —
+    /// see `Lockfile::refresh_self_referential_overrides`. A `$name` override
+    /// stores a *clone* of the direct dependency taken at parse time, which
+    /// otherwise goes stale the moment the direct dependency's resolved version
+    /// changes.
+    pub self_referential: ArrayHashMap<PackageNameHash, PackageNameHash>,
 }
 
 impl OverrideMap {
@@ -78,6 +88,20 @@ impl OverrideMap {
             // PERF(port): was ensureTotalCapacity + putAssumeCapacity — profile if hot
             new.map
                 .put_assume_capacity(*k, v.clone_in(pm, old_string_bytes, new_builder)?);
+        }
+
+        // `self_referential` keys are plain name hashes (no string-pool data), so a
+        // straight copy suffices — the referenced direct dependency is re-resolved
+        // against the new lockfile's buffers in `refresh_self_referential`.
+        new.self_referential
+            .ensure_total_capacity(self.self_referential.count())?;
+        for (k, v) in self
+            .self_referential
+            .keys()
+            .iter()
+            .zip(self.self_referential.values())
+        {
+            new.self_referential.put_assume_capacity(*k, *v);
         }
 
         Ok(new)
@@ -291,7 +315,7 @@ impl OverrideMap {
                 continue;
             }
 
-            if let Some(version) = parse_override_value(
+            if let Some(parsed) = parse_override_value(
                 "override",
                 lockfile_dependencies,
                 pm,
@@ -303,7 +327,10 @@ impl OverrideMap {
                 version_str,
                 builder,
             )? {
-                self.map.put_assume_capacity(name_hash, version);
+                self.map.put_assume_capacity(name_hash, parsed.dep);
+                if let Some(ref_name_hash) = parsed.self_referential_name_hash {
+                    self.self_referential.put(name_hash, ref_name_hash)?;
+                }
             }
         }
         Ok(())
@@ -399,7 +426,7 @@ impl OverrideMap {
                 continue;
             }
 
-            if let Some(version) = parse_override_value(
+            if let Some(parsed) = parse_override_value(
                 "resolution",
                 lockfile_dependencies,
                 pm,
@@ -412,11 +439,24 @@ impl OverrideMap {
                 builder,
             )? {
                 let name_hash = SemverBuilder::string_hash(k);
-                self.map.put_assume_capacity(name_hash, version);
+                self.map.put_assume_capacity(name_hash, parsed.dep);
+                if let Some(ref_name_hash) = parsed.self_referential_name_hash {
+                    self.self_referential.put(name_hash, ref_name_hash)?;
+                }
             }
         }
         Ok(())
     }
+}
+
+/// Result of resolving a single `overrides`/`resolutions` entry's value.
+pub struct ParsedOverride {
+    pub dep: Dependency,
+    /// For a `$name` self-reference, the referenced direct dependency's name
+    /// hash; `None` for a literal spec. Lets
+    /// `Lockfile::refresh_self_referential_overrides` re-sync the override
+    /// after the direct dependency is bumped.
+    pub self_referential_name_hash: Option<PackageNameHash>,
 }
 
 // PERF(port): was comptime monomorphization (`comptime field: []const u8`).
@@ -436,7 +476,7 @@ pub fn parse_override_value(
     key: &[u8],
     value: &[u8],
     builder: &mut StringBuilder,
-) -> Result<Option<Dependency>, Error> {
+) -> Result<Option<ParsedOverride>, Error> {
     if value.is_empty() {
         log.add_warning_fmt(Some(source), loc, format_args!("Missing {} value", field));
         return Ok(None);
@@ -456,7 +496,10 @@ pub fn parse_override_value(
                 .name
                 .eql(ref_name_str, builder.string_bytes.as_slice(), ref_name)
             {
-                return Ok(Some(dep.clone()));
+                return Ok(Some(ParsedOverride {
+                    dep: dep.clone(),
+                    self_referential_name_hash: Some(dep.name_hash),
+                }));
             }
         }
         log.add_warning_fmt(
@@ -501,11 +544,14 @@ pub fn parse_override_value(
         }
     };
 
-    Ok(Some(Dependency {
-        name,
-        name_hash,
-        version,
-        behavior: Behavior::default(),
+    Ok(Some(ParsedOverride {
+        dep: Dependency {
+            name,
+            name_hash,
+            version,
+            behavior: Behavior::default(),
+        },
+        self_referential_name_hash: None,
     }))
 }
 

--- a/test/cli/install/overrides.test.ts
+++ b/test/cli/install/overrides.test.ts
@@ -245,3 +245,67 @@ test("overrides do not apply to workspaces", async () => {
   expect(await exited).toBe(0);
   expect(await stderr.text()).not.toContain("Saved lockfile");
 });
+
+// https://github.com/oven-sh/bun/issues/31748
+// `bun update` bumps a direct dependency's resolved version and rewrites its
+// package.json range *after* resolution, but used to leave a `$name`
+// self-referencing override pointing at the pre-bump range. The saved bun.lock
+// then no longer matched the package.json it was written next to, so the
+// immediate next `bun install --frozen-lockfile` failed. `is-odd@0.1.0` has a
+// transitive `is-number: ^1.1.0`, so the stale `$is-number` override changes
+// how that transitive resolves — mirroring the issue's nuxt -> vite-node ->
+// vite shape that makes the frozen check fail.
+test("bun update re-syncs a self-referencing override so frozen install passes", async () => {
+  const tmp = tmpdirSync();
+  const pkgPath = join(tmp, "package.json");
+
+  writeFileSync(
+    pkgPath,
+    JSON.stringify({
+      name: "self-ref-override",
+      dependencies: { "is-number": "1.1.0", "is-odd": "0.1.0" },
+      overrides: { "is-number": "$is-number" },
+    }),
+  );
+  install(tmp, ["install", "--save-text-lockfile"]);
+
+  // Widen the range so `bun update` has a newer version to move to within the
+  // same major (1.1.0 -> 1.1.2). The lockfile is still consistent here.
+  writeFileSync(
+    pkgPath,
+    JSON.stringify({
+      name: "self-ref-override",
+      dependencies: { "is-number": "^1.1.0", "is-odd": "0.1.0" },
+      overrides: { "is-number": "$is-number" },
+    }),
+  );
+  install(tmp, ["install", "--frozen-lockfile"]);
+
+  const update = Bun.spawnSync({
+    cmd: [bunExe(), "update", "--linker=hoisted"],
+    cwd: tmp,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  expect(update.exitCode).toBe(0);
+
+  // The bumped package.json range and the override must agree, so the next
+  // install parses the same `$is-number` value the lockfile was saved with.
+  const pkg = JSON.parse(readFileSync(pkgPath).toString());
+  expect(pkg.dependencies["is-number"]).toBe("^1.1.2");
+  expect(pkg.overrides["is-number"]).toBe("$is-number");
+  const lockfile = readFileSync(join(tmp, "bun.lock")).toString();
+  expect(lockfile).toContain(`"overrides": {\n    "is-number": "^1.1.2",\n  }`);
+
+  // The regression: this frozen install must not report that the lockfile changed.
+  const frozen = Bun.spawnSync({
+    cmd: [bunExe(), "install", "--frozen-lockfile", "--linker=hoisted"],
+    cwd: tmp,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  expect(frozen.stderr.toString()).not.toContain("lockfile had changes, but lockfile is frozen");
+  expect(frozen.exitCode).toBe(0);
+});


### PR DESCRIPTION
Fixes #31748

## What

`bun update` writes a `bun.lock` that fails the very next `bun install --frozen-lockfile` when the project has a `$name` self-referencing override (`"overrides": { "vite": "$vite" }`) over a dependency that has a transitive on the overridden package.

This breaks weekly "update dependencies" CI bots: they run `bun update`, commit the result, and CI immediately red-X's on `bun install --frozen-lockfile`.

## Reproduce

```sh
mkdir repro && cd repro
cat > package.json <<'PKG'
{
  "name": "repro",
  "dependencies": { "is-number": "1.1.0", "is-odd": "0.1.0" },
  "overrides": { "is-number": "$is-number" }
}
PKG
bun install --save-text-lockfile            # locks is-number@1.1.0, override "1.1.0"
# widen the direct range so update has somewhere to go
# (is-odd@0.1.0 has a transitive is-number: ^1.1.0)
#   -> "is-number": "^1.1.0"
bun install --frozen-lockfile               # passes — consistent

bun update                                  # is-number 1.1.0 -> 1.1.2, "Saved lockfile"
bun install --frozen-lockfile               # ❌ "lockfile had changes, but lockfile is frozen"
```

(The issue reported this with `nuxt -> vite-node -> vite`; `is-odd -> is-number` is the same shape with immutable packages.)

## Cause

A `$name` override stores a *clone* of the direct dependency's `Dependency` captured when `package.json` is parsed. `bun update` resolves a newer version and rewrites `package.json`'s range (`^1.1.0` -> `^1.1.2`) **after** resolution, but nothing updates the stored override, which keeps the pre-bump `^1.1.0`.

The saved `bun.lock` then no longer matches the `package.json` it was written next to. On the next install, `Diff::generate` re-parses `$is-number` against the bumped `package.json` (-> `^1.1.2`), sees it differ from the lockfile's `^1.1.0`, and — because the override drives how the transitive `is-odd -> is-number` resolves — the resulting dependency tree differs, so the frozen check fails. A plain `bun install` afterwards reconciles it, which is the existing workaround.

## Fix

- `OverrideMap` now tracks which entries came from a `$name` self-reference (override key name hash -> referenced dependency name hash), carried through the lockfile `clean` clone.
- After `bun update` bumps a direct dependency, `Lockfile::refresh_self_referential_overrides` rewrites each self-referencing override whose referenced dependency is being updated to that dependency's **resolved** version, preserving the override's pin style (`^`/`~`/exact) so the value matches exactly what `PackageJSONEditor` writes into `package.json`.
- Only overrides whose referenced dependency is actually being updated are touched, so literal overrides (`"vite": "7.3.2"`) and dependencies `bun update` leaves alone are never rewritten.

## Verification

New regression test in `test/cli/install/overrides.test.ts`:

- without the fix: the saved lockfile keeps `"overrides": { "is-number": "^1.1.0" }` and the test fails (this is the bug).
- with the fix: the override becomes `^1.1.2`, matching `package.json`, and `bun install --frozen-lockfile` passes.

Also verified manually that `bun update` (no-args and with-args), `bun add`, literal (non-`$`) overrides, and projects without self-referencing overrides are unchanged, and that `test/cli/install/overrides.test.ts` and `test/cli/install/bun-update.test.ts` pass.
