### PR TITLE
Rework LinearFifo uninit accessors, replace stream raw-pointer/static-mut forges, thread JS errors through body bufferer

### DIFF
--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -202,7 +202,7 @@ impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
 /// internally for uniformity with the other buffer kinds. The fifo only ever
 /// writes valid `T` (or, in debug builds, the 0xAA poison over *discarded*
 /// slots — callers of `.Slice` fifos must treat the backing slice's contents
-/// as unspecified once handed to the fifo, same as the Zig `undefined` fill).
+/// as unspecified once handed to the fifo).
 pub struct SliceBuffer<'a, T>(&'a mut [T]);
 
 impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -24,34 +24,15 @@ pub enum LinearFifoBufferType {
     Dynamic,
 }
 
-/// Marker for element types where every *initialized* bit pattern is a valid
-/// value — integers and raw pointers. Bounds the [`LinearFifo::writable_slice`]
-/// family, which exposes logically-uninitialized slots as `&mut [T]` so
-/// byte-oriented callers can fill them in place.
-///
-/// This marker only legitimizes *forming* `&mut [T]` over those slots for
-/// write-before-read use. It does NOT make reading a never-written slot
-/// defined: under current Rust semantics, reading uninitialized memory is UB
-/// at every type (uninit bytes are valid only at `MaybeUninit`), regardless
-/// of this marker. Callers must write a slot before anything reads it, and
-/// the `update()` protocol ensures only written prefixes become readable.
-///
-/// Note this is deliberately narrower than `bytemuck::AnyBitPattern`, which
-/// excludes raw pointers (for the uninit-read and provenance reasons above);
-/// the pointer impls here are sound only because the exposed slots are
-/// write-only until `update()` marks them readable.
-///
-/// For any other `T` (enums, `NonNull`-bearing structs, anything with a
-/// validity invariant) those slots must never be materialized as `T`; such
-/// types go through `write_item` / `write_item_assume_capacity`, which write
-/// through the `MaybeUninit` storage directly.
+/// Element types where any initialized bit pattern is a valid value (integers,
+/// raw pointers). Bounds the [`LinearFifo::writable_slice`] family, which
+/// exposes not-yet-written slots as `&mut [T]`; callers must still write a
+/// slot before anything reads it. Other `T` (enums, `NonNull`-bearing structs)
+/// must go through `write_item` / `write_item_assume_capacity`.
 ///
 /// # Safety
 ///
-/// Implementors assert that any *initialized* bit pattern — including the
-/// `0xAA` debug poison fill — is a valid `T`, so a `&mut [T]` over poisoned
-/// (but written) slots cannot hold an invalid value. The write-before-read
-/// obligation above still applies to every caller.
+/// Implementors assert every initialized bit pattern is a valid `T`.
 pub unsafe trait AnyBitPattern: Copy {}
 
 macro_rules! impl_any_bit_pattern {
@@ -61,10 +42,9 @@ macro_rules! impl_any_bit_pattern {
     )*};
 }
 impl_any_bit_pattern!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
-// SAFETY: raw pointers have no validity invariant (any address, including
-// dangling/garbage, is a valid *value*; dereferencing is a separate contract).
+// SAFETY: raw pointers have no validity invariant (dereferencing is a separate contract).
 unsafe impl<T> AnyBitPattern for *mut T {}
-// SAFETY: see `*mut T` above.
+// SAFETY: same as `*mut T`.
 unsafe impl<T> AnyBitPattern for *const T {}
 
 /// Backing-storage abstraction; `DYNAMIC` is true for the `.Dynamic` variant.
@@ -73,11 +53,8 @@ unsafe impl<T> AnyBitPattern for *const T {}
 // instantiates `SliceBuffer` directly; `threading::Channel::init_slice` wraps
 // it for `.Slice` API parity.
 //
-// The accessors deliberately expose `MaybeUninit<T>`, never `&[T]`: only the
-// `LinearFifo` core knows which subranges are logically written, and it alone
-// assume-inits exactly those (see `readable_slice`). This is what keeps
-// non-any-bit-pattern element types (`NonNull`-bearing enums, `Strong`-bearing
-// structs, the event-loop `Task` enum) sound in a partially-filled fifo.
+// Accessors expose `MaybeUninit<T>`, never `&[T]`: only the `LinearFifo` core
+// knows which subranges are logically written, and it alone assume-inits them.
 pub trait LinearFifoBuffer<T> {
     const POWERS_OF_TWO: bool;
     const DYNAMIC: bool;
@@ -107,11 +84,8 @@ pub trait LinearFifoBuffer<T> {
 ///
 /// # Safety
 ///
-/// Every element of `s` must have been initialized (written through one of
-/// the fifo's write paths and still inside the `[head, head+count)` readable
-/// window), OR `T: AnyBitPattern` AND the returned slice is used strictly
-/// write-before-read (the `writable_slice` family's contract — reading a
-/// never-written slot is UB even for `AnyBitPattern` types).
+/// Every element of `s` must be initialized, or `T: AnyBitPattern` and the
+/// result used strictly write-before-read (the `writable_slice` contract).
 #[inline(always)]
 unsafe fn assume_init_slice<T>(s: &[MaybeUninit<T>]) -> &[T] {
     // SAFETY: forwarded to caller — see fn doc.
@@ -136,20 +110,14 @@ unsafe fn assume_init_slice_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
 #[inline(always)]
 fn write_copy<T: Copy>(dst: &mut [MaybeUninit<T>], src: &[T]) {
     debug_assert_eq!(dst.len(), src.len());
-    // SAFETY: `dst` is a unique borrow and `src` a shared one, so the ranges
-    // cannot overlap; lengths are equal; copying valid `T` bit patterns into
-    // `MaybeUninit<T>` slots initializes them.
+    // SAFETY: `dst` is a unique borrow so the ranges cannot overlap; lengths are equal.
     unsafe { ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<T>(), src.len()) };
 }
 
 /// Shift `slice[1..]` down to `slice[0..len-1]` (memmove). Used by
-/// `ordered_remove_item` for the four wrap/non-wrap segment shifts. Operates
-/// on the raw `MaybeUninit` storage: the shifted range may include
-/// logically-unwritten tail slots (the non-wrapped branch passes
-/// `buf[head+offset..]`, which extends past `head+count`), and a raw byte
-/// move of uninit slots is sound where a `&mut [T]` over them would not be.
-/// The duplicated tail slot is logically discarded by the subsequent
-/// `count -= 1`.
+/// `ordered_remove_item`. Operates on raw `MaybeUninit` storage because the
+/// shifted range may include logically-unwritten tail slots; the duplicated
+/// tail slot is discarded by the subsequent `count -= 1`.
 #[inline(always)]
 fn shift_down_one<T>(slice: &mut [MaybeUninit<T>]) {
     if slice.len() <= 1 {
@@ -198,11 +166,9 @@ impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
 
 /// `buffer_type == .Slice` — caller-provided `[]T`.
 ///
-/// The caller hands in initialized storage; it is viewed as `MaybeUninit<T>`
-/// internally for uniformity with the other buffer kinds. The fifo only ever
-/// writes valid `T` (or, in debug builds, the 0xAA poison over *discarded*
-/// slots — callers of `.Slice` fifos must treat the backing slice's contents
-/// as unspecified once handed to the fifo).
+/// Viewed as `MaybeUninit<T>` internally; callers must treat the backing
+/// slice's contents as unspecified once handed to the fifo (debug builds
+/// poison discarded slots).
 pub struct SliceBuffer<'a, T>(&'a mut [T]);
 
 impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {
@@ -211,15 +177,13 @@ impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {
 
     #[inline]
     fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
-        // SAFETY: `&[T]` → `&[MaybeUninit<T>]` is always sound (initialized is
-        // a subset of maybe-initialized; identical layout).
+        // SAFETY: `&[T]` → `&[MaybeUninit<T>]` is layout-identical and always sound.
         unsafe { &*(ptr::from_ref::<[T]>(self.0) as *const [MaybeUninit<T>]) }
     }
     #[inline]
     fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
-        // SAFETY: layout-identical view; the fifo never writes an
-        // uninitialized *value* through this (only valid `T` or the debug
-        // poison bytes over logically-discarded slots — see type-level doc).
+        // SAFETY: layout-identical view; the fifo only writes valid `T` (or
+        // debug poison over discarded slots — see type-level doc).
         unsafe { &mut *(ptr::from_mut::<[T]>(self.0) as *mut [MaybeUninit<T>]) }
     }
 }
@@ -263,17 +227,11 @@ impl<T> LinearFifoBuffer<T> for DynamicBuffer<T> {
 /// Ring buffer over `MaybeUninit<T>` storage.
 ///
 /// INVARIANT: exactly the slots in `[head, head+count)` (modulo wrap) are
-/// initialized; everything else is logically uninitialized (and 0xAA-poisoned
-/// in debug builds). Every accessor that materializes `&[T]`/`&mut [T]` does
-/// so only over that window — except the [`Self::writable_slice`] family,
-/// which is restricted to [`AnyBitPattern`] element types.
+/// initialized. Accessors materialize `&[T]` only over that window, except
+/// the [`Self::writable_slice`] family ([`AnyBitPattern`] only).
 ///
-/// DROP SEMANTICS: the fifo never drops `T`. `discard`/`Drop` simply forget
-/// the items (matching the original semantics where the buffer held raw
-/// `undefined`-able storage). Non-`Copy` element types that own resources
-/// (`PromisePair`'s promise strongs, boxed tasks, …) must be drained with
-/// `read_item` and released by the owner before the fifo is dropped;
-/// undrained items leak by design.
+/// The fifo never drops `T`: resource-owning items must be drained with
+/// `read_item` before drop, or they leak by design.
 pub struct LinearFifo<T, B: LinearFifoBuffer<T>> {
     buf: B,
     head: usize,
@@ -323,9 +281,7 @@ impl<T> LinearFifo<T, DynamicBuffer<T>> {
 }
 
 // `pub fn deinit` → Drop. Dynamic frees `buf` via `Box` drop; Static/Slice are
-// no-ops. Field drop glue covers it; no explicit impl needed. Note the fifo
-// intentionally does NOT drop remaining `T` items — see the type-level
-// DROP SEMANTICS note.
+// no-ops. Field drop glue covers it; no explicit impl needed.
 
 impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     #[inline]
@@ -361,7 +317,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             let head = self.head;
             let buf = self.buf.as_uninit_slice_mut();
             // SAFETY: src/dst within same allocation; ptr::copy is memmove.
-            // `MaybeUninit` copy is sound regardless of slot initialization.
             unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
             self.head = 0;
         } else {
@@ -482,9 +437,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     }
 
     /// First contiguous readable segment starting at `offset`, as raw
-    /// `MaybeUninit` storage. Every slot in the returned range is inside the
-    /// `[head, head+count)` initialized window — callers may overwrite it
-    /// with valid `T` (e.g. `unget`) or poison it (`discard`) but must not
+    /// `MaybeUninit` storage; callers may overwrite or poison it but must not
     /// read it as `T` without `assume_init`.
     fn readable_uninit_slice_mut(&mut self, offset: usize) -> &mut [MaybeUninit<T>] {
         if offset > self.count {
@@ -519,9 +472,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             let end = (self.head + self.count).min(buf_len);
             &buf[start..end]
         };
-        // SAFETY: `range` lies entirely within the `[head, head+count)`
-        // readable window (modulo wrap), every slot of which was initialized
-        // by a write path before `count` covered it.
+        // SAFETY: `range` is within the `[head, head+count)` initialized window.
         unsafe { assume_init_slice(range) }
     }
 
@@ -560,9 +511,8 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         if self.count == 0 {
             return None;
         }
-        // SAFETY: buf[head] is in the readable region (count > 0), hence
-        // initialized; we move it out and immediately discard(1), so the slot
-        // is never read again.
+        // SAFETY: buf[head] is initialized (count > 0); moved out then
+        // discard(1), so the slot is never read again.
         let c = unsafe {
             ptr::read(
                 self.buf
@@ -606,8 +556,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     }
 
     /// First contiguous writable segment starting at `offset`, as raw
-    /// `MaybeUninit` storage. The slots are logically uninitialized; callers
-    /// must fully write any prefix they later commit via [`Self::update`].
+    /// `MaybeUninit` storage (logically uninitialized slots).
     fn writable_uninit_slice(&mut self, offset: usize) -> &mut [MaybeUninit<T>] {
         let buf_len = self.buf_len();
         if offset > buf_len {
@@ -629,17 +578,14 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     /// Returns the first section of writable buffer.
     /// Note that this may be of length 0.
     ///
-    /// Restricted to [`AnyBitPattern`] element types because the returned
-    /// `&mut [T]` covers never-written slots; for other `T` use
-    /// [`Self::write_item`] / [`Self::write_item_assume_capacity`].
+    /// `T: AnyBitPattern` because the returned `&mut [T]` covers never-written
+    /// slots; for other `T` use [`Self::write_item`].
     pub fn writable_slice(&mut self, offset: usize) -> &mut [T]
     where
         T: AnyBitPattern,
     {
         let slice = self.writable_uninit_slice(offset);
-        // SAFETY: `T: AnyBitPattern` — every bit pattern is a valid `T`, so
-        // exposing not-yet-written slots as `&mut [T]` cannot create an
-        // invalid value.
+        // SAFETY: `T: AnyBitPattern` — every bit pattern is a valid `T`.
         unsafe { assume_init_slice_mut(slice) }
     }
 
@@ -757,9 +703,6 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
         self.rewind(src.len());
 
-        // The rewound slots `[head, head+src.len())` are logically
-        // uninitialized until this copy lands, so write through the
-        // `MaybeUninit` view rather than materializing `&mut [T]` over them.
         // reshaped for borrowck — copy into first chunk in a scoped
         // block, drop borrow, then re-borrow for the wrapped chunk.
         let slice_len = {
@@ -789,8 +732,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         } else {
             index %= self.buf_len();
         }
-        // SAFETY: `offset < count` ⇒ the slot is inside the readable window,
-        // hence initialized.
+        // SAFETY: `offset < count` ⇒ the slot is initialized.
         unsafe { self.buf.as_uninit_slice()[index].assume_init_read() }
     }
 
@@ -805,8 +747,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         } else {
             index %= self.buf_len();
         }
-        // SAFETY: `offset < count` ⇒ the slot is inside the readable window,
-        // hence initialized.
+        // SAFETY: `offset < count` ⇒ the slot is initialized.
         unsafe { self.buf.as_uninit_slice_mut()[index].assume_init_mut() }
     }
 
@@ -864,8 +805,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     // `src_reader(buf)` ≙ `reader.read(buf)`, `dest_writer(buf)` ≙
     // `writer.write(buf)`, both returning a count (`Ok(0)` from the reader
     // means EOF). This keeps `pump` generic over `T`, which `std::io` cannot.
-    // `T: AnyBitPattern` because the reader closure is handed the raw
-    // writable (not-yet-written) slots as `&mut [T]`.
+    // `T: AnyBitPattern`: the reader closure is handed not-yet-written slots as `&mut [T]`.
     pub fn pump<R, W, E>(&mut self, mut src_reader: R, dest_writer: &mut W) -> Result<(), E>
     where
         T: AnyBitPattern,
@@ -1126,14 +1066,9 @@ mod tests {
         per_type!(u8, u16, u64);
     }
 
-    // A `NonNull`-bearing enum: NOT any-bit-pattern-valid (a niche-optimized
-    // discriminant over a non-null pointer), mirroring the in-tree element
-    // types `bun_test::RefDataValue`, `ValkeyCommand::PromisePair`, and the
-    // event-loop `Task` enum. Pre-rework, *every* fifo accessor materialized
-    // `&[T]` over the whole (partially uninitialized) backing store, which is
-    // immediate UB for this type under Miri; post-rework only logically
-    // written subranges are assumed-init. Run with
-    // `cargo miri test -p bun_collections linear_fifo` to verify.
+    // NonNull-bearing enum (niche-optimized, NOT any-bit-pattern-valid), like
+    // the in-tree `Task` enum: verifies only logically written subranges are
+    // assumed-init. `cargo miri test -p bun_collections linear_fifo` checks this.
     #[derive(Clone, Copy, PartialEq, Eq, Debug)]
     enum PtrItem {
         Val(core::ptr::NonNull<i32>),
@@ -1149,8 +1084,7 @@ mod tests {
 
     fn deref_item(item: PtrItem) -> i32 {
         match item {
-            // SAFETY: pointer targets the `backing` array, which outlives the
-            // fifo in every test below.
+            // SAFETY: pointer targets `backing`, which outlives the fifo.
             PtrItem::Val(p) => unsafe { *p.as_ref() },
             PtrItem::Marker => -1,
         }
@@ -1162,9 +1096,7 @@ mod tests {
         let items = ptr_items(&backing);
 
         let mut fifo = LinearFifo::<PtrItem, StaticBuffer<PtrItem, 16>>::init();
-        // Recreate the wrapped layout from the i32 tests: write 12, read 8,
-        // write 10 → head=8, count=14, wraps. Every read/peek goes through a
-        // partially-uninitialized backing store.
+        // write 12, read 8, write 10 → head=8, count=14, wraps.
         for v in 0..12 {
             fifo.write_item(items[v]).unwrap();
         }

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -1182,7 +1182,9 @@ mod tests {
             .collect();
         assert_eq!(
             peeked,
-            vec![8, 9, 10, 11, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
+            vec![
+                8, 9, 10, 11, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109
+            ]
         );
 
         // wrapped ordered_remove_item with a niche-optimized element type

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -24,20 +24,69 @@ pub enum LinearFifoBufferType {
     Dynamic,
 }
 
+/// Marker for element types where every *initialized* bit pattern is a valid
+/// value — integers and raw pointers. Bounds the [`LinearFifo::writable_slice`]
+/// family, which exposes logically-uninitialized slots as `&mut [T]` so
+/// byte-oriented callers can fill them in place.
+///
+/// This marker only legitimizes *forming* `&mut [T]` over those slots for
+/// write-before-read use. It does NOT make reading a never-written slot
+/// defined: under current Rust semantics, reading uninitialized memory is UB
+/// at every type (uninit bytes are valid only at `MaybeUninit`), regardless
+/// of this marker. Callers must write a slot before anything reads it, and
+/// the `update()` protocol ensures only written prefixes become readable.
+///
+/// Note this is deliberately narrower than `bytemuck::AnyBitPattern`, which
+/// excludes raw pointers (for the uninit-read and provenance reasons above);
+/// the pointer impls here are sound only because the exposed slots are
+/// write-only until `update()` marks them readable.
+///
+/// For any other `T` (enums, `NonNull`-bearing structs, anything with a
+/// validity invariant) those slots must never be materialized as `T`; such
+/// types go through `write_item` / `write_item_assume_capacity`, which write
+/// through the `MaybeUninit` storage directly.
+///
+/// # Safety
+///
+/// Implementors assert that any *initialized* bit pattern — including the
+/// `0xAA` debug poison fill — is a valid `T`, so a `&mut [T]` over poisoned
+/// (but written) slots cannot hold an invalid value. The write-before-read
+/// obligation above still applies to every caller.
+pub unsafe trait AnyBitPattern: Copy {}
+
+macro_rules! impl_any_bit_pattern {
+    ($($T:ty),* $(,)?) => {$(
+        // SAFETY: primitive integers have no validity invariant.
+        unsafe impl AnyBitPattern for $T {}
+    )*};
+}
+impl_any_bit_pattern!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
+// SAFETY: raw pointers have no validity invariant (any address, including
+// dangling/garbage, is a valid *value*; dereferencing is a separate contract).
+unsafe impl<T> AnyBitPattern for *mut T {}
+// SAFETY: see `*mut T` above.
+unsafe impl<T> AnyBitPattern for *const T {}
+
 /// Backing-storage abstraction; `DYNAMIC` is true for the `.Dynamic` variant.
 // Trait + assoc-consts encode the structurally different layouts per
 // variant. No in-tree caller
 // instantiates `SliceBuffer` directly; `threading::Channel::init_slice` wraps
 // it for `.Slice` API parity.
+//
+// The accessors deliberately expose `MaybeUninit<T>`, never `&[T]`: only the
+// `LinearFifo` core knows which subranges are logically written, and it alone
+// assume-inits exactly those (see `readable_slice`). This is what keeps
+// non-any-bit-pattern element types (`NonNull`-bearing enums, `Strong`-bearing
+// structs, the event-loop `Task` enum) sound in a partially-filled fifo.
 pub trait LinearFifoBuffer<T> {
     const POWERS_OF_TWO: bool;
     const DYNAMIC: bool;
 
-    fn as_slice(&self) -> &[T];
-    fn as_mut_slice(&mut self) -> &mut [T];
+    fn as_uninit_slice(&self) -> &[MaybeUninit<T>];
+    fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>];
     #[inline]
     fn len(&self) -> usize {
-        self.as_slice().len()
+        self.as_uninit_slice().len()
     }
 
     /// Reallocate to exactly `new_size` elements, preserving the prefix.
@@ -53,36 +102,56 @@ pub trait LinearFifoBuffer<T> {
     }
 }
 
-/// Reinterpret `&[MaybeUninit<T>]` as `&[T]`. `MaybeUninit<T>` has identical
-/// layout to `T`; exposing uninitialized bytes as `T` is sound only when any
-/// bit pattern is a valid `T`. NOT every in-tree element type satisfies this:
-/// besides byte buffers and raw pointers, fifos today store `NonNull`-bearing
-/// enums (`bun_test::RefDataValue`), `JSPromiseStrong`-bearing structs
-/// (`ValkeyCommand::PromisePair`), and the `event_loop::Task` enum — see the
-/// `StaticBuffer` note below for the pending MaybeUninit accessor rework.
-/// Centralises the four per-buffer-kind casts behind one audited block.
+/// Reinterpret a *logically initialized* `&[MaybeUninit<T>]` subrange as
+/// `&[T]`. `MaybeUninit<T>` has identical layout to `T`.
+///
+/// # Safety
+///
+/// Every element of `s` must have been initialized (written through one of
+/// the fifo's write paths and still inside the `[head, head+count)` readable
+/// window), OR `T: AnyBitPattern` AND the returned slice is used strictly
+/// write-before-read (the `writable_slice` family's contract — reading a
+/// never-written slot is UB even for `AnyBitPattern` types).
 #[inline(always)]
-fn assume_init_slice<T>(s: &[MaybeUninit<T>]) -> &[T] {
-    // SAFETY: see fn doc.
+unsafe fn assume_init_slice<T>(s: &[MaybeUninit<T>]) -> &[T] {
+    // SAFETY: forwarded to caller — see fn doc.
     unsafe { &*(ptr::from_ref::<[MaybeUninit<T>]>(s) as *const [T]) }
 }
 
 /// Mutable variant of [`assume_init_slice`]. The input borrow is consumed by
 /// the cast, so the returned `&mut [T]` is the sole live reference into the
 /// allocation for its lifetime.
+///
+/// # Safety
+///
+/// Same initialization contract as [`assume_init_slice`].
 #[inline(always)]
-fn assume_init_slice_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
-    // SAFETY: see `assume_init_slice`.
+unsafe fn assume_init_slice_mut<T>(s: &mut [MaybeUninit<T>]) -> &mut [T] {
+    // SAFETY: forwarded to caller — see `assume_init_slice`.
     unsafe { &mut *(ptr::from_mut::<[MaybeUninit<T>]>(s) as *mut [T]) }
 }
 
-/// Shift `slice[1..]` down to `slice[0..len-1]` (memmove). Used by
-/// `ordered_remove_item` for the four wrap/non-wrap segment shifts. Not
-/// `slice::copy_within` because that requires `T: Copy`; this fifo permits
-/// move-only `T` (the duplicated tail slot is logically discarded by the
-/// subsequent `count -= 1`).
+/// Copy `src` into the (possibly uninitialized) destination slots,
+/// initializing them. Lengths must match exactly.
 #[inline(always)]
-fn shift_down_one<T>(slice: &mut [T]) {
+fn write_copy<T: Copy>(dst: &mut [MaybeUninit<T>], src: &[T]) {
+    debug_assert_eq!(dst.len(), src.len());
+    // SAFETY: `dst` is a unique borrow and `src` a shared one, so the ranges
+    // cannot overlap; lengths are equal; copying valid `T` bit patterns into
+    // `MaybeUninit<T>` slots initializes them.
+    unsafe { ptr::copy_nonoverlapping(src.as_ptr(), dst.as_mut_ptr().cast::<T>(), src.len()) };
+}
+
+/// Shift `slice[1..]` down to `slice[0..len-1]` (memmove). Used by
+/// `ordered_remove_item` for the four wrap/non-wrap segment shifts. Operates
+/// on the raw `MaybeUninit` storage: the shifted range may include
+/// logically-unwritten tail slots (the non-wrapped branch passes
+/// `buf[head+offset..]`, which extends past `head+count`), and a raw byte
+/// move of uninit slots is sound where a `&mut [T]` over them would not be.
+/// The duplicated tail slot is logically discarded by the subsequent
+/// `count -= 1`.
+#[inline(always)]
+fn shift_down_one<T>(slice: &mut [MaybeUninit<T>]) {
     if slice.len() <= 1 {
         return;
     }
@@ -93,7 +162,7 @@ fn shift_down_one<T>(slice: &mut [T]) {
 
 #[cfg(debug_assertions)]
 #[inline(always)]
-fn poison<T>(slice: &mut [T], n: usize) {
+fn poison<T>(slice: &mut [MaybeUninit<T>], n: usize) {
     debug_assert!(n <= slice.len());
     // SAFETY: writing 0xAA into the byte representation of `n` slots that are
     // about to be logically discarded; never read as `T` again.
@@ -109,19 +178,6 @@ fn poison<T>(slice: &mut [T], n: usize) {
 // ── .Static ───────────────────────────────────────────────────────────────────
 
 /// `buffer_type == .Static` — inline `[T; N]` storage.
-// INVARIANT: storage is MaybeUninit and exposed as &[T] via pointer cast
-// (`assume_init_slice`). The public API
-// (`writable_slice` hands out `&mut [T]` over not-yet-written slots) bakes in
-// the same exposure for every buffer kind. Sound only for `T` whose
-// any-bit-pattern is valid — and in-tree element types ALREADY violate that:
-// `RefDataValue` (NonNull<DescribeScope> payload), `PromisePair`
-// (JSPromiseStrong), and the `Task` enum are stored in fifos today, so
-// materialising `&[T]` over uninitialized slots for those types is latent UB.
-// The fix is reworking the accessors to operate on `&[MaybeUninit<T>]` and
-// only assume-init the logically-written subranges. That cannot be done by
-// touching this file alone — `writable_slice`-family callers in other crates
-// see the signature change — so it is deferred to a dedicated change with
-// Miri coverage for a NonNull-bearing element type.
 pub struct StaticBuffer<T, const N: usize>([MaybeUninit<T>; N]);
 
 impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
@@ -129,18 +185,24 @@ impl<T, const N: usize> LinearFifoBuffer<T> for StaticBuffer<T, N> {
     const DYNAMIC: bool = false;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        assume_init_slice(self.0.as_slice())
+    fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
+        self.0.as_slice()
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        assume_init_slice_mut(self.0.as_mut_slice())
+    fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        self.0.as_mut_slice()
     }
 }
 
 // ── .Slice ────────────────────────────────────────────────────────────────────
 
 /// `buffer_type == .Slice` — caller-provided `[]T`.
+///
+/// The caller hands in initialized storage; it is viewed as `MaybeUninit<T>`
+/// internally for uniformity with the other buffer kinds. The fifo only ever
+/// writes valid `T` (or, in debug builds, the 0xAA poison over *discarded*
+/// slots — callers of `.Slice` fifos must treat the backing slice's contents
+/// as unspecified once handed to the fifo, same as the Zig `undefined` fill).
 pub struct SliceBuffer<'a, T>(&'a mut [T]);
 
 impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {
@@ -148,12 +210,17 @@ impl<'a, T> LinearFifoBuffer<T> for SliceBuffer<'a, T> {
     const DYNAMIC: bool = false;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        self.0
+    fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
+        // SAFETY: `&[T]` → `&[MaybeUninit<T>]` is always sound (initialized is
+        // a subset of maybe-initialized; identical layout).
+        unsafe { &*(ptr::from_ref::<[T]>(self.0) as *const [MaybeUninit<T>]) }
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        self.0
+    fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        // SAFETY: layout-identical view; the fifo never writes an
+        // uninitialized *value* through this (only valid `T` or the debug
+        // poison bytes over logically-discarded slots — see type-level doc).
+        unsafe { &mut *(ptr::from_mut::<[T]>(self.0) as *mut [MaybeUninit<T>]) }
     }
 }
 
@@ -168,12 +235,12 @@ impl<T> LinearFifoBuffer<T> for DynamicBuffer<T> {
     const DYNAMIC: bool = true;
 
     #[inline]
-    fn as_slice(&self) -> &[T] {
-        assume_init_slice(&self.0)
+    fn as_uninit_slice(&self) -> &[MaybeUninit<T>] {
+        &self.0
     }
     #[inline]
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        assume_init_slice_mut(&mut self.0)
+    fn as_uninit_slice_mut(&mut self) -> &mut [MaybeUninit<T>] {
+        &mut self.0
     }
 
     fn realloc(&mut self, new_size: usize) -> Result<(), AllocError> {
@@ -193,6 +260,20 @@ impl<T> LinearFifoBuffer<T> for DynamicBuffer<T> {
 
 // ── LinearFifo ────────────────────────────────────────────────────────────────
 
+/// Ring buffer over `MaybeUninit<T>` storage.
+///
+/// INVARIANT: exactly the slots in `[head, head+count)` (modulo wrap) are
+/// initialized; everything else is logically uninitialized (and 0xAA-poisoned
+/// in debug builds). Every accessor that materializes `&[T]`/`&mut [T]` does
+/// so only over that window — except the [`Self::writable_slice`] family,
+/// which is restricted to [`AnyBitPattern`] element types.
+///
+/// DROP SEMANTICS: the fifo never drops `T`. `discard`/`Drop` simply forget
+/// the items (matching the original semantics where the buffer held raw
+/// `undefined`-able storage). Non-`Copy` element types that own resources
+/// (`PromisePair`'s promise strongs, boxed tasks, …) must be drained with
+/// `read_item` and released by the owner before the fifo is dropped;
+/// undrained items leak by design.
 pub struct LinearFifo<T, B: LinearFifoBuffer<T>> {
     buf: B,
     head: usize,
@@ -242,7 +323,9 @@ impl<T> LinearFifo<T, DynamicBuffer<T>> {
 }
 
 // `pub fn deinit` → Drop. Dynamic frees `buf` via `Box` drop; Static/Slice are
-// no-ops. Field drop glue covers it; no explicit impl needed.
+// no-ops. Field drop glue covers it; no explicit impl needed. Note the fifo
+// intentionally does NOT drop remaining `T` items — see the type-level
+// DROP SEMANTICS note.
 
 impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     #[inline]
@@ -276,8 +359,9 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             // this copy overlaps
             let count = self.count;
             let head = self.head;
-            let buf = self.buf.as_mut_slice();
+            let buf = self.buf.as_uninit_slice_mut();
             // SAFETY: src/dst within same allocation; ptr::copy is memmove.
+            // `MaybeUninit` copy is sound regardless of slot initialization.
             unsafe { ptr::copy(buf.as_ptr().add(head), buf.as_mut_ptr(), count) };
             self.head = 0;
         } else {
@@ -299,11 +383,12 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             while self.head != 0 {
                 let n = self.head.min(tmp_len);
                 let m = buf_len - n;
-                let buf = self.buf.as_mut_slice();
+                let buf = self.buf.as_uninit_slice_mut();
                 // SAFETY: `tmp` is disjoint from `buf`. The tmp↔buf copies move
                 // `n * size_of::<T>()` raw bytes (no `T` typed access through
                 // the 1-aligned scratch). The buf→buf shift overlaps, so use
-                // `ptr::copy` (memmove); it operates on properly-aligned `*T`.
+                // `ptr::copy` (memmove); it operates on properly-aligned
+                // `*MaybeUninit<T>`, which is sound for uninit slots too.
                 unsafe {
                     ptr::copy_nonoverlapping(buf.as_ptr().cast::<u8>(), tmp_ptr, n * t_size);
                     ptr::copy(buf.as_ptr().add(n), buf.as_mut_ptr(), m);
@@ -320,7 +405,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         #[cfg(debug_assertions)]
         {
             let count = self.count;
-            let unused = &mut self.buf.as_mut_slice()[count..];
+            let unused = &mut self.buf.as_uninit_slice_mut()[count..];
             // SAFETY: the tail past `count` is logically uninitialized; writing
             // the 0xAA poison pattern there cannot invalidate live items.
             unsafe {
@@ -365,11 +450,12 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             let count = self.count;
             let old = self.buf.alloc_swap(new_size)?;
             if count > 0 {
-                let new = self.buf.as_mut_slice();
+                let new = self.buf.as_uninit_slice_mut();
                 // After realign(), head==0 so readableSlice(0) == old[0..count].
-                // SAFETY: old and new are disjoint allocations.
+                // SAFETY: old and new are disjoint allocations; raw
+                // `MaybeUninit` copy of the initialized prefix.
                 unsafe {
-                    ptr::copy_nonoverlapping(old.as_ptr().cast::<T>(), new.as_mut_ptr(), count);
+                    ptr::copy_nonoverlapping(old.as_ptr(), new.as_mut_ptr(), count);
                 }
             }
             // `self.allocator.free(self.buf)` — `old` drops here.
@@ -395,15 +481,19 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         self.count
     }
 
-    /// Returns a writable slice from the 'read' end of the fifo
-    fn readable_slice_mut(&mut self, offset: usize) -> &mut [T] {
+    /// First contiguous readable segment starting at `offset`, as raw
+    /// `MaybeUninit` storage. Every slot in the returned range is inside the
+    /// `[head, head+count)` initialized window — callers may overwrite it
+    /// with valid `T` (e.g. `unget`) or poison it (`discard`) but must not
+    /// read it as `T` without `assume_init`.
+    fn readable_uninit_slice_mut(&mut self, offset: usize) -> &mut [MaybeUninit<T>] {
         if offset > self.count {
             return &mut [];
         }
         let buf_len = self.buf_len();
         let head = self.head;
         let count = self.count;
-        let buf = self.buf.as_mut_slice();
+        let buf = self.buf.as_uninit_slice_mut();
         let mut start = head + offset;
         if start >= buf_len {
             start -= buf_len;
@@ -420,15 +510,19 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             return &[];
         }
         let buf_len = self.buf_len();
-        let buf = self.buf.as_slice();
+        let buf = self.buf.as_uninit_slice();
         let mut start = self.head + offset;
-        if start >= buf_len {
+        let range = if start >= buf_len {
             start -= buf_len;
             &buf[start..start + (self.count - offset)]
         } else {
             let end = (self.head + self.count).min(buf_len);
             &buf[start..end]
-        }
+        };
+        // SAFETY: `range` lies entirely within the `[head, head+count)`
+        // readable window (modulo wrap), every slot of which was initialized
+        // by a write path before `count` covered it.
+        unsafe { assume_init_slice(range) }
     }
 
     /// Discard first `count` items in the fifo
@@ -439,13 +533,13 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         {
             // set old range to undefined. Note: may be wrapped around
             // reshaped for borrowck — capture len, then re-borrow.
-            let slice_len = self.readable_slice_mut(0).len();
+            let slice_len = self.readable_uninit_slice_mut(0).len();
             if slice_len >= count {
-                poison(self.readable_slice_mut(0), count);
+                poison(self.readable_uninit_slice_mut(0), count);
             } else {
-                poison(self.readable_slice_mut(0), slice_len);
+                poison(self.readable_uninit_slice_mut(0), slice_len);
                 let rem = count - slice_len;
-                poison(self.readable_slice_mut(slice_len), rem);
+                poison(self.readable_uninit_slice_mut(slice_len), rem);
             }
         }
 
@@ -466,9 +560,18 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         if self.count == 0 {
             return None;
         }
-        // SAFETY: buf[head] is in the readable region (count > 0); we move it
-        // out and immediately discard(1), so the slot is never read again.
-        let c = unsafe { ptr::read(self.buf.as_slice().as_ptr().add(self.head)) };
+        // SAFETY: buf[head] is in the readable region (count > 0), hence
+        // initialized; we move it out and immediately discard(1), so the slot
+        // is never read again.
+        let c = unsafe {
+            ptr::read(
+                self.buf
+                    .as_uninit_slice()
+                    .as_ptr()
+                    .add(self.head)
+                    .cast::<T>(),
+            )
+        };
         self.discard(1);
         Some(c)
     }
@@ -502,9 +605,10 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         self.buf_len() - self.count
     }
 
-    /// Returns the first section of writable buffer.
-    /// Note that this may be of length 0.
-    pub fn writable_slice(&mut self, offset: usize) -> &mut [T] {
+    /// First contiguous writable segment starting at `offset`, as raw
+    /// `MaybeUninit` storage. The slots are logically uninitialized; callers
+    /// must fully write any prefix they later commit via [`Self::update`].
+    fn writable_uninit_slice(&mut self, offset: usize) -> &mut [MaybeUninit<T>] {
         let buf_len = self.buf_len();
         if offset > buf_len {
             return &mut [];
@@ -512,7 +616,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         let head = self.head;
         let count = self.count;
         let writable = buf_len - count;
-        let buf = self.buf.as_mut_slice();
+        let buf = self.buf.as_uninit_slice_mut();
         let tail = head + offset + count;
         if tail < buf_len {
             &mut buf[tail..]
@@ -522,15 +626,35 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         }
     }
 
+    /// Returns the first section of writable buffer.
+    /// Note that this may be of length 0.
+    ///
+    /// Restricted to [`AnyBitPattern`] element types because the returned
+    /// `&mut [T]` covers never-written slots; for other `T` use
+    /// [`Self::write_item`] / [`Self::write_item_assume_capacity`].
+    pub fn writable_slice(&mut self, offset: usize) -> &mut [T]
+    where
+        T: AnyBitPattern,
+    {
+        let slice = self.writable_uninit_slice(offset);
+        // SAFETY: `T: AnyBitPattern` — every bit pattern is a valid `T`, so
+        // exposing not-yet-written slots as `&mut [T]` cannot create an
+        // invalid value.
+        unsafe { assume_init_slice_mut(slice) }
+    }
+
     /// Returns a writable buffer of at least `size` items, allocating memory as needed.
     /// Use `fifo.update` once you've written data to it.
-    pub fn writable_with_size(&mut self, size: usize) -> Result<&mut [T], AllocError> {
+    pub fn writable_with_size(&mut self, size: usize) -> Result<&mut [T], AllocError>
+    where
+        T: AnyBitPattern,
+    {
         self.ensure_unused_capacity(size)?;
 
         // try to avoid realigning buffer
         // reshaped for borrowck — check len, drop borrow, maybe
         // realign, then take the final borrow.
-        if self.writable_slice(0).len() < size {
+        if self.writable_uninit_slice(0).len() < size {
             self.realign();
         }
         let slice = self.writable_slice(0);
@@ -557,10 +681,10 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             // reshaped for borrowck — scoped block drops the
             // `writable` borrow before `self.update`.
             let n = {
-                let writable = self.writable_slice(0);
+                let writable = self.writable_uninit_slice(0);
                 debug_assert!(!writable.is_empty());
                 let n = writable.len().min(src_left.len());
-                writable[..n].copy_from_slice(&src_left[..n]);
+                write_copy(&mut writable[..n], &src_left[..n]);
                 n
             };
             self.update(n);
@@ -586,7 +710,16 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         // logically uninitialized — `ptr::write` does not drop the prior
         // bit-pattern, which is required for non-`Copy` `T` whose backing
         // storage is `MaybeUninit<T>`.
-        unsafe { ptr::write(self.buf.as_mut_slice().as_mut_ptr().add(tail), item) };
+        unsafe {
+            ptr::write(
+                self.buf
+                    .as_uninit_slice_mut()
+                    .as_mut_ptr()
+                    .add(tail)
+                    .cast::<T>(),
+                item,
+            )
+        };
         self.update(1);
     }
 
@@ -624,17 +757,20 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
         self.rewind(src.len());
 
+        // The rewound slots `[head, head+src.len())` are logically
+        // uninitialized until this copy lands, so write through the
+        // `MaybeUninit` view rather than materializing `&mut [T]` over them.
         // reshaped for borrowck — copy into first chunk in a scoped
         // block, drop borrow, then re-borrow for the wrapped chunk.
         let slice_len = {
-            let s = self.readable_slice_mut(0);
+            let s = self.readable_uninit_slice_mut(0);
             let n = s.len().min(src.len());
-            s[..n].copy_from_slice(&src[..n]);
+            write_copy(&mut s[..n], &src[..n]);
             s.len()
         };
         if src.len() > slice_len {
-            let slice2 = self.readable_slice_mut(slice_len);
-            slice2[..src.len() - slice_len].copy_from_slice(&src[slice_len..]);
+            let slice2 = self.readable_uninit_slice_mut(slice_len);
+            write_copy(&mut slice2[..src.len() - slice_len], &src[slice_len..]);
         }
         Ok(())
     }
@@ -653,7 +789,9 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         } else {
             index %= self.buf_len();
         }
-        self.buf.as_slice()[index]
+        // SAFETY: `offset < count` ⇒ the slot is inside the readable window,
+        // hence initialized.
+        unsafe { self.buf.as_uninit_slice()[index].assume_init_read() }
     }
 
     /// Returns the item at `offset`.
@@ -667,7 +805,9 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
         } else {
             index %= self.buf_len();
         }
-        &mut self.buf.as_mut_slice()[index]
+        // SAFETY: `offset < count` ⇒ the slot is inside the readable window,
+        // hence initialized.
+        unsafe { self.buf.as_uninit_slice_mut()[index].assume_init_mut() }
     }
 
     /// Remove one item at `offset` and MOVE all items after it up one.
@@ -684,7 +824,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
 
         if buf_len - head >= count {
             // If it doesnt overflow past the end, there is one copy to be done
-            let buf = self.buf.as_mut_slice();
+            let buf = self.buf.as_uninit_slice_mut();
             shift_down_one(&mut buf[head + offset..]);
         } else {
             let mut index = head + offset;
@@ -698,7 +838,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
             // prefix; `wrap_len <= head` (since `count <= buf_len`) so the
             // prefix never overlaps the tail.
             let wrap_len = head + count - buf_len;
-            let buf = self.buf.as_mut_slice();
+            let buf = self.buf.as_uninit_slice_mut();
             if index < head {
                 // If the item to remove is before the head, one slice is moved.
                 shift_down_one(&mut buf[index..wrap_len]);
@@ -706,11 +846,11 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
                 // The items before and after the head have to be shifted
                 // SAFETY: buf[0] is initialized (it's in the wrapped readable
                 // region); we move it to the end after shifting.
-                let wrap = unsafe { ptr::read(buf.as_ptr()) };
+                let wrap = unsafe { ptr::read(buf.as_ptr().cast::<T>()) };
                 shift_down_one(&mut buf[index..]);
                 // SAFETY: writing into the last slot; previous occupant already
                 // shifted down.
-                unsafe { ptr::write(buf.as_mut_ptr().add(buf_len - 1), wrap) };
+                unsafe { ptr::write(buf.as_mut_ptr().add(buf_len - 1).cast::<T>(), wrap) };
                 shift_down_one(&mut buf[..wrap_len]);
             }
         }
@@ -724,8 +864,11 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
     // `src_reader(buf)` ≙ `reader.read(buf)`, `dest_writer(buf)` ≙
     // `writer.write(buf)`, both returning a count (`Ok(0)` from the reader
     // means EOF). This keeps `pump` generic over `T`, which `std::io` cannot.
+    // `T: AnyBitPattern` because the reader closure is handed the raw
+    // writable (not-yet-written) slots as `&mut [T]`.
     pub fn pump<R, W, E>(&mut self, mut src_reader: R, dest_writer: &mut W) -> Result<(), E>
     where
+        T: AnyBitPattern,
         R: FnMut(&mut [T]) -> Result<usize, E>,
         W: FnMut(&[T]) -> Result<usize, E>,
     {
@@ -981,6 +1124,125 @@ mod tests {
             )*};
         }
         per_type!(u8, u16, u64);
+    }
+
+    // A `NonNull`-bearing enum: NOT any-bit-pattern-valid (a niche-optimized
+    // discriminant over a non-null pointer), mirroring the in-tree element
+    // types `bun_test::RefDataValue`, `ValkeyCommand::PromisePair`, and the
+    // event-loop `Task` enum. Pre-rework, *every* fifo accessor materialized
+    // `&[T]` over the whole (partially uninitialized) backing store, which is
+    // immediate UB for this type under Miri; post-rework only logically
+    // written subranges are assumed-init. Run with
+    // `cargo miri test -p bun_collections linear_fifo` to verify.
+    #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+    enum PtrItem {
+        Val(core::ptr::NonNull<i32>),
+        Marker,
+    }
+
+    fn ptr_items(backing: &[i32]) -> Vec<PtrItem> {
+        backing
+            .iter()
+            .map(|v| PtrItem::Val(core::ptr::NonNull::from(v)))
+            .collect()
+    }
+
+    fn deref_item(item: PtrItem) -> i32 {
+        match item {
+            // SAFETY: pointer targets the `backing` array, which outlives the
+            // fifo in every test below.
+            PtrItem::Val(p) => unsafe { *p.as_ref() },
+            PtrItem::Marker => -1,
+        }
+    }
+
+    #[test]
+    fn linear_fifo_nonnull_enum_static_wrapped() {
+        let backing: Vec<i32> = (0..110).collect();
+        let items = ptr_items(&backing);
+
+        let mut fifo = LinearFifo::<PtrItem, StaticBuffer<PtrItem, 16>>::init();
+        // Recreate the wrapped layout from the i32 tests: write 12, read 8,
+        // write 10 → head=8, count=14, wraps. Every read/peek goes through a
+        // partially-uninitialized backing store.
+        for v in 0..12 {
+            fifo.write_item(items[v]).unwrap();
+        }
+        for v in 0..8 {
+            assert_eq!(deref_item(fifo.read_item().unwrap()), v as i32);
+        }
+        for v in 100..110 {
+            fifo.write_item(items[v]).unwrap();
+        }
+        assert_eq!(fifo.readable_length(), 14);
+
+        // peek across the wrap point
+        let peeked: Vec<i32> = (0..fifo.readable_length())
+            .map(|i| deref_item(fifo.peek_item(i)))
+            .collect();
+        assert_eq!(
+            peeked,
+            vec![8, 9, 10, 11, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109]
+        );
+
+        // wrapped ordered_remove_item with a niche-optimized element type
+        fifo.ordered_remove_item(6);
+        let after: Vec<i32> = (0..fifo.readable_length())
+            .map(|i| deref_item(fifo.peek_item(i)))
+            .collect();
+        assert_eq!(
+            after,
+            vec![8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]
+        );
+
+        // unget puts an item back in front
+        let front = fifo.read_item().unwrap();
+        fifo.unget(&[front]).unwrap();
+        assert_eq!(deref_item(fifo.peek_item(0)), 8);
+
+        // readable_slice over the contiguous tail segment
+        let first_seg = fifo.readable_slice(0);
+        assert!(!first_seg.is_empty());
+        assert_eq!(deref_item(first_seg[0]), 8);
+
+        // drain fully
+        let mut drained = Vec::new();
+        while let Some(item) = fifo.read_item() {
+            drained.push(deref_item(item));
+        }
+        assert_eq!(
+            drained,
+            vec![8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]
+        );
+        assert_eq!(fifo.readable_length(), 0);
+    }
+
+    #[test]
+    fn linear_fifo_nonnull_enum_dynamic_growth() {
+        let backing: Vec<i32> = (0..64).collect();
+        let items = ptr_items(&backing);
+
+        let mut fifo = LinearFifo::<PtrItem, DynamicBuffer<PtrItem>>::init();
+        // Interleave writes/reads so growth (ensure_total_capacity →
+        // alloc_swap copy) happens with a non-zero head.
+        for v in 0..8 {
+            fifo.write_item(items[v]).unwrap();
+        }
+        for v in 0..4 {
+            assert_eq!(deref_item(fifo.read_item().unwrap()), v as i32);
+        }
+        for v in 8..64 {
+            fifo.write_item(items[v]).unwrap();
+        }
+        fifo.write_item(PtrItem::Marker).unwrap();
+
+        let mut out = Vec::new();
+        while let Some(item) = fifo.read_item() {
+            out.push(deref_item(item));
+        }
+        let mut expected: Vec<i32> = (4..64).collect();
+        expected.push(-1);
+        assert_eq!(out, expected);
     }
 
     // 16-slot static buffer: `POWERS_OF_TWO` is true, matching the in-tree

--- a/src/ptr/lib.rs
+++ b/src/ptr/lib.rs
@@ -383,9 +383,9 @@ pub unsafe fn boxed_slices_as_borrowed<T, A: core::alloc::Allocator>(s: &[Box<[T
 // inherited via auto-traits (no `unsafe impl` needed).
 //
 // This does NOT cover `&'static mut [u8]` / `&'static mut T` forges (e.g.
-// `FileReader::pending_view`, `Decompressor::seat` output, `CmdHandle::cmd_mut`)
-// — those are tracked under the sibling `static-widen-mut` pattern and want a
-// raw-pointer field or a future `RawSliceMut<T>`.
+// `Decompressor::seat` output, `CmdHandle::cmd_mut`) — those are tracked under
+// the sibling `static-widen-mut` pattern and want a raw-pointer field such as
+// `streams::RawSliceMut<T>` (which `FileReader::pending_view` now uses).
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// A byte slice backed by **process-lifetime** storage.

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -917,9 +917,7 @@ impl BufferOutputSink {
             // ref taken for the in-flight bufferer.
             unsafe { BufferOutputSink::deref(sink) };
             return match buffering_error {
-                // The original JS exception is still pending on the VM —
-                // propagate it instead of masking it with a synthetic
-                // "Failed to pipe stream" error.
+                // JS exception still pending on the VM — propagate, don't mask.
                 webcore::body::BufferError::Js(js_err) => Err(js_err),
                 webcore::body::BufferError::Native(e)
                     if e == bun_core::err!("StreamAlreadyUsed") =>

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -566,7 +566,7 @@ impl HTMLRewriterLoader {
                 // double-buffer.
                 // SAFETY: `pending` points at a heap WritablePending owned by
                 // the destination sink; valid for the duration of this call.
-                unsafe { (*pending).apply_backpressure(&mut self.output, bytes) };
+                unsafe { (*pending.as_ptr()).apply_backpressure(&mut self.output, bytes) };
             }
             Writable::IntoArray(_) | Writable::Owned(_) | Writable::Temporary(_) => {
                 self.signal.ready(
@@ -907,7 +907,7 @@ impl BufferOutputSink {
         // `<BufferOutputSink as OutputSink>::write/done` and forms a fresh
         // `&mut *sink`. Hoist the bufferer through a raw pointer so no `&mut`
         // derived from `*sink` is live across that callback.
-        let buffering_result: Result<(), bun_core::Error> = unsafe {
+        let buffering_result: Result<(), webcore::body::BufferError> = unsafe {
             let bufferer: *mut webcore::body::ValueBufferer =
                 (*sink).body_value_bufferer.as_mut().unwrap();
             (*bufferer).run(value, owned_readable_stream)
@@ -916,19 +916,25 @@ impl BufferOutputSink {
             // SAFETY: `sink` is a live `heap::into_raw` allocation; release the
             // ref taken for the in-flight bufferer.
             unsafe { BufferOutputSink::deref(sink) };
-            return Ok(match buffering_error {
-                e if e == bun_core::err!("StreamAlreadyUsed") => {
+            return match buffering_error {
+                // The original JS exception is still pending on the VM —
+                // propagate it instead of masking it with a synthetic
+                // "Failed to pipe stream" error.
+                webcore::body::BufferError::Js(js_err) => Err(js_err),
+                webcore::body::BufferError::Native(e)
+                    if e == bun_core::err!("StreamAlreadyUsed") =>
+                {
                     let err = system_error(
                         "ERR_STREAM_ALREADY_FINISHED",
                         "Stream already used, please create a new one",
                     );
-                    err.to_error_instance(global)
+                    Ok(err.to_error_instance(global))
                 }
-                _ => {
+                webcore::body::BufferError::Native(_) => {
                     let err = system_error("ERR_STREAM_CANNOT_PIPE", "Failed to pipe stream");
-                    err.to_error_instance(global)
+                    Ok(err.to_error_instance(global))
                 }
-            });
+            };
         }
 
         // sync error occurs — read via the Cell (shares SharedReadWrite

--- a/src/runtime/linear_fifo_testing.rs
+++ b/src/runtime/linear_fifo_testing.rs
@@ -31,11 +31,7 @@ type ProbeFifo = LinearFifo<i32, StaticBuffer<i32, 16>>;
 ///   1 — wrapped-prefix sub-branch (`index < head`), `head > count`:
 ///       write 12, read 12, write 8 → head=12 count=8, remove offset 5.
 ///   2 — same wrapped layout as 0, but with a `NonNull`-bearing element type
-///       (niche-optimized enum, NOT any-bit-pattern-valid). Covers the
-///       `MaybeUninit` accessor rework: pre-rework every accessor formed
-///       `&[T]` over the partially-uninitialized backing store, which is
-///       undefined behavior for such types; post-rework only the logically
-///       written window is assumed-init. Returns the pointed-to values.
+///       (not any-bit-pattern-valid); returns the pointed-to values.
 ///
 /// Any other scenario value returns an empty array.
 pub fn ordered_remove_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
@@ -86,23 +82,17 @@ pub fn ordered_remove_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
     Ok(array)
 }
 
-/// Scenario 2: rebuild the scenario-0 wrapped state (`head=8 count=14`,
-/// remove offset 6) in a fifo of `NonNull`-bearing enum items, then read the
-/// surviving items back through `peek_item` and dereference the pointers.
-/// Expected result is identical to scenario 0:
-/// `[8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]`.
+/// Scenario 2: the scenario-0 wrapped state with `NonNull`-bearing enum
+/// items; expected result identical to scenario 0.
 fn nonnull_probe(global: &JSGlobalObject) -> JsResult<JSValue> {
     use core::ptr::NonNull;
 
-    /// Niche-optimized over a non-null pointer — uninitialized slots read as
-    /// this type are invalid values, unlike the `i32` probe above.
     #[derive(Clone, Copy)]
     enum Item {
         Val(NonNull<i32>),
     }
 
-    // Stable addresses for the lifetime of this fn; the fifo stores pointers
-    // into this vec.
+    // Stable addresses; the fifo stores pointers into this vec.
     let backing: Vec<i32> = (0..110).collect();
     let item = |v: usize| Item::Val(NonNull::from(&backing[v]));
 
@@ -122,8 +112,7 @@ fn nonnull_probe(global: &JSGlobalObject) -> JsResult<JSValue> {
     let array = JSValue::create_empty_array(global, len)?;
     for i in 0..len {
         let Item::Val(p) = fifo.peek_item(i);
-        // SAFETY: every stored pointer targets `backing`, which is live until
-        // this fn returns.
+        // SAFETY: stored pointers target `backing`, live until this fn returns.
         let value = unsafe { *p.as_ref() };
         array.put_index(global, i as u32, JSValue::js_number_from_int32(value))?;
     }

--- a/src/runtime/linear_fifo_testing.rs
+++ b/src/runtime/linear_fifo_testing.rs
@@ -25,15 +25,25 @@ type ProbeFifo = LinearFifo<i32, StaticBuffer<i32, 16>>;
 /// Builds a wrapped `LinearFifo` for the requested scenario, removes one item,
 /// and returns the live items (FIFO order) as a JS `number[]`.
 ///
-/// Scenarios mirror issue #31563:
+/// Scenarios 0/1 mirror issue #31563:
 ///   0 — tail sub-branch (`index >= head`), `head < count`:
 ///       write 12, read 8, write 10 → head=8 count=14, remove offset 6.
 ///   1 — wrapped-prefix sub-branch (`index < head`), `head > count`:
 ///       write 12, read 12, write 8 → head=12 count=8, remove offset 5.
+///   2 — same wrapped layout as 0, but with a `NonNull`-bearing element type
+///       (niche-optimized enum, NOT any-bit-pattern-valid). Covers the
+///       `MaybeUninit` accessor rework: pre-rework every accessor formed
+///       `&[T]` over the partially-uninitialized backing store, which is
+///       undefined behavior for such types; post-rework only the logically
+///       written window is assumed-init. Returns the pointed-to values.
 ///
 /// Any other scenario value returns an empty array.
 pub fn ordered_remove_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let scenario = frame.argument(0).to_int32();
+
+    if scenario == 2 {
+        return nonnull_probe(global);
+    }
 
     let mut fifo = ProbeFifo::init();
     match scenario {
@@ -72,6 +82,50 @@ pub fn ordered_remove_probe(global: &JSGlobalObject, frame: &CallFrame) -> JsRes
             i as u32,
             JSValue::js_number_from_int32(fifo.peek_item(i)),
         )?;
+    }
+    Ok(array)
+}
+
+/// Scenario 2: rebuild the scenario-0 wrapped state (`head=8 count=14`,
+/// remove offset 6) in a fifo of `NonNull`-bearing enum items, then read the
+/// surviving items back through `peek_item` and dereference the pointers.
+/// Expected result is identical to scenario 0:
+/// `[8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]`.
+fn nonnull_probe(global: &JSGlobalObject) -> JsResult<JSValue> {
+    use core::ptr::NonNull;
+
+    /// Niche-optimized over a non-null pointer — uninitialized slots read as
+    /// this type are invalid values, unlike the `i32` probe above.
+    #[derive(Clone, Copy)]
+    enum Item {
+        Val(NonNull<i32>),
+    }
+
+    // Stable addresses for the lifetime of this fn; the fifo stores pointers
+    // into this vec.
+    let backing: Vec<i32> = (0..110).collect();
+    let item = |v: usize| Item::Val(NonNull::from(&backing[v]));
+
+    let mut fifo = LinearFifo::<Item, StaticBuffer<Item, 16>>::init();
+    for v in 0..12 {
+        fifo.write_item(item(v)).unwrap();
+    }
+    for _ in 0..8 {
+        fifo.read_item().unwrap();
+    }
+    for v in 100..110 {
+        fifo.write_item(item(v)).unwrap();
+    }
+    fifo.ordered_remove_item(6);
+
+    let len = fifo.readable_length();
+    let array = JSValue::create_empty_array(global, len)?;
+    for i in 0..len {
+        let Item::Val(p) = fifo.peek_item(i);
+        // SAFETY: every stored pointer targets `backing`, which is live until
+        // this fn returns.
+        let value = unsafe { *p.as_ref() };
+        array.put_index(global, i as u32, JSValue::js_number_from_int32(value))?;
     }
     Ok(array)
 }

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2166,6 +2166,36 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 pub(crate) type ValueBuffererCallback =
     fn(ctx: *mut c_void, bytes: &[u8], err: Option<ValueError>, is_async: bool);
 
+/// Error surface of [`ValueBufferer::run`] / `buffer_locked_body_value`.
+///
+/// Mirrors the original error union: stream-state failures are carried as
+/// native string-coded errors, while a JS exception raised during body
+/// conversion (e.g. `to_readable_stream`) is propagated as
+/// [`bun_jsc::JsError`] — the exception value itself stays *pending on the
+/// VM* (the repo-wide `JsError::Thrown` convention), so no GC rooting is
+/// needed here and callers can rethrow or inspect it via the exception scope
+/// instead of receiving a flattened synthetic "JSError" string.
+pub enum BufferError {
+    /// A JS exception is pending on the VM (or OOM/termination).
+    Js(bun_jsc::JsError),
+    /// Native stream-state failure (`StreamAlreadyUsed`, `InvalidStream`, …).
+    Native(bun_core::Error),
+}
+
+impl From<bun_jsc::JsError> for BufferError {
+    #[inline]
+    fn from(e: bun_jsc::JsError) -> Self {
+        BufferError::Js(e)
+    }
+}
+
+impl From<bun_core::Error> for BufferError {
+    #[inline]
+    fn from(e: bun_core::Error) -> Self {
+        BufferError::Native(e)
+    }
+}
+
 pub struct ValueBufferer<'a> {
     pub ctx: *mut c_void,
     pub on_finished_buffering: ValueBuffererCallback,
@@ -2220,13 +2250,13 @@ impl<'a> ValueBufferer<'a> {
         &mut self,
         value: &mut Value,
         owned_readable_stream: Option<ReadableStream>,
-    ) -> Result<(), bun_core::Error> {
+    ) -> Result<(), BufferError> {
         value.to_blob_if_possible();
 
         match value {
             Value::Used => {
                 bun_core::scoped_log!(BodyValueBufferer, "Used");
-                return Err(bun_core::err!("StreamAlreadyUsed"));
+                return Err(bun_core::err!("StreamAlreadyUsed").into());
             }
             Value::Empty | Value::Null => {
                 bun_core::scoped_log!(BodyValueBufferer, "Empty");
@@ -2404,7 +2434,7 @@ impl<'a> ValueBufferer<'a> {
         &mut self,
         value: &mut Value,
         owned_readable_stream: Option<ReadableStream>,
-    ) -> Result<(), bun_core::Error> {
+    ) -> Result<(), BufferError> {
         debug_assert!(matches!(value, Value::Locked(_)));
         let Value::Locked(locked) = value else {
             unreachable!()
@@ -2430,12 +2460,12 @@ impl<'a> ValueBufferer<'a> {
             *value = Value::Used;
 
             if stream.is_locked(self.global) {
-                return Err(bun_core::err!("StreamAlreadyUsed"));
+                return Err(bun_core::err!("StreamAlreadyUsed").into());
             }
 
             match stream.ptr {
                 webcore::readable_stream::Source::Invalid => {
-                    return Err(bun_core::err!("InvalidStream"));
+                    return Err(bun_core::err!("InvalidStream").into());
                 }
                 // toBlobIfPossible should've caught this
                 webcore::readable_stream::Source::Blob(_)
@@ -2444,7 +2474,7 @@ impl<'a> ValueBufferer<'a> {
                 | webcore::readable_stream::Source::Direct => {
                     // this is broken right now
                     // return self.create_js_sink(stream);
-                    return Err(bun_core::err!("UnsupportedStreamType"));
+                    return Err(bun_core::err!("UnsupportedStreamType").into());
                 }
                 webcore::readable_stream::Source::Bytes(byte_stream_ptr) => {
                     // BACKREF: see `Source::bytes()` — payload owned by the
@@ -2492,12 +2522,11 @@ impl<'a> ValueBufferer<'a> {
 
         if locked.on_receive_value.is_some() || locked.task.is_some() {
             // someone else is waiting for the stream or waiting for `onStartStreaming`
+            // A thrown exception propagates as `BufferError::Js` (pending on
+            // the VM) instead of being flattened to a synthetic string error.
             let readable = value
                 .to_readable_stream(self.global)
-                .map_err(|_| bun_core::err!("JSError"))?;
-            // The JS exception value is
-            // flattened to a string-coded error because `run`'s callers consume
-            // `bun_core::Error` (the exception itself stays pending on the VM).
+                .map_err(BufferError::Js)?;
             readable.ensure_still_alive();
             readable.protect();
             return self.buffer_locked_body_value(value, None);

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2166,15 +2166,9 @@ fn handle_body_already_used(global_object: &JSGlobalObject) -> JSValue {
 pub(crate) type ValueBuffererCallback =
     fn(ctx: *mut c_void, bytes: &[u8], err: Option<ValueError>, is_async: bool);
 
-/// Error surface of [`ValueBufferer::run`] / `buffer_locked_body_value`.
-///
-/// Mirrors the original error union: stream-state failures are carried as
-/// native string-coded errors, while a JS exception raised during body
-/// conversion (e.g. `to_readable_stream`) is propagated as
-/// [`bun_jsc::JsError`] — the exception value itself stays *pending on the
-/// VM* (the repo-wide `JsError::Thrown` convention), so no GC rooting is
-/// needed here and callers can rethrow or inspect it via the exception scope
-/// instead of receiving a flattened synthetic "JSError" string.
+/// Error from [`ValueBufferer::run`]: a native stream-state failure, or a JS
+/// exception left pending on the VM so callers can rethrow it instead of a
+/// flattened synthetic error.
 pub enum BufferError {
     /// A JS exception is pending on the VM (or OOM/termination).
     Js(bun_jsc::JsError),
@@ -2522,8 +2516,6 @@ impl<'a> ValueBufferer<'a> {
 
         if locked.on_receive_value.is_some() || locked.task.is_some() {
             // someone else is waiting for the stream or waiting for `onStartStreaming`
-            // A thrown exception propagates as `BufferError::Js` (pending on
-            // the VM) instead of being flattened to a synthetic string error.
             let readable = value
                 .to_readable_stream(self.global)
                 .map_err(BufferError::Js)?;

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -27,14 +27,9 @@ pub struct ByteStream {
     pub pending: JsCell<streams::Pending>,
     pub done: Cell<bool>,
     /// Borrowed view into a JS `Uint8Array` passed from `on_pull`; kept alive by `pending_value`.
-    // `RawSliceMut` (raw fat slice wrapper) because the backing store is
-    // JS-heap-owned and rooted via `pending_value: Strong`. Never freed by Rust.
-    //
-    // Intentionally never read: the fulfillment path (`on_data` pending
-    // branch) re-derives the destination from the GC-rooted `pending_value`
-    // via `as_array_buffer` (detach-safe). Keep it that way; reading this
-    // stored slice would reintroduce the dangling-on-detach hazard the
-    // re-derivation avoids.
+    // Never read back: the fulfillment path re-derives the destination from
+    // the GC-rooted `pending_value` (detach-safe); reading this stored slice
+    // would reintroduce the dangling-on-detach hazard.
     pub pending_buffer: Cell<streams::RawSliceMut<u8>>,
     pub pending_value: JsCell<StrongOptional>, // jsc.Strong.Optional
     pub offset: Cell<usize>,
@@ -454,14 +449,12 @@ impl ByteStream {
         }
 
         // Root the view BEFORE stashing the raw borrow, so the stored slice
-        // is never live without its GC anchor (both happen inside one
-        // JS-blocked region either way).
+        // is never live without its GC anchor.
         self.set_value(view);
         self.pending_buffer.set(streams::RawSliceMut::new(buffer));
 
         // R-2: `JsCell::as_ptr` yields the stable `*mut Pending` that the
-        // returned `streams::Result::Pending` raw-backref needs; non-null
-        // because it is derived from the embedded `pending` field of `self`.
+        // returned `streams::Result::Pending` raw-backref needs.
         streams::Result::Pending(NonNull::new(self.pending.as_ptr()).expect("embedded field"))
     }
 

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -1,4 +1,5 @@
 use core::cell::Cell;
+use core::ptr::NonNull;
 
 use bun_collections::VecExt;
 use bun_jsc::strong::Optional as StrongOptional;
@@ -26,9 +27,15 @@ pub struct ByteStream {
     pub pending: JsCell<streams::Pending>,
     pub done: Cell<bool>,
     /// Borrowed view into a JS `Uint8Array` passed from `on_pull`; kept alive by `pending_value`.
-    // Raw fat slice ptr because the backing store is JS-heap-owned and rooted via
-    // `pending_value: Strong`. Never freed by Rust.
-    pub pending_buffer: Cell<*mut [u8]>,
+    // `RawSliceMut` (raw fat slice wrapper) because the backing store is
+    // JS-heap-owned and rooted via `pending_value: Strong`. Never freed by Rust.
+    //
+    // Intentionally never read: the fulfillment path (`on_data` pending
+    // branch) re-derives the destination from the GC-rooted `pending_value`
+    // via `as_array_buffer` (detach-safe). Keep it that way; reading this
+    // stored slice would reintroduce the dangling-on-detach hazard the
+    // re-derivation avoids.
+    pub pending_buffer: Cell<streams::RawSliceMut<u8>>,
     pub pending_value: JsCell<StrongOptional>, // jsc.Strong.Optional
     pub offset: Cell<usize>,
     pub high_water_mark: blob::SizeType,
@@ -47,7 +54,7 @@ impl Default for ByteStream {
                 ..Default::default()
             }),
             done: Cell::new(false),
-            pending_buffer: Cell::new(Self::empty_pending_buffer()),
+            pending_buffer: Cell::new(streams::RawSliceMut::EMPTY),
             pending_value: JsCell::new(StrongOptional::empty()),
             offset: Cell::new(0),
             high_water_mark: 0,
@@ -104,11 +111,6 @@ impl readable_stream::SourceContext for ByteStream {
 bun_core::impl_field_parent! { ByteStream => Source.context; pub fn parent_const; pub fn parent; }
 
 impl ByteStream {
-    #[inline]
-    const fn empty_pending_buffer() -> *mut [u8] {
-        core::ptr::slice_from_raw_parts_mut(core::ptr::NonNull::<u8>::dangling().as_ptr(), 0)
-    }
-
     /// Init-time reset. Runs before the JS
     /// wrapper exists, so `&mut self` is sound here (R-2 exemption).
     pub(crate) fn setup(&mut self) {
@@ -285,7 +287,7 @@ impl ByteStream {
             let pending_buffer_len = pending_buf.len();
             debug_assert!(pending_buf.as_ptr() != chunk.as_ptr());
             pending_buf[..to_copy_len].copy_from_slice(&chunk[..to_copy_len]);
-            self.pending_buffer.set(Self::empty_pending_buffer());
+            self.pending_buffer.set(streams::RawSliceMut::EMPTY);
 
             let is_really_done =
                 self.has_received_last_chunk.get() && to_copy_len <= pending_buffer_len;
@@ -451,13 +453,16 @@ impl ByteStream {
             return streams::Result::Done;
         }
 
-        // Raw borrow of a JS-owned buffer; rooted by `set_value`.
-        self.pending_buffer.set(std::ptr::from_mut::<[u8]>(buffer));
+        // Root the view BEFORE stashing the raw borrow, so the stored slice
+        // is never live without its GC anchor (both happen inside one
+        // JS-blocked region either way).
         self.set_value(view);
+        self.pending_buffer.set(streams::RawSliceMut::new(buffer));
 
         // R-2: `JsCell::as_ptr` yields the stable `*mut Pending` that the
-        // returned `streams::Result::Pending` raw-backref needs.
-        streams::Result::Pending(self.pending.as_ptr())
+        // returned `streams::Result::Pending` raw-backref needs; non-null
+        // because it is derived from the embedded `pending` field of `self`.
+        streams::Result::Pending(NonNull::new(self.pending.as_ptr()).expect("embedded field"))
     }
 
     pub(crate) fn on_cancel(&self) {
@@ -473,7 +478,7 @@ impl ByteStream {
         self.pending_value.with_mut(|pv| pv.deinit());
 
         if !view.is_empty() {
-            self.pending_buffer.set(Self::empty_pending_buffer());
+            self.pending_buffer.set(streams::RawSliceMut::EMPTY);
             self.pending.with_mut(|p| {
                 p.result.release();
                 p.result = streams::Result::Done;
@@ -518,7 +523,7 @@ impl ByteStream {
         if !self.done.get() {
             self.done.set(true);
 
-            self.pending_buffer.set(Self::empty_pending_buffer());
+            self.pending_buffer.set(streams::RawSliceMut::EMPTY);
             let is_promise = self.pending.with_mut(|p| {
                 p.result.release();
                 p.result = streams::Result::Done;

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -19,9 +19,10 @@ use crate::webcore::streams;
 bun_core::declare_scope!(FileReader, visible);
 
 // `pending_view` and the `Js`/`Temporary` variants below borrow into a
-// JS-owned typed-array buffer kept alive by `pending_value: Strong` / `ensure_still_alive`.
-// Represented as unbounded `&mut [u8]` / `&[u8]` here to keep function bodies
-// readable; TODO(refactor): replace with a proper raw-slice wrapper (BACKREF lifetime).
+// JS-owned typed-array buffer kept alive by `pending_value: Strong` /
+// `ensure_still_alive`. Mutable views are carried as `streams::RawSliceMut<u8>`
+// (raw fat-pointer wrapper, no forged lifetime); each re-borrow to `&mut [u8]`
+// is a scoped `unsafe` block citing the GC rooting in force at that point.
 
 // R-2 (host-fn re-entrancy): every JS-exposed / vtable-reachable method takes
 // `&self`; per-field interior mutability via `Cell` (Copy) / `JsCell` (non-
@@ -42,12 +43,16 @@ pub struct FileReader {
     pub done: Cell<bool>,
     pub pending: JsCell<streams::Pending>,
     pub pending_value: JsCell<Strong>, // Strong.Optional
-    // TODO(refactor): `&'static mut [u8]` forge — borrows a JS typed-array buffer
-    // that GC can move/collect, and `&'static mut` asserts uniqueness the GC
-    // does not honour. `bun_ptr::Interned` is read-only by construction so
-    // does NOT cover this; tracked under the sibling `static-widen-mut`
-    // pattern (field should become `*mut [u8]` / `RawSliceMut<u8>`).
-    pub pending_view: JsCell<&'static mut [u8]>,
+    /// Borrowed view into the JS typed array of the in-flight pull, rooted by
+    /// `pending_value`. Raw wrapper (no lifetime, no uniqueness claim) — see
+    /// the note at the top of this file.
+    ///
+    /// Intentionally never read: every fulfillment path re-derives the
+    /// destination from the GC-rooted `pending_value` via `as_array_buffer`
+    /// (detach-safe — a detached view re-derives to an empty slice). Keep it
+    /// that way; reading this stored slice would reintroduce the
+    /// dangling-on-detach hazard the re-derivation avoids.
+    pub pending_view: Cell<streams::RawSliceMut<u8>>,
     pub fd: Cell<Fd>,
     /// Read-only after construction (set via struct literal in `from_blob_*`).
     pub start_offset: Option<usize>,
@@ -72,7 +77,7 @@ impl Default for FileReader {
             done: Cell::new(false),
             pending: JsCell::new(streams::Pending::default()),
             pending_value: JsCell::new(Strong::empty()),
-            pending_view: JsCell::new(&mut []),
+            pending_view: Cell::new(streams::RawSliceMut::EMPTY),
             fd: Cell::new(Fd::INVALID),
             start_offset: None,
             max_size: None,
@@ -97,9 +102,9 @@ pub const TAG: readable_stream::Tag = readable_stream::Tag::File;
 #[derive(strum::IntoStaticStr)]
 pub enum ReadDuringJSOnPullResult {
     None,
-    // TODO(refactor): `&'static mut` forge — sibling `static-widen-mut` pattern;
-    // see note on `FileReader::pending_view`.
-    Js(&'static mut [u8]),
+    /// In-flight JS pull buffer (rooted by the enclosing `on_pull` frame's
+    /// `EnsureStillAlive(array)`); raw wrapper, re-borrowed in tight scopes.
+    Js(streams::RawSliceMut<u8>),
     AmountRead(usize),
     /// Borrows the reader/JS buffer for the duration of one `on_pull` call
     /// only. Holder-lifetime, not process-lifetime — `RawSlice<u8>` per
@@ -623,10 +628,15 @@ impl FileReader {
             self.read_inside_on_pull.with_mut(|riop| match riop {
                 ReadDuringJSOnPullResult::Js(in_progress) => {
                     if in_progress.len() >= buf.len() && !has_more {
-                        in_progress[0..buf.len()].copy_from_slice(buf);
-                        let remaining: *mut [u8] = &raw mut in_progress[buf.len()..];
-                        // SAFETY: lifetime laundering — see the `static-widen-mut` note on `ReadDuringJSOnPullResult::Js`.
-                        let remaining = unsafe { &mut *remaining };
+                        // SAFETY: `in_progress` points into the JS typed array
+                        // rooted by the enclosing `on_pull` frame
+                        // (`EnsureStillAlive(array)`); this is the only live
+                        // reference into it, confined to this statement.
+                        let dst = unsafe { in_progress.slice_mut() };
+                        dst[..buf.len()].copy_from_slice(buf);
+                        // SAFETY: in-bounds — `buf.len() <= in_progress.len()`
+                        // checked above; same live allocation.
+                        let remaining = unsafe { in_progress.slice_from(buf.len()) };
                         *riop = ReadDuringJSOnPullResult::Js(remaining);
                     } else if !in_progress.is_empty() && !has_more {
                         // `buf` outlives the `on_pull` call that consumes this
@@ -768,7 +778,7 @@ impl FileReader {
 
             self.pending_value
                 .with_mut(|p| p.clear_without_deallocation());
-            self.pending_view.set(&mut []);
+            self.pending_view.set(streams::RawSliceMut::EMPTY);
             self.pending.with_mut(|p| p.run());
             close_if_needed!();
             return ret;
@@ -797,7 +807,7 @@ impl FileReader {
         !self.read_inside_on_pull.get().is_none()
     }
 
-    pub fn on_pull(&self, buffer: &'static mut [u8], array: JSValue) -> streams::Result {
+    pub fn on_pull(&self, buffer: streams::RawSliceMut<u8>, array: JSValue) -> streams::Result {
         // `buffer` borrows a JS typed array kept alive by `array`.
         array.ensure_still_alive();
         let _keep = EnsureStillAlive(array);
@@ -808,11 +818,15 @@ impl FileReader {
 
             self.pending_value
                 .with_mut(|p| p.clear_without_deallocation());
-            self.pending_view.set(&mut []);
+            self.pending_view.set(streams::RawSliceMut::EMPTY);
 
             if buffer.len() >= drained.len() as usize {
                 let drained_len = drained.len();
-                buffer[0..drained_len as usize].copy_from_slice(drained.slice());
+                // SAFETY: `buffer` points into the JS typed array kept alive by
+                // `array` (`EnsureStillAlive` above) for this whole call; this
+                // is the only live reference into it, confined to this statement.
+                let dst = unsafe { buffer.slice_mut() };
+                dst[0..drained_len as usize].copy_from_slice(drained.slice());
                 // drain() moved ownership of the allocation into `drained` and
                 // left `self.buffered` / the reader buffer empty, so free
                 // `drained` here — freeing `self.buffered` would be a no-op.
@@ -853,7 +867,10 @@ impl FileReader {
                 let global = self.parent_global();
                 self.pending_value.with_mut(|p| p.set(&global, array));
                 self.pending_view.set(buffer);
-                return streams::Result::Pending(self.pending.as_ptr());
+                // Non-null: derived from the embedded `pending` field of `self`.
+                return streams::Result::Pending(
+                    core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
+                );
             }
 
             let buffer_len = buffer.len();
@@ -894,7 +911,10 @@ impl FileReader {
                     self.pending_value.with_mut(|p| p.set(&global, array));
                     self.pending_view.set(remaining_buf);
                     bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
-                    return streams::Result::Pending(self.pending.as_ptr());
+                    // Non-null: derived from the embedded `pending` field of `self`.
+                    return streams::Result::Pending(
+                        core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
+                    );
                 }
                 ReadDuringJSOnPullResult::Temporary(buf) => {
                     bun_core::scoped_log!(FileReader, "onPull({}) = {}", buffer_len, buf.len());
@@ -939,7 +959,8 @@ impl FileReader {
 
         bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
 
-        streams::Result::Pending(self.pending.as_ptr())
+        // Non-null: derived from the embedded `pending` field of `self`.
+        streams::Result::Pending(core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"))
     }
 
     pub fn drain(&self) -> Vec<u8> {
@@ -1095,10 +1116,9 @@ impl readable_stream::SourceContext for FileReader {
         Self::on_start(self)
     }
     fn on_pull(&mut self, buf: &mut [u8], arr: JSValue) -> streams::Result {
-        // SAFETY: lifetime laundering — `buf` borrows a JS typed array kept alive
-        // by `arr` (see the lifetime note at the top of the file).
-        let buf = unsafe { &mut *std::ptr::from_mut::<[u8]>(buf) };
-        Self::on_pull(self, buf, arr)
+        // Wrap the borrow as a raw slice; `Self::on_pull` re-borrows it only in
+        // scopes covered by `arr`'s rooting (see the note at the top of the file).
+        Self::on_pull(self, streams::RawSliceMut::new(buf), arr)
     }
     fn on_cancel(&mut self) {
         Self::on_cancel(self)

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -892,8 +892,8 @@ impl FileReader {
                     if self.reader().is_done() {
                         return streams::Result::Done;
                     }
-                    // fallthrough — but `buffer` was moved into read_inside_on_pull.
-                    // Recover it from `remaining_buf` (amount_read == 0 ⇒ same slice).
+                    // fallthrough — `buffer` is a `RawSliceMut`, which is `Copy`;
+                    // `remaining_buf` is the same slice here (amount_read == 0).
                     let global = self.parent_global();
                     self.pending_value.with_mut(|p| p.set(&global, array));
                     self.pending_view.set(remaining_buf);
@@ -929,8 +929,8 @@ impl FileReader {
                     // are `None` (impossible — we just stored `Js(buffer)` above and
                     // `on_read_chunk` never sets `None`) and `AmountRead` (never
                     // produced by `on_read_chunk`). Unreachable in the current state
-                    // machine; if that invariant ever changes, the buffer slice must
-                    // be recovered from a captured raw ptr+len before the move.
+                    // machine; if that invariant ever changes, `buffer` is still
+                    // available here since `RawSliceMut` is `Copy`.
                     unreachable!(
                         "on_read_chunk never yields None/AmountRead while read_inside_on_pull == Js"
                     );

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -20,9 +20,8 @@ bun_core::declare_scope!(FileReader, visible);
 
 // `pending_view` and the `Js`/`Temporary` variants below borrow into a
 // JS-owned typed-array buffer kept alive by `pending_value: Strong` /
-// `ensure_still_alive`. Mutable views are carried as `streams::RawSliceMut<u8>`
-// (raw fat-pointer wrapper, no forged lifetime); each re-borrow to `&mut [u8]`
-// is a scoped `unsafe` block citing the GC rooting in force at that point.
+// `ensure_still_alive`. Mutable views are carried as `streams::RawSliceMut<u8>`;
+// each re-borrow cites the GC rooting in force at that point.
 
 // R-2 (host-fn re-entrancy): every JS-exposed / vtable-reachable method takes
 // `&self`; per-field interior mutability via `Cell` (Copy) / `JsCell` (non-
@@ -43,15 +42,10 @@ pub struct FileReader {
     pub done: Cell<bool>,
     pub pending: JsCell<streams::Pending>,
     pub pending_value: JsCell<Strong>, // Strong.Optional
-    /// Borrowed view into the JS typed array of the in-flight pull, rooted by
-    /// `pending_value`. Raw wrapper (no lifetime, no uniqueness claim) — see
-    /// the note at the top of this file.
-    ///
-    /// Intentionally never read: every fulfillment path re-derives the
-    /// destination from the GC-rooted `pending_value` via `as_array_buffer`
-    /// (detach-safe — a detached view re-derives to an empty slice). Keep it
-    /// that way; reading this stored slice would reintroduce the
-    /// dangling-on-detach hazard the re-derivation avoids.
+    /// View into the JS typed array of the in-flight pull, rooted by
+    /// `pending_value`. Never read back: fulfillment re-derives the
+    /// destination from `pending_value` (detach-safe); reading this stored
+    /// slice would reintroduce the dangling-on-detach hazard.
     pub pending_view: Cell<streams::RawSliceMut<u8>>,
     pub fd: Cell<Fd>,
     /// Read-only after construction (set via struct literal in `from_blob_*`).
@@ -102,8 +96,8 @@ pub const TAG: readable_stream::Tag = readable_stream::Tag::File;
 #[derive(strum::IntoStaticStr)]
 pub enum ReadDuringJSOnPullResult {
     None,
-    /// In-flight JS pull buffer (rooted by the enclosing `on_pull` frame's
-    /// `EnsureStillAlive(array)`); raw wrapper, re-borrowed in tight scopes.
+    /// In-flight JS pull buffer, rooted by the enclosing `on_pull` frame's
+    /// `EnsureStillAlive(array)`.
     Js(streams::RawSliceMut<u8>),
     AmountRead(usize),
     /// Borrows the reader/JS buffer for the duration of one `on_pull` call
@@ -628,14 +622,10 @@ impl FileReader {
             self.read_inside_on_pull.with_mut(|riop| match riop {
                 ReadDuringJSOnPullResult::Js(in_progress) => {
                     if in_progress.len() >= buf.len() && !has_more {
-                        // SAFETY: `in_progress` points into the JS typed array
-                        // rooted by the enclosing `on_pull` frame
-                        // (`EnsureStillAlive(array)`); this is the only live
-                        // reference into it, confined to this statement.
+                        // SAFETY: rooted by the enclosing `on_pull` frame; sole live reference, statement-scoped.
                         let dst = unsafe { in_progress.slice_mut() };
                         dst[..buf.len()].copy_from_slice(buf);
-                        // SAFETY: in-bounds — `buf.len() <= in_progress.len()`
-                        // checked above; same live allocation.
+                        // SAFETY: `buf.len() <= in_progress.len()` checked above.
                         let remaining = unsafe { in_progress.slice_from(buf.len()) };
                         *riop = ReadDuringJSOnPullResult::Js(remaining);
                     } else if !in_progress.is_empty() && !has_more {
@@ -822,9 +812,7 @@ impl FileReader {
 
             if buffer.len() >= drained.len() as usize {
                 let drained_len = drained.len();
-                // SAFETY: `buffer` points into the JS typed array kept alive by
-                // `array` (`EnsureStillAlive` above) for this whole call; this
-                // is the only live reference into it, confined to this statement.
+                // SAFETY: kept alive by `array` (`EnsureStillAlive` above); sole live reference, statement-scoped.
                 let dst = unsafe { buffer.slice_mut() };
                 dst[0..drained_len as usize].copy_from_slice(drained.slice());
                 // drain() moved ownership of the allocation into `drained` and
@@ -867,7 +855,6 @@ impl FileReader {
                 let global = self.parent_global();
                 self.pending_value.with_mut(|p| p.set(&global, array));
                 self.pending_view.set(buffer);
-                // Non-null: derived from the embedded `pending` field of `self`.
                 return streams::Result::Pending(
                     core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
                 );
@@ -911,7 +898,6 @@ impl FileReader {
                     self.pending_value.with_mut(|p| p.set(&global, array));
                     self.pending_view.set(remaining_buf);
                     bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
-                    // Non-null: derived from the embedded `pending` field of `self`.
                     return streams::Result::Pending(
                         core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
                     );
@@ -959,7 +945,6 @@ impl FileReader {
 
         bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
 
-        // Non-null: derived from the embedded `pending` field of `self`.
         streams::Result::Pending(
             core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
         )
@@ -1118,8 +1103,7 @@ impl readable_stream::SourceContext for FileReader {
         Self::on_start(self)
     }
     fn on_pull(&mut self, buf: &mut [u8], arr: JSValue) -> streams::Result {
-        // Wrap the borrow as a raw slice; `Self::on_pull` re-borrows it only in
-        // scopes covered by `arr`'s rooting (see the note at the top of the file).
+        // `Self::on_pull` re-borrows only in scopes covered by `arr`'s rooting.
         Self::on_pull(self, streams::RawSliceMut::new(buf), arr)
     }
     fn on_cancel(&mut self) {

--- a/src/runtime/webcore/FileReader.rs
+++ b/src/runtime/webcore/FileReader.rs
@@ -960,7 +960,9 @@ impl FileReader {
         bun_core::scoped_log!(FileReader, "onPull({}) = pending", buffer_len);
 
         // Non-null: derived from the embedded `pending` field of `self`.
-        streams::Result::Pending(core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"))
+        streams::Result::Pending(
+            core::ptr::NonNull::new(self.pending.as_ptr()).expect("embedded field"),
+        )
     }
 
     pub fn drain(&self) -> Vec<u8> {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1518,7 +1518,6 @@ impl FileSink {
                     p.consumed += pending_written as u64; // @truncate
                     p.result = streams::Writable::Owned(pending_written as u64);
                 });
-                // Non-null: derived from the embedded `pending` field of `self`.
                 streams::Writable::Pending(
                     NonNull::new(self.pending.as_ptr()).expect("embedded field"),
                 )

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1,5 +1,6 @@
 use core::cell::Cell;
 use core::ffi::c_void;
+use core::ptr::NonNull;
 use core::sync::atomic::{AtomicI32, Ordering};
 
 #[cfg(windows)]
@@ -1517,7 +1518,10 @@ impl FileSink {
                     p.consumed += pending_written as u64; // @truncate
                     p.result = streams::Writable::Owned(pending_written as u64);
                 });
-                streams::Writable::Pending(self.pending.as_ptr())
+                // Non-null: derived from the embedded `pending` field of `self`.
+                streams::Writable::Pending(
+                    NonNull::new(self.pending.as_ptr()).expect("embedded field"),
+                )
             }
         }
     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -46,6 +46,102 @@ pub mod result {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// RawSliceMut
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Non-owning *mutable* borrowed slice — the writable sibling of
+/// [`bun_ptr::RawSlice`]. Stores a fat `*mut [T]`, so it is `Copy`, never
+/// drops, and carries no lifetime: the holder structurally guarantees the
+/// backing storage outlives every use. In this module the backing store is a
+/// JS typed-array buffer rooted by a `Strong` (`pending_value`) or by
+/// `ensure_still_alive` on the owning view for the duration of the borrow.
+///
+/// Unlike `RawSlice`, re-borrowing is `unsafe`: the *uniqueness* of the
+/// returned `&mut [T]` is not enforced by construction, so every
+/// [`Self::slice_mut`] call site must argue (a) liveness (GC rooting) and
+/// (b) that no other reference into the same buffer is live for the scope of
+/// the borrow.
+#[repr(transparent)]
+pub struct RawSliceMut<T>(*mut [T]);
+
+impl<T> RawSliceMut<T> {
+    /// Empty slice (dangling, len 0). Safe to `len()`/`is_empty()`; a
+    /// `slice_mut()` of it yields `&mut []`.
+    pub const EMPTY: Self = RawSliceMut(core::ptr::slice_from_raw_parts_mut(
+        NonNull::<T>::dangling().as_ptr(),
+        0,
+    ));
+
+    /// Wrap a borrowed slice. Safe: stores the raw fat pointer; the
+    /// outlives-holder invariant is the caller's structural guarantee.
+    #[inline]
+    pub const fn new(s: &mut [T]) -> Self {
+        RawSliceMut(core::ptr::from_mut(s))
+    }
+
+    #[inline]
+    pub const fn as_ptr(self) -> *mut [T] {
+        self.0
+    }
+
+    #[inline]
+    pub const fn len(self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.0.len() == 0
+    }
+
+    /// Re-borrow as `&mut [T]` with a caller-chosen lifetime.
+    ///
+    /// # Safety
+    ///
+    /// For the entire lifetime `'a`: the backing storage must be live (for
+    /// JS-owned buffers: rooted against GC), all `len` elements initialized,
+    /// and no other reference into the same range live. Keep the borrow
+    /// scoped to a single statement wherever possible — JS host-function
+    /// re-entry can otherwise stack a second reference to the same buffer.
+    #[inline]
+    pub unsafe fn slice_mut<'a>(self) -> &'a mut [T] {
+        // SAFETY: forwarded to caller; `EMPTY` uses a dangling non-null
+        // pointer with len 0, which is a valid empty slice.
+        unsafe { &mut *self.0 }
+    }
+
+    /// Sub-slice from `start` to the end, without materializing a reference.
+    ///
+    /// # Safety
+    ///
+    /// `start <= self.len()`, and `self` must point at live storage (the
+    /// pointer arithmetic stays in-bounds of the original allocation).
+    #[inline]
+    pub unsafe fn slice_from(self, start: usize) -> Self {
+        debug_assert!(start <= self.len());
+        let len = self.len();
+        // SAFETY: caller contract — `start <= len`, so the offset pointer is
+        // within (or one-past-the-end of) the same allocation.
+        let base = unsafe { self.0.cast::<T>().add(start) };
+        RawSliceMut(core::ptr::slice_from_raw_parts_mut(base, len - start))
+    }
+}
+
+impl<T> Copy for RawSliceMut<T> {}
+impl<T> Clone for RawSliceMut<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> Default for RawSliceMut<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::EMPTY
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // Start
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -301,9 +397,11 @@ impl Start {
 
 pub enum StreamResult {
     // Self-referential: the pointee's `Pending.result` points back at this value, so a
-    // `&'a mut Pending` borrow can't be expressed; raw pointer with the BORROW_PARAM
-    // contract (pointee strictly outlives this result).
-    Pending(*mut Pending),
+    // `&'a mut Pending` borrow can't be expressed; `NonNull` with the BORROW_PARAM
+    // contract (pointee strictly outlives this result). Producers derive it
+    // from an embedded `JsCell` field of the source, so it is provably
+    // non-null at construction.
+    Pending(NonNull<Pending>),
     Err(StreamError),
     Done,
     Owned(Vec<u8>),
@@ -401,8 +499,9 @@ impl StreamResult {
 
 pub enum Writable {
     // Self-referential via WritablePending.result (see StreamResult::Pending above);
-    // raw pointer with the BORROW_PARAM contract.
-    Pending(*mut WritablePending),
+    // `NonNull` with the BORROW_PARAM contract (derived from an embedded
+    // `JsCell` field of the sink — provably non-null at construction).
+    Pending(NonNull<WritablePending>),
     Err(SysError),
     Done,
     Owned(BlobSizeType),
@@ -584,7 +683,7 @@ impl Writable {
             Writable::Done => JSValue::TRUE,
             Writable::Pending(pending) => {
                 // SAFETY: pending is a valid borrowed pointer per BORROW_PARAM classification
-                let prom = unsafe { &mut *pending }.promise(global_this);
+                let prom = unsafe { &mut *pending.as_ptr() }.promise(global_this);
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 JSPromise::opaque_ref(prom).to_js()
             }
@@ -893,7 +992,7 @@ impl StreamResult {
             StreamResult::IntoArrayAndDone(array) => Ok(JSValue::from(array.len)),
             StreamResult::Pending(pending) => {
                 // SAFETY: pending is a valid borrowed pointer per BORROW_PARAM classification
-                let promise = unsafe { &mut **pending }.promise(global_this);
+                let promise = unsafe { &mut *pending.as_ptr() }.promise(global_this);
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 let promise_js = JSPromise::opaque_ref(promise).to_js();
                 promise_js.protect();
@@ -2512,7 +2611,7 @@ pub enum ReadResult {
 impl ReadResult {
     pub fn to_stream(
         self,
-        pending: *mut Pending,
+        pending: NonNull<Pending>,
         buf: &mut [u8],
         view: JSValue,
         close_on_empty: bool,
@@ -2522,7 +2621,7 @@ impl ReadResult {
 
     pub fn to_stream_with_is_done(
         self,
-        pending: *mut Pending,
+        pending: NonNull<Pending>,
         buf: &mut [u8],
         view: JSValue,
         close_on_empty: bool,

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -49,31 +49,22 @@ pub mod result {
 // RawSliceMut
 // ──────────────────────────────────────────────────────────────────────────
 
-/// Non-owning *mutable* borrowed slice — the writable sibling of
-/// [`bun_ptr::RawSlice`]. Stores a fat `*mut [T]`, so it is `Copy`, never
-/// drops, and carries no lifetime: the holder structurally guarantees the
-/// backing storage outlives every use. In this module the backing store is a
-/// JS typed-array buffer rooted by a `Strong` (`pending_value`) or by
-/// `ensure_still_alive` on the owning view for the duration of the borrow.
-///
-/// Unlike `RawSlice`, re-borrowing is `unsafe`: the *uniqueness* of the
-/// returned `&mut [T]` is not enforced by construction, so every
-/// [`Self::slice_mut`] call site must argue (a) liveness (GC rooting) and
-/// (b) that no other reference into the same buffer is live for the scope of
-/// the borrow.
+/// Non-owning mutable slice — writable sibling of [`bun_ptr::RawSlice`].
+/// Stores a fat `*mut [T]`: `Copy`, no drop, no lifetime; the holder
+/// guarantees the backing storage (here a GC-rooted JS typed-array buffer)
+/// outlives every use. Unlike `RawSlice`, re-borrowing via [`Self::slice_mut`]
+/// is `unsafe`: each call site must argue liveness and uniqueness.
 #[repr(transparent)]
 pub struct RawSliceMut<T>(*mut [T]);
 
 impl<T> RawSliceMut<T> {
-    /// Empty slice (dangling, len 0). Safe to `len()`/`is_empty()`; a
-    /// `slice_mut()` of it yields `&mut []`.
+    /// Empty slice (dangling, len 0).
     pub const EMPTY: Self = RawSliceMut(core::ptr::slice_from_raw_parts_mut(
         NonNull::<T>::dangling().as_ptr(),
         0,
     ));
 
-    /// Wrap a borrowed slice. Safe: stores the raw fat pointer; the
-    /// outlives-holder invariant is the caller's structural guarantee.
+    /// Wrap a borrowed slice; the caller guarantees it outlives every use.
     #[inline]
     pub const fn new(s: &mut [T]) -> Self {
         RawSliceMut(core::ptr::from_mut(s))
@@ -98,15 +89,12 @@ impl<T> RawSliceMut<T> {
     ///
     /// # Safety
     ///
-    /// For the entire lifetime `'a`: the backing storage must be live (for
-    /// JS-owned buffers: rooted against GC), all `len` elements initialized,
-    /// and no other reference into the same range live. Keep the borrow
-    /// scoped to a single statement wherever possible — JS host-function
-    /// re-entry can otherwise stack a second reference to the same buffer.
+    /// For all of `'a`: storage live (GC-rooted for JS buffers), initialized,
+    /// and no other reference into the range. Keep borrows statement-scoped —
+    /// JS re-entry can otherwise alias the buffer.
     #[inline]
     pub unsafe fn slice_mut<'a>(self) -> &'a mut [T] {
-        // SAFETY: forwarded to caller; `EMPTY` uses a dangling non-null
-        // pointer with len 0, which is a valid empty slice.
+        // SAFETY: forwarded to caller; `EMPTY` is a valid dangling empty slice.
         unsafe { &mut *self.0 }
     }
 
@@ -114,14 +102,12 @@ impl<T> RawSliceMut<T> {
     ///
     /// # Safety
     ///
-    /// `start <= self.len()`, and `self` must point at live storage (the
-    /// pointer arithmetic stays in-bounds of the original allocation).
+    /// `start <= self.len()`, and `self` must point at live storage.
     #[inline]
     pub unsafe fn slice_from(self, start: usize) -> Self {
         debug_assert!(start <= self.len());
         let len = self.len();
-        // SAFETY: caller contract — `start <= len`, so the offset pointer is
-        // within (or one-past-the-end of) the same allocation.
+        // SAFETY: `start <= len` keeps the offset pointer in-bounds.
         let base = unsafe { self.0.cast::<T>().add(start) };
         RawSliceMut(core::ptr::slice_from_raw_parts_mut(base, len - start))
     }
@@ -398,9 +384,7 @@ impl Start {
 pub enum StreamResult {
     // Self-referential: the pointee's `Pending.result` points back at this value, so a
     // `&'a mut Pending` borrow can't be expressed; `NonNull` with the BORROW_PARAM
-    // contract (pointee strictly outlives this result). Producers derive it
-    // from an embedded `JsCell` field of the source, so it is provably
-    // non-null at construction.
+    // contract (pointee strictly outlives this result).
     Pending(NonNull<Pending>),
     Err(StreamError),
     Done,
@@ -499,8 +483,7 @@ impl StreamResult {
 
 pub enum Writable {
     // Self-referential via WritablePending.result (see StreamResult::Pending above);
-    // `NonNull` with the BORROW_PARAM contract (derived from an embedded
-    // `JsCell` field of the sink — provably non-null at construction).
+    // `NonNull` with the BORROW_PARAM contract.
     Pending(NonNull<WritablePending>),
     Err(SysError),
     Done,

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -32,3 +32,13 @@ test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch 
   // remove offset 5 -> index=(12+5)&15=1 < head -> wrapped-prefix sub-branch, drops 205.
   expect(linearFifoOrderedRemoveProbe(1)).toEqual([200, 201, 202, 203, 204, 206, 207]);
 });
+
+test("wrapped fifo of NonNull-bearing items survives peek/remove (MaybeUninit accessor rework)", () => {
+  // Scenario 2 rebuilds the scenario-0 wrapped state (head=8, count=14) with a
+  // niche-optimized NonNull-bearing element type. Before the MaybeUninit
+  // accessor rework, every fifo accessor formed `&[T]` over the partially
+  // uninitialized backing store — undefined behavior for such element types
+  // (the same shape as the in-tree RefDataValue / PromisePair / Task fifos).
+  // The probe returns the pointed-to values of the surviving items.
+  expect(linearFifoOrderedRemoveProbe(2)).toEqual([8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]);
+});

--- a/test/internal/linear-fifo.test.ts
+++ b/test/internal/linear-fifo.test.ts
@@ -34,11 +34,8 @@ test("ordered_remove_item preserves FIFO order in the wrapped prefix sub-branch 
 });
 
 test("wrapped fifo of NonNull-bearing items survives peek/remove (MaybeUninit accessor rework)", () => {
-  // Scenario 2 rebuilds the scenario-0 wrapped state (head=8, count=14) with a
-  // niche-optimized NonNull-bearing element type. Before the MaybeUninit
-  // accessor rework, every fifo accessor formed `&[T]` over the partially
-  // uninitialized backing store — undefined behavior for such element types
-  // (the same shape as the in-tree RefDataValue / PromisePair / Task fifos).
-  // The probe returns the pointed-to values of the surviving items.
+  // Scenario 2: the scenario-0 wrapped state (head=8, count=14) with a
+  // niche-optimized NonNull-bearing element type; the probe returns the
+  // pointed-to values of the surviving items.
   expect(linearFifoOrderedRemoveProbe(2)).toEqual([8, 9, 10, 11, 100, 101, 103, 104, 105, 106, 107, 108, 109]);
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1327,7 +1327,7 @@ it("subprocess stdout stream (pipe-backed FileReader) resolves pending pulls und
     cmd: [bunExe(), "-e", writer],
     env: bunEnv,
     stdout: "pipe",
-    stderr: "pipe",
+    stderr: "ignore",
   });
   let total = 0;
   let ok = true;

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1276,3 +1276,109 @@ it("auto-allocated byte stream chunks are zero-filled before being exposed to th
   expect(value.subarray(1).every(b => b === 0)).toBe(true);
   reader.cancel();
 });
+
+it("Bun.file().stream() pulls remain correct under forced GC (raw pending-view slice)", async () => {
+  // Regression coverage for the FileReader pending-view refactor: the
+  // in-flight pull buffer is a raw slice into a JS typed-array buffer rooted
+  // only by the pull's view value (previously held as a forged
+  // `&'static mut [u8]`). Force a full GC around every read to give a stale
+  // or wrongly-rooted buffer the best chance to be collected/moved; the
+  // assembled bytes must still match the file exactly.
+  const script = `
+    const size = 1 << 20;
+    const pattern = new Uint8Array(size);
+    for (let i = 0; i < size; i++) pattern[i] = (i * 7 + (i >> 8)) & 0xff;
+    await Bun.write("data.bin", pattern);
+    const reader = Bun.file("data.bin").stream().getReader();
+    let total = 0, ok = true, idx = 0;
+    while (true) {
+      Bun.gc(true);
+      const { done, value } = await reader.read();
+      Bun.gc(true);
+      if (done) break;
+      for (let i = 0; i < value.length; i++, idx++) {
+        if (value[i] !== ((idx * 7 + (idx >> 8)) & 0xff)) ok = false;
+      }
+      total += value.length;
+    }
+    console.log(JSON.stringify({ total, ok }));
+  `;
+  using dir = tempDir("filereader-gc-stream", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  // stderr is drained but deliberately not asserted on: the stdout JSON plus
+  // exit code cover the behavior, and benign warnings must not break this.
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(JSON.parse(stdout)).toEqual({ total: 1 << 20, ok: true });
+  expect(exitCode).toBe(0);
+});
+
+it("subprocess stdout stream (pipe-backed FileReader) resolves pending pulls under forced GC", async () => {
+  // A pipe-backed FileReader returns `Pending` from onPull when the writer is
+  // slower than the reader, exercising the pending-view/pending-result path
+  // (raw slice + NonNull pending backref). Force GC between chunks.
+  const writer = `
+    const chunk = Buffer.alloc(65536, 0xab);
+    for (let i = 0; i < 16; i++) {
+      await Bun.write(Bun.stdout, chunk);
+      await Bun.sleep(1);
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", writer],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  let total = 0;
+  let ok = true;
+  for await (const chunk of proc.stdout) {
+    Bun.gc(true);
+    for (let i = 0; i < chunk.length; i++) {
+      if (chunk[i] !== 0xab) ok = false;
+    }
+    total += chunk.length;
+  }
+  expect(ok).toBe(true);
+  expect(total).toBe(16 * 65536);
+  expect(await proc.exited).toBe(0);
+});
+
+it("fetch() body stream (ByteStream) resolves pending reads correctly under forced GC", async () => {
+  // The client reads faster than the server produces, so each read parks a
+  // pending pull (rooted view + raw pending buffer) that is later fulfilled
+  // by onData re-deriving the destination from the GC-rooted view.
+  const part = "0123456789abcdef".repeat(256); // 4096 bytes
+  const parts = 8;
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        async pull(controller) {
+          for (let i = 0; i < parts; i++) {
+            controller.enqueue(new TextEncoder().encode(part));
+            await Bun.sleep(1);
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/plain" } });
+    },
+  });
+  const res = await fetch(server.url);
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  while (true) {
+    Bun.gc(true);
+    const { done, value } = await reader.read();
+    if (done) break;
+    text += decoder.decode(value, { stream: true });
+  }
+  text += decoder.decode();
+  expect(text).toBe(part.repeat(parts));
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1278,12 +1278,9 @@ it("auto-allocated byte stream chunks are zero-filled before being exposed to th
 });
 
 it("Bun.file().stream() pulls remain correct under forced GC (raw pending-view slice)", async () => {
-  // Regression coverage for the FileReader pending-view refactor: the
-  // in-flight pull buffer is a raw slice into a JS typed-array buffer rooted
-  // only by the pull's view value (previously held as a forged
-  // `&'static mut [u8]`). Force a full GC around every read to give a stale
-  // or wrongly-rooted buffer the best chance to be collected/moved; the
-  // assembled bytes must still match the file exactly.
+  // The in-flight pull buffer is a raw slice into a JS typed-array rooted only
+  // by the pull's view value; force a full GC around every read to catch a
+  // stale or wrongly-rooted buffer.
   const script = `
     const size = 1 << 20;
     const pattern = new Uint8Array(size);
@@ -1310,8 +1307,7 @@ it("Bun.file().stream() pulls remain correct under forced GC (raw pending-view s
     cwd: String(dir),
     stderr: "pipe",
   });
-  // stderr is drained but deliberately not asserted on: the stdout JSON plus
-  // exit code cover the behavior, and benign warnings must not break this.
+  // stderr is drained but not asserted on; benign warnings must not break this.
   const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(JSON.parse(stdout)).toEqual({ total: 1 << 20, ok: true });
   expect(exitCode).toBe(0);
@@ -1319,8 +1315,7 @@ it("Bun.file().stream() pulls remain correct under forced GC (raw pending-view s
 
 it("subprocess stdout stream (pipe-backed FileReader) resolves pending pulls under forced GC", async () => {
   // A pipe-backed FileReader returns `Pending` from onPull when the writer is
-  // slower than the reader, exercising the pending-view/pending-result path
-  // (raw slice + NonNull pending backref). Force GC between chunks.
+  // slower than the reader; force GC between chunks.
   const writer = `
     const chunk = Buffer.alloc(65536, 0xab);
     for (let i = 0; i < 16; i++) {
@@ -1350,8 +1345,7 @@ it("subprocess stdout stream (pipe-backed FileReader) resolves pending pulls und
 
 it("fetch() body stream (ByteStream) resolves pending reads correctly under forced GC", async () => {
   // The client reads faster than the server produces, so each read parks a
-  // pending pull (rooted view + raw pending buffer) that is later fulfilled
-  // by onData re-deriving the destination from the GC-rooted view.
+  // pending pull that is fulfilled later from the GC-rooted view.
   const part = "0123456789abcdef".repeat(256); // 4096 bytes
   const parts = 8;
   using server = Bun.serve({

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -797,13 +797,8 @@ payloads.forEach(type => {
   });
 });
 
-// Regression guard (passes pre- and post-BufferError refactor): pins the
-// native stream-state error mapping that the BufferError split must preserve.
 // A JS-defined ReadableStream body is unsupported by transform() and has
-// always surfaced ERR_STREAM_CANNOT_PIPE (the Native catch-all branch).
-// The Js-propagation branch itself is not reachable from plain JS (it requires
-// to_readable_stream to throw inside the bufferer's double-waiter path), so it
-// has no direct JS-level test.
+// always surfaced ERR_STREAM_CANNOT_PIPE.
 it("transform() of a Response with a JS-defined ReadableStream body reports ERR_STREAM_CANNOT_PIPE", async () => {
   const stream = new ReadableStream({
     pull(controller) {
@@ -824,14 +819,9 @@ it("transform() of a Response with a JS-defined ReadableStream body reports ERR_
 });
 
 it("transform() of a streaming Response survives forced GC between chunks", async () => {
-  // Regression guard: exercises the body-value bufferer + sink backpressure
-  // (Writable pending backref) with full GCs interleaved between producer
-  // chunks. The Pending representation change it covers is behavior-neutral,
-  // so this is GC-stress coverage, not a pre-fix-failing test.
-  //
-  // The chunked body is served over HTTP because transform() only accepts
-  // native (fetched/file) bodies — JS-defined ReadableStream bodies throw
-  // ERR_STREAM_CANNOT_PIPE synchronously.
+  // GC-stress for the body-value bufferer + sink backpressure. The chunked
+  // body is served over HTTP because transform() only accepts native
+  // (fetched/file) bodies.
   const piece = "<p>x</p>";
   const perChunk = 64;
   const chunks = 16;

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -799,11 +799,12 @@ payloads.forEach(type => {
 
 // Regression guard (passes pre- and post-BufferError refactor): pins the
 // native stream-state error mapping that the BufferError split must preserve.
-// A locked/already-piped JS stream body has always surfaced ERR_STREAM_CANNOT_PIPE.
+// A JS-defined ReadableStream body is unsupported by transform() and has
+// always surfaced ERR_STREAM_CANNOT_PIPE (the Native catch-all branch).
 // The Js-propagation branch itself is not reachable from plain JS (it requires
 // to_readable_stream to throw inside the bufferer's double-waiter path), so it
 // has no direct JS-level test.
-it("transform() of a Response whose stream is already locked reports ERR_STREAM_CANNOT_PIPE", async () => {
+it("transform() of a Response with a JS-defined ReadableStream body reports ERR_STREAM_CANNOT_PIPE", async () => {
   const stream = new ReadableStream({
     pull(controller) {
       controller.enqueue(new TextEncoder().encode("<div>hello</div>"));
@@ -811,9 +812,6 @@ it("transform() of a Response whose stream is already locked reports ERR_STREAM_
     },
   });
   const response = new Response(stream, { headers: { "content-type": "text/html" } });
-  // Lock the body before transforming — the bufferer must surface the
-  // stream-state error (native error path), not a JS exception.
-  response.body.getReader();
 
   let outcome;
   try {

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -796,3 +796,77 @@ payloads.forEach(type => {
     expect(calls).toBeGreaterThan(0);
   });
 });
+
+// Regression guard (passes pre- and post-BufferError refactor): pins the
+// native stream-state error mapping that the BufferError split must preserve.
+// A locked/already-piped JS stream body has always surfaced ERR_STREAM_CANNOT_PIPE.
+// The Js-propagation branch itself is not reachable from plain JS (it requires
+// to_readable_stream to throw inside the bufferer's double-waiter path), so it
+// has no direct JS-level test.
+it("transform() of a Response whose stream is already locked reports ERR_STREAM_CANNOT_PIPE", async () => {
+  const stream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue(new TextEncoder().encode("<div>hello</div>"));
+      controller.close();
+    },
+  });
+  const response = new Response(stream, { headers: { "content-type": "text/html" } });
+  // Lock the body before transforming — the bufferer must surface the
+  // stream-state error (native error path), not a JS exception.
+  response.body.getReader();
+
+  let outcome;
+  try {
+    outcome = new HTMLRewriter().on("div", { element() {} }).transform(response);
+  } catch (e) {
+    outcome = e;
+  }
+  expect(outcome).toBeInstanceOf(Error);
+  expect(outcome.code).toBe("ERR_STREAM_CANNOT_PIPE");
+});
+
+it("transform() of a streaming Response survives forced GC between chunks", async () => {
+  // Regression guard: exercises the body-value bufferer + sink backpressure
+  // (Writable pending backref) with full GCs interleaved between producer
+  // chunks. The Pending representation change it covers is behavior-neutral,
+  // so this is GC-stress coverage, not a pre-fix-failing test.
+  //
+  // The chunked body is served over HTTP because transform() only accepts
+  // native (fetched/file) bodies — JS-defined ReadableStream bodies throw
+  // ERR_STREAM_CANNOT_PIPE synchronously.
+  const piece = "<p>x</p>";
+  const perChunk = 64;
+  const chunks = 16;
+  const encoder = new TextEncoder();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        async pull(controller) {
+          for (let i = 0; i < chunks; i++) {
+            controller.enqueue(encoder.encode(piece.repeat(perChunk)));
+            Bun.gc(true);
+            await Bun.sleep(1);
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, { headers: { "content-type": "text/html" } });
+    },
+  });
+
+  const res = await fetch(server.url);
+  let count = 0;
+  const transformed = new HTMLRewriter()
+    .on("p", {
+      element() {
+        count++;
+        Bun.gc(true);
+      },
+    })
+    .transform(res);
+  if (transformed instanceof Error) throw transformed;
+  const text = await transformed.text();
+  expect(text).toBe(piece.repeat(perChunk * chunks));
+  expect(count).toBe(perChunk * chunks);
+});


### PR DESCRIPTION
Three latent-UB / error-fidelity fixes in the streams and collections layers. (1) LinearFifo's buffer trait now exposes `&[MaybeUninit<T>]` instead of casting the whole (partially uninitialized) backing store to `&[T]`; only logically-written subranges are assumed-init, and the `writable_slice`/`writable_with_size`/`pump` family is gated behind a new `AnyBitPattern` marker (integers + raw pointers) so NonNull-bearing element types (test-runner result queue, valkey promise pairs, event-loop tasks) can no longer be materialized over uninit slots. (2) FileReader's `&'static mut [u8]` pending-view forge is replaced with a `RawSliceMut<u8>` raw fat-pointer wrapper (also adopted by ByteStream's `pending_buffer`); every re-borrow is a scoped unsafe block citing the GC rooting in force, and `StreamResult::Pending`/`Writable::Pending` payloads moved from bare `*mut` to `NonNull`. (3) `Body::ValueBufferer::run` no longer flattens thrown JS exceptions into a synthetic "JSError" string: a new two-variant `BufferError { Js, Native }` threads the pending-on-VM exception through, and the HTMLRewriter caller now rethrows the original exception instead of masking it with ERR_STREAM_CANNOT_PIPE. Tested via new Rust unit tests (including a NonNull-bearing element matrix designed to fail under Miri pre-fix), a new `bun:internal-for-testing` fifo probe scenario, and GC-stress JS tests for file/pipe/fetch streaming and HTMLRewriter transforms. NOTE (post-review): the JS tests are regression guards / GC-stress coverage, not pre-fix-failing validation — the representation changes are behavior-neutral and the BufferError::Js branch is unreachable from plain JS. The discriminating coverage is (a) the new NonNull-bearing Rust unit tests in linear_fifo.rs, designed to be Miri-UB pre-rework, and (b) the fifo probe scenario 2 in test/internal/linear-fifo.test.ts (old binaries return [] for unknown scenarios).

## Deferred

- WO-esc19-3: moving CookieMap__* / open_as_nonblocking_tty extern decls into runtime_sys/webcore_sys — the *_sys crates are outside this cluster's ownership; pure code motion with no remaining marker, lowest priority of the series.
- WO-067-1 step 1 placement: RawSliceMut lives in webcore::streams instead of bun_ptr (bun_ptr not owned by this cluster); follow-up code motion + re-export when coordinating with bun_ptr owners.
- esc03 option (a) (full &mut [MaybeUninit<T>] signatures for the writable_slice family across ~30 consumer files) — implemented the order's option (b) marker-bound variant instead, after verifying every in-tree caller is u8 or a raw pointer.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
