### PR TITLE
fix(types): add convenience methods to global ReadableStream interface

### DIFF
--- a/packages/bun-types/overrides.d.ts
+++ b/packages/bun-types/overrides.d.ts
@@ -34,6 +34,16 @@ declare module "stream/web" {
   }
 }
 
+// Add convenience methods to the global ReadableStream interface
+// so that stream.text(), stream.json(), stream.bytes() are available
+// without importing from "stream/web"
+interface ReadableStream<R = any> extends BunConsumerConvenienceMethods {
+  /**
+   * Consume as a Blob
+   */
+  blob(): Promise<Blob>;
+}
+
 declare module "buffer" {
   interface Blob extends BunConsumerConvenienceMethods {
     // We have to specify bytes again even though it comes from


### PR DESCRIPTION
Fixes #29401

## Problem
The `deprecated.d.ts` file marks `Bun.readableStreamToText()`, `Bun.readableStreamToBytes()`, etc. as deprecated, suggesting users should use `ReadableStream.text()`, `ReadableStream.bytes()`, etc. instead. However, these methods don't exist on the global `ReadableStream` type definition, causing TypeScript errors.

## Root Cause
In `overrides.d.ts`, the `ReadableStream` interface inside `declare module "stream/web"` correctly extends `BunConsumerConvenienceMethods` (which provides `.text()`, `.bytes()`, `.json()`). However, the global `ReadableStream` interface (defined in `globals.d.ts`) only extends `LibEmptyOrNodeReadableStream<R>` and does NOT include these convenience methods.

## Fix
Added a global `ReadableStream` interface extension in `overrides.d.ts` that includes `BunConsumerConvenienceMethods` and the `.blob()` method. This makes `stream.text()`, `stream.json()`, `stream.bytes()`, and `stream.blob()` available on all `ReadableStream` instances, matching what the deprecation messages suggest.

## Testing
```ts
declare const stream: ReadableStream;
// These should now work without TypeScript errors:
await stream.text();
await stream.json();
await stream.bytes();
await stream.blob();
```