### PR TITLE
Fix debug assertion when creating errors with empty messages

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2414,7 +2414,7 @@ JSC::EncodedJSValue SystemError__toErrorInstance(const SystemError* arg0, JSC::J
 
     auto& names = WebCore::builtinNames(vm);
 
-    JSC::JSObject* result = createError(globalObject, ErrorType::Error, message);
+    JSC::JSObject* result = Zig::createErrorAllowEmptyMessage(globalObject, ErrorType::Error, message);
 
     auto clientData = WebCore::clientData(vm);
 
@@ -6103,17 +6103,17 @@ CPP_DECL void JSC__VM__performOpportunisticallyScheduledTasks(JSC::VM* vm, doubl
 
 extern "C" EncodedJSValue JSC__createError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Zig::createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::Error, str->toWTFString(BunString::ZeroCopy)));
 }
 
 extern "C" EncodedJSValue JSC__createTypeError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createTypeError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Zig::createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::TypeError, str->toWTFString(BunString::ZeroCopy)));
 }
 
 extern "C" EncodedJSValue JSC__createRangeError(JSC::JSGlobalObject* globalObject, const BunString* str)
 {
-    return JSValue::encode(JSC::createRangeError(globalObject, str->toWTFString(BunString::ZeroCopy)));
+    return JSValue::encode(Zig::createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::RangeError, str->toWTFString(BunString::ZeroCopy)));
 }
 
 extern "C" EncodedJSValue ExpectMatcherUtils__getSingleton(JSC::JSGlobalObject* globalObject_)

--- a/src/jsc/bindings/helpers.h
+++ b/src/jsc/bindings/helpers.h
@@ -391,6 +391,17 @@ static const WTF::String toStringStatic(ZigString str)
     return WTF::String(AtomStringImpl::add(std::span { untagged, str.len }));
 }
 
+// JSC::createError and friends assert that the message is non-empty, but these
+// conversions accept arbitrary user-provided strings (e.g. `expect.unreachable("")`).
+// Construct the ErrorInstance directly for an empty message, matching what the
+// JSC helpers do in release builds (same as `new Error("")`).
+static JSC::JSObject* createErrorAllowEmptyMessage(JSC::JSGlobalObject* globalObject, JSC::ErrorType errorType, const WTF::String& message)
+{
+    if (message.isEmpty()) [[unlikely]]
+        return JSC::ErrorInstance::create(globalObject->vm(), globalObject->errorStructure(errorType), message, JSC::JSValue(), nullptr, JSC::TypeNothing, errorType);
+    return JSC::createError(globalObject, errorType, message);
+}
+
 static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
     WTF::String message = toString(*str);
@@ -399,7 +410,7 @@ static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* 
         return {};
     }
 
-    JSC::JSObject* result = JSC::createError(globalObject, message);
+    JSC::JSObject* result = createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::Error, message);
     JSC::EnsureStillAliveScope ensureAlive(result);
 
     return result;
@@ -407,7 +418,7 @@ static JSC::JSValue getErrorInstance(const ZigString* str, JSC::JSGlobalObject* 
 
 static JSC::JSValue getTypeErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    JSC::JSObject* result = JSC::createTypeError(globalObject, toStringCopy(*str));
+    JSC::JSObject* result = createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::TypeError, toStringCopy(*str));
     JSC::EnsureStillAliveScope ensureAlive(result);
 
     return result;
@@ -415,7 +426,7 @@ static JSC::JSValue getTypeErrorInstance(const ZigString* str, JSC::JSGlobalObje
 
 static JSC::JSValue getSyntaxErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    JSC::JSObject* result = JSC::createSyntaxError(globalObject, toStringCopy(*str));
+    JSC::JSObject* result = createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::SyntaxError, toStringCopy(*str));
     JSC::EnsureStillAliveScope ensureAlive(result);
 
     return result;
@@ -423,7 +434,7 @@ static JSC::JSValue getSyntaxErrorInstance(const ZigString* str, JSC::JSGlobalOb
 
 static JSC::JSValue getRangeErrorInstance(const ZigString* str, JSC::JSGlobalObject* globalObject)
 {
-    JSC::JSObject* result = JSC::createRangeError(globalObject, toStringCopy(*str));
+    JSC::JSObject* result = createErrorAllowEmptyMessage(globalObject, JSC::ErrorType::RangeError, toStringCopy(*str));
     JSC::EnsureStillAliveScope ensureAlive(result);
 
     return result;

--- a/test/js/bun/test/expect-unreaachable.test.ts
+++ b/test/js/bun/test/expect-unreaachable.test.ts
@@ -7,3 +7,16 @@ test("expect.unreachable()", () => {
   expect(() => expect.unreachable(error)).toThrow(error);
   expect(() => expect.unreachable()).toThrow("reached unreachable code");
 });
+
+test("expect.unreachable() with an empty message", () => {
+  // Creating an error from an empty user-provided string must not crash
+  let thrown: Error | undefined;
+  try {
+    expect.unreachable("");
+  } catch (e) {
+    thrown = e as Error;
+  }
+  expect(thrown).toBeInstanceOf(Error);
+  expect(thrown!.name).toBe("UnreachableError");
+  expect(thrown!.message).toBe("");
+});


### PR DESCRIPTION
### Crash

Fuzzilli found a deterministic abort in debug builds (fingerprint `Error.cpp(40)`):

```
ASSERTION FAILED: !message.isEmpty()
vendor/WebKit/Source/JavaScriptCore/runtime/Error.cpp(40) : JSObject *JSC::createError(JSGlobalObject *, const String &, ErrorInstance::SourceAppender)
```

Minimal repro:

```js
expect.unreachable("");
```

### Root cause

`JSC::createError` / `createTypeError` / `createRangeError` / `createSyntaxError` assert that the message is non-empty (debug builds only). Bun's generic string-to-Error conversion entry points forwarded arbitrary strings to them:

- `JSC__createError` / `JSC__createTypeError` / `JSC__createRangeError` (`bindings.cpp`), reached from Rust via `bun.String.to_error_instance` and friends. `expect.unreachable("")` passes the user's message straight through this path.
- `Zig::getErrorInstance` / `getTypeErrorInstance` / `getSyntaxErrorInstance` / `getRangeErrorInstance` (`helpers.h`), reached from `ZigString` conversions and the `global.throw*` format helpers.
- `SystemError__toErrorInstance`, which already substitutes `WTF::emptyString()` for an empty-tagged message before calling `createError`.

In release builds the assertion compiles out and `ErrorInstance::create` handles an empty message fine (same as `new Error("")`), so only debug builds aborted.

### Fix

Add `Zig::createErrorAllowEmptyMessage` in `helpers.h`: for an empty message it constructs the `ErrorInstance` directly with the same arguments the JSC helpers pass, skipping the assert; otherwise it defers to `JSC::createError(globalObject, errorType, message)`. All eight conversion sites above now go through it. The fixing change is the new helper; the rest of the diff is routing the existing call sites through it.

Release behavior is unchanged: `expect.unreachable("")` throws `UnreachableError` with an empty message both before and after, verified against the current release build.

### Test

`test/js/bun/test/expect-unreaachable.test.ts` gains a case calling `expect.unreachable("")` and asserting the thrown error's name and message. On an unfixed debug build the process aborts with the assertion (exit 134); with the fix it passes. Release builds pass both ways since the assertion only exists in debug.
