### PR TITLE
fuzzilli: stub process.execve in the REPRL wrapper

### DIFF
--- a/src/js/eval/fuzzilli-reprl.ts
+++ b/src/js/eval/fuzzilli-reprl.ts
@@ -13,6 +13,11 @@ globalThis.require = require;
 globalThis.__dirname = "/";
 globalThis.__filename = "/fuzzilli.js";
 
+// process.execve either replaces the process image (on success) or prints an
+// error and aborts (on failure, matching Node) — both of which kill the REPRL
+// child, so fuzzed scripts must not be able to reach the real implementation.
+process.execve = () => {};
+
 // ============================================================================
 // REPRL Protocol Loop
 // ============================================================================

--- a/test/js/bun/util/fuzzilli-reprl-execve.fixture.ts
+++ b/test/js/bun/util/fuzzilli-reprl-execve.fixture.ts
@@ -1,0 +1,82 @@
+// Drives the fuzzilli REPRL loop with in-process mocks for the control/data
+// FDs so the real src/js/eval/fuzzilli-reprl.ts source can be exercised in a
+// normal (non-fuzzilli) build. Feeds a payload that calls process.execve with
+// a nonexistent path: the real implementation prints an error and aborts the
+// process (SIGABRT) when exec fails, so the REPRL wrapper must stub it out
+// before running fuzzed scripts.
+
+import fs from "node:fs";
+import path from "node:path";
+
+const REPRL_CRFD = 100;
+const REPRL_CWFD = 101;
+const REPRL_DRFD = 102;
+
+const payloads = [
+  Buffer.from(`process.execve("fuzzilli-reprl-execve-does-not-exist", []);`, "utf8"),
+  Buffer.from(`globalThis.stillAlive = true;`, "utf8"),
+];
+
+// Script the control-read pipe (fd 100): HELO handshake, then one exec cycle
+// per payload (each followed by the 8-byte length), then EOF.
+const controlChunks: Buffer[] = [Buffer.from("HELO")];
+for (const payload of payloads) {
+  const size = Buffer.alloc(8);
+  size.writeBigUInt64LE(BigInt(payload.length), 0);
+  controlChunks.push(Buffer.from("exec"));
+  controlChunks.push(size);
+}
+let controlStream = Buffer.concat(controlChunks);
+
+// Data-read pipe (fd 102): the payload for each exec cycle.
+let dataStream = Buffer.concat(payloads);
+
+let statusWrites = 0;
+
+const realFstatSync = fs.fstatSync;
+const realReadSync = fs.readSync;
+const realWriteSync = fs.writeSync;
+
+(fs as any).fstatSync = function (fd: any, ...rest: any[]) {
+  if (fd === REPRL_CRFD) return {} as any;
+  return (realFstatSync as any).call(fs, fd, ...rest);
+};
+
+(fs as any).readSync = function (fd: any, buffer: any, offset: any, length: any, position: any) {
+  if (fd === REPRL_CRFD) {
+    const n = Math.min(length, controlStream.length);
+    controlStream.copy(buffer, offset, 0, n);
+    controlStream = controlStream.subarray(n);
+    return n;
+  }
+  if (fd === REPRL_DRFD) {
+    const n = Math.min(length, dataStream.length);
+    dataStream.copy(buffer, offset, 0, n);
+    dataStream = dataStream.subarray(n);
+    return n;
+  }
+  return (realReadSync as any).call(fs, fd, buffer, offset, length, position);
+};
+
+(fs as any).writeSync = function (fd: any, buffer: any, ...rest: any[]) {
+  if (fd === REPRL_CWFD) {
+    if (Buffer.isBuffer(buffer) && buffer.length === 4 && buffer.toString() !== "HELO") {
+      statusWrites++;
+    }
+    return Buffer.isBuffer(buffer) ? buffer.length : String(buffer).length;
+  }
+  return (realWriteSync as any).call(fs, fd, buffer, ...rest);
+};
+
+(globalThis as any).resetCoverage = () => {};
+(globalThis as any).require = require;
+
+const reprlSource = fs.readFileSync(
+  path.join(import.meta.dir, "..", "..", "..", "..", "src", "js", "eval", "fuzzilli-reprl.ts"),
+  "utf8",
+);
+(0, eval)(reprlSource);
+
+const liveAfterExecve = (globalThis as any).stillAlive === true;
+realWriteSync.call(fs, 1, `STATUS_WRITES=${statusWrites} LIVE=${liveAfterExecve}\n`);
+process.exit(statusWrites === 2 && liveAfterExecve ? 0 : 1);

--- a/test/js/bun/util/fuzzilli-reprl.test.ts
+++ b/test/js/bun/util/fuzzilli-reprl.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// The fuzzilli REPRL wrapper (src/js/eval/fuzzilli-reprl.ts) executes
+// fuzzer-generated scripts in-process. APIs that intentionally kill the
+// process outside of normal exception handling must be stubbed out before the
+// loop starts, otherwise every fuzz case reaching them is reported as a
+// crash. process.execve is one of those: on exec failure it prints an error
+// and aborts (matching Node), and on success it replaces the process image.
+test("REPRL loop survives a payload that calls process.execve", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "fuzzilli-reprl-execve.fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("process.execve failed");
+  expect(stdout).toContain("STATUS_WRITES=2 LIVE=true");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### What does this PR do?

Fuzzilli flagged a deterministic "crash" (fingerprint `7f8b0002990fc19e`) whose minimized body is just:

```js
process.execve("bgF", []);
```

`process.execve` is working as designed here: when the underlying `execve(2)` fails, Bun prints the error and calls `abort()`, matching Node (`test/js/node/test/parallel/test-process-execve-abort.js` and `test/js/node/process/process-execve.test.ts` assert exactly this). On success it replaces the process image. Either way the REPRL child dies, so every fuzz case that reaches `process.execve` is reported as a crash even though the runtime behavior is intentional.

The fuzzer's code prefix already neuters other intentionally-fatal APIs (`process.abort`, `console.profile`, `Bun.generateHeapSnapshot`, ...). This PR does the same for `process.execve` in Bun's own REPRL wrapper (`src/js/eval/fuzzilli-reprl.ts`), stubbing it out before the exec loop starts. Runtime behavior outside `bun fuzzilli` is unchanged.

Verified end to end with a `--fuzzilli=on` build driven over real REPRL FDs: the original fuzz case now executes with status 0 and the child stays alive for subsequent iterations; running the same script outside fuzzilli mode still aborts with the Node-parity error output, and the existing execve test suites still pass.

### How did you verify your code works?

- New test `test/js/bun/util/fuzzilli-reprl.test.ts` drives the real REPRL source with mocked control/data FDs and feeds it a payload calling `process.execve` with a nonexistent path. Without the stub the child aborts with `process.execve failed with error code ENOENT` before writing any status; with it the loop survives both exec cycles.
- `bun bd test test/js/node/process/process-execve.test.ts` and `bun bd test/js/node/test/parallel/test-process-execve-abort.js` still pass.