### PR TITLE
bundler: tree-shake unused objects with inlined-enum computed keys

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5972,13 +5972,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             js_ast::ExprData::EObject(ex) => {
                 for property in ex.properties.slice() {
-                    // The key must still be evaluated if it's computed or a spread
+                    // The key must still be evaluated if it's computed or a spread.
+                    // A computed key is side-effect free only if it's a primitive
+                    // literal; unwrap inlined enum members (e.g. `[A.FOO]`) first so
+                    // they're treated like the literal they inline to.
                     if property.kind == js_ast::g::PropertyKind::Spread
                         || (property.flags.contains(Flags::Property::IsComputed)
                             && !property
                                 .key
-                                .as_ref()
-                                .map(Expr::is_primitive_literal)
+                                .map(|key| key.unwrap_inlined().is_primitive_literal())
                                 .unwrap_or(false))
                         || property.flags.contains(Flags::Property::IsSpread)
                     {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1876,6 +1876,77 @@ describe("bundler", () => {
       `,
     },
   });
+  // https://github.com/oven-sh/bun/issues/31755
+  // An object literal whose computed keys are inlined enum members (e.g.
+  // `{ [A.FOO]: ... }`) has no side effects, so when the binding is unused it
+  // must be tree-shaken along with everything it references. The enum-member
+  // key is wrapped in an inlined-enum node; the side-effect check must look
+  // through that wrapper just like it does for a bare numeric-literal key.
+  itBundled("edgecase/TsEnumKeyedObjectTreeShaking#31755", {
+    files: {
+      "/entry.ts": `
+        import { A } from './lib';
+        console.log(JSON.stringify(A));
+      `,
+      "/lib.ts": `
+        export enum A { FOO, BAR }
+        export function fooFunctionREMOVE() {}
+        export const fooArrowFunctionREMOVE = () => {};
+        export const unusedObjectREMOVE = { [A.FOO]: fooFunctionREMOVE, [A.BAR]: fooArrowFunctionREMOVE };
+      `,
+    },
+    dce: true,
+    dceKeepMarkerCount: false,
+    assertNotPresent: {
+      "/out.js": ["fooFunctionREMOVE", "fooArrowFunctionREMOVE", "unusedObjectREMOVE"],
+    },
+    run: {
+      stdout: `{"0":"FOO","1":"BAR","FOO":0,"BAR":1}`,
+    },
+  });
+  // Same as above but with primitive-literal values, isolating the computed
+  // enum-member key as the thing that previously blocked removal.
+  itBundled("edgecase/TsEnumKeyedLiteralObjectTreeShaking#31755", {
+    files: {
+      "/entry.ts": `
+        import { A } from './lib';
+        console.log(JSON.stringify(A));
+      `,
+      "/lib.ts": `
+        export enum A { FOO, BAR }
+        export const unusedObjectREMOVE = { [A.FOO]: 1, [A.BAR]: 2 };
+      `,
+    },
+    dce: true,
+    dceKeepMarkerCount: false,
+    assertNotPresent: {
+      "/out.js": ["unusedObjectREMOVE"],
+    },
+    run: {
+      stdout: `{"0":"FOO","1":"BAR","FOO":0,"BAR":1}`,
+    },
+  });
+  // Guard against over-eager removal: a computed key that actually has side
+  // effects must keep the object alive even when the binding is unused.
+  itBundled("edgecase/ComputedKeyWithSideEffectsNotTreeShaken#31755", {
+    files: {
+      "/entry.ts": `
+        import './lib';
+        console.log('ok');
+      `,
+      "/lib.ts": `
+        export function sideEffectKept() { globalThis.hit = true; return 'k'; }
+        const keptObject = { [sideEffectKept()]: 1 };
+      `,
+    },
+    onAfterBundle(api) {
+      // The side-effecting key call must survive tree-shaking.
+      api.expectFile("/out.js").toContain("sideEffectKept");
+    },
+    run: {
+      stdout: `ok`,
+    },
+  });
   itBundled("edgecase/ImportMetaMain", {
     files: {
       "/entry.ts": /* js */ `

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -1927,16 +1927,18 @@ describe("bundler", () => {
     },
   });
   // Guard against over-eager removal: a computed key that actually has side
-  // effects must keep the object alive even when the binding is unused.
+  // effects must keep the object alive even when the binding is unused. The
+  // side effect is observed at runtime (the flag it sets is printed) so the
+  // test fails if the computed-key call is tree-shaken away.
   itBundled("edgecase/ComputedKeyWithSideEffectsNotTreeShaken#31755", {
     files: {
       "/entry.ts": `
         import './lib';
-        console.log('ok');
+        console.log(globalThis.hit === true ? 'side-effect-ran' : 'side-effect-missing');
       `,
       "/lib.ts": `
-        export function sideEffectKept() { globalThis.hit = true; return 'k'; }
-        const keptObject = { [sideEffectKept()]: 1 };
+        function sideEffectKept() { globalThis.hit = true; return 'k'; }
+        const unusedObject = { [sideEffectKept()]: 1 };
       `,
     },
     onAfterBundle(api) {
@@ -1944,7 +1946,7 @@ describe("bundler", () => {
       api.expectFile("/out.js").toContain("sideEffectKept");
     },
     run: {
-      stdout: `ok`,
+      stdout: `side-effect-ran`,
     },
   });
   itBundled("edgecase/ImportMetaMain", {


### PR DESCRIPTION
### What does this PR do?

Fixes #31755 — the bundler now dead-code-eliminates an unused object literal whose computed keys are inlined enum members, along with everything that object references.

### Reproduction

```ts
// lib.ts
export enum A { FOO, BAR }
export function fooFunction() {}
export const fooArrowFunction = () => {};
export const x = { [A.FOO]: fooFunction, [A.BAR]: fooArrowFunction };
```
```ts
// main.ts
import { A } from "./lib";
console.log(A);
```

Before (`x` and the functions it references are retained even though `x` is unused):

```console
$ bun build --minify main.ts
var n;((o)=>{o[o.FOO=0]="FOO";o[o.BAR=1]="BAR"})(n||={});function t(){}var r=()=>{},c={[0]:t,[1]:r};console.log(n);
```

After (`c` and `t`/`r` are gone, matching esbuild):

```console
$ bun build --minify main.ts
var n;((o)=>{o[o.FOO=0]="FOO";o[o.BAR=1]="BAR"})(n||={});console.log(n);
```

### Root cause

When checking whether an unused expression can be removed, the `EObject` arm of `expr_can_be_removed_if_unused_without_dce_check` (`src/js_parser/p.rs`) allows a **computed** key only if it is a primitive literal:

```rust
property.key.as_ref().map(Expr::is_primitive_literal).unwrap_or(false)
```

An enum-member reference like `[A.FOO]` is inlined to its constant value but wrapped in an `EInlinedEnum` node (so the printer can emit the `/* A.FOO */` comment). `is_primitive_literal` only matches bare literal tags (`ENumber`, `EString`, …) — **not** `EInlinedEnum` — so the computed key was treated as potentially side-effecting and the whole object (and everything it referenced) was conservatively kept. A plain `const`-inlined numeric key (a bare `ENumber`) was already eliminated correctly, so the gap was specific to enum-member keys.

### Fix

Unwrap the inlined-enum wrapper before the primitive-literal check, using the existing `Expr::unwrap_inlined()` helper that the codebase already uses for this purpose (and mirroring the `EInlinedEnum` arm of the same function, which unwraps to its inner value):

```rust
property.key.map(|key| key.unwrap_inlined().is_primitive_literal()).unwrap_or(false)
```

An enum-member computed key is now treated like the numeric/string literal it inlines to. Genuinely side-effecting computed keys are unaffected: a key that is a function call or an unbound identifier is not a primitive literal after unwrapping, so the object is still retained.

### Tests

`test/bundler/bundler_edgecase.test.ts` (`itBundled`, `dce: true`):

- **`TsEnumKeyedObjectTreeShaking#31755`** — the issue's repro; asserts the unused object and the functions it references are removed while the enum still works at runtime.
- **`TsEnumKeyedLiteralObjectTreeShaking#31755`** — isolates the enum-member key (primitive-literal values) as the thing that previously blocked removal.
- **`ComputedKeyWithSideEffectsNotTreeShaken#31755`** — guard: an object with a side-effecting computed key (`{ [sideEffect()]: 1 }`) is **not** removed, so the purity check wasn't loosened.

The first two fail on the current release (code not removed) and pass with this change; the guard passes both ways. The full `bundler_edgecase`, `bundler_minify`, and `bundler_regressions` suites remain green.
