### PR TITLE
ws: emit client 'unexpected-response' event for non-101 upgrades

### DIFF
--- a/src/http_jsc/websocket_client/CppWebSocket.rs
+++ b/src/http_jsc/websocket_client/CppWebSocket.rs
@@ -22,6 +22,16 @@ bun_opaque::opaque_ffi! {
     pub struct CppWebSocket;
 }
 
+/// `{ ptr, len }` view over a slice of `picohttp::Header` handed to C++.
+/// The element layout already matches the C++ `PicoHTTPHeader` (two
+/// `{ ptr, len }` slices), mirroring the fetch header path
+/// (`FetchHeaders::create_from_pico_headers`).
+#[repr(C)]
+pub(crate) struct PicoHeaders {
+    ptr: *const bun_picohttp::Header,
+    len: usize,
+}
+
 // FFI surface for `WebCore::WebSocket` (src/jsc/bindings/webcore/WebSocket.cpp).
 // Kept private to this module — the safe wrappers below are the only callers.
 //
@@ -45,6 +55,14 @@ unsafe extern "C" {
         deflate_params: *const websocket_deflate::Params,
     );
     safe fn WebSocket__didAbruptClose(websocket_context: &CppWebSocket, reason: ErrorCode);
+    fn WebSocket__didReceiveHandshakeResponse(
+        websocket_context: &CppWebSocket,
+        status_code: u16,
+        status_text: *const BunString,
+        pico_headers: *const PicoHeaders,
+        body: *const u8,
+        body_len: usize,
+    );
     fn WebSocket__didClose(websocket_context: &CppWebSocket, code: u16, reason: *const BunString);
     fn WebSocket__didReceiveText(
         websocket_context: &CppWebSocket,
@@ -75,6 +93,41 @@ impl CppWebSocket {
         let event_loop = VirtualMachine::get().event_loop_mut();
         event_loop.enter();
         WebSocket__didAbruptClose(self, reason);
+        event_loop.exit();
+    }
+
+    /// Delivers the server's non-101 upgrade response (status + headers + body)
+    /// to JS so the `ws` shim can emit `'unexpected-response'`. Must be called
+    /// before the abrupt-close dispatch so the event fires first.
+    ///
+    /// `headers` and `body` only need to outlive this call (C++ copies them).
+    pub(crate) fn did_receive_handshake_response(
+        &self,
+        status_code: u16,
+        status_text: &BunString,
+        headers: &[bun_picohttp::Header],
+        body: &[u8],
+    ) {
+        let pico = PicoHeaders {
+            ptr: headers.as_ptr(),
+            len: headers.len(),
+        };
+        // SAFETY: VirtualMachine::get() returns the live current-thread VM;
+        // event_loop() yields its raw event-loop pointer (live for VM lifetime).
+        let event_loop = VirtualMachine::get().event_loop_mut();
+        event_loop.enter();
+        // SAFETY: self is a valid C++ WebCore::WebSocket; status_text/pico/body
+        // all outlive the call (C++ copies their contents synchronously).
+        unsafe {
+            WebSocket__didReceiveHandshakeResponse(
+                self,
+                status_code,
+                std::ptr::from_ref(status_text),
+                std::ptr::from_ref(&pico),
+                body.as_ptr(),
+                body.len(),
+            )
+        };
         event_loop.exit();
     }
 

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -941,17 +941,12 @@ impl<const SSL: bool> HTTPClient<SSL> {
             body = &me.body;
         }
 
-        let is_first = me.body.is_empty();
-        const HTTP_101: &[u8] = b"HTTP/1.1 101 ";
-        if is_first && body.len() > HTTP_101.len() {
-            // fail early if we receive a non-101 status code
-            if !body.starts_with(HTTP_101) {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::Expected101StatusCode) };
-                return;
-            }
-        }
-
+        // PORT NOTE: the Zig code fast-failed here the moment the first bytes
+        // were not `HTTP/1.1 101 `. We instead parse the full response so
+        // `process_response` can hand the non-101 status/headers/body to JS for
+        // the `ws` `'unexpected-response'` event. `max_http_header_size()`
+        // still bounds buffering below, and a non-HTTP reply still fails via
+        // `MalformedHttpResponse` → `InvalidResponse`.
         let response = match picohttp::Response::parse(body, &mut me.headers_buf) {
             Ok(r) => r,
             Err(picohttp::ParseResponseError::MalformedHttpResponse) => {
@@ -1319,6 +1314,23 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let mut deflate_result = DeflateNegotiationResult::default();
 
         if response.status_code != 101 {
+            // Surface the failed upgrade's HTTP response (status + headers +
+            // body) to JS before terminating, so the `ws` shim can emit its
+            // `'unexpected-response'` event. `terminate` fires the error/close
+            // right after; the shim decides which to forward.
+            // SAFETY: short-lived read of `outgoing_websocket`; no reentrancy
+            // until `terminate` below.
+            if let Some(ws) = unsafe { (*this).outgoing_websocket } {
+                let status_text = BunString::clone_latin1(response.status);
+                let status_code = u16::try_from(response.status_code).unwrap_or(0);
+                CppWebSocket::opaque_ref(ws).did_receive_handshake_response(
+                    status_code,
+                    &status_text,
+                    response.headers.list,
+                    remain_buf,
+                );
+                status_text.deref();
+            }
             // SAFETY: no `&mut Self` is live across this call.
             unsafe { Self::terminate(this, ErrorCode::Expected101StatusCode) };
             return;

--- a/src/js/thirdparty/ws.js
+++ b/src/js/thirdparty/ws.js
@@ -10,6 +10,7 @@ const ReadyState_CLOSED = 3;
 
 const EventEmitter = require("node:events");
 const http = require("node:http");
+const { Readable } = require("node:stream");
 const onceObject = { once: true };
 const kBunInternals = Symbol.for("::bunternal::");
 const readyStates = ["CONNECTING", "OPEN", "CLOSING", "CLOSED"];
@@ -126,6 +127,12 @@ class BunWebSocket extends EventEmitter {
   #binaryType = "nodebuffer";
   // Bitset to track whether event handlers are set.
   #eventId = 0;
+  // Set once the server answers the upgrade with a non-101 status. Used to
+  // suppress the native error/close that follow (we surface the failure as
+  // `'unexpected-response'` or a `ws`-style error instead).
+  #handshakeResponseHandled = false;
+  // The simulated `http.ClientRequest` passed to `'unexpected-response'`.
+  #clientRequest;
 
   constructor(url, protocols, options) {
     super();
@@ -240,6 +247,7 @@ class BunWebSocket extends EventEmitter {
         _last: null,
       };
       EventEmitter.$call(nodeHttpClientRequestSimulated);
+      this.#clientRequest = nodeHttpClientRequestSimulated;
       finishRequest(nodeHttpClientRequestSimulated);
       if (!didCallEnd) {
         this.#createWebSocket(url, protocols, headers, method, proxy, tlsOptions, disableDeflate);
@@ -267,11 +275,74 @@ class BunWebSocket extends EventEmitter {
     let ws = (this.#ws = new WebSocket(url, wsOptions));
     ws.binaryType = "nodebuffer";
 
+    // The native WebSocket only dispatches "unexpected-response" when it sees a
+    // listener, so register eagerly. This lets us fire the `ws`
+    // `'unexpected-response'` event (or a matching error) for a non-101 upgrade
+    // and suppress the native error/close that immediately follow.
+    ws.addEventListener("unexpected-response", ({ data }) => {
+      this.#onUnexpectedResponse(data);
+    });
+
     return ws;
   }
 
+  #makeClientRequest(url, method) {
+    if (this.#clientRequest) return this.#clientRequest;
+    // Minimal http.ClientRequest-like object for the `req` argument. `ws`'s
+    // own fallback path (no listener) only duck-types `setHeader`/`abort`/
+    // `socket`; user listeners typically read `req.method`/`req.path`.
+    const req = {
+      __proto__: Object.create(EventEmitter.prototype),
+      setHeader() {},
+      getHeader() {},
+      removeHeader() {},
+      abort() {},
+      end() {},
+      write() {},
+      writeHead() {},
+      method,
+      path: url,
+      headersSent: true,
+      finished: true,
+      socket: null,
+      [Symbol.toStringTag]: "ClientRequest",
+    };
+    EventEmitter.$call(req);
+    this.#clientRequest = req;
+    return req;
+  }
+
+  #onUnexpectedResponse(data) {
+    if (this.#handshakeResponseHandled) return;
+    this.#handshakeResponseHandled = true;
+
+    const statusCode = data.statusCode;
+    const req = this.#makeClientRequest(this.#ws.url, "GET");
+
+    if (this.listenerCount("unexpected-response") > 0) {
+      // Build an http.IncomingMessage-like readable `res` the listener can
+      // inspect (statusCode/headers) and drain (res.on("data"/"end")).
+      const res = new Readable({ read() {} });
+      res.statusCode = statusCode;
+      res.statusMessage = data.statusMessage;
+      res.httpVersion = "1.1";
+      res.headers = data.headers;
+      res.rawHeaders = data.rawHeaders;
+      const body = data.body;
+      if (body && body.length) res.push(body);
+      res.push(null);
+      this.emit("unexpected-response", req, res);
+    } else {
+      // Mirror ws's abortHandshake: emit an error + close on the next tick.
+      process.nextTick(() => {
+        this.emit("error", new Error("Unexpected server response: " + statusCode));
+        this.emit("close", 1006, Buffer.alloc(0), false);
+      });
+    }
+  }
+
   #onOrOnce(event, listener, once) {
-    if (event === "unexpected-response" || event === "upgrade" || event === "redirect") {
+    if (event === "upgrade" || event === "redirect") {
       emitWarning(event, "ws.WebSocket '" + event + "' event is not implemented in bun");
     }
     const mask = 1 << eventIds[event];
@@ -297,6 +368,9 @@ class BunWebSocket extends EventEmitter {
         this.#ws.addEventListener(
           "close",
           ({ code, reason, wasClean }) => {
+            // A non-101 upgrade is surfaced via `'unexpected-response'` (or the
+            // error emitted there); don't also forward the native close.
+            if (this.#handshakeResponseHandled) return;
             this.emit("close", code, reason, wasClean);
           },
           once,
@@ -322,6 +396,8 @@ class BunWebSocket extends EventEmitter {
         this.#ws.addEventListener(
           "error",
           err => {
+            // See the close handler: the non-101 upgrade path owns the error.
+            if (this.#handshakeResponseHandled) return;
             this.emit("error", err);
           },
           once,

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1517,6 +1517,100 @@ void WebSocket::didReceiveBinaryData(const AtomString& eventName, const std::spa
     // });
 }
 
+namespace {
+// Mirrors the fetch header ABI (bindings.cpp PicoHTTPHeaders): a pointer to a
+// contiguous array of { {name_ptr,name_len}, {value_ptr,value_len} } records.
+struct PicoSlice {
+    const unsigned char* ptr;
+    size_t len;
+};
+struct PicoHeader {
+    PicoSlice name;
+    PicoSlice value;
+};
+struct PicoHeaders {
+    const PicoHeader* ptr;
+    size_t len;
+};
+
+// Builds the `{ statusCode, statusMessage, headers, rawHeaders, body }` object
+// the `ws` shim turns into an http.IncomingMessage-like `res` for the
+// `'unexpected-response'` event.
+JSC::JSValue createHandshakeResponseObject(JSC::JSGlobalObject* globalObject, unsigned short statusCode, const BunString* statusText, const void* picoHeaders, const uint8_t* body, size_t bodyLength)
+{
+    auto& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    const PicoHeaders headers = picoHeaders ? *reinterpret_cast<const PicoHeaders*>(picoHeaders) : PicoHeaders { nullptr, 0 };
+
+    JSC::JSObject* headersObject = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), JSC::JSFinalObject::defaultInlineCapacity);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSC::JSArray* rawHeaders = constructEmptyArray(globalObject, nullptr, headers.len * 2);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    unsigned rawIndex = 0;
+    for (size_t i = 0; i < headers.len; i++) {
+        const PicoHeader& header = headers.ptr[i];
+        if (header.name.len == 0)
+            continue;
+        String name = String::fromUTF8ReplacingInvalidSequences(std::span { header.name.ptr, header.name.len });
+        String value = String::fromUTF8ReplacingInvalidSequences(std::span { header.value.ptr, header.value.len });
+        JSC::JSString* jsValue = jsString(vm, value);
+        // http.IncomingMessage lowercases header names in `.headers`; preserve
+        // the wire casing/order in `.rawHeaders` (matching Node).
+        headersObject->putDirect(vm, JSC::Identifier::fromString(vm, name.convertToASCIILowercase()), jsValue, 0);
+        rawHeaders->putDirectIndex(globalObject, rawIndex++, jsString(vm, name));
+        RETURN_IF_EXCEPTION(scope, {});
+        rawHeaders->putDirectIndex(globalObject, rawIndex++, jsValue);
+        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    JSC::JSUint8Array* bodyBuffer = WebCore::createBuffer(globalObject, body, bodyLength);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSC::JSObject* result = JSC::constructEmptyObject(globalObject, globalObject->objectPrototype(), 5);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "statusCode"_s), JSC::jsNumber(statusCode), 0);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "statusMessage"_s), jsString(vm, statusText ? statusText->toWTFString(BunString::ZeroCopy) : String()), 0);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "headers"_s), headersObject, 0);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "rawHeaders"_s), rawHeaders, 0);
+    result->putDirect(vm, JSC::Identifier::fromString(vm, "body"_s), bodyBuffer, 0);
+    return result;
+}
+}
+
+void WebSocket::didReceiveHandshakeResponse(unsigned short statusCode, const BunString* statusText, const void* picoHeaders, const uint8_t* body, size_t bodyLength)
+{
+    if (m_state != CONNECTING)
+        return;
+
+    // The `ws` shim registers for this synchronously when the user wants the
+    // `'unexpected-response'` event; it then decides whether to emit it (and
+    // swallow the forthcoming error/close) or fall back to an error. A plain
+    // browser WebSocket has no listener here, so nothing is dispatched and the
+    // usual error/close from didFailWithErrorCode is the only observable effect.
+    if (!this->hasEventListeners("unexpected-response"_s))
+        return;
+
+    auto* context = scriptExecutionContext();
+    if (!context)
+        return;
+
+    auto* globalObject = context->jsGlobalObject();
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(globalObject->vm());
+    JSC::JSValue data = createHandshakeResponseObject(globalObject, statusCode, statusText, picoHeaders, body, bodyLength);
+    if (scope.exception() || !data) {
+        scope.clearExceptionExceptTermination();
+        return;
+    }
+
+    this->incPendingActivityCount();
+    MessageEvent::Init init;
+    init.data = data;
+    init.origin = this->m_url.string();
+    dispatchEvent(MessageEvent::create("unexpected-response"_s, WTF::move(init), EventIsTrusted::Yes));
+    this->decPendingActivityCount();
+}
+
 void WebSocket::didReceiveClose(CleanStatus wasClean, unsigned short code, WTF::String reason, bool isConnectionError)
 {
     // LOG(Network, "WebSocket %p didReceiveErrorMessage()", this);
@@ -1889,6 +1983,10 @@ extern "C" void WebSocket__didConnectWithTunnel(WebCore::WebSocket* webSocket, v
 extern "C" void WebSocket__didAbruptClose(WebCore::WebSocket* webSocket, Bun::WebSocketErrorCode errorCode)
 {
     webSocket->didFailWithErrorCode(errorCode);
+}
+extern "C" void WebSocket__didReceiveHandshakeResponse(WebCore::WebSocket* webSocket, uint16_t statusCode, const BunString* statusText, const void* picoHeaders, const uint8_t* body, size_t bodyLength)
+{
+    webSocket->didReceiveHandshakeResponse(statusCode, statusText, picoHeaders, body, bodyLength);
 }
 extern "C" void WebSocket__didClose(WebCore::WebSocket* webSocket, uint16_t errorCode, BunString* reason)
 {

--- a/src/jsc/bindings/webcore/WebSocket.h
+++ b/src/jsc/bindings/webcore/WebSocket.h
@@ -54,6 +54,8 @@ class ArrayBuffer;
 class ArrayBufferView;
 }
 
+struct BunString;
+
 extern "C" void Bun__WebSocket__freeSSLConfig(void* sslConfig);
 
 namespace WebCore {
@@ -203,6 +205,13 @@ public:
     void didConnect(us_socket_t* socket, char* bufferedData, size_t bufferedDataSize, const PerMessageDeflateParams* deflate_params, void* customSSLCtx);
     void didConnectWithTunnel(void* tunnel, char* bufferedData, size_t bufferedDataSize, const PerMessageDeflateParams* deflate_params);
     void didFailWithErrorCode(Bun::WebSocketErrorCode code);
+
+    // Delivers the server's non-101 upgrade response (status + headers + body)
+    // to JS via an "unexpected-response" event so the `ws` npm shim can emit
+    // its own `'unexpected-response'` event. Fires before the subsequent
+    // error/close from didFailWithErrorCode. `picoHeaders` points to a
+    // PicoHTTPHeaders { ptr, len } (same ABI as the fetch header path).
+    void didReceiveHandshakeResponse(unsigned short statusCode, const BunString* statusText, const void* picoHeaders, const uint8_t* body, size_t bodyLength);
 
     void didReceiveMessage(String&& message);
     void didReceiveData(const char* data, size_t length);

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -977,9 +977,7 @@ describe("unexpected-response (non-101 upgrade)", () => {
   });
 
   it("without a listener, emits 'error' then 'close' (Unexpected server response)", async () => {
-    const { server, port } = startServer(
-      "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
-    );
+    const { server, port } = startServer("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
 
     const events: string[] = [];
     const { promise, resolve, reject } = Promise.withResolvers<void>();

--- a/test/js/first_party/ws/ws.test.ts
+++ b/test/js/first_party/ws/ws.test.ts
@@ -5,7 +5,7 @@ import crypto from "crypto";
 import { once } from "events";
 import { bunEnv, bunExe } from "harness";
 import { createServer } from "http";
-import { AddressInfo, connect } from "net";
+import { AddressInfo, connect, createServer as netCreateServer } from "net";
 import path from "node:path";
 import { Server, WebSocket, WebSocketServer } from "ws";
 
@@ -904,5 +904,101 @@ describe("ping/pong no-arg payload", () => {
     const ws = new WebSocket("ws://localhost:" + (wss.address() as AddressInfo).port);
     ws.on("open", () => ws.pong(Buffer.from("hello")));
     await promise;
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/31792
+// A non-101 response to the upgrade (e.g. Chrome DevTools replying 401 on an
+// unknown /devtools/browser/<id> path) must surface to `ws` consumers:
+// - with an `'unexpected-response'` listener → the event fires with the real
+//   http.IncomingMessage-like `res` (statusCode/statusMessage/headers/body)
+//   and no error/close is emitted (matches Node `ws`).
+// - without one → `ws` emits `error` `Unexpected server response: <status>`
+//   followed by `close` (this is the path puppeteer/chrome-devtools-mcp use).
+describe("unexpected-response (non-101 upgrade)", () => {
+  // Raw TCP server that answers the WebSocket upgrade with a fixed HTTP
+  // response. Using a raw socket (rather than http.createServer) guarantees
+  // the non-101 bytes are flushed on the upgrade connection.
+  function startServer(response: string) {
+    const server = netCreateServer(socket => {
+      socket.once("data", () => {
+        socket.end(response);
+      });
+    });
+    const { promise, resolve } = Promise.withResolvers<number>();
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    return { server, port: promise };
+  }
+
+  it("fires 'unexpected-response' with the response status, headers and body", async () => {
+    const body = "No permission to access the Chrome DevTools.";
+    const { server, port } = startServer(
+      "HTTP/1.1 401 Unauthorized\r\n" +
+        "Content-Type: text/plain\r\n" +
+        "X-Custom: hello\r\n" +
+        `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+        "Connection: close\r\n\r\n" +
+        body,
+    );
+
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${await port}/devtools/browser/xxx`);
+    ws.on("open", () => reject(new Error("should not open")));
+    ws.on("error", err => reject(new Error("should not emit error: " + err.message)));
+    ws.on("unexpected-response", (req, res) => {
+      try {
+        expect(res.statusCode).toBe(401);
+        expect(res.statusMessage).toBe("Unauthorized");
+        expect(res.headers["x-custom"]).toBe("hello");
+        expect(res.headers["content-type"]).toBe("text/plain");
+        expect(req.method).toBe("GET");
+        let received = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk: string) => (received += chunk));
+        res.on("end", () => {
+          try {
+            expect(received).toBe(body);
+            resolve();
+          } catch (e) {
+            reject(e);
+          }
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    try {
+      await promise;
+    } finally {
+      ws.terminate();
+      server.close();
+    }
+  });
+
+  it("without a listener, emits 'error' then 'close' (Unexpected server response)", async () => {
+    const { server, port } = startServer(
+      "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+    );
+
+    const events: string[] = [];
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const ws = new WebSocket(`ws://127.0.0.1:${await port}/`);
+    ws.on("open", () => reject(new Error("should not open")));
+    ws.on("error", err => {
+      events.push("error:" + err.message);
+    });
+    ws.on("close", code => {
+      events.push("close:" + code);
+      resolve();
+    });
+
+    try {
+      await promise;
+      expect(events).toEqual(["error:Unexpected server response: 404", "close:1006"]);
+    } finally {
+      ws.terminate();
+      server.close();
+    }
   });
 });


### PR DESCRIPTION
## Problem

Fixes #31792.

Bun's `ws` client shim hardcoded the `'unexpected-response'` event as "not implemented" and printed a warning instead of firing it. When a server answers a WebSocket upgrade with a non-101 status (e.g. Chrome DevTools replying `401`/`404` on an unknown `/devtools/browser/<id>` path), the failed upgrade only surfaced as a generic `WebSocket connection ... failed: Expected 101 status code` error — not Node's `'unexpected-response'` event, and not Node's `Unexpected server response: <status>` error for the no-listener case.

This breaks `puppeteer` / `chrome-devtools-mcp`, which rely on this path (the former via the no-listener `Unexpected server response` error, the latter via an `'unexpected-response'` listener).

### Reproduction

```js
const net = require("net");
const WebSocket = require("ws");

// A server that answers the upgrade with a non-101 status
const server = net.createServer(sock =>
  sock.once("data", () => sock.end("HTTP/1.1 401 Unauthorized\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")),
);
server.listen(0, "127.0.0.1", () => {
  const ws = new WebSocket(`ws://127.0.0.1:${server.address().port}/devtools/browser/xxx`);
  ws.on("unexpected-response", (req, res) => { console.log("unexpected-response", res.statusCode); server.close(); });
});
```

**Before:** `[bun] Warning: ws.WebSocket 'unexpected-response' event is not implemented in bun` and the event never fires (an `'error'` with `Expected 101 status code` fires instead).
**After (matches Node):** `unexpected-response 401`.

## Cause

The native upgrade client (`WebSocketUpgradeClient`) fast-failed on any non-`HTTP/1.1 101 ` response and discarded the HTTP response (status, headers, body), terminating with a generic `Expected101StatusCode`. JS had nothing to build `(req, res)` from, so the shim stubbed the event with a warning.

## Fix

- **`WebSocketUpgradeClient`** no longer fast-fails on the `HTTP/1.1 101 ` prefix; it parses the full response so the existing `status_code != 101` branch in `process_response` can hand the status/headers/body to JS (via `CppWebSocket::did_receive_handshake_response`) **before** terminating. `max_http_header_size()` still bounds buffering, and a non-HTTP reply still fails with `InvalidResponse`.
- **`WebSocket::didReceiveHandshakeResponse`** (C++) builds a `{ statusCode, statusMessage, headers, rawHeaders, body }` object and dispatches an `"unexpected-response"` `MessageEvent`. It early-returns unless an `"unexpected-response"` listener is registered, so the browser-style `new WebSocket()` path pays nothing. Headers are passed using the same `{ptr,len}`-of-`picohttp::Header` ABI as the fetch header path.
- **`src/js/thirdparty/ws.js`** eagerly registers that native listener, and on a non-101 response:
  - with an `'unexpected-response'` listener → emits `'unexpected-response'(req, res)` with an `http.IncomingMessage`-like readable `res` (`statusCode`/`statusMessage`/`headers`/`rawHeaders` + the body as a stream) and suppresses the native error/close (matches Node — the user owns the connection).
  - without one → emits `error` `Unexpected server response: <status>` then `close` (matches Node's `abortHandshake`). This is the path puppeteer / chrome-devtools-mcp rely on.

The `'unexpected-response'` warning stub is removed; `'upgrade'` and `'redirect'` remain stubbed (out of scope for this issue).

## Verification

New tests in `test/js/first_party/ws/ws.test.ts` (`unexpected-response (non-101 upgrade)` describe), using an in-process raw-TCP server so the non-101 bytes are flushed deterministically:

- `'unexpected-response'` fires with `res.statusCode === 401`, `res.statusMessage`, the response `headers`, and the body drained via `res.on("data"/"end")`; no spurious `error`/`close`.
- Without a listener, the events are exactly `["error:Unexpected server response: 404", "close:1006"]` — verified byte-for-byte identical to Node `ws@8`.

Both tests pass under the debug (ASAN) build and fail under `USE_SYSTEM_BUN=1` (the event never fires; the no-listener case emits the old `Expected 101 status code`/`1002` instead), confirming they exercise the fix. Also verified: the happy-path 101 upgrade, `once("unexpected-response")`, and a `302` (no `followRedirects`) surfacing as `unexpected-response` with `res.headers.location` — all match Node.

## Relationship to #31408 and #5951

#31408 (open, issue #31406) implements the **`upgrade`** event for the **101** success path and introduces a `WebSocket::didReceiveHandshakeResponse` of its own (a `handshake` event). This PR implements the **`unexpected-response`** event for the **non-101** failure path — complementary, but it touches the same files (`WebSocket.{h,cpp}`, `CppWebSocket.rs`, `WebSocketUpgradeClient.rs`, `ws.js`) with a differently-shaped `didReceiveHandshakeResponse`. Whichever lands second will need a rebase; the two could also be unified onto a single handshake-response callback that drives both events.

#5951 tracks **both** the `'upgrade'` **and** `'unexpected-response'` warnings. This PR only implements the `'unexpected-response'` half, so it does **not** fully close #5951 — the `'upgrade'` half is #31408. I've intentionally not added `Fixes #5951` so it isn't auto-closed before `'upgrade'` also lands.