### PR TITLE
Replace the logger's no-op StringBuilder stub with real single-buffer message packing

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -20,11 +20,6 @@ use std::borrow::Cow;
 // `bun_alloc::AllocError` removed — the `add_*` / `clone` family is now
 // infallible (`Vec::push` / `io::Write` on `Vec<u8>` cannot fail in Rust).
 use bun_core::Output;
-// Two-phase (count → allocate → append) packer used by the
-// `clone_with_builder` family: every string of every cloned `Msg` is copied
-// into one builder-owned buffer, and that buffer is then anchored in the
-// destination `Log::owned_strings` so the borrowed views stay valid for the
-// life of the destination log (same ownership pattern as [`Log::dupe`]).
 use bun_core::StringBuilder;
 
 // Discriminants are wire-stable for serialization.
@@ -690,10 +685,7 @@ pub struct Location {
     // borrowed arm covers the common case where the slice points into
     // arena-owned source text.
     pub file: Cow<'static, [u8]>,
-    /// `Cow` for the same reason as `file`: the `Borrowed` arm may be a
-    /// lifetime-erased view into a `Source.path` or a recycled Log's
-    /// `owned_strings` buffer, so escaping `Location`s must be able to own it
-    /// (see [`Location::make_owned`]).
+    /// `Cow` for the same reason as `file`; see [`Location::make_owned`].
     pub namespace: Cow<'static, [u8]>,
     /// Text on the line, avoiding the need to refetch the source code
     pub line_text: Option<Cow<'static, [u8]>>,
@@ -713,10 +705,8 @@ pub struct Location {
     pub column: i32,
 }
 
-/// Deep-dupe a `namespace` value so the result owns its bytes (or borrows a
-/// true `'static` literal). The two interned values cover effectively every
-/// runtime namespace, keeping `Location::clone` allocation-free on the hot
-/// path.
+/// Deep-dupe a `namespace`, interning the common static values so
+/// `Location::clone` stays allocation-free on the hot path.
 fn dupe_namespace(ns: &Cow<'static, [u8]>) -> Cow<'static, [u8]> {
     match &**ns {
         b"file" => Cow::Borrowed(b"file"),
@@ -725,8 +715,7 @@ fn dupe_namespace(ns: &Cow<'static, [u8]>) -> Cow<'static, [u8]> {
     }
 }
 
-/// Force a string field into the `Owned` arm (interning the common static
-/// namespaces) so it cannot dangle once the backing `Log`/`Source` drops.
+/// Force into the `Owned` arm (interning the common static namespaces).
 fn own_cow(c: &mut Cow<'static, [u8]>) {
     if let Cow::Borrowed(b) = *c {
         *c = match b {
@@ -748,12 +737,6 @@ impl Clone for Location {
     fn clone(&self) -> Self {
         Location {
             file: Cow::Owned(self.file.to_vec()),
-            // `namespace` is a `Cow` so it can be deep-duped like
-            // `file`/`line_text`: after a recycled-log transfer
-            // (`Log::clone_to_with_recycled`) the `Borrowed` arm may point
-            // into the source Log's `owned_strings` buffer. `dupe_namespace`
-            // interns the overwhelmingly common static values so the hot
-            // path stays allocation-free.
             namespace: dupe_namespace(&self.namespace),
             line: self.line,
             column: self.column,
@@ -804,19 +787,13 @@ impl Location {
         <Self as Clone>::clone(self)
     }
 
-    /// Copy this location's strings into `builder`'s single backing buffer
-    /// and return a `Location` whose byte-slice fields borrow that buffer.
-    /// Caller contract: every field must have been [`Self::count`]ed into the
-    /// same builder before `allocate()`, and the builder's buffer must be
-    /// kept alive for as long as the returned `Location`
-    /// (`Log::clone_to_with_recycled` moves it into the destination log's
-    /// `owned_strings`).
+    /// Copy this location's strings into `builder`'s buffer; the returned
+    /// `Location` borrows that buffer. Caller contract: every field was
+    /// [`Self::count`]ed into the same builder before `allocate()`, and the
+    /// buffer must outlive the returned `Location`.
     pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Location {
-        // SAFETY (all `append_raw` calls below): the unbound-lifetime slices
-        // returned by `append_raw` alias the builder's heap buffer; per the
-        // caller contract above, that buffer is moved into the destination
-        // `Log::owned_strings` (`Box<[u8]>`, heap-stable) and outlives the
-        // returned `Location`. The bytes were reserved by `Self::count`.
+        // SAFETY: per the caller contract, the builder's buffer outlives the
+        // returned `Location` and the bytes were reserved by `Self::count`.
         Location {
             file: Cow::Borrowed(unsafe { builder.append_raw(&self.file) }),
             namespace: Cow::Borrowed(unsafe { builder.append_raw(&self.namespace) }),
@@ -832,10 +809,7 @@ impl Location {
     }
 
     /// Force every string field into owned storage so this `Location` can
-    /// outlive whatever backed its borrowed views (a `Source.contents`, a
-    /// recycled `Log::owned_strings` buffer, an arena). Must be called when a
-    /// `Msg` escapes a `Log` into a JS-visible object — see
-    /// [`Msg::make_owned`].
+    /// outlive whatever backed its borrowed views. See [`Msg::make_owned`].
     pub fn make_owned(&mut self) {
         own_cow(&mut self.file);
         own_cow(&mut self.namespace);
@@ -1010,14 +984,10 @@ impl Data {
         }
     }
 
-    /// See [`Location::clone_with_builder`] for the count/allocate/append and
-    /// buffer-lifetime caller contract.
+    /// See [`Location::clone_with_builder`] for the caller contract.
     pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Data {
         Data {
-            // SAFETY: same contract as `Location::clone_with_builder` — the
-            // builder's buffer is anchored in the destination
-            // `Log::owned_strings` and outlives the returned `Data`. The
-            // bytes were reserved by `Self::count`.
+            // SAFETY: same contract as `Location::clone_with_builder`.
             text: Cow::Borrowed(unsafe { builder.append_raw(&self.text) }),
             location: self
                 .location
@@ -1280,10 +1250,9 @@ impl Msg {
         }
     }
 
-    /// See [`Location::clone_with_builder`] for the count/allocate/append and
-    /// buffer-lifetime caller contract. `Metadata::Resolve`'s `specifier`
-    /// stays valid: it is a `BabyString` of offsets into `data.text`, and the
-    /// builder copies `text` byte-for-byte.
+    /// See [`Location::clone_with_builder`] for the caller contract.
+    /// `Metadata::Resolve`'s `specifier` stays valid: it is offsets into
+    /// `data.text`, which is copied byte-for-byte.
     pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Msg {
         Msg {
             kind: self.kind,
@@ -1298,15 +1267,9 @@ impl Msg {
         }
     }
 
-    /// Deep-copy every borrowed/lifetime-erased string in this message
-    /// (`data.text`, `location.file` / `namespace` / `line_text`, and every
-    /// note) into owned storage. After `Log::clone_to_with_recycled` those
-    /// strings are `Cow::Borrowed` views into the destination Log's
-    /// `owned_strings` packed buffer, so any `Msg` that escapes the Log into a
-    /// JS-visible object (`BuildMessage` / `ResolveMessage`) would dangle once
-    /// the Log drops. Call this at the escape boundary; `Metadata::Resolve`'s
-    /// `specifier` stays valid because it is a `BabyString` of offsets into
-    /// `data.text` and the bytes are copied verbatim.
+    /// Deep-copy every borrowed string into owned storage. Call when a `Msg`
+    /// escapes its `Log` into a JS-visible object — borrowed views into the
+    /// Log's `owned_strings` buffer would dangle once the Log drops.
     pub fn make_owned(&mut self) {
         self.data.make_owned();
         for note in self.notes.iter_mut() {
@@ -1718,10 +1681,8 @@ impl Log {
 
     pub fn reset(&mut self) {
         self.msgs.clear();
-        // The packed string buffers (see `clone_to_with_recycled` /
-        // `append_to`) only back `self.msgs`; once those are cleared nothing
-        // borrows them, so drop them too — otherwise a long-lived Log (e.g.
-        // the dev server's) accumulates one buffer per appended log forever.
+        // The packed buffers only back `self.msgs`; release them too, or a
+        // long-lived Log accumulates one buffer per appended log forever.
         self.owned_strings.clear();
         self.warnings = 0;
         self.errors = 0;
@@ -1849,12 +1810,9 @@ impl Log {
 
     pub fn clone_to_with_recycled(&mut self, other: &mut Log, recycled: bool) {
         if recycled && !self.msgs.is_empty() {
-            // `self`'s messages may borrow recycled source storage; pack every
-            // string of every message into one builder-owned buffer
-            // (count → allocate → append) and anchor that buffer in
-            // `other.owned_strings` — the same ownership pattern as
-            // [`Log::dupe`] — so the cloned messages' borrowed views stay
-            // valid for the life of `other`.
+            // `self`'s messages may borrow recycled source storage: pack every
+            // string into one buffer anchored in `other.owned_strings` so the
+            // cloned messages' borrowed views stay valid for the life of `other`.
             let mut string_builder = StringBuilder::default();
             for msg in &self.msgs {
                 msg.count(&mut string_builder);
@@ -1863,30 +1821,18 @@ impl Log {
                 string_builder
                     .allocate()
                     .expect("infallible: Box::new_uninit_slice aborts on OOM");
-                // Clone into a local Vec first and anchor the buffer in
-                // `other.owned_strings` *before* the cloned messages become
-                // visible in `other.msgs`: if anything unwinds mid-loop, the
-                // local Vec (whose `Cow::Borrowed`/`Str` views are dropped
-                // without dereferencing) and the builder's buffer are torn
-                // down together, and `other` never observes messages whose
-                // backing buffer is missing.
+                // Clone into a local Vec first so that on unwind `other` never
+                // observes messages whose backing buffer is missing.
                 let mut cloned_msgs = Vec::with_capacity(self.msgs.len());
                 for msg in &self.msgs {
                     cloned_msgs.push(msg.clone_with_builder(&mut string_builder));
                 }
-                // Every counted byte was appended above (`count` and
-                // `clone_with_builder` walk the same fields), so the buffer is
-                // fully initialized. `Box<[u8]>` is heap-stable across `Vec`
-                // growth, so the borrows in the cloned messages stay valid.
                 other.owned_strings.push(string_builder.move_to_slice());
                 other.msgs.extend(cloned_msgs);
             } else {
-                // Every string of every message is empty: there is nothing to
-                // pack, and `allocate(0)` would set `ptr = Some(dangling)`,
-                // tripping `debug_assert!(cap > 0)` in
-                // `StringBuilder::writable()` on the first append. Empty
-                // strings cannot dangle into recycled storage, so a plain
-                // deep clone is sound.
+                // Every string is empty (nothing can dangle), and `allocate(0)`
+                // would trip `StringBuilder::writable()`'s debug_assert, so
+                // deep-clone instead.
                 other.msgs.extend(self.msgs.iter().map(Msg::clone));
             }
         } else {
@@ -1914,8 +1860,7 @@ impl Log {
     pub fn clear_and_free(&mut self) {
         self.msgs.clear();
         self.msgs.shrink_to_fit();
-        // See `reset` — the packed string buffers only back `self.msgs`, so
-        // release them with the messages.
+        // See `reset` — the packed buffers go with the messages.
         self.owned_strings.clear();
         self.owned_strings.shrink_to_fit();
         // self.warnings = 0;

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1825,7 +1825,9 @@ impl Log {
         if recycled && !self.msgs.is_empty() {
             // `self`'s messages may borrow recycled source storage: pack every
             // string into one buffer anchored in `other.owned_strings` so the
-            // cloned messages' borrowed views stay valid for the life of `other`.
+            // cloned messages' borrowed views stay valid until `other` is
+            // `reset()`/`clear_and_free()`'d (which clear `msgs` before
+            // releasing `owned_strings`) or dropped.
             let mut string_builder = StringBuilder::default();
             for msg in &self.msgs {
                 msg.count(&mut string_builder);

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1547,8 +1547,11 @@ pub struct Log {
     /// that came from transient buffers (e.g. native-plugin C strings): a
     /// side-vector of `Box<[u8]>` owned by the `Log`; [`Log::dupe`] returns a
     /// lifetime-erased borrow into the just-pushed box. The borrow is valid
-    /// for the life of `self` because `Box<[u8]>` is heap-stable across `Vec`
-    /// growth. See PORTING.md §Allocators (arena pattern).
+    /// until the next [`Log::reset`]/[`Log::clear_and_free`] (which clear
+    /// this vector) or until the `Log` drops; `Box<[u8]>` is heap-stable
+    /// across `Vec` growth, and every `dupe` result lives in `self.msgs`,
+    /// which those methods clear first. See PORTING.md §Allocators (arena
+    /// pattern).
     pub owned_strings: Vec<Box<[u8]>>,
 
     /// Incremental line/column scanner for the messages this log creates, so
@@ -1581,18 +1584,24 @@ impl Default for Log {
 impl Log {
     /// Copy `s` into
     /// storage owned by this `Log` and return a `&'static [u8]` view. The
-    /// returned slice is valid for as long as `self` lives (the box is never
-    /// moved out of `owned_strings`); `'static` is a lifetime erasure matching
-    /// the `Str` alias used by `Location`/`Msg`. NOT a leak — the bytes free
-    /// when the `Log` drops.
+    /// returned slice is valid until the next [`Log::reset`] or
+    /// [`Log::clear_and_free`] (which clear `owned_strings`), or until the
+    /// `Log` drops; `'static` is a lifetime erasure matching the `Str` alias
+    /// used by `Location`/`Msg`. Sound because every `dupe` result is only
+    /// ever stored in `self.msgs`, which those methods clear in the same
+    /// call before releasing the backing boxes. NOT a leak — the bytes free
+    /// on clear or drop.
     pub fn dupe(&mut self, s: &[u8]) -> &'static [u8] {
         if s.is_empty() {
             return b"";
         }
         let boxed: Box<[u8]> = Box::from(s);
-        // SAFETY: ARENA — `boxed` is about to be pushed into `self.owned_strings`
-        // and never removed; its heap allocation is stable across the `Vec`'s
-        // growth, so the returned slice is valid for the life of `self`.
+        // SAFETY: ARENA — `boxed` is about to be pushed into `self.owned_strings`,
+        // whose boxes stay alive until `reset()`/`clear_and_free()` clear it or
+        // the `Log` drops; its heap allocation is stable across the `Vec`'s
+        // growth. The returned slice is only stored in `self.msgs`, which those
+        // methods clear before releasing the boxes, so it never outlives its
+        // backing storage.
         let view: &'static [u8] = unsafe { bun_collections::detach_lifetime(&boxed[..]) };
         self.owned_strings.push(boxed);
         view

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -707,8 +707,8 @@ pub struct Location {
 
 /// Deep-dupe a `namespace`, interning the common static values so
 /// `Location::clone` stays allocation-free on the hot path.
-fn dupe_namespace(ns: &Cow<'static, [u8]>) -> Cow<'static, [u8]> {
-    match &**ns {
+fn dupe_namespace(ns: &[u8]) -> Cow<'static, [u8]> {
+    match ns {
         b"file" => Cow::Borrowed(b"file"),
         b"" => Cow::Borrowed(b""),
         other => Cow::Owned(other.to_vec()),
@@ -794,16 +794,20 @@ impl Location {
     pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Location {
         // SAFETY: per the caller contract, the builder's buffer outlives the
         // returned `Location` and the bytes were reserved by `Self::count`.
+        let (file, namespace, line_text) = unsafe {
+            (
+                builder.append_raw(&self.file),
+                builder.append_raw(&self.namespace),
+                self.line_text.as_deref().map(|t| builder.append_raw(t)),
+            )
+        };
         Location {
-            file: Cow::Borrowed(unsafe { builder.append_raw(&self.file) }),
-            namespace: Cow::Borrowed(unsafe { builder.append_raw(&self.namespace) }),
+            file: Cow::Borrowed(file),
+            namespace: Cow::Borrowed(namespace),
             line: self.line,
             column: self.column,
             length: self.length,
-            line_text: self
-                .line_text
-                .as_deref()
-                .map(|t| Cow::Borrowed(unsafe { builder.append_raw(t) })),
+            line_text: line_text.map(Cow::Borrowed),
             offset: self.offset,
         }
     }

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -8,7 +8,8 @@
 #![feature(thread_local)]
 //! TODO: OWNERSHIP — almost every byte-slice field in this module has
 //! mixed/ambiguous ownership. Strings are sometimes literals, sometimes heap
-//! copies, sometimes slices into `Source.contents` or a `StringBuilder` arena.
+//! copies, sometimes slices into `Source.contents` or a packed buffer
+//! anchored in `Log::owned_strings`.
 //! They are kept as `&'static [u8]` to avoid lifetime params; a real ownership
 //! story (likely `bun_core::String` or a `'source` lifetime threaded through
 //! `Location`/`Data`/`Msg`) is still needed.
@@ -19,21 +20,12 @@ use std::borrow::Cow;
 // `bun_alloc::AllocError` removed — the `add_*` / `clone` family is now
 // infallible (`Vec::push` / `io::Write` on `Vec<u8>` cannot fail in Rust).
 use bun_core::Output;
-
-// TODO: swap to `bun_core::StringBuilder` once `clone_with_builder` is
-// reshaped to use `append_raw` (canonical's `append` borrows `&mut self`, which
-// breaks the `'static` slice pass-through this stub fakes).
-#[derive(Default)]
-pub struct StringBuilder;
-impl StringBuilder {
-    pub fn count(&mut self, s: &[u8]) {
-        let _ = s;
-    }
-    pub fn append(&mut self, s: &'static [u8]) -> &'static [u8] {
-        s
-    }
-    pub fn allocate(&mut self) {}
-}
+// Two-phase (count → allocate → append) packer used by the
+// `clone_with_builder` family: every string of every cloned `Msg` is copied
+// into one builder-owned buffer, and that buffer is then anchored in the
+// destination `Log::owned_strings` so the borrowed views stay valid for the
+// life of the destination log (same ownership pattern as [`Log::dupe`]).
+use bun_core::StringBuilder;
 
 // Discriminants are wire-stable for serialization.
 #[repr(u8)]
@@ -698,7 +690,11 @@ pub struct Location {
     // borrowed arm covers the common case where the slice points into
     // arena-owned source text.
     pub file: Cow<'static, [u8]>,
-    pub namespace: Str,
+    /// `Cow` for the same reason as `file`: the `Borrowed` arm may be a
+    /// lifetime-erased view into a `Source.path` or a recycled Log's
+    /// `owned_strings` buffer, so escaping `Location`s must be able to own it
+    /// (see [`Location::make_owned`]).
+    pub namespace: Cow<'static, [u8]>,
     /// Text on the line, avoiding the need to refetch the source code
     pub line_text: Option<Cow<'static, [u8]>>,
     /// Number of bytes this location should highlight.
@@ -717,6 +713,30 @@ pub struct Location {
     pub column: i32,
 }
 
+/// Deep-dupe a `namespace` value so the result owns its bytes (or borrows a
+/// true `'static` literal). The two interned values cover effectively every
+/// runtime namespace, keeping `Location::clone` allocation-free on the hot
+/// path.
+fn dupe_namespace(ns: &Cow<'static, [u8]>) -> Cow<'static, [u8]> {
+    match &**ns {
+        b"file" => Cow::Borrowed(b"file"),
+        b"" => Cow::Borrowed(b""),
+        other => Cow::Owned(other.to_vec()),
+    }
+}
+
+/// Force a string field into the `Owned` arm (interning the common static
+/// namespaces) so it cannot dangle once the backing `Log`/`Source` drops.
+fn own_cow(c: &mut Cow<'static, [u8]>) {
+    if let Cow::Borrowed(b) = *c {
+        *c = match b {
+            b"" => Cow::Borrowed(b""),
+            b"file" => Cow::Borrowed(b"file"),
+            other => Cow::Owned(other.to_vec()),
+        };
+    }
+}
+
 // NOT `#[derive(Clone)]`. `file` / `line_text` are
 // `Cow<'static, [u8]>` whose `Borrowed` arm may carry a lifetime-erased view
 // into `Source.contents` (see `init_or_null`, `css_parser.rs`, `error.rs`,
@@ -728,7 +748,13 @@ impl Clone for Location {
     fn clone(&self) -> Self {
         Location {
             file: Cow::Owned(self.file.to_vec()),
-            namespace: self.namespace,
+            // `namespace` is a `Cow` so it can be deep-duped like
+            // `file`/`line_text`: after a recycled-log transfer
+            // (`Log::clone_to_with_recycled`) the `Borrowed` arm may point
+            // into the source Log's `owned_strings` buffer. `dupe_namespace`
+            // interns the overwhelmingly common static values so the hot
+            // path stays allocation-free.
+            namespace: dupe_namespace(&self.namespace),
             line: self.line,
             column: self.column,
             length: self.length,
@@ -742,7 +768,7 @@ impl Default for Location {
     fn default() -> Self {
         Location {
             file: Cow::Borrowed(b""),
-            namespace: b"file",
+            namespace: Cow::Borrowed(b"file"),
             line_text: None,
             length: 0,
             offset: 0,
@@ -764,10 +790,10 @@ impl Location {
     }
 
     pub fn count(&self, builder: &mut StringBuilder) {
-        builder.count(self.file.as_ref().into_str());
-        builder.count(self.namespace);
+        builder.count(&self.file);
+        builder.count(&self.namespace);
         if let Some(text) = &self.line_text {
-            builder.count(text.as_ref().into_str());
+            builder.count(text);
         }
     }
 
@@ -778,21 +804,43 @@ impl Location {
         <Self as Clone>::clone(self)
     }
 
-    pub fn clone_with_builder(&self, _string_builder: &mut StringBuilder) -> Location {
-        // The local
-        // `StringBuilder` stub above is a no-op that returns its input, so a
-        // `Cow::Borrowed(append(s))` would alias `self`'s storage and dangle
-        // after `self.msgs.clear()` in `append_to_with_recycled`. Deep-copy
-        // here instead — same end-state as the real builder, just without the
-        // single-buffer packing.
+    /// Copy this location's strings into `builder`'s single backing buffer
+    /// and return a `Location` whose byte-slice fields borrow that buffer.
+    /// Caller contract: every field must have been [`Self::count`]ed into the
+    /// same builder before `allocate()`, and the builder's buffer must be
+    /// kept alive for as long as the returned `Location`
+    /// (`Log::clone_to_with_recycled` moves it into the destination log's
+    /// `owned_strings`).
+    pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Location {
+        // SAFETY (all `append_raw` calls below): the unbound-lifetime slices
+        // returned by `append_raw` alias the builder's heap buffer; per the
+        // caller contract above, that buffer is moved into the destination
+        // `Log::owned_strings` (`Box<[u8]>`, heap-stable) and outlives the
+        // returned `Location`. The bytes were reserved by `Self::count`.
         Location {
-            file: Cow::Owned(self.file.to_vec()),
-            namespace: self.namespace,
+            file: Cow::Borrowed(unsafe { builder.append_raw(&self.file) }),
+            namespace: Cow::Borrowed(unsafe { builder.append_raw(&self.namespace) }),
             line: self.line,
             column: self.column,
             length: self.length,
-            line_text: self.line_text.as_deref().map(|t| Cow::Owned(t.to_vec())),
+            line_text: self
+                .line_text
+                .as_deref()
+                .map(|t| Cow::Borrowed(unsafe { builder.append_raw(t) })),
             offset: self.offset,
+        }
+    }
+
+    /// Force every string field into owned storage so this `Location` can
+    /// outlive whatever backed its borrowed views (a `Source.contents`, a
+    /// recycled `Log::owned_strings` buffer, an arena). Must be called when a
+    /// `Msg` escapes a `Log` into a JS-visible object — see
+    /// [`Msg::make_owned`].
+    pub fn make_owned(&mut self) {
+        own_cow(&mut self.file);
+        own_cow(&mut self.namespace);
+        if let Some(line_text) = &mut self.line_text {
+            own_cow(line_text);
         }
     }
 
@@ -819,7 +867,7 @@ impl Location {
     ) -> Location {
         Location {
             file: Cow::Borrowed(file),
-            namespace,
+            namespace: Cow::Borrowed(namespace),
             line,
             column,
             length: length as usize,
@@ -852,7 +900,7 @@ impl Location {
             if r.is_empty() {
                 return Some(Location {
                     file: Cow::Borrowed(source.path.text),
-                    namespace: source.path.namespace,
+                    namespace: Cow::Borrowed(source.path.namespace),
                     line: -1,
                     column: -1,
                     length: 0,
@@ -872,7 +920,7 @@ impl Location {
 
             return Some(Location {
                 file: Cow::Borrowed(source.path.text),
-                namespace: source.path.namespace,
+                namespace: Cow::Borrowed(source.path.namespace),
                 line: usize2loc(data.line_count).start,
                 column: usize2loc(data.column_count).start,
                 length: if r.len > -1 {
@@ -962,19 +1010,15 @@ impl Data {
         }
     }
 
+    /// See [`Location::clone_with_builder`] for the count/allocate/append and
+    /// buffer-lifetime caller contract.
     pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Data {
         Data {
-            text: if !self.text.is_empty() {
-                // The local `StringBuilder`
-                // is a no-op stub (returns its input), so a bare `Cow::clone`
-                // would leave a `Borrowed` arm aliasing `self`'s storage and
-                // dangle after `self.msgs.clear()` in
-                // `append_to_with_recycled`. Deep-copy — same end-state as the
-                // real builder, just without the single-buffer packing.
-                Cow::Owned(self.text.to_vec())
-            } else {
-                Cow::Borrowed(b"")
-            },
+            // SAFETY: same contract as `Location::clone_with_builder` — the
+            // builder's buffer is anchored in the destination
+            // `Log::owned_strings` and outlives the returned `Data`. The
+            // bytes were reserved by `Self::count`.
+            text: Cow::Borrowed(unsafe { builder.append_raw(&self.text) }),
             location: self
                 .location
                 .as_ref()
@@ -986,6 +1030,14 @@ impl Data {
         builder.count(&self.text);
         if let Some(loc) = &self.location {
             loc.count(builder);
+        }
+    }
+
+    /// See [`Msg::make_owned`].
+    pub fn make_owned(&mut self) {
+        own_cow(&mut self.text);
+        if let Some(loc) = &mut self.location {
+            loc.make_owned();
         }
     }
 
@@ -1228,22 +1280,37 @@ impl Msg {
         }
     }
 
-    pub fn clone_with_builder(&self, notes: &mut [Data], builder: &mut StringBuilder) -> Msg {
+    /// See [`Location::clone_with_builder`] for the count/allocate/append and
+    /// buffer-lifetime caller contract. `Metadata::Resolve`'s `specifier`
+    /// stays valid: it is a `BabyString` of offsets into `data.text`, and the
+    /// builder copies `text` byte-for-byte.
+    pub fn clone_with_builder(&self, builder: &mut StringBuilder) -> Msg {
         Msg {
             kind: self.kind,
             data: self.data.clone_with_builder(builder),
             metadata: self.metadata,
-            notes: if !self.notes.is_empty() {
-                'brk: {
-                    for (i, note) in self.notes.iter().enumerate() {
-                        notes[i] = note.clone_with_builder(builder);
-                    }
-                    break 'brk notes[0..self.notes.len()].to_vec().into_boxed_slice();
-                }
-            } else {
-                Box::default()
-            },
+            notes: self
+                .notes
+                .iter()
+                .map(|note| note.clone_with_builder(builder))
+                .collect(),
             redact_sensitive_information: self.redact_sensitive_information,
+        }
+    }
+
+    /// Deep-copy every borrowed/lifetime-erased string in this message
+    /// (`data.text`, `location.file` / `namespace` / `line_text`, and every
+    /// note) into owned storage. After `Log::clone_to_with_recycled` those
+    /// strings are `Cow::Borrowed` views into the destination Log's
+    /// `owned_strings` packed buffer, so any `Msg` that escapes the Log into a
+    /// JS-visible object (`BuildMessage` / `ResolveMessage`) would dangle once
+    /// the Log drops. Call this at the escape boundary; `Metadata::Resolve`'s
+    /// `specifier` stays valid because it is a `BabyString` of offsets into
+    /// `data.text` and the bytes are copied verbatim.
+    pub fn make_owned(&mut self) {
+        self.data.make_owned();
+        for note in self.notes.iter_mut() {
+            note.make_owned();
         }
     }
 
@@ -1776,32 +1843,52 @@ impl Log {
     }
 
     pub fn clone_to_with_recycled(&mut self, other: &mut Log, recycled: bool) {
-        let dest_start = other.msgs.len();
-        other.msgs.extend(self.msgs.iter().map(Msg::clone));
-        other.warnings += self.warnings;
-        other.errors += self.errors;
-
-        if recycled {
-            let mut string_builder = StringBuilder;
-            let mut notes_count: usize = 0;
+        if recycled && !self.msgs.is_empty() {
+            // `self`'s messages may borrow recycled source storage; pack every
+            // string of every message into one builder-owned buffer
+            // (count → allocate → append) and anchor that buffer in
+            // `other.owned_strings` — the same ownership pattern as
+            // [`Log::dupe`] — so the cloned messages' borrowed views stay
+            // valid for the life of `other`.
+            let mut string_builder = StringBuilder::default();
             for msg in &self.msgs {
                 msg.count(&mut string_builder);
-                notes_count += msg.notes.len();
             }
-
-            string_builder.allocate();
-            let mut notes_buf = vec![Data::default(); notes_count];
-            let mut note_i: usize = 0;
-
-            // Index instead of zipping `self.msgs` with the tail of
-            // `other.msgs` to satisfy borrowck.
-            for (k, msg) in self.msgs.iter().enumerate() {
-                let j = dest_start + k;
-                other.msgs[j] =
-                    msg.clone_with_builder(&mut notes_buf[note_i..], &mut string_builder);
-                note_i += msg.notes.len();
+            if string_builder.cap > 0 {
+                string_builder
+                    .allocate()
+                    .expect("infallible: Box::new_uninit_slice aborts on OOM");
+                // Clone into a local Vec first and anchor the buffer in
+                // `other.owned_strings` *before* the cloned messages become
+                // visible in `other.msgs`: if anything unwinds mid-loop, the
+                // local Vec (whose `Cow::Borrowed`/`Str` views are dropped
+                // without dereferencing) and the builder's buffer are torn
+                // down together, and `other` never observes messages whose
+                // backing buffer is missing.
+                let mut cloned_msgs = Vec::with_capacity(self.msgs.len());
+                for msg in &self.msgs {
+                    cloned_msgs.push(msg.clone_with_builder(&mut string_builder));
+                }
+                // Every counted byte was appended above (`count` and
+                // `clone_with_builder` walk the same fields), so the buffer is
+                // fully initialized. `Box<[u8]>` is heap-stable across `Vec`
+                // growth, so the borrows in the cloned messages stay valid.
+                other.owned_strings.push(string_builder.move_to_slice());
+                other.msgs.extend(cloned_msgs);
+            } else {
+                // Every string of every message is empty: there is nothing to
+                // pack, and `allocate(0)` would set `ptr = Some(dangling)`,
+                // tripping `debug_assert!(cap > 0)` in
+                // `StringBuilder::writable()` on the first append. Empty
+                // strings cannot dangle into recycled storage, so a plain
+                // deep clone is sound.
+                other.msgs.extend(self.msgs.iter().map(Msg::clone));
             }
+        } else {
+            other.msgs.extend(self.msgs.iter().map(Msg::clone));
         }
+        other.warnings += self.warnings;
+        other.errors += self.errors;
     }
 
     pub fn append_to_with_recycled(&mut self, other: &mut Log, recycled: bool) {

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1718,6 +1718,11 @@ impl Log {
 
     pub fn reset(&mut self) {
         self.msgs.clear();
+        // The packed string buffers (see `clone_to_with_recycled` /
+        // `append_to`) only back `self.msgs`; once those are cleared nothing
+        // borrows them, so drop them too — otherwise a long-lived Log (e.g.
+        // the dev server's) accumulates one buffer per appended log forever.
+        self.owned_strings.clear();
         self.warnings = 0;
         self.errors = 0;
         // Drop the per-source scan cache with the messages it was built for;
@@ -1909,6 +1914,10 @@ impl Log {
     pub fn clear_and_free(&mut self) {
         self.msgs.clear();
         self.msgs.shrink_to_fit();
+        // See `reset` — the packed string buffers only back `self.msgs`, so
+        // release them with the messages.
+        self.owned_strings.clear();
+        self.owned_strings.shrink_to_fit();
         // self.warnings = 0;
         // self.errors = 0;
         // See `reset` — the scan cache goes with the messages.

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -199,7 +199,7 @@ impl ErrorLocation {
             .map(|lines| unsafe { &*std::ptr::from_ref::<[u8]>(lines.as_slice()[0]) });
         Ok(bun_ast::Location {
             file: std::borrow::Cow::Borrowed(source.path.text),
-            namespace: source.path.namespace,
+            namespace: std::borrow::Cow::Borrowed(source.path.namespace),
             line: i32::try_from(self.line + 1).expect("int cast"),
             column: i32::try_from(self.column).expect("int cast"),
             line_text: line_text.map(std::borrow::Cow::Borrowed),

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -83,9 +83,14 @@ impl BuildMessage {
     /// `BuildMessageClass__finalize` on lazy sweep.
     pub fn create(
         global: &JSGlobalObject,
-        msg: bun_ast::Msg,
+        mut msg: bun_ast::Msg,
         // resolve_result: *const Resolver.Result,
     ) -> JsResult<JSValue> {
+        // Escape boundary: this JS-visible object outlives the `Log` (and any
+        // `Source`/arena) that backed the message's borrowed string views —
+        // e.g. `Log::clone_to_with_recycled` leaves `Cow::Borrowed` views into
+        // the Log's `owned_strings` packed buffer. Own every byte now.
+        msg.make_owned();
         let build_error = BuildMessage {
             msg,
             // resolve_result: resolve_result.*,
@@ -155,7 +160,7 @@ impl BuildMessage {
         object.put(
             global,
             b"namespace",
-            ZigString::init(location.namespace).to_js(global),
+            ZigString::init(&location.namespace).to_js(global),
         );
         object.put(global, b"line", JSValue::from(location.line));
         object.put(global, b"column", JSValue::from(location.column));

--- a/src/jsc/BuildMessage.rs
+++ b/src/jsc/BuildMessage.rs
@@ -86,10 +86,8 @@ impl BuildMessage {
         mut msg: bun_ast::Msg,
         // resolve_result: *const Resolver.Result,
     ) -> JsResult<JSValue> {
-        // Escape boundary: this JS-visible object outlives the `Log` (and any
-        // `Source`/arena) that backed the message's borrowed string views —
-        // e.g. `Log::clone_to_with_recycled` leaves `Cow::Borrowed` views into
-        // the Log's `owned_strings` packed buffer. Own every byte now.
+        // This JS-visible object outlives the `Log`/`Source` that backed the
+        // message's borrowed string views.
         msg.make_owned();
         let build_error = BuildMessage {
             msg,

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -304,10 +304,8 @@ impl ResolveMessage {
         msg: &bun_ast::Msg,
         referrer: &[u8],
     ) -> JsResult<JSValue> {
-        // `Msg::clone` deep-dupes every string, but keep the escape boundary
-        // airtight against future `Clone` changes: this JS-visible object must
-        // not retain any view into a `Log`'s `owned_strings` buffer or a
-        // `Source`'s contents (see `Msg::make_owned`).
+        // This JS-visible object outlives the `Log`/`Source` that backed the
+        // message's borrowed string views.
         let mut msg = msg.clone();
         msg.make_owned();
         let resolve_error = ResolveMessage {

--- a/src/jsc/ResolveMessage.rs
+++ b/src/jsc/ResolveMessage.rs
@@ -304,8 +304,14 @@ impl ResolveMessage {
         msg: &bun_ast::Msg,
         referrer: &[u8],
     ) -> JsResult<JSValue> {
+        // `Msg::clone` deep-dupes every string, but keep the escape boundary
+        // airtight against future `Clone` changes: this JS-visible object must
+        // not retain any view into a `Log`'s `owned_strings` buffer or a
+        // `Source`'s contents (see `Msg::make_owned`).
+        let mut msg = msg.clone();
+        msg.make_owned();
         let resolve_error = ResolveMessage {
-            msg: msg.clone(),
+            msg,
             referrer: Some(Box::<[u8]>::from(referrer)),
             logged: Cell::new(false),
         };

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1319,7 +1319,8 @@ impl VirtualMachine {
                 // bound; the generated entry point is
                 // boxed into `macro_entry_points` and lives for the VM
                 // lifetime, and `entry_path` is only borrowed for the
-                // duration of `generate` (it copies into `code_buffer`).
+                // duration of `generate` (it is copied into the entry's
+                // owned `Source.contents` / `label_storage`).
                 let entry_path_static: &'static [u8] = bun_ast::IntoStr::into_str(entry_path);
                 MacroEntryPoint::generate(
                     &mut *ep,

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2541,6 +2541,41 @@ describe("bundler", () => {
       `);
     },
   });
+  // Regression: an empty import specifier used to panic ("reached unreachable
+  // code") while building the resolve-error message instead of reporting a
+  // normal "Could not resolve" diagnostic.
+  itBundled("edgecase/ImportEmptyStringDoesNotPanic", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import "";
+        console.log("unreachable");
+      `,
+    },
+    bundleErrors: {
+      "/entry.ts": ['Could not resolve: ""'],
+    },
+  });
+  // The bundler copies diagnostics out of per-parse-task logs into a single
+  // packed buffer owned by the destination log (the parse task's source
+  // buffers are recycled afterwards). Assert the message — including the
+  // dynamic key name interpolated from the source — survives that copy intact
+  // for a TOML parse error, which always takes the recycled-log path.
+  // Note: this is a behavior-preservation guard for the packed-buffer copy
+  // (it catches corruption/UAF in that path, e.g. under ASAN), not a
+  // differential regression test — the previous implementation deep-copied
+  // each string and also produced correct output.
+  itBundled("edgecase/TomlErrorMessageSurvivesLogTransfer", {
+    files: {
+      "/entry.ts": /* ts */ `
+        import config from "./config.toml";
+        console.log(config);
+      `,
+      "/config.toml": `duplicated_key_name = 1\nduplicated_key_name = 2\n`,
+    },
+    bundleErrors: {
+      "/config.toml": ["Cannot redefine key 'duplicated_key_name'"],
+    },
+  });
 });
 
 for (const backend of ["api", "cli"] as const) {

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2541,9 +2541,8 @@ describe("bundler", () => {
       `);
     },
   });
-  // Regression: an empty import specifier used to panic ("reached unreachable
-  // code") while building the resolve-error message instead of reporting a
-  // normal "Could not resolve" diagnostic.
+  // An empty import specifier used to panic while building the resolve-error
+  // message instead of reporting a normal "Could not resolve" diagnostic.
   itBundled("edgecase/ImportEmptyStringDoesNotPanic", {
     files: {
       "/entry.ts": /* ts */ `
@@ -2555,15 +2554,9 @@ describe("bundler", () => {
       "/entry.ts": ['Could not resolve: ""'],
     },
   });
-  // The bundler copies diagnostics out of per-parse-task logs into a single
-  // packed buffer owned by the destination log (the parse task's source
-  // buffers are recycled afterwards). Assert the message — including the
-  // dynamic key name interpolated from the source — survives that copy intact
-  // for a TOML parse error, which always takes the recycled-log path.
-  // Note: this is a behavior-preservation guard for the packed-buffer copy
-  // (it catches corruption/UAF in that path, e.g. under ASAN), not a
-  // differential regression test — the previous implementation deep-copied
-  // each string and also produced correct output.
+  // A TOML parse error always takes the recycled-log path, where diagnostics
+  // are packed into a buffer owned by the destination log before the parse
+  // task's source buffers are reused. Assert the message survives that copy.
   itBundled("edgecase/TomlErrorMessageSurvivesLogTransfer", {
     files: {
       "/entry.ts": /* ts */ `

--- a/test/cli/run/syntax.test.ts
+++ b/test/cli/run/syntax.test.ts
@@ -339,14 +339,10 @@ describe.concurrent("exit code 0", () => {
   }
 });
 
-// The runtime parses files into recycled (shared/arena) source buffers, and
-// diagnostics are copied out of the per-parse log into a packed buffer owned
-// by the destination log before the source buffer is reused. Assert the
-// complete diagnostic — message, note, file path, and the source line echoed
-// in the error output — survives that transfer intact. This is a
-// behavior-preservation guard for the packed-buffer copy (corruption/UAF in
-// that path would garble this output or trip ASAN), not a differential
-// regression test.
+// Diagnostics are copied out of the per-parse log into a packed buffer owned
+// by the destination log before the recycled source buffer is reused. Assert
+// the complete diagnostic (message, note, file path, echoed source line)
+// survives that transfer.
 test("parse error with a note survives recycled source buffers", async () => {
   const fixturePath = tempDirWithFiles("recycled-log-note", {
     "bad.js": `const xyzDuplicateName = 1;\nconst xyzDuplicateName = 2;\n`,
@@ -362,8 +358,7 @@ test("parse error with a note survives recycled source buffers", async () => {
   expect(stderr).toContain('"xyzDuplicateName" has already been declared');
   expect(stderr).toContain('"xyzDuplicateName" was originally declared here');
   expect(stderr).toContain("bad.js");
-  // The echoed source lines come from `Location.line_text`, which rides
-  // through the packed-buffer copy.
+  // Echoed source lines come from `Location.line_text`.
   expect(stderr).toContain("const xyzDuplicateName = 2;");
   expect(stderr).toContain("const xyzDuplicateName = 1;");
   expect(exitCode).not.toBe(0);

--- a/test/cli/run/syntax.test.ts
+++ b/test/cli/run/syntax.test.ts
@@ -338,3 +338,33 @@ describe.concurrent("exit code 0", () => {
     });
   }
 });
+
+// The runtime parses files into recycled (shared/arena) source buffers, and
+// diagnostics are copied out of the per-parse log into a packed buffer owned
+// by the destination log before the source buffer is reused. Assert the
+// complete diagnostic — message, note, file path, and the source line echoed
+// in the error output — survives that transfer intact. This is a
+// behavior-preservation guard for the packed-buffer copy (corruption/UAF in
+// that path would garble this output or trip ASAN), not a differential
+// regression test.
+test("parse error with a note survives recycled source buffers", async () => {
+  const fixturePath = tempDirWithFiles("recycled-log-note", {
+    "bad.js": `const xyzDuplicateName = 1;\nconst xyzDuplicateName = 2;\n`,
+  });
+  await using proc = Bun.spawn([bunExe(), "./bad.js"], {
+    env: bunEnv,
+    cwd: fixturePath,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain('"xyzDuplicateName" has already been declared');
+  expect(stderr).toContain('"xyzDuplicateName" was originally declared here');
+  expect(stderr).toContain("bad.js");
+  // The echoed source lines come from `Location.line_text`, which rides
+  // through the packed-buffer copy.
+  expect(stderr).toContain("const xyzDuplicateName = 2;");
+  expect(stderr).toContain("const xyzDuplicateName = 1;");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/cli/run/syntax.test.ts
+++ b/test/cli/run/syntax.test.ts
@@ -350,7 +350,7 @@ test("parse error with a note survives recycled source buffers", async () => {
   await using proc = Bun.spawn([bunExe(), "./bad.js"], {
     env: bunEnv,
     cwd: fixturePath,
-    stdout: "pipe",
+    stdout: "ignore",
     stderr: "pipe",
     stdin: "ignore",
   });


### PR DESCRIPTION
The logger's clone_with_builder family was built around a local no-op StringBuilder stub that pretended to pack strings but actually deep-copied each string into its own heap allocation, and Log::clone_to_with_recycled cloned every message twice on the recycled path (once deeply, then again through the stub, discarding the first copy). This switches the family to the canonical two-phase bun_core::StringBuilder: all strings of all transferred messages are counted, allocated once, and appended into a single packed buffer, which is then anchored in the destination Log's owned_strings side-vector (the same ownership pattern Log::dupe already uses) so the borrowed views in the cloned messages stay valid for the life of the destination log. The double-clone on the recycled path is gone, and Msg::clone_with_builder no longer needs a caller-provided notes scratch slice. Resolve-error specifier offsets (BabyString into Data.text) remain valid because the text bytes are copied verbatim. Tested via bundler tests asserting a TOML parse error message (which always takes the recycled-log transfer path) arrives intact including interpolated key names, a regression test that an empty import specifier reports 'Could not resolve: ""' instead of panicking, and a bun-run test asserting a redeclaration error with its note and echoed source lines survives the recycled-source transfer.

## Deferred

- 003 marker 1 (src/ast/lib.rs Str/IntoStr 'static erasure anchor): removing the erasure requires either threading a 'source lifetime through Location/Data/Msg/Source (12+ downstream crates) or converting fields constructed by struct literals in src/css, src/js_parser, src/bundler, src/runtime — all outside this cluster's owned files. TODO anchor deliberately left in place per the audit's no-hiding rule.
- 003 marker 3 (src/ast/import_record.rs ImportRecord.path: Path<'static>): every constructor in src/js_parser/** and src/bundler/** fills this field; a type change cannot compile without editing files owned by other clusters.
- 003 marker 4 (src/ast/import_record.rs ImportRecord.original_path: &'static [u8]): fill sites (bundle_v2.rs:5814, AstBuilder.rs:180, prepareCssAstsForChunk.rs, postProcessJSChunk.rs) assign borrowed slices/literals; same cross-file blocker.
- 004 (src/ast/nodes.rs Part.scopes: StoreSlice<*mut Scope>): both the 'bump-threading and the StoreRef<Scope> intermediate require rewriting the fill sites (src/js_parser/p.rs:255/3590/5386/9157, src/bundler/AstBuilder.rs:553) and the read site (src/bundler/linker_context/renameSymbolsInChunk.rs:403), all outside this cluster's owned files; a field-type-only change cannot compile.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
