### PR TITLE
bun test --isolate: release leaked-handle global pins; attach module_info on the sync module path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.rustup
 .claude/settings.local.json
+.cargo
+Library/Caches
 .direnv
 .DS_Store
 .env

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -208,6 +208,16 @@ export const bindgen = $zig("bindgen_test.zig", "getBindgenTestFunctions") as {
 };
 
 export const noOpForTesting = $cpp("NoOpForTesting.cpp", "createNoOpForTesting");
+
+/**
+ * `bun test --isolate` SourceProvider cache introspection: returns the cached
+ * provider's JSC sourceType name ("Module", "BunTranspiledModule", ...) for a
+ * resolved specifier, or null when the specifier isn't cached.
+ */
+export const isolatedModuleCacheSourceType: (specifier: string) => string | null = $cpp(
+  "IsolatedModuleCache.cpp",
+  "createIsolatedModuleCacheSourceTypeForTesting",
+);
 export const Dequeue = require("internal/fifo");
 
 export const fs = require("node:fs/promises").$data;

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4777,6 +4777,15 @@ impl VirtualMachine {
         // AbortSignal timeout in the heap belongs to the outgoing file (the
         // new global doesn't exist yet), so drop them eagerly, same as
         // `global_exit()`. Runs no user JS.
+        //
+        // The hook also runs `StatWatcherScheduler::shutdown_for_exit` first:
+        // it drains the (already-closed — see
+        // `close_all_watchers_for_isolation` above) watcher queue and retires
+        // the per-VM scheduler singleton, which the next file's first
+        // `fs.watchFile` lazily recreates. That per-file reset is intentional
+        // — the scheduler's queue and in-flight work-pool task belong to the
+        // outgoing file, and its brief spin-wait is bounded by at most one
+        // in-flight `stat()`.
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: live per-thread VM on the JS thread; `runtime_state`
             // stays installed for the whole test run.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4699,6 +4699,11 @@ impl VirtualMachine {
             .remove_listening_socket_for_watch_mode(socket);
     }
 
+    /// Callers must run `bun_runtime::jsc_hooks::close_isolation_handles(vm)`
+    /// first so leaked watchers/servers are stopped (dropping their JS-side
+    /// Strongs, which otherwise pin the outgoing global) before the blind
+    /// socket-group close below. That helper lives in the higher-tier crate
+    /// and cannot be called from here.
     pub fn swap_global_for_test_isolation(&mut self) {
         debug_assert!(self.test_isolation_enabled);
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4699,13 +4699,6 @@ impl VirtualMachine {
             .remove_listening_socket_for_watch_mode(socket);
     }
 
-    /// Spec VirtualMachine.zig:2505 `swapGlobalForTestIsolation`.
-    ///
-    /// Callers must run `bun_runtime::jsc_hooks::close_isolation_handles()`
-    /// first: the socket-group walk below blindly closes fds, which would
-    /// leave a leaked server's `has_listener()` true and its strong
-    /// `js_value` pinning the outgoing global (fetch handler closure and
-    /// all) for the rest of the run.
     pub fn swap_global_for_test_isolation(&mut self) {
         debug_assert!(self.test_isolation_enabled);
 

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4700,20 +4700,16 @@ impl VirtualMachine {
     }
 
     /// Spec VirtualMachine.zig:2505 `swapGlobalForTestIsolation`.
+    ///
+    /// Callers must run `bun_runtime::jsc_hooks::close_isolation_handles()`
+    /// first: the socket-group walk below blindly closes fds, which would
+    /// leave a leaked server's `has_listener()` true and its strong
+    /// `js_value` pinning the outgoing global (fetch handler closure and
+    /// all) for the rest of the run.
     pub fn swap_global_for_test_isolation(&mut self) {
         debug_assert!(self.test_isolation_enabled);
 
         let _ = self.event_loop_mut().drain_microtasks();
-
-        if let Some(rare) = self.rare_data.as_deref_mut() {
-            rare.close_all_watchers_for_isolation();
-            // Stop leaked servers through their own lifecycle (listener close +
-            // `js_value` downgrade) BEFORE the blind socket-group walk below.
-            // The walk only closes fds — the server would keep `has_listener()`
-            // true and its strong `js_value` would pin the outgoing global
-            // (fetch handler closure and all) for the rest of the run.
-            rare.stop_all_servers_for_isolation();
-        }
 
         {
             // Groups that must survive the per-file isolation swap: this
@@ -4779,8 +4775,8 @@ impl VirtualMachine {
         // `global_exit()`. Runs no user JS.
         //
         // The hook also runs `StatWatcherScheduler::shutdown_for_exit` first:
-        // it drains the (already-closed — see
-        // `close_all_watchers_for_isolation` above) watcher queue and retires
+        // it drains the (already-closed — the caller ran
+        // `close_isolation_handles` before this swap) watcher queue and retires
         // the per-VM scheduler singleton, which the next file's first
         // `fs.watchFile` lazily recreates. That per-file reset is intentional
         // — the scheduler's queue and in-flight work-pool task belong to the

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4707,6 +4707,12 @@ impl VirtualMachine {
 
         if let Some(rare) = self.rare_data.as_deref_mut() {
             rare.close_all_watchers_for_isolation();
+            // Stop leaked servers through their own lifecycle (listener close +
+            // `js_value` downgrade) BEFORE the blind socket-group walk below.
+            // The walk only closes fds — the server would keep `has_listener()`
+            // true and its strong `js_value` would pin the outgoing global
+            // (fetch handler closure and all) for the rest of the run.
+            rare.stop_all_servers_for_isolation();
         }
 
         {
@@ -4763,6 +4769,19 @@ impl VirtualMachine {
         self.auto_killer.clear();
 
         self.test_isolation_generation = self.test_isolation_generation.wrapping_add(1);
+
+        // Generation-stale JS timers would otherwise release their pins only
+        // when they fire — a module-scope `setTimeout(cb, 3_600_000)` keeps a
+        // Strong on its wrapper (and thereby the outgoing global's whole
+        // graph) for an hour. Every TimeoutObject / ImmediateObject /
+        // AbortSignal timeout in the heap belongs to the outgoing file (the
+        // new global doesn't exist yet), so drop them eagerly, same as
+        // `global_exit()`. Runs no user JS.
+        if let Some(hooks) = runtime_hooks() {
+            // SAFETY: live per-thread VM on the JS thread; `runtime_state`
+            // stays installed for the whole test run.
+            unsafe { (hooks.cancel_all_timers)(core::ptr::from_mut(self)) };
+        }
 
         self.overridden_main.deinit();
         self.entry_point_result.value.deinit();

--- a/src/jsc/bindings/IsolatedModuleCache.cpp
+++ b/src/jsc/bindings/IsolatedModuleCache.cpp
@@ -1,7 +1,10 @@
 #include "IsolatedModuleCache.h"
 #include "BunClientData.h"
 #include "ModuleLoader.h"
+#include "ZigGlobalObject.h"
 #include "ZigSourceProvider.h"
+#include "JavaScriptCore/JSCInlines.h"
+#include <JavaScriptCore/JSFunction.h>
 
 namespace Bun {
 
@@ -43,6 +46,38 @@ void IsolatedModuleCache::evict(JSC::VM& vm, const WTF::String& key)
 void IsolatedModuleCache::clear(JSC::VM& vm)
 {
     WebCore::clientData(vm)->isolationSourceProviderCache.clear();
+}
+
+// Test-only (bun:internal-for-testing). Returns the cached provider's
+// JSC::SourceProviderSourceType name for a resolved specifier, or null when
+// the key isn't cached. Lets tests assert that transpiled ESM enters the
+// cache as BunTranspiledModule (module_info attached — record rebuilt without
+// re-parsing) rather than a plain Module.
+JSC_DEFINE_HOST_FUNCTION(jsFunctionIsolatedModuleCacheSourceType, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    auto key = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto* provider = IsolatedModuleCache::lookup(vm, key);
+    if (!provider)
+        return JSC::JSValue::encode(JSC::jsNull());
+    switch (provider->sourceType()) {
+    case JSC::SourceProviderSourceType::Program:
+        return JSC::JSValue::encode(JSC::jsNontrivialString(vm, "Program"_s));
+    case JSC::SourceProviderSourceType::Module:
+        return JSC::JSValue::encode(JSC::jsNontrivialString(vm, "Module"_s));
+    case JSC::SourceProviderSourceType::BunTranspiledModule:
+        return JSC::JSValue::encode(JSC::jsNontrivialString(vm, "BunTranspiledModule"_s));
+    default:
+        return JSC::JSValue::encode(JSC::jsNumber(static_cast<unsigned>(provider->sourceType())));
+    }
+}
+
+JSC::JSValue createIsolatedModuleCacheSourceTypeForTesting(Zig::GlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    return JSC::JSFunction::create(vm, globalObject, 1, "isolatedModuleCacheSourceType"_s, jsFunctionIsolatedModuleCacheSourceType, JSC::ImplementationVisibility::Public);
 }
 
 } // namespace Bun

--- a/src/jsc/bindings/IsolatedModuleCache.cpp
+++ b/src/jsc/bindings/IsolatedModuleCache.cpp
@@ -70,7 +70,10 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionIsolatedModuleCacheSourceType, (JSC::JSGlobal
     case JSC::SourceProviderSourceType::BunTranspiledModule:
         return JSC::JSValue::encode(JSC::jsNontrivialString(vm, "BunTranspiledModule"_s));
     default:
-        return JSC::JSValue::encode(JSC::jsNumber(static_cast<unsigned>(provider->sourceType())));
+        // Unreachable today (isTagCacheable only admits JS-ish tags, whose
+        // providers are Program/Module/BunTranspiledModule), but keep the
+        // `string | null` contract if that ever widens.
+        return JSC::JSValue::encode(JSC::jsNontrivialString(vm, "Unknown"_s));
     }
 }
 

--- a/src/jsc/bindings/IsolatedModuleCache.h
+++ b/src/jsc/bindings/IsolatedModuleCache.h
@@ -4,6 +4,7 @@
 #include "headers-handwritten.h"
 
 namespace Zig {
+class GlobalObject;
 class SourceProvider;
 }
 
@@ -58,5 +59,9 @@ public:
     static void evict(JSC::VM&, const WTF::String& key);
     static void clear(JSC::VM&);
 };
+
+// bun:internal-for-testing — returns the cached provider's sourceType name
+// for a resolved specifier, or null when not cached.
+JSC::JSValue createIsolatedModuleCacheSourceTypeForTesting(Zig::GlobalObject* globalObject);
 
 } // namespace Bun

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -297,6 +297,12 @@ pub struct RareData {
 
     pub fs_watchers_for_isolation: Vec<IsolationWatcher>,
     pub stat_watchers_for_isolation: Vec<IsolationWatcher>,
+    /// Listening `Bun.serve`/node:http servers (erased `NewServer<SSL, DEBUG>`
+    /// + monomorphized stop fn). `bun test --isolate` teardown stops each one
+    /// properly — blind-closing the listen socket at the uws layer leaves the
+    /// server's `has_listener()` true and its strong `js_value` pinning the
+    /// outgoing global forever.
+    pub servers_for_isolation: Vec<IsolationWatcher>,
 
     pub temp_pipe_read_buffer: Option<Box<PipeReadBuffer>>,
 
@@ -358,6 +364,7 @@ impl Default for RareData {
             listening_sockets_for_watch_mode: Mutex::new(Vec::new()),
             fs_watchers_for_isolation: Vec::new(),
             stat_watchers_for_isolation: Vec::new(),
+            servers_for_isolation: Vec::new(),
             temp_pipe_read_buffer: None,
             s3_default_client: Strong::empty(),
             default_csrf_secret: Box::default(),
@@ -864,6 +871,40 @@ impl RareData {
                 break;
             };
             // SAFETY: registered via add_stat_watcher_for_isolation; still live.
+            unsafe { (w.close)(w.ptr) };
+            core::hint::black_box(this);
+        }
+    }
+
+    // ── isolation servers (Bun.serve / node:http) ─────────────────────────
+    pub fn add_server_for_isolation(&mut self, server: *mut c_void, stop: unsafe fn(*mut c_void)) {
+        self.servers_for_isolation.push(IsolationWatcher {
+            ptr: server,
+            close: stop,
+        });
+    }
+    pub fn remove_server_for_isolation(&mut self, server: *mut c_void) {
+        if let Some(i) = self
+            .servers_for_isolation
+            .iter()
+            .position(|w| w.ptr == server)
+        {
+            self.servers_for_isolation.swap_remove(i);
+        }
+    }
+    pub fn stop_all_servers_for_isolation(&mut self) {
+        // Same R-2 noalias mitigation as `close_all_watchers_for_isolation`:
+        // `stop` re-enters JS (abrupt close fires socket handlers), which can
+        // call `Bun.serve` again and push onto this Vec mid-drain.
+        let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
+        loop {
+            // SAFETY: `this` is the unique live `RareData` (boxed by VM);
+            // momentary `&mut` only, ended before the re-entrant stop.
+            let Some(w) = (unsafe { &mut (*this).servers_for_isolation }).pop() else {
+                break;
+            };
+            // SAFETY: registered via add_server_for_isolation; the server
+            // unregisters in `stop_listening`/`deinit` before it is freed.
             unsafe { (w.close)(w.ptr) };
             core::hint::black_box(this);
         }

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -33,9 +33,9 @@ use super::uuid::UUID;
 //     → moved to `bun_runtime::jsc_hooks::RuntimeState` (already there).
 //   - `cron_jobs` / `node_fs_stat_watcher_scheduler` / `websocket_deflate`
 //     → erased `*mut c_void` slots; high tier lazy-inits.
-//   - `fs_watchers_for_isolation` / `stat_watchers_for_isolation` → per-entry
-//     (ptr, close-fn) so `close_all_watchers_for_isolation` works without
-//     naming the watcher types.
+//   - the `bun test --isolate` watcher/server registries → moved to
+//     `bun_runtime::jsc_hooks::IsolationHandles` so the entries keep their
+//     concrete types.
 //   - `stdin/stdout/stderr_store` → erased `*mut blob::Store` constructed via
 //     `__bun_stdio_blob_store_new` (link-time extern; same fn MiniEventLoop uses).
 //   - `valkey_context` was a stateless ZST with empty `deinit`; dropped.
@@ -194,19 +194,6 @@ impl CleanupHook {
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// IsolationWatcher — per-entry vtable so `close_all_watchers_for_isolation`
-// can fire `detach`/`close` without naming `bun_runtime::node::FSWatcher` /
-// `StatWatcher` (cycle break, docs/PORTING.md §Dispatch cold path).
-// ──────────────────────────────────────────────────────────────────────────
-
-#[derive(Copy, Clone)]
-pub struct IsolationWatcher {
-    pub ptr: *mut c_void,
-    /// `FSWatcher::detach` / `StatWatcher::close` — supplied by the registrant.
-    pub close: unsafe fn(*mut c_void),
-}
-
 /// Erased high-tier slot with paired destructor (e.g. `WebSocketDeflate::RareData`).
 pub struct ErasedBox {
     pub ptr: NonNull<c_void>,
@@ -295,15 +282,6 @@ pub struct RareData {
     /// owns the data, no sidecar `Mutex<()>`).
     pub listening_sockets_for_watch_mode: Mutex<Vec<Fd>>,
 
-    pub fs_watchers_for_isolation: Vec<IsolationWatcher>,
-    pub stat_watchers_for_isolation: Vec<IsolationWatcher>,
-    /// Listening `Bun.serve`/node:http servers (erased `NewServer<SSL, DEBUG>`
-    /// + monomorphized stop fn). `bun test --isolate` teardown stops each one
-    /// properly — blind-closing the listen socket at the uws layer leaves the
-    /// server's `has_listener()` true and its strong `js_value` pinning the
-    /// outgoing global forever.
-    pub servers_for_isolation: Vec<IsolationWatcher>,
-
     pub temp_pipe_read_buffer: Option<Box<PipeReadBuffer>>,
 
     // PORT NOTE: `aws_signature_cache` field dropped — storage moved DOWN to
@@ -362,9 +340,6 @@ impl Default for RareData {
             mime_types: None,
             node_fs_stat_watcher_scheduler: None,
             listening_sockets_for_watch_mode: Mutex::new(Vec::new()),
-            fs_watchers_for_isolation: Vec::new(),
-            stat_watchers_for_isolation: Vec::new(),
-            servers_for_isolation: Vec::new(),
             temp_pipe_read_buffer: None,
             s3_default_client: Strong::empty(),
             default_csrf_secret: Box::default(),
@@ -803,110 +778,6 @@ impl RareData {
             // Prevent TIME_WAIT state so the relaunched process can rebind.
             syscall::disable_linger(socket);
             socket.close();
-        }
-    }
-
-    // ── isolation watchers (FSWatcher / StatWatcher) ──────────────────────
-    pub fn add_fs_watcher_for_isolation(
-        &mut self,
-        watcher: *mut c_void,
-        detach: unsafe fn(*mut c_void),
-    ) {
-        self.fs_watchers_for_isolation.push(IsolationWatcher {
-            ptr: watcher,
-            close: detach,
-        });
-    }
-    pub fn remove_fs_watcher_for_isolation(&mut self, watcher: *mut c_void) {
-        if let Some(i) = self
-            .fs_watchers_for_isolation
-            .iter()
-            .position(|w| w.ptr == watcher)
-        {
-            self.fs_watchers_for_isolation.swap_remove(i);
-        }
-    }
-    pub fn add_stat_watcher_for_isolation(
-        &mut self,
-        watcher: *mut c_void,
-        close: unsafe fn(*mut c_void),
-    ) {
-        self.stat_watchers_for_isolation.push(IsolationWatcher {
-            ptr: watcher,
-            close,
-        });
-    }
-    pub fn remove_stat_watcher_for_isolation(&mut self, watcher: *mut c_void) {
-        if let Some(i) = self
-            .stat_watchers_for_isolation
-            .iter()
-            .position(|w| w.ptr == watcher)
-        {
-            self.stat_watchers_for_isolation.swap_remove(i);
-        }
-    }
-    pub fn close_all_watchers_for_isolation(&mut self) {
-        // R-2 noalias mitigation (PORT_NOTES_PLAN R-2; precedent
-        // `b818e70e1c57` NodeHTTPResponse::cork): `(w.close)(w.ptr)` is an
-        // opaque fn-pointer call that receives nothing derived from `self`. It
-        // re-enters JS (FSWatcher.close → "close" event), which can call
-        // `add_*_watcher_for_isolation` and push back onto these same Vecs.
-        // With `noalias self`, LLVM may cache the Vec's `len`/`ptr` across the
-        // call body and miss the push. ASM-verified PROVEN_CACHED. Launder
-        // `self` so every `pop()` goes through an opaque pointer.
-        let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        loop {
-            // SAFETY: `this` is the unique live `RareData` (boxed by VM);
-            // momentary `&mut` only, ended before the re-entrant close.
-            let Some(w) = (unsafe { &mut (*this).fs_watchers_for_isolation }).pop() else {
-                break;
-            };
-            // SAFETY: registered via add_fs_watcher_for_isolation; still live.
-            unsafe { (w.close)(w.ptr) };
-            core::hint::black_box(this);
-        }
-        loop {
-            // SAFETY: as above.
-            let Some(w) = (unsafe { &mut (*this).stat_watchers_for_isolation }).pop() else {
-                break;
-            };
-            // SAFETY: registered via add_stat_watcher_for_isolation; still live.
-            unsafe { (w.close)(w.ptr) };
-            core::hint::black_box(this);
-        }
-    }
-
-    // ── isolation servers (Bun.serve / node:http) ─────────────────────────
-    pub fn add_server_for_isolation(&mut self, server: *mut c_void, stop: unsafe fn(*mut c_void)) {
-        self.servers_for_isolation.push(IsolationWatcher {
-            ptr: server,
-            close: stop,
-        });
-    }
-    pub fn remove_server_for_isolation(&mut self, server: *mut c_void) {
-        if let Some(i) = self
-            .servers_for_isolation
-            .iter()
-            .position(|w| w.ptr == server)
-        {
-            self.servers_for_isolation.swap_remove(i);
-        }
-    }
-    pub fn stop_all_servers_for_isolation(&mut self) {
-        // Same R-2 noalias mitigation as `close_all_watchers_for_isolation`:
-        // `stop` re-enters JS (abrupt close fires socket handlers), which can
-        // call `Bun.serve` again and push onto this Vec mid-drain.
-        let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        loop {
-            // SAFETY: `this` is the unique live `RareData` (boxed by VM);
-            // momentary `&mut` only, ended before the re-entrant stop.
-            let Some(w) = (unsafe { &mut (*this).servers_for_isolation }).pop() else {
-                break;
-            };
-            // SAFETY: registered via add_server_for_isolation; the server
-            // unregisters in `stop_listening`/`deinit` before it is freed.
-            unsafe { (w.close)(w.ptr) };
-            core::hint::black_box(this);
         }
     }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1660,6 +1660,24 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
             }
             server_ref.js_value.set_strong(obj, global_object);
 
+            {
+                // SAFETY: bun_vm() returns the live thread-local VM.
+                let vm = global_object.bun_vm().as_mut();
+                if vm.test_isolation_enabled {
+                    // `bun test --isolate` teardown stops this server if the
+                    // test file leaks it; unregistered in `stop_listening`.
+                    vm.rare_data().add_server_for_isolation(
+                        server.cast::<core::ffi::c_void>(),
+                        |p| {
+                            // SAFETY: `p` is the server registered above; the
+                            // entry is removed in `stop_listening`/`deinit`
+                            // before the server is freed.
+                            unsafe { (*p.cast::<$ServerType>()).stop(true) }
+                        },
+                    );
+                }
+            }
+
             if config.allow_hot {
                 // SAFETY: same VM pointer; re-borrow after the earlier `vm` mut
                 // borrow was released by the `hot_map()` arm above.

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1662,7 +1662,12 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
 
             if global_object.bun_vm().test_isolation_enabled {
                 if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                    handles.servers.push(AnyServer::from(server.cast_const()));
+                    bun_core::handle_oom(handles.put(
+                        crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                            server.cast_const(),
+                        )),
+                        (),
+                    ));
                 }
             }
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1662,8 +1662,6 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
 
             if global_object.bun_vm().test_isolation_enabled {
                 if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                    // `bun test --isolate` teardown stops this server if the
-                    // test file leaks it; unregistered in `stop_listening`.
                     handles.servers.push(AnyServer::from(server.cast_const()));
                 }
             }

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1660,21 +1660,11 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
             }
             server_ref.js_value.set_strong(obj, global_object);
 
-            {
-                // SAFETY: bun_vm() returns the live thread-local VM.
-                let vm = global_object.bun_vm().as_mut();
-                if vm.test_isolation_enabled {
+            if global_object.bun_vm().test_isolation_enabled {
+                if let Some(handles) = crate::jsc_hooks::isolation_handles() {
                     // `bun test --isolate` teardown stops this server if the
                     // test file leaks it; unregistered in `stop_listening`.
-                    vm.rare_data().add_server_for_isolation(
-                        server.cast::<core::ffi::c_void>(),
-                        |p| {
-                            // SAFETY: `p` is the server registered above; the
-                            // entry is removed in `stop_listening`/`deinit`
-                            // before the server is freed.
-                            unsafe { (*p.cast::<$ServerType>()).stop(true) }
-                        },
-                    );
+                    handles.servers.push(AnyServer::from(server.cast_const()));
                 }
             }
 

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -617,7 +617,7 @@ impl<'a> WorkerLoop<'a> {
             ) {
                 test_command::handle_top_level_test_error_before_javascript_start(err);
             }
-            crate::jsc_hooks::close_isolation_handles();
+            crate::jsc_hooks::close_isolation_handles(vm);
             vm.swap_global_for_test_isolation();
             self.reporter
                 .jest

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -617,6 +617,9 @@ impl<'a> WorkerLoop<'a> {
             ) {
                 test_command::handle_top_level_test_error_before_javascript_start(err);
             }
+            // Close leaked watchers/servers through their own lifecycle
+            // before the swap's blind fd close.
+            crate::jsc_hooks::close_isolation_handles();
             vm.swap_global_for_test_isolation();
             self.reporter
                 .jest

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -617,8 +617,6 @@ impl<'a> WorkerLoop<'a> {
             ) {
                 test_command::handle_top_level_test_error_before_javascript_start(err);
             }
-            // Close leaked watchers/servers through their own lifecycle
-            // before the swap's blind fd close.
             crate::jsc_hooks::close_isolation_handles();
             vm.swap_global_for_test_isolation();
             self.reporter

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3064,8 +3064,6 @@ impl TestCommand {
                         reporter.jest.default_timeout_override = u32::MAX;
                         Global::mimalloc_cleanup(false);
                         if isolate {
-                            // Close leaked watchers/servers through their own
-                            // lifecycle before the swap's blind fd close.
                             crate::jsc_hooks::close_isolation_handles();
                             vm.swap_global_for_test_isolation();
                             reporter

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3064,7 +3064,7 @@ impl TestCommand {
                         reporter.jest.default_timeout_override = u32::MAX;
                         Global::mimalloc_cleanup(false);
                         if isolate {
-                            crate::jsc_hooks::close_isolation_handles();
+                            crate::jsc_hooks::close_isolation_handles(vm);
                             vm.swap_global_for_test_isolation();
                             reporter
                                 .jest

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3064,6 +3064,9 @@ impl TestCommand {
                         reporter.jest.default_timeout_override = u32::MAX;
                         Global::mimalloc_cleanup(false);
                         if isolate {
+                            // Close leaked watchers/servers through their own
+                            // lifecycle before the swap's blind fd close.
+                            crate::jsc_hooks::close_isolation_handles();
                             vm.swap_global_for_test_isolation();
                             reporter
                                 .jest

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1642,11 +1642,16 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     }
 }
 
-pub(crate) fn close_isolation_handles() {
+pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
     let state = runtime_state();
     if state.is_null() {
         return;
     }
+    // A microtask still pending at end-of-file (e.g. queued by
+    // `tick_immediate_tasks` or `handle_rejected_promises`) can register new
+    // handles when it runs. Drain first so they land in the registry before
+    // it empties — matches the swap's own drain-before-teardown ordering.
+    let _ = vm.event_loop_mut().drain_microtasks();
     loop {
         // SAFETY: live boxed per-thread `RuntimeState`; the borrow ends before
         // the close below re-enters JS.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2775,7 +2775,24 @@ fn transpile_source_code_inner(
                             list: core::mem::take(&mut entry.sourcemap).into_vec(),
                         },
                     );
-                    // TODO(b2-blocked): `ModuleInfoDeserialized::create_from_cached_record`.
+                    // Spec :423-428 — under --isolate, attach the cached ESM
+                    // record so the C++ side caches a `BunTranspiledModule`
+                    // SourceProvider and later files rebuild the module record
+                    // from it instead of re-parsing the transpiled source in
+                    // every fresh global (mirrors RuntimeTranspilerStore.rs).
+                    // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                    let module_info: *mut c_void = if unsafe { &*jsc_vm }
+                        .use_isolation_source_provider_cache()
+                        && entry.metadata.module_type != CacheModuleType::Cjs
+                        && !entry.esm_record.is_empty()
+                    {
+                        bun_bundler::analyze_transpiled_module::ModuleInfoDeserialized
+                            ::create_from_cached_record(&entry.esm_record)
+                            .map(|b| bun_core::heap::into_raw(b).cast())
+                            .unwrap_or(core::ptr::null_mut())
+                    } else {
+                        core::ptr::null_mut()
+                    };
                     let source_code = match &mut entry.output_code {
                         OutputCode::String(s) => *s,
                         OutputCode::Utf8(utf8) => {
@@ -2841,7 +2858,7 @@ fn transpile_source_code_inner(
                         specifier: input_specifier.dupe_ref(),
                         source_url: create_if_different(input_specifier, path.text),
                         is_commonjs_module,
-                        // TODO(b2-blocked): `module_info` (:423-428).
+                        module_info,
                         tag,
                         ..Default::default()
                     }));
@@ -2932,7 +2949,36 @@ fn transpile_source_code_inner(
                 // Spec :516-523.
                 let is_commonjs_module = parse_result.ast.has_commonjs_export_names
                     || parse_result.ast.exports_kind == bun_ast::ExportsKind::Cjs;
-                // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
+                // Under --isolate, collect the printer's ESM-record analysis so
+                // the cached SourceProvider becomes a `BunTranspiledModule` and
+                // later files rebuild the module record without re-parsing
+                // (mirrors RuntimeTranspilerStore.rs).
+                // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
+                let mut module_info: Option<
+                    Box<bun_bundler::analyze_transpiled_module::ModuleInfo>,
+                > = if unsafe { &*jsc_vm }.use_isolation_source_provider_cache()
+                    && !is_commonjs_module
+                    && loader.is_java_script_like()
+                {
+                    Some(bun_bundler::analyze_transpiled_module::ModuleInfo::create(
+                        loader.is_type_script(),
+                    ))
+                } else {
+                    None
+                };
+                // Spec ModuleLoader.zig:523 — the printer doesn't record
+                // top-level-await; propagate it so the cached record keeps the
+                // module's evaluation-promise semantics.
+                if let Some(mi) = module_info.as_deref_mut() {
+                    mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
+                }
+                // PORT NOTE: derive `*mut` from a `&mut` borrow (not `&x as
+                // *const _ as *mut _`, which is Stacked-Borrows UB). The
+                // `&mut` borrow ends here; the raw pointer stays valid until
+                // `module_info` is moved/touched again (after the print call).
+                let module_info_ptr: Option<
+                    *mut bun_bundler::analyze_transpiled_module::ModuleInfo,
+                > = module_info.as_deref_mut().map(std::ptr::from_mut);
 
                 // ── js_printer::print ───────────────────────────────────────
                 // Spec :525-539.
@@ -2977,7 +3023,7 @@ fn transpile_source_code_inner(
                         unsafe { (*jsc_vm).source_map_handler((*extra).source_code_printer) };
                     // SAFETY: per fn contract — `jsc_vm` / `extra.source_code_printer`
                     // are live; the printer borrow is scoped to this call.
-                    unsafe {
+                    let print_result = unsafe {
                         (*jsc_vm).transpiler.print_with_source_map(
                             // Same per-call arena that `parse_options.arena`
                             // built `parse_result.ast` from — the printer's
@@ -2988,12 +3034,17 @@ fn transpile_source_code_inner(
                             &mut *(*extra).source_code_printer,
                             bun_js_printer::Format::EsmAscii,
                             mapper.get(),
-                            // TODO(b2-blocked): `analyze_transpiled_module::
-                            // ModuleInfo::create` (spec :516-523) — pass it
-                            // through once the create-side above is un-gated.
-                            None,
-                        )?;
+                            module_info_ptr,
+                        )
+                    };
+                    // Spec :524 `errdefer module_info.destroy()` — explicit
+                    // destroy (not Drop) mirrors the async-path error arm.
+                    if print_result.is_err() {
+                        if let Some(mi) = module_info.take() {
+                            mi.destroy();
+                        }
                     }
+                    print_result?;
                 }
 
                 if is_main {
@@ -3020,8 +3071,12 @@ fn transpile_source_code_inner(
                         )
                     };
                     resolved_source.is_commonjs_module = is_commonjs_module;
-                    // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
-                    resolved_source.module_info = core::ptr::null_mut();
+                    resolved_source.module_info = module_info
+                        .map(|mi| {
+                            use bun_bundler::analyze_transpiled_module::ModuleInfoExt;
+                            bun_core::heap::into_raw(mi.into_deserialized()).cast()
+                        })
+                        .unwrap_or(core::ptr::null_mut());
                     return Ok(OwnedResolvedSource::from(resolved_source));
                 }
 
@@ -3104,8 +3159,15 @@ fn transpile_source_code_inner(
                     specifier: input_specifier.dupe_ref(),
                     source_url: create_if_different(input_specifier, path.text),
                     is_commonjs_module,
-                    // TODO(b2-blocked): `analyze_transpiled_module::ModuleInfo::create`.
-                    module_info: core::ptr::null_mut(),
+                    // Spec :551 — `module_info.asDeserialized()`; ownership
+                    // transfers to the `ResolvedSource` (the C++ SourceProvider
+                    // frees it via `zig__ModuleInfoDeserialized__deinit`).
+                    module_info: module_info
+                        .map(|mi| {
+                            use bun_bundler::analyze_transpiled_module::ModuleInfoExt;
+                            bun_core::heap::into_raw(mi.into_deserialized()).cast()
+                        })
+                        .unwrap_or(core::ptr::null_mut()),
                     tag,
                     ..Default::default()
                 }));

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -100,47 +100,14 @@ pub struct RuntimeState {
     pub isolation_handles: IsolationHandles,
 }
 
-#[derive(Default)]
-pub struct IsolationHandles {
-    pub fs_watchers: Vec<ptr::NonNull<crate::node::node_fs_watcher::FSWatcher>>,
-    pub stat_watchers: Vec<ptr::NonNull<crate::node::node_fs_stat_watcher::StatWatcher>>,
-    pub servers: Vec<crate::server::AnyServer>,
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IsolationHandle {
+    FsWatcher(ptr::NonNull<crate::node::node_fs_watcher::FSWatcher>),
+    StatWatcher(ptr::NonNull<crate::node::node_fs_stat_watcher::StatWatcher>),
+    Server(crate::server::AnyServer),
 }
 
-impl IsolationHandles {
-    pub fn remove_fs_watcher(&mut self, watcher: *const crate::node::node_fs_watcher::FSWatcher) {
-        if let Some(i) = self
-            .fs_watchers
-            .iter()
-            .position(|p| p.as_ptr().cast_const() == watcher)
-        {
-            self.fs_watchers.swap_remove(i);
-        }
-    }
-
-    pub fn remove_stat_watcher(
-        &mut self,
-        watcher: *const crate::node::node_fs_stat_watcher::StatWatcher,
-    ) {
-        if let Some(i) = self
-            .stat_watchers
-            .iter()
-            .position(|p| p.as_ptr().cast_const() == watcher)
-        {
-            self.stat_watchers.swap_remove(i);
-        }
-    }
-
-    pub fn remove_server(&mut self, server: *const ()) {
-        if let Some(i) = self
-            .servers
-            .iter()
-            .position(|s| s.ptr.cast_const() == server)
-        {
-            self.servers.swap_remove(i);
-        }
-    }
-}
+pub type IsolationHandles = bun_collections::ArrayHashMap<IsolationHandle, ()>;
 
 thread_local! {
     /// One `RuntimeState` per JS thread (`VirtualMachine` is per-thread).
@@ -1680,36 +1647,15 @@ pub(crate) fn close_isolation_handles() {
     if state.is_null() {
         return;
     }
-    // close/stop may re-enter JS (close/error handlers), which can register
-    // new handles into ANY of the three registries — e.g. a server's close
-    // handler calling fs.watch() after the fs_watchers pass already finished.
-    // Repeat full passes until one makes no progress.
     loop {
-        let mut made_progress = false;
-        loop {
-            let Some(w) = (unsafe { &mut (*state).isolation_handles.fs_watchers }).pop() else {
-                break;
-            };
-            made_progress = true;
-            // SAFETY: live until it unregisters in `detach`.
-            unsafe { w.as_ref() }.close_for_isolation();
-        }
-        loop {
-            let Some(w) = (unsafe { &mut (*state).isolation_handles.stat_watchers }).pop() else {
-                break;
-            };
-            made_progress = true;
-            bun_ptr::ParentRef::from(w).close();
-        }
-        loop {
-            let Some(mut s) = (unsafe { &mut (*state).isolation_handles.servers }).pop() else {
-                break;
-            };
-            made_progress = true;
-            s.stop(true);
-        }
-        if !made_progress {
+        let Some(kv) = (unsafe { &mut (*state).isolation_handles }).pop() else {
             break;
+        };
+        match kv.key {
+            // SAFETY: live until it unregisters in `detach`.
+            IsolationHandle::FsWatcher(w) => unsafe { w.as_ref() }.close_for_isolation(),
+            IsolationHandle::StatWatcher(w) => bun_ptr::ParentRef::from(w).close(),
+            IsolationHandle::Server(mut s) => s.stop(true),
         }
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -97,20 +97,9 @@ pub struct RuntimeState {
     /// Boxed because `HiveAllocator` is `Fallback<HiveRef<Body::Value, 256>, 256>`
     /// — far too large to construct on the stack inside `Box::new(RuntimeState{..})`.
     pub body_value_pool: Box<crate::webcore::body::HiveAllocator>,
-    /// `bun test --isolate` registries — see [`IsolationHandles`]. Drained by
-    /// [`close_isolation_handles`] right before each global swap.
     pub isolation_handles: IsolationHandles,
 }
 
-/// Handles a `bun test --isolate` file can leak whose teardown must run
-/// through the type's own lifecycle at the global swap: blind-closing their
-/// fds at the uws layer leaves `has_pending_activity()` / `has_listener()`
-/// true, and the handle's strong JS ref pins the outgoing global (cached
-/// listener or fetch-handler closure and all) for the rest of the run.
-///
-/// Entries unregister themselves (`FSWatcher::detach`, `StatWatcher::deinit`,
-/// `NewServer::{stop_listening, deinit}`) before they are freed, so every
-/// stored pointer is live.
 #[derive(Default)]
 pub struct IsolationHandles {
     pub fs_watchers: Vec<ptr::NonNull<crate::node::node_fs_watcher::FSWatcher>>,
@@ -211,21 +200,13 @@ pub(crate) fn timer_all_mut() -> &'static mut timer::All {
     unsafe { &mut (*state).timer }
 }
 
-/// This thread's [`IsolationHandles`] registries. `None` only before
-/// `init_runtime_state` / after `deinit_runtime_state` (no watcher or server
-/// can outlive that window, so callers just skip).
-///
-/// Same `&'static mut` contract as [`timer_all_mut`]: single JS thread, and
-/// every use is a single add/remove expression with no JS re-entry while the
-/// borrow is live. The drain ([`close_isolation_handles`]) re-enters JS, so it
-/// goes through the raw [`runtime_state`] pointer instead.
 #[inline]
 pub(crate) fn isolation_handles() -> Option<&'static mut IsolationHandles> {
     let state = runtime_state();
     if state.is_null() {
         return None;
     }
-    // SAFETY: `state` is the live boxed per-thread `RuntimeState`; see above.
+    // SAFETY: live boxed per-thread `RuntimeState`.
     Some(unsafe { &mut (*state).isolation_handles })
 }
 
@@ -1694,34 +1675,22 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     }
 }
 
-/// `bun test --isolate` teardown: close every leaked `FSWatcher`/`StatWatcher`
-/// and stop every leaked server through its own lifecycle (see
-/// [`IsolationHandles`]). The test runner calls this right before
-/// `swap_global_for_test_isolation` — the swap's blind socket-group walk only
-/// closes fds, which would leave `has_listener()` true and the handles'
-/// strong JS refs pinning the outgoing global for the rest of the run.
 pub(crate) fn close_isolation_handles() {
     let state = runtime_state();
     if state.is_null() {
         return;
     }
-    // Each close/stop below may re-enter JS (close/error handlers), which can
-    // register new handles or unregister others mid-drain — pop one entry at
-    // a time through the raw `state` pointer so no `&mut` into the registry
-    // is live across the call.
     loop {
         let Some(w) = (unsafe { &mut (*state).isolation_handles.fs_watchers }).pop() else {
             break;
         };
-        // SAFETY: entries are live (unregistered in `detach` before free).
+        // SAFETY: live until it unregisters in `detach`.
         unsafe { w.as_ref() }.close_for_isolation();
     }
     loop {
         let Some(w) = (unsafe { &mut (*state).isolation_handles.stat_watchers }).pop() else {
             break;
         };
-        // BACKREF — entries are live (unregistered in `deinit` before free);
-        // `ParentRef` Deref gives safe `&StatWatcher`.
         bun_ptr::ParentRef::from(w).close();
     }
     loop {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1680,24 +1680,37 @@ pub(crate) fn close_isolation_handles() {
     if state.is_null() {
         return;
     }
+    // close/stop may re-enter JS (close/error handlers), which can register
+    // new handles into ANY of the three registries — e.g. a server's close
+    // handler calling fs.watch() after the fs_watchers pass already finished.
+    // Repeat full passes until one makes no progress.
     loop {
-        let Some(w) = (unsafe { &mut (*state).isolation_handles.fs_watchers }).pop() else {
+        let mut made_progress = false;
+        loop {
+            let Some(w) = (unsafe { &mut (*state).isolation_handles.fs_watchers }).pop() else {
+                break;
+            };
+            made_progress = true;
+            // SAFETY: live until it unregisters in `detach`.
+            unsafe { w.as_ref() }.close_for_isolation();
+        }
+        loop {
+            let Some(w) = (unsafe { &mut (*state).isolation_handles.stat_watchers }).pop() else {
+                break;
+            };
+            made_progress = true;
+            bun_ptr::ParentRef::from(w).close();
+        }
+        loop {
+            let Some(mut s) = (unsafe { &mut (*state).isolation_handles.servers }).pop() else {
+                break;
+            };
+            made_progress = true;
+            s.stop(true);
+        }
+        if !made_progress {
             break;
-        };
-        // SAFETY: live until it unregisters in `detach`.
-        unsafe { w.as_ref() }.close_for_isolation();
-    }
-    loop {
-        let Some(w) = (unsafe { &mut (*state).isolation_handles.stat_watchers }).pop() else {
-            break;
-        };
-        bun_ptr::ParentRef::from(w).close();
-    }
-    loop {
-        let Some(mut s) = (unsafe { &mut (*state).isolation_handles.servers }).pop() else {
-            break;
-        };
-        s.stop(true);
+        }
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1648,6 +1648,8 @@ pub(crate) fn close_isolation_handles() {
         return;
     }
     loop {
+        // SAFETY: live boxed per-thread `RuntimeState`; the borrow ends before
+        // the close below re-enters JS.
         let Some(kv) = (unsafe { &mut (*state).isolation_handles }).pop() else {
             break;
         };

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1661,6 +1661,9 @@ pub(crate) fn close_isolation_handles(vm: &mut VirtualMachine) {
         match kv.key {
             // SAFETY: live until it unregisters in `detach`.
             IsolationHandle::FsWatcher(w) => unsafe { w.as_ref() }.close_for_isolation(),
+            // Live until it unregisters in `close()` (JS thread, us) — a
+            // registered entry implies `close()` has not run, and `deinit`
+            // cannot fire before `close()` drops the wrapper's Strong ref.
             IsolationHandle::StatWatcher(w) => bun_ptr::ParentRef::from(w).close(),
             IsolationHandle::Server(mut s) => s.stop(true),
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -97,6 +97,60 @@ pub struct RuntimeState {
     /// Boxed because `HiveAllocator` is `Fallback<HiveRef<Body::Value, 256>, 256>`
     /// — far too large to construct on the stack inside `Box::new(RuntimeState{..})`.
     pub body_value_pool: Box<crate::webcore::body::HiveAllocator>,
+    /// `bun test --isolate` registries — see [`IsolationHandles`]. Drained by
+    /// [`close_isolation_handles`] right before each global swap.
+    pub isolation_handles: IsolationHandles,
+}
+
+/// Handles a `bun test --isolate` file can leak whose teardown must run
+/// through the type's own lifecycle at the global swap: blind-closing their
+/// fds at the uws layer leaves `has_pending_activity()` / `has_listener()`
+/// true, and the handle's strong JS ref pins the outgoing global (cached
+/// listener or fetch-handler closure and all) for the rest of the run.
+///
+/// Entries unregister themselves (`FSWatcher::detach`, `StatWatcher::deinit`,
+/// `NewServer::{stop_listening, deinit}`) before they are freed, so every
+/// stored pointer is live.
+#[derive(Default)]
+pub struct IsolationHandles {
+    pub fs_watchers: Vec<ptr::NonNull<crate::node::node_fs_watcher::FSWatcher>>,
+    pub stat_watchers: Vec<ptr::NonNull<crate::node::node_fs_stat_watcher::StatWatcher>>,
+    pub servers: Vec<crate::server::AnyServer>,
+}
+
+impl IsolationHandles {
+    pub fn remove_fs_watcher(&mut self, watcher: *const crate::node::node_fs_watcher::FSWatcher) {
+        if let Some(i) = self
+            .fs_watchers
+            .iter()
+            .position(|p| p.as_ptr().cast_const() == watcher)
+        {
+            self.fs_watchers.swap_remove(i);
+        }
+    }
+
+    pub fn remove_stat_watcher(
+        &mut self,
+        watcher: *const crate::node::node_fs_stat_watcher::StatWatcher,
+    ) {
+        if let Some(i) = self
+            .stat_watchers
+            .iter()
+            .position(|p| p.as_ptr().cast_const() == watcher)
+        {
+            self.stat_watchers.swap_remove(i);
+        }
+    }
+
+    pub fn remove_server(&mut self, server: *const ()) {
+        if let Some(i) = self
+            .servers
+            .iter()
+            .position(|s| s.ptr.cast_const() == server)
+        {
+            self.servers.swap_remove(i);
+        }
+    }
 }
 
 thread_local! {
@@ -155,6 +209,24 @@ pub(crate) fn timer_all_mut() -> &'static mut timer::All {
     // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
     // single JS thread so no concurrent `&mut`.
     unsafe { &mut (*state).timer }
+}
+
+/// This thread's [`IsolationHandles`] registries. `None` only before
+/// `init_runtime_state` / after `deinit_runtime_state` (no watcher or server
+/// can outlive that window, so callers just skip).
+///
+/// Same `&'static mut` contract as [`timer_all_mut`]: single JS thread, and
+/// every use is a single add/remove expression with no JS re-entry while the
+/// borrow is live. The drain ([`close_isolation_handles`]) re-enters JS, so it
+/// goes through the raw [`runtime_state`] pointer instead.
+#[inline]
+pub(crate) fn isolation_handles() -> Option<&'static mut IsolationHandles> {
+    let state = runtime_state();
+    if state.is_null() {
+        return None;
+    }
+    // SAFETY: `state` is the live boxed per-thread `RuntimeState`; see above.
+    Some(unsafe { &mut (*state).isolation_handles })
 }
 
 /// Per-VM lazy DNS resolver storage. Shared borrow only — c-ares callbacks
@@ -314,6 +386,7 @@ unsafe fn init_runtime_state(
         // `mi_heap_new`/`mi_heap_destroy` pair.
         transpiler_arena: Box::new(bun_alloc::Arena::borrowing_default()),
         body_value_pool: Box::new(crate::webcore::body::HiveAllocator::init()),
+        isolation_handles: IsolationHandles::default(),
     }));
     RUNTIME_STATE.with(|c| c.set(state));
 
@@ -1618,6 +1691,44 @@ unsafe fn cancel_all_timers(vm: *mut VirtualMachine) {
     // contract. `addr_of_mut!` does not materialize a `&mut RuntimeState`.
     unsafe {
         crate::timer::All::cancel_all_timeout_objects(ptr::addr_of_mut!((*state).timer), vm);
+    }
+}
+
+/// `bun test --isolate` teardown: close every leaked `FSWatcher`/`StatWatcher`
+/// and stop every leaked server through its own lifecycle (see
+/// [`IsolationHandles`]). The test runner calls this right before
+/// `swap_global_for_test_isolation` — the swap's blind socket-group walk only
+/// closes fds, which would leave `has_listener()` true and the handles'
+/// strong JS refs pinning the outgoing global for the rest of the run.
+pub(crate) fn close_isolation_handles() {
+    let state = runtime_state();
+    if state.is_null() {
+        return;
+    }
+    // Each close/stop below may re-enter JS (close/error handlers), which can
+    // register new handles or unregister others mid-drain — pop one entry at
+    // a time through the raw `state` pointer so no `&mut` into the registry
+    // is live across the call.
+    loop {
+        let Some(w) = (unsafe { &mut (*state).isolation_handles.fs_watchers }).pop() else {
+            break;
+        };
+        // SAFETY: entries are live (unregistered in `detach` before free).
+        unsafe { w.as_ref() }.close_for_isolation();
+    }
+    loop {
+        let Some(w) = (unsafe { &mut (*state).isolation_handles.stat_watchers }).pop() else {
+            break;
+        };
+        // BACKREF — entries are live (unregistered in `deinit` before free);
+        // `ParentRef` Deref gives safe `&StatWatcher`.
+        bun_ptr::ParentRef::from(w).close();
+    }
+    loop {
+        let Some(mut s) = (unsafe { &mut (*state).isolation_handles.servers }).pop() else {
+            break;
+        };
+        s.stop(true);
     }
 }
 

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -714,14 +714,14 @@ impl StatWatcher {
         // collapses the per-site raw deref.
         let this_ref = ParentRef::from(NonNull::new(this).expect("deinit: watcher"));
 
-        // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
-        if this_ref.ctx.test_isolation_enabled {
-            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::StatWatcher(
-                    NonNull::new(this).expect("deinit: watcher"),
-                ));
-            }
-        }
+        // Isolation-registry removal lives in `close()`, NOT here: the last
+        // `deref` can happen on the work-pool thread (queue ref dropped in
+        // `work_pool_callback` / `InitialStatTask`), where the thread-local
+        // `isolation_handles()` is null and the removal would silently no-op,
+        // leaving a dangling registry pointer. Every deinit of a registered
+        // watcher is preceded by a JS-thread `close()` (the Strong `this_value`
+        // self-ref keeps the wrapper alive until `close()` downgrades it, so
+        // `finalize` cannot drop the wrapper ref first).
         this_ref.persistent.set(false);
         if cfg!(debug_assertions) {
             if this_ref.poll_ref.get().is_active() {
@@ -769,7 +769,20 @@ impl StatWatcher {
     }
 
     /// Stops file watching but does not free the instance.
+    ///
+    /// Always runs on the JS thread (`do_close`, `close_isolation_handles`,
+    /// `shutdown_for_exit`), so this is where the watcher leaves the
+    /// isolation registry — `deinit` can fire on the work-pool thread where
+    /// the thread-local registry is unreachable.
     pub(crate) fn close(&self) {
+        // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
+        if self.ctx.test_isolation_enabled {
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::StatWatcher(
+                    NonNull::from(self),
+                ));
+            }
+        }
         if self.persistent.get() {
             self.persistent.set(false);
         }

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -716,14 +716,9 @@ impl StatWatcher {
 
         // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if this_ref.ctx.test_isolation_enabled {
-            // `as_mut()` routes through the thread-local `*mut VM` (write
-            // provenance) so `rare_data()`'s `&mut self` borrow is sound on
-            // the JS thread.
-            this_ref
-                .ctx
-                .as_mut()
-                .rare_data()
-                .remove_stat_watcher_for_isolation(this.cast::<c_void>());
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                handles.remove_stat_watcher(this.cast_const());
+            }
         }
         this_ref.persistent.set(false);
         if cfg!(debug_assertions) {
@@ -1037,25 +1032,13 @@ impl StatWatcher {
         js::listener_set_cached(js_this, &args.global_this, args.listener);
         // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if this_ref.ctx.test_isolation_enabled {
-            // `as_mut()` routes through the thread-local `*mut VM` (write
-            // provenance) so `rare_data()`'s `&mut self` borrow is sound.
-            this_ref
-                .ctx
-                .as_mut()
-                .rare_data()
-                .add_stat_watcher_for_isolation(
-                    this_ptr.cast::<c_void>(),
-                    // §Dispatch cold-path vtable — `bun_jsc::RareData` stores
-                    // (ptr, close-fn) so it can fire close without naming
-                    // StatWatcher. BACKREF — `p` is the live watcher we registered
-                    // above; `ParentRef` Deref gives safe `&StatWatcher`.
-                    |p| {
-                        ParentRef::from(
-                            NonNull::new(p.cast::<StatWatcher>()).expect("isolation close cb"),
-                        )
-                        .close()
-                    },
-                );
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                // `bun test --isolate` teardown closes this watcher if the
+                // test file leaks it; unregistered in `deinit`.
+                handles
+                    .stat_watchers
+                    .push(NonNull::new(this_ptr).expect("init: watcher"));
+            }
         }
         // SAFETY: `this_ptr` was just leaked from `Box`; live with refcount 1.
         InitialStatTask::create_and_schedule(this_ptr);

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -717,7 +717,9 @@ impl StatWatcher {
         // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if this_ref.ctx.test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.remove_stat_watcher(this.cast_const());
+                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::StatWatcher(
+                    NonNull::new(this).expect("deinit: watcher"),
+                ));
             }
         }
         this_ref.persistent.set(false);
@@ -1033,9 +1035,12 @@ impl StatWatcher {
         // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if this_ref.ctx.test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles
-                    .stat_watchers
-                    .push(NonNull::new(this_ptr).expect("init: watcher"));
+                bun_core::handle_oom(handles.put(
+                    crate::jsc_hooks::IsolationHandle::StatWatcher(
+                        NonNull::new(this_ptr).expect("init: watcher"),
+                    ),
+                    (),
+                ));
             }
         }
         // SAFETY: `this_ptr` was just leaked from `Box`; live with refcount 1.

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -1033,8 +1033,6 @@ impl StatWatcher {
         // `ctx` is a `BackRef<VirtualMachine>` (JSC_BORROW); safe Deref.
         if this_ref.ctx.test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                // `bun test --isolate` teardown closes this watcher if the
-                // test file leaks it; unregistered in `deinit`.
                 handles
                     .stat_watchers
                     .push(NonNull::new(this_ptr).expect("init: watcher"));

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1151,8 +1151,6 @@ impl FSWatcher {
         };
         if vm_ref.test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                // `bun test --isolate` teardown closes this watcher if the
-                // test file leaks it; unregistered in `detach`.
                 handles
                     .fs_watchers
                     .push(core::ptr::NonNull::new(ctx).expect("init: watcher"));

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1006,7 +1006,9 @@ impl FSWatcher {
         let ctx_ptr = self.as_ctx_ptr().cast::<c_void>();
         if self.vm().test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.remove_fs_watcher(self.as_ctx_ptr().cast_const());
+                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::FsWatcher(
+                    core::ptr::NonNull::from(self),
+                ));
             }
         }
 
@@ -1151,9 +1153,12 @@ impl FSWatcher {
         };
         if vm_ref.test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles
-                    .fs_watchers
-                    .push(core::ptr::NonNull::new(ctx).expect("init: watcher"));
+                bun_core::handle_oom(handles.put(
+                    crate::jsc_hooks::IsolationHandle::FsWatcher(
+                        core::ptr::NonNull::new(ctx).expect("init: watcher"),
+                    ),
+                    (),
+                ));
             }
         }
         Ok(ctx)

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1005,9 +1005,9 @@ impl FSWatcher {
     pub fn detach(&self) {
         let ctx_ptr = self.as_ctx_ptr().cast::<c_void>();
         if self.vm().test_isolation_enabled {
-            self.vm()
-                .rare_data()
-                .remove_fs_watcher_for_isolation(ctx_ptr);
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                handles.remove_fs_watcher(self.as_ctx_ptr().cast_const());
+            }
         }
 
         if let Some(watcher) = self.path_watcher.take() {
@@ -1150,19 +1150,13 @@ impl FSWatcher {
             )
         };
         if vm_ref.test_isolation_enabled {
-            // `as_mut()` routes through the thread-local `*mut VM` (write
-            // provenance) so `rare_data()`'s `&mut self` borrow is sound.
-            vm_ref.as_mut().rare_data().add_fs_watcher_for_isolation(
-                ctx.cast::<c_void>(),
-                // §Dispatch cold-path vtable — `bun_jsc::RareData` stores
-                // (ptr, close-fn) so it can fire the close without naming
-                // FSWatcher.
-                |p| {
-                    // SAFETY: `p` is the `ctx` registered above; still live
-                    // until `remove_fs_watcher_for_isolation` runs.
-                    unsafe { (*p.cast::<FSWatcher>()).close_for_isolation() }
-                },
-            );
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                // `bun test --isolate` teardown closes this watcher if the
+                // test file leaks it; unregistered in `detach`.
+                handles
+                    .fs_watchers
+                    .push(core::ptr::NonNull::new(ctx).expect("init: watcher"));
+            }
         }
         Ok(ctx)
     }

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -982,6 +982,25 @@ impl FSWatcher {
         // TODO(port): bun.Mutex lock/unlock — verify RAII guard vs manual unlock semantics.
     }
 
+    /// `bun test --isolate` teardown: `close()` minus the `'close'` event (no
+    /// user JS mid-swap; parity with `StatWatcher::close`). Dropping the
+    /// initial pending-activity ref is the load-bearing part — `detach()`
+    /// alone leaves `pending_activity_count` at 1, so `has_pending_activity()`
+    /// stays true forever and the GC can never collect the wrapper, pinning
+    /// the cached listener (and the outgoing file's entire global) for the
+    /// rest of the run.
+    pub fn close_for_isolation(&self) {
+        self.mutex.lock();
+        if !self.closed.get() {
+            self.closed.set(true);
+            self.mutex.unlock();
+            self.detach();
+            self.unref_task();
+        } else {
+            self.mutex.unlock();
+        }
+    }
+
     // this can be called multiple times
     pub fn detach(&self) {
         let ctx_ptr = self.as_ctx_ptr().cast::<c_void>();
@@ -1136,11 +1155,12 @@ impl FSWatcher {
             vm_ref.as_mut().rare_data().add_fs_watcher_for_isolation(
                 ctx.cast::<c_void>(),
                 // §Dispatch cold-path vtable — `bun_jsc::RareData` stores
-                // (ptr, close-fn) so it can fire detach without naming FSWatcher.
+                // (ptr, close-fn) so it can fire the close without naming
+                // FSWatcher.
                 |p| {
                     // SAFETY: `p` is the `ctx` registered above; still live
                     // until `remove_fs_watcher_for_isolation` runs.
-                    unsafe { (*p.cast::<FSWatcher>()).detach() }
+                    unsafe { (*p.cast::<FSWatcher>()).close_for_isolation() }
                 },
             );
         }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1537,6 +1537,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
     pub fn stop_listening(&mut self, abrupt: bool) {
         // httplog!("stopListening", .{});
 
+        if self.vm().test_isolation_enabled {
+            // SAFETY: `vm_mut()` is the live thread-local VM pointer.
+            unsafe {
+                (*self.vm_mut())
+                    .rare_data()
+                    .remove_server_for_isolation(core::ptr::from_mut(self).cast());
+            }
+        }
+
         if Self::HAS_H3 {
             if let Some(h3l) = self.h3_listener.take() {
                 // Graceful: GOAWAY + drain via the still-open UDP socket; the
@@ -1863,6 +1872,16 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // This should've already been handled in stop_listening; however, when
         // the JS VM terminates, it hypothetically might not call stop_listening.
         this_ref.notify_inspector_server_stopped();
+        if this_ref.vm().test_isolation_enabled {
+            // Backstop for the same hypothetical — never leave a dangling
+            // registry entry behind the free below.
+            // SAFETY: `vm_mut()` is the live thread-local VM pointer.
+            unsafe {
+                (*this_ref.vm_mut())
+                    .rare_data()
+                    .remove_server_for_isolation(this.cast());
+            }
+        }
 
         // PORT NOTE: owned-field cleanup (all_closed_promise / user_routes /
         // config / on_clienterror / h3_alt_svc / dev_server / plugins) is

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1870,8 +1870,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // the JS VM terminates, it hypothetically might not call stop_listening.
         this_ref.notify_inspector_server_stopped();
         if this_ref.vm().test_isolation_enabled {
-            // Backstop for the same hypothetical — never leave a dangling
-            // registry entry behind the free below.
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
                 handles.remove_server(this.cast::<()>().cast_const());
             }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1538,11 +1538,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // httplog!("stopListening", .{});
 
         if self.vm().test_isolation_enabled {
-            // SAFETY: `vm_mut()` is the live thread-local VM pointer.
-            unsafe {
-                (*self.vm_mut())
-                    .rare_data()
-                    .remove_server_for_isolation(core::ptr::from_mut(self).cast());
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                handles.remove_server(core::ptr::from_ref(self).cast());
             }
         }
 
@@ -1875,11 +1872,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         if this_ref.vm().test_isolation_enabled {
             // Backstop for the same hypothetical — never leave a dangling
             // registry entry behind the free below.
-            // SAFETY: `vm_mut()` is the live thread-local VM pointer.
-            unsafe {
-                (*this_ref.vm_mut())
-                    .rare_data()
-                    .remove_server_for_isolation(this.cast());
+            if let Some(handles) = crate::jsc_hooks::isolation_handles() {
+                handles.remove_server(this.cast::<()>().cast_const());
             }
         }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1539,7 +1539,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         if self.vm().test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.remove_server(core::ptr::from_ref(self).cast());
+                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                    core::ptr::from_ref(self),
+                )));
             }
         }
 
@@ -1871,7 +1873,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         this_ref.notify_inspector_server_stopped();
         if this_ref.vm().test_isolation_enabled {
             if let Some(handles) = crate::jsc_hooks::isolation_handles() {
-                handles.remove_server(this.cast::<()>().cast_const());
+                handles.swap_remove(&crate::jsc_hooks::IsolationHandle::Server(AnyServer::from(
+                    this.cast_const(),
+                )));
             }
         }
 
@@ -3255,7 +3259,7 @@ pub type DebugHTTPSServer = NewServer<true, true>;
 // hand-roll the tag here. AnyServer is cold-path (per-request, not per-tick).
 // PERF(port): was TaggedPointerUnion pack — 8→16 bytes; ~handful of instances.
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AnyServerTag {
     HTTPServer = 0,
     HTTPSServer = 1,
@@ -3263,7 +3267,7 @@ pub enum AnyServerTag {
     DebugHTTPSServer = 3,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct AnyServer {
     pub tag: AnyServerTag,
     pub ptr: *mut (),

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -761,20 +761,22 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
 // thread), not in the refcount destructor; otherwise the file-boundary drain
 // pops a dangling pointer and calls close() on freed memory (UAF, caught by
 // ASAN).
-test.concurrent("--isolate: unwatchFile'd watcher freed on the work pool leaves no dangling registry entry", async () => {
-  // The dance, per file:
-  //   1. watchFile, then touch the file until the listener fires — proof the
-  //      initial stat completed and the watcher sits in the scheduler queue
-  //      (queue ref taken).
-  //   2. unwatchFile (close: Strong self-ref downgraded) + Bun.gc (wrapper
-  //      finalized: wrapper ref dropped).
-  //   3. sleep past a few 10ms scheduler ticks so the work-pool callback pops
-  //      the closed watcher and drops the queue ref — the last one — freeing
-  //      the watcher on the work-pool thread. No JS-observable signal exists
-  //      for that free, hence the bounded sleep.
-  // The file boundary after each file then drains the isolation registry,
-  // which must no longer reference the freed watcher.
-  const raceFixture = `
+test.concurrent(
+  "--isolate: unwatchFile'd watcher freed on the work pool leaves no dangling registry entry",
+  async () => {
+    // The dance, per file:
+    //   1. watchFile, then touch the file until the listener fires — proof the
+    //      initial stat completed and the watcher sits in the scheduler queue
+    //      (queue ref taken).
+    //   2. unwatchFile (close: Strong self-ref downgraded) + Bun.gc (wrapper
+    //      finalized: wrapper ref dropped).
+    //   3. sleep past a few 10ms scheduler ticks so the work-pool callback pops
+    //      the closed watcher and drops the queue ref — the last one — freeing
+    //      the watcher on the work-pool thread. No JS-observable signal exists
+    //      for that free, hence the bounded sleep.
+    // The file boundary after each file then drains the isolation registry,
+    // which must no longer reference the freed watcher.
+    const raceFixture = `
     import { test } from "bun:test";
     import fs from "node:fs";
     import path from "node:path";
@@ -797,23 +799,24 @@ test.concurrent("--isolate: unwatchFile'd watcher freed on the work pool leaves 
       }
     });
   `;
-  // Two identical files: the drain runs at the boundary BETWEEN files, so the
-  // first file's registry is drained while the second exists to force it.
-  using dir = tempDir("isolate-statwatcher-race", {
-    "a.test.js": raceFixture,
-    "b.test.js": raceFixture,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--isolate"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-  expect(stderr).toContain("2 pass");
-  expect(exitCode).toBe(0);
-});
+    // Two identical files: the drain runs at the boundary BETWEEN files, so the
+    // first file's registry is drained while the second exists to force it.
+    using dir = tempDir("isolate-statwatcher-race", {
+      "a.test.js": raceFixture,
+      "b.test.js": raceFixture,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("2 pass");
+    expect(exitCode).toBe(0);
+  },
+);
 
 // The synchronous module-load path (require(esm), importSync) must attach the
 // transpiler's ESM-record analysis (module_info) to the ResolvedSource under

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -751,3 +751,58 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
   }, 60_000);
 });
+
+// The synchronous module-load path (require(esm), importSync) must attach the
+// transpiler's ESM-record analysis (module_info) to the ResolvedSource under
+// --isolate, exactly like the async path does. module_info is what turns the
+// cached SourceProvider into a BunTranspiledModule, letting every later file
+// rebuild the module record from the cache instead of re-running JSC's parser
+// over the transpiled source in its fresh global (CPU + transient allocations
+// per file; ~1.2s/file for a 3000-export module in a debug build). Run 1
+// exercises the fresh-transpile branch; run 2 hits the on-disk
+// RuntimeTranspilerCache entry (esm_record branch).
+test.concurrent(
+  "--isolate: require(esm) caches a BunTranspiledModule SourceProvider",
+  async () => {
+    // Wide enough to clear the RuntimeTranspilerCache minimum size (4KB).
+    let big = "";
+    for (let i = 0; i < 500; i++) big += `export function f${i}(x){return x+${i};}\n`;
+    big += `export const COUNT = 500;\n`;
+
+    using dir = tempDir("isolate-sync-provider", {
+      "big.mjs": big,
+      "a.test.ts": `
+      import { test, expect } from "bun:test";
+      import { isolatedModuleCacheSourceType } from "bun:internal-for-testing";
+
+      test("require(esm) provider carries module_info", () => {
+        const path = require.resolve("./big.mjs");
+        const m = require("./big.mjs");
+        expect(m.COUNT).toBe(500);
+        expect(m.f42(1)).toBe(43);
+        expect(isolatedModuleCacheSourceType(path)).toBe("BunTranspiledModule");
+      });
+    `,
+    });
+
+    const cacheDir = `${String(dir)}/transpiler-cache`;
+    for (const run of [1, 2]) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", "--isolate", "./a.test.ts"],
+        env: {
+          ...bunEnv,
+          BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+          BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+        },
+        cwd: String(dir),
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr, `run ${run}`).toContain("1 pass");
+      expect(stderr, `run ${run}`).toContain("0 fail");
+      expect(exitCode, `run ${run}`).toBe(0);
+    }
+  },
+  60_000,
+);

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
+
+// Every case spawns at least one full `bun test --isolate` child; the heavy
+// ones (8-file leak fixtures, 500-2000-export module_info modules) exceed the
+// 5s default on debug/ASAN runners.
+setDefaultTimeout(isASAN ? 120_000 : 30_000);
 
 // Two test files where the first leaks state and the second observes it.
 // Under --isolate the second file must see a clean world.
@@ -522,20 +527,18 @@ test.concurrent("--isolate: SourceProvider cache covers node_modules .mjs and ty
   expect(exitCode).toBe(0);
 });
 
-test.concurrent(
-  "--isolate: cached SourceProvider's module_info rebuilds correct exports",
-  async () => {
-    // A wide module so the printer-generated module_info has thousands of
-    // export entries. Under --isolate, file b hits the SourceProvider cache and
-    // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
-    // instead of re-parsing. If the record is wrong, named imports would be
-    // undefined or the count would mismatch.
-    const N = 2000;
-    let big = "";
-    for (let i = 0; i < N; i++) big += `export function f${i}(x){return x+${i};}\n`;
-    big += `export const COUNT = ${N};\n`;
+test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct exports", async () => {
+  // A wide module so the printer-generated module_info has thousands of
+  // export entries. Under --isolate, file b hits the SourceProvider cache and
+  // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
+  // instead of re-parsing. If the record is wrong, named imports would be
+  // undefined or the count would mismatch.
+  const N = 2000;
+  let big = "";
+  for (let i = 0; i < N; i++) big += `export function f${i}(x){return x+${i};}\n`;
+  big += `export const COUNT = ${N};\n`;
 
-    const tBody = (name: string) => `
+  const tBody = (name: string) => `
     import { test, expect } from "bun:test";
     import { f0, f1, f${N - 1}, COUNT } from "./big";
     import * as all from "./big";
@@ -548,26 +551,24 @@ test.concurrent(
     });
   `;
 
-    using dir = tempDir("isolate-module-info", {
-      "big.ts": big,
-      "a.test.ts": tBody("a"),
-      "b.test.ts": tBody("b"),
-      "c.test.ts": tBody("c"),
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts", "./c.test.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toContain("3 pass");
-    expect(stderr).toContain("0 fail");
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+  using dir = tempDir("isolate-module-info", {
+    "big.ts": big,
+    "a.test.ts": tBody("a"),
+    "b.test.ts": tBody("b"),
+    "c.test.ts": tBody("c"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts", "./c.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("3 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
 
 test.concurrent(
   "--isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export",
@@ -728,7 +729,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
-  }, 60_000);
+  });
 
   test("Bun.serve left running", async () => {
     using dir = tempDir(
@@ -738,7 +739,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
-  }, 60_000);
+  });
 
   test("long setTimeout/setInterval left pending", async () => {
     using dir = tempDir(
@@ -749,7 +750,7 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
-  }, 60_000);
+  });
 });
 
 // The synchronous module-load path (require(esm), importSync) must attach the
@@ -761,17 +762,15 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
 // per file; ~1.2s/file for a 3000-export module in a debug build). Run 1
 // exercises the fresh-transpile branch; run 2 hits the on-disk
 // RuntimeTranspilerCache entry (esm_record branch).
-test.concurrent(
-  "--isolate: require(esm) caches a BunTranspiledModule SourceProvider",
-  async () => {
-    // Wide enough to clear the RuntimeTranspilerCache minimum size (4KB).
-    let big = "";
-    for (let i = 0; i < 500; i++) big += `export function f${i}(x){return x+${i};}\n`;
-    big += `export const COUNT = 500;\n`;
+test.concurrent("--isolate: require(esm) caches a BunTranspiledModule SourceProvider", async () => {
+  // Wide enough to clear the RuntimeTranspilerCache minimum size (4KB).
+  let big = "";
+  for (let i = 0; i < 500; i++) big += `export function f${i}(x){return x+${i};}\n`;
+  big += `export const COUNT = 500;\n`;
 
-    using dir = tempDir("isolate-sync-provider", {
-      "big.mjs": big,
-      "a.test.ts": `
+  using dir = tempDir("isolate-sync-provider", {
+    "big.mjs": big,
+    "a.test.ts": `
       import { test, expect } from "bun:test";
       import { isolatedModuleCacheSourceType } from "bun:internal-for-testing";
 
@@ -783,26 +782,24 @@ test.concurrent(
         expect(isolatedModuleCacheSourceType(path)).toBe("BunTranspiledModule");
       });
     `,
-    });
+  });
 
-    const cacheDir = `${String(dir)}/transpiler-cache`;
-    for (const run of [1, 2]) {
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", "--isolate", "./a.test.ts"],
-        env: {
-          ...bunEnv,
-          BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
-          BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
-        },
-        cwd: String(dir),
-        stderr: "pipe",
-        stdout: "pipe",
-      });
-      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect(stderr, `run ${run}`).toContain("1 pass");
-      expect(stderr, `run ${run}`).toContain("0 fail");
-      expect(exitCode, `run ${run}`).toBe(0);
-    }
-  },
-  60_000,
-);
+  const cacheDir = `${String(dir)}/transpiler-cache`;
+  for (const run of [1, 2]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./a.test.ts"],
+      env: {
+        ...bunEnv,
+        BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1",
+        BUN_RUNTIME_TRANSPILER_CACHE_PATH: cacheDir,
+      },
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr, `run ${run}`).toContain("1 pass");
+    expect(stderr, `run ${run}`).toContain("0 fail");
+    expect(exitCode, `run ${run}`).toBe(0);
+  }
+});

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -563,7 +563,7 @@ test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct
   expect(stderr).toContain("3 pass");
   expect(stderr).toContain("0 fail");
   expect(exitCode).toBe(0);
-});
+}, 60_000);
 
 test.concurrent(
   "--isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export",
@@ -656,4 +656,94 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
   expect(stderr).toContain("2 pass");
   expect(stderr).toContain("0 fail");
   expect(exitCode).toBe(0);
+});
+
+// Each of these leaked handles used to pin its test file's ENTIRE global
+// object (and therefore the file's module graph) for the rest of a
+// `bun test --isolate` run, growing memory by one full global per file:
+//
+// - fs.watch: isolation teardown called FSWatcher.detach(), which never drops
+//   the initial pending_activity_count ref, so hasPendingActivity() stayed
+//   true forever and the GC could never collect the wrapper or its cached
+//   listener closure.
+// - Bun.serve: the swap blind-closed the listen socket at the uws layer; the
+//   Server object never learned, kept hasListener() true, and its strong
+//   js_value (fetch handler closure) pinned the global.
+// - setTimeout/setInterval: generation-stale timers only self-cancelled when
+//   they FIRED, so a module-scope long timer held a Strong on its wrapper
+//   until the deadline (effectively forever for hour-scale timers).
+//
+// Each fixture runs 8 isolated files that leak one handle apiece, forces a
+// full GC, and counts live GlobalObject cells. Pinned globals accumulate
+// (the last file sees 8); collectable ones plateau (current + a lagging one
+// or two).
+describe.concurrent("--isolate: collects globals pinned by leaked handles", () => {
+  const LEAK_FILE_COUNT = 8;
+
+  function makeLeakFixture(dirt: string): Record<string, string> {
+    const files: Record<string, string> = {};
+    for (let i = 1; i <= LEAK_FILE_COUNT; i++) {
+      files[`file_${i}.test.js`] = `
+        import { test, expect } from "bun:test";
+        import { heapStats } from "bun:jsc";
+        ${dirt}
+        test("leak-${i}", () => {
+          Bun.gc(true);
+          Bun.gc(true);
+          const globals = heapStats().objectTypeCounts.GlobalObject ?? 0;
+          console.log("GLOBALS=" + globals);
+          expect(globals).toBeGreaterThan(0);
+        });
+      `;
+    }
+    return files;
+  }
+
+  async function maxLiveGlobals(dir: string): Promise<number> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(`${LEAK_FILE_COUNT} pass`);
+    expect(exitCode).toBe(0);
+    const counts = [...stdout.matchAll(/GLOBALS=(\d+)/g)].map(m => Number(m[1]));
+    expect(counts).toHaveLength(LEAK_FILE_COUNT);
+    return Math.max(...counts);
+  }
+
+  test("fs.watch left open", async () => {
+    using dir = tempDir(
+      "isolate-leak-watch",
+      makeLeakFixture(`
+        import fs from "node:fs";
+        const watcher = fs.watch(import.meta.dir, () => {});
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  }, 60_000);
+
+  test("Bun.serve left running", async () => {
+    using dir = tempDir(
+      "isolate-leak-serve",
+      makeLeakFixture(`
+        const server = Bun.serve({ port: 0, fetch: () => new Response("x") });
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  }, 60_000);
+
+  test("long setTimeout/setInterval left pending", async () => {
+    using dir = tempDir(
+      "isolate-leak-timers",
+      makeLeakFixture(`
+        setTimeout(() => {}, 3_600_000);
+        setInterval(() => {}, 3_600_000);
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  }, 60_000);
 });

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -522,18 +522,20 @@ test.concurrent("--isolate: SourceProvider cache covers node_modules .mjs and ty
   expect(exitCode).toBe(0);
 });
 
-test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct exports", async () => {
-  // A wide module so the printer-generated module_info has thousands of
-  // export entries. Under --isolate, file b hits the SourceProvider cache and
-  // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
-  // instead of re-parsing. If the record is wrong, named imports would be
-  // undefined or the count would mismatch.
-  const N = 2000;
-  let big = "";
-  for (let i = 0; i < N; i++) big += `export function f${i}(x){return x+${i};}\n`;
-  big += `export const COUNT = ${N};\n`;
+test.concurrent(
+  "--isolate: cached SourceProvider's module_info rebuilds correct exports",
+  async () => {
+    // A wide module so the printer-generated module_info has thousands of
+    // export entries. Under --isolate, file b hits the SourceProvider cache and
+    // rebuilds JSModuleRecord from the cached module_info (Bun__analyzeTranspiledModule)
+    // instead of re-parsing. If the record is wrong, named imports would be
+    // undefined or the count would mismatch.
+    const N = 2000;
+    let big = "";
+    for (let i = 0; i < N; i++) big += `export function f${i}(x){return x+${i};}\n`;
+    big += `export const COUNT = ${N};\n`;
 
-  const tBody = (name: string) => `
+    const tBody = (name: string) => `
     import { test, expect } from "bun:test";
     import { f0, f1, f${N - 1}, COUNT } from "./big";
     import * as all from "./big";
@@ -546,24 +548,26 @@ test.concurrent("--isolate: cached SourceProvider's module_info rebuilds correct
     });
   `;
 
-  using dir = tempDir("isolate-module-info", {
-    "big.ts": big,
-    "a.test.ts": tBody("a"),
-    "b.test.ts": tBody("b"),
-    "c.test.ts": tBody("c"),
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts", "./c.test.ts"],
-    env: bunEnv,
-    cwd: String(dir),
-    stderr: "pipe",
-    stdout: "pipe",
-  });
-  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toContain("3 pass");
-  expect(stderr).toContain("0 fail");
-  expect(exitCode).toBe(0);
-}, 60_000);
+    using dir = tempDir("isolate-module-info", {
+      "big.ts": big,
+      "a.test.ts": tBody("a"),
+      "b.test.ts": tBody("b"),
+      "c.test.ts": tBody("c"),
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--isolate", "./a.test.ts", "./b.test.ts", "./c.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("3 pass");
+    expect(stderr).toContain("0 fail");
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);
 
 test.concurrent(
   "--isolate: cached module_info handles `import * as ns; export { ns }` as a Namespace export",

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -753,6 +753,68 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
   });
 });
 
+// fs.watchFile's StatWatcher is thread-safe-refcounted: the scheduler queue
+// holds a ref that is dropped on the work-pool thread. After unwatchFile +
+// GC of the JS wrapper, that queue ref is the LAST ref, so the watcher is
+// freed off the JS thread — where the thread-local isolation registry is
+// unreachable. The registry entry must therefore be removed in close() (JS
+// thread), not in the refcount destructor; otherwise the file-boundary drain
+// pops a dangling pointer and calls close() on freed memory (UAF, caught by
+// ASAN).
+test.concurrent("--isolate: unwatchFile'd watcher freed on the work pool leaves no dangling registry entry", async () => {
+  // The dance, per file:
+  //   1. watchFile, then touch the file until the listener fires — proof the
+  //      initial stat completed and the watcher sits in the scheduler queue
+  //      (queue ref taken).
+  //   2. unwatchFile (close: Strong self-ref downgraded) + Bun.gc (wrapper
+  //      finalized: wrapper ref dropped).
+  //   3. sleep past a few 10ms scheduler ticks so the work-pool callback pops
+  //      the closed watcher and drops the queue ref — the last one — freeing
+  //      the watcher on the work-pool thread. No JS-observable signal exists
+  //      for that free, hence the bounded sleep.
+  // The file boundary after each file then drains the isolation registry,
+  // which must no longer reference the freed watcher.
+  const raceFixture = `
+    import { test } from "bun:test";
+    import fs from "node:fs";
+    import path from "node:path";
+
+    test("unwatchFile then free on work pool", async () => {
+      const target = path.join(import.meta.dir, "watched-" + path.basename(import.meta.path) + ".txt");
+      for (let round = 0; round < 3; round++) {
+        fs.writeFileSync(target, "0");
+        await (async function arm() {
+          const fired = Promise.withResolvers();
+          fs.watchFile(target, { interval: 10 }, () => fired.resolve());
+          const poker = setInterval(() => fs.writeFileSync(target, String(Math.random())), 10);
+          await fired.promise;
+          clearInterval(poker);
+          fs.unwatchFile(target);
+        })();
+        Bun.gc(true);
+        Bun.gc(true);
+        await Bun.sleep(250);
+      }
+    });
+  `;
+  // Two identical files: the drain runs at the boundary BETWEEN files, so the
+  // first file's registry is drained while the second exists to force it.
+  using dir = tempDir("isolate-statwatcher-race", {
+    "a.test.js": raceFixture,
+    "b.test.js": raceFixture,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("2 pass");
+  expect(exitCode).toBe(0);
+});
+
 // The synchronous module-load path (require(esm), importSync) must attach the
 // transpiler's ESM-record analysis (module_info) to the ResolvedSource under
 // --isolate, exactly like the async path does. module_info is what turns the

--- a/test/napi/napi-app/.gitignore
+++ b/test/napi/napi-app/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.log
 build
+Library


### PR DESCRIPTION
### What

Two `bun test --isolate` memory/CPU fixes found while auditing test isolation between the Zig spec and the Rust port:

1. **Leaked handles pinned the outgoing global forever.** A test file that leaks an `fs.watch` handle, a running `Bun.serve`/node:http server, or a long `setTimeout`/`setInterval` used to pin its **entire global object** (module graph, closures, everything) for the rest of the run — memory grew by one full global per such file, exactly the "leaked handles" scenario `--isolate` exists to absorb.
2. **The synchronous module path skipped the isolation source cache's module records.** `require(esm)`/`importSync` passed `module_info: null` (spec: ModuleLoader.zig:423-428/:516-551; only the async `RuntimeTranspilerStore` path had been ported), so cached SourceProviders stayed plain `Module` and every isolated file re-ran JSC's parser over the transpiled source to rebuild the record in its fresh global.

### Reproduction

8 isolated files, each leaking one handle and counting live globals after a forced full GC:

```sh
mkdir leak && cd leak
for i in $(seq 1 8); do cat > "f$i.test.js" <<'JS'
import { test, expect } from "bun:test";
import { heapStats } from "bun:jsc";
import fs from "node:fs";
const w = fs.watch(import.meta.dir, () => {});          // or: Bun.serve({ port: 0, fetch: () => new Response("x") });
test("t", () => {                                        // or: setTimeout(() => {}, 3_600_000);
  Bun.gc(true); Bun.gc(true);
  console.log("GLOBALS=" + heapStats().objectTypeCounts.GlobalObject);
  expect(1).toBe(1);
});
JS
done
bun test --isolate   # GLOBALS climbs 1,2,3,...,8 — every old global retained
```

For the sync path: 8 isolated files `require()`ing one 3000-export `.mjs` — every file pays a full JSC re-parse (~1.2s/file debug, ~20% slower loads in release) instead of rebuilding the record from the cache.

### Cause

`swapGlobalForTestIsolation` gcUnprotects the outgoing global so its graph becomes collectable — but three handle types kept independent GC roots into it:

1. **fs.watch** — isolation teardown (`closeAllWatchersForIsolation`) calls `FSWatcher.detach()`, which never drops the initial `pending_activity_count = 1` ref. Only `close()` does. `hasPendingActivity()` therefore stays true forever and JSC can never collect the wrapper, whose cached listener closure roots the global. (Stat watchers register `close()` and don't leak.)
2. **Bun.serve** — the swap's socket-group walk closes the listen socket *fd* at the uws layer, but the Server object never learns: `hasListener()` stays true, so its strong `js_value` (fetch handler closure) roots the global. node:http servers go through the same path.
3. **Timers** — generation-stale `TimeoutObject`s only self-cancel when they *fire*; until then the armed timer holds a Strong on its wrapper. A module-scope `setInterval(fn, 3_600_000)` roots its global for an hour — effectively the whole run.

And on the sync module path, `module_info` is what flips the cached provider to `BunTranspiledModule` (`ZigSourceProvider.cpp` — "allows JSC to skip parsing during the analyze phase"); without it the cache only dedupes transpiles, not the per-global re-parse.

### Fix

All gated on `test_isolation_enabled` / `use_isolation_source_provider_cache()`; zero behavior change outside `--isolate`/`--parallel`:

- `FSWatcher::close_for_isolation()` — `close()` minus the `'close'` event (no user JS mid-swap, parity with `StatWatcher::close`); the isolation registry now calls it so the pending-activity ref drops and the wrapper becomes collectable.
- Watchers and servers register into a per-VM `IsolationHandles` set on `RuntimeState` (unified `ArrayHashMap` registry, maintainer refactor of the original per-kind `rare_data` registries). `close_isolation_handles()` drains it before each global swap, popping until empty so close/error handlers that register new handles are also swept. Servers register on successful listen, unregister in `stop_listening()`/`deinit()`, and each leaked server is stopped through its real lifecycle (listener close, poll unref, `js_value` downgrade) *before* the blind socket-group walk.
- `close_isolation_handles()` drains microtasks first: a microtask still pending at end-of-file can register a handle when it runs, and must land in the registry before it empties (keeps the pre-refactor drain-before-teardown ordering).
- `StatWatcher` leaves the registry in `close()` (always the JS thread), not in the refcount destructor: the last deref can land on the work-pool thread, where the thread-local registry is unreachable, so the old placement silently skipped removal and left a dangling pointer that the next file-boundary drain closed. ASAN: `heap-use-after-free ... in StatWatcher::close`, `freed by thread T11 (Bun Pool 0) ... work_pool_callback`.
- The swap now invokes the existing `cancel_all_timers` hook (the same sweep `global_exit()` uses) right after bumping the isolation generation, eagerly releasing every `TimeoutObject`/`ImmediateObject`/`AbortSignal.timeout` pin. Internal timers (DNS, BunTest, SQL, …) are untouched by that sweep's tag filter.
- Sync module path: fresh transpiles collect the printer's ESM-record analysis (`ModuleInfo::create` + `has_tla`, destroyed on print failure) and attach it to `ResolvedSource` as a deserialized record — which also makes the sync path persist `esm_record` into on-disk RuntimeTranspilerCache entries; disk-cache hits deserialize the stored `esm_record` (`create_from_cached_record`). Mirrors `RuntimeTranspilerStore.rs` exactly.
- Test-only: `bun:internal-for-testing` gains `isolatedModuleCacheSourceType(path)` (thin lookup over the per-VM cache) so the sync-path test can assert the provider type deterministically.

Complementary to #31772 (which clears the old global's module registry + forces a collection): that PR makes a *collectable* global's graph actually get reclaimed; this one makes pinned globals collectable in the first place. No overlapping hunks beyond both touching `swap_global_for_test_isolation`.

### Verification

- New tests in `test/cli/test/isolation.test.ts`:
  - `--isolate: collects globals pinned by leaked handles` (3 fixtures × 8 isolated files, asserting max live `GlobalObject` ≤ 4): on baseline all three fail with `Received: 8` (every global pinned); with the fix the count plateaus at 2–3.
  - `--isolate: require(esm) caches a BunTranspiledModule SourceProvider`: asserts the cached provider type for a `require`d ESM module across both the fresh-transpile and disk-cache-hit (`BUN_RUNTIME_TRANSPILER_CACHE_PATH`) branches. Fails on baseline with `"Module"`.
- `--isolate: unwatchFile'd watcher freed on the work pool leaves no dangling registry entry`: watchFile until the listener fires (scheduler queue ref exists), then unwatchFile + `Bun.gc` + sleep past a few scheduler ticks so the work pool drops the last ref; without the close()-side unregistration ASAN aborts at the file boundary with the heap-use-after-free above.
- Full `isolation.test.ts`: 19/19 pass with the fixes; each new test verified to fail with the matching source change stashed.
- Kitchen-sink repro (watch + serve + timers + listeners + dangling promises per file, 14 files): heap flat at 50MB / 3 globals, was +17MB & +1 global per file.
- Release-binary measurement for the sync path: per-file load of a 3000-export module drops to async-path parity (~4.6ms vs ~5.7ms; debug-build cost matches the async path's existing module_info profile).
- Adjacent suites checked on this container: `parallel.test.ts` fails 4 scheduling-sensitive cases *identically on baseline and fix* (machine-capacity artifacts); `fs.watch.test.ts` fails only the 2 run-as-root permission cases (baseline too); `serve-listen.test.ts` 27/27.


### Peak RSS benchmark (50 isolated test files × 50 shared 1MB modules)

Method: 50 `.test.ts` files, each statically importing the same 50 shared modules; each shared module is **~1MB of source** (≈1MB transpiled: 9,000 exported functions + a 64×512-char retained string table), so one file's evaluated import graph is ~50MB of JS and per-global retention is unmistakable in RSS. All contents are salted with a per-generation runtime value and regenerated before every run, and the child runs with `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0`, so the on-disk runtime transpiler cache can never replay entries (the in-memory `--isolate` SourceProvider cache stays active, as in production). Peak RSS = `VmHWM` of the `bun test` process, polled at 25ms; 3 runs each, fresh salt per run. Linux x64, release builds, local.

**Clean suite** (no leaked handles):

| binary | `--isolate` peak RSS (3 runs) | wall | no `--isolate` (reference) |
|---|---|---|---|
| bun 1.3.14 (pre-port Zig, system) | 1696 / 1752 / 1694 MB | ~25s | ~1397 MB |
| release @ base `a3464c666` (pre-PR) | 1489 / 1476 / 1479 MB | ~23s | ~1182 MB |
| release @ PR head `9de5ec654` | 1493 / 1469 / 1477 MB | ~23s | ~1191 MB |

Neutral, as expected: static imports load through the async path (which already attached `module_info`) and nothing leaks, so none of this PR's paths fire beyond the per-swap sweeps — which cost nothing measurable.

**Leaked-handle suite** — identical fixture, plus one `Bun.serve({ port: 0, ... })` leaked at module scope of every test file (the scenario this PR fixes):

| binary | `--isolate` peak RSS (3 runs) | wall |
|---|---|---|
| bun 1.3.14 (before) | **10912 / 10920 / 10721 MB** | ~38s |
| release @ base `a3464c666` (before) | **8502 / 9559 / 8512 MB** | ~36s |
| release @ PR head (after) | **2798 / 2789 / 2993 MB** | ~25.5s |

Before the fix, every leaked server pins its file's entire ~50MB global graph for the rest of the run — peak RSS grows linearly with file count (≈10.9GB at just 50 files; an OOM at suite scale). With the fix, leaked servers are stopped at each swap, the globals become collectable, and peak RSS drops ~3.5× (and wall time ~33%, from reduced GC pressure). The residual gap over the clean suite (~1.3GB) is the transiently-pinned current/previous global plus GC lag — bounded, not growing with file count.

(At a 10KB-module scale the same fixture showed all three binaries within noise of each other on the clean suite — 158-161MB — confirming Zig↔Rust port parity; the 1MB scale is what makes the retention effects dominate RSS.)

