### PR TITLE
test(sql): use container.host instead of hardcoded localhost in 'Connect using uri'

### DIFF
--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -1457,7 +1457,9 @@ if (isDockerEnabled()) {
             login_md5.username +
             ":" +
             (login_md5.password || "") +
-            "@localhost:" +
+            "@" +
+            container.host +
+            ":" +
             container.port.toString() +
             "/" +
             options.db,


### PR DESCRIPTION
## What
One-line fix in `test/js/sql/sql.test.ts`: the "Connect using uri" test built its connection string with a hardcoded `@localhost:` instead of `container.host`.

## Why
Every other test in the file uses `container.host` (which respects `BUN_DOCKER_TEST_HOST`, added in #31731), so they pass against any Docker setup — local or remote daemon. This one test only worked when the daemon is on the same machine. Against a remote daemon it fails instantly with `PostgresError: Connection closed`, and that single subtest marks the whole 845-test file as failed even though the other 844 pass.

## How verified
With this change, the full `sql.test.ts` passes (843 pass / 2 todo / 0 fail) against a remote Docker daemon on macOS arm64, and behavior on a local daemon is unchanged (`container.host` resolves to `127.0.0.1` there).