### PR TITLE
child_process: match Node's spawnSync result shape when spawn fails

### DIFF
--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -507,12 +507,12 @@ function spawnSync(file, args, options) {
     );
     error.spawnargs = ArrayPrototypeSlice.$call(options.args, 1);
     return {
-      signal: null,
-      status: null,
-      output: [null, null, null],
       pid: 0,
-      stdout: null,
-      stderr: null,
+      output: null,
+      stdout: undefined,
+      stderr: undefined,
+      status: null,
+      signal: null,
       error,
     };
   }
@@ -545,7 +545,6 @@ function spawnSync(file, args, options) {
     }
   }
 
-  var error;
   try {
     var {
       stdout = null,
@@ -575,9 +574,21 @@ function spawnSync(file, args, options) {
       maxBuffer: options.maxBuffer,
     });
   } catch (err) {
-    error = err;
-    stdout = null;
-    stderr = null;
+    // Bun.spawnSync threw, so the child never started (e.g. ENOENT / EACCES).
+    // Node reports this "never started" case with a dedicated result shape:
+    // the process has no pid, no output and no exit status, and stdout/stderr
+    // are left undefined rather than null.
+    err.syscall = "spawnSync " + options.file;
+    err.spawnargs = ArrayPrototypeSlice.$call(options.args, 1);
+    return {
+      pid: 0,
+      output: null,
+      stdout: undefined,
+      stderr: undefined,
+      status: null,
+      signal: null,
+      error: err,
+    };
   }
 
   // When stdio is redirected to a file descriptor, Bun.spawnSync returns the fd number
@@ -587,15 +598,11 @@ function spawnSync(file, args, options) {
 
   const result = {
     signal: signalCode ?? null,
-    status: exitCode,
+    status: exitCode ?? null,
     // TODO: Need to expose extra pipes from Bun.spawnSync to child_process
     output: [null, outputStdout, outputStderr],
     pid,
   };
-
-  if (error) {
-    result.error = error;
-  }
 
   if (outputStdout && encoding && encoding !== "buffer") {
     result.output[1] = result.output[1]?.toString(encoding);
@@ -608,7 +615,7 @@ function spawnSync(file, args, options) {
   result.stdout = result.output[1];
   result.stderr = result.output[2];
 
-  if (exitedDueToTimeout && error == null) {
+  if (exitedDueToTimeout) {
     result.error = new SystemError(
       "spawnSync " + options.file + " ETIMEDOUT",
       options.file,
@@ -617,7 +624,7 @@ function spawnSync(file, args, options) {
       "ETIMEDOUT",
     );
   }
-  if (exitedDueToMaxBuffer && error == null) {
+  if (exitedDueToMaxBuffer) {
     result.error = new SystemError(
       "spawnSync " + options.file + " ENOBUFS (stdout or stderr buffer reached maxBuffer size limit)",
       options.file,

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -542,14 +542,38 @@ it.if(!isWindows)("spawnSync correctly reports signal codes", () => {
   expect(signal).toBe("SIGTRAP");
 });
 
-it("spawnSync(does-not-exist)", () => {
+it("spawnSync(does-not-exist) matches Node's ENOENT result shape", () => {
   const x = spawnSync("does-not-exist");
+  // The spawn itself failed, so the child never started. Node reports this
+  // "never started" case with status/signal/output null, pid 0, and leaves
+  // stdout/stderr undefined (see https://github.com/oven-sh/bun/issues/31767).
   expect(x.error?.code).toEqual("ENOENT");
+  expect(x.error.errno).toEqual(-2);
   expect(x.error.path).toEqual("does-not-exist");
+  expect(x.error.syscall).toEqual("spawnSync does-not-exist");
+  expect(x.error.spawnargs).toEqual([]);
+  expect(x.status).toEqual(null);
   expect(x.signal).toEqual(null);
-  expect(x.output).toEqual([null, null, null]);
-  expect(x.stdout).toEqual(null);
-  expect(x.stderr).toEqual(null);
+  expect(x.output).toEqual(null);
+  expect(x.pid).toEqual(0);
+  expect(x.stdout).toBeUndefined();
+  expect(x.stderr).toBeUndefined();
+});
+
+it("spawnSync() success path keeps a Node-compatible result shape", () => {
+  const x = spawnSync(bunExe(), ["-v"], { env: bunEnv });
+  // The child ran to completion, so output/pid/stdout/stderr are real and
+  // there is no error. This must stay untouched by the ENOENT fix above.
+  expect(x.error).toBeUndefined();
+  expect(x.status).toEqual(0);
+  expect(x.signal).toEqual(null);
+  expect(x.pid).toBeGreaterThan(0);
+  expect(x.output).toHaveLength(3);
+  expect(x.output[0]).toEqual(null);
+  expect(Buffer.isBuffer(x.stdout)).toBe(true);
+  expect(Buffer.isBuffer(x.stderr)).toBe(true);
+  expect(x.output[1]).toBe(x.stdout);
+  expect(x.output[2]).toBe(x.stderr);
 });
 
 // https://github.com/oven-sh/bun/issues/32067

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
-import { promisify } from "node:util";
+import { getSystemErrorName, promisify } from "node:util";
 import path from "path";
 const debug = process.env.DEBUG ? console.log : () => {};
 
@@ -548,7 +548,9 @@ it("spawnSync(does-not-exist) matches Node's ENOENT result shape", () => {
   // "never started" case with status/signal/output null, pid 0, and leaves
   // stdout/stderr undefined (see https://github.com/oven-sh/bun/issues/31767).
   expect(x.error?.code).toEqual("ENOENT");
-  expect(x.error.errno).toEqual(-2);
+  // errno is the libuv-negated value, which differs by platform (-2 on POSIX,
+  // -4058 on Windows); assert via its name like Node's own spawnsync test does.
+  expect(getSystemErrorName(x.error.errno)).toEqual("ENOENT");
   expect(x.error.path).toEqual("does-not-exist");
   expect(x.error.syscall).toEqual("spawnSync does-not-exist");
   expect(x.error.spawnargs).toEqual([]);

--- a/test/js/node/child_process/spawnsync-error-shape.node.mts
+++ b/test/js/node/child_process/spawnsync-error-shape.node.mts
@@ -1,0 +1,55 @@
+/**
+ * All tests in this file should also run in Node.js.
+ *
+ * Do not add any tests that only run in Bun.
+ *
+ * Regression coverage for https://github.com/oven-sh/bun/issues/31767:
+ * spawnSync's result object must match Node's shape on the spawn-failure
+ * path (the child never started) as well as the normal process-ran path.
+ */
+
+import { test } from "node:test";
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import { getSystemErrorName } from "node:util";
+
+test("spawnSync(nonexistent) reports the ENOENT 'never started' shape", () => {
+  const r = spawnSync("spawnsync-does-not-exist", ["arg0", "arg1"]);
+
+  // The error describes the failed spawn.
+  assert.strictEqual(r.error.code, "ENOENT");
+  // errno is the libuv-negated value, which differs by platform (-2 on POSIX,
+  // -4058 on Windows), so compare by name like Node's own spawnsync test does.
+  assert.strictEqual(getSystemErrorName(r.error.errno), "ENOENT");
+  assert.strictEqual(r.error.syscall, "spawnSync spawnsync-does-not-exist");
+  assert.strictEqual(r.error.path, "spawnsync-does-not-exist");
+  assert.deepStrictEqual(r.error.spawnargs, ["arg0", "arg1"]);
+
+  // Because the child never started, the rest of the result is the
+  // "never started" shape: no status/signal/output, pid 0, and stdout/stderr
+  // are left undefined (not null).
+  assert.strictEqual(r.status, null);
+  assert.strictEqual(r.signal, null);
+  assert.strictEqual(r.output, null);
+  assert.strictEqual(r.pid, 0);
+  assert.strictEqual(r.stdout, undefined);
+  assert.strictEqual(r.stderr, undefined);
+});
+
+test("spawnSync(success) keeps the process-ran shape", () => {
+  const r = spawnSync(process.execPath, ["-e", "process.stdout.write('ok')"]);
+
+  // The child ran to completion: real pid/output/stdout/stderr, no error.
+  assert.strictEqual(r.error, undefined);
+  assert.strictEqual(r.status, 0);
+  assert.strictEqual(r.signal, null);
+  assert.ok(typeof r.pid === "number" && r.pid > 0);
+  assert.strictEqual(r.output.length, 3);
+  assert.strictEqual(r.output[0], null);
+  assert.ok(Buffer.isBuffer(r.stdout));
+  assert.ok(Buffer.isBuffer(r.stderr));
+  assert.strictEqual(r.stdout.toString(), "ok");
+  // stdout/stderr alias output[1]/output[2].
+  assert.strictEqual(r.output[1], r.stdout);
+  assert.strictEqual(r.output[2], r.stderr);
+});

--- a/test/js/node/child_process/spawnsync-error-shape.test.ts
+++ b/test/js/node/child_process/spawnsync-error-shape.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, nodeExe } from "harness";
+import { join } from "node:path";
+
+// The assertions live in spawnsync-error-shape.node.mts and encode Node's
+// spawnSync result shape. Running the same file under both Node and Bun proves
+// the fix for https://github.com/oven-sh/bun/issues/31767 matches Node exactly.
+const fixture = join(import.meta.dir, "spawnsync-error-shape.node.mts");
+
+async function run(cmd: string[]) {
+  await using proc = Bun.spawn({
+    cmd,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("spawnSync error/result shape parity", () => {
+  test.if(!!nodeExe())("tests pass on node.js", async () => {
+    const { stdout, stderr, exitCode } = await run([nodeExe()!, "--test", fixture]);
+    const output = stdout + stderr;
+    // node --test reports failures both in the summary and via a non-zero exit.
+    expect(output).toContain("pass 2");
+    expect(output).toContain("fail 0");
+    expect(exitCode).toBe(0);
+  });
+
+  test("tests pass on bun", async () => {
+    const { stdout, stderr } = await run([bunExe(), "test", fixture]);
+    const output = stdout + stderr;
+    // `bun test` on a node:test file does not propagate failures to the exit
+    // code, so assert on the reported pass/fail counts instead.
+    expect(output).toContain(" 2 pass");
+    expect(output).toContain(" 0 fail");
+  });
+});

--- a/test/js/node/child_process/spawnsync-error-shape.test.ts
+++ b/test/js/node/child_process/spawnsync-error-shape.test.ts
@@ -16,25 +16,20 @@ async function run(cmd: string[]) {
     env: bunEnv,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout, stderr, exitCode };
+  return { output: stdout + stderr, exitCode };
 }
 
 describe("spawnSync error/result shape parity", () => {
   test.if(!!nodeExe())("tests pass on node.js", async () => {
-    const { stdout, stderr, exitCode } = await run([nodeExe()!, "--test", fixture]);
-    const output = stdout + stderr;
-    // node --test reports failures both in the summary and via a non-zero exit.
+    const { output, exitCode } = await run([nodeExe()!, "--test", fixture]);
+    // Guard against a "0 tests ran" false pass, then require a clean exit.
     expect(output).toContain("pass 2");
-    expect(output).toContain("fail 0");
     expect(exitCode).toBe(0);
   });
 
   test("tests pass on bun", async () => {
-    const { stdout, stderr } = await run([bunExe(), "test", fixture]);
-    const output = stdout + stderr;
-    // `bun test` on a node:test file does not propagate failures to the exit
-    // code, so assert on the reported pass/fail counts instead.
-    expect(output).toContain(" 2 pass");
-    expect(output).toContain(" 0 fail");
+    const { output, exitCode } = await run([bunExe(), "test", fixture]);
+    expect(output).toContain("2 pass");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #31767

## Repro

```js
const { spawnSync } = require("child_process");
console.log(spawnSync("doesnotexist"));
```

## Problem

When `spawnSync` is given a binary it can't start (`ENOENT`/`EACCES`), Bun's result object diverges from Node's. Node reports a dedicated "the child never started" shape; Bun returned leftover `undefined`s and a stale output array:

| Field    | Node (spawn failed) | Bun (before) | Bun (after) |
|----------|---------------------|--------------|-------------|
| `error`  | `Error` w/ `code/errno/syscall/path/spawnargs` | ✅ same | ✅ same |
| `signal` | `null`              | `null`       | `null`      |
| `status` | `null`              | `undefined`  | `null`      |
| `output` | `null`              | `[null, null, null]` | `null` |
| `pid`    | `0`                 | `undefined`  | `0`         |
| `stdout` | `undefined`         | `null`       | `undefined` |
| `stderr` | `undefined`         | `null`       | `undefined` |

## Cause

In `src/js/node/child_process.ts`, the `spawnSync` `catch` block only recorded the error and cleared `stdout`/`stderr`. The `exitCode`, `signalCode` and `pid` destructuring targets were never assigned (so they stayed `undefined`), and the result object was then built the same way as the success path — yielding `status: undefined`, `pid: undefined`, `output: [null, null, null]`, `stdout/stderr: null`.

## Fix

Return early from the `catch` with Node's "never started" shape (`pid: 0`, `output: null`, `stdout/stderr: undefined`, `status/signal: null`), after setting the error's `syscall`/`spawnargs`. The same shape is applied to the `windowsBatchFileError` early-return, which is the same class of pre-spawn failure (`EINVAL` before the child starts).

Crucially this only touches the **spawn-failure** path. When the child actually runs — success, non-zero exit, signal kill, `ETIMEDOUT`, `ENOBUFS` — Node keeps a real `pid`, an `output` array and real `stdout`/`stderr`, and so does Bun (verified below). The distinguishing factor is whether the process started, not merely whether an `error` is present.

Dead code left by the early return (`var error`, the `if (error)` assignment, and the `&& error == null` guards on the timeout/maxBuffer synthesis) is removed.

## Verification

New/updated tests in `test/js/node/child_process/child_process.test.ts`:
- `spawnSync(does-not-exist)` now asserts the full Node-matching ENOENT shape (previously it asserted the buggy `output: [null,null,null]` / `stdout: null` / `stderr: null`).
- A success-path guard asserts the running-child shape stays intact (`status: 0`, real `pid`, `output` length 3, Buffer `stdout`/`stderr`, no `error`).

```
# Fail-before (baked release bun, no fix):
$ USE_SYSTEM_BUN=1 bun test test/js/node/child_process/child_process.test.ts -t spawnSync
(fail) spawnSync(does-not-exist) matches Node's ENOENT result shape
  status: expected null, received undefined

# Pass-after (debug build):
$ bun bd test test/js/node/child_process/child_process.test.ts -t spawnSync
 4 pass  0 fail
```

Node's own upstream tests still pass with the fix:
```
$ bun bd test/js/node/test/parallel/test-child-process-spawnsync.js          # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-spawnsync-timeout.js  # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-spawnsync-maxbuf.js   # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-execsync-maxbuf.js    # exit 0
$ bun bd test/js/node/test/parallel/test-child-process-execfilesync-maxbuf.js # exit 0
```
(`test-child-process-spawnsync.js` exercises the `ENOENT` error path including `spawnargs`.)
