### PR TITLE
fix: widen non-bigint fs.statfs block fields to avoid int32 truncation on >8TB filesystems

### DIFF
--- a/src/runtime/node/StatFS.rs
+++ b/src/runtime/node/StatFS.rs
@@ -4,7 +4,7 @@ use bun_jsc::{JSGlobalObject, JSValue, JsResult};
 // On POSIX this is `libc::statfs`; on Windows it's `uv_statfs_t` (the value
 // `sys_uv::statfs` returns / `uv_fs_statfs` writes into `req.ptr`). Field
 // names match (`f_type`/`f_bsize`/…); widths differ (u64 vs platform-specific)
-// but `init` does an explicit `as i64`/`as $Int` truncate so either shape works.
+// but `init` normalizes them through `i64` so either shape works.
 #[cfg(unix)]
 pub(crate) type RawStatFS = libc::statfs;
 #[cfg(not(unix))]
@@ -14,7 +14,9 @@ pub(crate) type RawStatFS = bun_sys::StatFS;
 // integer type via `const Int = if (big) i64 else i32;`. Stable Rust const
 // generics cannot select a field type from a `const BIG: bool`, so we generate
 // the two concrete instantiations with a small macro. The two exported aliases
-// (`StatFSSmall`, `StatFSBig`) are the only call sites.
+// (`StatFSSmall`, `StatFSBig`) are the only call sites. Both Rust instantiations
+// use i64 storage because the non-bigint C binding also accepts i64 and turns
+// the fields into JS numbers.
 macro_rules! define_statfs_type {
     ($name:ident, $Int:ty, big = $big:expr) => {
         #[allow(non_snake_case)]
@@ -82,10 +84,9 @@ macro_rules! define_statfs_type {
                 #[cfg(target_arch = "wasm32")]
                 compile_error!("Unsupported OS");
 
-                // @truncate(@as(i64, @intCast(x))) — @intCast to i64 then @truncate to Int.
                 // PORT NOTE: platform field types vary (u32/i64/u64); `as i64` matches
-                // Zig's @intCast for the in-range values statfs reports, then `as $Int`
-                // is the @truncate (intentional wrap).
+                // Zig's @intCast for the in-range values statfs reports, and `$Int`
+                // keeps the generated concrete struct fields consistent.
                 Self {
                     _fstype: (fstype_ as i64) as $Int,
                     _bsize: (bsize_ as i64) as $Int,
@@ -128,7 +129,7 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-define_statfs_type!(StatFSSmall, i32, big = false);
+define_statfs_type!(StatFSSmall, i64, big = false);
 define_statfs_type!(StatFSBig, i64, big = true);
 
 /// Union between `Stats` and `BigIntStats` where the type can be decided at runtime

--- a/test/js/node/test/parallel/test-fs-statfs.js
+++ b/test/js/node/test/parallel/test-fs-statfs.js
@@ -1,7 +1,10 @@
 'use strict';
 const common = require('../common');
 const assert = require('node:assert');
+const childProcess = require('node:child_process');
 const fs = require('node:fs');
+const path = require('node:path');
+const tmpdir = require('../common/tmpdir');
 
 function verifyStatFsObject(statfs, isBigint = false) {
   const valueType = isBigint ? 'bigint' : 'number';
@@ -36,6 +39,120 @@ fs.statfs(__filename, { bigint: true }, function(err, stats) {
 {
   const statFsBigIntObj = fs.statfsSync(__filename, { bigint: true });
   verifyStatFsObject(statFsBigIntObj, true);
+}
+
+{
+  const statFsObj = fs.statfsSync(__filename);
+  const statFsBigIntObj = fs.statfsSync(__filename, { bigint: true });
+
+  [
+    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree',
+  ].forEach((k) => {
+    if (Number.isSafeInteger(statFsObj[k]))
+      assert.strictEqual(BigInt(statFsObj[k]), statFsBigIntObj[k]);
+  });
+}
+
+if (common.isLinux) {
+  tmpdir.refresh();
+  const source = tmpdir.resolve('statfs-large-block-counts.c');
+  const library = tmpdir.resolve('statfs-large-block-counts.so');
+
+  fs.writeFileSync(source, `
+#define _GNU_SOURCE
+#define _LARGEFILE64_SOURCE
+#include <string.h>
+#include <sys/vfs.h>
+
+static void fill_statfs(struct statfs *buf) {
+  memset(buf, 0, sizeof(*buf));
+  buf->f_type = 0x01021994;
+  buf->f_bsize = 4096;
+  buf->f_blocks = 3248532185ULL;
+  buf->f_bfree = 3248532186ULL;
+  buf->f_bavail = 3248532185ULL;
+  buf->f_files = 1000;
+  buf->f_ffree = 999;
+}
+
+int statfs(const char *path, struct statfs *buf) {
+  fill_statfs(buf);
+  return 0;
+}
+
+#ifdef __GLIBC__
+static void fill_statfs64(struct statfs64 *buf) {
+  memset(buf, 0, sizeof(*buf));
+  buf->f_type = 0x01021994;
+  buf->f_bsize = 4096;
+  buf->f_blocks = 3248532185ULL;
+  buf->f_bfree = 3248532186ULL;
+  buf->f_bavail = 3248532185ULL;
+  buf->f_files = 1000;
+  buf->f_ffree = 999;
+}
+
+int statfs64(const char *path, struct statfs64 *buf) {
+  fill_statfs64(buf);
+  return 0;
+}
+#endif
+`);
+
+  const cc = childProcess.spawnSync('cc', [
+    '-shared',
+    '-fPIC',
+    source,
+    '-o',
+    library,
+  ], { encoding: 'utf8' });
+  assert.ifError(cc.error);
+  assert.strictEqual(cc.status, 0, cc.stderr);
+
+  const child = childProcess.spawnSync(process.execPath, [
+    '-e',
+    `
+      const assert = require('node:assert');
+      const fs = require('node:fs');
+
+      function verifyNumberStats(stats) {
+        assert.strictEqual(typeof stats.blocks, 'number');
+        assert.strictEqual(typeof stats.bfree, 'number');
+        assert.strictEqual(typeof stats.bavail, 'number');
+        assert.strictEqual(stats.blocks, 3248532185);
+        assert.strictEqual(stats.bfree, 3248532186);
+        assert.strictEqual(stats.bavail, 3248532185);
+        assert.ok(stats.bavail > 0);
+      }
+
+      function verifyBigIntStats(stats) {
+        assert.strictEqual(typeof stats.bavail, 'bigint');
+        assert.strictEqual(stats.blocks, 3248532185n);
+        assert.strictEqual(stats.bfree, 3248532186n);
+        assert.strictEqual(stats.bavail, 3248532185n);
+      }
+
+      verifyNumberStats(fs.statfsSync(__filename));
+      verifyBigIntStats(fs.statfsSync(__filename, { bigint: true }));
+      fs.statfs(__filename, (err, stats) => {
+        assert.ifError(err);
+        verifyNumberStats(stats);
+      });
+      fs.statfs(__filename, { bigint: true }, (err, stats) => {
+        assert.ifError(err);
+        verifyBigIntStats(stats);
+      });
+    `,
+  ], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      BUN_DEBUG_QUIET_LOGS: '1',
+      LD_PRELOAD: [library, process.env.LD_PRELOAD].filter(Boolean).join(path.delimiter),
+    },
+  });
+  assert.ifError(child.error);
+  assert.strictEqual(child.status, 0, child.stderr);
 }
 
 [false, 1, {}, [], null, undefined].forEach((input) => {


### PR DESCRIPTION
### What does this PR do?

## Summary
Fixes the non-bigint `fs.statfs` / `fs.statfsSync` path on linux-x64, where `blocks`, `bfree`, and `bavail` were truncated to a signed 32-bit integer. In `src/runtime/node/StatFS.rs` the small variant was instantiated with `$Int = i32`, so `init()`'s `(field as i64) as $Int` truncated large `u64` block counts; this switches `StatFSSmall` to `i64` storage, matching `StatFSBig`.

## Why this matters
Issue #31510 reports that any volume whose block count exceeds 2^31 wraps negative, so `bavail * bsize` goes negative; the reporter saw `-1046435111` where Node returns `3248532185` on a ~13.3 TB btrfs volume. The `Bun__createJSStatFSObject` C binding already takes every field as `i64`, so the JS object carries values up to 2^53 safely. The `{ bigint: true }` path was already correct and is unchanged.

### How did you verify your code works?

`test/js/node/test/parallel/test-fs-statfs.js` adds a Linux case that builds a `cc -shared` `statfs`/`statfs64` interposer reporting `f_blocks`/`f_bavail` above 2^31, then asserts the non-bigint path returns positive plain numbers (`bavail: 3248532185`) and the bigint path returns the matching BigInt. It also cross-checks that every safe-integer field equals its `{ bigint: true }` counterpart. Full suite runs in CI.

Fixes #31510
