### PR TITLE
ci: mirror Intel SDE on CI asset host and fail fast on a bad baseline download

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -766,7 +766,7 @@ function getVerifyBaselineStep(platform, options) {
           `echo Extracting Intel SDE...`,
           `7z x -y sde.tar.xz || exit /b 1`,
           `7z x -y sde.tar || exit /b 1`,
-          `ren sde-external-${SDE_VERSION}-win sde-external`,
+          `ren sde-external-${SDE_VERSION}-win sde-external || exit /b 1`,
         ]
       : [
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -708,7 +708,16 @@ function getEmulatorBinary(platform) {
 }
 
 const SDE_VERSION = "9.58.0-2025-06-16";
-const SDE_URL = `https://downloadmirror.intel.com/859732/sde-external-${SDE_VERSION}-win.tar.xz`;
+// Mirror the Intel SDE tarball on our own CI asset host instead of fetching it
+// from Intel's download center directly. The downloadmirror.intel.com path
+// embeds a numeric file id that Intel rotates per release; once rotated, the
+// old id returns 403 Forbidden and every verify-baseline run fails. Intel's
+// license forbids public redistribution, but bun-ci-assets.bun.sh is an
+// access-controlled CI asset host (same one used for the Windows code-signing
+// tooling), so it is an internal mirror rather than a public redistribution.
+// To bump SDE: download sde-external-<version>-win.tar.xz from Intel, upload it
+// to the bucket under the same filename, then update SDE_VERSION here.
+const SDE_URL = `https://bun-ci-assets.bun.sh/sde-external-${SDE_VERSION}-win.tar.xz`;
 
 /**
  * @param {Platform} platform
@@ -742,15 +751,21 @@ function getVerifyBaselineStep(platform, options) {
   const setupCommands =
     os === "windows"
       ? [
+          // Buildkite runs this array as one cmd.exe batch file, and batch does
+          // not stop on error: without explicit `|| exit /b 1`, a failed line is
+          // ignored and only the last line's exit code becomes the step result.
+          // A failed download then left a 0-byte sde.tar.xz for 7z to choke on,
+          // surfacing as a confusing "Cannot open the file as archive" instead of
+          // the real HTTP error. Propagate every fallible step's exit code.
           `echo Downloading build artifacts...`,
-          `buildkite-agent artifact download ${profileDir}.zip . --step ${targetKey}-build-bun`,
+          `buildkite-agent artifact download ${profileDir}.zip . --step ${targetKey}-build-bun || exit /b 1`,
           `echo Extracting ${profileDir}.zip...`,
-          `tar -xf ${profileDir}.zip`,
-          `echo Downloading Intel SDE...`,
-          `curl.exe -fsSL -o sde.tar.xz "${SDE_URL}"`,
+          `tar -xf ${profileDir}.zip || exit /b 1`,
+          `echo Downloading Intel SDE from ${SDE_URL}...`,
+          `curl.exe -fsSL -o sde.tar.xz "${SDE_URL}" || (echo Failed to download Intel SDE from ${SDE_URL} & exit /b 1)`,
           `echo Extracting Intel SDE...`,
-          `7z x -y sde.tar.xz`,
-          `7z x -y sde.tar`,
+          `7z x -y sde.tar.xz || exit /b 1`,
+          `7z x -y sde.tar || exit /b 1`,
           `ren sde-external-${SDE_VERSION}-win sde-external`,
         ]
       : [


### PR DESCRIPTION
Addresses #31872 (not auto-closing: this removes the rotating-id failure class and makes the step fail fast, but the lane only goes fully green after the one-time tarball upload described below, which needs bucket access).

## Problem

The `windows-x64-baseline-verify-baseline` lane fails deterministically on every build, including main, before the verifier ever runs:

```
Downloading Intel SDE...
Extracting Intel SDE...
1 file, 0 bytes
ERROR: sde.tar.xz
Cannot open the file as archive
🚨 Error: The command exited with status 2
```

## Root cause

Two separate problems compounded into that confusing failure.

1. **The pinned Intel URL 403s.** SDE was fetched from `downloadmirror.intel.com/859732/...`. That path embeds a numeric file id that Intel rotates per release; once rotated, the old id returns `403 Forbidden`, which is what every recent build hit.

   ```
   $ curl -sIL https://downloadmirror.intel.com/859732/sde-external-9.58.0-2025-06-16-win.tar.xz
   HTTP/1.1 403 Forbidden
   ```

2. **The step ignored the failed download.** Windows Buildkite agents run a step's `command:` array as a single `cmd.exe` batch file (the agent shell is `cmd.exe /S /C`, set in `scripts/agent.mjs`). Batch does not stop on error: only the **last** line's exit code becomes the step result. So the failed `curl.exe` (exit 22) was ignored, `7z` then ran on a 0-byte `sde.tar.xz`, and its exit 2 / "Cannot open the file as archive" became the step result, hiding the real HTTP error.

## Fix

`.buildkite/ci.mjs`:

- **Move SDE off the rotating Intel id.** Point `SDE_URL` at our own CI asset host, `bun-ci-assets.bun.sh` (the same access-controlled host already used for the Windows code-signing tooling in `.buildkite/scripts/sign-windows-artifacts.ps1`). A stable path there does not rotate, so the lane no longer breaks on every SDE release. This matches the existing "mirror a flaky upstream on our own storage" pattern (see the nssm mirror in `scripts/bootstrap.ps1`).
- **Fail fast on a bad download or extraction.** Append `|| exit /b 1` to every fallible line in the Windows setup array and echo the URL on a download failure, so a future 403/404 surfaces as `Failed to download Intel SDE from <url>` with curl's real status instead of a cryptic `7z` error.

The generated batch now reads:

```bat
buildkite-agent artifact download <profile>.zip . --step <target>-build-bun || exit /b 1
tar -xf <profile>.zip || exit /b 1
echo Downloading Intel SDE from https://bun-ci-assets.bun.sh/sde-external-9.58.0-2025-06-16-win.tar.xz...
curl.exe -fsSL -o sde.tar.xz "https://bun-ci-assets.bun.sh/sde-external-9.58.0-2025-06-16-win.tar.xz" || (echo Failed to download Intel SDE from https://bun-ci-assets.bun.sh/sde-external-9.58.0-2025-06-16-win.tar.xz & exit /b 1)
7z x -y sde.tar.xz || exit /b 1
7z x -y sde.tar || exit /b 1
ren sde-external-9.58.0-2025-06-16-win sde-external
```

## One manual step required before this turns the lane green

I cannot upload the tarball or reach Intel's download center from CI, so a maintainer with bucket access needs to do a one-time upload:

1. Download `sde-external-9.58.0-2025-06-16-win.tar.xz` from Intel's SDE page.
2. Upload it to `bun-ci-assets.bun.sh` under that exact filename (so the URL above resolves).

Intel's license forbids public redistribution; `bun-ci-assets.bun.sh` is an access-controlled CI asset host, i.e. an internal mirror, not a public redistribution. After the upload, bumping SDE is just: upload the new tarball under the new filename and update `SDE_VERSION`.

## Verification

- `node --check .buildkite/ci.mjs` passes; `prettier --check` clean.
- Rendered the generated batch for the Windows verify-baseline step and confirmed the exact command strings above (no shell metacharacters in the URL that would need batch escaping).
- Confirmed `https://downloadmirror.intel.com/859732/...` returns 403 and `https://bun-ci-assets.bun.sh/` is reachable.
- On CI (build 60694), `windows-x64-baseline-verify-baseline` now exits **status 1** at the download step with `Failed to download Intel SDE from <url>`, instead of the old cryptic exit-2 `7z` error. That is the fail-fast guard firing on the not-yet-uploaded tarball (the bucket path currently 404s), i.e. the expected state until the one-time upload above lands. The guard change itself is verified by that transition; the lane turns green once the tarball is uploaded. The other red lanes on that build (alpine/musl `test-bun` at exit 2, darwin `test-bun` "Expired") are unrelated pre-existing flake on lanes this diff does not touch: the change is confined to the Windows arm of `getVerifyBaselineStep`, and `needsBaselineVerification` does not even emit a verify-baseline step for darwin.

This is a CI config change with no runtime/`src` component and no pipeline-generator test surface in the repo, so there is no `bun bd test` to add. The robustness change (`|| exit /b 1`) is complete and correct on its own; the URL change turns a recurring rotating-id outage into a one-step upload. I could not verify an end-to-end green lane from this environment because the tarball upload requires bucket access I don't have.



