### PR TITLE
Remove lifetime-erased and aliased-pointer patterns across install, router, ini, shell IO, and bake

### DIFF
--- a/src/bun.js.rs
+++ b/src/bun.js.rs
@@ -48,7 +48,6 @@ pub use crate::hw_exports::{on_reject_entry_point_result, on_resolve_entry_point
 fn dump_build_error(vm: &mut VirtualMachine) {
     Output::flush();
 
-    let writer = Output::error_writer_buffered();
     // `defer Output.flush()` — RAII guard flushes buffered stderr on every exit path.
     let _flush = Output::flush_guard();
 
@@ -56,7 +55,7 @@ fn dump_build_error(vm: &mut VirtualMachine) {
         // SAFETY: `vm.log` is set during `VirtualMachine::init` to the VM-owned log and
         // remains valid for the lifetime of `vm`; the `&mut VirtualMachine` borrow above
         // guarantees exclusive access to it here.
-        let _ = unsafe { p.as_mut() }.print(std::ptr::from_mut(writer));
+        let _ = Output::with_error_writer_buffered(|w| unsafe { p.as_mut() }.print(w));
     }
 }
 

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1060,16 +1060,10 @@ pub fn raw_error_writer() -> StreamType {
     SOURCE.with_borrow(|s| s.raw_error_stream)
 }
 
-// ─── Closure-scoped writer accessors (preferred) ────────────────────────────
-//
-// Replacements for the legacy `&'static mut` accessors below. The closure
-// receives a **raw** `*mut io::Writer` — the same discipline as
-// `with_dest_writer`/`print_to`: writes route through `IntoLogWrite` /
-// the vtable fn pointers (or a deliberately scoped `unsafe { &mut *w }`
-// reborrow when the callee provably does not re-enter this module), so a
-// re-entrant output call from inside `f` (scoped loggers, `flush()`,
-// `Display` impls) never aliases a live `&mut Writer` and never trips the
-// thread-local `RefCell` (the borrow is dropped before `f` runs).
+// Closure-scoped writer accessors: the closure receives a raw `*mut
+// io::Writer` (same discipline as `with_dest_writer`) so a re-entrant output
+// call from inside `f` never aliases a live `&mut Writer` and never trips
+// the thread-local `RefCell`.
 
 #[inline]
 fn with_source_writer<R>(
@@ -1077,30 +1071,30 @@ fn with_source_writer<R>(
     f: impl FnOnce(*mut io::Writer) -> R,
 ) -> R {
     debug_assert!(SOURCE_SET.get());
-    // Drop the RefCell borrow before invoking `f` (see `with_dest_writer`).
+    // Drop the RefCell borrow before invoking `f`.
     let w: *mut io::Writer = SOURCE.with_borrow_mut(|s| std::ptr::from_mut(project(s)));
     f(w)
 }
 
-/// Run `f` with the unbuffered stdout writer (raw pointer; see module note above).
+/// Run `f` with the unbuffered stdout writer.
 #[inline]
 pub fn with_writer<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
     with_source_writer(Source::stream, f)
 }
 
-/// Run `f` with the buffered stdout writer (raw pointer; see module note above).
+/// Run `f` with the buffered stdout writer.
 #[inline]
 pub fn with_writer_buffered<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
     with_source_writer(Source::buffered_stream, f)
 }
 
-/// Run `f` with the unbuffered stderr writer (raw pointer; see module note above).
+/// Run `f` with the unbuffered stderr writer.
 #[inline]
 pub fn with_error_writer<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
     with_source_writer(Source::error_stream, f)
 }
 
-/// Run `f` with the buffered stderr writer (raw pointer; see module note above).
+/// Run `f` with the buffered stderr writer.
 #[inline]
 pub fn with_error_writer_buffered<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
     with_source_writer(Source::buffered_error_stream, f)
@@ -1112,10 +1106,7 @@ pub fn with_error_writer_buffered<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R 
 // TODO: these accessors hand out a `&'static mut` to a thread-local
 // `Source` field, and callers only use it briefly. Returning `&'static mut`
 // is *unsound* if two are alive at once — a known-unsound shim until the
-// remaining callers migrate to the `with_*` closure accessors above (the
-// crates this campaign owns already have; the rest are a mechanical
-// follow-up, after which these five accessors and `source_writer_escape`
-// can be deleted).
+// remaining callers migrate to the `with_*` closure accessors above.
 //
 // `source_writer_escape` centralises the escape: one `unsafe` for all five
 // public `*_writer*()` accessors (nonnull-asref reduction: 5 sites → 1).

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1060,13 +1060,62 @@ pub fn raw_error_writer() -> StreamType {
     SOURCE.with_borrow(|s| s.raw_error_stream)
 }
 
+// ─── Closure-scoped writer accessors (preferred) ────────────────────────────
+//
+// Replacements for the legacy `&'static mut` accessors below. The closure
+// receives a **raw** `*mut io::Writer` — the same discipline as
+// `with_dest_writer`/`print_to`: writes route through `IntoLogWrite` /
+// the vtable fn pointers (or a deliberately scoped `unsafe { &mut *w }`
+// reborrow when the callee provably does not re-enter this module), so a
+// re-entrant output call from inside `f` (scoped loggers, `flush()`,
+// `Display` impls) never aliases a live `&mut Writer` and never trips the
+// thread-local `RefCell` (the borrow is dropped before `f` runs).
+
+#[inline]
+fn with_source_writer<R>(
+    project: fn(&mut Source) -> &mut io::Writer,
+    f: impl FnOnce(*mut io::Writer) -> R,
+) -> R {
+    debug_assert!(SOURCE_SET.get());
+    // Drop the RefCell borrow before invoking `f` (see `with_dest_writer`).
+    let w: *mut io::Writer = SOURCE.with_borrow_mut(|s| std::ptr::from_mut(project(s)));
+    f(w)
+}
+
+/// Run `f` with the unbuffered stdout writer (raw pointer; see module note above).
+#[inline]
+pub fn with_writer<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
+    with_source_writer(Source::stream, f)
+}
+
+/// Run `f` with the buffered stdout writer (raw pointer; see module note above).
+#[inline]
+pub fn with_writer_buffered<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
+    with_source_writer(Source::buffered_stream, f)
+}
+
+/// Run `f` with the unbuffered stderr writer (raw pointer; see module note above).
+#[inline]
+pub fn with_error_writer<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
+    with_source_writer(Source::error_stream, f)
+}
+
+/// Run `f` with the buffered stderr writer (raw pointer; see module note above).
+#[inline]
+pub fn with_error_writer_buffered<R>(f: impl FnOnce(*mut io::Writer) -> R) -> R {
+    with_source_writer(Source::buffered_error_stream, f)
+}
+
 // Possible perf follow-up: migrate callers of these unbuffered accessors to
 // the buffered writer.
 //
 // TODO: these accessors hand out a `&'static mut` to a thread-local
 // `Source` field, and callers only use it briefly. Returning `&'static mut`
-// is *unsound* if two are alive at once — a known-unsound shim until callers
-// migrate to `with_error_writer(|w| ..)`.
+// is *unsound* if two are alive at once — a known-unsound shim until the
+// remaining callers migrate to the `with_*` closure accessors above (the
+// crates this campaign owns already have; the rest are a mechanical
+// follow-up, after which these five accessors and `source_writer_escape`
+// can be deleted).
 //
 // `source_writer_escape` centralises the escape: one `unsafe` for all five
 // public `*_writer*()` accessors (nonnull-asref reduction: 5 sites → 1).

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -1,57 +1,120 @@
 use bun_core::strings;
 use bun_url::PercentEncoding;
 
-// TODO: lifetime — every `&'static [u8]` field below actually borrows from
-// either the `parse()` input slice or, when the input was percent-encoded, from
-// `_decoded_storage`. Add a
-// lifetime param to `URLPath` so the input-borrow case is checked.
+/// Byte range into [`URLPath::backing`]. `start == end == 0` is the empty
+/// sentinel produced by `Default` (valid against any backing, including
+/// `None`).
+#[derive(Clone, Copy, Default)]
+struct Span {
+    start: usize,
+    end: usize,
+}
+
+/// Parsed request path. Fully owned: `parse()` copies (or percent-decodes)
+/// the input into `backing`, and every component is stored as a byte range
+/// into that single allocation — no borrowed or lifetime-erased slices, so
+/// the struct can be stored anywhere without a use-after-free surface.
 #[derive(Default)]
 pub struct URLPath {
-    pub extname: &'static [u8],
-    pub path: &'static [u8],
-    pub pathname: &'static [u8],
-    pub first_segment: &'static [u8],
-    pub query_string: &'static [u8],
+    extname: Span,
+    path: Span,
+    pathname: Span,
+    first_segment: Span,
+    query_string: Span,
+    /// `true` when the normalized `path` is the literal `"."` (root), which
+    /// is not a subslice of `backing`.
+    path_is_dot: bool,
     pub needs_redirect: bool,
     /// Treat URLs as non-sourcemap URLS
     /// Then at the very end, we check.
     pub is_source_map: bool,
-    /// Owned backing storage for the slice fields when `parse()` had to
-    /// percent-decode. Heap-stable: the slice fields above point into this
-    /// allocation, which is never resized and lives exactly as long as `self`.
-    /// Owning the decode buffer
-    /// per-URLPath removes the use-after-free that a shared growable buffer
-    /// would introduce on the next `parse()` call.
-    ///
-    /// `URLPath` must not be `Clone`: copying the slice fields without this
-    /// owner would re-introduce the dangling hazard.
-    _decoded_storage: Option<Box<[u8]>>,
+    /// Owned backing bytes for every span above. `None` only for
+    /// `URLPath::default()` (all spans empty).
+    backing: Option<Box<[u8]>>,
 }
 
 impl URLPath {
-    /// Take ownership of the percent-decode buffer, if `parse()` had to
-    /// allocate one. The slice fields of `self` keep pointing into the
-    /// returned allocation — the caller must keep it alive for as long as any
-    /// of those slices (or sub-slices of them) are read; dropping it while
-    /// they are still in use leaves them dangling.
-    #[must_use = "dropping the returned storage dangles the slice fields of this URLPath"]
-    pub fn take_decoded_storage(&mut self) -> Option<Box<[u8]>> {
-        self._decoded_storage.take()
+    #[inline]
+    fn slice(&self, s: Span) -> &[u8] {
+        match &self.backing {
+            Some(b) => &b[s.start..s.end],
+            None => &[],
+        }
+    }
+
+    /// File extension of the (possibly sourcemap-stripped) path, without the
+    /// leading dot. Empty when there is none.
+    #[inline]
+    pub fn extname(&self) -> &[u8] {
+        self.slice(self.extname)
+    }
+
+    /// Normalized path: pathname without the leading `/` and without the
+    /// query string; `"."` for the root path.
+    #[inline]
+    pub fn path(&self) -> &[u8] {
+        if self.path_is_dot {
+            return b".";
+        }
+        self.slice(self.path)
+    }
+
+    /// The full (decoded) pathname, including the query string if present.
+    #[inline]
+    pub fn pathname(&self) -> &[u8] {
+        self.slice(self.pathname)
+    }
+
+    /// First path segment (between the leading `/` and the next `/`).
+    #[inline]
+    pub fn first_segment(&self) -> &[u8] {
+        self.slice(self.first_segment)
+    }
+
+    /// The query string, starting at `?`. Empty when there is none.
+    #[inline]
+    pub fn query_string(&self) -> &[u8] {
+        self.slice(self.query_string)
+    }
+
+    /// Take ownership of the backing allocation. The spans stored in `self`
+    /// were computed against exactly these bytes, so slices previously read
+    /// through the accessors remain valid against the returned `Box` (heap
+    /// address is stable across the move). After this call the accessors on
+    /// `self` all return empty slices.
+    #[must_use = "dropping the returned storage frees the bytes previously returned by this URLPath's accessors"]
+    pub fn take_backing(&mut self) -> Option<Box<[u8]>> {
+        self.backing.take()
     }
 }
 
-// Design note: a growable shared (e.g. threadlocal) decode buffer cannot work
-// here — the next `parse()` may reallocate it and dangle every prior URLPath —
-// so instead each URLPath that needs decoding owns its decode buffer in
-// `_decoded_storage`. This costs one small allocation only on the
-// percent-encoded path, which is the rare case.
+/// Offset range of `sub` within `parent`. `sub` must be a subslice of
+/// `parent` (always the case in `parse` below — every component is sliced
+/// out of the single `decoded_pathname` buffer).
+#[inline]
+fn span_of(parent: &[u8], sub: &[u8]) -> Span {
+    debug_assert!(sub.is_empty() || {
+        let p = parent.as_ptr() as usize;
+        let s = sub.as_ptr() as usize;
+        s >= p && s + sub.len() <= p + parent.len()
+    });
+    if sub.is_empty() {
+        return Span::default();
+    }
+    let start = sub.as_ptr() as usize - parent.as_ptr() as usize;
+    Span {
+        start,
+        end: start + sub.len(),
+    }
+}
 
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
-    let mut decoded_pathname: &[u8] = possibly_encoded_pathname_;
-    let mut decoded_storage: Option<Box<[u8]>> = None;
     let mut needs_redirect = false;
 
-    if strings::index_of_char(decoded_pathname, b'%').is_some() {
+    // Own the bytes up front: either a percent-decoded copy or a plain copy
+    // of the input. All spans below index into this one allocation.
+    let backing: Box<[u8]> = if strings::index_of_char(possibly_encoded_pathname_, b'%').is_some()
+    {
         // The in-place decode buffer is capped at 16384 bytes of input.
         let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];
 
@@ -63,16 +126,11 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         )?;
         debug_assert!(n as usize <= buf.len());
         buf.truncate(n as usize);
-        // Freeze into a heap-stable Box and park it in `decoded_storage` before
-        // borrowing: the slice fields in the returned URLPath borrow from this
-        // allocation, and the Box is later moved into that same URLPath, so the
-        // borrow is valid for the struct's whole lifetime (Box heap address is
-        // stable across moves). NLL releases the local borrow after the last
-        // use of `decoded_pathname` in the struct-literal field initialisers,
-        // before `_decoded_storage` is moved.
-        decoded_storage = Some(buf.into_boxed_slice());
-        decoded_pathname = decoded_storage.as_deref().unwrap();
-    }
+        buf.into_boxed_slice()
+    } else {
+        Box::from(possibly_encoded_pathname_)
+    };
+    let decoded_pathname: &[u8] = &backing;
 
     let mut question_mark_i: i32 = -1;
     let mut period_i: i32 = -1;
@@ -152,38 +210,31 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         }
     }
 
-    // TODO: lifetime — see struct-level note. `extend` launders the borrow
-    // to `'static` to match the field type; remove once URLPath gains a
-    // proper lifetime parameter for the input-borrow case.
-    #[inline(always)]
-    fn extend(s: &[u8]) -> &'static [u8] {
-        // SAFETY: local fn-item — every call below passes a slice that borrows
-        // either the parser's input or `decoded_storage`, both of which are
-        // moved into / outlive the returned `URLPath` (self-referential store).
-        unsafe { bun_collections::detach_lifetime(s) }
-    }
-
+    let path_is_dot = decoded_pathname.len() == 1;
     Ok(URLPath {
-        extname: extend(if !is_source_map {
-            extname
-        } else {
-            backup_extname
-        }),
+        extname: span_of(
+            decoded_pathname,
+            if !is_source_map { extname } else { backup_extname },
+        ),
         is_source_map,
-        pathname: extend(decoded_pathname),
-        first_segment: extend(first_segment),
-        path: extend(if decoded_pathname.len() == 1 {
-            b"."
+        pathname: span_of(decoded_pathname, decoded_pathname),
+        first_segment: span_of(decoded_pathname, first_segment),
+        path_is_dot,
+        path: if path_is_dot {
+            Span::default()
         } else {
-            path
-        }),
-        query_string: extend(if question_mark_i > -1 {
-            &decoded_pathname
-                [usize::try_from(question_mark_i).expect("int cast")..decoded_pathname.len()]
-        } else {
-            b""
-        }),
+            span_of(decoded_pathname, path)
+        },
+        query_string: span_of(
+            decoded_pathname,
+            if question_mark_i > -1 {
+                &decoded_pathname
+                    [usize::try_from(question_mark_i).expect("int cast")..decoded_pathname.len()]
+            } else {
+                b""
+            },
+        ),
         needs_redirect,
-        _decoded_storage: decoded_storage,
+        backing: Some(backing),
     })
 }

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -93,11 +93,13 @@ impl URLPath {
 /// out of the single `decoded_pathname` buffer).
 #[inline]
 fn span_of(parent: &[u8], sub: &[u8]) -> Span {
-    debug_assert!(sub.is_empty() || {
-        let p = parent.as_ptr() as usize;
-        let s = sub.as_ptr() as usize;
-        s >= p && s + sub.len() <= p + parent.len()
-    });
+    debug_assert!(
+        sub.is_empty() || {
+            let p = parent.as_ptr() as usize;
+            let s = sub.as_ptr() as usize;
+            s >= p && s + sub.len() <= p + parent.len()
+        }
+    );
     if sub.is_empty() {
         return Span::default();
     }
@@ -113,8 +115,7 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
 
     // Own the bytes up front: either a percent-decoded copy or a plain copy
     // of the input. All spans below index into this one allocation.
-    let backing: Box<[u8]> = if strings::index_of_char(possibly_encoded_pathname_, b'%').is_some()
-    {
+    let backing: Box<[u8]> = if strings::index_of_char(possibly_encoded_pathname_, b'%').is_some() {
         // The in-place decode buffer is capped at 16384 bytes of input.
         let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];
 
@@ -214,7 +215,11 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
     Ok(URLPath {
         extname: span_of(
             decoded_pathname,
-            if !is_source_map { extname } else { backup_extname },
+            if !is_source_map {
+                extname
+            } else {
+                backup_extname
+            },
         ),
         is_source_map,
         pathname: span_of(decoded_pathname, decoded_pathname),

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -1,19 +1,15 @@
 use bun_core::strings;
 use bun_url::PercentEncoding;
 
-/// Byte range into [`URLPath::backing`]. `start == end == 0` is the empty
-/// sentinel produced by `Default` (valid against any backing, including
-/// `None`).
+/// Byte range into [`URLPath::backing`]; `Default` is the empty sentinel.
 #[derive(Clone, Copy, Default)]
 struct Span {
     start: usize,
     end: usize,
 }
 
-/// Parsed request path. Fully owned: `parse()` copies (or percent-decodes)
-/// the input into `backing`, and every component is stored as a byte range
-/// into that single allocation — no borrowed or lifetime-erased slices, so
-/// the struct can be stored anywhere without a use-after-free surface.
+/// Parsed request path. Fully owned: every component is a byte range into
+/// `backing`, so the struct can be stored anywhere.
 #[derive(Default)]
 pub struct URLPath {
     extname: Span,
@@ -21,15 +17,14 @@ pub struct URLPath {
     pathname: Span,
     first_segment: Span,
     query_string: Span,
-    /// `true` when the normalized `path` is the literal `"."` (root), which
-    /// is not a subslice of `backing`.
+    /// The normalized `path` is the literal `"."` (root), which is not a
+    /// subslice of `backing`.
     path_is_dot: bool,
     pub needs_redirect: bool,
     /// Treat URLs as non-sourcemap URLS
     /// Then at the very end, we check.
     pub is_source_map: bool,
-    /// Owned backing bytes for every span above. `None` only for
-    /// `URLPath::default()` (all spans empty).
+    /// Owned backing bytes for every span above; `None` only for `default()`.
     backing: Option<Box<[u8]>>,
 }
 
@@ -42,15 +37,14 @@ impl URLPath {
         }
     }
 
-    /// File extension of the (possibly sourcemap-stripped) path, without the
-    /// leading dot. Empty when there is none.
+    /// File extension without the leading dot; empty when there is none.
     #[inline]
     pub fn extname(&self) -> &[u8] {
         self.slice(self.extname)
     }
 
-    /// Normalized path: pathname without the leading `/` and without the
-    /// query string; `"."` for the root path.
+    /// Normalized path: pathname without the leading `/` or query string;
+    /// `"."` for the root path.
     #[inline]
     pub fn path(&self) -> &[u8] {
         if self.path_is_dot {
@@ -71,28 +65,22 @@ impl URLPath {
         self.slice(self.first_segment)
     }
 
-    /// The query string, starting at `?`. Empty when there is none.
+    /// Query string, starting at `?`; empty when there is none.
     #[inline]
     pub fn query_string(&self) -> &[u8] {
         self.slice(self.query_string)
     }
 
-    /// Take ownership of the backing allocation. The spans stored in `self`
-    /// were computed against exactly these bytes, so slices previously read
-    /// through the accessors remain valid against the returned `Box` (heap
-    /// address is stable across the move). After this call the accessors on
-    /// `self` all return empty slices, except `path()`, which still returns
-    /// `b"."` when the path is the root (`path_is_dot` is unaffected — `b"."`
-    /// is a static literal, not backed by this allocation).
+    /// Take ownership of the backing allocation; slices previously read
+    /// through the accessors stay valid against the returned `Box`. Afterwards
+    /// the accessors return empty (except the root `"."` case of `path()`).
     #[must_use = "dropping the returned storage frees the bytes previously returned by this URLPath's accessors"]
     pub fn take_backing(&mut self) -> Option<Box<[u8]>> {
         self.backing.take()
     }
 }
 
-/// Offset range of `sub` within `parent`. `sub` must be a subslice of
-/// `parent` (always the case in `parse` below — every component is sliced
-/// out of the single `decoded_pathname` buffer).
+/// Offset range of `sub` within `parent`; `sub` must be a subslice of `parent`.
 #[inline]
 fn span_of(parent: &[u8], sub: &[u8]) -> Span {
     debug_assert!(
@@ -115,8 +103,7 @@ fn span_of(parent: &[u8], sub: &[u8]) -> Span {
 pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::DecodeError> {
     let mut needs_redirect = false;
 
-    // Own the bytes up front: either a percent-decoded copy or a plain copy
-    // of the input. All spans below index into this one allocation.
+    // Own the bytes up front; all spans below index into this one allocation.
     let backing: Box<[u8]> = if strings::index_of_char(possibly_encoded_pathname_, b'%').is_some() {
         // The in-place decode buffer is capped at 16384 bytes of input.
         let capped = &possibly_encoded_pathname_[..possibly_encoded_pathname_.len().min(16384)];

--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -81,7 +81,9 @@ impl URLPath {
     /// were computed against exactly these bytes, so slices previously read
     /// through the accessors remain valid against the returned `Box` (heap
     /// address is stable across the move). After this call the accessors on
-    /// `self` all return empty slices.
+    /// `self` all return empty slices, except `path()`, which still returns
+    /// `b"."` when the path is the root (`path_is_dot` is unaffected — `b"."`
+    /// is a static literal, not backed by this allocation).
     #[must_use = "dropping the returned storage frees the bytes previously returned by this URLPath's accessors"]
     pub fn take_backing(&mut self) -> Option<Box<[u8]>> {
         self.backing.take()

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -260,20 +260,16 @@ mod draft {
     // Parser
     // ──────────────────────────────────────────────────────────────────────────
 
-    /// `'a` is the parse-input lifetime (`src` and the caller-owned `arena`
-    /// the output `Expr` tree borrows); `'e` is the env-loader's own data
-    /// lifetime, split from `'a` so a `&mut DotEnvLoader<'static>` (the
-    /// VM-owned loader) can be reborrowed for a shorter parser lifetime
-    /// despite `&mut` invariance.
+    /// `'a` is the parse-input lifetime; `'e` is the env-loader's data
+    /// lifetime, split from `'a` so a `&mut DotEnvLoader<'static>` can be
+    /// reborrowed for a shorter parser lifetime despite `&mut` invariance.
     pub struct Parser<'a, 'e: 'a> {
         pub opts: Options,
         pub source: Source,
         pub src: &'a [u8],
         pub out: Expr,
         pub logger: Log,
-        /// Caller-owned bump arena; everything in `out` that isn't a borrow of
-        /// `src` is allocated here, so the arena must outlive every read of
-        /// `out`.
+        /// Caller-owned arena; must outlive every read of `out`.
         pub arena: &'a Arena,
         pub env: &'a mut DotEnvLoader<'e>,
     }
@@ -330,18 +326,10 @@ mod draft {
             }
         }
 
-        // deinit -> Drop: `logger` is owned and drops automatically; the
-        // arena is caller-owned.
-
         pub fn parse(&mut self) -> OOM<()> {
-            // `self.arena` is a `Copy` reference; reading it out detaches the
-            // `'a` arena borrow from the `&mut self` borrow below.
             let bump: &'a Arena = self.arena;
             let src = self.src;
             let mut iter = src.split(|&b| b == b'\n');
-            // `head` is a `Copy` store handle (the `E::Object` lives in the
-            // Expr Store, not on `self`); deref through it per use instead of
-            // holding a raw pointer across `prepare_str` calls.
             let mut head: StoreRef<E::Object> = match self.out.data {
                 ExprData::EObject(o) => o,
                 _ => unreachable!("Parser.out is E.Object"),
@@ -527,8 +515,6 @@ mod draft {
                     _ => value_raw,
                 };
 
-                // Deref the store handle; the pointee lives in the Expr
-                // Store, valid for the duration of parse().
                 let head_ref: &mut E::Object = &mut *head;
 
                 if is_array {
@@ -1335,10 +1321,8 @@ mod draft {
         source: &Source,
         configs: &mut Vec<ConfigItem>,
     ) -> OOM<()> {
-        // The arena is owned here (declared before `parser`, so it drops
-        // after it); every string read out of `parser.out` below either
-        // borrows `source.contents` or this arena, and everything kept past
-        // this function is duped.
+        // Arena declared before `parser` so it drops after it; everything
+        // kept past this function is duped.
         let arena = Arena::new();
         let bump = &arena;
         let mut parser = Parser::init(npmrc_path.as_bytes(), source.contents.as_ref(), env, bump);

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -234,7 +234,7 @@ mod draft {
     use bun_alloc::{AllocError, Arena, ArenaVec, ArenaVecExt as _};
     use bun_api::{self, BunInstall, NpmRegistry, npm_registry};
     use bun_ast::E::Rope;
-    use bun_ast::{E, Expr, ExprData};
+    use bun_ast::{E, Expr, ExprData, StoreRef};
     use bun_ast::{IntoStr, Loc, Log, Source};
     use bun_collections::{ArrayHashMap, VecExt};
     use bun_core::ZStr;
@@ -260,14 +260,22 @@ mod draft {
     // Parser
     // ──────────────────────────────────────────────────────────────────────────
 
-    pub struct Parser<'a> {
+    /// `'a` is the parse-input lifetime (`src` and the caller-owned `arena`
+    /// the output `Expr` tree borrows); `'e` is the env-loader's own data
+    /// lifetime, split from `'a` so a `&mut DotEnvLoader<'static>` (the
+    /// VM-owned loader) can be reborrowed for a shorter parser lifetime
+    /// despite `&mut` invariance.
+    pub struct Parser<'a, 'e: 'a> {
         pub opts: Options,
         pub source: Source,
         pub src: &'a [u8],
         pub out: Expr,
         pub logger: Log,
-        pub arena: Arena,
-        pub env: &'a mut DotEnvLoader<'a>,
+        /// Caller-owned bump arena; everything in `out` that isn't a borrow of
+        /// `src` is allocated here, so the arena must outlive every read of
+        /// `out`.
+        pub arena: &'a Arena,
+        pub env: &'a mut DotEnvLoader<'e>,
     }
 
     // The result type depends on the usage (`.section -> *Rope`, `.key ->
@@ -297,8 +305,13 @@ mod draft {
         bun_core::enum_unwrap!(PrepareResult, Key     => into fn into_key     -> &'bump [u8]);
     }
 
-    impl<'a> Parser<'a> {
-        pub fn init(path: &[u8], src: &'a [u8], env: &'a mut DotEnvLoader<'a>) -> Parser<'a> {
+    impl<'a, 'e: 'a> Parser<'a, 'e> {
+        pub fn init(
+            path: &[u8],
+            src: &'a [u8],
+            env: &'a mut DotEnvLoader<'e>,
+            arena: &'a Arena,
+        ) -> Parser<'a, 'e> {
             // TODO: bun_ast::Source<'bump> — `Source::init_path_string`
             // currently takes `Str = &'static [u8]`; once the lower tier threads a
             // lifetime through `Source`, pass `path`/`src` directly. They outlive
@@ -312,27 +325,27 @@ mod draft {
                 src,
                 out: Expr::init(E::Object::default(), Loc::EMPTY),
                 source: Source::init_path_string(path_s, src_s),
-                arena: Arena::new(),
+                arena,
                 env,
             }
         }
 
-        // deinit -> Drop: `logger` and `arena` are owned and drop automatically.
+        // deinit -> Drop: `logger` is owned and drops automatically; the
+        // arena is caller-owned.
 
-        pub fn parse(&mut self, bump: &'a Arena) -> OOM<()> {
-            // borrowck — `arena_allocator` is passed separately (rather than
-            // read off `self.arena`) to avoid overlapping &mut self borrows.
+        pub fn parse(&mut self) -> OOM<()> {
+            // `self.arena` is a `Copy` reference; reading it out detaches the
+            // `'a` arena borrow from the `&mut self` borrow below.
+            let bump: &'a Arena = self.arena;
             let src = self.src;
             let mut iter = src.split(|&b| b == b'\n');
-            // TODO: borrowck — `head` aliases into `self.out.data.e_object` while
-            // `self` is also borrowed mutably for prepare_str(). Kept as raw `*mut`
-            // (the underlying `E::Object` lives in the Expr Store, not on `self`).
-            let mut head: *mut E::Object = std::ptr::from_mut::<E::Object>(
-                self.out
-                    .data
-                    .e_object_mut()
-                    .expect("Parser.out is E.Object"),
-            );
+            // `head` is a `Copy` store handle (the `E::Object` lives in the
+            // Expr Store, not on `self`); deref through it per use instead of
+            // holding a raw pointer across `prepare_str` calls.
+            let mut head: StoreRef<E::Object> = match self.out.data {
+                ExprData::EObject(o) => o,
+                _ => unreachable!("Parser.out is E.Object"),
+            };
 
             let ropealloc = bump;
 
@@ -386,7 +399,7 @@ mod draft {
                             .data
                             .e_object_mut()
                             .expect("Parser.out is E.Object");
-                        let mut parent_object = match root.get_or_put_object(section, bump) {
+                        let parent_object = match root.get_or_put_object(section, bump) {
                             Ok(v) => v,
                             Err(E::SetError::OutOfMemory) => return Err(AllocError),
                             Err(E::SetError::Clobber) => {
@@ -425,12 +438,10 @@ mod draft {
                                 break 'treat_as_key;
                             }
                         };
-                        head = std::ptr::from_mut::<E::Object>(
-                            parent_object
-                                .data
-                                .e_object_mut()
-                                .expect("get_or_put_object returns E.Object"),
-                        );
+                        head = match parent_object.data {
+                            ExprData::EObject(o) => o,
+                            _ => unreachable!("get_or_put_object returns E.Object"),
+                        };
                         break 'treat_as_key;
                     }
                     if !treat_as_key {
@@ -516,9 +527,9 @@ mod draft {
                     _ => value_raw,
                 };
 
-                // SAFETY: head points into self.out's E::Object tree, valid for the
-                // duration of parse().
-                let head_ref = unsafe { &mut *head };
+                // Deref the store handle; the pointee lives in the Expr
+                // Store, valid for the duration of parse().
+                let head_ref: &mut E::Object = &mut *head;
 
                 if is_array {
                     if let Some(val) = head_ref.get(key) {
@@ -1312,9 +1323,7 @@ mod draft {
                 }
                 Output::flush();
             }
-            let _ = log.print(std::ptr::from_mut::<bun_core::io::Writer>(
-                Output::error_writer(),
-            ));
+            let _ = Output::with_error_writer(|w| log.print(w));
         }
     }
 
@@ -1326,25 +1335,14 @@ mod draft {
         source: &Source,
         configs: &mut Vec<ConfigItem>,
     ) -> OOM<()> {
-        // TODO: lifetime — `Parser<'a>` ties `src` and `env: &'a mut DotEnvLoader<'a>`
-        // to a single invariant `'a`; threading that through this fn signature poisons
-        // the `load_npmrc_config` loop (env borrowed-for-'a across iterations). The
-        // local `parser` is dropped before this fn returns, so erase both to a fresh
-        // `'p` (matches `Parser::init`'s own erasures for `path`/`src`).
-        // SAFETY: `parser` does not outlive `env`/`source.contents`.
-        let contents: &'static [u8] = source.contents.as_ref().into_str();
-        // SAFETY: `parser` is dropped before this function returns and so does not
-        // outlive `env` or its borrowed data; this cast only erases lifetimes.
-        let env = unsafe {
-            &mut *std::ptr::from_mut::<DotEnvLoader<'_>>(env).cast::<DotEnvLoader<'static>>()
-        };
-        let mut parser = Parser::init(npmrc_path.as_bytes(), contents, env);
-        // TODO: borrowck — `parser.arena` is borrowed while `parser` is `&mut`.
-        // TODO(refactor): restructure Parser so the bump is passed externally or split borrows.
-        let bump_ptr: *const Arena = &raw const parser.arena;
-        // SAFETY: arena outlives all bump-allocated slices used below.
-        let bump: &Arena = unsafe { &*bump_ptr };
-        parser.parse(bump)?;
+        // The arena is owned here (declared before `parser`, so it drops
+        // after it); every string read out of `parser.out` below either
+        // borrows `source.contents` or this arena, and everything kept past
+        // this function is duped.
+        let arena = Arena::new();
+        let bump = &arena;
+        let mut parser = Parser::init(npmrc_path.as_bytes(), source.contents.as_ref(), env, bump);
+        parser.parse()?;
         // Need to be very, very careful here with strings.
         // They are allocated in the Parser's arena, which of course gets
         // deinitialized at the end of the scope.
@@ -1522,7 +1520,7 @@ mod draft {
         let mut registry_map = install.scoped.take().unwrap_or_default();
 
         // SAFETY: `parser.out` is an `E::Object` produced by `Parser::parse`; the
-        // arena pointee lives until `parser` drops at end of fn.
+        // arena pointee lives until the local arena drops at end of fn.
         let out_obj: &E::Object = unsafe {
             &*parser
                 .out

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -84,9 +84,9 @@ pub struct NetworkTask {
     /// Extract `Task` pre-created on the main thread so the HTTP thread can
     /// schedule it on the worker pool as soon as the first body chunk arrives.
     // `'static` matches `PreallocatedTaskStore =
-    // HiveArrayFallback<Task<'static>, 64>` which this slot is borrowed from
+    // HiveArrayFallback<Task, 64>` which this slot is borrowed from
     // and returned to (`discard_unused_streaming_state`).
-    pub streaming_extract_task: *mut Task<'static>,
+    pub streaming_extract_task: *mut Task,
     /// Set by the HTTP thread the first time it commits this request to
     /// the streaming path. Once true, `notify` never pushes this task to
     /// `async_network_task_queue` — the extract Task published by

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -83,9 +83,8 @@ pub struct NetworkTask {
     pub tarball_stream: Option<Box<TarballStream>>,
     /// Extract `Task` pre-created on the main thread so the HTTP thread can
     /// schedule it on the worker pool as soon as the first body chunk arrives.
-    // `'static` matches `PreallocatedTaskStore =
-    // HiveArrayFallback<Task, 64>` which this slot is borrowed from
-    // and returned to (`discard_unused_streaming_state`).
+    // Borrowed from / returned to `PreallocatedTaskStore`
+    // (`discard_unused_streaming_state`).
     pub streaming_extract_task: *mut Task,
     /// Set by the HTTP thread the first time it commits this request to
     /// the streaming path. Once true, `notify` never pushes this task to

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -28,9 +28,12 @@ pub struct PackageInstall<'a> {
     /// short-lived `Dir` held by the caller — `PackageInstall` never closes it.
     pub cache_dir: Fd,
     pub cache_dir_subpath: &'a ZStr,
-    // TODO: `destination_dir_subpath` aliases into `destination_dir_subpath_buf`;
-    // borrowck will reject simultaneous &ZStr + &mut [u8]. Consider storing only the len.
-    pub destination_dir_subpath: &'a ZStr,
+    /// Length of the NUL-terminated destination subpath prefix stored in
+    /// `destination_dir_subpath_buf` (`destination_dir_subpath_buf[len] == 0`).
+    /// Use [`Self::destination_dir_subpath`] for the `&ZStr` view; install
+    /// steps temporarily append suffixes into the buf past this prefix and
+    /// restore the NUL afterwards.
+    pub destination_dir_subpath_len: usize,
     pub destination_dir_subpath_buf: &'a mut [u8],
 
     pub progress: Option<&'a mut Progress>,
@@ -760,6 +763,14 @@ impl UninstallTask {
 // ───────────────────────────── impl PackageInstall ─────────────────────────────
 
 impl<'a> PackageInstall<'a> {
+    /// NUL-terminated prefix view into `destination_dir_subpath_buf`.
+    fn destination_dir_subpath(&self) -> &ZStr {
+        ZStr::from_buf(
+            self.destination_dir_subpath_buf,
+            self.destination_dir_subpath_len,
+        )
+    }
+
     ///
     fn verify_patch_hash(&mut self, patch: Patch, root_node_modules_dir: &Dir) -> bool {
         // hash from the .patch file, to be checked against bun tag
@@ -768,7 +779,7 @@ impl<'a> PackageInstall<'a> {
         let bunhashtag = buntaghashbuf_make(&mut buf, patchfile_contents_hash);
 
         let patch_tag_path = path::resolve_path::join_z::<path::platform::Posix>(&[
-            self.destination_dir_subpath.as_bytes(),
+            self.destination_dir_subpath().as_bytes(),
             bunhashtag,
         ]);
 
@@ -795,7 +806,7 @@ impl<'a> PackageInstall<'a> {
     // 1. verify that .bun-tag exists (was it installed from bun?)
     // 2. check .bun-tag against the resolved version
     fn verify_git_resolution(&mut self, repo: &Repository, root_node_modules_dir: &Dir) -> bool {
-        let dest_len = self.destination_dir_subpath.len();
+        let dest_len = self.destination_dir_subpath_len;
         let suffix: &[u8] = &[SEP, b'.', b'b', b'u', b'n', b'-', b't', b'a', b'g'];
         // Reshaped for borrowck — write into buf via raw indices.
         self.destination_dir_subpath_buf[dest_len..dest_len + suffix.len()].copy_from_slice(suffix);
@@ -862,7 +873,7 @@ impl<'a> PackageInstall<'a> {
     // it might not exist
     fn verify_transitive_symlinked_folder(&self, root_node_modules_dir: &Dir) -> bool {
         self.node_modules
-            .directory_exists_at(root_node_modules_dir, self.destination_dir_subpath)
+            .directory_exists_at(root_node_modules_dir, self.destination_dir_subpath())
     }
 
     fn get_installed_package_json_source(
@@ -876,7 +887,7 @@ impl<'a> PackageInstall<'a> {
         mutable.reset();
         mutable.expand_to_capacity();
 
-        let dest_len = self.destination_dir_subpath.len();
+        let dest_len = self.destination_dir_subpath_len;
         // Write the literal directly into the path buffer; no intermediate Vec.
         let suffix: &[u8] = &[
             SEP, b'p', b'a', b'c', b'k', b'a', b'g', b'e', b'.', b'j', b's', b'o', b'n',
@@ -1104,7 +1115,7 @@ impl<'a> PackageInstall<'a> {
         }
 
         let subdir = match destination_dir.make_open_path(
-            self.destination_dir_subpath.as_bytes(),
+            self.destination_dir_subpath().as_bytes(),
             OpenDirOptions::default(),
         ) {
             Ok(d) => d,
@@ -1124,8 +1135,8 @@ impl<'a> PackageInstall<'a> {
         &mut self,
         destination_dir: &Dir,
     ) -> Result<InstallResult, bun_core::Error> {
-        if self.destination_dir_subpath.as_bytes()[0] == b'@' {
-            if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath, SEP) {
+        if self.destination_dir_subpath().as_bytes()[0] == b'@' {
+            if let Some(slash) = strings::index_of_char_z(self.destination_dir_subpath(), SEP) {
                 let slash = slash as usize;
                 self.destination_dir_subpath_buf[slash] = 0;
                 // SAFETY: NUL written above.
@@ -1139,7 +1150,7 @@ impl<'a> PackageInstall<'a> {
             self.cache_dir,
             self.cache_dir_subpath,
             destination_dir.fd(),
-            self.destination_dir_subpath,
+            self.destination_dir_subpath(),
         ) {
             Ok(()) => Ok(InstallResult::Success),
             Err(e) => match e.get_errno() {
@@ -1164,7 +1175,7 @@ impl<'a> PackageInstall<'a> {
         method: Method,
     ) -> InstallResult {
         let destbase = destination_dir;
-        let destpath = self.destination_dir_subpath;
+        let destpath = self.destination_dir_subpath();
 
         state.cached_package_dir = match {
             #[cfg(windows)]
@@ -1983,7 +1994,7 @@ impl<'a> PackageInstall<'a> {
     }
 
     pub fn uninstall(&self, destination_dir: &Dir) {
-        let _ = destination_dir.delete_tree(self.destination_dir_subpath.as_bytes());
+        let _ = destination_dir.delete_tree(self.destination_dir_subpath().as_bytes());
     }
 
     pub fn uninstall_before_install(&self, destination_dir: &Dir) {
@@ -2002,7 +2013,7 @@ impl<'a> PackageInstall<'a> {
 
         match sys::renameat(
             destination_dir.fd(),
-            self.destination_dir_subpath,
+            self.destination_dir_subpath(),
             destination_dir.fd(),
             temp_path,
         ) {
@@ -2129,7 +2140,7 @@ impl<'a> PackageInstall<'a> {
     }
 
     pub fn install_from_link(&mut self, skip_delete: bool, destination_dir: &Dir) -> InstallResult {
-        let dest_path = self.destination_dir_subpath;
+        let dest_path = self.destination_dir_subpath();
         // If this fails, we don't care.
         // we'll catch it the next error
         if !skip_delete && dest_path.as_bytes() != b"." {
@@ -2262,7 +2273,7 @@ impl<'a> PackageInstall<'a> {
                 Err(err_) => 'brk: {
                     let mut err = err_;
                     if err.get_errno() == sys::E::EEXIST {
-                        let _ = sys::rmdirat(destination_dir.fd(), self.destination_dir_subpath);
+                        let _ = sys::rmdirat(destination_dir.fd(), self.destination_dir_subpath());
                         match sys::symlink_or_junction(dest_z, target_z, None) {
                             Err(e) => err = e,
                             Ok(_) => break 'brk,
@@ -2444,7 +2455,7 @@ impl<'a> PackageInstall<'a> {
 
         // If this fails, we don't care.
         // we'll catch it the next error
-        if !skip_delete && self.destination_dir_subpath.as_bytes() != b"." {
+        if !skip_delete && self.destination_dir_subpath().as_bytes() != b"." {
             self.uninstall_before_install(destination_dir);
         }
 

--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -28,11 +28,9 @@ pub struct PackageInstall<'a> {
     /// short-lived `Dir` held by the caller — `PackageInstall` never closes it.
     pub cache_dir: Fd,
     pub cache_dir_subpath: &'a ZStr,
-    /// Length of the NUL-terminated destination subpath prefix stored in
-    /// `destination_dir_subpath_buf` (`destination_dir_subpath_buf[len] == 0`).
-    /// Use [`Self::destination_dir_subpath`] for the `&ZStr` view; install
-    /// steps temporarily append suffixes into the buf past this prefix and
-    /// restore the NUL afterwards.
+    /// Length of the NUL-terminated subpath prefix in
+    /// `destination_dir_subpath_buf`; install steps temporarily append past
+    /// it and restore the NUL. See [`Self::destination_dir_subpath`].
     pub destination_dir_subpath_len: usize,
     pub destination_dir_subpath_buf: &'a mut [u8],
 

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1202,12 +1202,9 @@ impl<'a> PackageInstaller<'a> {
             return;
         }
 
-        // Write the alias prefix + NUL into the subpath buffer up front.
-        // `PackageInstall` stores only the prefix length plus the single
-        // `&mut [u8]` buffer borrow; the `&ZStr` view is re-derived on demand
-        // (`PackageInstall::destination_dir_subpath`), so no aliased pair of
-        // references exists. The buffer borrow is created via a raw pointer
-        // because `progress_mut()` below reborrows all of `self`.
+        // Write the alias prefix + NUL into the subpath buffer up front;
+        // taken via raw pointer because `progress_mut()` below reborrows all
+        // of `self`.
         let subpath_buf_ptr: *mut PathBuffer = &raw mut self.destination_dir_subpath_buf;
         let destination_dir_subpath_len: usize = {
             let alias_slice = alias.slice(string_buf!());

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1202,22 +1202,21 @@ impl<'a> PackageInstaller<'a> {
             return;
         }
 
-        // `PackageInstall` stores both `destination_dir_subpath: &mut ZStr`
-        // and `destination_dir_subpath_buf: &mut [u8]` aliasing the same bytes.
-        // Derive BOTH from a single `*mut PathBuffer`
-        // so neither `&mut` invalidates the other under stacked-borrows.
+        // Write the alias prefix + NUL into the subpath buffer up front.
+        // `PackageInstall` stores only the prefix length plus the single
+        // `&mut [u8]` buffer borrow; the `&ZStr` view is re-derived on demand
+        // (`PackageInstall::destination_dir_subpath`), so no aliased pair of
+        // references exists. The buffer borrow is created via a raw pointer
+        // because `progress_mut()` below reborrows all of `self`.
         let subpath_buf_ptr: *mut PathBuffer = &raw mut self.destination_dir_subpath_buf;
-        let destination_dir_subpath: &mut ZStr = {
+        let destination_dir_subpath_len: usize = {
             let alias_slice = alias.slice(string_buf!());
             // SAFETY: `subpath_buf_ptr` is the unique borrow of the field; valid for
             // the lifetime of this fn body.
             let buf = unsafe { &mut *subpath_buf_ptr };
             buf[..alias_slice.len()].copy_from_slice(alias_slice);
             buf[alias_slice.len()] = 0;
-            // SAFETY: buf[alias_slice.len()] == 0 written above; pointer derives from
-            // `subpath_buf_ptr` so it shares provenance with `destination_dir_subpath_buf`
-            // below.
-            unsafe { ZStr::from_raw_mut((*subpath_buf_ptr).as_mut_ptr(), alias_slice.len()) }
+            alias_slice.len()
         };
 
         let pkg_name_hash = self.pkg_name_hashes[package_id as usize];
@@ -1307,10 +1306,9 @@ impl<'a> PackageInstaller<'a> {
                 None
             },
             cache_dir: Fd::INVALID, // assigned below
-            destination_dir_subpath,
+            destination_dir_subpath_len,
             // SAFETY: `subpath_buf_ptr` = `&raw mut self.destination_dir_subpath_buf`; the
-            // field outlives `installer`. `destination_dir_subpath` above derives from the
-            // same raw pointer, so this `&mut` does not invalidate it under stacked-borrows.
+            // field outlives `installer` and this is the only live reference into it.
             destination_dir_subpath_buf: unsafe { (*subpath_buf_ptr).as_mut_slice() },
             package_name: pkg_name,
             patch: patch_patch.map(|_| package_install::Patch {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -307,9 +307,9 @@ pub(crate) type TaskCallbackList = Vec<TaskCallbackContext>;
 pub(crate) type TaskDependencyQueue =
     HashMap<Task::Id, TaskCallbackList /* , IdentityContext<Task::Id>, 80 */>;
 
-type PreallocatedTaskStore = HiveArrayFallback<Task::Task<'static>, 64>;
+type PreallocatedTaskStore = HiveArrayFallback<Task::Task, 64>;
 type PreallocatedNetworkTasks = HiveArrayFallback<NetworkTask, 128>;
-type ResolveTaskQueue = UnboundedQueue<Task::Task<'static> /* , .next */>;
+type ResolveTaskQueue = UnboundedQueue<Task::Task /* , .next */>;
 
 type RepositoryMap = HashMap<Task::Id, Fd /* , IdentityContext<Task::Id>, 80 */>;
 pub(crate) type FolderResolutionMap =
@@ -866,9 +866,7 @@ impl PackageManager {
             // so we only need a shared borrow here — the sole invariant is
             // that no `&mut bun_ast::Log` to the pointee is live, which holds on this path.
             // `IntoLogWrite` is impl'd for `*mut io::Writer`, not `&mut`.
-            let _ = self
-                .log_mut()
-                .print(std::ptr::from_mut(Output::error_writer()));
+            let _ = Output::with_error_writer(|w| self.log_mut().print(w));
         }
         Global::crash();
     }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -353,8 +353,7 @@ pub unsafe fn enqueue_parse_npm_package(
     network_task: *mut NetworkTask,
 ) -> *mut ThreadPool::Task {
     // SAFETY: `this` is a live `&mut PackageManager`; `network_task` is a
-    // freshly-vended pool slot whose `'static` reborrow matches the
-    // `Task<'static>` slot lifetime.
+    // freshly-vended pool slot that outlives the resolve task.
     let task_value = unsafe {
         Task::Task {
             package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
@@ -365,7 +364,7 @@ pub unsafe fn enqueue_parse_npm_package(
             request: crate::package_manager_task::Request {
                 package_manifest: ManuallyDrop::new(
                     crate::package_manager_task::PackageManifestRequest {
-                        network: &mut *network_task,
+                        network: network_task,
                         name,
                     },
                 ),
@@ -1622,10 +1621,9 @@ fn init_extract_task(
     this: &mut PackageManager,
     tarball: &ExtractTarball,
     network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
+) -> *mut Task::Task {
     // SAFETY: `this` is a live `&mut PackageManager`; `network_task` is a
-    // freshly-vended pool slot whose `'static` reborrow matches the
-    // `Task<'static>` slot lifetime.
+    // freshly-vended pool slot that outlives the resolve task.
     let task_value = unsafe {
         Task::Task {
             package_manager: Some(bun_ptr::ParentRef::from_raw_mut(std::ptr::from_mut::<
@@ -1635,7 +1633,7 @@ fn init_extract_task(
             tag: crate::package_manager_task::Tag::Extract,
             request: crate::package_manager_task::Request {
                 extract: ManuallyDrop::new(crate::package_manager_task::ExtractRequest {
-                    network: &mut *network_task,
+                    network: network_task,
                     tarball: ExtractTarball {
                         skip_verify: !this
                             .options
@@ -1672,7 +1670,7 @@ pub fn create_extract_task_for_streaming(
     this: &mut PackageManager,
     tarball: &ExtractTarball,
     network_task: *mut NetworkTask,
-) -> *mut Task::Task<'static> {
+) -> *mut Task::Task {
     init_extract_task(this, tarball, network_task)
 }
 
@@ -2957,7 +2955,7 @@ impl PackageManager {
         &mut self,
         tarball: &ExtractTarball,
         network_task: *mut NetworkTask,
-    ) -> *mut Task::Task<'static> {
+    ) -> *mut Task::Task {
         create_extract_task_for_streaming(self, tarball, network_task)
     }
 

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1034,8 +1034,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
             }
             Task::Tag::Extract | Task::Tag::LocalTarball => {
                 // capture the `*mut NetworkTask` up front (only for the
-                // Extract arm) so the defer body need not move the `&mut` out
-                // through `ManuallyDrop`'s immutable `Deref`.
+                // Extract arm) for the defer body.
                 let net_ptr: *mut NetworkTask = if task.tag == Task::Tag::Extract {
                     task.request_extract().network
                 } else {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -971,10 +971,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let err = task.err.unwrap_or_else(|| bun_core::err!("Failed"));
 
                     if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
-                        // SAFETY: `req.network` is the pool-owned NetworkTask
-                        // for this task; the pool slot is returned only by the
-                        // `defer!` above, which runs at scope exit — after
-                        // this read.
+                        // SAFETY: the pool slot is returned only by the `defer!`
+                        // above, which runs after this read.
                         let url_buf = unsafe { &(*req.network).url_buf };
                         C::on_package_manifest_error(extract_ctx, name, err, url_buf);
                     } else {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -940,7 +940,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
             // `IntoLogWrite` is implemented for `*mut bun_core::io::Writer`,
             // not `&mut Writer` (the underlying `Writer` is the FFI shape).
             // Propagate the write error (WriteFailed) out of `run_tasks`.
-            task.log.print(std::ptr::from_mut(Output::error_writer()))?;
+            Output::with_error_writer(|w| task.log.print(w))?;
             if task.log.errors > 0 {
                 manager.any_failed_to_install = true;
             }
@@ -949,13 +949,8 @@ pub fn run_tasks<C: RunTasksCallbacks>(
 
         match task.tag {
             Task::Tag::PackageManifest => {
-                // capture the `*mut NetworkTask` up front — the
-                // `&'a mut NetworkTask` field can't be moved out through
-                // `ManuallyDrop`'s immutable `Deref` inside the defer body.
-                let net_ptr: *mut NetworkTask = {
-                    let req = task.request_package_manifest_mut();
-                    &raw mut *req.network
-                };
+                // capture the `*mut NetworkTask` up front for the defer body.
+                let net_ptr: *mut NetworkTask = task.request_package_manifest().network;
                 scopeguard::defer! {
                     // SAFETY: see the put-task `defer!` above — `manager_ptr` is the
                     // function-scope provenance root; `net_ptr` is the network task
@@ -976,7 +971,12 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                     let err = task.err.unwrap_or_else(|| bun_core::err!("Failed"));
 
                     if C::HAS_ON_PACKAGE_MANIFEST_ERROR {
-                        C::on_package_manifest_error(extract_ctx, name, err, &req.network.url_buf);
+                        // SAFETY: `req.network` is the pool-owned NetworkTask
+                        // for this task; the pool slot is returned only by the
+                        // `defer!` above, which runs at scope exit — after
+                        // this read.
+                        let url_buf = unsafe { &(*req.network).url_buf };
+                        C::on_package_manifest_error(extract_ctx, name, err, url_buf);
                     } else {
                         bun_ast::add_error_pretty!(
                             manager.log_mut(),
@@ -1037,8 +1037,7 @@ pub fn run_tasks<C: RunTasksCallbacks>(
                 // Extract arm) so the defer body need not move the `&mut` out
                 // through `ManuallyDrop`'s immutable `Deref`.
                 let net_ptr: *mut NetworkTask = if task.tag == Task::Tag::Extract {
-                    let req = task.request_extract_mut();
-                    &raw mut *req.network
+                    task.request_extract().network
                 } else {
                     core::ptr::null_mut()
                 };

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -19,11 +19,9 @@ use crate::{
 
 use bun_dotenv as dot_env;
 
-/// Task lives in an intrusive cross-thread queue (`next`, `package_manager`
-/// BACKREF), so the request payloads hold `*mut NetworkTask` raw pointers —
-/// the manager thread retains its own pointers into the same `NetworkTask`
-/// while the task is in flight, so an exclusive `&mut` borrow cannot soundly
-/// cross that boundary. See `Request` for the deref discipline.
+/// Lives in an intrusive cross-thread queue; request payloads hold
+/// `*mut NetworkTask` because the manager thread keeps its own pointers into
+/// the same slot while the task is in flight.
 pub struct Task {
     pub tag: Tag,
     pub request: Request,
@@ -264,12 +262,8 @@ impl Task {
                     // SAFETY: tag == PackageManifest discriminates the union
                     let manifest = unsafe { &mut *this.request.package_manifest };
 
-                    // SAFETY: `network` points to the pool-owned NetworkTask
-                    // vended for this resolve task. Access is temporally
-                    // partitioned: the manager thread wrote it before enqueue
-                    // and does not touch it again until this task is pushed to
-                    // `resolve_tasks`, so this worker-thread reborrow is
-                    // exclusive while it is live (scoped to this arm).
+                    // SAFETY: pool-owned slot; the manager thread does not touch
+                    // it while the task is in flight, so this reborrow is exclusive.
                     let network = unsafe { &mut *manifest.network };
                     // Take ownership so the
                     // multi-MB manifest buffer drops on every exit of this arm
@@ -388,10 +382,7 @@ impl Task {
 
                     // SAFETY: tag == Extract discriminates the union
                     let extract = unsafe { &mut *this.request.extract };
-                    // SAFETY: same temporal-partition argument as the
-                    // PackageManifest arm above — the pool slot is exclusively
-                    // this worker's while the task is in flight; the reborrow
-                    // is scoped to this statement.
+                    // SAFETY: same argument as the PackageManifest arm above.
                     let network = unsafe { &mut *extract.network };
                     // Take ownership so the
                     // tarball body drops on every exit of this arm.
@@ -654,9 +645,8 @@ pub union Request {
 
 pub struct PackageManifestRequest {
     pub name: StringOrTinyString,
-    // SHARED — pool-owned `NetworkTask` slot (`preallocated_network_tasks`);
-    // outlives the task and is never freed while the task is in flight.
-    // Deref with a statement-scoped `unsafe { &mut * }` reborrow only.
+    // SHARED — pool-owned `NetworkTask` slot that outlives the task; deref
+    // with a statement-scoped reborrow only.
     pub network: *mut NetworkTask,
 }
 

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -19,13 +19,14 @@ use crate::{
 
 use bun_dotenv as dot_env;
 
-/// `'a` is forced by LIFETIMES.tsv (BORROW_PARAM on `Request::*.network`).
-/// TODO: lifetime — Task lives in an intrusive cross-thread queue
-/// (`next`, `package_manager` BACKREF). A `&'a mut NetworkTask` cannot soundly
-/// cross that boundary; Phase B should likely demote to `*mut NetworkTask`.
-pub struct Task<'a> {
+/// Task lives in an intrusive cross-thread queue (`next`, `package_manager`
+/// BACKREF), so the request payloads hold `*mut NetworkTask` raw pointers —
+/// the manager thread retains its own pointers into the same `NetworkTask`
+/// while the task is in flight, so an exclusive `&mut` borrow cannot soundly
+/// cross that boundary. See `Request` for the deref discipline.
+pub struct Task {
     pub tag: Tag,
-    pub request: Request<'a>,
+    pub request: Request,
     pub data: Data,
     /// default: `Status::Waiting`
     pub status: Status,
@@ -42,14 +43,14 @@ pub struct Task<'a> {
     pub apply_patch_task: Option<Box<PatchTask>>,
     /// INTRUSIVE — `bun.UnboundedQueue(Task, .next)`
     /// default: null
-    pub next: bun_threading::Link<Task<'a>>,
+    pub next: bun_threading::Link<Task>,
 }
 
 /// Callers MUST overwrite `tag`, `request`, `id`, `package_manager` before
 /// the task is observed. Exposed as a module-level fn so call sites that import this
 /// module as `Task` can write `..Task::uninit()` in struct-update position.
 #[inline]
-pub(crate) fn uninit() -> Task<'static> {
+pub(crate) fn uninit() -> Task {
     Task {
         // Overwritten by every caller; placeholder value.
         tag: Tag::PackageManifest,
@@ -79,7 +80,7 @@ pub(crate) fn uninit() -> Task<'static> {
 
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<Task>`;
 // `link()` always projects to it.
-unsafe impl<'a> bun_threading::Linked for Task<'a> {
+unsafe impl bun_threading::Linked for Task {
     #[inline]
     unsafe fn link(item: *mut Self) -> *const bun_threading::Link<Self> {
         // SAFETY: `item` is valid and properly aligned per `UnboundedQueue` contract.
@@ -161,7 +162,7 @@ impl Id {
     }
 }
 
-impl<'a> Task<'a> {
+impl Task {
     // ── Tag-checked projectors for the untagged `Request`/`Data` unions ────
     // `Task.tag` is the single discriminant for both; every variant payload is
     // POD or `ManuallyDrop`-wrapped (no drop on overwrite), so reading the
@@ -169,8 +170,8 @@ impl<'a> Task<'a> {
     // `as *const $Ty` cast unwraps `ManuallyDrop<$Ty>` (`repr(transparent)`).
     bun_core::extern_union_accessors! {
         tag: tag as Tag, value: request;
-        PackageManifest => request_package_manifest @ package_manifest: PackageManifestRequest<'a>, mut request_package_manifest_mut;
-        Extract         => request_extract          @ extract:          ExtractRequest<'a>,         mut request_extract_mut;
+        PackageManifest => request_package_manifest @ package_manifest: PackageManifestRequest, mut request_package_manifest_mut;
+        Extract         => request_extract          @ extract:          ExtractRequest,         mut request_extract_mut;
         GitClone        => request_git_clone        @ git_clone:        GitCloneRequest,            mut request_git_clone_mut;
         GitCheckout     => request_git_checkout     @ git_checkout:     GitCheckoutRequest,         mut request_git_checkout_mut;
         LocalTarball    => request_local_tarball    @ local_tarball:    LocalTarballRequest,        mut request_local_tarball_mut;
@@ -231,15 +232,15 @@ impl<'a> Task<'a> {
     }
 }
 
-impl<'a> Task<'a> {
+impl Task {
     pub unsafe fn callback(task: *mut thread_pool::Task) {
         Output::Source::configure_thread();
 
         // SAFETY: `task` points to the `threadpool_task` field of a `Task`
         // (this is the only place this `thread_pool::Task` callback is registered).
-        let this: *mut Task<'a> = unsafe { bun_core::from_field_ptr!(Task, threadpool_task, task) };
+        let this: *mut Task = unsafe { bun_core::from_field_ptr!(Task, threadpool_task, task) };
         // SAFETY: exclusive access — task runs on exactly one worker thread
-        let this: &mut Task<'a> = unsafe { &mut *this };
+        let this: &mut Task = unsafe { &mut *this };
         // BACKREF (LIFETIMES.tsv:598) — `package_manager` outlives every task it
         // owns. The `ParentRef` is `Copy` and gives safe `Deref` for the
         // shared-read sites below; `manager` is kept as a raw `*mut` for the
@@ -263,10 +264,13 @@ impl<'a> Task<'a> {
                     // SAFETY: tag == PackageManifest discriminates the union
                     let manifest = unsafe { &mut *this.request.package_manifest };
 
-                    // split-borrow `manifest.network` so the mutable
-                    // `response_buffer` borrow doesn't overlap the immutable
-                    // `response`/`callback` reads below.
-                    let network = &mut *manifest.network;
+                    // SAFETY: `network` points to the pool-owned NetworkTask
+                    // vended for this resolve task. Access is temporally
+                    // partitioned: the manager thread wrote it before enqueue
+                    // and does not touch it again until this task is pushed to
+                    // `resolve_tasks`, so this worker-thread reborrow is
+                    // exclusive while it is live (scoped to this arm).
+                    let network = unsafe { &mut *manifest.network };
                     // Take ownership so the
                     // multi-MB manifest buffer drops on every exit of this arm
                     // instead of staying live on the NetworkTask until recycle.
@@ -384,9 +388,14 @@ impl<'a> Task<'a> {
 
                     // SAFETY: tag == Extract discriminates the union
                     let extract = unsafe { &mut *this.request.extract };
+                    // SAFETY: same temporal-partition argument as the
+                    // PackageManifest arm above — the pool slot is exclusively
+                    // this worker's while the task is in flight; the reborrow
+                    // is scoped to this statement.
+                    let network = unsafe { &mut *extract.network };
                     // Take ownership so the
                     // tarball body drops on every exit of this arm.
-                    let mut buffer = core::mem::take(&mut extract.network.response_buffer);
+                    let mut buffer = core::mem::take(&mut network.response_buffer);
 
                     let result = match extract.tarball.run(&mut this.log, buffer.slice()) {
                         Ok(v) => v,
@@ -566,16 +575,11 @@ impl<'a> Task<'a> {
                 };
                 if apply.logger.errors > 0 {
                     // `defer pt.callback.apply.logger.deinit()` → `Log` drops with `pt`.
-                    let _ = apply
-                        .logger
-                        .print(std::ptr::from_mut(Output::error_writer()));
+                    let _ = Output::with_error_writer(|w| apply.logger.print(w));
                 }
             }
         }
-        let task = core::ptr::NonNull::from(this).cast::<Task<'static>>();
-        // SAFETY: `Task<'a>` is layout-identical for all `'a` (the lifetime is
-        // a phantom on `&mut NetworkTask` borrows that the queue never reads
-        // through); erasing to `'static` is sound for the queue.
+        let task = core::ptr::NonNull::from(this);
         // `UnboundedQueue::push` takes `&self` (lock-free), so reach it via a
         // shared raw deref — no `&mut PackageManager` is formed.
         unsafe {
@@ -638,27 +642,27 @@ pub union Data {
 }
 
 /// Untagged union. Discriminated externally by `Task.tag`.
-pub union Request<'a> {
+pub union Request {
     /// package name
     // todo: Registry URL
-    pub package_manifest: ManuallyDrop<PackageManifestRequest<'a>>,
-    pub extract: ManuallyDrop<ExtractRequest<'a>>,
+    pub package_manifest: ManuallyDrop<PackageManifestRequest>,
+    pub extract: ManuallyDrop<ExtractRequest>,
     pub git_clone: ManuallyDrop<GitCloneRequest>,
     pub git_checkout: ManuallyDrop<GitCheckoutRequest>,
     pub local_tarball: ManuallyDrop<LocalTarballRequest>,
 }
 
-pub struct PackageManifestRequest<'a> {
+pub struct PackageManifestRequest {
     pub name: StringOrTinyString,
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO: lifetime — see note on `Task<'a>`; likely should demote to `*mut NetworkTask`.
-    pub network: &'a mut NetworkTask,
+    // SHARED — pool-owned `NetworkTask` slot (`preallocated_network_tasks`);
+    // outlives the task and is never freed while the task is in flight.
+    // Deref with a statement-scoped `unsafe { &mut * }` reborrow only.
+    pub network: *mut NetworkTask,
 }
 
-pub struct ExtractRequest<'a> {
-    // BORROW_PARAM per LIFETIMES.tsv
-    // TODO: lifetime — see note on `Task<'a>`; likely should demote to `*mut NetworkTask`.
-    pub network: &'a mut NetworkTask,
+pub struct ExtractRequest {
+    // SHARED — pool-owned `NetworkTask` slot; see `PackageManifestRequest::network`.
+    pub network: *mut NetworkTask,
     pub tarball: ExtractTarball,
 }
 

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -40,8 +40,6 @@ use crate::integrity::{self, Integrity};
 use crate::package_manager_real::PackageManager;
 
 // `crate::Task` is a `()` stub; the real Task lives in `package_manager_task`.
-// `'static` is sound here because we only ever hold raw `*mut Task` and never
-// materialise a `&'static` borrow of the inner `Request` lifetime.
 type Task = crate::package_manager_task::Task;
 
 bun_output::declare_scope!(TarballStream, hidden);

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -42,7 +42,7 @@ use crate::package_manager_real::PackageManager;
 // `crate::Task` is a `()` stub; the real Task lives in `package_manager_task`.
 // `'static` is sound here because we only ever hold raw `*mut Task` and never
 // materialise a `&'static` borrow of the inner `Request` lifetime.
-type Task = crate::package_manager_task::Task<'static>;
+type Task = crate::package_manager_task::Task;
 
 bun_output::declare_scope!(TarballStream, hidden);
 

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -223,6 +223,13 @@ pub(crate) fn install_isolated_packages(
 ) -> Result<crate::package_install::Summary, AllocError> {
     analytics::features::isolated_bun_install.fetch_add(1, Ordering::Relaxed);
 
+    // Provenance root for the progress-node cleanup scopeguard below;
+    // shadowing `manager` with a reborrow through it makes every body access a
+    // child of `mgr_root`, so the guard's later deref keeps provenance.
+    let mgr_root: *mut PackageManager = manager;
+    // SAFETY: `mgr_root` is freshly derived from the unique `&mut` fn param.
+    let manager = unsafe { &mut *mgr_root };
+
     // Take a raw pointer so column borrows below don't tie up `&mut manager`
     // (which owns the lockfile).
     let lockfile: *mut Lockfile = &raw mut *manager.lockfile;
@@ -1942,6 +1949,20 @@ pub(crate) fn install_isolated_packages(
             manager.scripts_node = Some(core::ptr::NonNull::from(&mut scripts_node));
             manager.downloads_node = Some(&raw mut download_node);
         }
+
+        // The stored pointers target the stack locals above; clear them on
+        // EVERY exit path (including the early `?` returns below) — otherwise
+        // the long-lived `PackageManager` would retain pointers into this
+        // dead frame and `scripts_node_mut()`/`downloads_node_mut()` consumers
+        // would deref dangling pointers. Declared after the node locals so it
+        // drops before them.
+        let _clear_progress_nodes = scopeguard::guard(mgr_root, |mgr| {
+            // SAFETY: `mgr` is the provenance root of `manager`, which
+            // outlives this frame; no `&mut PackageManager` is live at drop.
+            let m = unsafe { &mut *mgr };
+            m.scripts_node = None;
+            m.downloads_node = None;
+        });
 
         let nodes_slice = store.nodes.slice();
         let node_pkg_ids = nodes_slice.items_pkg_id();

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -224,8 +224,7 @@ pub(crate) fn install_isolated_packages(
     analytics::features::isolated_bun_install.fetch_add(1, Ordering::Relaxed);
 
     // Provenance root for the progress-node cleanup scopeguard below;
-    // shadowing `manager` with a reborrow through it makes every body access a
-    // child of `mgr_root`, so the guard's later deref keeps provenance.
+    // reborrow `manager` through it so the guard's later deref stays valid.
     let mgr_root: *mut PackageManager = manager;
     // SAFETY: `mgr_root` is freshly derived from the unique `&mut` fn param.
     let manager = unsafe { &mut *mgr_root };
@@ -1951,14 +1950,11 @@ pub(crate) fn install_isolated_packages(
         }
 
         // The stored pointers target the stack locals above; clear them on
-        // EVERY exit path (including the early `?` returns below) — otherwise
-        // the long-lived `PackageManager` would retain pointers into this
-        // dead frame and `scripts_node_mut()`/`downloads_node_mut()` consumers
-        // would deref dangling pointers. Declared after the node locals so it
-        // drops before them.
+        // every exit path so `PackageManager` never retains pointers into a
+        // dead frame. Declared after the node locals so it drops before them.
         let _clear_progress_nodes = scopeguard::guard(mgr_root, |mgr| {
-            // SAFETY: `mgr` is the provenance root of `manager`, which
-            // outlives this frame; no `&mut PackageManager` is live at drop.
+            // SAFETY: the manager outlives this frame; no `&mut PackageManager`
+            // is live at drop.
             let m = unsafe { &mut *mgr };
             m.scripts_node = None;
             m.downloads_node = None;

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2593,11 +2593,6 @@ pub(crate) fn install_isolated_packages(
             progress.root.end();
             *progress = Progress::default();
         }
-        // Defensive: clear the stack-local progress-node pointers so the
-        // accessors can't observe dangling pointers after this frame returns.
-        installer.manager_mut().scripts_node = None;
-        installer.manager_mut().downloads_node = None;
-
         if Environment::CI_ASSERT {
             let mut done = true;
             'next_entry: for (_entry_id, entry_step) in

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -831,8 +831,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
 
             if stdout_len > 0 {
                 let stdout = self.stdout.final_buffer();
-                // SAFETY (scoped reborrow): `write_fmt` over a `BStr` of plain
-                // bytes does not re-enter `bun_core::output`.
+                // SAFETY: `write_fmt` here does not re-enter `bun_core::output`.
                 let _ = Output::with_error_writer(|w| {
                     unsafe { &mut *w }
                         .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())))
@@ -843,7 +842,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
 
             if stderr_len > 0 {
                 let stderr = self.stderr.final_buffer();
-                // SAFETY (scoped reborrow): see the stdout arm above.
+                // SAFETY: see the stdout arm above.
                 let _ = Output::with_error_writer(|w| {
                     unsafe { &mut *w }
                         .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())))

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -831,16 +831,23 @@ impl<'a> LifecycleScriptSubprocess<'a> {
 
             if stdout_len > 0 {
                 let stdout = self.stdout.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())));
+                // SAFETY (scoped reborrow): `write_fmt` over a `BStr` of plain
+                // bytes does not re-enter `bun_core::output`.
+                let _ = Output::with_error_writer(|w| {
+                    unsafe { &mut *w }
+                        .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())))
+                });
                 stdout.clear();
                 stdout.shrink_to_fit();
             }
 
             if stderr_len > 0 {
                 let stderr = self.stderr.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())));
+                // SAFETY (scoped reborrow): see the stdout arm above.
+                let _ = Output::with_error_writer(|w| {
+                    unsafe { &mut *w }
+                        .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())))
+                });
                 stderr.clear();
                 stderr.shrink_to_fit();
             }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1778,10 +1778,7 @@ impl<'a> Printer<'a> {
                     ),
                 }
                 if log.errors > 0 {
-                    // `IntoLogWrite` is implemented for `*mut bun_core::io::Writer`,
-                    // not `&mut &mut Writer` — pass the raw vtable pointer.
-                    let ew: *mut bun_core::io::Writer = Output::error_writer();
-                    log.print(ew)?;
+                    Output::with_error_writer(|w| log.print(w))?;
                 }
                 Global::crash();
             }
@@ -1797,8 +1794,12 @@ impl<'a> Printer<'a> {
             crate::lockfile::LoadResult::Ok(_) => {}
         }
 
-        let writer = Output::writer_buffered();
-        match Self::print_with_lockfile(&lockfile, format, writer) {
+        // SAFETY (scoped reborrow): `print_with_lockfile` is a pure
+        // serializer — it writes through `W` and never re-enters
+        // `bun_core::output`, so no second `&mut Writer` can alias this one.
+        match Output::with_writer_buffered(|w| {
+            Self::print_with_lockfile(&lockfile, format, unsafe { &mut *w })
+        }) {
             Ok(()) => {}
             Err(e) if e == err!("OutOfMemory") => bun_core::out_of_memory(),
             Err(e) if e == err!("BrokenPipe") || e == err!("WriteFailed") => return Ok(()),
@@ -3146,8 +3147,9 @@ impl Lockfile {
         if print_name_version_string {
             Output::flush();
             Output::disable_buffering();
-            Output::writer()
-                .write_all(alphabetized_name_version_string)
+            // SAFETY (scoped reborrow): `write_all` goes straight to the
+            // stream vtable and does not re-enter `bun_core::output`.
+            Output::with_writer(|w| unsafe { &mut *w }.write_all(alphabetized_name_version_string))
                 .expect("unreachable");
             Output::enable_buffering();
         }

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1794,9 +1794,7 @@ impl<'a> Printer<'a> {
             crate::lockfile::LoadResult::Ok(_) => {}
         }
 
-        // SAFETY (scoped reborrow): `print_with_lockfile` is a pure
-        // serializer — it writes through `W` and never re-enters
-        // `bun_core::output`, so no second `&mut Writer` can alias this one.
+        // SAFETY: `print_with_lockfile` never re-enters `bun_core::output`.
         match Output::with_writer_buffered(|w| {
             Self::print_with_lockfile(&lockfile, format, unsafe { &mut *w })
         }) {
@@ -3147,8 +3145,7 @@ impl Lockfile {
         if print_name_version_string {
             Output::flush();
             Output::disable_buffering();
-            // SAFETY (scoped reborrow): `write_all` goes straight to the
-            // stream vtable and does not re-enter `bun_core::output`.
+            // SAFETY: `write_all` does not re-enter `bun_core::output`.
             Output::with_writer(|w| unsafe { &mut *w }.write_all(alphabetized_name_version_string))
                 .expect("unreachable");
             Output::enable_buffering();

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1626,7 +1626,7 @@ impl Package<u64> {
         let json = match crate::bun_json::parse_package_json_utf8(source, log, &bump) {
             Ok(j) => j,
             Err(err) => {
-                let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+                let _ = Output::with_error_writer(|w| log.print(w));
                 bun_core::pretty_errorln!(
                     "<r><red>{}<r> parsing package.json in <b>\"{}\"<r>",
                     err.name(),

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -479,10 +479,9 @@ impl PatchTask {
 
         // 3. copy the unpatched files into temp dir
         let cache_dir_subpath_z: &ZStr = patch.cache_dir_subpath_without_patch_hash.as_zstr();
-        // `PackageInstall` requires the destination subpath to be the
-        // NUL-terminated prefix of `destination_dir_subpath_buf` (it re-derives
-        // the `&ZStr` view from the buffer + length), so copy the tempdir name
-        // into a dedicated buffer rather than borrowing `tmpname_buf` twice.
+        // `PackageInstall` re-derives the subpath view from buffer + length,
+        // so copy the tempdir name into a dedicated buffer rather than
+        // borrowing `tmpname_buf` twice.
         let mut dest_subpath_buf = [0u8; 1024];
         dest_subpath_buf[..tempdir_name.len() + 1]
             .copy_from_slice(tempdir_name.as_bytes_with_nul());

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -247,9 +247,7 @@ impl PatchTask {
                 "failed to apply patchfile ({})",
                 format_args!("{}", BStr::new(&apply.patchfilepath)),
             );
-            let _ = apply
-                .logger
-                .print(std::ptr::from_mut(Output::error_writer()));
+            let _ = Output::with_error_writer(|w| apply.logger.print(w));
         }
     }
 
@@ -266,9 +264,7 @@ impl PatchTask {
         let Some(hash) = calc_hash.result else {
             if log_level != LogLevel::Silent {
                 if calc_hash.logger.has_errors() {
-                    let _ = calc_hash
-                        .logger
-                        .print(std::ptr::from_mut(Output::error_writer()));
+                    let _ = Output::with_error_writer(|w| calc_hash.logger.print(w));
                 } else {
                     Output::err_generic(
                         "Failed to calculate hash for patch <b>{}<r>",
@@ -483,15 +479,10 @@ impl PatchTask {
 
         // 3. copy the unpatched files into temp dir
         let cache_dir_subpath_z: &ZStr = patch.cache_dir_subpath_without_patch_hash.as_zstr();
-        // Borrowck — `tempdir_name` borrows `tmpname_buf` mutably, but
-        // `PackageInstall` also wants `&mut tmpname_buf[..]` for
-        // `destination_dir_subpath_buf`. `PackageInstall` assumes
-        // `destination_dir_subpath` is a prefix slice *into*
-        // `destination_dir_subpath_buf` (see `verifyGitResolution` /
-        // `verifyPackageJSONNameAndVersion`), and that aliasing can't be
-        // expressed with `&ZStr` + `&mut [u8]`, so use a separate buffer but
-        // mirror the prefix bytes so the invariant holds for any future call
-        // that reaches those paths.
+        // `PackageInstall` requires the destination subpath to be the
+        // NUL-terminated prefix of `destination_dir_subpath_buf` (it re-derives
+        // the `&ZStr` view from the buffer + length), so copy the tempdir name
+        // into a dedicated buffer rather than borrowing `tmpname_buf` twice.
         let mut dest_subpath_buf = [0u8; 1024];
         dest_subpath_buf[..tempdir_name.len() + 1]
             .copy_from_slice(tempdir_name.as_bytes_with_nul());
@@ -501,7 +492,7 @@ impl PatchTask {
         let mut pkg_install = PackageInstall {
             cache_dir: patch.cache_dir,
             cache_dir_subpath: cache_dir_subpath_z,
-            destination_dir_subpath: tempdir_name,
+            destination_dir_subpath_len: tempdir_name.len(),
             destination_dir_subpath_buf: &mut dest_subpath_buf[..],
             patch: None,
             progress: None,

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -200,20 +200,14 @@ impl IniTestingAPIs {
         let utf8str = bunstr.to_utf8();
 
         let env = global.bun_vm().as_mut().transpiler.env_mut();
-        // `Parser::init` ties `src: &'a [u8]` and
-        // `env: &'a mut DotEnvLoader<'a>` to one invariant `'a`; the VM-owned
-        // env is `'static`, so erase `src` to match. SAFETY: `parser` is dropped
-        // before `utf8str` (drop order is reverse of declaration); no borrow
-        // escapes this function. Same pattern as `bun_ini::load_npmrc`.
-        let src: &'static [u8] = bun_ast::IntoStr::into_str(utf8str.slice());
-        let mut parser = Parser::init(b"<src>", src, env);
-
-        // Borrowck — `Parser::parse` takes `&'a Arena`; split the borrow via
-        // raw ptr so the bump outlives the `&mut parser` for the call.
-        let arena_ptr: *const bun_alloc::Arena = &raw const parser.arena;
-        // SAFETY: `parser.arena` is not moved/dropped for the lifetime of `parser`.
-        let bump: &bun_alloc::Arena = unsafe { &*arena_ptr };
-        parser.parse(bump)?;
+        // `Parser<'a, 'e>` splits the env-data lifetime (`'e`, here the
+        // VM-owned loader's) from the parse-input lifetime `'a`, so `utf8str`
+        // and the local arena are borrowed directly — no `'static` erasure or
+        // raw-pointer borrow splitting. `utf8str` and `arena` are declared
+        // before `parser`, so they outlive every borrow it holds.
+        let arena = bun_alloc::Arena::new();
+        let mut parser = Parser::init(b"<src>", utf8str.slice(), env, &arena);
+        parser.parse()?;
 
         match bun_js_parser_jsc::expr_to_js(&parser.out, global) {
             Ok(v) => Ok(v),

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -200,11 +200,6 @@ impl IniTestingAPIs {
         let utf8str = bunstr.to_utf8();
 
         let env = global.bun_vm().as_mut().transpiler.env_mut();
-        // `Parser<'a, 'e>` splits the env-data lifetime (`'e`, here the
-        // VM-owned loader's) from the parse-input lifetime `'a`, so `utf8str`
-        // and the local arena are borrowed directly — no `'static` erasure or
-        // raw-pointer borrow splitting. `utf8str` and `arena` are declared
-        // before `parser`, so they outlive every borrow it holds.
         let arena = bun_alloc::Arena::new();
         let mut parser = Parser::init(b"<src>", utf8str.slice(), env, &arena);
         parser.parse()?;

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -557,9 +557,8 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
-    /// API parity with the Windows `BaseWindowsPipeWriter::start_movable`:
-    /// POSIX never transfers fd ownership, so this simply forwards the inner
-    /// fd and leaves `rawfd` untouched.
+    /// API parity with Windows `start_movable`: POSIX never transfers fd
+    /// ownership, so this forwards to [`Self::start`].
     #[cfg(not(windows))]
     pub fn start_movable(
         &mut self,
@@ -1327,12 +1326,9 @@ pub trait BaseWindowsPipeWriter {
         self.start_with_current_pipe()
     }
 
-    /// Plain-`Fd` start. When `Source::open` produces a uv pipe/tty, libuv
-    /// (`uv_pipe_open`/`uv_tty_init`) takes ownership of the HANDLE and
-    /// `uv_close` will close it — a caller that retains a copy of `rawfd` and
-    /// closes it later double-closes. Callers that retain the fd must use
-    /// [`Self::start_movable`], which disarms their slot on the ownership
-    /// transfer.
+    /// Plain-`Fd` start. When the source opens as a uv pipe/tty, libuv takes
+    /// ownership of the HANDLE; callers that retain the fd must use
+    /// [`Self::start_movable`] to avoid a double-close.
     fn start(&mut self, rawfd: Fd, _pollable: bool) -> sys::Result<()> {
         let fd = rawfd;
         debug_assert!(self.source().is_none());
@@ -1351,13 +1347,10 @@ pub trait BaseWindowsPipeWriter {
         self.start_with_current_pipe()
     }
 
-    /// `start` variant for callers that retain their fd slot past the call:
-    /// when libuv takes ownership of the HANDLE (the `Source::Pipe`/
-    /// `Source::Tty` success path), `rawfd` is `take()`n so the caller's
-    /// later close/Drop is a no-op instead of a double-close. On the
-    /// `Source::File`/`SyncFile` path — and on open failure — the slot is
-    /// left untouched: the caller still owns the fd (and fallback paths like
-    /// the shell's EBADF→`start_with_file` rely on it staying valid).
+    /// Like [`Self::start`], but when libuv takes ownership of the HANDLE
+    /// (`Source::Pipe`/`Tty`), `rawfd` is `take()`n so the caller's later
+    /// close is a no-op. On the `File`/`SyncFile` path — and on open failure —
+    /// the caller still owns the fd.
     fn start_movable(
         &mut self,
         rawfd: &mut sys::MovableIfWindowsFd,

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -557,6 +557,18 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
+    /// API parity with the Windows `BaseWindowsPipeWriter::start_movable`:
+    /// POSIX never transfers fd ownership, so this simply forwards the inner
+    /// fd and leaves `rawfd` untouched.
+    #[cfg(not(windows))]
+    pub fn start_movable(
+        &mut self,
+        rawfd: &mut sys::MovableIfWindowsFd,
+        pollable: bool,
+    ) -> sys::Result<()> {
+        self.start(rawfd.get_posix(), pollable)
+    }
+
     /// On POSIX a `MovableIfWindowsFd` never transfers ownership, so callers
     /// pass the plain `Fd` (via `MovableIfWindowsFd::get_posix()` when needed).
     pub fn start(&mut self, rawfd: Fd, pollable: bool) -> sys::Result<()> {
@@ -1315,7 +1327,12 @@ pub trait BaseWindowsPipeWriter {
         self.start_with_current_pipe()
     }
 
-    // TODO: MovableIfWindowsFd overload — add a separate start_movable().
+    /// Plain-`Fd` start. When `Source::open` produces a uv pipe/tty, libuv
+    /// (`uv_pipe_open`/`uv_tty_init`) takes ownership of the HANDLE and
+    /// `uv_close` will close it — a caller that retains a copy of `rawfd` and
+    /// closes it later double-closes. Callers that retain the fd must use
+    /// [`Self::start_movable`], which disarms their slot on the ownership
+    /// transfer.
     fn start(&mut self, rawfd: Fd, _pollable: bool) -> sys::Result<()> {
         let fd = rawfd;
         debug_assert!(self.source().is_none());
@@ -1327,12 +1344,37 @@ pub trait BaseWindowsPipeWriter {
             sys::Result::Ok(source) => source,
             sys::Result::Err(err) => return sys::Result::Err(err),
         };
-        // Creating a uv_pipe/uv_tty takes ownership of the file descriptor
-        // TODO: Change the type of the parameter and update all places to
-        //       use MovableFD
-        // TODO: take ownership of the fd for pipe/tty sources via a MovableFd
-        // overload.
-        let _ = matches!(source, Source::Pipe(_) | Source::Tty(_));
+        source.set_data(core::ptr::from_mut(self).cast::<c_void>());
+        *self.source_mut() = Some(source);
+        let p = self.parent_ptr();
+        self.set_parent(p);
+        self.start_with_current_pipe()
+    }
+
+    /// `start` variant for callers that retain their fd slot past the call:
+    /// when libuv takes ownership of the HANDLE (the `Source::Pipe`/
+    /// `Source::Tty` success path), `rawfd` is `take()`n so the caller's
+    /// later close/Drop is a no-op instead of a double-close. On the
+    /// `Source::File`/`SyncFile` path — and on open failure — the slot is
+    /// left untouched: the caller still owns the fd (and fallback paths like
+    /// the shell's EBADF→`start_with_file` rely on it staying valid).
+    fn start_movable(
+        &mut self,
+        rawfd: &mut sys::MovableIfWindowsFd,
+        _pollable: bool,
+    ) -> sys::Result<()> {
+        let fd = rawfd.get().expect("start_movable: fd was already moved");
+        debug_assert!(self.source().is_none());
+        // SAFETY: parent is BACKREF set via set_parent; valid while writer alive.
+        let loop_ = unsafe { Self::Parent::loop_(self.parent_ptr()) };
+        let mut source = match Source::open(loop_, fd) {
+            sys::Result::Ok(source) => source,
+            sys::Result::Err(err) => return sys::Result::Err(err),
+        };
+        // Creating a uv_pipe/uv_tty takes ownership of the file descriptor.
+        if matches!(source, Source::Pipe(_) | Source::Tty(_)) {
+            let _ = rawfd.take();
+        }
         source.set_data(core::ptr::from_mut(self).cast::<c_void>());
         *self.source_mut() = Some(source);
         let p = self.parent_ptr();

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -289,10 +289,8 @@ impl<'a> Router<'a> {
 
         // PERF: a borrowed `List<'a>` cannot soundly live in a `'static` thread_local,
         // so we allocate per-request; revisit with an arena/SmallVec if hot.
-        // NOTE: the `Match` returned by `match_page` borrows `ctx` (through
-        // `ctx.url()`'s accessor slices), so the mutable `ctx` calls below are
-        // hoisted out of the block: the redirect path is copied to an owned
-        // buffer and handled after the borrow ends.
+        // The `Match` borrows `ctx`, so the mutable `ctx` calls are hoisted
+        // out: the redirect path is copied out and handled after the borrow ends.
         let redirect_to: Option<Vec<u8>> = {
             let mut params_list = route_param::List::default();
             if let Some(route) = app
@@ -336,10 +334,8 @@ pub const BANNED_DIRS: [&[u8]; 1] = [b"node_modules"];
 
 pub struct RouteIndex {
     // The `Box` is load-bearing: `Routes::index` / `Routes::static_` hold
-    // `NonNull<Route>` / `*const Route` into the box interiors. The SoA list
-    // below moves the `Box` handles on realloc, but the boxed `Route`
-    // allocations themselves never move, so those pointers stay valid —
-    // storing `Route` inline in the column would dangle them.
+    // pointers into the box interiors; the SoA list moves the `Box` handles
+    // on realloc, but the boxed `Route`s never move.
     pub route: Box<Route>,
     pub name: &'static [u8],
     pub match_name: &'static [u8],
@@ -359,20 +355,15 @@ bun_collections::multi_array_columns! {
     }
 }
 
-/// `MultiArrayList(RouteIndex)` with per-field column accessors
-/// (`items_route()`, `items_name()`, … via [`RouteIndexColumns`]).
-///
-/// Newtype rather than a bare alias because `MultiArrayList`'s `Drop`
-/// intentionally frees the slab only (no per-element destructors — see its
-/// `Drop` doc); the `route` column uniquely owns `Box<Route>` allocations, so
-/// this wrapper runs `drop_elements()` first.
+/// `MultiArrayList(RouteIndex)` with per-field column accessors.
+/// Newtype so `Drop` runs `drop_elements()` first: the `route` column owns
+/// `Box<Route>` allocations and the inner list's `Drop` frees the slab only.
 #[derive(Default)]
 pub struct RouteIndexList(bun_collections::MultiArrayList<RouteIndex>);
 
 impl Drop for RouteIndexList {
     fn drop(&mut self) {
-        // Frees the `Box<Route>` column payloads; the slab itself is freed by
-        // the inner list's own Drop.
+        // Frees the `Box<Route>` payloads; the inner Drop frees the slab.
         self.0.drop_elements();
     }
 }

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -272,11 +272,11 @@ impl<'a> Router<'a> {
         ctx.set_matched_route(None);
 
         // If there's an extname assume it's an asset and not a page
-        match ctx.url().extname.len() {
+        match ctx.url().extname().len() {
             0 => {}
             // json is used for updating the route client-side without a page reload
             4 /* "json".len */ => {
-                if ctx.url().extname != b"json" {
+                if ctx.url().extname() != b"json" {
                     ctx.handle_request()?;
                     return Ok(());
                 }
@@ -289,30 +289,40 @@ impl<'a> Router<'a> {
 
         // PERF: a borrowed `List<'a>` cannot soundly live in a `'static` thread_local,
         // so we allocate per-request; revisit with an arena/SmallVec if hot.
-        {
+        // NOTE: the `Match` returned by `match_page` borrows `ctx` (through
+        // `ctx.url()`'s accessor slices), so the mutable `ctx` calls below are
+        // hoisted out of the block: the redirect path is copied to an owned
+        // buffer and handled after the borrow ends.
+        let redirect_to: Option<Vec<u8>> = {
             let mut params_list = route_param::List::default();
             if let Some(route) = app
                 .routes
                 .match_page(&app.config.dir, ctx.url(), &mut params_list)
             {
                 if let Some(redirect) = route.redirect_path {
-                    ctx.handle_redirect(redirect)?;
-                    return Ok(());
-                }
+                    Some(redirect.to_vec())
+                } else {
+                    debug_assert!(!route.path.is_empty());
 
-                debug_assert!(!route.path.is_empty());
-
-                if let Some(watcher) = server.watcher_mut() {
-                    if watcher.watchloop_handle().is_none() {
-                        let _ = watcher.start();
+                    if let Some(watcher) = server.watcher_mut() {
+                        if watcher.watchloop_handle().is_none() {
+                            let _ = watcher.start();
+                        }
                     }
-                }
 
-                // ctx.matched_route = route;
-                // RequestContextType.JavaScriptHandler.enqueue(ctx, server, &params_list) catch {
-                //     server.javascript_enabled = false;
-                // };
+                    // ctx.matched_route = route;
+                    // RequestContextType.JavaScriptHandler.enqueue(ctx, server, &params_list) catch {
+                    //     server.javascript_enabled = false;
+                    // };
+                    None
+                }
+            } else {
+                None
             }
+        };
+        if let Some(redirect) = redirect_to {
+            ctx.handle_redirect(&redirect)?;
+            return Ok(());
         }
 
         if !ctx.controlled() && !ctx.has_called_done() {
@@ -324,77 +334,61 @@ impl<'a> Router<'a> {
 
 pub const BANNED_DIRS: [&[u8]; 1] = [b"node_modules"];
 
-struct RouteIndex {
-    route: Box<Route>,
-    name: &'static [u8],
-    match_name: &'static [u8],
-    filepath: &'static [u8],
-    public_path: &'static [u8],
-    hash: u32,
-}
-
-// TODO(b2-blocked): bun_collections::MultiArrayElement derive — proc-macro not
-// yet landed, so MultiArrayList<RouteIndex> can't expose per-field column
-// accessors. Hand-rolled SoA struct until the derive exists.
-#[derive(Default)]
-pub struct RouteIndexList {
+pub struct RouteIndex {
     // The `Box` is load-bearing: `Routes::index` / `Routes::static_` hold
-    // `NonNull<Route>` / `*const Route` into the box interiors; unboxing
-    // would dangle them on `Vec` realloc.
-    #[expect(clippy::vec_box)]
-    route: Vec<Box<Route>>,
-    name: Vec<&'static [u8]>,
-    match_name: Vec<&'static [u8]>,
-    filepath: Vec<&'static [u8]>,
-    public_path: Vec<&'static [u8]>,
-    hash: Vec<u32>,
+    // `NonNull<Route>` / `*const Route` into the box interiors. The SoA list
+    // below moves the `Box` handles on realloc, but the boxed `Route`
+    // allocations themselves never move, so those pointers stay valid —
+    // storing `Route` inline in the column would dangle them.
+    pub route: Box<Route>,
+    pub name: &'static [u8],
+    pub match_name: &'static [u8],
+    pub filepath: &'static [u8],
+    pub public_path: &'static [u8],
+    pub hash: u32,
 }
 
-impl RouteIndexList {
-    pub fn set_capacity(&mut self, cap: usize) -> Result<(), CoreError> {
-        self.route.reserve_exact(cap);
-        self.name.reserve_exact(cap);
-        self.match_name.reserve_exact(cap);
-        self.filepath.reserve_exact(cap);
-        self.public_path.reserve_exact(cap);
-        self.hash.reserve_exact(cap);
-        Ok(())
+bun_collections::multi_array_columns! {
+    pub trait RouteIndexColumns for RouteIndex {
+        route: Box<Route>,
+        name: &'static [u8],
+        match_name: &'static [u8],
+        filepath: &'static [u8],
+        public_path: &'static [u8],
+        hash: u32,
     }
-    pub(crate) fn push(&mut self, item: RouteIndex) {
-        self.route.push(item.route);
-        self.name.push(item.name);
-        self.match_name.push(item.match_name);
-        self.filepath.push(item.filepath);
-        self.public_path.push(item.public_path);
-        self.hash.push(item.hash);
+}
+
+/// `MultiArrayList(RouteIndex)` with per-field column accessors
+/// (`items_route()`, `items_name()`, … via [`RouteIndexColumns`]).
+///
+/// Newtype rather than a bare alias because `MultiArrayList`'s `Drop`
+/// intentionally frees the slab only (no per-element destructors — see its
+/// `Drop` doc); the `route` column uniquely owns `Box<Route>` allocations, so
+/// this wrapper runs `drop_elements()` first.
+#[derive(Default)]
+pub struct RouteIndexList(bun_collections::MultiArrayList<RouteIndex>);
+
+impl Drop for RouteIndexList {
+    fn drop(&mut self) {
+        // Frees the `Box<Route>` column payloads; the slab itself is freed by
+        // the inner list's own Drop.
+        self.0.drop_elements();
     }
+}
+
+impl core::ops::Deref for RouteIndexList {
+    type Target = bun_collections::MultiArrayList<RouteIndex>;
     #[inline]
-    pub fn len(&self) -> usize {
-        self.route.len()
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
+}
+
+impl core::ops::DerefMut for RouteIndexList {
     #[inline]
-    pub fn items_route(&self) -> &[Box<Route>] {
-        &self.route
-    }
-    #[inline]
-    pub fn items_name(&self) -> &[&'static [u8]] {
-        &self.name
-    }
-    #[inline]
-    pub fn items_match_name(&self) -> &[&'static [u8]] {
-        &self.match_name
-    }
-    #[inline]
-    pub fn items_filepath(&self) -> &[&'static [u8]] {
-        &self.filepath
-    }
-    #[inline]
-    pub fn items_public_path(&self) -> &[&'static [u8]] {
-        &self.public_path
-    }
-    #[inline]
-    pub fn items_hash(&self) -> &[u32] {
-        &self.hash
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -447,11 +441,11 @@ impl Routes {
     pub fn match_page_with_allocator<'p>(
         &mut self,
         _: &[u8],
-        url_path: &URLPath,
+        url_path: &'p URLPath,
         params: &'p mut route_param::List<'p>,
     ) -> Option<Match<'p>> {
         // Trim trailing slash
-        let mut path = url_path.path;
+        let mut path = url_path.path();
         let mut redirect = false;
 
         // Normalize trailing slash
@@ -494,11 +488,11 @@ impl Routes {
                     params: std::ptr::from_mut(params),
                     name: index.name,
                     path: index.abs_path.as_bytes(),
-                    pathname: url_path.pathname,
+                    pathname: url_path.pathname(),
                     basename: index.basename,
                     hash: INDEX_ROUTE_HASH,
                     file_path: index.abs_path.as_bytes(),
-                    query_string: url_path.query_string,
+                    query_string: url_path.query_string(),
                     client_framework_enabled: self.client_framework_enabled,
                     redirect_path: None,
                 });
@@ -515,11 +509,11 @@ impl Routes {
                 params: std::ptr::from_mut(params),
                 name: route.name,
                 path: route.abs_path.as_bytes(),
-                pathname: url_path.pathname,
+                pathname: url_path.pathname(),
                 basename: route.basename,
                 hash: route.full_hash,
                 file_path: route.abs_path.as_bytes(),
-                query_string: url_path.query_string,
+                query_string: url_path.query_string(),
                 client_framework_enabled: self.client_framework_enabled,
                 redirect_path: None,
             });
@@ -531,7 +525,7 @@ impl Routes {
     pub fn match_page<'p>(
         &mut self,
         _: &[u8],
-        url_path: &URLPath,
+        url_path: &'p URLPath,
         params: &'p mut route_param::List<'p>,
     ) -> Option<Match<'p>> {
         self.match_page_with_allocator(b"", url_path, params)
@@ -734,6 +728,7 @@ impl<'a> RouteLoader<'a> {
         route_list
             .set_capacity(this.all_routes.len())
             .expect("unreachable");
+        let route_capacity = this.all_routes.len();
 
         let mut dynamic_start: Option<usize> = None;
         let mut index_id: Option<usize> = None;
@@ -752,7 +747,8 @@ impl<'a> RouteLoader<'a> {
                 route.match_name.as_bytes(),
                 route.public_path.as_bytes(),
             );
-            route_list.push(RouteIndex {
+            debug_assert!(route_list.len() < route_capacity);
+            route_list.append_assume_capacity(RouteIndex {
                 name: route.name,
                 filepath,
                 match_name,
@@ -2104,7 +2100,7 @@ mod tests {
             // still flushes diagnostics on early-return for parity.
             let _err_dump = scopeguard::guard(core::ptr::from_mut(&mut log), |log| {
                 // SAFETY: pointer to a stack local that outlives this guard.
-                let _ = unsafe { &*log }.print(bun_core::output::error_writer());
+                let _ = bun_core::output::with_error_writer(|w| unsafe { &*log }.print(w));
             });
 
             // const opts = Options.BundleOptions{ .target = .browser, ... };
@@ -2175,7 +2171,7 @@ mod tests {
             let mut log = bun_ast::Log::init();
             let _err_dump = scopeguard::guard(core::ptr::from_mut(&mut log), |log| {
                 // SAFETY: pointer to a stack local that outlives this guard.
-                let _ = unsafe { &*log }.print(bun_core::output::error_writer());
+                let _ = bun_core::output::with_error_writer(|w| unsafe { &*log }.print(w));
             });
 
             let opts = bun_resolver::options::BundleOptions {

--- a/src/router/lib.rs
+++ b/src/router/lib.rs
@@ -725,9 +725,7 @@ impl<'a> RouteLoader<'a> {
             .sort_unstable_by(|a, b| sorter::sort_by_name_cmp(a, b));
 
         let mut route_list = RouteIndexList::default();
-        route_list
-            .set_capacity(this.all_routes.len())
-            .expect("unreachable");
+        bun_core::handle_oom(route_list.set_capacity(this.all_routes.len()));
         let route_capacity = this.all_routes.len();
 
         let mut dynamic_start: Option<usize> = None;

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -587,16 +587,10 @@ impl FileSystemRouter {
             };
         }
 
-        // SAFETY: self-ref construction prelude — `route` below borrows these bytes via
-        // `URLPath`, and `path` is then MOVED into the same `MatchedRoute` Box that stores
-        // `route`. Borrowck can't see that the allocation travels with the borrow, so we
-        // detach the slice from `path`'s ownership here. The bytes stay valid: `path` is
-        // never dropped on any path between here and `MatchedRoute::init` taking ownership
-        // (early returns above this point already dropped/replaced `path`), except when
-        // `URLPath::parse` percent-decoded — in that case nothing borrows `path_bytes`
-        // anymore and `path` is swapped for the decode buffer below.
-        let path_bytes: &[u8] = unsafe { bun_ptr::detach_lifetime(path.slice()) };
-        let mut url_path = match URLPath::parse(path_bytes) {
+        // `URLPath::parse` copies (or percent-decodes) the input into its own
+        // backing allocation, so `path`'s bytes are only borrowed for the
+        // duration of the call.
+        let mut url_path = match URLPath::parse(path.slice()) {
             Ok(v) => v,
             Err(err) => {
                 return Err(global_this.throw(format_args!(
@@ -619,15 +613,21 @@ impl FileSystemRouter {
             return Ok(JSValue::NULL);
         };
 
-        // If `URLPath::parse` had to percent-decode, `route.pathname`/`query_string` and
-        // the param values borrow the decode buffer — not `path` — and that buffer would
-        // be freed when `url_path` drops at the end of this call. Take ownership of it and
-        // make it the backing allocation instead. (`Box<[u8]>` -> `Vec<u8>` ->
-        // `ZigStringSlice::Owned` reuses the same heap allocation, so the borrowed slices
-        // stay valid; nothing in `route` points into the original encoded `path` once a
-        // decode happened.)
-        if let Some(decoded) = url_path.take_decoded_storage() {
-            path = ZigStringSlice::init_owned(decoded.into_vec());
+        // `route.pathname`/`query_string` and the param values borrow
+        // `url_path`'s backing allocation, which would be freed when
+        // `url_path` drops at the end of this call. Widen the match, take
+        // ownership of the backing, and make it the `MatchedRoute` backing
+        // instead. (`Box<[u8]>` -> `Vec<u8>` -> `ZigStringSlice::Owned`
+        // reuses the same heap allocation, so the borrowed slices stay
+        // valid; nothing in `route` points into the original encoded `path`.)
+        //
+        // SAFETY: same invariant as the `detach_lifetime` inside
+        // `MatchedRoute::init` — every borrowed slice points into the backing
+        // moved (via `path`) into the same Box that stores this match, or
+        // into the resolver's process-lifetime DirnameStore.
+        let route: RouterMatch<'static> = unsafe { route.detach_lifetime() };
+        if let Some(backing) = url_path.take_backing() {
+            path = ZigStringSlice::init_owned(backing.into_vec());
         }
 
         // MOVE `path`

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -604,7 +604,7 @@ impl FileSystemRouter {
         // `defer params.deinit(allocator)` → Drop
         // SAFETY: R-2 — short-lived `&mut Router` for the route lookup;
         // `match_page_with_allocator` is pure (no JS re-entry), and the returned
-        // `Match<'p>` borrows `params`/`path_bytes`, not `*router`, so the
+        // `Match<'p>` borrows `params`/`url_path`, not `*router`, so the
         // exclusive borrow ends at the `;`.
         let Some(route) = unsafe { this.router.get_mut() }
             .routes

--- a/src/runtime/api/filesystem_router.rs
+++ b/src/runtime/api/filesystem_router.rs
@@ -587,9 +587,6 @@ impl FileSystemRouter {
             };
         }
 
-        // `URLPath::parse` copies (or percent-decodes) the input into its own
-        // backing allocation, so `path`'s bytes are only borrowed for the
-        // duration of the call.
         let mut url_path = match URLPath::parse(path.slice()) {
             Ok(v) => v,
             Err(err) => {
@@ -613,18 +610,11 @@ impl FileSystemRouter {
             return Ok(JSValue::NULL);
         };
 
-        // `route.pathname`/`query_string` and the param values borrow
-        // `url_path`'s backing allocation, which would be freed when
-        // `url_path` drops at the end of this call. Widen the match, take
-        // ownership of the backing, and make it the `MatchedRoute` backing
-        // instead. (`Box<[u8]>` -> `Vec<u8>` -> `ZigStringSlice::Owned`
-        // reuses the same heap allocation, so the borrowed slices stay
-        // valid; nothing in `route` points into the original encoded `path`.)
-        //
-        // SAFETY: same invariant as the `detach_lifetime` inside
-        // `MatchedRoute::init` — every borrowed slice points into the backing
-        // moved (via `path`) into the same Box that stores this match, or
-        // into the resolver's process-lifetime DirnameStore.
+        // The match borrows `url_path`'s backing, which would drop at the end
+        // of this call; take ownership and make it the `MatchedRoute` backing.
+        // SAFETY: every borrowed slice points into the backing moved (via
+        // `path`) into the same Box that stores this match, or into the
+        // process-lifetime DirnameStore.
         let route: RouterMatch<'static> = unsafe { route.detach_lifetime() };
         if let Some(backing) = url_path.take_backing() {
             path = ZigStringSlice::init_owned(backing.into_vec());

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5377,9 +5377,7 @@ impl DevServer {
                         // teardown loop in `deinit` (explicit `.deref()` — RefPtr
                         // has no Drop).
                         // SAFETY: caller guarantees `html` is a live allocation.
-                        html_bundle: unsafe {
-                            bun_ptr::RefPtr::<HTMLBundleRoute>::init_ref(html)
-                        },
+                        html_bundle: unsafe { bun_ptr::RefPtr::<HTMLBundleRoute>::init_ref(html) },
                         bundled_file: incremental_graph_index,
                         script_injection_offset: None,
                         cached_response: None,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1247,6 +1247,10 @@ impl Drop for DevServer {
                     // SAFETY: stored ref from `init_from_any_blob`; no live borrow.
                     unsafe { StaticRoute::deref_(cached.as_ptr()) };
                 }
+                // Release the intrusive ref taken at store time in
+                // `get_or_put_route_bundle` (`RefPtr` has no Drop, so this is
+                // the explicit matching deref).
+                html.html_bundle.deref();
             }
         }
 
@@ -2472,8 +2476,7 @@ impl DevServer {
                 }
             }
             route_bundle::Data::Html(html) => {
-                // SAFETY: html_bundle is a live *mut HTMLBundleRoute (held strong by route_bundle::Html)
-                let bundle_path = unsafe { &(&(*html.html_bundle).bundle).path };
+                let bundle_path = &html.html_bundle.bundle.path;
                 entry_points.append(bundle_path, entry_point_list::Flags::CLIENT)?;
             }
         }
@@ -2878,10 +2881,7 @@ impl DevServer {
         // is read-only in this fn — `&RouteBundle` suffices.
         let html = route_bundle.data.html();
         debug_assert!(route_bundle.server_state == route_bundle::State::Loaded);
-        debug_assert!(
-            // SAFETY: `html_bundle` is a live `*mut HTMLBundleRoute` held strong by `route_bundle::Html`.
-            unsafe { (*html.html_bundle).dev_server_id.get() } == Some(route_bundle_index)
-        );
+        debug_assert!(html.html_bundle.dev_server_id.get() == Some(route_bundle_index));
         debug_assert!(html.cached_response.is_none());
         let script_injection_offset = html.script_injection_offset.unwrap().get_usize();
         let bundled_html = html.bundled_html_text.as_ref().unwrap();
@@ -2893,8 +2893,7 @@ impl DevServer {
         let after_head_end = &bundled_html[script_injection_offset..];
 
         let mut display_name = strings::without_suffix_comptime(
-            // SAFETY: html_bundle is a live *mut HTMLBundleRoute (held strong by route_bundle::Html)
-            paths::basename(unsafe { &(&(*html.html_bundle).bundle).path }),
+            paths::basename(&html.html_bundle.bundle.path),
             b".html",
         );
         // TODO: function for URL safe chars
@@ -3432,7 +3431,7 @@ impl DevServer {
             if cfg!(debug_assertions) {
                 bun_core::debug_warn!("dev.log should not be written into when using DevServer");
             }
-            let _ = self.log.print(std::ptr::from_mut(Output::error_writer()));
+            let _ = Output::with_error_writer(|w| self.log.print(w));
         }
         Ok(())
     }
@@ -4859,11 +4858,7 @@ pub(super) fn finalize_bundle(
                     // / `dev.router` / `dev.server_graph` reads below stay disjoint.
                     break 'brk match &dev.route_bundles[route_bundle_index.get() as usize].data {
                         route_bundle::Data::Html(html) => {
-                            Some(dev.relative_path(
-                                &mut *buf,
-                                // SAFETY: `html_bundle` is held strong by `route_bundle::Html`; live here.
-                                &unsafe { &*html.html_bundle }.bundle.path,
-                            ))
+                            Some(dev.relative_path(&mut *buf, &html.html_bundle.bundle.path))
                         }
                         route_bundle::Data::Framework(fw) => 'file_name: {
                             let route = dev.router.route_ptr(fw.route_index);
@@ -5377,12 +5372,14 @@ impl DevServer {
                     let file = &mut self.client_graph.bundled_files.values_mut()
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
-                    // Bump the intrusive refcount; matched by
-                    // `RouteBundle::deinit`'s deref of `html_bundle`.
-                    // SAFETY: `html` is a live IntrusiveRc-managed allocation.
-                    unsafe { bun_ptr::RefCount::<HTMLBundleRoute>::ref_(html) };
                     break 'brk route_bundle::Data::Html(route_bundle::Html {
-                        html_bundle: html,
+                        // Takes one intrusive ref; released by the route-bundle
+                        // teardown loop in `deinit` (explicit `.deref()` — RefPtr
+                        // has no Drop).
+                        // SAFETY: caller guarantees `html` is a live allocation.
+                        html_bundle: unsafe {
+                            bun_ptr::RefPtr::<HTMLBundleRoute>::init_ref(html)
+                        },
                         bundled_file: incremental_graph_index,
                         script_injection_offset: None,
                         cached_response: None,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1247,9 +1247,8 @@ impl Drop for DevServer {
                     // SAFETY: stored ref from `init_from_any_blob`; no live borrow.
                     unsafe { StaticRoute::deref_(cached.as_ptr()) };
                 }
-                // Release the intrusive ref taken at store time in
-                // `get_or_put_route_bundle` (`RefPtr` has no Drop, so this is
-                // the explicit matching deref).
+                // Release the ref taken in `get_or_put_route_bundle`
+                // (`RefPtr` has no Drop).
                 html.html_bundle.deref();
             }
         }
@@ -5373,9 +5372,8 @@ impl DevServer {
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
                     break 'brk route_bundle::Data::Html(route_bundle::Html {
-                        // Takes one intrusive ref; released by the route-bundle
-                        // teardown loop in `deinit` (explicit `.deref()` — RefPtr
-                        // has no Drop).
+                        // Ref released by `deinit`'s route-bundle teardown
+                        // (`RefPtr` has no Drop).
                         // SAFETY: caller guarantees `html` is a live allocation.
                         html_bundle: unsafe { bun_ptr::RefPtr::<HTMLBundleRoute>::init_ref(html) },
                         bundled_file: incremental_graph_index,

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -34,10 +34,8 @@ pub struct Framework {
 }
 
 pub struct Html {
-    /// SHARED (LIFETIMES.tsv): the slot owns one intrusive ref, taken via
-    /// `RefPtr::init_ref` when DevServer stores it in `get_or_put_route_bundle`.
-    /// `RefPtr` has no `Drop` — the owned ref is released explicitly by
-    /// `DevServer::deinit`'s route-bundle teardown loop (`html_bundle.deref()`).
+    /// Owns one intrusive ref; `RefPtr` has no `Drop`, so `DevServer`'s
+    /// route-bundle teardown releases it explicitly.
     pub html_bundle: bun_ptr::RefPtr<HTMLBundleRoute>,
     pub bundled_file: incremental_graph::ClientFileIndex,
     pub script_injection_offset: Option<ByteOffset>,

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -34,12 +34,11 @@ pub struct Framework {
 }
 
 pub struct Html {
-    /// SHARED (LIFETIMES.tsv): DevServer increments the route's intrusive
-    /// refcount via `.initRef(html)` when storing; `.deref()` on drop.
-    /// Stored as raw ptr because `HTMLBundleRoute` does not yet impl
-    /// `bun_ptr::RefCounted` (gated server-side).
-    // TODO: switch to bun_ptr::RefPtr<HTMLBundleRoute> once the RefCounted impl is real.
-    pub html_bundle: *mut HTMLBundleRoute,
+    /// SHARED (LIFETIMES.tsv): the slot owns one intrusive ref, taken via
+    /// `RefPtr::init_ref` when DevServer stores it in `get_or_put_route_bundle`.
+    /// `RefPtr` has no `Drop` — the owned ref is released explicitly by
+    /// `DevServer::deinit`'s route-bundle teardown loop (`html_bundle.deref()`).
+    pub html_bundle: bun_ptr::RefPtr<HTMLBundleRoute>,
     pub bundled_file: incremental_graph::ClientFileIndex,
     pub script_injection_offset: Option<ByteOffset>,
     pub bundled_html_text: Option<Box<[u8]>>,
@@ -168,4 +167,4 @@ impl RouteBundle {
 //   - client_bundle / cached_response: Option<Arc<StaticRoute>> drop = .deref()
 //   - Framework: StrongOptional fields drop = .deinit()
 //   - Html: bundled_html_text Box<[u8]> drop = allocator.free()
-//           html_bundle RefPtr drop = .deref()
+//           html_bundle: explicit .deref() in DevServer::deinit (RefPtr has no Drop)

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -254,7 +254,7 @@ fn fail_with_build_error(vm: &mut VirtualMachine) -> ! {
     // `vm.log` is the process-lifetime ctx.log set in build_command;
     // `log_ref()` is the safe accessor encapsulating the NonNull deref.
     if let Some(log) = vm.log_ref() {
-        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+        let _ = Output::with_error_writer(|w| log.print(w));
     }
     Global::exit(1);
 }
@@ -533,9 +533,7 @@ pub(super) fn build_with_vm(
             }
             bun_core::err_generic!("Failed to resolve all imports required by the framework");
             Output::flush();
-            let _ = server_transpiler
-                .log()
-                .print(std::ptr::from_mut(Output::error_writer()));
+            let _ = Output::with_error_writer(|w| server_transpiler.log().print(w));
             Global::crash();
         }
     };

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -542,8 +542,7 @@ impl Route {
                         // `Log::print` accepts it via the `*mut io::Writer`
                         // `IntoLogWrite` adapter and dispatches on
                         // `enable_ansi_colors_stderr` internally.
-                        let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
-                        let _ = log.print(writer);
+                        let _ = bun_output::with_error_writer_buffered(|w| log.print(w));
                         bun_output::flush();
                     }
                 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -312,7 +312,7 @@ impl<const SSL: bool, const DEBUG: bool> Drop for NewServer<SSL, DEBUG> {
         if let Some(p) = self.plugins.take() {
             // SAFETY: `plugins` carries the `heap::alloc` provenance from
             // `ServePlugins::init`; this releases the server's counted ref.
-            unsafe { ServePlugins::deref_(p.as_ptr()) };
+            unsafe { ServePlugins::deref(p.as_ptr()) };
         }
     }
 }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -833,14 +833,9 @@ pub struct ServerInitContext<'a> {
 // ─── ServePlugins ────────────────────────────────────────────────────────────
 /// State machine to handle loading plugins asynchronously. This structure is not thread-safe.
 ///
-/// Intrusively refcounted via `#[derive(bun_ptr::CellRefCounted)]` (which also
-/// emits the `AnyRefCounted` bridge, so `bun_ptr::IntrusiveRc<ServePlugins>` /
-/// `ScopedRef` work). The refcount is incremented while other objects
-/// (HTMLBundle routes, DevServer) wait on plugin loads; the raw `*ServePlugins`
-/// crosses FFI as the JSPromise then/catch context pointer; the last deref
-/// frees. The derive's `deref` projects the count via `addr_of!` and frees
-/// through the original allocation pointer, preserving the `heap::alloc`
-/// provenance from [`ServePlugins::init`].
+/// Intrusively refcounted via `#[derive(bun_ptr::CellRefCounted)]`; the raw
+/// pointer crosses FFI as the JSPromise then/catch context and the last deref
+/// frees, preserving the `heap::alloc` provenance from [`ServePlugins::init`].
 #[derive(bun_ptr::CellRefCounted)]
 pub struct ServePlugins {
     state: ServePluginsState,
@@ -893,10 +888,7 @@ impl ServePlugins {
         }))
     }
 
-    // `ref_()` / `deref(this: *mut Self)` are emitted by the
-    // `CellRefCounted` derive; the deref projects the refcount via `addr_of!`
-    // (never forming `&Self`) and frees through the raw allocation pointer,
-    // so provenance from `init()`'s `heap::into_raw` is preserved.
+    // `ref_()` / `deref(this: *mut Self)` are emitted by the `CellRefCounted` derive.
 
     pub fn get_or_start_load(
         &mut self,
@@ -1136,10 +1128,8 @@ pub(super) fn on_resolve_impl(
 
     let [plugins_result, plugins_js] = callframe.arguments_as_array::<2>();
     let plugins = plugins_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); the
-    // adopted guard's drop-deref pairs with that ref (provenance: the raw ptr
-    // round-trips FFI untouched, so the final free sees `init()`'s allocation
-    // pointer).
+    // SAFETY: `plugins` was heap-allocated and ref()'d before `.then()`; the
+    // adopted guard's drop-deref pairs with that ref.
     let _guard = unsafe { bun_ptr::ScopedRef::<ServePlugins>::adopt(plugins) };
     plugins_result.ensure_still_alive();
 
@@ -1155,8 +1145,7 @@ pub(super) fn on_reject_impl(global: &JSGlobalObject, callframe: &CallFrame) -> 
 
     let [error_js, plugin_js] = callframe.arguments_as_array::<2>();
     let plugins = plugin_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); the
-    // adopted guard's drop-deref pairs with that ref (see on_resolve above).
+    // SAFETY: see `on_resolve_impl`.
     let _guard = unsafe { bun_ptr::ScopedRef::<ServePlugins>::adopt(plugins) };
     // SAFETY: pointer was passed via .then() above
     unsafe { &mut *plugins }.handle_on_reject(global, error_js);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -832,13 +832,20 @@ pub struct ServerInitContext<'a> {
 
 // ─── ServePlugins ────────────────────────────────────────────────────────────
 /// State machine to handle loading plugins asynchronously. This structure is not thread-safe.
+///
+/// Intrusively refcounted via `#[derive(bun_ptr::CellRefCounted)]` (which also
+/// emits the `AnyRefCounted` bridge, so `bun_ptr::IntrusiveRc<ServePlugins>` /
+/// `ScopedRef` work). The refcount is incremented while other objects
+/// (HTMLBundle routes, DevServer) wait on plugin loads; the raw `*ServePlugins`
+/// crosses FFI as the JSPromise then/catch context pointer; the last deref
+/// frees. The derive's `deref` projects the count via `addr_of!` and frees
+/// through the original allocation pointer, preserving the `heap::alloc`
+/// provenance from [`ServePlugins::init`].
+#[derive(bun_ptr::CellRefCounted)]
 pub struct ServePlugins {
     state: ServePluginsState,
     ref_count: core::cell::Cell<u32>,
 }
-
-// Reference count is incremented while there are other objects waiting on plugin loads.
-// Maps to bun_ptr::IntrusiveRc<ServePlugins> — *ServePlugins crosses FFI as promise context ptr.
 
 pub enum ServePluginsState {
     Unqueued(Box<[Box<[u8]>]>),
@@ -886,43 +893,10 @@ impl ServePlugins {
         }))
     }
 
-    pub fn ref_(&self) {
-        self.ref_count.set(self.ref_count.get() + 1);
-    }
-
-    /// Bump the refcount and return an RAII guard that derefs on `Drop`.
-    ///
-    /// # Safety
-    /// `this` must originate from [`ServePlugins::init`] (carry `heap::alloc`
-    /// write provenance) so the eventual `deref_` can free it. Do **not** derive
-    /// `this` from a `&Self`/`&mut Self` reborrow — under Stacked Borrows that
-    /// pointer is invalidated by later writes through the reference and cannot
-    /// be used to deallocate.
-    #[inline]
-    unsafe fn guard_ref(this: *mut Self) -> ServePluginsRef {
-        // SAFETY: caller contract — `this` is live.
-        unsafe { (*this).ref_() };
-        ServePluginsRef(this)
-    }
-
-    /// Decrement the intrusive refcount, freeing the allocation when it hits zero.
-    ///
-    /// Takes the raw `*mut` (not `&self`) so the original `heap::alloc` provenance
-    /// from [`ServePlugins::init`] is preserved for the final `heap::take` — going
-    /// through `&self` would narrow provenance to read-only and make the drop UB.
-    ///
-    /// SAFETY: `this` must originate from [`ServePlugins::init`] and the caller must
-    /// hold a counted reference.
-    pub unsafe fn deref_(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live while refcount > 0
-        let rc = unsafe { &(*this).ref_count };
-        let n = rc.get() - 1;
-        rc.set(n);
-        if n == 0 {
-            // SAFETY: refcount hit zero; `this` carries the heap::alloc provenance from init()
-            unsafe { drop(bun_core::heap::take(this)) };
-        }
-    }
+    // `ref_()` / `deref(this: *mut Self)` are emitted by the
+    // `CellRefCounted` derive; the deref projects the refcount via `addr_of!`
+    // (never forming `&Self`) and frees through the raw allocation pointer,
+    // so provenance from `init()`'s `heap::into_raw` is preserved.
 
     pub fn get_or_start_load(
         &mut self,
@@ -989,7 +963,7 @@ impl ServePlugins {
         // lives in the caller (`get_or_load_plugins`), which holds the heap-allocated
         // `*mut ServePlugins` directly. Deriving the guard's pointer from `&mut self`
         // here would give it a tag that is invalidated by the writes to `self.state`
-        // below (Stacked Borrows), making the eventual `heap::take` in `deref_` UB.
+        // below (Stacked Borrows), making the eventual free in `deref` UB.
 
         let plugin = JSBundler::Plugin::create(global, bun_jsc::BunPluginTarget::Browser);
         // SAFETY: `Plugin::create` returns a freshly-boxed `*mut Plugin` (single owner).
@@ -1142,35 +1116,6 @@ impl ServePlugins {
     }
 }
 
-/// RAII owner of one counted reference to a [`ServePlugins`]. Drops the
-/// reference via [`ServePlugins::deref_`] on scope exit.
-///
-/// Holds the raw `*mut` from [`ServePlugins::init`] so the final `heap::take`
-/// has write/dealloc provenance over the whole allocation. Never construct this
-/// from a pointer derived through `&ServePlugins` — that yields a SharedReadOnly
-/// tag under Stacked Borrows and freeing through it is UB.
-struct ServePluginsRef(*mut ServePlugins);
-
-impl ServePluginsRef {
-    /// Adopt an existing +1 reference (no increment).
-    ///
-    /// # Safety
-    /// Caller must own one counted reference to `ptr`, and `ptr` must carry the
-    /// `heap::alloc` provenance from [`ServePlugins::init`].
-    #[inline]
-    unsafe fn adopt(ptr: *mut ServePlugins) -> Self {
-        Self(ptr)
-    }
-}
-
-impl Drop for ServePluginsRef {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: constructed via `adopt`/`guard_ref` with a live counted ref.
-        unsafe { ServePlugins::deref_(self.0) };
-    }
-}
-
 impl Drop for ServePlugins {
     fn drop(&mut self) {
         match &self.state {
@@ -1191,8 +1136,11 @@ pub(super) fn on_resolve_impl(
 
     let [plugins_result, plugins_js] = callframe.arguments_as_array::<2>();
     let plugins = plugins_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); deref pairs with that ref
-    let _guard = unsafe { ServePluginsRef::adopt(plugins) };
+    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); the
+    // adopted guard's drop-deref pairs with that ref (provenance: the raw ptr
+    // round-trips FFI untouched, so the final free sees `init()`'s allocation
+    // pointer).
+    let _guard = unsafe { bun_ptr::ScopedRef::<ServePlugins>::adopt(plugins) };
     plugins_result.ensure_still_alive();
 
     // SAFETY: pointer was passed via .then() above
@@ -1207,8 +1155,9 @@ pub(super) fn on_reject_impl(global: &JSGlobalObject, callframe: &CallFrame) -> 
 
     let [error_js, plugin_js] = callframe.arguments_as_array::<2>();
     let plugins = plugin_js.as_promise_ptr::<ServePlugins>();
-    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); deref pairs with that ref
-    let _guard = unsafe { ServePluginsRef::adopt(plugins) };
+    // SAFETY: `plugins` was heap-allocated and ref()'d before .then(); the
+    // adopted guard's drop-deref pairs with that ref (see on_resolve above).
+    let _guard = unsafe { bun_ptr::ScopedRef::<ServePlugins>::adopt(plugins) };
     // SAFETY: pointer was passed via .then() above
     unsafe { &mut *plugins }.handle_on_reject(global, error_js);
 
@@ -1427,8 +1376,9 @@ where
             // `&mut *p` reborrow below and remains valid for `heap::take` on drop.
             //
             // SAFETY: `p` was produced by `ServePlugins::init` (heap::alloc) and is
-            // live while held in `self.plugins`.
-            let _deref_guard = unsafe { ServePlugins::guard_ref(p.as_ptr()) };
+            // live while held in `self.plugins`; the guard's deref-on-drop can
+            // run a re-entrant plugin-rejection path that releases other refs.
+            let _deref_guard = unsafe { bun_ptr::ScopedRef::<ServePlugins>::new(p.as_ptr()) };
             // SAFETY: `plugins` holds a counted ref produced by
             // `ServePlugins::init` (heap::alloc); intrusive refcount permits
             // mutation through any owner. No other `&mut ServePlugins` is live

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -127,6 +127,60 @@ impl IOReader {
             .expect("IOReader::keepalive after last Arc dropped")
     }
 
+    /// Keepalive for the bun_io vtable callbacks: like [`Self::keepalive`],
+    /// but if the guard turns out to hold the LAST strong ref when it drops,
+    /// the final release hops to the event loop ([`Self::async_deinit`])
+    /// instead of running `Drop for IOReader` — which tears down the embedded
+    /// `BufferedReader` — under the read-loop frame that is still on the
+    /// stack below the callback.
+    #[inline]
+    fn callback_keepalive(&self) -> CallbackKeepalive {
+        CallbackKeepalive(Some(self.keepalive()))
+    }
+
+    /// Hand the final strong ref to the event loop: `Drop for IOReader` then
+    /// runs from the `ShellIOReaderAsyncDeinit` dispatch arm on the next tick,
+    /// with no bun_io frame on the stack.
+    fn async_deinit(this: std::sync::Arc<IOReader>) {
+        use bun_event_loop::{ConcurrentTask::AutoDeinit, EventLoopTaskPtr};
+        let evtloop = this.state().evtloop;
+        // Transfer the strong ref into the task; `deinit_on_main_thread` (the
+        // dispatch consumer) decrements it on the next tick.
+        let raw: *mut IOReader = std::sync::Arc::into_raw(this).cast_mut();
+        match evtloop {
+            EventLoopHandle::Js { .. } => {
+                let payload = bun_core::heap::into_raw(Box::new(
+                    crate::shell::dispatch_tasks::AsyncDeinitReader {
+                        reader: raw,
+                        concurrent_task: Default::default(),
+                    },
+                ));
+                // SAFETY: `payload` is the live heap allocation created above;
+                // ownership transfers to the queue and is reclaimed
+                // (`heap::take`) by `AsyncDeinitReader::run_from_main_thread`.
+                // The embedded `ConcurrentTask` is enqueued exactly once.
+                unsafe {
+                    let ct = (*payload)
+                        .concurrent_task
+                        .from(payload, AutoDeinit::ManualDeinit);
+                    evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
+                        js: std::ptr::from_mut(ct),
+                    });
+                }
+            }
+            EventLoopHandle::Mini(_) => {
+                fn deinit_mini(reader: *mut IOReader, _: *mut core::ffi::c_void) {
+                    IOReader::deinit_on_main_thread(reader);
+                }
+                let any = bun_jsc::AnyTaskWithExtraContext::AnyTaskWithExtraContext::from_callback_auto_deinit(
+                    raw,
+                    deinit_mini,
+                );
+                evtloop.enqueue_task_concurrent(EventLoopTaskPtr { mini: any });
+            }
+        }
+    }
+
     pub fn init(fd: Fd, evtloop: EventLoopHandle) -> std::sync::Arc<IOReader> {
         let mut reader = ReaderImpl::init::<IOReader>();
         #[cfg(not(windows))]
@@ -275,8 +329,9 @@ impl IOReader {
         // `dispatch_read_chunk` → `Cat::on_io_reader_chunk` may drop the last
         // external Arc; hold one across the whole body so the trailing
         // `state()` accesses (and `run_yield`'s re-read of `interp`) see live
-        // memory.
-        let _keepalive = self.keepalive();
+        // memory. If ours ends up being the last ref, the guard defers the
+        // final release past the read-loop frame below us.
+        let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         // NOTE: reshaped for borrowck — `dispatch_read_chunk`/`run_yield`
         // both re-derive `state()` (and the interpreter callback may re-enter
@@ -320,8 +375,9 @@ impl IOReader {
 
     fn on_reader_error(&self, err: &sys::Error) {
         // `dispatch_reader_done` may drop the last external Arc; keep `self`
-        // alive across the loop.
-        let _keepalive = self.keepalive();
+        // alive across the loop (deferred final release — see
+        // `callback_keepalive`).
+        let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         let s = self.state();
         s.err = Some(err.to_shell_system_error());
@@ -341,8 +397,9 @@ impl IOReader {
         // `dispatch_reader_done` → `Cat::on_io_reader_done` drops Cat's
         // `Arc<IOReader>`; if that was the last external ref, `self` is freed
         // mid-loop and `run_yield`'s `state().interp` reads 0xdfdf poison.
-        // Hold a strong ref across the body.
-        let _keepalive = self.keepalive();
+        // Hold a strong ref across the body (deferred final release — see
+        // `callback_keepalive`).
+        let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         let s = self.state();
         let readers: Vec<ChildPtr> = s.readers.clone();
@@ -396,12 +453,10 @@ bun_io::impl_buffered_reader_parent! {
 
 impl Drop for IOReader {
     fn drop(&mut self) {
-        // With `Arc` the last ref drops after the callback returns, so this
-        // does not run from inside a read callback while BufferedReader is
-        // still iterating.
-        // TODO: revisit if a child callback can drop the last Arc while
-        // BufferedReader is still on the stack — would need the
-        // EventLoopTask hop once the shell EventLoopHandle shim is real.
+        // Never runs under a bun_io read-loop frame: the vtable callbacks
+        // hold a `callback_keepalive` guard, and if that guard turns out to
+        // own the last strong ref it hops the final release to the event loop
+        // (`async_deinit`) instead of dropping inline.
         let s = self.state.get_mut();
         let r = self.reader.get_mut();
         if s.fd != Fd::INVALID {
@@ -463,5 +518,41 @@ fn dispatch_reader_done(
         ReaderTag::Cat => {
             crate::shell::builtins::cat::Cat::on_io_reader_done(interp, child.node, err)
         }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Deferred final release (async-deinit hop)
+// ──────────────────────────────────────────────────────────────────────────
+
+impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::AsyncDeinitReader {
+    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellIOReaderAsyncDeinit;
+}
+
+/// Guard holding a strong ref taken inside a bun_io vtable callback. On drop,
+/// a non-final ref is released inline; the FINAL ref is handed to
+/// [`IOReader::async_deinit`] so teardown never runs under the read loop.
+///
+/// The `strong_count == 1` check is not racy because every strong and weak
+/// handle to an `IOReader` is confined to the shell event-loop thread (the
+/// interpreter tree, child states, and `self_weak` all live there, and the
+/// `Cell`-based `State` makes the type unfit to share across threads), so no
+/// other thread can clone or drop a handle between the count check and the
+/// hand-off to `async_deinit`.
+///
+/// Shutdown edge: the hop enqueues the final ref as an event-loop task; if
+/// the loop is already shutting down and never ticks again, that ref (and
+/// its fd) is leaked rather than freed under a live callback frame — the
+/// intended trade.
+struct CallbackKeepalive(Option<std::sync::Arc<IOReader>>);
+
+impl Drop for CallbackKeepalive {
+    fn drop(&mut self) {
+        let Some(ka) = self.0.take() else { return };
+        if std::sync::Arc::strong_count(&ka) > 1 {
+            // Not the last ref — plain drop.
+            return;
+        }
+        IOReader::async_deinit(ka);
     }
 }

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -127,25 +127,18 @@ impl IOReader {
             .expect("IOReader::keepalive after last Arc dropped")
     }
 
-    /// Keepalive for the bun_io vtable callbacks: like [`Self::keepalive`],
-    /// but if the guard turns out to hold the LAST strong ref when it drops,
-    /// the final release hops to the event loop ([`Self::async_deinit`])
-    /// instead of running `Drop for IOReader` — which tears down the embedded
-    /// `BufferedReader` — under the read-loop frame that is still on the
-    /// stack below the callback.
+    /// Like [`Self::keepalive`], but a final ref hops to the event loop
+    /// ([`Self::async_deinit`]) instead of dropping under the read-loop frame.
     #[inline]
     fn callback_keepalive(&self) -> CallbackKeepalive {
         CallbackKeepalive(Some(self.keepalive()))
     }
 
-    /// Hand the final strong ref to the event loop: `Drop for IOReader` then
-    /// runs from the `ShellIOReaderAsyncDeinit` dispatch arm on the next tick,
-    /// with no bun_io frame on the stack.
+    /// Hands the final strong ref to the event loop so `Drop` runs on the
+    /// next tick, with no bun_io frame on the stack.
     fn async_deinit(this: std::sync::Arc<IOReader>) {
         use bun_event_loop::{ConcurrentTask::AutoDeinit, EventLoopTaskPtr};
         let evtloop = this.state().evtloop;
-        // Transfer the strong ref into the task; `deinit_on_main_thread` (the
-        // dispatch consumer) decrements it on the next tick.
         let raw: *mut IOReader = std::sync::Arc::into_raw(this).cast_mut();
         match evtloop {
             EventLoopHandle::Js { .. } => {
@@ -155,10 +148,8 @@ impl IOReader {
                         concurrent_task: Default::default(),
                     },
                 ));
-                // SAFETY: `payload` is the live heap allocation created above;
-                // ownership transfers to the queue and is reclaimed
-                // (`heap::take`) by `AsyncDeinitReader::run_from_main_thread`.
-                // The embedded `ConcurrentTask` is enqueued exactly once.
+                // SAFETY: `payload` ownership transfers to the queue; reclaimed
+                // once by `AsyncDeinitReader::run_from_main_thread`.
                 unsafe {
                     let ct = (*payload)
                         .concurrent_task
@@ -329,8 +320,7 @@ impl IOReader {
         // `dispatch_read_chunk` → `Cat::on_io_reader_chunk` may drop the last
         // external Arc; hold one across the whole body so the trailing
         // `state()` accesses (and `run_yield`'s re-read of `interp`) see live
-        // memory. If ours ends up being the last ref, the guard defers the
-        // final release past the read-loop frame below us.
+        // memory.
         let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         // NOTE: reshaped for borrowck — `dispatch_read_chunk`/`run_yield`
@@ -375,8 +365,7 @@ impl IOReader {
 
     fn on_reader_error(&self, err: &sys::Error) {
         // `dispatch_reader_done` may drop the last external Arc; keep `self`
-        // alive across the loop (deferred final release — see
-        // `callback_keepalive`).
+        // alive across the loop.
         let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         let s = self.state();
@@ -397,8 +386,7 @@ impl IOReader {
         // `dispatch_reader_done` → `Cat::on_io_reader_done` drops Cat's
         // `Arc<IOReader>`; if that was the last external ref, `self` is freed
         // mid-loop and `run_yield`'s `state().interp` reads 0xdfdf poison.
-        // Hold a strong ref across the body (deferred final release — see
-        // `callback_keepalive`).
+        // Hold a strong ref across the body.
         let _keepalive = self.callback_keepalive();
         self.set_reading(false);
         let s = self.state();
@@ -453,10 +441,8 @@ bun_io::impl_buffered_reader_parent! {
 
 impl Drop for IOReader {
     fn drop(&mut self) {
-        // Never runs under a bun_io read-loop frame: the vtable callbacks
-        // hold a `callback_keepalive` guard, and if that guard turns out to
-        // own the last strong ref it hops the final release to the event loop
-        // (`async_deinit`) instead of dropping inline.
+        // Never runs under a bun_io read-loop frame: callbacks hold a
+        // `callback_keepalive` guard that hops a final ref to the event loop.
         let s = self.state.get_mut();
         let r = self.reader.get_mut();
         if s.fd != Fd::INVALID {
@@ -521,36 +507,21 @@ fn dispatch_reader_done(
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Deferred final release (async-deinit hop)
-// ──────────────────────────────────────────────────────────────────────────
-
 impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::AsyncDeinitReader {
     const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellIOReaderAsyncDeinit;
 }
 
-/// Guard holding a strong ref taken inside a bun_io vtable callback. On drop,
-/// a non-final ref is released inline; the FINAL ref is handed to
+/// Keepalive taken inside a bun_io callback; a final ref is handed to
 /// [`IOReader::async_deinit`] so teardown never runs under the read loop.
-///
-/// The `strong_count == 1` check is not racy because every strong and weak
-/// handle to an `IOReader` is confined to the shell event-loop thread (the
-/// interpreter tree, child states, and `self_weak` all live there, and the
-/// `Cell`-based `State` makes the type unfit to share across threads), so no
-/// other thread can clone or drop a handle between the count check and the
-/// hand-off to `async_deinit`.
-///
-/// Shutdown edge: the hop enqueues the final ref as an event-loop task; if
-/// the loop is already shutting down and never ticks again, that ref (and
-/// its fd) is leaked rather than freed under a live callback frame — the
-/// intended trade.
+/// The `strong_count == 1` check is not racy: all `IOReader` handles are
+/// confined to the shell event-loop thread. If the loop never ticks again
+/// (shutdown), the final ref leaks — the intended trade.
 struct CallbackKeepalive(Option<std::sync::Arc<IOReader>>);
 
 impl Drop for CallbackKeepalive {
     fn drop(&mut self) {
         let Some(ka) = self.0.take() else { return };
         if std::sync::Arc::strong_count(&ka) > 1 {
-            // Not the last ref — plain drop.
             return;
         }
         IOReader::async_deinit(ka);

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -263,25 +263,18 @@ impl IOWriter {
             .expect("IOWriter::keepalive after last Arc dropped")
     }
 
-    /// Keepalive for PipeWriter/poll callback frames: like
-    /// [`Self::keepalive`], but if the guard ends up holding the LAST strong
-    /// ref when it drops, the final release hops to the event loop
-    /// ([`Self::async_deinit`]) instead of running `Drop for IOWriter` —
-    /// which closes the writer/poll/fd — under a writer frame that is still
-    /// on the stack.
+    /// Like [`Self::keepalive`], but a final ref hops to the event loop
+    /// ([`Self::async_deinit`]) instead of dropping under a writer frame.
     #[inline]
     fn callback_keepalive(&self) -> CallbackKeepalive {
         CallbackKeepalive(Some(self.keepalive()))
     }
 
-    /// Hand the final strong ref to the event loop: `Drop for IOWriter` then
-    /// runs from the `ShellIOWriterAsyncDeinit` dispatch arm on the next
-    /// tick, with no PipeWriter/poll frame on the stack.
+    /// Hands the final strong ref to the event loop so `Drop` runs on the
+    /// next tick, with no PipeWriter/poll frame on the stack.
     fn async_deinit(this: std::sync::Arc<IOWriter>) {
         use bun_event_loop::{ConcurrentTask::AutoDeinit, EventLoopTaskPtr};
         let evtloop = this.state().evtloop;
-        // Transfer the strong ref into the task; `deinit_on_main_thread` (the
-        // dispatch consumer) decrements it on the next tick.
         let raw: *mut IOWriter = std::sync::Arc::into_raw(this).cast_mut();
         match evtloop {
             EventLoopHandle::Js { .. } => {
@@ -291,10 +284,8 @@ impl IOWriter {
                         concurrent_task: Default::default(),
                     },
                 ));
-                // SAFETY: `payload` is the live heap allocation created above;
-                // ownership transfers to the queue and is reclaimed
-                // (`heap::take`) by `AsyncDeinitWriter::run_from_main_thread`.
-                // The embedded `ConcurrentTask` is enqueued exactly once.
+                // SAFETY: `payload` ownership transfers to the queue; reclaimed
+                // once by `AsyncDeinitWriter::run_from_main_thread`.
                 unsafe {
                     let ct = (*payload)
                         .concurrent_task
@@ -317,8 +308,8 @@ impl IOWriter {
         }
     }
 
-    /// Read-only accessor for the `is_socket` flag (used by
-    /// `ShellSubprocess::spawn` to decide `no_sigpipe`).
+    /// Whether the underlying fd is a socket (`ShellSubprocess::spawn` uses
+    /// this to decide `no_sigpipe`).
     #[inline]
     pub fn is_socket(&self) -> bool {
         self.state().flags.is_socket
@@ -422,26 +413,17 @@ impl IOWriter {
     fn __start(&self) -> sys::Result<()> {
         let s = self.state();
         crate::shell_log!("IOWriter(fd={}) __start()", s.fd);
-        // `start_movable`: on Windows, libuv takes ownership of the HANDLE
-        // when the source opens as a uv pipe/tty; the writer then `take()`s
-        // the movable slot so we know to disarm our retained `s.fd` (whose
-        // Drop/deinit close would otherwise double-close the HANDLE libuv's
-        // `uv_close` closes). On POSIX this is identical to `start`.
+        // On Windows, libuv takes ownership of the HANDLE when the source
+        // opens as a uv pipe/tty; the taken slot tells us to disarm `s.fd` so
+        // Drop doesn't double-close. On POSIX this is identical to `start`.
         let mut movable_fd = bun_sys::MovableIfWindowsFd::init(s.fd);
         let start_result = s.writer.start_movable(&mut movable_fd, s.flags.pollable);
         #[cfg(windows)]
         {
             if !movable_fd.is_owned() {
-                // Ownership transferred to libuv: `start_movable` `take()`s
-                // the slot only after the source opened as Pipe/Tty, and from
-                // `uv_pipe_open`/`uv_tty_init` onward libuv's `uv_close`
-                // closes the HANDLE — even if a later step of start fails. So
-                // the disarm is keyed on the slot alone, not on the overall
-                // start result. The `Source::File`/`SyncFile` case — incl.
-                // the EBADF→`start_with_file` fallback below, which `return`s
-                // early — leaves the slot owned and keeps `s.fd` valid: with
-                // `owns_fd=false` PipeWriter does NOT close it there, so Drop
-                // must.
+                // libuv owns the HANDLE from `uv_pipe_open`/`uv_tty_init`
+                // onward, even if a later start step fails — so key the
+                // disarm on the slot, not on `start_result`.
                 s.fd = Fd::INVALID;
             }
         }
@@ -753,9 +735,7 @@ impl IOWriter {
     fn do_file_write(&self) -> Yield {
         // `drain_buffered_data`/`on_error` below re-enter the interpreter and
         // may drop the last external Arc; hold one across the whole body so the
-        // trailing `set_writing(false)` defer runs on a live `self`. If ours
-        // ends up being the last ref, the guard defers the final release to
-        // the event loop (the caller may still touch `&self` after we return).
+        // trailing `set_writing(false)` defer runs on a live `self`.
         let _keepalive = self.callback_keepalive();
         {
             let s = self.state();
@@ -911,7 +891,6 @@ impl IOWriter {
     }
 
     fn on_error(&self, err: &sys::Error) {
-        // Deferred final release — see `callback_keepalive`.
         let _keepalive = self.callback_keepalive();
         self.set_writing(false);
         let s = self.state();
@@ -1197,9 +1176,8 @@ fn drain_buffered_data(
 impl Drop for IOWriter {
     fn drop(&mut self) {
         // Never runs under a PipeWriter/poll callback frame: those frames
-        // hold a `callback_keepalive` guard, and if that guard turns out to
-        // own the last strong ref it hops the final release to the event loop
-        // (`async_deinit`) instead of dropping inline.
+        // hold a `callback_keepalive` guard that hops a final ref to the
+        // event loop.
         let s = self.state.get_mut();
         crate::shell_log!("IOWriter(fd={}) deinit", s.fd);
         #[cfg(not(windows))]
@@ -1270,36 +1248,21 @@ pub(crate) fn on_io_writer_chunk(
     }
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Deferred final release (async-deinit hop)
-// ──────────────────────────────────────────────────────────────────────────
-
 impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::AsyncDeinitWriter {
     const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellIOWriterAsyncDeinit;
 }
 
-/// Guard holding a strong ref taken inside a PipeWriter/poll callback frame.
-/// On drop, a non-final ref is released inline; the FINAL ref is handed to
-/// [`IOWriter::async_deinit`] so teardown never runs under a writer frame.
-///
-/// The `strong_count == 1` check is not racy because every strong and weak
-/// handle to an `IOWriter` is confined to the shell event-loop thread (the
-/// interpreter tree, child states, and `self_weak` all live there, and the
-/// `Cell`-based `State` makes the type unfit to share across threads), so no
-/// other thread can clone or drop a handle between the count check and the
-/// hand-off to `async_deinit`.
-///
-/// Shutdown edge: the hop enqueues the final ref as an event-loop task; if
-/// the loop is already shutting down and never ticks again, that ref (and
-/// its fd) is leaked rather than freed under a live callback frame — the
-/// intended trade.
+/// Keepalive taken inside a PipeWriter/poll callback; a final ref is handed
+/// to [`IOWriter::async_deinit`] so teardown never runs under a writer frame.
+/// The `strong_count == 1` check is not racy: all `IOWriter` handles are
+/// confined to the shell event-loop thread. If the loop never ticks again
+/// (shutdown), the final ref leaks — the intended trade.
 struct CallbackKeepalive(Option<std::sync::Arc<IOWriter>>);
 
 impl Drop for CallbackKeepalive {
     fn drop(&mut self) {
         let Some(ka) = self.0.take() else { return };
         if std::sync::Arc::strong_count(&ka) > 1 {
-            // Not the last ref — plain drop.
             return;
         }
         IOWriter::async_deinit(ka);

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -176,7 +176,7 @@ pub fn on_poll(writer: &mut Poll, size_hint: isize, hup: bool) {
     // `parent` is the backref stashed via `set_parent` in `IOWriter::init`;
     // `writer` is a field of `*parent`, so the pointee is live. Re-enter via
     // `&self` (UnsafeCell aliasing model). `ParentRef::Deref → &IOWriter`.
-    let _keepalive = parent.keepalive();
+    let _keepalive = parent.callback_keepalive();
     writer.on_poll(size_hint, hup);
 }
 
@@ -261,6 +261,60 @@ impl IOWriter {
             .self_weak
             .upgrade()
             .expect("IOWriter::keepalive after last Arc dropped")
+    }
+
+    /// Keepalive for PipeWriter/poll callback frames: like
+    /// [`Self::keepalive`], but if the guard ends up holding the LAST strong
+    /// ref when it drops, the final release hops to the event loop
+    /// ([`Self::async_deinit`]) instead of running `Drop for IOWriter` —
+    /// which closes the writer/poll/fd — under a writer frame that is still
+    /// on the stack.
+    #[inline]
+    fn callback_keepalive(&self) -> CallbackKeepalive {
+        CallbackKeepalive(Some(self.keepalive()))
+    }
+
+    /// Hand the final strong ref to the event loop: `Drop for IOWriter` then
+    /// runs from the `ShellIOWriterAsyncDeinit` dispatch arm on the next
+    /// tick, with no PipeWriter/poll frame on the stack.
+    fn async_deinit(this: std::sync::Arc<IOWriter>) {
+        use bun_event_loop::{ConcurrentTask::AutoDeinit, EventLoopTaskPtr};
+        let evtloop = this.state().evtloop;
+        // Transfer the strong ref into the task; `deinit_on_main_thread` (the
+        // dispatch consumer) decrements it on the next tick.
+        let raw: *mut IOWriter = std::sync::Arc::into_raw(this).cast_mut();
+        match evtloop {
+            EventLoopHandle::Js { .. } => {
+                let payload = bun_core::heap::into_raw(Box::new(
+                    crate::shell::dispatch_tasks::AsyncDeinitWriter {
+                        writer: raw,
+                        concurrent_task: Default::default(),
+                    },
+                ));
+                // SAFETY: `payload` is the live heap allocation created above;
+                // ownership transfers to the queue and is reclaimed
+                // (`heap::take`) by `AsyncDeinitWriter::run_from_main_thread`.
+                // The embedded `ConcurrentTask` is enqueued exactly once.
+                unsafe {
+                    let ct = (*payload)
+                        .concurrent_task
+                        .from(payload, AutoDeinit::ManualDeinit);
+                    evtloop.enqueue_task_concurrent(EventLoopTaskPtr {
+                        js: std::ptr::from_mut(ct),
+                    });
+                }
+            }
+            EventLoopHandle::Mini(_) => {
+                fn deinit_mini(writer: *mut IOWriter, _: *mut core::ffi::c_void) {
+                    IOWriter::deinit_on_main_thread(writer);
+                }
+                let any = bun_jsc::AnyTaskWithExtraContext::AnyTaskWithExtraContext::from_callback_auto_deinit(
+                    raw,
+                    deinit_mini,
+                );
+                evtloop.enqueue_task_concurrent(EventLoopTaskPtr { mini: any });
+            }
+        }
     }
 
     /// Read-only accessor for the `is_socket` flag (used by
@@ -368,7 +422,34 @@ impl IOWriter {
     fn __start(&self) -> sys::Result<()> {
         let s = self.state();
         crate::shell_log!("IOWriter(fd={}) __start()", s.fd);
-        if let Err(e) = s.writer.start(s.fd, s.flags.pollable) {
+        // `start_movable`: on Windows, libuv takes ownership of the HANDLE
+        // when the source opens as a uv pipe/tty; the writer then `take()`s
+        // the movable slot so we know to disarm our retained `s.fd` (whose
+        // Drop/deinit close would otherwise double-close the HANDLE libuv's
+        // `uv_close` closes). On POSIX this is identical to `start`.
+        let mut movable_fd = bun_sys::MovableIfWindowsFd::init(s.fd);
+        let start_result = s.writer.start_movable(&mut movable_fd, s.flags.pollable);
+        #[cfg(windows)]
+        {
+            if !movable_fd.is_owned() {
+                // Ownership transferred to libuv: `start_movable` `take()`s
+                // the slot only after the source opened as Pipe/Tty, and from
+                // `uv_pipe_open`/`uv_tty_init` onward libuv's `uv_close`
+                // closes the HANDLE — even if a later step of start fails. So
+                // the disarm is keyed on the slot alone, not on the overall
+                // start result. The `Source::File`/`SyncFile` case — incl.
+                // the EBADF→`start_with_file` fallback below, which `return`s
+                // early — leaves the slot owned and keeps `s.fd` valid: with
+                // `owns_fd=false` PipeWriter does NOT close it there, so Drop
+                // must.
+                s.fd = Fd::INVALID;
+            }
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = &movable_fd;
+        }
+        if let Err(e) = start_result {
             #[cfg(not(windows))]
             {
                 // We get this if we pass in a file descriptor that is not
@@ -425,25 +506,6 @@ impl IOWriter {
                 }
             }
             return Err(e);
-        }
-        #[cfg(windows)]
-        {
-            // When `Source::open` produced a uv pipe/tty, libuv has TAKEN
-            // OWNERSHIP of the underlying HANDLE
-            // (`uv_pipe_open`/`uv_tty_init`) and `uv_close` (issued by
-            // `s.writer.close()` in Drop) will close it.
-            // `BaseWindowsPipeWriter::start` does not invalidate the stored
-            // fd (TODO at PipeWriter.rs:1277), so disarm the Drop close here
-            // instead. The `Source::File`/`SyncFile` case (incl. the
-            // EBADF→`start_with_file` fallback above, which `return`s early)
-            // keeps `s.fd` valid: with `owns_fd=false` PipeWriter does NOT
-            // close it there, so Drop must.
-            if matches!(
-                s.writer.source,
-                Some(bun_io::Source::Pipe(_) | bun_io::Source::Tty(_))
-            ) {
-                s.fd = Fd::INVALID;
-            }
         }
         #[cfg(not(windows))]
         {
@@ -691,8 +753,10 @@ impl IOWriter {
     fn do_file_write(&self) -> Yield {
         // `drain_buffered_data`/`on_error` below re-enter the interpreter and
         // may drop the last external Arc; hold one across the whole body so the
-        // trailing `set_writing(false)` defer runs on a live `self`.
-        let _keepalive = self.keepalive();
+        // trailing `set_writing(false)` defer runs on a live `self`. If ours
+        // ends up being the last ref, the guard defers the final release to
+        // the event loop (the caller may still touch `&self` after we return).
+        let _keepalive = self.callback_keepalive();
         {
             let s = self.state();
             debug_assert!(!s.flags.pollable);
@@ -847,7 +911,8 @@ impl IOWriter {
     }
 
     fn on_error(&self, err: &sys::Error) {
-        let _keepalive = self.keepalive();
+        // Deferred final release — see `callback_keepalive`.
+        let _keepalive = self.callback_keepalive();
         self.set_writing(false);
         let s = self.state();
         if err.get_errno() == E::EPIPE {
@@ -1052,7 +1117,7 @@ bun_io::impl_buffered_writer_parent! {
     // Hold a keepalive across Windows on_write re-entry: `on_write_pollable` →
     // `run_yield` → `bump` may fire `on_io_writer_chunk`, which can drop the
     // last external `Arc<IOWriter>` (and the inline `uv_write_t`) mid-callback.
-    win_on_write_guard = |this| (&*this).keepalive(),
+    win_on_write_guard = |this| (&*this).callback_keepalive(),
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -1131,12 +1196,10 @@ fn drain_buffered_data(
 
 impl Drop for IOWriter {
     fn drop(&mut self) {
-        // With `Arc` the last ref drops *after* the callback returns, so the
-        // synchronous path is safe (PipeWriter cannot touch us after free).
-        // TODO: if a PipeWriter callback is on the stack when the last
-        // Arc drops (possible via re-entrant child deinit), we need the async
-        // hop. Revisit once `bun_event_loop::EventLoopTask` is wired to the
-        // shell's `EventLoopHandle` shim.
+        // Never runs under a PipeWriter/poll callback frame: those frames
+        // hold a `callback_keepalive` guard, and if that guard turns out to
+        // own the last strong ref it hops the final release to the event loop
+        // (`async_deinit`) instead of dropping inline.
         let s = self.state.get_mut();
         crate::shell_log!("IOWriter(fd={}) deinit", s.fd);
         #[cfg(not(windows))]
@@ -1204,5 +1267,41 @@ pub(crate) fn on_io_writer_chunk(
             let cw = unsafe { &mut *child.raw.cast::<crate::shell::subproc::CapturedWriter>() };
             cw.on_iowriter_chunk(written, err)
         }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Deferred final release (async-deinit hop)
+// ──────────────────────────────────────────────────────────────────────────
+
+impl bun_event_loop::Taskable for crate::shell::dispatch_tasks::AsyncDeinitWriter {
+    const TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::ShellIOWriterAsyncDeinit;
+}
+
+/// Guard holding a strong ref taken inside a PipeWriter/poll callback frame.
+/// On drop, a non-final ref is released inline; the FINAL ref is handed to
+/// [`IOWriter::async_deinit`] so teardown never runs under a writer frame.
+///
+/// The `strong_count == 1` check is not racy because every strong and weak
+/// handle to an `IOWriter` is confined to the shell event-loop thread (the
+/// interpreter tree, child states, and `self_weak` all live there, and the
+/// `Cell`-based `State` makes the type unfit to share across threads), so no
+/// other thread can clone or drop a handle between the count check and the
+/// hand-off to `async_deinit`.
+///
+/// Shutdown edge: the hop enqueues the final ref as an event-loop task; if
+/// the loop is already shutting down and never ticks again, that ref (and
+/// its fd) is leaked rather than freed under a live callback frame — the
+/// intended trade.
+struct CallbackKeepalive(Option<std::sync::Arc<IOWriter>>);
+
+impl Drop for CallbackKeepalive {
+    fn drop(&mut self) {
+        let Some(ka) = self.0.take() else { return };
+        if std::sync::Arc::strong_count(&ka) > 1 {
+            // Not the last ref — plain drop.
+            return;
+        }
+        IOWriter::async_deinit(ka);
     }
 }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -888,41 +888,16 @@ pub struct Param {
 pub(crate) type ParamList = Vec<Param>;
 
 /// QueryString array-backed hash table that does few allocations and preserves the original order
+#[derive(Clone)]
 pub struct QueryStringMap {
     // Allocator field dropped — global mimalloc per PORTING.md.
-    // `slice` is self-referential (points into `buffer`) when decoding
-    // happened, otherwise borrows the caller's query_string. Stored as raw fat ptr.
-    slice: *const [u8],
+    // All `StringPointer`s in `list` index into `buffer[..slice_len]`. The
+    // nothing-needs-decoding fast path copies the caller's query string into
+    // `buffer`, so the map never borrows external memory and is fully owned.
+    slice_len: usize,
     pub buffer: Vec<u8>,
     pub list: ParamList,
     pub name_count: Option<usize>,
-}
-
-impl Clone for QueryStringMap {
-    fn clone(&self) -> Self {
-        let buffer = self.buffer.clone();
-        // Re-derive `slice` so the clone doesn't dangle into the original buffer.
-        // If the original `slice` did NOT point into our own buffer (the
-        // nothing-needs-decoding fast path borrows the caller's query_string),
-        // keep it as-is — both clones borrow the same external slice.
-        // SAFETY: `self.slice` is valid for the lifetime of `self` — it either points
-        // into `self.buffer` (decoding path) or borrows an external query_string the
-        // caller keeps alive (nothing-needs-decoding fast path).
-        let self_slice = unsafe { &*self.slice };
-        let slice =
-            if !self.buffer.is_empty() && bun_alloc::is_slice_in_buffer(self_slice, &self.buffer) {
-                let len = self_slice.len();
-                &raw const buffer[..len]
-            } else {
-                self.slice
-            };
-        Self {
-            slice,
-            buffer,
-            list: self.list.clone(),
-            name_count: self.name_count,
-        }
-    }
 }
 
 thread_local! {
@@ -949,9 +924,7 @@ impl QueryStringMap {
     }
 
     pub fn str(&self, ptr: api::StringPointer) -> &[u8] {
-        // SAFETY: `slice` is valid for the lifetime of `self` (either borrows
-        // `self.buffer` or an external query_string the caller keeps alive).
-        let slice = unsafe { &*self.slice };
+        let slice = &self.buffer[..self.slice_len];
         &slice[ptr.offset as usize..ptr.offset as usize + ptr.length as usize]
     }
 
@@ -1131,11 +1104,10 @@ impl QueryStringMap {
 
         // buf.expandToCapacity() — Vec doesn't expose this; not needed since we slice by buf_writer_pos
         let _ = nothing_needs_decoding;
-        let slice_ptr: *const [u8] = &raw const buf[0..buf_writer_pos as usize];
         Ok(Some(QueryStringMap {
             list,
             buffer: buf,
-            slice: slice_ptr,
+            slice_len: buf_writer_pos as usize,
             name_count: None,
         }))
     }
@@ -1185,11 +1157,14 @@ impl QueryStringMap {
                 });
             }
 
+            // Copy the query string so the map owns its backing bytes; the
+            // existing StringPointer offsets remain valid against the copy.
+            let buffer = query_string.to_vec();
+            let slice_len = buffer.len();
             return Ok(Some(QueryStringMap {
                 list,
-                buffer: Vec::new(),
-                // `slice` borrows the caller's query_string; lifetime not tracked here
-                slice: std::ptr::from_ref::<[u8]>(query_string),
+                buffer,
+                slice_len,
                 name_count: None,
             }));
         }
@@ -1250,11 +1225,10 @@ impl QueryStringMap {
             });
         }
 
-        let slice_ptr: *const [u8] = &raw const buf[0..buf_writer_pos as usize];
         Ok(Some(QueryStringMap {
             list,
             buffer: buf,
-            slice: slice_ptr,
+            slice_len: buf_writer_pos as usize,
             name_count: None,
         }))
     }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -891,9 +891,8 @@ pub(crate) type ParamList = Vec<Param>;
 #[derive(Clone)]
 pub struct QueryStringMap {
     // Allocator field dropped — global mimalloc per PORTING.md.
-    // All `StringPointer`s in `list` index into `buffer[..slice_len]`. The
-    // nothing-needs-decoding fast path copies the caller's query string into
-    // `buffer`, so the map never borrows external memory and is fully owned.
+    // All `StringPointer`s in `list` index into `buffer[..slice_len]`; the
+    // map fully owns its backing bytes.
     slice_len: usize,
     pub buffer: Vec<u8>,
     pub list: ParamList,

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9514,3 +9514,99 @@ it("does not create a cache index entry outside the cache directory for a depend
   expect(outOk).toContain("1 package installed");
   expect(exitCodeOk).toBe(0);
 });
+
+it("installs and re-verifies scoped folder dependencies (destination subpath buffer handling)", async () => {
+  // The installer writes the destination path (`@scope/pkg`) into a single
+  // path buffer and temporarily appends suffixes (`/package.json`, NUL at the
+  // scope's `/`) into the same buffer during install/verify. A bug in the
+  // prefix/length bookkeeping corrupts the install path for scoped packages
+  // specifically. Install twice: the second run takes the verify path that
+  // appends `/package.json` past the stored prefix.
+  using dir = tempDir("scoped-folder-dep", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: {
+        "@myscope/aliased": "file:./vendor/scoped-pkg",
+        "plain-pkg": "file:./vendor/plain-pkg",
+      },
+    }),
+    "vendor/scoped-pkg/package.json": JSON.stringify({ name: "@myscope/aliased", version: "1.2.3" }),
+    "vendor/scoped-pkg/index.js": "module.exports = 'scoped';",
+    "vendor/plain-pkg/package.json": JSON.stringify({ name: "plain-pkg", version: "0.0.1" }),
+    "vendor/plain-pkg/index.js": "module.exports = 'plain';",
+  });
+
+  for (let run = 0; run < 2; run++) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  const installedScoped = await file(join(String(dir), "node_modules", "@myscope", "aliased", "package.json")).json();
+  expect(installedScoped.name).toBe("@myscope/aliased");
+  expect(installedScoped.version).toBe("1.2.3");
+  const installedPlain = await file(join(String(dir), "node_modules", "plain-pkg", "package.json")).json();
+  expect(installedPlain.name).toBe("plain-pkg");
+
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('@myscope/aliased'), require('plain-pkg'))"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, , runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(runOut.trim()).toBe("scoped plain");
+  expect(runExit).toBe(0);
+});
+
+it("isolated install of scoped folder dependencies succeeds and reports progress cleanup safely", async () => {
+  // Exercises the isolated-install path whose progress-node pointers are now
+  // cleared by a scopeguard on every exit (previously only on the success
+  // path). A success run plus an immediate second run (lockfile present)
+  // covers both the fresh-store and verify paths.
+  using dir = tempDir("isolated-scoped-folder-dep", {
+    "package.json": JSON.stringify({
+      name: "app-isolated",
+      version: "1.0.0",
+      dependencies: {
+        "@myscope/dep": "file:./vendor/dep",
+      },
+    }),
+    "bunfig.toml": `[install]\nlinker = "isolated"\n`,
+    "vendor/dep/package.json": JSON.stringify({ name: "@myscope/dep", version: "2.0.0" }),
+    "vendor/dep/index.js": "module.exports = 'isolated-dep';",
+  });
+
+  for (let run = 0; run < 2; run++) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(exitCode).toBe(0);
+  }
+
+  await using runProc = spawn({
+    cmd: [bunExe(), "-e", "console.log(require('@myscope/dep'))"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [runOut, , runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
+  expect(runOut.trim()).toBe("isolated-dep");
+  expect(runExit).toBe(0);
+});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9569,10 +9569,9 @@ it("installs and re-verifies scoped folder dependencies (destination subpath buf
 });
 
 it("isolated install of scoped folder dependencies succeeds and reports progress cleanup safely", async () => {
-  // Exercises the isolated-install path whose progress-node pointers are now
-  // cleared by a scopeguard on every exit (previously only on the success
-  // path). A success run plus an immediate second run (lockfile present)
-  // covers both the fresh-store and verify paths.
+  // Exercises the isolated-install path, whose progress-node pointers must
+  // be cleared on every exit path. A success run plus an immediate second run
+  // (lockfile present) covers both the fresh-store and verify paths.
   using dir = tempDir("isolated-scoped-folder-dep", {
     "package.json": JSON.stringify({
       name: "app-isolated",

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -666,8 +666,7 @@ test("bun pm cache rm does not create the directory named by a project-local .en
 
 it("pm hash-string prints the alphabetized lockfile string through the scoped stdout writer", async () => {
   // `bun pm hash-string` writes the lockfile's alphabetized name@version
-  // string through the closure-scoped stdout writer accessor (which replaced
-  // the legacy `&'static mut` thread-local writer escape). Output must be
+  // string through the closure-scoped stdout writer accessor; output must be
   // complete and the process must exit cleanly.
   using dir = tempDir("pm-hash-string-writer", {
     "package.json": JSON.stringify({

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -685,7 +685,8 @@ it("pm hash-string prints the alphabetized lockfile string through the scoped st
     stdout: "pipe",
     stderr: "pipe",
   });
-  expect(await install.exited).toBe(0);
+  const [, , installExitCode] = await Promise.all([install.stdout.text(), install.stderr.text(), install.exited]);
+  expect(installExitCode).toBe(0);
 
   await using proc = spawn({
     cmd: [bunExe(), "pm", "hash-string"],

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -663,3 +663,40 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+it("pm hash-string prints the alphabetized lockfile string through the scoped stdout writer", async () => {
+  // `bun pm hash-string` writes the lockfile's alphabetized name@version
+  // string through the closure-scoped stdout writer accessor (which replaced
+  // the legacy `&'static mut` thread-local writer escape). Output must be
+  // complete and the process must exit cleanly.
+  using dir = tempDir("pm-hash-string-writer", {
+    "package.json": JSON.stringify({
+      name: "hash-string-app",
+      version: "1.0.0",
+      dependencies: { "local-a": "file:./a", "local-b": "file:./b" },
+    }),
+    "a/package.json": JSON.stringify({ name: "local-a", version: "0.0.1" }),
+    "b/package.json": JSON.stringify({ name: "local-b", version: "0.0.2" }),
+  });
+
+  await using install = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(await install.exited).toBe(0);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "pm", "hash-string"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(out).toContain("local-a");
+  expect(out).toContain("local-b");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -673,3 +673,92 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
   proc.kill();
   await proc.exited;
 });
+
+const pluginFixtureFiles = {
+  "bunfig.toml": `
+[serve.static]
+plugins = ["./plugin.ts"]
+`,
+  "plugin.ts": /*ts*/ `
+const plugin: Bun.BunPlugin = {
+  name: "marker-plugin",
+  setup(build) {
+    build.onLoad({ filter: /marker\\.js$/ }, () => ({
+      contents: "globalThis.__marker = 'from-plugin';",
+      loader: "js",
+    }));
+  },
+};
+export default plugin;
+`,
+  "index.html": /*html*/ `
+    <!DOCTYPE html>
+    <html>
+      <head><script type="module" src="marker.js"></script></head>
+      <body><h1>plugin serve test</h1></body>
+    </html>
+  `,
+  "marker.js": `globalThis.__marker = "original";`,
+};
+
+test("html route with serve.static plugin injects plugin contents (production)", async () => {
+  // Exercises ServePlugins' intrusive refcount: the bunfig `serve.static`
+  // plugin is loaded asynchronously while the HTML route waits on it, and
+  // the promise context pointer round-trips FFI.
+  const dir = tempDirWithFiles("html-plugin-prod-test", pluginFixtureFiles);
+
+  await using process = Bun.spawn({
+    cmd: [bunExe(), "index.html", "--port=0"],
+    env: { ...bunEnv, NODE_ENV: "production" },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const serverUrl = await getServerUrl(process);
+
+  const response = await fetch(serverUrl);
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  expect(html).toContain("plugin serve test");
+  const m = html.match(/src="(\/chunk-[a-z0-9]+\.js)"/);
+  expect(m).not.toBeNull();
+
+  // The bundled script must contain the plugin-injected contents.
+  const js = await fetch(new URL(m![1], serverUrl).href).then(r => r.text());
+  expect(js).toContain("from-plugin");
+  expect(js).not.toContain('"original"');
+
+  process.kill();
+  await process.exited;
+});
+
+test("dev server html route serves repeatedly and shuts down cleanly", async () => {
+  // Exercises the DevServer's per-route strong ref on the HTMLBundle route
+  // (taken when the route bundle is created, released at dev-server
+  // teardown) — a double-release crashes at shutdown, a missed one leaks.
+  // Repeated fetches re-enter the cached-route path; clean exit verifies
+  // teardown. Assertions deliberately avoid depending on the dev-mode HTML
+  // script-injection shape.
+  const dir = tempDirWithFiles("html-dev-route-test", pluginFixtureFiles);
+
+  await using process = Bun.spawn({
+    cmd: [bunExe(), "index.html", "--port=0"],
+    env: { ...bunEnv, NODE_ENV: "development" },
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const serverUrl = await getServerUrl(process);
+
+  for (let i = 0; i < 5; i++) {
+    const response = await fetch(serverUrl);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("plugin serve test");
+  }
+
+  process.kill();
+  await process.exited;
+});

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -585,3 +585,41 @@ const wtf = {
     },
   },
 };
+
+describe("parser arena ownership", () => {
+  // The ini parser now borrows a caller-owned arena (instead of owning one
+  // behind raw-pointer borrow splitting). Repeated parses of inputs that
+  // allocate heavily from the arena (env expansion, quoted-JSON values,
+  // dotted sections) must each produce identical, self-consistent results —
+  // a dangling arena borrow would corrupt or crash on re-parse.
+  test("repeated parses with quoted values and dotted sections are stable", () => {
+    const ini = /* ini */ `
+top = plain value
+quoted = "json \\"value\\" here"
+[a.b.c]
+arr[] = one
+arr[] = two
+[section two]
+x = 1
+`;
+    const first = parse(ini);
+    for (let i = 0; i < 32; i++) {
+      const again = parse(ini);
+      expect(again).toEqual(first);
+    }
+    expect(first.top).toBe("plain value");
+    expect(first.a.b.c.arr).toEqual(["one", "two"]);
+    expect(first["section two"].x).toBe("1");
+  });
+
+  test("large input spanning many arena chunks parses correctly", () => {
+    const lines = [];
+    for (let i = 0; i < 2000; i++) {
+      lines.push(`key${i} = value-${"v".repeat(64)}-${i}`);
+    }
+    const out = parse(lines.join("\n"));
+    expect(out.key0).toBe(`value-${"v".repeat(64)}-0`);
+    expect(out.key1999).toBe(`value-${"v".repeat(64)}-1999`);
+    expect(Object.keys(out).length).toBe(2000);
+  });
+});

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -613,13 +613,14 @@ x = 1
   });
 
   test("large input spanning many arena chunks parses correctly", () => {
+    const filler = Buffer.alloc(64, "v").toString();
     const lines = [];
     for (let i = 0; i < 2000; i++) {
-      lines.push(`key${i} = value-${"v".repeat(64)}-${i}`);
+      lines.push(`key${i} = value-${filler}-${i}`);
     }
     const out = parse(lines.join("\n"));
-    expect(out.key0).toBe(`value-${"v".repeat(64)}-0`);
-    expect(out.key1999).toBe(`value-${"v".repeat(64)}-1999`);
+    expect(out.key0).toBe(`value-${filler}-0`);
+    expect(out.key1999).toBe(`value-${filler}-1999`);
     expect(Object.keys(out).length).toBe(2000);
   });
 });

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -587,11 +587,9 @@ const wtf = {
 };
 
 describe("parser arena ownership", () => {
-  // The ini parser now borrows a caller-owned arena (instead of owning one
-  // behind raw-pointer borrow splitting). Repeated parses of inputs that
-  // allocate heavily from the arena (env expansion, quoted-JSON values,
-  // dotted sections) must each produce identical, self-consistent results —
-  // a dangling arena borrow would corrupt or crash on re-parse.
+  // Repeated parses of inputs that allocate heavily from the parser arena
+  // (env expansion, quoted-JSON values, dotted sections) must each produce
+  // identical results — a dangling arena borrow would corrupt on re-parse.
   test("repeated parses with quoted values and dotted sections are stable", () => {
     const ini = /* ini */ `
 top = plain value

--- a/test/js/bun/shell/epipe.test.ts
+++ b/test/js/bun/shell/epipe.test.ts
@@ -36,9 +36,9 @@ describe.if(isPosix)("IOReader/IOWriter teardown under callback frames", () => {
   });
 
   test("cat into early-exiting consumer, repeated", async () => {
-    const big = "x".repeat(64 * 1024) + "\n";
+    const big = Buffer.alloc(64 * 1024, "x").toString() + "\n";
     const dir = tempDirWithFiles("shell-ioreader-teardown", {
-      "big.txt": big.repeat(8),
+      "big.txt": Buffer.alloc(big.length * 8, big).toString(),
     });
     for (let i = 0; i < 25; i++) {
       const out = await Bun.$`cat ${dir}/big.txt | head -n 1`.text();

--- a/test/js/bun/shell/epipe.test.ts
+++ b/test/js/bun/shell/epipe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { isPosix, tempDirWithFiles } from "harness";
 import { createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -17,6 +17,64 @@ describe.if(isPosix)("IOWriter epipe", () => {
     const results = await Promise.all(promises);
     for (const result of results) {
       expect(result).toBe("y\ny\ny\ny\ny\ny\ny\ny\ny\ny\n");
+    }
+  });
+});
+
+describe.if(isPosix)("IOReader/IOWriter teardown under callback frames", () => {
+  // The shell's IOReader/IOWriter defer their FINAL ref release to the event
+  // loop when it would otherwise run inside a bun_io read/write callback
+  // frame (tearing down the BufferedReader/PipeWriter that is still on the
+  // stack). These pipelines end readers/writers mid-stream (head exits early,
+  // broken pipes via `yes`), which is the path where a child callback can
+  // drop the last reference during dispatch.
+  test("many sequential broken pipes with cat readers", async () => {
+    for (let i = 0; i < 50; i++) {
+      const out = await Bun.$`yes | head -n 3`.text();
+      expect(out).toBe("y\ny\ny\n");
+    }
+  });
+
+  test("cat into early-exiting consumer, repeated", async () => {
+    const big = "x".repeat(64 * 1024) + "\n";
+    const dir = tempDirWithFiles("shell-ioreader-teardown", {
+      "big.txt": big.repeat(8),
+    });
+    for (let i = 0; i < 25; i++) {
+      const out = await Bun.$`cat ${dir}/big.txt | head -n 1`.text();
+      expect(out).toBe(big);
+    }
+  });
+
+  test("concurrent pipelines tearing down mid-stream", async () => {
+    const results = await Promise.all(
+      Array(64)
+        .fill(0)
+        .map(() => Bun.$`yes | head -n 2`.text()),
+    );
+    for (const r of results) expect(r).toBe("y\ny\n");
+  });
+});
+
+describe("IOWriter fd ownership across start", () => {
+  // On Windows, opening a shell IOWriter over a pipe/tty hands HANDLE
+  // ownership to libuv (`uv_pipe_open`); the writer start path must disarm
+  // the retained fd so teardown doesn't double-close it (POSIX is unaffected
+  // but runs the same code shape). Repeat enough times that a double-close
+  // would hit a reused fd and corrupt an unrelated pipeline.
+  test("repeated pipelines with writers into pipes", async () => {
+    for (let i = 0; i < 40; i++) {
+      const out = await Bun.$`echo hello-${i} | cat`.text();
+      expect(out).toBe(`hello-${i}\n`);
+    }
+  });
+
+  test("repeated redirects to files keep fds valid", async () => {
+    const dir = tempDirWithFiles("shell-iowriter-fd", { "seed.txt": "seed\n" });
+    for (let i = 0; i < 25; i++) {
+      await Bun.$`echo line-${i} > ${dir}/out-${i % 3}.txt`;
+      const content = await Bun.$`cat ${dir}/out-${i % 3}.txt`.text();
+      expect(content).toBe(`line-${i}\n`);
     }
   });
 });

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -746,11 +746,8 @@ it("query map and params stay valid under forced GC (owned URLPath/QueryStringMa
 });
 
 it("matches routes with extensions, sourcemap suffixes and root path after the SoA route-list rewrite", () => {
-  // Exercises RouteIndexList (now MultiArrayList-backed): construction over
-  // static + dynamic routes, the per-column accessors used by match, and that
-  // the boxed Route allocations stay valid for matching after the list is
-  // fully built (the routes column stores Box handles whose pointees are
-  // referenced by the index/static tables).
+  // Exercises RouteIndexList over static + dynamic routes; the boxed Route
+  // allocations must stay valid for matching after the list is fully built.
   const { dir } = make([
     "index.tsx",
     "a.tsx",

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -692,3 +692,85 @@ it("does not match a dynamic route whose static segment merely collides on lengt
   // A different segment that only collides on (length, 32-bit hash) must not.
   expect(router.match(`/${attackSegment}/42`)).toBeNull();
 });
+
+it("query map and params stay valid under forced GC (owned URLPath/QueryStringMap backing)", async () => {
+  // `MatchedRoute.query`/`params` are backed by an owned copy of the request
+  // path: neither may point at the caller's (transient) URL string or at a
+  // shared decode buffer. Loop matches with both plain and percent-encoded
+  // URLs, forcing GC between the match and the reads so a dangling backing
+  // buffer would be reused/poisoned before the values are observed.
+  // Run in a subprocess so a crash is observable instead of killing the runner.
+  using dir = tempDir("fsr-gc-query-backing", {
+    "pages/posts/[id].tsx": "export default 1;",
+  });
+
+  const code = /* ts */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(path.join(String(dir), "pages"))},
+      style: "nextjs",
+      fileExtensions: [".tsx"],
+    });
+    const matches = [];
+    for (let i = 0; i < 64; i++) {
+      // Build the URL from parts so the string is a fresh heap allocation
+      // each iteration (collectable as soon as match() returns).
+      const id = "item%20" + i;
+      const m = router.match("/posts/" + id + "?name=foo%20bar&i=" + i + "&dup=a&dup=b");
+      if (!m) throw new Error("expected match at " + i);
+      matches.push([m, i]);
+      Bun.gc(true);
+    }
+    Bun.gc(true);
+    for (const [m, i] of matches) {
+      if (m.params.id !== "item " + i) throw new Error("param corrupted at " + i + ": " + JSON.stringify(m.params.id));
+      const q = m.query;
+      if (q.name !== "foo bar") throw new Error("query name corrupted at " + i + ": " + JSON.stringify(q.name));
+      if (q.i !== String(i)) throw new Error("query i corrupted at " + i + ": " + JSON.stringify(q.i));
+      Bun.gc(true);
+      // Re-read after another collection; the map must be stable.
+      if (m.query.name !== "foo bar") throw new Error("query re-read corrupted at " + i);
+    }
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+it("matches routes with extensions, sourcemap suffixes and root path after the SoA route-list rewrite", () => {
+  // Exercises RouteIndexList (now MultiArrayList-backed): construction over
+  // static + dynamic routes, the per-column accessors used by match, and that
+  // the boxed Route allocations stay valid for matching after the list is
+  // fully built (the routes column stores Box handles whose pointees are
+  // referenced by the index/static tables).
+  const { dir } = make([
+    "index.tsx",
+    "a.tsx",
+    "b.tsx",
+    "abc/index.tsx",
+    "abc/[id].tsx",
+    "abc/def/[id].tsx",
+    "[id].tsx",
+  ]);
+  const router = new Bun.FileSystemRouter({ dir, style: "nextjs" });
+  expect(router.match("/")?.name).toBe("/");
+  expect(router.match("/a")?.name).toBe("/a");
+  expect(router.match("/abc")?.name).toBe("/abc");
+  expect(router.match("/abc/123")?.name).toBe("/abc/[id]");
+  expect(router.match("/abc/def/456")?.params.id).toBe("456");
+  expect(router.match("/zzz")?.name).toBe("/[id]");
+  // .map extension handling goes through URLPath's sourcemap backup-extname
+  // path: "/a.js.map" is normalized to the path segment "a.js", which falls
+  // through the static routes and matches the root dynamic route.
+  const mapMatch = router.match("/a.js.map");
+  expect(mapMatch?.name).toBe("/[id]");
+  expect(mapMatch?.params.id).toBe("a.js");
+});


### PR DESCRIPTION
A batch of deferred soundness restructures: QueryStringMap and URLPath now own their backing bytes (offset spans instead of 'static-laundered self-referential slices), the bun_ini Parser borrows a caller-owned arena with a split env lifetime instead of raw-pointer borrow splitting, PackageInstall stores the destination-subpath prefix as a length (killing the aliased &ZStr + &mut [u8] pair), and the install Task request payloads hold *mut NetworkTask instead of an aliased &mut across the cross-thread queue. The dev server's HTML route slot is now a bun_ptr::RefPtr with an explicit teardown deref (fixing a leaked ref), ServePlugins moved onto the CellRefCounted derive with ScopedRef guards, shell IOReader/IOWriter defer their final Arc release to the event loop when it would otherwise free the reader/writer under a live bun_io callback frame, and Windows PipeWriter gained start_movable so libuv's HANDLE-ownership transfer disarms the caller's retained fd. The hand-rolled router SoA list was replaced with MultiArrayList plus multi_array_columns! accessors, the isolated-install progress-node pointers are now cleared by a scopeguard on every exit path, and closure-scoped output writer accessors replaced the legacy &'static mut escapes at all call sites in these crates. Tested via filesystem-router GC-stress and percent-decode subprocess tests, ini re-parse stability tests, scoped/isolated folder-dependency install tests, shell pipeline teardown stress tests, a production serve.static plugin end-to-end test plus a dev-server HTML-route repeated-fetch/teardown test, and a bun pm hash-string output test.

## Deferred

- 007-C1 remainder: migrate ~25 non-owned files off the legacy &'static mut accessors, then delete the five accessors + source_writer_escape (mechanical follow-up; TODO updated in output.rs)
- 051-C1 bake_body arena-lifetime threading (crate-wide 'bump threading through Framework/UserOptions/DevServer/production and bun_bundler bake types; a partial landing would ship a half-threaded lifetime, which is forbidden)
- esc08-1 full reshape: move install progress nodes off the stack into PackageManager (aliasing/self-reference redesign; interim scopeguard hardening landed)
- esc08-2 DependencyMap source_buf de-erasure (requires edits to src/resolver/resolver.rs, owned by cluster 02; design options recorded in the order)
- esc13 (a)/(b) router matched_route enqueue path + Zig integration-test port (explicitly requires a maintainer decision; tracking comments left in place)
- 024-2 step 4: bun_ast Source<'a> lifetime threading (cross-crate campaign; documented erasures remain in Parser::init)

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
