### PR TITLE
http2: give HPACK DecodeResult an honest lifetime and copy headers out at the parser boundary

### DIFF
--- a/src/http/lshpack.rs
+++ b/src/http/lshpack.rs
@@ -29,12 +29,9 @@ pub struct HPACK {
     self_: *mut c_void,
 }
 
-/// One decoded header. `name`/`value` borrow the thread-local scratch buffer
-/// the C wrapper decodes into, so the borrow is tied to the `HPACK` instance:
-/// the compiler rejects a subsequent `decode`/`encode` through the same
-/// instance while the slices are live. The scratch buffer is shared by every
-/// `HPACK` instance on the thread, so callers must still copy the bytes out
-/// before handing control to code that may drive a *different* instance.
+/// One decoded header. `name`/`value` point into a thread-local scratch
+/// buffer shared by every `HPACK` instance on the thread; copy the bytes out
+/// before the next decode/encode through any instance.
 pub struct DecodeResult<'a> {
     pub name: &'a [u8],
     pub value: &'a [u8],
@@ -58,10 +55,8 @@ bun_core::named_error_set!(HpackError);
 impl HPACK {
     pub const LSHPACK_MAX_HEADER_SIZE: usize = 65536;
 
-    /// The returned `DecodeResult` borrows this instance for as long as its
-    /// `name`/`value` slices are used; copy/clone the bytes out before the
-    /// next decode/encode call (the slices point into a thread_local buffer
-    /// that every `HPACK` instance on the thread reuses).
+    /// `DecodeResult` name/value point into a thread_local shared buffer;
+    /// copy them out before the next decode/encode call.
     pub fn decode(&mut self, src: &[u8]) -> Result<DecodeResult<'_>, HpackError> {
         let mut header = lshpack_header::default();
         // SAFETY: genuine FFI — only the `(src.as_ptr(), src.len())` pair carries

--- a/src/http/lshpack.rs
+++ b/src/http/lshpack.rs
@@ -29,11 +29,15 @@ pub struct HPACK {
     self_: *mut c_void,
 }
 
-pub struct DecodeResult {
-    // TODO: lifetime — name/value point into an FFI thread_local shared buffer,
-    // valid only until the next decode/encode call. Consider `DecodeResult<'a>`.
-    pub name: &'static [u8],
-    pub value: &'static [u8],
+/// One decoded header. `name`/`value` borrow the thread-local scratch buffer
+/// the C wrapper decodes into, so the borrow is tied to the `HPACK` instance:
+/// the compiler rejects a subsequent `decode`/`encode` through the same
+/// instance while the slices are live. The scratch buffer is shared by every
+/// `HPACK` instance on the thread, so callers must still copy the bytes out
+/// before handing control to code that may drive a *different* instance.
+pub struct DecodeResult<'a> {
+    pub name: &'a [u8],
+    pub value: &'a [u8],
     pub never_index: bool,
     pub well_know: u16,
     /// offset of the next header position in src
@@ -54,8 +58,11 @@ bun_core::named_error_set!(HpackError);
 impl HPACK {
     pub const LSHPACK_MAX_HEADER_SIZE: usize = 65536;
 
-    /// DecodeResult name and value uses a thread_local shared buffer and should be copy/cloned before the next decode/encode call
-    pub fn decode(&mut self, src: &[u8]) -> Result<DecodeResult, HpackError> {
+    /// The returned `DecodeResult` borrows this instance for as long as its
+    /// `name`/`value` slices are used; copy/clone the bytes out before the
+    /// next decode/encode call (the slices point into a thread_local buffer
+    /// that every `HPACK` instance on the thread reuses).
+    pub fn decode(&mut self, src: &[u8]) -> Result<DecodeResult<'_>, HpackError> {
         let mut header = lshpack_header::default();
         // SAFETY: genuine FFI — only the `(src.as_ptr(), src.len())` pair carries
         // an obligation here (in-bounds read), discharged by `src: &[u8]`. The

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2144,16 +2144,11 @@ impl AbortListener for SignalRef {
     }
 }
 
-/// Owned copy of one decoded HPACK header.
-///
-/// `lshpack::DecodeResult` borrows a thread-local scratch buffer that the next
-/// `decode`/`encode` call reuses — and the header-block loop's error paths
-/// (`send_go_away` → `encode`) drive an encode on the same `JsCell`-held HPACK
-/// state while a decoded header is still in use. The `JsCell` also cannot let
-/// the decode borrow escape `with_mut`. So the bytes are copied out at the
-/// decode boundary; name and value share one buffer, split at `name_len`.
-/// Headers that fit in [`HEADER_VALUE_INLINE_CAP`] bytes are stored inline so
-/// the per-header decode path does not allocate; larger ones spill to the heap.
+/// Owned copy of one decoded HPACK header. `lshpack::DecodeResult` borrows a
+/// thread-local scratch buffer that the next decode/encode reuses (e.g.
+/// `send_go_away` → `encode` while a decoded header is still in use), so the
+/// bytes are copied out at the decode boundary. Name and value share one
+/// buffer, split at `name_len`; small headers are stored inline.
 pub(crate) struct HeaderValue {
     data: HeaderValueData,
     name_len: usize,
@@ -2163,9 +2158,7 @@ pub(crate) struct HeaderValue {
     next: usize,
 }
 
-/// Inline capacity for one decoded header (name + value combined). Sized so
-/// typical headers (short name, value up to ~128 bytes) avoid a heap
-/// allocation on the per-header decode path.
+/// Inline capacity (name + value combined); typical headers avoid a heap allocation.
 const HEADER_VALUE_INLINE_CAP: usize = 160;
 
 enum HeaderValueData {
@@ -2263,9 +2256,7 @@ impl H2FrameParser {
         self.hpack.with_mut(|hpack| {
             if let Some(hpack) = hpack.as_mut() {
                 let decoded = hpack.decode(src_buffer).map_err(bun_core::Error::from)?;
-                // Copy out of the decoder's scratch buffer before the borrow
-                // ends: the slices are only valid until the next
-                // decode/encode call (see `HeaderValue`).
+                // Copy out of the decoder's scratch buffer (see `HeaderValue`).
                 return Ok(HeaderValue::new(
                     decoded.name,
                     decoded.value,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2144,7 +2144,79 @@ impl AbortListener for SignalRef {
     }
 }
 
-type HeaderValue = lshpack::DecodeResult;
+/// Owned copy of one decoded HPACK header.
+///
+/// `lshpack::DecodeResult` borrows a thread-local scratch buffer that the next
+/// `decode`/`encode` call reuses — and the header-block loop's error paths
+/// (`send_go_away` → `encode`) drive an encode on the same `JsCell`-held HPACK
+/// state while a decoded header is still in use. The `JsCell` also cannot let
+/// the decode borrow escape `with_mut`. So the bytes are copied out at the
+/// decode boundary; name and value share one buffer, split at `name_len`.
+/// Headers that fit in [`HEADER_VALUE_INLINE_CAP`] bytes are stored inline so
+/// the per-header decode path does not allocate; larger ones spill to the heap.
+pub(crate) struct HeaderValue {
+    data: HeaderValueData,
+    name_len: usize,
+    never_index: bool,
+    well_know: u16,
+    /// offset of the next header position in src
+    next: usize,
+}
+
+/// Inline capacity for one decoded header (name + value combined). Sized so
+/// typical headers (short name, value up to ~128 bytes) avoid a heap
+/// allocation on the per-header decode path.
+const HEADER_VALUE_INLINE_CAP: usize = 160;
+
+enum HeaderValueData {
+    Inline {
+        buf: [u8; HEADER_VALUE_INLINE_CAP],
+        len: usize,
+    },
+    Heap(Vec<u8>),
+}
+
+impl HeaderValue {
+    fn new(name: &[u8], value: &[u8], never_index: bool, well_know: u16, next: usize) -> Self {
+        let total = name.len() + value.len();
+        let data = if total <= HEADER_VALUE_INLINE_CAP {
+            let mut buf = [0u8; HEADER_VALUE_INLINE_CAP];
+            buf[..name.len()].copy_from_slice(name);
+            buf[name.len()..total].copy_from_slice(value);
+            HeaderValueData::Inline { buf, len: total }
+        } else {
+            let mut data = Vec::with_capacity(total);
+            data.extend_from_slice(name);
+            data.extend_from_slice(value);
+            HeaderValueData::Heap(data)
+        };
+        Self {
+            data,
+            name_len: name.len(),
+            never_index,
+            well_know,
+            next,
+        }
+    }
+
+    #[inline]
+    fn bytes(&self) -> &[u8] {
+        match &self.data {
+            HeaderValueData::Inline { buf, len } => &buf[..*len],
+            HeaderValueData::Heap(data) => data,
+        }
+    }
+
+    #[inline]
+    fn name(&self) -> &[u8] {
+        &self.bytes()[..self.name_len]
+    }
+
+    #[inline]
+    fn value(&self) -> &[u8] {
+        &self.bytes()[self.name_len..]
+    }
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // H2FrameParser impl — core methods
@@ -2190,7 +2262,17 @@ impl H2FrameParser {
     pub(crate) fn decode(&self, src_buffer: &[u8]) -> Result<HeaderValue, bun_core::Error> {
         self.hpack.with_mut(|hpack| {
             if let Some(hpack) = hpack.as_mut() {
-                return hpack.decode(src_buffer).map_err(bun_core::Error::from);
+                let decoded = hpack.decode(src_buffer).map_err(bun_core::Error::from)?;
+                // Copy out of the decoder's scratch buffer before the borrow
+                // ends: the slices are only valid until the next
+                // decode/encode call (see `HeaderValue`).
+                return Ok(HeaderValue::new(
+                    decoded.name,
+                    decoded.value,
+                    decoded.never_index,
+                    decoded.well_know,
+                    decoded.next,
+                ));
             }
             Err(bun_core::err!("UnableToDecode"))
         })
@@ -3329,10 +3411,10 @@ impl H2FrameParser {
             bun_output::scoped_log!(
                 H2FrameParser,
                 "header {} {}",
-                BStr::new(header.name),
-                BStr::new(header.value)
+                BStr::new(header.name()),
+                BStr::new(header.value())
             );
-            if self.is_server.get() && header.name == b":status" {
+            if self.is_server.get() && header.name() == b":status" {
                 self.send_go_away(
                     stream_id,
                     ErrorCode::PROTOCOL_ERROR,
@@ -3346,7 +3428,7 @@ impl H2FrameParser {
             // RFC 7540 Section 6.5.2: Calculate header list size
             // Size = name length + value length + HPACK entry overhead per header
             stream.header_block_size +=
-                header.name.len() + header.value.len() + HPACK_ENTRY_OVERHEAD;
+                header.name().len() + header.value().len() + HPACK_ENTRY_OVERHEAD;
             stream.header_block_count += 1;
 
             // Check against maxHeaderListSize / maxHeaderListPairs.
@@ -3359,7 +3441,7 @@ impl H2FrameParser {
                 continue;
             }
 
-            let is_pseudo_header = header.name.first() == Some(&b':');
+            let is_pseudo_header = header.name().first() == Some(&b':');
             if is_pseudo_header {
                 if seen_regular_header {
                     malformed = true;
@@ -3367,8 +3449,8 @@ impl H2FrameParser {
             } else {
                 seen_regular_header = true;
             }
-            if is_pseudo_header || header.name == b"content-length" {
-                if let Some(idx) = single_value_headers_index_of(header.name) {
+            if is_pseudo_header || header.name() == b"content-length" {
+                if let Some(idx) = single_value_headers_index_of(header.name()) {
                     if single_value_headers[idx] {
                         malformed = true;
                     }
@@ -3377,14 +3459,14 @@ impl H2FrameParser {
             }
 
             if malformed
-                || is_malformed_field_name(header.name)
-                || is_malformed_field_value(header.value)
-                || is_forbidden_connection_specific_header(header.name, header.value)
+                || is_malformed_field_name(header.name())
+                || is_malformed_field_value(header.value())
+                || is_forbidden_connection_specific_header(header.name(), header.value())
                 || (is_pseudo_header
                     && !if self.is_server.get() {
-                        is_valid_request_pseudo_header(header.name)
+                        is_valid_request_pseudo_header(header.name())
                     } else {
-                        is_valid_response_pseudo_header(header.name)
+                        is_valid_response_pseudo_header(header.name())
                     })
             {
                 malformed = true;
@@ -3394,7 +3476,7 @@ impl H2FrameParser {
                 headers.push(&global_object, js_header_name)?;
                 headers.push(
                     &global_object,
-                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.value)?,
+                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.value())?,
                 )?;
                 if header.never_index {
                     if sensitive_headers.is_undefined() {
@@ -3405,9 +3487,9 @@ impl H2FrameParser {
                 }
             } else {
                 let js_header_name =
-                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.name)?;
+                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.name())?;
                 let js_header_value =
-                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.value)?;
+                    bun_jsc::bun_string_jsc::create_utf8_for_js(&global_object, header.value())?;
 
                 if header.never_index {
                     if sensitive_headers.is_undefined() {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2713,11 +2713,8 @@ it("http2 client keeps parsing a socket chunk whose ArrayBuffer is transferred b
 });
 
 it("http2 server sends GOAWAY PROTOCOL_ERROR when a request header block contains :status", async () => {
-  // A response pseudo-header in a request hits the decoder's
-  // GOAWAY-while-decoding error path: the parser writes a GOAWAY and
-  // dispatches the error into JS while the freshly decoded header is still in
-  // scope, so the decoded name/value bytes must be owned copies rather than
-  // views into the HPACK scratch buffer that the next decode/encode reuses.
+  // A response pseudo-header in a request triggers a GOAWAY (an encode)
+  // while the freshly decoded header is still in use.
   const delivered = [];
   const server = http2.createServer();
   server.on("stream", (stream, headers) => {
@@ -2777,12 +2774,8 @@ it("http2 server sends GOAWAY PROTOCOL_ERROR when a request header block contain
 });
 
 it("http2 decoded header bytes stay intact across interleaved decode/encode and GC", async () => {
-  // Server and client share one event-loop thread, so every request/response
-  // pair interleaves HPACK decodes and encodes on the same thread-local
-  // scratch buffer. Repeated values exercise dynamic-table indexed decodes,
-  // never-index headers exercise the sensitive-header path, and forced GC
-  // between rounds provokes collection while decoded headers are in flight.
-  // Every header must come back byte-exact on every round.
+  // Server and client share one thread, so each request/response interleaves
+  // HPACK decodes and encodes on the same thread-local scratch buffer.
   await using proc = Bun.spawn({
     cmd: [
       bunExe(),

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2711,3 +2711,147 @@ it("http2 client keeps parsing a socket chunk whose ArrayBuffer is transferred b
   expect(stdout).toContain('PINGS:["4141414141414141","4242424242424242"]');
   expect(exitCode).toBe(0);
 });
+
+it("http2 server sends GOAWAY PROTOCOL_ERROR when a request header block contains :status", async () => {
+  // A response pseudo-header in a request hits the decoder's
+  // GOAWAY-while-decoding error path: the parser writes a GOAWAY and
+  // dispatches the error into JS while the freshly decoded header is still in
+  // scope, so the decoded name/value bytes must be owned copies rather than
+  // views into the HPACK scratch buffer that the next decode/encode reuses.
+  const delivered = [];
+  const server = http2.createServer();
+  server.on("stream", (stream, headers) => {
+    delivered.push(headers);
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  const { promise: listening, resolve: onListening } = Promise.withResolvers();
+  server.listen(0, "127.0.0.1", onListening);
+  await listening;
+  const port = server.address().port;
+
+  const frames = [];
+  const { promise: exchanged, resolve: onExchanged, reject: onSocketError } = Promise.withResolvers();
+  const socket = net.connect(port, "127.0.0.1", () => {
+    socket.write(http2utils.kClientMagic);
+    socket.write(new http2utils.SettingsFrame(false).data);
+    // HEADERS on stream 1 with END_HEADERS | END_STREAM. 0x88 is the fully
+    // indexed static-table entry ":status: 200".
+    socket.write(new http2utils.HeadersFrame(1, Buffer.from([0x88]), 0, true, true).data);
+  });
+  socket.on("error", onSocketError);
+  let received = Buffer.alloc(0);
+  socket.on("data", chunk => {
+    received = Buffer.concat([received, chunk]);
+    while (received.length >= 9) {
+      const length = received.readUIntBE(0, 3);
+      if (received.length < 9 + length) break;
+      const frame = {
+        type: received[3],
+        streamId: received.readUInt32BE(5) & 0x7fffffff,
+        payload: Buffer.from(received.subarray(9, 9 + length)),
+      };
+      received = received.subarray(9 + length);
+      frames.push(frame);
+      if (frame.type === 7) {
+        onExchanged();
+        return;
+      }
+    }
+  });
+  socket.on("close", () => onExchanged());
+
+  try {
+    await exchanged;
+    const goaway = frames.find(f => f.type === 7);
+    expect(goaway).toBeDefined();
+    // GOAWAY payload: last stream id (4 bytes), error code (4 bytes), debug data.
+    expect(goaway.payload.readUInt32BE(4)).toBe(http2.constants.NGHTTP2_PROTOCOL_ERROR);
+    expect(goaway.payload.subarray(8).toString()).toContain(":status");
+    // The malformed request never reaches the application.
+    expect(delivered).toEqual([]);
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});
+
+it("http2 decoded header bytes stay intact across interleaved decode/encode and GC", async () => {
+  // Server and client share one event-loop thread, so every request/response
+  // pair interleaves HPACK decodes and encodes on the same thread-local
+  // scratch buffer. Repeated values exercise dynamic-table indexed decodes,
+  // never-index headers exercise the sensitive-header path, and forced GC
+  // between rounds provokes collection while decoded headers are in flight.
+  // Every header must come back byte-exact on every round.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+      const http2 = require("node:http2");
+      const assert = require("node:assert");
+
+      const server = http2.createServer();
+      server.on("stream", (stream, headers) => {
+        const res = { ":status": 200 };
+        for (const name in headers) {
+          if (name.startsWith("x-")) res["e-" + name] = headers[name];
+        }
+        res[http2.sensitiveHeaders] = ["e-x-secret"];
+        stream.respond(res);
+        stream.end("done");
+      });
+      server.listen(0, "127.0.0.1", async () => {
+        try {
+          const port = server.address().port;
+          const client = http2.connect("http://127.0.0.1:" + port);
+          client.on("error", err => {
+            console.error(err);
+            process.exit(1);
+          });
+          for (let i = 0; i < 40; i++) {
+            const reqHeaders = { ":path": "/" + i };
+            for (let j = 0; j < 12; j++) {
+              // Fixed values are HPACK dynamic-table indexed after round 0;
+              // varying values are literal every round.
+              reqHeaders["x-fixed-" + j] = "value-" + j + "-" + "p".repeat(64);
+              reqHeaders["x-vary-" + j] = i + "-" + j + "-" + "q".repeat(48);
+            }
+            reqHeaders["x-secret"] = "hunter2-" + i;
+            reqHeaders[http2.sensitiveHeaders] = ["x-secret"];
+            const resHeaders = await new Promise((resolve, reject) => {
+              const req = client.request(reqHeaders);
+              req.on("response", resolve);
+              req.on("error", reject);
+              req.resume();
+              req.end();
+            });
+            assert.strictEqual(resHeaders[":status"], 200);
+            for (let j = 0; j < 12; j++) {
+              assert.strictEqual(resHeaders["e-x-fixed-" + j], reqHeaders["x-fixed-" + j]);
+              assert.strictEqual(resHeaders["e-x-vary-" + j], reqHeaders["x-vary-" + j]);
+            }
+            assert.strictEqual(resHeaders["e-x-secret"], "hunter2-" + i);
+            assert.ok(resHeaders[http2.sensitiveHeaders].includes("e-x-secret"));
+            if (i % 8 === 0) Bun.gc(true);
+          }
+          client.close();
+          server.close();
+          console.log("OK");
+        } catch (err) {
+          console.error(err);
+          process.exit(1);
+        }
+      });
+      `,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout, `subprocess stderr:\n${stderr}`).toContain("OK");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2809,13 +2809,15 @@ it("http2 decoded header bytes stay intact across interleaved decode/encode and 
             console.error(err);
             process.exit(1);
           });
+          const pSuffix = Buffer.alloc(64, "p").toString();
+          const qSuffix = Buffer.alloc(48, "q").toString();
           for (let i = 0; i < 40; i++) {
             const reqHeaders = { ":path": "/" + i };
             for (let j = 0; j < 12; j++) {
               // Fixed values are HPACK dynamic-table indexed after round 0;
               // varying values are literal every round.
-              reqHeaders["x-fixed-" + j] = "value-" + j + "-" + "p".repeat(64);
-              reqHeaders["x-vary-" + j] = i + "-" + j + "-" + "q".repeat(48);
+              reqHeaders["x-fixed-" + j] = "value-" + j + "-" + pSuffix;
+              reqHeaders["x-vary-" + j] = i + "-" + j + "-" + qSuffix;
             }
             reqHeaders["x-secret"] = "hunter2-" + i;
             reqHeaders[http2.sensitiveHeaders] = ["x-secret"];


### PR DESCRIPTION
lshpack::DecodeResult exposed name/value as &'static [u8] even though the slices point into a thread-local scratch buffer that the next decode or encode call (from any HPACK instance on the same thread) overwrites. The fake 'static lifetime let the slices outlive their validity with no compiler enforcement; the HTTP/2 frame parser also returned them out of its JsCell::with_mut closure and held them across error paths (send_go_away dispatches into JS, which can re-enter the parser and run an encode that clobbers the buffer). DecodeResult is now DecodeResult<'a>, borrowing the HPACK instance so a subsequent decode/encode through the same instance is rejected at compile time, and H2FrameParser::decode copies the name/value bytes into an owned HeaderValue (160-byte inline buffer for typical headers, heap spill for larger ones, split at name_len) inside the with_mut closure, so nothing referencing the scratch buffer escapes the cell. The h2_client decode loops in dispatch.rs already use the slices within a single iteration and compile unchanged against the new lifetime. Tested with a raw-socket test asserting a server answers a request carrying :status with GOAWAY PROTOCOL_ERROR (the decode-error-path that re-enters JS mid-block), and a subprocess test that round-trips 40 requests x 25 headers (dynamic-table indexed, literal, and never-index sensitive headers) through a same-thread server+client with forced GC between rounds, asserting every header comes back byte-exact. Both tests are regression guards for the hazard paths, not fix-distinguishing (the pre-fix usage was behaviorally correct; the compiler enforces the fix). Apply step must: cargo check the workspace (dispatch.rs verified by inspection only), run bun bd test http2, run the http2 suite under ASAN, and run the h2 headers-throughput bench before/after.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
