### PR TITLE
Replace lying lifetimes on heap-allocated file-copy tasks with BackRef

### DIFF
--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -35,8 +35,15 @@ pub struct ConcurrentPromiseTask<'a, Context: ConcurrentPromiseTaskContext> {
     /// `EventLoop`) outlives every task scheduled on it.
     pub event_loop: BackRef<EventLoop>,
     pub promise: JSPromiseStrong,
-    pub global_this: &'a JSGlobalObject,
+    /// BACKREF — captured from the JS thread at create time; the VM (and its
+    /// global object) outlives every task scheduled on it. The task is
+    /// heap-allocated and crosses threads, so a borrowed reference would lie
+    /// about the lifetime.
+    pub global_this: BackRef<JSGlobalObject>,
     pub concurrent_task: ConcurrentTask,
+    /// Keeps the public `ConcurrentPromiseTask<'a, _>` lifetime parameter (used
+    /// by `Context` type aliases downstream) now that no field borrows for `'a`.
+    pub _global_lifetime: core::marker::PhantomData<&'a ()>,
 
     // This is a poll because we want it to enter the uSockets loop
     // (`ref` is a Rust keyword, hence `ref_`)
@@ -68,8 +75,9 @@ impl<'a, Context: ConcurrentPromiseTaskContext> ConcurrentPromiseTask<'a, Contex
                 callback: Self::run_from_thread_pool,
             },
             promise: JSPromiseStrong::init(global_this),
-            global_this,
+            global_this: BackRef::new(global_this),
             concurrent_task: ConcurrentTask::default(),
+            _global_lifetime: core::marker::PhantomData,
             ref_: KeepAlive::default(),
         });
         this.ref_.ref_(Async::js_vm_ctx());

--- a/src/jsc/ConcurrentPromiseTask.rs
+++ b/src/jsc/ConcurrentPromiseTask.rs
@@ -35,14 +35,10 @@ pub struct ConcurrentPromiseTask<'a, Context: ConcurrentPromiseTaskContext> {
     /// `EventLoop`) outlives every task scheduled on it.
     pub event_loop: BackRef<EventLoop>,
     pub promise: JSPromiseStrong,
-    /// BACKREF — captured from the JS thread at create time; the VM (and its
-    /// global object) outlives every task scheduled on it. The task is
-    /// heap-allocated and crosses threads, so a borrowed reference would lie
-    /// about the lifetime.
+    /// BACKREF — the VM (and its global object) outlives every task scheduled on it.
     pub global_this: BackRef<JSGlobalObject>,
     pub concurrent_task: ConcurrentTask,
-    /// Keeps the public `ConcurrentPromiseTask<'a, _>` lifetime parameter (used
-    /// by `Context` type aliases downstream) now that no field borrows for `'a`.
+    /// Preserves the public `'a` parameter now that no field borrows it.
     pub _global_lifetime: core::marker::PhantomData<&'a ()>,
 
     // This is a poll because we want it to enter the uSockets loop

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -581,22 +581,23 @@ mod _async_tasks {
             pub task: WorkPoolTask,
         }
 
-        bun_threading::intrusive_work_task!(AsyncMkdirp, task);
+        bun_threading::owned_task!(AsyncMkdirp, task);
 
         impl AsyncMkdirp {
-            pub fn new(init: AsyncMkdirp) -> Box<Self> {
-                Box::new(init)
+            /// Heap-allocate and hand the task to the work pool, which owns the
+            /// allocation and frees it after `run_owned` returns.
+            pub fn schedule(init: AsyncMkdirp) {
+                WorkPool::schedule_new(init);
             }
 
-            /// # Safety
-            /// `task` must point to the `task` field of a live `AsyncMkdirp`.
-            fn work_pool_callback(task: *mut WorkPoolTask) {
-                // SAFETY: task points to AsyncMkdirp.task
-                let this = unsafe { &mut *AsyncMkdirp::from_task_ptr(task) };
-
+            // `owned_task!` requires `fn run_owned(self: Box<Self>)`; clippy::boxed_local
+            // is a false positive on this macro contract.
+            #[allow(clippy::boxed_local)]
+            fn run_owned(self: Box<Self>) {
                 let mut node_fs = NodeFS::default();
-                // SAFETY: caller keeps `path` alive until completion
-                let path = unsafe { &*this.path };
+                // SAFETY: the scheduling caller keeps `path` alive until `completion`
+                // runs (it points into caller-owned state, not this box).
+                let path = unsafe { &*self.path };
                 let result = node_fs.mkdir_recursive(&args::Mkdir {
                     path: PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(
                         path, false,
@@ -606,21 +607,18 @@ mod _async_tasks {
                 });
                 match result {
                     Err(err) => {
-                        (this.completion)(
-                            this.completion_ctx,
+                        (self.completion)(
+                            self.completion_ctx,
                             // `with_path` already clones into a fresh `Box<[u8]>`; pass the
                             // existing path slice.
                             Err(err.with_path(&err.path)),
                         );
                     }
                     Ok(_) => {
-                        (this.completion)(this.completion_ctx, Ok(()));
+                        (self.completion)(self.completion_ctx, Ok(()));
                     }
                 }
-            }
-
-            pub fn schedule(&mut self) {
-                WorkPool::schedule(&raw mut self.task);
+                // `self` drops here, freeing the box the work pool handed back.
             }
         }
 
@@ -630,7 +628,7 @@ mod _async_tasks {
                     completion_ctx: core::ptr::null_mut(),
                     completion: |_, _| {},
                     path: core::ptr::slice_from_raw_parts(core::ptr::null(), 0),
-                    task: work_pool_task(Self::work_pool_callback),
+                    task: WorkPoolTask::default(),
                 }
             }
         }

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1709,17 +1709,15 @@ impl CopyFileWindows {
         };
 
         self.event_loop.ref_concurrently();
-        // Box::leak: the work pool holds a raw pointer to the task; the
-        // completion path owns and frees it (same as `WriteFileWindows::mkdirp`).
-        Box::leak(node_fs::async_::AsyncMkdirp::new(
-            node_fs::async_::AsyncMkdirp {
-                completion: on_mkdirp_complete_concurrent,
-                completion_ctx: core::ptr::from_mut(self).cast::<()>(),
-                path,
-                ..Default::default()
-            },
-        ))
-        .schedule();
+        // `AsyncMkdirp::schedule` heap-allocates the task and hands ownership
+        // to the work pool, which frees it after the completion callback
+        // returns (same as `WriteFileWindows::mkdirp`).
+        node_fs::async_::AsyncMkdirp::schedule(node_fs::async_::AsyncMkdirp {
+            completion: on_mkdirp_complete_concurrent,
+            completion_ctx: core::ptr::from_mut(self).cast::<()>(),
+            path,
+            ..Default::default()
+        });
     }
 
     fn on_mkdirp_complete(&mut self) {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -61,10 +61,7 @@ pub struct CopyFile {
     pub read_len: SizeType,
     pub read_off: SizeType,
 
-    /// BACKREF — captured from the JS thread at create time; the VM (and its
-    /// global object) outlives every task scheduled on it. This struct is
-    /// Box-allocated and crosses threads, so a borrowed reference would lie
-    /// about the lifetime.
+    /// BACKREF — the VM (and its global object) outlives every task scheduled on it.
     pub global_this: BackRef<JSGlobalObject>,
 
     pub mkdirp_if_not_exists: bool,
@@ -129,8 +126,6 @@ impl CopyFile {
     }
 
     pub fn reject(&mut self, promise: &mut JSPromise) -> Result<(), jsc::JsTerminated> {
-        // Copy the BackRef out so the `&JSGlobalObject` below borrows the
-        // local, not `self` (which is mutated in between).
         let global_this = self.global_this;
         let mut system_error: SystemError = self.system_error.take().unwrap_or_default();
         if matches!(
@@ -995,10 +990,7 @@ pub struct CopyFileWindows {
     pub promise: jsc::JSPromiseStrong,
     pub mkdirp_if_not_exists: bool,
     pub destination_mode: Option<Mode>,
-    /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
-    /// `EventLoop`) outlives every libuv request scheduled on it. This struct is
-    /// heap-allocated and re-entered from libuv callbacks, so a borrowed
-    /// reference would lie about the lifetime.
+    /// BACKREF — the VM (and its `EventLoop`) outlives every libuv request scheduled on it.
     pub event_loop: BackRef<jsc::event_loop::EventLoop>,
 
     pub size: SizeType,
@@ -1717,12 +1709,8 @@ impl CopyFileWindows {
         };
 
         self.event_loop.ref_concurrently();
-        // LIFETIME: `AsyncMkdirp::new` returns `Box<Self>`. A temporary `Box`
-        // would drop at end-of-statement, freeing the allocation immediately
-        // after `schedule()` stashes a raw `*mut WorkPoolTask` into the work
-        // pool, so the worker thread would dereference freed memory. `Box::leak`
-        // hands ownership to the work-pool/completion path (same pattern as
-        // `WriteFileWindows::mkdirp` in write_file.rs).
+        // Box::leak: the work pool holds a raw pointer to the task; the
+        // completion path owns and frees it (same as `WriteFileWindows::mkdirp`).
         Box::leak(node_fs::async_::AsyncMkdirp::new(
             node_fs::async_::AsyncMkdirp {
                 completion: on_mkdirp_complete_concurrent,
@@ -1840,8 +1828,6 @@ fn on_mkdirp_complete_concurrent(ctx: *mut (), err_: bun_sys::Maybe<()>) {
         unsafe { (*this).on_mkdirp_complete() };
         Ok(())
     }
-    // Copy the `BackRef` out before the cross-thread handoff so no borrow of
-    // `this` is formally live once the JS thread may free the task.
     let event_loop = this.event_loop;
     event_loop.enqueue_task_concurrent(jsc::ConcurrentTask::create(
         jsc::ManagedTask::ManagedTask::new::<CopyFileWindows>(this, call_erased),

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1717,12 +1717,20 @@ impl CopyFileWindows {
         };
 
         self.event_loop.ref_concurrently();
-        node_fs::async_::AsyncMkdirp::new(node_fs::async_::AsyncMkdirp {
-            completion: on_mkdirp_complete_concurrent,
-            completion_ctx: core::ptr::from_mut(self).cast::<()>(),
-            path,
-            ..Default::default()
-        })
+        // LIFETIME: `AsyncMkdirp::new` returns `Box<Self>`. A temporary `Box`
+        // would drop at end-of-statement, freeing the allocation immediately
+        // after `schedule()` stashes a raw `*mut WorkPoolTask` into the work
+        // pool, so the worker thread would dereference freed memory. `Box::leak`
+        // hands ownership to the work-pool/completion path (same pattern as
+        // `WriteFileWindows::mkdirp` in write_file.rs).
+        Box::leak(node_fs::async_::AsyncMkdirp::new(
+            node_fs::async_::AsyncMkdirp {
+                completion: on_mkdirp_complete_concurrent,
+                completion_ctx: core::ptr::from_mut(self).cast::<()>(),
+                path,
+                ..Default::default()
+            },
+        ))
         .schedule();
     }
 

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1571,9 +1571,7 @@ impl CopyFileWindows {
 
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
         // calls enter() now and exit() on drop.
-        let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr())
-        };
+        let _guard = unsafe { jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr()) };
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
         unsafe { Self::destroy(core::ptr::from_mut(self)) };
         // `promise` points to a GC-owned `JSPromise` cell, not into `self`; valid after `destroy`.
@@ -1657,9 +1655,7 @@ impl CopyFileWindows {
         let promise = JSPromise::opaque_mut(self.promise.swap());
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
         // calls enter() now and exit() on drop.
-        let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr())
-        };
+        let _guard = unsafe { jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr()) };
 
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
         unsafe { Self::destroy(core::ptr::from_mut(self)) };

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -8,6 +8,7 @@ use crate::webcore::node_types::PathOrFileDescriptor;
 use bun_io as aio;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue};
 use bun_paths::PathBuffer;
+use bun_ptr::BackRef;
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(not(windows))]
@@ -41,7 +42,7 @@ fn to_jsc_system_error(e: &SystemError) -> jsc::SystemError {
 // CopyFile (POSIX, blocking off-thread)
 // ───────────────────────────────────────────────────────────────────────────
 
-pub struct CopyFile<'a> {
+pub struct CopyFile {
     pub destination_file_store: store::File,
     pub source_file_store: store::File,
     // `StoreRef` is the thread-safe refcounted handle;
@@ -60,10 +61,11 @@ pub struct CopyFile<'a> {
     pub read_len: SizeType,
     pub read_off: SizeType,
 
-    // per LIFETIMES.tsv: JSC_BORROW → &JSGlobalObject
-    // TODO(refactor): lifetime — this struct is Box-allocated and crosses threads;
-    // `'a` here is unsound in practice. Likely should be *const JSGlobalObject.
-    pub global_this: &'a JSGlobalObject,
+    /// BACKREF — captured from the JS thread at create time; the VM (and its
+    /// global object) outlives every task scheduled on it. This struct is
+    /// Box-allocated and crosses threads, so a borrowed reference would lie
+    /// about the lifetime.
+    pub global_this: BackRef<JSGlobalObject>,
 
     pub mkdirp_if_not_exists: bool,
     pub destination_mode: Option<Mode>,
@@ -73,7 +75,7 @@ pub type ResultType = Result<SizeType, bun_core::Error>;
 
 pub type Callback = fn(ctx: *mut c_void, len: ResultType);
 
-impl MkdirpTarget for CopyFile<'_> {
+impl MkdirpTarget for CopyFile {
     fn mkdirp_if_not_exists(&self) -> bool {
         self.mkdirp_if_not_exists
     }
@@ -85,7 +87,7 @@ impl MkdirpTarget for CopyFile<'_> {
     }
 }
 
-impl jsc::concurrent_promise_task::ConcurrentPromiseTaskContext for CopyFile<'_> {
+impl jsc::concurrent_promise_task::ConcurrentPromiseTaskContext for CopyFile {
     const TASK_TAG: bun_event_loop::TaskTag = bun_event_loop::task_tag::CopyFilePromiseTask;
     fn run(&mut self) {
         self.run_async();
@@ -95,8 +97,8 @@ impl jsc::concurrent_promise_task::ConcurrentPromiseTaskContext for CopyFile<'_>
     }
 }
 
-impl<'a> CopyFile<'a> {
-    pub fn create(
+impl CopyFile {
+    pub fn create<'a>(
         store: StoreRef,
         source_store: StoreRef,
         off: SizeType,
@@ -112,7 +114,7 @@ impl<'a> CopyFile<'a> {
             source_store: Some(source_store),
             offset: off,
             max_length: max_len,
-            global_this,
+            global_this: BackRef::new(global_this),
             mkdirp_if_not_exists,
             destination_mode,
             // defaults:
@@ -127,6 +129,8 @@ impl<'a> CopyFile<'a> {
     }
 
     pub fn reject(&mut self, promise: &mut JSPromise) -> Result<(), jsc::JsTerminated> {
+        // Copy the BackRef out so the `&JSGlobalObject` below borrows the
+        // local, not `self` (which is mutated in between).
         let global_this = self.global_this;
         let mut system_error: SystemError = self.system_error.take().unwrap_or_default();
         if matches!(
@@ -143,11 +147,11 @@ impl<'a> CopyFile<'a> {
         }
 
         let instance = to_jsc_system_error(&system_error)
-            .to_error_instance_with_async_stack(self.global_this, promise);
+            .to_error_instance_with_async_stack(global_this.get(), promise);
         if let Some(store) = self.store.take() {
             drop(store); // deref()
         }
-        promise.reject(global_this, Ok(instance))
+        promise.reject(global_this.get(), Ok(instance))
     }
 
     pub fn then(&mut self, promise: &mut JSPromise) -> Result<(), jsc::JsTerminated> {
@@ -158,7 +162,7 @@ impl<'a> CopyFile<'a> {
         }
 
         promise.resolve(
-            self.global_this,
+            self.global_this.get(),
             JSValue::js_number_from_uint64(self.read_len as u64),
         )
     }
@@ -983,7 +987,7 @@ impl TryWith {
 // ───────────────────────────────────────────────────────────────────────────
 
 #[cfg(windows)]
-pub struct CopyFileWindows<'a> {
+pub struct CopyFileWindows {
     pub destination_file_store: StoreRef,
     pub source_file_store: StoreRef,
 
@@ -991,10 +995,11 @@ pub struct CopyFileWindows<'a> {
     pub promise: jsc::JSPromiseStrong,
     pub mkdirp_if_not_exists: bool,
     pub destination_mode: Option<Mode>,
-    // per LIFETIMES.tsv: JSC_BORROW → &jsc::EventLoop
-    // TODO(refactor): lifetime — heap-allocated and re-entered from libuv callbacks;
-    // likely should be *const jsc::EventLoop.
-    pub event_loop: &'a jsc::event_loop::EventLoop,
+    /// BACKREF — captured from the JS-thread VM at create time; the VM (and its
+    /// `EventLoop`) outlives every libuv request scheduled on it. This struct is
+    /// heap-allocated and re-entered from libuv callbacks, so a borrowed
+    /// reference would lie about the lifetime.
+    pub event_loop: BackRef<jsc::event_loop::EventLoop>,
 
     pub size: SizeType,
 
@@ -1042,7 +1047,7 @@ impl Default for ReadWriteLoop {
 // borrow checker can see `self.read_write_loop` / `self.io_request` / `self.event_loop`
 // as disjoint field accesses through a single `&mut self`.
 #[cfg(windows)]
-impl<'a> CopyFileWindows<'a> {
+impl CopyFileWindows {
     fn read_write_loop_start(&mut self) -> bun_sys::Result<()> {
         self.read_write_loop.read_buf.reserve_exact(64 * 1024);
 
@@ -1267,7 +1272,7 @@ extern "C" fn on_write(req: *mut libuv::fs_t) {
 }
 
 #[cfg(windows)]
-impl<'a> CopyFileWindows<'a> {
+impl CopyFileWindows {
     pub fn on_read_write_loop_complete(&mut self) {
         self.event_loop.unref_concurrently();
 
@@ -1280,14 +1285,14 @@ impl<'a> CopyFileWindows<'a> {
         self.on_complete(written);
     }
 
-    pub fn new(init: CopyFileWindows<'a>) -> Box<CopyFileWindows<'a>> {
+    pub fn new(init: CopyFileWindows) -> Box<CopyFileWindows> {
         Box::new(init)
     }
 
     pub fn init(
         destination_file_store: StoreRef,
         source_file_store: StoreRef,
-        event_loop: &'a jsc::event_loop::EventLoop,
+        event_loop: &jsc::event_loop::EventLoop,
         mkdirp_if_not_exists: bool,
         size_: SizeType,
         destination_mode: Option<Mode>,
@@ -1300,7 +1305,7 @@ impl<'a> CopyFileWindows<'a> {
             promise: jsc::JSPromiseStrong::init(global),
             // SAFETY: all-zero is a valid libuv::fs_t
             io_request: bun_core::ffi::zeroed::<libuv::fs_t>(),
-            event_loop,
+            event_loop: BackRef::new(event_loop),
             mkdirp_if_not_exists,
             destination_mode,
             size: size_,
@@ -1567,7 +1572,7 @@ impl<'a> CopyFileWindows<'a> {
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
         // calls enter() now and exit() on drop.
         let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop as *const _ as *mut _)
+            jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr())
         };
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
         unsafe { Self::destroy(core::ptr::from_mut(self)) };
@@ -1653,7 +1658,7 @@ impl<'a> CopyFileWindows<'a> {
         // SAFETY: VM-owned event loop is valid for the process lifetime; `enter_scope`
         // calls enter() now and exit() on drop.
         let _guard = unsafe {
-            jsc::event_loop::EventLoop::enter_scope(self.event_loop as *const _ as *mut _)
+            jsc::event_loop::EventLoop::enter_scope(self.event_loop.as_ptr())
         };
 
         // SAFETY: self was heap-allocated in init(); destroy reclaims and drops it. self is not accessed afterward.
@@ -1824,17 +1829,19 @@ fn on_mkdirp_complete_concurrent(ctx: *mut (), err_: bun_sys::Maybe<()>) {
     };
     // `bun_event_loop::JsResult` carries the low-tier `ErasedJsError`; shim the
     // callback signature to match `ManagedTask::new`'s `fn(*mut T) -> JsResult<()>`.
-    fn call_erased(this: *mut CopyFileWindows<'_>) -> bun_event_loop::JsResult<()> {
+    fn call_erased(this: *mut CopyFileWindows) -> bun_event_loop::JsResult<()> {
         // SAFETY: `this` is the heap-allocated `CopyFileWindows` passed to
         // `ManagedTask::new` below; `on_mkdirp_complete` may free it via `throw`, so we
         // do not touch `this` afterward.
         unsafe { (*this).on_mkdirp_complete() };
         Ok(())
     }
-    this.event_loop
-        .enqueue_task_concurrent(jsc::ConcurrentTask::create(
-            jsc::ManagedTask::ManagedTask::new::<CopyFileWindows>(this, call_erased),
-        ));
+    // Copy the `BackRef` out before the cross-thread handoff so no borrow of
+    // `this` is formally live once the JS thread may free the task.
+    let event_loop = this.event_loop;
+    event_loop.enqueue_task_concurrent(jsc::ConcurrentTask::create(
+        jsc::ManagedTask::ManagedTask::new::<CopyFileWindows>(this, call_erased),
+    ));
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -1871,5 +1878,5 @@ fn unsupported_non_regular_file_error() -> SystemError {
 // so these are constructor fns instead of `const` values.
 
 pub type CopyFilePromiseTask<'a> =
-    jsc::concurrent_promise_task::ConcurrentPromiseTask<'a, CopyFile<'a>>;
+    jsc::concurrent_promise_task::ConcurrentPromiseTask<'a, CopyFile>;
 pub type CopyFilePromiseTaskEventLoopTask = jsc::EventLoopTask;

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -961,19 +961,17 @@ mod windows_impl {
             // `AsyncMkdirp::schedule` heap-allocates the task and hands
             // ownership to the work pool, which frees it after the completion
             // callback returns.
-            crate::node::fs::async_::AsyncMkdirp::schedule(
-                crate::node::fs::async_::AsyncMkdirp {
-                    completion: Self::on_mkdirp_complete_concurrent,
-                    completion_ctx: ctx,
-                    // BORROW: AsyncMkdirp.path is `*const [u8]` (not owned); `path`
-                    // points into `self.file_blob.store`, which outlives the mkdirp
-                    // task (it's released only in `deinit()`).
-                    path: bun_core::dirname(path)
-                        // this shouldn't happen
-                        .unwrap_or(path) as *const [u8],
-                    ..Default::default()
-                },
-            );
+            crate::node::fs::async_::AsyncMkdirp::schedule(crate::node::fs::async_::AsyncMkdirp {
+                completion: Self::on_mkdirp_complete_concurrent,
+                completion_ctx: ctx,
+                // BORROW: AsyncMkdirp.path is `*const [u8]` (not owned); `path`
+                // points into `self.file_blob.store`, which outlives the mkdirp
+                // task (it's released only in `deinit()`).
+                path: bun_core::dirname(path)
+                    // this shouldn't happen
+                    .unwrap_or(path) as *const [u8],
+                ..Default::default()
+            });
         }
 
         /// # Safety

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -958,14 +958,10 @@ mod windows_impl {
                 .pathlike
                 .path()
                 .slice();
-            // LIFETIME: `AsyncMkdirp::new` returns `Box<Self>`. The allocation
-            // is intentionally leaked here and freed by `work_pool_callback`
-            // after invoking `completion`. A temporary
-            // `Box` would drop at end-of-statement, freeing the allocation immediately
-            // after `schedule()` stashes a raw `*mut WorkPoolTask` into the work pool,
-            // so the worker thread would dereference freed memory. `Box::leak` hands
-            // ownership to the work-pool/completion path.
-            Box::leak(crate::node::fs::async_::AsyncMkdirp::new(
+            // `AsyncMkdirp::schedule` heap-allocates the task and hands
+            // ownership to the work pool, which frees it after the completion
+            // callback returns.
+            crate::node::fs::async_::AsyncMkdirp::schedule(
                 crate::node::fs::async_::AsyncMkdirp {
                     completion: Self::on_mkdirp_complete_concurrent,
                     completion_ctx: ctx,
@@ -977,8 +973,7 @@ mod windows_impl {
                         .unwrap_or(path) as *const [u8],
                     ..Default::default()
                 },
-            ))
-            .schedule();
+            );
         }
 
         /// # Safety

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -607,11 +607,8 @@ const IS_UV_FS_COPYFILE_DISABLED =
 });
 
 describe("Bun.write file-to-file copy task liveness", () => {
-  // The file->file copy task is heap-allocated, scheduled on the work pool
-  // (POSIX) or libuv (Windows), and re-entered after the scheduling stack
-  // frame is gone. This is smoke coverage for those copy-task paths (success,
-  // mkdirp retry, and rejection) under forced GC pressure — a liveness
-  // contract guard, not a test that fails on any released build.
+  // Smoke coverage for the heap-allocated copy task (success, mkdirp retry,
+  // rejection) under forced GC pressure.
   it("file->file copies survive forced GC between scheduling and completion", async () => {
     using dir = tempDir("bun-write-copyfile-gc", {
       "src.txt": Buffer.alloc(64 * 1024, "A").toString(),
@@ -628,10 +625,8 @@ describe("Bun.write file-to-file copy task liveness", () => {
         Bun.gc(true);
         const written = await Promise.all(pending);
         Bun.gc(true);
-        // Windows' default uv_fs_copyfile path resolves with a byte count read
-        // from a statbuf that libuv's fs__copyfile never populates, so the
-        // promise value is 0 there; assert the resolved counts on POSIX only
-        // and verify the on-disk sizes everywhere below.
+        // Windows resolves with 0 (libuv's fs__copyfile never fills statbuf);
+        // assert resolved counts on POSIX only, on-disk sizes everywhere.
         if (process.platform !== "win32" && !written.every(n => n === expected.length)) {
           throw new Error("unexpected byte counts: " + JSON.stringify(written));
         }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -614,9 +614,10 @@ describe("Bun.write file-to-file copy task liveness", () => {
   // contract guard, not a test that fails on any released build.
   it("file->file copies survive forced GC between scheduling and completion", async () => {
     using dir = tempDir("bun-write-copyfile-gc", {
-      "src.txt": "A".repeat(64 * 1024),
+      "src.txt": Buffer.alloc(64 * 1024, "A").toString(),
       "copy-gc.js": `
-        const expected = "A".repeat(64 * 1024);
+        const fs = require("fs");
+        const expected = Buffer.alloc(64 * 1024, "A").toString();
         const pending = [];
         for (let i = 0; i < 50; i++) {
           // Nested destination exercises the mkdirp -> retry path too.
@@ -627,8 +628,16 @@ describe("Bun.write file-to-file copy task liveness", () => {
         Bun.gc(true);
         const written = await Promise.all(pending);
         Bun.gc(true);
-        if (!written.every(n => n === expected.length)) {
+        // Windows' default uv_fs_copyfile path resolves with a byte count read
+        // from a statbuf that libuv's fs__copyfile never populates, so the
+        // promise value is 0 there; assert the resolved counts on POSIX only
+        // and verify the on-disk sizes everywhere below.
+        if (process.platform !== "win32" && !written.every(n => n === expected.length)) {
           throw new Error("unexpected byte counts: " + JSON.stringify(written));
+        }
+        for (let i = 0; i < 50; i++) {
+          const size = fs.statSync(\`out/\${i}/dest.txt\`).size;
+          if (size !== expected.length) throw new Error("size mismatch at " + i + ": " + size);
         }
         for (const i of [0, 25, 49]) {
           const text = await Bun.file(\`out/\${i}/dest.txt\`).text();

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,6 +1,16 @@
 import { describe, expect, it, test } from "bun:test";
 import fs, { mkdirSync } from "fs";
-import { bunEnv, bunExe, exampleHtml, exampleSite, gcTick, isWindows, tempDir, withoutAggressiveGC } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  exampleHtml,
+  exampleSite,
+  gcTick,
+  isWindows,
+  normalizeBunSnapshot,
+  tempDir,
+  withoutAggressiveGC,
+} from "harness";
 import path, { join } from "path";
 
 let i = 0;
@@ -593,5 +603,65 @@ const IS_UV_FS_COPYFILE_DISABLED =
     Bun.gc(true);
 
     expect(f.name).toBe(filePath);
+  });
+});
+
+describe("Bun.write file-to-file copy task liveness", () => {
+  // The file->file copy task is heap-allocated, scheduled on the work pool
+  // (POSIX) or libuv (Windows), and re-entered after the scheduling stack
+  // frame is gone. This is smoke coverage for those copy-task paths (success,
+  // mkdirp retry, and rejection) under forced GC pressure — a liveness
+  // contract guard, not a test that fails on any released build.
+  it("file->file copies survive forced GC between scheduling and completion", async () => {
+    using dir = tempDir("bun-write-copyfile-gc", {
+      "src.txt": "A".repeat(64 * 1024),
+      "copy-gc.js": `
+        const expected = "A".repeat(64 * 1024);
+        const pending = [];
+        for (let i = 0; i < 50; i++) {
+          // Nested destination exercises the mkdirp -> retry path too.
+          const promise = Bun.write(Bun.file(\`out/\${i}/dest.txt\`), Bun.file("src.txt"));
+          if (i % 10 === 0) Bun.gc(true);
+          pending.push(promise);
+        }
+        Bun.gc(true);
+        const written = await Promise.all(pending);
+        Bun.gc(true);
+        if (!written.every(n => n === expected.length)) {
+          throw new Error("unexpected byte counts: " + JSON.stringify(written));
+        }
+        for (const i of [0, 25, 49]) {
+          const text = await Bun.file(\`out/\${i}/dest.txt\`).text();
+          if (text !== expected) throw new Error("content mismatch at " + i);
+        }
+
+        // Rejection path: missing source must reject (not crash) after GC.
+        const failing = Bun.write(Bun.file("out/err.txt"), Bun.file("does-not-exist.txt"));
+        Bun.gc(true);
+        let code = null;
+        try {
+          await failing;
+        } catch (e) {
+          code = e?.code;
+        }
+        Bun.gc(true);
+        if (code !== "ENOENT") throw new Error("expected ENOENT rejection, got " + code);
+        console.log("OK");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "copy-gc.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(normalizeBunSnapshot(stdout)).toBe("OK");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
CopyFile<'a> and CopyFileWindows<'a> are Box-allocated, handed to the work pool / libuv, and re-entered from callbacks after the constructing stack frame is gone, so their `&'a JSGlobalObject` / `&'a EventLoop` fields claimed a borrow lifetime that was false in practice. This converts both fields (and the matching `global_this` field on the shared ConcurrentPromiseTask wrapper, which has the same heap-task shape) to `bun_ptr::BackRef`, the established lifetime-erased back-reference type whose invariant (VM/event-loop outlives every task scheduled on it) matches the actual runtime contract. CopyFile and CopyFileWindows lose their lifetime parameters; the public `ConcurrentPromiseTask<'a, _>` signature is preserved via PhantomData so downstream type aliases (glob, transpiler, image) are untouched, and the `CopyFilePromiseTask<'a>` alias plus dispatch.rs call sites compile unchanged. No `'static` erasure is introduced and all event-loop accesses on the Windows path (uv_loop, ref/unref_concurrently, global_ref, enter_scope) go through the BackRef without holding `&` borrows across libuv callbacks. Tested by a new subprocess test in bun-write.test.js that schedules 50 file-to-file copies (including the mkdirp path) plus a missing-source rejection, forcing Bun.gc(true) between scheduling and completion, asserting byte counts, content, ENOENT, and exit 0.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
