### PR TITLE
Add npm strict-ssl support to bun install

### DIFF
--- a/src/api/schema.peechy
+++ b/src/api/schema.peechy
@@ -592,6 +592,7 @@ message BunInstall {
   bool frozen_lockfile = 19;
   bool exact = 20;
   uint32 concurrent_scripts = 21;
+  bool strict_ssl = 22;
 }
 
 struct ClientServerModule {

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -1380,6 +1380,14 @@ mod draft {
             }
         }
 
+        if let Some(query) = out.as_property(b"strict-ssl") {
+            if let Some(str_) = query.expr.as_utf8_string_literal() {
+                install.strict_ssl = Some(matches!(str_, b"true" | b"1"));
+            } else if let Some(b) = query.expr.as_bool() {
+                install.strict_ssl = Some(b);
+            }
+        }
+
         if let Some(query) = out.as_property(b"ca") {
             if let Some(str_) = query.expr.as_utf8_string_literal() {
                 install.ca = Some(bun_api::Ca::Str(Box::<[u8]>::from(str_)));

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -916,7 +916,7 @@ impl PackageManager {
     }
 
     pub fn tls_reject_unauthorized(&mut self) -> bool {
-        self.env_mut().get_tls_reject_unauthorized()
+        self.options.strict_ssl && self.env_mut().get_tls_reject_unauthorized()
     }
 
     pub fn compute_is_continuous_integration(&self) -> bool {

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -52,6 +52,7 @@ pub struct Options {
 
     pub ca: Box<[Box<[u8]>]>,
     pub ca_file_name: &'static [u8],
+    pub strict_ssl: bool,
 
     // if set to `false` in bunfig, save a binary lockfile
     pub save_text_lockfile: Option<bool>,
@@ -135,6 +136,7 @@ impl Default for Options {
             publish_config: PublishConfig::default(),
             ca: Box::default(),
             ca_file_name: b"",
+            strict_ssl: true,
             save_text_lockfile: None,
             lockfile_only: false,
             git_tag_version: true,
@@ -456,6 +458,10 @@ impl Options {
 
             if let Some(cafile) = config.cafile.as_deref() {
                 self.ca_file_name = leak_static(cafile);
+            }
+
+            if let Some(strict_ssl) = config.strict_ssl {
+                self.strict_ssl = strict_ssl;
             }
 
             if config.disable_cache.unwrap_or(false) {

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -313,6 +313,8 @@ pub mod api {
         pub exact: Option<bool>,
         /// concurrent_scripts
         pub concurrent_scripts: Option<u32>,
+        /// strict-ssl
+        pub strict_ssl: Option<bool>,
 
         pub cafile: Option<Box<[u8]>>,
         pub save_text_lockfile: Option<bool>,

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -123,6 +123,37 @@ describe("auto-install", () => {
 });
 
 describe("certificate authority", () => {
+  const mockNpmRegistryFetch = function (port: () => number): (req: Request) => Promise<Response> {
+    return async function (req: Request) {
+      const url = new URL(req.url);
+
+      if (url.pathname.endsWith("/no-deps-1.0.0.tgz")) {
+        return new Response(Bun.file(join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz")));
+      }
+
+      if (url.pathname === "/no-deps" || url.pathname === "/no-deps/") {
+        return Response.json({
+          _id: "no-deps",
+          name: "no-deps",
+          "dist-tags": {
+            latest: "1.0.0",
+          },
+          versions: {
+            "1.0.0": {
+              name: "no-deps",
+              version: "1.0.0",
+              dependencies: {},
+              dist: {
+                tarball: `https://localhost:${port()}/no-deps-1.0.0.tgz`,
+              },
+            },
+          },
+        });
+      }
+
+      return new Response("Not found", { status: 404 });
+    };
+  };
   const mockRegistryFetch = function (opts?: any): (req: Request) => Promise<Response> {
     return async function (req: Request) {
       if (req.url.includes("no-deps")) {
@@ -392,6 +423,109 @@ ljelkjwelkgjw;lekj;lkejflkj
     expect(out).not.toContain("no-deps");
     const err = await stderr.text();
     expect(err).toContain("HTTPThread: the CA is invalid");
+    expect(await exited).toBe(1);
+  });
+
+  test(".npmrc strict-ssl=false allows self-signed HTTPS registry and tarball", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: mockNpmRegistryFetch(() => server.port),
+      ...tls,
+    });
+
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "bunfig.toml"),
+        `
+[install]
+cache = false
+`,
+      ),
+      write(
+        join(packageDir, ".npmrc"),
+        `
+registry=https://localhost:${server.port}/
+strict-ssl=false
+`,
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const out = await stdout.text();
+    expect(out).toContain("+ no-deps@");
+
+    const err = await stderr.text();
+    expect(err).not.toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(err).not.toContain("ERR_TLS_CERT_ALTNAME_INVALID");
+    expect(err).not.toContain("error:");
+
+    expect(await exited).toBe(0);
+  });
+
+  test("self-signed HTTPS registry is rejected when strict-ssl is not disabled", async () => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: mockNpmRegistryFetch(() => server.port),
+      ...tls,
+    });
+
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          dependencies: {
+            "no-deps": "1.0.0",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "bunfig.toml"),
+        `
+[install]
+cache = false
+`,
+      ),
+      write(
+        join(packageDir, ".npmrc"),
+        `
+registry=https://localhost:${server.port}/
+`,
+      ),
+    ]);
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stderr: "pipe",
+      stdout: "pipe",
+      env,
+    });
+
+    const out = await stdout.text();
+    expect(out).not.toContain("+ no-deps@");
+
+    const err = stderrForInstall(await stderr.text());
+    expect(err).toContain("DEPTH_ZERO_SELF_SIGNED_CERT");
+
     expect(await exited).toBe(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?

Adds support for npm-compatible `.npmrc` `strict-ssl=false` during `bun install`.

This allows installs from private HTTPS registries using self-signed or otherwise locally trusted certificates when users explicitly disable strict SSL verification.

implements #4979

### How did you verify your code works?

- added regression coverage for `.npmrc` with `strict-ssl=false`
- added coverage that the default behavior still rejects invalid TLS certificates
- ran `bun run rust:check`
- built locally with the debug no-ASan profile because the default macOS ASan debug binary aborts during `bun-debug --revision` with `AddressSanitizer: CHECK failed: sanitizer_procmaps_mac.cpp:214`
- ran the targeted registry install test with the locally built no-ASan debug binary:
  `node scripts/runner.node.mjs --exec-path ./build/debug/bun-debug test/cli/install/bun-install-registry.test.ts`