### PR TITLE
transpiler cache: don't replay plain-run entries under bun test

### DIFF
--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -421,12 +421,25 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
-                // note that we do not include .inject_jest_globals, as we bail out of the cache entirely if this is true
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01; matches Zig `std.mem.asBytes(&bools)`.
             // `bool: NoUninit`, `u8: AnyBitPattern` → `cast_slice` is statically sound.
             hasher.update(bytemuck::cast_slice::<bool, u8>(&bools));
+
+            // `inject_jest_globals` is hashed separately (not in the bools array)
+            // so plain-run hashes stay byte-identical and existing cache entries
+            // remain valid. `bun test` sets it for every module it loads, and
+            // bare `describe`/`test`/`expect` only work because the parser
+            // injects an import from "bun:test" — so an entry transpiled by a
+            // plain `bun <file>` run (no injection) must never be replayed by
+            // the test runner, or the file silently registers zero tests.
+            // Parses where the injection actually fires still never write an
+            // entry at all (`input_hash` is cleared after injecting, see
+            // parse_entry.rs).
+            if self.inject_jest_globals {
+                hasher.update(b"jest");
+            }
 
             // Hash --feature flags. These directly affect transpiled output via
             // feature("NAME") replacement in visitExpr.zig. When empty, we add

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -421,25 +421,15 @@ pub mod Runtime {
                 self.standard_decorators,
                 self.lower_using,
                 self.repl_mode,
+                // `inject_jest_globals` is deliberately absent: parses with it
+                // set are keyed to a different cache *filename* instead (see
+                // `RuntimeTranspilerCache::get`), so plain-run and `bun test`
+                // entries coexist rather than evicting each other.
             ];
 
             // `[bool; N]` is N bytes of 0x00/0x01; matches Zig `std.mem.asBytes(&bools)`.
             // `bool: NoUninit`, `u8: AnyBitPattern` → `cast_slice` is statically sound.
             hasher.update(bytemuck::cast_slice::<bool, u8>(&bools));
-
-            // `inject_jest_globals` is hashed separately (not in the bools array)
-            // so plain-run hashes stay byte-identical and existing cache entries
-            // remain valid. `bun test` sets it for every module it loads, and
-            // bare `describe`/`test`/`expect` only work because the parser
-            // injects an import from "bun:test" — so an entry transpiled by a
-            // plain `bun <file>` run (no injection) must never be replayed by
-            // the test runner, or the file silently registers zero tests.
-            // Parses where the injection actually fires still never write an
-            // entry at all (`input_hash` is cleared after injecting, see
-            // parse_entry.rs).
-            if self.inject_jest_globals {
-                hasher.update(b"jest");
-            }
 
             // Hash --feature flags. These directly affect transpiled output via
             // feature("NAME") replacement in visitExpr.zig. When empty, we add

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -59,6 +59,11 @@ static BUN_DEBUG_RESTORE_FROM_CACHE: AtomicBool = AtomicBool::new(false);
 
 const SEED: u64 = 42;
 
+/// `input_hash` seed for parses with `Features::inject_jest_globals` set, so
+/// those entries land under a different cache *filename* than plain-run
+/// entries for the same bytes (see `get`).
+const INJECT_JEST_GLOBALS_SEED: u64 = u64::from_le_bytes(*b"bun:test");
+
 #[repr(u8)]
 #[derive(Copy, Clone, Eq, PartialEq, Default)]
 pub enum ModuleType {
@@ -965,7 +970,26 @@ impl RuntimeTranspilerCache {
             return false;
         }
 
-        let input_hash = self.input_hash.unwrap_or_else(|| hash(&source.contents));
+        // `bun test` sets `inject_jest_globals` for every module it loads, and
+        // bare `describe`/`test`/`expect` only work because the parser injects
+        // an import from "bun:test" — so an entry transpiled by a plain
+        // `bun <file>` run (no injection) must never be replayed by the test
+        // runner, or the file silently registers zero tests. Key such parses
+        // to a different cache filename via a distinct hash seed, rather than
+        // folding the flag into `features_hash`: the filename is derived from
+        // `input_hash` alone and a stored-features mismatch *deletes* the
+        // entry, so a features-level split would make alternating `bun x.js` ↔
+        // `bun test` evict and re-transpile every shared dependency on each
+        // switch, while distinct filenames let both entries coexist. Parses
+        // where the injection actually fires still never write an entry at all
+        // (`input_hash` is cleared after injecting, see parse_entry.rs).
+        let input_hash = self.input_hash.unwrap_or_else(|| {
+            if parser_options.features.inject_jest_globals {
+                Wyhash::hash(INJECT_JEST_GLOBALS_SEED, &source.contents)
+            } else {
+                hash(&source.contents)
+            }
+        });
         self.input_hash = Some(input_hash);
         self.input_byte_length = Some(source.contents.len() as u64);
 

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -263,11 +263,9 @@ describe("transpiler cache", () => {
   });
   test("bun test does not replay a cache entry written by a plain run", () => {
     // `bun test` binds bare `describe`/`test`/`expect` by injecting an import
-    // from "bun:test" at transpile time, and `inject_jest_globals` is
-    // deliberately excluded from the features hash. A plain `bun <file>` run
-    // of the same bytes transpiles without that injection and writes a cache
-    // entry under the same key, so replaying the entry under `bun test` would
-    // silently register zero tests.
+    // from "bun:test" at transpile time. A plain `bun <file>` run of the same
+    // bytes transpiles without that injection, so replaying its cache entry
+    // under `bun test` would silently register zero tests.
     const code =
       `console.log("DESCRIBE_IS:" + typeof describe);\n` +
       `if (typeof describe !== "undefined") {\n` +

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -261,6 +261,42 @@ describe("transpiler cache", () => {
     expect(run(["--feature=OTHER", "--feature=SUPER_SECRET"])).toBe("enabled");
     expect(newCacheCount()).toBe(0); // cache hit, order doesn't matter
   });
+  test("bun test does not replay a cache entry written by a plain run", () => {
+    // `bun test` binds bare `describe`/`test`/`expect` by injecting an import
+    // from "bun:test" at transpile time, and `inject_jest_globals` is
+    // deliberately excluded from the features hash. A plain `bun <file>` run
+    // of the same bytes transpiles without that injection and writes a cache
+    // entry under the same key, so replaying the entry under `bun test` would
+    // silently register zero tests.
+    const code =
+      `console.log("DESCRIBE_IS:" + typeof describe);\n` +
+      `if (typeof describe !== "undefined") {\n` +
+      `  describe("poisoned", () => {\n` +
+      `    test("jest globals are injected", () => {\n` +
+      `      expect(1).toBe(1);\n` +
+      `    });\n` +
+      `  });\n` +
+      `}\n`;
+    const filler = Buffer.alloc((50 * 1024 * 1.5) | 0, "/").toString();
+    writeFileSync(join(temp_dir, "poisoned.test.ts"), code + "//" + filler);
+
+    // Plain run: no jest globals; writes the cache entry.
+    const plain = bunRun(join(temp_dir, "poisoned.test.ts"), env);
+    expect(plain.stdout).toBe("DESCRIBE_IS:undefined");
+    expect(newCacheCount()).toBe(1);
+
+    // The test runner must re-transpile instead of replaying the entry.
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "test", "poisoned.test.ts"],
+      cwd: temp_dir,
+      env,
+    });
+    const stdout = result.stdout.toString();
+    const stderr = result.stderr.toString();
+    expect(stdout).toContain("DESCRIBE_IS:function");
+    expect(stderr).toContain("1 pass");
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 test("rejects cached module records containing out-of-range string indices", () => {


### PR DESCRIPTION
## Repro

```sh
# any test file >= 4 KiB (MINIMUM_CACHE_SIZE) using bare jest globals
bun foo.test.ts        # plain run — writes a runtime transpiler cache entry
bun test foo.test.ts   # replays it: 0 pass, 0 fail, exit 0
```

After the plain run, `bun test` reports `typeof describe === "undefined"` inside the file and silently registers **zero tests** while exiting 0. This is exactly the sequence a limits/ratchet-style test encodes (`bun ./test/internal/ban-words.test.ts` to regenerate, then `bun test` to check), and how it was found.

## Cause

`bun test` binds bare `describe`/`test`/`expect` by injecting an import from `"bun:test"` at transpile time (`inject_jest_globals`). That flag is deliberately excluded from the cache's features hash — the design note says "we bail out of the cache entirely if this is true" — but the bail only exists on the **put** side (`input_hash` is cleared after injecting). The **get** side never bails, so an entry written by a plain `bun <file>` run (no injection) is replayed verbatim by the test runner.

Bailing out of `get()` whenever the flag is set is not an option either: `bun test` sets `inject_jest_globals` for every module the VM loads, and modules that don't use bare jest globals are *supposed* to cache — `--isolate`'s serialized-module-record restore depends on it (covered by the existing "rejects cached module records…" test).

## Fix

Key parses with `inject_jest_globals` set to a **different cache filename**: `RuntimeTranspilerCache::get` derives `input_hash` — which alone determines the filename — with a distinct Wyhash seed when the flag is set (`src/jsc/RuntimeTranspilerCache.rs`). Effects:

- the test runner can never open a plain-run entry (different filename), so the replay is structurally impossible
- plain-run filenames are unchanged, so existing caches stay valid
- plain-run and test-run entries for shared dependencies **coexist**: alternating `bun x.js` ↔ `bun test` keeps a 100% hit rate in both contexts. (Folding the flag into `features_hash` instead — this PR's first iteration — would delete + re-transpile every shared ≥4 KiB dependency on each switch, because the filename is keyed on `input_hash` alone and a stored-features mismatch unlinks the entry.)
- parses where the injection actually fires still never write an entry (unchanged put-side bail)
- non-injected modules loaded under `bun test` keep caching, so `--isolate` restore is unaffected

## Verification

- new test in `test/cli/run/transpiler-cache.test.ts` ("bun test does not replay a cache entry written by a plain run"): fails with `src/` at main (`DESCRIBE_IS:undefined`, 0 tests registered), passes with the fix
- full `transpiler-cache.test.ts` suite: 12 pass, 0 fail (debug build), including the `--feature` invalidation and `--isolate` esm_record tests
- thrash check: alternating `bun main.ts` ↔ `bun test main.test.ts` 4× over a shared 5.9 KiB dependency leaves exactly two cache entries with byte- and mtime-identical files — zero unlinks/rewrites
- `cargo check`, `cargo clippy`, `cargo fmt --check` clean on `bun_js_parser` + `bun_jsc`
