### PR TITLE
Add space, channels, and hasAlpha to Bun.Image metadata()

### DIFF
--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -43,12 +43,20 @@ new Bun.Image(input, {
 
 ## Metadata
 
-Read `width`, `height`, and `format` without decoding pixel data:
+Read dimensions, format, and colour layout without decoding pixel data:
 
 ```ts
-const { width, height, format } = await new Bun.Image(input).metadata();
-// => { width: 1920, height: 1080, format: "jpeg" }
+const { width, height, format, space, channels, hasAlpha } = await new Bun.Image(input).metadata();
+// => { width: 1920, height: 1080, format: "jpeg", space: "srgb", channels: 3, hasAlpha: false }
 ```
+
+| Field      | Meaning                                                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `space`    | Colour space in Sharp's vocabulary: `"srgb"`, `"b-w"` (greyscale), `"cmyk"`, `"rgb16"`/`"grey16"` (16-bit PNG)                                      |
+| `channels` | Channel count of the source: 1 grey, 2 grey+alpha, 3 RGB, 4 RGB+alpha or CMYK                                                                       |
+| `hasAlpha` | Whether the source carries transparency — an alpha channel, a PNG `tRNS` chunk, a BMP alpha mask, or GIF palette transparency. JPEG: always `false` |
+
+`hasAlpha` makes format negotiation cheap: keep PNG/WebP when the source actually has transparency, serve JPEG otherwise.
 
 ## Resize
 

--- a/docs/runtime/image.mdx
+++ b/docs/runtime/image.mdx
@@ -43,7 +43,7 @@ new Bun.Image(input, {
 
 ## Metadata
 
-Read dimensions, format, and colour layout without decoding pixel data:
+Read dimensions, format, and colour layout without decoding pixel data (HEIC/AVIF/TIFF have no header probe and fall back to a full decode on the system backend):
 
 ```ts
 const { width, height, format, space, channels, hasAlpha } = await new Bun.Image(input).metadata();

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9206,8 +9206,9 @@ declare module "bun" {
     /** Run the pipeline and return base64-encoded output. */
     toBase64(): Promise<string>;
     /**
-     * Read the header only — no pixel decode — and report dimensions,
-     * format, colour space, channel count, and alpha presence.
+     * Report dimensions, format, colour space, channel count, and alpha
+     * presence. Header-only for JPEG/PNG/WebP/BMP/GIF; HEIC/AVIF/TIFF have
+     * no header probe and fall back to a full decode via the system backend.
      */
     metadata(): Promise<Image.Metadata>;
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -9025,10 +9025,33 @@ declare module "bun" {
       saturation?: number;
     }
 
+    /**
+     * Colour space of the source image, using sharp/libvips vocabulary:
+     * - `"srgb"` — RGB(A), including palette images
+     * - `"b-w"` — greyscale (with or without alpha)
+     * - `"cmyk"` — CMYK or YCCK JPEG
+     * - `"rgb16"` / `"grey16"` — 16-bit-per-channel PNG
+     */
+    type ColorSpace = "srgb" | "b-w" | "cmyk" | "rgb16" | "grey16";
+
     interface Metadata {
       width: number;
       height: number;
       format: Format;
+      space: ColorSpace;
+      /**
+       * Channel count of the source: 1 (grey), 2 (grey+alpha), 3 (RGB),
+       * 4 (RGB+alpha or CMYK). Transparency stored out-of-band (PNG `tRNS`,
+       * GIF transparent index) counts as a channel, matching sharp.
+       */
+      channels: 1 | 2 | 3 | 4;
+      /**
+       * Whether the source carries transparency — an alpha channel, a PNG
+       * `tRNS` chunk, a BMP alpha mask, or GIF palette transparency. JPEG is
+       * always `false`. Useful for content negotiation: serve PNG/WebP when
+       * `true`, JPEG otherwise.
+       */
+      hasAlpha: boolean;
     }
   }
 
@@ -9182,7 +9205,10 @@ declare module "bun" {
     blob(): Promise<Blob>;
     /** Run the pipeline and return base64-encoded output. */
     toBase64(): Promise<string>;
-    /** Decode just enough to read width/height/format. */
+    /**
+     * Read the header only — no pixel decode — and report dimensions,
+     * format, colour space, channel count, and alpha presence.
+     */
     metadata(): Promise<Image.Metadata>;
 
     /** Populated after the first awaited terminal; `-1` before. */

--- a/src/jsc/bindings/image_coregraphics_shim.cpp
+++ b/src/jsc/bindings/image_coregraphics_shim.cpp
@@ -278,11 +278,7 @@ enum : int32_t { CG_OK = 0,
     CG_ENCODE_FAILED = 3,
     CG_TOO_MANY_PIXELS = 4 };
 
-// Decode `bytes[0..len)` into a caller-allocated RGBA8 buffer.
-// Two-phase: pass `out=nullptr` to get dimensions (and, if `out_has_alpha` is
-// non-null, whether the source has an alpha channel); then call again with a
-// buffer of `w*h*4` to fill it. Avoids allocating in C++ so the caller owns
-// the buffer like every other decode path.
+// Two-phase: `out=nullptr` probes dimensions (+ `out_has_alpha` if non-null); then fill a `w*h*4` buffer.
 int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
     uint32_t* out_w, uint32_t* out_h, uint8_t* out, int32_t* out_has_alpha)
 {

--- a/src/jsc/bindings/image_coregraphics_shim.cpp
+++ b/src/jsc/bindings/image_coregraphics_shim.cpp
@@ -279,11 +279,12 @@ enum : int32_t { CG_OK = 0,
     CG_TOO_MANY_PIXELS = 4 };
 
 // Decode `bytes[0..len)` into a caller-allocated RGBA8 buffer.
-// Two-phase: pass `out=nullptr` to get dimensions; then call again with a
+// Two-phase: pass `out=nullptr` to get dimensions (and, if `out_has_alpha` is
+// non-null, whether the source has an alpha channel); then call again with a
 // buffer of `w*h*4` to fill it. Avoids allocating in C++ so the caller owns
 // the buffer like every other decode path.
 int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_pixels,
-    uint32_t* out_w, uint32_t* out_h, uint8_t* out)
+    uint32_t* out_w, uint32_t* out_h, uint8_t* out, int32_t* out_has_alpha)
 {
     auto s = load();
     if (!s) return CG_UNAVAILABLE;
@@ -317,6 +318,10 @@ int32_t bun_coregraphics_decode(const uint8_t* bytes, size_t len, uint64_t max_p
     if (!out) {
         *out_w = static_cast<uint32_t>(w);
         *out_h = static_cast<uint32_t>(h);
+        if (out_has_alpha) {
+            uint32_t a = s->CGImageGetAlphaInfo(r.img);
+            *out_has_alpha = !(a == kBunCGImageAlphaNone || a == kBunCGImageAlphaNoneSkipLast || a == kBunCGImageAlphaNoneSkipFirst);
+        }
         return CG_OK; // dimensions-only probe
     }
     // TOCTOU guard: the input is a borrowed-but-mutable JS slice and this runs
@@ -595,7 +600,7 @@ int64_t bun_coregraphics_clipboard_change_count()
 #else
 // Non-Apple: stubs so the link succeeds; callers only reference these on
 // macOS so they're dead code, but LTO needs the definitions.
-extern "C" int bun_coregraphics_decode(const void*, unsigned long, unsigned long long, void*, void*, void*) { return 1; }
+extern "C" int bun_coregraphics_decode(const void*, unsigned long, unsigned long long, void*, void*, void*, void*) { return 1; }
 extern "C" int bun_coregraphics_encode(const void*, unsigned, unsigned, int, int, void*, void*) { return 1; }
 extern "C" int bun_coregraphics_scale(const void*, unsigned, unsigned, void*, unsigned, unsigned) { return 1; }
 extern "C" int bun_coregraphics_rotate90(const void*, unsigned, unsigned, void*, unsigned) { return 1; }

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -48,8 +48,6 @@ fn format_name(f: codecs::Format) -> &'static str {
     }
 }
 
-/// Build the `.metadata()` result object — shared by the JS-thread fast
-/// path in `do_metadata` and the WorkPool delivery in `then()`.
 fn metadata_to_js(
     global: &JSGlobalObject,
     w: u32,
@@ -1702,10 +1700,7 @@ impl PipelineTask {
         }
 
         if matches!(self.kind, Kind::Metadata) {
-            // Reached only for HEIC/AVIF/TIFF (probe fell through) — the
-            // system backend has already decoded to RGBA8 and the source
-            // channel layout is gone, so derive the colour facts from the
-            // pixels. An all-opaque alpha plane reports as 3-channel.
+            // HEIC/AVIF/TIFF: the system backend decoded to RGBA8 already, so alpha is read from pixels.
             let has_alpha = decoded.rgba.chunks_exact(4).any(|px| px[3] != 0xFF);
             self.result = TaskResult::Meta {
                 w: decoded.width,

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -48,6 +48,37 @@ fn format_name(f: codecs::Format) -> &'static str {
     }
 }
 
+/// Build the `.metadata()` result object — shared by the JS-thread fast
+/// path in `do_metadata` and the WorkPool delivery in `then()`.
+fn metadata_to_js(
+    global: &JSGlobalObject,
+    w: u32,
+    h: u32,
+    format: codecs::Format,
+    color: codecs::ColorInfo,
+) -> JsResult<JSValue> {
+    let obj = JSValue::create_empty_object(global, 6);
+    obj.put(global, b"width", JSValue::js_number(f64::from(w)));
+    obj.put(global, b"height", JSValue::js_number(f64::from(h)));
+    obj.put(
+        global,
+        b"format",
+        bun_core::String::static_(format_name(format)).to_js(global)?,
+    );
+    obj.put(
+        global,
+        b"space",
+        bun_core::String::static_(color.space.name()).to_js(global)?,
+    );
+    obj.put(
+        global,
+        b"channels",
+        JSValue::js_number(f64::from(color.channels)),
+    );
+    obj.put(global, b"hasAlpha", JSValue::js_boolean(color.has_alpha));
+    Ok(obj)
+}
+
 // `pub const js = jsc.Codegen.JSImage;` — `fromJS`/`fromJSDirect`/`toJS` are
 // provided by `#[bun_jsc::JsClass]` codegen (see PORTING.md §JSC types). The
 // `sourceJS` cached-value accessors are emitted by `generate-classes.ts` into
@@ -942,14 +973,7 @@ impl Image {
                     }
                     self.last_width.set(i32::try_from(w).expect("int cast"));
                     self.last_height.set(i32::try_from(h).expect("int cast"));
-                    let obj = JSValue::create_empty_object(global, 3);
-                    obj.put(global, b"width", JSValue::js_number(f64::from(w)));
-                    obj.put(global, b"height", JSValue::js_number(f64::from(h)));
-                    obj.put(
-                        global,
-                        b"format",
-                        bun_core::String::static_(format_name(p.format)).to_js(global)?,
-                    );
+                    let obj = metadata_to_js(global, w, h, p.format, p.color)?;
                     return Ok(JSPromise::resolved_promise_value(global, obj));
                 }
                 // HEIC/AVIF need the system backend → fall through to async.
@@ -1520,6 +1544,7 @@ pub enum TaskResult {
         w: u32,
         h: u32,
         format: codecs::Format,
+        color: codecs::ColorInfo,
     },
     Err(codecs::Error),
     IoErr(sys::Error),
@@ -1613,6 +1638,7 @@ impl PipelineTask {
                         w,
                         h,
                         format: p.format,
+                        color: p.color,
                     };
                     return;
                 }
@@ -1676,11 +1702,20 @@ impl PipelineTask {
         }
 
         if matches!(self.kind, Kind::Metadata) {
-            // Reached only for HEIC/AVIF (probe fell through).
+            // Reached only for HEIC/AVIF/TIFF (probe fell through) — the
+            // system backend has already decoded to RGBA8 and the source
+            // channel layout is gone, so derive the colour facts from the
+            // pixels. An all-opaque alpha plane reports as 3-channel.
+            let has_alpha = decoded.rgba.chunks_exact(4).any(|px| px[3] != 0xFF);
             self.result = TaskResult::Meta {
                 w: decoded.width,
                 h: decoded.height,
                 format: src_format,
+                color: codecs::ColorInfo {
+                    space: codecs::Space::Srgb,
+                    channels: if has_alpha { 4 } else { 3 },
+                    has_alpha,
+                },
             };
             return;
         }
@@ -1907,14 +1942,16 @@ impl PipelineTask {
                     }
                 }
             }
-            TaskResult::Meta { w, h, format } => {
-                let obj = JSValue::create_empty_object(global, 3);
-                obj.put(global, b"width", JSValue::js_number(f64::from(w)));
-                obj.put(global, b"height", JSValue::js_number(f64::from(h)));
-                let fmt_js = bun_core::String::static_(format_name(format))
-                    .to_js(global)
-                    .unwrap_or(JSValue::UNDEFINED);
-                obj.put(global, b"format", fmt_js);
+            TaskResult::Meta {
+                w,
+                h,
+                format,
+                color,
+            } => {
+                let obj = match metadata_to_js(global, w, h, format, color) {
+                    Ok(o) => o,
+                    Err(_) => return promise.reject(global, Err(jsc::JsError::Thrown)),
+                };
                 promise.resolve(global, obj)?;
             }
             TaskResult::Err(e) => promise.reject(global, Ok(reject_error(global, e)))?,

--- a/src/runtime/image/backend_coregraphics.rs
+++ b/src/runtime/image/backend_coregraphics.rs
@@ -69,7 +69,8 @@ unsafe extern "C" {
         max_pixels: u64,
         out_w: *mut u32,
         out_h: *mut u32,
-        out: *mut u8, // nullable
+        out: *mut u8,            // nullable
+        out_has_alpha: *mut i32, // nullable; only written on the probe phase
     ) -> i32;
 
     #[allow(dead_code)]
@@ -100,10 +101,17 @@ fn map_err(rc: i32) -> BackendError {
     }
 }
 
-/// Dimensions only: ImageIO parses the container header without running the codec.
-pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<(u32, u32), BackendError> {
+pub(crate) struct ProbeInfo {
+    pub width: u32,
+    pub height: u32,
+    pub has_alpha: bool,
+}
+
+/// Header only: ImageIO parses the container without running the codec.
+pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<ProbeInfo, BackendError> {
     let mut w: u32 = 0;
     let mut h: u32 = 0;
+    let mut has_alpha: i32 = 0;
     // SAFETY: bytes is a valid slice; out=null signals "probe only" to the shim.
     match unsafe {
         bun_coregraphics_decode(
@@ -113,9 +121,14 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<(u32, u32), Backend
             &raw mut w,
             &raw mut h,
             core::ptr::null_mut(),
+            &raw mut has_alpha,
         )
     } {
-        CG_OK => Ok((w, h)),
+        CG_OK => Ok(ProbeInfo {
+            width: w,
+            height: h,
+            has_alpha: has_alpha != 0,
+        }),
         rc => Err(map_err(rc)),
     }
 }
@@ -133,6 +146,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, B
             max_pixels,
             &raw mut w,
             &raw mut h,
+            core::ptr::null_mut(),
             core::ptr::null_mut(),
         )
     } {
@@ -153,6 +167,7 @@ pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, B
             &raw mut w,
             &raw mut h,
             out.as_mut_ptr(),
+            core::ptr::null_mut(),
         )
     } {
         CG_OK => {}

--- a/src/runtime/image/codec_gif.rs
+++ b/src/runtime/image/codec_gif.rs
@@ -129,8 +129,7 @@ impl Dict {
     }
 }
 
-/// Header-only: whether a Graphic Control Extension before the first image
-/// descriptor sets the transparent-colour flag. Same block walk as `decode`.
+/// Whether a GCE before the first image descriptor sets the transparent-colour flag.
 pub(crate) fn first_frame_transparent(bytes: &[u8]) -> bool {
     if bytes.len() < 13 {
         return false;

--- a/src/runtime/image/codec_gif.rs
+++ b/src/runtime/image/codec_gif.rs
@@ -129,6 +129,46 @@ impl Dict {
     }
 }
 
+/// Header-only: whether a Graphic Control Extension before the first image
+/// descriptor sets the transparent-colour flag. Same block walk as `decode`.
+pub(crate) fn first_frame_transparent(bytes: &[u8]) -> bool {
+    if bytes.len() < 13 {
+        return false;
+    }
+    let lsd_packed = bytes[10];
+    let gct_len: usize = if lsd_packed & 0x80 != 0 {
+        (1usize << ((lsd_packed & 7) + 1)) * 3
+    } else {
+        0
+    };
+    let mut i: usize = 13 + gct_len;
+    let mut trns = false;
+    while i < bytes.len() {
+        match bytes[i] {
+            0x21 => {
+                if i + 2 > bytes.len() {
+                    return false;
+                }
+                let label = bytes[i + 1];
+                i += 2;
+                if label == 0xF9 && i + 6 <= bytes.len() && bytes[i] == 4 {
+                    trns = bytes[i + 1] & 1 != 0;
+                }
+                while i < bytes.len() {
+                    let n: usize = bytes[i] as usize;
+                    i += 1 + n;
+                    if n == 0 {
+                        break;
+                    }
+                }
+            }
+            0x2C => return trns,
+            _ => return false,
+        }
+    }
+    false
+}
+
 pub(crate) fn decode(bytes: &[u8], max_pixels: u64) -> Result<codecs::Decoded, codecs::Error> {
     // ── header + LSD ───────────────────────────────────────────────────────
     if bytes.len() < 13 || !(&bytes[0..6] == b"GIF89a" || &bytes[0..6] == b"GIF87a") {

--- a/src/runtime/image/codec_jpeg.rs
+++ b/src/runtime/image/codec_jpeg.rs
@@ -107,7 +107,8 @@ const TJPARAM_QUALITY: c_int = 3;
 const TJPARAM_SUBSAMP: c_int = 4;
 pub(crate) const TJPARAM_JPEGWIDTH: c_int = 5;
 pub(crate) const TJPARAM_JPEGHEIGHT: c_int = 6;
-const TJPARAM_COLORSPACE: c_int = 8;
+/// Read-only after `tj3DecompressHeader`; one of the TJCS values below.
+pub(crate) const TJPARAM_COLORSPACE: c_int = 8;
 const TJPARAM_PROGRESSIVE: c_int = 12;
 const TJPARAM_MAXPIXELS: c_int = 24;
 /// `2` = save only APP2/ICC_PROFILE markers (enough for colour management,
@@ -116,8 +117,10 @@ const TJPARAM_MAXPIXELS: c_int = 24;
 const TJPARAM_SAVEMARKERS: c_int = 25;
 const TJPF_RGBA: c_int = 7;
 const TJPF_CMYK: c_int = 11;
-const TJCS_CMYK: c_int = 3;
-const TJCS_YCCK: c_int = 4;
+// tjcs enum values from turbojpeg.h (RGB=0, YCbCr=1, …).
+pub(crate) const TJCS_GRAY: c_int = 2;
+pub(crate) const TJCS_CMYK: c_int = 3;
+pub(crate) const TJCS_YCCK: c_int = 4;
 const TJSAMP_420: c_int = 2;
 
 pub(crate) fn decode(

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -28,6 +28,59 @@ unsafe extern "C" {
     pub(crate) fn WebPFree(ptr: *mut c_void);
 }
 
+/// `struct WebPBitstreamFeatures` — header-level facts from
+/// `WebPGetFeatures`. Only `width`/`height`/`has_alpha` are read; the rest
+/// is here for the C layout.
+#[repr(C)]
+pub(crate) struct WebPBitstreamFeatures {
+    pub width: c_int,
+    pub height: c_int,
+    /// True if the bitstream contains an alpha channel (VP8X ALPH chunk or
+    /// the VP8L alpha_is_used flag).
+    pub has_alpha: c_int,
+    pub has_animation: c_int,
+    /// 0 = undefined/mixed, 1 = lossy, 2 = lossless.
+    pub format: c_int,
+    pad: [u32; 5],
+}
+
+/// `WEBP_DECODER_ABI_VERSION` from decode.h — pinned to the libwebp commit
+/// like the mux/demux versions below.
+const WEBP_DECODER_ABI_VERSION: c_int = 0x0210;
+
+// `WebPGetFeatures()` is a static-inline header wrapper over this
+// version-checked entry point, same pattern as WebPDemuxInternal below.
+unsafe extern "C" {
+    fn WebPGetFeaturesInternal(
+        data: *const u8,
+        len: usize,
+        features: *mut WebPBitstreamFeatures,
+        version: c_int,
+    ) -> c_int;
+}
+
+/// Header-only feature probe. `None` on a malformed or truncated header —
+/// the acceptance set is identical to `WebPGetInfo` (libwebp implements
+/// both over the same `GetFeatures`).
+pub(crate) fn get_features(bytes: &[u8]) -> Option<WebPBitstreamFeatures> {
+    // SAFETY: all-zero is a valid WebPBitstreamFeatures (#[repr(C)] POD ints).
+    let mut f: WebPBitstreamFeatures = unsafe { bun_core::ffi::zeroed_unchecked() };
+    // SAFETY: (ptr,len) from a valid live slice; f is a valid out-param.
+    // VP8_STATUS_OK == 0.
+    if unsafe {
+        WebPGetFeaturesInternal(
+            bytes.as_ptr(),
+            bytes.len(),
+            &raw mut f,
+            WEBP_DECODER_ABI_VERSION,
+        )
+    } != 0
+    {
+        return None;
+    }
+    Some(f)
+}
+
 // ─── libwebpmux / libwebpdemux ──────────────────────────────────────────────
 // WebP carries colour profiles (and EXIF/XMP) in a VP8X RIFF container that
 // wraps the VP8/VP8L bitstream. `WebPEncodeRGBA` only emits the bare

--- a/src/runtime/image/codec_webp.rs
+++ b/src/runtime/image/codec_webp.rs
@@ -28,15 +28,11 @@ unsafe extern "C" {
     pub(crate) fn WebPFree(ptr: *mut c_void);
 }
 
-/// `struct WebPBitstreamFeatures` — header-level facts from
-/// `WebPGetFeatures`. Only `width`/`height`/`has_alpha` are read; the rest
-/// is here for the C layout.
+/// `struct WebPBitstreamFeatures` from libwebp's decode.h.
 #[repr(C)]
 pub(crate) struct WebPBitstreamFeatures {
     pub width: c_int,
     pub height: c_int,
-    /// True if the bitstream contains an alpha channel (VP8X ALPH chunk or
-    /// the VP8L alpha_is_used flag).
     pub has_alpha: c_int,
     pub has_animation: c_int,
     /// 0 = undefined/mixed, 1 = lossy, 2 = lossless.
@@ -44,12 +40,10 @@ pub(crate) struct WebPBitstreamFeatures {
     pad: [u32; 5],
 }
 
-/// `WEBP_DECODER_ABI_VERSION` from decode.h — pinned to the libwebp commit
-/// like the mux/demux versions below.
+/// `WEBP_DECODER_ABI_VERSION` from decode.h, pinned like the mux/demux versions below.
 const WEBP_DECODER_ABI_VERSION: c_int = 0x0210;
 
-// `WebPGetFeatures()` is a static-inline header wrapper over this
-// version-checked entry point, same pattern as WebPDemuxInternal below.
+// `WebPGetFeatures()` is a static-inline wrapper over this version-checked entry point.
 unsafe extern "C" {
     fn WebPGetFeaturesInternal(
         data: *const u8,
@@ -59,9 +53,7 @@ unsafe extern "C" {
     ) -> c_int;
 }
 
-/// Header-only feature probe. `None` on a malformed or truncated header —
-/// the acceptance set is identical to `WebPGetInfo` (libwebp implements
-/// both over the same `GetFeatures`).
+/// Header-only probe; accepts exactly the inputs `WebPGetInfo` accepts.
 pub(crate) fn get_features(bytes: &[u8]) -> Option<WebPBitstreamFeatures> {
     // SAFETY: all-zero is a valid WebPBitstreamFeatures (#[repr(C)] POD ints).
     let mut f: WebPBitstreamFeatures = unsafe { bun_core::ffi::zeroed_unchecked() };

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -331,13 +331,11 @@ pub(crate) fn guard(w: u32, h: u32, max_pixels: u64) -> Result<(), Error> {
     Ok(())
 }
 
-/// `metadata().space` vocabulary — sharp/libvips interpretation names
-/// (`srgb`, `b-w`, `cmyk`, `rgb16`, `grey16`) so content-negotiation code
-/// written against sharp ports unchanged.
+/// `metadata().space`, using sharp/libvips interpretation names.
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub enum Space {
     Srgb,
-    /// Greyscale — libvips spells it "b-w".
+    /// Greyscale; libvips spells it "b-w".
     Bw,
     Cmyk,
     /// 16-bit-per-channel RGB (PNG bit depth 16).
@@ -358,14 +356,11 @@ impl Space {
     }
 }
 
-/// Colour facts for `.metadata()` — read from the same per-format headers
-/// as the dimensions, describing the SOURCE (the pipeline itself is RGBA8
-/// everywhere regardless).
+/// Source colour layout for `.metadata()`; the decode pipeline itself is always RGBA8.
 #[derive(Copy, Clone)]
 pub struct ColorInfo {
     pub space: Space,
-    /// Channel count as sharp reports it: 1 grey, 2 grey+alpha, 3 RGB,
-    /// 4 RGB+alpha or CMYK.
+    /// 1 grey, 2 grey+alpha, 3 RGB, 4 RGB+alpha or CMYK (sharp's counting).
     pub channels: u8,
     pub has_alpha: bool,
 }
@@ -377,13 +372,7 @@ pub(crate) struct Probe {
     pub color: ColorInfo,
 }
 
-/// Whether a PNG carries a tRNS chunk — transparency for the colour types
-/// with no native alpha channel (grey/truecolour colour-key, palette
-/// alpha). Walks the chunk list from the first chunk after IHDR; tRNS must
-/// precede IDAT per the spec, so the walk stops there. Lengths are
-/// attacker bytes: every read is bounds-checked and the offset advance is
-/// overflow-checked, and each step consumes ≥12 bytes so the walk is
-/// linear in the input.
+/// Walks PNG chunks up to IDAT (tRNS must precede it per spec) with checked offsets.
 fn png_has_trns(bytes: &[u8]) -> bool {
     let mut off: usize = 8;
     loop {
@@ -425,9 +414,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             h = u32::from_be_bytes(bytes[20..24].try_into().expect("infallible: size matches"));
             let bit_depth = bytes[24];
             let color_type = bytes[25];
-            // PNG colour types: 0 grey, 2 truecolour, 3 indexed, 4
-            // grey+alpha, 6 truecolour+alpha. Anything else is a corrupt
-            // header the decoder would reject too.
+            // PNG colour types: 0 grey, 2 RGB, 3 indexed, 4 grey+alpha, 6 RGBA.
             let (base_channels, grey): (u8, bool) = match color_type {
                 0 => (1, true),
                 2 => (3, false),
@@ -436,9 +423,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 6 => (4, false),
                 _ => return Err(Error::DecodeFailed),
             };
-            // Legal depths per colour type (PNG spec §11.2.2) — the same
-            // table libspng's check_ihdr enforces at decode, so metadata()
-            // and bytes() keep agreeing on what's corrupt.
+            // Same depth-per-type table as libspng's check_ihdr (PNG spec §11.2.2).
             if !matches!(
                 (color_type, bit_depth),
                 (0, 1 | 2 | 4 | 8 | 16) | (2 | 4 | 6, 8 | 16) | (3, 1 | 2 | 4 | 8)
@@ -446,9 +431,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 return Err(Error::DecodeFailed);
             }
             let native_alpha = color_type == 4 || color_type == 6;
-            // Types without a native alpha channel can still carry
-            // transparency via a tRNS chunk; libvips expands that to a real
-            // channel on load and sharp counts it, so match.
+            // tRNS transparency counts as a channel, matching libvips/sharp.
             let has_alpha = native_alpha || png_has_trns(bytes);
             color = ColorInfo {
                 space: match (grey, bit_depth == 16) {
@@ -479,9 +462,6 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             }
             w = u32::try_from(rw).expect("int cast");
             h = u32::try_from(rh).expect("int cast");
-            // JPEG never has alpha. Grey decodes to 1 channel; CMYK and its
-            // YCCK transport both report as 4-channel "cmyk"; everything
-            // else (YCbCr/RGB, or an unreadable param) is 3-channel sRGB.
             // SAFETY: same handle invariant as above.
             color = match unsafe { jpeg::tj3Get(handle.as_ptr(), jpeg::TJPARAM_COLORSPACE) } {
                 jpeg::TJCS_GRAY => ColorInfo {
@@ -502,9 +482,6 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             };
         }
         Format::Webp => {
-            // Same header parse as `WebPGetInfo` (both are GetFeatures
-            // internally) plus the alpha flag — VP8X ALPH chunk or the VP8L
-            // alpha_is_used bit.
             let f = webp::get_features(bytes).ok_or(Error::DecodeFailed)?;
             if f.width <= 0 || f.height <= 0 {
                 return Err(Error::DecodeFailed);
@@ -522,8 +499,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             let ih = bmp::parse_header(bytes)?;
             w = ih.width;
             h = ih.height;
-            // Alpha only with an explicit V4+ BITFIELDS alpha mask; plain
-            // 32-bit BI_RGB's 4th byte is reserved (see parse_header).
+            // Only a V4+ BITFIELDS alpha mask counts; see parse_header.
             let has_alpha = ih.a_mask != 0;
             color = ColorInfo {
                 space: Space::Srgb,
@@ -540,13 +516,11 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 as u32;
             h = u16::from_le_bytes(bytes[8..10].try_into().expect("infallible: size matches"))
                 as u32;
-            // GIF decodes to RGBA unconditionally (transparency is a
-            // per-frame palette flag, not a header fact); sharp/libvips
-            // reports every GIF as 4-channel with alpha — match that.
+            let has_alpha = gif::first_frame_transparent(bytes);
             color = ColorInfo {
                 space: Space::Srgb,
-                channels: 4,
-                has_alpha: true,
+                channels: if has_alpha { 4 } else { 3 },
+                has_alpha,
             };
         }
         Format::Tiff | Format::Heic | Format::Avif => {
@@ -560,9 +534,14 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 }
                 match system_backend::BackendError::split(system_backend::probe(bytes, max_pixels))
                 {
-                    Ok(Some((pw, ph))) => {
-                        w = pw;
-                        h = ph;
+                    Ok(Some(p)) => {
+                        w = p.width;
+                        h = p.height;
+                        color = ColorInfo {
+                            space: Space::Srgb,
+                            channels: if p.has_alpha { 4 } else { 3 },
+                            has_alpha: p.has_alpha,
+                        };
                     }
                     Ok(None) => return Err(Error::UnsupportedOnPlatform),
                     Err(e) => return Err(e),

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -331,10 +331,79 @@ pub(crate) fn guard(w: u32, h: u32, max_pixels: u64) -> Result<(), Error> {
     Ok(())
 }
 
+/// `metadata().space` vocabulary — sharp/libvips interpretation names
+/// (`srgb`, `b-w`, `cmyk`, `rgb16`, `grey16`) so content-negotiation code
+/// written against sharp ports unchanged.
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Space {
+    Srgb,
+    /// Greyscale — libvips spells it "b-w".
+    Bw,
+    Cmyk,
+    /// 16-bit-per-channel RGB (PNG bit depth 16).
+    Rgb16,
+    /// 16-bit-per-channel greyscale (PNG bit depth 16).
+    Grey16,
+}
+
+impl Space {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Space::Srgb => "srgb",
+            Space::Bw => "b-w",
+            Space::Cmyk => "cmyk",
+            Space::Rgb16 => "rgb16",
+            Space::Grey16 => "grey16",
+        }
+    }
+}
+
+/// Colour facts for `.metadata()` — read from the same per-format headers
+/// as the dimensions, describing the SOURCE (the pipeline itself is RGBA8
+/// everywhere regardless).
+#[derive(Copy, Clone)]
+pub struct ColorInfo {
+    pub space: Space,
+    /// Channel count as sharp reports it: 1 grey, 2 grey+alpha, 3 RGB,
+    /// 4 RGB+alpha or CMYK.
+    pub channels: u8,
+    pub has_alpha: bool,
+}
+
 pub(crate) struct Probe {
     pub format: Format,
     pub width: u32,
     pub height: u32,
+    pub color: ColorInfo,
+}
+
+/// Whether a PNG carries a tRNS chunk — transparency for the colour types
+/// with no native alpha channel (grey/truecolour colour-key, palette
+/// alpha). Walks the chunk list from the first chunk after IHDR; tRNS must
+/// precede IDAT per the spec, so the walk stops there. Lengths are
+/// attacker bytes: every read is bounds-checked and the offset advance is
+/// overflow-checked, and each step consumes ≥12 bytes so the walk is
+/// linear in the input.
+fn png_has_trns(bytes: &[u8]) -> bool {
+    let mut off: usize = 8;
+    loop {
+        let Some(hdr) = bytes.get(off..off + 8) else {
+            return false;
+        };
+        let len = u32::from_be_bytes(hdr[0..4].try_into().expect("infallible: size matches"));
+        match &hdr[4..8] {
+            b"tRNS" => return true,
+            b"IDAT" | b"IEND" => return false,
+            _ => {}
+        }
+        off = match off
+            .checked_add(len as usize)
+            .and_then(|n| n.checked_add(12))
+        {
+            Some(n) => n,
+            None => return false,
+        };
+    }
 }
 
 /// Header-only dimensions probe for `.metadata()`. Decoding the full RGBA for
@@ -345,14 +414,42 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
     let fmt = Format::sniff(bytes).ok_or(Error::UnknownFormat)?;
     let w: u32;
     let h: u32;
+    let color: ColorInfo;
     match fmt {
         Format::Png => {
-            // sig(8) · IHDR{len(4) type(4) w(4) h(4) ...}
-            if bytes.len() < 24 {
+            // sig(8) · IHDR{len(4) type(4) w(4) h(4) depth(1) colour(1) ...}
+            if bytes.len() < 26 {
                 return Err(Error::DecodeFailed);
             }
             w = u32::from_be_bytes(bytes[16..20].try_into().expect("infallible: size matches"));
             h = u32::from_be_bytes(bytes[20..24].try_into().expect("infallible: size matches"));
+            let bit_depth = bytes[24];
+            // PNG colour types: 0 grey, 2 truecolour, 3 indexed, 4
+            // grey+alpha, 6 truecolour+alpha. Anything else is a corrupt
+            // header the decoder would reject too.
+            let (base_channels, grey): (u8, bool) = match bytes[25] {
+                0 => (1, true),
+                2 => (3, false),
+                3 => (3, false), // palette entries are RGB
+                4 => (2, true),
+                6 => (4, false),
+                _ => return Err(Error::DecodeFailed),
+            };
+            let native_alpha = bytes[25] == 4 || bytes[25] == 6;
+            // Types without a native alpha channel can still carry
+            // transparency via a tRNS chunk; libvips expands that to a real
+            // channel on load and sharp counts it, so match.
+            let has_alpha = native_alpha || png_has_trns(bytes);
+            color = ColorInfo {
+                space: match (grey, bit_depth == 16) {
+                    (true, false) => Space::Bw,
+                    (true, true) => Space::Grey16,
+                    (false, false) => Space::Srgb,
+                    (false, true) => Space::Rgb16,
+                },
+                channels: base_channels + u8::from(has_alpha && !native_alpha),
+                has_alpha,
+            };
         }
         Format::Jpeg => {
             // turbojpeg's header decode is already cheap (no scan data read).
@@ -372,25 +469,57 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             }
             w = u32::try_from(rw).expect("int cast");
             h = u32::try_from(rh).expect("int cast");
+            // JPEG never has alpha. Grey decodes to 1 channel; CMYK and its
+            // YCCK transport both report as 4-channel "cmyk"; everything
+            // else (YCbCr/RGB, or an unreadable param) is 3-channel sRGB.
+            // SAFETY: same handle invariant as above.
+            color = match unsafe { jpeg::tj3Get(handle.as_ptr(), jpeg::TJPARAM_COLORSPACE) } {
+                jpeg::TJCS_GRAY => ColorInfo {
+                    space: Space::Bw,
+                    channels: 1,
+                    has_alpha: false,
+                },
+                jpeg::TJCS_CMYK | jpeg::TJCS_YCCK => ColorInfo {
+                    space: Space::Cmyk,
+                    channels: 4,
+                    has_alpha: false,
+                },
+                _ => ColorInfo {
+                    space: Space::Srgb,
+                    channels: 3,
+                    has_alpha: false,
+                },
+            };
         }
         Format::Webp => {
-            let mut cw: c_int = 0;
-            let mut ch: c_int = 0;
-            // SAFETY: (ptr,len) from a valid live slice; cw/ch are valid `*mut c_int` out-params.
-            if unsafe { webp::WebPGetInfo(bytes.as_ptr(), bytes.len(), &raw mut cw, &raw mut ch) }
-                == 0
-                || cw <= 0
-                || ch <= 0
-            {
+            // Same header parse as `WebPGetInfo` (both are GetFeatures
+            // internally) plus the alpha flag — VP8X ALPH chunk or the VP8L
+            // alpha_is_used bit.
+            let f = webp::get_features(bytes).ok_or(Error::DecodeFailed)?;
+            if f.width <= 0 || f.height <= 0 {
                 return Err(Error::DecodeFailed);
             }
-            w = u32::try_from(cw).expect("int cast");
-            h = u32::try_from(ch).expect("int cast");
+            w = u32::try_from(f.width).expect("int cast");
+            h = u32::try_from(f.height).expect("int cast");
+            let has_alpha = f.has_alpha != 0;
+            color = ColorInfo {
+                space: Space::Srgb,
+                channels: if has_alpha { 4 } else { 3 },
+                has_alpha,
+            };
         }
         Format::Bmp => {
             let ih = bmp::parse_header(bytes)?;
             w = ih.width;
             h = ih.height;
+            // Alpha only with an explicit V4+ BITFIELDS alpha mask; plain
+            // 32-bit BI_RGB's 4th byte is reserved (see parse_header).
+            let has_alpha = ih.a_mask != 0;
+            color = ColorInfo {
+                space: Space::Srgb,
+                channels: if has_alpha { 4 } else { 3 },
+                has_alpha,
+            };
         }
         Format::Gif => {
             // sig(6) · LSD: w(u16le) h(u16le) …
@@ -401,6 +530,14 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 as u32;
             h = u16::from_le_bytes(bytes[8..10].try_into().expect("infallible: size matches"))
                 as u32;
+            // GIF decodes to RGBA unconditionally (transparency is a
+            // per-frame palette flag, not a header fact); sharp/libvips
+            // reports every GIF as 4-channel with alpha — match that.
+            color = ColorInfo {
+                space: Space::Srgb,
+                channels: 4,
+                has_alpha: true,
+            };
         }
         Format::Tiff | Format::Heic | Format::Avif => {
             // ImageIO reads the dimensions from the container; the codec only runs in decode().
@@ -435,6 +572,7 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
         format: fmt,
         width: w,
         height: h,
+        color,
     })
 }
 

--- a/src/runtime/image/codecs.rs
+++ b/src/runtime/image/codecs.rs
@@ -424,10 +424,11 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
             w = u32::from_be_bytes(bytes[16..20].try_into().expect("infallible: size matches"));
             h = u32::from_be_bytes(bytes[20..24].try_into().expect("infallible: size matches"));
             let bit_depth = bytes[24];
+            let color_type = bytes[25];
             // PNG colour types: 0 grey, 2 truecolour, 3 indexed, 4
             // grey+alpha, 6 truecolour+alpha. Anything else is a corrupt
             // header the decoder would reject too.
-            let (base_channels, grey): (u8, bool) = match bytes[25] {
+            let (base_channels, grey): (u8, bool) = match color_type {
                 0 => (1, true),
                 2 => (3, false),
                 3 => (3, false), // palette entries are RGB
@@ -435,7 +436,16 @@ pub(crate) fn probe(bytes: &[u8], max_pixels: u64) -> Result<Probe, Error> {
                 6 => (4, false),
                 _ => return Err(Error::DecodeFailed),
             };
-            let native_alpha = bytes[25] == 4 || bytes[25] == 6;
+            // Legal depths per colour type (PNG spec §11.2.2) — the same
+            // table libspng's check_ihdr enforces at decode, so metadata()
+            // and bytes() keep agreeing on what's corrupt.
+            if !matches!(
+                (color_type, bit_depth),
+                (0, 1 | 2 | 4 | 8 | 16) | (2 | 4 | 6, 8 | 16) | (3, 1 | 2 | 4 | 8)
+            ) {
+                return Err(Error::DecodeFailed);
+            }
+            let native_alpha = color_type == 4 || color_type == 6;
             // Types without a native alpha channel can still carry
             // transparency via a tRNS chunk; libvips expands that to a real
             // channel on load and sharp counts it, so match.

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -349,8 +349,9 @@ describe("hostile header dimensions", () => {
       buf[off] = val;
       const dv = new DataView(buf.buffer, buf.byteOffset);
       dv.setUint32(29, crc32(buf.subarray(12, 29)));
-      // metadata() is header-only and IHDR is structurally readable; full
-      // decode is what must reject.
+      // The probe validates colour type and bit depth against the same
+      // table libspng enforces, so metadata() and full decode both reject.
+      expect(await survives(new Bun.Image(buf).metadata())).toBe("rejected");
       expect(await survives(new Bun.Image(buf).bytes())).toBe("rejected");
     }
   });

--- a/test/js/bun/image/image-adversarial.test.ts
+++ b/test/js/bun/image/image-adversarial.test.ts
@@ -400,7 +400,14 @@ describe("malformed PNG structure", () => {
   test("IHDR CRC mismatch is tolerated (spng default ignores CRC)", async () => {
     const buf = Buffer.from(tinyPng);
     buf[29] ^= 0xff;
-    expect(await new Bun.Image(buf).metadata()).toEqual({ width: 2, height: 2, format: "png" });
+    expect(await new Bun.Image(buf).metadata()).toEqual({
+      width: 2,
+      height: 2,
+      format: "png",
+      space: "srgb",
+      channels: 4,
+      hasAlpha: true,
+    });
   });
 
   test("IDAT CRC and zlib adler32 mismatches are tolerated (checksums are skipped on decode)", async () => {
@@ -414,7 +421,14 @@ describe("malformed PNG structure", () => {
 
   test("missing IEND is tolerated (spec recovery: stream ending after a complete IDAT is valid)", async () => {
     const buf = tinyPng.subarray(0, tinyPng.length - 12);
-    expect(await new Bun.Image(buf).metadata()).toEqual({ width: 2, height: 2, format: "png" });
+    expect(await new Bun.Image(buf).metadata()).toEqual({
+      width: 2,
+      height: 2,
+      format: "png",
+      space: "srgb",
+      channels: 4,
+      hasAlpha: true,
+    });
   });
 
   test("IDAT with zlib bomb (header says small, IDAT inflates huge)", async () => {
@@ -707,7 +721,7 @@ describe("hostile option objects", () => {
   test("data: URL input (base64)", async () => {
     const url = "data:image/png;base64," + Buffer.from(tinyPng).toString("base64");
     const meta = await new Bun.Image(url).metadata();
-    expect(meta).toEqual({ width: 2, height: 2, format: "png" });
+    expect(meta).toEqual({ width: 2, height: 2, format: "png", space: "srgb", channels: 4, hasAlpha: true });
   });
 
   test("data: URL with bad base64 throws", () => {

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -170,7 +170,7 @@ describe("Bun.Image", () => {
     // the terminal is awaited, then the pipeline task runs — both off-thread.
     const img = new Bun.Image(Bun.file(p));
     const meta = await img.metadata();
-    expect(meta).toEqual({ width: 4, height: 3, format: "png" });
+    expect(meta).toEqual({ width: 4, height: 3, format: "png", space: "srgb", channels: 4, hasAlpha: true });
     // Second terminal on the same instance reuses the now-.owned bytes
     // (no re-read).
     const out = await img.png().bytes();
@@ -254,8 +254,121 @@ describe("Bun.Image", () => {
     expect(meta.width).toBe(4);
     expect(meta.height).toBe(3);
     expect(meta.format).toBe("png");
+    expect(meta.space).toBe("srgb");
+    expect(meta.channels).toBe(4);
+    expect(meta.hasAlpha).toBe(true);
     expect(img.width).toBe(4);
     expect(img.height).toBe(3);
+  });
+
+  // space / channels / hasAlpha use sharp's vocabulary; every expectation
+  // below was cross-checked against sharp 0.34.5 (libvips 8.17) on the same
+  // bytes.
+  describe("metadata() colour info", () => {
+    // PNG with an arbitrary colour type: 0 grey, 2 RGB, 3 indexed,
+    // 4 grey+alpha, 6 RGBA. `extra` splices chunks (e.g. tRNS) between
+    // IHDR and IDAT.
+    function makePngVariant(
+      colorType: 0 | 2 | 3 | 4 | 6,
+      bitDepth: number,
+      extra: [string, Uint8Array][] = [],
+      palette?: Uint8Array,
+    ): Uint8Array {
+      const w = 2,
+        h = 2;
+      const ihdr = new Uint8Array(13);
+      const iv = new DataView(ihdr.buffer);
+      iv.setUint32(0, w);
+      iv.setUint32(4, h);
+      ihdr[8] = bitDepth;
+      ihdr[9] = colorType;
+      const bpp = { 0: 1, 2: 3, 3: 1, 4: 2, 6: 4 }[colorType] * (bitDepth / 8);
+      const raw = Buffer.alloc(h * (1 + w * bpp), 100);
+      for (let y = 0; y < h; y++) raw[y * (1 + w * bpp)] = 0; // filter byte
+      const parts = [Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]), pngChunk("IHDR", ihdr)];
+      if (palette) parts.push(pngChunk("PLTE", palette));
+      for (const [t, d] of extra) parts.push(pngChunk(t, d));
+      parts.push(pngChunk("IDAT", zlib.deflateSync(raw)), pngChunk("IEND", new Uint8Array(0)));
+      return Buffer.concat(parts);
+    }
+    const pal = new Uint8Array([255, 0, 0, 0, 255, 0]);
+
+    test.each([
+      ["grey", makePngVariant(0, 8), { space: "b-w", channels: 1, hasAlpha: false }],
+      ["RGB", makePngVariant(2, 8), { space: "srgb", channels: 3, hasAlpha: false }],
+      ["indexed", makePngVariant(3, 8, [], pal), { space: "srgb", channels: 3, hasAlpha: false }],
+      ["grey+alpha", makePngVariant(4, 8), { space: "b-w", channels: 2, hasAlpha: true }],
+      ["RGBA", makePngVariant(6, 8), { space: "srgb", channels: 4, hasAlpha: true }],
+      // tRNS adds transparency to the alpha-less colour types; sharp counts
+      // it as a real channel because libvips expands it on load.
+      ["grey + tRNS", makePngVariant(0, 8, [["tRNS", new Uint8Array([0, 100])]]), { space: "b-w", channels: 2, hasAlpha: true }], // prettier-ignore
+      ["RGB + tRNS", makePngVariant(2, 8, [["tRNS", new Uint8Array([0, 100, 0, 100, 0, 100])]]), { space: "srgb", channels: 4, hasAlpha: true }], // prettier-ignore
+      ["indexed + tRNS", makePngVariant(3, 8, [["tRNS", new Uint8Array([128])]], pal), { space: "srgb", channels: 4, hasAlpha: true }], // prettier-ignore
+      // 16-bit depth folds into the space name, libvips-style.
+      ["16-bit RGB", makePngVariant(2, 16), { space: "rgb16", channels: 3, hasAlpha: false }],
+      ["16-bit RGBA", makePngVariant(6, 16), { space: "rgb16", channels: 4, hasAlpha: true }],
+      ["16-bit grey", makePngVariant(0, 16), { space: "grey16", channels: 1, hasAlpha: false }],
+    ] as const)("PNG %s", async (_name, png, expected) => {
+      const meta = await new Bun.Image(png).metadata();
+      expect({ space: meta.space, channels: meta.channels, hasAlpha: meta.hasAlpha }).toEqual(expected);
+    });
+
+    test("PNG with an invalid colour type rejects", async () => {
+      const bad = Buffer.from(makePngVariant(2, 8));
+      bad[25] = 7; // not a legal PNG colour type
+      await expect(new Bun.Image(bad).metadata()).rejects.toThrow(/decode/i);
+    });
+
+    test("JPEG is 3-channel srgb with no alpha", async () => {
+      const jpg = await new Bun.Image(cornersPng).jpeg().bytes();
+      const meta = await new Bun.Image(jpg).metadata();
+      expect({ space: meta.space, channels: meta.channels, hasAlpha: meta.hasAlpha }).toEqual({
+        space: "srgb",
+        channels: 3,
+        hasAlpha: false,
+      });
+    });
+
+    // Bun's encoder only emits YCbCr, so greyscale/CMYK inputs are pre-baked:
+    // sharp(rgb).toColourspace("b-w" | "cmyk").jpeg() with sharp 0.34.5, 4×4.
+    const greyJpeg = Buffer.from(
+      "/9j/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/wAALCAAEAAQBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACP/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8ANz//2Q==",
+      "base64",
+    );
+    const cmykJpeg = Buffer.from(
+      "/9j/7gAOQWRvYmUAZAAAAAAA/9sAQwAGBAUGBQQGBgUGBwcGCAoQCgoJCQoUDg8MEBcUGBgXFBYWGh0lHxobIxwWFiAsICMmJykqKRkfLTAtKDAlKCko/8AAFAgABAAEBEMRAE0RAFkRAEsRAP/EABYAAQEBAAAAAAAAAAAAAAAAAAYHCP/EABQQAQAAAAAAAAAAAAAAAAAAAAD/2gAOBEMATQBZAEsAAD8ANKCbsxv/2Q==",
+      "base64",
+    );
+
+    test("greyscale JPEG reports b-w with 1 channel", async () => {
+      const meta = await new Bun.Image(greyJpeg).metadata();
+      expect(meta).toEqual({ width: 4, height: 4, format: "jpeg", space: "b-w", channels: 1, hasAlpha: false });
+    });
+
+    test("CMYK JPEG reports cmyk with 4 channels", async () => {
+      const meta = await new Bun.Image(cmykJpeg).metadata();
+      expect(meta).toEqual({ width: 4, height: 4, format: "jpeg", space: "cmyk", channels: 4, hasAlpha: false });
+    });
+
+    test.each([
+      ["lossy", {}],
+      ["lossless", { lossless: true }],
+    ] as const)("WebP (%s) tracks alpha from the bitstream", async (_name, opts) => {
+      const opaque = makePng(2, 2, () => [1, 2, 3, 255]);
+      const transparent = makePng(2, 2, () => [1, 2, 3, 128]);
+      const o = await new Bun.Image(await new Bun.Image(opaque).webp(opts).bytes()).metadata();
+      expect({ space: o.space, channels: o.channels, hasAlpha: o.hasAlpha }).toEqual({
+        space: "srgb",
+        channels: 3,
+        hasAlpha: false,
+      });
+      const t = await new Bun.Image(await new Bun.Image(transparent).webp(opts).bytes()).metadata();
+      expect({ space: t.space, channels: t.channels, hasAlpha: t.hasAlpha }).toEqual({
+        space: "srgb",
+        channels: 4,
+        hasAlpha: true,
+      });
+    });
   });
 
   test("PNG → PNG round-trip preserves every pixel", async () => {
@@ -867,10 +980,10 @@ describe("Bun.Image", () => {
     const withExif = Buffer.concat([jpg.subarray(0, 2), app1, jpg.subarray(2)]);
 
     const meta = await new Bun.Image(withExif).metadata();
-    expect(meta).toEqual({ width: 2, height: 4, format: "jpeg" });
+    expect(meta).toEqual({ width: 2, height: 4, format: "jpeg", space: "srgb", channels: 3, hasAlpha: false });
     // And opting out leaves it landscape.
     const raw = await new Bun.Image(withExif, { autoOrient: false }).metadata();
-    expect(raw).toEqual({ width: 4, height: 2, format: "jpeg" });
+    expect(raw).toEqual({ width: 4, height: 2, format: "jpeg", space: "srgb", channels: 3, hasAlpha: false });
   });
 
   test("rejects on unrecognised input", async () => {
@@ -1085,7 +1198,14 @@ describe("Bun.Image", () => {
       const [b64, url] = await Promise.all([img.toBase64(), img.dataurl()]);
       expect(url).toBe(`data:image/png;base64,${b64}`);
       // Round-trip: the constructor accepts data: URLs.
-      expect(await new Bun.Image(url).metadata()).toEqual({ width: 4, height: 3, format: "png" });
+      expect(await new Bun.Image(url).metadata()).toEqual({
+        width: 4,
+        height: 3,
+        format: "png",
+        space: "srgb",
+        channels: 4,
+        hasAlpha: true,
+      });
       // Format follows the chained encoder.
       expect(await new Bun.Image(cornersPng).webp().dataurl()).toMatch(/^data:image\/webp;base64,/);
     });
@@ -1271,7 +1391,7 @@ describe("Bun.Image", () => {
       const buf = new Uint8Array(await res.arrayBuffer());
       expect(String.fromCharCode(...buf.subarray(8, 12))).toBe("WEBP");
       const meta = await new Bun.Image(buf).metadata();
-      expect(meta).toEqual({ width: 4, height: 4, format: "webp" });
+      expect(meta).toEqual({ width: 4, height: 4, format: "webp", space: "srgb", channels: 3, hasAlpha: false });
     });
 
     test("new Request({body: image}) works the same way", async () => {
@@ -1335,7 +1455,34 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
     }
     // BMP header is fully valid → metadata succeeds everywhere.
     const meta = await new Bun.Image(makeBmp24(7, 3, () => [0, 0, 0])).metadata();
-    expect(meta).toEqual({ width: 7, height: 3, format: "bmp" });
+    expect(meta).toEqual({ width: 7, height: 3, format: "bmp", space: "srgb", channels: 3, hasAlpha: false });
+  });
+
+  test("BMP metadata() reports alpha only for a V4 BITFIELDS alpha mask", async () => {
+    // 1×1 32-bpp V4HEADER; `alphaMask` 0 ⇒ the 4th byte is reserved padding.
+    function bmp32(alphaMask: number) {
+      const buf = new Uint8Array(14 + 108 + 4);
+      const dv = new DataView(buf.buffer);
+      buf[0] = 0x42;
+      buf[1] = 0x4d;
+      dv.setUint32(2, buf.length, true);
+      dv.setUint32(10, 14 + 108, true);
+      dv.setUint32(14, 108, true); // biSize = V4
+      dv.setInt32(18, 1, true);
+      dv.setInt32(22, 1, true);
+      dv.setUint16(26, 1, true);
+      dv.setUint16(28, 32, true);
+      dv.setUint32(30, 3, true); // BI_BITFIELDS
+      dv.setUint32(54, 0x00ff0000, true);
+      dv.setUint32(58, 0x0000ff00, true);
+      dv.setUint32(62, 0x000000ff, true);
+      dv.setUint32(66, alphaMask, true);
+      return buf;
+    }
+    const withAlpha = await new Bun.Image(bmp32(0xff000000)).metadata();
+    expect(withAlpha).toEqual({ width: 1, height: 1, format: "bmp", space: "srgb", channels: 4, hasAlpha: true });
+    const reserved = await new Bun.Image(bmp32(0)).metadata();
+    expect(reserved).toEqual({ width: 1, height: 1, format: "bmp", space: "srgb", channels: 3, hasAlpha: false });
   });
 
   test.each(["bun", "system"] as const)("BMP→PNG round-trips colour & orientation (backend=%s)", async be => {
@@ -1481,7 +1628,14 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
 
   test.each(["bun", "system"] as const)("GIF: 1×1 minimal (backend=%s)", async be => {
     const g = makeGif(1, 1, [[0xff, 0x80, 0x40]], () => 0);
-    expect(await new Bun.Image(g).metadata()).toEqual({ width: 1, height: 1, format: "gif" });
+    expect(await new Bun.Image(g).metadata()).toEqual({
+      width: 1,
+      height: 1,
+      format: "gif",
+      space: "srgb",
+      channels: 4,
+      hasAlpha: true,
+    });
     expect([...(await gifPixels(g, be)).data.subarray(0, 4)]).toEqual([0xff, 0x80, 0x40, 0xff]);
   });
 
@@ -1548,7 +1702,7 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
     // earlier tests' side-effect on the process-global).
     Bun.Image.backend = "bun";
     const m = await new Bun.Image(g).metadata();
-    expect(m).toEqual({ width: 2, height: 2, format: "gif" });
+    expect(m).toEqual({ width: 2, height: 2, format: "gif", space: "srgb", channels: 4, hasAlpha: true });
     // And actually decode (exercises Bits.drain too).
     const out = await new Bun.Image(g).png().bytes();
     expect(out[0]).toBe(0x89);

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -319,6 +319,17 @@ describe("Bun.Image", () => {
       await expect(new Bun.Image(bad).metadata()).rejects.toThrow(/decode/i);
     });
 
+    test("PNG with an illegal bit-depth/colour-type pair rejects", async () => {
+      // Truecolour only allows depths 8/16; indexed only 1/2/4/8 (spec
+      // §11.2.2 — libspng rejects these at decode too).
+      const rgb4 = Buffer.from(makePngVariant(2, 8));
+      rgb4[24] = 4;
+      await expect(new Bun.Image(rgb4).metadata()).rejects.toThrow(/decode/i);
+      const indexed16 = Buffer.from(makePngVariant(3, 8, [], pal));
+      indexed16[24] = 16;
+      await expect(new Bun.Image(indexed16).metadata()).rejects.toThrow(/decode/i);
+    });
+
     test("JPEG is 3-channel srgb with no alpha", async () => {
       const jpg = await new Bun.Image(cornersPng).jpeg().bytes();
       const meta = await new Bun.Image(jpg).metadata();

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -224,10 +224,24 @@ describe("Bun.Image", () => {
     for (const k of proxyKeys) process.env[k] = "";
     try {
       const fromS3 = new Bun.Image(client.file("src.png"));
-      expect(await fromS3.metadata()).toEqual({ width: 4, height: 3, format: "png" });
+      expect(await fromS3.metadata()).toEqual({
+        width: 4,
+        height: 3,
+        format: "png",
+        space: "srgb",
+        channels: 4,
+        hasAlpha: true,
+      });
       // Second terminal reuses the downloaded bytes.
       expect((await fromS3.png().bytes())[0]).toBe(0x89);
-      expect(await client.file("src.png").image().metadata()).toEqual({ width: 4, height: 3, format: "png" });
+      expect(await client.file("src.png").image().metadata()).toEqual({
+        width: 4,
+        height: 3,
+        format: "png",
+        space: "srgb",
+        channels: 4,
+        hasAlpha: true,
+      });
 
       // Download failure rejects the terminal with the S3 error.
       expect(
@@ -947,7 +961,14 @@ describe("Bun.Image", () => {
       ["CMYK (Adobe transform=0)", cmykJpeg],
       ["YCCK (Adobe transform=2)", ycckJpeg],
     ])("%s decodes to sRGB", async (_name, fixture) => {
-      expect(await new Bun.Image(fixture).metadata()).toEqual({ width: 64, height: 64, format: "jpeg" });
+      expect(await new Bun.Image(fixture).metadata()).toEqual({
+        width: 64,
+        height: 64,
+        format: "jpeg",
+        space: "cmyk",
+        channels: 4,
+        hasAlpha: false,
+      });
       const { w, h, data } = decodePngRaw(await new Bun.Image(fixture).png().bytes());
       expect([w, h]).toEqual([64, 64]);
       expectQuadrants(data, w);

--- a/test/js/bun/image/image.test.ts
+++ b/test/js/bun/image/image.test.ts
@@ -1665,10 +1665,23 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
       height: 1,
       format: "gif",
       space: "srgb",
-      channels: 4,
-      hasAlpha: true,
+      channels: 3,
+      hasAlpha: false,
     });
     expect([...(await gifPixels(g, be)).data.subarray(0, 4)]).toEqual([0xff, 0x80, 0x40, 0xff]);
+  });
+
+  test("GIF: metadata() reports alpha only when the GCE transparency flag is set", async () => {
+    // Matches sharp/libvips: an opaque GIF is 3-channel, a GCE with the
+    // transparent-colour flag makes it 4-channel.
+    const pal: [number, number, number][] = [
+      [255, 0, 0],
+      [0, 255, 0],
+    ];
+    const opaque = await new Bun.Image(makeGif(2, 1, pal, x => x)).metadata();
+    expect(opaque).toEqual({ width: 2, height: 1, format: "gif", space: "srgb", channels: 3, hasAlpha: false });
+    const transparent = await new Bun.Image(makeGif(2, 1, pal, x => x, { trns: 1 })).metadata();
+    expect(transparent).toEqual({ width: 2, height: 1, format: "gif", space: "srgb", channels: 4, hasAlpha: true });
   });
 
   test("GIF: width-growth boundary (forces 3→4→5-bit transitions mid-row)", async () => {
@@ -1734,7 +1747,7 @@ describe("decode-only formats (BMP / TIFF / GIF)", () => {
     // earlier tests' side-effect on the process-global).
     Bun.Image.backend = "bun";
     const m = await new Bun.Image(g).metadata();
-    expect(m).toEqual({ width: 2, height: 2, format: "gif", space: "srgb", channels: 4, hasAlpha: true });
+    expect(m).toEqual({ width: 2, height: 2, format: "gif", space: "srgb", channels: 3, hasAlpha: false });
     // And actually decode (exercises Bits.drain too).
     const out = await new Bun.Image(g).png().bytes();
     expect(out[0]).toBe(0x89);

--- a/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
+++ b/test/js/bun/jsc-stress/fixtures/simd-baseline.test.ts
@@ -271,9 +271,23 @@ describe("JPEG codec: libjpeg-turbo jsimd runtime dispatch", () => {
     const source = png((x, y) => [x * 3, y * 6, (x + y) & 0xff]);
     for (const progressive of [false, true]) {
       const jpeg = await new Bun.Image(source).jpeg({ quality: 90, progressive }).bytes();
-      expect(await new Bun.Image(jpeg).metadata()).toEqual({ width, height, format: "jpeg" });
+      expect(await new Bun.Image(jpeg).metadata()).toEqual({
+        width,
+        height,
+        format: "jpeg",
+        space: "srgb",
+        channels: 3,
+        hasAlpha: false,
+      });
       const decoded = await new Bun.Image(jpeg).png().bytes();
-      expect(await new Bun.Image(decoded).metadata()).toEqual({ width, height, format: "png" });
+      expect(await new Bun.Image(decoded).metadata()).toEqual({
+        width,
+        height,
+        format: "png",
+        space: "srgb",
+        channels: 4,
+        hasAlpha: true,
+      });
     }
   });
 });


### PR DESCRIPTION
Fixes #31896

`Bun.Image.prototype.metadata()` returned only `{ width, height, format }`, so there was no way to tell whether a source image has transparency (for PNG-vs-JPEG content negotiation) without re-decoding it through another library.

`metadata()` now also reports `space`, `channels`, and `hasAlpha`, using sharp's vocabulary so code written against sharp ports unchanged:

```ts
await new Bun.Image(input).metadata();
// { width: 1920, height: 1080, format: "jpeg", space: "srgb", channels: 3, hasAlpha: false }
```

- `space`: `"srgb" | "b-w" | "cmyk" | "rgb16" | "grey16"` (libvips interpretation names)
- `channels`: `1 | 2 | 3 | 4`
- `hasAlpha`: alpha channel, PNG `tRNS`, BMP alpha mask, or GIF transparency

### How

The probe stays header-only; the new facts come from bytes each format's header read already touches:

- **PNG**: colour type + bit depth from IHDR, plus a bounded chunk walk for `tRNS` (transparency on grey/truecolour/indexed images; must precede IDAT per spec). Invalid colour types now reject the same way the decoder would.
- **JPEG**: `TJPARAM_COLORSPACE` from the `tj3DecompressHeader` call the probe already makes (`b-w` for grey, `cmyk` for CMYK/YCCK, `srgb` otherwise; never alpha).
- **WebP**: `WebPGetFeatures` instead of `WebPGetInfo`. libwebp implements both over the same `GetFeatures`, so the accept/reject set is identical; features additionally carries the alpha flag (VP8X ALPH chunk or VP8L `alpha_is_used`).
- **BMP**: the V4+ BITFIELDS alpha mask `parse_header` already extracts (plain 32-bit BI_RGB's 4th byte is reserved and stays non-alpha).
- **GIF**: 3 channels and no alpha unless a Graphic Control Extension before the first image descriptor sets the transparent-colour flag, then 4 and `true`. Matches libvips/sharp on the same bytes (an earlier draft reported every GIF as RGBA; that came from sharp's own GIF encoder always emitting a GCE).
- **HEIC/AVIF/TIFF**: on macOS the ImageIO header probe also returns `CGImageGetAlphaInfo`, so no decode. On Windows (WIC) there is no header probe, so metadata() falls back to the full decode and reads alpha from the RGBA plane.

Every expectation was cross-checked against sharp 0.34.5 (libvips 8.17) on the same bytes, including the tRNS channel-count behavior (`grey+tRNS` is 2 channels, `indexed+tRNS` is 4) and the `rgb16`/`grey16` spelling for 16-bit PNG.

### Verification

New tests in `test/js/bun/image/image.test.ts` ("metadata() colour info"): the full PNG colour-type x tRNS x bit-depth matrix, greyscale and CMYK JPEG fixtures (generated with sharp, since Bun's encoder only emits YCbCr), WebP lossy/lossless alpha tracking, BMP V4 alpha-mask vs reserved-byte, and opaque vs GCE-transparent GIF. `simd-baseline.test.ts` (added on main since the branch) updated for the new shape. Existing `metadata()` shape assertions in both image test files updated for the new fields.

All fail on the unfixed build (the fields are absent) and pass with this change:

```
bun bd test test/js/bun/image/image.test.ts              # 120 pass
bun bd test test/js/bun/image/image-adversarial.test.ts  #  62 pass
bun bd test test/js/bun/image/image-vs-sharp.test.ts     #  29 pass
bun bd test test/js/bun/image/image-kernels.test.ts      #  37 pass
```

Types (`Image.Metadata`, new `Image.ColorSpace`) and `docs/runtime/image.mdx` updated in the same PR.

Note: #31896 also mentions `density`/`hasProfile`/`orientation` as optional; those are left for a follow-up to keep this focused on the three fields the content-negotiation use case needs.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/image/image.test.ts, test/js/bun/image/image-adversarial.test.ts

<!-- robobun:evidence:end -->