### PR TITLE
repl: keep multi-byte UTF-8 input in the interactive line editor

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -171,8 +171,11 @@ enum Key {
     AltLeft,
     AltRight,
 
-    // Regular printable character
+    // Regular printable ASCII character
     Char(u8),
+
+    // A full multi-byte UTF-8 sequence (len bytes of the array are valid)
+    Text([u8; 4], usize),
 
     // Unknown/unhandled
     Unknown,
@@ -415,16 +418,42 @@ impl LineEditor {
         Ok(())
     }
 
+    /// Byte offset of the start of the codepoint ending just before `pos`.
+    /// Walks back over UTF-8 continuation bytes (0x80..=0xBF).
+    fn prev_boundary(&self, pos: usize) -> usize {
+        let mut i = pos;
+        while i > 0 {
+            i -= 1;
+            if self.buffer[i] & 0xC0 != 0x80 {
+                break;
+            }
+        }
+        i
+    }
+
+    /// Byte offset of the start of the codepoint after the one beginning at
+    /// `pos`. Advances by the lead byte's UTF-8 sequence length, clamped to the
+    /// buffer so a truncated/invalid sequence still makes progress.
+    fn next_boundary(&self, pos: usize) -> usize {
+        if pos >= self.buffer.len() {
+            return self.buffer.len();
+        }
+        let step = (strings::wtf8_byte_sequence_length(self.buffer[pos]) as usize).max(1);
+        (pos + step).min(self.buffer.len())
+    }
+
     pub(crate) fn delete_char(&mut self) {
         if self.cursor < self.buffer.len() {
-            self.buffer.remove(self.cursor);
+            let end = self.next_boundary(self.cursor);
+            self.buffer.drain(self.cursor..end);
         }
     }
 
     pub(crate) fn backspace(&mut self) {
         if self.cursor > 0 {
-            self.cursor -= 1;
-            self.buffer.remove(self.cursor);
+            let start = self.prev_boundary(self.cursor);
+            self.buffer.drain(start..self.cursor);
+            self.cursor = start;
         }
     }
 
@@ -461,13 +490,13 @@ impl LineEditor {
 
     pub(crate) fn move_left(&mut self) {
         if self.cursor > 0 {
-            self.cursor -= 1;
+            self.cursor = self.prev_boundary(self.cursor);
         }
     }
 
     pub(crate) fn move_right(&mut self) {
         if self.cursor < self.buffer.len() {
-            self.cursor += 1;
+            self.cursor = self.next_boundary(self.cursor);
         }
     }
 
@@ -1133,6 +1162,28 @@ impl<'a> Repl<'a> {
             return Some(Key::Escape);
         }
 
+        // Multi-byte UTF-8: assemble the whole sequence so it is inserted as
+        // one unit. A lone/invalid lead byte yields a length of 0; fall back to
+        // reading it as a single raw byte so it is still dropped (not split).
+        let seq_len = strings::utf8_byte_sequence_length(byte) as usize;
+        if seq_len > 1 {
+            let mut bytes = [0u8; 4];
+            bytes[0] = byte;
+            for slot in bytes.iter_mut().take(seq_len).skip(1) {
+                let Some(cont) = self.read_byte() else {
+                    // Stream ended mid-sequence; drop the truncated bytes.
+                    return Some(Key::Unknown);
+                };
+                // A byte that is not a continuation byte (0x80..=0xBF) means the
+                // sequence is malformed; drop it rather than corrupt the buffer.
+                if cont & 0xC0 != 0x80 {
+                    return Some(Key::Unknown);
+                }
+                *slot = cont;
+            }
+            return Some(Key::Text(bytes, seq_len));
+        }
+
         Some(Key::from_byte(byte))
     }
 
@@ -1185,8 +1236,13 @@ impl<'a> Repl<'a> {
             self.write(line);
         }
 
-        // Position cursor
-        let cursor_pos = prompt_len + self.line_editor.cursor;
+        // Position cursor. The cursor is a byte offset, but the terminal column
+        // is the display width of the text before it, so multi-byte UTF-8 and
+        // wide (e.g. CJK) characters advance the column correctly.
+        let cursor_col = strings::visible::width::exclude_ansi_colors::utf8(
+            &line[..self.line_editor.cursor],
+        );
+        let cursor_pos = prompt_len + cursor_col;
         if cursor_pos < self.terminal_width as usize {
             self.write(b"\r");
             if cursor_pos > 0 {
@@ -2084,6 +2140,10 @@ impl<'a> Repl<'a> {
                 }
                 Key::Char(c) => {
                     let _ = self.line_editor.insert(c);
+                    self.refresh_line();
+                }
+                Key::Text(bytes, len) => {
+                    let _ = self.line_editor.insert_slice(&bytes[..len]);
                     self.refresh_line();
                 }
                 _ => {}

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1189,8 +1189,10 @@ impl<'a> Repl<'a> {
                     return Some(Key::Unknown);
                 };
                 // A byte that is not a continuation byte (0x80..=0xBF) means the
-                // sequence is malformed; drop it rather than corrupt the buffer.
+                // sequence is malformed; drop the lead bytes but push this one
+                // back so the next read_key sees it (it starts a new keystroke).
                 if cont & 0xC0 != 0x80 {
+                    self.stdin_buf_start -= 1;
                     return Some(Key::Unknown);
                 }
                 *slot = cont;

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1239,9 +1239,8 @@ impl<'a> Repl<'a> {
         // Position cursor. The cursor is a byte offset, but the terminal column
         // is the display width of the text before it, so multi-byte UTF-8 and
         // wide (e.g. CJK) characters advance the column correctly.
-        let cursor_col = strings::visible::width::exclude_ansi_colors::utf8(
-            &line[..self.line_editor.cursor],
-        );
+        let cursor_col =
+            strings::visible::width::exclude_ansi_colors::utf8(&line[..self.line_editor.cursor]);
         let cursor_pos = prompt_len + cursor_col;
         if cursor_pos < self.terminal_width as usize {
             self.write(b"\r");

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -527,12 +527,26 @@ impl LineEditor {
     }
 
     pub(crate) fn swap(&mut self) {
-        if self.cursor > 0 && self.cursor < self.buffer.len() {
-            self.buffer.swap(self.cursor - 1, self.cursor);
-            self.cursor += 1;
-        } else if self.cursor > 1 && self.cursor == self.buffer.len() {
-            self.buffer.swap(self.cursor - 2, self.cursor - 1);
-        }
+        // Transpose two whole codepoints (not bytes), so multi-byte UTF-8 is
+        // not split. Mid-line swaps the codepoint before the cursor with the
+        // one at it and advances past both; at end-of-line it transposes the
+        // last two codepoints.
+        let (left_start, mid, right_end) = if self.cursor > 0 && self.cursor < self.buffer.len() {
+            let mid = self.cursor;
+            (self.prev_boundary(mid), mid, self.next_boundary(mid))
+        } else if self.cursor == self.buffer.len() {
+            let mid = self.prev_boundary(self.cursor);
+            if mid == 0 {
+                return; // fewer than two codepoints
+            }
+            (self.prev_boundary(mid), mid, self.cursor)
+        } else {
+            return;
+        };
+        // Rotate the two adjacent codepoint ranges [left_start, mid) and
+        // [mid, right_end): moving the left range to the end swaps them.
+        self.buffer[left_start..right_end].rotate_left(mid - left_start);
+        self.cursor = right_end;
     }
 
     pub(crate) fn get_line(&self) -> &[u8] {

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1195,6 +1195,13 @@ impl<'a> Repl<'a> {
                 }
                 *slot = cont;
             }
+            // Reject overlong encodings, surrogates, and values above U+10FFFF,
+            // which pass the continuation-byte shape check but are not valid
+            // UTF-8. Keeping the buffer valid avoids feeding bad bytes to the
+            // highlighter and parser.
+            if !strings::is_valid_utf8(&bytes[..seq_len]) {
+                return Some(Key::Unknown);
+            }
             return Some(Key::Text(bytes, seq_len));
         }
 

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1162,6 +1162,19 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       await waitFor(/\n\s*2\b/);
     });
   });
+
+  test("a stray lead byte does not swallow the next keystroke", async () => {
+    await withTerminalRepl(async ({ terminal, send, waitFor }) => {
+      // 0xC2 is a 2-byte lead; the following byte (0x62 'b') is not a
+      // continuation byte, so the lead is dropped. The 'b' must still be
+      // processed, giving a clean "ab" (length 2), not "a" (length 1).
+      send('"a');
+      await waitFor("a");
+      terminal.write(new Uint8Array([0xc2, 0x62])); // stray lead + 'b'
+      send('".length\n');
+      await waitFor(/\n\s*2\b/);
+    });
+  });
 });
 
 // History file written on REPL exit must be owner-only (0600), since it can

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1079,6 +1079,59 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       await waitFor("99");
     });
   });
+
+  // Regression for #31871: the line editor read input one byte at a time and
+  // dropped every byte >= 0x80, so multi-byte UTF-8 (Korean, emoji, etc.) was
+  // silently discarded and the evaluated expression differed from what was typed.
+  test("keeps multi-byte UTF-8 characters typed into the line editor", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      send('"a한b".length\n');
+      // "a한b".length is 3; before the fix the 한 was dropped and it was 2.
+      await waitFor(/\n\s*3\b/);
+      // The echoed input line must still contain the Korean character.
+      expect(allOutput()).toContain("한");
+    });
+  });
+
+  test("keeps a full Korean string typed into the line editor", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      send('"안녕하세요 영재님".length\n');
+      // 9 characters; before the fix only the ASCII space survived -> 1.
+      await waitFor(/\n\s*9\b/);
+      expect(allOutput()).toContain("안녕하세요 영재님");
+    });
+  });
+
+  test("backspace deletes a whole multi-byte character", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      // Type a Korean char then backspace over it; byte-wise stepping would
+      // leave a truncated UTF-8 sequence behind.
+      send("한");
+      await waitFor("한");
+      send("\x7f"); // Backspace
+      send('"ok".length\n');
+      await waitFor(/\n\s*2\b/);
+      // The dangling Korean char must be gone, leaving a clean expression.
+      expect(allOutput()).toContain('"ok".length');
+    });
+  });
+
+  test("left-arrow navigation steps over a whole multi-byte character", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      // Type `"한"`, then left-arrow twice to land between the opening quote
+      // and 한 (the second move must skip all 3 bytes of 한, not land mid-char),
+      // and insert `b`. The buffer becomes `"b한"`, whose length is 2.
+      send('"한"');
+      await waitFor("한");
+      send("\x1b[D"); // left: between 한 and the closing quote
+      send("\x1b[D"); // left: between the opening quote and 한 (skips 3 bytes)
+      send("b");
+      send("\x05"); // Ctrl+E: move to end of line
+      send(".length\n");
+      await waitFor(/\n\s*2\b/);
+      expect(allOutput()).toContain('"b한"');
+    });
+  });
 });
 
 // History file written on REPL exit must be owner-only (0600), since it can

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1149,6 +1149,19 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       expect(allOutput()).toContain('"b한"');
     });
   });
+
+  test("drops a malformed UTF-8 sequence instead of corrupting the buffer", async () => {
+    await withTerminalRepl(async ({ terminal, send, waitFor }) => {
+      // ED A0 80 encodes the lone surrogate U+D800: it has a valid lead byte
+      // and continuation-byte shape but is not valid UTF-8. It must be dropped,
+      // leaving a clean "ab" (length 2), not fed into the buffer.
+      send('"a');
+      await waitFor("a");
+      terminal.write(new Uint8Array([0xed, 0xa0, 0x80]));
+      send('b".length\n');
+      await waitFor(/\n\s*2\b/);
+    });
+  });
 });
 
 // History file written on REPL exit must be owner-only (0600), since it can

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1132,6 +1132,23 @@ describe.todoIf(isWindows)("Bun REPL (Terminal)", () => {
       expect(allOutput()).toContain('"b한"');
     });
   });
+
+  test("Ctrl+T transposes whole multi-byte characters", async () => {
+    await withTerminalRepl(async ({ send, waitFor, allOutput }) => {
+      // Type `"한b"`, move the cursor between 한 and b, then Ctrl+T. Byte-wise
+      // transposition would split 한; it must swap the two whole codepoints so
+      // the buffer becomes `"b한"` (length 2), not corrupted UTF-8.
+      send('"한b"');
+      await waitFor("한b");
+      send("\x1b[D"); // left: between b and the closing quote
+      send("\x1b[D"); // left: between 한 and b
+      send("\x14"); // Ctrl+T: transpose 한 and b -> "b한"
+      send("\x05"); // Ctrl+E: move to end of line
+      send(".length\n");
+      await waitFor(/\n\s*2\b/);
+      expect(allOutput()).toContain('"b한"');
+    });
+  });
 });
 
 // History file written on REPL exit must be owner-only (0600), since it can


### PR DESCRIPTION
Fixes #31871

Related to #27556 (same root cause: non-ASCII characters not accepted in `bun repl`). The interactive line editor only runs under a PTY, which is POSIX-only today, so this does not change the Windows REPL path that issue describes.

## What

The interactive `bun repl` line editor silently drops every non-ASCII byte typed or pasted into the input line, so Korean (and any multi-byte UTF-8) characters vanish and the evaluated expression differs from what the user typed.

## Reproduction

The line editor only activates when both stdin and stdout are TTYs, so it has to be driven under a PTY. With a debug build:

```console
$ bun repl
> "a한b".length
```

Expected `3` (matches `bun -e '"a한b".length'`). Before this change the `한` never appears, the buffer becomes `"ab".length`, and the result is `2`. The issue's second example, `"안녕하세요 영재님".length`, collapses to `" ".length` (only the ASCII space survives).

## Root cause

In `src/runtime/cli/repl.rs`, `Key::from_byte` maps any byte `>= 128` to `Key::Unknown`:

```rust
32..=126 => Key::Char(byte),
_ => Key::Unknown,
```

`read_key` reads a single byte and, for non-ESC input, calls `from_byte`. Every UTF-8 lead and continuation byte is `>= 0x80`, so it becomes `Key::Unknown`, which the main input loop drops via its `_ => {}` arm. A 3-byte character like `한` therefore produces three dropped events.

## Fix

- `read_key` now recognizes a UTF-8 lead byte, reads the rest of the sequence, and returns it as a single new `Key::Text([u8; 4], len)` event, inserted through the existing `LineEditor::insert_slice`. A truncated or malformed sequence (stream ends mid-character, or a byte that is not a continuation byte) is dropped rather than corrupting the buffer.
- `move_left` / `move_right` / `backspace` / `delete_char` stepped one byte at a time, which would split a multi-byte character. They now step whole codepoints via two small helpers (`prev_boundary` / `next_boundary`).
- `refresh_line` positioned the cursor using the byte offset as a terminal column. It now uses the visible display width of the text before the cursor (`strings::visible::width::exclude_ansi_colors::utf8`), so multi-byte and wide (CJK) characters advance the column correctly.

ASCII input is unchanged: single bytes still flow through `Key::Char`.

## Verification

Four PTY-driven tests added to `test/js/bun/repl/repl.test.ts` (under the existing `Bun REPL (Terminal)` suite, which is already gated off on Windows):

- `"a한b".length` evaluates to `3` and the echoed line keeps the `한`
- `"안녕하세요 영재님".length` evaluates to `9` and the full string is preserved
- backspace over a Korean character deletes the whole codepoint (leftover `"ok".length` evaluates to `2`)
- left-arrow navigation steps over a whole multi-byte character before inserting (`"b한".length` evaluates to `2`)

All four fail on the unfixed build (the expected output never appears) and pass with the fix. Reverting only the cursor-stepping helpers makes the backspace and left-arrow tests fail while input still assembles, confirming each part of the change is exercised. The full `repl.test.ts` suite (114 tests) passes with `bun bd test`.