### PR TITLE
Upgrade self-reported Node.js version from 24.3.0 to 24.16.0

### DIFF
--- a/.buildkite/Dockerfile
+++ b/.buildkite/Dockerfile
@@ -106,7 +106,7 @@ RUN --mount=type=tmpfs,target=/tmp \
 # match scripts/bootstrap.sh nodejs_version_exact() so container and bare-
 # metal agents use the same runtime. .tar.gz (not .xz) to match bootstrap.sh
 # and avoid needing xz-utils.
-ARG NODE_VERSION="24.3.0"
+ARG NODE_VERSION="24.16.0"
 RUN ARCH=$(if [ "$TARGETARCH" = "arm64" ]; then echo "arm64"; else echo "x64"; fi) && \
     curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${ARCH}.tar.gz" \
       | tar -xz -C /usr/local --strip-components=1 && \

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         clang = pkgs.clang_21;
         lld = pkgs.lld_21;
 
-        # Node.js 24 - matching the bootstrap script (targets 24.3.0, actual version from nixpkgs-unstable)
+        # Node.js 24 - matching the bootstrap script (targets 24.16.0, actual version from nixpkgs-unstable)
         nodejs = pkgs.nodejs_24;
 
         # Build tools and dependencies

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,4 +1,4 @@
-# Version: 19
+# Version: 20
 # A script that installs the dependencies needed to build and test Bun on Windows.
 # Supports both x64 and ARM64 using Scoop for package management.
 # Used by Azure [build images] pipeline.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -217,7 +217,7 @@ function Install-Git {
 function Install-NodeJs {
   # Pin to match the ABI version Bun expects (NODE_MODULE_VERSION 137).
   # Latest Node (25.x) uses ABI 141 which breaks node-gyp tests.
-  $nodejsVersion = "24.3.0"
+  $nodejsVersion = "24.16.0"
   Install-Scoop-Package "nodejs@$nodejsVersion" -Command node
 
   # Seed node-gyp's cache so napi tests don't re-download headers + node.lib

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Version: 34
+# Version: 35
 
 # A script that installs the dependencies needed to build and test Bun.
 # This should work on macOS and Linux with a POSIX shell.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -780,7 +780,7 @@ install_common_software() {
 }
 
 nodejs_version_exact() {
-	print "24.3.0"
+	print "24.16.0"
 }
 
 nodejs_version() {

--- a/scripts/build/deps/nodejs-headers.ts
+++ b/scripts/build/deps/nodejs-headers.ts
@@ -14,7 +14,7 @@ import type { Dependency } from "../source.ts";
  * download URL, and passed to zig as -Dreported_nodejs_version.
  * Override via `--nodejs-version=X.Y.Z` to test a bump.
  */
-export const NODEJS_VERSION = "24.3.0";
+export const NODEJS_VERSION = "24.16.0";
 
 /** Node.js NODE_MODULE_VERSION — for native addon ABI compat. */
 export const NODEJS_ABI_VERSION = "137";

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -742,7 +742,7 @@ export const defines: Flag[] = [
   },
   {
     // Shell-escaped quotes so clang receives literal quotes in the define
-    // (the preprocessor needs the string to be "24.3.0", not bare 24.3.0).
+    // (the preprocessor needs the string to be "24.16.0", not bare 24.16.0).
     flag: c => `REPORTED_NODEJS_VERSION=\\"${c.nodejsVersion}\\"`,
     desc: "Node.js version string reported by process.version",
   },

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -245,7 +245,7 @@ static JSValue constructVersions(VM& vm, JSObject* processObject)
 
     // Use commit hash for zstd (semantic version extraction not working yet)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "zstd"_s), JSC::jsOwnedString(vm, ASCIILiteral::fromLiteralUnsafe(BUN_VERSION_ZSTD_HASH)), 0);
-    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("13.6.233.10-node.18"_s))), 0);
+    object->putDirect(vm, JSC::Identifier::fromString(vm, "v8"_s), JSValue(JSC::jsOwnedString(vm, String("13.6.233.17-node.49"_s))), 0);
 #if OS(WINDOWS)
     object->putDirect(vm, JSC::Identifier::fromString(vm, "uv"_s), JSValue(JSC::jsOwnedString(vm, String::fromLatin1(uv_version_string()))), 0);
 #else

--- a/src/jsc/bindings/BunProcessReportObjectWindows.cpp
+++ b/src/jsc/bindings/BunProcessReportObjectWindows.cpp
@@ -97,7 +97,7 @@ JSValue constructReportObjectWindows(VM& vm, Zig::GlobalObject* globalObject, Pr
         // Component versions - just add the minimum needed
         JSObject* versions = constructEmptyObject(globalObject, globalObject->objectPrototype());
         versions->putDirect(vm, Identifier::fromString(vm, "node"_s), jsString(vm, String(REPORTED_NODEJS_VERSION ""_s)), 0);
-        versions->putDirect(vm, Identifier::fromString(vm, "v8"_s), jsString(vm, String("13.6.233.10-node.18"_s)), 0);
+        versions->putDirect(vm, Identifier::fromString(vm, "v8"_s), jsString(vm, String("13.6.233.17-node.49"_s)), 0);
         versions->putDirect(vm, Identifier::fromString(vm, "uv"_s), jsString(vm, String::fromLatin1(uv_version_string())), 0);
         versions->putDirect(vm, Identifier::fromString(vm, "modules"_s), jsString(vm, String("137"_s)), 0);
         header->putDirect(vm, Identifier::fromString(vm, "componentVersions"_s), versions, 0);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -426,7 +426,7 @@ describe.concurrent(() => {
     });
 
     let [out, exited] = await Promise.all([new Response(subprocess.stdout).text(), subprocess.exited]);
-    expect(out.trim()).toEqual("v24.3.0");
+    expect(out.trim()).toEqual("v24.16.0");
     expect(exited).toBe(0);
   });
 
@@ -1175,8 +1175,8 @@ it.each(["stdin", "stdout", "stderr"])("%s stream accessor should handle excepti
 });
 
 it("process.versions", () => {
-  expect(process.versions.node).toEqual("24.3.0");
-  expect(process.versions.v8).toEqual("13.6.233.10-node.18");
+  expect(process.versions.node).toEqual("24.16.0");
+  expect(process.versions.v8).toEqual("13.6.233.17-node.49");
   expect(process.versions.napi).toEqual("10");
   expect(process.versions.modules).toEqual("137");
 });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -187,7 +187,7 @@ describe.concurrent("napi", () => {
       expect(result).toEndWith("str: abcdef");
     });
 
-    // TODO: once we upgrade the Node version on macOS and musl to Node v24.3.0, remove this TODO
+    // TODO: once we upgrade the Node version on macOS and musl to Node v24.16.0, remove this TODO
     it.todoIf(isCI && (isMacOS || isMusl))("copies auto len", async () => {
       const result = await checkSameOutput("test_napi_get_value_string_utf8_with_buffer", ["abcdef", 424242]);
       expect(result).toEndWith("str: abcdef");

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -187,7 +187,7 @@ describe.concurrent("napi", () => {
       expect(result).toEndWith("str: abcdef");
     });
 
-    // TODO: once we upgrade the Node version on macOS and musl to Node v24.16.0, remove this TODO
+    // Skipped on macOS/musl CI until their Node version is upgraded to v24.16.0.
     it.todoIf(isCI && (isMacOS || isMusl))("copies auto len", async () => {
       const result = await checkSameOutput("test_napi_get_value_string_utf8_with_buffer", ["abcdef", 424242]);
       expect(result).toEndWith("str: abcdef");

--- a/test/napi/node-napi-tests/harness.ts
+++ b/test/napi/node-napi-tests/harness.ts
@@ -14,7 +14,7 @@ export async function build(dir: string) {
     stdin: "inherit",
     env: {
       ...bunEnv,
-      npm_config_target: "v24.3.0",
+      npm_config_target: "v24.16.0",
       CXXFLAGS: (bunEnv.CXXFLAGS ?? "") + (process.platform == "win32" ? " -std=c++20" : " -std=gnu++20"),
       // on linux CI, node-gyp will default to g++ and the version installed there is very old,
       // so we make it use clang instead

--- a/test/v8/bad-modules/mismatched_abi_version.cpp
+++ b/test/v8/bad-modules/mismatched_abi_version.cpp
@@ -8,7 +8,7 @@ void init(v8::Local<v8::Object> exports, v8::Local<v8::Value> module,
 
 extern "C" {
 static node::node_module _module = {
-    // bun expects 137 (Node.js 24.3.0)
+    // bun expects 137 (Node.js 24.16.0)
     42,                           // nm_version
     0,                            // nm_flags
     nullptr,                      // nm_dso_handle

--- a/test/v8/bad-modules/no_entrypoint.cpp
+++ b/test/v8/bad-modules/no_entrypoint.cpp
@@ -2,7 +2,7 @@
 
 extern "C" {
 static node::node_module _module = {
-    137,                 // nm_version (Node.js 24.3.0)
+    137,                 // nm_version (Node.js 24.16.0)
     0,                   // nm_flags
     nullptr,             // nm_dso_handle
     "no_entrypoint.cpp", // nm_filename

--- a/test/v8/v8.test.ts
+++ b/test/v8/v8.test.ts
@@ -21,7 +21,7 @@ enum BuildMode {
 delete bunEnv.CC;
 delete bunEnv.CXX;
 
-// Node.js 24.3.0 requires C++20
+// Node.js 24.16.0 requires C++20
 bunEnv.CXXFLAGS ??= "";
 if (process.platform == "darwin") {
   bunEnv.CXXFLAGS += " -std=gnu++20";


### PR DESCRIPTION
## Problem

`test/cli/install/bunx.test.ts > should handle package that requires node 24` fails on **every platform** in CI. The test runs against the live npm registry:

```ts
cmd: [bunExe(), "x", "--bun", "@angular/cli@latest", "--help"],
...
expect(err).not.toContain("error:");
expect(exited).toBe(0);
```

`@angular/cli@latest` published a new version check that rejects the Node.js version bun reports:

```
Node.js version v24.3.0 detected.
The Angular CLI requires a minimum Node.js version of v22.22.3 or v24.15.0 or v26.0.0.
```

bun reports `process.version = v24.3.0`, so the CLI exits non-zero (`expect(exited).toBe(0)` fails and the error text trips `expect(err).not.toContain("error:")`). This is external drift — it reproduces identically on old bun binaries and on main — not a regression in any PR, so the fix is a version bump.

## Fix

Bump the self-reported Node.js version `24.3.0` → `24.16.0` (latest 24.x, satisfies Angular's `>= 24.15.0`).

`NODE_MODULE_VERSION` (the N-API / native-addon ABI) is **137** across the entire 24.x line and `napi` stays **10**, so the addon ABI is unchanged — only version strings move. `process.versions.v8` is updated to match the V8 shipped in Node v24.16.0 (`13.6.233.17-node.49`, verified against `nodejs/node@v24.16.0`).

- `scripts/build/deps/nodejs-headers.ts` — `NODEJS_VERSION` → `24.16.0`. This constant feeds the headers download URL and the `REPORTED_NODEJS_VERSION` compile-time macro that drives `process.version` / `process.versions.node`. `NODEJS_ABI_VERSION` stays `137`.
- `src/jsc/bindings/BunProcess.cpp`, `src/jsc/bindings/BunProcessReportObjectWindows.cpp` — `process.versions.v8` `13.6.233.10-node.18` → `13.6.233.17-node.49`.
- `scripts/bootstrap.sh`, `scripts/bootstrap.ps1`, `.buildkite/Dockerfile` — pin the CI agents' Node to `24.16.0` so the host runtime matches the reported version.
- `test/js/node/process/process.test.js` — assert `24.16.0` / `13.6.233.17-node.49`.
- `test/napi/node-napi-tests/harness.ts` — `npm_config_target: v24.16.0`.
- `test/v8/bad-modules/*.cpp`, `test/v8/v8.test.ts`, `test/napi/napi.test.ts` — comment/reference updates to `24.16.0`.

The `[publish images]` tag mirrors the previous bump (172aecb02e, 22.6.0 → 24.3.0): the `bootstrap.sh` / `Dockerfile` changes require republishing the CI agent images so the host `node` matches. This is the maintainer-coordinated step the issue called out.

## Verification

Built debug and confirmed the runtime now reports the target versions:

```
$ bun bd -e "console.log(process.version, process.versions.node, process.versions.v8, process.versions.modules, process.versions.napi)"
v24.16.0 24.16.0 13.6.233.17-node.49 137 10
```

`bun bd test test/js/node/process/process.test.js -t "process.versions"` passes. The `process.versions.v8` assertion is a hardcoded literal in `src/` — reverting the `src/` change makes that assertion fail (`13.6.233.10-node.18`), and restoring it passes, confirming the test exercises the code change.

Verified the headers tarball for v24.16.0 resolves (`https://nodejs.org/dist/v24.16.0/node-v24.16.0-headers.tar.gz` → HTTP 200) and `NODE_MODULE_VERSION` for v24.16.0 is 137.

Closes #31797