### PR TITLE
Bundler ParseTask ownership, socket adopt, and watcher thread handoff fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2288,6 +2288,7 @@ version = "0.0.0"
 dependencies = [
  "bitflags",
  "bstr",
+ "bun_ast",
  "bun_collections",
  "bun_core",
  "bun_paths",

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -64,26 +64,15 @@ mod EventLoop {
 // ContentsOrFd
 // ───────────────────────────────────────────────────────────────────────────
 
-/// Provenance-explicit backing for [`ContentsOrFd::Contents`].
-///
-/// Neither variant owns the bytes and neither runs `Drop` — the variants exist
-/// so the keep-alive contract is visible and matchable at every site instead
-/// of hiding behind a bare `&'static [u8]`. Native-plugin
-/// (`onBeforeParse`) buffers never flow through here: they enter as
-/// `cache::Contents::External` on the `CacheEntry`, and their destructor is
-/// the separate `ParseTask::external_free_function`, moved into
-/// `Result.external` exactly once when the task completes.
+/// Backing provenance for [`ContentsOrFd::Contents`]. Neither variant owns
+/// the bytes; native-plugin (`onBeforeParse`) buffers never flow through here.
 #[derive(Copy, Clone)]
 pub enum ContentsBacking {
-    /// Truly `'static` bytes: the embedded `bun:runtime` source and the empty
-    /// placeholder.
+    /// Truly `'static` bytes (embedded sources, empty placeholder).
     Static(&'static [u8]),
-    /// Bytes kept alive by the owning `BundleV2` for the duration of the
-    /// bundle pass — `graph.input_files` source contents (see
-    /// `interned_slice`), or `free_list` allocations (decoded `data:` URLs,
-    /// JS `onLoad` plugin buffers). The `'static` here is forged at the
-    /// construction site; the real lifetime is the bundle pass, which
-    /// strictly outlives every `ParseTask`.
+    /// Bytes kept alive by the owning `BundleV2` for the bundle pass
+    /// (`graph.input_files` / `free_list`); the `'static` is forged at the
+    /// construction site.
     BundleOwned(&'static [u8]),
 }
 
@@ -104,18 +93,16 @@ pub enum ContentsOrFd {
 }
 
 impl ContentsOrFd {
-    /// Empty static contents — the `Default` placeholder.
     pub const EMPTY: ContentsOrFd = ContentsOrFd::Contents(ContentsBacking::Static(b""));
 
-    /// Contents that are genuinely `'static` (embedded sources).
+    /// Genuinely `'static` contents (embedded sources).
     #[inline]
     pub fn static_contents(bytes: &'static [u8]) -> ContentsOrFd {
         ContentsOrFd::Contents(ContentsBacking::Static(bytes))
     }
 
-    /// Contents kept alive by the owning `BundleV2` for the bundle pass
-    /// (graph `input_files` / `free_list` storage). The caller is responsible
-    /// for the keep-alive; see [`ContentsBacking::BundleOwned`].
+    /// Contents the caller keeps alive for the bundle pass; see
+    /// [`ContentsBacking::BundleOwned`].
     #[inline]
     pub fn bundle_owned(bytes: &'static [u8]) -> ContentsOrFd {
         ContentsOrFd::Contents(ContentsBacking::BundleOwned(bytes))
@@ -1557,9 +1544,8 @@ pub mod parse_worker {
                 };
             }
             ContentsOrFd::Contents(backing) => {
-                // Both `ContentsBacking` arms are caller-kept-alive borrows
-                // (static or bundle-owned) → `SharedBuffer` provenance, which
-                // `Entry::deinit` never frees.
+                // Caller-kept-alive borrows → `SharedBuffer` provenance;
+                // `Entry::deinit` never frees it.
                 let contents = backing.as_slice();
                 Ok(CacheEntry {
                     contents: crate::cache::Contents::SharedBuffer {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -64,14 +64,62 @@ mod EventLoop {
 // ContentsOrFd
 // ───────────────────────────────────────────────────────────────────────────
 
+/// Provenance-explicit backing for [`ContentsOrFd::Contents`].
+///
+/// Neither variant owns the bytes and neither runs `Drop` — the variants exist
+/// so the keep-alive contract is visible and matchable at every site instead
+/// of hiding behind a bare `&'static [u8]`. Native-plugin
+/// (`onBeforeParse`) buffers never flow through here: they enter as
+/// `cache::Contents::External` on the `CacheEntry`, and their destructor is
+/// the separate `ParseTask::external_free_function`, moved into
+/// `Result.external` exactly once when the task completes.
+#[derive(Copy, Clone)]
+pub enum ContentsBacking {
+    /// Truly `'static` bytes: the embedded `bun:runtime` source and the empty
+    /// placeholder.
+    Static(&'static [u8]),
+    /// Bytes kept alive by the owning `BundleV2` for the duration of the
+    /// bundle pass — `graph.input_files` source contents (see
+    /// `interned_slice`), or `free_list` allocations (decoded `data:` URLs,
+    /// JS `onLoad` plugin buffers). The `'static` here is forged at the
+    /// construction site; the real lifetime is the bundle pass, which
+    /// strictly outlives every `ParseTask`.
+    BundleOwned(&'static [u8]),
+}
+
+impl ContentsBacking {
+    #[inline]
+    pub fn as_slice(&self) -> &'static [u8] {
+        match *self {
+            ContentsBacking::Static(s) | ContentsBacking::BundleOwned(s) => s,
+        }
+    }
+}
+
 #[derive(bun_core::EnumTag)]
 #[enum_tag(existing = ContentsOrFdTag)]
 pub enum ContentsOrFd {
     Fd { dir: Fd, file: Fd },
-    // The `'static` is ownership-erased: contents may be arena-owned,
-    // plugin-owned, or truly static (runtime source). The producer keeps the
-    // backing allocation alive for the duration of the bundle pass.
-    Contents(&'static [u8]),
+    Contents(ContentsBacking),
+}
+
+impl ContentsOrFd {
+    /// Empty static contents — the `Default` placeholder.
+    pub const EMPTY: ContentsOrFd = ContentsOrFd::Contents(ContentsBacking::Static(b""));
+
+    /// Contents that are genuinely `'static` (embedded sources).
+    #[inline]
+    pub fn static_contents(bytes: &'static [u8]) -> ContentsOrFd {
+        ContentsOrFd::Contents(ContentsBacking::Static(bytes))
+    }
+
+    /// Contents kept alive by the owning `BundleV2` for the bundle pass
+    /// (graph `input_files` / `free_list` storage). The caller is responsible
+    /// for the keep-alive; see [`ContentsBacking::BundleOwned`].
+    #[inline]
+    pub fn bundle_owned(bytes: &'static [u8]) -> ContentsOrFd {
+        ContentsOrFd::Contents(ContentsBacking::BundleOwned(bytes))
+    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, strum::IntoStaticStr)]
@@ -298,7 +346,7 @@ impl Default for ParseTask {
             ctx: None,
             path: Fs::Path::init(b""),
             secondary_path_for_commonjs_interop: None,
-            contents_or_fd: ContentsOrFd::Contents(b""),
+            contents_or_fd: ContentsOrFd::EMPTY,
             external_free_function: ExternalFreeFunction::NONE,
             side_effects: bun_ast::SideEffects::HasSideEffects,
             loader: None,
@@ -540,7 +588,7 @@ pub mod parse_worker {
                 parse: false,
                 ..Default::default()
             },
-            contents_or_fd: ContentsOrFd::Contents(runtime_code.as_bytes()),
+            contents_or_fd: ContentsOrFd::static_contents(runtime_code.as_bytes()),
             source_index: Index::RUNTIME,
             loader: Some(Loader::Js),
             known_target: target,
@@ -1508,14 +1556,20 @@ pub mod parse_worker {
                     }
                 };
             }
-            ContentsOrFd::Contents(contents) => Ok(CacheEntry {
-                contents: crate::cache::Contents::SharedBuffer {
-                    ptr: contents.as_ptr(),
-                    len: contents.len(),
-                },
-                fd: Fd::INVALID,
-                ..Default::default()
-            }),
+            ContentsOrFd::Contents(backing) => {
+                // Both `ContentsBacking` arms are caller-kept-alive borrows
+                // (static or bundle-owned) → `SharedBuffer` provenance, which
+                // `Entry::deinit` never frees.
+                let contents = backing.as_slice();
+                Ok(CacheEntry {
+                    contents: crate::cache::Contents::SharedBuffer {
+                        ptr: contents.as_ptr(),
+                        len: contents.len(),
+                    },
+                    fd: Fd::INVALID,
+                    ..Default::default()
+                })
+            }
         }
     }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -49,10 +49,7 @@ pub struct ThreadPool {
     // `wake_for_idle_events`) take `&self` — so the safe `Deref` projection is
     // sufficient and the per-read `unsafe { p.as_ref() }` disappears.
     pub io_pool: Option<bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>>,
-    // Owned-vs-borrowed is encoded in the variant (no `is_owned` flag to keep
-    // in sync). All driver methods (`schedule`, `warm`, `wake_for_idle_events`)
-    // take `&self`, so callers go through the safe [`Self::worker_pool`]
-    // accessor. Private: the only out-of-module reader uses the accessor.
+    // Read through the [`Self::worker_pool`] accessor.
     worker_pool: WorkerPool,
     // Per PORTING.md §Concurrency ("Mutex<T> owns T"), the lock is folded into
     // the field so `get_worker` can take `&self` — `Worker::get` is entered
@@ -69,24 +66,14 @@ pub struct ThreadPool {
     pub v2: *const BundleV2<'static>,
 }
 
-/// Maybe-owned wrapper for the bundler's worker pool. Mirrors the `io_pool`
-/// field's move to a safe projection: ownership is explicit in the variant
-/// instead of a raw pointer + `worker_pool_is_owned` flag.
-///
-/// `ThreadPool` is arena-allocated and the arena runs no `Drop`, so the
-/// `Owned` box is freed explicitly in [`ThreadPool::deinit`] (which replaces
-/// the variant with `Unset`), never by drop glue.
+/// Maybe-owned worker pool. `ThreadPool` is arena-allocated (no drop glue),
+/// so the `Owned` box is freed explicitly in [`ThreadPool::deinit`].
 enum WorkerPool {
-    /// Placeholder for `ThreadPool::default()` before `init` overwrites it,
-    /// and the post-`deinit` state. Reaching [`ThreadPool::worker_pool`] in
-    /// this state is a logic bug.
+    /// Pre-`init` / post-`deinit` placeholder.
     Unset,
-    /// Pool created by this `ThreadPool` in `init`; shut down and freed in
-    /// `deinit`.
+    /// Created in `init`; freed in `deinit`.
     Owned(Box<ThreadPoolLib::ThreadPool>),
-    /// Caller-provided pool (e.g. the process-wide `WorkPool` singleton, or
-    /// the runtime's pool for in-process `Bun.build()`); strictly outlives
-    /// this `ThreadPool` and is never freed here.
+    /// Caller-provided pool that outlives this `ThreadPool`.
     Borrowed(bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>),
 }
 
@@ -263,11 +250,9 @@ impl ThreadPool {
         })
     }
 
-    /// Explicit teardown (no Drop on
-    /// `ThreadPool` because `Graph.pool` is `NonNull<ThreadPool>` and the arena
-    /// owns the storage — arena reset runs no drop glue, so the `Owned` box
-    /// must be freed here). Borrowed pools are left untouched: the runtime
-    /// still owns them.
+    /// Explicit teardown (no Drop on `ThreadPool` because `Graph.pool` is
+    /// `NonNull<ThreadPool>` and the arena owns the storage; arena reset runs
+    /// no drop glue).
     pub fn deinit(&mut self) {
         if let WorkerPool::Owned(pool) =
             core::mem::replace(&mut self.worker_pool, WorkerPool::Unset)
@@ -279,16 +264,12 @@ impl ThreadPool {
         }
     }
 
-    /// Safe accessor for the underlying `bun_threading::ThreadPool`. The
-    /// variant is set in `init` before any caller can observe `self`; all
-    /// driver methods take `&self`, so no caller needs more than this shared
-    /// projection.
+    /// Safe accessor for the underlying `bun_threading::ThreadPool`; the
+    /// variant is set in `init` before any caller can observe `self`.
     #[inline]
     pub fn worker_pool(&self) -> &ThreadPoolLib::ThreadPool {
         match &self.worker_pool {
             WorkerPool::Owned(pool) => &**pool,
-            // `ParentRef` derefs to the caller-owned pool, which strictly
-            // outlives this `ThreadPool`.
             WorkerPool::Borrowed(pool) => &**pool,
             WorkerPool::Unset => {
                 unreachable!("bundler ThreadPool worker_pool read before init / after deinit")
@@ -351,10 +332,8 @@ impl ThreadPool {
             let ContentsOrFd::Contents(backing) = parse_task.contents_or_fd else {
                 unreachable!()
             };
-            // Both `ContentsBacking` arms are caller-kept-alive borrows
-            // (static or bundle-owned), so map to the `SharedBuffer`
-            // provenance tag — `Entry::deinit` never frees it. This matches
-            // the mapping in `get_code_for_parse_task_without_plugins`.
+            // Caller-kept-alive borrows → `SharedBuffer` provenance;
+            // `Entry::deinit` never frees it.
             let contents = backing.as_slice();
             parse_task.stage = ParseTaskStage::NeedsParse(CacheEntry {
                 contents: if contents.is_empty() {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -269,7 +269,8 @@ impl ThreadPool {
     /// must be freed here). Borrowed pools are left untouched: the runtime
     /// still owns them.
     pub fn deinit(&mut self) {
-        if let WorkerPool::Owned(pool) = core::mem::replace(&mut self.worker_pool, WorkerPool::Unset)
+        if let WorkerPool::Owned(pool) =
+            core::mem::replace(&mut self.worker_pool, WorkerPool::Unset)
         {
             drop(pool);
         }

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -49,11 +49,11 @@ pub struct ThreadPool {
     // `wake_for_idle_events`) take `&self` — so the safe `Deref` projection is
     // sufficient and the per-read `unsafe { p.as_ref() }` disappears.
     pub io_pool: Option<bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>>,
-    // Conditionally owned via `worker_pool_is_owned`; kept raw so callers
-    // (bundle_v2.rs) can dereference for `wake_for_idle_events()` without a
-    // borrow on `ThreadPool`.
-    pub worker_pool: *mut ThreadPoolLib::ThreadPool,
-    pub worker_pool_is_owned: bool,
+    // Owned-vs-borrowed is encoded in the variant (no `is_owned` flag to keep
+    // in sync). All driver methods (`schedule`, `warm`, `wake_for_idle_events`)
+    // take `&self`, so callers go through the safe [`Self::worker_pool`]
+    // accessor. Private: the only out-of-module reader uses the accessor.
+    worker_pool: WorkerPool,
     // Per PORTING.md §Concurrency ("Mutex<T> owns T"), the lock is folded into
     // the field so `get_worker` can take `&self` — `Worker::get` is entered
     // concurrently from arbitrary worker-pool threads, and a `&mut self` here
@@ -67,6 +67,27 @@ pub struct ThreadPool {
     // BACKREF (LIFETIMES.tsv row 170: ThreadPool.v2). `BundleV2` is generic
     // over `'a`; erase to `'static` behind the raw pointer like ParseTask.ctx.
     pub v2: *const BundleV2<'static>,
+}
+
+/// Maybe-owned wrapper for the bundler's worker pool. Mirrors the `io_pool`
+/// field's move to a safe projection: ownership is explicit in the variant
+/// instead of a raw pointer + `worker_pool_is_owned` flag.
+///
+/// `ThreadPool` is arena-allocated and the arena runs no `Drop`, so the
+/// `Owned` box is freed explicitly in [`ThreadPool::deinit`] (which replaces
+/// the variant with `Unset`), never by drop glue.
+enum WorkerPool {
+    /// Placeholder for `ThreadPool::default()` before `init` overwrites it,
+    /// and the post-`deinit` state. Reaching [`ThreadPool::worker_pool`] in
+    /// this state is a logic bug.
+    Unset,
+    /// Pool created by this `ThreadPool` in `init`; shut down and freed in
+    /// `deinit`.
+    Owned(Box<ThreadPoolLib::ThreadPool>),
+    /// Caller-provided pool (e.g. the process-wide `WorkPool` singleton, or
+    /// the runtime's pool for in-process `Bun.build()`); strictly outlives
+    /// this `ThreadPool` and is never freed here.
+    Borrowed(bun_ptr::ParentRef<ThreadPoolLib::ThreadPool>),
 }
 
 // SAFETY: `ThreadPool` is shared across worker threads; the only mutated
@@ -87,8 +108,7 @@ impl Default for ThreadPool {
     fn default() -> Self {
         Self {
             io_pool: None,
-            worker_pool: ptr::null_mut(),
-            worker_pool_is_owned: false,
+            worker_pool: WorkerPool::Unset,
             workers_assignments: bun_threading::Guarded::new(ArrayHashMap::default()),
             generation: POOL_GENERATION.fetch_add(1, Ordering::Relaxed),
             v2: ptr::null(),
@@ -213,38 +233,23 @@ impl ThreadPool {
         // `Option<NonNull<_>>` (not `Option<&mut _>`): callers pass the
         // process-wide `WorkPool` singleton (`OnceLock`-backed, shared across
         // worker threads). Materializing `&mut` from that provenance is UB
-        // under Stacked Borrows even if the body never writes through it; the
-        // pool is stored as `*mut` in the struct anyway, so keep it raw
-        // end-to-end.
+        // under Stacked Borrows even if the body never writes through it;
+        // `ParentRef` keeps it a shared projection end-to-end.
         worker_pool: Option<NonNull<ThreadPoolLib::ThreadPool>>,
     ) -> Result<ThreadPool, bun_alloc::AllocError> {
-        // The pool is `heap::alloc`'d (global
-        // heap), so `deinit()` must `heap::take` it back; record ownership.
-        let owned = worker_pool.is_none();
-        let pool: *mut ThreadPoolLib::ThreadPool = match worker_pool {
-            Some(p) => p.as_ptr(),
+        let worker_pool = match worker_pool {
+            Some(p) => WorkerPool::Borrowed(bun_ptr::ParentRef::from(p)),
             None => {
                 let cpu_count = bun_core::get_thread_count();
-                let pool = bun_core::heap::into_raw(Box::new(ThreadPoolLib::ThreadPool::init(
-                    ThreadPoolLib::Config {
-                        max_threads: u32::from(cpu_count),
-                        ..Default::default()
-                    },
-                )));
+                let pool = Box::new(ThreadPoolLib::ThreadPool::init(ThreadPoolLib::Config {
+                    max_threads: u32::from(cpu_count),
+                    ..Default::default()
+                }));
                 bun_core::scoped_log!(ThreadPool, "{} workers", cpu_count);
-                pool
+                WorkerPool::Owned(pool)
             }
         };
-        let mut this = Self::init_with_pool(v2, pool);
-        this.worker_pool_is_owned = owned;
-        Ok(this)
-    }
-
-    pub fn init_with_pool(
-        v2: &BundleV2<'_>,
-        worker_pool: *mut ThreadPoolLib::ThreadPool,
-    ) -> ThreadPool {
-        ThreadPool {
+        Ok(ThreadPool {
             worker_pool,
             io_pool: if Self::uses_io_pool() {
                 Some(io_thread_pool::acquire().into())
@@ -253,20 +258,20 @@ impl ThreadPool {
             },
             // BACKREF: lifetime erased behind the raw pointer.
             v2: std::ptr::from_ref(v2).cast::<BundleV2<'static>>(),
-            worker_pool_is_owned: false,
             workers_assignments: bun_threading::Guarded::new(ArrayHashMap::default()),
             generation: POOL_GENERATION.fetch_add(1, Ordering::Relaxed),
-        }
+        })
     }
 
     /// Explicit teardown (no Drop on
     /// `ThreadPool` because `Graph.pool` is `NonNull<ThreadPool>` and the arena
-    /// owns the storage).
+    /// owns the storage — arena reset runs no drop glue, so the `Owned` box
+    /// must be freed here). Borrowed pools are left untouched: the runtime
+    /// still owns them.
     pub fn deinit(&mut self) {
-        if self.worker_pool_is_owned {
-            // SAFETY: worker_pool was heap-allocated in `init()` when owned.
-            unsafe { drop(bun_core::heap::take(self.worker_pool)) };
-            self.worker_pool = ptr::null_mut();
+        if let WorkerPool::Owned(pool) = core::mem::replace(&mut self.worker_pool, WorkerPool::Unset)
+        {
+            drop(pool);
         }
         if Self::uses_io_pool() {
             io_thread_pool::release();
@@ -274,14 +279,20 @@ impl ThreadPool {
     }
 
     /// Safe accessor for the underlying `bun_threading::ThreadPool`. The
-    /// pointer is set in `init`/`init_with_pool` and never null while `self`
-    /// is observable; encapsulating the deref keeps callers out of `unsafe`.
+    /// variant is set in `init` before any caller can observe `self`; all
+    /// driver methods take `&self`, so no caller needs more than this shared
+    /// projection.
     #[inline]
     pub fn worker_pool(&self) -> &ThreadPoolLib::ThreadPool {
-        debug_assert!(!self.worker_pool.is_null());
-        // SAFETY: `worker_pool` is initialized before any caller can observe
-        // `self` and lives until `deinit_v2`; all driver methods take `&self`.
-        unsafe { &*self.worker_pool }
+        match &self.worker_pool {
+            WorkerPool::Owned(pool) => &**pool,
+            // `ParentRef` derefs to the caller-owned pool, which strictly
+            // outlives this `ThreadPool`.
+            WorkerPool::Borrowed(pool) => &**pool,
+            WorkerPool::Unset => {
+                unreachable!("bundler ThreadPool worker_pool read before init / after deinit")
+            }
+        }
     }
 
     /// Safe accessor for the IO pool. `Some` only when `uses_io_pool()`; the
@@ -336,19 +347,19 @@ impl ThreadPool {
         if matches!(parse_task.contents_or_fd, ContentsOrFd::Contents(_))
             && matches!(parse_task.stage, ParseTaskStage::NeedsSourceCode)
         {
-            let ContentsOrFd::Contents(contents) = parse_task.contents_or_fd else {
+            let ContentsOrFd::Contents(backing) = parse_task.contents_or_fd else {
                 unreachable!()
             };
-            // `cache::Contents` has no borrowed-slice variant; the
-            // contract (see ParseTask.rs `run_with_source_code` defer) is that
-            // `entry.deinit()` is *skipped* when `contents_or_fd == .contents`,
-            // so an `External` provenance tag (no-op deinit) is the correct
-            // mapping for these unowned bytes.
+            // Both `ContentsBacking` arms are caller-kept-alive borrows
+            // (static or bundle-owned), so map to the `SharedBuffer`
+            // provenance tag — `Entry::deinit` never frees it. This matches
+            // the mapping in `get_code_for_parse_task_without_plugins`.
+            let contents = backing.as_slice();
             parse_task.stage = ParseTaskStage::NeedsParse(CacheEntry {
                 contents: if contents.is_empty() {
                     Contents::Empty
                 } else {
-                    Contents::External {
+                    Contents::SharedBuffer {
                         ptr: contents.as_ptr(),
                         len: contents.len(),
                     }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2835,8 +2835,10 @@ pub mod bv2_impl {
                 std::ptr::from_mut(this.arena().alloc(ThreadPool::default()));
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
 
-            // SAFETY: arena slot is live for the bundle pass; the default value
-            // written above has no Drop, so overwriting via `*pool = ...` is fine.
+            // SAFETY: arena slot is live for the bundle pass; dropping the
+            // default value written above is a no-op (`WorkerPool::Unset`
+            // variant, empty workers map), so overwriting via `*pool = ...`
+            // frees nothing it shouldn't.
             unsafe {
                 *pool = ThreadPool::init(&*this, thread_pool)?;
             }
@@ -3569,7 +3571,7 @@ pub mod bv2_impl {
             // `arena()` ends before we take `&mut self` below.
             let task: *mut ParseTask = self.arena().alloc(ParseTask {
                 path: task_path,
-                contents_or_fd: parse_task::ContentsOrFd::Contents(contents),
+                contents_or_fd: parse_task::ContentsOrFd::bundle_owned(contents),
                 side_effects: bun_ast::SideEffects::HasSideEffects,
                 jsx,
                 source_index: bun_ast::Index::init(source_index.get()),
@@ -4367,7 +4369,7 @@ pub mod bv2_impl {
                         .insert(crate::Graph::InputFileFlags::IS_PLUGIN_FILE);
                     let parse_task = load.parse_task_mut();
                     parse_task.loader = Some(code.loader);
-                    parse_task.contents_or_fd = parse_task::ContentsOrFd::Contents(source_code);
+                    parse_task.contents_or_fd = parse_task::ContentsOrFd::bundle_owned(source_code);
                     this.graph.pool().schedule(parse_task);
 
                     if this.bun_watcher.is_some() {
@@ -4400,7 +4402,7 @@ pub mod bv2_impl {
                                 fd,
                                 &load.path,
                                 bun_wyhash::hash(load.path.as_ref()) as u32,
-                                bun_watcher::Loader(code.loader as u8),
+                                code.loader,
                                 bun_sys::Fd::INVALID,
                                 None,
                             );
@@ -5557,7 +5559,7 @@ pub mod bv2_impl {
                 // (after all ParseTasks have completed); the `Box<[u8]>` is heap-stable.
                 let decoded: &'static [u8] =
                     unsafe { bun_ptr::detach_lifetime_ref::<[u8]>(self.free_list.last().unwrap()) };
-                parse.contents_or_fd = parse_task::ContentsOrFd::Contents(decoded);
+                parse.contents_or_fd = parse_task::ContentsOrFd::bundle_owned(decoded);
                 parse.loader = Some(match data_url.decode_mime_type().category {
                     bun_http_types::MimeType::Category::Javascript => Loader::Js,
                     bun_http_types::MimeType::Category::Css => Loader::Css,
@@ -6821,7 +6823,7 @@ pub mod bv2_impl {
                                 parse_result.watcher_data.fd,
                                 source_path,
                                 bun_wyhash::hash(source_path) as u32,
-                                bun_watcher::Loader(loader as u8),
+                                loader,
                                 parse_result.watcher_data.dir_fd,
                                 None,
                             );

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2835,10 +2835,8 @@ pub mod bv2_impl {
                 std::ptr::from_mut(this.arena().alloc(ThreadPool::default()));
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
 
-            // SAFETY: arena slot is live for the bundle pass; dropping the
-            // default value written above is a no-op (`WorkerPool::Unset`
-            // variant, empty workers map), so overwriting via `*pool = ...`
-            // frees nothing it shouldn't.
+            // SAFETY: arena slot is live for the bundle pass; the default
+            // value written above drops nothing.
             unsafe {
                 *pool = ThreadPool::init(&*this, thread_pool)?;
             }

--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -510,16 +510,15 @@ impl JavaScript {
 
         let result = match parser.parse() {
             Ok(r) => r,
-            Err(err) => {
+            Err(failure) => {
                 // `Parser::parse` consumes `self`, so `parser` is gone in this
                 // arm. The `&'a mut temp_log` it held is released, so read
-                // `temp_log.errors` directly. The lexer range is lost; fall
-                // back to `Range::None`.
-                // TODO: thread the failing token range through the `Err`
-                // payload (make `_parse` return a `(Error, Range)` pair) so the
+                // `temp_log.errors` directly. The failing token's range was
+                // captured inside the parser (while the lexer was still
+                // alive) and travels here in `ParseFailure`, so the
                 // diagnostic points at the failing token.
                 if temp_log.errors == 0 {
-                    log.add_range_error(Some(source), bun_ast::Range::None, err.name().as_bytes());
+                    log.add_range_error(Some(source), failure.range, failure.err.name().as_bytes());
                 }
                 let _ = temp_log.append_to_maybe_recycled(log, source);
                 return Ok(None);

--- a/src/bundler/cache.rs
+++ b/src/bundler/cache.rs
@@ -513,10 +513,7 @@ impl JavaScript {
             Err(failure) => {
                 // `Parser::parse` consumes `self`, so `parser` is gone in this
                 // arm. The `&'a mut temp_log` it held is released, so read
-                // `temp_log.errors` directly. The failing token's range was
-                // captured inside the parser (while the lexer was still
-                // alive) and travels here in `ParseFailure`, so the
-                // diagnostic points at the failing token.
+                // `temp_log.errors` directly.
                 if temp_log.errors == 0 {
                     log.add_range_error(Some(source), failure.range, failure.err.name().as_bytes());
                 }

--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -4,7 +4,6 @@ use bstr::BStr;
 
 use bun_core::fmt as bun_fmt;
 use bun_core::strings;
-use bun_paths::{self, MAX_PATH_BYTES, PathBuffer};
 use bun_wyhash::{self, Wyhash11};
 
 use crate::Transpiler;
@@ -20,8 +19,8 @@ pub mod Fs {
 }
 
 pub struct FallbackEntryPoint {
-    pub code_buffer: [u8; 8192],
-    pub path_buffer: PathBuffer,
+    /// The generated code is owned by `source.contents` (`Cow::Owned`), so the
+    /// entry is not self-referential and may move freely.
     pub source: bun_ast::Source,
     // Only ever assigned the literal "" (no writer anywhere in the tree); never freed.
     pub built_code: &'static [u8],
@@ -30,8 +29,6 @@ pub struct FallbackEntryPoint {
 impl Default for FallbackEntryPoint {
     fn default() -> Self {
         Self {
-            code_buffer: [0u8; 8192],
-            path_buffer: PathBuffer::uninit(),
             source: bun_ast::Source::default(),
             built_code: b"",
         }
@@ -65,44 +62,29 @@ impl FallbackEntryPoint {
             .client_css_in_js
             != ClientCssInJs::AutoOnImportCss;
 
-        // self-referential — when the rendered code fits in
-        // `entry.code_buffer` the Source borrows it (disjoint-field write to
-        // `entry.source` while `entry.code_buffer` is shared-borrowed). On
-        // overflow the Source owns the bytes via `Cow::Owned` (so Drop
-        // frees it).
         // assemble bytes directly (not `write!`+`BStr`) so a
         // non-UTF-8 byte in `input_path` is emitted verbatim,
         // not lossily replaced with U+FFFD by `BStr as Display`.
-        macro_rules! render_into_entry {
-            ($prefix:expr, $suffix:expr) => {{
-                let prefix: &[u8] = $prefix;
-                let suffix: &[u8] = $suffix;
-                let count = prefix.len() + input_path.len() + suffix.len();
-                if count < entry.code_buffer.len() {
-                    let buf = &mut entry.code_buffer;
-                    buf[..prefix.len()].copy_from_slice(prefix);
-                    buf[prefix.len()..prefix.len() + input_path.len()].copy_from_slice(input_path);
-                    buf[prefix.len() + input_path.len()..count].copy_from_slice(suffix);
-                    entry.source =
-                        bun_ast::Source::init_path_string(input_path, &entry.code_buffer[..count]);
-                } else {
-                    let mut v: Vec<u8> = Vec::with_capacity(count);
-                    v.extend_from_slice(prefix);
-                    v.extend_from_slice(input_path);
-                    v.extend_from_slice(suffix);
-                    entry.source = bun_ast::Source::init_path_string_owned(input_path, v);
-                }
-            }};
-        }
-
-        if disable_css_imports {
-            render_into_entry!(
+        let (prefix, suffix): (&[u8], &[u8]) = if disable_css_imports {
+            (
                 b"globalThis.Bun_disableCSSImports = true;\nimport boot from '",
-                b"';\nboot(globalThis.__BUN_DATA__);"
-            );
+                b"';\nboot(globalThis.__BUN_DATA__);",
+            )
         } else {
-            render_into_entry!(b"import boot from '", b"';\nboot(globalThis.__BUN_DATA__);");
-        }
+            (
+                b"import boot from '",
+                b"';\nboot(globalThis.__BUN_DATA__);",
+            )
+        };
+        // The Source owns the rendered bytes (`Cow::Owned`), so nothing in
+        // `entry` is borrowed and the entry may move or be cloned-from freely.
+        // The path borrows the caller's `input_path` (lifetime-erased by
+        // `IntoStr`), same contract as before.
+        let mut code: Vec<u8> = Vec::with_capacity(prefix.len() + input_path.len() + suffix.len());
+        code.extend_from_slice(prefix);
+        code.extend_from_slice(input_path);
+        code.extend_from_slice(suffix);
+        entry.source = bun_ast::Source::init_path_string_owned(input_path, code);
 
         entry.source.path.namespace = b"fallback-entry";
         Ok(())
@@ -110,16 +92,22 @@ impl FallbackEntryPoint {
 }
 
 pub struct ClientEntryPoint {
-    pub code_buffer: [u8; 8192],
-    pub path_buffer: PathBuffer,
+    /// Heap backing for `source.path.text`. Boxed so the path bytes stay at a
+    /// stable address when the entry itself moves (the old inline
+    /// `path_buffer` made the entry self-referential and unmovable while
+    /// `source` was in use). Written exactly once: `generate` debug-asserts
+    /// the box is still empty, because replacing it would free the previous
+    /// allocation under any `Source` cloned from `source` (the clone
+    /// deep-copies the owned contents but copies the borrowed path). The
+    /// entry must also not be dropped while such a clone is alive.
+    path_storage: Box<[u8]>,
     pub source: bun_ast::Source,
 }
 
 impl Default for ClientEntryPoint {
     fn default() -> Self {
         Self {
-            code_buffer: [0u8; 8192],
-            path_buffer: PathBuffer::uninit(),
+            path_storage: Box::default(),
             source: bun_ast::Source::default(),
         }
     }
@@ -181,6 +169,13 @@ impl ClientEntryPoint {
         TranspilerType: TranspilerLike,
     {
         let entry = self;
+        // Single-generation invariant: regenerating would free the previous
+        // `path_storage` box while a `Source` cloned from an earlier
+        // `generate` may still borrow its path text (see field doc).
+        debug_assert!(
+            entry.path_storage.is_empty(),
+            "ClientEntryPoint::generate called twice on the same entry"
+        );
         // This is *extremely* naive.
         // The basic idea here is this:
         // --
@@ -200,14 +195,12 @@ impl ClientEntryPoint {
             .client_css_in_js
             != ClientCssInJs::AutoOnImportCss;
 
-        // INVARIANT: self-referential — `code` borrows `entry.code_buffer` and is
-        // stored into `entry.source` (lifetime erased), so `entry` must not move
-        // or drop while `entry.source` is in use. See note in
-        // FallbackEntryPoint::generate.
-        let code: &[u8] = if disable_css_imports {
-            let mut cursor = std::io::Cursor::new(&mut entry.code_buffer[..]);
+        // The generated code is owned by the `Source` (`Cow::Owned`), so a
+        // clone of `entry.source` carries its own copy of the contents.
+        let mut code: Vec<u8> = Vec::new();
+        if disable_css_imports {
             write!(
-                &mut cursor,
+                &mut code,
                 "globalThis.Bun_disableCSSImports = true;\n\
                  import boot from '{}';\n\
                  import * as EntryPoint from '{}{}';\n\
@@ -216,13 +209,10 @@ impl ClientEntryPoint {
                 BStr::new(dir_to_use),
                 BStr::new(original_path.filename),
             )
-            .map_err(|_| bun_core::err!("NoSpaceLeft"))?;
-            let n = cursor.position() as usize;
-            &entry.code_buffer[..n]
+            .map_err(|_| bun_core::err!("FormatError"))?;
         } else {
-            let mut cursor = std::io::Cursor::new(&mut entry.code_buffer[..]);
             write!(
-                &mut cursor,
+                &mut code,
                 "import boot from '{}';\n\
                  if ('setLoaded' in boot) boot.setLoaded(loaded);\n\
                  import * as EntryPoint from '{}{}';\n\
@@ -231,10 +221,8 @@ impl ClientEntryPoint {
                 BStr::new(dir_to_use),
                 BStr::new(original_path.filename),
             )
-            .map_err(|_| bun_core::err!("NoSpaceLeft"))?;
-            let n = cursor.position() as usize;
-            &entry.code_buffer[..n]
-        };
+            .map_err(|_| bun_core::err!("FormatError"))?;
+        }
 
         // `bun_paths::fs::PathName<'static>` → `bun_paths::fs::PathName<'static>`: field-identical
         // mirrors (see `#[repr(C)]` note on both); spell out the copy instead of a cast.
@@ -244,10 +232,15 @@ impl ClientEntryPoint {
             ext: original_path.ext,
             filename: original_path.filename,
         };
-        entry.source = bun_ast::Source::init_path_string(
-            Self::generate_entry_point_path(&mut entry.path_buffer.0, &original_path_borrowed),
-            code,
-        );
+        // Render the synthetic entry path into pooled scratch, then copy it
+        // into the entry-owned heap box so `source.path` borrows storage that
+        // is address-stable across moves of the entry (see field doc).
+        let mut scratch = bun_paths::path_buffer_pool::get();
+        let generated_path =
+            Self::generate_entry_point_path(scratch.as_mut_slice(), &original_path_borrowed);
+        entry.path_storage = generated_path.to_vec().into_boxed_slice();
+        drop(scratch);
+        entry.source = bun_ast::Source::init_path_string_owned(&*entry.path_storage, code);
         entry.source.path.namespace = b"client-entry";
         Ok(())
     }
@@ -357,16 +350,21 @@ impl ServerEntryPoint {
 // protected. This is mostly a workaround for being unable to call ESM exported
 // functions from C++. When that is resolved, we should remove this.
 pub struct MacroEntryPoint {
-    pub code_buffer: [u8; MAX_PATH_BYTES * 2 + 500],
-    pub output_code_buffer: [u8; MAX_PATH_BYTES * 8 + 500],
+    /// Heap backing for `source.path.text` (the macro label / specifier).
+    /// Boxed so the bytes are address-stable when the entry moves; the
+    /// generated code itself is owned by `source.contents` (`Cow::Owned`).
+    /// Entries are cached in `VirtualMachine.macro_entry_points` for the VM
+    /// lifetime, so the box (and the path borrowing it) is never freed while
+    /// readers exist. (The old inline `code_buffer`/`output_code_buffer`
+    /// made the entry self-referential — and 66 KB — for no benefit.)
+    label_storage: Box<[u8]>,
     pub source: bun_ast::Source,
 }
 
 impl Default for MacroEntryPoint {
     fn default() -> Self {
         Self {
-            code_buffer: [0u8; MAX_PATH_BYTES * 2 + 500],
-            output_code_buffer: [0u8; MAX_PATH_BYTES * 8 + 500],
+            label_storage: Box::default(),
             source: bun_ast::Source::default(),
         }
     }
@@ -418,22 +416,25 @@ impl MacroEntryPoint {
         macro_id: i32,
         macro_label_: &[u8],
     ) -> Result<(), bun_core::Error> {
+        // Single-generation invariant: entries are generated once per cache
+        // slot (`VirtualMachine.macro_entry_points` vacant arm); regenerating
+        // would free the previous `label_storage` box under the path borrow
+        // held by `source`.
+        debug_assert!(
+            entry.label_storage.is_empty(),
+            "MacroEntryPoint::generate called twice on the same entry"
+        );
         let dir_to_use: &[u8] = if import_path.dir.is_empty() {
             b""
         } else {
             import_path.dir_with_trailing_slash()
         };
-        // reshaped for borrowck — capture the label length, write the
-        // body via a scoped &mut borrow, then re-borrow `code_buffer` immutably
-        // for the (label, code) slices passed to `init_path_string`.
-        let label_len = macro_label_.len();
-        entry.code_buffer[..label_len].copy_from_slice(macro_label_);
 
-        let code_len: usize = 'brk: {
+        let mut code: Vec<u8> = Vec::new();
+        'brk: {
             if import_path.base == b"bun" {
-                let mut cursor = std::io::Cursor::new(&mut entry.code_buffer[label_len..]);
                 write!(
-                    &mut cursor,
+                    &mut code,
                     "//Auto-generated file\n\
                      var Macros;\n\
                      try {{\n\
@@ -452,13 +453,12 @@ impl MacroEntryPoint {
                     BStr::new(function_name),
                     macro_id,
                 )
-                .map_err(|_| bun_core::err!("NoSpaceLeft"))?;
-                break 'brk cursor.position() as usize;
+                .map_err(|_| bun_core::err!("FormatError"))?;
+                break 'brk;
             }
 
-            let mut cursor = std::io::Cursor::new(&mut entry.code_buffer[label_len..]);
             write!(
-                &mut cursor,
+                &mut code,
                 "//Auto-generated file\n\
                  var Macros;\n\
                  try {{\n\
@@ -505,17 +505,16 @@ impl MacroEntryPoint {
                 macro_id,
                 BStr::new(function_name),
             )
-            .map_err(|_| bun_core::err!("NoSpaceLeft"))?;
-            cursor.position() as usize
-        };
+            .map_err(|_| bun_core::err!("FormatError"))?;
+        }
 
-        // INVARIANT: self-referential — `macro_label`/`code` borrow
-        // `entry.code_buffer` and are stored into `entry.source` (lifetime erased
-        // via `IntoStr`), so `entry` must not move or drop while `entry.source`
-        // is in use.
-        let macro_label: &[u8] = &entry.code_buffer[..label_len];
-        let code: &[u8] = &entry.code_buffer[label_len..label_len + code_len];
-        entry.source = bun_ast::Source::init_path_string(macro_label, code);
+        // The label backs `source.path.text`: copy it into the entry-owned
+        // heap box (address-stable across moves of the entry; see field doc),
+        // and let the `Source` own the generated code outright. The entry is
+        // heap-pinned in `VirtualMachine.macro_entry_points` for the VM
+        // lifetime, so the path borrow never outlives its backing.
+        entry.label_storage = macro_label_.to_vec().into_boxed_slice();
+        entry.source = bun_ast::Source::init_path_string_owned(&*entry.label_storage, code);
         // `Path::init` already set `text = macro_label`; only override namespace.
         entry.source.path.namespace = js_ast::Macro::NAMESPACE;
         Ok(())

--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -71,10 +71,7 @@ impl FallbackEntryPoint {
                 b"';\nboot(globalThis.__BUN_DATA__);",
             )
         } else {
-            (
-                b"import boot from '",
-                b"';\nboot(globalThis.__BUN_DATA__);",
-            )
+            (b"import boot from '", b"';\nboot(globalThis.__BUN_DATA__);")
         };
         // The Source owns the rendered bytes (`Cow::Owned`), so nothing in
         // `entry` is borrowed and the entry may move or be cloned-from freely.

--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -19,8 +19,7 @@ pub mod Fs {
 }
 
 pub struct FallbackEntryPoint {
-    /// The generated code is owned by `source.contents` (`Cow::Owned`), so the
-    /// entry is not self-referential and may move freely.
+    /// Owns its contents (`Cow::Owned`); not self-referential.
     pub source: bun_ast::Source,
     // Only ever assigned the literal "" (no writer anywhere in the tree); never freed.
     pub built_code: &'static [u8],
@@ -73,10 +72,6 @@ impl FallbackEntryPoint {
         } else {
             (b"import boot from '", b"';\nboot(globalThis.__BUN_DATA__);")
         };
-        // The Source owns the rendered bytes (`Cow::Owned`), so nothing in
-        // `entry` is borrowed and the entry may move or be cloned-from freely.
-        // The path borrows the caller's `input_path` (lifetime-erased by
-        // `IntoStr`), same contract as before.
         let mut code: Vec<u8> = Vec::with_capacity(prefix.len() + input_path.len() + suffix.len());
         code.extend_from_slice(prefix);
         code.extend_from_slice(input_path);
@@ -89,14 +84,9 @@ impl FallbackEntryPoint {
 }
 
 pub struct ClientEntryPoint {
-    /// Heap backing for `source.path.text`. Boxed so the path bytes stay at a
-    /// stable address when the entry itself moves (the old inline
-    /// `path_buffer` made the entry self-referential and unmovable while
-    /// `source` was in use). Written exactly once: `generate` debug-asserts
-    /// the box is still empty, because replacing it would free the previous
-    /// allocation under any `Source` cloned from `source` (the clone
-    /// deep-copies the owned contents but copies the borrowed path). The
-    /// entry must also not be dropped while such a clone is alive.
+    /// Heap backing for `source.path.text`, address-stable across moves of
+    /// the entry. Written exactly once: replacing it would free the path
+    /// borrowed by any `Source` cloned from `source`.
     path_storage: Box<[u8]>,
     pub source: bun_ast::Source,
 }
@@ -166,9 +156,8 @@ impl ClientEntryPoint {
         TranspilerType: TranspilerLike,
     {
         let entry = self;
-        // Single-generation invariant: regenerating would free the previous
-        // `path_storage` box while a `Source` cloned from an earlier
-        // `generate` may still borrow its path text (see field doc).
+        // See `path_storage`: regenerating would free the path borrowed by an
+        // earlier `Source`.
         debug_assert!(
             entry.path_storage.is_empty(),
             "ClientEntryPoint::generate called twice on the same entry"
@@ -192,8 +181,6 @@ impl ClientEntryPoint {
             .client_css_in_js
             != ClientCssInJs::AutoOnImportCss;
 
-        // The generated code is owned by the `Source` (`Cow::Owned`), so a
-        // clone of `entry.source` carries its own copy of the contents.
         let mut code: Vec<u8> = Vec::new();
         if disable_css_imports {
             write!(
@@ -229,9 +216,7 @@ impl ClientEntryPoint {
             ext: original_path.ext,
             filename: original_path.filename,
         };
-        // Render the synthetic entry path into pooled scratch, then copy it
-        // into the entry-owned heap box so `source.path` borrows storage that
-        // is address-stable across moves of the entry (see field doc).
+        // Copy the rendered path into the entry-owned box (see `path_storage`).
         let mut scratch = bun_paths::path_buffer_pool::get();
         let generated_path =
             Self::generate_entry_point_path(scratch.as_mut_slice(), &original_path_borrowed);
@@ -347,13 +332,9 @@ impl ServerEntryPoint {
 // protected. This is mostly a workaround for being unable to call ESM exported
 // functions from C++. When that is resolved, we should remove this.
 pub struct MacroEntryPoint {
-    /// Heap backing for `source.path.text` (the macro label / specifier).
-    /// Boxed so the bytes are address-stable when the entry moves; the
-    /// generated code itself is owned by `source.contents` (`Cow::Owned`).
-    /// Entries are cached in `VirtualMachine.macro_entry_points` for the VM
-    /// lifetime, so the box (and the path borrowing it) is never freed while
-    /// readers exist. (The old inline `code_buffer`/`output_code_buffer`
-    /// made the entry self-referential — and 66 KB — for no benefit.)
+    /// Heap backing for `source.path.text` (the macro label), address-stable
+    /// across moves of the entry; the generated code is owned by
+    /// `source.contents`.
     label_storage: Box<[u8]>,
     pub source: bun_ast::Source,
 }
@@ -413,10 +394,8 @@ impl MacroEntryPoint {
         macro_id: i32,
         macro_label_: &[u8],
     ) -> Result<(), bun_core::Error> {
-        // Single-generation invariant: entries are generated once per cache
-        // slot (`VirtualMachine.macro_entry_points` vacant arm); regenerating
-        // would free the previous `label_storage` box under the path borrow
-        // held by `source`.
+        // Regenerating would free the `label_storage` box under the path
+        // borrow held by `source`.
         debug_assert!(
             entry.label_storage.is_empty(),
             "MacroEntryPoint::generate called twice on the same entry"
@@ -505,11 +484,6 @@ impl MacroEntryPoint {
             .map_err(|_| bun_core::err!("FormatError"))?;
         }
 
-        // The label backs `source.path.text`: copy it into the entry-owned
-        // heap box (address-stable across moves of the entry; see field doc),
-        // and let the `Source` own the generated code outright. The entry is
-        // heap-pinned in `VirtualMachine.macro_entry_points` for the VM
-        // lifetime, so the path borrow never outlives its backing.
         entry.label_storage = macro_label_.to_vec().into_boxed_slice();
         entry.source = bun_ast::Source::init_path_string_owned(&*entry.label_storage, code);
         // `Path::init` already set `text = macro_label`; only override namespace.

--- a/src/js_parser/lib.rs
+++ b/src/js_parser/lib.rs
@@ -32,7 +32,7 @@ pub mod typescript;
 pub mod visit;
 
 pub use p::P;
-pub use parse::parse_entry::{Options as ParserOptions, Parser};
+pub use parse::parse_entry::{Options as ParserOptions, ParseFailure, Parser};
 
 // Full impl lives in *_jsc; this stub re-exposes the JSC-free constants and a
 // placeholder `MacroContext` so lower-tier crates (bundler, transpiler) that

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -339,6 +339,31 @@ impl<'a> Parser<'a> {
     }
 }
 
+/// Error payload of [`Parser::parse`].
+///
+/// `parse()` consumes the parser by value, so by the time the caller sees the
+/// `Err` the lexer (and its current token position) is gone. The failing
+/// token's range is captured here, inside `_parse`, while the lexer is still
+/// alive, so callers can point their diagnostic at the failing token instead
+/// of `Range::None`.
+#[derive(Copy, Clone)]
+pub struct ParseFailure {
+    pub err: Error,
+    /// The lexer's token range at the moment the parse failed.
+    pub range: js_ast::Range,
+}
+
+impl From<Error> for ParseFailure {
+    /// Used by error paths that fail before a parser (and lexer) exists —
+    /// e.g. `P::init` inside `init_p!` — where no token range is available.
+    fn from(err: Error) -> Self {
+        ParseFailure {
+            err,
+            range: js_ast::Range::None,
+        }
+    }
+}
+
 // ── live `Parser::parse` / `Parser::scan_imports` symbols ────────────────
 // `parse()` is the real const-generic dispatcher. `_parse` carries the correct `<const TS, JX>`
 // shape but its body is blocked on `P::{init, prepare_for_visit_pass,
@@ -347,7 +372,7 @@ impl<'a> Parser<'a> {
 // surface lands.
 impl<'a> Parser<'a> {
     #[cfg_attr(not(target_arch = "wasm32"), allow(unused_mut))]
-    pub fn parse(mut self) -> Result<crate::Result<'a>, Error> {
+    pub fn parse(mut self) -> Result<crate::Result<'a>, ParseFailure> {
         #[cfg(target_arch = "wasm32")]
         {
             self.options.ts = true;
@@ -709,7 +734,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    fn _parse<const TS: bool>(self) -> Result<crate::Result<'a>, Error> {
+    fn _parse<const TS: bool>(self) -> Result<crate::Result<'a>, ParseFailure> {
         // `Source.path` is `Path<'static>`, so
         // `path.text` satisfies `Action::Parse(&'static [u8])` directly.
         let _action_guard = bun_crash_handler::scoped_action(bun_crash_handler::Action::Parse(
@@ -738,8 +763,13 @@ impl<'a> Parser<'a> {
         let mut __p = init_p!(P<'_, TS, false>;
             bump, log, source, define, lexer, options);
         // SAFETY: `init_p!` only yields after `init` succeeded.
-        let p: &mut P<'_, TS, false> = unsafe { __p.assume_init_mut() };
+        let p: &mut P<'a, TS, false> = unsafe { __p.assume_init_mut() };
 
+        // The whole fallible parse body runs through an inner closure so that
+        // on the error path the failing token's range can still be read off
+        // `p.lexer` (which the closure only reborrows) before `P` is dropped.
+        // The range travels to callers in `ParseFailure`.
+        let run = |p: &mut P<'a, TS, false>| -> Result<crate::Result<'a>, Error> {
         if p.options.features.hot_module_reloading {
             debug_assert!(!p.options.tree_shaking);
         }
@@ -2204,6 +2234,15 @@ impl<'a> Parser<'a> {
             wrap_mode,
             hashbang,
         )?))
+        };
+
+        run(&mut *p).map_err(|err| ParseFailure {
+            // The closure's reborrow of `p` has ended; the lexer is still
+            // alive here, so capture the failing token's range for the
+            // caller's diagnostic.
+            range: p.lexer.range(),
+            err,
+        })
     }
 
     // associated fn (was `&self` reading `self.lexer.source.contents`)

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -339,13 +339,9 @@ impl<'a> Parser<'a> {
     }
 }
 
-/// Error payload of [`Parser::parse`].
-///
-/// `parse()` consumes the parser by value, so by the time the caller sees the
-/// `Err` the lexer (and its current token position) is gone. The failing
-/// token's range is captured here, inside `_parse`, while the lexer is still
-/// alive, so callers can point their diagnostic at the failing token instead
-/// of `Range::None`.
+/// Error payload of [`Parser::parse`]: the error plus the failing token's
+/// range, captured while the lexer is still alive (`parse()` consumes the
+/// parser, so the caller can't read it).
 #[derive(Copy, Clone)]
 pub struct ParseFailure {
     pub err: Error,
@@ -354,8 +350,7 @@ pub struct ParseFailure {
 }
 
 impl From<Error> for ParseFailure {
-    /// Used by error paths that fail before a parser (and lexer) exists —
-    /// e.g. `P::init` inside `init_p!` — where no token range is available.
+    /// For error paths that fail before a lexer exists; no range available.
     fn from(err: Error) -> Self {
         ParseFailure {
             err,
@@ -765,10 +760,8 @@ impl<'a> Parser<'a> {
         // SAFETY: `init_p!` only yields after `init` succeeded.
         let p: &mut P<'a, TS, false> = unsafe { __p.assume_init_mut() };
 
-        // The whole fallible parse body runs through an inner closure so that
-        // on the error path the failing token's range can still be read off
-        // `p.lexer` (which the closure only reborrows) before `P` is dropped.
-        // The range travels to callers in `ParseFailure`.
+        // Inner closure so the error path can still read the failing token's
+        // range off `p.lexer` before `P` is dropped.
         let run = |p: &mut P<'a, TS, false>| -> Result<crate::Result<'a>, Error> {
             if p.options.features.hot_module_reloading {
                 debug_assert!(!p.options.tree_shaking);
@@ -2258,9 +2251,6 @@ impl<'a> Parser<'a> {
         };
 
         run(&mut *p).map_err(|err| ParseFailure {
-            // The closure's reborrow of `p` has ended; the lexer is still
-            // alive here, so capture the failing token's range for the
-            // caller's diagnostic.
             range: p.lexer.range(),
             err,
         })

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -770,364 +770,1053 @@ impl<'a> Parser<'a> {
         // `p.lexer` (which the closure only reborrows) before `P` is dropped.
         // The range travels to callers in `ParseFailure`.
         let run = |p: &mut P<'a, TS, false>| -> Result<crate::Result<'a>, Error> {
-        if p.options.features.hot_module_reloading {
-            debug_assert!(!p.options.tree_shaking);
-        }
-
-        // Instead of doing "should_fold_typescript_constant_expressions or features.minify_syntax"
-        // Let's enable this flag file-wide
-        if p.options.features.minify_syntax || p.options.features.inlining {
-            p.should_fold_typescript_constant_expressions = true;
-        }
-
-        // Pre-sized to typical worst-case binary-expression nesting depth.
-        p.binary_expression_stack = BumpVec::with_capacity_in(41, p.arena);
-        p.binary_expression_simplify_stack = BumpVec::with_capacity_in(47, p.arena);
-
-        // defer {
-        //     if (p.allocated_names_pool) |pool| {
-        //         pool.data = p.allocated_names;
-        //         pool.release();
-        //         p.allocated_names_pool = null;
-        //     }
-        // }
-
-        // Consume a leading hashbang comment
-        let mut hashbang: &[u8] = b"";
-        if p.lexer.token == js_lexer::T::THashbang {
-            hashbang = p.lexer.identifier;
-            p.lexer.next()?;
-        }
-
-        // Detect a leading "// @bun" pragma
-        if p.options.features.dont_bundle_twice {
-            if let Some(pragma) = Self::has_bun_pragma(&source.contents, !hashbang.is_empty()) {
-                return Ok(crate::Result::AlreadyBundled(pragma));
+            if p.options.features.hot_module_reloading {
+                debug_assert!(!p.options.tree_shaking);
             }
-        }
 
-        // We must check the cache only after we've consumed the hashbang and leading // @bun pragma
-        // We don't want to ever put files with `// @bun` into this cache, as that would be wasteful.
-        #[cfg(not(target_arch = "wasm32"))]
-        if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {
-            if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                // `Path::is_node_module`/`is_jsx_file` live on the resolver
-                // `fs::Path` (not the logger stub) — their bodies are inlined here.
-                let path = &p.source.path;
-                #[cfg(windows)]
-                const NM: &[u8] = b"\\node_modules\\";
-                #[cfg(not(windows))]
-                const NM: &[u8] = b"/node_modules/";
-                let name = path.name();
-                let is_node_module = strings::last_index_of(name.dir, NM).is_some();
-                let is_jsx_file = strings::has_suffix_comptime(name.filename, b".jsx")
-                    || strings::has_suffix_comptime(name.filename, b".tsx");
-                if cache.get(
-                    p.source,
-                    core::ptr::NonNull::from(&p.options).cast::<()>(),
-                    p.options.jsx.parse && (!is_node_module || is_jsx_file),
-                ) {
-                    return Ok(crate::Result::Cached);
+            // Instead of doing "should_fold_typescript_constant_expressions or features.minify_syntax"
+            // Let's enable this flag file-wide
+            if p.options.features.minify_syntax || p.options.features.inlining {
+                p.should_fold_typescript_constant_expressions = true;
+            }
+
+            // Pre-sized to typical worst-case binary-expression nesting depth.
+            p.binary_expression_stack = BumpVec::with_capacity_in(41, p.arena);
+            p.binary_expression_simplify_stack = BumpVec::with_capacity_in(47, p.arena);
+
+            // defer {
+            //     if (p.allocated_names_pool) |pool| {
+            //         pool.data = p.allocated_names;
+            //         pool.release();
+            //         p.allocated_names_pool = null;
+            //     }
+            // }
+
+            // Consume a leading hashbang comment
+            let mut hashbang: &[u8] = b"";
+            if p.lexer.token == js_lexer::T::THashbang {
+                hashbang = p.lexer.identifier;
+                p.lexer.next()?;
+            }
+
+            // Detect a leading "// @bun" pragma
+            if p.options.features.dont_bundle_twice {
+                if let Some(pragma) = Self::has_bun_pragma(&source.contents, !hashbang.is_empty()) {
+                    return Ok(crate::Result::AlreadyBundled(pragma));
                 }
             }
-        }
 
-        // Parse the file in the first pass, but do not bind symbols
-        let mut opts = ParseStatementOptions {
-            is_module_scope: true,
-            ..Default::default()
-        };
-        let mut parse_tracer = bun_core::perf::trace("JSParser::parse");
-
-        // Parsing seems to take around 2x as much time as visiting.
-        // Which makes sense.
-        // June 4: "Parsing took: 18028000"
-        // June 4: "Rest of this took: 8003000"
-        let stmts: &'a mut [Stmt] = match p.parse_stmts_up_to(js_lexer::T::TEndOfFile, &mut opts) {
-            Ok(s) => s.into_bump_slice_mut(),
-            Err(e) => {
-                parse_tracer.end();
-                if e == err!("StackOverflow") {
-                    // The lexer location won't be totally accurate, but it's kind of helpful.
-                    p.log().add_error(
-                        Some(p.source),
-                        p.lexer.loc(),
-                        b"Maximum call stack size exceeded",
-                    );
-
-                    // Return a SyntaxError so that we reuse existing code for handling errors.
-                    return Err(err!("SyntaxError"));
-                }
-
-                return Err(e);
-            }
-        };
-
-        parse_tracer.end();
-
-        // Halt parsing right here if there were any errors
-        // This fixes various conditions that would cause crashes due to the AST being in an invalid state while visiting
-        // In a number of situations, we continue to parsing despite errors so that we can report more errors to the user
-        //   Example where NOT halting causes a crash: A TS enum with a number literal as a member name
-        //     https://discord.com/channels/876711213126520882/876711213126520885/1039325382488371280
-        if p.log().errors > orig_error_count {
-            return Err(err!("SyntaxError"));
-        }
-
-        // A second guard dropped at end of `_parse` restores the previous action.
-        let _visit_action_guard =
-            bun_crash_handler::scoped_action(bun_crash_handler::Action::Visit(source.path.text));
-
-        let mut visit_tracer = bun_core::perf::trace("JSParser::visit");
-        p.prepare_for_visit_pass()?;
-
-        let mut before = BumpVec::<js_ast::Part>::new_in(p.arena);
-        let mut after = BumpVec::<js_ast::Part>::new_in(p.arena);
-        let mut parts = BumpVec::<js_ast::Part>::new_in(p.arena);
-        // (Element ownership is transferred into `parts` below via bitwise copy + set_len(0).)
-
-        if p.options.bundle {
-            // The bundler requires a part for generated module wrappers. This
-            // part must be at the start as it is referred to by index.
-            before.push(js_ast::Part::default());
-        }
-
-        // --inspect-brk
-        if p.options.features.set_breakpoint_on_first_line {
-            let debugger_stmts = p.arena.alloc_slice_fill_with(1, |_| Stmt {
-                data: js_ast::StmtData::SDebugger(Default::default()),
-                loc: bun_ast::Loc::EMPTY,
-            });
-            before.push(js_ast::Part {
-                stmts: debugger_stmts.into(),
-                ..Default::default()
-            });
-        }
-
-        // When "using" declarations appear at the top level, we change all TDZ
-        // variables in the top-level scope into "var" so that they aren't harmed
-        // when they are moved into the try/catch statement that lowering will
-        // generate.
-        //
-        // This is necessary because exported function declarations must be hoisted
-        // outside of the try/catch statement because they can be evaluated before
-        // this module is evaluated due to ESM cross-file function hoisting. And
-        // these function bodies might reference anything else in this scope, which
-        // must still work when those things are moved inside a try/catch statement.
-        //
-        // Before:
-        //
-        //   using foo = get()
-        //   export function fn() {
-        //     return [foo, new Bar]
-        //   }
-        //   class Bar {}
-        //
-        // After ("fn" is hoisted, "Bar" is converted to "var"):
-        //
-        //   export function fn() {
-        //     return [foo, new Bar]
-        //   }
-        //   try {
-        //     var foo = get();
-        //     var Bar = class {};
-        //   } catch (_) {
-        //     ...
-        //   } finally {
-        //     ...
-        //   }
-        //
-        // This is also necessary because other code might be appended to the code
-        // that we're processing and expect to be able to access top-level variables.
-        p.will_wrap_module_in_try_catch_for_using = p.should_lower_using_declarations(stmts);
-
-        // Bind symbols in a second pass over the AST. I started off doing this in a
-        // single pass, but it turns out it's pretty much impossible to do this
-        // correctly while handling arrow functions because of the grammar
-        // ambiguities.
-        //
-        // Note that top-level lowered "using" declarations disable tree-shaking
-        // because we only do tree-shaking on top-level statements and lowering
-        // a top-level "using" declaration moves all top-level statements into a
-        // nested scope.
-        if !p.options.tree_shaking || p.will_wrap_module_in_try_catch_for_using {
-            // When tree shaking is disabled, everything comes in a single part
-            p.append_part(&mut parts, stmts)?;
-        } else {
-            // Preprocess TypeScript enums to improve code generation. Otherwise
-            // uses of an enum before that enum has been declared won't be inlined:
-            //
-            //   console.log(Foo.FOO) // We want "FOO" to be inlined here
-            //   const enum Foo { FOO = 0 }
-            //
-            // The TypeScript compiler itself contains code with this pattern, so
-            // it's important to implement this optimization.
-
-            // `Loc` lacks `Hash` (logger crate), so the
-            // `scopes_in_order_for_enum` lookups linear-scan `keys()` —
-            // fine at small N (one
-            // entry per top-level `enum`). `scope_order_to_visit` is
-            // `&'a [_]` (a `Copy` cursor) so save/restore is a plain value
-            // copy.
-            let arena = p.arena;
-            let mut preprocessed_enums: BumpVec<BumpVec<'a, js_ast::Part>> = BumpVec::new_in(arena);
-            let mut preprocessed_enum_i: usize = 0;
-            if p.scopes_in_order_for_enum.count() > 0 {
-                for stmt in stmts.iter_mut() {
-                    if matches!(stmt.data, js_ast::StmtData::SEnum(_)) {
-                        let old_scopes_in_order = p.scope_order_to_visit;
-                        let idx = p
-                            .scopes_in_order_for_enum
-                            .keys()
-                            .iter()
-                            .position(|k| *k == stmt.loc)
-                            .expect("enum scope-order entry recorded during parse");
-                        // Map stores `&'a [ScopeOrder]`; shared borrow may freely alias the inner
-                        // re-lookup performed by `append_part → visit_stmts`.
-                        p.scope_order_to_visit = p.scopes_in_order_for_enum.values()[idx];
-
-                        let mut enum_parts = BumpVec::<js_ast::Part>::new_in(arena);
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut enum_parts, sliced)?;
-                        preprocessed_enums.push(enum_parts);
-
-                        p.scope_order_to_visit = old_scopes_in_order;
+            // We must check the cache only after we've consumed the hashbang and leading // @bun pragma
+            // We don't want to ever put files with `// @bun` into this cache, as that would be wasteful.
+            #[cfg(not(target_arch = "wasm32"))]
+            if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {
+                if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+                    // `Path::is_node_module`/`is_jsx_file` live on the resolver
+                    // `fs::Path` (not the logger stub) — their bodies are inlined here.
+                    let path = &p.source.path;
+                    #[cfg(windows)]
+                    const NM: &[u8] = b"\\node_modules\\";
+                    #[cfg(not(windows))]
+                    const NM: &[u8] = b"/node_modules/";
+                    let name = path.name();
+                    let is_node_module = strings::last_index_of(name.dir, NM).is_some();
+                    let is_jsx_file = strings::has_suffix_comptime(name.filename, b".jsx")
+                        || strings::has_suffix_comptime(name.filename, b".tsx");
+                    if cache.get(
+                        p.source,
+                        core::ptr::NonNull::from(&p.options).cast::<()>(),
+                        p.options.jsx.parse && (!is_node_module || is_jsx_file),
+                    ) {
+                        return Ok(crate::Result::Cached);
                     }
                 }
             }
 
-            // When tree shaking is enabled, each top-level statement is potentially a separate part.
-            for stmt in stmts.iter() {
-                match &stmt.data {
-                    js_ast::StmtData::SLocal(local) => {
-                        if (local.decls.len_u32() as usize) > 1 {
-                            for decl in local.decls.slice() {
-                                // `S::Local`/`Decl` are not `Copy`;
-                                // rebuild the struct instead of `**local`.
-                                let _local = S::Local {
-                                    kind: local.kind,
-                                    is_export: local.is_export,
-                                    was_ts_import_equals: local.was_ts_import_equals,
-                                    was_commonjs_export: local.was_commonjs_export,
-                                    decls: G::DeclList::init_one(G::Decl {
-                                        binding: decl.binding,
-                                        value: decl.value,
-                                    }),
-                                };
-                                let new_stmt = p.s(_local, stmt.loc);
-                                let sliced = arena.alloc_slice_copy(&[new_stmt]);
+            // Parse the file in the first pass, but do not bind symbols
+            let mut opts = ParseStatementOptions {
+                is_module_scope: true,
+                ..Default::default()
+            };
+            let mut parse_tracer = bun_core::perf::trace("JSParser::parse");
+
+            // Parsing seems to take around 2x as much time as visiting.
+            // Which makes sense.
+            // June 4: "Parsing took: 18028000"
+            // June 4: "Rest of this took: 8003000"
+            let stmts: &'a mut [Stmt] =
+                match p.parse_stmts_up_to(js_lexer::T::TEndOfFile, &mut opts) {
+                    Ok(s) => s.into_bump_slice_mut(),
+                    Err(e) => {
+                        parse_tracer.end();
+                        if e == err!("StackOverflow") {
+                            // The lexer location won't be totally accurate, but it's kind of helpful.
+                            p.log().add_error(
+                                Some(p.source),
+                                p.lexer.loc(),
+                                b"Maximum call stack size exceeded",
+                            );
+
+                            // Return a SyntaxError so that we reuse existing code for handling errors.
+                            return Err(err!("SyntaxError"));
+                        }
+
+                        return Err(e);
+                    }
+                };
+
+            parse_tracer.end();
+
+            // Halt parsing right here if there were any errors
+            // This fixes various conditions that would cause crashes due to the AST being in an invalid state while visiting
+            // In a number of situations, we continue to parsing despite errors so that we can report more errors to the user
+            //   Example where NOT halting causes a crash: A TS enum with a number literal as a member name
+            //     https://discord.com/channels/876711213126520882/876711213126520885/1039325382488371280
+            if p.log().errors > orig_error_count {
+                return Err(err!("SyntaxError"));
+            }
+
+            // A second guard dropped at end of `_parse` restores the previous action.
+            let _visit_action_guard = bun_crash_handler::scoped_action(
+                bun_crash_handler::Action::Visit(source.path.text),
+            );
+
+            let mut visit_tracer = bun_core::perf::trace("JSParser::visit");
+            p.prepare_for_visit_pass()?;
+
+            let mut before = BumpVec::<js_ast::Part>::new_in(p.arena);
+            let mut after = BumpVec::<js_ast::Part>::new_in(p.arena);
+            let mut parts = BumpVec::<js_ast::Part>::new_in(p.arena);
+            // (Element ownership is transferred into `parts` below via bitwise copy + set_len(0).)
+
+            if p.options.bundle {
+                // The bundler requires a part for generated module wrappers. This
+                // part must be at the start as it is referred to by index.
+                before.push(js_ast::Part::default());
+            }
+
+            // --inspect-brk
+            if p.options.features.set_breakpoint_on_first_line {
+                let debugger_stmts = p.arena.alloc_slice_fill_with(1, |_| Stmt {
+                    data: js_ast::StmtData::SDebugger(Default::default()),
+                    loc: bun_ast::Loc::EMPTY,
+                });
+                before.push(js_ast::Part {
+                    stmts: debugger_stmts.into(),
+                    ..Default::default()
+                });
+            }
+
+            // When "using" declarations appear at the top level, we change all TDZ
+            // variables in the top-level scope into "var" so that they aren't harmed
+            // when they are moved into the try/catch statement that lowering will
+            // generate.
+            //
+            // This is necessary because exported function declarations must be hoisted
+            // outside of the try/catch statement because they can be evaluated before
+            // this module is evaluated due to ESM cross-file function hoisting. And
+            // these function bodies might reference anything else in this scope, which
+            // must still work when those things are moved inside a try/catch statement.
+            //
+            // Before:
+            //
+            //   using foo = get()
+            //   export function fn() {
+            //     return [foo, new Bar]
+            //   }
+            //   class Bar {}
+            //
+            // After ("fn" is hoisted, "Bar" is converted to "var"):
+            //
+            //   export function fn() {
+            //     return [foo, new Bar]
+            //   }
+            //   try {
+            //     var foo = get();
+            //     var Bar = class {};
+            //   } catch (_) {
+            //     ...
+            //   } finally {
+            //     ...
+            //   }
+            //
+            // This is also necessary because other code might be appended to the code
+            // that we're processing and expect to be able to access top-level variables.
+            p.will_wrap_module_in_try_catch_for_using = p.should_lower_using_declarations(stmts);
+
+            // Bind symbols in a second pass over the AST. I started off doing this in a
+            // single pass, but it turns out it's pretty much impossible to do this
+            // correctly while handling arrow functions because of the grammar
+            // ambiguities.
+            //
+            // Note that top-level lowered "using" declarations disable tree-shaking
+            // because we only do tree-shaking on top-level statements and lowering
+            // a top-level "using" declaration moves all top-level statements into a
+            // nested scope.
+            if !p.options.tree_shaking || p.will_wrap_module_in_try_catch_for_using {
+                // When tree shaking is disabled, everything comes in a single part
+                p.append_part(&mut parts, stmts)?;
+            } else {
+                // Preprocess TypeScript enums to improve code generation. Otherwise
+                // uses of an enum before that enum has been declared won't be inlined:
+                //
+                //   console.log(Foo.FOO) // We want "FOO" to be inlined here
+                //   const enum Foo { FOO = 0 }
+                //
+                // The TypeScript compiler itself contains code with this pattern, so
+                // it's important to implement this optimization.
+
+                // `Loc` lacks `Hash` (logger crate), so the
+                // `scopes_in_order_for_enum` lookups linear-scan `keys()` —
+                // fine at small N (one
+                // entry per top-level `enum`). `scope_order_to_visit` is
+                // `&'a [_]` (a `Copy` cursor) so save/restore is a plain value
+                // copy.
+                let arena = p.arena;
+                let mut preprocessed_enums: BumpVec<BumpVec<'a, js_ast::Part>> =
+                    BumpVec::new_in(arena);
+                let mut preprocessed_enum_i: usize = 0;
+                if p.scopes_in_order_for_enum.count() > 0 {
+                    for stmt in stmts.iter_mut() {
+                        if matches!(stmt.data, js_ast::StmtData::SEnum(_)) {
+                            let old_scopes_in_order = p.scope_order_to_visit;
+                            let idx = p
+                                .scopes_in_order_for_enum
+                                .keys()
+                                .iter()
+                                .position(|k| *k == stmt.loc)
+                                .expect("enum scope-order entry recorded during parse");
+                            // Map stores `&'a [ScopeOrder]`; shared borrow may freely alias the inner
+                            // re-lookup performed by `append_part → visit_stmts`.
+                            p.scope_order_to_visit = p.scopes_in_order_for_enum.values()[idx];
+
+                            let mut enum_parts = BumpVec::<js_ast::Part>::new_in(arena);
+                            let sliced = arena.alloc_slice_copy(&[*stmt]);
+                            p.append_part(&mut enum_parts, sliced)?;
+                            preprocessed_enums.push(enum_parts);
+
+                            p.scope_order_to_visit = old_scopes_in_order;
+                        }
+                    }
+                }
+
+                // When tree shaking is enabled, each top-level statement is potentially a separate part.
+                for stmt in stmts.iter() {
+                    match &stmt.data {
+                        js_ast::StmtData::SLocal(local) => {
+                            if (local.decls.len_u32() as usize) > 1 {
+                                for decl in local.decls.slice() {
+                                    // `S::Local`/`Decl` are not `Copy`;
+                                    // rebuild the struct instead of `**local`.
+                                    let _local = S::Local {
+                                        kind: local.kind,
+                                        is_export: local.is_export,
+                                        was_ts_import_equals: local.was_ts_import_equals,
+                                        was_commonjs_export: local.was_commonjs_export,
+                                        decls: G::DeclList::init_one(G::Decl {
+                                            binding: decl.binding,
+                                            value: decl.value,
+                                        }),
+                                    };
+                                    let new_stmt = p.s(_local, stmt.loc);
+                                    let sliced = arena.alloc_slice_copy(&[new_stmt]);
+                                    p.append_part(&mut parts, sliced)?;
+                                }
+                            } else {
+                                let sliced = arena.alloc_slice_copy(&[*stmt]);
                                 p.append_part(&mut parts, sliced)?;
                             }
-                        } else {
+                        }
+                        js_ast::StmtData::SImport(_)
+                        | js_ast::StmtData::SExportFrom(_)
+                        | js_ast::StmtData::SExportStar(_) => {
+                            let parts_list = if p.options.bundle {
+                                // Move imports (and import-like exports) to the top of the file to
+                                // ensure that if they are converted to a require() call, the effects
+                                // will take place before any other statements are evaluated.
+                                &mut before
+                            } else {
+                                // If we aren't doing any format conversion, just keep these statements
+                                // inline where they were. Exports are sorted so order doesn't matter:
+                                // https://262.ecma-international.org/6.0/#sec-module-namespace-exotic-objects.
+                                // However, this is likely an aesthetic issue that some people will
+                                // complain about. In addition, there are code transformation tools
+                                // such as TypeScript and Babel with bugs where the order of exports
+                                // in the file is incorrectly preserved instead of sorted, so preserving
+                                // the order of exports ourselves here may be preferable.
+                                &mut parts
+                            };
+
+                            let sliced = arena.alloc_slice_copy(&[*stmt]);
+                            p.append_part(parts_list, sliced)?;
+                        }
+
+                        js_ast::StmtData::SClass(class) => {
+                            // Move class export statements to the top of the file if we can
+                            // This automatically resolves some cyclical import issues
+                            // https://github.com/kysely-org/kysely/issues/412
+                            let should_move = !p.options.bundle && class.class.can_be_moved();
+
+                            let sliced = arena.alloc_slice_copy(&[*stmt]);
+                            p.append_part(&mut parts, sliced)?;
+
+                            if should_move {
+                                // `Part` isn't `Copy`; pop+push instead of last+truncate.
+                                before.push(parts.pop().expect("unreachable"));
+                            }
+                        }
+                        js_ast::StmtData::SExportDefault(value) => {
+                            // We move export default statements when we can
+                            // This automatically resolves some cyclical import issues in packages like luxon
+                            // https://github.com/oven-sh/bun/issues/1961
+                            let should_move = !p.options.bundle && value.can_be_moved();
+                            let sliced = arena.alloc_slice_copy(&[*stmt]);
+                            p.append_part(&mut parts, sliced)?;
+
+                            if should_move {
+                                before.push(parts.pop().expect("unreachable"));
+                            }
+                        }
+                        js_ast::StmtData::SEnum(_) => {
+                            // `Part` isn't `Clone`; move out the
+                            // pre-visited parts instead of `appendSlice`.
+                            let enum_parts = core::mem::replace(
+                                &mut preprocessed_enums[preprocessed_enum_i],
+                                BumpVec::new_in(arena),
+                            );
+                            for part in enum_parts {
+                                parts.push(part);
+                            }
+                            preprocessed_enum_i += 1;
+
+                            let idx = p
+                                .scopes_in_order_for_enum
+                                .keys()
+                                .iter()
+                                .position(|k| *k == stmt.loc)
+                                .expect("enum scope-order entry");
+                            let enum_scope_count = p.scopes_in_order_for_enum.values()[idx].len();
+                            // Advance the shared-slice cursor past this enum's scopes.
+                            p.scope_order_to_visit = &p.scope_order_to_visit[enum_scope_count..];
+                        }
+                        _ => {
                             let sliced = arena.alloc_slice_copy(&[*stmt]);
                             p.append_part(&mut parts, sliced)?;
                         }
                     }
-                    js_ast::StmtData::SImport(_)
-                    | js_ast::StmtData::SExportFrom(_)
-                    | js_ast::StmtData::SExportStar(_) => {
-                        let parts_list = if p.options.bundle {
-                            // Move imports (and import-like exports) to the top of the file to
-                            // ensure that if they are converted to a require() call, the effects
-                            // will take place before any other statements are evaluated.
-                            &mut before
-                        } else {
-                            // If we aren't doing any format conversion, just keep these statements
-                            // inline where they were. Exports are sorted so order doesn't matter:
-                            // https://262.ecma-international.org/6.0/#sec-module-namespace-exotic-objects.
-                            // However, this is likely an aesthetic issue that some people will
-                            // complain about. In addition, there are code transformation tools
-                            // such as TypeScript and Babel with bugs where the order of exports
-                            // in the file is incorrectly preserved instead of sorted, so preserving
-                            // the order of exports ourselves here may be preferable.
-                            &mut parts
+                }
+            }
+
+            visit_tracer.end();
+
+            // If there were errors while visiting, also halt here
+            if p.log().errors > orig_error_count {
+                return Err(err!("SyntaxError"));
+            }
+
+            // `perf::Ctx` ends the span in its `Drop` impl — bind it for the rest of `_parse`.
+            let _postvisit_tracer = bun_core::perf::trace("JSParser::postvisit");
+
+            let mut uses_dirname =
+                p.symbols.as_slice()[p.dirname_ref.inner_index() as usize].use_count_estimate > 0;
+            let mut uses_filename =
+                p.symbols.as_slice()[p.filename_ref.inner_index() as usize].use_count_estimate > 0;
+
+            // Handle dirname and filename at bundle-time
+            // We always inject it at the top of the module
+            //
+            // This inlines
+            //
+            //    var __dirname = "foo/bar"
+            //    var __filename = "foo/bar/baz.js"
+            //
+            if p.options.bundle || !p.options.features.commonjs_at_runtime {
+                if uses_dirname || uses_filename {
+                    let count = (uses_dirname as usize) + (uses_filename as usize);
+                    let mut declared_symbols =
+                        bun_ast::DeclaredSymbolList::init_capacity(count).expect("unreachable");
+                    let decls = p
+                        .arena
+                        .alloc_slice_fill_with::<G::Decl, _>(count, |_| G::Decl::default());
+                    if uses_dirname {
+                        decls[0] = G::Decl {
+                            binding: p.b(
+                                B::Identifier {
+                                    r#ref: p.dirname_ref,
+                                },
+                                bun_ast::Loc::EMPTY,
+                            ),
+                            value: Some(p.new_expr(
+                                E::String {
+                                    data: p.source.path.name().dir.into(),
+                                    ..Default::default()
+                                },
+                                bun_ast::Loc::EMPTY,
+                            )),
                         };
-
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(parts_list, sliced)?;
+                        declared_symbols.append_assume_capacity(DeclaredSymbol {
+                            ref_: p.dirname_ref,
+                            is_top_level: true,
+                        });
+                    }
+                    if uses_filename {
+                        decls[uses_dirname as usize] = G::Decl {
+                            binding: p.b(
+                                B::Identifier {
+                                    r#ref: p.filename_ref,
+                                },
+                                bun_ast::Loc::EMPTY,
+                            ),
+                            value: Some(p.new_expr(
+                                E::String {
+                                    data: p.source.path.text.into(),
+                                    ..Default::default()
+                                },
+                                bun_ast::Loc::EMPTY,
+                            )),
+                        };
+                        declared_symbols.append_assume_capacity(DeclaredSymbol {
+                            ref_: p.filename_ref,
+                            is_top_level: true,
+                        });
                     }
 
-                    js_ast::StmtData::SClass(class) => {
-                        // Move class export statements to the top of the file if we can
-                        // This automatically resolves some cyclical import issues
-                        // https://github.com/kysely-org/kysely/issues/412
-                        let should_move = !p.options.bundle && class.class.can_be_moved();
+                    let part_stmts = p.arena.alloc_slice_fill_with(1, |_| {
+                        p.s(
+                            S::Local {
+                                kind: js_ast::LocalKind::KVar,
+                                decls: {
+                                    let mut dl = G::DeclList::init_capacity(decls.len());
+                                    for d in decls.iter_mut() {
+                                        dl.append_assume_capacity(core::mem::take(d));
+                                    }
+                                    dl
+                                },
+                                ..Default::default()
+                            },
+                            bun_ast::Loc::EMPTY,
+                        )
+                    });
+                    before.push(js_ast::Part {
+                        stmts: part_stmts.into(),
+                        declared_symbols,
+                        tag: bun_ast::PartTag::DirnameFilename,
+                        ..Default::default()
+                    });
+                    uses_dirname = false;
+                    uses_filename = false;
+                }
+            }
 
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut parts, sliced)?;
+            // This is a workaround for broken module environment checks in packages like lodash-es
+            // https://github.com/lodash/lodash/issues/5660
+            let mut force_esm = false;
 
-                        if should_move {
-                            // `Part` isn't `Copy`; pop+push instead of last+truncate.
-                            before.push(parts.pop().expect("unreachable"));
-                        }
-                    }
-                    js_ast::StmtData::SExportDefault(value) => {
-                        // We move export default statements when we can
-                        // This automatically resolves some cyclical import issues in packages like luxon
-                        // https://github.com/oven-sh/bun/issues/1961
-                        let should_move = !p.options.bundle && value.can_be_moved();
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut parts, sliced)?;
+            if p.should_unwrap_commonjs_to_esm() {
+                if !p.imports_to_convert_from_require.as_slice().is_empty() {
+                    let all_stmts = p.arena.alloc_slice_fill_with::<Stmt, _>(
+                        p.imports_to_convert_from_require.len(),
+                        |_| Stmt {
+                            loc: bun_ast::Loc::EMPTY,
+                            data: js_ast::StmtData::SEmpty(S::Empty {}),
+                        },
+                    );
+                    before.reserve(p.imports_to_convert_from_require.len());
 
-                        if should_move {
-                            before.push(parts.pop().expect("unreachable"));
-                        }
-                    }
-                    js_ast::StmtData::SEnum(_) => {
-                        // `Part` isn't `Clone`; move out the
-                        // pre-visited parts instead of `appendSlice`.
-                        let enum_parts = core::mem::replace(
-                            &mut preprocessed_enums[preprocessed_enum_i],
-                            BumpVec::new_in(arena),
+                    let mut remaining_stmts: &mut [Stmt] = all_stmts;
+
+                    for i in 0..p.imports_to_convert_from_require.len() {
+                        // borrowck — copy out the three Copy fields so the
+                        // immutable borrow of `p.imports_to_convert_from_require`
+                        // ends before `p.module_scope_mut()` takes `&mut self`.
+                        let (ns_ref, ns_loc, import_record_id) = {
+                            let deferred_import = &p.imports_to_convert_from_require[i];
+                            (
+                                deferred_import
+                                    .namespace
+                                    .ref_
+                                    .expect("infallible: ref bound"),
+                                deferred_import.namespace.loc,
+                                deferred_import.import_record_id,
+                            )
+                        };
+                        let (import_part_stmts, rest) = remaining_stmts.split_at_mut(1);
+                        remaining_stmts = rest;
+
+                        VecExt::append(&mut p.module_scope_mut().generated, ns_ref);
+
+                        import_part_stmts[0] = Stmt::alloc(
+                            S::Import {
+                                star_name_loc: Some(ns_loc),
+                                import_record_index: import_record_id,
+                                namespace_ref: ns_ref,
+                                default_name: None,
+                                items: bun_ast::StoreSlice::EMPTY,
+                                is_single_line: false,
+                                phase_defer: false,
+                            },
+                            ns_loc,
                         );
-                        for part in enum_parts {
-                            parts.push(part);
-                        }
-                        preprocessed_enum_i += 1;
-
-                        let idx = p
-                            .scopes_in_order_for_enum
-                            .keys()
-                            .iter()
-                            .position(|k| *k == stmt.loc)
-                            .expect("enum scope-order entry");
-                        let enum_scope_count = p.scopes_in_order_for_enum.values()[idx].len();
-                        // Advance the shared-slice cursor past this enum's scopes.
-                        p.scope_order_to_visit = &p.scope_order_to_visit[enum_scope_count..];
+                        let mut declared_symbols =
+                            bun_ast::DeclaredSymbolList::init_capacity(1).expect("unreachable");
+                        declared_symbols.append_assume_capacity(DeclaredSymbol {
+                            ref_: ns_ref,
+                            is_top_level: true,
+                        });
+                        before.push(js_ast::Part {
+                            stmts: import_part_stmts.into(),
+                            declared_symbols,
+                            tag: bun_ast::PartTag::ImportToConvertFromRequire,
+                            // This part has a single symbol, so it may be removed if unused.
+                            can_be_removed_if_unused: true,
+                            ..Default::default()
+                        });
                     }
-                    _ => {
-                        let sliced = arena.alloc_slice_copy(&[*stmt]);
-                        p.append_part(&mut parts, sliced)?;
+                    debug_assert!(remaining_stmts.is_empty());
+                }
+
+                if p.commonjs_named_exports.count() > 0 {
+                    // borrowck — `deoptimize_commonjs_named_exports` mut-borrows
+                    // `self`, so the `values()`/`keys()` slices are read once into locals.
+                    let export_names_len = p.commonjs_named_exports.keys().len();
+                    let first_export_ref_loc = p.commonjs_named_exports.values()[0].loc_ref.loc;
+                    let export_refs_len = p.commonjs_named_exports.values().len();
+
+                    'break_optimize: {
+                        if !p.commonjs_named_exports_deoptimized {
+                            let mut needs_decl_count: usize = 0;
+                            for export_ref in p.commonjs_named_exports.values().iter() {
+                                needs_decl_count += export_ref.needs_decl as usize;
+                            }
+                            // This is a workaround for packages which have broken ESM checks
+                            // If they never actually assign to exports.foo, only check for it
+                            // and the package specifies type "module"
+                            // and the package uses ESM syntax
+                            // We should just say
+                            // You're ESM and lying about it.
+                            if p.options.module_type == options::ModuleType::Esm
+                                || p.has_es_module_syntax
+                            {
+                                if needs_decl_count == export_names_len {
+                                    force_esm = true;
+                                    break 'break_optimize;
+                                }
+                            }
+
+                            if needs_decl_count > 0 {
+                                p.symbols.as_mut_slice()[p.exports_ref.inner_index() as usize]
+                                    .use_count_estimate += export_refs_len as u32;
+                                p.deoptimize_commonjs_named_exports();
+                            }
+                        }
+                    }
+
+                    if !p.commonjs_named_exports_deoptimized && p.esm_export_keyword.len == 0 {
+                        p.esm_export_keyword.loc = first_export_ref_loc;
+                        p.esm_export_keyword.len = 5;
                     }
                 }
             }
-        }
 
-        visit_tracer.end();
+            if parts.len() < 4 && parts.len() > 0 && p.options.features.unwrap_commonjs_to_esm {
+                // Specially handle modules shaped like this:
+                //
+                //   CommonJS:
+                //
+                //    if (process.env.NODE_ENV === 'production')
+                //         module.exports = require('./foo.prod.js')
+                //     else
+                //         module.exports = require('./foo.dev.js')
+                //
+                // Find the part containing the actual module.exports = require() statement,
+                // skipping over parts that only contain comments, directives, and empty statements.
+                // This handles files like:
+                //
+                //    /*!
+                //     * express
+                //     * MIT Licensed
+                //     */
+                //    'use strict';
+                //    module.exports = require('./lib/express');
+                //
+                // When tree-shaking is enabled, each statement becomes its own part, so we need
+                // to look across all parts to find the single meaningful statement.
+                struct StmtAndPart {
+                    stmt: Stmt,
+                    part_idx: usize,
+                }
+                let stmt_and_part: Option<StmtAndPart> = 'brk: {
+                    let mut found: Option<StmtAndPart> = None;
+                    for (part_idx, part) in parts.iter().enumerate() {
+                        // `Part.stmts` is a `StoreSlice<Stmt>` (arena-owned). It is
+                        // only ever populated from bump-allocated slices in this fn.
+                        for s in part.stmts.iter() {
+                            match s.data {
+                                js_ast::StmtData::SComment(_)
+                                | js_ast::StmtData::SDirective(_)
+                                | js_ast::StmtData::SEmpty(_) => continue,
+                                _ => {
+                                    // If we already found a non-trivial statement, there's more than one
+                                    if found.is_some() {
+                                        break 'brk None;
+                                    }
+                                    found = Some(StmtAndPart { stmt: *s, part_idx });
+                                }
+                            }
+                        }
+                    }
+                    found
+                };
+                if let Some(found) = stmt_and_part {
+                    let stmt = found.stmt;
+                    let part = &mut parts[found.part_idx];
+                    if p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate
+                        == 1
+                    {
+                        if let js_ast::StmtData::SExpr(s_expr) = &stmt.data {
+                            let value: Expr = s_expr.value;
 
-        // If there were errors while visiting, also halt here
-        if p.log().errors > orig_error_count {
-            return Err(err!("SyntaxError"));
-        }
+                            if let js_ast::ExprData::EBinary(bin) = &value.data {
+                                let left = bin.left;
+                                let right = bin.right;
+                                if bin.op == js_ast::op::Code::BinAssign
+                                    && matches!(&left.data, js_ast::ExprData::EDot(d)
+                                    if d.name == b"exports"
+                                        && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
+                                            if id.ref_.eql(p.module_ref)))
+                                {
+                                    let redirect_import_record_index: Option<u32> = 'inner_brk: {
+                                        // general case:
+                                        //
+                                        //      module.exports = require("foo");
+                                        //
+                                        if let js_ast::ExprData::ERequireString(req) = &right.data {
+                                            break 'inner_brk Some(req.import_record_index);
+                                        }
 
-        // `perf::Ctx` ends the span in its `Drop` impl — bind it for the rest of `_parse`.
-        let _postvisit_tracer = bun_core::perf::trace("JSParser::postvisit");
+                                        // special case: a module for us to unwrap
+                                        //
+                                        //      module.exports = require("react/jsx-runtime")
+                                        //                       ^ was converted into:
+                                        //
+                                        //      import * as Foo from 'bar';
+                                        //      module.exports = Foo;
+                                        //
+                                        // This is what fixes #3537
+                                        if let js_ast::ExprData::EIdentifier(id) = &right.data {
+                                            if p.import_records.len() == 1
+                                                && p.imports_to_convert_from_require.len() == 1
+                                                && p.imports_to_convert_from_require.as_slice()[0]
+                                                    .namespace
+                                                    .ref_
+                                                    .unwrap()
+                                                    .eql(id.ref_)
+                                            {
+                                                // We know it's 0 because there is only one import in the whole file
+                                                // so that one import must be the one we're looking for
+                                                break 'inner_brk Some(0);
+                                            }
+                                        }
 
-        let mut uses_dirname =
-            p.symbols.as_slice()[p.dirname_ref.inner_index() as usize].use_count_estimate > 0;
-        let mut uses_filename =
-            p.symbols.as_slice()[p.filename_ref.inner_index() as usize].use_count_estimate > 0;
+                                        None
+                                    };
+                                    if let Some(id) = redirect_import_record_index {
+                                        part.symbol_uses = Default::default();
+                                        return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
+                                            import_records: p
+                                                .import_records
+                                                .move_to_baby_list(p.arena),
+                                            redirect_import_record_index: Some(id),
+                                            named_imports: core::mem::take(&mut *p.named_imports),
+                                            named_exports: core::mem::take(&mut p.named_exports),
+                                            ..js_ast::Ast::empty_in(p.arena)
+                                        })));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
-        // Handle dirname and filename at bundle-time
-        // We always inject it at the top of the module
-        //
-        // This inlines
-        //
-        //    var __dirname = "foo/bar"
-        //    var __filename = "foo/bar/baz.js"
-        //
-        if p.options.bundle || !p.options.features.commonjs_at_runtime {
-            if uses_dirname || uses_filename {
+                if p.commonjs_named_exports_deoptimized
+                    && p.options.features.unwrap_commonjs_to_esm
+                    && p.unwrap_all_requires
+                    && p.imports_to_convert_from_require.len() == 1
+                    && p.import_records.len() == 1
+                    && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate
+                        == 1
+                {
+                    'outer_part_loop: for part in parts.iter_mut() {
+                        // Specially handle modules shaped like this:
+                        //
+                        //    doSomeStuff();
+                        //    module.exports = require('./foo.js');
+                        //
+                        // An example is react-dom/index.js, which does a DCE check.
+                        // Snapshot the StoreSlice (Copy) so the `&mut` borrow over the
+                        // arena slice doesn't conflict with the `part.stmts = …` rewrite
+                        // below.
+                        let part_stmts_ss = part.stmts;
+                        let part_stmts: &mut [Stmt] = part_stmts_ss.slice_mut();
+                        if part_stmts.len() > 1 {
+                            break;
+                        }
+
+                        for j in 0..part_stmts.len() {
+                            let stmt = &mut part_stmts[j];
+                            if let js_ast::StmtData::SExpr(s_expr) = &stmt.data {
+                                let value: Expr = s_expr.value;
+
+                                if let js_ast::ExprData::EBinary(bin_ptr) = value.data {
+                                    let mut bin = bin_ptr;
+                                    loop {
+                                        let left = bin.left;
+                                        let right = bin.right;
+
+                                        if bin.op == js_ast::op::Code::BinAssign
+                                            && matches!(
+                                                right.data,
+                                                js_ast::ExprData::ERequireString(_)
+                                            )
+                                            && matches!(&left.data, js_ast::ExprData::EDot(d)
+                                            if d.name == b"exports"
+                                                && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
+                                                    if id.ref_.eql(p.module_ref)))
+                                        {
+                                            let req = match &right.data {
+                                                js_ast::ExprData::ERequireString(r) => r,
+                                                _ => unreachable!(),
+                                            };
+                                            p.export_star_import_records
+                                                .push(req.import_record_index);
+                                            let namespace_ref =
+                                                p.imports_to_convert_from_require.as_slice()
+                                                    [req.unwrapped_id as usize]
+                                                    .namespace
+                                                    .ref_
+                                                    .unwrap();
+
+                                            let stmt_loc = stmt.loc;
+                                            part.stmts = {
+                                                let mut new_stmts =
+                                                    BumpVec::<Stmt>::with_capacity_in(
+                                                        part.stmts.len() + 1,
+                                                        p.arena,
+                                                    );
+                                                new_stmts.extend_from_slice(&part_stmts[0..j]);
+
+                                                new_stmts.push(Stmt::alloc(
+                                                    S::ExportStar {
+                                                        import_record_index: req
+                                                            .import_record_index,
+                                                        namespace_ref,
+                                                        alias: None,
+                                                    },
+                                                    stmt_loc,
+                                                ));
+                                                new_stmts.extend_from_slice(&part_stmts[j + 1..]);
+                                                bun_ast::StoreSlice::from_bump(new_stmts)
+                                            };
+
+                                            part.import_record_indices
+                                                .push(req.import_record_index);
+                                            p.symbols.as_mut_slice()
+                                                [p.module_ref.inner_index() as usize]
+                                                .use_count_estimate = 0;
+                                            let ns_idx = namespace_ref.inner_index() as usize;
+                                            p.symbols.as_mut_slice()[ns_idx].use_count_estimate =
+                                                p.symbols.as_slice()[ns_idx]
+                                                    .use_count_estimate
+                                                    .saturating_sub(1);
+                                            let _ = part.symbol_uses.swap_remove(&namespace_ref);
+
+                                            for (i, before_part) in before.iter().enumerate() {
+                                                if before_part.tag
+                                                    == bun_ast::PartTag::ImportToConvertFromRequire
+                                                {
+                                                    let _ = before.swap_remove(i);
+                                                    break;
+                                                }
+                                            }
+
+                                            if p.esm_export_keyword.len == 0 {
+                                                p.esm_export_keyword.loc = stmt_loc;
+                                                p.esm_export_keyword.len = 5;
+                                            }
+                                            p.commonjs_named_exports_deoptimized = false;
+                                            break;
+                                        }
+
+                                        if let js_ast::ExprData::EBinary(rb) = right.data {
+                                            bin = rb;
+                                            continue;
+                                        }
+
+                                        break;
+                                    }
+                                    let _ = bin_ptr;
+                                }
+                            }
+                        }
+                        let _ = &mut *part;
+                        continue 'outer_part_loop;
+                    }
+                }
+            } else if p.options.bundle && parts.is_empty() {
+                // This flag is disabled because it breaks circular export * as from
+                //
+                //  entry.js:
+                //
+                //    export * from './foo';
+                //
+                //  foo.js:
+                //
+                //    export const foo = 123
+                //    export * as ns from './foo'
+                //
+                // This is permanently disabled (see the circular-export breakage above).
+                if false {
+                    // If the file only contains "export * from './blah'
+                    // we pretend the file never existed in the first place.
+                    // the semantic difference here is in export default statements
+                    // note: export_star_import_records are not filled in yet
+
+                    if !before.is_empty() && p.import_records.len() == 1 {
+                        let export_star_redirect: Option<&S::ExportStar> = 'brk: {
+                            let mut export_star: Option<&S::ExportStar> = None;
+                            for part in before.iter() {
+                                for stmt in part.stmts.iter() {
+                                    match &stmt.data {
+                                        js_ast::StmtData::SExportStar(star) => {
+                                            if star.alias.is_some() {
+                                                break 'brk None;
+                                            }
+
+                                            if export_star.is_some() {
+                                                break 'brk None;
+                                            }
+
+                                            export_star = Some(&**star);
+                                        }
+                                        js_ast::StmtData::SEmpty(_)
+                                        | js_ast::StmtData::SComment(_) => {}
+                                        _ => {
+                                            break 'brk None;
+                                        }
+                                    }
+                                }
+                            }
+                            export_star
+                        };
+
+                        if let Some(star) = export_star_redirect {
+                            return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
+                                import_records: p.import_records.move_to_baby_list(p.arena),
+                                redirect_import_record_index: Some(star.import_record_index),
+                                named_imports: core::mem::take(&mut *p.named_imports),
+                                named_exports: core::mem::take(&mut p.named_exports),
+                                ..js_ast::Ast::empty_in(p.arena)
+                            })));
+                        }
+                    }
+                }
+            }
+
+            // Analyze cross-part dependencies for tree shaking and code splitting.
+            // The if/else-if/else-match below exhaustively assigns this on every path.
+            let mut exports_kind: js_ast::ExportsKind;
+            let exports_ref_usage_count =
+                p.symbols.as_slice()[p.exports_ref.inner_index() as usize].use_count_estimate;
+            let uses_exports_ref = exports_ref_usage_count > 0;
+
+            if uses_exports_ref && p.commonjs_named_exports.count() > 0 && !force_esm {
+                p.deoptimize_commonjs_named_exports();
+            }
+
+            let uses_module_ref =
+                p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate > 0;
+
+            let mut wrap_mode: WrapMode = WrapMode::None;
+
+            if p.is_deoptimized_commonjs() {
+                exports_kind = js_ast::ExportsKind::Cjs;
+            } else if p.esm_export_keyword.len > 0 || p.top_level_await_keyword.len > 0 {
+                exports_kind = js_ast::ExportsKind::Esm;
+            } else if uses_exports_ref
+                || uses_module_ref
+                || p.has_top_level_return
+                || p.has_with_scope
+            {
+                exports_kind = js_ast::ExportsKind::Cjs;
+                if p.options.features.commonjs_at_runtime {
+                    wrap_mode = WrapMode::BunCommonjs;
+
+                    let import_record: Option<&ImportRecord> = 'brk: {
+                        for import_record in p.import_records.items() {
+                            if import_record.flags.intersects(
+                                ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED,
+                            ) {
+                                continue;
+                            }
+                            if import_record.kind == bun_ast::ImportKind::Stmt {
+                                break 'brk Some(import_record);
+                            }
+                        }
+
+                        None
+                    };
+
+                    // make it an error to use an import statement with a commonjs exports usage
+                    if let Some(record) = import_record {
+                        // find the usage of the export symbol
+
+                        let mut notes = BumpVec::<bun_ast::Data>::new_in(p.arena);
+
+                        notes.push(bun_ast::Data {
+                            text: {
+                                use std::io::Write;
+                                let mut v = Vec::<u8>::new();
+                                let _ = write!(
+                                    &mut v,
+                                    "Try require({}) instead",
+                                    bun_core::fmt::QuotedFormatter {
+                                        text: record.path.text
+                                    }
+                                );
+                                std::borrow::Cow::Owned(v)
+                            },
+                            ..Default::default()
+                        });
+
+                        if uses_module_ref {
+                            notes.push(bun_ast::Data {
+                                text: std::borrow::Cow::Borrowed(
+                                    b"This file is CommonJS because 'module' was used",
+                                ),
+                                ..Default::default()
+                            });
+                        }
+
+                        if uses_exports_ref {
+                            notes.push(bun_ast::Data {
+                                text: std::borrow::Cow::Borrowed(
+                                    b"This file is CommonJS because 'exports' was used",
+                                ),
+                                ..Default::default()
+                            });
+                        }
+
+                        if p.has_top_level_return {
+                            notes.push(bun_ast::Data {
+                                text: std::borrow::Cow::Borrowed(
+                                    b"This file is CommonJS because top-level return was used",
+                                ),
+                                ..Default::default()
+                            });
+                        }
+
+                        if p.has_with_scope {
+                            notes.push(bun_ast::Data {
+                                text: std::borrow::Cow::Borrowed(
+                                    b"This file is CommonJS because a \"with\" statement is used",
+                                ),
+                                ..Default::default()
+                            });
+                        }
+
+                        p.log().add_range_error_with_notes(
+                            Some(p.source),
+                            record.range,
+                            b"Cannot use import statement with CommonJS-only features".as_slice(),
+                            notes.into_iter().collect::<Vec<_>>().into_boxed_slice(),
+                        );
+                    }
+                }
+            } else {
+                match p.options.module_type {
+                    // ".cjs" or ".cts" or ("type: commonjs" and (".js" or ".jsx" or ".ts" or ".tsx"))
+                    options::ModuleType::Cjs => {
+                        // There are no commonjs-only features used (require is allowed in ESM)
+                        debug_assert!(
+                            !uses_exports_ref
+                                && !uses_module_ref
+                                && !p.has_top_level_return
+                                && !p.has_with_scope
+                        );
+                        // Use ESM if the file has ES module syntax (import)
+                        exports_kind = if p.has_es_module_syntax {
+                            js_ast::ExportsKind::Esm
+                        } else {
+                            js_ast::ExportsKind::Cjs
+                        };
+                    }
+                    options::ModuleType::Esm => {
+                        exports_kind = js_ast::ExportsKind::Esm;
+                    }
+                    options::ModuleType::Unknown => {
+                        // Divergence from esbuild and Node.js: we default to ESM
+                        // when there are no exports.
+                        //
+                        // However, this breaks certain packages.
+                        // For example, the checkpoint-client used by
+                        // Prisma does an eval("__dirname") but does not export
+                        // anything.
+                        //
+                        // If they use an import statement, we say it's ESM because that's not allowed in CommonJS files.
+                        let uses_any_import_statements = 'brk: {
+                            for import_record in p.import_records.items() {
+                                if import_record.flags.intersects(
+                                    ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED,
+                                ) {
+                                    continue;
+                                }
+                                if import_record.kind == bun_ast::ImportKind::Stmt {
+                                    break 'brk true;
+                                }
+                            }
+
+                            false
+                        };
+
+                        if uses_any_import_statements {
+                            exports_kind = js_ast::ExportsKind::Esm;
+                        }
+                        // Otherwise, if they use CommonJS features its CommonJS.
+                        // If you add a 'use strict'; at the top, you probably meant CommonJS because "use strict"; does nothing in ESM.
+                        else if p.symbols.as_slice()[p.require_ref.inner_index() as usize]
+                            .use_count_estimate
+                            > 0
+                            || uses_dirname
+                            || uses_filename
+                            || (!p.options.bundle
+                            // SAFETY: `module_scope` is non-null after `prepare_for_visit_pass`.
+                            && p.module_scope().strict_mode
+                                == bun_ast::StrictModeKind::ExplicitStrictMode)
+                        {
+                            exports_kind = js_ast::ExportsKind::Cjs;
+                        } else {
+                            // If unknown, we default to ESM
+                            exports_kind = js_ast::ExportsKind::Esm;
+                        }
+                    }
+                }
+
+                if exports_kind == js_ast::ExportsKind::Cjs
+                    && p.options.features.commonjs_at_runtime
+                {
+                    wrap_mode = WrapMode::BunCommonjs;
+                }
+            }
+
+            // Handle dirname and filename at runtime.
+            //
+            // If we reach this point, it means:
+            //
+            // 1) we are building an ESM file that uses __dirname or __filename
+            // 2) we are targeting bun's runtime.
+            // 3) we are not bundling.
+            //
+            if exports_kind == js_ast::ExportsKind::Esm && (uses_dirname || uses_filename) {
+                debug_assert!(!p.options.bundle);
                 let count = (uses_dirname as usize) + (uses_filename as usize);
                 let mut declared_symbols =
                     bun_ast::DeclaredSymbolList::init_capacity(count).expect("unreachable");
@@ -1135,6 +1824,8 @@ impl<'a> Parser<'a> {
                     .arena
                     .alloc_slice_fill_with::<G::Decl, _>(count, |_| G::Decl::default());
                 if uses_dirname {
+                    // var __dirname = import.meta
+                    let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
                     decls[0] = G::Decl {
                         binding: p.b(
                             B::Identifier {
@@ -1143,8 +1834,10 @@ impl<'a> Parser<'a> {
                             bun_ast::Loc::EMPTY,
                         ),
                         value: Some(p.new_expr(
-                            E::String {
-                                data: p.source.path.name().dir.into(),
+                            E::Dot {
+                                name: b"dir".into(),
+                                name_loc: bun_ast::Loc::EMPTY,
+                                target: import_meta,
                                 ..Default::default()
                             },
                             bun_ast::Loc::EMPTY,
@@ -1156,6 +1849,8 @@ impl<'a> Parser<'a> {
                     });
                 }
                 if uses_filename {
+                    // var __filename = import.meta.path
+                    let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
                     decls[uses_dirname as usize] = G::Decl {
                         binding: p.b(
                             B::Identifier {
@@ -1164,8 +1859,10 @@ impl<'a> Parser<'a> {
                             bun_ast::Loc::EMPTY,
                         ),
                         value: Some(p.new_expr(
-                            E::String {
-                                data: p.source.path.text.into(),
+                            E::Dot {
+                                name: b"path".into(),
+                                name_loc: bun_ast::Loc::EMPTY,
+                                target: import_meta,
                                 ..Default::default()
                             },
                             bun_ast::Loc::EMPTY,
@@ -1199,1041 +1896,365 @@ impl<'a> Parser<'a> {
                     tag: bun_ast::PartTag::DirnameFilename,
                     ..Default::default()
                 });
-                uses_dirname = false;
-                uses_filename = false;
             }
-        }
 
-        // This is a workaround for broken module environment checks in packages like lodash-es
-        // https://github.com/lodash/lodash/issues/5660
-        let mut force_esm = false;
+            if exports_kind == js_ast::ExportsKind::Esm
+                && p.commonjs_named_exports.count() > 0
+                && !p.unwrap_all_requires
+                && !force_esm
+            {
+                exports_kind = js_ast::ExportsKind::EsmWithDynamicFallbackFromCjs;
+            }
 
-        if p.should_unwrap_commonjs_to_esm() {
-            if !p.imports_to_convert_from_require.as_slice().is_empty() {
-                let all_stmts = p.arena.alloc_slice_fill_with::<Stmt, _>(
-                    p.imports_to_convert_from_require.len(),
-                    |_| Stmt {
-                        loc: bun_ast::Loc::EMPTY,
-                        data: js_ast::StmtData::SEmpty(S::Empty {}),
-                    },
-                );
-                before.reserve(p.imports_to_convert_from_require.len());
+            // Auto inject jest globals into the test file
+            'outer: {
+                if !p.options.features.inject_jest_globals {
+                    break 'outer;
+                }
 
-                let mut remaining_stmts: &mut [Stmt] = all_stmts;
+                for item in p.import_records.items() {
+                    // skip if they did import it
+                    if item.path.text == b"bun:test"
+                        || item.path.text == b"@jest/globals"
+                        || item.path.text == b"vitest"
+                    {
+                        if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+                            // If we rewrote import paths, we need to disable the runtime transpiler cache
+                            if item.path.text != b"bun:test" {
+                                cache.input_hash = None;
+                            }
+                        }
 
-                for i in 0..p.imports_to_convert_from_require.len() {
-                    // borrowck — copy out the three Copy fields so the
-                    // immutable borrow of `p.imports_to_convert_from_require`
-                    // ends before `p.module_scope_mut()` takes `&mut self`.
-                    let (ns_ref, ns_loc, import_record_id) = {
-                        let deferred_import = &p.imports_to_convert_from_require[i];
-                        (
-                            deferred_import
-                                .namespace
-                                .ref_
-                                .expect("infallible: ref bound"),
-                            deferred_import.namespace.loc,
-                            deferred_import.import_record_id,
-                        )
-                    };
-                    let (import_part_stmts, rest) = remaining_stmts.split_at_mut(1);
-                    remaining_stmts = rest;
+                        break 'outer;
+                    }
+                }
 
-                    VecExt::append(&mut p.module_scope_mut().generated, ns_ref);
+                // if they didn't use any of the jest globals, don't inject it, I guess.
+                // Iterates the static `Jest::FIELDS`
+                // table (`&[(&'static str, fn(&Jest) -> Ref)]`); declaration order
+                // determines the emitted clause/property order.
+                let items_count: usize = {
+                    let mut count: usize = 0;
+                    for (_name, get_ref) in Jest::FIELDS {
+                        count += (p.symbols.as_slice()[get_ref(&p.jest).inner_index() as usize]
+                            .use_count_estimate
+                            > 0) as usize;
+                    }
+                    count
+                };
+                if items_count == 0 {
+                    break 'outer;
+                }
 
-                    import_part_stmts[0] = Stmt::alloc(
-                        S::Import {
-                            star_name_loc: Some(ns_loc),
+                let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
+                declared_symbols.ensure_total_capacity(items_count)?;
+
+                // For CommonJS modules, use require instead of import
+                if exports_kind == js_ast::ExportsKind::Cjs {
+                    let import_record_id = p.add_import_record(
+                        bun_ast::ImportKind::Require,
+                        bun_ast::Loc::EMPTY,
+                        b"bun:test",
+                    );
+
+                    // Create object binding pattern for destructuring
+                    let mut properties =
+                        BumpVec::<B::Property>::with_capacity_in(items_count, p.arena);
+                    for (symbol_name, get_ref) in Jest::FIELDS {
+                        let r = get_ref(&p.jest);
+                        if p.symbols.as_slice()[r.inner_index() as usize].use_count_estimate > 0 {
+                            let key = p.new_expr(
+                                E::String {
+                                    data: symbol_name.as_bytes().into(),
+                                    ..Default::default()
+                                },
+                                bun_ast::Loc::EMPTY,
+                            );
+                            let value = p.b(B::Identifier { r#ref: r }, bun_ast::Loc::EMPTY);
+                            properties.push(B::Property {
+                                flags: bun_ast::flags::PROPERTY_NONE,
+                                key,
+                                value,
+                                default_value: None,
+                            });
+                            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                                ref_: r,
+                                is_top_level: true,
+                            });
+                        }
+                    }
+                    let properties = bun_ast::StoreSlice::from_bump(properties);
+
+                    // Create: const { test, expect, ... } = require("bun:test")
+                    let binding = p.b(
+                        B::Object {
+                            properties,
+                            is_single_line: false,
+                        },
+                        bun_ast::Loc::EMPTY,
+                    );
+                    let value = p.new_expr(
+                        E::RequireString {
                             import_record_index: import_record_id,
-                            namespace_ref: ns_ref,
+                            ..Default::default()
+                        },
+                        bun_ast::Loc::EMPTY,
+                    );
+                    let mut decls = G::DeclList::init_capacity(1);
+                    decls.append_assume_capacity(G::Decl {
+                        binding,
+                        value: Some(value),
+                    });
+
+                    let local_stmt = p.s(
+                        S::Local {
+                            kind: js_ast::LocalKind::KConst,
+                            decls,
+                            ..Default::default()
+                        },
+                        bun_ast::Loc::EMPTY,
+                    );
+                    let part_stmts = p.arena.alloc_slice_fill_with(1, |_| local_stmt);
+
+                    before.push(js_ast::Part {
+                        stmts: part_stmts.into(),
+                        declared_symbols,
+                        import_record_indices: js_ast::PartImportRecordIndices::init_one(
+                            import_record_id,
+                        ),
+                        tag: bun_ast::PartTag::BunTest,
+                        ..Default::default()
+                    });
+                } else {
+                    let import_record_id = p.add_import_record(
+                        bun_ast::ImportKind::Stmt,
+                        bun_ast::Loc::EMPTY,
+                        b"bun:test",
+                    );
+
+                    // For ESM modules, use import statement
+                    let mut clauses =
+                        BumpVec::<js_ast::ClauseItem>::with_capacity_in(items_count, p.arena);
+                    for (symbol_name, get_ref) in Jest::FIELDS {
+                        let r = get_ref(&p.jest);
+                        if p.symbols.as_slice()[r.inner_index() as usize].use_count_estimate > 0 {
+                            clauses.push(js_ast::ClauseItem {
+                                name: js_ast::LocRef {
+                                    ref_: Some(r),
+                                    loc: bun_ast::Loc::EMPTY,
+                                },
+                                alias: js_ast::StoreStr::new(symbol_name.as_bytes()),
+                                alias_loc: bun_ast::Loc::EMPTY,
+                                original_name: js_ast::StoreStr::new(b""),
+                            });
+                            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                                ref_: r,
+                                is_top_level: true,
+                            });
+                        }
+                    }
+                    let clauses = bun_ast::StoreSlice::from_bump(clauses);
+
+                    let namespace_ref = p
+                        .declare_symbol(
+                            js_ast::symbol::Kind::Unbound,
+                            bun_ast::Loc::EMPTY,
+                            b"bun_test_import_namespace_for_internal_use_only",
+                        )
+                        .expect("unreachable");
+                    let import_stmt = p.s(
+                        S::Import {
+                            namespace_ref,
+                            items: clauses,
+                            import_record_index: import_record_id,
                             default_name: None,
-                            items: bun_ast::StoreSlice::EMPTY,
+                            star_name_loc: None,
                             is_single_line: false,
                             phase_defer: false,
                         },
-                        ns_loc,
+                        bun_ast::Loc::EMPTY,
                     );
-                    let mut declared_symbols =
-                        bun_ast::DeclaredSymbolList::init_capacity(1).expect("unreachable");
-                    declared_symbols.append_assume_capacity(DeclaredSymbol {
-                        ref_: ns_ref,
-                        is_top_level: true,
-                    });
+
+                    let part_stmts = p.arena.alloc_slice_fill_with(1, |_| import_stmt);
                     before.push(js_ast::Part {
-                        stmts: import_part_stmts.into(),
+                        stmts: part_stmts.into(),
                         declared_symbols,
-                        tag: bun_ast::PartTag::ImportToConvertFromRequire,
-                        // This part has a single symbol, so it may be removed if unused.
-                        can_be_removed_if_unused: true,
+                        import_record_indices: js_ast::PartImportRecordIndices::init_one(
+                            import_record_id,
+                        ),
+                        tag: bun_ast::PartTag::BunTest,
                         ..Default::default()
                     });
                 }
-                debug_assert!(remaining_stmts.is_empty());
-            }
 
-            if p.commonjs_named_exports.count() > 0 {
-                // borrowck — `deoptimize_commonjs_named_exports` mut-borrows
-                // `self`, so the `values()`/`keys()` slices are read once into locals.
-                let export_names_len = p.commonjs_named_exports.keys().len();
-                let first_export_ref_loc = p.commonjs_named_exports.values()[0].loc_ref.loc;
-                let export_refs_len = p.commonjs_named_exports.values().len();
-
-                'break_optimize: {
-                    if !p.commonjs_named_exports_deoptimized {
-                        let mut needs_decl_count: usize = 0;
-                        for export_ref in p.commonjs_named_exports.values().iter() {
-                            needs_decl_count += export_ref.needs_decl as usize;
-                        }
-                        // This is a workaround for packages which have broken ESM checks
-                        // If they never actually assign to exports.foo, only check for it
-                        // and the package specifies type "module"
-                        // and the package uses ESM syntax
-                        // We should just say
-                        // You're ESM and lying about it.
-                        if p.options.module_type == options::ModuleType::Esm
-                            || p.has_es_module_syntax
-                        {
-                            if needs_decl_count == export_names_len {
-                                force_esm = true;
-                                break 'break_optimize;
-                            }
-                        }
-
-                        if needs_decl_count > 0 {
-                            p.symbols.as_mut_slice()[p.exports_ref.inner_index() as usize]
-                                .use_count_estimate += export_refs_len as u32;
-                            p.deoptimize_commonjs_named_exports();
-                        }
-                    }
-                }
-
-                if !p.commonjs_named_exports_deoptimized && p.esm_export_keyword.len == 0 {
-                    p.esm_export_keyword.loc = first_export_ref_loc;
-                    p.esm_export_keyword.len = 5;
-                }
-            }
-        }
-
-        if parts.len() < 4 && parts.len() > 0 && p.options.features.unwrap_commonjs_to_esm {
-            // Specially handle modules shaped like this:
-            //
-            //   CommonJS:
-            //
-            //    if (process.env.NODE_ENV === 'production')
-            //         module.exports = require('./foo.prod.js')
-            //     else
-            //         module.exports = require('./foo.dev.js')
-            //
-            // Find the part containing the actual module.exports = require() statement,
-            // skipping over parts that only contain comments, directives, and empty statements.
-            // This handles files like:
-            //
-            //    /*!
-            //     * express
-            //     * MIT Licensed
-            //     */
-            //    'use strict';
-            //    module.exports = require('./lib/express');
-            //
-            // When tree-shaking is enabled, each statement becomes its own part, so we need
-            // to look across all parts to find the single meaningful statement.
-            struct StmtAndPart {
-                stmt: Stmt,
-                part_idx: usize,
-            }
-            let stmt_and_part: Option<StmtAndPart> = 'brk: {
-                let mut found: Option<StmtAndPart> = None;
-                for (part_idx, part) in parts.iter().enumerate() {
-                    // `Part.stmts` is a `StoreSlice<Stmt>` (arena-owned). It is
-                    // only ever populated from bump-allocated slices in this fn.
-                    for s in part.stmts.iter() {
-                        match s.data {
-                            js_ast::StmtData::SComment(_)
-                            | js_ast::StmtData::SDirective(_)
-                            | js_ast::StmtData::SEmpty(_) => continue,
-                            _ => {
-                                // If we already found a non-trivial statement, there's more than one
-                                if found.is_some() {
-                                    break 'brk None;
-                                }
-                                found = Some(StmtAndPart { stmt: *s, part_idx });
-                            }
-                        }
-                    }
-                }
-                found
-            };
-            if let Some(found) = stmt_and_part {
-                let stmt = found.stmt;
-                let part = &mut parts[found.part_idx];
-                if p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
-                {
-                    if let js_ast::StmtData::SExpr(s_expr) = &stmt.data {
-                        let value: Expr = s_expr.value;
-
-                        if let js_ast::ExprData::EBinary(bin) = &value.data {
-                            let left = bin.left;
-                            let right = bin.right;
-                            if bin.op == js_ast::op::Code::BinAssign
-                                && matches!(&left.data, js_ast::ExprData::EDot(d)
-                                    if d.name == b"exports"
-                                        && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
-                                            if id.ref_.eql(p.module_ref)))
-                            {
-                                let redirect_import_record_index: Option<u32> = 'inner_brk: {
-                                    // general case:
-                                    //
-                                    //      module.exports = require("foo");
-                                    //
-                                    if let js_ast::ExprData::ERequireString(req) = &right.data {
-                                        break 'inner_brk Some(req.import_record_index);
-                                    }
-
-                                    // special case: a module for us to unwrap
-                                    //
-                                    //      module.exports = require("react/jsx-runtime")
-                                    //                       ^ was converted into:
-                                    //
-                                    //      import * as Foo from 'bar';
-                                    //      module.exports = Foo;
-                                    //
-                                    // This is what fixes #3537
-                                    if let js_ast::ExprData::EIdentifier(id) = &right.data {
-                                        if p.import_records.len() == 1
-                                            && p.imports_to_convert_from_require.len() == 1
-                                            && p.imports_to_convert_from_require.as_slice()[0]
-                                                .namespace
-                                                .ref_
-                                                .unwrap()
-                                                .eql(id.ref_)
-                                        {
-                                            // We know it's 0 because there is only one import in the whole file
-                                            // so that one import must be the one we're looking for
-                                            break 'inner_brk Some(0);
-                                        }
-                                    }
-
-                                    None
-                                };
-                                if let Some(id) = redirect_import_record_index {
-                                    part.symbol_uses = Default::default();
-                                    return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
-                                        import_records: p.import_records.move_to_baby_list(p.arena),
-                                        redirect_import_record_index: Some(id),
-                                        named_imports: core::mem::take(&mut *p.named_imports),
-                                        named_exports: core::mem::take(&mut p.named_exports),
-                                        ..js_ast::Ast::empty_in(p.arena)
-                                    })));
-                                }
-                            }
-                        }
-                    }
+                // If we injected jest globals, we need to disable the runtime transpiler cache
+                if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+                    cache.input_hash = None;
                 }
             }
 
-            if p.commonjs_named_exports_deoptimized
-                && p.options.features.unwrap_commonjs_to_esm
-                && p.unwrap_all_requires
-                && p.imports_to_convert_from_require.len() == 1
-                && p.import_records.len() == 1
-                && p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate == 1
-            {
-                'outer_part_loop: for part in parts.iter_mut() {
-                    // Specially handle modules shaped like this:
-                    //
-                    //    doSomeStuff();
-                    //    module.exports = require('./foo.js');
-                    //
-                    // An example is react-dom/index.js, which does a DCE check.
-                    // Snapshot the StoreSlice (Copy) so the `&mut` borrow over the
-                    // arena slice doesn't conflict with the `part.stmts = …` rewrite
-                    // below.
-                    let part_stmts_ss = part.stmts;
-                    let part_stmts: &mut [Stmt] = part_stmts_ss.slice_mut();
-                    if part_stmts.len() > 1 {
-                        break;
-                    }
-
-                    for j in 0..part_stmts.len() {
-                        let stmt = &mut part_stmts[j];
-                        if let js_ast::StmtData::SExpr(s_expr) = &stmt.data {
-                            let value: Expr = s_expr.value;
-
-                            if let js_ast::ExprData::EBinary(bin_ptr) = value.data {
-                                let mut bin = bin_ptr;
-                                loop {
-                                    let left = bin.left;
-                                    let right = bin.right;
-
-                                    if bin.op == js_ast::op::Code::BinAssign
-                                        && matches!(right.data, js_ast::ExprData::ERequireString(_))
-                                        && matches!(&left.data, js_ast::ExprData::EDot(d)
-                                            if d.name == b"exports"
-                                                && matches!(&d.target.data, js_ast::ExprData::EIdentifier(id)
-                                                    if id.ref_.eql(p.module_ref)))
-                                    {
-                                        let req = match &right.data {
-                                            js_ast::ExprData::ERequireString(r) => r,
-                                            _ => unreachable!(),
-                                        };
-                                        p.export_star_import_records.push(req.import_record_index);
-                                        let namespace_ref =
-                                            p.imports_to_convert_from_require.as_slice()
-                                                [req.unwrapped_id as usize]
-                                                .namespace
-                                                .ref_
-                                                .unwrap();
-
-                                        let stmt_loc = stmt.loc;
-                                        part.stmts = {
-                                            let mut new_stmts = BumpVec::<Stmt>::with_capacity_in(
-                                                part.stmts.len() + 1,
-                                                p.arena,
-                                            );
-                                            new_stmts.extend_from_slice(&part_stmts[0..j]);
-
-                                            new_stmts.push(Stmt::alloc(
-                                                S::ExportStar {
-                                                    import_record_index: req.import_record_index,
-                                                    namespace_ref,
-                                                    alias: None,
-                                                },
-                                                stmt_loc,
-                                            ));
-                                            new_stmts.extend_from_slice(&part_stmts[j + 1..]);
-                                            bun_ast::StoreSlice::from_bump(new_stmts)
-                                        };
-
-                                        part.import_record_indices.push(req.import_record_index);
-                                        p.symbols.as_mut_slice()
-                                            [p.module_ref.inner_index() as usize]
-                                            .use_count_estimate = 0;
-                                        let ns_idx = namespace_ref.inner_index() as usize;
-                                        p.symbols.as_mut_slice()[ns_idx].use_count_estimate =
-                                            p.symbols.as_slice()[ns_idx]
-                                                .use_count_estimate
-                                                .saturating_sub(1);
-                                        let _ = part.symbol_uses.swap_remove(&namespace_ref);
-
-                                        for (i, before_part) in before.iter().enumerate() {
-                                            if before_part.tag
-                                                == bun_ast::PartTag::ImportToConvertFromRequire
-                                            {
-                                                let _ = before.swap_remove(i);
-                                                break;
-                                            }
-                                        }
-
-                                        if p.esm_export_keyword.len == 0 {
-                                            p.esm_export_keyword.loc = stmt_loc;
-                                            p.esm_export_keyword.len = 5;
-                                        }
-                                        p.commonjs_named_exports_deoptimized = false;
-                                        break;
-                                    }
-
-                                    if let js_ast::ExprData::EBinary(rb) = right.data {
-                                        bin = rb;
-                                        continue;
-                                    }
-
-                                    break;
-                                }
-                                let _ = bin_ptr;
-                            }
-                        }
-                    }
-                    let _ = &mut *part;
-                    continue 'outer_part_loop;
+            if p.has_called_runtime {
+                let mut runtime_imports: [u8; RuntimeImports::ALL.len()] =
+                    [0; RuntimeImports::ALL.len()];
+                let mut iter = p.runtime_imports.iter();
+                let mut i: usize = 0;
+                while let Some(entry) = iter.next() {
+                    runtime_imports[i] = u8::try_from(entry.key).expect("int cast");
+                    i += 1;
                 }
-            }
-        } else if p.options.bundle && parts.is_empty() {
-            // This flag is disabled because it breaks circular export * as from
-            //
-            //  entry.js:
-            //
-            //    export * from './foo';
-            //
-            //  foo.js:
-            //
-            //    export const foo = 123
-            //    export * as ns from './foo'
-            //
-            // This is permanently disabled (see the circular-export breakage above).
-            if false {
-                // If the file only contains "export * from './blah'
-                // we pretend the file never existed in the first place.
-                // the semantic difference here is in export default statements
-                // note: export_star_import_records are not filled in yet
 
-                if !before.is_empty() && p.import_records.len() == 1 {
-                    let export_star_redirect: Option<&S::ExportStar> = 'brk: {
-                        let mut export_star: Option<&S::ExportStar> = None;
-                        for part in before.iter() {
-                            for stmt in part.stmts.iter() {
-                                match &stmt.data {
-                                    js_ast::StmtData::SExportStar(star) => {
-                                        if star.alias.is_some() {
-                                            break 'brk None;
-                                        }
-
-                                        if export_star.is_some() {
-                                            break 'brk None;
-                                        }
-
-                                        export_star = Some(&**star);
-                                    }
-                                    js_ast::StmtData::SEmpty(_) | js_ast::StmtData::SComment(_) => {
-                                    }
-                                    _ => {
-                                        break 'brk None;
-                                    }
-                                }
-                            }
-                        }
-                        export_star
-                    };
-
-                    if let Some(star) = export_star_redirect {
-                        return Ok(crate::Result::Ast(Box::new(js_ast::Ast {
-                            import_records: p.import_records.move_to_baby_list(p.arena),
-                            redirect_import_record_index: Some(star.import_record_index),
-                            named_imports: core::mem::take(&mut *p.named_imports),
-                            named_exports: core::mem::take(&mut p.named_exports),
-                            ..js_ast::Ast::empty_in(p.arena)
-                        })));
-                    }
-                }
-            }
-        }
-
-        // Analyze cross-part dependencies for tree shaking and code splitting.
-        // The if/else-if/else-match below exhaustively assigns this on every path.
-        let mut exports_kind: js_ast::ExportsKind;
-        let exports_ref_usage_count =
-            p.symbols.as_slice()[p.exports_ref.inner_index() as usize].use_count_estimate;
-        let uses_exports_ref = exports_ref_usage_count > 0;
-
-        if uses_exports_ref && p.commonjs_named_exports.count() > 0 && !force_esm {
-            p.deoptimize_commonjs_named_exports();
-        }
-
-        let uses_module_ref =
-            p.symbols.as_slice()[p.module_ref.inner_index() as usize].use_count_estimate > 0;
-
-        let mut wrap_mode: WrapMode = WrapMode::None;
-
-        if p.is_deoptimized_commonjs() {
-            exports_kind = js_ast::ExportsKind::Cjs;
-        } else if p.esm_export_keyword.len > 0 || p.top_level_await_keyword.len > 0 {
-            exports_kind = js_ast::ExportsKind::Esm;
-        } else if uses_exports_ref || uses_module_ref || p.has_top_level_return || p.has_with_scope
-        {
-            exports_kind = js_ast::ExportsKind::Cjs;
-            if p.options.features.commonjs_at_runtime {
-                wrap_mode = WrapMode::BunCommonjs;
-
-                let import_record: Option<&ImportRecord> = 'brk: {
-                    for import_record in p.import_records.items() {
-                        if import_record.flags.intersects(
-                            ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED,
-                        ) {
-                            continue;
-                        }
-                        if import_record.kind == bun_ast::ImportKind::Stmt {
-                            break 'brk Some(import_record);
-                        }
-                    }
-
-                    None
-                };
-
-                // make it an error to use an import statement with a commonjs exports usage
-                if let Some(record) = import_record {
-                    // find the usage of the export symbol
-
-                    let mut notes = BumpVec::<bun_ast::Data>::new_in(p.arena);
-
-                    notes.push(bun_ast::Data {
-                        text: {
-                            use std::io::Write;
-                            let mut v = Vec::<u8>::new();
-                            let _ = write!(
-                                &mut v,
-                                "Try require({}) instead",
-                                bun_core::fmt::QuotedFormatter {
-                                    text: record.path.text
-                                }
-                            );
-                            std::borrow::Cow::Owned(v)
-                        },
-                        ..Default::default()
-                    });
-
-                    if uses_module_ref {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because 'module' was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if uses_exports_ref {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because 'exports' was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if p.has_top_level_return {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because top-level return was used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    if p.has_with_scope {
-                        notes.push(bun_ast::Data {
-                            text: std::borrow::Cow::Borrowed(
-                                b"This file is CommonJS because a \"with\" statement is used",
-                            ),
-                            ..Default::default()
-                        });
-                    }
-
-                    p.log().add_range_error_with_notes(
-                        Some(p.source),
-                        record.range,
-                        b"Cannot use import statement with CommonJS-only features".as_slice(),
-                        notes.into_iter().collect::<Vec<_>>().into_boxed_slice(),
-                    );
-                }
-            }
-        } else {
-            match p.options.module_type {
-                // ".cjs" or ".cts" or ("type: commonjs" and (".js" or ".jsx" or ".ts" or ".tsx"))
-                options::ModuleType::Cjs => {
-                    // There are no commonjs-only features used (require is allowed in ESM)
-                    debug_assert!(
-                        !uses_exports_ref
-                            && !uses_module_ref
-                            && !p.has_top_level_return
-                            && !p.has_with_scope
-                    );
-                    // Use ESM if the file has ES module syntax (import)
-                    exports_kind = if p.has_es_module_syntax {
-                        js_ast::ExportsKind::Esm
-                    } else {
-                        js_ast::ExportsKind::Cjs
-                    };
-                }
-                options::ModuleType::Esm => {
-                    exports_kind = js_ast::ExportsKind::Esm;
-                }
-                options::ModuleType::Unknown => {
-                    // Divergence from esbuild and Node.js: we default to ESM
-                    // when there are no exports.
-                    //
-                    // However, this breaks certain packages.
-                    // For example, the checkpoint-client used by
-                    // Prisma does an eval("__dirname") but does not export
-                    // anything.
-                    //
-                    // If they use an import statement, we say it's ESM because that's not allowed in CommonJS files.
-                    let uses_any_import_statements = 'brk: {
-                        for import_record in p.import_records.items() {
-                            if import_record.flags.intersects(
-                                ImportRecordFlags::IS_INTERNAL | ImportRecordFlags::IS_UNUSED,
-                            ) {
-                                continue;
-                            }
-                            if import_record.kind == bun_ast::ImportKind::Stmt {
-                                break 'brk true;
-                            }
-                        }
-
-                        false
-                    };
-
-                    if uses_any_import_statements {
-                        exports_kind = js_ast::ExportsKind::Esm;
-                    }
-                    // Otherwise, if they use CommonJS features its CommonJS.
-                    // If you add a 'use strict'; at the top, you probably meant CommonJS because "use strict"; does nothing in ESM.
-                    else if p.symbols.as_slice()[p.require_ref.inner_index() as usize]
-                        .use_count_estimate
-                        > 0
-                        || uses_dirname
-                        || uses_filename
-                        || (!p.options.bundle
-                            // SAFETY: `module_scope` is non-null after `prepare_for_visit_pass`.
-                            && p.module_scope().strict_mode
-                                == bun_ast::StrictModeKind::ExplicitStrictMode)
-                    {
-                        exports_kind = js_ast::ExportsKind::Cjs;
-                    } else {
-                        // If unknown, we default to ESM
-                        exports_kind = js_ast::ExportsKind::Esm;
-                    }
-                }
-            }
-
-            if exports_kind == js_ast::ExportsKind::Cjs && p.options.features.commonjs_at_runtime {
-                wrap_mode = WrapMode::BunCommonjs;
-            }
-        }
-
-        // Handle dirname and filename at runtime.
-        //
-        // If we reach this point, it means:
-        //
-        // 1) we are building an ESM file that uses __dirname or __filename
-        // 2) we are targeting bun's runtime.
-        // 3) we are not bundling.
-        //
-        if exports_kind == js_ast::ExportsKind::Esm && (uses_dirname || uses_filename) {
-            debug_assert!(!p.options.bundle);
-            let count = (uses_dirname as usize) + (uses_filename as usize);
-            let mut declared_symbols =
-                bun_ast::DeclaredSymbolList::init_capacity(count).expect("unreachable");
-            let decls = p
-                .arena
-                .alloc_slice_fill_with::<G::Decl, _>(count, |_| G::Decl::default());
-            if uses_dirname {
-                // var __dirname = import.meta
-                let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
-                decls[0] = G::Decl {
-                    binding: p.b(
-                        B::Identifier {
-                            r#ref: p.dirname_ref,
-                        },
-                        bun_ast::Loc::EMPTY,
-                    ),
-                    value: Some(p.new_expr(
-                        E::Dot {
-                            name: b"dir".into(),
-                            name_loc: bun_ast::Loc::EMPTY,
-                            target: import_meta,
-                            ..Default::default()
-                        },
-                        bun_ast::Loc::EMPTY,
-                    )),
-                };
-                declared_symbols.append_assume_capacity(DeclaredSymbol {
-                    ref_: p.dirname_ref,
-                    is_top_level: true,
-                });
-            }
-            if uses_filename {
-                // var __filename = import.meta.path
-                let import_meta = p.new_expr(E::ImportMeta {}, bun_ast::Loc::EMPTY);
-                decls[uses_dirname as usize] = G::Decl {
-                    binding: p.b(
-                        B::Identifier {
-                            r#ref: p.filename_ref,
-                        },
-                        bun_ast::Loc::EMPTY,
-                    ),
-                    value: Some(p.new_expr(
-                        E::Dot {
-                            name: b"path".into(),
-                            name_loc: bun_ast::Loc::EMPTY,
-                            target: import_meta,
-                            ..Default::default()
-                        },
-                        bun_ast::Loc::EMPTY,
-                    )),
-                };
-                declared_symbols.append_assume_capacity(DeclaredSymbol {
-                    ref_: p.filename_ref,
-                    is_top_level: true,
-                });
-            }
-
-            let part_stmts = p.arena.alloc_slice_fill_with(1, |_| {
-                p.s(
-                    S::Local {
-                        kind: js_ast::LocalKind::KVar,
-                        decls: {
-                            let mut dl = G::DeclList::init_capacity(decls.len());
-                            for d in decls.iter_mut() {
-                                dl.append_assume_capacity(core::mem::take(d));
-                            }
-                            dl
-                        },
-                        ..Default::default()
-                    },
-                    bun_ast::Loc::EMPTY,
-                )
-            });
-            before.push(js_ast::Part {
-                stmts: part_stmts.into(),
-                declared_symbols,
-                tag: bun_ast::PartTag::DirnameFilename,
-                ..Default::default()
-            });
-        }
-
-        if exports_kind == js_ast::ExportsKind::Esm
-            && p.commonjs_named_exports.count() > 0
-            && !p.unwrap_all_requires
-            && !force_esm
-        {
-            exports_kind = js_ast::ExportsKind::EsmWithDynamicFallbackFromCjs;
-        }
-
-        // Auto inject jest globals into the test file
-        'outer: {
-            if !p.options.features.inject_jest_globals {
-                break 'outer;
-            }
-
-            for item in p.import_records.items() {
-                // skip if they did import it
-                if item.path.text == b"bun:test"
-                    || item.path.text == b"@jest/globals"
-                    || item.path.text == b"vitest"
-                {
-                    if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                        // If we rewrote import paths, we need to disable the runtime transpiler cache
-                        if item.path.text != b"bun:test" {
-                            cache.input_hash = None;
-                        }
-                    }
-
-                    break 'outer;
-                }
-            }
-
-            // if they didn't use any of the jest globals, don't inject it, I guess.
-            // Iterates the static `Jest::FIELDS`
-            // table (`&[(&'static str, fn(&Jest) -> Ref)]`); declaration order
-            // determines the emitted clause/property order.
-            let items_count: usize = {
-                let mut count: usize = 0;
-                for (_name, get_ref) in Jest::FIELDS {
-                    count += (p.symbols.as_slice()[get_ref(&p.jest).inner_index() as usize]
-                        .use_count_estimate
-                        > 0) as usize;
-                }
-                count
-            };
-            if items_count == 0 {
-                break 'outer;
-            }
-
-            let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
-            declared_symbols.ensure_total_capacity(items_count)?;
-
-            // For CommonJS modules, use require instead of import
-            if exports_kind == js_ast::ExportsKind::Cjs {
-                let import_record_id = p.add_import_record(
-                    bun_ast::ImportKind::Require,
-                    bun_ast::Loc::EMPTY,
-                    b"bun:test",
-                );
-
-                // Create object binding pattern for destructuring
-                let mut properties = BumpVec::<B::Property>::with_capacity_in(items_count, p.arena);
-                for (symbol_name, get_ref) in Jest::FIELDS {
-                    let r = get_ref(&p.jest);
-                    if p.symbols.as_slice()[r.inner_index() as usize].use_count_estimate > 0 {
-                        let key = p.new_expr(
-                            E::String {
-                                data: symbol_name.as_bytes().into(),
-                                ..Default::default()
-                            },
-                            bun_ast::Loc::EMPTY,
-                        );
-                        let value = p.b(B::Identifier { r#ref: r }, bun_ast::Loc::EMPTY);
-                        properties.push(B::Property {
-                            flags: bun_ast::flags::PROPERTY_NONE,
-                            key,
-                            value,
-                            default_value: None,
-                        });
-                        declared_symbols.append_assume_capacity(DeclaredSymbol {
-                            ref_: r,
-                            is_top_level: true,
-                        });
-                    }
-                }
-                let properties = bun_ast::StoreSlice::from_bump(properties);
-
-                // Create: const { test, expect, ... } = require("bun:test")
-                let binding = p.b(
-                    B::Object {
-                        properties,
-                        is_single_line: false,
-                    },
-                    bun_ast::Loc::EMPTY,
-                );
-                let value = p.new_expr(
-                    E::RequireString {
-                        import_record_index: import_record_id,
-                        ..Default::default()
-                    },
-                    bun_ast::Loc::EMPTY,
-                );
-                let mut decls = G::DeclList::init_capacity(1);
-                decls.append_assume_capacity(G::Decl {
-                    binding,
-                    value: Some(value),
+                runtime_imports[0..i].sort_unstable_by(|a, b| {
+                    RuntimeImports::ALL_SORTED_INDEX[*a as usize]
+                        .cmp(&RuntimeImports::ALL_SORTED_INDEX[*b as usize])
                 });
 
-                let local_stmt = p.s(
-                    S::Local {
-                        kind: js_ast::LocalKind::KConst,
-                        decls,
-                        ..Default::default()
-                    },
-                    bun_ast::Loc::EMPTY,
-                );
-                let part_stmts = p.arena.alloc_slice_fill_with(1, |_| local_stmt);
-
-                before.push(js_ast::Part {
-                    stmts: part_stmts.into(),
-                    declared_symbols,
-                    import_record_indices: js_ast::PartImportRecordIndices::init_one(
-                        import_record_id,
-                    ),
-                    tag: bun_ast::PartTag::BunTest,
-                    ..Default::default()
-                });
-            } else {
-                let import_record_id = p.add_import_record(
-                    bun_ast::ImportKind::Stmt,
-                    bun_ast::Loc::EMPTY,
-                    b"bun:test",
-                );
-
-                // For ESM modules, use import statement
-                let mut clauses =
-                    BumpVec::<js_ast::ClauseItem>::with_capacity_in(items_count, p.arena);
-                for (symbol_name, get_ref) in Jest::FIELDS {
-                    let r = get_ref(&p.jest);
-                    if p.symbols.as_slice()[r.inner_index() as usize].use_count_estimate > 0 {
-                        clauses.push(js_ast::ClauseItem {
-                            name: js_ast::LocRef {
-                                ref_: Some(r),
-                                loc: bun_ast::Loc::EMPTY,
-                            },
-                            alias: js_ast::StoreStr::new(symbol_name.as_bytes()),
-                            alias_loc: bun_ast::Loc::EMPTY,
-                            original_name: js_ast::StoreStr::new(b""),
-                        });
-                        declared_symbols.append_assume_capacity(DeclaredSymbol {
-                            ref_: r,
-                            is_top_level: true,
-                        });
-                    }
-                }
-                let clauses = bun_ast::StoreSlice::from_bump(clauses);
-
-                let namespace_ref = p
-                    .declare_symbol(
-                        js_ast::symbol::Kind::Unbound,
-                        bun_ast::Loc::EMPTY,
-                        b"bun_test_import_namespace_for_internal_use_only",
+                if i > 0 {
+                    // snapshot to break the `&mut self` ↔ `&self.runtime_imports`
+                    // borrow overlap in `generate_import_stmt(symbols: &Sym)`; the callee
+                    // never touches `self.runtime_imports`, so the clone is purely a
+                    // borrow-checker workaround.
+                    let symbols = p.runtime_imports.clone();
+                    p.generate_import_stmt(
+                        RuntimeImports::NAME,
+                        &runtime_imports[0..i],
+                        &mut before,
+                        &symbols,
+                        None,
+                        b"import_",
+                        true,
                     )
                     .expect("unreachable");
-                let import_stmt = p.s(
-                    S::Import {
-                        namespace_ref,
-                        items: clauses,
-                        import_record_index: import_record_id,
-                        default_name: None,
-                        star_name_loc: None,
-                        is_single_line: false,
-                        phase_defer: false,
-                    },
-                    bun_ast::Loc::EMPTY,
-                );
-
-                let part_stmts = p.arena.alloc_slice_fill_with(1, |_| import_stmt);
-                before.push(js_ast::Part {
-                    stmts: part_stmts.into(),
-                    declared_symbols,
-                    import_record_indices: js_ast::PartImportRecordIndices::init_one(
-                        import_record_id,
-                    ),
-                    tag: bun_ast::PartTag::BunTest,
-                    ..Default::default()
-                });
-            }
-
-            // If we injected jest globals, we need to disable the runtime transpiler cache
-            if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                cache.input_hash = None;
-            }
-        }
-
-        if p.has_called_runtime {
-            let mut runtime_imports: [u8; RuntimeImports::ALL.len()] =
-                [0; RuntimeImports::ALL.len()];
-            let mut iter = p.runtime_imports.iter();
-            let mut i: usize = 0;
-            while let Some(entry) = iter.next() {
-                runtime_imports[i] = u8::try_from(entry.key).expect("int cast");
-                i += 1;
-            }
-
-            runtime_imports[0..i].sort_unstable_by(|a, b| {
-                RuntimeImports::ALL_SORTED_INDEX[*a as usize]
-                    .cmp(&RuntimeImports::ALL_SORTED_INDEX[*b as usize])
-            });
-
-            if i > 0 {
-                // snapshot to break the `&mut self` ↔ `&self.runtime_imports`
-                // borrow overlap in `generate_import_stmt(symbols: &Sym)`; the callee
-                // never touches `self.runtime_imports`, so the clone is purely a
-                // borrow-checker workaround.
-                let symbols = p.runtime_imports.clone();
-                p.generate_import_stmt(
-                    RuntimeImports::NAME,
-                    &runtime_imports[0..i],
-                    &mut before,
-                    &symbols,
-                    None,
-                    b"import_",
-                    true,
-                )
-                .expect("unreachable");
-            }
-        }
-
-        // handle new way to do automatic JSX imports which fixes symbol collision issues
-        if p.options.jsx.parse
-            && p.options.features.auto_import_jsx
-            && p.options.jsx.runtime == options::JSX::Runtime::Automatic
-        {
-            // `generate_import_stmt` takes `&mut self` plus `import_path: &'a [u8]`
-            // and `symbols: &Sym`, so the Pragma-owned `Box<[u8]>` paths are copied into the
-            // bump arena (giving them the required `'a` lifetime) and `jsx_imports` is moved
-            // out via `take` (it is `Default`) to avoid an overlapping `&self.jsx_imports`
-            // borrow. The callee never reads `self.jsx_imports`, so the take/restore is
-            // semantically a no-op.
-            let import_source: &'a [u8] = p.arena.alloc_slice_copy(p.options.jsx.import_source());
-            let package_name: &'a [u8] = p.arena.alloc_slice_copy(&p.options.jsx.package_name);
-            let jsx_imports = core::mem::take(&mut p.jsx_imports);
-
-            let mut buf: [&'static [u8]; 3] = [b"", b"", b""];
-            let runtime_import_names = jsx_imports.runtime_import_names(&mut buf);
-
-            if !runtime_import_names.is_empty() {
-                p.generate_import_stmt(
-                    import_source,
-                    runtime_import_names,
-                    &mut before,
-                    &jsx_imports,
-                    None,
-                    b"",
-                    false,
-                )
-                .expect("unreachable");
-            }
-
-            let source_import_names = jsx_imports.source_import_names();
-            if !source_import_names.is_empty() {
-                p.generate_import_stmt(
-                    package_name,
-                    source_import_names,
-                    &mut before,
-                    &jsx_imports,
-                    None,
-                    b"",
-                    false,
-                )
-                .expect("unreachable");
-            }
-
-            p.jsx_imports = jsx_imports;
-        }
-
-        if p.server_components_wrap_ref.is_valid() {
-            let fw = p.options.framework.unwrap_or_else(|| {
-                panic!("server components requires a framework configured, but none was set")
-            });
-            let sc = fw.server_components.as_ref().unwrap();
-            p.generate_react_refresh_import(
-                &mut before,
-                &sc.server_runtime_import[..],
-                &[crate::p::ReactRefreshImportClause {
-                    name: &sc.server_register_client_reference[..],
-                    r#ref: p.server_components_wrap_ref,
-                    enabled: true,
-                }],
-            )?;
-        }
-
-        if p.react_refresh.register_used || p.react_refresh.signature_used {
-            p.generate_react_refresh_import(
-                &mut before,
-                match p.options.framework {
-                    Some(fw) => &fw.react_fast_refresh.as_ref().unwrap().import_source[..],
-                    None => b"react-refresh/runtime",
-                },
-                &[
-                    crate::p::ReactRefreshImportClause {
-                        name: b"register",
-                        enabled: p.react_refresh.register_used,
-                        r#ref: p.react_refresh.register_ref,
-                    },
-                    crate::p::ReactRefreshImportClause {
-                        name: b"createSignatureFunctionForTransform",
-                        enabled: p.react_refresh.signature_used,
-                        r#ref: p.react_refresh.create_signature_ref,
-                    },
-                ],
-            )?;
-        }
-
-        // Bake: transform global `Response` to use `import { Response } from 'bun:app'`
-        #[allow(deprecated)]
-        if !p.response_ref.is_null() && {
-            // We only want to do this if the symbol is used and didn't get
-            // bound to some other value
-            let symbol: &Symbol = &p.symbols.as_slice()[p.response_ref.inner_index() as usize];
-            !symbol.has_link() && symbol.use_count_estimate > 0
-        } {
-            p.generate_import_stmt_for_bake_response(&mut before)?;
-        }
-
-        if !before.is_empty() || !after.is_empty() {
-            // Single up-front reserve; the inner
-            // reserve() calls in prepend_from / append become no-ops.
-            parts.reserve(before.len() + after.len());
-            parts.prepend_from(&mut before);
-            parts.append(&mut after);
-        }
-
-        // Pop the module scope to apply the "ContainsDirectEval" rules
-        // p.popScope();
-
-        #[cfg(not(target_arch = "wasm32"))]
-        if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {
-            if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
-                if p.macro_call_count != 0 {
-                    // disable this for:
-                    // - macros
-                    cache.input_hash = None;
-                } else {
-                    cache.exports_kind = exports_kind;
                 }
             }
-        }
 
-        Ok(crate::Result::Ast(p.to_ast(
-            &mut parts,
-            exports_kind,
-            wrap_mode,
-            hashbang,
-        )?))
+            // handle new way to do automatic JSX imports which fixes symbol collision issues
+            if p.options.jsx.parse
+                && p.options.features.auto_import_jsx
+                && p.options.jsx.runtime == options::JSX::Runtime::Automatic
+            {
+                // `generate_import_stmt` takes `&mut self` plus `import_path: &'a [u8]`
+                // and `symbols: &Sym`, so the Pragma-owned `Box<[u8]>` paths are copied into the
+                // bump arena (giving them the required `'a` lifetime) and `jsx_imports` is moved
+                // out via `take` (it is `Default`) to avoid an overlapping `&self.jsx_imports`
+                // borrow. The callee never reads `self.jsx_imports`, so the take/restore is
+                // semantically a no-op.
+                let import_source: &'a [u8] =
+                    p.arena.alloc_slice_copy(p.options.jsx.import_source());
+                let package_name: &'a [u8] = p.arena.alloc_slice_copy(&p.options.jsx.package_name);
+                let jsx_imports = core::mem::take(&mut p.jsx_imports);
+
+                let mut buf: [&'static [u8]; 3] = [b"", b"", b""];
+                let runtime_import_names = jsx_imports.runtime_import_names(&mut buf);
+
+                if !runtime_import_names.is_empty() {
+                    p.generate_import_stmt(
+                        import_source,
+                        runtime_import_names,
+                        &mut before,
+                        &jsx_imports,
+                        None,
+                        b"",
+                        false,
+                    )
+                    .expect("unreachable");
+                }
+
+                let source_import_names = jsx_imports.source_import_names();
+                if !source_import_names.is_empty() {
+                    p.generate_import_stmt(
+                        package_name,
+                        source_import_names,
+                        &mut before,
+                        &jsx_imports,
+                        None,
+                        b"",
+                        false,
+                    )
+                    .expect("unreachable");
+                }
+
+                p.jsx_imports = jsx_imports;
+            }
+
+            if p.server_components_wrap_ref.is_valid() {
+                let fw = p.options.framework.unwrap_or_else(|| {
+                    panic!("server components requires a framework configured, but none was set")
+                });
+                let sc = fw.server_components.as_ref().unwrap();
+                p.generate_react_refresh_import(
+                    &mut before,
+                    &sc.server_runtime_import[..],
+                    &[crate::p::ReactRefreshImportClause {
+                        name: &sc.server_register_client_reference[..],
+                        r#ref: p.server_components_wrap_ref,
+                        enabled: true,
+                    }],
+                )?;
+            }
+
+            if p.react_refresh.register_used || p.react_refresh.signature_used {
+                p.generate_react_refresh_import(
+                    &mut before,
+                    match p.options.framework {
+                        Some(fw) => &fw.react_fast_refresh.as_ref().unwrap().import_source[..],
+                        None => b"react-refresh/runtime",
+                    },
+                    &[
+                        crate::p::ReactRefreshImportClause {
+                            name: b"register",
+                            enabled: p.react_refresh.register_used,
+                            r#ref: p.react_refresh.register_ref,
+                        },
+                        crate::p::ReactRefreshImportClause {
+                            name: b"createSignatureFunctionForTransform",
+                            enabled: p.react_refresh.signature_used,
+                            r#ref: p.react_refresh.create_signature_ref,
+                        },
+                    ],
+                )?;
+            }
+
+            // Bake: transform global `Response` to use `import { Response } from 'bun:app'`
+            #[allow(deprecated)]
+            if !p.response_ref.is_null() && {
+                // We only want to do this if the symbol is used and didn't get
+                // bound to some other value
+                let symbol: &Symbol = &p.symbols.as_slice()[p.response_ref.inner_index() as usize];
+                !symbol.has_link() && symbol.use_count_estimate > 0
+            } {
+                p.generate_import_stmt_for_bake_response(&mut before)?;
+            }
+
+            if !before.is_empty() || !after.is_empty() {
+                // Single up-front reserve; the inner
+                // reserve() calls in prepend_from / append become no-ops.
+                parts.reserve(before.len() + after.len());
+                parts.prepend_from(&mut before);
+                parts.append(&mut after);
+            }
+
+            // Pop the module scope to apply the "ContainsDirectEval" rules
+            // p.popScope();
+
+            #[cfg(not(target_arch = "wasm32"))]
+            if bun_core::feature_flags::RUNTIME_TRANSPILER_CACHE {
+                if let Some(cache) = p.options.features.runtime_transpiler_cache_mut() {
+                    if p.macro_call_count != 0 {
+                        // disable this for:
+                        // - macros
+                        cache.input_hash = None;
+                    } else {
+                        cache.exports_kind = exports_kind;
+                    }
+                }
+            }
+
+            Ok(crate::Result::Ast(p.to_ast(
+                &mut parts,
+                exports_kind,
+                wrap_mode,
+                hashbang,
+            )?))
         };
 
         run(&mut *p).map_err(|err| ParseFailure {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1319,9 +1319,8 @@ impl VirtualMachine {
                 // bound; the generated entry point is
                 // boxed into `macro_entry_points` and lives for the VM
                 // lifetime, and `entry_path` is only borrowed for the
-                // duration of `generate` (it is formatted into the
-                // `Source`-owned generated code; the path label backing
-                // `source.path.text` is copied into `label_storage`).
+                // duration of `generate` (it is copied into entry-owned
+                // storage).
                 let entry_path_static: &'static [u8] = bun_ast::IntoStr::into_str(entry_path);
                 MacroEntryPoint::generate(
                     &mut *ep,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1319,7 +1319,9 @@ impl VirtualMachine {
                 // bound; the generated entry point is
                 // boxed into `macro_entry_points` and lives for the VM
                 // lifetime, and `entry_path` is only borrowed for the
-                // duration of `generate` (it copies into `code_buffer`).
+                // duration of `generate` (it is formatted into the
+                // `Source`-owned generated code; the path label backing
+                // `source.path.text` is copied into `label_storage`).
                 let entry_path_static: &'static [u8] = bun_ast::IntoStr::into_str(entry_path);
                 MacroEntryPoint::generate(
                     &mut *ep,

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -30,12 +30,6 @@ pub enum ImportWatcher {
     Watch(Box<Watcher>),
 }
 
-// Drift guard for the bun_watcher CYCLEBREAK `Loader` newtype: its `File`
-// constant must mirror `bun_ast::Loader::File` —
-// the watcher stores that value for auto-watched directories. This crate sees
-// both types, so the compile-time check lives here.
-const _: () = assert!(bun_watcher::Loader::File.0 == bun_ast::Loader::File as u8);
-
 impl ImportWatcher {
     pub fn start(&mut self) -> Result<(), bun_core::Error> {
         match self {
@@ -107,11 +101,9 @@ impl ImportWatcher {
 
     #[inline]
     pub fn add_file_by_path_slow(&mut self, file_path: &[u8], loader: bun_ast::Loader) -> bool {
-        // Note: bun_watcher::Loader is an opaque newtype over u8;
-        // wrap the bun_ast::Loader discriminant.
         match self {
             ImportWatcher::Hot(w) | ImportWatcher::Watch(w) => {
-                w.add_file_by_path_slow(file_path, bun_watcher::Loader(loader as u8))
+                w.add_file_by_path_slow(file_path, loader)
             }
             ImportWatcher::None => true,
         }
@@ -131,14 +123,7 @@ impl ImportWatcher {
     ) -> bun_sys::Result<()> {
         match self {
             ImportWatcher::Hot(watcher) | ImportWatcher::Watch(watcher) => watcher
-                .add_file::<COPY_FILE_PATH>(
-                    fd,
-                    file_path,
-                    hash,
-                    bun_watcher::Loader(loader as u8),
-                    dir_fd,
-                    package_json,
-                ),
+                .add_file::<COPY_FILE_PATH>(fd, file_path, hash, loader, dir_fd, package_json),
             ImportWatcher::None => Ok(()),
         }
     }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1531,7 +1531,7 @@ pub mod js_bundler {
                 // Faster path: skip the extra threadpool dispatch
                 // SAFETY: bv2 backref is valid; pool/worker_pool are live for bundle.
                 unsafe {
-                    (*(*(*this.bv2).graph.pool.as_ptr()).worker_pool).schedule(
+                    (*(*this.bv2).graph.pool.as_ptr()).worker_pool().schedule(
                         bun_threading::thread_pool::Batch::from(core::ptr::addr_of_mut!(
                             (*this.parse_task.as_ptr()).task
                         )),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2892,10 +2892,13 @@ impl<const SSL: bool> NewSocket<SSL> {
             .rare_data()
             .bun_connect_group::<true>(vm);
         // SAFETY: `raw_socket` is the live `*mut us_socket_t` extracted from
-        // `InternalSocket::Connected` above; `owned_ssl_ctx` is the +1 ref
-        // taken from SecureContext/ssl_ctx_cache and never null here.
+        // `InternalSocket::Connected` above; per the adopt_tls contract it is
+        // consumed here and never used again (only `new_raw` from here on);
+        // `owned_ssl_ctx` is the +1 ref taken from SecureContext/ssl_ctx_cache
+        // and never null here.
         let new_raw: NonNull<uws::us_socket_t> = match unsafe {
-            (*raw_socket).adopt_tls(
+            uws::us_socket_t::adopt_tls(
+                raw_socket,
                 group,
                 uws::SocketKind::BunSocketTls,
                 &mut *((*tls_ptr).owned_ssl_ctx.get().unwrap()),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2891,11 +2891,8 @@ impl<const SSL: bool> NewSocket<SSL> {
             .as_mut()
             .rare_data()
             .bun_connect_group::<true>(vm);
-        // SAFETY: `raw_socket` is the live `*mut us_socket_t` extracted from
-        // `InternalSocket::Connected` above; per the adopt_tls contract it is
-        // consumed here and never used again (only `new_raw` from here on);
-        // `owned_ssl_ctx` is the +1 ref taken from SecureContext/ssl_ctx_cache
-        // and never null here.
+        // SAFETY: `raw_socket` is live and consumed here (only `new_raw` is
+        // used after); `owned_ssl_ctx` is a +1 ref, never null here.
         let new_raw: NonNull<uws::us_socket_t> = match unsafe {
             uws::us_socket_t::adopt_tls(
                 raw_socket,

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -265,7 +265,9 @@ impl<'a> Snapshots<'a> {
             &arena,
         )?;
 
-        let parse_result = parser.parse()?;
+        // `parse()` fails with a `ParseFailure` (error + failing-token range);
+        // only the error is needed here — the range is for diagnostics.
+        let parse_result = parser.parse().map_err(|failure| failure.err)?;
         let mut ast = match parse_result {
             bun_js_parser::Result::Ast(ast) => ast,
             _ => return Err(bun_core::err!("ParseError")),

--- a/src/runtime/test_runner/snapshot.rs
+++ b/src/runtime/test_runner/snapshot.rs
@@ -265,8 +265,6 @@ impl<'a> Snapshots<'a> {
             &arena,
         )?;
 
-        // `parse()` fails with a `ParseFailure` (error + failing-token range);
-        // only the error is needed here — the range is for diagnostics.
         let parse_result = parser.parse().map_err(|failure| failure.err)?;
         let mut ast = match parse_result {
             bun_js_parser::Result::Ast(ast) => ast,

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -353,16 +353,20 @@ impl MySQLConnection {
         // the slot as `Option<NonNull<_>>`.
         let ext_size = core::mem::size_of::<Option<core::ptr::NonNull<JSMySQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`; adopt_tls may
-        // realloc and return a different ptr.
-        let Some(new_socket) = (unsafe { &mut *raw }).adopt_tls(
-            tls_group,
-            bun_uws::SocketKind::MysqlTls,
-            ssl_ctx,
-            sni,
-            ext_size,
-            ext_size,
-        ) else {
+        // SAFETY: `raw` is a live connected `us_socket_t*`, consumed by this
+        // call and never used again (adopt_tls may realloc and return a
+        // different ptr; only `new_socket` is used from here on).
+        let Some(new_socket) = (unsafe {
+            uws::us_socket_t::adopt_tls(
+                raw,
+                tls_group,
+                bun_uws::SocketKind::MysqlTls,
+                ssl_ctx,
+                sni,
+                ext_size,
+                ext_size,
+            )
+        }) else {
             return Err(FlushQueueError::AuthenticationFailed);
         };
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -353,9 +353,8 @@ impl MySQLConnection {
         // the slot as `Option<NonNull<_>>`.
         let ext_size = core::mem::size_of::<Option<core::ptr::NonNull<JSMySQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`, consumed by this
-        // call and never used again (adopt_tls may realloc and return a
-        // different ptr; only `new_socket` is used from here on).
+        // SAFETY: `raw` is a live connected socket, consumed here (adopt_tls
+        // may realloc; only `new_socket` is used after).
         let Some(new_socket) = (unsafe {
             uws::us_socket_t::adopt_tls(
                 raw,

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -465,9 +465,8 @@ impl PostgresSQLConnection {
         let ext_size =
             core::mem::size_of::<Option<core::ptr::NonNull<PostgresSQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`, consumed by this
-        // call and never used again (adopt_tls may realloc and return a
-        // different ptr; only `new_socket` is used from here on).
+        // SAFETY: `raw` is a live connected socket, consumed here (adopt_tls
+        // may realloc; only `new_socket` is used after).
         let Some(new_socket) = (unsafe {
             uws::us_socket_t::adopt_tls(
                 raw,

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -465,16 +465,20 @@ impl PostgresSQLConnection {
         let ext_size =
             core::mem::size_of::<Option<core::ptr::NonNull<PostgresSQLConnection>>>() as i32;
 
-        // SAFETY: `raw` is a live connected `us_socket_t*`; adopt_tls may
-        // realloc and return a different ptr.
-        let Some(new_socket) = (unsafe { &mut *raw }).adopt_tls(
-            tls_group,
-            bun_uws::SocketKind::PostgresTls,
-            ssl_ctx,
-            sni,
-            ext_size,
-            ext_size,
-        ) else {
+        // SAFETY: `raw` is a live connected `us_socket_t*`, consumed by this
+        // call and never used again (adopt_tls may realloc and return a
+        // different ptr; only `new_socket` is used from here on).
+        let Some(new_socket) = (unsafe {
+            uws::us_socket_t::adopt_tls(
+                raw,
+                tls_group,
+                bun_uws::SocketKind::PostgresTls,
+                ssl_ctx,
+                sni,
+                ext_size,
+                ext_size,
+            )
+        }) else {
             self.fail(
                 b"Failed to upgrade to TLS",
                 AnyPostgresError::TLSUpgradeFailed,

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -212,24 +212,15 @@ impl us_socket_t {
     }
 
     /// Move this socket to a new group/kind, optionally resizing its ext.
-    /// Returns the (possibly relocated) socket.
-    ///
-    /// Takes a raw pointer (not `&mut self`) on purpose: the C side may
-    /// reallocate the socket, so a `&mut self` receiver would leave the caller
-    /// holding a reference to a freed allocation after the call.
+    /// Returns the (possibly relocated) socket. Raw pointer (not `&mut self`)
+    /// because the C side may reallocate.
     ///
     /// # Safety
-    /// `this` must point to a live socket. The call consumes the allocation:
-    /// `this` (and any pointer derived from it, e.g. into its ext storage) is
-    /// invalid after the call. Re-bind exclusively to the returned pointer.
-    ///
-    /// Edge case: if the socket is already closed or shut down, the C side
-    /// early-returns the OLD pointer without resizing ext or re-stamping
-    /// group/kind. The returned pointer is then the input allocation,
-    /// un-resized and still dispatched under the old kind — callers must not
-    /// repoint ext to a new owner type in that case, or events will be
-    /// dispatched on the old kind with the new ext (type confusion). Do not
-    /// adopt sockets that may be shut down.
+    /// `this` must be a live socket and is consumed: `this` and any derived
+    /// pointer (e.g. into ext) are invalid after the call; re-bind to the
+    /// returned pointer. For an already closed/shut-down socket the C side
+    /// returns the OLD pointer un-resized and un-restamped — repointing ext
+    /// then is type confusion. Do not adopt sockets that may be shut down.
     pub unsafe fn adopt(
         this: *mut us_socket_t,
         g: &mut SocketGroup,
@@ -249,17 +240,11 @@ impl us_socket_t {
     /// `us_socket_upgrade_to_tls` / `wrapTLS`.
     ///
     /// # Safety
-    /// Same contract as [`Self::adopt`]: `this` must point to a live socket
-    /// and must not be used after the call — the C side may reallocate and
-    /// return a different pointer. Re-bind exclusively to the returned
-    /// pointer (including any `ext` pointers, which must be re-derived from
-    /// the new allocation before `start_tls_handshake`).
-    ///
-    /// Edge case: the C side returns `NULL` only for already-closed sockets;
-    /// a half-shut-down socket (`shutdown(WR)`) hits [`Self::adopt`]'s
-    /// early-return and yields the OLD allocation un-resized and
-    /// un-restamped — see the caveat on [`Self::adopt`]. Do not call this on
-    /// sockets that may be shut down.
+    /// Same contract as [`Self::adopt`]: `this` is consumed; re-bind to the
+    /// returned pointer (re-derive any `ext` pointers before
+    /// `start_tls_handshake`). `NULL` is returned only for already-closed
+    /// sockets; a half-shut-down socket yields the OLD allocation un-resized
+    /// (see [`Self::adopt`]). Do not call on sockets that may be shut down.
     pub unsafe fn adopt_tls(
         this: *mut us_socket_t,
         g: &mut SocketGroup,

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -212,17 +212,34 @@ impl us_socket_t {
     }
 
     /// Move this socket to a new group/kind, optionally resizing its ext.
-    /// Returns the (possibly relocated) socket; `self` is invalid after.
-    // TODO: take `self` by value — it is consumed/invalidated; the returned ptr may be a different allocation
-    pub fn adopt(
-        &mut self,
+    /// Returns the (possibly relocated) socket.
+    ///
+    /// Takes a raw pointer (not `&mut self`) on purpose: the C side may
+    /// reallocate the socket, so a `&mut self` receiver would leave the caller
+    /// holding a reference to a freed allocation after the call.
+    ///
+    /// # Safety
+    /// `this` must point to a live socket. The call consumes the allocation:
+    /// `this` (and any pointer derived from it, e.g. into its ext storage) is
+    /// invalid after the call. Re-bind exclusively to the returned pointer.
+    ///
+    /// Edge case: if the socket is already closed or shut down, the C side
+    /// early-returns the OLD pointer without resizing ext or re-stamping
+    /// group/kind. The returned pointer is then the input allocation,
+    /// un-resized and still dispatched under the old kind — callers must not
+    /// repoint ext to a new owner type in that case, or events will be
+    /// dispatched on the old kind with the new ext (type confusion). Do not
+    /// adopt sockets that may be shut down.
+    pub unsafe fn adopt(
+        this: *mut us_socket_t,
         g: &mut SocketGroup,
         k: SocketKind,
         old_ext: i32,
         new_ext: i32,
     ) -> Option<NonNull<us_socket_t>> {
-        // SAFETY: self and g are live; C may realloc and return a different us_socket_t*
-        unsafe { NonNull::new(c::us_socket_adopt(self, g, k as u8, old_ext, new_ext)) }
+        // SAFETY: caller contract — `this` and `g` are live; C may realloc and
+        // return a different us_socket_t*
+        unsafe { NonNull::new(c::us_socket_adopt(this, g, k as u8, old_ext, new_ext)) }
     }
 
     /// `adopt` + attach a fresh `SSL*` from `ssl_ctx` (refcounted by the C
@@ -230,9 +247,21 @@ impl us_socket_t {
     /// caller must repoint `ext` first (so any dispatch lands in the new
     /// owner) and then call `start_tls_handshake`. Replaces
     /// `us_socket_upgrade_to_tls` / `wrapTLS`.
-    // TODO: take `self` by value — it is consumed/invalidated; the returned ptr may be a different allocation
-    pub fn adopt_tls(
-        &mut self,
+    ///
+    /// # Safety
+    /// Same contract as [`Self::adopt`]: `this` must point to a live socket
+    /// and must not be used after the call — the C side may reallocate and
+    /// return a different pointer. Re-bind exclusively to the returned
+    /// pointer (including any `ext` pointers, which must be re-derived from
+    /// the new allocation before `start_tls_handshake`).
+    ///
+    /// Edge case: the C side returns `NULL` only for already-closed sockets;
+    /// a half-shut-down socket (`shutdown(WR)`) hits [`Self::adopt`]'s
+    /// early-return and yields the OLD allocation un-resized and
+    /// un-restamped — see the caveat on [`Self::adopt`]. Do not call this on
+    /// sockets that may be shut down.
+    pub unsafe fn adopt_tls(
+        this: *mut us_socket_t,
         g: &mut SocketGroup,
         k: SocketKind,
         ssl_ctx: &mut SslCtx,
@@ -240,11 +269,12 @@ impl us_socket_t {
         old_ext: i32,
         new_ext: i32,
     ) -> Option<NonNull<us_socket_t>> {
-        // SAFETY: self/g/ssl_ctx are live; sni is null or a valid C string; C may
-        // realloc and return a different us_socket_t*
+        // SAFETY: caller contract — `this`/`g`/`ssl_ctx` are live; sni is null
+        // or a valid C string; C may realloc and return a different
+        // us_socket_t*
         unsafe {
             NonNull::new(c::us_socket_adopt_tls(
-                self,
+                this,
                 g,
                 k as u8,
                 ssl_ctx,

--- a/src/watcher/Cargo.toml
+++ b/src/watcher/Cargo.toml
@@ -19,6 +19,7 @@ enum-map.workspace = true
 enumset.workspace = true
 libc.workspace = true
 bitflags.workspace = true
+bun_ast.workspace = true
 bun_core.workspace = true
 bun_ptr.workspace = true
 bun_collections.workspace = true

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -221,34 +221,19 @@ impl Watcher {
 
     pub fn start(&mut self) -> Result<(), bun_core::Error> {
         debug_assert!(!self.watchloop_handle.load());
-        /// The heap `Watcher` pointer handed to the spawned watcher thread.
-        ///
-        /// `Watcher` itself is not `Send` (raw `ctx` pointer), so the crossing
-        /// is made explicit with this newtype instead of laundering the
-        /// pointer through `usize`.
+        /// `Watcher` is not `Send` (raw `ctx` pointer); this newtype makes
+        /// the thread crossing explicit.
         struct WatcherThreadPtr(*mut Watcher);
         impl WatcherThreadPtr {
-            /// Consume the wrapper for the inner pointer. A method (rather
-            /// than field destructuring inside the spawned closure) so the
-            /// closure captures the whole `Send` newtype — precise closure
-            /// capture would otherwise capture the raw `.0` field directly
-            /// and lose the `unsafe impl Send`.
+            /// A method (not field destructuring in the closure) so the
+            /// closure captures the whole `Send` newtype, not the raw `.0`.
             fn into_inner(self) -> *mut Watcher {
                 self.0
             }
         }
-        // SAFETY: ownership invariant (see `shutdown`): exactly one of
-        // {watcher thread, `shutdown` caller} reclaims the heap `Watcher`,
-        // decided by `watchloop_handle`. Until `thread_main` reclaims the Box
-        // the allocation stays live. This invariant covers only *who frees
-        // the Box* — it does NOT make the crossing fully sound. Known gaps,
-        // deferred to the fix in progress for issue #30644:
-        // - `thread_main` holds `&mut Watcher` for the whole watch loop while
-        //   the main thread derives `&mut Watcher` for `add_file`/
-        //   `append_file`; `mutex` guards the watchlist data but not the
-        //   whole-struct `&mut` aliasing.
-        // - A thread that was spawned but has not yet stored
-        //   `watchloop_handle = true` races `shutdown`'s no-thread free path.
+        // SAFETY: exactly one of {watcher thread, `shutdown` caller} reclaims
+        // the heap `Watcher`, decided by `watchloop_handle` (see `shutdown`).
+        // Known aliasing/race gaps remain; tracked in #30644.
         unsafe impl Send for WatcherThreadPtr {}
         let this = WatcherThreadPtr(std::ptr::from_mut::<Watcher>(self));
         self.thread = Some(
@@ -256,9 +241,8 @@ impl Watcher {
                 .name("FileWatcher".into())
                 .spawn(move || {
                     let this = this.into_inner();
-                    // SAFETY: `this` is the unique heap pointer produced by
-                    // `init()`; the spawned thread takes ownership and
-                    // `thread_main` reclaims the Box after the loop exits.
+                    // SAFETY: unique heap pointer from `init()`; the thread
+                    // owns it and `thread_main` reclaims the Box.
                     let _ = unsafe { Watcher::thread_main(this) };
                 })
                 .expect("spawn FileWatcher thread"),
@@ -273,21 +257,14 @@ impl Watcher {
     // watcher thread instead of dropping here).
     //
     // Ownership invariant: exactly one of {watcher thread, shutdown caller}
-    // reclaims the heap `Watcher`, decided by `watchloop_handle`. Once
-    // `thread_main` has stored `true`, the thread owns the Box and frees it
-    // after `watch_loop` exits; this function only signals it via
-    // `running`/`close_descriptors`. Otherwise the Box is reclaimed inline
-    // here.
+    // reclaims the heap `Watcher`, decided by `watchloop_handle`. If the
+    // thread owns it, this function only signals via
+    // `running`/`close_descriptors`; otherwise the Box is reclaimed inline.
     /// # Safety
     /// `this` must be the unique heap pointer returned from `init()`; ownership
-    /// transfers here on the no-thread path (the Box is reclaimed). Must not
-    /// be called after the watcher thread may already have freed the Box
-    /// (i.e. call it at most once, before dropping the last reference to the
-    /// watcher), and must not be called concurrently with a freshly spawned
-    /// watcher thread that has not yet stored `watchloop_handle = true` — in
-    /// that window this function takes the no-thread free path while the
-    /// thread still holds the pointer (known race, deferred to the fix in
-    /// progress for issue #30644).
+    /// transfers here on the no-thread path (the Box is reclaimed). Call at
+    /// most once, and not concurrently with a freshly spawned watcher thread
+    /// that has not yet stored `watchloop_handle = true` (known race, #30644).
     pub unsafe fn shutdown(this: *mut Self, close_descriptors: bool) {
         // SAFETY: caller passes the unique heap pointer returned from init()
         let me = unsafe { &mut *this };

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -221,16 +221,45 @@ impl Watcher {
 
     pub fn start(&mut self) -> Result<(), bun_core::Error> {
         debug_assert!(!self.watchloop_handle.load());
-        // Watcher must be Send across the spawned thread boundary; we pass a
-        // raw pointer (as usize) and uphold the safety contract manually.
-        let this = std::ptr::from_mut::<Watcher>(self) as usize;
-        // SAFETY: Watcher outlives the thread; shutdown() coordinates teardown
-        // via `running`/`close_descriptors` and the thread frees the Box.
+        /// The heap `Watcher` pointer handed to the spawned watcher thread.
+        ///
+        /// `Watcher` itself is not `Send` (raw `ctx` pointer), so the crossing
+        /// is made explicit with this newtype instead of laundering the
+        /// pointer through `usize`.
+        struct WatcherThreadPtr(*mut Watcher);
+        impl WatcherThreadPtr {
+            /// Consume the wrapper for the inner pointer. A method (rather
+            /// than field destructuring inside the spawned closure) so the
+            /// closure captures the whole `Send` newtype — precise closure
+            /// capture would otherwise capture the raw `.0` field directly
+            /// and lose the `unsafe impl Send`.
+            fn into_inner(self) -> *mut Watcher {
+                self.0
+            }
+        }
+        // SAFETY: ownership invariant (see `shutdown`): exactly one of
+        // {watcher thread, `shutdown` caller} reclaims the heap `Watcher`,
+        // decided by `watchloop_handle`. Until `thread_main` reclaims the Box
+        // the allocation stays live. This invariant covers only *who frees
+        // the Box* — it does NOT make the crossing fully sound. Known gaps,
+        // deferred to the fix in progress for issue #30644:
+        // - `thread_main` holds `&mut Watcher` for the whole watch loop while
+        //   the main thread derives `&mut Watcher` for `add_file`/
+        //   `append_file`; `mutex` guards the watchlist data but not the
+        //   whole-struct `&mut` aliasing.
+        // - A thread that was spawned but has not yet stored
+        //   `watchloop_handle = true` races `shutdown`'s no-thread free path.
+        unsafe impl Send for WatcherThreadPtr {}
+        let this = WatcherThreadPtr(std::ptr::from_mut::<Watcher>(self));
         self.thread = Some(
             std::thread::Builder::new()
                 .name("FileWatcher".into())
-                .spawn(move || unsafe {
-                    let _ = Watcher::thread_main(this as *mut Watcher);
+                .spawn(move || {
+                    let this = this.into_inner();
+                    // SAFETY: `this` is the unique heap pointer produced by
+                    // `init()`; the spawned thread takes ownership and
+                    // `thread_main` reclaims the Box after the loop exits.
+                    let _ = unsafe { Watcher::thread_main(this) };
                 })
                 .expect("spawn FileWatcher thread"),
         );
@@ -242,10 +271,23 @@ impl Watcher {
     // Per PORTING.md, `pub fn deinit` is never the public name; renamed to
     // `shutdown` (not `close(self)` because ownership may transfer to the
     // watcher thread instead of dropping here).
-    // TODO: ownership model — needs heap::take or an Arc to make this sound.
+    //
+    // Ownership invariant: exactly one of {watcher thread, shutdown caller}
+    // reclaims the heap `Watcher`, decided by `watchloop_handle`. Once
+    // `thread_main` has stored `true`, the thread owns the Box and frees it
+    // after `watch_loop` exits; this function only signals it via
+    // `running`/`close_descriptors`. Otherwise the Box is reclaimed inline
+    // here.
     /// # Safety
     /// `this` must be the unique heap pointer returned from `init()`; ownership
-    /// transfers here on the no-thread path (the Box is reclaimed).
+    /// transfers here on the no-thread path (the Box is reclaimed). Must not
+    /// be called after the watcher thread may already have freed the Box
+    /// (i.e. call it at most once, before dropping the last reference to the
+    /// watcher), and must not be called concurrently with a freshly spawned
+    /// watcher thread that has not yet stored `watchloop_handle = true` — in
+    /// that window this function takes the no-thread free path while the
+    /// thread still holds the pointer (known race, deferred to the fix in
+    /// progress for issue #30644).
     pub unsafe fn shutdown(this: *mut Self, close_descriptors: bool) {
         // SAFETY: caller passes the unique heap pointer returned from init()
         let me = unsafe { &mut *this };
@@ -321,9 +363,8 @@ impl Watcher {
         Output::flush();
 
         // SAFETY: `this` is the heap allocation from init(); the watcher thread
-        // owns it now and no `&`/`&mut` borrow of it remains live (the scoped
-        // `me` above has ended).
-        // TODO: ownership model — see shutdown()
+        // owns it now (ownership invariant — see `shutdown`) and no `&`/`&mut`
+        // borrow of it remains live (the scoped `me` above has ended).
         drop(unsafe { bun_core::heap::take(this) });
         Ok(())
     }

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -36,21 +36,8 @@ pub use watcher_impl::{
     WatchItem, WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
 };
 
-// ─── upward-crate placeholders (CYCLEBREAK) ───────────────────────────────
-//
-// These belong to higher-tier crates that don't yet expose a usable surface
-// to depend on. Watcher only stores/passes them through; never dereferenced.
-
-/// Opaque forward-decl of `bun_ast::Loader` (cycle-break: bun_watcher sits
-/// below bun_ast in the crate graph). Watcher only stores the value in
-/// `WatchItem.loader` and passes it through; callers construct it via
-/// `Loader(bun_ast::Loader as u8)` at the boundary.
-#[derive(Clone, Copy, Default)]
-pub struct Loader(pub u8);
-impl Loader {
-    /// Mirrors `bun_ast::Loader::File as u8`;
-    /// keep the discriminant in sync with `src/ast/loader.rs`. A compile-time
-    /// drift guard lives in `src/jsc/hot_reloader.rs` (a crate that sees both
-    /// types).
-    pub const File: Loader = Loader(5);
-}
+/// The watcher only stores `Loader` in `WatchItem.loader` and passes it
+/// through. `bun_ast` has no dependency on `bun_watcher`, so depending on the
+/// real type is acyclic; re-exporting it replaces the old duplicate `u8`
+/// newtype (and the compile-time drift guard that kept the two in sync).
+pub use bun_ast::Loader;

--- a/src/watcher/lib.rs
+++ b/src/watcher/lib.rs
@@ -36,8 +36,6 @@ pub use watcher_impl::{
     WatchItem, WatchItemColumns, WatchItemIndex, WatchItemKind, WatchList, Watcher, WatcherContext,
 };
 
-/// The watcher only stores `Loader` in `WatchItem.loader` and passes it
-/// through. `bun_ast` has no dependency on `bun_watcher`, so depending on the
-/// real type is acyclic; re-exporting it replaces the old duplicate `u8`
-/// newtype (and the compile-time drift guard that kept the two in sync).
+/// Stored in `WatchItem.loader` and passed through; replaces the old
+/// cycle-break `u8` newtype.
 pub use bun_ast::Loader;

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1391,3 +1391,127 @@ test("Bun.build can be called thousands of times in one process without crashing
   expect(stdout.trim()).toBe("OK 400");
   expect(exitCode).toBe(0);
 }, 180_000);
+
+describe("bundler worker pool ownership", () => {
+  // Exercise test for an internal ownership refactor (no user-visible
+  // behavior change): it cannot fail on the pre-refactor code, but a
+  // regression in pool ownership shows up here as a crash/double-free,
+  // especially under ASAN.
+  // In-process `Bun.build()` borrows the process-wide worker pool, while the
+  // CLI `bun build` path creates — and must tear down — its own pool. Run both
+  // repeatedly: a double-free or leaked-ownership bug in the bundler
+  // ThreadPool's owned-vs-borrowed pool handling crashes or corrupts the
+  // following build instead of completing it.
+  test("repeated in-process builds (borrowed pool) stay healthy", async () => {
+    const dir = tempDirWithFiles("build-pool-borrowed", {
+      "entry.js": `import { value } from "./dep.js";\nconsole.log(value);`,
+      "dep.js": `export const value = "pool-ok";`,
+    });
+
+    for (let i = 0; i < 8; i++) {
+      const build = await Bun.build({
+        entrypoints: [join(dir, "entry.js")],
+      });
+      expect(build.success).toBe(true);
+      expect(await build.outputs[0].text()).toContain("pool-ok");
+    }
+  });
+
+  test("CLI build (owned pool) completes and exits cleanly", async () => {
+    const dir = tempDirWithFiles("build-pool-owned", {
+      "entry.js": `import { value } from "./dep.js";\nconsole.log(value);`,
+      "dep.js": `export const value = "pool-ok";`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", join(dir, "entry.js")],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toContain("pool-ok");
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe("bundle-owned parse-task contents", () => {
+  // Exercise test for an internal ownership refactor (no user-visible
+  // behavior change): it cannot fail on the pre-refactor code, but a stale
+  // or freed borrow on a worker thread shows up here as corrupted output or
+  // a crash, especially under ASAN.
+  // `data:` URL bodies live in the bundle's free list, and JS onLoad plugin
+  // buffers live in the graph's input-file storage; parse tasks running on
+  // worker threads only borrow them. Build repeatedly with both kinds of
+  // contents (one large enough that a stale borrow crashes loudly or produces
+  // corrupt output) and execute the result.
+  test("data: URL and onLoad plugin contents stay alive for the bundle pass", async () => {
+    const SIZE = 256 * 1024;
+    const big = `"${"x".repeat(SIZE)}"`;
+    const dir = tempDirWithFiles("build-contents-provenance", {
+      "entry.js": `
+        import "data:text/javascript,globalThis.fromDataURL=1;";
+        import { size } from "virtual:big";
+        console.log("size=" + size, "data=" + globalThis.fromDataURL);
+      `,
+    });
+
+    for (let i = 0; i < 4; i++) {
+      const build = await Bun.build({
+        entrypoints: [join(dir, "entry.js")],
+        plugins: [
+          {
+            name: "virtual-big",
+            setup(builder) {
+              builder.onResolve({ filter: /^virtual:big$/ }, args => ({
+                path: args.path,
+                namespace: "virt",
+              }));
+              builder.onLoad({ filter: /.*/, namespace: "virt" }, () => ({
+                contents: `const data = ${big}; export const size = data.length;`,
+                loader: "js",
+              }));
+            },
+          },
+        ],
+      });
+      expect(build.success).toBe(true);
+
+      const outFile = join(dir, `out-${i}.js`);
+      await Bun.write(outFile, await build.outputs[0].text());
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), outFile],
+        env: bunEnv,
+        cwd: dir,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toBe(`size=${SIZE} data=1`);
+      expect(exitCode).toBe(0);
+    }
+  });
+});
+
+test("syntax error diagnostics point at the failing token", async () => {
+  // Pins the pre-existing contract that a plain syntax error produces a
+  // BuildMessage with a real position (the lexer logs a ranged diagnostic
+  // before the parser bails). NOTE: this does NOT cover the rarer
+  // parse-failed-with-zero-logged-errors fallback path (where the diagnostic
+  // range comes from the parse failure payload instead of a logged lexer
+  // error) — a plain syntax error like this one always logs a ranged lexer
+  // error first, so that fallback never fires here.
+  const dir = tempDirWithFiles("syntax-error-position", {
+    "bad.ts": `const ok = 1;\nconst broken = {;\n`,
+  });
+  const x = await buildNoThrow({
+    entrypoints: [join(dir, "bad.ts")],
+    outdir: join(dir, "out"),
+  });
+  expect(x.success).toBe(false);
+  expect(x.logs.length).toBeGreaterThanOrEqual(1);
+  const withPosition = x.logs.find(l => l.position);
+  expect(withPosition).toBeTruthy();
+  expect(withPosition!.position!.lineText).toContain("broken");
+});

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1448,7 +1448,7 @@ describe("bundle-owned parse-task contents", () => {
   // corrupt output) and execute the result.
   test("data: URL and onLoad plugin contents stay alive for the bundle pass", async () => {
     const SIZE = 256 * 1024;
-    const big = `"${"x".repeat(SIZE)}"`;
+    const big = `"${Buffer.alloc(SIZE, "x").toString()}"`;
     const dir = tempDirWithFiles("build-contents-provenance", {
       "entry.js": `
         import "data:text/javascript,globalThis.fromDataURL=1;";

--- a/test/bundler/bun-build-api.test.ts
+++ b/test/bundler/bun-build-api.test.ts
@@ -1393,15 +1393,9 @@ test("Bun.build can be called thousands of times in one process without crashing
 }, 180_000);
 
 describe("bundler worker pool ownership", () => {
-  // Exercise test for an internal ownership refactor (no user-visible
-  // behavior change): it cannot fail on the pre-refactor code, but a
-  // regression in pool ownership shows up here as a crash/double-free,
-  // especially under ASAN.
-  // In-process `Bun.build()` borrows the process-wide worker pool, while the
-  // CLI `bun build` path creates — and must tear down — its own pool. Run both
-  // repeatedly: a double-free or leaked-ownership bug in the bundler
-  // ThreadPool's owned-vs-borrowed pool handling crashes or corrupts the
-  // following build instead of completing it.
+  // In-process `Bun.build()` borrows the process-wide worker pool; CLI
+  // `bun build` creates and tears down its own. An ownership bug shows up as
+  // a crash/double-free, especially under ASAN.
   test("repeated in-process builds (borrowed pool) stay healthy", async () => {
     const dir = tempDirWithFiles("build-pool-borrowed", {
       "entry.js": `import { value } from "./dep.js";\nconsole.log(value);`,
@@ -1437,15 +1431,10 @@ describe("bundler worker pool ownership", () => {
 });
 
 describe("bundle-owned parse-task contents", () => {
-  // Exercise test for an internal ownership refactor (no user-visible
-  // behavior change): it cannot fail on the pre-refactor code, but a stale
-  // or freed borrow on a worker thread shows up here as corrupted output or
-  // a crash, especially under ASAN.
-  // `data:` URL bodies live in the bundle's free list, and JS onLoad plugin
-  // buffers live in the graph's input-file storage; parse tasks running on
-  // worker threads only borrow them. Build repeatedly with both kinds of
-  // contents (one large enough that a stale borrow crashes loudly or produces
-  // corrupt output) and execute the result.
+  // `data:` URL bodies live in the bundle's free list and onLoad plugin
+  // buffers in the graph's input-file storage; parse tasks on worker threads
+  // only borrow them. A stale borrow shows up as corrupted output or a
+  // crash, especially under ASAN.
   test("data: URL and onLoad plugin contents stay alive for the bundle pass", async () => {
     const SIZE = 256 * 1024;
     const big = `"${Buffer.alloc(SIZE, "x").toString()}"`;
@@ -1495,13 +1484,10 @@ describe("bundle-owned parse-task contents", () => {
 });
 
 test("syntax error diagnostics point at the failing token", async () => {
-  // Pins the pre-existing contract that a plain syntax error produces a
-  // BuildMessage with a real position (the lexer logs a ranged diagnostic
-  // before the parser bails). NOTE: this does NOT cover the rarer
-  // parse-failed-with-zero-logged-errors fallback path (where the diagnostic
-  // range comes from the parse failure payload instead of a logged lexer
-  // error) — a plain syntax error like this one always logs a ranged lexer
-  // error first, so that fallback never fires here.
+  // A plain syntax error must produce a BuildMessage with a real position.
+  // Does NOT cover the parse-failed-with-zero-logged-errors fallback (range
+  // from the parse failure payload) — the lexer always logs a ranged error
+  // first here.
   const dir = tempDirWithFiles("syntax-error-position", {
     "bad.ts": `const ok = 1;\nconst broken = {;\n`,
   });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -132,17 +132,10 @@ test("ireturnapromise", async () => {
 });
 
 test("macro entry points stay valid across GC and repeated imports", async () => {
-  // Exercise test for an internal ownership refactor (no user-visible
-  // behavior change): it cannot fail on the pre-refactor code, but a dangling
-  // entry-point label or contents shows up here as a crash or corrupted
-  // module text, especially under ASAN.
-  // Each (module, export) macro pair generates a synthetic macro entry-point
-  // source that is cached for the VM lifetime; its generated code and its
-  // label (the entry's module-path text) must stay readable while JSC loads
-  // the entry and after later garbage collections. Use a deeply nested import
-  // path (long label), several distinct macros, and forced GC between
-  // transpiles — a dangling entry-point source crashes or corrupts the output
-  // instead of printing the expected lines.
+  // Each (module, export) macro pair caches a synthetic entry-point source
+  // for the VM lifetime; its code and path label must stay readable across
+  // GCs. A dangling entry-point source crashes or corrupts output,
+  // especially under ASAN.
   const deep = "deep/".repeat(16);
   const macroModule = `
     export function one() { return 1; }

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -1,5 +1,6 @@
 import { escapeHTML } from "bun" assert { type: "macro" };
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import defaultMacro, {
   addStrings,
   addStringsUTF16,
@@ -128,4 +129,59 @@ test("namespace import", () => {
 
 test("ireturnapromise", async () => {
   expect(await ireturnapromise()).toEqual("aaa");
+});
+
+test("macro entry points stay valid across GC and repeated imports", async () => {
+  // Exercise test for an internal ownership refactor (no user-visible
+  // behavior change): it cannot fail on the pre-refactor code, but a dangling
+  // entry-point label or contents shows up here as a crash or corrupted
+  // module text, especially under ASAN.
+  // Each (module, export) macro pair generates a synthetic macro entry-point
+  // source that is cached for the VM lifetime; its generated code and its
+  // label (the entry's module-path text) must stay readable while JSC loads
+  // the entry and after later garbage collections. Use a deeply nested import
+  // path (long label), several distinct macros, and forced GC between
+  // transpiles — a dangling entry-point source crashes or corrupts the output
+  // instead of printing the expected lines.
+  const deep = "deep/".repeat(16);
+  const macroModule = `
+    export function one() { return 1; }
+    export function two() { return "two"; }
+    export function three() { return { n: 3 }; }
+  `;
+  const files: Record<string, string> = {
+    [`${deep}macros.ts`]: macroModule,
+    "main.ts": `
+      for (let i = 0; i < 3; i++) {
+        Bun.gc(true);
+        const m = await import("./fixture-" + i + ".ts");
+        console.log(m.result);
+        Bun.gc(true);
+      }
+    `,
+  };
+  for (let i = 0; i < 3; i++) {
+    files[`fixture-${i}.ts`] = `
+      import { one, two, three } from "./${deep}macros.ts" assert { type: "macro" };
+      export const result = JSON.stringify([one(), two(), three()]);
+    `;
+  }
+  using dir = tempDir("macro-entry-points", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Debug builds print unscoped "[macro] call <name>" logger lines; drop them
+  // before comparing.
+  const lines = stdout
+    .trim()
+    .split("\n")
+    .filter(line => !line.startsWith("[macro]"));
+  expect(lines.join("\n")).toBe(Array(3).fill('[1,"two",{"n":3}]').join("\n"));
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -770,14 +770,9 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
 it(
   "--hot process that exits right after the watcher starts shuts down cleanly",
   async () => {
-    // Regression pin for the watcher teardown window targeted by the fix in
-    // progress for issue #30644 (deinit right after init): the file-watcher
-    // thread takes ownership of its heap state at startup and frees it during
-    // teardown; exiting immediately after start exercises the narrow window
-    // between thread spawn and the watch loop running. Repeat a few times so
-    // a racy teardown shows up as a crash or bad exit code. This pins the
-    // currently-working behavior; it is not a differential test for the Send
-    // newtype change (which is behavior-preserving by design).
+    // Exiting right after start exercises the narrow window between watcher
+    // thread spawn and the watch loop running (#30644); a racy teardown
+    // shows up as a crash or bad exit code.
     using dir = tempDir("hot-immediate-exit", {
       "exit.js": `console.log("ready");\nprocess.exit(0);\n`,
     });

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { beforeEach, expect, it } from "bun:test";
 import { copyFileSync, cpSync, readFileSync, renameSync, rmSync, unlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, isDebug, tmpdirSync, waitForFileToExist } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync, waitForFileToExist } from "harness";
 import { join } from "path";
 
 const timeout = isDebug ? Infinity : 10_000;
@@ -765,4 +765,35 @@ ${Buffer.alloc(counter * 2, " ").toString()}throw new Error(${counter});`,
     // TODO: bun has a memory leak when --hot is used on very large files
   },
   longTimeout,
+);
+
+it(
+  "--hot process that exits right after the watcher starts shuts down cleanly",
+  async () => {
+    // Regression pin for the watcher teardown window targeted by the fix in
+    // progress for issue #30644 (deinit right after init): the file-watcher
+    // thread takes ownership of its heap state at startup and frees it during
+    // teardown; exiting immediately after start exercises the narrow window
+    // between thread spawn and the watch loop running. Repeat a few times so
+    // a racy teardown shows up as a crash or bad exit code. This pins the
+    // currently-working behavior; it is not a differential test for the Send
+    // newtype change (which is behavior-preserving by design).
+    using dir = tempDir("hot-immediate-exit", {
+      "exit.js": `console.log("ready");\nprocess.exit(0);\n`,
+    });
+    for (let i = 0; i < 5; i++) {
+      await using proc = spawn({
+        cmd: [bunExe(), "--hot", "run", "exit.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("ready\n");
+      expect(exitCode).toBe(0);
+    }
+  },
+  timeout,
 );

--- a/test/cli/hot/hot.test.ts
+++ b/test/cli/hot/hot.test.ts
@@ -785,8 +785,9 @@ it(
         stderr: "pipe",
         stdin: "ignore",
       });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stdout).toBe("ready\n");
+      expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     }
   },


### PR DESCRIPTION
Two coupled change sets that share the bundler ParseTask contents-ownership API (`ContentsOrFd::bundle_owned`), landed together because neither compiles alone.

## Make socket adopt consuming, formalize watcher thread handoff, thread parse-failure ranges, dedupe watcher Loader

Four related cleanups around unsound or lossy seams. us_socket_t::adopt/adopt_tls previously took &mut self even though the C side may reallocate the socket, leaving the caller's reference pointing at a freed allocation; they are now unsafe associated functions taking the raw pointer with an explicit consume-the-allocation contract, and all three TLS-upgrade call sites (Bun.connect upgradeTLS, MySQL, Postgres) were re-audited to only touch the returned pointer. The file-watcher thread spawn no longer launders its heap pointer through usize: an explicit Send newtype carries the documented single-owner handoff invariant, and the ownership contract between shutdown() and thread_main() is now documented at both ends. js_parser's Parser::parse now returns a ParseFailure { err, range } payload that captures the lexer's token range at the moment of failure (the parser is consumed by value, so the range was previously lost and bundler diagnostics fell back to an empty range); the bundler cache uses it to point parse-failure diagnostics at the failing token. Finally, bun_watcher's duplicate u8 Loader newtype (plus its compile-time drift guard in hot_reloader) is replaced by re-exporting bun_ast::Loader directly — the dependency is acyclic. Tested with a forced-GC upgradeTLS subprocess loop, a --hot immediate-exit lifecycle test, and a Bun.build syntax-error position assertion.

## Make bundler ParseTask contents, worker-pool ownership, and entry-point sources ownership-explicit

Three latent-UAF-shaped ownership erasures in the bundler are made explicit. ParseTask's ContentsOrFd::Contents previously carried a bare lifetime-erased &'static [u8] whose backing could be static, graph-owned, or free-list-owned with nothing recording which; it now carries a ContentsBacking enum (Static vs BundleOwned) with constructors at every site, and the worker-side conversion now tags the bytes as SharedBuffer (caller-kept-alive) consistently with the non-plugin read path instead of External. The bundler ThreadPool's raw worker_pool pointer plus worker_pool_is_owned flag is replaced by a private Owned(Box)/Borrowed(ParentRef) enum with the existing safe worker_pool() accessor; the one raw field deref in JSBundler.rs now goes through the accessor, and deinit frees only the Owned arm (the struct is arena-allocated, so the box is still freed explicitly, never by drop glue). The entry-point generators (FallbackEntryPoint, ClientEntryPoint, MacroEntryPoint) no longer store Sources that borrow inline buffers in the same struct: generated code is now owned by the Source (Cow::Owned, so clones deep-copy), path text borrows a heap Box that is address-stable across moves, and MacroEntryPoint drops ~66KB of dead inline buffers per cached macro entry. Tested via repeated in-process Bun.build (borrowed pool) and CLI bun build (owned pool), a build that round-trips data: URL and large onLoad plugin contents through worker threads and executes the output, and a subprocess macro test using a deeply nested macro module with forced GC between transpiles.

## Verification

Implemented and verified on a unified integration branch: full debug build (linux-x64, ASAN), cargo check across the workspace, and the affected test files run against the debug build (failures cross-checked against main's build to exclude pre-existing issues). Each change was reviewed twice (compile/API correctness and GC/concurrency/semantics lenses) with findings repaired before landing.
