### PR TITLE
ci: platform smoke check before running tests

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -829,7 +829,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       // Platform smoke check: runner.node.mjs asserts the agent matches what
       // this step targets before running any test (see assertExpectedPlatform).
-      // `release` is only asserted where the lane pins an exact version —
+      // `release` is only asserted where the lane pins an exact version:
       // darwin aarch64 "previous" and darwin x64 intentionally float across
       // macOS versions, and the windows "2019" label doesn't match the
       // kernel-style version the agent reports.

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -827,6 +827,19 @@ function getTestBunStep(platform, options, testOptions = {}) {
     timeout_in_minutes: profile === "asan" || os === "windows" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
+      // Platform smoke check: runner.node.mjs asserts the agent matches what
+      // this step targets before running any test (see assertExpectedPlatform).
+      // `release` is only asserted where the lane pins an exact version —
+      // darwin aarch64 "previous" and darwin x64 intentionally float across
+      // macOS versions, and the windows "2019" label doesn't match the
+      // kernel-style version the agent reports.
+      EXPECTED_PLATFORM_OS: platform.os,
+      EXPECTED_PLATFORM_ARCH: platform.arch,
+      ...(platform.abi ? { EXPECTED_PLATFORM_ABI: platform.abi } : {}),
+      ...(platform.os === "linux" && platform.distro ? { EXPECTED_PLATFORM_DISTRO: platform.distro } : {}),
+      ...(platform.os === "linux" || (platform.os === "darwin" && platform.arch === "aarch64" && platform.tier === "latest")
+        ? { EXPECTED_PLATFORM_RELEASE: platform.release }
+        : {}),
     },
     command:
       os === "windows"

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -458,7 +458,15 @@ function assertExpectedPlatform() {
     process.exit(1);
   }
 
-  !isQuiet && console.log("Platform check:", checks.filter(([, e]) => e).map(([k, e]) => `${k}=${e}`).join(" "), "(ok)");
+  !isQuiet &&
+    console.log(
+      "Platform check:",
+      checks
+        .filter(([, e]) => e)
+        .map(([k, e]) => `${k}=${e}`)
+        .join(" "),
+      "(ok)",
+    );
 }
 
 async function runTests() {

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -420,9 +420,6 @@ function getTestModifiers(testPath) {
 }
 
 /**
- * @returns {Promise<TestResult[]>}
- */
-/**
  * Smoke-checks that this agent actually matches the platform the CI step was
  * generated for. The step exports EXPECTED_PLATFORM_* (see getTestBunStep in
  * .buildkite/ci.mjs); we compare against the same utils the agent uses to
@@ -451,10 +448,14 @@ function assertExpectedPlatform() {
     checks.push(["release", expectedRelease, ok ? expectedRelease : actualRelease]);
   }
 
-  const mismatches = checks.filter(([, expected, actual]) => expected && actual && expected !== actual);
+  // Fail closed: a declared expectation with no detectable actual value is a
+  // mismatch (e.g. a musl step on a box where the ABI probe fails).
+  const mismatches = checks.filter(([, expected, actual]) => expected && expected !== actual);
   if (mismatches.length) {
-    const details = mismatches.map(([k, e, a]) => `${k}: step expects "${e}", agent is "${a}"`).join("\n  ");
-    console.error(`Platform smoke check FAILED — this job landed on the wrong agent:\n  ${details}`);
+    const details = mismatches
+      .map(([k, e, a]) => `${k}: step expects "${e}", agent is ${a ? `"${a}"` : "(undetected)"}`)
+      .join("\n  ");
+    console.error(`Platform smoke check FAILED, this job landed on the wrong agent:\n  ${details}`);
     process.exit(1);
   }
 
@@ -469,6 +470,9 @@ function assertExpectedPlatform() {
     );
 }
 
+/**
+ * @returns {Promise<TestResult[]>}
+ */
 async function runTests() {
   assertExpectedPlatform();
 

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -422,7 +422,48 @@ function getTestModifiers(testPath) {
 /**
  * @returns {Promise<TestResult[]>}
  */
+/**
+ * Smoke-checks that this agent actually matches the platform the CI step was
+ * generated for. The step exports EXPECTED_PLATFORM_* (see getTestBunStep in
+ * .buildkite/ci.mjs); we compare against the same utils the agent uses to
+ * emit its tags. Catches misrouted jobs (e.g. a macOS 26 step landing on a
+ * macOS 15 box) before any test runs, instead of producing silently-wrong
+ * results for a whole shard.
+ */
+function assertExpectedPlatform() {
+  const expectedOs = process.env["EXPECTED_PLATFORM_OS"];
+  if (!expectedOs) {
+    return; // step does not declare expectations (e.g. local runs)
+  }
+
+  const checks = [
+    ["os", expectedOs, getOs()],
+    ["arch", process.env["EXPECTED_PLATFORM_ARCH"], getArch()],
+    ["abi", process.env["EXPECTED_PLATFORM_ABI"], getAbi()],
+    ["distro", process.env["EXPECTED_PLATFORM_DISTRO"], getDistro()],
+  ];
+
+  const expectedRelease = process.env["EXPECTED_PLATFORM_RELEASE"];
+  if (expectedRelease) {
+    // Major-version prefix match: "26" accepts "26.4", "25.04" accepts "25.04.1".
+    const actualRelease = getDistroVersion();
+    const ok = actualRelease === expectedRelease || `${actualRelease}.`.startsWith(`${expectedRelease}.`);
+    checks.push(["release", expectedRelease, ok ? expectedRelease : actualRelease]);
+  }
+
+  const mismatches = checks.filter(([, expected, actual]) => expected && actual && expected !== actual);
+  if (mismatches.length) {
+    const details = mismatches.map(([k, e, a]) => `${k}: step expects "${e}", agent is "${a}"`).join("\n  ");
+    console.error(`Platform smoke check FAILED — this job landed on the wrong agent:\n  ${details}`);
+    process.exit(1);
+  }
+
+  !isQuiet && console.log("Platform check:", checks.filter(([, e]) => e).map(([k, e]) => `${k}=${e}`).join(" "), "(ok)");
+}
+
 async function runTests() {
+  assertExpectedPlatform();
+
   let execPath;
   if (options["step"]) {
     execPath = await getExecPathFromBuildKite(options["step"], options["build-id"]);


### PR DESCRIPTION
## What
Test steps now declare what platform they were generated for (`EXPECTED_PLATFORM_OS/ARCH/ABI/DISTRO/RELEASE` in `getTestBunStep`), and `runner.node.mjs` asserts the agent actually matches before running any test, using the same `scripts/utils.mjs` helpers the agent uses to emit its tags, so expectation and reality come from one source of truth.

## Why
A misrouted job (a macOS 26 step landing on a macOS 15 box, an alpine/musl step on a glibc agent) currently runs the entire shard and produces silently-wrong results that look green. With this change it fails in the first second with a message naming the exact mismatch:

```
Platform smoke check FAILED, this job landed on the wrong agent:
  release: step expects "26", agent is "15.7"
```

## Notes
- The check fails closed: a declared expectation with no detectable actual value (for example the ABI probe failing) is a mismatch, rendered as `(undetected)`.
- `release` is only asserted where the lane pins an exact version. darwin aarch64 `previous` and darwin x64 float across macOS versions by design; the windows "2019" label doesn't match the kernel-style version agents report.
- No-op for local runs (no `EXPECTED_PLATFORM_OS` in env).
- Passing steps log one line: `Platform check: os=darwin arch=aarch64 release=26 (ok)`.
