### PR TITLE
Replace six redundant unsafe blocks with safe std equivalents

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -73,11 +73,10 @@ impl<T> StoreRef<T> {
     /// constants). Mutation through the resulting `StoreRef` is UB.
     #[inline]
     pub const fn from_static(r: &'static T) -> Self {
-        // SAFETY: `r` is a non-null, aligned, dereferenceable `'static`
-        // reference. Provenance is shared/read-only: the pointee is *never*
-        // written through — `DerefMut` on a `StoreRef` produced here is UB and
+        // Provenance is shared/read-only: the pointee is *never* written
+        // through — `DerefMut` on a `StoreRef` produced here is UB and
         // callers must not do so (audited: only `Deref`/`get()` reads occur).
-        StoreRef(unsafe { NonNull::new_unchecked(core::ptr::from_ref(r).cast_mut()) })
+        StoreRef(NonNull::from_ref(r))
     }
     /// Borrow the pointee (explicit form of `Deref`).
     #[inline]

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -73,9 +73,6 @@ impl<T> StoreRef<T> {
     /// constants). Mutation through the resulting `StoreRef` is UB.
     #[inline]
     pub const fn from_static(r: &'static T) -> Self {
-        // Provenance is shared/read-only: the pointee is *never* written
-        // through — `DerefMut` on a `StoreRef` produced here is UB and
-        // callers must not do so (audited: only `Deref`/`get()` reads occur).
         StoreRef(NonNull::from_ref(r))
     }
     /// Borrow the pointee (explicit form of `Deref`).
@@ -185,8 +182,7 @@ impl StoreStr {
     #[inline]
     pub const fn new(s: &[u8]) -> Self {
         debug_assert!(s.len() <= u32::MAX as usize);
-        // SAFETY: `&[u8]` always has a non-null data pointer.
-        let ptr = unsafe { NonNull::new_unchecked(s.as_ptr().cast_mut()) };
+        let ptr = NonNull::from_ref(s).cast::<u8>();
         StoreStr {
             ptr,
             len: s.len() as u32,
@@ -362,8 +358,7 @@ impl<T> StoreSlice<T> {
     #[inline]
     pub const fn new(s: &[T]) -> Self {
         debug_assert!(s.len() <= u32::MAX as usize);
-        // SAFETY: `&[T]` always has a non-null data pointer.
-        let ptr = unsafe { NonNull::new_unchecked(s.as_ptr().cast_mut()) };
+        let ptr = NonNull::from_ref(s).cast::<T>();
         StoreSlice {
             ptr,
             len: s.len() as u32,
@@ -376,8 +371,7 @@ impl<T> StoreSlice<T> {
     #[inline]
     pub fn new_mut(s: &mut [T]) -> Self {
         debug_assert!(s.len() <= u32::MAX as usize);
-        // SAFETY: `&mut [T]` always has a non-null data pointer.
-        let ptr = unsafe { NonNull::new_unchecked(s.as_mut_ptr()) };
+        let ptr = NonNull::from_mut(s).cast::<T>();
         StoreSlice {
             ptr,
             len: s.len() as u32,

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1529,9 +1529,7 @@ impl<A: Allocator + Default> StringHashMapKey<A> {
     /// slice by reference; never freed on drop.
     #[inline]
     pub(crate) const fn borrowed(s: &'static [u8]) -> Self {
-        // `&[u8]`'s pointer is always non-null (dangling for `len == 0`).
-        // SAFETY: `as_ptr()` on a slice reference is never null.
-        let ptr = unsafe { core::ptr::NonNull::new_unchecked(s.as_ptr().cast_mut()) };
+        let ptr = core::ptr::NonNull::from_ref(s).cast::<u8>();
         Self {
             ptr,
             len_tag: s.len(),

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2389,18 +2389,12 @@ mod draft {
     // The v1/v2 trace-string
     // format encodes exactly 7 hex chars. `Environment::GIT_SHA_SHORT` is 9 chars and would
     // shift every following VLQ byte, making bun.report unable to decode the URL.
-    const GIT_SHA: &str = {
-        const fn sha7(s: &'static str) -> &'static str {
-            // GIT_SHA is ASCII hex; `split_at` const-panics if the input is
-            // shorter than 7 bytes or byte 7 is not a char boundary.
-            s.split_at(7).0
-        }
-        if !Environment::GIT_SHA.is_empty() {
-            sha7(Environment::GIT_SHA)
-        } else {
-            "unknown"
-        }
+    const GIT_SHA: &str = if !Environment::GIT_SHA.is_empty() {
+        Environment::GIT_SHA.split_at(7).0
+    } else {
+        "unknown"
     };
+    const _: () = assert!(GIT_SHA.len() == 7);
 
     struct StackLine {
         address: i32,

--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2391,10 +2391,9 @@ mod draft {
     // shift every following VLQ byte, making bun.report unable to decode the URL.
     const GIT_SHA: &str = {
         const fn sha7(s: &'static str) -> &'static str {
-            let (head, _) = s.as_bytes().split_at(7);
-            // SAFETY: GIT_SHA is ASCII hex; the first 7 bytes are a valid UTF-8
-            // prefix. `split_at` const-panics if the input is shorter than 7.
-            unsafe { core::str::from_utf8_unchecked(head) }
+            // GIT_SHA is ASCII hex; `split_at` const-panics if the input is
+            // shorter than 7 bytes or byte 7 is not a char boundary.
+            s.split_at(7).0
         }
         if !Environment::GIT_SHA.is_empty() {
             sha7(Environment::GIT_SHA)

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -151,6 +151,38 @@ test("the crash report lists the CPU features", async () => {
   expect(exitCode).not.toBe(0);
 });
 
+// The v1/v2 trace string is decoded positionally by bun.report:
+// <platform char><command char><format version char><7-char commit sha><vlq...>.
+// The sha segment must be exactly the first 7 characters of the full revision;
+// a longer or shorter prefix shifts every following byte and the URL becomes
+// undecodable.
+test("crash report trace string embeds the 7-char commit sha", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic", "--debug-crash-handler-use-trace-string"],
+    // Unset rather than empty: an unset BUN_CRASH_REPORT_URL prints the
+    // default base, and BUN_ENABLE_CRASH_REPORTING=0 keeps the upload off.
+    env: { ...bunEnv, BUN_CRASH_REPORT_URL: undefined, BUN_ENABLE_CRASH_REPORTING: "0" },
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("oh no: Bun has crashed. This indicates a bug in Bun, not your code");
+
+  // The report URL is printed as <base>/<bun version>/<trace string...>.
+  const base = "https://bun.report/";
+  const start = stderr.indexOf(base);
+  expect(start).toBeGreaterThanOrEqual(0);
+  const reportUrl = stderr.slice(start).split(/\s/, 1)[0];
+  const [, version, metadata] = new URL(reportUrl).pathname.split("/");
+  expect(version.length).toBeGreaterThan(0);
+
+  // metadata[0] is the platform char and metadata[1] the command char (one
+  // byte each), so the format version and sha always start at fixed offsets.
+  expect(metadata[2]).toMatch(/^[12]$/);
+  const expectedSha = Bun.revision ? Bun.revision.slice(0, 7) : "unknown";
+  expect(metadata.slice(3, 10)).toBe(expectedSha);
+  expect(exitCode).not.toBe(0);
+});
+
 // POSIX-only: Windows refuses to remove a directory that is any process's cwd.
 describe.if(isPosix)("cwd deleted before startup", () => {
   test.concurrent.each(["install", "test"])("bun %s prints the cwd-deleted hint", async cmd => {

--- a/test/cli/run/run-crash-handler.test.ts
+++ b/test/cli/run/run-crash-handler.test.ts
@@ -151,11 +151,10 @@ test("the crash report lists the CPU features", async () => {
   expect(exitCode).not.toBe(0);
 });
 
-// The v1/v2 trace string is decoded positionally by bun.report:
+// bun.report decodes the v1/v2 trace string positionally:
 // <platform char><command char><format version char><7-char commit sha><vlq...>.
-// The sha segment must be exactly the first 7 characters of the full revision;
-// a longer or shorter prefix shifts every following byte and the URL becomes
-// undecodable.
+// This pins the offset and content of the version and sha segments. The sha
+// length itself is a compile-time assert next to GIT_SHA in the crash handler.
 test("crash report trace string embeds the 7-char commit sha", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), path.join(import.meta.dir, "fixture-crash.js"), "panic", "--debug-crash-handler-use-trace-string"],


### PR DESCRIPTION
Removes six `unsafe` blocks whose only job std does safely at identical cost. No behavior change.

- `src/ast/nodes.rs`: `StoreRef::from_static`, `StoreStr::new`, `StoreSlice::new` and `StoreSlice::new_mut` each built a `NonNull` from a reference with `NonNull::new_unchecked(...as_ptr()...)`. `NonNull::from_ref` / `NonNull::from_mut` (const since Rust 1.89) encode the non-null guarantee in the type system and yield the same pointer with the same provenance (shared for the `&` constructors, unique for `new_mut`), including the dangling-but-aligned pointer for empty slices.
- `src/collections/array_hash_map.rs`: `StringHashMapKey::borrowed` gets the same `NonNull::from_ref(s).cast::<u8>()` treatment (stays `pub(crate)`).
- `src/crash_handler/lib.rs`: the `sha7` helper split `as_bytes()` and then called `from_utf8_unchecked`. `str::split_at` (const since 1.86) does both steps safely, so the helper is inlined away. A new `const _: () = assert!(GIT_SHA.len() == 7);` makes a wrong prefix length (for example switching to the 9-char `GIT_SHA_SHORT`) a build failure instead of an undecodable bun.report URL.

All replacements are const-evaluated or compile to identical code; no branch is added at runtime. An earlier revision also swapped `from_utf8_unchecked` for checked `from_utf8` in the `generated_symbol_name!` macro; that was reverted per review to avoid the unnecessary validation.

Test: `test/cli/run/run-crash-handler.test.ts` gains a case that pins the trace string header layout bun.report decodes positionally: platform char, command char, format version char, then the first 7 characters of `Bun.revision` at offset 3. The length is enforced by the const assert; the test covers offset and content, which nothing else exercised. It unsets `BUN_CRASH_REPORT_URL` and sets `BUN_ENABLE_CRASH_REPORTING=0` so no upload happens, matching the file's convention for deliberate crashes.

History: rebuilt on current main after the branch went stale (conflicts in `array_hash_map.rs`, where `borrowed` became `pub(crate)`, and in the test file, which gained the no-upload convention).

Verification:

- `cargo check -p bun_ast -p bun_collections -p bun_crash_handler` clean, `cargo fmt --check` clean
- `bun bd` builds (the const assert is evaluated with a real 40-char sha baked in)
- `bun bd test test/cli/run/run-crash-handler.test.ts`: 29 pass, 7 skip, also with `BUN_CRASH_REPORT_URL` set in the parent environment as the CI runner does
- `bun bd test test/bundler/transpiler/transpiler.test.js` (230 tests, exercises `StoreStr`/`StoreSlice` throughout the parser), `test/bundler/bundler_env.test.ts` and `transpiler/template-literal.test.ts` (the `StoreRef::from_static` define paths)

[daily-code-quality]

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 14 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/run/run-crash-handler.test.ts

<!-- robobun:evidence:end -->