### PR TITLE
node:module: default runMain() argument to process.argv[1]

### DIFF
--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -18,6 +18,7 @@
 
 #include "PathInlines.h"
 #include "ZigGlobalObject.h"
+#include "BunProcess.h"
 #include "headers.h"
 #include "ErrorCode.h"
 
@@ -782,6 +783,23 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto arg1 = callFrame->argument(0);
+
+    // Node defaults the argument to process.argv[1] (the main entry point):
+    // `function executeUserEntryPoint(main = process.argv[1])`. Without this,
+    // `runMain()` with no argument would coerce `undefined` to the literal
+    // string "undefined" and fail to resolve it as a module.
+    if (arg1.isUndefined()) {
+        auto* zigGlobalObject = defaultGlobalObject(globalObject);
+        if (auto* process = zigGlobalObject->processObject()) {
+            JSValue argv = process->getArgv(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (auto* argvArray = dynamicDowncast<JSArray>(argv)) {
+                arg1 = argvArray->getIndex(globalObject, 1);
+                RETURN_IF_EXCEPTION(scope, {});
+            }
+        }
+    }
+
     auto name = arg1.toWTFString(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
 

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -890,6 +890,32 @@ console.log("survived", require("./late.js"));`,
     expect(stdout.trim()).toBe("pass");
     expect(await proc.exited).toBe(0);
   });
+
+  // https://github.com/oven-sh/bun/issues/31773
+  // runMain() with no argument must default to process.argv[1] (the current
+  // main entry) like Node, instead of coercing `undefined` to the string
+  // "undefined" and failing to resolve it as a module.
+  test.each([
+    ["esm", "entry.mjs", `import { runMain } from "node:module";\nrunMain();\nconsole.log("ran");\n`],
+    ["cjs", "entry.cjs", `const { runMain } = require("node:module");\nrunMain();\nconsole.log("ran");\n`],
+  ])("runMain() with no argument defaults to the main entry (%s)", async (_name, filename, source) => {
+    using dir = tempDir("run-main-no-arg", { [filename]: source });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), filename],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("Cannot find package");
+    expect(stdout.trim()).toBe("ran");
+    expect(exitCode).toBe(0);
+  });
+
   test.each(["no args", "--access-early"])("children, %s", async arg => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), path.join(import.meta.dir, "children-fixture/a.cjs"), arg],


### PR DESCRIPTION
Closes #31773

## Repro

```js
// index.mjs
import { runMain } from "node:module";
runMain();
```

```console
$ bun run index.mjs
error: Cannot find package 'undefined' from ''
```

Same result via `require("node:module").runMain()`.

## Cause

`jsFunctionRunMain` in `src/jsc/modules/NodeModuleModule.cpp` read
`callFrame->argument(0)` and passed it straight to `toWTFString()`. When
called with no argument, `argument(0)` is `undefined`, which coerces to the
literal string `"undefined"`. `loadAndEvaluateModule` then tried to resolve a
module named `"undefined"`, producing `Cannot find package 'undefined' from ''`.

Node defaults the argument to the current main entry point:

```js
function executeUserEntryPoint(main = process.argv[1]) { ... }
```

so a bare `runMain()` re-runs the already-loaded main module — a no-op, since
it's already cached — and doesn't throw.

## Fix

When no argument is passed, default to `process.argv[1]` (the main entry),
matching Node. Bun's own startup path always calls `runMain` with an explicit
main specifier, so this only affects user calls with no argument.

## Verification

- `import { runMain } ... ; runMain()` and the `require("node:module").runMain()`
  CJS equivalent now exit 0 with no error, matching `node`.
- Added `test.each` coverage (ESM + CJS) in
  `test/js/node/module/node-module-module.test.js`. The tests fail on the
  released build (`Cannot find package 'undefined' from ''`) and pass with this
  change. All 31 tests in the file pass; the existing `Module.runMain` tests
  are unaffected.