### PR TITLE
fs.watch: type FSWatcher's wrapper self-reference as JsRef instead of a bare JSValue

### DIFF
--- a/src/jsc/JSRef.rs
+++ b/src/jsc/JSRef.rs
@@ -250,3 +250,21 @@ impl Default for JsRef {
         JsRef::empty()
     }
 }
+
+/// Forwarding accessors for the common `JsCell<JsRef>` field shape, so call
+/// sites read `field.try_get()` / `field.get_or_undefined()` instead of the
+/// double-step `field.get().try_get()` / `field.get().get()`.
+impl crate::JsCell<JsRef> {
+    /// [`JsRef::try_get`] on the contained ref: the live `JSValue`, or `None`
+    /// if empty/finalized.
+    #[inline]
+    pub fn try_get(&self) -> Option<JSValue> {
+        self.get().try_get()
+    }
+
+    /// [`JsRef::get`] on the contained ref: `try_get().unwrap_or(UNDEFINED)`.
+    #[inline]
+    pub fn get_or_undefined(&self) -> JSValue {
+        self.get().get()
+    }
+}

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -713,7 +713,7 @@ impl FSWatcher {
     /// Returns `UNDEFINED` if the wrapper reference has been cleared.
     #[inline]
     pub fn js_this(&self) -> JSValue {
-        self.js_this.get().get()
+        self.js_this.get_or_undefined()
     }
 
     /// `FSWatcher.initJS`. Takes `*mut Self` so the
@@ -783,7 +783,7 @@ impl FSWatcher {
         // so both calls are inlined at the end of this function.
 
         err.ensure_still_alive();
-        let js_this = self.js_this.get().try_get();
+        let js_this = self.js_this.try_get();
         if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
             if let Some(listener) = js::listener_get_cached(js_this) {
@@ -815,7 +815,7 @@ impl FSWatcher {
         }
         // Reshaped for borrowck — `defer this.close()` moved to fn end.
 
-        let js_this = self.js_this.get().try_get();
+        let js_this = self.js_this.try_get();
         if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
             if let Some(listener) = js::listener_get_cached(js_this) {
@@ -833,7 +833,7 @@ impl FSWatcher {
     }
 
     pub fn emit_with_filename<const EVENT_TYPE: EventType>(&self, file_name: JSValue) {
-        let Some(js_this) = self.js_this.get().try_get() else {
+        let Some(js_this) = self.js_this.try_get() else {
             return;
         };
         let Some(listener) = js::listener_get_cached(js_this) else {
@@ -844,7 +844,7 @@ impl FSWatcher {
 
     pub fn emit<const EVENT_TYPE: EventType>(&self, file_name: &[u8]) {
         debug_assert!(EVENT_TYPE != EventType::Error);
-        let Some(js_this) = self.js_this.get().try_get() else {
+        let Some(js_this) = self.js_this.try_get() else {
             return;
         };
         let Some(listener) = js::listener_get_cached(js_this) else {
@@ -947,7 +947,7 @@ impl FSWatcher {
             self.closed.set(true);
             // Read before `detach()` clears the ref; pending activity still
             // roots the wrapper for the close-event emit below.
-            let js_this = self.js_this.get().try_get();
+            let js_this = self.js_this.try_get();
             self.mutex.unlock();
             self.detach();
 

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -53,15 +53,9 @@ pub struct FSWatcher {
     path_watcher: Cell<Option<*mut path_watcher::PathWatcher>>,
     poll_ref: JsCell<KeepAlive>,
     global_this: GlobalRef,
-    /// Reference to the JS wrapper object. Held **weak** on purpose: the
-    /// wrapper's GC liveness is rooted by `has_pending_activity()`
-    /// (`pending_activity_count` starts at 1 and stays > 0 until `close()`/
-    /// `detach()`), never by this field. A `Strong` here would be a self-ref
-    /// cycle that pins the wrapper forever. `detach()` resets it to
-    /// `JsRef::empty()` (idempotent); every reader goes through `try_get()`.
-    /// Note `try_get()` only observes an explicit `detach()` clearing the
-    /// field — it cannot detect GC collection on its own; the finalize →
-    /// `detach()` ordering is what prevents a stale read.
+    /// JS wrapper object, held weak: the wrapper is rooted by
+    /// `has_pending_activity()` while the watcher is open; a strong ref here
+    /// would self-pin it forever. Cleared by `detach()`.
     js_this: JsCell<JsRef>,
     // pub(super): read directly by `win_watcher::PathWatcher::emit`.
     pub(super) encoding: Encoding,
@@ -743,8 +737,6 @@ impl FSWatcher {
         // `heap::take(this)`.
         let js_this = unsafe { Self::to_js_ptr(this, &this_ref.global_this) };
         js_this.ensure_still_alive();
-        // Weak on purpose: `has_pending_activity()` roots the wrapper while
-        // the watcher is live; a Strong here would self-pin it forever.
         this_ref.js_this.set(JsRef::init_weak(js_this));
         js::listener_set_cached(js_this, &this_ref.global_this, listener);
 
@@ -791,8 +783,6 @@ impl FSWatcher {
         // so both calls are inlined at the end of this function.
 
         err.ensure_still_alive();
-        // Copy the value out; the `&JsRef` borrow must not be held across the
-        // re-entrant listener call below (it may `close()` -> `detach()`).
         let js_this = self.js_this.get().try_get();
         if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
@@ -825,8 +815,6 @@ impl FSWatcher {
         }
         // Reshaped for borrowck — `defer this.close()` moved to fn end.
 
-        // Copy out; do not hold the `&JsRef` borrow across the re-entrant
-        // listener call below.
         let js_this = self.js_this.get().try_get();
         if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
@@ -957,9 +945,8 @@ impl FSWatcher {
         self.mutex.lock();
         if !self.closed.get() {
             self.closed.set(true);
-            // Copy the wrapper value out before `detach()` clears the ref;
-            // `pending_activity_count` is still > 0 here so the copied
-            // JSValue stays valid for the close-event emit below.
+            // Read before `detach()` clears the ref; pending activity still
+            // roots the wrapper for the close-event emit below.
             let js_this = self.js_this.get().try_get();
             self.mutex.unlock();
             self.detach();

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -16,7 +16,7 @@ use bun_jsc::event_loop::EventLoop;
 use bun_jsc::node::PathLike;
 use bun_jsc::{
     self as jsc, AbortSignal, AbortSignalRef, ArgumentsSlice, CallFrame, CommonAbortReason,
-    CommonAbortReasonExt as _, GlobalRef, JSGlobalObject, JSValue, JsResult, SysErrorJsc,
+    CommonAbortReasonExt as _, GlobalRef, JSGlobalObject, JSValue, JsRef, JsResult, SysErrorJsc,
     VirtualMachineRef as VirtualMachine, ZigStringJsc as _,
 };
 use bun_paths::resolve_path::{self as Path, platform};
@@ -53,8 +53,16 @@ pub struct FSWatcher {
     path_watcher: Cell<Option<*mut path_watcher::PathWatcher>>,
     poll_ref: JsCell<KeepAlive>,
     global_this: GlobalRef,
-    // TODO: bare JSValue heap field — self-wrapper; consider JsRef.
-    pub(super) js_this: Cell<JSValue>,
+    /// Reference to the JS wrapper object. Held **weak** on purpose: the
+    /// wrapper's GC liveness is rooted by `has_pending_activity()`
+    /// (`pending_activity_count` starts at 1 and stays > 0 until `close()`/
+    /// `detach()`), never by this field. A `Strong` here would be a self-ref
+    /// cycle that pins the wrapper forever. `detach()` resets it to
+    /// `JsRef::empty()` (idempotent); every reader goes through `try_get()`.
+    /// Note `try_get()` only observes an explicit `detach()` clearing the
+    /// field — it cannot detect GC collection on its own; the finalize →
+    /// `detach()` ordering is what prevents a stale read.
+    js_this: JsCell<JsRef>,
     // pub(super): read directly by `win_watcher::PathWatcher::emit`.
     pub(super) encoding: Encoding,
 
@@ -708,9 +716,10 @@ impl AbortListener for FSWatcher {
 
 impl FSWatcher {
     /// Read access to the JS wrapper value. Exposed for `NodeFS::watch`.
+    /// Returns `UNDEFINED` if the wrapper reference has been cleared.
     #[inline]
     pub fn js_this(&self) -> JSValue {
-        self.js_this.get()
+        self.js_this.get().get()
     }
 
     /// `FSWatcher.initJS`. Takes `*mut Self` so the
@@ -734,7 +743,9 @@ impl FSWatcher {
         // `heap::take(this)`.
         let js_this = unsafe { Self::to_js_ptr(this, &this_ref.global_this) };
         js_this.ensure_still_alive();
-        this_ref.js_this.set(js_this);
+        // Weak on purpose: `has_pending_activity()` roots the wrapper while
+        // the watcher is live; a Strong here would self-pin it forever.
+        this_ref.js_this.set(JsRef::init_weak(js_this));
         js::listener_set_cached(js_this, &this_ref.global_this, listener);
 
         if let Some(s) = this_ref.signal.get() {
@@ -780,8 +791,10 @@ impl FSWatcher {
         // so both calls are inlined at the end of this function.
 
         err.ensure_still_alive();
-        let js_this = self.js_this.get();
-        if !js_this.is_empty() {
+        // Copy the value out; the `&JsRef` borrow must not be held across the
+        // re-entrant listener call below (it may `close()` -> `detach()`).
+        let js_this = self.js_this.get().try_get();
+        if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
             if let Some(listener) = js::listener_get_cached(js_this) {
                 listener.ensure_still_alive();
@@ -812,8 +825,10 @@ impl FSWatcher {
         }
         // Reshaped for borrowck — `defer this.close()` moved to fn end.
 
-        let js_this = self.js_this.get();
-        if !js_this.is_empty() {
+        // Copy out; do not hold the `&JsRef` borrow across the re-entrant
+        // listener call below.
+        let js_this = self.js_this.get().try_get();
+        if let Some(js_this) = js_this {
             js_this.ensure_still_alive();
             if let Some(listener) = js::listener_get_cached(js_this) {
                 listener.ensure_still_alive();
@@ -830,10 +845,9 @@ impl FSWatcher {
     }
 
     pub fn emit_with_filename<const EVENT_TYPE: EventType>(&self, file_name: JSValue) {
-        let js_this = self.js_this.get();
-        if js_this.is_empty() {
+        let Some(js_this) = self.js_this.get().try_get() else {
             return;
-        }
+        };
         let Some(listener) = js::listener_get_cached(js_this) else {
             return;
         };
@@ -842,10 +856,9 @@ impl FSWatcher {
 
     pub fn emit<const EVENT_TYPE: EventType>(&self, file_name: &[u8]) {
         debug_assert!(EVENT_TYPE != EventType::Error);
-        let js_this = self.js_this.get();
-        if js_this.is_empty() {
+        let Some(js_this) = self.js_this.get().try_get() else {
             return;
-        }
+        };
         let Some(listener) = js::listener_get_cached(js_this) else {
             return;
         };
@@ -944,11 +957,14 @@ impl FSWatcher {
         self.mutex.lock();
         if !self.closed.get() {
             self.closed.set(true);
-            let js_this = self.js_this.get();
+            // Copy the wrapper value out before `detach()` clears the ref;
+            // `pending_activity_count` is still > 0 here so the copied
+            // JSValue stays valid for the close-event emit below.
+            let js_this = self.js_this.get().try_get();
             self.mutex.unlock();
             self.detach();
 
-            if !js_this.is_empty() {
+            if let Some(js_this) = js_this {
                 if let Some(listener) = js::listener_get_cached(js_this) {
                     // `closed` is already true so `refTask()` would return false without
                     // incrementing; bump the counter directly so the `unrefTask()` below is
@@ -1023,7 +1039,8 @@ impl FSWatcher {
             signal.clean_native_bindings(ctx_ptr);
         }
 
-        self.js_this.set(JSValue::ZERO);
+        // Idempotent: `detach()` can run more than once (close + finalize).
+        self.js_this.set(JsRef::empty());
     }
 
     #[bun_jsc::host_fn(method)]
@@ -1083,7 +1100,7 @@ impl FSWatcher {
             persistent: Cell::new(args.persistent),
             path_watcher: Cell::new(None),
             global_this: GlobalRef::from(args.global_this),
-            js_this: Cell::new(JSValue::ZERO),
+            js_this: JsCell::new(JsRef::empty()),
             encoding: args.encoding,
             closed: Cell::new(false),
             verbose: args.verbose,

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1073,16 +1073,10 @@ test("fs.watch reports an error for relative paths that no longer fit in the pat
   expect(exitCode).toBe(0);
 });
 
-// The native FSWatcher keeps a reference to its own JS wrapper to look up the
-// cached event listener when emitting. That reference is intentionally weak
-// (the wrapper is rooted by hasPendingActivity while the watcher is open), so
-// every emit path (change/rename, error, abort, close) must tolerate GC runs
-// between creation, event delivery, abort, and close without the wrapper
-// reference dangling. This subprocess exercises all four paths with forced GC
-// between every step. Regression guard for the weak-self-reference plumbing:
-// the migration this covers was behavior-preserving, so this also passes on
-// older builds — it exists to catch a future rooting/clearing mistake in any
-// of these paths (which would crash the subprocess or drop the awaited events).
+// The native FSWatcher holds a weak reference to its JS wrapper (rooted by
+// hasPendingActivity while open). Exercise every emit path (change, error,
+// abort, close) with forced GC between steps; a rooting/clearing mistake
+// crashes the subprocess or drops the awaited events.
 test("fs.watch wrapper reference survives GC across event, abort and close paths", async () => {
   using dir = tempDir("fswatch-jsref-gc", { "target.txt": "x" });
   const watchDir = String(dir);

--- a/test/js/node/watch/fs.watch.test.ts
+++ b/test/js/node/watch/fs.watch.test.ts
@@ -1072,3 +1072,112 @@ test("fs.watch reports an error for relative paths that no longer fit in the pat
   // the subprocess instead of throwing a catchable error.
   expect(exitCode).toBe(0);
 });
+
+// The native FSWatcher keeps a reference to its own JS wrapper to look up the
+// cached event listener when emitting. That reference is intentionally weak
+// (the wrapper is rooted by hasPendingActivity while the watcher is open), so
+// every emit path (change/rename, error, abort, close) must tolerate GC runs
+// between creation, event delivery, abort, and close without the wrapper
+// reference dangling. This subprocess exercises all four paths with forced GC
+// between every step. Regression guard for the weak-self-reference plumbing:
+// the migration this covers was behavior-preserving, so this also passes on
+// older builds — it exists to catch a future rooting/clearing mistake in any
+// of these paths (which would crash the subprocess or drop the awaited events).
+test("fs.watch wrapper reference survives GC across event, abort and close paths", async () => {
+  using dir = tempDir("fswatch-jsref-gc", { "target.txt": "x" });
+  const watchDir = String(dir);
+
+  const fixture = /* js */ `
+    const fs = require("fs");
+    const path = require("path");
+    const dir = ${JSON.stringify(watchDir)};
+    const file = path.join(dir, "target.txt");
+
+    // Write-and-poll until \`done()\` reports true; bounded so a missed event
+    // becomes a crisp error instead of a hang with no diagnostics.
+    async function pokeUntil(done, label) {
+      for (let attempt = 0; attempt < 500; attempt++) {
+        if (done()) return;
+        fs.writeFileSync(file, label + " " + attempt + " " + Math.random());
+        Bun.gc(true);
+        await Bun.sleep(10);
+      }
+      throw new Error("event never delivered: " + label);
+    }
+
+    async function main() {
+      // Phase 1: event delivery + close event, with GC forced between steps.
+      for (let round = 0; round < 3; round++) {
+        let sawEvent;
+        const gotEvent = new Promise(resolve => (sawEvent = resolve));
+        const watcher = fs.watch(dir, () => sawEvent());
+        Bun.gc(true);
+
+        // Keep touching the file until the event lands (watch registration
+        // can race the first write on some platforms).
+        let delivered = false;
+        gotEvent.then(() => (delivered = true));
+        await pokeUntil(() => delivered, "round " + round);
+        await gotEvent;
+
+        const gotClose = new Promise(resolve => watcher.once("close", resolve));
+        Bun.gc(true);
+        watcher.close();
+        Bun.gc(true);
+        await gotClose;
+      }
+
+      // Phase 2: abort path under GC pressure.
+      for (let i = 0; i < 3; i++) {
+        const ac = new AbortController();
+        const watcher = fs.watch(dir, { signal: ac.signal }, () => {});
+        const gotAbort = new Promise((resolve, reject) => {
+          watcher.once("error", err =>
+            err.message === "The operation was aborted." ? resolve() : reject(err),
+          );
+        });
+        Bun.gc(true);
+        ac.abort();
+        Bun.gc(true);
+        await gotAbort;
+      }
+
+      // Phase 3: double-close and close-from-inside-listener under GC.
+      {
+        let closeFromListener;
+        const closedFromListener = new Promise(resolve => (closeFromListener = resolve));
+        const watcher = fs.watch(dir, () => {
+          Bun.gc(true);
+          watcher.close(); // re-entrant close from inside the native emit
+          watcher.close(); // second close must be a no-op
+          closeFromListener();
+        });
+        let done = false;
+        closedFromListener.then(() => (done = true));
+        await pokeUntil(() => done, "phase3");
+        await closedFromListener;
+        Bun.gc(true);
+      }
+
+      Bun.gc(true);
+      console.log("OK");
+    }
+
+    main().catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout.trim()).toBe("OK");
+  expect(exitCode).toBe(0);
+}, 30_000);


### PR DESCRIPTION
FSWatcher stored its reference to its own JS wrapper as a bare Cell<JSValue>, an untyped encoded value with no expression of its GC contract. The wrapper's liveness is rooted by hasPendingActivity() (pending_activity_count starts at 1 and stays positive until close/detach), so the field is now a JsCell<JsRef> held weak on purpose — a Strong here would be a self-reference cycle that pins the wrapper forever. All readers (emit, emit_with_filename, emit_error, emit_abort, close, the js_this() accessor) now go through JsRef::try_get() and copy the value out before any re-entrant listener call, and detach() idempotently resets the ref to JsRef::empty(). Behavior is unchanged; the field is now typed for its GC role and every read is null-checked through one audited path. Tested with a new subprocess GC-stress test in fs.watch.test.ts that forces Bun.gc(true) between watcher creation, event delivery, abort-signal abort, re-entrant close-from-listener, double close, and close-event emission, asserting all events arrive and the process exits cleanly.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
