### PR TITLE
fix(plugin): check for exception after stringifying Bun.plugin target

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,8 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,25 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("propagates exceptions thrown while stringifying 'target'", () => {
+    let setupCalled = false;
+    const opts = {
+      setup: () => {
+        setupCalled = true;
+      },
+      target: {
+        toString() {
+          throw new Error("failed to stringify target");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("failed to stringify target");
+    expect(setupCalled).toBe(false);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What

Fixes a fuzzer-found abort (fingerprint `b6a69a4427e5f393`): debug builds hit `ASSERTION FAILED: Unexpected exception observed ... ExceptionScope.h(61) assertNoException` when `Bun.plugin()` is passed a config whose `target` property throws during string conversion.

```js
Bun.plugin({
  setup: () => {},
  target: { toString() { throw new Error("boom"); } },
});
```

### Why

`setupBunPlugin` in `src/jsc/bindings/BunPlugin.cpp` called `targetValue.toStringOrNull(globalObject)`, which invokes a user-defined `toString`. When that throws, `toStringOrNull` returns `nullptr` — but the code treated `nullptr` as "target isn't a string, ignore it" and kept going with the exception still pending, re-entering the VM to build the builder object and call `setup()`. Debug builds abort on the exception-scope assertion at that point.

### Fix

Add `RETURN_IF_EXCEPTION` after the `toStringOrNull` conversion (and after the rope-string resolution in `value()`), so the user's exception propagates out of `Bun.plugin()` instead of leaking into the setup call.

### Test

Added a case to `test/js/bun/plugin/plugins.test.ts` next to the existing invalid-`target` test: a throwing `toString` on `target` must propagate its error and must not invoke `setup()`. On an unfixed debug build the test process aborts with the assertion; with the fix, all 30 tests in the file pass (also verified under `BUN_JSC_validateExceptionChecks=1`).