### PR TITLE
Add `--no-bun` flag to override `bun = true` from bunfig

### DIFF
--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -320,6 +320,9 @@ pub(crate) const AUTO_OR_RUN_PARAMS: &[ParamType] = &[
         "-b, --bun                         Force a script or package to use Bun's runtime instead of Node.js (via symlinking node)"
     ),
     parse_param!(
+        "--no-bun                          Force a script or package to use Node.js instead of Bun's runtime, overriding `bun = true` in bunfig.toml"
+    ),
+    parse_param!(
         "--no-orphans                      Exit when the parent process dies, and on exit SIGKILL every descendant. Linux/macOS only."
     ),
     parse_param!(
@@ -1409,9 +1412,19 @@ pub fn parse(cmd: CommandTag, ctx: Context<'_>) -> Result<api::TransformOptions,
         cmd,
         CommandTag::RunCommand | CommandTag::AutoCommand | CommandTag::BunxCommand
     ) {
-        // "run.bun" in bunfig.toml
-        if args.flag(b"--bun") {
+        // "run.bun" in bunfig.toml. CLI flags override the bunfig value in either
+        // direction: --bun forces it on, --no-bun forces it off. The two are
+        // mutually exclusive (see the --compile-autoload-bunfig pair below).
+        let force_bun = args.flag(b"--bun");
+        let force_no_bun = args.flag(b"--no-bun");
+        if force_bun && force_no_bun {
+            Output::err_generic("Cannot use both --bun and --no-bun", ());
+            Global::crash();
+        }
+        if force_bun {
             ctx.debug.run_in_bun = true;
+        } else if force_no_bun {
+            ctx.debug.run_in_bun = false;
         }
     }
 

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -86,6 +86,8 @@ impl Options {
         let mut maybe_package_name: Option<&'static [u8]> = None;
         let mut has_version = false; //  --version
         let mut has_revision = false; // --revision
+        let mut force_bun = false; // --bun / -b
+        let mut force_no_bun = false; // --no-bun
         let mut i: usize = 0;
 
         // SAFETY: `opts` is only ever returned when a package name is found, otherwise the process exits.
@@ -115,7 +117,9 @@ impl Options {
                 } else if positional == b"--silent" {
                     opts.silent_install = true;
                 } else if positional == b"--bun" || positional == b"-b" {
-                    ctx.debug.run_in_bun = true;
+                    force_bun = true;
+                } else if positional == b"--no-bun" {
+                    force_no_bun = true;
                 } else if positional == b"--no-install" {
                     opts.no_install = true;
                 } else if positional == b"--package" || positional == b"-p" {
@@ -163,6 +167,18 @@ impl Options {
             }
 
             i += 1;
+        }
+
+        // --bun and --no-bun are mutually exclusive. Resolved after the loop so
+        // the run/auto path (see Arguments.rs) and bunx behave identically.
+        if force_bun && force_no_bun {
+            Output::err_generic("Cannot use both --bun and --no-bun", format_args!(""));
+            Global::exit(1);
+        }
+        if force_bun {
+            ctx.debug.run_in_bun = true;
+        } else if force_no_bun {
+            ctx.debug.run_in_bun = false;
         }
 
         // Handle --package flag case differently

--- a/test/cli/install/bun-run-bunfig.test.ts
+++ b/test/cli/install/bun-run-bunfig.test.ts
@@ -54,6 +54,60 @@ describe.each(["bun run", "bun"])(`%s`, cmd => {
     });
   });
 
+  test("--no-bun overrides `bun = true` in bunfig", async () => {
+    const bunfig = toTOMLString({
+      run: {
+        bun: true,
+      },
+    });
+
+    const cwd = tempDirWithFiles("run.where.node.no-bun", {
+      "bunfig.toml": bunfig,
+      "package.json": JSON.stringify(
+        {
+          scripts: {
+            "where-node": `which node`,
+          },
+        },
+        null,
+        2,
+      ),
+    });
+
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "--silent", "--no-bun", ...runCmd, "where-node"],
+      env: bunEnv,
+      stderr: "inherit",
+      stdout: "pipe",
+      stdin: "ignore",
+      cwd,
+    });
+    const nodeBin = result.stdout.toString().trim();
+
+    // With `bun = true` in bunfig but --no-bun on the CLI, `node` must resolve
+    // to the real Node.js, not the symlinked Bun runtime.
+    expect(realpathSync(nodeBin)).toBe(realpathSync(node));
+    expect(result.success).toBeTrue();
+  });
+
+  test("--bun and --no-bun together is an error", async () => {
+    const cwd = tempDirWithFiles("run.bun.conflict", {
+      "package.json": JSON.stringify({ scripts: { noop: "true" } }, null, 2),
+    });
+
+    const result = Bun.spawnSync({
+      cmd: [bunExe(), "--bun", "--no-bun", ...runCmd, "noop"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      stdin: "ignore",
+      cwd,
+    });
+
+    expect(result.stderr.toString()).toContain("Cannot use both --bun and --no-bun");
+    expect(result.success).toBeFalse();
+  });
+
   describe.each(["bun", "system", "default"])(`run.shell = "%s"`, shellStr => {
     if (isWindows && shellStr === "system") return; // windows always uses the bun shell now
     const shell = shellStr === "default" ? (isWindows ? "bun" : "system") : shellStr;


### PR DESCRIPTION
## What

Adds a `--no-bun` flag for `bun run` / `bunx` that forces a command to use **real Node.js** even when `[run] bun = true` is set in `bunfig.toml`.

Today `[run] bun = true` forces every script under Bun's runtime (via the symlinked `node` shim), and `--bun` could only force it *on* — there was no way to opt a single command back out. `--no-bun` is the explicit negation, so the CLI now overrides the bunfig value in **both** directions:

- `--bun` → force on
- `--no-bun` → force off

This mirrors the install command's existing config-default + CLI-override idiom (`--save`/`--no-save`, `--frozen-lockfile`, …).

## Why

Closes #31497. A user has `[run] bun = true` globally, but Vitest browser mode hangs under Bun. `bun --no-bun run test:browser` runs that one command under real Node while everything else still uses Bun.

## Changes

- `src/runtime/cli/Arguments.rs` — `--no-bun` param + override branch (sets `ctx.debug.run_in_bun = false`)
- `src/runtime/cli/bunx_command.rs` — same negation for `bunx`
- `test/cli/install/bun-run-bunfig.test.ts` — test that `--no-bun` overrides `bun = true`

All run paths (`run_command`, `filter_run`, `multi_run`, `bunx`) read the single `ctx.debug.run_in_bun` field, set once after bunfig loads, so the override applies to filtered/workspace runs too.

## Test

Verified locally on macOS against a clean build of the committed code:

- `bun bd test test/cli/install/bun-run-bunfig.test.ts -t no-bun` → **2 pass, 0 fail**
- `USE_SYSTEM_BUN=1` → **fails** (system Bun ignores `--no-bun`), confirming the test exercises the change
- `bun -c=bunfig.toml --no-bun run <script>` → spawned `node` resolves to real Node (`typeof Bun === "undefined"`)
- `bunx --bun <bin>` → Bun; `bunx --bun --no-bun <bin>` → real Node (negation wins)

Windows' separate `node`-shim path was not exercised locally — relying on CI for cross-platform coverage.