### PR TITLE
bundler: fix dev server crash when a CSS rebuild fails import resolution

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5720,9 +5720,13 @@ pub mod bv2_impl {
                 // `graph.ast.items(.import_records)[importer_source_index]` when
                 // they complete. Without this, the graph entry stays at
                 // JSAst.empty and the deferred plugin callback index-out-of-
-                // bounds crashes in BundleV2.onResolve / runResolver. The linker
-                // never runs because `transpiler.log.errors > 0` aborts the
-                // build before link time, so saving the AST is safe.
+                // bounds crashes in BundleV2.onResolve / runResolver. In a
+                // non-dev build the linker never runs after this error
+                // (`transpiler.log.errors > 0` aborts before link time). The
+                // dev server does link with failed files, but it filters them
+                // out by their empty `parts` list and never reads a failed
+                // file's import_records, so saving them is safe — unlike the
+                // `css` slot below.
                 let result_heap = *result.ast.import_records.allocator();
                 this.graph.ast.items_import_records_mut()[source_index.0 as usize] =
                     core::mem::replace(

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5730,9 +5730,19 @@ pub mod bv2_impl {
                         bun_alloc::ArenaVec::new_in(result_heap),
                     );
 
-                // Move the CSS stylesheet onto the graph row so teardown can find
-                // and drop it — the `Success` arm that would normally do this is skipped.
-                this.graph.ast.items_css_mut()[source_index.0 as usize] = result.ast.css.take();
+                // Drop the parsed stylesheet now — the `Success` arm that would
+                // normally move it onto the graph row is skipped. It must not be
+                // parked on the graph row either: the dev server proceeds with
+                // failed files and treats a populated `css` slot as a
+                // successfully parsed CSS file (CSS entry point discovery and
+                // import ordering in `finish_from_bake_dev_server`), so a parked
+                // stylesheet would produce a CSS chunk for a failed file while
+                // `graph.css_file_count` stays 0.
+                if let Some(css_ref) = result.ast.css.take() {
+                    // SAFETY: live arena pointer, uniquely owned here (the graph
+                    // row for this file stays `None`); dropped exactly once.
+                    unsafe { core::ptr::drop_in_place(css_ref.as_ptr()) };
+                }
 
                 parse_result.value = parse_task::ResultValue::Err(parse_task::ResultError {
                     err,

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -206,6 +206,46 @@ devTest("syntax error crash", {
     expect((await dev.fetch("/")).status).toBe(500);
   },
 });
+devTest("css url resolve error on hot reload is recoverable", {
+  files: {
+    "styles.css": `
+      body {
+        color: red;
+      }
+    `,
+    "index.html": emptyHtmlFile({
+      styles: ["styles.css"],
+      body: `hello world`,
+    }),
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(200);
+    // A CSS file that parses but fails import resolution must fail the
+    // rebuild with an error instead of being treated as a valid CSS chunk.
+    // previously: panic: assertion failed: !chunk.content.is_css()
+    await dev.write(
+      "styles.css",
+      `
+        body {
+          background-image: url(./missing.png);
+        }
+      `,
+      {
+        errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
+      },
+    );
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.write(
+      "styles.css",
+      `
+        body {
+          color: blue;
+        }
+      `,
+    );
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
 devTest("circular css imports handle hot reload", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -219,22 +219,29 @@ devTest("css url resolve error on hot reload is recoverable", {
     }),
   },
   async test(dev) {
-    expect((await dev.fetch("/")).status).toBe(200);
-    // A CSS file that parses but fails import resolution must fail the
-    // rebuild with an error instead of being treated as a valid CSS chunk.
-    // previously: panic: assertion failed: !chunk.content.is_css()
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          background-image: url(./missing.png);
-        }
-      `,
-      {
-        errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
-      },
-    );
-    expect((await dev.fetch("/")).status).toBe(500);
+    {
+      await using c = await dev.client("/");
+      await c.style("body").color.expect.toBe("red");
+      // A CSS file that parses but fails import resolution must fail the
+      // rebuild with an error instead of being treated as a valid CSS chunk.
+      // previously: panic: assertion failed: !chunk.content.is_css()
+      await dev.write(
+        "styles.css",
+        `
+          body {
+            background-image: url(./missing.png);
+          }
+        `,
+        {
+          errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
+        },
+      );
+      expect((await dev.fetch("/")).status).toBe(500);
+    }
+    // Recovery is checked without a connected client: when a failed CSS root
+    // recovers, the patch currently ships the HTML route as a JS module
+    // without the route-reload flag, which trips a client-side debug assert
+    // (tracked in https://github.com/oven-sh/bun/issues/31908).
     await dev.write(
       "styles.css",
       `


### PR DESCRIPTION
Fixes #31903

### Repro

Debug builds panic during a dev server hot reload when a CSS file parses but fails import resolution (for example an unterminated `url(` that tokenizes to a URL, or a `url(./missing.png)` pointing at a file that does not exist):

```
panic: assertion failed: !chunk.content.is_css()
bun_bundler::linker_context::generate_chunks_in_parallel::generate_chunks_in_parallel::<true>
    src/bundler/linker_context/generateChunksInParallel.rs:132
<bun_bundler::bundle_v2::BundleV2>::finish_from_bake_dev_server
```

Both of these existing tests crash on main with `DevServer crashed while waiting for hot reload`:

```bash
bun bd test test/bake/dev/css.test.ts -t "syntax error crash"
bun bd test test/bake/dev/css.test.ts -t "css import before create project relative"
```

### Cause

`graph.css_file_count` is only incremented when a parse task completes successfully with a CSS AST. When resolution fails after a successful CSS parse, `run_resolution_for_parse_task` converts the result to an error, and (since the leak fixes in #30875) moved the parsed stylesheet onto the graph row so teardown could free it. That comment assumed the linker never runs after such an error, but the dev server intentionally proceeds with failed files, and `finish_from_bake_dev_server` treats a populated `css` slot as "successfully parsed CSS" when discovering CSS entry points. The failed file was therefore re-added as a CSS entry point and got a CSS chunk while `css_file_count` stayed 0, tripping the `debug_assert!(!chunk.content.is_css())` in `generate_chunks_in_parallel`. In release builds the assert compiles out and the CSS dedup/prepare pass is silently skipped for that chunk. The Zig implementation never stored the CSS AST on this path, so the dev server's invariant held there.

The parked AST also diverged from the reference in `find_imported_files_in_css_order` (a failed file's stale rules could be included in another chunk's import order) and `scan_css_imports`.

### Fix

Drop the stylesheet at the failure site in `run_resolution_for_parse_task` instead of parking it on the graph row. The graph row stays `None` for failed files, restoring the invariant every dev server consumer of the `css` column relies on, and the stylesheet's non-arena allocations are still freed (same `drop_in_place` the teardown pass uses).

### Verification

- New test `test/bake/dev/css.test.ts` "css url resolve error on hot reload is recoverable" fails on the unfixed build with `DevServer crashed while waiting for hot reload` and passes with the fix: a connected client asserts the exact error overlay text and the route returns 500, then recovery back to a 200 is checked after the error is fixed. Exercising the recovery with the client still connected hits a separate, pre-existing HMR patch bug (the HTML route module is shipped without the route-reload flag), tracked in #31908.
- Full `test/bake/dev/css.test.ts` (14 tests, including the two previously-crashing ones), `test/bake/dev/html.test.ts`, `test/bake/dev/bundle.test.ts`, `test/bake/dev/hot.test.ts`, and `test/bake/dev/plugins.test.ts` pass on the debug/ASAN build.
- Non-dev path (`Bun.build` with a CSS entry whose `url()` fails to resolve) still reports `Could not resolve` and is clean under ASAN.

