### PR TITLE
Reuse parser-owned stack in unused binary-comma simplification

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -574,8 +574,7 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // These are backed by stack fallback allocators in _parse, and are uninitialized until then.
     pub binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor>,
     // Reusable stack for `SideEffects::simplify_unused_binary_comma_expr`;
-    // avoids per-call allocation. Callers record a bottom watermark and
-    // truncate back to it on exit (the path is recursive).
+    // the path is recursive, so callers truncate back to their entry watermark.
     pub binary_expression_simplify_stack: ListManaged<'a, BinaryExpressionSimplifyVisitor>,
 
     /// We build up enough information about the TypeScript namespace hierarchy to
@@ -9132,10 +9131,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             require_resolve_transposer: RequireResolveTransposer::dangling(),
             source,
             // A `&'a mut Vec<Stmt>` cannot be left uninitialized, so allocate
-            // an empty placeholder in the arena. The placeholder is permanent:
-            // `MacroState::prepend_stmts` is write-only (written once, never
-            // read), so the visit pass intentionally does not wire a real
-            // backref — see visit/mod.rs and parser.rs.
+            // an empty placeholder in the arena. It is permanent:
+            // `MacroState::prepend_stmts` is write-only, so it is never rewired.
             macro_: MacroState::init(arena.alloc(Vec::new())),
             current_scope: scope,
             module_scope: scope,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -574,7 +574,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     // These are backed by stack fallback allocators in _parse, and are uninitialized until then.
     pub binary_expression_stack: ListManaged<'a, BinaryExpressionVisitor>,
     // Reusable stack for `SideEffects::simplify_unused_binary_comma_expr`;
-    // avoids per-call allocation once that path is wired to push into it.
+    // avoids per-call allocation. Callers record a bottom watermark and
+    // truncate back to it on exit (the path is recursive).
     pub binary_expression_simplify_stack: ListManaged<'a, BinaryExpressionSimplifyVisitor>,
 
     /// We build up enough information about the TypeScript namespace hierarchy to
@@ -9131,8 +9132,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             require_resolve_transposer: RequireResolveTransposer::dangling(),
             source,
             // A `&'a mut Vec<Stmt>` cannot be left uninitialized, so allocate
-            // an empty placeholder in the arena (real list is wired by the visit
-            // pass before any macro expansion runs).
+            // an empty placeholder in the arena. The placeholder is permanent:
+            // `MacroState::prepend_stmts` is write-only (written once, never
+            // read), so the visit pass intentionally does not wire a real
+            // backref — see visit/mod.rs and parser.rs.
             macro_: MacroState::init(arena.alloc(Vec::new())),
             current_scope: scope,
             module_scope: scope,

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -34,7 +34,7 @@ impl Default for Result {
 #[derive(Clone, Copy)]
 pub struct BinaryExpressionSimplifyVisitor {
     // ARENA: points into the AST store (see LIFETIMES.tsv)
-    pub bin: *const E::Binary,
+    pub bin: StoreRef<E::Binary>,
 }
 
 impl SideEffects {
@@ -528,19 +528,21 @@ impl SideEffects {
             Op::Code::BinStrictEq | Op::Code::BinStrictNe | Op::Code::BinComma
         ));
 
-        // Ideally this would reuse `p.binary_expression_simplify_stack` to avoid
-        // per-call allocation, but that `P` field is currently `ListManaged<'a, ()>`
-        // (placeholder element type — see P.rs:537); until it's reshaped to
-        // `BinaryExpressionSimplifyVisitor` we use a local Vec.
-        let mut stack: Vec<StoreRef<E::Binary>> = Vec::with_capacity(8);
-        stack.push(root_bin);
+        // Reuse the parser-owned stack to avoid per-call allocation. This
+        // function recurses through `simplify_unused_expr`, so record a bottom
+        // watermark on entry and truncate back to it before returning — inner
+        // frames only ever touch elements above their own watermark.
+        let stack_bottom = p.binary_expression_simplify_stack.len();
+        p.binary_expression_simplify_stack
+            .push(BinaryExpressionSimplifyVisitor { bin: root_bin });
 
         // Build stack up of expressions
         let mut left: Expr = root_bin.left;
         while let ExprData::EBinary(left_bin) = left.data {
             match left_bin.op {
                 Op::Code::BinStrictEq | Op::Code::BinStrictNe | Op::Code::BinComma => {
-                    stack.push(left_bin);
+                    p.binary_expression_simplify_stack
+                        .push(BinaryExpressionSimplifyVisitor { bin: left_bin });
                     left = left_bin.left;
                 }
                 _ => break,
@@ -548,15 +550,18 @@ impl SideEffects {
         }
 
         // Ride the stack downwards
-        let mut i = stack.len();
+        let mut i = p.binary_expression_simplify_stack.len();
         let mut result = Self::simplify_unused_expr(p, left).unwrap_or(Expr::EMPTY);
-        while i > 0 {
+        while i > stack_bottom {
             i -= 1;
-            let top = stack[i];
-            let right = top.right;
+            // Copy the element out before re-entering `simplify_unused_expr`
+            // (which takes `&mut P` and may push/truncate above our watermark).
+            let top = p.binary_expression_simplify_stack[i];
+            let right = top.bin.right;
             let visited_right = Self::simplify_unused_expr(p, right).unwrap_or(Expr::EMPTY);
             result = Expr::join_with_comma(result, visited_right);
         }
+        p.binary_expression_simplify_stack.truncate(stack_bottom);
 
         if result.is_missing() {
             None

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -528,10 +528,8 @@ impl SideEffects {
             Op::Code::BinStrictEq | Op::Code::BinStrictNe | Op::Code::BinComma
         ));
 
-        // Reuse the parser-owned stack to avoid per-call allocation. This
-        // function recurses through `simplify_unused_expr`, so record a bottom
-        // watermark on entry and truncate back to it before returning — inner
-        // frames only ever touch elements above their own watermark.
+        // This function recurses through `simplify_unused_expr`, so each frame
+        // only touches elements above its watermark and truncates back on exit.
         let stack_bottom = p.binary_expression_simplify_stack.len();
         p.binary_expression_simplify_stack
             .push(BinaryExpressionSimplifyVisitor { bin: root_bin });
@@ -554,8 +552,6 @@ impl SideEffects {
         let mut result = Self::simplify_unused_expr(p, left).unwrap_or(Expr::EMPTY);
         while i > stack_bottom {
             i -= 1;
-            // Copy the element out before re-entering `simplify_unused_expr`
-            // (which takes `&mut P` and may push/truncate above our watermark).
             let top = p.binary_expression_simplify_stack[i];
             let right = top.bin.right;
             let visited_right = Self::simplify_unused_expr(p, right).unwrap_or(Expr::EMPTY);

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -213,21 +213,17 @@ describe("bundler", () => {
     },
   });
   itBundled("minify/UnusedCommaAndStrictEqChains", {
-    // Exercises the parser's reusable binary-comma simplification stack:
-    // long left-nested comma chains (many stack entries in one frame) plus
-    // comma/strict-eq operands nested on the right (recursive re-entry while
-    // the outer frame's stack slice is still live). Side-effecting calls must
-    // survive in source order; pure strict-eq comparisons must be dropped.
+    // Exercises the reusable binary-comma simplification stack, including
+    // recursive re-entry while an outer frame's stack slice is still live.
     files: {
       "/entry.js": /* js */ `
         function eff(n) { console.log(n); return n; }
-        // Deep left-nested comma chain (comma is left-associative).
+        // Deep left-nested comma chain.
         (${new Array(60)
           .fill(null)
           .map((_, i) => `eff(${i + 1})`)
           .join(", ")});
-        // Comma chain whose right operands are themselves comma chains
-        // (forces recursion through the shared stack).
+        // Comma chain whose right operands are themselves comma chains.
         (eff(61), (eff(62), (eff(63), eff(64)), eff(65)), eff(66));
         // Unused strict-eq/ne: pure comparison dropped, operand side effects kept.
         (eff(67) === (eff(68), eff(69)), eff(70));
@@ -245,7 +241,6 @@ describe("bundler", () => {
     },
     onAfterBundle(api) {
       const code = api.readFile("/out.js");
-      // The unused strict equality comparisons themselves must be eliminated.
       expect(code).not.toContain("===");
       expect(code).not.toContain("!==");
     },

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -212,6 +212,44 @@ describe("bundler", () => {
       expect([...code.matchAll(/var /g)]).toHaveLength(1);
     },
   });
+  itBundled("minify/UnusedCommaAndStrictEqChains", {
+    // Exercises the parser's reusable binary-comma simplification stack:
+    // long left-nested comma chains (many stack entries in one frame) plus
+    // comma/strict-eq operands nested on the right (recursive re-entry while
+    // the outer frame's stack slice is still live). Side-effecting calls must
+    // survive in source order; pure strict-eq comparisons must be dropped.
+    files: {
+      "/entry.js": /* js */ `
+        function eff(n) { console.log(n); return n; }
+        // Deep left-nested comma chain (comma is left-associative).
+        (${new Array(60)
+          .fill(null)
+          .map((_, i) => `eff(${i + 1})`)
+          .join(", ")});
+        // Comma chain whose right operands are themselves comma chains
+        // (forces recursion through the shared stack).
+        (eff(61), (eff(62), (eff(63), eff(64)), eff(65)), eff(66));
+        // Unused strict-eq/ne: pure comparison dropped, operand side effects kept.
+        (eff(67) === (eff(68), eff(69)), eff(70));
+        ((eff(71), eff(72)) !== eff(73), (eff(74), eff(75)) === eff(76));
+        console.log("done");
+      `,
+    },
+    minifySyntax: true,
+    run: {
+      stdout:
+        new Array(76)
+          .fill(null)
+          .map((_, i) => String(i + 1))
+          .join("\n") + "\ndone",
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      // The unused strict equality comparisons themselves must be eliminated.
+      expect(code).not.toContain("===");
+      expect(code).not.toContain("!==");
+    },
+  });
   itBundled("minify/Infinity", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
SideEffects::simplify_unused_binary_comma_expr allocated a fresh local Vec on every call even though the parser already carries a reusable binary_expression_simplify_stack pre-reserved for exactly this path. The function now records a bottom watermark on entry, pushes onto the parser-owned stack, and truncates back to the watermark on exit, so recursive re-entry through simplify_unused_expr only ever touches elements above its own watermark — identical iteration order, no per-call heap allocation. BinaryExpressionSimplifyVisitor's element type was reshaped from a raw const pointer to a safe arena StoreRef so the stack holds the same element type the call site already used. A stale comment above the MacroState::init placeholder in p.rs was also corrected: prepend_stmts is write-only in the visit pass, so the placeholder Vec is permanent, matching the comments in visit/mod.rs and parser.rs. Tested by a new bundler minify test that drives deep left-nested comma chains (more entries than the pre-reserved capacity), right-nested comma chains that force recursive re-entry on the shared stack, and unused strict-eq/ne expressions, asserting side effects survive in source order and the pure comparisons are eliminated.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
