### PR TITLE
Parse computed string literal enum member names

### DIFF
--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -640,9 +640,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.lexer.next()?;
                 js_lexer::is_identifier(value.name.slice())
             } else if p.lexer.token == T::TOpenBracket {
-                // TypeScript allows computed enum member names when the
-                // expression is a string literal or a substitution-free
-                // template literal: "enum E { ['a'] = 1, [`b`] = 2 }".
+                // tsc accepts ['a'] and [`a`] (substitution-free) as member names.
                 p.lexer.next()?;
                 if p.lexer.token != T::TStringLiteral
                     && p.lexer.token != T::TNoSubstitutionTemplateLiteral

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -637,16 +637,34 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let estr = p.lexer.to_utf8_e_string()?;
                 debug_assert!(!estr.is_utf16);
                 value.name = estr.data;
+                p.lexer.next()?;
+                js_lexer::is_identifier(value.name.slice())
+            } else if p.lexer.token == T::TOpenBracket {
+                // TypeScript allows computed enum member names when the
+                // expression is a string literal or a substitution-free
+                // template literal: "enum E { ['a'] = 1, [`b`] = 2 }".
+                p.lexer.next()?;
+                if p.lexer.token != T::TStringLiteral
+                    && p.lexer.token != T::TNoSubstitutionTemplateLiteral
+                {
+                    p.lexer.expect(T::TStringLiteral)?;
+                    return Err(crate::Error::SyntaxError);
+                }
+                let estr = p.lexer.to_utf8_e_string()?;
+                debug_assert!(!estr.is_utf16);
+                value.name = estr.data;
+                p.lexer.next()?;
+                p.lexer.expect(T::TCloseBracket)?;
                 js_lexer::is_identifier(value.name.slice())
             } else if p.lexer.is_identifier_or_keyword() {
                 value.name = js_ast::StoreStr::new(p.lexer.identifier);
+                p.lexer.next()?;
                 true
             } else {
                 p.lexer.expect(T::TIdentifier)?;
                 // error early, name is still `undefined`
                 return Err(crate::Error::SyntaxError);
             };
-            p.lexer.next()?;
 
             // Identifiers can be referenced by other values
             if !opts.is_typescript_declare && needs_symbol {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1058,8 +1058,37 @@ describe("Bun.Transpiler", () => {
     it("malformed enums", () => {
       const err = ts.expectParseError;
 
-      err("enum Foo { [2]: 'hi' }", 'Expected identifier but found "["');
+      err("enum Foo { [2]: 'hi' }", 'Expected string but found "2"');
       err("enum [] { a }", 'Expected identifier but found "["');
+      // Only string literals and substitution-free template literals are
+      // valid computed enum member names.
+      err("enum Foo { ['a' + 'b'] = 1 }", 'Expected "]" but found "+"');
+      err("enum Foo { [`t${1}`] = 1 }", 'Expected string but found "`t${"');
+      err("enum Foo { [Symbol.iterator] = 1 }", 'Expected string but found "Symbol"');
+    });
+
+    it("enum members with computed string literal names", () => {
+      const exp = ts.expectPrinted_;
+
+      exp(
+        "enum E { ['with space'] = 1 }",
+        'var E;\n((E) => {\n  E[E["with space"] = 1] = "with space";\n})(E ||= {});\n',
+      );
+      exp("enum E { [`tmpl`] = 2 }", 'var E;\n((E) => {\n  E[E["tmpl"] = 2] = "tmpl";\n})(E ||= {});\n');
+      // A computed name that is a valid identifier can be referenced by
+      // later members, same as a string literal name.
+      exp(
+        "enum E { ['A'] = 5, B = A * 2 }",
+        'var E;\n((E) => {\n  E[E["A"] = 5] = "A";\n  E[E["B"] = 10] = "B";\n})(E ||= {});\n',
+      );
+      exp(
+        "enum E { ['x'], ['y z'] }",
+        'var E;\n((E) => {\n  E[E["x"] = 0] = "x";\n  E[E["y z"] = 1] = "y z";\n})(E ||= {});\n',
+      );
+      exp(
+        "const enum CE { ['c'] = 9 } console.log(CE.c)",
+        'var CE;\n((CE) => {\n  CE[CE["c"] = 9] = "c";\n})(CE ||= {});\nconsole.log(9 /* c */);\n',
+      );
     });
 
     it("rejects yield/await/this/super in enum initializers", () => {


### PR DESCRIPTION
The TypeScript parser rejected enum members whose name is a computed property name, which tsc accepts when the expression is a string literal or a substitution-free template literal.

## Repro

```console
$ cat enum.ts
enum E { ['with space'] = 1 }
console.log(E['with space'], E[1])
$ bun enum.ts
1 | enum E { ['with space'] = 1 }
             ^
error: Expected identifier but found "["
```

tsc compiles this and prints `1 with space`. Verified against tsc 3.9.10, 4.0.8, 4.4.4, 4.9.5, 5.0.4, 5.2.2, 5.4.5, 5.6.3, 5.8.3, 5.9.3, and 6.0.2: all accept it (`--noEmit` exit 0), so this is longstanding tsc behavior, not a recent addition. In the compiler this is explicit: `computeEnumMemberValue` in the checker only emits TS1164 ("Computed property names are not allowed in enums") for `isComputedNonLiteralName`, defined as `name.kind === ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression)`, where `isStringLiteralLike` covers string literals and no-substitution template literals. Computed numeric literal names (`[1]`) fall through to the "An enum member cannot have a numeric name" error (TS2452), same as non-computed numeric names.

## Cause

`parse_typescript_enum_stmt` in `src/js_parser/parse/parse_typescript.rs` only accepted an identifier or a string literal as the member name. esbuild also rejects the computed forms, so this is a deliberate divergence from esbuild to match tsc.

## Fix

Add a `TOpenBracket` branch to the member-name parse that accepts a string literal or a `TNoSubstitutionTemplateLiteral`, reuses the string-literal handling (including the "referenceable when the name is a valid identifier" rule), and requires the closing `]`. Other expressions inside the brackets remain parse errors (they are errors in tsc too: TS1164 for non-literals, TS2452 for numeric literals).

```console
$ bun enum.ts
1 with space
```

Cross-member references and const enum inlining work the same as for string literal names:

```ts
enum E { ['A'] = 5, B = A * 2 }   // E.B === 10
const enum CE { ['c'] = 9 }       // usages inline to 9 /* c */
```

## Verification

New `enum members with computed string literal names` test in `test/bundler/transpiler/transpiler.test.js` asserts the exact lowered output for the quoted, template, cross-reference, auto-increment, and const enum cases, and the `malformed enums` test now pins the errors for the still-invalid computed forms (`['a' + 'b']`, `` [`t${1}`] ``, `[Symbol.iterator]`, `[2]`). Both fail on an unfixed build (`Expected identifier but found "["`) and pass with this change. Lowered output was cross-checked against tsc's emit for the same inputs (`E[E['with space'] = 1] = 'with space'`).

<!-- robobun:evidence:begin -->

---

**[auto-merge]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.42ms]
(pass) Bun.Transpiler > normalizes \r\n [9.78ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.39ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [13.86ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [3.90ms]
(pass) Bun.Transpiler > property access inlining > works [4.36ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.56ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [80.15ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [37.73ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [468.34ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional
... (truncated)

release without fix: 2 failed, 22 skipped
bun test v1.4.3-canary.1 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.16ms]
(pass) Bun.Transpiler > normalizes \r\n [0.23ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.15ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.18ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.05ms]
(pass) Bun.Transpiler > property access inlining > works [0.05ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.04ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.01ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.36ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [6.85ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.51ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.08ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [8.55ms]
(pass) Bun.Transpiler > normalizes \r\n [10.54ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [6.77ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [14.54ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [4.15ms]
(pass) Bun.Transpiler > property access inlining > works [5.15ms]
(pass) Bun.Transpiler > property access inlining > works nested [4.84ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [80.77ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [35.59ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [336.40ms]
(pass) Bun.Transpiler > property access inlining > bails out on optiona
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 820ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[0/4] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
[1m[92m   Compiling[0m bun_resolver v0.0.0 (/workspace/bun/src/resolver)
[1m[92m   Compiling[0m bun_ini v0.0.0 (/workspace/bun/src/ini)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_router v0.0.0 (/workspace/bun/src/router)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/workspace/bun/src/bundler_jsc)
[1m[92m   Compiling[0m bun_sourcemap_jsc v0.0.0 (/works
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/parse/parse_typescript.rs    | 18 ++++++++++++++++-
 test/bundler/transpiler/transpiler.test.js | 31 +++++++++++++++++++++++++++++-
 2 files changed, 47 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js_parser/parse/parse_typescript.rs         6      7     32
test/bundler/transpiler/transpiler.test.js      1      2     32
```

</details>

<!-- robobun:evidence:end -->