### PR TITLE
ffi: reject a negative read offset instead of aborting

### DIFF
--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -274,7 +274,14 @@ pub mod reader {
             return Err(global_object.throw_invalid_arguments(format_args!("Expected a pointer")));
         }
         let off = if arguments.len() > 1 {
-            usize::try_from(arguments[1].to_int32()).expect("int cast")
+            // The offset is a non-negative byte offset added to the address. A negative
+            // value from JS must be rejected, not converted: `usize::try_from` of a
+            // negative int errors, and panicking on it would abort the process.
+            usize::try_from(arguments[1].to_int32()).map_err(|_| {
+                global_object.throw_invalid_arguments(format_args!(
+                    "Expected byte offset to be a non-negative integer"
+                ))
+            })?
         } else {
             0usize
         };

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -647,6 +647,22 @@ it("read", () => {
   delete globalThis.buffer;
 });
 
+it("read.* throws on a negative byte offset instead of aborting", () => {
+  globalThis.buffer = new Uint8Array(16);
+  const addr = ptr(buffer);
+  // Every reader shares the same offset-validation path. A negative offset must
+  // throw the validation error, not abort the process (and not surface a downstream
+  // access fault as some other throw).
+  for (const name of ["u8", "u16", "u32", "u64", "i8", "i16", "i32", "i64", "intptr", "ptr", "f32", "f64"]) {
+    const read_negative = () => read[name](addr, -1);
+    expect(read_negative).toThrow(TypeError);
+    expect(read_negative).toThrow(/non-negative/);
+  }
+  // A valid non-negative offset still works.
+  expect(read.u8(addr, 0)).toBe(0);
+  delete globalThis.buffer;
+});
+
 if (ok) {
   describe("run ffi", () => {
     ffiRunner(false);


### PR DESCRIPTION
## What this does

`bun:ffi` `read.*(ptr, offset)` aborts the process when the offset is negative. The shared reader slow path converts the JS offset to an unsigned index and panics on a negative value instead of rejecting it.

**Fix:** a byte offset must be non-negative, so a negative value throws a `TypeError` instead of being converted. Valid positive offsets are unchanged.

## Verification

Real red/green: an unpatched build aborts on a negative offset; patched throws.

| Check | Result |
| --- | --- |
| every `read.*` reader, negative offset | unpatched aborts, patched throws |
| `read` positive-offset cases | unchanged |

## Review map

- `src/runtime/ffi/FFIObject.rs`: `reader::addr_from_args` rejects a negative offset (`usize::try_from(to_int32())` flowed into `.expect`) instead of panicking
- `test/js/bun/ffi/ffi.test.js`: every `read.*` reader throws on a negative offset
