### PR TITLE
node:vm: restore the previous SIGINT disposition after a breakOnSigint run

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1166,9 +1166,10 @@ bool isSignalName(WTF::String input)
 
 extern "C" void Bun__onSignalForJS(int signalNumber, Zig::GlobalObject* globalObject)
 {
-    // Only populated once process.on(<signal>) adds a listener. SigintWatcher
-    // forwards SIGINT here when no vm context is registered to be interrupted,
-    // which can happen before any listener exists: nothing to dispatch to.
+    // Lazily allocated in onDidChangeListeners. Null means no signal listener
+    // has been registered yet, so there is nothing to dispatch; SigintWatcher
+    // can forward SIGINT here in that state when no vm context is registered
+    // to be interrupted.
     if (!signalNumberToNameMap) [[unlikely]]
         return;
 

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1166,6 +1166,12 @@ bool isSignalName(WTF::String input)
 
 extern "C" void Bun__onSignalForJS(int signalNumber, Zig::GlobalObject* globalObject)
 {
+    // Only populated once process.on(<signal>) adds a listener. SigintWatcher
+    // forwards SIGINT here when no vm context is registered to be interrupted,
+    // which can happen before any listener exists: nothing to dispatch to.
+    if (!signalNumberToNameMap) [[unlikely]]
+        return;
+
     Process* process = globalObject->processObject();
 
     String signalName = signalNumberToNameMap->get(signalNumber);

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -20,12 +20,21 @@ static BOOL WindowsCtrlHandler(DWORD signal)
 
     return false;
 }
+#else
+static void handleSigint(int)
+{
+    SigintWatcher::get().signalReceived();
+}
 #endif
 
 SigintWatcher::SigintWatcher()
     : m_semaphore(1)
 {
     m_globalObjects.reserveInitialCapacity(16);
+#if !OS(WINDOWS)
+    memset(&m_previousAction, 0, sizeof(struct sigaction));
+    m_previousAction.sa_handler = SIG_DFL;
+#endif
 }
 
 SigintWatcher::~SigintWatcher()
@@ -37,26 +46,34 @@ void SigintWatcher::install()
 {
 #if OS(WINDOWS)
     SetConsoleCtrlHandler(WindowsCtrlHandler, true);
+
+    if (m_installed.exchange(true)) {
+        return;
+    }
 #else
     Bun__ensureSignalHandler();
 
     struct sigaction action;
     memset(&action, 0, sizeof(struct sigaction));
 
-    action.sa_handler = [](int signalNumber) {
-        get().signalReceived();
-    };
+    action.sa_handler = handleSigint;
 
     sigemptyset(&action.sa_mask);
     sigaddset(&action.sa_mask, SIGINT);
     action.sa_flags = 0;
 
-    sigaction(SIGINT, &action, nullptr);
-#endif
+    struct sigaction previous;
+    memset(&previous, 0, sizeof(struct sigaction));
+    sigaction(SIGINT, &action, &previous);
 
     if (m_installed.exchange(true)) {
         return;
     }
+
+    // Whatever SIGINT did before we took it over: SIG_DFL, or the handler
+    // process.on("SIGINT") installed. uninstall() restores it.
+    m_previousAction = previous;
+#endif
 
     m_thread = WTF::Thread::create("SigintWatcher"_s, [this] {
         while (m_installed.load()) {
@@ -90,13 +107,13 @@ void SigintWatcher::uninstall()
 #if OS(WINDOWS)
         SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        struct sigaction action;
-        memset(&action, 0, sizeof(struct sigaction));
-        action.sa_handler = Bun__onPosixSignal;
-        sigemptyset(&action.sa_mask);
-        sigaddset(&action.sa_mask, SIGINT);
-        action.sa_flags = SA_RESTART;
-        sigaction(SIGINT, &action, nullptr);
+        // Leave SIGINT alone if someone else claimed it while we were watching:
+        // a process.on("SIGINT") listener registered mid-run owns it now.
+        struct sigaction current;
+        memset(&current, 0, sizeof(struct sigaction));
+        if (sigaction(SIGINT, nullptr, &current) == 0 && current.sa_handler == handleSigint) {
+            sigaction(SIGINT, &m_previousAction, nullptr);
+        }
 #endif
 
         m_semaphore.signal();

--- a/src/jsc/bindings/vm/SigintWatcher.cpp
+++ b/src/jsc/bindings/vm/SigintWatcher.cpp
@@ -107,12 +107,15 @@ void SigintWatcher::uninstall()
 #if OS(WINDOWS)
         SetConsoleCtrlHandler(WindowsCtrlHandler, false);
 #else
-        // Leave SIGINT alone if someone else claimed it while we were watching:
-        // a process.on("SIGINT") listener registered mid-run owns it now.
+        // Restore the disposition install() replaced, unless someone else
+        // claimed SIGINT while we were watching: a process.on("SIGINT")
+        // listener registered mid-run owns it now. Swap before comparing so a
+        // handler installed between a separate read and write could not be
+        // clobbered, mirroring the signal() swap in onDidChangeListeners.
         struct sigaction current;
         memset(&current, 0, sizeof(struct sigaction));
-        if (sigaction(SIGINT, nullptr, &current) == 0 && current.sa_handler == handleSigint) {
-            sigaction(SIGINT, &m_previousAction, nullptr);
+        if (sigaction(SIGINT, &m_previousAction, &current) == 0 && current.sa_handler != handleSigint) {
+            sigaction(SIGINT, &current, nullptr);
         }
 #endif
 

--- a/src/jsc/bindings/vm/SigintWatcher.h
+++ b/src/jsc/bindings/vm/SigintWatcher.h
@@ -7,6 +7,10 @@
 
 #include <atomic>
 
+#if !OS(WINDOWS)
+#include <signal.h>
+#endif
+
 namespace Bun {
 
 template<typename T>
@@ -106,6 +110,10 @@ private:
     WTF::Vector<JSC::JSGlobalObject*> m_globalObjects;
     WTF::Vector<SigintReceiver*> m_receivers;
     uint32_t m_refCount = 0;
+#if !OS(WINDOWS)
+    // The SIGINT disposition install() replaced, restored by uninstall().
+    struct sigaction m_previousAction;
+#endif
 
     bool signalAll();
 };

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
 import {
   compileFunction,
   constants,
@@ -1234,5 +1234,75 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ab=B ba=A");
     expect(exitCode).toBe(0);
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/31885
+describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT disposition", () => {
+  // Printed after the vm run, so the parent only signals once SIGINT is back in
+  // whatever state the script left it. kill() delivers the signal before it
+  // returns, so a child still alive here swallowed it: fail, rather than hang.
+  const stayAliveThenReady = `
+    setTimeout(() => { process.stdout.write("survived\\n"); process.exit(7); }, 1500);
+    process.stdout.write("ready\\n");
+  `;
+
+  async function sigintAfterReady(fixture: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "inherit",
+    });
+
+    let stdout = "";
+    const ready = Promise.withResolvers<void>();
+    const drained = (async () => {
+      const decoder = new TextDecoder();
+      for await (const chunk of proc.stdout) {
+        stdout += decoder.decode(chunk, { stream: true });
+        if (stdout.includes("ready\n")) ready.resolve();
+      }
+    })();
+    proc.exited.then(() => ready.reject(new Error(`child exited before printing "ready": ${stdout}`)));
+
+    await ready.promise;
+    proc.kill("SIGINT");
+
+    const exitCode = await proc.exited;
+    await drained;
+    return { stdout, exitCode, signalCode: proc.signalCode };
+  }
+
+  test("SIGINT terminates the process when no listener was ever registered", async () => {
+    const result = await sigintAfterReady(`
+      require("node:vm").runInNewContext("1 + 1", {}, { breakOnSigint: true });
+      ${stayAliveThenReady}
+    `);
+
+    // SIG_DFL, same as node: exit 130, no "survived".
+    expect(result).toEqual({ stdout: "ready\n", exitCode: 130, signalCode: "SIGINT" });
+  });
+
+  test("a listener registered before the run still receives SIGINT after it", async () => {
+    const result = await sigintAfterReady(`
+      process.on("SIGINT", () => { process.stdout.write("listener\\n"); process.exit(0); });
+      require("node:vm").runInNewContext("1 + 1", {}, { breakOnSigint: true });
+      ${stayAliveThenReady}
+    `);
+
+    expect(result).toEqual({ stdout: "ready\nlistener\n", exitCode: 0, signalCode: null });
+  });
+
+  test("removing the last listener after the run hands SIGINT back to the default", async () => {
+    const result = await sigintAfterReady(`
+      const listener = () => { process.stdout.write("listener\\n"); process.exit(0); };
+      process.on("SIGINT", listener);
+      require("node:vm").runInNewContext("1 + 1", {}, { breakOnSigint: true });
+      process.off("SIGINT", listener);
+      ${stayAliveThenReady}
+    `);
+
+    expect(result).toEqual({ stdout: "ready\n", exitCode: 130, signalCode: "SIGINT" });
   });
 });

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1238,7 +1238,7 @@ describe("node:vm SourceTextModule cyclic graph linking", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/31885
-describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT disposition", () => {
+describe.concurrent.skipIf(isWindows)("breakOnSigint restores the previous SIGINT disposition", () => {
   // Printed after the vm run, so the parent only signals once SIGINT is back in
   // whatever state the script left it. kill() delivers the signal before it
   // returns, so a child still alive here swallowed it: fail, rather than hang.
@@ -1252,7 +1252,7 @@ describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT dispositi
       cmd: [bunExe(), "-e", fixture],
       env: bunEnv,
       stdout: "pipe",
-      stderr: "inherit",
+      stderr: "pipe",
     });
 
     let stdout = "";
@@ -1269,9 +1269,9 @@ describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT dispositi
     await ready.promise;
     proc.kill("SIGINT");
 
-    const exitCode = await proc.exited;
+    const [exitCode, stderr] = await Promise.all([proc.exited, proc.stderr.text()]);
     await drained;
-    return { stdout, exitCode, signalCode: proc.signalCode };
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
   test("SIGINT terminates the process when no listener was ever registered", async () => {
@@ -1281,7 +1281,7 @@ describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT dispositi
     `);
 
     // SIG_DFL, same as node: exit 130, no "survived".
-    expect(result).toEqual({ stdout: "ready\n", exitCode: 130, signalCode: "SIGINT" });
+    expect(result).toEqual({ stdout: "ready\n", stderr: "", exitCode: 130, signalCode: "SIGINT" });
   });
 
   test("a listener registered before the run still receives SIGINT after it", async () => {
@@ -1291,7 +1291,7 @@ describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT dispositi
       ${stayAliveThenReady}
     `);
 
-    expect(result).toEqual({ stdout: "ready\nlistener\n", exitCode: 0, signalCode: null });
+    expect(result).toEqual({ stdout: "ready\nlistener\n", stderr: "", exitCode: 0, signalCode: null });
   });
 
   test("removing the last listener after the run hands SIGINT back to the default", async () => {
@@ -1303,6 +1303,23 @@ describe.skipIf(isWindows)("breakOnSigint restores the previous SIGINT dispositi
       ${stayAliveThenReady}
     `);
 
-    expect(result).toEqual({ stdout: "ready\n", exitCode: 130, signalCode: "SIGINT" });
+    expect(result).toEqual({ stdout: "ready\n", stderr: "", exitCode: 130, signalCode: "SIGINT" });
+  });
+
+  test("a listener registered during the run still receives SIGINT after it", async () => {
+    // Node v26 exits 130 here: its SigintWatchdog restores the sigaction it
+    // replaced without checking who owns SIGINT now, so the listener stays in
+    // process.listeners("SIGINT") but never fires. Bun leaves a handler
+    // installed mid-run in place so signalToContextIdsMap and the sigaction
+    // agree; uninstall() only restores when its own handler is still current.
+    const result = await sigintAfterReady(`
+      require("node:vm").runInThisContext(
+        'process.on("SIGINT", () => { process.stdout.write("listener\\\\n"); process.exit(0); })',
+        { breakOnSigint: true },
+      );
+      ${stayAliveThenReady}
+    `);
+
+    expect(result).toEqual({ stdout: "ready\nlistener\n", stderr: "", exitCode: 0, signalCode: null });
   });
 });


### PR DESCRIPTION
Fixes #31885.

## Repro

```js
import * as vm from "node:vm";

vm.runInNewContext("1 + 1", {}, { breakOnSigint: true });
process.kill(process.pid, "SIGINT"); // or Ctrl-C, kill -INT, a supervisor shutdown
await new Promise(r => setTimeout(r, 300));
console.log("still alive after SIGINT with no listener (should have died)");
```

`node` exits 130 from SIGINT's default disposition. Bun segfaults:

```
panic(main thread): Segmentation fault at address 0x0
```

```
../../src/jsc/bindings/BunProcess.cpp:1171:48: runtime error: member call on null pointer of type 'WTF::HashMap<int, WTF::String>'
```

## Cause

`SigintWatcher::uninstall()` pointed SIGINT at `Bun__onPosixSignal` instead of putting back the disposition `install()` had replaced:

```cpp
action.sa_handler = Bun__onPosixSignal;
sigaction(SIGINT, &action, nullptr);
```

So any `breakOnSigint` evaluation costs the process its default SIGINT behavior permanently, and every later SIGINT is routed into `Bun__onSignalForJS`. That function dereferences `signalNumberToNameMap`, which is lazily allocated in `onDidChangeListeners` and is still null here:

```cpp
String signalName = signalNumberToNameMap->get(signalNumber); // null here
```

Two symptoms fall out of the same root cause:

| after a `breakOnSigint` run | before | node |
| --- | --- | --- |
| no signal listener, SIGINT | segfault (null map) | exit 130 |
| listener added then removed, SIGINT | swallowed, process lives on | exit 130 |

The second case is the one the reporter originally hit ("the program no longer terminates on SIGINT"); the crash only shows up when no listener was ever registered, because that is the only time the map is still null.

## Fix

`install()` records the `sigaction` it replaces, and `uninstall()` restores it. The restore is conditional on our handler still being the installed one, so a `process.on("SIGINT")` listener registered during the run keeps SIGINT (otherwise `signalToContextIdsMap` and the kernel disposition disagree and a later listener never fires). The check is a swap-then-compare rather than a read-then-write so a handler installed from the main thread between the two calls cannot be clobbered by a worker's `deref()`.

`Bun__onSignalForJS` additionally returns early when the map is null. The watcher thread forwards SIGINT there when no vm context is registered to interrupt, which can happen before any listener exists (the window between `ref()` and `registerGlobalObject()`, and between `unregisterGlobalObject()` and `deref()`).

## Verification

Four tests in `test/js/node/vm/vm.test.ts`, covering both symptoms, the before-run listener path, and the mid-run listener path that drives `uninstall()` down its skip-restore branch. Against the unfixed build:

```
(fail) SIGINT terminates the process when no listener was ever registered
         expected { exitCode: 130, signalCode: "SIGINT" }
         received { exitCode: 139, signalCode: "SIGSEGV" }
(pass) a listener registered before the run still receives SIGINT after it
(fail) removing the last listener after the run hands SIGINT back to the default
         expected { stdout: "ready\n",          exitCode: 130, signalCode: "SIGINT" }
         received { stdout: "ready\nsurvived\n", exitCode: 7,   signalCode: null }
(pass) a listener registered during the run still receives SIGINT after it
```

All four pass with the fix, and `bun-debug` now exits 130 on the repro, same as node.

The mid-run case deliberately diverges from node: node's `SigintWatchdog` restores the saved sigaction unconditionally, so a listener added inside the script is left in `process.listeners("SIGINT")` but never fires (node exits 130 there). Bun leaves a handler it did not install in place.

<details>
<summary>node's own vm/signal suites, on the debug build</summary>

```
test/js/node/test/parallel/test-vm-sigint.js                  exit=0
test/js/node/test/parallel/test-vm-sigint-existing-handler.js exit=0
test/js/node/test/sequential/test-vm-break-on-sigint.js       exit=0
test/js/node/test/parallel/test-signal-handler.js             exit=0
test/js/node/test/parallel/test-signal-unregister.js          exit=0
test/js/node/test/parallel/test-util-sigint-watchdog.js       exit=0
```

`test-vm-sigint-existing-handler.js` is the load-bearing one: it asserts that listeners attached before the run do not fire during it, and do fire on the SIGINTs that follow.

</details>
