### PR TITLE
run: do not run a same-named $PATH binary for `bun run --if-present`

### DIFF
--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2690,7 +2690,13 @@ impl RunCommand {
         // Search the prepended `.bin` dirs
         // (PATH minus ORIGINAL_PATH) unless `--bun` was passed, in which case
         // search the whole stitched PATH.
-        {
+        //
+        // Skip this when `--if-present` is set: the flag means "run it only if
+        // the named script/entrypoint exists", so a missing script must not
+        // fall through to a same-named binary on `$PATH` (e.g. `bun run
+        // --if-present test` running `/usr/bin/test`). npm's `--if-present`
+        // likewise only consults the package.json `scripts` object.
+        if !ctx.runtime_options.if_present {
             let _ = force_using_bun;
             // SAFETY: `Transpiler::init` always sets `fs`; resolver-cache lifetime.
             let fs = unsafe { &mut *this_transpiler.fs };

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2651,8 +2651,11 @@ impl RunCommand {
         }
 
         // ── Windows .bunx fast-path ──────────────────────────────────────────
+        // Skipped under `--if-present` for the same reason as the
+        // `node_modules/.bin` / `$PATH` fallback below: a missing script must
+        // not fall through to a same-named `node_modules\.bin\<name>.bunx`.
         #[cfg(windows)]
-        if bun_core::FeatureFlags::WINDOWS_BUNX_FAST_PATH {
+        if bun_core::FeatureFlags::WINDOWS_BUNX_FAST_PATH && !ctx.runtime_options.if_present {
             // SAFETY: process-lifetime static, single-threaded CLI dispatch.
             let buf = unsafe { &mut *bunx_fast_path_buffers::DIRECT_LAUNCH_BUFFER.get() };
             // NT object-manager prefix (`\??\`), NOT the Win32 long-path

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -1,6 +1,8 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { chmodSync } from "fs";
+import { join } from "path";
+import { bunEnv, bunExe, isPosix, tempDirWithFiles } from "harness";
 
 let cwd: string;
 
@@ -114,6 +116,83 @@ describe("bun --if-present", () => {
     });
     expect(stdout.toString()).toMatch(/Here!/);
     expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/31877
+// `bun run --if-present <name>` must only run a package.json script, matching
+// npm. A missing script that happens to share a name with a binary on $PATH or
+// in node_modules/.bin must not be executed; `--if-present` exits 0 instead.
+describe("bun run --if-present does not fall back to a same-named binary", () => {
+  test.skipIf(!isPosix)("does not run a system $PATH binary", () => {
+    // `test` is /usr/bin/test on POSIX; with no args it exits 1. Before the
+    // fix, `bun run --if-present test` executed it and exited 1.
+    const dir = tempDirWithFiles("if-present-path", {
+      "package.json": JSON.stringify({ name: "no-scripts" }),
+    });
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--if-present", "test"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toBeEmpty();
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isPosix)("does not run a node_modules/.bin binary", () => {
+    const dir = tempDirWithFiles("if-present-bin", {
+      "package.json": JSON.stringify({ name: "no-scripts" }),
+      "node_modules/.bin/mytool": "#!/bin/sh\necho BIN_RAN\nexit 3\n",
+    });
+    chmodSync(join(dir, "node_modules", ".bin", "mytool"), 0o755);
+    const { exitCode, stdout, stderr } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--if-present", "mytool"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).not.toContain("BIN_RAN");
+    expect(stderr.toString()).toBeEmpty();
+    expect(exitCode).toBe(0);
+  });
+
+  // The fix is scoped to --if-present: without it, the node_modules/.bin entry
+  // must still run, so a test that deletes the `if_present` guard fails here.
+  test.skipIf(!isPosix)("without --if-present, the node_modules/.bin binary still runs", () => {
+    const dir = tempDirWithFiles("if-present-bin-control", {
+      "package.json": JSON.stringify({ name: "no-scripts" }),
+      "node_modules/.bin/mytool": "#!/bin/sh\necho BIN_RAN\nexit 3\n",
+    });
+    chmodSync(join(dir, "node_modules", ".bin", "mytool"), 0o755);
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "mytool"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toContain("BIN_RAN");
+    expect(exitCode).toBe(3);
+  });
+
+  // A present script must still run even though --if-present is set.
+  test("still runs a present script", () => {
+    const dir = tempDirWithFiles("if-present-present", {
+      "package.json": JSON.stringify({ name: "has-script", scripts: { test: "echo SCRIPT_RAN" } }),
+    });
+    const { exitCode, stdout } = spawnSync({
+      cwd: dir,
+      cmd: [bunExe(), "run", "--if-present", "test"],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(stdout.toString()).toContain("SCRIPT_RAN");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -175,10 +175,7 @@ describe("bun run --if-present does not fall back to a same-named binary", () =>
     expect(exitCode).toBe(3);
   });
 
-  // On Windows the node_modules/.bin entry is a `.bunx` shim launched by the
-  // bunx fast-path, which is a separate code path from the POSIX $PATH search.
-  // A valid `.bunx` can only be produced by `bun install`, so install a local
-  // dep whose bin would print/exit non-zero if launched.
+  // Windows uses a `.bunx` shim (separate launch path); install a dep to make one.
   describe.if(isWindows)("windows .bunx fast-path", () => {
     function makeProject(prefix: string) {
       const dir = tempDirWithFiles(prefix, {

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -121,13 +121,9 @@ describe("bun --if-present", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/31877
-// `bun run --if-present <name>` must only run a package.json script, matching
-// npm. A missing script that happens to share a name with a binary on $PATH or
-// in node_modules/.bin must not be executed; `--if-present` exits 0 instead.
 describe("bun run --if-present does not fall back to a same-named binary", () => {
+  // `test` is /usr/bin/test on POSIX; with no args it exits 1.
   test.skipIf(!isPosix)("does not run a system $PATH binary", () => {
-    // `test` is /usr/bin/test on POSIX; with no args it exits 1. Before the
-    // fix, `bun run --if-present test` executed it and exited 1.
     const dir = tempDirWithFiles("if-present-path", {
       "package.json": JSON.stringify({ name: "no-scripts" }),
     });
@@ -161,8 +157,7 @@ describe("bun run --if-present does not fall back to a same-named binary", () =>
     expect(exitCode).toBe(0);
   });
 
-  // The fix is scoped to --if-present: without it, the node_modules/.bin entry
-  // must still run, so a test that deletes the `if_present` guard fails here.
+  // Control: the fix is scoped to --if-present, so without it the binary runs.
   test.skipIf(!isPosix)("without --if-present, the node_modules/.bin binary still runs", () => {
     const dir = tempDirWithFiles("if-present-bin-control", {
       "package.json": JSON.stringify({ name: "no-scripts" }),
@@ -180,7 +175,6 @@ describe("bun run --if-present does not fall back to a same-named binary", () =>
     expect(exitCode).toBe(3);
   });
 
-  // A present script must still run even though --if-present is set.
   test("still runs a present script", () => {
     const dir = tempDirWithFiles("if-present-present", {
       "package.json": JSON.stringify({ name: "has-script", scripts: { test: "echo SCRIPT_RAN" } }),

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { chmodSync } from "fs";
-import { bunEnv, bunExe, isPosix, tempDirWithFiles } from "harness";
+import { chmodSync, existsSync } from "fs";
+import { bunEnv, bunExe, isPosix, isWindows, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 let cwd: string;
@@ -173,6 +173,60 @@ describe("bun run --if-present does not fall back to a same-named binary", () =>
     });
     expect(stdout.toString()).toContain("BIN_RAN");
     expect(exitCode).toBe(3);
+  });
+
+  // On Windows the node_modules/.bin entry is a `.bunx` shim launched by the
+  // bunx fast-path, which is a separate code path from the POSIX $PATH search.
+  // A valid `.bunx` can only be produced by `bun install`, so install a local
+  // dep whose bin would print/exit non-zero if launched.
+  describe.if(isWindows)("windows .bunx fast-path", () => {
+    function makeProject(prefix: string) {
+      const dir = tempDirWithFiles(prefix, {
+        "package.json": JSON.stringify({
+          name: "test-project",
+          version: "1.0.0",
+          dependencies: { "mytool-pkg": "file:./mytool-pkg" },
+        }),
+        "mytool-pkg/package.json": JSON.stringify({
+          name: "mytool-pkg",
+          version: "1.0.0",
+          bin: { mytool: "./index.js" },
+        }),
+        "mytool-pkg/index.js": "console.log('BIN_RAN'); process.exit(3);\n",
+      });
+      const install = spawnSync({ cwd: dir, cmd: [bunExe(), "install"], env: bunEnv, stdout: "pipe", stderr: "pipe" });
+      expect(install.exitCode).toBe(0);
+      expect(existsSync(join(dir, "node_modules", ".bin", "mytool.bunx"))).toBe(true);
+      return dir;
+    }
+
+    test("does not run a .bunx binary", () => {
+      const dir = makeProject("if-present-bunx");
+      const { exitCode, stdout, stderr } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), "run", "--if-present", "mytool"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).not.toContain("BIN_RAN");
+      expect(stderr.toString()).toBeEmpty();
+      expect(exitCode).toBe(0);
+    });
+
+    // Control: without --if-present, the .bunx binary still runs.
+    test("without --if-present, the .bunx binary still runs", () => {
+      const dir = makeProject("if-present-bunx-control");
+      const { exitCode, stdout } = spawnSync({
+        cwd: dir,
+        cmd: [bunExe(), "run", "mytool"],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(stdout.toString()).toContain("BIN_RAN");
+      expect(exitCode).toBe(3);
+    });
   });
 
   test("still runs a present script", () => {

--- a/test/cli/run/if-present.test.ts
+++ b/test/cli/run/if-present.test.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
 import { chmodSync } from "fs";
-import { join } from "path";
 import { bunEnv, bunExe, isPosix, tempDirWithFiles } from "harness";
+import { join } from "path";
 
 let cwd: string;
 


### PR DESCRIPTION
Fixes #31877

### Repro

```console
$ mkdir /tmp/ifpresent && cd /tmp/ifpresent
$ bun init -y          # package.json has no "scripts"
$ bun run --if-present test
error: "/usr/bin/test" exited with code 1
note: a package.json script "test" was not found
$ echo $?
1
```

Expected: exit code `0`. npm does this right (`npm run --if-present test` exits 0).

The bug is not specific to `test`: any missing script name that collides with a binary on `$PATH` or in `node_modules/.bin` gets executed.

```console
$ bun run --if-present ls     # runs /usr/bin/ls, prints the directory
$ bun run --if-present false  # runs /usr/bin/false, exits 1
```

### Cause

In `RunCommand::exec_with_cfg` (`src/runtime/cli/run_command.rs`), for `bun run --if-present <name>`:

1. package.json script lookup: `<name>` is not in `scripts`, falls through.
2. module resolution fallback: `<name>` does not resolve as a module, falls through.
3. `node_modules/.bin` / system `$PATH` fallback: `which()` finds `/usr/bin/test` and runs it.
4. The `--if-present` early-return (`if ctx.runtime_options.if_present { return Ok(true); }`) sat *after* step 3, so it was never reached once a binary had been executed.

### Fix

Skip the `node_modules/.bin` / `$PATH` binary fallback when `--if-present` is set, so control reaches the `if_present` early-return and exits 0. This matches npm, whose `run-script --if-present` only consults the package.json `scripts` object and never searches `$PATH` or `node_modules/.bin`.

The change is scoped to `--if-present`: without the flag, `bun run <name>` still runs a `node_modules/.bin` or `$PATH` binary exactly as before.

### Verification

New tests in `test/cli/run/if-present.test.ts`:

- `does not run a system $PATH binary` (POSIX): `bun run --if-present test` with no `test` script exits 0 and prints nothing.
- `does not run a node_modules/.bin binary` (POSIX): a `node_modules/.bin/mytool` is not executed under `--if-present`.
- `without --if-present, the node_modules/.bin binary still runs`: control proving the fix is scoped (deleting the guard fails this test's sibling).
- `still runs a present script`: a present script runs even with `--if-present`.

The two `--if-present` tests fail on the current release and pass with this change:

<details>
<summary>USE_SYSTEM_BUN (fails) vs debug build (passes)</summary>

```
# USE_SYSTEM_BUN=1
(fail) ... > does not run a system $PATH binary
  Received: "error: \"/usr/bin/test\" exited with code 1\nnote: a package.json script \"test\" was not found\n"
(fail) ... > does not run a node_modules/.bin binary
  Expected to not contain: "BIN_RAN"  Received: "BIN_RAN\n"
 10 pass, 2 fail

# bun bd
 12 pass, 0 fail
```

</details>
