### PR TITLE
resolver: root dir-cache slot pointers at the singleton and drop browser-map borrow erasures

### DIFF
--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -459,21 +459,58 @@ impl DirInfo {
 // COUNT mirrors `fs::preallocate::counts::DIR_ENTRY`.
 pub type HashMap = allocators::BSSMapInner<DirInfo, 2048, true>;
 
+/// Insert `value` at `result`'s slot in the BSSMap singleton and return a slot
+/// pointer re-derived from the raw singleton (see [`slot_ptr_at`]).
+///
+/// Takes the raw map pointer (not `&mut HashMap`) on purpose: a `&mut self`
+/// receiver would be FnEntry-protected for the whole call under Stacked
+/// Borrows, and `slot_ptr_at` accesses the map through the singleton's root
+/// tag — an *ancestor* of that protected Unique — which would disable the
+/// protected tag (UB). The inherent `put` instead runs through a local
+/// reborrow that dies before `slot_ptr_at` touches the root.
+///
+/// The `&mut DirInfo` the inherent `put` returns is deliberately DISCARDED:
+/// its tag would descend from the local reborrow, which any later fresh
+/// `&mut *hash_map_instance()` Unique retag would pop (`backing_buf` is inline
+/// in the map allocation). The re-derived pointer is rooted at the static and
+/// survives sibling retags outright.
+///
+/// # Safety
+/// `map` must be the live `hash_map_instance()` singleton and the caller must
+/// hold the resolver mutex.
+pub(crate) unsafe fn put_slot(
+    map: *mut HashMap,
+    result: &mut allocators::Result,
+    value: DirInfo,
+) -> core::result::Result<*mut DirInfo, bun_core::Error> {
+    // `map` is always the `hash_map_instance()` singleton: `Resolver.dir_cache`
+    // is set to it in `init1` and never reassigned, and no other `HashMap`
+    // instance exists. `slot_ptr_at` below relies on this.
+    debug_assert!(core::ptr::eq(
+        map.cast_const(),
+        hash_map_instance().cast_const()
+    ));
+    // SAFETY: caller contract — `map` is the live singleton; resolver mutex
+    // held. The method-call auto-ref `&mut *map` ends when `put` returns, so
+    // no protector is live when `slot_ptr_at` accesses the root below.
+    unsafe { (*map).put(result, value) }.map_err(bun_core::Error::from)?;
+    // SAFETY: `result.index` was just assigned (or confirmed) by `put`, so it
+    // is a non-sentinel, in-bounds, initialized slot; callers hold the
+    // resolver mutex.
+    Ok(unsafe { slot_ptr_at(result.index) }.expect("put assigned a non-sentinel index"))
+}
+
 /// Resolver-side extension trait adapting `BSSMapInner`'s inherent surface to
 /// the resolver's error type (`bun_core::Error`) and pointer-return shape, plus
-/// `values_mut` which has no inherent equivalent. The four name-colliding
+/// `values_mut` which has no inherent equivalent. The name-colliding
 /// methods are shadowed by inherent methods under dot-syntax (Rust resolves
 /// inherent before trait), so the bodies below delegate without recursing.
+/// (`put` is NOT here: it must not take `&mut self` — see [`put_slot`].)
 pub trait HashMapExt {
     fn get_or_put(
         &mut self,
         key: &[u8],
     ) -> core::result::Result<allocators::Result, bun_core::Error>;
-    fn put(
-        &mut self,
-        result: &mut allocators::Result,
-        value: DirInfo,
-    ) -> core::result::Result<*mut DirInfo, bun_core::Error>;
     fn mark_not_found(&mut self, result: allocators::Result);
     fn remove(&mut self, key: &[u8]) -> bool;
     fn values_mut(&mut self) -> core::slice::IterMut<'_, DirInfo>;
@@ -486,32 +523,6 @@ impl HashMapExt for HashMap {
     ) -> core::result::Result<allocators::Result, bun_core::Error> {
         // Dot-syntax picks inherent `BSSMapInner::get_or_put` (inherent > trait); not recursive.
         self.get_or_put(key).map_err(Into::into)
-    }
-    #[inline]
-    fn put(
-        &mut self,
-        result: &mut allocators::Result,
-        value: DirInfo,
-    ) -> core::result::Result<*mut DirInfo, bun_core::Error> {
-        // `self` is always the `hash_map_instance()` singleton: `Resolver.dir_cache`
-        // is set to it in `init1` and never reassigned, and no other `HashMap`
-        // instance exists. `slot_ptr_at` below relies on this.
-        debug_assert!(core::ptr::eq(
-            core::ptr::from_ref::<HashMap>(self),
-            hash_map_instance().cast_const(),
-        ));
-        // `result.index` is written back, so `&mut`. The `&mut DirInfo` the
-        // inherent `put` returns is deliberately DISCARDED: its tag descends from
-        // the caller's `&mut HashMap`, which any later fresh
-        // `&mut *hash_map_instance()` Unique retag would pop (`backing_buf` is
-        // inline in the map allocation). Re-derive the slot pointer from the raw
-        // singleton instead so its provenance is rooted at the static and
-        // survives sibling retags outright (see `slot_ptr_at`).
-        self.put(result, value).map_err(bun_core::Error::from)?;
-        // SAFETY: `result.index` was just assigned (or confirmed) by `put`, so it
-        // is a non-sentinel, in-bounds, initialized slot; callers hold the
-        // resolver mutex.
-        Ok(unsafe { slot_ptr_at(result.index) }.expect("put assigned a non-sentinel index"))
     }
     #[inline]
     fn mark_not_found(&mut self, result: allocators::Result) {

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -10,7 +10,7 @@ use crate::package_json::PackageJSON;
 use crate::tsconfig_json::TSConfigJSON;
 
 pub use allocators::IndexType;
-use allocators::NOT_FOUND;
+use allocators::{NOT_FOUND, UNASSIGNED};
 
 pub type Index = IndexType;
 
@@ -341,6 +341,76 @@ fn ref_at_index(index: Index) -> Option<DirInfoRef> {
     unsafe { (*hash_map_instance()).at_index(index) }.map(DirInfoRef::from_slot)
 }
 
+/// Derive the slot pointer for `index` directly from the raw singleton
+/// (`hash_map_instance()`), so its provenance is rooted in the `DIR_INFO_MAP`
+/// static rather than a transient `&mut HashMap`.
+///
+/// `backing_buf` is stored inline in the `BSSMapInner` allocation, so a slot
+/// pointer derived through a `&mut HashMap` (e.g. the `&mut DirInfo` that
+/// `BSSMapInner::put` returns) is popped by ANY later fresh
+/// `&mut *hash_map_instance()` Unique retag under Stacked Borrows. Inline-slot
+/// pointers re-derived here use a raw place projection (no intermediate
+/// reference), so they descend from the static's root provenance and survive
+/// sibling `&mut HashMap` retags outright.
+///
+/// Overflow slots live in separately-boxed `OverflowListBlock` allocations.
+/// Under shallow-retag semantics a sibling `&mut HashMap` retag only touches
+/// the inline map bytes and leaves block-interior pointers alone, but under
+/// field retagging (e.g. Miri's default) the fresh `&mut` descends into the
+/// `overflow_list`'s `Box`ed blocks and pops them just like inline slots —
+/// do not treat overflow slot pointers as retag-immune. They are addressed
+/// the same way `at_index` addresses them, re-rooting only the intermediate
+/// `&mut OverflowList` auto-ref at `raw`. Their durability is in any case
+/// bounded by later unique access to the same block (`at_index_mut`
+/// re-uniques the block's `items`), a pre-existing property of the overflow
+/// store — callers that stash slot pointers long-term must not rely on
+/// overflow slots surviving unrelated overflow-arm traffic.
+///
+/// Returns `None` for the `NOT_FOUND` / `UNASSIGNED` sentinels.
+///
+/// # Safety
+/// A non-sentinel `index` must have been assigned by `put` (slot initialized),
+/// and the caller must hold the resolver mutex. Inline-arm bounds are checked
+/// (panic on violation, matching the inherent `at_index` failure mode);
+/// initialization remains the caller's contract.
+pub(crate) unsafe fn slot_ptr_at(index: Index) -> Option<*mut DirInfo> {
+    if index.index() == NOT_FOUND.index() || index.index() == UNASSIGNED.index() {
+        return None;
+    }
+    let raw = hash_map_instance();
+    if index.is_overflow() {
+        // SAFETY: caller contract — assigned overflow index under the resolver
+        // mutex. The `&mut OverflowList` auto-ref is derived from `raw`
+        // (SharedReadWrite root), not from any caller `&mut HashMap`.
+        Some(std::ptr::from_mut::<DirInfo>(unsafe {
+            (*raw).overflow_list.at_index_mut(index)
+        }))
+    } else {
+        // SAFETY (read): raw place read of a `Copy` scalar — no retag.
+        let used = u32::from(unsafe { (*raw).backing_buf_used });
+        // Unconditional (release too): the inherent `at_index` path this
+        // mirrors bounds-checks the slot via array indexing, so a corrupted
+        // index panics there. Keep that failure mode — a silent out-of-bounds
+        // slot pointer would be written through by `put` callers.
+        assert!(
+            index.index() < used,
+            "dir cache slot index {} out of bounds (used: {used})",
+            index.index(),
+        );
+        // SAFETY: caller contract — `index.index() < backing_buf_used` and the
+        // slot was initialized by `put`. `addr_of_mut!` is a raw place
+        // projection: no reference to the slot (or the map) is materialized,
+        // so the result is a direct child of the singleton's root provenance.
+        // `MaybeUninit<DirInfo>` is `#[repr(transparent)]`, so the cast is
+        // layout-sound.
+        Some(unsafe {
+            core::ptr::addr_of_mut!((*raw).backing_buf)
+                .cast::<DirInfo>()
+                .add(index.index() as usize)
+        })
+    }
+}
+
 bitflags::bitflags! {
     #[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
     pub struct Flags: u8 {
@@ -423,17 +493,25 @@ impl HashMapExt for HashMap {
         result: &mut allocators::Result,
         value: DirInfo,
     ) -> core::result::Result<*mut DirInfo, bun_core::Error> {
-        // `result.index` is written back, so `&mut`. Inherent returns `&mut DirInfo`;
-        // erase to `*mut` so callers can stash it past borrowck. NOTE (Stacked Borrows):
-        // this erasure does NOT make the pointer survive a sibling `&mut HashMap` Unique
-        // retag of the same `BSSMapInner` allocation — `backing_buf` is inline, so a fresh
-        // `&mut *dir_cache()` pops every tag derived here. Callers MUST derive all slot
-        // pointers from a single bound `&mut HashMap` (see resolver.rs `dir_info_cached_*`).
-        // TODO: derive via `addr_of_mut!` from the raw singleton (SharedReadWrite
-        // provenance) so slot pointers survive sibling retags outright.
-        self.put(result, value)
-            .map(std::ptr::from_mut::<DirInfo>)
-            .map_err(Into::into)
+        // `self` is always the `hash_map_instance()` singleton: `Resolver.dir_cache`
+        // is set to it in `init1` and never reassigned, and no other `HashMap`
+        // instance exists. `slot_ptr_at` below relies on this.
+        debug_assert!(core::ptr::eq(
+            core::ptr::from_ref::<HashMap>(self),
+            hash_map_instance().cast_const(),
+        ));
+        // `result.index` is written back, so `&mut`. The `&mut DirInfo` the
+        // inherent `put` returns is deliberately DISCARDED: its tag descends from
+        // the caller's `&mut HashMap`, which any later fresh
+        // `&mut *hash_map_instance()` Unique retag would pop (`backing_buf` is
+        // inline in the map allocation). Re-derive the slot pointer from the raw
+        // singleton instead so its provenance is rooted at the static and
+        // survives sibling retags outright (see `slot_ptr_at`).
+        self.put(result, value).map_err(bun_core::Error::from)?;
+        // SAFETY: `result.index` was just assigned (or confirmed) by `put`, so it
+        // is a non-sentinel, in-bounds, initialized slot; callers hold the
+        // resolver mutex.
+        Ok(unsafe { slot_ptr_at(result.index) }.expect("put assigned a non-sentinel index"))
     }
     #[inline]
     fn mark_not_found(&mut self, result: allocators::Result) {

--- a/src/resolver/dir_info.rs
+++ b/src/resolver/dir_info.rs
@@ -341,68 +341,36 @@ fn ref_at_index(index: Index) -> Option<DirInfoRef> {
     unsafe { (*hash_map_instance()).at_index(index) }.map(DirInfoRef::from_slot)
 }
 
-/// Derive the slot pointer for `index` directly from the raw singleton
-/// (`hash_map_instance()`), so its provenance is rooted in the `DIR_INFO_MAP`
-/// static rather than a transient `&mut HashMap`.
-///
-/// `backing_buf` is stored inline in the `BSSMapInner` allocation, so a slot
-/// pointer derived through a `&mut HashMap` (e.g. the `&mut DirInfo` that
-/// `BSSMapInner::put` returns) is popped by ANY later fresh
-/// `&mut *hash_map_instance()` Unique retag under Stacked Borrows. Inline-slot
-/// pointers re-derived here use a raw place projection (no intermediate
-/// reference), so they descend from the static's root provenance and survive
-/// sibling `&mut HashMap` retags outright.
-///
-/// Overflow slots live in separately-boxed `OverflowListBlock` allocations.
-/// Under shallow-retag semantics a sibling `&mut HashMap` retag only touches
-/// the inline map bytes and leaves block-interior pointers alone, but under
-/// field retagging (e.g. Miri's default) the fresh `&mut` descends into the
-/// `overflow_list`'s `Box`ed blocks and pops them just like inline slots —
-/// do not treat overflow slot pointers as retag-immune. They are addressed
-/// the same way `at_index` addresses them, re-rooting only the intermediate
-/// `&mut OverflowList` auto-ref at `raw`. Their durability is in any case
-/// bounded by later unique access to the same block (`at_index_mut`
-/// re-uniques the block's `items`), a pre-existing property of the overflow
-/// store — callers that stash slot pointers long-term must not rely on
-/// overflow slots surviving unrelated overflow-arm traffic.
-///
+/// Slot pointer for `index`, derived from the raw singleton so its provenance
+/// is rooted in the `DIR_INFO_MAP` static — it survives later `&mut HashMap`
+/// retags that would pop a pointer projected through a transient borrow.
 /// Returns `None` for the `NOT_FOUND` / `UNASSIGNED` sentinels.
 ///
 /// # Safety
 /// A non-sentinel `index` must have been assigned by `put` (slot initialized),
-/// and the caller must hold the resolver mutex. Inline-arm bounds are checked
-/// (panic on violation, matching the inherent `at_index` failure mode);
-/// initialization remains the caller's contract.
+/// and the caller must hold the resolver mutex.
 pub(crate) unsafe fn slot_ptr_at(index: Index) -> Option<*mut DirInfo> {
     if index.index() == NOT_FOUND.index() || index.index() == UNASSIGNED.index() {
         return None;
     }
     let raw = hash_map_instance();
     if index.is_overflow() {
-        // SAFETY: caller contract — assigned overflow index under the resolver
-        // mutex. The `&mut OverflowList` auto-ref is derived from `raw`
-        // (SharedReadWrite root), not from any caller `&mut HashMap`.
+        // SAFETY: assigned overflow index; resolver mutex held.
         Some(std::ptr::from_mut::<DirInfo>(unsafe {
             (*raw).overflow_list.at_index_mut(index)
         }))
     } else {
-        // SAFETY (read): raw place read of a `Copy` scalar — no retag.
+        // SAFETY: raw place read of a `Copy` scalar.
         let used = u32::from(unsafe { (*raw).backing_buf_used });
-        // Unconditional (release too): the inherent `at_index` path this
-        // mirrors bounds-checks the slot via array indexing, so a corrupted
-        // index panics there. Keep that failure mode — a silent out-of-bounds
-        // slot pointer would be written through by `put` callers.
+        // Unconditional assert: keep the inherent `at_index` panic-on-bad-index
+        // failure mode rather than handing out an out-of-bounds pointer.
         assert!(
             index.index() < used,
             "dir cache slot index {} out of bounds (used: {used})",
             index.index(),
         );
-        // SAFETY: caller contract — `index.index() < backing_buf_used` and the
-        // slot was initialized by `put`. `addr_of_mut!` is a raw place
-        // projection: no reference to the slot (or the map) is materialized,
-        // so the result is a direct child of the singleton's root provenance.
-        // `MaybeUninit<DirInfo>` is `#[repr(transparent)]`, so the cast is
-        // layout-sound.
+        // SAFETY: in-bounds initialized slot; raw place projection keeps the
+        // static's root provenance.
         Some(unsafe {
             core::ptr::addr_of_mut!((*raw).backing_buf)
                 .cast::<DirInfo>()
@@ -459,21 +427,10 @@ impl DirInfo {
 // COUNT mirrors `fs::preallocate::counts::DIR_ENTRY`.
 pub type HashMap = allocators::BSSMapInner<DirInfo, 2048, true>;
 
-/// Insert `value` at `result`'s slot in the BSSMap singleton and return a slot
-/// pointer re-derived from the raw singleton (see [`slot_ptr_at`]).
-///
-/// Takes the raw map pointer (not `&mut HashMap`) on purpose: a `&mut self`
-/// receiver would be FnEntry-protected for the whole call under Stacked
-/// Borrows, and `slot_ptr_at` accesses the map through the singleton's root
-/// tag — an *ancestor* of that protected Unique — which would disable the
-/// protected tag (UB). The inherent `put` instead runs through a local
-/// reborrow that dies before `slot_ptr_at` touches the root.
-///
-/// The `&mut DirInfo` the inherent `put` returns is deliberately DISCARDED:
-/// its tag would descend from the local reborrow, which any later fresh
-/// `&mut *hash_map_instance()` Unique retag would pop (`backing_buf` is inline
-/// in the map allocation). The re-derived pointer is rooted at the static and
-/// survives sibling retags outright.
+/// Insert `value` at `result`'s slot and return a retag-durable slot pointer
+/// (see [`slot_ptr_at`]). Takes a raw map pointer, not `&mut self`: a
+/// protected `&mut` receiver would be invalidated when `slot_ptr_at` goes
+/// through the singleton's root tag.
 ///
 /// # Safety
 /// `map` must be the live `hash_map_instance()` singleton and the caller must
@@ -483,20 +440,14 @@ pub(crate) unsafe fn put_slot(
     result: &mut allocators::Result,
     value: DirInfo,
 ) -> core::result::Result<*mut DirInfo, bun_core::Error> {
-    // `map` is always the `hash_map_instance()` singleton: `Resolver.dir_cache`
-    // is set to it in `init1` and never reassigned, and no other `HashMap`
-    // instance exists. `slot_ptr_at` below relies on this.
     debug_assert!(core::ptr::eq(
         map.cast_const(),
         hash_map_instance().cast_const()
     ));
-    // SAFETY: caller contract — `map` is the live singleton; resolver mutex
-    // held. The method-call auto-ref `&mut *map` ends when `put` returns, so
-    // no protector is live when `slot_ptr_at` accesses the root below.
+    // SAFETY: `map` is the live singleton; resolver mutex held. The auto-ref
+    // `&mut *map` ends when `put` returns, before `slot_ptr_at` runs.
     unsafe { (*map).put(result, value) }.map_err(bun_core::Error::from)?;
-    // SAFETY: `result.index` was just assigned (or confirmed) by `put`, so it
-    // is a non-sentinel, in-bounds, initialized slot; callers hold the
-    // resolver mutex.
+    // SAFETY: `put` just assigned a non-sentinel, initialized index.
     Ok(unsafe { slot_ptr_at(result.index) }.expect("put assigned a non-sentinel index"))
 }
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -855,14 +855,9 @@ impl<'a> Resolver<'a> {
     /// Stacked Borrows: each call pushes a fresh Unique tag on the BSSMap
     /// allocation, so any `*mut DirInfo` previously projected from an earlier
     /// `dir_cache_mut()` borrow is popped. Slot pointers that must survive a
-    /// subsequent map access are re-derived from the raw singleton:
-    /// `DirInfo::put_slot` does this internally, and `DirInfo::slot_ptr_at`
-    /// covers index-based lookups (see `dir_info_cached_miss`,
-    /// `dir_info_for_resolution`). This is NOT yet universal: read paths that
-    /// go through `at_index(..).map(DirInfoRef::from_slot)` (e.g. the
-    /// cache-hit arm of `dir_info_cached_maybe_log`) and
-    /// `DirInfo::ref_at_index` still hand out refs whose tags descend from a
-    /// transient borrow; those are only durable until the next map access.
+    /// subsequent map access are re-derived from the raw singleton via
+    /// `DirInfo::put_slot` / `DirInfo::slot_ptr_at`; refs from `at_index` /
+    /// `ref_at_index` are only durable until the next map access.
     #[inline(always)]
     pub fn dir_cache_mut(&mut self) -> &mut DirInfo::HashMap {
         // SAFETY: ARENA — `self.dir_cache` is the never-null
@@ -3428,11 +3423,9 @@ impl<'a> Resolver<'a> {
         let mut dir_cache_info_result = self.dir_cache_mut().get_or_put(dir_path)?;
         if dir_cache_info_result.status == allocators::ItemStatus::Exists {
             // we've already looked up this package before
-            // SAFETY: `Exists` means `index` was assigned by `put`; resolver
-            // mutex held. `from_raw`: `slot_ptr_at` yields a live BSSMap slot
-            // rooted at the raw singleton, so the returned ref survives the
-            // caller's later map reborrows (`load_node_modules` holds it
-            // across further `&mut self` calls).
+            // SAFETY: `Exists` index was assigned by `put`; resolver mutex held.
+            // The slot pointer is rooted at the singleton, so the returned ref
+            // survives the caller's later map reborrows.
             return Ok(unsafe { DirInfo::slot_ptr_at(dir_cache_info_result.index) }
                 .map(|p| unsafe { DirInfoRef::from_raw(p) }));
         }
@@ -3561,9 +3554,6 @@ impl<'a> Resolver<'a> {
 
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
-        // NOTE: `DirInfo::put_slot` returns a `*mut` re-derived from the raw
-        // singleton (`DirInfo::slot_ptr_at`), so `self.dir_cache` (and `*self`)
-        // are reborrowable for the call below without popping this pointer.
         // SAFETY: `dir_cache()` is the live singleton; resolver mutex held.
         let dir_info_ptr: *mut DirInfo::DirInfo = unsafe {
             DirInfo::put_slot(
@@ -4639,12 +4629,9 @@ impl<'a> Resolver<'a> {
 
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
-            // SAFETY: ARENA — `dir_cache()` singleton (see NOTE). Stacked Borrows:
-            // `DirInfo::put_slot` re-derives the returned slot pointer from the raw
-            // singleton (`DirInfo::slot_ptr_at`), and `parent_dir_ptr` is derived
-            // the same way below — both pointers are rooted at the static, so the
-            // later map reborrows inside `dir_info_uncached` cannot pop their tags.
             // SAFETY: `dir_cache()` is the live singleton; resolver mutex held.
+            // Both slot pointers are rooted at the singleton, so the map
+            // reborrows inside `dir_info_uncached` cannot pop them.
             let dir_info_ptr: *mut DirInfo::DirInfo = unsafe {
                 DirInfo::put_slot(
                     self.dir_cache(),
@@ -4652,9 +4639,8 @@ impl<'a> Resolver<'a> {
                     DirInfo::DirInfo::default(),
                 )
             }?;
-            // SAFETY: `top_parent.index` is either a sentinel (`slot_ptr_at`
-            // returns `None`) or a slot previously assigned by `put`; resolver
-            // mutex held. `from_raw`: `slot_ptr_at` yields a live BSSMap slot.
+            // SAFETY: `top_parent.index` is a sentinel or a slot assigned by
+            // `put`; resolver mutex held.
             let parent_dir_ptr = unsafe { DirInfo::slot_ptr_at(top_parent.index) }
                 .map(|p| unsafe { DirInfoRef::from_raw(p) });
 
@@ -6011,25 +5997,18 @@ impl<'a> Resolver<'a> {
     ) -> core::result::Result<(), bun_core::Error> {
         let result = _result;
 
-        // SAFETY: RealFS is the process-global ARENA singleton. Derive `rfs_ptr` from
-        // the raw `*mut FileSystem` field (not a `&mut`), and pass it straight through
-        // to `Entry::kind`/`Entry::symlink` — those take the resolver by raw pointer
-        // and reborrow internally only for the duration of the lazy stat, so no
-        // `&mut RealFS` is ever materialized in this frame and the interleaved
-        // `self.fs_ref()` / `parse_package_json()` / `parse_tsconfig()` calls below
-        // cannot invalidate it under Stacked Borrows.
+        // SAFETY: RealFS is the process-global ARENA singleton. `Entry::kind` /
+        // `Entry::symlink` take it by raw pointer and reborrow only internally,
+        // so the interleaved `&mut self` calls below cannot invalidate `rfs_ptr`
+        // under Stacked Borrows.
         let rfs_ptr: *mut Fs::file_system::RealFS = self.rfs_ptr();
-        // ARENA-backed `DirEntry`: the caller passes `_entries` as a live slot in the
-        // global BSSMap-backed entries cache, and the payload `DirEntry` is a separate
-        // process-lifetime allocation, so a shared `BackRef` survives unrelated
-        // entries-map traffic. Every use in this function is a `&self` read
-        // (`get_comptime_query` / `has_comptime_query` / `.fd`); `Entry` cache fields
-        // mutate through `Cell` under `entries_mutex`, which the caller holds.
-        // SAFETY: `_entries` is a live `EntriesOption` slot (caller contract).
+        // SAFETY: `_entries` is a live slot (caller contract); the payload
+        // `DirEntry` is a separate process-lifetime allocation, so the shared
+        // `BackRef` survives entries-map traffic. All uses below are `&self`
+        // reads under `entries_mutex`.
         let dir_entries = bun_ptr::BackRef::new(unsafe { &*_entries }.entries());
         macro_rules! entries {
             () => {
-                // Fresh safe shared borrow of the ARENA-backed `DirEntry` (see note above).
                 dir_entries.get()
             };
         }
@@ -6202,9 +6181,6 @@ impl<'a> Resolver<'a> {
             if !self.opts.preserve_symlinks {
                 if let Some(parent_entries) = parent_.get_entries_ref(self.generation) {
                     if let Some(lookup) = parent_entries.get(base) {
-                        // Read-only `.fd` access through the shared `entries!()`
-                        // borrow of the ARENA-backed `DirEntry` (see the note at
-                        // the top of this function).
                         let entries_fd = entries!().fd;
                         if entries_fd.is_valid()
                             && !lookup.entry().cache().fd.is_valid()
@@ -6589,13 +6565,9 @@ pub struct BrowserMapPath<'b> {
 }
 
 impl<'b> BrowserMapPath<'b> {
-    /// On a match, only `self.remapped` is updated — that is the sole field
-    /// callers read after a successful call. `cleaned` / `input_path` are
-    /// read-only inputs set at construction (`check_browser_map` reads
-    /// `input_path` only between *unsuccessful* calls, where it is untouched),
-    /// so the matched candidate itself — which would otherwise borrow the
-    /// threadlocal `extension_path` / `tsconfig_base_url` scratch buffers — is
-    /// never stored back into the checker.
+    /// On a match only `self.remapped` is updated; the matched candidate may
+    /// borrow threadlocal scratch buffers and must never be stored back into
+    /// the checker.
     pub fn check_path(&mut self, path_to_check: &[u8]) -> bool {
         let map = self.map;
 

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -854,9 +854,15 @@ impl<'a> Resolver<'a> {
     ///
     /// Stacked Borrows: each call pushes a fresh Unique tag on the BSSMap
     /// allocation, so any `*mut DirInfo` previously projected from an earlier
-    /// `dir_cache_mut()` borrow is popped. Callers that need a slot pointer to
-    /// survive a subsequent map access must route both through ONE bound
-    /// `&mut HashMap` (see `dir_info_for_resolution` / `dir_info_cached_maybe_log`).
+    /// `dir_cache_mut()` borrow is popped. Slot pointers that must survive a
+    /// subsequent map access are re-derived from the raw singleton:
+    /// `HashMapExt::put` does this internally, and `DirInfo::slot_ptr_at`
+    /// covers index-based lookups (see `dir_info_cached_miss`,
+    /// `dir_info_for_resolution`). This is NOT yet universal: read paths that
+    /// go through `at_index(..).map(DirInfoRef::from_slot)` (e.g. the
+    /// cache-hit arm of `dir_info_cached_maybe_log`) and
+    /// `DirInfo::ref_at_index` still hand out refs whose tags descend from a
+    /// transient borrow; those are only durable until the next map access.
     #[inline(always)]
     pub fn dir_cache_mut(&mut self) -> &mut DirInfo::HashMap {
         // SAFETY: ARENA — `self.dir_cache` is the never-null
@@ -3419,17 +3425,16 @@ impl<'a> Resolver<'a> {
         let dir_path = strings::without_trailing_slash_windows_path(dir_path_maybe_trail_slash);
 
         Self::assert_valid_cache_key(dir_path);
-        // Stacked Borrows: bind ONE `&mut HashMap` and route both the lookup and the slot
-        // projection through it so the returned `*mut DirInfo` shares a parent tag with the
-        // borrow it was derived from (a second `dir_cache_mut()` Unique retag of the
-        // whole `BSSMapInner` would otherwise pop it).
-        let dc = self.dir_cache_mut();
-        let mut dir_cache_info_result = dc.get_or_put(dir_path)?;
+        let mut dir_cache_info_result = self.dir_cache_mut().get_or_put(dir_path)?;
         if dir_cache_info_result.status == allocators::ItemStatus::Exists {
             // we've already looked up this package before
-            return Ok(dc
-                .at_index(dir_cache_info_result.index)
-                .map(DirInfoRef::from_slot));
+            // SAFETY: `Exists` means `index` was assigned by `put`; resolver
+            // mutex held. `from_raw`: `slot_ptr_at` yields a live BSSMap slot
+            // rooted at the raw singleton, so the returned ref survives the
+            // caller's later map reborrows (`load_node_modules` holds it
+            // across further `&mut self` calls).
+            return Ok(unsafe { DirInfo::slot_ptr_at(dir_cache_info_result.index) }
+                .map(|p| unsafe { DirInfoRef::from_raw(p) }));
         }
         // SAFETY: PORT (Stacked Borrows) — derive `rfs` from the raw `*mut FileSystem`
         // field via `addr_of_mut!` so later `&mut *self.log()` / `&mut *self.dir_cache()`
@@ -3556,8 +3561,9 @@ impl<'a> Resolver<'a> {
 
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
-        // NOTE: erase the `&mut DirInfo` borrow to `*mut` immediately so
-        // `self.dir_cache` (and `*self`) are reborrowable for the call below.
+        // NOTE: `HashMapExt::put` returns a `*mut` re-derived from the raw
+        // singleton (`DirInfo::slot_ptr_at`), so `self.dir_cache` (and `*self`)
+        // are reborrowable for the call below without popping this pointer.
         let dir_info_ptr: *mut DirInfo::DirInfo = self
             .dir_cache_mut()
             .put(&mut dir_cache_info_result, DirInfo::DirInfo::default())
@@ -4628,19 +4634,19 @@ impl<'a> Resolver<'a> {
 
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
-            // NOTE: erase the `&mut DirInfo` borrow to `*mut` immediately so
-            // `self.dir_cache` (and `*self`) are reborrowable for the call below.
-            // SAFETY: ARENA — `dir_cache()` singleton (see NOTE). Stacked Borrows: bind
-            // ONE `&mut HashMap` and derive BOTH slot pointers from it so they share a parent
-            // tag — a second `&mut *self.dir_cache()` Unique retag of the whole `BSSMapInner`
-            // (whose `backing_buf` is inline) would pop `dir_info_ptr`'s tag before
-            // `dir_info_uncached` writes through it.
-            // NOTE: erasing `&mut V` to `*mut V` does NOT, by itself, survive a sibling Unique
-            // retag of the parent allocation; the shared `dc` parent is what keeps both live.
-            let dc = self.dir_cache_mut();
-            let dir_info_ptr: *mut DirInfo::DirInfo =
-                dc.put(&mut queue_top.result, DirInfo::DirInfo::default())?;
-            let parent_dir_ptr = dc.at_index(top_parent.index).map(DirInfoRef::from_slot);
+            // SAFETY: ARENA — `dir_cache()` singleton (see NOTE). Stacked Borrows:
+            // `HashMapExt::put` re-derives the returned slot pointer from the raw
+            // singleton (`DirInfo::slot_ptr_at`), and `parent_dir_ptr` is derived
+            // the same way below — both pointers are rooted at the static, so the
+            // later map reborrows inside `dir_info_uncached` cannot pop their tags.
+            let dir_info_ptr: *mut DirInfo::DirInfo = self
+                .dir_cache_mut()
+                .put(&mut queue_top.result, DirInfo::DirInfo::default())?;
+            // SAFETY: `top_parent.index` is either a sentinel (`slot_ptr_at`
+            // returns `None`) or a slot previously assigned by `put`; resolver
+            // mutex held. `from_raw`: `slot_ptr_at` yields a live BSSMap slot.
+            let parent_dir_ptr = unsafe { DirInfo::slot_ptr_at(top_parent.index) }
+                .map(|p| unsafe { DirInfoRef::from_raw(p) });
 
             self.dir_info_uncached(
                 dir_info_ptr,
@@ -5995,27 +6001,26 @@ impl<'a> Resolver<'a> {
     ) -> core::result::Result<(), bun_core::Error> {
         let result = _result;
 
-        // SAFETY: RealFS / DirEntry are global ARENA singletons (BSSMap-backed).
-        // Derive `rfs_ptr` from the raw `*mut FileSystem` field so later `unsafe { &mut *self.fs() }` calls
-        // (`abs_buf` / `dirname_store.append_slice` in the parent-symlink block) cannot
-        // invalidate it under Stacked Borrows. Re-borrow at EACH use site so no `&mut`
-        // outlives a `unsafe { &mut *self.fs() }` / `get_entries()` / `parse_package_json()` call.
-        // TODO: split RealFS borrow once entries iteration is interior-mutability-backed.
+        // SAFETY: RealFS is the process-global ARENA singleton. Derive `rfs_ptr` from
+        // the raw `*mut FileSystem` field (not a `&mut`), and pass it straight through
+        // to `Entry::kind`/`Entry::symlink` — those take the resolver by raw pointer
+        // and reborrow internally only for the duration of the lazy stat, so no
+        // `&mut RealFS` is ever materialized in this frame and the interleaved
+        // `self.fs_ref()` / `parse_package_json()` / `parse_tsconfig()` calls below
+        // cannot invalidate it under Stacked Borrows.
         let rfs_ptr: *mut Fs::file_system::RealFS = self.rfs_ptr();
-        // SAFETY: caller passes `_entries` as a live slot in the global BSSMap-backed entries cache (ARENA).
-        let entries_ptr: *mut Fs::file_system::DirEntry = unsafe { &mut *_entries }.entries_mut();
-        // NOTE: re-borrow per use; see SAFETY note above.
-        macro_rules! rfs {
-            () => {
-                // SAFETY: `rfs_ptr` points at the process-global RealFS singleton; see note above.
-                // Caller must invoke from an `unsafe` block (all sites wrap the unsafe `kind`/`symlink` call).
-                &mut *rfs_ptr
-            };
-        }
+        // ARENA-backed `DirEntry`: the caller passes `_entries` as a live slot in the
+        // global BSSMap-backed entries cache, and the payload `DirEntry` is a separate
+        // process-lifetime allocation, so a shared `BackRef` survives unrelated
+        // entries-map traffic. Every use in this function is a `&self` read
+        // (`get_comptime_query` / `has_comptime_query` / `.fd`); `Entry` cache fields
+        // mutate through `Cell` under `entries_mutex`, which the caller holds.
+        // SAFETY: `_entries` is a live `EntriesOption` slot (caller contract).
+        let dir_entries = bun_ptr::BackRef::new(unsafe { &*_entries }.entries());
         macro_rules! entries {
             () => {
-                // SAFETY: `entries_ptr` is a live BSSMap-backed `DirEntry` slot (ARENA); see note above.
-                unsafe { &mut *entries_ptr }
+                // Fresh safe shared borrow of the ARENA-backed `DirEntry` (see note above).
+                dir_entries.get()
             };
         }
 
@@ -6056,8 +6061,8 @@ impl<'a> Resolver<'a> {
             if let Some(entry) = entries!().get_comptime_query(b"node_modules") {
                 info.flags.set_present(
                     DirInfo::Flag::HasNodeModules,
-                    // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                    unsafe { entry.entry().kind(rfs!(), self.store_fd) }
+                    // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                    unsafe { entry.entry().kind(rfs_ptr, self.store_fd) }
                         == Fs::file_system::EntryKind::Dir,
                 );
             }
@@ -6108,8 +6113,8 @@ impl<'a> Resolver<'a> {
 
                 if info.is_node_modules() {
                     if let Some(q) = entries!().get_comptime_query(b".bin") {
-                        // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                        if unsafe { q.entry().kind(rfs!(), self.store_fd) }
+                        // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                        if unsafe { q.entry().kind(rfs_ptr, self.store_fd) }
                             == Fs::file_system::EntryKind::Dir
                         {
                             // SAFETY: BIN_FOLDERS_LOADED is single-thread init-once; protected by RESOLVER_MUTEX held by callers.
@@ -6187,9 +6192,9 @@ impl<'a> Resolver<'a> {
             if !self.opts.preserve_symlinks {
                 if let Some(parent_entries) = parent_.get_entries_ref(self.generation) {
                     if let Some(lookup) = parent_entries.get(base) {
-                        // `entries_ptr` is a slot in the BSSMap-backed entries singleton —
-                        // route the read-only `.fd` access through the existing
-                        // `entries!()` re-borrow macro instead of a raw-ptr deref.
+                        // Read-only `.fd` access through the shared `entries!()`
+                        // borrow of the ARENA-backed `DirEntry` (see the note at
+                        // the top of this function).
                         let entries_fd = entries!().fd;
                         if entries_fd.is_valid()
                             && !lookup.entry().cache().fd.is_valid()
@@ -6201,8 +6206,8 @@ impl<'a> Resolver<'a> {
                         // dies (NLL) before any later `&mut` to this slot.
                         let entry = lookup.entry();
 
-                        // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                        let mut symlink = unsafe { entry.symlink(rfs!(), self.store_fd) };
+                        // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                        let mut symlink = unsafe { entry.symlink(rfs_ptr, self.store_fd) };
                         if !symlink.is_empty() {
                             if let Some(logs) = self.debug_logs.as_mut() {
                                 let mut buf = Vec::new();
@@ -6262,8 +6267,8 @@ impl<'a> Resolver<'a> {
                 // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
                 // dies (NLL) before any later `&mut` to this slot.
                 let entry = lookup.entry();
-                // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                if unsafe { entry.kind(rfs!(), self.store_fd) } == Fs::file_system::EntryKind::File
+                // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                if unsafe { entry.kind(rfs_ptr, self.store_fd) } == Fs::file_system::EntryKind::File
                 {
                     info.package_json = if self.use_package_manager()
                         && !info.has_node_modules()
@@ -6332,8 +6337,8 @@ impl<'a> Resolver<'a> {
                     // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
                     // dies (NLL) before any later `&mut` to this slot.
                     let entry = lookup.entry();
-                    // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                    if unsafe { entry.kind(rfs!(), self.store_fd) }
+                    // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                    if unsafe { entry.kind(rfs_ptr, self.store_fd) }
                         == Fs::file_system::EntryKind::File
                     {
                         let parts = [path, b"tsconfig.json".as_slice()];
@@ -6348,8 +6353,8 @@ impl<'a> Resolver<'a> {
                         // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
                         // dies (NLL) before any later `&mut` to this slot.
                         let entry = lookup.entry();
-                        // SAFETY: entries_mutex held; rfs points at the process-global RealFS.
-                        if unsafe { entry.kind(rfs!(), self.store_fd) }
+                        // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                        if unsafe { entry.kind(rfs_ptr, self.store_fd) }
                             == Fs::file_system::EntryKind::File
                         {
                             let parts = [path, b"jsconfig.json".as_slice()];
@@ -6574,6 +6579,13 @@ pub struct BrowserMapPath<'b> {
 }
 
 impl<'b> BrowserMapPath<'b> {
+    /// On a match, only `self.remapped` is updated — that is the sole field
+    /// callers read after a successful call. `cleaned` / `input_path` are
+    /// read-only inputs set at construction (`check_browser_map` reads
+    /// `input_path` only between *unsuccessful* calls, where it is untouched),
+    /// so the matched candidate itself — which would otherwise borrow the
+    /// threadlocal `extension_path` / `tsconfig_base_url` scratch buffers — is
+    /// never stored back into the checker.
     pub fn check_path(&mut self, path_to_check: &[u8]) -> bool {
         let map = self.map;
 
@@ -6585,8 +6597,6 @@ impl<'b> BrowserMapPath<'b> {
             // cache is process-global); the `'b` borrow on `map` artificially shortens
             // what is process-lifetime storage. `Interned` is the canonical proof type.
             self.remapped = unsafe { bun_ptr::Interned::assume(result) }.as_bytes();
-            // SAFETY: extending borrow of caller-owned slice; consumed before checker is dropped (TODO: thread explicit lifetime).
-            self.input_path = unsafe { &*std::ptr::from_ref::<[u8]>(path_to_check) };
             return true;
         }
 
@@ -6609,10 +6619,6 @@ impl<'b> BrowserMapPath<'b> {
                 if let Some(_remapped) = map.get(new_path) {
                     // SAFETY: ARENA — see `result` note above.
                     self.remapped = unsafe { bun_ptr::Interned::assume(_remapped) }.as_bytes();
-                    // SAFETY: `new_path` borrows the threadlocal `extension_path` buf; consumed before next overwrite (TODO: thread explicit lifetime).
-                    self.cleaned = unsafe { &*std::ptr::from_ref::<[u8]>(new_path) };
-                    // SAFETY: same as above.
-                    self.input_path = unsafe { &*std::ptr::from_ref::<[u8]>(new_path) };
                     return true;
                 }
             }
@@ -6636,8 +6642,6 @@ impl<'b> BrowserMapPath<'b> {
         if let Some(_remapped) = map.get(index_path) {
             // SAFETY: ARENA — see `result` note above.
             self.remapped = unsafe { bun_ptr::Interned::assume(_remapped) }.as_bytes();
-            // SAFETY: `index_path` borrows the threadlocal `extension_path` buf; consumed before next overwrite (TODO: thread explicit lifetime).
-            self.input_path = unsafe { &*std::ptr::from_ref::<[u8]>(index_path) };
             return true;
         }
 
@@ -6657,10 +6661,6 @@ impl<'b> BrowserMapPath<'b> {
                 if let Some(_remapped) = map.get(new_path) {
                     // SAFETY: ARENA — see `result` note above.
                     self.remapped = unsafe { bun_ptr::Interned::assume(_remapped) }.as_bytes();
-                    // SAFETY: `new_path` borrows the threadlocal `extension_path` buf; consumed before next overwrite (TODO: thread explicit lifetime).
-                    self.cleaned = unsafe { &*std::ptr::from_ref::<[u8]>(new_path) };
-                    // SAFETY: same as above.
-                    self.input_path = unsafe { &*std::ptr::from_ref::<[u8]>(new_path) };
                     return true;
                 }
             }

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -856,7 +856,7 @@ impl<'a> Resolver<'a> {
     /// allocation, so any `*mut DirInfo` previously projected from an earlier
     /// `dir_cache_mut()` borrow is popped. Slot pointers that must survive a
     /// subsequent map access are re-derived from the raw singleton:
-    /// `HashMapExt::put` does this internally, and `DirInfo::slot_ptr_at`
+    /// `DirInfo::put_slot` does this internally, and `DirInfo::slot_ptr_at`
     /// covers index-based lookups (see `dir_info_cached_miss`,
     /// `dir_info_for_resolution`). This is NOT yet universal: read paths that
     /// go through `at_index(..).map(DirInfoRef::from_slot)` (e.g. the
@@ -3561,13 +3561,18 @@ impl<'a> Resolver<'a> {
 
         // We must initialize it as empty so that the result index is correct.
         // This is important so that browser_scope has a valid index.
-        // NOTE: `HashMapExt::put` returns a `*mut` re-derived from the raw
+        // NOTE: `DirInfo::put_slot` returns a `*mut` re-derived from the raw
         // singleton (`DirInfo::slot_ptr_at`), so `self.dir_cache` (and `*self`)
         // are reborrowable for the call below without popping this pointer.
-        let dir_info_ptr: *mut DirInfo::DirInfo = self
-            .dir_cache_mut()
-            .put(&mut dir_cache_info_result, DirInfo::DirInfo::default())
-            .expect("unreachable");
+        // SAFETY: `dir_cache()` is the live singleton; resolver mutex held.
+        let dir_info_ptr: *mut DirInfo::DirInfo = unsafe {
+            DirInfo::put_slot(
+                self.dir_cache(),
+                &mut dir_cache_info_result,
+                DirInfo::DirInfo::default(),
+            )
+        }
+        .expect("unreachable");
 
         // `dir_path` is a slice into the threadlocal `bufs(.path_in_global_disk_cache)` buffer,
         // which gets overwritten on the next auto-install resolution. `dirInfoUncached` stores
@@ -4635,13 +4640,18 @@ impl<'a> Resolver<'a> {
             // We must initialize it as empty so that the result index is correct.
             // This is important so that browser_scope has a valid index.
             // SAFETY: ARENA — `dir_cache()` singleton (see NOTE). Stacked Borrows:
-            // `HashMapExt::put` re-derives the returned slot pointer from the raw
+            // `DirInfo::put_slot` re-derives the returned slot pointer from the raw
             // singleton (`DirInfo::slot_ptr_at`), and `parent_dir_ptr` is derived
             // the same way below — both pointers are rooted at the static, so the
             // later map reborrows inside `dir_info_uncached` cannot pop their tags.
-            let dir_info_ptr: *mut DirInfo::DirInfo = self
-                .dir_cache_mut()
-                .put(&mut queue_top.result, DirInfo::DirInfo::default())?;
+            // SAFETY: `dir_cache()` is the live singleton; resolver mutex held.
+            let dir_info_ptr: *mut DirInfo::DirInfo = unsafe {
+                DirInfo::put_slot(
+                    self.dir_cache(),
+                    &mut queue_top.result,
+                    DirInfo::DirInfo::default(),
+                )
+            }?;
             // SAFETY: `top_parent.index` is either a sentinel (`slot_ptr_at`
             // returns `None`) or a slot previously assigned by `put`; resolver
             // mutex held. `from_raw`: `slot_ptr_at` yields a live BSSMap slot.

--- a/test/bundler/esbuild/packagejson.test.ts
+++ b/test/bundler/esbuild/packagejson.test.ts
@@ -2038,3 +2038,71 @@ describe("bundler", () => {
     },
   });
 });
+
+describe("bundler", () => {
+  // The browser-map checker probes candidates in four stages: exact key, key +
+  // implicit extension, key + "/index", and key + "/index" + implicit extension.
+  // Only the remap *target* of a successful probe may be consumed by the
+  // resolver — the matched candidate string itself (which can point into
+  // scratch storage) must not leak into later resolution. These cases pin each
+  // probe stage individually through a relative import.
+  itBundled("packagejson/BrowserMapProbeStages", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import {value as a} from './demo-pkg/exact.js'
+        import {value as b} from './demo-pkg/with-ext'
+        import {value as c} from './demo-pkg/as-index'
+        import {value as d} from './demo-pkg/as-index-ext'
+        console.log(a, b, c, d)
+      `,
+      "/Users/user/project/src/demo-pkg/package.json": /* json */ `
+        {
+          "browser": {
+            "./exact.js": "./remapped/exact.js",
+            "./with-ext.js": "./remapped/with-ext.js",
+            "./as-index/index": "./remapped/as-index.js",
+            "./as-index-ext/index.js": "./remapped/as-index-ext.js"
+          }
+        }
+      `,
+      "/Users/user/project/src/demo-pkg/exact.js": `export let value = 'node'`,
+      "/Users/user/project/src/demo-pkg/with-ext.js": `export let value = 'node'`,
+      "/Users/user/project/src/demo-pkg/as-index/index.js": `export let value = 'node'`,
+      "/Users/user/project/src/demo-pkg/as-index-ext/index.js": `export let value = 'node'`,
+      "/Users/user/project/src/demo-pkg/remapped/exact.js": `export let value = 'exact'`,
+      "/Users/user/project/src/demo-pkg/remapped/with-ext.js": `export let value = 'with-ext'`,
+      "/Users/user/project/src/demo-pkg/remapped/as-index.js": `export let value = 'as-index'`,
+      "/Users/user/project/src/demo-pkg/remapped/as-index-ext.js": `export let value = 'as-index-ext'`,
+    },
+    run: {
+      stdout: "exact with-ext as-index as-index-ext",
+    },
+  });
+  // Browser-map keys are normalized at parse time ("./name" -> "name"), so a
+  // "./name" entry also remaps the *package path* "name" imported from within
+  // the same package (Browserify compatibility quirk); the normalized key
+  // matches the package specifier on the checker's first probe.
+  itBundled("packagejson/BrowserMapDotSlashOverridesPackagePath", {
+    files: {
+      "/Users/user/project/src/entry.js": /* js */ `
+        import {value} from './demo-pkg'
+        console.log(value)
+      `,
+      "/Users/user/project/src/demo-pkg/package.json": /* json */ `
+        {
+          "main": "./main.js",
+          "browser": {
+            "./fake-pkg": "./fake-pkg-browser.js"
+          }
+        }
+      `,
+      "/Users/user/project/src/demo-pkg/main.js": /* js */ `
+        export {value} from 'fake-pkg'
+      `,
+      "/Users/user/project/src/demo-pkg/fake-pkg-browser.js": `export let value = 'browser-override'`,
+    },
+    run: {
+      stdout: "browser-override",
+    },
+  });
+});

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -779,3 +779,46 @@ describe("resolving external URL specifiers with non-ASCII characters", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+// Stress the resolver's directory-info cache: resolve through hundreds of
+// distinct package directories (each `put` hands back a slot pointer into the
+// shared dir-cache that must stay valid while the cache keeps growing) plus a
+// deep directory chain (the cache-miss walk stashes a parent slot pointer
+// across subsequent cache insertions). A stale/corrupted slot pointer shows up
+// as wrong resolution results or a crash, not a clean error.
+it("resolves through many directories without corrupting the dir cache", async () => {
+  const files: Record<string, string> = {};
+  const N = 200;
+  let imports = "";
+  for (let i = 0; i < N; i++) {
+    files[`node_modules/pkg-${i}/package.json`] = JSON.stringify({
+      name: `pkg-${i}`,
+      main: "./lib/index.js",
+    });
+    files[`node_modules/pkg-${i}/lib/index.js`] = `module.exports = ${i};`;
+    imports += `total += require("pkg-${i}");\n`;
+  }
+
+  // Deep chain: resolving the leaf populates one cache entry per path
+  // component in a single cache-miss walk, and requiring packages *from* the
+  // leaf walks every parent directory back up through the now-cached entries.
+  // Depth 30 keeps the absolute path well under Windows' 260-char MAX_PATH
+  // even with a long CI temp-dir prefix; the cache-miss walk is exercised the
+  // same at this depth.
+  let deep = "deep";
+  for (let d = 0; d < 30; d++) deep += `/d${d}`;
+  files[`${deep}/leaf.js`] = `module.exports = require("pkg-3") + require("pkg-77");`;
+  files["index.js"] = `let total = 0;\n${imports}console.log(total);\nconsole.log(require("./${deep}/leaf.js"));`;
+
+  const dir = tempDirWithFiles("dir-cache-stress", files);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.js"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe(`${(N * (N - 1)) / 2}\n${3 + 77}\n`);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -819,6 +819,7 @@ it("resolves through many directories without corrupting the dir cache", async (
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
   expect(stdout).toBe(`${(N * (N - 1)) / 2}\n${3 + 77}\n`);
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
The DirInfo dir-cache `put()` returned a slot pointer derived from a transient `&mut HashMap`; because the map's backing buffer is stored inline, any later fresh reborrow of the singleton invalidated previously stashed slot pointers under Stacked Borrows, and the only protection was an unenforced calling convention. `put()` now re-derives the returned pointer (and `dir_info_cached_miss`'s parent slot pointer, via a new `slot_ptr_at` helper) directly from the raw singleton with a raw place projection, so slot pointers survive sibling map reborrows outright; the inline-arm bounds check is unconditional (a corrupted index panics, matching the old at_index failure mode, instead of yielding an out-of-bounds slot pointer), and dir_info_for_resolution's cache-hit arm was migrated to the same re-derivation. The browser-map checker (`BrowserMapPath::check_path`) stored matched candidate strings back into the checker through four lifetime-erasing casts into threadlocal scratch buffers; those stores were dead (callers only read `remapped` after a match), so they are removed along with all four erasures. `dir_info_uncached` no longer materializes `&mut RealFS` / `&mut DirEntry` per use: the raw fs pointer is passed straight through to the lazy-stat helpers and the directory entry is read through a shared BackRef, matching the existing pattern in `load_as_file`. New regression-pin tests cover each probe stage of the browser-map checker plus the './'-key package-path quirk, and a resolver stress test resolves through 200 packages and a 30-deep directory chain (kept under Windows MAX_PATH) to exercise dir-cache slot-pointer stability. These tests pin behavior parity — all three orders are aliasing hardening / dead-store removal with no intended behavior change, so they pass before and after; the actual verification gate is the build plus the resolver/bundler suites (and Miri-style reasoning recorded in the code comments). NOT YET RUN: no build or test has been executed on this branch — the post-cluster build+verify phase must run test/bundler/esbuild/packagejson.test.ts, test/js/bun/resolve/resolve.test.ts, and the resolver-heavy suites before merge.

## Deferred

- WO-047-A resolver entry-point &'static [u8] lifetime erasure of import_path (cross-crate Result/MatchResult lifetime threading; consumers in bundler/runtime are outside this cluster's owned files, so a correct partial landing is impossible)

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
