### PR TITLE
dns: give DNS requests their own resolver ref for the pending-cache completion path

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -487,9 +487,10 @@ pub(super) mod lib_uv_backend {
                 // and the promise is rejected with a DNSException.
                 if let Some(resolver) = (*request).resolver_for_caching.take() {
                     let resolver_ptr = resolver.as_ptr();
-                    // `resolver` is the request's own ref: it keeps the Resolver
-                    // alive across the drain (which frees `*request`).
-                    scopeguard::defer! { resolver.deref(); };
+                    // Adopt the request's own ref into an RAII guard: it keeps
+                    // the Resolver alive across the drain (which frees
+                    // `*request`) and derefs on every exit path.
+                    let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                     if (*request).cache.pending_cache() {
                         (*resolver_ptr).drain_pending_host_native(
                             (*request).cache.pos_in_pending(),
@@ -706,13 +707,11 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_cares` (which frees `*this`) and
-                // is released only after the completion bookkeeping ran.
-                scopeguard::defer! {
-                    (*resolver_ptr).request_completed();
-                    resolver.deref();
-                };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_cares` (which frees
+                // `*this`) and derefs on every exit path, after the completion
+                // bookkeeping ran.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_cares::<T>(
                         (*this).cache.pos_in_pending(),
@@ -720,8 +719,10 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
                         timeout,
                         result,
                     );
+                    (*resolver_ptr).request_completed();
                     return;
                 }
+                (*resolver_ptr).request_completed();
             }
 
             // Consume the request and move `head` out by value; `ptr::read`
@@ -857,9 +858,10 @@ impl GetHostByAddrInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_addr_cares` (which frees `*this`).
-                scopeguard::defer! { resolver.deref(); };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_addr_cares` (which
+                // frees `*this`) and derefs on every exit path.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_addr_cares(
                         (*this).cache.pos_in_pending(),
@@ -1118,13 +1120,11 @@ impl GetNameInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_name_info_cares` (which frees
-                // `*this`) and is released only after the completion bookkeeping.
-                scopeguard::defer! {
-                    (*resolver_ptr).request_completed();
-                    resolver.deref();
-                };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_name_info_cares` (which
+                // frees `*this`) and derefs on every exit path, after the
+                // completion bookkeeping ran.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_name_info_cares(
                         (*this).cache.pos_in_pending(),
@@ -1132,8 +1132,10 @@ impl GetNameInfoRequest {
                         timeout,
                         result,
                     );
+                    (*resolver_ptr).request_completed();
                     return;
                 }
+                (*resolver_ptr).request_completed();
             }
 
             // Consume the request and move `head` out by value; `ptr::read`
@@ -1499,9 +1501,10 @@ impl GetAddrInfoRequest {
 
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_host_native` (which frees `*this`).
-                scopeguard::defer! { resolver.deref(); };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_host_native` (which
+                // frees `*this`) and derefs on every exit path.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_native(
                         (*this).cache.pos_in_pending(),
@@ -1559,9 +1562,10 @@ impl GetAddrInfoRequest {
                     let any = GetAddrInfoResultAny::List(result);
                     if let Some(resolver) = (*this).resolver_for_caching.take() {
                         let resolver_ptr = resolver.as_ptr();
-                        // `resolver` is this request's own ref: it keeps the
-                        // Resolver alive across the drain (which frees `*this`).
-                        scopeguard::defer! { resolver.deref(); };
+                        // Adopt the request's own ref into an RAII guard: it
+                        // keeps the Resolver alive across the drain (which
+                        // frees `*this`) and derefs on every exit path.
+                        let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                         if (*this).cache.pending_cache() {
                             (*resolver_ptr).drain_pending_host_native(
                                 (*this).cache.pos_in_pending(),
@@ -1612,9 +1616,10 @@ impl GetAddrInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_host_cares` (which frees `*this`).
-                scopeguard::defer! { resolver.deref(); };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_host_cares` (which
+                // frees `*this`) and derefs on every exit path.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_cares(
                         (*this).cache.pos_in_pending(),
@@ -1669,9 +1674,10 @@ impl GetAddrInfoRequest {
 
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // `resolver` is this request's own ref: it keeps the Resolver
-                // alive across `drain_pending_host_native` (which frees `*this`).
-                scopeguard::defer! { resolver.deref(); };
+                // Adopt the request's own ref into an RAII guard: it keeps the
+                // Resolver alive across `drain_pending_host_native` (which
+                // frees `*this`) and derefs on every exit path.
+                let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_native(
                         (*this).cache.pos_in_pending(),

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -264,7 +264,17 @@ pub(super) mod lib_info {
                         c.put(slot);
                     });
                 }
-                // Drop the KeepAlive + resolver ref that `GetAddrInfoRequest.init` took.
+                // Release the caching ref taken in `GetAddrInfoRequest::init`
+                // (the callback that would normally release it never runs).
+                // This cannot be the last ref: `this: &Resolver` is borrowed
+                // from the callframe-rooted JS wrapper, whose ref the caller
+                // still holds, so deref-to-zero is impossible here.
+                if let Some(resolver) = (*request).resolver_for_caching.take() {
+                    resolver.deref();
+                }
+                // The head is inline (`allocated == false`), so `destroy` is a
+                // no-op for it; the KeepAlive + head resolver ref are released
+                // by `DNSLookup`'s Drop when the request box drops below.
                 DNSLookup::destroy(&raw mut (*request).head);
                 drop(bun_core::heap::take(request));
             }
@@ -475,9 +485,13 @@ pub(super) mod lib_uv_backend {
                 // or UV_ENOMEM). Route the error through the same path the async
                 // completion would have taken so the pending-cache slot is released
                 // and the promise is rejected with a DNSException.
-                if let Some(resolver) = (*request).resolver_for_caching {
+                if let Some(resolver) = (*request).resolver_for_caching.take() {
+                    let resolver_ptr = resolver.as_ptr();
+                    // `resolver` is the request's own ref: it keeps the Resolver
+                    // alive across the drain (which frees `*request`).
+                    scopeguard::defer! { resolver.deref(); };
                     if (*request).cache.pending_cache() {
-                        (*resolver).drain_pending_host_native(
+                        (*resolver_ptr).drain_pending_host_native(
                             (*request).cache.pos_in_pending(),
                             (*request).head.global_this(),
                             rc.int(),
@@ -592,8 +606,10 @@ pub trait CAresRecordType: Sized {
 }
 
 pub struct ResolveInfoRequest<T: CAresRecordType> {
-    // TODO: should be Option<&'a Resolver> (struct gets <'a>); raw ptr until reconciled with intrusive RC
-    pub resolver_for_caching: Option<*mut Resolver>,
+    /// SHARED — this request's own ref on the Resolver whose pending-cache
+    /// slot it occupies; taken in `init()`, released on the completion path
+    /// (RefPtr does not deref on Drop).
+    pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
     pub head: CAresLookup<T>,
@@ -644,7 +660,10 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
+            // ref_count. This ref is independent of `head.resolver`'s and is released on
+            // the completion path so the pending-cache deref never relies on the head ref.
+            resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
             head: CAresLookup {
@@ -666,7 +685,6 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         if let LookupCacheHit::New(new) = cache {
             // SAFETY: `new` is &mut into resolver's HiveArray buffer
             unsafe {
-                (*request).resolver_for_caching = resolver;
                 let pos = (*resolver.unwrap())
                     .pending_cache_for::<T>(cache_field)
                     .index_of(new)
@@ -686,10 +704,17 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
     ) {
         // SAFETY: this is the heap-allocated request c-ares calls back with
         unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_cares` (which frees `*this`) and
+                // is released only after the completion bookkeeping ran.
+                scopeguard::defer! {
+                    (*resolver_ptr).request_completed();
+                    resolver.deref();
+                };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_cares::<T>(
+                    (*resolver_ptr).drain_pending_cares::<T>(
                         (*this).cache.pos_in_pending(),
                         err_,
                         timeout,
@@ -732,8 +757,10 @@ impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetHostByAddrInfoRequest {
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub resolver_for_caching: Option<*mut Resolver>,
+    /// SHARED — this request's own ref on the Resolver whose pending-cache
+    /// slot it occupies; taken in `init()`, released on the completion path
+    /// (RefPtr does not deref on Drop).
+    pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
     pub head: CAresReverse,
@@ -785,7 +812,10 @@ impl GetHostByAddrInfoRequest {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
+            // ref_count. This ref is independent of `head.resolver`'s and is released on
+            // the completion path so the pending-cache deref never relies on the head ref.
+            resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
             head: CAresReverse {
@@ -805,7 +835,6 @@ impl GetHostByAddrInfoRequest {
         if let LookupCacheHit::New(new) = cache {
             // SAFETY: `new` is &mut into resolver's HiveArray buffer; resolver/request are live.
             unsafe {
-                (*request).resolver_for_caching = resolver;
                 let pos = (*resolver.unwrap())
                     .pending_addr_cache_cares
                     .get()
@@ -826,9 +855,13 @@ impl GetHostByAddrInfoRequest {
     ) {
         // SAFETY: this is the heap-allocated request c-ares calls back with
         unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_addr_cares` (which frees `*this`).
+                scopeguard::defer! { resolver.deref(); };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_addr_cares(
+                    (*resolver_ptr).drain_pending_addr_cares(
                         (*this).cache.pos_in_pending(),
                         err_,
                         timeout,
@@ -983,8 +1016,12 @@ impl Drop for CAresNameInfo {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetNameInfoRequest {
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub resolver_for_caching: Option<*mut Resolver>,
+    /// SHARED — this request's own ref on the Resolver whose pending-cache
+    /// slot it occupies; taken in `init()`, released on the completion path.
+    /// `CAresNameInfo` (the head) holds no resolver ref of its own, so this is
+    /// the only thing keeping the Resolver alive for the completion-path deref
+    /// (RefPtr does not deref on Drop).
+    pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
     pub head: CAresNameInfo,
@@ -1036,7 +1073,10 @@ impl GetNameInfoRequest {
         poll_ref.ref_(js_event_loop_ctx());
         let name_len = name.len();
         let request = bun_core::heap::into_raw(Box::new(Self {
-            resolver_for_caching: resolver,
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
+            // ref_count. The head (`CAresNameInfo`) holds no resolver ref, so this ref is
+            // what keeps the Resolver alive until the completion path releases it.
+            resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
             head: CAresNameInfo {
@@ -1054,7 +1094,6 @@ impl GetNameInfoRequest {
         if let LookupCacheHit::New(new) = cache {
             // SAFETY: `new` points into the resolver's HiveArray buffer; resolver/request are live.
             unsafe {
-                (*request).resolver_for_caching = resolver;
                 let pos = (*resolver.unwrap())
                     .pending_nameinfo_cache_cares
                     .get()
@@ -1075,12 +1114,19 @@ impl GetNameInfoRequest {
         result: Option<c_ares::struct_nameinfo>,
     ) {
         // SAFETY: `this` is the heap-allocated request c-ares calls back with;
-        // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
+        // `resolver` (if set) is this request's own intrusive ref taken at init time.
         unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
-                scopeguard::defer! { (*resolver).request_completed() };
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_name_info_cares` (which frees
+                // `*this`) and is released only after the completion bookkeeping.
+                scopeguard::defer! {
+                    (*resolver_ptr).request_completed();
+                    resolver.deref();
+                };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_name_info_cares(
+                    (*resolver_ptr).drain_pending_name_info_cares(
                         (*this).cache.pos_in_pending(),
                         err_,
                         timeout,
@@ -1125,8 +1171,10 @@ impl c_ares::NameinfoHandler for GetNameInfoRequest {
 
 pub struct GetAddrInfoRequest {
     pub backend: get_addr_info_request::Backend,
-    // TODO: should be Option<&'a Resolver>; raw ptr for now
-    pub resolver_for_caching: Option<*mut Resolver>,
+    /// SHARED — this request's own ref on the Resolver whose pending-cache
+    /// slot it occupies; taken in `init()`, released on the completion path
+    /// (RefPtr does not deref on Drop).
+    pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
     pub head: DNSLookup,
@@ -1376,7 +1424,10 @@ impl GetAddrInfoRequest {
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
             backend,
-            resolver_for_caching: resolver,
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
+            // ref_count. This ref is independent of `head.resolver`'s and is released on
+            // the completion path so the pending-cache deref never relies on the head ref.
+            resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash: query.hash(),
             cache: CacheConfig::default(),
             head: DNSLookup {
@@ -1407,7 +1458,6 @@ impl GetAddrInfoRequest {
         if let CacheHit::New(new) = cache {
             // SAFETY: `new` is &mut into resolver's HiveArray buffer; resolver/request are live.
             unsafe {
-                (*request).resolver_for_caching = resolver;
                 let pos = (*resolver.unwrap())
                     .pending_host_cache(cache_field)
                     .index_of(new)
@@ -1447,9 +1497,13 @@ impl GetAddrInfoRequest {
                 }
             }
 
-            if let Some(resolver) = (*this).resolver_for_caching {
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_host_native` (which frees `*this`).
+                scopeguard::defer! { resolver.deref(); };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_host_native(
+                    (*resolver_ptr).drain_pending_host_native(
                         (*this).cache.pos_in_pending(),
                         (*this).head.global_this(),
                         status,
@@ -1503,9 +1557,13 @@ impl GetAddrInfoRequest {
                     // `ResultAny` impls `Drop` (frees the list) — the by-value drop
                     // at the end of whichever callee receives `any`.
                     let any = GetAddrInfoResultAny::List(result);
-                    if let Some(resolver) = (*this).resolver_for_caching {
+                    if let Some(resolver) = (*this).resolver_for_caching.take() {
+                        let resolver_ptr = resolver.as_ptr();
+                        // `resolver` is this request's own ref: it keeps the
+                        // Resolver alive across the drain (which frees `*this`).
+                        scopeguard::defer! { resolver.deref(); };
                         if (*this).cache.pending_cache() {
-                            (*resolver).drain_pending_host_native(
+                            (*resolver_ptr).drain_pending_host_native(
                                 (*this).cache.pos_in_pending(),
                                 (*this).head.global_this(),
                                 0,
@@ -1550,11 +1608,15 @@ impl GetAddrInfoRequest {
     ) {
         bun_output::scoped_log!(GetAddrInfoRequest, "onCaresComplete");
         // SAFETY: `this` is the heap-allocated request c-ares calls back with;
-        // `resolver` (if set) is the live intrusive-RC ctx stored at init time.
+        // `resolver` (if set) is this request's own intrusive ref taken at init time.
         unsafe {
-            if let Some(resolver) = (*this).resolver_for_caching {
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_host_cares` (which frees `*this`).
+                scopeguard::defer! { resolver.deref(); };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_host_cares(
+                    (*resolver_ptr).drain_pending_host_cares(
                         (*this).cache.pos_in_pending(),
                         err_,
                         timeout,
@@ -1605,9 +1667,13 @@ impl GetAddrInfoRequest {
                 GetAddrInfoResultAny::List(list)
             };
 
-            if let Some(resolver) = (*this).resolver_for_caching {
+            if let Some(resolver) = (*this).resolver_for_caching.take() {
+                let resolver_ptr = resolver.as_ptr();
+                // `resolver` is this request's own ref: it keeps the Resolver
+                // alive across `drain_pending_host_native` (which frees `*this`).
+                scopeguard::defer! { resolver.deref(); };
                 if (*this).cache.pending_cache() {
-                    (*resolver).drain_pending_host_native(
+                    (*resolver_ptr).drain_pending_host_native(
                         (*this).cache.pos_in_pending(),
                         (*this).head.global_this(),
                         retcode,

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -264,17 +264,11 @@ pub(super) mod lib_info {
                         c.put(slot);
                     });
                 }
-                // Release the caching ref taken in `GetAddrInfoRequest::init`
-                // (the callback that would normally release it never runs).
-                // This cannot be the last ref: `this: &Resolver` is borrowed
-                // from the callframe-rooted JS wrapper, whose ref the caller
-                // still holds, so deref-to-zero is impossible here.
+                // Release the caching ref from init(); the completion callback
+                // that would normally release it never runs.
                 if let Some(resolver) = (*request).resolver_for_caching.take() {
                     resolver.deref();
                 }
-                // The head is inline (`allocated == false`), so `destroy` is a
-                // no-op for it; the KeepAlive + head resolver ref are released
-                // by `DNSLookup`'s Drop when the request box drops below.
                 DNSLookup::destroy(&raw mut (*request).head);
                 drop(bun_core::heap::take(request));
             }
@@ -487,9 +481,7 @@ pub(super) mod lib_uv_backend {
                 // and the promise is rejected with a DNSException.
                 if let Some(resolver) = (*request).resolver_for_caching.take() {
                     let resolver_ptr = resolver.as_ptr();
-                    // Adopt the request's own ref into an RAII guard: it keeps
-                    // the Resolver alive across the drain (which frees
-                    // `*request`) and derefs on every exit path.
+                    // Guard keeps the Resolver alive past the drain, which frees `*request`.
                     let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                     if (*request).cache.pending_cache() {
                         (*resolver_ptr).drain_pending_host_native(
@@ -607,9 +599,7 @@ pub trait CAresRecordType: Sized {
 }
 
 pub struct ResolveInfoRequest<T: CAresRecordType> {
-    /// SHARED — this request's own ref on the Resolver whose pending-cache
-    /// slot it occupies; taken in `init()`, released on the completion path
-    /// (RefPtr does not deref on Drop).
+    /// SHARED — request's own ref, taken in `init()`, released on the completion path (not on Drop).
     pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
@@ -661,9 +651,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
-            // ref_count. This ref is independent of `head.resolver`'s and is released on
-            // the completion path so the pending-cache deref never relies on the head ref.
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
             resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
@@ -707,10 +695,7 @@ impl<T: CAresRecordType> ResolveInfoRequest<T> {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_cares` (which frees
-                // `*this`) and derefs on every exit path, after the completion
-                // bookkeeping ran.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_cares::<T>(
@@ -758,9 +743,7 @@ impl<T: CAresRecordType> c_ares::ResolveHandler for ResolveInfoRequest<T> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetHostByAddrInfoRequest {
-    /// SHARED — this request's own ref on the Resolver whose pending-cache
-    /// slot it occupies; taken in `init()`, released on the completion path
-    /// (RefPtr does not deref on Drop).
+    /// SHARED — request's own ref, taken in `init()`, released on the completion path (not on Drop).
     pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
@@ -813,9 +796,7 @@ impl GetHostByAddrInfoRequest {
         let mut poll_ref = KeepAlive::init();
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
-            // ref_count. This ref is independent of `head.resolver`'s and is released on
-            // the completion path so the pending-cache deref never relies on the head ref.
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
             resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
@@ -858,9 +839,7 @@ impl GetHostByAddrInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_addr_cares` (which
-                // frees `*this`) and derefs on every exit path.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_addr_cares(
@@ -1018,11 +997,8 @@ impl Drop for CAresNameInfo {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct GetNameInfoRequest {
-    /// SHARED — this request's own ref on the Resolver whose pending-cache
-    /// slot it occupies; taken in `init()`, released on the completion path.
-    /// `CAresNameInfo` (the head) holds no resolver ref of its own, so this is
-    /// the only thing keeping the Resolver alive for the completion-path deref
-    /// (RefPtr does not deref on Drop).
+    /// SHARED — request's own ref, taken in `init()`, released on the completion path (not on
+    /// Drop). The head (`CAresNameInfo`) holds no resolver ref, so this is the only one.
     pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
@@ -1075,9 +1051,7 @@ impl GetNameInfoRequest {
         poll_ref.ref_(js_event_loop_ctx());
         let name_len = name.len();
         let request = bun_core::heap::into_raw(Box::new(Self {
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
-            // ref_count. The head (`CAresNameInfo`) holds no resolver ref, so this ref is
-            // what keeps the Resolver alive until the completion path releases it.
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
             resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash,
             cache: CacheConfig::default(),
@@ -1120,10 +1094,7 @@ impl GetNameInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_name_info_cares` (which
-                // frees `*this`) and derefs on every exit path, after the
-                // completion bookkeeping ran.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_name_info_cares(
@@ -1173,9 +1144,7 @@ impl c_ares::NameinfoHandler for GetNameInfoRequest {
 
 pub struct GetAddrInfoRequest {
     pub backend: get_addr_info_request::Backend,
-    /// SHARED — this request's own ref on the Resolver whose pending-cache
-    /// slot it occupies; taken in `init()`, released on the completion path
-    /// (RefPtr does not deref on Drop).
+    /// SHARED — request's own ref, taken in `init()`, released on the completion path (not on Drop).
     pub resolver_for_caching: Option<bun_ptr::IntrusiveRc<Resolver>>,
     pub hash: u64,
     pub cache: CacheConfig,
@@ -1426,9 +1395,7 @@ impl GetAddrInfoRequest {
         poll_ref.ref_(js_event_loop_ctx());
         let request = bun_core::heap::into_raw(Box::new(Self {
             backend,
-            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded
-            // ref_count. This ref is independent of `head.resolver`'s and is released on
-            // the completion path so the pending-cache deref never relies on the head ref.
+            // SAFETY: resolver is a live intrusive-RC m_ctx; init_ref bumps the embedded ref_count.
             resolver_for_caching: resolver.map(|r| unsafe { bun_ptr::IntrusiveRc::init_ref(r) }),
             hash: query.hash(),
             cache: CacheConfig::default(),
@@ -1501,9 +1468,7 @@ impl GetAddrInfoRequest {
 
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_host_native` (which
-                // frees `*this`) and derefs on every exit path.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_native(
@@ -1562,9 +1527,7 @@ impl GetAddrInfoRequest {
                     let any = GetAddrInfoResultAny::List(result);
                     if let Some(resolver) = (*this).resolver_for_caching.take() {
                         let resolver_ptr = resolver.as_ptr();
-                        // Adopt the request's own ref into an RAII guard: it
-                        // keeps the Resolver alive across the drain (which
-                        // frees `*this`) and derefs on every exit path.
+                        // Guard keeps the Resolver alive past the drain, which frees `*this`.
                         let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                         if (*this).cache.pending_cache() {
                             (*resolver_ptr).drain_pending_host_native(
@@ -1616,9 +1579,7 @@ impl GetAddrInfoRequest {
         unsafe {
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_host_cares` (which
-                // frees `*this`) and derefs on every exit path.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_cares(
@@ -1674,9 +1635,7 @@ impl GetAddrInfoRequest {
 
             if let Some(resolver) = (*this).resolver_for_caching.take() {
                 let resolver_ptr = resolver.as_ptr();
-                // Adopt the request's own ref into an RAII guard: it keeps the
-                // Resolver alive across `drain_pending_host_native` (which
-                // frees `*this`) and derefs on every exit path.
+                // Guard keeps the Resolver alive past the drain, which frees `*this`.
                 let _resolver_ref = bun_ptr::ScopedRef::adopt(resolver.leak());
                 if (*this).cache.pending_cache() {
                     (*resolver_ptr).drain_pending_host_native(

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -574,40 +574,30 @@ describe("hostnames containing NUL bytes", () => {
 });
 
 describe("resolver liveness across pending-cache completion", () => {
-  // Smoke coverage for the per-request resolver refs taken for the
-  // pending-cache completion path: each request takes its own ref in init()
-  // and releases it exactly once on completion. A double-release or a
-  // premature release (resolver torn down while requests drain) crashes the
-  // subprocess; an unbalanced ref shows up as a Resolver leak under LSan.
-  // Note: this is NOT a pre-fix-failing repro — c-ares dispatch sites hold
-  // their own scoped refs, so the old raw-pointer deref did not crash from
-  // JS. It exists to exercise every take()/release path post-change.
+  // Each request takes its own resolver ref in init() and releases it once on
+  // completion; a double or premature release crashes the subprocess.
   test("coalesced + cached DNS requests balance their resolver refs", async () => {
     const script = `
       const dns = require("node:dns");
 
       async function burst(make) {
-        // Identical concurrent queries coalesce onto one pending-cache
-        // slot; the extras append to the in-flight request's lookup list.
+        // Identical concurrent queries coalesce onto one pending-cache slot.
         await Promise.allSettled([make(), make(), make()]);
         Bun.gc(true);
       }
 
       async function gcResolverMidFlight() {
-        // Non-routable TEST-NET server: every query exercises the full
-        // c-ares completion/drain path via a fast deterministic timeout.
+        // Non-routable TEST-NET server: queries hit the c-ares drain path via timeout.
         let resolver = new dns.promises.Resolver({ timeout: 100, tries: 1 });
         resolver.setServers(["192.0.2.1"]);
         const pending = [];
         for (let i = 0; i < 3; i++) {
-          // Same names on purpose: 1 slot owner + coalesced waiters per type.
           pending.push(resolver.resolveTxt("txt.bun-test.invalid").catch(() => {}));
           pending.push(resolver.resolve4("a.bun-test.invalid").catch(() => {}));
           pending.push(resolver.reverse("192.0.2.55").catch(() => {}));
         }
-        // Drop the only JS reference while the queries are still in flight
-        // and force GC, so completion runs with no JS wrapper rooting the
-        // resolver beyond the native refs the requests themselves hold.
+        // Drop the only JS reference mid-flight so completion runs with only
+        // the requests' native refs keeping the resolver alive.
         resolver = null;
         Bun.gc(true);
         await Promise.all(pending);
@@ -615,11 +605,9 @@ describe("resolver liveness across pending-cache completion", () => {
       }
 
       await gcResolverMidFlight();
-      // lookupService -> GetNameInfoRequest release path. Routes through the
-      // module-global default resolver (never refcount-destroyed), so this is
-      // pure take()/release smoke coverage, not a liveness repro.
+      // lookupService -> GetNameInfoRequest release path.
       await burst(() => dns.promises.lookupService("127.0.0.1", 80).catch(() => {}));
-      // lookup -> GetAddrInfoRequest native-backend pending-cache release path.
+      // lookup -> GetAddrInfoRequest native-backend release path.
       await burst(() => dns.promises.lookup("localhost").catch(() => {}));
       Bun.gc(true);
       console.log("done");

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -630,6 +630,7 @@ describe("resolver liveness across pending-cache completion", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
     expect(stdout.trim()).toBe("done");
     expect(exitCode).toBe(0);
   });

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { isWindows } from "harness";
+import { bunEnv, bunExe, isWindows } from "harness";
 import * as dns from "node:dns";
 import * as dns_promises from "node:dns/promises";
 import * as fs from "node:fs";
@@ -570,5 +570,67 @@ describe("hostnames containing NUL bytes", () => {
   it("plain localhost still resolves", async () => {
     const { address } = await dns_promises.lookup("localhost");
     expect(["127.0.0.1", "::1"]).toContain(address);
+  });
+});
+
+describe("resolver liveness across pending-cache completion", () => {
+  // Smoke coverage for the per-request resolver refs taken for the
+  // pending-cache completion path: each request takes its own ref in init()
+  // and releases it exactly once on completion. A double-release or a
+  // premature release (resolver torn down while requests drain) crashes the
+  // subprocess; an unbalanced ref shows up as a Resolver leak under LSan.
+  // Note: this is NOT a pre-fix-failing repro — c-ares dispatch sites hold
+  // their own scoped refs, so the old raw-pointer deref did not crash from
+  // JS. It exists to exercise every take()/release path post-change.
+  test("coalesced + cached DNS requests balance their resolver refs", async () => {
+    const script = `
+      const dns = require("node:dns");
+
+      async function burst(make) {
+        // Identical concurrent queries coalesce onto one pending-cache
+        // slot; the extras append to the in-flight request's lookup list.
+        await Promise.allSettled([make(), make(), make()]);
+        Bun.gc(true);
+      }
+
+      async function gcResolverMidFlight() {
+        // Non-routable TEST-NET server: every query exercises the full
+        // c-ares completion/drain path via a fast deterministic timeout.
+        let resolver = new dns.promises.Resolver({ timeout: 100, tries: 1 });
+        resolver.setServers(["192.0.2.1"]);
+        const pending = [];
+        for (let i = 0; i < 3; i++) {
+          // Same names on purpose: 1 slot owner + coalesced waiters per type.
+          pending.push(resolver.resolveTxt("txt.bun-test.invalid").catch(() => {}));
+          pending.push(resolver.resolve4("a.bun-test.invalid").catch(() => {}));
+          pending.push(resolver.reverse("192.0.2.55").catch(() => {}));
+        }
+        // Drop the only JS reference while the queries are still in flight
+        // and force GC, so completion runs with no JS wrapper rooting the
+        // resolver beyond the native refs the requests themselves hold.
+        resolver = null;
+        Bun.gc(true);
+        await Promise.all(pending);
+        Bun.gc(true);
+      }
+
+      await gcResolverMidFlight();
+      // lookupService -> GetNameInfoRequest release path. Routes through the
+      // module-global default resolver (never refcount-destroyed), so this is
+      // pure take()/release smoke coverage, not a liveness repro.
+      await burst(() => dns.promises.lookupService("127.0.0.1", 80).catch(() => {}));
+      // lookup -> GetAddrInfoRequest native-backend pending-cache release path.
+      await burst(() => dns.promises.lookup("localhost").catch(() => {}));
+      Bun.gc(true);
+      console.log("done");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("done");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
The four DNS request structs (ResolveInfoRequest<T>, GetHostByAddrInfoRequest, GetNameInfoRequest, GetAddrInfoRequest) stored `resolver_for_caching` as a bare `Option<*mut Resolver>` and dereferenced it on the completion path to clear the resolver's pending-cache slot. The pointer's liveness piggybacked on the head node's intrusive ref, which is released while the drain runs (the drain frees the request box, and the head's Drop derefs the resolver) - so the post-drain `request_completed()` deref could outlive the last ref. GetNameInfoRequest's head (CAresNameInfo) holds no resolver ref at all, so nothing modeled the resolver's liveness for lookupService completions (an unmodeled invariant rather than a JS-reachable crash: lookupService only routes through the never-refcount-destroyed global default resolver, and c-ares dispatch sites hold their own scoped refs). The field is now `Option<IntrusiveRc<Resolver>>`: each request takes its own ref in init() and releases it (after `request_completed()` where applicable) once the completion bookkeeping has run, including the synchronous-failure paths (macOS getaddrinfo_async_start errno, Windows uv_getaddrinfo rc<0) that free the request without a callback. Smoke-tested with a subprocess test in node-dns.test.js (post-fix ref-balance coverage, not a pre-fix-failing repro) that coalesces concurrent identical resolveTxt/resolve4/reverse queries on a custom Resolver, drops the only JS reference mid-flight, and forces GC across completions, plus one lookupService/lookup burst each, asserting clean output and exit 0. Verify phase MUST run: bun bd --asan test test/js/node/dns/ and test/js/bun/dns/ plus an LSan pass (no Resolver leak), and bun run rust:check-all for the modified cfg(windows)/cfg(macos) arms.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
