### PR TITLE
Report Node.js v24.16.0

### DIFF
--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -217,7 +217,7 @@ function Install-Git {
 function Install-NodeJs {
   # Pin to match the ABI version Bun expects (NODE_MODULE_VERSION 137).
   # Latest Node (25.x) uses ABI 141 which breaks node-gyp tests.
-  $nodejsVersion = "24.3.0"
+  $nodejsVersion = "24.16.0"
   Install-Scoop-Package "nodejs@$nodejsVersion" -Command node
 
   # Seed node-gyp's cache so napi tests don't re-download headers + node.lib

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -780,7 +780,7 @@ install_common_software() {
 }
 
 nodejs_version_exact() {
-	print "24.3.0"
+	print "24.16.0"
 }
 
 nodejs_version() {

--- a/scripts/build/deps/nodejs-headers.ts
+++ b/scripts/build/deps/nodejs-headers.ts
@@ -14,7 +14,7 @@ import type { Dependency } from "../source.ts";
  * download URL, and passed to zig as -Dreported_nodejs_version.
  * Override via `--nodejs-version=X.Y.Z` to test a bump.
  */
-export const NODEJS_VERSION = "24.3.0";
+export const NODEJS_VERSION = "24.16.0";
 
 /** Node.js NODE_MODULE_VERSION — for native addon ABI compat. */
 export const NODEJS_ABI_VERSION = "137";

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -245,7 +245,7 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 
     // Use commit hash for zstd (semantic version extraction not working yet)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "zstd"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_ZSTD_HASH)), 0);
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("13.6.233.10-node.18"_s))), 0);
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("13.6.233.17-node.49"_s))), 0);
 #if OS(WINDOWS)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "uv"_s), JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))), 0);
 #else

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -97,7 +97,7 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
         // Component versions - just add the minimum needed
         JSObject* versions = constructEmptyObject(globalObject, globalObject->objectPrototype());
         versions->putDirect(vm, Identifier::fromString(vm, "node"_s), jsString(vm, String(REPORTED_NODEJS_VERSION ""_s)), 0);
-        versions->putDirect(vm, Identifier::fromString(vm, "v8"_s), jsString(vm, String("13.6.233.10-node.18"_s)), 0);
+        versions->putDirect(vm, Identifier::fromString(vm, "v8"_s), jsString(vm, String("13.6.233.17-node.49"_s)), 0);
         versions->putDirect(vm, Identifier::fromString(vm, "uv"_s), jsString(vm, String::fromLatin1(uv_version_string())), 0);
         versions->putDirect(vm, Identifier::fromString(vm, "modules"_s), jsString(vm, String("137"_s)), 0);
         header->putDirect(vm, Identifier::fromString(vm, "componentVersions"_s), versions, 0);

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -14,7 +14,7 @@ export async function build(dir: string) {
     stdin: "inherit",
     env: {
       ...bunEnv,
-      npm_config_target: "v24.3.0",
+      npm_config_target: "v24.16.0",
       CXXFLAGS: (bunEnv.CXXFLAGS ?? "") + (process.platform == "win32" ? " -std=c++20" : " -std=gnu++20"),
       // on linux CI, node-gyp will default to g++ and the version installed there is very old,
       // so we make it use clang instead


### PR DESCRIPTION
Bumps the self-reported Node.js version from 24.3.0 to 24.16.0 (V8 `13.6.233.17-node.49`, same V8 line; `NODE_MODULE_VERSION` stays 137, N-API max stays 10 — version strings only).

### Why
`@angular/cli` 22.0.0 (published 2026-06-03) requires Node ≥ 24.15.0, so `bunx @angular/cli` now exits 3 with "The Angular CLI requires a minimum Node.js version" — which is failing `test/cli/install/bunx.test.ts` ("should handle package that requires node 24") in CI as bunx caches expire. More packages will follow as the ecosystem adopts the newer engines floor.

### Changes
- `scripts/build/deps/nodejs-headers.ts`: `NODEJS_VERSION` → 24.16.0 (also moves the N-API headers download to the matching tarball)
- `scripts/bootstrap.sh` / `scripts/bootstrap.ps1`: provisioned Node → 24.16.0
- `BunProcess.cpp` / `BunProcessReportObjectWindows.cpp`: `process.versions.v8` → `13.6.233.17-node.49`
- `test/napi/node-napi-tests/harness.ts`: `npm_config_target` → v24.16.0

### Verification
- `process.version` → `v24.16.0`, `process.versions.v8` → `13.6.233.17-node.49`, `process.config.variables.node_module_version` → `137`
- `bun x --bun @angular/cli@latest --version` exits 0 (was exit 3)
- napi suite: identical results to main locally (the local-only failures are debug-build 5s-timeout artifacts, present on main too); v8 suite blocked locally by a node-gyp env issue equally on main — relying on CI for both