### PR TITLE
crypto: fix X509Certificate.ca returning true for certs without basicConstraints

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -1031,7 +1031,14 @@ bool X509View::isCA() const
 {
     ClearErrorOnReturn clearErrorOnReturn;
     if (cert_ == nullptr) return false;
-    return X509_check_ca(const_cast<X509*>(cert_)) == 1;
+
+    // Not X509_check_ca() == 1 as in Node: BoringSSL returns 1 for v1 certs
+    // where OpenSSL returns 2. Match Node by checking the flags directly.
+    X509* cert = const_cast<X509*>(cert_);
+    const uint32_t flags = X509_get_extension_flags(cert);
+    if ((flags & (EXFLAG_BCONS | EXFLAG_CA)) != (EXFLAG_BCONS | EXFLAG_CA))
+        return false;
+    return (X509_get_key_usage(cert) & X509v3_KU_KEY_CERT_SIGN) != 0;
 }
 
 bool X509View::isIssuedBy(const X509View& issuer) const

--- a/test/js/node/crypto/x509-subclass.test.ts
+++ b/test/js/node/crypto/x509-subclass.test.ts
@@ -129,3 +129,69 @@ describe("X509Certificate#checkIssued", () => {
     expect(() => agent1.checkIssued("" as any)).toThrow();
   });
 });
+
+// X509Certificate.ca must be true only for certificates with a basicConstraints
+// extension that sets CA:TRUE (matching Node/OpenSSL's X509_check_ca() == 1).
+// Bun uses BoringSSL, whose X509_check_ca() returns 1 for X.509 v1 certificates
+// too, so the old `== 1` check reported a v1 cert with no basicConstraints as a
+// CA. https://github.com/oven-sh/bun/issues/31810
+describe("X509Certificate#ca", () => {
+  // Self-signed X.509 v1 certificate with no extensions (no basicConstraints).
+  const v1NoExtensions = new X509Certificate(`-----BEGIN CERTIFICATE-----
+MIICAjCCAagCCQDFYI3zR8B/izAKBggqhkjOPQQDAjAPMQ0wCwYDVQQDDAR0ZXN0
+MB4XDTI2MDUyODE3MDYwNVoXDTM2MDUyNTE3MDYwNVowDzENMAsGA1UEAwwEdGVz
+dDCCAUswggEDBgcqhkjOPQIBMIH3AgEBMCwGByqGSM49AQECIQD/////AAAAAQAA
+AAAAAAAAAAAAAP///////////////zBbBCD/////AAAAAQAAAAAAAAAAAAAAAP//
+/////////////AQgWsY12Ko6k+ez671VdpiGvGUdBrDMU7D2O848PifSYEsDFQDE
+nTYIhucEk2pmeOETnSa3gZ9+kARBBGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPSh
+OUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfUCIQD/////AAAA
+AP//////////vOb6racXnoTzucrC/GMlUQIBAQNCAAR1hd/nVei+or93b6B6lA0v
+U52t80TD/E7NVfub7GJbHxbCX48zQH8YzMEsi/C/0G6N0/kf/ilwVuZXzwPVuTM/
+MAoGCCqGSM49BAMCA0gAMEUCIFTzv2XBNlegDgPaDlhmcxwOx9FaIfy/9SF6+qmV
+7IPSAiEAkQ1u46qvg4y2tr47yLzr0PbtPVYgjNS7VYLNDWf/btw=
+-----END CERTIFICATE-----
+`);
+
+  // Self-signed X.509 v3 certificate with basicConstraints CA:TRUE.
+  const v3CaTrue = new X509Certificate(`-----BEGIN CERTIFICATE-----
+MIIBjDCCATGgAwIBAgIUd0nA46zMcwqssVnVDNJ0F1APFuIwCgYIKoZIzj0EAwIw
+EzERMA8GA1UEAwwITXlSb290Q0EwHhcNMjYwNjA0MTYyMDM2WhcNMzYwNjAxMTYy
+MDM2WjATMREwDwYDVQQDDAhNeVJvb3RDQTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABH5Mm74kubMd96Z5D09xITJcBhAiByKbnzyMRgcA14MlMmRXP9N812rhsyM6
+drajhDSLmtoeaLfdf+0YnndMppWjYzBhMB0GA1UdDgQWBBT/fNxTnDHehlFQZpEt
+DhbKDuhG+DAfBgNVHSMEGDAWgBT/fNxTnDHehlFQZpEtDhbKDuhG+DAPBgNVHRMB
+Af8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAKBggqhkjOPQQDAgNJADBGAiEAwON8
+/nnAceDckQ0nD3etz11m120RFm0z3yGyPs2jmBQCIQCS7+FmRZYmXNAoqZFGtBmL
+ALUH18cGAJfxlfxayzf4DA==
+-----END CERTIFICATE-----
+`);
+
+  // X.509 v3 certificate with basicConstraints CA:FALSE.
+  const v3CaFalse = new X509Certificate(`-----BEGIN CERTIFICATE-----
+MIIBkDCCATagAwIBAgIUG78W7gb1zr+WfA6NLqonnbC7C0YwCgYIKoZIzj0EAwIw
+EzERMA8GA1UEAwwITXlSb290Q0EwHhcNMjYwNjA0MTYyMDM2WhcNMjcwNjA0MTYy
+MDM2WjAbMRkwFwYDVQQDDBBsZWFmLmV4YW1wbGUuY29tMFkwEwYHKoZIzj0CAQYI
+KoZIzj0DAQcDQgAE0Evk10/eXIG+PdR75ROVkXGsjygjbX+XtChIHDg9FNRdGQ01
+DpqtLuJZ10EA3KfhqcIkC529yYvEpmYBobb+CqNgMF4wDAYDVR0TAQH/BAIwADAO
+BgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFBPT7oz30YdjZ9Hykvt9MX87p7lBMB8G
+A1UdIwQYMBaAFP983FOcMd6GUVBmkS0OFsoO6Eb4MAoGCCqGSM49BAMCA0gAMEUC
+IQCMSgMdAzb2vAAqjc0c5ZSIbx+H6OyzIa47vJJAoL0aXAIgCLUr3IR6L/NJO5Vm
+3yGsEHv16ABxoz4cPe2uxJ2BNsk=
+-----END CERTIFICATE-----
+`);
+
+  test("is false for a v1 certificate with no basicConstraints", () => {
+    expect(v1NoExtensions.ca).toBe(false);
+    expect(v1NoExtensions.toLegacyObject().ca).toBe(false);
+  });
+
+  test("is true for a v3 certificate with basicConstraints CA:TRUE", () => {
+    expect(v3CaTrue.ca).toBe(true);
+    expect(v3CaTrue.toLegacyObject().ca).toBe(true);
+  });
+
+  test("is false for a v3 certificate with basicConstraints CA:FALSE", () => {
+    expect(v3CaFalse.ca).toBe(false);
+    expect(v3CaFalse.toLegacyObject().ca).toBe(false);
+  });
+});

--- a/test/js/node/crypto/x509-subclass.test.ts
+++ b/test/js/node/crypto/x509-subclass.test.ts
@@ -130,11 +130,8 @@ describe("X509Certificate#checkIssued", () => {
   });
 });
 
-// X509Certificate.ca must be true only for certificates with a basicConstraints
-// extension that sets CA:TRUE (matching Node/OpenSSL's X509_check_ca() == 1).
-// Bun uses BoringSSL, whose X509_check_ca() returns 1 for X.509 v1 certificates
-// too, so the old `== 1` check reported a v1 cert with no basicConstraints as a
-// CA. https://github.com/oven-sh/bun/issues/31810
+// .ca is true only for certificates whose basicConstraints set CA:TRUE.
+// https://github.com/oven-sh/bun/issues/31810
 describe("X509Certificate#ca", () => {
   // Self-signed X.509 v1 certificate with no extensions (no basicConstraints).
   const v1NoExtensions = new X509Certificate(`-----BEGIN CERTIFICATE-----

--- a/test/js/node/crypto/x509-subclass.test.ts
+++ b/test/js/node/crypto/x509-subclass.test.ts
@@ -194,4 +194,43 @@ IQCMSgMdAzb2vAAqjc0c5ZSIbx+H6OyzIa47vJJAoL0aXAIgCLUr3IR6L/NJO5Vm
     expect(v3CaFalse.ca).toBe(false);
     expect(v3CaFalse.toLegacyObject().ca).toBe(false);
   });
+
+  // Self-signed X.509 v3 certificate with basicConstraints CA:TRUE and no
+  // keyUsage extension. Absent keyUsage allows all usages, so this is a CA.
+  const v3CaTrueNoKeyUsage = new X509Certificate(`-----BEGIN CERTIFICATE-----
+MIIBeDCCAR+gAwIBAgIUHT2JuI0NIIyi6TVSMFnmvrkWn4gwCgYIKoZIzj0EAwIw
+EjEQMA4GA1UEAwwHTm9LVS1DQTAeFw0yNjA5MDIwOTUzNTZaFw0zNjA4MzAwOTUz
+NTZaMBIxEDAOBgNVBAMMB05vS1UtQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNC
+AAR7xWmKAtFVZyRs9FzWASJh7oJyVXMkl95YtB6O8l1fMUFAWdtmnMs5Zfnyce5H
+69BGppFAfRacFynbTkIYr1soo1MwUTAdBgNVHQ4EFgQUjwEK42UtlVwNOTHr2Uxu
+z6WhDQMwHwYDVR0jBBgwFoAUjwEK42UtlVwNOTHr2Uxuz6WhDQMwDwYDVR0TAQH/
+BAUwAwEB/zAKBggqhkjOPQQDAgNHADBEAiAFadic93/x4K/rc/F3d8NKIHzXfKJv
+rDfzgtk7kZ3sSAIgebdk3gZ/tzu0HcYN84YDIgmUNH3dFN/DL8sG1pWD94g=
+-----END CERTIFICATE-----
+`);
+
+  // Self-signed X.509 v3 certificate with basicConstraints CA:TRUE but a
+  // keyUsage extension that omits keyCertSign. Not a CA, matching Node.
+  const v3CaTrueNoCertSign = new X509Certificate(`-----BEGIN CERTIFICATE-----
+MIIBizCCATGgAwIBAgIUDbrkpWKP+EuGiDj88iIx2jmiWWAwCgYIKoZIzj0EAwIw
+EzERMA8GA1UEAwwIQmFkS1UtQ0EwHhcNMjYwOTAyMDk1MzU2WhcNMzYwODMwMDk1
+MzU2WjATMREwDwYDVQQDDAhCYWRLVS1DQTBZMBMGByqGSM49AgEGCCqGSM49AwEH
+A0IABHvFaYoC0VVnJGz0XNYBImHugnJVcySX3li0Ho7yXV8xQUBZ22acyzll+fJx
+7kfr0EamkUB9FpwXKdtOQhivWyijYzBhMB0GA1UdDgQWBBSPAQrjZS2VXA05MevZ
+TG7PpaENAzAfBgNVHSMEGDAWgBSPAQrjZS2VXA05MevZTG7PpaENAzAPBgNVHRMB
+Af8EBTADAQH/MA4GA1UdDwEB/wQEAwIHgDAKBggqhkjOPQQDAgNIADBFAiEA3Ol0
+RcxWXw7xfL0LpSYylWfqVrkTE2JUWaiLMwKhiN8CIEK0D0bR3jd5uFG7QUYudOI9
+FnsAZB/i9iiFjmi19obo
+-----END CERTIFICATE-----
+`);
+
+  test("is true for a v3 CA:TRUE certificate with no keyUsage extension", () => {
+    expect(v3CaTrueNoKeyUsage.ca).toBe(true);
+    expect(v3CaTrueNoKeyUsage.toLegacyObject().ca).toBe(true);
+  });
+
+  test("is false for a v3 CA:TRUE certificate whose keyUsage omits keyCertSign", () => {
+    expect(v3CaTrueNoCertSign.ca).toBe(false);
+    expect(v3CaTrueNoCertSign.toLegacyObject().ca).toBe(false);
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes `X509Certificate.ca` returning `true` for certificates that have no `basicConstraints` extension (e.g. self-signed X.509 **v1** certs). Node returns `false` for these. Closes #31810.

```js
import { X509Certificate } from "node:crypto";

// Self-signed X.509 v1 cert, no extensions (no basicConstraints).
const cert = new X509Certificate(v1Pem);
console.log(cert.ca);                    // Node: false  | Bun (before): true
console.log(cert.toLegacyObject().ca);   // Node: false  | Bun (before): true
```

### Root cause

`X509View::isCA()` (`src/jsc/bindings/ncrypto.cpp`) compared `X509_check_ca(...) == 1`, ported verbatim from Node's `ncrypto`. That works on **OpenSSL** (Node) but not on **BoringSSL** (Bun):

- OpenSSL's `X509_check_ca()` returns `2` for an X.509 v1 cert (historical compat), so `== 1` is `false`.
- BoringSSL's `X509_check_ca()` returns **`1`** for a v1 cert — its header documents *"If `x509` is an X509v1 certificate, and thus has no extensions, it is considered eligible."* So `== 1` is `true`.

The `== 1` pattern is not portable to BoringSSL.

### Fix

Check the certificate's extension flags directly, which both backends expose via the public `X509_get_extension_flags()` / `X509_get_key_usage()` API. A cert is a CA per RFC 5280 §4.2.1.9 only when it has a `basicConstraints` extension with `CA:TRUE` (and its `keyUsage`, if present, allows certificate signing):

```cpp
const uint32_t flags = X509_get_extension_flags(cert);
if ((flags & (EXFLAG_BCONS | EXFLAG_CA)) != (EXFLAG_BCONS | EXFLAG_CA))
    return false;
return (X509_get_key_usage(cert) & X509v3_KU_KEY_CERT_SIGN) != 0;
```

This exactly reproduces OpenSSL/Node's `X509_check_ca() == 1` result (only a v3 cert with `basicConstraints CA:TRUE` is a CA) on both TLS backends. All three consumers — the `.ca` getter, `toLegacyObject()`, and `toJSON()` — route through `isCA()`, so they're all fixed.

### Verification

Matches Node across v1 / v3-CA:TRUE / v3-CA:FALSE:

| cert | Node | Bun before | Bun after |
|---|---|---|---|
| v1, no extensions | `false` | `true` ❌ | `false` ✅ |
| v3, `basicConstraints CA:TRUE` | `true` | `true` | `true` ✅ |
| v3, `basicConstraints CA:FALSE` | `false` | `false` | `false` ✅ |

Test added to `test/js/node/crypto/x509-subclass.test.ts` (`X509Certificate#ca`), alongside the sister-bug coverage for `checkIssued()` (#31570). Confirmed it fails on `main` (v1 case reports `true`) and passes with this change; the v3 positive case is exercised so the fix can't regress real CA certs.

Sister bug: #31570 (`checkIssued()` returned the cert instead of a boolean).

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 3 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509-subclass.test.ts"
bun test v1.4.1 (a6c4cc276)

test/js/node/crypto/x509-subclass.test.ts:
(pass) X509Certificate > constructor has .prototype property [19.74ms]
(pass) X509Certificate > prototype has expected methods [7.07ms]
(pass) X509Certificate > instance uses correct prototype [7.24ms]
(pass) X509Certificate > can be subclassed [12.88ms]
(pass) X509Certificate > subclass prototype chain is correct [70.22ms]
(pass) X509Certificate > subclass instance accesses X509 getters correctly [8.66ms]
(pass) X509Certificate > serialNumber and modulus are uppercase hex (Node.js/OpenSSL compat) [12.16ms]
(pass) X509Certificate#checkIssued > returns true when the certificate was issued by the other certificate [2.70ms]
(pass) X509Certificate#checkIssued > returns true for a self-signed certificate checked against itself [2.96ms]
(pass) X509Certificate#checkIssued > returns false for an unrelated issuer [2.37ms]
(pass) X509Certificate#checkIssued > returns false for a non-self-signed certificate checked against itself [2.
... (truncated)

release without fix: 1 FAILED
bun test v1.4.1-canary.1 (a6c4cc276)

test/js/node/crypto/x509-subclass.test.ts:
(pass) X509Certificate > constructor has .prototype property [0.03ms]
(pass) X509Certificate > prototype has expected methods [0.02ms]
(pass) X509Certificate > instance uses correct prototype [0.05ms]
(pass) X509Certificate > can be subclassed [0.12ms]
(pass) X509Certificate > subclass prototype chain is correct [0.68ms]
(pass) X509Certificate > subclass instance accesses X509 getters correctly [0.11ms]
(pass) X509Certificate > serialNumber and modulus are uppercase hex (Node.js/OpenSSL compat) [0.17ms]
(pass) X509Certificate#checkIssued > returns true when the certificate was issued by the other certificate [0.04ms]
(pass) X509Certificate#checkIssued > returns true for a self-signed certificate checked against itself [0.02ms]
(pass) X509Certificate#checkIssued > returns false for an unrelated issuer [0.02ms]
(pass) X509Certificate#checkIssued > returns false for a non-self-signed certificate checked against itself [0.01ms]
(pass) X509Certificate#checkIssued > throws ERR_INVALID_ARG_TYPE when the argument is not an X509Certificate [0.06ms]
176 | 3yGsEHv16ABxoz4cPe2uxJ2BNsk=
177 | -----E
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" "test/js/node/crypto/x509-subclass.test.ts"
bun test v1.4.1 (a6c4cc276)

test/js/node/crypto/x509-subclass.test.ts:
(pass) X509Certificate > constructor has .prototype property [12.33ms]
(pass) X509Certificate > prototype has expected methods [3.97ms]
(pass) X509Certificate > instance uses correct prototype [3.46ms]
(pass) X509Certificate > can be subclassed [7.93ms]
(pass) X509Certificate > subclass prototype chain is correct [40.33ms]
(pass) X509Certificate > subclass instance accesses X509 getters correctly [5.06ms]
(pass) X509Certificate > serialNumber and modulus are uppercase hex (Node.js/OpenSSL compat) [7.09ms]
(pass) X509Certificate#checkIssued > returns true when the certificate was issued by the other certificate [1.49ms]
(pass) X509Certificate#checkIssued > returns true for a self-signed certificate checked against itself [1.82ms]
(pass) X509Certificate#checkIssued > returns false for an unrelated issuer [1.42ms]
(pass) X509Certificate#checkIssued > returns false for a non-self-signed certificate checked against itself [1.73
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 620ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[2/6] gen cpp.rs (cppbind)
[2/6] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 34s
[3/6] link bun-profile
[5/6] strip bun
[5/6] bun-profile --revision
1.4.1-canary.1+a76a4e5d2
[build] done
bun test v1.4.1-canary.1 (a76a4e5d2)

test/js/node/crypto/x509-subclass.test.ts:
(pass) X509Certificate > constructor has .prototype property [0.02ms]
(pass) X509Certificate > prototype has expected methods [0.02ms]
(pass) X509Certificate > instance uses correct prototype [0.04ms]
(pass) X509Certificate > can be subclassed [0.11ms]
(pass) X509Certificate > subclass prototype chain is correct [0.66ms]
(pass) X509Certificate > subclass instance accesses X509 getters correctly [0.11ms]
(pass) X509Certificate > serialNumber and modulus are uppercase hex (Node.js/OpenSSL compat) [0.17ms]
(pass) X509Certificate#checkIs
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ncrypto.cpp              |   9 ++-
 test/js/node/crypto/x509-subclass.test.ts | 102 ++++++++++++++++++++++++++++++
 2 files changed, 110 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/jsc/bindings/ncrypto.cpp                   5      4     15
test/js/node/crypto/x509-subclass.test.ts      3      3     15
```

</details>

**root cause** · written by the author bot

The bug was that Bun's X509View::isCA() relied on X509_check_ca() == 1, but BoringSSL's implementation of that function diverges from OpenSSL's and returns 1 for X.509 v1 certificates that have no basicConstraints extension, causing such certificates to be incorrectly reported as CAs in violation of RFC 5280. The fix replaces the reliance on X509_check_ca() with an explicit, library-portable check that a certificate is a CA only if it carries a basicConstraints extension with CA:TRUE and, when a keyUsage extension is present, that keyUsage permits certificate signing via keyCertSign. This m…

<!-- robobun:evidence:end -->