### PR TITLE
ci: bake Intel SDE into the Windows image for verify-baseline

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -776,7 +776,7 @@ function getVerifyBaselineStep(platform, options) {
     timeout_in_minutes: hasWebKitChanges(options) ? 30 : 10,
     command: [
       ...setupCommands,
-      `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml`,
+      `cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml${os === "windows" ? " || exit /b 1" : ""}`,
       `bun scripts/verify-baseline.ts --binary ${profileDir}/${profileExe} --emulator ${emulator}${jitStressFlag}`,
     ],
   };

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -702,13 +702,13 @@ function needsBaselineVerification(platform) {
  */
 function getEmulatorBinary(platform) {
   const { os, arch } = platform;
-  if (os === "windows") return "sde-external/sde.exe";
+  // Intel SDE is baked into the Windows image by scripts/bootstrap.ps1
+  // (Install-IntelSde): downloadmirror.intel.com sits behind a bot challenge
+  // that blocks non-browser clients, so it cannot be downloaded at job time.
+  if (os === "windows") return "C:\\intel-sde\\sde.exe";
   if (arch === "aarch64") return "qemu-aarch64-static";
   return "qemu-x86_64-static";
 }
-
-const SDE_VERSION = "9.58.0-2025-06-16";
-const SDE_URL = `https://downloadmirror.intel.com/859732/sde-external-${SDE_VERSION}-win.tar.xz`;
 
 /**
  * @param {Platform} platform
@@ -742,16 +742,13 @@ function getVerifyBaselineStep(platform, options) {
   const setupCommands =
     os === "windows"
       ? [
+          // cmd.exe batch does not stop on error: without `|| exit /b 1` a
+          // failed line is ignored and only the last command's exit code
+          // becomes the step result.
           `echo Downloading build artifacts...`,
-          `buildkite-agent artifact download ${profileDir}.zip . --step ${targetKey}-build-bun`,
+          `buildkite-agent artifact download ${profileDir}.zip . --step ${targetKey}-build-bun || exit /b 1`,
           `echo Extracting ${profileDir}.zip...`,
-          `tar -xf ${profileDir}.zip`,
-          `echo Downloading Intel SDE...`,
-          `curl.exe -fsSL -o sde.tar.xz "${SDE_URL}"`,
-          `echo Extracting Intel SDE...`,
-          `7z x -y sde.tar.xz`,
-          `7z x -y sde.tar`,
-          `ren sde-external-${SDE_VERSION}-win sde-external`,
+          `tar -xf ${profileDir}.zip || exit /b 1`,
         ]
       : [
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -436,6 +436,9 @@ function Install-IntelSde {
   $tarXz = Download-File "https://buncistore.blob.core.windows.net/artifacts/sde-external-$version-win.tar.xz" -Name "sde-external-$version-win.tar.xz"
   $actualHash = (Get-FileHash $tarXz -Algorithm SHA256).Hash
   if ($actualHash -ne $sha256) {
+    # Delete the bad file: Download-File skips the download when the target
+    # already exists, so leaving it would poison every subsequent run.
+    Remove-Item $tarXz -ErrorAction SilentlyContinue
     throw "Intel SDE checksum mismatch: expected $sha256, got $actualHash"
   }
 

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,4 +1,4 @@
-# Version: 19
+# Version: 20
 # A script that installs the dependencies needed to build and test Bun on Windows.
 # Supports both x64 and ARM64 using Scoop for package management.
 # Used by Azure [build images] pipeline.
@@ -413,6 +413,54 @@ function Install-Ccache {
   Add-To-Path $installDir
 }
 
+function Install-IntelSde {
+  # Intel SDE lets verify-baseline run the x64-baseline build on an emulated
+  # pre-AVX CPU (sde.exe -nhm). It is baked into the image because
+  # downloadmirror.intel.com sits behind a bot challenge that blocks
+  # non-browser downloads, both from CI jobs and from this bake VM. The
+  # tarball is mirrored, unmodified, on our blob storage, which the Intel
+  # Simplified Software License it ships under permits.
+  # To bump: download sde-external-<version>-win.tar.xz from
+  # https://www.intel.com/content/www/us/en/download/684897/ in a browser,
+  # upload it to the artifacts container, then update $version and $sha256
+  # (Intel publishes the SHA256 on the download page).
+  $version = "9.58.0-2025-06-16"
+  $sha256 = "EBB8B3B63FCB0B6C1F9721118BA4883703D2AED9E0DB2DEFED4E44FBA78D9CA9"
+  $installDir = "C:\intel-sde"
+
+  if (Test-Path "$installDir\sde.exe") {
+    return
+  }
+
+  Write-Output "Installing Intel SDE $version..."
+  $tarXz = Download-File "https://buncistore.blob.core.windows.net/artifacts/sde-external-$version-win.tar.xz" -Name "sde-external-$version-win.tar.xz"
+  $actualHash = (Get-FileHash $tarXz -Algorithm SHA256).Hash
+  if ($actualHash -ne $sha256) {
+    throw "Intel SDE checksum mismatch: expected $sha256, got $actualHash"
+  }
+
+  $sevenZip = Which 7z -Required
+  $extractDir = "$env:TEMP\sde-extract"
+  & $sevenZip x -y "-o$extractDir" $tarXz | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to extract $tarXz"
+  }
+  & $sevenZip x -y "-o$extractDir" "$extractDir\sde-external-$version-win.tar" | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to extract sde-external-$version-win.tar"
+  }
+
+  # Keep the whole kit directory intact: sde.exe resolves its Pin DLLs
+  # relative to its own location.
+  Move-Item "$extractDir\sde-external-$version-win" $installDir -Force
+  Remove-Item $tarXz -ErrorAction SilentlyContinue
+  Remove-Item $extractDir -Recurse -ErrorAction SilentlyContinue
+
+  if (-not (Test-Path "$installDir\sde.exe")) {
+    throw "Intel SDE install failed: $installDir\sde.exe not found"
+  }
+}
+
 function Install-Bun {
   if (Which bun) {
     return
@@ -711,6 +759,12 @@ Install-Ccache
 Install-Rust
 Install-Visual-Studio
 Install-PdbAddr2line
+
+# x64-only: Intel SDE for the verify-baseline step (emulates a pre-AVX CPU);
+# only the x64-baseline build is verified under it.
+if (-not $script:IsARM64) {
+  Install-IntelSde
+}
 
 function Prefetch-Build-Deps {
   # Bake a read-only download cache for scripts/build/download.ts

--- a/scripts/verify-baseline.ts
+++ b/scripts/verify-baseline.ts
@@ -34,7 +34,8 @@ function resolveEmulator(name: string): string {
     const fallback = Bun.which(name.slice(0, -"-static".length));
     if (fallback) return fallback;
   }
-  // Last resort: resolve as a relative path (e.g. sde-external/sde.exe)
+  // Last resort: resolve as a path (absolute paths like C:\intel-sde\sde.exe
+  // pass through unchanged, relative paths resolve against cwd)
   return resolve(name);
 }
 


### PR DESCRIPTION
Fixes #31872. Supersedes #31873 (mirror-at-job-time approach; this removes the job-time download entirely).

## Problem

Every `windows-x64-baseline - verify-baseline` run since 2026-06-04 fails before the verifier starts:

```
Downloading Intel SDE...
Extracting Intel SDE...
1 file, 0 bytes
ERROR: sde.tar.xz
Cannot open the file as archive
```

`downloadmirror.intel.com` now fronts all downloads with a bot challenge that returns HTTP 202 with an empty body to non-browser clients (verified against multiple file IDs, including the current SDE 10.8 release — the URL we pin is still valid, the host just no longer serves CLI clients). `curl -fsSL` treats 202 as success, so the step extracted a 0-byte tarball.

## Fix

Bake SDE into the Windows x64 CI image instead of downloading it on every run:

- **bootstrap.ps1**: new `Install-IntelSde` (x64 only) downloads `sde-external-9.58.0-2025-06-16-win.tar.xz` from our CI blob mirror, verifies Intel's published SHA256 (`EBB8…D9CA9`), and extracts the kit to `C:\intel-sde` (directory kept intact — sde.exe resolves its Pin DLLs relative to itself). Image version 19 → 20. The tarball is mirrored unmodified; the Intel Simplified Software License it ships under permits redistribution without modification.
- **ci.mjs**: verify-baseline uses the baked `C:\intel-sde\sde.exe`; the download/extract lines are gone. The remaining batch lines get `|| exit /b 1` so a failure stops the step with the real error (cmd.exe otherwise continues past failed lines — that's why this broke as a confusing 7z error).
- **verify-baseline.ts**: comment-only; it already resolves absolute emulator paths and runs SDE from its own directory.

## Validation

- bootstrap.ps1 parses clean (PowerShell AST parser); ci.mjs passes `node --check`.
- Mirror blob verified anonymously fetchable and byte-identical to Intel's published SHA256.
- The commit message carries `[build windows images]`, so this build bakes a throwaway image (exercising `Install-IntelSde` for real) and runs the Windows jobs against it.

## Rollout

After review and a green `[build windows images]` run: run `[publish images]` from this branch (~2-3 h) to publish `windows-x64-2019-v20`, **then** merge. Merging first would point main's jobs at a not-yet-published image.