### PR TITLE
css: thread the arena lifetime through ToCssResultInternal

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2288,11 +2288,8 @@ pub struct ToCssResult {
     pub code: Vec<u8>,
     /// A map of CSS module exports, if the `css_modules` option was enabled
     /// during parsing.
-    // TODO: arena lifetime — CssModuleExports/References borrow the printer
-    // arena and `self`. `'static` placeholder: `Printer<'a>` has a single
-    // lifetime that unifies the writer with the arena, and `to_css` prints
-    // into a function-local buffer, so the maps cannot be returned at their
-    // real lifetime until `Printer` splits the writer lifetime from `'a`.
+    // TODO: arena lifetime — `'static` placeholder until `Printer` splits the
+    // writer lifetime from the arena lifetime `'a`.
     pub exports: Option<CssModuleExports<'static>>,
     /// A map of CSS module references, if the `css_modules` config had
     /// `dashed_idents` enabled.
@@ -2302,9 +2299,7 @@ pub struct ToCssResult {
     pub dependencies: Option<Vec<Dependency>>,
 }
 
-/// Borrow-checked result of `to_css_with_writer`: the css-module maps borrow
-/// the printer arena / stylesheet (`'a`) instead of being detached to
-/// `'static` like the public `ToCssResult`.
+/// Like `ToCssResult`, but with the css-module maps at their real borrowed lifetime.
 pub struct ToCssResultInternal<'a> {
     pub exports: Option<CssModuleExports<'a>>,
     pub references: Option<CssModuleReferences<'a>>,
@@ -2693,9 +2688,8 @@ mod stylesheet_impl {
                     references_mut,
                 ));
 
-                // No `?` while `css_module` is set: it holds the
-                // pointer-detached `&mut references`, which must not survive an
-                // early return out of the frame that owns `references`.
+                // `css_module` holds a pointer-detached `&mut references`; clear
+                // it before any return out of the frame that owns `references`.
                 if let Err(e) = self.rules.to_css(printer) {
                     printer.css_module = None;
                     return Err(e);
@@ -2741,9 +2735,7 @@ mod stylesheet_impl {
             // Make sure we always have capacity > 0: https://github.com/napi-rs/napi-rs/issues/1124.
             // PERF: this always heap-allocates — profile if hot.
             let mut dest: Vec<u8> = Vec::with_capacity(1);
-            // Destructure straight from the call: a named `result` binding
-            // would keep the `&mut dest` writer borrow live until its drop,
-            // blocking the move of `dest` into the returned `ToCssResult`.
+            // Destructure in place so the writer borrow ends before `dest` moves.
             let ToCssResultInternal {
                 exports,
                 references,
@@ -2756,15 +2748,12 @@ mod stylesheet_impl {
                 local_names,
                 symbols,
             )?;
-            // SAFETY: `'bump`-erasure at the public `ToCssResult` boundary.
-            // `Printer`'s single lifetime ties the css-module maps to the
-            // function-local `dest` writer borrow, but the maps only borrow
-            // `self` and `arena`, both of which outlive the returned
-            // `ToCssResult` (caller-owned; see the field TODO on the struct).
+            // SAFETY: the maps only borrow `self` and `arena`, both of which
+            // outlive the returned `ToCssResult`.
             let exports = exports.map(|exports| unsafe {
                 core::mem::transmute::<CssModuleExports<'_>, CssModuleExports<'static>>(exports)
             });
-            // SAFETY: same erasure as `exports` above.
+            // SAFETY: same as `exports` above.
             let references = references.map(|references| unsafe {
                 core::mem::transmute::<CssModuleReferences<'_>, CssModuleReferences<'static>>(
                     references,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2288,8 +2288,11 @@ pub struct ToCssResult {
     pub code: Vec<u8>,
     /// A map of CSS module exports, if the `css_modules` option was enabled
     /// during parsing.
-    // TODO: arena lifetime — CssModuleExports/References borrow the
-    // parser arena. `'static` placeholder until `<'bump>` threads.
+    // TODO: arena lifetime — CssModuleExports/References borrow the printer
+    // arena and `self`. `'static` placeholder: `Printer<'a>` has a single
+    // lifetime that unifies the writer with the arena, and `to_css` prints
+    // into a function-local buffer, so the maps cannot be returned at their
+    // real lifetime until `Printer` splits the writer lifetime from `'a`.
     pub exports: Option<CssModuleExports<'static>>,
     /// A map of CSS module references, if the `css_modules` config had
     /// `dashed_idents` enabled.
@@ -2299,9 +2302,12 @@ pub struct ToCssResult {
     pub dependencies: Option<Vec<Dependency>>,
 }
 
-pub struct ToCssResultInternal {
-    pub exports: Option<CssModuleExports<'static>>,
-    pub references: Option<CssModuleReferences<'static>>,
+/// Borrow-checked result of `to_css_with_writer`: the css-module maps borrow
+/// the printer arena / stylesheet (`'a`) instead of being detached to
+/// `'static` like the public `ToCssResult`.
+pub struct ToCssResultInternal<'a> {
+    pub exports: Option<CssModuleExports<'a>>,
+    pub references: Option<CssModuleReferences<'a>>,
     pub dependencies: Option<Vec<Dependency>>,
 }
 
@@ -2631,7 +2637,7 @@ mod stylesheet_impl {
             import_info: Option<ImportInfo<'a>>,
             local_names: Option<&'a LocalsResultsMap>,
             symbols: &'a bun_ast::symbol::Map,
-        ) -> PrintResult<ToCssResultInternal> {
+        ) -> PrintResult<ToCssResultInternal<'a>> {
             // Note: PrinterOptions has `&mut SourceMap` and so isn't Copy; capture
             // the lone field we re-read after moving `options` into Printer::new.
             let project_root = options.project_root;
@@ -2657,7 +2663,7 @@ mod stylesheet_impl {
             &'a self,
             printer: &mut Printer<'a>,
             project_root: Option<&[u8]>,
-        ) -> Result<ToCssResultInternal, PrintErr> {
+        ) -> Result<ToCssResultInternal<'a>, PrintErr> {
             // #[cfg(feature = "sourcemap")] { printer.sources = Some(&self.sources); }
             // #[cfg(feature = "sourcemap")] if printer.source_map.is_some() { ... }
 
@@ -2687,8 +2693,17 @@ mod stylesheet_impl {
                     references_mut,
                 ));
 
-                self.rules.to_css(printer)?;
-                printer.newline()?;
+                // No `?` while `css_module` is set: it holds the
+                // pointer-detached `&mut references`, which must not survive an
+                // early return out of the frame that owns `references`.
+                if let Err(e) = self.rules.to_css(printer) {
+                    printer.css_module = None;
+                    return Err(e);
+                }
+                if let Err(e) = printer.newline() {
+                    printer.css_module = None;
+                    return Err(e);
+                }
 
                 let dependencies = printer.dependencies.take().map(|v| v.into_iter().collect());
                 let exports = core::mem::take(
@@ -2698,19 +2713,6 @@ mod stylesheet_impl {
                 // moving `references` into the result.
                 printer.css_module = None;
 
-                // SAFETY: `'bump`-erasure — `ToCssResultInternal` carries `'static`
-                // placeholders for `CssModuleExports`/`References` until the arena
-                // lifetime threads (see field TODO at the struct def).
-                let exports = unsafe {
-                    core::mem::transmute::<CssModuleExports<'_>, CssModuleExports<'static>>(exports)
-                };
-                // SAFETY: same `'bump`-erasure as `exports` above; the backing arena
-                // outlives the returned `ToCssResultInternal`.
-                let references = unsafe {
-                    core::mem::transmute::<CssModuleReferences<'_>, CssModuleReferences<'static>>(
-                        references,
-                    )
-                };
                 return Ok(ToCssResultInternal {
                     dependencies,
                     exports: Some(exports),
@@ -2739,7 +2741,14 @@ mod stylesheet_impl {
             // Make sure we always have capacity > 0: https://github.com/napi-rs/napi-rs/issues/1124.
             // PERF: this always heap-allocates — profile if hot.
             let mut dest: Vec<u8> = Vec::with_capacity(1);
-            let result = self.to_css_with_writer(
+            // Destructure straight from the call: a named `result` binding
+            // would keep the `&mut dest` writer borrow live until its drop,
+            // blocking the move of `dest` into the returned `ToCssResult`.
+            let ToCssResultInternal {
+                exports,
+                references,
+                dependencies,
+            } = self.to_css_with_writer(
                 arena,
                 &mut dest,
                 options,
@@ -2747,11 +2756,25 @@ mod stylesheet_impl {
                 local_names,
                 symbols,
             )?;
+            // SAFETY: `'bump`-erasure at the public `ToCssResult` boundary.
+            // `Printer`'s single lifetime ties the css-module maps to the
+            // function-local `dest` writer borrow, but the maps only borrow
+            // `self` and `arena`, both of which outlive the returned
+            // `ToCssResult` (caller-owned; see the field TODO on the struct).
+            let exports = exports.map(|exports| unsafe {
+                core::mem::transmute::<CssModuleExports<'_>, CssModuleExports<'static>>(exports)
+            });
+            // SAFETY: same erasure as `exports` above.
+            let references = references.map(|references| unsafe {
+                core::mem::transmute::<CssModuleReferences<'_>, CssModuleReferences<'static>>(
+                    references,
+                )
+            });
             return Ok(ToCssResult {
                 code: dest,
-                dependencies: result.dependencies,
-                exports: result.exports,
-                references: result.references,
+                dependencies,
+                exports,
+                references,
             });
         }
 

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -100,11 +100,6 @@ describe("css", () => {
     },
   });
 
-  // Exercises the css-module export map produced by StyleSheet printing
-  // (`to_css`/`to_css_with_writer`): multiple locally-scoped classes and a
-  // `composes:` entry must all survive into the generated JS exports object,
-  // and the hashed local names in the printed CSS must match the names in the
-  // exports map.
   itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
     files: {
       "/entry.js": `
@@ -121,18 +116,15 @@ describe("css", () => {
     onAfterBundle(api) {
       const js = api.readFile("/out/entry.js");
 
-      // Both locally-scoped classes appear in the exports object with their
-      // hashed names.
       const alpha = js.match(/alpha:\s*"(alpha_[A-Za-z0-9_-]+)"/);
       expect(alpha).not.toBeNull();
-      // `composes: alpha` means the betaGamma export value contains both its
-      // own hashed name and alpha's hashed name.
+      // `composes: alpha` => betaGamma's export contains both hashed names.
       const beta = js.match(/betaGamma:\s*"([^"]+)"/);
       expect(beta).not.toBeNull();
       expect(beta![1]).toContain("betaGamma_");
       expect(beta![1]).toContain(alpha![1]);
 
-      // The printed CSS uses the same hashed names the exports map reports.
+      // Printed CSS must use the same hashed names as the exports map.
       const css = api.readFile("/out/entry.css");
       expect(css).toContain(`.${alpha![1]}`);
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -99,4 +99,44 @@ describe("css", () => {
       `);
     },
   });
+
+  // Exercises the css-module export map produced by StyleSheet printing
+  // (`to_css`/`to_css_with_writer`): multiple locally-scoped classes and a
+  // `composes:` entry must all survive into the generated JS exports object,
+  // and the hashed local names in the printed CSS must match the names in the
+  // exports map.
+  itBundled("css-module/ExportsMapMultipleClassesAndComposes", {
+    files: {
+      "/entry.js": `
+        import styles from './styles.module.css';
+        console.log(styles.alpha, styles.betaGamma);
+      `,
+      "/styles.module.css": `
+        .alpha { color: red; }
+        .betaGamma { composes: alpha; color: blue; }
+      `,
+    },
+    entryPoints: ["/entry.js"],
+    outdir: "/out",
+    onAfterBundle(api) {
+      const js = api.readFile("/out/entry.js");
+
+      // Both locally-scoped classes appear in the exports object with their
+      // hashed names.
+      const alpha = js.match(/alpha:\s*"(alpha_[A-Za-z0-9_-]+)"/);
+      expect(alpha).not.toBeNull();
+      // `composes: alpha` means the betaGamma export value contains both its
+      // own hashed name and alpha's hashed name.
+      const beta = js.match(/betaGamma:\s*"([^"]+)"/);
+      expect(beta).not.toBeNull();
+      expect(beta![1]).toContain("betaGamma_");
+      expect(beta![1]).toContain(alpha![1]);
+
+      // The printed CSS uses the same hashed names the exports map reports.
+      const css = api.readFile("/out/entry.css");
+      expect(css).toContain(`.${alpha![1]}`);
+      const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
+      expect(css).toContain(`.${betaOwn}`);
+    },
+  });
 });


### PR DESCRIPTION
The CSS printer's internal result type carried 'static-erased CssModuleExports/CssModuleReferences maps even though every value in them borrows the printer arena and the stylesheet, with two unsafe transmutes performed deep inside to_css_with_writer_impl. This threads a real lifetime parameter through ToCssResultInternal<'a>, to_css_with_writer, and to_css_with_writer_impl, deleting both transmutes from the printing path so the bundler's CSS chunk generation now receives borrow-checked results. The single remaining erasure is confined to the public to_css wrapper, where Printer's unified writer/arena lifetime forces it (the writer is a function-local buffer); it is documented at that one boundary. Verification is the borrow checker accepting the printing path with the two deep transmutes deleted (the change is type-level); a new bundler css-modules test round-trips a multi-class exports map with composes through printing as a regression lock, not as proof of the fix. Repair pass: fixed an E0505 in StyleSheet::to_css (ToCssResultInternal must be fully consumed before the writer buffer is moved into ToCssResult) and cleared printer.css_module on the css-modules error paths so the detached &mut to the local references map cannot dangle past an early return. The remainder of the crate-wide 'bump threading campaign (Token<'a>, ParserOptions<'a>, AtRulePrelude<'a>, StyleSheet/CssRule<'bump>) is intentionally not included: each of those type changes fans out into css/rules, css/properties, css/error, css/printer and bundler consumers and cannot land partially.

## Deferred

- 016: Token<'a> payloads in lib.rs + src_str deletion (fans out into css/error.rs, css/printer.rs, css/media_query.rs, css/properties/*, css/rules/* — files owned by other clusters / outside this cluster)
- 016: ParserOptions<'a>.filename (22 consumer files outside ownership)
- 016: StyleSheet<'bump> fields (license_comments, options) and parse/parse_with/StyleAttribute::parse &'static Bump relaxation (unsound to relax the parameter without StyleSheet capturing the lifetime; full change is PR #30905 scope across css/rules + css/properties)
- 016: AtRulePrelude<'a> payloads (requires lifetime on CustomAtRuleParser::Prelude and rule structs in css/rules/*)
- 016: PropertyUsage<'a>.custom_properties borrow (consumed by scanImportsAndExports.rs, requires StyleSheet<'bump>)
- 016: Token::eql derive(PartialEq) (explicitly sequenced after Token<'a> lands; CssEql impl lives in css/properties/custom.rs)
- 016: rules/container.rs parse_feature arena threading (no behavior gap in Rust — the parser carries the arena that Zig passed via ParserOptions.allocator; re-thread lands with ParserOptions<'a>)

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
