### PR TITLE
http: fix use-after-free when aborting an h2 request after its custom TLS context is evicted

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -817,6 +817,11 @@ impl<'a> AsyncHTTP<'a> {
                         tunnel.deref();
                     }
                     debug_assert!(client.h2.is_none());
+                    // A leader must have resolved (and freed) its PendingConnect
+                    // before the terminal callback: the entry lives in the
+                    // context list we may be about to drop below, and its
+                    // `waiters` hold raw pointers to other in-flight clients.
+                    debug_assert!(client.pending_h2.is_none());
                     if let Some(ctx) = client.custom_ssl_ctx.take() {
                         // Release the strong ref the clone took in set_custom_ssl_ctx.
                         ctx.deref();

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -1048,7 +1048,11 @@ impl<const SSL: bool> HTTPContext<SSL> {
                     ssl_config: cfg,
                     reject_unauthorized: client.flags.reject_unauthorized,
                     host_header_hash: client.proxy_auth_hash(),
-                    ..Default::default()
+                    // `SSL` is true on this branch, so `Self` is
+                    // `HTTPContext<true>`; the cast only unifies the
+                    // const-generic instantiations (same layout).
+                    ctx: NonNull::from(&mut *self).cast::<HTTPContext<true>>(),
+                    waiters: Vec::new(),
                 });
                 // `client.pending_h2 = pc` stores a *borrowed* backref into the
                 // Vec-owned allocation so `resolve_pending_h2` can dispatch

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -826,17 +826,38 @@ impl ClientSession {
         for client in core::mem::take(&mut self.pending_attach) {
             pending_client_mut(client).h2_fail(err);
         }
-        for &e in self.streams.values() {
-            let client = stream_mut(e).client.take();
-            if let Some(c) = client {
-                stream_client_mut(c).h2 = None;
+        if self.delivering {
+            // Re-entered from a terminal callback inside onData's deliver loop
+            // (the client teardown dropped the last ref on a custom SSL
+            // context, whose Drop force-closed this session's socket). The
+            // loop's current stream is still in `streams`, and the loop
+            // dereferences it — and calls `remove_stream` on it — after the
+            // callback returns, so freeing it here would be a use-after-free
+            // and double-free there. Fail the clients but leave the map
+            // entries: every remaining stream is client-less after this, so
+            // the deliver loop unlinks and frees each exactly once.
+            for &e in self.streams.values() {
+                let client = stream_mut(e).client.take();
+                if let Some(c) = client {
+                    stream_client_mut(c).h2 = None;
+                }
+                if let Some(c) = client {
+                    stream_client_mut(c).h2_fail(err);
+                }
             }
-            drop_stream(e);
-            if let Some(c) = client {
-                stream_client_mut(c).h2_fail(err);
+        } else {
+            for &e in self.streams.values() {
+                let client = stream_mut(e).client.take();
+                if let Some(c) = client {
+                    stream_client_mut(c).h2 = None;
+                }
+                drop_stream(e);
+                if let Some(c) = client {
+                    stream_client_mut(c).h2_fail(err);
+                }
             }
+            self.streams.clear_retaining_capacity();
         }
-        self.streams.clear_retaining_capacity();
         // SAFETY: `self: &mut Self` carries write provenance to the Box alloc.
         unsafe { ClientSession::deref(self) };
     }

--- a/src/http/h2_client/ClientSession.rs
+++ b/src/http/h2_client/ClientSession.rs
@@ -862,6 +862,18 @@ impl ClientSession {
     /// Called from the HTTP thread's shutdown queue when a fetch on this
     /// session is aborted. RST_STREAMs that one request; siblings continue.
     pub fn abort_by_http_id(&mut self, async_http_id: u32) {
+        // Failing the aborted request runs its result callback synchronously
+        // (`fail_from_h2` → `dispatch_result_and_reset` →
+        // `on_async_http_callback_raw`), and that teardown releases the
+        // client's strong ref on its custom SSL context. When the context
+        // cache entry was already evicted and this was the last in-flight
+        // request, the context Drop runs re-entrantly and force-closes every
+        // socket in its group — including this session's — so `on_close`
+        // releases both the registry and socket-ext refs underneath us. Hold
+        // a ref for the duration so the `rearm_timeout`/`maybe_release` tail
+        // below doesn't run on a freed session (same guard as `on_data`/
+        // `on_writable`/`on_close`).
+        let _guard = self.ref_scope();
         // Find the index via a raw-ptr field read first, then swap_remove, so
         // no `&mut HTTPClient` is held across the Vec mutation and no `&mut`
         // is materialised during iteration.

--- a/src/http/h2_client/PendingConnect.rs
+++ b/src/http/h2_client/PendingConnect.rs
@@ -10,7 +10,6 @@ use crate::HTTPClient;
 use crate::NewHTTPContext;
 use crate::ssl_config::SSLConfig;
 
-#[derive(Default)]
 pub struct PendingConnect {
     pub hostname: Box<[u8]>,
     pub port: u16,
@@ -23,6 +22,15 @@ pub struct PendingConnect {
     /// exists, so a strict caller never waits on a connect started by a lax one.
     pub reject_unauthorized: bool,
     pub host_header_hash: u64,
+    /// The context whose `pending_h2_connects` list owns this entry, recorded
+    /// at registration (`HTTPContext::connect`). `resolve_pending_h2` must
+    /// unregister from exactly this list — looking the context up through the
+    /// leader's `get_ssl_ctx()` at resolve time would miss (stranding the
+    /// entry and its waiters) if the leader's custom context ever changed in
+    /// between. BACKREF: the leader's `custom_ssl_ctx` strong ref (or the
+    /// static `https_context`) keeps the pointee alive while this entry is
+    /// registered.
+    pub ctx: NonNull<NewHTTPContext<true>>,
     // BACKREF: waiters are borrowed HTTP clients owned elsewhere; lifetime-erased.
     pub waiters: Vec<NonNull<HTTPClient<'static>>>,
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -742,8 +742,11 @@ impl Drop for HTTPClient<'_> {
         // only, no shutdown).
         self.close_proxy_tunnel(false);
         // The session detaches `h2` before any terminal callback, so this should
-        // be None by the time the result callback's deinit path runs.
+        // be None by the time the result callback's deinit path runs. Same for
+        // `pending_h2`: every terminal path resolves it (freeing the list entry
+        // whose `waiters` borrow other live clients) before teardown.
         debug_assert!(self.h2.is_none());
+        debug_assert!(self.pending_h2.is_none());
         // tls_props: Option<SharedPtr> — Drop releases strong ref.
         if let Some(ctx) = self.custom_ssl_ctx.take() {
             // Release the strong ref taken in set_custom_ssl_ctx.
@@ -3821,13 +3824,26 @@ impl<'a> HTTPClient<'a> {
         let Some(pc_ptr) = self.pending_h2.take() else {
             return;
         };
-        // `pc_ptr` is a backref into the context's `pending_h2_connects` Vec,
-        // set in `HTTPContext::connect`; unregister_from swaps the owning Box
-        // out so we can iterate and drop it here.
-        let Some(pc) = h2::PendingConnect::unregister_from(
-            pc_ptr.as_ptr(),
-            Self::ssl_ctx_mut(self.get_ssl_ctx::<true>()),
-        ) else {
+        // `pc_ptr` is a backref into the owning context's `pending_h2_connects`
+        // Vec, set in `HTTPContext::connect`; unregister_from swaps the owning
+        // Box out so we can iterate and drop it here. Unregister from the
+        // context recorded at registration (`pc.ctx`) — NOT `get_ssl_ctx()`,
+        // which reflects the client's *current* custom context and would miss
+        // the list (stranding the entry and its parked waiters forever) if
+        // that ever diverged from the registering one.
+        //
+        // SAFETY: `pending_h2` is non-null only while the entry is registered
+        // (every terminal path resolves it before the leader releases its
+        // context ref), so `pc_ptr` points at the live Box owned by
+        // `pc.ctx.pending_h2_connects` and `pc.ctx` is valid.
+        let ctx = unsafe { pc_ptr.as_ref() }.ctx;
+        let pc =
+            h2::PendingConnect::unregister_from(pc_ptr.as_ptr(), Self::ssl_ctx_mut(ctx.as_ptr()));
+        debug_assert!(
+            pc.is_some(),
+            "PendingConnect missing from the context it was registered in"
+        );
+        let Some(pc) = pc else {
             return;
         };
         // pc drops at scope exit (was `defer pc.deinit()`)

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -2207,16 +2207,31 @@ test.skipIf(!isASAN)(
         process.exit(0);
       `);
       // Gate the server-side RST on the subprocess having finished eviction.
-      let stderrHead = "";
-      for await (const chunk of proc.stderr) {
-        stderrHead += Buffer.from(chunk).toString();
-        if (stderrHead.includes("evicted")) break;
+      // Read through a single reader rather than for-await (whose early exit
+      // cancels the stream): a regression's ASAN report is written to stderr
+      // AFTER this signal, and must stay readable so it lands in the failure
+      // diff below instead of being discarded.
+      const errReader = proc.stderr.getReader();
+      let stderr = "";
+      while (!stderr.includes("evicted")) {
+        const { value, done } = await errReader.read();
+        if (value) stderr += Buffer.from(value).toString();
+        if (done) break;
       }
-      expect(stderrHead).toContain("evicted");
+      expect(stderr).toContain("evicted");
       heldStream!.close(http2.constants.NGHTTP2_CANCEL);
+      // Drain the tail so any crash output becomes part of the assertion.
+      while (true) {
+        const { value, done } = await errReader.read();
+        if (value) stderr += Buffer.from(value).toString();
+        if (done) break;
+      }
       const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout.trim()).toBe("rst-ok");
-      expect(exitCode).toBe(0);
+      expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+        stdout: "rst-ok",
+        stderr: "evicted",
+        exitCode: 0,
+      });
     } finally {
       heldStream?.destroy();
       server.close();

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -2068,3 +2068,83 @@ test("h2: per-request `timeout` extends the session idle deadline, and {timeout:
     server.close();
   }
 }, 60_000);
+
+// Aborting the last in-flight request on an h2 session whose custom SSL
+// context was already evicted from the cache used to free the session out
+// from under `abortByHttpId`: failing the request runs the result callback
+// synchronously, the teardown drops the client's last ref on the custom
+// context, and the context's Drop force-closes the session socket — running
+// the session's onClose (and final deref) re-entrantly before abortByHttpId's
+// rearmTimeout/maybeRelease tail executes. Only observable under ASAN; in
+// release builds the freed read is silent heap corruption.
+// Serial: creates 61 distinct custom TLS contexts to overflow the 60-entry
+// context cache, which would evict concurrent siblings' contexts mid-test.
+test.skipIf(!isASAN)(
+  "aborting an h2 request after its custom TLS context is evicted does not use freed session memory",
+  async () => {
+    let heldStream: http2.ServerHttp2Stream | undefined;
+    const server = makeH2Server();
+    server.on("sessionError", () => {});
+    server.on("stream", (stream, headers) => {
+      stream.on("error", () => {});
+      if (headers[":path"] === "/hold") {
+        // Headers + one chunk, then hold the stream open so the client's
+        // stream (and its abort-tracker entry) stays live until the abort.
+        stream.respond({ ":status": 200 });
+        stream.write("chunk");
+        heldStream = stream;
+        return;
+      }
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = await spawnFetch(`
+        const url = "https://localhost:${port}";
+        const ac = new AbortController();
+        // serverName forces a custom SSL context (distinct per value), so the
+        // held request's context is a refcounted cache entry.
+        const held = await fetch(url + "/hold", {
+          protocol: "http2",
+          signal: ac.signal,
+          tls: { serverName: "localhost", rejectUnauthorized: false },
+        });
+        const reader = held.body.getReader();
+        await reader.read(); // first chunk — the h2 stream is attached and live
+        // 61 more distinct configs overflow the 60-entry custom-context cache
+        // and evict the held request's entry; its context survives only on the
+        // held client's own ref.
+        for (let i = 0; i < 61; i += 8) {
+          const batch = [];
+          for (let j = i; j < Math.min(i + 8, 61); j++) {
+            batch.push(
+              fetch(url, { tls: { serverName: "evict-" + j + ".test", rejectUnauthorized: false } })
+                .then(r => r.arrayBuffer())
+                .catch(() => {}),
+            );
+          }
+          await Promise.all(batch);
+        }
+        // Abort tears down the last client of the evicted context: the context
+        // drop must not free the session while abortByHttpId is still on it.
+        ac.abort();
+        await reader.read().catch(() => {});
+        // Prove the HTTP thread survived processing the abort.
+        const after = await fetch(url, { tls: { rejectUnauthorized: false } });
+        await after.arrayBuffer();
+        console.log("aborted-ok");
+        process.exit(0);
+      `);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("aborted-ok");
+      expect(exitCode).toBe(0);
+    } finally {
+      heldStream?.destroy();
+      server.close();
+    }
+  },
+);

--- a/test/js/web/fetch/fetch-http2-client.test.ts
+++ b/test/js/web/fetch/fetch-http2-client.test.ts
@@ -2148,3 +2148,78 @@ test.skipIf(!isASAN)(
     }
   },
 );
+
+// Sibling of the abort case above, triggered by the server instead: an
+// RST_STREAM on the held stream makes the deliver loop run the terminal
+// callback while the stream is still in the session map. The callback tears
+// down the last client of the evicted custom context, whose Drop force-closes
+// the session socket; onClose used to free that very stream, and the deliver
+// loop then read and double-freed it when control unwound. Only observable
+// under ASAN. Serial for the same cache-eviction reason as above.
+test.skipIf(!isASAN)(
+  "server RST on an h2 stream after its custom TLS context is evicted does not double-free the stream",
+  async () => {
+    let heldStream: http2.ServerHttp2Stream | undefined;
+    const server = makeH2Server();
+    server.on("sessionError", () => {});
+    server.on("stream", (stream, headers) => {
+      stream.on("error", () => {});
+      if (headers[":path"] === "/hold") {
+        stream.respond({ ":status": 200 });
+        stream.write("chunk");
+        heldStream = stream;
+        return;
+      }
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as import("node:net").AddressInfo;
+    try {
+      await using proc = await spawnFetch(`
+        const url = "https://localhost:${port}";
+        const held = await fetch(url + "/hold", {
+          protocol: "http2",
+          tls: { serverName: "localhost", rejectUnauthorized: false },
+        });
+        const reader = held.body.getReader();
+        await reader.read(); // first chunk — the h2 stream is attached and live
+        for (let i = 0; i < 61; i += 8) {
+          const batch = [];
+          for (let j = i; j < Math.min(i + 8, 61); j++) {
+            batch.push(
+              fetch(url, { tls: { serverName: "evict-" + j + ".test", rejectUnauthorized: false } })
+                .then(r => r.arrayBuffer())
+                .catch(() => {}),
+            );
+          }
+          await Promise.all(batch);
+        }
+        // Tell the test to RST the held stream server-side, then wait for the
+        // failure to arrive through the deliver loop.
+        process.stderr.write("evicted\\n");
+        await reader.read().catch(() => {});
+        // Prove the HTTP thread survived delivering the reset.
+        const after = await fetch(url, { tls: { rejectUnauthorized: false } });
+        await after.arrayBuffer();
+        console.log("rst-ok");
+        process.exit(0);
+      `);
+      // Gate the server-side RST on the subprocess having finished eviction.
+      let stderrHead = "";
+      for await (const chunk of proc.stderr) {
+        stderrHead += Buffer.from(chunk).toString();
+        if (stderrHead.includes("evicted")) break;
+      }
+      expect(stderrHead).toContain("evicted");
+      heldStream!.close(http2.constants.NGHTTP2_CANCEL);
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout.trim()).toBe("rst-ok");
+      expect(exitCode).toBe(0);
+    } finally {
+      heldStream?.destroy();
+      server.close();
+    }
+  },
+);


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free / double-free crash cluster in the HTTP/2 fetch client around custom SSL context eviction.

**Problem**

A crash-reporter cluster new in the HTTP/2 fetch client (all on the HTTP thread, ~97% of events tagged `abort_signal`, heavy on custom-TLS workloads; same family as the teardown corruption in #31660) traces to three lifecycle defects around custom SSL contexts. All share one re-entrancy: a terminal result callback runs synchronously on the HTTP thread, its teardown releases the client's strong ref on its custom SSL context, and if the context's cache entry was already evicted (60-entry LRU overflow or 30-minute TTL) that was the **last ref** — the context `Drop` runs mid-callback, `group.close_all()` force-closes the session's socket, and `on_close` tears the session down underneath whatever frame triggered the callback.

**1. `ClientSession::abort_by_http_id` runs on a freed session.** It was the only HTTP-thread entry point into the session without a `ref_scope` guard. The re-entrant `on_close` releases the registry and socket-ext refs, freeing the session — then `abort_by_http_id` continues with `self.rearm_timeout()` / `self.maybe_release()` on freed memory.

```
ERROR: AddressSanitizer: heap-use-after-free READ of size 8 thread T2 (HTTP Client)
    #7 rearm_timeout      src/http/h2_client/ClientSession.rs:514
    #8 abort_by_http_id   src/http/h2_client/ClientSession.rs:852
freed by: rc_deref_with_context ← on_close  ClientSession.rs:801
allocated by: ClientSession::create          ClientSession.rs:233
```

**2. The deliver loop double-frees its current stream** (found in review, server-triggered sibling of #1 — plausibly the non-abort slice of the cluster). Every terminal branch of `deliver_stream` runs its callback while the stream is still in `session.streams`; the re-entrant `on_close` freed all mapped streams, then the loop unwound and dereferenced + `remove_stream`'d the freed one.

```
ERROR: AddressSanitizer: heap-use-after-free READ of size 1 thread T2 (HTTP Client)
    #2 on_data (deliver loop)  src/http/h2_client/ClientSession.rs:706
freed by: drop_stream ← on_close ClientSession.rs:793 ← HTTPContext Drop ← on_async_http_callback_raw
allocated by: Stream::new ← attach ← first_call
```

**3. `resolve_pending_h2` unregistered the `PendingConnect` from the wrong list if the leader's context ever diverged.** It looked the context up via `get_ssl_ctx()` *at resolve time* rather than using the context the entry was registered in. On a miss the entry — and every coalesced waiter parked in it — is stranded in the original context's list forever. The 1.3.14-era code additionally freed the entry unconditionally on that path, which double-freed it when the owning context was later torn down.

**Fix**

- `abort_by_http_id` holds a `ref_scope` guard for its duration, matching `on_data`/`on_writable`/`on_close`. After the re-entrant close, the tail is safe: `rearm_timeout` sees empty streams (write-only timer clear) and `maybe_release` early-returns on the registry sentinel.
- `on_close` re-entered while `delivering` fails the remaining streams' clients but leaves the map entries to the deliver loop, which unlinks and frees each stream exactly once through its existing `remove_stream` tail.
- `PendingConnect` records its owning context at registration (`HTTPContext::connect`), and `resolve_pending_h2` unregisters from exactly that list, with a debug assert that the entry was found.
- Teardown (`on_async_http_callback_raw`, `HTTPClient::drop`) asserts `pending_h2` was resolved, so a leader torn down with a registered entry fails loudly in debug instead of leaving dangling waiters.

### How did you verify your code works?

Two ASAN-gated regression tests in `test/js/web/fetch/fetch-http2-client.test.ts`: both hold an h2 stream open on a custom context (`tls: { serverName }`) and overflow the 60-entry context cache with 61 distinct configs to evict it, then terminate the held request — one via `AbortSignal` (bug 1), one via server `RST_STREAM` (bug 2). Each fails deterministically with the corresponding ASAN report above before its fix, passes after.

- `fetch-http2-client.test.ts`: 60/60 pass with the fixes
- `fetch-http2-leak.test.ts` 7/7, `fetch-http2-adversarial.test.ts` 15/15, `fetch-proxy-tls-intern-race` and abort suites pass
- `fetch.test.ts`: 325 pass / 25 fail, byte-identical to baseline without the fix (pre-existing environment failures: IPv6, root-user permissions)

### Note on CI

The diff is green everywhere it runs; both red builds are unrelated to this change:

- **Every failed `test-bun` lane in builds 60271 and 60277 fails on `test/cli/install/bunx.test.ts`** -> "should handle package that requires node 24": `@angular/cli 22.0.0` (published 2026-06-03) requires Node >= 22.22.3 / 24.15.0 / 26.0.0 and exits 3 against the Node version Bun reports (v24.3.0). Reproduced with the stock release bun; this breaks every PR built after that release and needs a fix on main (bump the reported Node version or pin the test's Angular version).
- Three known-pattern flakes hopped lanes between the builds: `test-retry-repeats-basic.test.ts` (darwin aarch64), `streams-leak.test.ts` (chunk-count timing, `expect(chunks.length).toBeGreaterThan(20)` got 18, two alpine lanes), and `fetch-leak.test.ts` fixture-6 (windows 11 aarch64 only: RSS drift 7 MB vs 5 MB allowed over plain-HTTP `Bun.serve` fetches -- a code path that never reaches the h2/TLS code this PR changes; the same test passed on the other 14 platforms).
- No failure in either build touches `src/http` or the tests added here; the new ASAN regression tests pass on the x64-asan lane, and three lanes that were red on the first build went green on the second.


