### PR TITLE
ffi: reject non-void return types for threadsafe JSCallback

### DIFF
--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -1301,7 +1301,10 @@ impl FFI {
                 Some(ZigString::init(b"Out of memory").to_error_instance(global_this))
             })
         {
-            return Ok(val);
+            // The JSCallback constructor destructures `{ ctx, ptr }` from this
+            // return, so a returned error is silently dropped (`ptr === undefined`).
+            // Throw it instead, the way dlopen() does.
+            return Err(global_this.throw_value(val));
         }
 
         // TODO: WeakRefHandle that automatically frees it?
@@ -1840,7 +1843,7 @@ pub(super) fn generate_symbol_for_function(
         ));
     }
 
-    if function.threadsafe && return_type != ABIType::Void {
+    if threadsafe && return_type != ABIType::Void {
         return Ok(Some(
             ZigString::static_(b"Threadsafe functions must return void").to_error_instance(global),
         ));

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -576,6 +576,24 @@ function ffiRunner(fast) {
           await 1;
         });
       }
+
+      it("rejects non-void return types", () => {
+        // threadsafe callbacks are delivered asynchronously and can't return a value to native code
+        expect(
+          () =>
+            new JSCallback(() => 1, {
+              args: ["int"],
+              returns: "int",
+              threadsafe: true,
+            }),
+        ).toThrow("Threadsafe functions must return void");
+      });
+    });
+
+    it("JSCallback surfaces construction errors instead of returning ptr === undefined", () => {
+      // A native validation error was returned as a value and silently dropped by the
+      // constructor's { ctx, ptr } destructure (ptr === undefined); it now throws.
+      expect(() => new JSCallback(() => 1, { args: ["int"], returns: "notarealtype" })).toThrow("Unknown return type");
     });
 
     describe("integer identities work for all possible values", () => {


### PR DESCRIPTION
## What this does

Safe JS can construct a thread-safe `JSCallback` with a non-void return type. A thread-safe callback is delivered asynchronously and cannot return a value to native code, so its caller reads garbage. Bun accepts it instead of rejecting it.

**Fix:** reject the non-void case (check the parsed `threadsafe` flag), and throw the error like `dlopen()` instead of returning a value the constructor silently dropped.

## Verification

Red on `main`, green after.

| Check | Result |
| --- | --- |
| non-void thread-safe `JSCallback` | throws `Threadsafe functions must return void` |
| invalid `JSCallback` options | throw, not silent `ptr === undefined` |
| void thread-safe callbacks | unchanged |
| `fmt`, `clippy` | clean |

## Review map

- `ffi_body.rs` (guard): check the parsed local `threadsafe`, not the stale `function.threadsafe`
- `ffi_body.rs` (callback): throw the construction error, not return it
- `ffi.test.js`: non-void threadsafe rejected; invalid options throw
