### PR TITLE
Keep required parens around a new expression callee

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1476,27 +1476,41 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
 /// `new a.b.c()` is identical to `new (a.b.c)()` — a plain member chain binds
 /// into the `new` target — so those parens may be dropped. But `new (a().b)()`
 /// must stay parenthesized: unwrapped, `new a().b()` reparses as
-/// `(new a()).b()`. Likewise an optional chain (`new (a?.b)()`) is a syntax
-/// error without the parens (`new` may not appear in an optional chain).
+/// `(new a()).b()`. Likewise an optional chain that reaches the `new`
+/// (`new (a?.b)()`) is a syntax error without the parens (`new` may not appear
+/// in an optional chain).
 ///
-/// Walks the `EDot`/`EIndex`/`ETemplate` (tagged) chain and returns `true` when
-/// a descendant `ECall` or optional-chain node makes the parens load-bearing.
+/// Walks the `EDot`/`EIndex`/`ETemplate` (tagged) chain toward its base:
+///
+/// - a `ECall` anywhere always needs the parens — nothing else isolates a call
+///   from the `new` (`new a().b()` → `(new a()).b()`);
+/// - an optional-chain link needs the parens only while it still reaches the top
+///   of the chain. Once a non-optional access sits above it, the printer's
+///   `HasNonOptionalChainParent` handling already wraps that optional chain
+///   (`(a?.b).c`), and everything below it is inside those parens, so no outer
+///   wrap is needed and the walk can stop.
 fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
     use js_ast::ExprData;
     let mut current = expr;
+    // Tracks whether a non-optional member/index access sits above `current`,
+    // which is exactly when `HasNonOptionalChainParent` isolates a nested
+    // optional chain for us.
+    let mut crossed_non_optional_access = false;
     loop {
         match &current.data {
             ExprData::ECall(_) => return true,
             ExprData::EDot(e) => {
                 if e.optional_chain.is_some() {
-                    return true;
+                    return !crossed_non_optional_access;
                 }
+                crossed_non_optional_access = true;
                 current = &e.target;
             }
             ExprData::EIndex(e) => {
                 if e.optional_chain.is_some() {
-                    return true;
+                    return !crossed_non_optional_access;
                 }
+                crossed_non_optional_access = true;
                 current = &e.target;
             }
             ExprData::ETemplate(e) => match &e.tag {
@@ -4225,15 +4239,10 @@ pub mod __gated_printer {
 
                     if let Some(tag) = &e.tag {
                         self.add_source_mapping(expr.loc);
-                        // Optional chains are forbidden in template tags
-                        // `Expr::is_optional_chain` is gated upstream; inline its body.
-                        let is_optional_chain = match &expr.data {
-                            ExprData::EDot(d) => d.optional_chain.is_some(),
-                            ExprData::EIndex(i) => i.optional_chain.is_some(),
-                            ExprData::ECall(c) => c.optional_chain.is_some(),
-                            _ => false,
-                        };
-                        if is_optional_chain {
+                        // An optional chain may not directly tag a template literal
+                        // (`a?.b`t`` is a SyntaxError), so wrap the tag in parens.
+                        // The check is on the tag, not on this `ETemplate` node.
+                        if tag.is_optional_chain() {
                             self.print(b"(");
                             self.print_expr(*tag, Level::Lowest, ExprFlag::none());
                             self.print(b")");

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1469,6 +1469,45 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
     }
 }
 
+/// When a member access, index, or tagged template is the direct callee of a
+/// `new` expression, the surrounding parentheses are only required when the
+/// chain contains a call or optional chain that `new` would otherwise capture.
+///
+/// `new a.b.c()` is identical to `new (a.b.c)()` — a plain member chain binds
+/// into the `new` target — so those parens may be dropped. But `new (a().b)()`
+/// must stay parenthesized: unwrapped, `new a().b()` reparses as
+/// `(new a()).b()`. Likewise an optional chain (`new (a?.b)()`) is a syntax
+/// error without the parens (`new` may not appear in an optional chain).
+///
+/// Walks the `EDot`/`EIndex`/`ETemplate` (tagged) chain and returns `true` when
+/// a descendant `ECall` or optional-chain node makes the parens load-bearing.
+fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
+    use js_ast::ExprData;
+    let mut current = expr;
+    loop {
+        match &current.data {
+            ExprData::ECall(_) => return true,
+            ExprData::EDot(e) => {
+                if e.optional_chain.is_some() {
+                    return true;
+                }
+                current = &e.target;
+            }
+            ExprData::EIndex(e) => {
+                if e.optional_chain.is_some() {
+                    return true;
+                }
+                current = &e.target;
+            }
+            ExprData::ETemplate(e) => match &e.tag {
+                Some(tag) => current = tag,
+                None => return false,
+            },
+            _ => return false,
+        }
+    }
+}
+
 pub enum PrintResult {
     Result(PrintResultSuccess),
     Err(bun_core::Error),
@@ -3670,7 +3709,17 @@ pub mod __gated_printer {
                 ExprData::EDot(e) => {
                     let is_optional_chain = e.optional_chain == Some(js_ast::OptionalChain::Start);
 
-                    let mut wrap = false;
+                    // As the callee of `new`, wrap the whole member chain in parens when it
+                    // contains a call or optional chain; `new (a().b)()` must not reparse as
+                    // `(new a()).b()`. The parens then protect the inner call, so drop
+                    // `ForbidCall` before descending to avoid wrapping it a second time.
+                    let mut wrap = (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
+                        && new_callee_needs_parens(&expr);
+                    if wrap {
+                        self.print(b"(");
+                        flags.remove(ExprFlag::ForbidCall);
+                    }
+
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
@@ -3682,7 +3731,7 @@ pub mod __gated_printer {
                             return;
                         }
                     } else {
-                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        if !wrap && flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
                         }
@@ -3720,7 +3769,16 @@ pub mod __gated_printer {
                     }
                 }
                 ExprData::EIndex(e) => {
-                    let mut wrap = false;
+                    // See `EDot`: wrap the whole chain in parens as a `new` callee when it
+                    // contains a call or optional chain, and drop `ForbidCall` so the inner
+                    // call isn't parenthesized on its own.
+                    let mut wrap = (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
+                        && new_callee_needs_parens(&expr);
+                    if wrap {
+                        self.print(b"(");
+                        flags.remove(ExprFlag::ForbidCall);
+                    }
+
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
@@ -3736,7 +3794,7 @@ pub mod __gated_printer {
                             }
                         }
                     } else {
-                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        if !wrap && flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
                         }
@@ -4154,6 +4212,17 @@ pub mod __gated_printer {
                         }
                     }
 
+                    // As the callee of `new`, a tagged template whose tag contains a call
+                    // must be wrapped as a whole: `new (a()`b`)()` must not reparse as
+                    // `(new a())`b``. A plain tag (`new (a`b`)()`) needs no parens since a
+                    // tagged template is itself a member expression.
+                    let new_wrap = e.tag.is_some()
+                        && (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
+                        && new_callee_needs_parens(&expr);
+                    if new_wrap {
+                        self.print(b"(");
+                    }
+
                     if let Some(tag) = &e.tag {
                         self.add_source_mapping(expr.loc);
                         // Optional chains are forbidden in template tags
@@ -4206,6 +4275,10 @@ pub mod __gated_printer {
                         }
                     }
                     self.print(b"`");
+
+                    if new_wrap {
+                        self.print(b")");
+                    }
                 }
                 ExprData::ERegExp(e) => {
                     self.add_source_mapping(expr.loc);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1498,6 +1498,11 @@ fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
     // which is exactly when `HasNonOptionalChainParent` isolates a nested
     // optional chain for us.
     let mut crossed_non_optional_access = false;
+    // `EDot`/`EIndex` forward `ForbidCall` to their target, so a call at the base
+    // of such a chain wraps itself (`new (require("m")).f`). A tagged template
+    // does not — it prints its tag with `ForbidCall` dropped — so a call reached
+    // only through template tags must be hoisted and wrapped here instead.
+    let mut crossed_template = false;
     loop {
         match &current.data {
             ExprData::ECall(e) => {
@@ -1510,11 +1515,12 @@ fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
                 return true;
             }
             // `import(...)`, `require(...)`, and `require.resolve(...)` also print
-            // as calls and are captured by `new` the same way `ECall` is; none of
-            // them can be an optional chain.
+            // as calls. Through an `EDot`/`EIndex` chain the forwarded `ForbidCall`
+            // already wraps them, so only hoist the wrap when they are reached
+            // through a template tag (none of them can be an optional chain).
             ExprData::EImport(_)
             | ExprData::ERequireString(_)
-            | ExprData::ERequireResolveString(_) => return true,
+            | ExprData::ERequireResolveString(_) => return crossed_template,
             ExprData::EDot(e) => {
                 if e.optional_chain.is_some() {
                     return !crossed_non_optional_access;
@@ -1536,6 +1542,7 @@ fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
                 // expression `new` accepts, so no outer wrap is needed below it.
                 Some(tag) => {
                     crossed_non_optional_access = true;
+                    crossed_template = true;
                     current = tag;
                 }
                 None => return false,

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1482,13 +1482,15 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
 ///
 /// Walks the `EDot`/`EIndex`/`ETemplate` (tagged) chain toward its base:
 ///
-/// - a `ECall` anywhere always needs the parens — nothing else isolates a call
-///   from the `new` (`new a().b()` → `(new a()).b()`);
-/// - an optional-chain link needs the parens only while it still reaches the top
-///   of the chain. Once a non-optional access (or a tagged template) sits above
-///   it, the inner chain is already parenthesized on its own — by the printer's
-///   `HasNonOptionalChainParent` handling (`(a?.b).c`) or the template-tag wrap
-///   (`(a?.b)`t``) — so it is inside those parens and no outer wrap is needed.
+/// - a non-optional call (`ECall`, `import(...)`, `require(...)`) always needs
+///   the parens — nothing isolates a plain call from the `new`
+///   (`new a().b()` → `(new a()).b()`);
+/// - an optional-chain link (including an optional call) needs the parens only
+///   while it still reaches the top of the chain. Once a non-optional access (or
+///   a tagged template) sits above it, the inner chain is already parenthesized
+///   on its own — by the printer's `HasNonOptionalChainParent` handling
+///   (`(a?.b).c`) or the template-tag wrap (`(a?.b)`t``) — so it is inside those
+///   parens and no outer wrap is needed.
 fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
     use js_ast::ExprData;
     let mut current = expr;
@@ -1498,7 +1500,21 @@ fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
     let mut crossed_non_optional_access = false;
     loop {
         match &current.data {
-            ExprData::ECall(_) => return true,
+            ExprData::ECall(e) => {
+                // An optional-chain call below a crossed boundary is isolated the
+                // same way an optional `EDot`/`EIndex` is; a non-optional call is
+                // never isolated, so it always needs the parens.
+                if e.optional_chain.is_some() {
+                    return !crossed_non_optional_access;
+                }
+                return true;
+            }
+            // `import(...)`, `require(...)`, and `require.resolve(...)` also print
+            // as calls and are captured by `new` the same way `ECall` is; none of
+            // them can be an optional chain.
+            ExprData::EImport(_)
+            | ExprData::ERequireString(_)
+            | ExprData::ERequireResolveString(_) => return true,
             ExprData::EDot(e) => {
                 if e.optional_chain.is_some() {
                     return !crossed_non_optional_access;

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1469,9 +1469,9 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
     }
 }
 
-/// When a member access, index, or tagged template is the direct callee of a
-/// `new` expression, the surrounding parentheses are only required when the
-/// chain contains a call or optional chain that `new` would otherwise capture.
+/// Decides, once per `ENew`, whether its callee must be printed inside
+/// parentheses: only when the callee chain contains a call or optional chain
+/// that `new` would otherwise capture.
 ///
 /// `new a.b.c()` is identical to `new (a.b.c)()` — a plain member chain binds
 /// into the `new` target — so those parens may be dropped. But `new (a().b)()`
@@ -1480,11 +1480,14 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
 /// (`new (a?.b)()`) is a syntax error without the parens (`new` may not appear
 /// in an optional chain).
 ///
-/// Walks the `EDot`/`EIndex`/`ETemplate` (tagged) chain toward its base:
+/// Returning `false` routes the callee through the `Level::New` + `ForbidCall`
+/// path unchanged, where a call at the base of a member chain still wraps just
+/// itself (`new (require("m")).f`). Walks the `EDot`/`EIndex`/`ETemplate`
+/// (tagged) chain toward its base:
 ///
-/// - a non-optional call (`ECall`, `import(...)`, `require(...)`) always needs
-///   the parens — nothing isolates a plain call from the `new`
-///   (`new a().b()` → `(new a()).b()`);
+/// - a non-optional `ECall`, or `import(...)`/`require(...)` reached through a
+///   template tag (which drops `ForbidCall`), always needs the parens — nothing
+///   else isolates a plain call from the `new` (`new a().b()` → `(new a()).b()`);
 /// - an optional-chain link (including an optional call) needs the parens only
 ///   while it still reaches the top of the chain. Once a non-optional access (or
 ///   a tagged template) sits above it, the inner chain is already parenthesized
@@ -3540,7 +3543,16 @@ pub mod __gated_printer {
                     self.add_source_mapping(expr.loc);
                     self.print(b"new");
                     self.print_space();
-                    self.print_expr(e.target, Level::New, ExprFlag::forbid_call());
+                    // Deciding the callee's parens once here keeps it a single
+                    // O(depth) walk per `new`; leaving it to the member arms would
+                    // re-walk the chain at every level while `ForbidCall` forwards.
+                    if new_callee_needs_parens(&e.target) {
+                        self.print(b"(");
+                        self.print_expr(e.target, Level::Lowest, ExprFlag::none());
+                        self.print(b")");
+                    } else {
+                        self.print_expr(e.target, Level::New, ExprFlag::forbid_call());
+                    }
                     let args = e.args.slice();
                     if !args.is_empty() || level.gte(Level::Postfix) {
                         self.print(b"(");
@@ -3753,17 +3765,7 @@ pub mod __gated_printer {
                 ExprData::EDot(e) => {
                     let is_optional_chain = e.optional_chain == Some(js_ast::OptionalChain::Start);
 
-                    // As the callee of `new`, wrap the whole member chain in parens when it
-                    // contains a call or optional chain; `new (a().b)()` must not reparse as
-                    // `(new a()).b()`. The parens then protect the inner call, so drop
-                    // `ForbidCall` before descending to avoid wrapping it a second time.
-                    let mut wrap = (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
-                        && new_callee_needs_parens(&expr);
-                    if wrap {
-                        self.print(b"(");
-                        flags.remove(ExprFlag::ForbidCall);
-                    }
-
+                    let mut wrap = false;
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
@@ -3775,9 +3777,13 @@ pub mod __gated_printer {
                             return;
                         }
                     } else {
-                        if !wrap && flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
+                            // These parens isolate the whole optional chain, so a
+                            // call inside it no longer needs its own parens as a
+                            // `new` callee.
+                            flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
@@ -3813,16 +3819,7 @@ pub mod __gated_printer {
                     }
                 }
                 ExprData::EIndex(e) => {
-                    // See `EDot`: wrap the whole chain in parens as a `new` callee when it
-                    // contains a call or optional chain, and drop `ForbidCall` so the inner
-                    // call isn't parenthesized on its own.
-                    let mut wrap = (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
-                        && new_callee_needs_parens(&expr);
-                    if wrap {
-                        self.print(b"(");
-                        flags.remove(ExprFlag::ForbidCall);
-                    }
-
+                    let mut wrap = false;
                     if e.optional_chain.is_none() {
                         flags.insert(ExprFlag::HasNonOptionalChainParent);
 
@@ -3838,9 +3835,13 @@ pub mod __gated_printer {
                             }
                         }
                     } else {
-                        if !wrap && flags.contains(ExprFlag::HasNonOptionalChainParent) {
+                        if flags.contains(ExprFlag::HasNonOptionalChainParent) {
                             wrap = true;
                             self.print(b"(");
+                            // These parens isolate the whole optional chain, so a
+                            // call inside it no longer needs its own parens as a
+                            // `new` callee.
+                            flags.remove(ExprFlag::ForbidCall);
                         }
                         flags.remove(ExprFlag::HasNonOptionalChainParent);
                     }
@@ -4256,17 +4257,6 @@ pub mod __gated_printer {
                         }
                     }
 
-                    // As the callee of `new`, a tagged template whose tag contains a call
-                    // must be wrapped as a whole: `new (a()`b`)()` must not reparse as
-                    // `(new a())`b``. A plain tag (`new (a`b`)()`) needs no parens since a
-                    // tagged template is itself a member expression.
-                    let new_wrap = e.tag.is_some()
-                        && (level.gte(Level::New) || flags.contains(ExprFlag::ForbidCall))
-                        && new_callee_needs_parens(&expr);
-                    if new_wrap {
-                        self.print(b"(");
-                    }
-
                     if let Some(tag) = &e.tag {
                         self.add_source_mapping(expr.loc);
                         // An optional chain may not directly tag a template literal
@@ -4314,10 +4304,6 @@ pub mod __gated_printer {
                         }
                     }
                     self.print(b"`");
-
-                    if new_wrap {
-                        self.print(b")");
-                    }
                 }
                 ExprData::ERegExp(e) => {
                     self.add_source_mapping(expr.loc);

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1485,10 +1485,10 @@ fn is_identifier_or_numeric_constant_or_property_access(expr: &js_ast::Expr) -> 
 /// - a `ECall` anywhere always needs the parens — nothing else isolates a call
 ///   from the `new` (`new a().b()` → `(new a()).b()`);
 /// - an optional-chain link needs the parens only while it still reaches the top
-///   of the chain. Once a non-optional access sits above it, the printer's
-///   `HasNonOptionalChainParent` handling already wraps that optional chain
-///   (`(a?.b).c`), and everything below it is inside those parens, so no outer
-///   wrap is needed and the walk can stop.
+///   of the chain. Once a non-optional access (or a tagged template) sits above
+///   it, the inner chain is already parenthesized on its own — by the printer's
+///   `HasNonOptionalChainParent` handling (`(a?.b).c`) or the template-tag wrap
+///   (`(a?.b)`t``) — so it is inside those parens and no outer wrap is needed.
 fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
     use js_ast::ExprData;
     let mut current = expr;
@@ -1514,7 +1514,14 @@ fn new_callee_needs_parens(expr: &js_ast::Expr) -> bool {
                 current = &e.target;
             }
             ExprData::ETemplate(e) => match &e.tag {
-                Some(tag) => current = tag,
+                // A tagged template isolates an optional-chain tag the same way a
+                // non-optional access does: the tag is independently parenthesized
+                // when printed (`(a?.b)`t``), making the whole template a member
+                // expression `new` accepts, so no outer wrap is needed below it.
+                Some(tag) => {
+                    crossed_non_optional_access = true;
+                    current = tag;
+                }
                 None => return false,
             },
             _ => return false,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1022,6 +1022,16 @@ function foo() {}
       exp("new ((a?.b)`tpl`)();", "new (a?.b)`tpl`");
       exp("new ((a?.b)`tpl`.c)();", "new (a?.b)`tpl`.c");
       exp("new (a()`tpl`)();", "new (a()`tpl`)");
+
+      // An optional-chain call isolated below a non-optional access or template is
+      // wrapped on its own too, so no outer parens (a plain call still needs them).
+      exp("new ((a?.()).b)();", "new (a?.()).b");
+      exp("new ((a?.b())`tpl`)();", "new (a?.b())`tpl`");
+
+      // `import(...)` and `require(...)` print as calls, so a template-tagged one
+      // must stay wrapped as a `new` callee (otherwise `new import(x)`tpl`` /
+      // `new require("m").f`tpl`` reparse against the wrong subexpression).
+      exp("new (import(x)`tpl`)();", "new (import(x)`tpl`)");
     });
 
     it("wraps an optional-chain tag of a template literal", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1007,6 +1007,22 @@ function foo() {}
       exp("new (a.b.c)();", "new a.b.c");
       exp("new (a`bar`)();", "new a`bar`");
       exp("new (a.b.c.d)();", "new a.b.c.d");
+
+      // An optional chain that is already isolated below a non-optional access is
+      // wrapped by the printer's existing optional-chain handling, so the `new`
+      // callee needs no second pair of parens around the whole chain.
+      exp("new ((a?.b).c)();", "new (a?.b).c");
+      exp("new ((a?.b).c.d)();", "new (a?.b).c.d");
+      exp("new ((a?.b)[c])();", "new (a?.b)[c]");
+      exp("new ((a()?.b).c)();", "new (a()?.b).c");
+    });
+
+    it("wraps an optional-chain tag of a template literal", () => {
+      // `a?.b`tpl`` is a SyntaxError (an optional chain may not directly tag a
+      // template literal), so the tag must be parenthesized when printed.
+      ts.expectPrinted_("(a?.b)`tpl`;", "(a?.b)`tpl`");
+      ts.expectPrinted_("(a?.b())`tpl`;", "(a?.b())`tpl`");
+      ts.expectPrinted_("(a?.[b])`tpl`;", "(a?.[b])`tpl`");
     });
 
     it("modifiers", () => {
@@ -4801,7 +4817,7 @@ describe("new expression callee parenthesization", () => {
   // reparsed as `(new foo())`bar`` and the optional-chain form became an illegal
   // `new` inside an optional chain (a syntax error). Run the transpiled program
   // end-to-end and confirm it still builds the class instance.
-  test.each([
+  test.concurrent.each([
     ["tagged template tag with a call", "const foo = () => (args) => class A {}; console.log(new (foo()`bar`)());"],
     ["optional chain", "const baz = () => ({ qux: class A {} }); console.log(new (baz()?.qux)());"],
     ["optional chain with a call", "const a = () => ({ b: class A {} }); console.log(new (a()?.b)());"],

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1015,6 +1015,13 @@ function foo() {}
       exp("new ((a?.b).c.d)();", "new (a?.b).c.d");
       exp("new ((a?.b)[c])();", "new (a?.b)[c]");
       exp("new ((a()?.b).c)();", "new (a()?.b).c");
+
+      // A tagged template likewise isolates an optional-chain tag (it gets its own
+      // parens), so the whole template is a member expression and no outer parens
+      // are needed — but a call in the tag still forces them.
+      exp("new ((a?.b)`tpl`)();", "new (a?.b)`tpl`");
+      exp("new ((a?.b)`tpl`.c)();", "new (a?.b)`tpl`.c");
+      exp("new (a()`tpl`)();", "new (a()`tpl`)");
     });
 
     it("wraps an optional-chain tag of a template literal", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
 import { join } from "path";
 
@@ -979,6 +979,34 @@ function foo() {}
         "const obj = { getClass() { return class MyClass {}; } }; const C = obj!.getClass(); const instance = new C();",
         "const obj = { getClass() {\n  return class MyClass {\n  };\n} };\nconst C = obj.getClass();\nconst instance = new C",
       );
+    });
+
+    // https://github.com/oven-sh/bun/issues/31812
+    it("keeps required parens around a new expression callee", () => {
+      const exp = ts.expectPrinted_;
+
+      // Member/index/tagged-template/optional-chain callees that contain a call or
+      // optional chain must stay parenthesized: without the parens, `new`'s
+      // arguments and the trailing member/template/call would reparse against the
+      // wrong subexpression (e.g. `new (a().b)()` -> `(new a()).b()`).
+      exp("new (a().b)();", "new (a().b)");
+      exp("new (a()[b])();", "new (a()[b])");
+      exp("new (a().b.c)();", "new (a().b.c)");
+      exp("new (a()`bar`)();", "new (a()`bar`)");
+      exp("new (a()?.b)();", "new (a()?.b)");
+      exp("new (a.b()?.c)();", "new (a.b()?.c)");
+      exp("new (a().b())();", "new (a().b())");
+
+      // Optional chains can never be a bare `new` callee (`new a?.b` is a syntax
+      // error), so the parens are required even without a call in the chain.
+      exp("new (a?.b)();", "new (a?.b)");
+      exp("new (a?.b.c)();", "new (a?.b.c)");
+
+      // A plain member chain or tag binds into the `new` target, so the parens are
+      // redundant and must not be re-emitted (no over-wrapping).
+      exp("new (a.b.c)();", "new a.b.c");
+      exp("new (a`bar`)();", "new a`bar`");
+      exp("new (a.b.c.d)();", "new a.b.c.d");
     });
 
     it("modifiers", () => {
@@ -4762,5 +4790,32 @@ describe("multi-line comment scanning", () => {
     expectParseError(`/*${pad600}*`, message);
     expectParseError(`/*${Buffer.alloc(600, "*").toString()}`, message);
     expectParseError(`/*${pad600}🦊`, message);
+  });
+});
+
+describe("new expression callee parenthesization", () => {
+  // https://github.com/oven-sh/bun/issues/31812
+  // The printer used to drop the parens required around a `new` callee that was
+  // a tagged template whose tag contains a call, or an optional chain. Both
+  // changed the meaning of the transpiled program: the tagged-template form
+  // reparsed as `(new foo())`bar`` and the optional-chain form became an illegal
+  // `new` inside an optional chain (a syntax error). Run the transpiled program
+  // end-to-end and confirm it still builds the class instance.
+  test.each([
+    ["tagged template tag with a call", "const foo = () => (args) => class A {}; console.log(new (foo()`bar`)());"],
+    ["optional chain", "const baz = () => ({ qux: class A {} }); console.log(new (baz()?.qux)());"],
+    ["optional chain with a call", "const a = () => ({ b: class A {} }); console.log(new (a()?.b)());"],
+    ["optional chain without a call", "const o = { b: class A {} }; console.log(new (o?.b)());"],
+  ])("evaluates %s correctly", async (_name, code) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("A {}\n");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes #31812

## Repro

```console
$ bun -p 'const foo = () => (args) => class A {}; new (foo()`bar`)();'
TypeError: function is not a constructor (evaluating 'new foo()')

$ bun -p 'const baz = () => ({ qux: class A {} }); new (baz()?.qux)();'
SyntaxError: Cannot call constructor in an optional chain.
```

Both should print `A {}` (matching `node -p`).

## Cause

The printer mis-transpiles the callee (target) of a `new` expression. `new`
prints its target at `Level::New` with `ExprFlag::ForbidCall`, and the target
is then responsible for wrapping itself in parens if needed. Only `ECall`
actually consulted `level.gte(Level::New) || ForbidCall` to wrap; `EDot`,
`EIndex`, and tagged `ETemplate` did not:

- `ETemplate` printed its tag at `Level::Postfix` with `ExprFlag::none()`,
  **dropping** `ForbidCall`, so `new (foo()`bar`)()` emitted `new foo()`bar``,
  which reparses as `(new foo())`bar``.
- `EDot`/`EIndex` only forwarded `ForbidCall` down to their target, so for an
  optional-chain callee the parens landed on the inner call
  (`new (baz())?.qux`) — and `new` inside an optional chain is a `SyntaxError`.

## Fix

`src/js_printer/lib.rs`: `ENew` now decides once, before printing its target,
whether the whole callee must be parenthesized. A new helper
`new_callee_needs_parens` walks the member/index/tagged-template chain toward
its base and returns `true` when it contains a call or a top-reaching optional
chain that `new` would otherwise capture. If so, `ENew` prints the parens and
the target at `Level::Lowest` without `ForbidCall`; otherwise the original
`Level::New` + `ForbidCall` path runs unchanged (so a call at the base of a
member chain still wraps just itself, e.g. `new (require("m")).f`).

Deciding at `ENew` keeps it a single O(depth) walk per `new` expression; an
earlier revision made the decision in the `EDot`/`EIndex`/`ETemplate` arms,
which re-walked the chain at every level while `ForbidCall` forwarded
(O(n^2) for `new a.b.c.d()`). A plain member chain (`new (a.b.c)()`) still
drops the redundant parens since `new a.b.c()` is identical, and an optional
chain already isolated below a non-optional access keeps the minimal form
(`new (a?.b).c`, not `new ((a?.b).c)`).

Also fixes a pre-existing dead check in the tagged-template printer: the
optional-chain test matched on the template node instead of the tag, so
`(a?.b)`tpl`` printed as the invalid `a?.b`tpl``; it now uses
`tag.is_optional_chain()`.

Transpiled output before → after:

| source | before | after |
| --- | --- | --- |
| `new (foo()`bar`)()` | `new foo()`bar`` ❌ | `new (foo()`bar`)` ✅ |
| `new (baz()?.qux)()` | `new (baz())?.qux` ❌ | `new (baz()?.qux)` ✅ |
| `new (a?.b)()` | `new a?.b` ❌ | `new (a?.b)` ✅ |
| `new (a.b.c)()` | `new a.b.c` ✅ | `new a.b.c` ✅ |

Same bug was reported against esbuild (evanw/esbuild#4477) and Babel
(babel/babel#18045).

## Verification

- Both issue cases now print `A {}` (also under `--minify`).
- A 24-case semantic round-trip (member / index / tagged-template /
  optional-chain / nested-`new` / isolated-optional-chain) matches `node`
  exactly, with no over-wrapping; a 30-case printer matrix is byte-identical
  before and after the decide-at-`ENew` refactor.
- Added tests in `test/bundler/transpiler/transpiler.test.js`: an
  `expectPrinted_` test asserting exact paren placement, and an end-to-end
  concurrent `test.each` that runs the transpiled program and checks it builds
  `A {}`. All fail before the fix and pass after.
- Existing transpiler + esbuild printer suites pass (`transpiler`,
  `esbuild/default`, `dce`, `extra`, `lower`, `ts`), and node's
  `test-buffer-indexof.js` (which pins the exact
  `new (require("buffer")).Buffer.prototype.lastIndexOf(...)` serialization)
  passes.
