### PR TITLE
css: route UnknownAtRule.name and Selectors::NamespaceUrl 'static-erasure markers to the bump-lifetime campaign

### DIFF
--- a/src/css/rules/unknown.rs
+++ b/src/css/rules/unknown.rs
@@ -5,9 +5,8 @@ use crate::{PrintErr, Printer};
 /// An unknown at-rule, stored as raw tokens.
 pub struct UnknownAtRule {
     /// The name of the at-rule (without the @).
-    // TODO: arena lifetime — slice backed by parser arena. Must land with the
-    // crate-wide `'bump` lifetime-threading campaign (UnknownAtRule<'a> ripples
-    // through CssRule and css_parser.rs); do not fix piecemeal.
+    // TODO: arena lifetime — slice backed by parser arena. Requires threading
+    // `'bump` through CssRule and css_parser.rs; not fixable piecemeal.
     pub name: &'static [u8],
     /// The prelude of the rule.
     pub prelude: TokenList,

--- a/src/css/rules/unknown.rs
+++ b/src/css/rules/unknown.rs
@@ -5,7 +5,9 @@ use crate::{PrintErr, Printer};
 /// An unknown at-rule, stored as raw tokens.
 pub struct UnknownAtRule {
     /// The name of the at-rule (without the @).
-    // TODO: arena lifetime — slice backed by parser arena.
+    // TODO: arena lifetime — slice backed by parser arena. Must land with the
+    // crate-wide `'bump` lifetime-threading campaign (UnknownAtRule<'a> ripples
+    // through CssRule and css_parser.rs); do not fix piecemeal.
     pub name: &'static [u8],
     /// The prelude of the rule.
     pub prelude: TokenList,

--- a/src/css/selectors/mod.rs
+++ b/src/css/selectors/mod.rs
@@ -47,10 +47,9 @@ pub mod impl_ {
         type LocalIdentifier = IdentOrRef;
         type LocalName = Ident;
         type NamespacePrefix = Ident;
-        // TODO: lifetime — should borrow the parser input. Must land with the
-        // crate-wide `'bump` lifetime-threading campaign (requires lifetime-
-        // parameterized SelectorImpl/`Selectors<'a>` threading through every
-        // selector consumer); do not fix piecemeal.
+        // TODO: lifetime — should borrow the parser input. Requires a
+        // lifetime-parameterized SelectorImpl threaded through every selector
+        // consumer; not fixable piecemeal.
         type NamespaceUrl = &'static [u8];
         type BorrowedNamespaceUrl = &'static [u8];
         type BorrowedLocalName = Ident;

--- a/src/css/selectors/mod.rs
+++ b/src/css/selectors/mod.rs
@@ -47,7 +47,10 @@ pub mod impl_ {
         type LocalIdentifier = IdentOrRef;
         type LocalName = Ident;
         type NamespacePrefix = Ident;
-        // TODO: lifetime — should borrow the parser input.
+        // TODO: lifetime — should borrow the parser input. Must land with the
+        // crate-wide `'bump` lifetime-threading campaign (requires lifetime-
+        // parameterized SelectorImpl/`Selectors<'a>` threading through every
+        // selector consumer); do not fix piecemeal.
         type NamespaceUrl = &'static [u8];
         type BorrowedNamespaceUrl = &'static [u8];
         type BorrowedLocalName = Ident;


### PR DESCRIPTION
The two remaining bun_css 'static-erasure markers in this cluster (UnknownAtRule.name in src/css/rules/unknown.rs and SelectorImpl::NamespaceUrl in src/css/selectors/mod.rs) are the same crate-wide 'bump lifetime-threading class as the Group 016 campaign. Their producers and consumers live in css_parser.rs and selectors/parser.rs, so any partial lifetime threading from these two files alone would create invariant-lifetime dead ends — the work order itself mandates they land only with the dedicated campaign PR. This change annotates both TODO markers with the campaign routing and the do-not-fix-piecemeal constraint so future sweeps do not attempt an unsound partial fix. No behavior change; no tests needed.

## Deferred

- mk07 entry 1 (UnknownAtRule.name &'static [u8] -> &'a [u8]): blocked on Group 016 crate-wide 'bump threading; producers in css_parser.rs:1490/2034/2077 and CssRule in rules/mod.rs are outside this cluster's ownership and a partial threading is explicitly forbidden by the order
- mk07 entry 2 (Selectors::NamespaceUrl &'static [u8] -> borrowed): blocked on the same campaign; requires lifetime-parameterized SelectorImpl threading through selectors/parser.rs (4000+ lines) and every selector consumer

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
