### PR TITLE
console.dir: honor maxArrayLength in the native formatter

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4183,6 +4183,13 @@ declare module "bun" {
      * Whether to compact the output
      */
     compact?: boolean;
+    /**
+     * Maximum number of array elements to include when formatting. Set to
+     * `null` or `Infinity` to show all elements.
+     *
+     * @default 100
+     */
+    maxArrayLength?: number | null;
   }
 
   type WebSocketOptionsProtocolsOrProtocol =

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4667,7 +4667,7 @@ pub mod formatter {
                         // of holes (`empty_start`) is part of the elided tail,
                         // so count from its start and clear it so it doesn't
                         // also leak into the trailing `N x empty items` summary.
-                        let elided_from = empty_start.map_or(u64::from(i), u64::from);
+                        let elided_from = u64::from(empty_start.unwrap_or(i));
                         let remaining = len - elided_from;
                         empty_start = None;
                         writer.print_comma::<C>();

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -584,6 +584,11 @@ fn message_with_type_and_level_(
                     print_options.enable_colors = colors_prop.to_boolean();
                 }
             }
+            if let Some(max_array_length_prop) = opts.get(global, b"maxArrayLength")? {
+                if let Some(max) = resolve_max_array_length(max_array_length_prop) {
+                    print_options.max_array_length = max;
+                }
+            }
         }
     }
 
@@ -1303,6 +1308,37 @@ pub fn write_trace(writer: &mut dyn bun_io::Write, global: &JSGlobalObject) {
 // FormatOptions
 // ───────────────────────────────────────────────────────────────────────────
 
+/// Default number of array elements printed before eliding the rest. Matches
+/// Node's `util.inspect` default (`maxArrayLength: 100`).
+pub const DEFAULT_MAX_ARRAY_LENGTH: u32 = 100;
+
+/// Resolve a user-supplied `maxArrayLength` option to the element cap.
+///
+/// Matches Node's `util.inspect` semantics: `null` means no limit
+/// (`Infinity`, represented here as `u32::MAX`), negative values clamp to 0,
+/// and non-integers / `NaN` are floored. A missing / `undefined` value leaves
+/// the current cap unchanged (handled by the caller via `JSValue::get`).
+fn resolve_max_array_length(value: JSValue) -> Option<u32> {
+    if value.is_null() {
+        return Some(u32::MAX);
+    }
+    if value.is_number() {
+        let v = value.as_number();
+        if v.is_nan() {
+            return Some(0);
+        }
+        if v >= f64::from(u32::MAX) {
+            return Some(u32::MAX);
+        }
+        if v <= 0.0 {
+            return Some(0);
+        }
+        // Node floors the value (`output.length` is integer-indexed).
+        return Some(v as u32);
+    }
+    None
+}
+
 #[derive(Clone, Copy)]
 pub struct FormatOptions {
     pub enable_colors: bool,
@@ -1311,6 +1347,7 @@ pub struct FormatOptions {
     pub ordered_properties: bool,
     pub quote_strings: bool,
     pub max_depth: u16,
+    pub max_array_length: u32,
     pub single_line: bool,
     pub default_indent: u16,
     pub error_display_level: ErrorDisplayLevel,
@@ -1325,6 +1362,7 @@ impl Default for FormatOptions {
             ordered_properties: false,
             quote_strings: false,
             max_depth: 2,
+            max_array_length: DEFAULT_MAX_ARRAY_LENGTH,
             single_line: false,
             default_indent: 0,
             error_display_level: ErrorDisplayLevel::Full,
@@ -1436,6 +1474,11 @@ impl FormatOptions {
             if let Some(opt) = arg1.get_boolean_loose(global_this, "compact")? {
                 self.single_line = opt;
             }
+            if let Some(opt) = arg1.get(global_this, "maxArrayLength")? {
+                if let Some(max) = resolve_max_array_length(opt) {
+                    self.max_array_length = max;
+                }
+            }
         } else {
             // formatOptions.show_hidden = arg1.toBoolean();
             if !arguments.is_empty() {
@@ -1491,6 +1534,7 @@ pub fn format2(
         fmt.ordered_properties = options.ordered_properties;
         fmt.quote_strings = options.quote_strings;
         fmt.max_depth = options.max_depth;
+        fmt.max_array_length = options.max_array_length;
         fmt.single_line = options.single_line;
         fmt.indent = u32::from(options.default_indent);
         fmt.stack_check = StackCheck::init();
@@ -1556,6 +1600,7 @@ pub fn format2(
     fmt.ordered_properties = options.ordered_properties;
     fmt.quote_strings = options.quote_strings;
     fmt.max_depth = options.max_depth;
+    fmt.max_array_length = options.max_array_length;
     fmt.single_line = options.single_line;
     fmt.indent = u32::from(options.default_indent);
     fmt.stack_check = StackCheck::init();
@@ -1753,6 +1798,7 @@ pub mod formatter {
         pub indent: u32,
         pub depth: u16,
         pub max_depth: u16,
+        pub max_array_length: u32,
         pub quote_strings: bool,
         pub quote_keys: bool,
         pub failed: bool,
@@ -1783,6 +1829,7 @@ pub mod formatter {
                 indent: 0,
                 depth: 0,
                 max_depth: 8,
+                max_array_length: DEFAULT_MAX_ARRAY_LENGTH,
                 quote_strings: false,
                 quote_keys: false,
                 failed: false,
@@ -1822,6 +1869,7 @@ pub mod formatter {
                 indent: self.indent,
                 depth: self.depth,
                 max_depth: self.max_depth,
+                max_array_length: self.max_array_length,
                 quote_strings: self.quote_strings,
                 quote_keys: self.quote_keys,
                 failed: self.failed,
@@ -4512,6 +4560,20 @@ pub mod formatter {
                 return Ok(());
             }
 
+            // `maxArrayLength: 0` elides every element. Node prints
+            // `[ ... N more items ]` inline (the per-element loop below always
+            // prints index 0, so this case is handled up front).
+            if self.max_array_length == 0 {
+                writer.write_all(b"[ ");
+                writer.pretty::<C>(
+                    "... N more items".len(),
+                    format_args!("{}... {} more items{}", pf!("<r><d>"), len, pf!("<r>")),
+                );
+                writer.write_all(b" ]");
+                writer.add_for_new_line(2);
+                return Ok(());
+            }
+
             let mut was_good_time = self.always_newline_scope ||
                 // heuristic: more than 10, probably should have a newline before it
                 len > 10;
@@ -4576,7 +4638,7 @@ pub mod formatter {
                         i += 1;
                         continue;
                     }
-                    if nonempty_count >= 100 {
+                    if nonempty_count >= self.max_array_length {
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4591,14 +4591,15 @@ pub mod formatter {
                     // `[ ... N more items` and fall through to the
                     // named-property pass (Node: `[ ... N more items, foo: 1 ]`).
                     if self.max_array_length == 0 {
-                        // Nothing is printed, so the element-count heuristic
-                        // (`len > 10`) should not force a multi-line close.
-                        was_good_time = false;
-                        // Mirror the normal first-element opener (below): when
-                        // `sorted`/`ordered_properties` is set the close goes
-                        // multi-line, so the opener must match to stay
-                        // symmetric. Otherwise keep it inline.
-                        if !self.single_line && self.ordered_properties {
+                        // Mirror the normal first-element opener (below) so the
+                        // brackets stay symmetric with the close. Nothing is
+                        // printed, so the element-count heuristic (`len > 10`)
+                        // should not apply, but the close also honors
+                        // `ordered_properties` and the content-driven
+                        // `good_time_for_a_new_line` wrap — capture the latter
+                        // here exactly as the normal opener does.
+                        was_good_time = writer.good_time_for_a_new_line(self.indent);
+                        if !self.single_line && (self.ordered_properties || was_good_time) {
                             writer.reset_line(self.indent);
                             writer.write_all(b"[\n");
                             writer.write_indent(self.indent);

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4591,12 +4591,22 @@ pub mod formatter {
                     // `[ ... N more items` and fall through to the
                     // named-property pass (Node: `[ ... N more items, foo: 1 ]`).
                     if self.max_array_length == 0 {
-                        // Nothing is printed, so keep the brackets inline
-                        // regardless of the element count (`len > 10` would
-                        // otherwise force a multi-line close).
+                        // Nothing is printed, so the element-count heuristic
+                        // (`len > 10`) should not force a multi-line close.
                         was_good_time = false;
-                        writer.write_all(b"[ ");
-                        writer.add_for_new_line(2);
+                        // Mirror the normal first-element opener (below): when
+                        // `sorted`/`ordered_properties` is set the close goes
+                        // multi-line, so the opener must match to stay
+                        // symmetric. Otherwise keep it inline.
+                        if !self.single_line && self.ordered_properties {
+                            writer.reset_line(self.indent);
+                            writer.write_all(b"[\n");
+                            writer.write_indent(self.indent);
+                            writer.add_for_new_line(1);
+                        } else {
+                            writer.write_all(b"[ ");
+                            writer.add_for_new_line(2);
+                        }
                         writer.pretty::<C>(
                             "... N more items".len(),
                             format_args!(

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4670,10 +4670,18 @@ pub mod formatter {
                         let elided_from = u64::from(empty_start.unwrap_or(i));
                         let remaining = len - elided_from;
                         empty_start = None;
-                        writer.print_comma::<C>();
-                        writer.write_all(b"\n"); // we want the line break to be unconditional here
-                        *writer.estimated_line_length = 0;
-                        writer.write_indent(self.indent);
+                        // Only emit the separator if something was already
+                        // printed inside the brackets. When the array starts
+                        // with an elided hole (`elided_from == 0`) nothing
+                        // precedes the elision, so a comma would dangle after
+                        // `[` — mirror the `if empty > 0` guard used by the
+                        // hole-flush path below.
+                        if elided_from > 0 {
+                            writer.print_comma::<C>();
+                            writer.write_all(b"\n"); // we want the line break to be unconditional here
+                            *writer.estimated_line_length = 0;
+                            writer.write_indent(self.indent);
+                        }
                         writer.pretty::<C>(
                             "... N more items".len(),
                             format_args!(

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4567,26 +4567,6 @@ pub mod formatter {
                 return Ok(());
             }
 
-            // `maxArrayLength: 0` elides every element. Node prints
-            // `[ ... N more items ]` inline (the per-element loop below always
-            // prints index 0, so this case is handled up front).
-            if self.max_array_length == 0 {
-                writer.write_all(b"[ ");
-                writer.pretty::<C>(
-                    "... N more items".len(),
-                    format_args!(
-                        "{}... {} more item{}{}",
-                        pf!("<r><d>"),
-                        len,
-                        more_items_plural(len),
-                        pf!("<r>")
-                    ),
-                );
-                writer.write_all(b" ]");
-                writer.add_for_new_line(2);
-                return Ok(());
-            }
-
             let mut was_good_time = self.always_newline_scope ||
                 // heuristic: more than 10, probably should have a newline before it
                 len > 10;
@@ -4602,7 +4582,37 @@ pub mod formatter {
                 self.quote_strings = true;
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 let mut empty_start: Option<u32> = None;
+                // Index of the next element to consider. Doubles as the
+                // "entries printed so far" signal for the named-property pass
+                // below (a leading comma is emitted when it is > 0).
+                let mut i: u32 = 1;
                 'first: {
+                    // `maxArrayLength: 0` elides every element — print
+                    // `[ ... N more items` and fall through to the
+                    // named-property pass (Node: `[ ... N more items, foo: 1 ]`).
+                    if self.max_array_length == 0 {
+                        // Nothing is printed, so keep the brackets inline
+                        // regardless of the element count (`len > 10` would
+                        // otherwise force a multi-line close).
+                        was_good_time = false;
+                        writer.write_all(b"[ ");
+                        writer.add_for_new_line(2);
+                        writer.pretty::<C>(
+                            "... N more items".len(),
+                            format_args!(
+                                "{}... {} more item{}{}",
+                                pf!("<r><d>"),
+                                len,
+                                more_items_plural(len),
+                                pf!("<r>")
+                            ),
+                        );
+                        // Past the end so the element loop is skipped; `i > 0`
+                        // still makes the named-property pass emit a comma.
+                        i = len as u32;
+                        break 'first;
+                    }
+
                     let element = value.get_direct_index(self.global_this, 0);
 
                     let tag = Tag::get_advanced(element, self.global_this, tag_opts)?;
@@ -4639,9 +4649,10 @@ pub mod formatter {
                     }
                 }
 
-                let mut i: u32 = 1;
                 let mut nonempty_count: u32 = 1;
 
+                // `i` is already past the end when `maxArrayLength: 0` elided
+                // everything, so this loop is naturally skipped in that case.
                 while (i as u64) < len {
                     let element = value.get_direct_index(self.global_this, i);
                     if element.is_empty() {
@@ -4652,7 +4663,13 @@ pub mod formatter {
                         continue;
                     }
                     if nonempty_count >= self.max_array_length {
-                        let remaining = len - u64::from(i);
+                        // Elide everything from here to the end. A pending run
+                        // of holes (`empty_start`) is part of the elided tail,
+                        // so count from its start and clear it so it doesn't
+                        // also leak into the trailing `N x empty items` summary.
+                        let elided_from = empty_start.map_or(u64::from(i), u64::from);
+                        let remaining = len - elided_from;
+                        empty_start = None;
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -1312,6 +1312,13 @@ pub fn write_trace(writer: &mut dyn bun_io::Write, global: &JSGlobalObject) {
 /// Node's `util.inspect` default (`maxArrayLength: 100`).
 pub const DEFAULT_MAX_ARRAY_LENGTH: u32 = 100;
 
+/// Pluralize the `... N more item(s)` elision message. Node prints the
+/// singular "item" only when exactly one element remains
+/// (`remaining === 1 ? "" : "s"` in `util.inspect`).
+fn more_items_plural(remaining: u64) -> &'static str {
+    if remaining == 1 { "" } else { "s" }
+}
+
 /// Resolve a user-supplied `maxArrayLength` option to the element cap.
 ///
 /// Matches Node's `util.inspect` semantics: `null` means no limit
@@ -4567,7 +4574,13 @@ pub mod formatter {
                 writer.write_all(b"[ ");
                 writer.pretty::<C>(
                     "... N more items".len(),
-                    format_args!("{}... {} more items{}", pf!("<r><d>"), len, pf!("<r>")),
+                    format_args!(
+                        "{}... {} more item{}{}",
+                        pf!("<r><d>"),
+                        len,
+                        more_items_plural(len),
+                        pf!("<r>")
+                    ),
                 );
                 writer.write_all(b" ]");
                 writer.add_for_new_line(2);
@@ -4639,6 +4652,7 @@ pub mod formatter {
                         continue;
                     }
                     if nonempty_count >= self.max_array_length {
+                        let remaining = len - u64::from(i);
                         writer.print_comma::<C>();
                         writer.write_all(b"\n"); // we want the line break to be unconditional here
                         *writer.estimated_line_length = 0;
@@ -4646,9 +4660,10 @@ pub mod formatter {
                         writer.pretty::<C>(
                             "... N more items".len(),
                             format_args!(
-                                "{}... {} more items{}",
+                                "{}... {} more item{}{}",
                                 pf!("<r><d>"),
-                                len - u64::from(i),
+                                remaining,
+                                more_items_plural(remaining),
                                 pf!("<r>")
                             ),
                         );

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -68,6 +68,18 @@ test("Bun.inspect maxArrayLength equal to the array length prints everything", (
   expect(Bun.inspect([1, 2, 3, 4, 5], { maxArrayLength: 5 })).toBe("[ 1, 2, 3, 4, 5 ]");
 });
 
+test("Bun.inspect uses singular 'item' when exactly one element is elided", () => {
+  // in-loop truncation: 6 elements, cap 5 -> 1 remaining
+  expect(Bun.inspect([1, 2, 3, 4, 5, 6], { maxArrayLength: 5 })).toMatchInlineSnapshot(`
+    "[ 1, 2, 3, 4, 5,
+      ... 1 more item ]"
+  `);
+  // maxArrayLength: 0 on a single-element array -> 1 remaining
+  expect(Bun.inspect([1], { maxArrayLength: 0 })).toBe("[ ... 1 more item ]");
+  // 2 remaining stays plural
+  expect(Bun.inspect([1, 2], { maxArrayLength: 0 })).toBe("[ ... 2 more items ]");
+});
+
 test.concurrent("console.dir honors maxArrayLength", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -1,0 +1,113 @@
+// https://github.com/oven-sh/bun/issues/31808
+//
+// `console.dir(arr, { maxArrayLength: N })` and `Bun.inspect(arr, { maxArrayLength: N })`
+// ignored the `maxArrayLength` option: the native formatter always truncated
+// arrays at a hardcoded cap of 100 items regardless of the value passed.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const makeArray = (length: number) => Array.from({ length }, (_, i) => i);
+
+test("Bun.inspect honors maxArrayLength (truncation)", () => {
+  const arr = makeArray(200);
+  expect(Bun.inspect(arr, { maxArrayLength: 5 })).toMatchInlineSnapshot(`
+    "[
+      0, 1, 2, 3, 4,
+      ... 195 more items
+    ]"
+  `);
+});
+
+test("Bun.inspect maxArrayLength larger than the array prints everything", () => {
+  const arr = makeArray(150);
+  const out = Bun.inspect(arr, { maxArrayLength: 200 });
+  expect(out).toContain("149");
+  expect(out).not.toContain("more items");
+});
+
+test("Bun.inspect maxArrayLength shorter than the default truncates below 100", () => {
+  const arr = makeArray(50);
+  expect(Bun.inspect(arr, { maxArrayLength: 3 })).toMatchInlineSnapshot(`
+    "[
+      0, 1, 2,
+      ... 47 more items
+    ]"
+  `);
+});
+
+test("Bun.inspect maxArrayLength: 0 elides every element", () => {
+  expect(Bun.inspect([1, 2, 3], { maxArrayLength: 0 })).toBe("[ ... 3 more items ]");
+});
+
+test("Bun.inspect maxArrayLength negative clamps to 0", () => {
+  expect(Bun.inspect([1, 2, 3], { maxArrayLength: -5 })).toBe("[ ... 3 more items ]");
+});
+
+test("Bun.inspect maxArrayLength: null means no limit", () => {
+  const arr = makeArray(150);
+  const out = Bun.inspect(arr, { maxArrayLength: null });
+  expect(out).toContain("149");
+  expect(out).not.toContain("more items");
+});
+
+test("Bun.inspect maxArrayLength: Infinity means no limit", () => {
+  const arr = makeArray(150);
+  const out = Bun.inspect(arr, { maxArrayLength: Infinity });
+  expect(out).toContain("149");
+  expect(out).not.toContain("more items");
+});
+
+test("Bun.inspect without maxArrayLength still defaults to 100", () => {
+  const arr = makeArray(200);
+  const out = Bun.inspect(arr);
+  expect(out).toContain("... 100 more items");
+  expect(out).not.toContain("101");
+});
+
+test("Bun.inspect maxArrayLength equal to the array length prints everything", () => {
+  expect(Bun.inspect([1, 2, 3, 4, 5], { maxArrayLength: 5 })).toBe("[ 1, 2, 3, 4, 5 ]");
+});
+
+test.concurrent("console.dir honors maxArrayLength", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("[\n  0, 1, 2, 3, 4,\n  ... 195 more items\n]\n");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("console.dir maxArrayLength larger than the array prints everything", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", "const a = Array.from({length:150}, (_,i)=>i); console.dir(a, {maxArrayLength: 200});"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toContain("149");
+  expect(stdout).not.toContain("more items");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("node:console Console path still honors maxArrayLength", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      'const {Console}=require("node:console"); new Console(process.stdout).dir(Array.from({length:200},(_,i)=>i),{maxArrayLength:5});',
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toBe("[ 0, 1, 2, 3, 4, ... 195 more items ]\n");
+  expect(exitCode).toBe(0);
+});

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -86,8 +86,7 @@ test("Bun.inspect maxArrayLength still prints named own properties", () => {
     '[ ... 3 more items, foo: "bar" ]',
   );
   // Truncating mid-array keeps trailing named properties too.
-  expect(Bun.inspect(Object.assign([1, 2, 3, 4, 5], { foo: "bar" }), { maxArrayLength: 2 }))
-    .toMatchInlineSnapshot(`
+  expect(Bun.inspect(Object.assign([1, 2, 3, 4, 5], { foo: "bar" }), { maxArrayLength: 2 })).toMatchInlineSnapshot(`
     "[ 1, 2,
       ... 3 more items, foo: "bar" ]"
   `);

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -80,6 +80,33 @@ test("Bun.inspect uses singular 'item' when exactly one element is elided", () =
   expect(Bun.inspect([1, 2], { maxArrayLength: 0 })).toBe("[ ... 2 more items ]");
 });
 
+test("Bun.inspect maxArrayLength still prints named own properties", () => {
+  // maxArrayLength: 0 must not swallow non-index properties attached to the array.
+  expect(Bun.inspect(Object.assign([1, 2, 3], { foo: "bar" }), { maxArrayLength: 0 })).toBe(
+    '[ ... 3 more items, foo: "bar" ]',
+  );
+  // Truncating mid-array keeps trailing named properties too.
+  expect(Bun.inspect(Object.assign([1, 2, 3, 4, 5], { foo: "bar" }), { maxArrayLength: 2 }))
+    .toMatchInlineSnapshot(`
+    "[ 1, 2,
+      ... 3 more items, foo: "bar" ]"
+  `);
+});
+
+test("Bun.inspect maxArrayLength counts holes at the truncation boundary", () => {
+  // A hole at the cap boundary belongs to the elided tail and must be counted
+  // (3 remaining: the hole at index 1 plus indices 2 and 3), not leak into a
+  // bogus trailing "empty items" summary.
+  expect(Bun.inspect([1, , 3, 4], { maxArrayLength: 1 })).toMatchInlineSnapshot(`
+    "[ 1,
+      ... 3 more items ]"
+  `);
+  expect(Bun.inspect([1, 2, , , 5, 6], { maxArrayLength: 2 })).toMatchInlineSnapshot(`
+    "[ 1, 2,
+      ... 4 more items ]"
+  `);
+});
+
 test.concurrent("console.dir honors maxArrayLength", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -124,6 +124,20 @@ test("Bun.inspect maxArrayLength: 0 keeps brackets symmetric with sorted", () =>
   expect(Bun.inspect([1, 2, 3], { maxArrayLength: 0 })).toBe("[ ... 3 more items ]");
 });
 
+test("Bun.inspect maxArrayLength: 0 stays symmetric when the line is already wrapped", () => {
+  // Nested under a long key, the line already exceeds the wrap threshold at
+  // entry, so the all-elided opener must go multi-line to match the close
+  // (same as the normal opener would) — not inline-open/multi-line-close.
+  const obj = { aVeryLongPropertyNameThatPushesTheLinePastEightyCharactersBeforeTheArrayValue: [1, 2, 3] };
+  expect(Bun.inspect(obj, { maxArrayLength: 0 })).toMatchInlineSnapshot(`
+    "{
+      aVeryLongPropertyNameThatPushesTheLinePastEightyCharactersBeforeTheArrayValue: [
+        ... 3 more items
+      ],
+    }"
+  `);
+});
+
 test.concurrent("console.dir honors maxArrayLength", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -106,6 +106,13 @@ test("Bun.inspect maxArrayLength counts holes at the truncation boundary", () =>
   `);
 });
 
+test("Bun.inspect maxArrayLength elides a leading hole without a dangling comma", () => {
+  // When the array starts with a hole and the cap truncates immediately,
+  // nothing precedes the elision, so no leading `,` should be emitted.
+  expect(Bun.inspect([, 1, 2], { maxArrayLength: 1 })).toBe("[ ... 3 more items ]");
+  expect(Bun.inspect([, , , 1], { maxArrayLength: 1 })).toBe("[ ... 4 more items ]");
+});
+
 test.concurrent("console.dir honors maxArrayLength", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -113,6 +113,17 @@ test("Bun.inspect maxArrayLength elides a leading hole without a dangling comma"
   expect(Bun.inspect([, , , 1], { maxArrayLength: 1 })).toBe("[ ... 4 more items ]");
 });
 
+test("Bun.inspect maxArrayLength: 0 keeps brackets symmetric with sorted", () => {
+  // The all-elided opener must mirror the close: `sorted` opens and closes
+  // multi-line, plain stays inline — never inline-open/multi-line-close.
+  expect(Bun.inspect([1, 2, 3], { maxArrayLength: 0, sorted: true })).toMatchInlineSnapshot(`
+    "[
+      ... 3 more items
+    ]"
+  `);
+  expect(Bun.inspect([1, 2, 3], { maxArrayLength: 0 })).toBe("[ ... 3 more items ]");
+});
+
 test.concurrent("console.dir honors maxArrayLength", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", "const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});"],

--- a/test/regression/issue/31808.test.ts
+++ b/test/regression/issue/31808.test.ts
@@ -4,7 +4,7 @@
 // ignored the `maxArrayLength` option: the native formatter always truncated
 // arrays at a hardcoded cap of 100 items regardless of the value passed.
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
 
 const makeArray = (length: number) => Array.from({ length }, (_, i) => i);
 
@@ -115,7 +115,12 @@ test.concurrent("console.dir honors maxArrayLength", async () => {
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toBe("[\n  0, 1, 2, 3, 4,\n  ... 195 more items\n]\n");
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "[
+      0, 1, 2, 3, 4,
+      ... 195 more items
+    ]"
+  `);
   expect(exitCode).toBe(0);
 });
 
@@ -146,6 +151,6 @@ test.concurrent("node:console Console path still honors maxArrayLength", async (
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
-  expect(stdout).toBe("[ 0, 1, 2, 3, 4, ... 195 more items ]\n");
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"[ 0, 1, 2, 3, 4, ... 195 more items ]"`);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## What

Fixes #31808. `console.dir(arr, { maxArrayLength: N })` and `Bun.inspect(arr, { maxArrayLength: N })` ignored the `maxArrayLength` option — the native formatter always truncated arrays at a hardcoded cap of **100** items regardless of the value passed. This is a regression: per the issue, `maxArrayLength` worked in v1.1.0 and stopped taking effect somewhere before v1.3.14. Node honors it.

```console
$ node -e 'const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});'
[ 0, 1, 2, 3, 4, ... 195 more items ]

# before
$ bun -e 'const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});'
[
  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, ... (up to index 99) ...
  ... 100 more items
]

# after
$ bun -e 'const a = Array.from({length:200}, (_,i)=>i); console.dir(a, {maxArrayLength: 5});'
[
  0, 1, 2, 3, 4,
  ... 195 more items
]
```

## Root cause

The native console + inspect formatter lives in `src/jsc/ConsoleObject.rs`. It read `depth`/`colors` from the options object but never `maxArrayLength`, and the array printer hardcoded its element cap to `100`. There was no `max_array_length` on `FormatOptions` / `Formatter` at all, so `Bun.inspect` and `console.dir` had no way to pass the option down.

(The JS `new (require("node:console").Console)(...)` path was already correct — it delegates to `util.inspect` in `src/js/internal/util/inspect.js`, a separate implementation that was not touched here.)

## Fix

- Add a `max_array_length: u32` field to `FormatOptions` and `Formatter`, defaulting to `100` (`DEFAULT_MAX_ARRAY_LENGTH`) so existing behavior is unchanged when the option is absent.
- Read `maxArrayLength` in the `console.dir` options arm and in `FormatOptions::from_js` (the `Bun.inspect` path), then thread it into the `Formatter` in both `format2` branches and in `shallow_clone` (so nested arrays inherit it).
- Replace the hardcoded `>= 100` array cap with the configured value, and handle `maxArrayLength: 0` up front (Node prints `[ ... N more items ]` inline).
- `resolve_max_array_length` matches Node semantics: `null`/`Infinity` → no limit, negative → clamp to 0, non-integer → floored, `NaN` → 0, missing/`undefined` → leave default.
- Singularize the elision message when exactly one element remains (`... 1 more item`), matching Node and Bun's JS `util.inspect`. This also fixes the pre-existing plural ("1 more items") in the default in-loop truncation path.

Follow-up fixes for truncation edge cases that `maxArrayLength` made trivially reachable (from review):

- `maxArrayLength: 0` on an array with named own properties no longer drops them — the all-elided case now flows through the same named-property pass as the in-loop truncation, so `Bun.inspect(Object.assign([1,2,3],{foo:1}), {maxArrayLength:0})` prints `[ ... 3 more items, foo: 1 ]` like Node.
- A hole sitting at the truncation boundary no longer leaks a bogus `N x empty items` marker and is counted correctly in the remaining total (`[1, , 3, 4]` with `maxArrayLength: 1` → `... 3 more items`).
- A leading hole with a small cap no longer produces a dangling leading comma (`[, 1, 2]` with `maxArrayLength: 1` → `[ ... 3 more items ]`).

Also declared `maxArrayLength?: number | null` on the public `BunInspectOptions` type (`packages/bun-types/bun.d.ts`) to match the runtime.

Scope notes:
- Bun's Map/Set/TypedArray printers do not currently truncate at all (a separate, pre-existing divergence from Node's default-100). This change is limited to arrays — what the issue reports — to avoid introducing new default-truncation behavior for those types.
- Bun counts only non-empty elements toward the cap and renders holes as `N x empty items`, whereas Node counts collapsed hole-runs as budget-consuming `<N empty items>` entries. That's a pre-existing sparse-array formatting divergence (unchanged by the default-100 cap) and is left as-is here.

## Verification

New regression test `test/regression/issue/31808.test.ts` covers `Bun.inspect` and `console.dir` for truncation, expansion beyond the default, `0`/negative/`null`/`Infinity`, the singular/plural boundary, named own properties, sparse holes at the boundary, the unchanged default-100, and the JS `Console` path.

- `bun bd test test/regression/issue/31808.test.ts` → 15 pass
- Against the unfixed binary → 12 fail (confirms the test exercises the fix; the 3 that pass are controls for behavior that was already correct)
- Existing `test/js/bun/console/` and `test/js/bun/util/inspect.test.js` suites still pass.


