### PR TITLE
fix(base64): don't overflow on VLQ::encode(i32::MIN) in the crash handler path

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -293,10 +293,14 @@ pub mod vlq {
         let mut len: u8 = 0;
         let mut bytes: [u8; VLQ_MAX_IN_BYTES] = [0; VLQ_MAX_IN_BYTES];
 
+        // Sign-magnitude: i32::MIN has no representation (its magnitude
+        // overflows the u32 VLQ), so it wraps to "-0" instead of panicking.
+        // The crash handler encodes bitcast u32 address halves through here
+        // and must not panic while already reporting a crash.
         let mut vlq: u32 = if value >= 0 {
             (value << 1) as u32
         } else {
-            ((-value << 1) | 1) as u32
+            (value.unsigned_abs() << 1) | 1
         };
 
         // source mappings are limited to i32
@@ -403,6 +407,30 @@ pub mod vlq {
     #[inline]
     pub fn decode_assume_valid(encoded: &[u8], start: usize) -> VLQResult {
         decode_impl::<true>(encoded, start)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn encode_decode_roundtrip() {
+            for value in [0, 1, -1, 255, 256, -255, -256, i32::MAX, i32::MIN + 1] {
+                let encoded = VLQ::encode(value);
+                let result = decode(encoded.slice(), 0);
+                assert_eq!(result.value, value);
+                assert_eq!(result.start, encoded.len as usize);
+            }
+            assert_eq!(VLQ::encode(i32::MAX).slice(), b"+/////D");
+            assert_eq!(VLQ::encode(i32::MIN + 1).slice(), b"//////D");
+        }
+
+        #[test]
+        fn encode_i32_min_does_not_panic() {
+            // i32::MIN is outside the sign-magnitude domain; it wraps to "-0".
+            let encoded = VLQ::encode(i32::MIN);
+            assert_eq!(decode(encoded.slice(), 0).value, 0);
+        }
     }
 }
 

--- a/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
+++ b/test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts
@@ -251,6 +251,48 @@ describe("InternalSourceMap.fromVLQ validation", () => {
   });
 });
 
+describe("InternalSourceMap.toVLQ", () => {
+  test.concurrent("window state of i32::MIN must not crash the VLQ encoder", async () => {
+    // SyncEntry state is raw i32, so a blob whose first window starts at
+    // generated column i32::MIN makes appendVLQTo pass a delta of exactly
+    // i32::MIN to VLQ.encode. i32::MIN has no sign-magnitude representation;
+    // the encoder's magnitude negation overflowed on it (debug builds abort
+    // with "attempt to negate with overflow"). The crash handler reaches the
+    // same encoder edge with bitcast u32 address halves while reporting a
+    // crash. fromVLQ rejects negative absolutes, so craft the blob by hand.
+    // Run in a child process so the abort is recorded as a failure here
+    // instead of taking down the test runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { internalSourceMap } = require("bun:internal-for-testing");
+         // Blob layout (see src/sourcemap/InternalSourceMap.rs):
+         // [0..8] total_len u64, [8..16] mapping_count u64,
+         // [16..24] input_line_count u64, [24..28] sync_count u32,
+         // [28..32] stream_offset u32, [32..56] SyncEntry, [56..88] window
+         // header (count=1, no deltas), [88] stream tail pad.
+         const blob = new Uint8Array(89);
+         const dv = new DataView(blob.buffer);
+         dv.setBigUint64(0, 89n, true); // total_len
+         dv.setBigUint64(8, 1n, true); // mapping_count
+         dv.setUint32(24, 1, true); // sync_count
+         dv.setUint32(28, 56, true); // stream_offset
+         dv.setInt32(36, -2147483648, true); // SyncEntry.generated_column
+         blob[56] = 1; // window mapping count
+         console.log("TOVLQ: " + internalSourceMap.toVLQ(blob));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    // i32::MIN wraps to the "-0" encoding ("B"); the other three fields are 0.
+    expect(stdout).toBe("TOVLQ: BAAA\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe("InternalSourceMap round-trip", () => {
   test("synthetic: fromVLQ → toVLQ preserves all 4-field positions; names dropped, 1-field skipped", () => {
     const vlqIn = buildSyntheticVLQ();


### PR DESCRIPTION
### Problem

Fuzzilli hit a nested panic while Bun was already processing a crash in a debug build:

```
panic: assertion failed: self.protection_count > 0
...
panicked at src/base64/lib.rs:318:15:
attempt to negate with overflow
thread panicked while processing panic. aborting.
```

The crash handler encodes backtrace addresses into the bun.report trace string by splitting each u64 into two u32 halves and bitcasting them to `i32` (`write_u64_as_two_vlqs` in `src/crash_handler/lib.rs`). `vlq::encode_slow_path` computes the magnitude of negative values with `-value`, which overflows for `i32::MIN`. So an address half of exactly `0x80000000` panics the panic hook: debug builds abort before the crash report or backtrace is written, and release builds silently wrap. The Zig reference (`src/sourcemap/VLQ.zig`) has the same checked negation, so this was inherited by the port; sourcemap callers never pass `i32::MIN`, only the crash handler's bitcast address halves do.

### Fix

Compute the magnitude with `value.unsigned_abs()` in `encode_slow_path` (`src/base64/lib.rs`). The sign-magnitude VLQ format cannot represent `i32::MIN` in 32 bits regardless (its magnitude is 2^31), so that one value keeps degrading to "-0" exactly as release builds already emit, and the wire format bun.report decodes is unchanged. Everything in the representable domain `-(2^31 - 1)..=2^31 - 1` encodes identically to before. The encoder just can't panic anymore, which matters because it runs inside the panic hook.

### Test

JS-level regression test in `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts`: `InternalSourceMap` sync-entry state is raw i32 and `appendVLQTo` computes deltas with `saturating_sub`, so a hand-crafted blob whose first window starts at generated column `i32::MIN` drives `VLQ::encode(i32::MIN)` through the existing `bun:internal-for-testing` `toVLQ` surface. On the unfixed encoder the spawned process aborts with "attempt to negate with overflow" (debug builds); with the fix it emits the wrapped "-0" encoding (`BAAA`) and exits 0.

Also unit tests in the `vlq` module of `bun_base64`: a roundtrip over the representable domain including both extremes (pinning the documented `"+/////D"` / `"//////D"` encodings), and `encode(i32::MIN)` decoding to 0 without panicking. The latter fails on the unfixed code with the same overflow panic (`cargo test -p bun_base64`). `bun_base64` is in `MIRI_CRATES`, so CI runs these via `cargo miri test` on changes under `src/base64/`; verified locally that miri passes.

The crash handler trigger itself (a backtrace address half equal to `0x80000000`) is not controllable from a test; the sourcemap path exercises the identical encoder edge.

The primary crash in the fuzzer report (the `protection_count` assert) is fixed separately in #31859.

