### PR TITLE
test: pin @angular/cli version in bunx node-version test

### DIFF
--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -503,8 +503,15 @@ it.concurrent("should handle postinstall scripts correctly with symlinked bunx",
 
 it.concurrent("should handle package that requires node 24", async () => {
   const { x_dir, env } = setup();
+  // Pinned on purpose. @angular/cli's bin checks process.version at runtime
+  // and exits 3 when it's too old, which is what this test guards against
+  // (bun used to report node 22.6.0 and failed this check). The `latest` tag
+  // is a moving target: 22.0.0 started requiring ^22.22.3 || ^24.15.0 ||
+  // >=26.0.0, which bun's reported node version (24.3.0) does not satisfy,
+  // so tracking `latest` broke CI on every PR. 21.1.3 requires ^20.19.0 ||
+  // ^22.12.0 || >=24.0.0 and stays satisfied after future version bumps.
   const subprocess = spawn({
-    cmd: [bunExe(), "x", "--bun", "@angular/cli@latest", "--help"],
+    cmd: [bunExe(), "x", "--bun", "@angular/cli@21.1.3", "--help"],
     cwd: x_dir,
     stdout: "pipe",
     stdin: "inherit",
@@ -514,6 +521,7 @@ it.concurrent("should handle package that requires node 24", async () => {
 
   let [err, out, exited] = await Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited]);
   expect(err).not.toContain("error:");
+  expect(err).not.toContain("requires a minimum Node.js version");
   expect(out.trim()).not.toContain(Bun.version);
   expect(exited).toBe(0);
 });


### PR DESCRIPTION
### What

`test/cli/install/bunx.test.ts` > "should handle package that requires node 24" has been failing on every PR across all platforms since 2026-06-03:

```
error: expect(received).toBe(expected)
Expected: 0
Received: 3
      at <anonymous> (test/cli/install/bunx.test.ts:518:18)
```

### Cause

The test runs `bun x --bun @angular/cli@latest --help`. `@angular/cli@22.0.0` was published on 2026-06-03 and its bin performs a runtime `process.version` check requiring `^22.22.3 || ^24.15.0 || >=26.0.0`. Bun reports node 24.3.0, which does not satisfy that range, so the CLI exits with code 3:

```
Node.js version v24.3.0 detected.
The Angular CLI requires a minimum Node.js version of v22.22.3 or v24.15.0 or v26.0.0.
```

Tracking the mutable `latest` tag means the test breaks whenever Angular raises its engine floor past Bun's reported node version, unrelated to any change under test.

### Fix

Pin `@angular/cli@21.1.3`, whose requirement (`^20.19.0 || ^22.12.0 || >=24.0.0`) is satisfied by the current reported version and by future bumps (including the 26.3.0 bump in #31818, which also restores `latest` compatibility for users). The test still exercises what it was added for in #20772: a package whose bin rejects node versions older than 24 must run under `bun x --bun`. Also assert the version-check error message is absent so a future failure points at the cause instead of just a nonzero exit code.

### Verification

- Before: `bun x --bun @angular/cli@latest --help` exits 3 with the message above.
- After: `bun test test/cli/install/bunx.test.ts -t "should handle package that requires node 24"` passes (1 pass, 4 expect calls). Full file: 31 pass / 1 skip, remaining 2 failures are sandbox TLS interception on codeload.github.com (`UNABLE_TO_VERIFY_LEAF_SIGNATURE`), unrelated and green in CI.


Fixes #31797

Fixes #32029
