### PR TITLE
Restore smol-gated retain-with-limit reset for the module loader transpile arena

### DIFF
--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -55,18 +55,31 @@ impl ModuleLoader {
     /// `VirtualMachine`, so passing both would alias (PORTING.md §Forbidden).
     /// Access `module_loader` through `jsc_vm` instead.
     pub fn reset_arena(jsc_vm: &mut VirtualMachine) {
-        // PERF: this unconditionally calls `reset()`. Per
-        // `MimallocArena::reset_retain_with_limit`'s doc comment, the
-        // "mimalloc's segment cache keeps pages warm anyway" theory behind
-        // unconditional `reset()` proved wrong (purged pages get re-committed
-        // and re-zeroed each cycle), which is why the cap-gated retain exists
-        // and the other call sites use `reset_retain_with_limit(8 MiB)`.
-        // Switching to the retain-with-limit form (when not in smol mode) is
-        // a perf-sensitive change that
-        // needs benchmarking (transpile arena RSS vs cycle cost), so it is
-        // tracked as a dedicated work order rather than changed inline.
+        let smol = jsc_vm.smol;
         if let Some(arena) = jsc_vm.module_loader.transpile_source_code_arena.as_mut() {
-            arena.reset();
+            if smol {
+                // `--smol` trades CPU for the lowest steady-state RSS: always
+                // pay `mi_heap_destroy` + `mi_heap_new` so no dead transpile
+                // garbage is retained between modules.
+                arena.reset();
+                bun_core::scoped_log!(ModuleLoader, "reset_arena: free_all");
+            } else {
+                // Cap-gated retain, matching the other per-cycle arena call
+                // sites — see `MimallocArena::reset_retain_with_limit` for why
+                // retaining the warm heap (bounded by the 8 MiB cap) beats an
+                // unconditional destroy/new round-trip (purged pages get
+                // re-committed and re-zeroed each cycle otherwise).
+                let retained = arena.reset_retain_with_limit(8 * 1024 * 1024);
+                // Debug-only observability for the branch taken (`retained` =
+                // footprint stayed under the cap; `recycled` = over-cap, full
+                // destroy/new). Asserted by
+                // test/js/bun/resolve/load-same-js-file-a-lot.test.ts.
+                bun_core::scoped_log!(
+                    ModuleLoader,
+                    "reset_arena: {}",
+                    if retained { "retained" } else { "recycled" }
+                );
+            }
         }
     }
 }

--- a/src/jsc/ModuleLoader.rs
+++ b/src/jsc/ModuleLoader.rs
@@ -58,22 +58,12 @@ impl ModuleLoader {
         let smol = jsc_vm.smol;
         if let Some(arena) = jsc_vm.module_loader.transpile_source_code_arena.as_mut() {
             if smol {
-                // `--smol` trades CPU for the lowest steady-state RSS: always
-                // pay `mi_heap_destroy` + `mi_heap_new` so no dead transpile
-                // garbage is retained between modules.
+                // --smol prioritizes RSS: always destroy, retain nothing.
                 arena.reset();
                 bun_core::scoped_log!(ModuleLoader, "reset_arena: free_all");
             } else {
-                // Cap-gated retain, matching the other per-cycle arena call
-                // sites — see `MimallocArena::reset_retain_with_limit` for why
-                // retaining the warm heap (bounded by the 8 MiB cap) beats an
-                // unconditional destroy/new round-trip (purged pages get
-                // re-committed and re-zeroed each cycle otherwise).
                 let retained = arena.reset_retain_with_limit(8 * 1024 * 1024);
-                // Debug-only observability for the branch taken (`retained` =
-                // footprint stayed under the cap; `recycled` = over-cap, full
-                // destroy/new). Asserted by
-                // test/js/bun/resolve/load-same-js-file-a-lot.test.ts.
+                // Asserted by load-same-js-file-a-lot.test.ts.
                 bun_core::scoped_log!(
                     ModuleLoader,
                     "reset_arena: {}",

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3961,13 +3961,6 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // mirror WebWorker__teardownJSCVM — leave any pending exception in place
     }
-    // Mirror WebWorker__teardownJSCVM: with a termination request set,
-    // NapiEnv::mustDeferFinalizers() returns false, so napi finalizers swept
-    // by the collectNow() below run immediately instead of being enqueued as
-    // NapiFinalizerTasks on an event loop that will never tick again (LSan
-    // reports each never-drained task allocation as a leak — flaky in
-    // test/regression/issue/30205.test.ts under BUN_DESTRUCT_VM_ON_EXIT).
-    vm.setHasTerminationRequest();
     gcUnprotect(globalObject);
     globalObject = nullptr;
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3961,6 +3961,13 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // mirror WebWorker__teardownJSCVM — leave any pending exception in place
     }
+    // Mirror WebWorker__teardownJSCVM: with a termination request set,
+    // NapiEnv::mustDeferFinalizers() returns false, so napi finalizers swept
+    // by the collectNow() below run immediately instead of being enqueued as
+    // NapiFinalizerTasks on an event loop that will never tick again (LSan
+    // reports each never-drained task allocation as a leak — flaky in
+    // test/regression/issue/30205.test.ts under BUN_DESTRUCT_VM_ON_EXIT).
+    vm.setHasTerminationRequest();
     gcUnprotect(globalObject);
     globalObject = nullptr;
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1188,6 +1188,20 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
             for_each_fs_async_op!(__fs_destroy);
             true
         }
+        // Deferred napi finalizers enqueued by a GC that the loop never got
+        // to drain. Running the addon callback this late is not safe (it may
+        // call back into JS), so drop the box without dispatching — same
+        // policy as `NapiFinalizerTask::schedule`'s shutdown branch. The drop
+        // releases the `Ref<NapiEnv>` while the env is still alive (we run
+        // before `destructOnExit`); the addon's external data is reclaimed by
+        // the OS at process exit.
+        task_tag::NapiFinalizerTask => {
+            // SAFETY: `task.ptr` is the `Box<NapiFinalizerTask>` from
+            // `NapiFinalizerTask::schedule` (`heap::into_raw`); the loop will
+            // never dispatch it, so we hold the sole reference.
+            drop(unsafe { bun_core::heap::take(task.ptr.cast::<NapiFinalizerTask>()) });
+            true
+        }
         // Re-queued by the caller; the box stays reachable from the
         // static-rooted VM. Dispatching the type-erased `AnyTask` callback
         // is not generally safe at shutdown (e.g. `AsyncModule::on_done`,

--- a/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
+++ b/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 
 const asanIsSlowMultiplier = isASAN ? 0.2 : 1;
 const count = Math.floor(10000 * asanIsSlowMultiplier);
@@ -33,6 +33,126 @@ test(
   },
   isDebug || isASAN ? 20_000 : 5000,
 );
+
+// The module loader's per-transpile arena reset (ModuleLoader::reset_arena)
+// runs after every *synchronous* transpile cycle — require() takes this path;
+// dynamic import() of non-main JS-like modules routes through the concurrent
+// transpiler store and never reaches it. Under --smol the heap is destroyed
+// outright (free_all); otherwise the warm heap is retained while its
+// footprint stays under an 8 MiB cap and recycled once a module pushes it
+// past the cap. On the success path the give-back guard inside the transpile
+// hook resets the arena before parking it, so reset_arena's over-limit branch
+// only sees a fat arena on the parse-error path (the arena is parked un-reset
+// there so error log spans stay valid) — hence the oversized *broken* modules
+// below.
+//
+// On debug builds the branch taken is asserted via the BUN_DEBUG_ModuleLoader
+// scoped log, so reverting to an unconditional reset (or inverting the smol
+// gate) fails this test. In any build, a bug in either reset path (freeing
+// memory a parked source still references, corrupting the retained heap)
+// would crash or corrupt module evaluation in the subprocess.
+for (const smol of [false, true]) {
+  test(
+    `transpile arena reset policy (${smol ? "--smol" : "default"})`,
+    async () => {
+      const iters = isASAN || isDebug ? 50 : 200;
+      const brokenCount = isASAN || isDebug ? 1 : 2;
+
+      // Each big module must push the transpile arena past the 8 MiB retain
+      // cap before the parser finishes: 150k statements at well over ~55
+      // bytes of arena footprint each (Stmt + S.Local + Decl + Binding +
+      // E.Number + symbol) clears the cap with margin.
+      const bigLines: string[] = [];
+      for (let i = 0; i < 150_000; i++) {
+        bigLines.push(`const v${i} = ${i};`);
+      }
+      const bigValid = bigLines.join("\n") + "\nexport const sum = v0 + v149999;";
+      // Syntax error at the END so the parser allocates the full AST into
+      // the arena before failing; the error path parks the arena un-reset
+      // and reset_arena reclaims it (over-limit branch in default mode).
+      const bigBroken = bigLines.join("\n") + "\n}";
+
+      const files: Record<string, string> = {
+        "big_valid.ts": bigValid,
+        "driver.ts": `
+          let total = 0;
+          let caught = 0;
+          for (let i = 0; i < ${iters}; i++) {
+            // require(), not import(): dynamic import of a non-main module
+            // goes through the concurrent transpiler store and skips the
+            // module loader's synchronous arena reset entirely.
+            const m = require("./small_" + i + ".ts");
+            total += m.value;
+            if (i % 10 === 0) Bun.gc(true);
+          }
+          for (let i = 0; i < ${brokenCount}; i++) {
+            try {
+              require("./big_broken_" + i + ".ts");
+            } catch {
+              caught++;
+            }
+            Bun.gc(true);
+          }
+          total += require("./big_valid.ts").sum;
+          Bun.gc(true);
+          console.log("total=" + total + " caught=" + caught);
+        `,
+      };
+      for (let i = 0; i < iters; i++) {
+        files[`small_${i}.ts`] = `export const value: number = 1;\n`;
+      }
+      for (let i = 0; i < brokenCount; i++) {
+        files[`big_broken_${i}.ts`] = bigBroken;
+      }
+
+      using dir = tempDir("transpile-arena-reset", files);
+
+      const cmd = [bunExe()];
+      if (smol) cmd.push("--smol");
+      cmd.push("driver.ts");
+
+      await using proc = Bun.spawn({
+        cmd,
+        // The scoped log is compiled out of release builds; only ask for it
+        // (and assert on it) when the build under test is a debug build.
+        env: isDebug ? { ...bunEnv, BUN_DEBUG_ModuleLoader: "1" } : bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toContain(`total=${iters + 149999} caught=${brokenCount}`);
+      if (isDebug) {
+        // Differential assertions: count reset_arena branch logs. Pre-change
+        // behavior (unconditional destroy/new) or an inverted smol gate
+        // produces the wrong branch tags and fails here.
+        const logs = stdout + stderr;
+        const occurrences = (needle: string) => logs.split(needle).length - 1;
+        if (smol) {
+          // --smol must always take the full-destroy path.
+          expect(occurrences("reset_arena: free_all")).toBeGreaterThanOrEqual(iters + brokenCount);
+          expect(occurrences("reset_arena: retained")).toBe(0);
+          expect(occurrences("reset_arena: recycled")).toBe(0);
+        } else {
+          // Default mode: post-success resets see an already-recycled arena
+          // (under the cap, so retained); each oversized parse failure parks
+          // a fat arena and must trip the over-limit recycle. If the broken
+          // fixture ever stops clearing the 8 MiB cap, the recycled
+          // assertion fails instead of silently losing branch coverage.
+          expect(occurrences("reset_arena: retained")).toBeGreaterThanOrEqual(iters);
+          expect(occurrences("reset_arena: recycled")).toBeGreaterThanOrEqual(brokenCount);
+          expect(occurrences("reset_arena: free_all")).toBe(0);
+        }
+      } else {
+        expect(stderr).toBe("");
+      }
+      expect(exitCode).toBe(0);
+    },
+    isDebug || isASAN ? 120_000 : 30_000,
+  );
+}
 
 test(`load the same empty JS file ${count} times`, async () => {
   const prev = Bun.unsafe.gcAggressionLevel();

--- a/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
+++ b/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
@@ -121,7 +121,7 @@ for (const smol of [false, true]) {
           expect(occurrences("reset_arena: free_all")).toBe(0);
         }
       } else {
-        expect(stderr).toBe("");
+        expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
       }
       expect(exitCode).toBe(0);
     },

--- a/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
+++ b/test/js/bun/resolve/load-same-js-file-a-lot.test.ts
@@ -34,23 +34,11 @@ test(
   isDebug || isASAN ? 20_000 : 5000,
 );
 
-// The module loader's per-transpile arena reset (ModuleLoader::reset_arena)
-// runs after every *synchronous* transpile cycle — require() takes this path;
-// dynamic import() of non-main JS-like modules routes through the concurrent
-// transpiler store and never reaches it. Under --smol the heap is destroyed
-// outright (free_all); otherwise the warm heap is retained while its
-// footprint stays under an 8 MiB cap and recycled once a module pushes it
-// past the cap. On the success path the give-back guard inside the transpile
-// hook resets the arena before parking it, so reset_arena's over-limit branch
-// only sees a fat arena on the parse-error path (the arena is parked un-reset
-// there so error log spans stay valid) — hence the oversized *broken* modules
-// below.
-//
-// On debug builds the branch taken is asserted via the BUN_DEBUG_ModuleLoader
-// scoped log, so reverting to an unconditional reset (or inverting the smol
-// gate) fails this test. In any build, a bug in either reset path (freeing
-// memory a parked source still references, corrupting the retained heap)
-// would crash or corrupt module evaluation in the subprocess.
+// ModuleLoader::reset_arena: --smol destroys the transpile arena every cycle;
+// otherwise it retains the warm heap under an 8 MiB cap and recycles when over.
+// The over-cap branch is only reachable via the parse-error path (success
+// resets the arena before parking it), hence the oversized broken modules.
+// Debug builds assert the branch taken via the BUN_DEBUG_ModuleLoader log.
 for (const smol of [false, true]) {
   test(
     `transpile arena reset policy (${smol ? "--smol" : "default"})`,
@@ -58,18 +46,13 @@ for (const smol of [false, true]) {
       const iters = isASAN || isDebug ? 50 : 200;
       const brokenCount = isASAN || isDebug ? 1 : 2;
 
-      // Each big module must push the transpile arena past the 8 MiB retain
-      // cap before the parser finishes: 150k statements at well over ~55
-      // bytes of arena footprint each (Stmt + S.Local + Decl + Binding +
-      // E.Number + symbol) clears the cap with margin.
+      // 150k statements pushes the transpile arena well past the 8 MiB cap.
       const bigLines: string[] = [];
       for (let i = 0; i < 150_000; i++) {
         bigLines.push(`const v${i} = ${i};`);
       }
       const bigValid = bigLines.join("\n") + "\nexport const sum = v0 + v149999;";
-      // Syntax error at the END so the parser allocates the full AST into
-      // the arena before failing; the error path parks the arena un-reset
-      // and reset_arena reclaims it (over-limit branch in default mode).
+      // Syntax error at the end so the full AST is in the arena before failing.
       const bigBroken = bigLines.join("\n") + "\n}";
 
       const files: Record<string, string> = {
@@ -78,9 +61,8 @@ for (const smol of [false, true]) {
           let total = 0;
           let caught = 0;
           for (let i = 0; i < ${iters}; i++) {
-            // require(), not import(): dynamic import of a non-main module
-            // goes through the concurrent transpiler store and skips the
-            // module loader's synchronous arena reset entirely.
+            // require(), not import(): dynamic import skips the synchronous
+            // arena reset (concurrent transpiler store).
             const m = require("./small_" + i + ".ts");
             total += m.value;
             if (i % 10 === 0) Bun.gc(true);
@@ -113,8 +95,7 @@ for (const smol of [false, true]) {
 
       await using proc = Bun.spawn({
         cmd,
-        // The scoped log is compiled out of release builds; only ask for it
-        // (and assert on it) when the build under test is a debug build.
+        // The scoped log is compiled out of release builds.
         env: isDebug ? { ...bunEnv, BUN_DEBUG_ModuleLoader: "1" } : bunEnv,
         cwd: String(dir),
         stdout: "pipe",
@@ -125,22 +106,16 @@ for (const smol of [false, true]) {
 
       expect(stdout).toContain(`total=${iters + 149999} caught=${brokenCount}`);
       if (isDebug) {
-        // Differential assertions: count reset_arena branch logs. Pre-change
-        // behavior (unconditional destroy/new) or an inverted smol gate
-        // produces the wrong branch tags and fails here.
         const logs = stdout + stderr;
         const occurrences = (needle: string) => logs.split(needle).length - 1;
         if (smol) {
-          // --smol must always take the full-destroy path.
           expect(occurrences("reset_arena: free_all")).toBeGreaterThanOrEqual(iters + brokenCount);
           expect(occurrences("reset_arena: retained")).toBe(0);
           expect(occurrences("reset_arena: recycled")).toBe(0);
         } else {
-          // Default mode: post-success resets see an already-recycled arena
-          // (under the cap, so retained); each oversized parse failure parks
-          // a fat arena and must trip the over-limit recycle. If the broken
-          // fixture ever stops clearing the 8 MiB cap, the recycled
-          // assertion fails instead of silently losing branch coverage.
+          // Each oversized parse failure must trip the over-cap recycle; if the
+          // broken fixture stops clearing the cap, this fails rather than
+          // silently losing branch coverage.
           expect(occurrences("reset_arena: retained")).toBeGreaterThanOrEqual(iters);
           expect(occurrences("reset_arena: recycled")).toBeGreaterThanOrEqual(brokenCount);
           expect(occurrences("reset_arena: free_all")).toBe(0);

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -22,6 +22,5 @@ test("Printing errors does not leak", () => {
   console.log(`RSS increased by ${diff} MB`);
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
-  // The transpile arena retains up to 8 MiB between resets (ModuleLoader::reset_arena).
-  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 20);
+  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 10);
 }, 10_000);

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -22,5 +22,9 @@ test("Printing errors does not leak", () => {
   console.log(`RSS increased by ${diff} MB`);
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
-  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 10);
+  // The module loader's transpile arena intentionally retains up to 8 MiB of
+  // warm heap between resets (see ModuleLoader::reset_arena), and the retained
+  // footprint oscillates between zero and that cap, so RSS sampled at the
+  // baseline vs the end can differ by up to ~8 MB without any leak.
+  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 20);
 }, 10_000);

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -22,6 +22,8 @@ test("Printing errors does not leak", () => {
   console.log(`RSS increased by ${diff} MB`);
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
-  // The transpile arena retains up to 8 MiB between resets (ModuleLoader::reset_arena).
+  // Bun.inspect(Error) reaches ModuleLoader::reset_arena via the ZigException
+  // stack-remap path, so the 8 MiB retain-with-limit arena policy raises the
+  // measured delta.
   expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 20);
 }, 10_000);

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -22,9 +22,6 @@ test("Printing errors does not leak", () => {
   console.log(`RSS increased by ${diff} MB`);
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
-  // The module loader's transpile arena intentionally retains up to 8 MiB of
-  // warm heap between resets (see ModuleLoader::reset_arena), and the retained
-  // footprint oscillates between zero and that cap, so RSS sampled at the
-  // baseline vs the end can differ by up to ~8 MB without any leak.
+  // The transpile arena retains up to 8 MiB between resets (ModuleLoader::reset_arena).
   expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 20);
 }, 10_000);

--- a/test/js/bun/util/inspect-error-leak.test.js
+++ b/test/js/bun/util/inspect-error-leak.test.js
@@ -22,5 +22,6 @@ test("Printing errors does not leak", () => {
   console.log(`RSS increased by ${diff} MB`);
   // ASAN's free quarantine (default 256 MB) plus redzones and glibc page
   // retention inflate RSS even when nothing is leaking.
-  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 10);
+  // The transpile arena retains up to 8 MiB between resets (ModuleLoader::reset_arena).
+  expect(diff, `RSS grew by ${diff} MB after ${perBatch * repeat} iterations`).toBeLessThan(isASAN ? 400 : 20);
 }, 10_000);


### PR DESCRIPTION
ModuleLoader::reset_arena unconditionally destroyed and recreated the per-transpile mimalloc heap after every module, diverging from the intended behavior: a full reset only under --smol, and an 8 MiB cap-gated retain otherwise. The unconditional destroy/new round-trip pays mi_heap_destroy teardown plus page re-commit and re-zero on every transpile cycle; every other per-cycle arena call site (bundler chunk generation, installer, renamer, bake router, the transpiler store hook) already uses reset_retain_with_limit(8 MiB), and the MimallocArena doc comment documents why the 'segment cache keeps pages warm anyway' rationale for unconditional reset was wrong. reset_arena now reads vm.smol and calls reset() under --smol (lowest steady-state RSS) and reset_retain_with_limit(8 * 1024 * 1024) otherwise, matching the other call sites, and emits a BUN_DEBUG_ModuleLoader scoped log of the branch taken (free_all/retained/recycled; debug builds only, compiled out of release). Tested with a subprocess stress test that require()s many distinct small modules (require forces the synchronous transpile path through reset_arena; dynamic import routes through the concurrent transpiler store and skips it) plus oversized 150k-statement modules with a trailing syntax error (the parse-error path parks the arena un-reset, so it is the only path where reset_arena sees an over-cap arena and recycles), with forced GC interleaved, in both default and --smol modes; on debug builds the test counts the branch-tag logs differentially (default: retained>=iters, recycled>=brokenCount, zero free_all; --smol: free_all only), so a revert to unconditional reset or an inverted smol gate fails. Outstanding verify-phase action: run the transpile-heavy before/after RSS+time benchmark the work order requires and record the numbers in reports2/24-fix.md.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
