### PR TITLE
test runner: store Scanner.fs as a raw pointer instead of casting away shared refs

### DIFF
--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -8,6 +8,7 @@ use bun_core::ZStr;
 use bun_core::err;
 use bun_core::{StringOrTinyString, strings};
 use bun_output::{declare_scope, scoped_log};
+use bun_paths::resolve_path::{join_abs_string_buf, platform};
 use bun_paths::{self, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::{self as fs, DirEntryIterator, EntriesOption, FileSystem};
@@ -27,13 +28,16 @@ pub struct Scanner<'a> {
     pub dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
     pub test_files: Vec<Interned>,
-    // dirname_store appends are fine through `&self` (interior-mutable bss
-    // string list), but `read_dir_with_name`/`next` derive `&mut RealFS` from
-    // this `&FileSystem` via lint-silenced `&T` -> `&mut T` casts — that is
-    // UB-adjacent debt, not a settled design. This field should become
-    // `*mut FileSystem` (the shape `Transpiler.fs` already uses; init would
-    // store `transpiler.fs` directly) or RealFS needs interior mutability.
-    pub fs: &'a FileSystem,
+    /// Pointer to the process-singleton `FileSystem` (the shape
+    /// `Transpiler.fs` uses). Reads outside the directory-iterator callback
+    /// go through the [`Self::fs()`] accessor; reads on the callback path
+    /// (`next` and its callees) use field-precise place projections
+    /// (`Self::top_level_dir`, `Self::filename_store`) so no
+    /// whole-struct `&FileSystem` is formed while the resolver holds `&mut`
+    /// to the singleton's `fs` field. The two mutation sites
+    /// (`read_dir_with_name`, `next`) derive `&mut`/`*mut RealFS` directly
+    /// from this pointer so writes carry genuine write provenance.
+    pub fs: *mut FileSystem,
     pub open_dir_buf: PathBuffer,
     pub scan_dir_buf: PathBuffer,
     pub options: &'a BundleOptions<'a>,
@@ -94,15 +98,76 @@ impl<'a> Scanner<'a> {
             path_ignore_patterns: &[],
             dirs_to_scan: Fifo::new(),
             options: &transpiler.options,
-            // SAFETY: `Transpiler.fs` is the process-singleton `*mut FileSystem`;
+            // `Transpiler.fs` is the process-singleton `*mut FileSystem`;
             // it outlives the scanner.
-            fs: unsafe { &*transpiler.fs },
+            fs: transpiler.fs,
             test_files: results,
             open_dir_buf: PathBuffer::uninit(),
             scan_dir_buf: PathBuffer::uninit(),
             has_iterated: false,
             search_count: 0,
         })
+    }
+
+    /// Shared-read access to the process-singleton [`FileSystem`].
+    ///
+    /// `'static` is sound: the singleton is initialized once at startup and
+    /// never freed. The unbounded lifetime also keeps reads like
+    /// `self.fs().abs_buf(…, &mut self.scan_dir_buf)` borrow-compatible with
+    /// `&mut` borrows of other `Scanner` fields.
+    ///
+    /// Must NOT be called on the directory-iterator callback path (`next`
+    /// and its callees): for the whole body of
+    /// `read_directory_with_iterator` the resolver holds a live `&mut` to
+    /// the singleton's `fs` field, and a whole-struct `&FileSystem` formed
+    /// here would span that field — an aliasing violation even if the
+    /// reference is immediately dropped. The callback path uses the
+    /// field-precise `Self::top_level_dir`/`Self::filename_store`
+    /// projections instead, which never touch the `fs` field's bytes.
+    #[inline]
+    pub(crate) fn fs(&self) -> &'static FileSystem {
+        // SAFETY: `self.fs` points at the process-singleton `FileSystem`
+        // (see `init`), which lives for the whole process. Callers are
+        // outside `read_directory_with_iterator`, so no `&mut` to any part
+        // of the singleton is live (see doc comment).
+        unsafe { &*self.fs }
+    }
+
+    /// Field-precise copy of the singleton's `top_level_dir`.
+    ///
+    /// Safe to call on the iterator-callback path (`next` and its callees),
+    /// unlike `Self::fs()`: the raw place projection reads only the
+    /// `top_level_dir` field's bytes, which are disjoint from the `fs:
+    /// Implementation` field mutably borrowed by
+    /// `read_directory_with_iterator` for the duration of the walk.
+    #[inline]
+    fn top_level_dir(&self) -> &'static [u8] {
+        // SAFETY: `self.fs` points at the process-singleton `FileSystem`,
+        // live for the whole process; the projection reads only the
+        // `top_level_dir` field, never forming a reference that spans the
+        // mutably-borrowed `fs` field.
+        unsafe { (*self.fs).top_level_dir }
+    }
+
+    /// Field-precise copy of the singleton's `filename_store` handle. Same
+    /// callback-path rationale as `Self::top_level_dir`.
+    #[inline]
+    fn filename_store(&self) -> &'static fs::FilenameStore {
+        // SAFETY: same as `top_level_dir`; reads only the `filename_store`
+        // field, disjoint from the mutably-borrowed `fs` field.
+        unsafe { (*self.fs).filename_store }
+    }
+
+    /// Joins `parts` against the singleton's `top_level_dir` into `buf` —
+    /// `FileSystem::abs_buf` minus the whole-struct `&FileSystem` receiver,
+    /// for use on the iterator-callback path (see `Self::top_level_dir`).
+    #[inline]
+    fn abs_buf_projected<'b>(
+        top_level_dir: &'static [u8],
+        parts: &[&[u8]],
+        buf: &'b mut [u8],
+    ) -> &'b [u8] {
+        join_abs_string_buf::<platform::Loose>(top_level_dir, buf, parts)
     }
 
     /// Take the list of test files out of this scanner. Caller owns the returned
@@ -112,11 +177,11 @@ impl<'a> Scanner<'a> {
     }
 
     pub fn scan(&mut self, path_literal: &[u8]) -> Result<(), ScanError> {
-        let parts: [&[u8]; 2] = [self.fs.top_level_dir, path_literal];
+        let parts: [&[u8]; 2] = [self.fs().top_level_dir, path_literal];
         // reshaped for borrowck — abs_buf's return keeps a &mut borrow
         // of scan_dir_buf alive across the &mut self calls below. Capture only the
         // length, then reconstruct a detached slice from the raw buffer pointer.
-        let path_len = self.fs.abs_buf(&parts, &mut self.scan_dir_buf).len();
+        let path_len = self.fs().abs_buf(&parts, &mut self.scan_dir_buf).len();
         // SAFETY: scan_dir_buf is not written again for the remainder of this
         // function — read_dir_with_name/next() only touch open_dir_buf — so the
         // bytes at [0, path_len) remain valid while `path` is live.
@@ -132,7 +197,7 @@ impl<'a> Scanner<'a> {
             if e == err!("NotDir") || e == err!("ENOTDIR") {
                 if self.is_test_file(path) {
                     let stored = self
-                        .fs
+                        .fs()
                         .filename_store
                         .append_slice(path)
                         .map_err(|_| ScanError::OutOfMemory)?;
@@ -188,7 +253,7 @@ impl<'a> Scanner<'a> {
                 let dir = entry.relative_dir;
 
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = self.fs.abs_buf(&parts2, &mut self.open_dir_buf);
+                let path2 = self.fs().abs_buf(&parts2, &mut self.open_dir_buf);
                 let path2_len = path2.len();
                 self.open_dir_buf[path2_len] = 0;
                 let name_len = entry.name.slice().len();
@@ -205,7 +270,7 @@ impl<'a> Scanner<'a> {
                 };
                 let child_dir = bun_sys::Dir::from_fd(child_fd);
                 let path2 = self
-                    .fs
+                    .fs()
                     .dirname_store
                     .append_slice(&self.open_dir_buf[..path2_len])
                     .map_err(|_| ScanError::OutOfMemory)?;
@@ -217,7 +282,7 @@ impl<'a> Scanner<'a> {
             #[cfg(windows)]
             {
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = self.fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
+                let path2 = self.fs().abs_buf_z(&parts2, &mut self.open_dir_buf);
                 let Ok(child_fd) = bun_sys::open_dir_no_renaming_or_deleting_windows(
                     Fd::INVALID,
                     path2.as_bytes(),
@@ -226,7 +291,7 @@ impl<'a> Scanner<'a> {
                 };
                 let child_dir = bun_sys::Dir::from_fd(child_fd);
                 let stored = self
-                    .fs
+                    .fs()
                     .dirname_store
                     .append_slice(path2.as_bytes())
                     .map_err(|_| ScanError::OutOfMemory)?;
@@ -244,20 +309,24 @@ impl<'a> Scanner<'a> {
         name: &[u8],
         handle: Option<bun_sys::Dir>,
     ) -> Result<&'static mut EntriesOption, bun_core::Error> {
-        // `read_directory_with_iterator` takes `*mut RealFS` and an
-        // iterator. `self.fs` is `&FileSystem` here, but
-        // the underlying `RealFS` is the process singleton and is mutated
-        // through `*mut` everywhere else (see `Transpiler.fs: *mut FileSystem`);
-        // cast away `&` to call it. Serialised by
-        // `RealFS.entries_mutex` inside the callee. This `&T` -> `&mut T` cast
-        // is lint-silenced UB-adjacent debt; the real fix is storing
-        // `Scanner.fs` as `*mut FileSystem` (see the field doc).
-        let real_fs = core::ptr::from_ref(&self.fs.fs).cast_mut();
+        // Copy the pointer out before `from_mut(self)` so `self` is not read
+        // again once the iterator's raw `*mut Scanner` exists.
+        let fs_ptr = self.fs;
         let iter = ScannerDirIter(std::ptr::from_mut::<Scanner<'a>>(self));
         let raw = handle.map(bun_sys::Dir::into_raw);
-        // SAFETY: see comment above — `real_fs` aliases the singleton.
-        #[allow(invalid_reference_casting)]
-        unsafe { &mut *real_fs }.read_directory_with_iterator(name, raw, 0, true, iter)
+        // SAFETY: `fs_ptr` points at the process-singleton `FileSystem`, so
+        // the `&mut RealFS` below carries genuine write provenance and
+        // borrows only the `fs: Implementation` field (reads of other
+        // singleton fields on the callback path use disjoint place
+        // projections — see `top_level_dir`/`filename_store`). One aliasing
+        // caveat remains: the callee re-enters `Scanner::next` through the
+        // iterator while this `&mut` is live, and `next` passes
+        // `Entry::kind` a sibling `&raw mut (*self.fs).fs` to the same
+        // field. That reentrant `*mut`-mediated access is `Entry::kind`'s
+        // documented contract (every resolver caller does the same, with
+        // mutation serialised by `RealFS.entries_mutex`) — accepted,
+        // pre-existing debt rather than an exclusivity guarantee.
+        unsafe { &mut (*fs_ptr).fs }.read_directory_with_iterator(name, raw, 0, true, iter)
     }
 
     pub fn could_be_test_file<const NEEDS_TEST_SUFFIX: bool>(&self, name: &[u8]) -> bool {
@@ -312,7 +381,9 @@ impl<'a> Scanner<'a> {
         if self.path_ignore_patterns.is_empty() {
             return false;
         }
-        let rel_path = bun_paths::resolve_path::relative(self.fs.top_level_dir, abs_path);
+        // Field-precise read: this runs on the iterator-callback path (via
+        // `next` -> `is_test_file`), where `fs()` must not be used.
+        let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
 
         // Build rel_path + '/' once. rel_path is a relative path from the project
         // root; 4096 bytes covers any sane test directory depth (POSIX PATH_MAX).
@@ -355,10 +426,18 @@ impl<'a> Scanner<'a> {
     pub fn next(&mut self, entry: &mut fs::Entry, fd: Fd) {
         let name = entry.base_lowercase();
         self.has_iterated = true;
-        // `Entry::kind` takes `*mut RealFS`; cast the
-        // shared singleton ref — `kind()` only stat()s through it.
-        let real_fs = (&raw const self.fs.fs).cast_mut();
-        // SAFETY: entries_mutex held; real_fs points at the process-global RealFS.
+        // `Entry::kind` takes `*mut RealFS`; derive it from the singleton
+        // pointer so it carries write provenance — `kind()` only stat()s
+        // through it.
+        // SAFETY: `self.fs` points at the process-singleton `FileSystem`.
+        let real_fs = unsafe { &raw mut (*self.fs).fs };
+        // SAFETY: `real_fs` points at the process-global `RealFS`. On the
+        // iterator-callback path the caller (`read_directory_with_iterator`)
+        // holds `entries_mutex`, serialising the reentrant access (see
+        // `read_dir_with_name`). On the cached-cwd path (`scan` calling
+        // `next` directly) the mutex is NOT held; that path is
+        // single-threaded — the scan runs to completion on one thread before
+        // any test executes.
         match unsafe { entry.kind(real_fs, true) } {
             fs::EntryKind::Dir => {
                 if (!name.is_empty() && name[0] == b'.') || name == b"node_modules" {
@@ -383,7 +462,12 @@ impl<'a> Scanner<'a> {
                     // reshaped for borrowck — drop the &mut borrow from
                     // abs_buf and reborrow open_dir_buf immutably so &self methods
                     // can be called with the slice.
-                    let dir_path_len = self.fs.abs_buf(&parts, &mut self.open_dir_buf).len();
+                    let dir_path_len = Self::abs_buf_projected(
+                        self.top_level_dir(),
+                        &parts,
+                        &mut self.open_dir_buf,
+                    )
+                    .len();
                     let dir_path = &self.open_dir_buf[..dir_path_len];
                     if self.matches_path_ignore_pattern(dir_path) {
                         return;
@@ -415,11 +499,16 @@ impl<'a> Scanner<'a> {
                 // reshaped for borrowck — drop the &mut borrow from
                 // abs_buf and reborrow open_dir_buf immutably so &self methods
                 // below can be called with the slice.
-                let path_len = self.fs.abs_buf(&parts, &mut self.open_dir_buf).len();
+                let path_len = Self::abs_buf_projected(
+                    self.top_level_dir(),
+                    &parts,
+                    &mut self.open_dir_buf,
+                )
+                .len();
                 let path = &self.open_dir_buf[..path_len];
 
                 if !self.does_absolute_path_match_filter(path) {
-                    let rel_path = bun_paths::resolve_path::relative(self.fs.top_level_dir, path);
+                    let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), path);
                     if !self.does_path_match_filter(rel_path) {
                         return;
                     }
@@ -429,7 +518,7 @@ impl<'a> Scanner<'a> {
                     return;
                 }
 
-                let stored = match self.fs.filename_store.append_slice(path) {
+                let stored = match self.filename_store().append_slice(path) {
                     Ok(s) => s,
                     Err(_) => bun_core::out_of_memory(),
                 };

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -499,12 +499,9 @@ impl<'a> Scanner<'a> {
                 // reshaped for borrowck — drop the &mut borrow from
                 // abs_buf and reborrow open_dir_buf immutably so &self methods
                 // below can be called with the slice.
-                let path_len = Self::abs_buf_projected(
-                    self.top_level_dir(),
-                    &parts,
-                    &mut self.open_dir_buf,
-                )
-                .len();
+                let path_len =
+                    Self::abs_buf_projected(self.top_level_dir(), &parts, &mut self.open_dir_buf)
+                        .len();
                 let path = &self.open_dir_buf[..path_len];
 
                 if !self.does_absolute_path_match_filter(path) {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -28,10 +28,6 @@ pub struct Scanner<'a> {
     pub dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
     pub test_files: Vec<Interned>,
-    /// Process-singleton `FileSystem` (same shape as `Transpiler.fs`). On the
-    /// iterator-callback path (`next` and callees) the resolver holds `&mut`
-    /// to the singleton's `fs` field, so use the field-precise projections
-    /// (`Self::top_level_dir`, `Self::filename_store`) there, not `Self::fs()`.
     pub fs: *mut FileSystem,
     pub open_dir_buf: PathBuffer,
     pub scan_dir_buf: PathBuffer,
@@ -102,35 +98,24 @@ impl<'a> Scanner<'a> {
         })
     }
 
-    /// Shared-read access to the process-singleton [`FileSystem`]. Must NOT
-    /// be called on the iterator-callback path (`next` and its callees) — the
-    /// resolver holds `&mut` to the singleton's `fs` field there; use the
-    /// field-precise projections instead.
     #[inline]
     pub(crate) fn fs(&self) -> &'static FileSystem {
-        // SAFETY: process-singleton, lives for the whole process; callers are
-        // outside the iterator callback, so no `&mut` to the singleton is live.
+        // SAFETY: process-singleton; no `&mut` to it is live outside the iterator callback.
         unsafe { &*self.fs }
     }
 
-    /// `top_level_dir` via a field-precise projection — unlike [`Self::fs()`],
-    /// safe on the iterator-callback path.
     #[inline]
     fn top_level_dir(&self) -> &'static [u8] {
-        // SAFETY: process-singleton; the projection never spans the
-        // mutably-borrowed `fs` field.
+        // SAFETY: field-precise projection; never spans the mutably-borrowed `fs` field.
         unsafe { (*self.fs).top_level_dir }
     }
 
-    /// `filename_store` via a field-precise projection; see `top_level_dir`.
     #[inline]
     fn filename_store(&self) -> &'static fs::FilenameStore {
         // SAFETY: same as `top_level_dir`.
         unsafe { (*self.fs).filename_store }
     }
 
-    /// `FileSystem::abs_buf` without the whole-struct receiver, for the
-    /// iterator-callback path.
     #[inline]
     fn abs_buf_projected<'b>(
         top_level_dir: &'static [u8],
@@ -251,8 +236,6 @@ impl<'a> Scanner<'a> {
             }
             #[cfg(windows)]
             {
-                // One fs() call up front: a second would conflict with
-                // path2's borrow of open_dir_buf.
                 let fs = self.fs();
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
                 let path2 = fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
@@ -281,15 +264,10 @@ impl<'a> Scanner<'a> {
         name: &[u8],
         handle: Option<bun_sys::Dir>,
     ) -> Result<&'static mut EntriesOption, bun_core::Error> {
-        // Copy the pointer out before `from_mut(self)` so `self` is not read
-        // again once the iterator's raw `*mut Scanner` exists.
         let fs_ptr = self.fs;
         let iter = ScannerDirIter(std::ptr::from_mut::<Scanner<'a>>(self));
         let raw = handle.map(bun_sys::Dir::into_raw);
-        // SAFETY: process-singleton; this `&mut` borrows only the `fs` field.
-        // The callee re-enters `next`, which stat()s through a sibling `*mut`
-        // to the same field — `Entry::kind`'s documented contract, serialised
-        // by `RealFS.entries_mutex`.
+        // SAFETY: borrows only the `fs` field; re-entrant access is serialised by `RealFS.entries_mutex`.
         unsafe { &mut (*fs_ptr).fs }.read_directory_with_iterator(name, raw, 0, true, iter)
     }
 
@@ -345,7 +323,6 @@ impl<'a> Scanner<'a> {
         if self.path_ignore_patterns.is_empty() {
             return false;
         }
-        // Runs on the iterator-callback path, where `fs()` must not be used.
         let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
 
         // Build rel_path + '/' once. rel_path is a relative path from the project
@@ -391,8 +368,7 @@ impl<'a> Scanner<'a> {
         self.has_iterated = true;
         // SAFETY: `self.fs` is the process singleton.
         let real_fs = unsafe { &raw mut (*self.fs).fs };
-        // SAFETY: on the iterator-callback path the caller holds
-        // `entries_mutex`; the direct `scan` -> `next` path is single-threaded.
+        // SAFETY: caller holds `entries_mutex`; the direct path is single-threaded.
         match unsafe { entry.kind(real_fs, true) } {
             fs::EntryKind::Dir => {
                 if (!name.is_empty() && name[0] == b'.') || name == b"node_modules" {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -281,8 +281,12 @@ impl<'a> Scanner<'a> {
             }
             #[cfg(windows)]
             {
+                // Grab the `&'static FileSystem` up front so `path2`'s
+                // borrow of `open_dir_buf` doesn't conflict with a second
+                // `self.fs()` call below.
+                let fs = self.fs();
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = self.fs().abs_buf_z(&parts2, &mut self.open_dir_buf);
+                let path2 = fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
                 let Ok(child_fd) = bun_sys::open_dir_no_renaming_or_deleting_windows(
                     Fd::INVALID,
                     path2.as_bytes(),
@@ -290,8 +294,7 @@ impl<'a> Scanner<'a> {
                     continue;
                 };
                 let child_dir = bun_sys::Dir::from_fd(child_fd);
-                let stored = self
-                    .fs()
+                let stored = fs
                     .dirname_store
                     .append_slice(path2.as_bytes())
                     .map_err(|_| ScanError::OutOfMemory)?;
@@ -382,7 +385,7 @@ impl<'a> Scanner<'a> {
             return false;
         }
         // Field-precise read: this runs on the iterator-callback path (via
-        // `next` -> `is_test_file`), where `fs()` must not be used.
+        // `next`), where `fs()` must not be used.
         let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
 
         // Build rel_path + '/' once. rel_path is a relative path from the project

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -28,15 +28,10 @@ pub struct Scanner<'a> {
     pub dirs_to_scan: Fifo,
     /// Paths to test files found while scanning.
     pub test_files: Vec<Interned>,
-    /// Pointer to the process-singleton `FileSystem` (the shape
-    /// `Transpiler.fs` uses). Reads outside the directory-iterator callback
-    /// go through the [`Self::fs()`] accessor; reads on the callback path
-    /// (`next` and its callees) use field-precise place projections
-    /// (`Self::top_level_dir`, `Self::filename_store`) so no
-    /// whole-struct `&FileSystem` is formed while the resolver holds `&mut`
-    /// to the singleton's `fs` field. The two mutation sites
-    /// (`read_dir_with_name`, `next`) derive `&mut`/`*mut RealFS` directly
-    /// from this pointer so writes carry genuine write provenance.
+    /// Process-singleton `FileSystem` (same shape as `Transpiler.fs`). On the
+    /// iterator-callback path (`next` and callees) the resolver holds `&mut`
+    /// to the singleton's `fs` field, so use the field-precise projections
+    /// (`Self::top_level_dir`, `Self::filename_store`) there, not `Self::fs()`.
     pub fs: *mut FileSystem,
     pub open_dir_buf: PathBuffer,
     pub scan_dir_buf: PathBuffer,
@@ -98,8 +93,6 @@ impl<'a> Scanner<'a> {
             path_ignore_patterns: &[],
             dirs_to_scan: Fifo::new(),
             options: &transpiler.options,
-            // `Transpiler.fs` is the process-singleton `*mut FileSystem`;
-            // it outlives the scanner.
             fs: transpiler.fs,
             test_files: results,
             open_dir_buf: PathBuffer::uninit(),
@@ -109,58 +102,35 @@ impl<'a> Scanner<'a> {
         })
     }
 
-    /// Shared-read access to the process-singleton [`FileSystem`].
-    ///
-    /// `'static` is sound: the singleton is initialized once at startup and
-    /// never freed. The unbounded lifetime also keeps reads like
-    /// `self.fs().abs_buf(…, &mut self.scan_dir_buf)` borrow-compatible with
-    /// `&mut` borrows of other `Scanner` fields.
-    ///
-    /// Must NOT be called on the directory-iterator callback path (`next`
-    /// and its callees): for the whole body of
-    /// `read_directory_with_iterator` the resolver holds a live `&mut` to
-    /// the singleton's `fs` field, and a whole-struct `&FileSystem` formed
-    /// here would span that field — an aliasing violation even if the
-    /// reference is immediately dropped. The callback path uses the
-    /// field-precise `Self::top_level_dir`/`Self::filename_store`
-    /// projections instead, which never touch the `fs` field's bytes.
+    /// Shared-read access to the process-singleton [`FileSystem`]. Must NOT
+    /// be called on the iterator-callback path (`next` and its callees) — the
+    /// resolver holds `&mut` to the singleton's `fs` field there; use the
+    /// field-precise projections instead.
     #[inline]
     pub(crate) fn fs(&self) -> &'static FileSystem {
-        // SAFETY: `self.fs` points at the process-singleton `FileSystem`
-        // (see `init`), which lives for the whole process. Callers are
-        // outside `read_directory_with_iterator`, so no `&mut` to any part
-        // of the singleton is live (see doc comment).
+        // SAFETY: process-singleton, lives for the whole process; callers are
+        // outside the iterator callback, so no `&mut` to the singleton is live.
         unsafe { &*self.fs }
     }
 
-    /// Field-precise copy of the singleton's `top_level_dir`.
-    ///
-    /// Safe to call on the iterator-callback path (`next` and its callees),
-    /// unlike `Self::fs()`: the raw place projection reads only the
-    /// `top_level_dir` field's bytes, which are disjoint from the `fs:
-    /// Implementation` field mutably borrowed by
-    /// `read_directory_with_iterator` for the duration of the walk.
+    /// `top_level_dir` via a field-precise projection — unlike [`Self::fs()`],
+    /// safe on the iterator-callback path.
     #[inline]
     fn top_level_dir(&self) -> &'static [u8] {
-        // SAFETY: `self.fs` points at the process-singleton `FileSystem`,
-        // live for the whole process; the projection reads only the
-        // `top_level_dir` field, never forming a reference that spans the
+        // SAFETY: process-singleton; the projection never spans the
         // mutably-borrowed `fs` field.
         unsafe { (*self.fs).top_level_dir }
     }
 
-    /// Field-precise copy of the singleton's `filename_store` handle. Same
-    /// callback-path rationale as `Self::top_level_dir`.
+    /// `filename_store` via a field-precise projection; see `top_level_dir`.
     #[inline]
     fn filename_store(&self) -> &'static fs::FilenameStore {
-        // SAFETY: same as `top_level_dir`; reads only the `filename_store`
-        // field, disjoint from the mutably-borrowed `fs` field.
+        // SAFETY: same as `top_level_dir`.
         unsafe { (*self.fs).filename_store }
     }
 
-    /// Joins `parts` against the singleton's `top_level_dir` into `buf` —
-    /// `FileSystem::abs_buf` minus the whole-struct `&FileSystem` receiver,
-    /// for use on the iterator-callback path (see `Self::top_level_dir`).
+    /// `FileSystem::abs_buf` without the whole-struct receiver, for the
+    /// iterator-callback path.
     #[inline]
     fn abs_buf_projected<'b>(
         top_level_dir: &'static [u8],
@@ -281,9 +251,8 @@ impl<'a> Scanner<'a> {
             }
             #[cfg(windows)]
             {
-                // Grab the `&'static FileSystem` up front so `path2`'s
-                // borrow of `open_dir_buf` doesn't conflict with a second
-                // `self.fs()` call below.
+                // One fs() call up front: a second would conflict with
+                // path2's borrow of open_dir_buf.
                 let fs = self.fs();
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
                 let path2 = fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
@@ -317,18 +286,10 @@ impl<'a> Scanner<'a> {
         let fs_ptr = self.fs;
         let iter = ScannerDirIter(std::ptr::from_mut::<Scanner<'a>>(self));
         let raw = handle.map(bun_sys::Dir::into_raw);
-        // SAFETY: `fs_ptr` points at the process-singleton `FileSystem`, so
-        // the `&mut RealFS` below carries genuine write provenance and
-        // borrows only the `fs: Implementation` field (reads of other
-        // singleton fields on the callback path use disjoint place
-        // projections — see `top_level_dir`/`filename_store`). One aliasing
-        // caveat remains: the callee re-enters `Scanner::next` through the
-        // iterator while this `&mut` is live, and `next` passes
-        // `Entry::kind` a sibling `&raw mut (*self.fs).fs` to the same
-        // field. That reentrant `*mut`-mediated access is `Entry::kind`'s
-        // documented contract (every resolver caller does the same, with
-        // mutation serialised by `RealFS.entries_mutex`) — accepted,
-        // pre-existing debt rather than an exclusivity guarantee.
+        // SAFETY: process-singleton; this `&mut` borrows only the `fs` field.
+        // The callee re-enters `next`, which stat()s through a sibling `*mut`
+        // to the same field — `Entry::kind`'s documented contract, serialised
+        // by `RealFS.entries_mutex`.
         unsafe { &mut (*fs_ptr).fs }.read_directory_with_iterator(name, raw, 0, true, iter)
     }
 
@@ -384,8 +345,7 @@ impl<'a> Scanner<'a> {
         if self.path_ignore_patterns.is_empty() {
             return false;
         }
-        // Field-precise read: this runs on the iterator-callback path (via
-        // `next`), where `fs()` must not be used.
+        // Runs on the iterator-callback path, where `fs()` must not be used.
         let rel_path = bun_paths::resolve_path::relative(self.top_level_dir(), abs_path);
 
         // Build rel_path + '/' once. rel_path is a relative path from the project
@@ -429,18 +389,10 @@ impl<'a> Scanner<'a> {
     pub fn next(&mut self, entry: &mut fs::Entry, fd: Fd) {
         let name = entry.base_lowercase();
         self.has_iterated = true;
-        // `Entry::kind` takes `*mut RealFS`; derive it from the singleton
-        // pointer so it carries write provenance — `kind()` only stat()s
-        // through it.
-        // SAFETY: `self.fs` points at the process-singleton `FileSystem`.
+        // SAFETY: `self.fs` is the process singleton.
         let real_fs = unsafe { &raw mut (*self.fs).fs };
-        // SAFETY: `real_fs` points at the process-global `RealFS`. On the
-        // iterator-callback path the caller (`read_directory_with_iterator`)
-        // holds `entries_mutex`, serialising the reentrant access (see
-        // `read_dir_with_name`). On the cached-cwd path (`scan` calling
-        // `next` directly) the mutex is NOT held; that path is
-        // single-threaded — the scan runs to completion on one thread before
-        // any test executes.
+        // SAFETY: on the iterator-callback path the caller holds
+        // `entries_mutex`; the direct `scan` -> `next` path is single-threaded.
         match unsafe { entry.kind(real_fs, true) } {
             fs::EntryKind::Dir => {
                 if (!name.is_empty() && name[0] == b'.') || name == b"node_modules" {

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2377,14 +2377,14 @@ impl TestCommand {
             let dir_to_scan: &[u8] = 'brk: {
                 if !ctx.debug.test_directory.is_empty() {
                     dir_to_scan_owned = resolve_path::join_abs::<bun_path::platform::Auto>(
-                        scanner.fs.top_level_dir,
+                        scanner.fs().top_level_dir,
                         &ctx.debug.test_directory,
                     )
                     .into();
                     break 'brk &dir_to_scan_owned;
                 }
 
-                break 'brk scanner.fs.top_level_dir;
+                break 'brk scanner.fs().top_level_dir;
             };
 
             match scanner.scan(dir_to_scan) {

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1473,7 +1473,7 @@ function runTest({
   }
 }
 
-describe("test file discovery (scanner)", () => {
+describe.concurrent("test file discovery (scanner)", () => {
   test("discovers tests in deeply nested directories and prunes dot-dirs and node_modules", async () => {
     const files: Record<string, string> = {
       "a_first.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a_first"); });`,

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1472,3 +1472,88 @@ function runTest({
     rmSync(cwd, { recursive: true });
   }
 }
+
+describe("test file discovery (scanner)", () => {
+  test("discovers tests in deeply nested directories and prunes dot-dirs and node_modules", async () => {
+    const files: Record<string, string> = {
+      "a_first.test.ts": `import { test } from "bun:test"; test("a", () => { console.log("RAN a_first"); });`,
+      "b_second.test.ts": `import { test } from "bun:test"; test("b", () => { console.log("RAN b_second"); });`,
+      "styles.spec.tsx": `import { test } from "bun:test"; test("spec", () => { console.log("RAN spec"); });`,
+      "not-a-test.ts": `console.log("SHOULD NOT RUN plain");`,
+      "nested/deep/inner.test.ts": `import { test } from "bun:test"; test("inner", () => { console.log("RAN inner"); });`,
+      "nested/util.ts": `export const x = 1;`,
+      ".hidden/skipped.test.ts": `import { test } from "bun:test"; test("hidden", () => { console.log("SHOULD NOT RUN hidden"); });`,
+      "node_modules/pkg/skipped.test.ts": `import { test } from "bun:test"; test("nm", () => { console.log("SHOULD NOT RUN node_modules"); });`,
+    };
+    // Long directory chain so the scanner's directory FIFO and per-directory
+    // reads are exercised many times in a single scan.
+    let prefix = "chain";
+    for (let i = 0; i < 32; i++) {
+      prefix += `/d${i}`;
+      files[`${prefix}/leaf${i}.test.ts`] = `import { test } from "bun:test"; test("leaf${i}", () => {});`;
+    }
+    using dir = tempDir("scanner-discovery", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RAN a_first");
+    expect(stdout).toContain("RAN b_second");
+    expect(stdout).toContain("RAN spec");
+    expect(stdout).toContain("RAN inner");
+    expect(stdout).not.toContain("SHOULD NOT RUN");
+    // 4 named tests + 32 chain leaves
+    expect(stderr).toContain(" 36 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("scanning a relative subdirectory only runs tests under it", async () => {
+    using dir = tempDir("scanner-subdir", {
+      "root_only.test.ts": `import { test } from "bun:test"; test("root", () => { console.log("RAN root"); });`,
+      "nested/inner.test.ts": `import { test } from "bun:test"; test("inner", () => { console.log("RAN inner"); });`,
+      "nested/deeper/most.test.ts": `import { test } from "bun:test"; test("most", () => { console.log("RAN most"); });`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./nested"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RAN inner");
+    expect(stdout).toContain("RAN most");
+    expect(stdout).not.toContain("RAN root");
+    expect(stderr).toContain(" 2 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("scanning a relative file path that is not a directory runs that single file", async () => {
+    using dir = tempDir("scanner-single-file", {
+      "solo.test.ts": `import { test } from "bun:test"; test("solo", () => { console.log("RAN solo"); });`,
+      "other.test.ts": `import { test } from "bun:test"; test("other", () => { console.log("RAN other"); });`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./solo.test.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RAN solo");
+    expect(stdout).not.toContain("RAN other");
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
The bun test file-discovery Scanner held its FileSystem as a shared reference but derived `&mut RealFS` from it in two places (`read_dir_with_name` and `next`) via `#[allow(invalid_reference_casting)]` `&T` -> `&mut T` casts, giving the writes read-only provenance — undefined behavior under Rust's aliasing rules. The fix changes `Scanner.fs` to `*mut FileSystem` (the same shape `Transpiler.fs` already uses), storing `transpiler.fs` directly in `Scanner::init`. The two mutation sites now derive `&mut (*self.fs).fs` / `&raw mut (*self.fs).fs` with genuine write provenance, and the lint allow is gone. Reads outside the directory-iterator callback go through a new `fs()` accessor returning `&'static FileSystem` (sound: the singleton lives for the whole process); reads on the callback path (`next` and callees, which run while the resolver holds `&mut` to the singleton's `fs` field) use field-precise place projections (`top_level_dir`/`filename_store`/`abs_buf_projected`) so no whole-struct `&FileSystem` spans the mutably-borrowed field. The remaining reentrant `Entry::kind` `*mut` reborrow is the resolver's documented, entries_mutex-serialised contract and is called out in the SAFETY comments. The two `scanner.fs.top_level_dir` reads in test_command.rs were updated to use the accessor. New scanner-discovery tests in test/cli/test/bun-test.test.ts (deep nested scanning, dot-dir/node_modules pruning, subdirectory positional, single-file NotDir path) are behavior guards over the rewritten paths — the refactor has no intended behavior change, so they are not pre/post discriminators; verification is the build/test phase.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
