### PR TITLE
Keep client WebSocket.bufferedAmount from resetting to zero after close

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -225,7 +225,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // the destructor's finalize() — does not leak. When reached via
         // fail(), outgoing_websocket is already None and this is a no-op.
         if had_tunnel {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
+            this.dispatch_abrupt_close(ErrorCode::Ended, None);
         }
     }
 
@@ -235,7 +235,12 @@ impl<const SSL: bool> WebSocket<SSL> {
         jsc::mark_binding!();
         if let Some((ws, _cpp_ref)) = self.outgoing_websocket.replace(None) {
             log!("fail ({})", <&'static str>::from(code));
-            ws.did_abrupt_close(code);
+            // Snapshot the backlog before did_abrupt_close(): it drops the
+            // connection (kind -> None) then fires the JS close event, so C++
+            // must be handed the amount now or an onclose read of bufferedAmount
+            // would see 0 (the send buffer lives until cancel() below).
+            let buffered = self.buffered_amount();
+            ws.did_abrupt_close(code, buffered);
         }
 
         self.cancel_guarded();
@@ -290,18 +295,25 @@ impl<const SSL: bool> WebSocket<SSL> {
         if let Some((code, reason)) = self.close_dispatch_pending.take() {
             // The socket closed while our close frame was mid-flush; the peer
             // either got it or didn't, but JS should still see the
-            // user-initiated code/reason (not an abrupt 1006).
+            // user-initiated code/reason (not an abrupt 1006). Snapshot the
+            // backlog before clear_data() frees it so bufferedAmount stays
+            // non-zero when frames went unsent.
+            let buffered = self.buffered_amount();
             self.detach_tcp();
             self.clear_data();
-            self.dispatch_close(code, reason);
+            self.dispatch_close(code, reason, buffered);
             // For the socket.
             self.release_io_ref();
             return;
         }
+        // Snapshot the backlog before clear_data() frees it, so the close event
+        // does not see bufferedAmount reset to 0 (e.g. peer RST with unsent
+        // frames).
+        let buffered = self.buffered_amount();
         self.clear_data();
         self.detach_tcp();
 
-        self.dispatch_abrupt_close(ErrorCode::Ended);
+        self.dispatch_abrupt_close(ErrorCode::Ended, Some(buffered));
 
         // For the socket.
         self.release_io_ref();
@@ -1048,9 +1060,20 @@ impl<const SSL: bool> WebSocket<SSL> {
                 true
             }
             Err(true) => {
-                // `terminate → clear_data` resets `send_buffer`; drop the
-                // taken fifo without restoring.
-                drop(buf);
+                // Restore the backlog before terminating: fail() snapshots
+                // send_buffer.readable_length() for bufferedAmount, so it must
+                // still be here. `terminate → cancel → clear_data` frees it
+                // immediately afterward, so this does not leak.
+                //
+                // KNOWN GAP (tunnel only): if the tunnel's SslWrapper::write_data
+                // hits a fatal SSL error it fires on_close → fail() *synchronously
+                // inside* the write above — before this restore — so that
+                // bufferedAmount snapshot reads 0. `self.send_buffer` cannot be
+                // kept populated across the write without either aliasing UB (the
+                // slice handed to write is borrowed from it) or an extra per-flush
+                // copy; the window is a fatal-handshake/close-notify error
+                // mid-flush, and 0 there is no worse than the pre-feature behavior.
+                self.send_buffer.replace(buf);
                 self.terminate(ErrorCode::FailedToWrite);
                 false
             }
@@ -1063,7 +1086,7 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     fn send_pong(&self) -> bool {
         if !self.has_tcp() {
-            self.dispatch_abrupt_close(ErrorCode::Ended);
+            self.dispatch_abrupt_close(ErrorCode::Ended, None);
             return false;
         }
 
@@ -1102,7 +1125,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             return;
         }
         if !self.has_tcp() {
-            self.dispatch_abrupt_close(ErrorCode::Ended);
+            self.dispatch_abrupt_close(ErrorCode::Ended, None);
             self.clear_data();
             return;
         }
@@ -1142,9 +1165,13 @@ impl<const SSL: bool> WebSocket<SSL> {
         if self.enqueue_encoded_bytes(&frame[..frame_len]) {
             let dispatch_code = dispatch_code.unwrap_or(code);
             if self.send_buffer.borrow().readable_length() == 0 {
+                // Snapshot the unsent backlog before clear_data() frees it, so
+                // the JS close event does not see bufferedAmount reset to 0
+                // (spec: it does not reset once the connection closes).
+                let buffered = self.buffered_amount();
                 self.shutdown_after_close_frame();
                 self.clear_data();
-                self.dispatch_close(dispatch_code, reason);
+                self.dispatch_close(dispatch_code, reason, buffered);
             } else {
                 // The close frame was only partially written; the remainder is
                 // in send_buffer. clear_data() would discard it (and the
@@ -1171,9 +1198,12 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     fn finish_pending_close(&self) {
         if let Some((code, reason)) = self.close_dispatch_pending.take() {
+            // Snapshot the backlog before clear_data() frees it so a deferred
+            // close still reports any bytes that went unsent.
+            let buffered = self.buffered_amount();
             self.shutdown_after_close_frame();
             self.clear_data();
-            self.dispatch_close(code, reason);
+            self.dispatch_close(code, reason, buffered);
         }
     }
 
@@ -1269,7 +1299,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         let _guard = RefPtr::from_this(this);
 
         if !this.has_tcp() || op > 0xF {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
+            this.dispatch_abrupt_close(ErrorCode::Ended, None);
             return;
         }
 
@@ -1305,12 +1335,13 @@ impl<const SSL: bool> WebSocket<SSL> {
         !tcp.is_closed() && !tcp.is_shutdown()
     }
 
+
     pub(crate) fn write_string(this: ThisPtr<Self>, str: &EncodedSlice, op: u8) {
         // See write_binary_data() — tunnel.write() can re-enter fail().
         let _guard = RefPtr::from_this(this);
 
         if !this.has_tcp() {
-            this.dispatch_abrupt_close(ErrorCode::Ended);
+            this.dispatch_abrupt_close(ErrorCode::Ended, None);
             return;
         }
 
@@ -1346,23 +1377,30 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     /// May free `self`.
-    fn dispatch_abrupt_close(&self, code: ErrorCode) {
+    ///
+    /// `buffered_override` lets a caller that already cleared the send buffer
+    /// (e.g. `handle_close()` calls `clear_data()` first) pass the backlog it
+    /// captured beforehand. `None` snapshots the live send buffer here.
+    fn dispatch_abrupt_close(&self, code: ErrorCode, buffered_override: Option<usize>) {
         let Some((out, _cpp_ref)) = self.outgoing_websocket.replace(None) else {
             return;
         };
         self.unref_keep_alive();
         jsc::mark_binding!();
-        out.did_abrupt_close(code);
+        // Capture the unsent backlog so C++ can keep bufferedAmount from
+        // resetting to 0 on abrupt close.
+        let buffered = buffered_override.unwrap_or_else(|| self.buffered_amount());
+        out.did_abrupt_close(code, buffered);
     }
 
     /// May free `self`.
-    fn dispatch_close(&self, code: u16, reason: bun_core::String) {
+    fn dispatch_close(&self, code: u16, reason: bun_core::String, buffered_amount: usize) {
         let Some((out, _cpp_ref)) = self.outgoing_websocket.replace(None) else {
             return;
         };
         self.unref_keep_alive();
         jsc::mark_binding!();
-        out.did_close(code, reason);
+        out.did_close(code, reason, buffered_amount);
     }
 
     pub(crate) fn close(this: ThisPtr<Self>, code: u16, reason: Option<&EncodedSlice>) {
@@ -1588,6 +1626,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // This is under-estimated a little, as we don't include usockets context.
         cost
     }
+
 }
 
 impl<const SSL: bool> Drop for WebSocket<SSL> {

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1335,7 +1335,6 @@ impl<const SSL: bool> WebSocket<SSL> {
         !tcp.is_closed() && !tcp.is_shutdown()
     }
 
-
     pub(crate) fn write_string(this: ThisPtr<Self>, str: &EncodedSlice, op: u8) {
         // See write_binary_data() — tunnel.write() can re-enter fail().
         let _guard = RefPtr::from_this(this);

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1625,7 +1625,6 @@ impl<const SSL: bool> WebSocket<SSL> {
         // This is under-estimated a little, as we don't include usockets context.
         cost
     }
-
 }
 
 impl<const SSL: bool> Drop for WebSocket<SSL> {

--- a/src/http_jsc/websocket_client/CppWebSocket.rs
+++ b/src/http_jsc/websocket_client/CppWebSocket.rs
@@ -54,7 +54,11 @@ unsafe extern "C" {
         buffered_data: Option<Box<InitialData>>,
         deflate_params: Option<&websocket_deflate::Params>,
     );
-    safe fn WebSocket__didAbruptClose(websocket_context: &CppWebSocket, reason: ErrorCode);
+    safe fn WebSocket__didAbruptClose(
+        websocket_context: &CppWebSocket,
+        reason: ErrorCode,
+        buffered_amount: usize,
+    );
     safe fn WebSocket__didReceiveHandshakeResponse(
         websocket_context: &CppWebSocket,
         status_code: u16,
@@ -62,7 +66,12 @@ unsafe extern "C" {
         headers: FfiSlice<'_, RawHeader<'_>>,
         body: FfiSlice<'_>,
     );
-    safe fn WebSocket__didClose(websocket_context: &CppWebSocket, code: u16, reason: BunString);
+    safe fn WebSocket__didClose(
+        websocket_context: &CppWebSocket,
+        code: u16,
+        reason: BunString,
+        buffered_amount: usize,
+    );
     safe fn WebSocket__didReceiveText(
         websocket_context: &CppWebSocket,
         clone: bool,
@@ -85,12 +94,13 @@ unsafe extern "C" {
 // borrows (often while `&mut WebSocket<SSL>` is also live), so `&mut self`
 // would force needless `unsafe { &mut *ptr }` at every site.
 impl CppWebSocket {
-    pub(crate) fn did_abrupt_close(&self, reason: ErrorCode) {
-        // SAFETY: VirtualMachine::get() returns the live current-thread VM;
-        // event_loop() yields its raw event-loop pointer (live for VM lifetime).
+    /// `buffered_amount` is the sender's unsent backlog captured *before* this
+    /// call (the connection's send buffer may be freed during the abrupt-close
+    /// teardown), so C++ can keep `WebSocket.bufferedAmount` from resetting to 0.
+    pub(crate) fn did_abrupt_close(&self, reason: ErrorCode, buffered_amount: usize) {
         let event_loop = VirtualMachine::get().event_loop_mut();
         event_loop.enter();
-        WebSocket__didAbruptClose(self, reason);
+        WebSocket__didAbruptClose(self, reason, buffered_amount);
         event_loop.exit();
     }
 
@@ -114,10 +124,13 @@ impl CppWebSocket {
         event_loop.exit();
     }
 
-    pub(crate) fn did_close(&self, code: u16, reason: BunString) {
+    /// `buffered_amount` is the sender's unsent backlog captured *before* this
+    /// call (the send buffer is freed during close teardown), so C++ can keep
+    /// `WebSocket.bufferedAmount` from resetting to 0 once closed.
+    pub(crate) fn did_close(&self, code: u16, reason: BunString, buffered_amount: usize) {
         let event_loop = VirtualMachine::get().event_loop_mut();
         event_loop.enter();
-        WebSocket__didClose(self, code, reason);
+        WebSocket__didClose(self, code, reason, buffered_amount);
         event_loop.exit();
     }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -569,7 +569,8 @@ where
     /// may free `this`.
     fn dispatch_abrupt_close(this: ThisPtr<Self>, code: ErrorCode) {
         if let Some((ws, _cpp_ref)) = this.outgoing_websocket.replace(None) {
-            ws.did_abrupt_close(code);
+            // The upgrade handshake has no send buffer yet, so the backlog is 0.
+            ws.did_abrupt_close(code, 0);
         }
     }
 

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -168,6 +168,13 @@ static unsigned saturateAdd(unsigned a, unsigned b)
     return a + b;
 }
 
+static unsigned clampToUnsigned(size_t value)
+{
+    return value > std::numeric_limits<unsigned>::max()
+        ? std::numeric_limits<unsigned>::max()
+        : static_cast<unsigned>(value);
+}
+
 ASCIILiteral WebSocket::subprotocolSeparator()
 {
     return ", "_s;
@@ -730,6 +737,12 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::send(WebCore::JSBlob* blob)
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
+        // Mirror the String/ArrayBuffer/ArrayBufferView send() overloads: per
+        // spec, send() after close increases bufferedAmount by the size of the
+        // data instead of transmitting it.
+        size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
@@ -752,7 +765,6 @@ void WebSocket::sendWebSocketData(const char* baseAddress, size_t length, const 
     switch (m_connectedWebSocketKind) {
     case ConnectedWebSocketKind::Client: {
         Bun__WebSocketClient__writeBinaryData(this->m_connectedWebSocket.client, reinterpret_cast<const unsigned char*>(baseAddress), length, static_cast<uint8_t>(op));
-        // this->m_connectedWebSocket.client->send({ baseAddress, length }, opCode);
         break;
     }
     case ConnectedWebSocketKind::ClientSSL: {
@@ -771,7 +783,6 @@ void WebSocket::sendWebSocketString(const String& message, const Opcode op)
     case ConnectedWebSocketKind::Client: {
         auto slice = Zig::toEncodedSlice(message);
         Bun__WebSocketClient__writeString(this->m_connectedWebSocket.client, &slice, static_cast<uint8_t>(op));
-        // this->m_connectedWebSocket.client->send({ baseAddress, length }, opCode);
         break;
     }
     case ConnectedWebSocketKind::ClientSSL: {
@@ -849,6 +860,9 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
     m_state = CLOSING;
     switch (m_connectedWebSocketKind) {
     case ConnectedWebSocketKind::Client: {
+        // No eager bufferedAmount snapshot (unlike terminate()): close() keeps
+        // the kind set for deferred close, so bufferedAmount() reads the live
+        // buffer and didClose() applies the native client's final snapshot.
         EncodedSlice reasonSlice = Zig::toEncodedSlice(reason);
         Bun__WebSocketClient__close(this->m_connectedWebSocket.client, code, &reasonSlice);
         break;
@@ -880,6 +894,10 @@ ExceptionOr<void> WebSocket::terminate()
         return {};
     }
     m_state = CLOSING;
+    // cancelConnectedClient() detaches the native client before it frees the
+    // send buffer, so any callback it makes can no longer report the backlog;
+    // snapshot it first so bufferedAmount does not reset to 0 (see bufferedAmount()).
+    m_bufferedAmount = connectedClientBufferedAmount();
     cancelConnectedClient();
     return {};
 }
@@ -1143,24 +1161,28 @@ WebSocket::State WebSocket::readyState() const
     return m_state;
 }
 
-unsigned WebSocket::bufferedAmount() const
+unsigned WebSocket::connectedClientBufferedAmount() const
 {
-    // Live: bytes queued in the native client (frames not yet written to the
-    // socket, plus the proxy tunnel's pending ciphertext). m_bufferedAmount
-    // only carries the leftover reported at close.
-    size_t live = 0;
+    // While the connection is live (including the deferred-close window) query
+    // the live send-buffer size so backpressure is observable; it falls as the
+    // peer drains. Once the connection is gone, m_bufferedAmount holds the final
+    // snapshot from didClose()/didFailWithErrorCode() (or terminate()'s eager one).
     switch (m_connectedWebSocketKind) {
     case ConnectedWebSocketKind::Client:
-        live = Bun__WebSocketClient__bufferedAmount(m_connectedWebSocket.client);
-        break;
+        return clampToUnsigned(Bun__WebSocketClient__bufferedAmount(this->m_connectedWebSocket.client));
     case ConnectedWebSocketKind::ClientSSL:
-        live = Bun__WebSocketClientTLS__bufferedAmount(m_connectedWebSocket.clientSSL);
-        break;
+        return clampToUnsigned(Bun__WebSocketClientTLS__bufferedAmount(this->m_connectedWebSocket.clientSSL));
     case ConnectedWebSocketKind::None:
-        break;
+        return m_bufferedAmount;
     }
-    unsigned clamped = live > std::numeric_limits<unsigned>::max() ? std::numeric_limits<unsigned>::max() : static_cast<unsigned>(live);
-    return saturateAdd(saturateAdd(m_bufferedAmount, clamped), m_bufferedAmountAfterClose);
+    return m_bufferedAmount;
+}
+
+unsigned WebSocket::bufferedAmount() const
+{
+    // m_bufferedAmountAfterClose counts the payloads of send()/ping()/pong()
+    // calls made once the socket was closing or closed; they are never written.
+    return saturateAdd(connectedClientBufferedAmount(), m_bufferedAmountAfterClose);
 }
 
 String WebSocket::protocol() const
@@ -1475,7 +1497,7 @@ void WebSocket::didStartClosingHandshake()
     // });
 }
 
-void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, const String& reason)
+void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, const String& reason, size_t bufferedAmountSnapshot)
 {
     // LOG(Network, "WebSocket %p didClose()", this);
     if (this->m_connectedWebSocketKind == ConnectedWebSocketKind::None)
@@ -1483,7 +1505,10 @@ void WebSocket::didClose(unsigned unhandledBufferedAmount, unsigned short code, 
 
     // queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [this, unhandledBufferedAmount, closingHandshakeCompletion, code, reason] {
     bool wasClean = m_state == CLOSING && !unhandledBufferedAmount && code != 0; // WebSocketChannel::CloseEventCodeAbnormalClosure;
-    m_bufferedAmount = unhandledBufferedAmount;
+    // Don't reset the backlog: the native client captures the unsent bytes
+    // before teardown and passes them via bufferedAmountSnapshot. Per spec
+    // bufferedAmount must not drop to 0 once closed, so keep the largest.
+    m_bufferedAmount = std::max({ m_bufferedAmount, unhandledBufferedAmount, clampToUnsigned(bufferedAmountSnapshot) });
     ASSERT(scriptExecutionContext());
     this->m_connectedWebSocketKind = ConnectedWebSocketKind::None;
     this->m_upgradeClient = nullptr;
@@ -1545,12 +1570,21 @@ void WebSocket::didConnect(us_socket_t* socket, void* bufferedData, const PerMes
     this->didConnect();
 }
 
-void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code)
+void WebSocket::didFailWithErrorCode(Bun::WebSocketErrorCode code, size_t bufferedAmount)
 {
     // from new WebSocket() -> connect()
 
     if (m_state == CLOSED)
         return;
+
+    // Keep the backlog reported before this abrupt close (captured on the Rust
+    // side, since the connection's send buffer is freed during teardown) so
+    // bufferedAmount does not reset to 0 — see bufferedAmount(). Keep the larger
+    // value; this also makes the socket-close path (buffer already cleared → 0)
+    // a no-op.
+    unsigned clamped = clampToUnsigned(bufferedAmount);
+    if (clamped > m_bufferedAmount)
+        m_bufferedAmount = clamped;
 
     this->m_upgradeClient = nullptr;
     if (this->m_connectedWebSocketKind == ConnectedWebSocketKind::ClientSSL) {
@@ -1766,11 +1800,11 @@ extern "C" void WebSocket__didReceiveHandshakeResponse(WebCore::WebSocket* webSo
     webSocket->didReceiveHandshakeResponse(statusCode, statusMessage.span(), std::span(headers.ptr, headers.len), body.span());
 }
 
-extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, Bun::WebSocketErrorCode errorCode)
+extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, Bun::WebSocketErrorCode errorCode, size_t bufferedAmount)
 {
-    webSocket->didFailWithErrorCode(errorCode);
+    webSocket->didFailWithErrorCode(errorCode, bufferedAmount);
 }
-extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, BunString reason)
+extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, BunString reason, size_t bufferedAmount)
 {
     WTF::String wtf_reason = reason.transferToWTFString();
     // The Rust client only calls this after a completed close handshake
@@ -1778,8 +1812,13 @@ extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t erro
     // server-initiated close m_state is still OPEN here; transition to
     // CLOSING so didClose() reports wasClean = true. Abnormal closes go
     // through WebSocket__didAbruptClose instead.
+    //
+    // Pass the queued backlog as bufferedAmountSnapshot (not as
+    // unhandledBufferedAmount): this close handshake completed cleanly, so
+    // wasClean must stay true regardless of any application data still queued,
+    // but bufferedAmount must not reset to 0 (spec).
     webSocket->didStartClosingHandshake();
-    webSocket->didClose(0, errorCode, WTF::move(wtf_reason));
+    webSocket->didClose(0, errorCode, WTF::move(wtf_reason), bufferedAmount);
 }
 
 extern "C" void WebSocket__didReceiveText(WebCore::WebSocket* webSocket, bool clone, const EncodedSlice* str)
@@ -1827,6 +1866,11 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::ping(WebCore::JSBlob* blob)
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
+        // Match the String/ArrayBuffer/ArrayBufferView ping() overloads, which
+        // accumulate into bufferedAmount after close rather than transmitting.
+        size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 
@@ -1851,6 +1895,11 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::pong(WebCore::JSBlob* blob)
     if (m_state == CONNECTING)
         return Exception { InvalidStateError };
     if (m_state == CLOSING || m_state == CLOSED) {
+        // Match the String/ArrayBuffer/ArrayBufferView pong() overloads, which
+        // accumulate into bufferedAmount after close rather than transmitting.
+        size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
 

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -988,6 +988,9 @@ ExceptionOr<void> WebSocket::ping()
 
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
+        // Match ping(String) with an empty payload: both send the same frame
+        // when OPEN, so both account the same 6 framing bytes after close.
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(0));
         return {};
     }
 
@@ -1074,6 +1077,8 @@ ExceptionOr<void> WebSocket::pong()
 
     // No exception is raised if the connection was once established but has subsequently been closed.
     if (m_state == CLOSING || m_state == CLOSED) {
+        // Match pong(String) with an empty payload: see ping().
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(0));
         return {};
     }
 

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -739,9 +739,11 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::send(WebCore::JSBlob* blob)
     if (m_state == CLOSING || m_state == CLOSED) {
         // Mirror the String/ArrayBuffer/ArrayBufferView send() overloads: per
         // spec, send() after close increases bufferedAmount by the size of the
-        // data instead of transmitting it.
+        // data instead of transmitting it. Clamp before saturateAdd: a
+        // file-backed Blob can exceed 4 GiB, and the implicit size_t->unsigned
+        // narrowing would wrap before the saturation check runs.
         size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, clampToUnsigned(payloadSize));
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
@@ -1868,8 +1870,9 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::ping(WebCore::JSBlob* blob)
     if (m_state == CLOSING || m_state == CLOSED) {
         // Match the String/ArrayBuffer/ArrayBufferView ping() overloads, which
         // accumulate into bufferedAmount after close rather than transmitting.
+        // clampToUnsigned: see send(JSBlob*).
         size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, clampToUnsigned(payloadSize));
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }
@@ -1897,8 +1900,9 @@ WebCore::ExceptionOr<void> WebCore::WebSocket::pong(WebCore::JSBlob* blob)
     if (m_state == CLOSING || m_state == CLOSED) {
         // Match the String/ArrayBuffer/ArrayBufferView pong() overloads, which
         // accumulate into bufferedAmount after close rather than transmitting.
+        // clampToUnsigned: see send(JSBlob*).
         size_t payloadSize = Blob__getSize(JSC::JSValue::encode(blob));
-        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, payloadSize);
+        m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, clampToUnsigned(payloadSize));
         m_bufferedAmountAfterClose = saturateAdd(m_bufferedAmountAfterClose, getFramingOverhead(payloadSize));
         return {};
     }

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -203,10 +203,10 @@ public:
 
     void didConnect();
     void didStartClosingHandshake();
-    void didClose(unsigned unhandledBufferedAmount, unsigned short code, const String& reason);
+    void didClose(unsigned unhandledBufferedAmount, unsigned short code, const String& reason, size_t bufferedAmountSnapshot = 0);
     void didConnect(us_socket_t* socket, void* bufferedData, const PerMessageDeflateParams* deflate_params, void* customSSLCtx);
     void didConnectWithTunnel(void* tunnel, void* bufferedData, const PerMessageDeflateParams* deflate_params);
-    void didFailWithErrorCode(Bun::WebSocketErrorCode code);
+    void didFailWithErrorCode(Bun::WebSocketErrorCode code, size_t bufferedAmount = 0);
 
     void didReceiveMessage(String&& message);
     void didReceiveBinaryData(const AtomString& eventName, const std::span<const uint8_t> binaryData);
@@ -336,6 +336,9 @@ private:
     void cancelUpgradeClient();
     bool applyPauseToConnectedClient();
     void cancelConnectedClient();
+    // The connected client's unsent backlog (framed bytes), or the snapshot kept from close once
+    // the client is gone. Excludes m_bufferedAmountAfterClose.
+    unsigned connectedClientBufferedAmount() const;
     bool m_rejectUnauthorized { false };
     bool m_paused { false };
     // Default matches pre-existing behavior: advertise permessage-deflate in the upgrade

--- a/test/js/web/websocket/websocket-buffered-amount.test.ts
+++ b/test/js/web/websocket/websocket-buffered-amount.test.ts
@@ -314,6 +314,38 @@ describe("WebSocket.bufferedAmount (client)", () => {
     }
   });
 
+  // terminate() is close()'s abrupt sibling: it cancels the native client
+  // synchronously, so the C++ side snapshots the backlog eagerly before the
+  // send buffer is freed. The snapshot must survive the call.
+  test("does not reset to 0 after terminate() while a backlog is queued", async () => {
+    const { port, close } = await nonDrainingServer();
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<{ beforeTerminate: number; afterTerminate: number }>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7c).toString();
+        for (let i = 0; i < 4000; i++) ws.send(chunk);
+        const beforeTerminate = ws.bufferedAmount;
+        // terminate() dispatches error/close synchronously; here they are
+        // expected, not failures.
+        ws.onerror = null;
+        ws.terminate();
+        const afterTerminate = ws.bufferedAmount;
+        resolve({ beforeTerminate, afterTerminate });
+      };
+      const { beforeTerminate, afterTerminate } = await promise;
+
+      expect(beforeTerminate).toBeGreaterThan(64 * 1024);
+      // terminate() snapshots the backlog before cancel frees the send buffer;
+      // the connection is gone afterward, so the value is frozen (same small
+      // flush tolerance as the close() case).
+      expect(afterTerminate).toBeGreaterThan(beforeTerminate * 0.95);
+    } finally {
+      close();
+    }
+  });
+
   // Every send()/ping()/pong() overload must account for data queued after
   // close() the same way the spec requires for send() ("increase the
   // bufferedAmount attribute by the size of the data"). The Blob overloads were
@@ -420,13 +452,18 @@ describe("WebSocket.bufferedAmount (client)", () => {
         resolve(max);
       };
       const max = await promise;
+      // The first promise is settled now; rewire failure events at the drain
+      // wait so an unexpected error/close fails fast instead of hanging (an
+      // abrupt close freezes bufferedAmount non-zero, so the poll would spin).
+      ws.onerror = ws.onclose = e => received.reject(new Error(`unexpected ${e.type} event during drain`));
       expect(max).toBeGreaterThan(payloadBytes);
 
       // The peer has the payloads; only the tail of the last frame can still be
       // in flight, so the live value must settle back to exactly 0.
       await received.promise;
-      while (ws.bufferedAmount !== 0) await Bun.sleep(1);
+      while (ws.bufferedAmount !== 0 && ws.readyState === WebSocket.OPEN) await Bun.sleep(1);
       expect(ws.readyState).toBe(WebSocket.OPEN);
+      expect(ws.bufferedAmount).toBe(0);
       ws.onclose = null;
       ws.close();
     } finally {

--- a/test/js/web/websocket/websocket-buffered-amount.test.ts
+++ b/test/js/web/websocket/websocket-buffered-amount.test.ts
@@ -372,9 +372,19 @@ describe("WebSocket.bufferedAmount (client)", () => {
         samples.push(ws.bufferedAmount);
         ws.pong(blob());
         samples.push(ws.bufferedAmount);
-        resolve(samples);
+        // The no-argument forms send the same empty control frame as ping("")
+        // when OPEN, so they must account the same 6 framing bytes after close.
+        const beforeEmptyPing = ws.bufferedAmount;
+        ws.ping();
+        const afterEmptyPing = ws.bufferedAmount;
+        ws.pong();
+        const afterEmptyPong = ws.bufferedAmount;
+        resolve([...samples, afterEmptyPing - beforeEmptyPing, afterEmptyPong - afterEmptyPing]);
       };
-      const samples = await promise;
+      const all = await promise;
+      const emptyPongDelta = all.pop()!;
+      const emptyPingDelta = all.pop()!;
+      const samples = all;
 
       // Each Blob overload must add at least the blob's raw size. Before the fix
       // the Blob branch alone returned without touching bufferedAmount, so the
@@ -382,6 +392,9 @@ describe("WebSocket.bufferedAmount (client)", () => {
       for (let i = 1; i < samples.length; i++) {
         expect(samples[i] - samples[i - 1]).toBeGreaterThanOrEqual(blobBytes);
       }
+      // 2-byte header + 4-byte masking key.
+      expect(emptyPingDelta).toBe(6);
+      expect(emptyPongDelta).toBe(6);
     } finally {
       close();
     }

--- a/test/js/web/websocket/websocket-buffered-amount.test.ts
+++ b/test/js/web/websocket/websocket-buffered-amount.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { tls } from "harness";
 import crypto from "node:crypto";
 import net from "node:net";
@@ -172,4 +172,360 @@ describe("WebSocket.bufferedAmount", () => {
       origin.close();
     }
   }, 60_000);
+});
+
+const WS_MAGIC = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+// Raw TCP server that completes the WebSocket handshake and then stops reading
+// from the socket (`pause()`), so the client's outbound frames cannot drain to
+// the peer and pile up in the in-process send buffer. `afterUpgrade`, when
+// provided, runs once right after the handshake (read side still paused) to
+// drive a specific behaviour: resume reading, write a frame, or destroy the
+// socket.
+function nonDrainingServer(afterUpgrade?: (sock: net.Socket) => void): Promise<{ port: number; close: () => void }> {
+  return new Promise((resolve, reject) => {
+    // Track live sockets so close() can destroy them. server.close() only stops
+    // accepting; after the deferred-close refactor a backlogged ws.close() waits
+    // for the socket to die, so leaving the paused peer alive pins the client's
+    // multi-MB send buffer for the rest of the run.
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer(sock => {
+      sockets.add(sock);
+      sock.on("close", () => sockets.delete(sock));
+      let buf = "";
+      let upgraded = false;
+      sock.on("data", d => {
+        if (upgraded) return;
+        buf += d.toString("latin1");
+        if (!buf.includes("\r\n\r\n")) return;
+        const key = /sec-websocket-key:\s*(.+)\r\n/i.exec(buf)?.[1]?.trim() ?? "";
+        const accept = crypto
+          .createHash("sha1")
+          .update(key + WS_MAGIC)
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\n" +
+            "Upgrade: websocket\r\n" +
+            "Connection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+        upgraded = true;
+        sock.pause(); // never read the client's frames
+        afterUpgrade?.(sock);
+      });
+      sock.on("error", () => {});
+    });
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({
+        port: address.port,
+        close: () => {
+          for (const s of sockets) s.destroy();
+          server.close();
+        },
+      });
+    });
+  });
+}
+
+// A server must not mask the frames it sends; a masked frame is a protocol
+// violation that makes the client abort the connection via the abrupt-close
+// (fail) path rather than a graceful close handshake.
+function maskedServerFrame(): Buffer {
+  const payload = Buffer.from("x");
+  // FIN + opcode 0x2 (binary), MASK bit set, 1-byte length, 4-byte mask key.
+  const header = Buffer.from([0x82, 0x80 | payload.length, 0x01, 0x02, 0x03, 0x04]);
+  const masked = Buffer.from(payload);
+  for (let i = 0; i < masked.length; i++) masked[i] ^= header[2 + (i % 4)];
+  return Buffer.concat([header, masked]);
+}
+
+// A valid (unmasked) server Close frame with status 1000. Triggers the client's
+// graceful close handshake (echo Close), not the abrupt-close path.
+function serverCloseFrame(): Buffer {
+  // FIN + opcode 0x8 (close), unmasked, 2-byte payload = status code 1000.
+  return Buffer.from([0x88, 0x02, 0x03, 0xe8]);
+}
+
+describe("WebSocket.bufferedAmount (client)", () => {
+  test("reflects the backlog queued to a peer that stopped reading", async () => {
+    const { port, close } = await nonDrainingServer();
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<{ atOpen: number; max: number }>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      ws.onopen = () => {
+        // Nothing queued yet: the baseline must be 0, not a constant.
+        const atOpen = ws.bufferedAmount;
+        const chunk = Buffer.alloc(64 * 1024, 0x79).toString();
+        let max = atOpen;
+        // 4000 * 64 KiB = ~250 MiB — far more than any socket buffer can accept,
+        // so the excess must queue in-process.
+        for (let i = 0; i < 4000; i++) {
+          ws.send(chunk);
+          if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+        }
+        resolve({ atOpen, max });
+      };
+      const { atOpen, max } = await promise;
+      ws.close();
+
+      // Baseline with nothing queued.
+      expect(atOpen).toBe(0);
+      // Before the fix, bufferedAmount was hard-wired to 0 for the client
+      // WebSocket. It must now track the unsent backlog — which is far larger
+      // than a single 64 KiB frame once the peer stops reading.
+      expect(max).toBeGreaterThan(64 * 1024);
+    } finally {
+      close();
+    }
+  });
+
+  // Per the WHATWG spec, bufferedAmount "does not reset to zero once the
+  // connection closes" — after close() it only increases with further send().
+  test("does not reset to 0 after close() while a backlog is queued", async () => {
+    const { port, close } = await nonDrainingServer();
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<{ beforeClose: number; afterClose: number }>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7a).toString();
+        for (let i = 0; i < 4000; i++) ws.send(chunk);
+        const beforeClose = ws.bufferedAmount;
+        ws.close();
+        // Reading immediately after close() must retain the queued backlog,
+        // not snap back to 0.
+        const afterClose = ws.bufferedAmount;
+        resolve({ beforeClose, afterClose });
+      };
+      const { beforeClose, afterClose } = await promise;
+
+      expect(beforeClose).toBeGreaterThan(64 * 1024);
+      // The backlog must survive the close() transition: per spec bufferedAmount
+      // does not reset to 0 once closed. close() leaves the connection set while
+      // the buffer drains, so afterClose still reads the live backlog and stays
+      // essentially the whole queue (a few frames may flush to the OS buffer
+      // between the two reads, so allow a small tolerance).
+      expect(afterClose).toBeGreaterThan(beforeClose * 0.95);
+    } finally {
+      close();
+    }
+  });
+
+  // Every send()/ping()/pong() overload must account for data queued after
+  // close() the same way the spec requires for send() ("increase the
+  // bufferedAmount attribute by the size of the data"). The Blob overloads were
+  // the only ones that returned without accounting; they must now match their
+  // String/ArrayBuffer/ArrayBufferView siblings. With no backlog queued, close()
+  // dispatches synchronously and releases the connection, so each post-close
+  // call adds deterministically to m_bufferedAmountAfterClose.
+  test("send/ping/pong(Blob) after close() increase bufferedAmount like the other overloads", async () => {
+    const blobBytes = 4096;
+    const { port, close } = await nonDrainingServer();
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<number[]>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      ws.onopen = () => {
+        // With an empty buffer, close() releases the connection synchronously, so
+        // bufferedAmount is the final snapshot plus post-close accumulation only.
+        ws.close();
+        const blob = () => new Blob([new Uint8Array(blobBytes)]);
+        const samples = [ws.bufferedAmount];
+        ws.send(blob());
+        samples.push(ws.bufferedAmount);
+        ws.ping(blob());
+        samples.push(ws.bufferedAmount);
+        ws.pong(blob());
+        samples.push(ws.bufferedAmount);
+        resolve(samples);
+      };
+      const samples = await promise;
+
+      // Each Blob overload must add at least the blob's raw size. Before the fix
+      // the Blob branch alone returned without touching bufferedAmount, so the
+      // value would not move between samples.
+      for (let i = 1; i < samples.length; i++) {
+        expect(samples[i] - samples[i - 1]).toBeGreaterThanOrEqual(blobBytes);
+      }
+    } finally {
+      close();
+    }
+  });
+
+  // Counterpart to the retention tests: when the peer reads, a backlog queued
+  // before close() transmits and the close event must report the drained total,
+  // not a stale close-time snapshot (which would wrongly count transmitted bytes
+  // as still buffered). The ~MiB backlog builds during the synchronous send loop
+  // (the event loop cannot drain mid-loop) and the reading peer empties it after.
+  test("drains toward 0 after a graceful close once a reading peer empties the backlog", async () => {
+    // resume() undoes the handshake's pause(), so this peer keeps draining the
+    // client's frames instead of letting them pile up.
+    const { port, close } = await nonDrainingServer(sock => sock.resume());
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      let maxBuffered = 0;
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7e).toString();
+        for (let i = 0; i < 500; i++) {
+          ws.send(chunk);
+          if (ws.bufferedAmount > maxBuffered) maxBuffered = ws.bufferedAmount;
+        }
+        ws.close();
+      };
+      ws.onclose = () => resolve(ws.bufferedAmount);
+      const onClose = await promise;
+
+      // A large backlog existed at close() time.
+      expect(maxBuffered).toBeGreaterThan(64 * 1024);
+      // By the close event the peer has read it, so bufferedAmount reflects the
+      // transmitted bytes rather than the close-time high-water mark.
+      expect(onClose).toBeLessThan(maxBuffered / 2);
+    } finally {
+      close();
+    }
+  });
+
+  // While the socket stays OPEN the value is live: it rises during a burst and
+  // returns to 0 once the peer has read everything, so callers can wait for
+  // backpressure to clear before sending more.
+  test("returns to 0 while open once a reading peer has drained the backlog", async () => {
+    const frames = 500;
+    const payloadBytes = 64 * 1024;
+    const received = Promise.withResolvers<void>();
+    const { port, close } = await nonDrainingServer(sock => {
+      let bytes = 0;
+      sock.on("data", d => {
+        bytes += d.length;
+        if (bytes >= frames * payloadBytes) received.resolve();
+      });
+      sock.resume();
+    });
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      ws.onerror = () => reject(new Error("unexpected error event"));
+      ws.onclose = () => reject(new Error("unexpected close event"));
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(payloadBytes, 0x7f).toString();
+        let max = 0;
+        for (let i = 0; i < frames; i++) {
+          ws.send(chunk);
+          if (ws.bufferedAmount > max) max = ws.bufferedAmount;
+        }
+        resolve(max);
+      };
+      const max = await promise;
+      expect(max).toBeGreaterThan(payloadBytes);
+
+      // The peer has the payloads; only the tail of the last frame can still be
+      // in flight, so the live value must settle back to exactly 0.
+      await received.promise;
+      while (ws.bufferedAmount !== 0) await Bun.sleep(1);
+      expect(ws.readyState).toBe(WebSocket.OPEN);
+      ws.onclose = null;
+      ws.close();
+    } finally {
+      close();
+    }
+  });
+
+  // The abrupt-close path (protocol error / timeout / write failure) must also
+  // preserve the backlog: the spec's "does not reset to 0" guarantee is not
+  // limited to graceful close(). Here the server sends a masked frame (illegal
+  // from a server), which aborts the client via the fail() path.
+  test("does not reset to 0 on an abrupt close while a backlog is queued", async () => {
+    const { port, close } = await nonDrainingServer(sock => sock.write(maskedServerFrame()));
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve } = Promise.withResolvers<{ beforeClose: number; onClose: number }>();
+      let beforeClose = 0;
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7b).toString();
+        // Synchronous flood: completes before the event loop processes the
+        // server's incoming masked frame, so the backlog is queued first.
+        for (let i = 0; i < 4000; i++) ws.send(chunk);
+        beforeClose = ws.bufferedAmount;
+      };
+      // The illegal frame aborts the connection; bufferedAmount read in the
+      // close handler must still reflect the queued backlog.
+      ws.onclose = () => resolve({ beforeClose, onClose: ws.bufferedAmount });
+      ws.onerror = () => {};
+      const { beforeClose: queued, onClose } = await promise;
+
+      expect(queued).toBeGreaterThan(64 * 1024);
+      // Must not reset to 0 on the abrupt close: the backlog is still queued.
+      // (Not an exact match: a few frames may drain between the read above and
+      // the close, so assert it stays a large backlog rather than an exact value.)
+      expect(onClose).toBeGreaterThan(64 * 1024);
+    } finally {
+      close();
+    }
+  });
+
+  // The server-initiated close (peer sends a valid Close frame) is a fourth
+  // close path. With an undrainable backlog the client defers the close until
+  // the transport dies, so the peer drops the connection right after the Close
+  // frame; the close event must still preserve the backlog, not reset it to 0.
+  test("does not reset to 0 on a server-initiated close while a backlog is queued", async () => {
+    // Stop reading so the client's sends pile up, send a valid Close frame, then
+    // drop the connection so the deferred close completes.
+    const { port, close } = await nonDrainingServer(sock => {
+      sock.write(serverCloseFrame());
+      sock.destroy();
+    });
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve } = Promise.withResolvers<{ beforeClose: number; onClose: number }>();
+      let beforeClose = 0;
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7c).toString();
+        for (let i = 0; i < 4000; i++) ws.send(chunk);
+        beforeClose = ws.bufferedAmount;
+      };
+      ws.onclose = () => resolve({ beforeClose, onClose: ws.bufferedAmount });
+      ws.onerror = () => {};
+      const { beforeClose: queued, onClose } = await promise;
+
+      expect(queued).toBeGreaterThan(64 * 1024);
+      // The backlog must survive the server-initiated close.
+      expect(onClose).toBeGreaterThan(64 * 1024);
+    } finally {
+      close();
+    }
+  });
+
+  // An abrupt socket close (no WebSocket Close handshake) while a backlog is
+  // queued must also preserve bufferedAmount. Depending on the platform's event
+  // loop this routes through either handle_close() (socket-close callback) or
+  // handle_end() -> fail(); both snapshot the backlog before freeing it.
+  test("does not reset to 0 on an abrupt socket close while a backlog is queued", async () => {
+    // Stop reading so the client's sends pile up, then abruptly destroy the
+    // connection (sends FIN; the client's own writes to the closed peer may then
+    // draw an RST); no WebSocket Close handshake either way.
+    const { port, close } = await nonDrainingServer(sock => sock.destroy());
+    try {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/`);
+      const { promise, resolve } = Promise.withResolvers<{ beforeClose: number; onClose: number }>();
+      let beforeClose = 0;
+      ws.onopen = () => {
+        const chunk = Buffer.alloc(64 * 1024, 0x7d).toString();
+        for (let i = 0; i < 4000; i++) ws.send(chunk);
+        beforeClose = ws.bufferedAmount;
+      };
+      ws.onclose = () => resolve({ beforeClose, onClose: ws.bufferedAmount });
+      ws.onerror = () => {};
+      const { beforeClose: queued, onClose } = await promise;
+
+      expect(queued).toBeGreaterThan(64 * 1024);
+      // The backlog must survive the abrupt socket close.
+      expect(onClose).toBeGreaterThan(64 * 1024);
+    } finally {
+      close();
+    }
+  });
 });


### PR DESCRIPTION
Fixes #31760

#40566 implemented the live client `bufferedAmount`. This PR is now the follow-up that keeps the value correct through close.

### Problem

- After #40566, `bufferedAmount` resets to `0` on every close path that drops the native client: `terminate()`, a protocol-error abort, a server-initiated close, and a peer TCP close. The WHATWG spec says the value "does not reset to zero once the connection closes". `didClose` (`src/jsc/bindings/webcore/WebSocket.cpp:1500`) receives no snapshot and `didFailWithErrorCode` takes no buffered argument, so the queued backlog is lost with the send buffer.
- The `Blob` overloads of `send()`/`ping()`/`pong()` and the no-argument `ping()`/`pong()` return early after close without adding to `m_bufferedAmountAfterClose`, unlike the String and ArrayBuffer overloads.

### Fix

- Every Rust close path (`fail`, `handle_close`, `send_close_with_body`, `finish_pending_close`) snapshots `buffered_amount()` before `clear_data()` frees the buffer and passes it through `WebSocket__didClose`/`WebSocket__didAbruptClose`. `didClose()` keeps the largest of the current value and the snapshot, so `wasClean` stays true on a clean close. `terminate()` snapshots eagerly in C++ before `cancelConnectedClient()` detaches the client.
- The Blob overloads accumulate `clampToUnsigned(size) + getFramingOverhead(size)` after close. The no-argument `ping()`/`pong()` add their 6 framing bytes, matching `ping("")`.
- Verified: `test/js/web/websocket/websocket-buffered-amount.test.ts` gains 9 retention tests, 5 of which fail on main. The 7 live-tracking tests from #40566 still pass, as does the rest of `test/js/web/websocket/`.

### Background

- The native client frees its send buffer in `clear_data()` during teardown, so the backlog must be read before that point and carried across the FFI callback.
- `m_bufferedAmount` holds the final snapshot once the client is detached. `m_bufferedAmountAfterClose` counts payloads handed to `send()`/`ping()`/`pong()` after close, which are never written.

<details><summary>Notes</summary>

This PR originally implemented the whole client `bufferedAmount` (live getter plus retention). #40566 landed an independent live implementation, so this branch was rebased down to the retention and post-close accounting delta on top of it. The FFI getter, the tunnel accessor, and the `headers.h` declarations now come from main. The close-path snapshot threading, the `didClose`/`didFailWithErrorCode` max-keeping, the `terminate()` eager snapshot, and the overload accounting are this PR's remaining content, unchanged from the reviewed versions. Earlier review rounds (memory-safety, aliasing, clamping) all applied to these paths and their findings are preserved.

Known gap (tunnel only, documented in-source): a fatal SSL error inside the tunnel's `write_data` fires `fail()` before the send buffer is restored, so that snapshot reads 0. No worse than the pre-feature behavior.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 28 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-buffered-amount.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/websocket/websocket-buffered-amount.test.ts:
(pass) WebSocket.bufferedAmount (ws) > counts bytes the peer has not accepted and drains to 0 [955.91ms]
(pass) WebSocket.bufferedAmount (wss) > counts bytes the peer has not accepted and drains to 0 [1084.52ms]
(pass) WebSocket.bufferedAmount (wss via http:// proxy) > counts bytes the peer has not accepted and drains to 0 [748.03ms]
(pass) WebSocket.bufferedAmount (wss via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [705.60ms]
(pass) WebSocket.bufferedAmount (ws via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [682.33ms]
(pass) WebSocket.bufferedAmount > is 0 once a small message has been written [56.94ms]
(pass) WebSocket.bufferedAmount > ws package reports the same number [802.02ms]
(pass) WebSocket.bufferedAmount (client) > reflects the backlog queued to a peer that stopped reading [2168.76ms]
(pass) WebSocket.bufferedAmount (client) > 
... (truncated)

release without fix: 15 FAILED
bun test v1.4.1-canary.1 (adc354d99)

test/js/web/websocket/websocket-buffered-amount.test.ts:
107 | 
108 |         for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
109 | 
110 |         // The kernel and any proxy absorbed some; the rest is ours to report.
111 |         const queued = ws.bufferedAmount;
112 |         expect(queued).toBeGreaterThan(TOTAL_BYTES / 2);
                             ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 33554432
Received: 0

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-buffered-amount.test.ts:112:24)
(fail) WebSocket.bufferedAmount (ws) > counts bytes the peer has not accepted and drains to 0 [66.78ms]
107 | 
108 |         for (let i = 0; i < TOTAL; i++) ws.send(CHUNK);
109 | 
110 |         // The kernel and any proxy absorbed some; the rest is ours to report.
111 |         const queued = ws.bufferedAmount;
112 |         expect(queued).toBeGreaterThan(TOTAL_BYTES / 2);
                             ^
error: expect(received).toBeGreaterThan(expected)

Expected: > 33554432
Received: 0

      at <anonymous> (/workspace/bun/test/js/web/websocket/websocket-buffered-amount.test.ts:112:24)
(fail) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/websocket/websocket-buffered-amount.test.ts
bun test v1.4.1 (adc354d99)

test/js/web/websocket/websocket-buffered-amount.test.ts:
(pass) WebSocket.bufferedAmount (ws) > counts bytes the peer has not accepted and drains to 0 [965.77ms]
(pass) WebSocket.bufferedAmount (wss) > counts bytes the peer has not accepted and drains to 0 [1087.37ms]
(pass) WebSocket.bufferedAmount (wss via http:// proxy) > counts bytes the peer has not accepted and drains to 0 [749.17ms]
(pass) WebSocket.bufferedAmount (wss via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [835.84ms]
(pass) WebSocket.bufferedAmount (ws via https:// proxy) > counts bytes the peer has not accepted and drains to 0 [635.40ms]
(pass) WebSocket.bufferedAmount > is 0 once a small message has been written [52.60ms]
(pass) WebSocket.bufferedAmount > ws package reports the same number [870.11ms]
(pass) WebSocket.bufferedAmount (client) > reflects the backlog queued to a peer that stopped reading [2223.95ms]
(pass) WebSocket.bufferedAmount (client) > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 645ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[5/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[6/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[7/13] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 243 extern-C blocks audited
[8/13] gen cpp.rs (cppbind)
[8/13] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunf
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/websocket_client.rs                   |  73 +++-
 src/http_jsc/websocket_client/CppWebSocket.rs      |  29 +-
 .../websocket_client/WebSocketUpgradeClient.rs     |   3 +-
 src/jsc/bindings/webcore/WebSocket.cpp             | 100 +++--
 src/jsc/bindings/webcore/WebSocket.h               |   7 +-
 .../websocket/websocket-buffered-amount.test.ts    | 408 ++++++++++++++++++++-
 6 files changed, 569 insertions(+), 51 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 28

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/http_jsc/websocket_client.rs                            39     52     67
src/http_jsc/websocket_client/CppWebSocket.rs                9     13     65
src/http_jsc/websocket_client/WebSocketUpgradeClient.rs      3      3     65
src/jsc/bindings/webcore/WebSocket.cpp                      26     32     67
src/jsc/bindings/webcore/WebSocket.h                         4      5     67
test/js/web/websocket/websocket-buffered-amount.test.ts     27     32     64
```

</details>

**root cause** · written by the author bot

The client WebSocket's bufferedAmount lost any queued send backlog the moment the connection was torn down, because the native close and failure paths discarded the buffer before the getter could observe it, leaving the value stuck at zero after close, terminate, or an abrupt disconnect. The fix snapshots the native send backlog before teardown, threads that count through the close and error callbacks into the C++ layer, and retains the larger of the snapshot and any previously recorded amount. It also accounts for data queued after close in the Blob and no-argument send overloads, so buffe…

<!-- robobun:evidence:end -->