### PR TITLE
Reset SIGTRAP before the crash handler's final trap so crashes terminate on aarch64

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2961,6 +2961,14 @@ mod draft {
                 libc::SIGFPE,
                 libc::SIGHUP,
                 libc::SIGTERM,
+                // The trap below raises SIGTRAP on aarch64 (`brk`), not the
+                // SIGILL of x86_64's `ud2`. If JS registered a SIGTRAP
+                // listener (`process.on("SIGTRAP")` — npm's `signal-exit`
+                // package does), the forwarding sigaction returns after
+                // enqueueing, the trap instruction re-executes, and the
+                // process spins in signal delivery forever instead of dying.
+                // Reset it so the first trap is lethal.
+                libc::SIGTRAP,
             ] {
                 // SAFETY: &sigact is a valid sigaction; null oldact is permitted.
                 unsafe {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -1,6 +1,6 @@
 import { crash_handler } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isLinux, mergeWindowEnvs } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux, isPosix, mergeWindowEnvs } from "harness";
 import path from "path";
 const { getMachOImageZeroOffset } = crash_handler;
 
@@ -35,6 +35,52 @@ test.if(isDebug && isLinux && hasSymbolizer)(
     expect(stdout).not.toContain("capture_stack_trace");
   },
   60_000, // symbolizing the debug binary takes several seconds
+);
+
+// The crash handler's final trap raises SIGILL on x86_64 (ud2) but SIGTRAP on
+// aarch64 (brk). `crash()` resets trap-signal dispositions to SIG_DFL right
+// before trapping so that the first trap is lethal — SIGTRAP was missing from
+// that list. A JS-registered listener (`process.on("SIGTRAP")`, which npm's
+// widely-used signal-exit package installs) is backed by a real sigaction that
+// enqueues to the JS thread and returns; returning from a synchronous trap
+// re-executes the trap instruction, so on aarch64 a crashing process would
+// spin in signal delivery forever (pinning a core) instead of dying.
+test.if(isPosix)(
+  "panic terminates the process even when JS registered trap-signal listeners",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `process.on("SIGTRAP", () => {});
+         process.on("SIGILL", () => {});
+         require("bun:internal-for-testing").crash_handler.panic();`,
+        // Make debug builds take the fast trace-string path instead of
+        // spawning llvm-symbolizer, which can take tens of seconds.
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    // Without the fix the child never exits — it loops SIGTRAP delivery on the
+    // trap instruction. Bound the wait and fail explicitly rather than hanging
+    // the test runner and leaking a core-pinning process.
+    const exited = await Promise.race([proc.exited, Bun.sleep(8_000).then(() => "spinning" as const)]);
+    if (exited === "spinning") {
+      proc.kill("SIGKILL");
+    }
+
+    const stderr = await proc.stderr.text();
+    expect(exited, `process should have died from the trap, stderr:\n${stderr}`).not.toBe("spinning");
+
+    // It went through the crash handler...
+    expect(stderr).toContain("invoked crashByPanic() handler");
+    // ...and died from the trap's default action, not a clean exit, and not a
+    // JS-observed SIGTRAP (the JS listener must never swallow the crash).
+    expect(proc.signalCode === null ? proc.exitCode : proc.signalCode).not.toBe(0);
+  },
+  20_000,
 );
 
 test.if(process.platform === "darwin")("macOS has the assumed image offset", () => {


### PR DESCRIPTION
### Symptom

On aarch64, a bun process that hits the crash handler with a JS `SIGTRAP` listener registered does not die — it spins forever in kernel signal delivery, pinning one core, with `crash` → `_sigtramp` at the top of every sample. Observed in the wild as bun-based CLI processes surviving their closed terminal tab at 100% CPU: the revoked tty fd triggered the `FilePoll::unregister_with_fd` unwrap panic (fixed separately in #31701), and the panic then failed to terminate the process. Any crash funnels into this path (`rust_panic_hook` → `crash()`, `crash_handler()` → `crash()`), so every panic/segfault on aarch64 becomes an immortal core-pinning process when such a listener exists.

### Cause

`crash()` resets SIGSEGV/SIGILL/SIGBUS/SIGABRT/SIGFPE/SIGHUP/SIGTERM to `SIG_DFL`, then executes `core::intrinsics::abort()` (Zig heritage: `@trap()`). That trap is `ud2` → SIGILL on x86_64 — covered by the list — but `brk` → **SIGTRAP** on aarch64, which the list omits.

`process.on("SIGTRAP")` installs a real sigaction (`BunProcess.cpp`) whose handler enqueues to the JS thread and returns. Returning from a handler for a *synchronous* trap re-executes the trapping instruction with PC unchanged: `brk` → SIGTRAP → handler returns → `brk` → … forever. The JS listener never observes anything because the crashing thread never returns to the event loop. npm's `signal-exit` package — ubiquitous in CLI apps (npm itself vendors its signal list, which is quoted in our own `c-bindings.cpp`) — registers exactly this listener set, SIGTRAP included, so real-world exposure is broad.

### Fix

Add `libc::SIGTRAP` to the `SIG_DFL` reset list in `crash()` (`src/crash_handler/lib.rs`), so the first trap is lethal regardless of what JS registered. One-line behavior change; x86_64 (`ud2`/SIGILL) was already covered and is unchanged.

### Test

`test/cli/run/run-crash-handler.test.ts`: child registers `process.on("SIGTRAP")` **and** `process.on("SIGILL")` (the invariant is arch-independent; the trap signal isn't), triggers a real panic via `bun:internal-for-testing`, and asserts the process dies through the crash handler rather than spinning — the wait is bounded and the child is SIGKILLed on failure so a buggy build fails cleanly instead of leaking a core-pinning process.

**Gate note:** the missing signal is only raised by the trap on aarch64, so the test can only fail-before on aarch64 lanes (Linux and macOS); on x86_64 it passes with and without the patch. Same situation as #31701's darwin-only fail-before. The mechanism and the test's sensitivity were verified on x86_64 by temporarily removing SIGILL (x86_64's trap signal) from the reset list: the test then catches the spin at its 8s bound and fails — byte-for-byte the aarch64 failure mode.

### Verification

- `bun bd test test/cli/run/run-crash-handler.test.ts` (debug+ASAN, x86_64 Linux): 6 pass, 1 skip (darwin-only), 0 fail; new test completes in ~1s
- Mechanism proof above (remove-SIGILL build → test fails at the spin bound; restored → passes)
- `cargo check` + `cargo clippy -p bun_crash_handler` clean on x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu, aarch64-apple-darwin
