### PR TITLE
fix: unprotect HTMLRewriter callback exceptions

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1605,9 +1605,14 @@ fn create_lolhtml_error(global: &JSGlobalObject) -> JSValue {
         // SAFETY: VM-owned pointer; valid while VM lives.
         let slot = unsafe { &mut *err_ptr };
         if !slot.is_empty() {
-            // it's a promise rejection
+            // It is either a protected callback exception captured by
+            // `handler_callback`, or an unprotected promise rejection reason
+            // captured by the VM rejection handler.
             let result = *slot;
             *slot = JSValue::ZERO;
+            if result.is_exception(core::ptr::from_ref(global.vm()).cast_mut()) {
+                result.unprotect();
+            }
             return result;
         }
     }

--- a/test/js/workerd/html-rewriter-leak.test.ts
+++ b/test/js/workerd/html-rewriter-leak.test.ts
@@ -1,6 +1,75 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isDebug } from "harness";
 
+test("HTMLRewriter does not leak exceptions thrown from handlers", async () => {
+  const code = /* js */ `
+    const { heapStats } = require("bun:jsc");
+
+    async function settle() {
+      for (let i = 0; i < 8; i++) {
+        Bun.gc(true);
+        await Bun.sleep(0);
+      }
+    }
+
+    function counts() {
+      const stats = heapStats();
+      return {
+        Error: stats.objectTypeCounts.Error ?? 0,
+        Exception: stats.objectTypeCounts.Exception ?? 0,
+        protectedException: stats.protectedObjectTypeCounts.Exception ?? 0,
+      };
+    }
+
+    await settle();
+    const before = counts();
+
+    let caught = 0;
+    for (let i = 0; i < 100; i++) {
+      const rewriter = new HTMLRewriter().on("div", {
+        element() {
+          throw new Error("handler failed");
+        },
+      });
+
+      try {
+        rewriter.transform("<div>hello</div>");
+      } catch (error) {
+        if (error.message !== "handler failed") throw error;
+        caught++;
+      }
+
+      if (i % 25 === 0) {
+        await settle();
+      }
+    }
+
+    await settle();
+    const after = counts();
+
+    console.log(JSON.stringify({ caught, before, after }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+
+  const { caught, before, after } = JSON.parse(stdout.trim());
+  expect(caught).toBe(100);
+
+  expect(after.protectedException).toBeLessThanOrEqual(before.protectedException);
+  expect(after.Exception).toBeLessThanOrEqual(before.Exception + 1);
+  expect(after.Error).toBeLessThanOrEqual(before.Error + 1);
+  expect(exitCode).toBe(0);
+});
+
 // Each .on() / .onDocument() call heap-allocates an ElementHandler / DocumentHandler
 // struct via bun.default_allocator. When the HTMLRewriter is garbage-collected,
 // LOLHTMLContext.deinit() must destroy those allocations. Previously it only


### PR DESCRIPTION
## Summary

- Unprotect captured `HTMLRewriter` callback exceptions when the lol-html error path consumes them
- Add a regression test for protected `Exception` roots leaking from thrown handler errors

## Test plan

- `USE_SYSTEM_BUN=1 bun test test/js/workerd/html-rewriter-leak.test.ts -t "HTMLRewriter does not leak exceptions thrown from handlers"` fails before the fix with `protectedException: 100`
- `bun bd test test/js/workerd/html-rewriter-leak.test.ts -t "HTMLRewriter does not leak exceptions thrown from handlers"`
- `bun bd test test/js/workerd/html-rewriter-leak.test.ts test/js/workerd/html-rewriter.test.js test/regression/issue/19219.test.ts test/regression/issue/21680.test.ts`
- `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 bun bd test test/js/workerd/html-rewriter-leak.test.ts test/regression/issue/19219.test.ts test/regression/issue/21680.test.ts -t "HTMLRewriter"`

Closes #31804
