### PR TITLE
test: make mock functions construct a proper instance

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -826,7 +827,7 @@ static JSValue createMockResult(JSC::VM& vm, Zig::GlobalObject* globalObject, co
     return result;
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+static JSC::EncodedJSValue jsMockFunctionCallImpl(JSGlobalObject* lexicalGlobalObject, CallFrame* callframe, JSValue thisValue)
 {
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
@@ -838,7 +839,6 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -979,6 +979,55 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    return jsMockFunctionCallImpl(lexicalGlobalObject, callframe, callframe->thisValue());
+}
+
+// [[Construct]] must return an object, so this follows the same steps as an
+// ordinary JS function (which is what jest's mockConstructor is): create the
+// instance from newTarget's prototype, run the mock with it as |this|, and
+// return the instance unless the implementation returned an object itself.
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSMockFunction* fn = dynamicDowncast<JSMockFunction>(callframe->jsCallee());
+    if (!fn) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Expected callee to be mock function"_s);
+        return {};
+    }
+
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSGlobalObject* functionGlobalObject = JSC::getFunctionRealm(globalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, {});
+    Structure* structure = JSC::InternalFunction::createSubclassStructure(globalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = JSC::constructEmptyObject(vm, structure);
+
+    JSC::JSArray* instances = fn->instances.get();
+    if (instances) {
+        instances->push(globalObject, thisObject);
+        RETURN_IF_EXCEPTION(scope, {});
+    } else {
+        JSC::ObjectInitializationScope object(vm);
+        instances = JSC::JSArray::tryCreateUninitializedRestricted(
+            object,
+            globalObject->arrayStructureForIndexingTypeDuringAllocation(JSC::ArrayWithContiguous),
+            1);
+        instances->initializeIndex(object, 0, thisObject);
+        fn->instances.set(vm, fn, instances);
+    }
+
+    JSValue returnValue = JSValue::decode(jsMockFunctionCallImpl(lexicalGlobalObject, callframe, thisObject));
+    RETURN_IF_EXCEPTION(scope, {});
+
+    if (returnValue && returnValue.isObject())
+        return JSValue::encode(returnValue);
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,74 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  describe("called as a constructor", () => {
+    test("returns a new instance and records it", () => {
+      const fn = jest.fn();
+      const a = new fn();
+      expect(typeof a).toBe("object");
+      expect(a).not.toBeNull();
+      const b = Reflect.construct(fn, []);
+      expect(typeof b).toBe("object");
+      expect(b).not.toBe(a);
+      expect(fn.mock.instances[0]).toBe(a);
+      expect(fn.mock.instances[1]).toBe(b);
+      expect(fn.mock.contexts[0]).toBe(a);
+      expect(fn.mock.contexts[1]).toBe(b);
+      expect(fn.mock.calls).toEqual([[], []]);
+      expect(fn.mock.results[0]).toEqual({ type: "return", value: undefined });
+    });
+
+    test("implementation runs with the instance as this", () => {
+      const fn = jest.fn(function (value) {
+        this.value = value;
+      });
+      const a = new fn(42);
+      expect(a.value).toBe(42);
+      expect(fn.mock.calls[0]).toEqual([42]);
+      expect(fn.mock.results[0]).toEqual({ type: "return", value: undefined });
+    });
+
+    test("object returned from the implementation becomes the result", () => {
+      const obj = { tag: "explicit" };
+      const fn = jest.fn(() => obj);
+      expect(new fn()).toBe(obj);
+    });
+
+    test("primitive returned from the implementation is ignored", () => {
+      const fn = jest.fn(() => 42);
+      const a = new fn();
+      expect(typeof a).toBe("object");
+      expect(a).not.toBeNull();
+      expect(fn.mock.results[0]).toEqual({ type: "return", value: 42 });
+    });
+
+    test("mockReturnValue with an object becomes the result", () => {
+      const obj = { tag: "return value" };
+      const fn = jest.fn();
+      fn.mockReturnValue(obj);
+      expect(new fn()).toBe(obj);
+    });
+
+    test("uses the prototype property when set", () => {
+      const fn = jest.fn();
+      fn.prototype = { marker: true };
+      const a = new fn();
+      expect(Object.getPrototypeOf(a)).toBe(fn.prototype);
+      expect(a instanceof fn).toBe(true);
+      expect(a.marker).toBe(true);
+    });
+
+    test("throwing implementation still records the instance", () => {
+      const instance = new Error("boom");
+      const fn = jest.fn(() => {
+        throw instance;
+      });
+      expect(() => new fn()).toThrow("boom");
+      expect(fn.mock.instances).toHaveLength(1);
+      expect(fn.mock.results[0]).toEqual({ type: "throw", value: instance });
+    });
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a Fuzzilli-found assertion failure (fingerprint `JSObject.h(1346)`, `ASSERTION FAILED: cell->isObjectSlow()`) reached by constructing a `bun:test` mock function:

```js
const fn = Bun.jest().mock(); // or jest.fn(), mock(), vi.fn()
Reflect.construct(fn, []);
```

**Root cause:** `JSMockFunction` passed `jsMockFunctionCall` as both the call and the construct handler:

```cpp
: Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
```

so `[[Construct]]` returned whatever the mock implementation returned, `undefined` by default. JSC requires a native `[[Construct]]` to return an object: `Reflect.construct` goes through `Interpreter::executeConstruct`, which does `asObject(result)` on the return value. On `undefined` that asserts in debug builds and is type confusion in release builds. The bytecode path doesn't assert, so `new fn()` silently evaluated to `undefined`, which also violates the spec (a `new` expression always produces an object).

**Fix:** add a dedicated `jsMockFunctionConstruct` that follows ordinary function `[[Construct]]` semantics, which is exactly what jest's `mockConstructor` (a plain JS function) does:

1. Create the instance via `OrdinaryCreateFromConstructor(newTarget, "%Object.prototype%")` (the same `getFunctionRealm` + `InternalFunction::createSubclassStructure` pattern JSC's `ObjectConstructor` uses), so an assigned `fn.prototype` is honored.
2. Record the instance in `mock.instances` (the array already existed, was exposed on `fn.mock`, and was cleared by `mockClear`/`mockReset`, but nothing ever wrote to it).
3. Run the shared mock logic with the instance as `this`, so `mock.contexts`, `mock.calls`, and `mock.results` record the same things jest records for `new`.
4. Return the implementation's return value if it's an object, otherwise the instance.

The load-bearing change is the constructor list at `JSMockFunction(...)`: `jsMockFunctionCall, jsMockFunctionCall` becomes `jsMockFunctionCall, jsMockFunctionConstruct`. The old handler body is unchanged, just extracted into `jsMockFunctionCallImpl` taking `thisValue` as a parameter (during native construct the callframe's this slot holds newTarget, not a this value).

### How did you verify your code works?

- The original Fuzzilli crash script and the minimized repro run cleanly on the debug+ASAN build (previously: `ASSERTION FAILED: cell->isObjectSlow()` / `isCell()`).
- New tests in `test/js/bun/test/mock-fn.test.js` under `mock() > called as a constructor`: 5 of the 7 fail on the unfixed build (`new fn()` is `undefined`, `mock.instances` stays empty); the other 2 pin the "implementation returned an object wins" contract that already worked and must keep working. This file is written to also run under real Jest and Vitest, and the assertions match jest's documented `mock.instances` behavior for `new`.
- Full `mock-fn.test.js` (79 tests), `mock-disposable.test.ts`, `mock/mock-module.test.ts`, `spyMatchers.test.ts`, `expect-toHaveReturnedWith.test.js`, and `jest-extended.test.js` pass with the debug build.
- `BUN_JSC_validateExceptionChecks=1` is clean on the new path, including a `newTarget.prototype` proxy trap that throws.
- GC stress: 5000 `new fn()` iterations with `Bun.gc(true)` keeps all recorded instances alive.

Known remaining divergence from jest, unchanged by this PR: a bare mock function has no own `prototype` property (jest's mocks are plain functions, so `new jest.fn() instanceof fn` works there without assigning `fn.prototype` first).
