### PR TITLE
Add experimental sandboxed execution mode to Bun Shell ($.sandbox)

### DIFF
--- a/docs/runtime/shell.mdx
+++ b/docs/runtime/shell.mdx
@@ -628,6 +628,88 @@ await $`git ls-remote origin ${branch}`;
 
 ---
 
+## Sandboxed shells (experimental)
+
+`$.sandbox(options)` creates a restricted shell for running untrusted shell commands. Because Bun Shell implements its commands natively, the policy is enforced inside the interpreter, before any command or filesystem operation executes.
+
+```js
+import { $ } from "bun";
+
+const box = $.sandbox({
+  commands: { deny: ["rm"] },
+  fs: {
+    read: ["/workspace/data"],
+    write: ["/workspace/data/out"],
+  },
+  limits: { timeout: 5_000, maxOutputBytes: 1024 * 1024 },
+});
+
+await box`ls /workspace/data`; // ok
+await box`cat /etc/passwd`; // fails: read access not permitted in sandbox
+await box`git status`; // fails: external commands are not permitted in sandbox
+```
+
+The returned function is `$`-compatible: it supports interpolation, `.cwd()`, `.env()`, `.quiet()`, `.nothrow()`, `.text()`, and friends, and inherits the `cwd`/`env`/`throws` configuration of the shell it derives from (`Bun.$` or a `new $.Shell()` instance). A sandboxed shell cannot be re-sandboxed; derive a new sandbox from an unsandboxed shell instead.
+
+Blocked commands and file operations fail with exit code `1` and a `... not permitted in sandbox` message on stderr, so they compose with `&&`, `||`, and `.nothrow()` like any other failing command. Exceeded limits reject the promise with a descriptive error.
+
+### Command policy
+
+Only Bun Shell builtins can run inside a sandbox — external binaries are always blocked, before any `PATH` lookup happens. `commands.allow` and `commands.deny` restrict the builtin set further:
+
+```js
+const box = $.sandbox({
+  commands: {
+    allow: ["echo", "ls", "seq"], // only these builtins may run
+    deny: ["rm"], // deny always wins over allow
+  },
+});
+```
+
+Unknown command names in `allow`/`deny` throw, listing the valid builtin names. The available builtin set matches the regular shell's: on POSIX platforms `cat` and `cp` currently delegate to system binaries, so inside a sandbox they are blocked like any external command.
+
+Because external binaries cannot run, environment tricks like `PATH=/evil cmd` cannot smuggle a command in, and `which` never probes the host filesystem — it only reports policy-permitted builtins.
+
+### Filesystem policy
+
+By default a sandboxed shell has **no filesystem access**. `fs.read` and `fs.write` grant access under absolute path prefixes; a `write` prefix also grants read. Omit `write` for a read-only sandbox.
+
+Every path the script touches — command operands, redirect targets, glob walks, `cd`, and `[[ -f ... ]]` tests — is resolved against the shell's working directory and through symlinks before it is compared against the prefixes. This is what stops the classic escapes:
+
+```js
+const box = $.sandbox({ fs: { read: ["/workspace/data"] } });
+
+await box`ls /workspace/data/../secrets`; // fails: `..` is resolved first
+await box`echo x < /workspace/data/link`; // fails if `link` points outside
+await box`echo /etc/*`; // fails: glob walks outside the prefixes are refused
+await box`cd /etc`; // fails: the new cwd must be readable
+```
+
+File tests like `[[ -f /etc/passwd ]]` answer as if the file does not exist, so scripts cannot probe the host tree. Recursive operations (`ls -R`, `rm -r`) stay under their checked roots because traversal never follows symlinks.
+
+Paths granted to the policy and paths checked at runtime are both canonicalized the same way (symlinks resolved via the deepest existing ancestor), so grants work even when the directory itself is reached through a symlink, such as `/tmp` on macOS.
+
+### Network policy
+
+A sandboxed script cannot reach the network: external binaries are blocked, and no shell builtin performs network I/O. The `network` option is reserved for future allowlists and currently only accepts `false` (the default); passing `true` throws.
+
+### Limits
+
+- `limits.timeout` — wall-clock limit in milliseconds for the whole script. When it expires, the promise rejects with `Shell command timed out after <n>ms (sandbox limits.timeout)` and the interpreter stops scheduling work.
+- `limits.maxOutputBytes` — caps the total bytes the script may write to stdout, stderr, and file redirects combined. When exceeded, the promise rejects with `Shell command output exceeded <n> bytes (sandbox limits.maxOutputBytes)`.
+
+Both rejections carry the output captured up to that point on `error.stdout` / `error.stderr`.
+
+### Current limitations
+
+This API is experimental, and the policy surface is designed to grow (finer-grained network rules and an overlay filesystem where writes land in a scratch layer are planned). Current limitations to be aware of:
+
+- JavaScript objects interpolated into the command (`Bun.file()`, `Response`, buffers) are provided by the calling code, not the untrusted script, so they are intentionally not subject to the filesystem policy.
+- A builtin blocked forever on a pipe that never receives data keeps its read poll active after a timeout; the promise still rejects and the caller regains control.
+- Path checks happen when an operation starts. With external binaries disabled, scripts cannot race the interpreter from another thread, but processes outside the sandbox mutating the same tree concurrently can still change what a checked path points at.
+
+---
+
 ## Credits
 
 Large parts of this API were inspired by [zx](https://github.com/google/zx), [dax](https://github.com/dsherret/dax), and [bnx](https://github.com/wobsoriano/bnx). Thank you to the authors of those projects.

--- a/packages/bun-types/shell.d.ts
+++ b/packages/bun-types/shell.d.ts
@@ -77,6 +77,105 @@ declare module "bun" {
     function throws(shouldThrow: boolean): $;
 
     /**
+     * **Experimental.** Create a sandboxed shell for running untrusted shell
+     * commands. Policy is enforced inside Bun's shell interpreter, before any
+     * command or filesystem operation executes:
+     *
+     * - Only Bun Shell builtins may run; external binaries are always
+     *   blocked. `commands.allow` / `commands.deny` restrict the builtin set
+     *   further.
+     * - Filesystem access is denied unless a path's symlink-resolved form is
+     *   under one of the `fs.read` / `fs.write` prefixes. A `write` prefix
+     *   also grants read access; omit `write` for a read-only sandbox.
+     * - The sandbox has no network access: no builtin performs network I/O
+     *   and external binaries cannot run. `network` is reserved and only
+     *   accepts `false`.
+     * - `limits.timeout` / `limits.maxOutputBytes` stop runaway commands by
+     *   rejecting the promise with a descriptive error.
+     *
+     * Blocked commands and file operations fail with exit code 1 and a
+     * `"... not permitted in sandbox"` message on stderr, so `&&`/`||` and
+     * `.nothrow()` compose normally.
+     *
+     * The returned shell inherits this shell's current `cwd`, `env`, and
+     * `throws` settings. It cannot be re-sandboxed; derive a new sandbox from
+     * an unsandboxed shell instead.
+     *
+     * @param options Sandbox policy. An empty object is the most restrictive
+     * policy: all builtins, no filesystem access, no limits.
+     *
+     * @example
+     * ```js
+     * import { $ } from "bun";
+     *
+     * const box = $.sandbox({
+     *   commands: { deny: ["rm"] },
+     *   fs: { read: ["/workspace/data"], write: ["/workspace/data/out"] },
+     *   limits: { timeout: 5_000, maxOutputBytes: 1024 * 1024 },
+     * });
+     *
+     * await box`ls /workspace/data`; // ok
+     * await box`cat /etc/passwd`;    // rejects: read access not permitted in sandbox
+     * ```
+     */
+    function sandbox(options: ShellSandboxOptions): $;
+
+    /**
+     * Policy for a sandboxed shell created with `$.sandbox()`.
+     */
+    interface ShellSandboxOptions {
+      /**
+       * Which commands the sandboxed shell may run. External binaries are
+       * always blocked; these lists filter Bun Shell's builtin commands.
+       * Unknown command names throw.
+       */
+      commands?: {
+        /**
+         * If present, only these builtins may run.
+         * @default all builtins
+         */
+        allow?: string[];
+        /**
+         * These builtins may never run, even when listed in `allow`.
+         */
+        deny?: string[];
+      };
+      /**
+       * Filesystem path prefixes the sandboxed shell may touch. Paths must be
+       * absolute. Every path a command, redirect, glob, or `[[ -f ... ]]`
+       * test uses is resolved against the shell's cwd and through symlinks
+       * before it is compared, so `..` segments and symlinks cannot escape.
+       * @default no filesystem access
+       */
+      fs?: {
+        /** Prefixes that may be read (listed, globbed, or used as input). */
+        read?: string[];
+        /** Prefixes that may be written. A write prefix also grants read. */
+        write?: string[];
+      };
+      /**
+       * Reserved. Sandboxed shells cannot access the network (external
+       * binaries are blocked and no builtin performs network I/O), so the
+       * only supported value is `false`.
+       * @default false
+       */
+      network?: false;
+      /** Resource limits for the whole script. */
+      limits?: {
+        /**
+         * Wall-clock limit in milliseconds. When exceeded, the promise
+         * rejects and the interpreter stops scheduling work.
+         */
+        timeout?: number;
+        /**
+         * Maximum total bytes the script may write to stdout, stderr, and
+         * file redirects combined. When exceeded, the promise rejects.
+         */
+        maxOutputBytes?: number;
+      };
+    }
+
+    /**
      * A shell command that runs once awaited, or once an output method like
      * `.text()` or `.json()` is called.
      *

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -196,6 +196,7 @@ pub enum Tag {
     ValkeyConnectionTimeout,
     ValkeyConnectionReconnect,
     SubprocessTimeout,
+    ShellInterpreterTimeout,
     DevServerSweepSourceMaps,
     DevServerMemoryVisualizerTick,
     AbortSignalTimeout,

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -24,8 +24,8 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
       super("");
     }
 
-    initialize(output: ShellOutput, code: number) {
-      this.message = `Failed with exit code ${code}`;
+    initialize(output: ShellOutput, code: number, message?: string) {
+      this.message = message !== undefined ? message : `Failed with exit code ${code}`;
       this.#output = output;
       this.name = "ShellError";
 
@@ -108,7 +108,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     #hasRun: boolean = false;
     #throws: boolean = true;
     #resolve: (code: number, stdout: Buffer, stderr: Buffer) => void;
-    #reject: (code: number, stdout: Buffer, stderr: Buffer) => void;
+    #reject: (code: number, stdout: Buffer, stderr: Buffer, message?: string) => void;
 
     constructor(args: $ZigGeneratedClasses.ParsedShellScript, throws: boolean) {
       // Create the error immediately so it captures the stacktrace at the point
@@ -131,8 +131,8 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
             res(out);
           }
         };
-        reject = (code, stdout, stderr) => {
-          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code);
+        reject = (code, stdout, stderr, message) => {
+          potentialError!.initialize(new ShellOutput(stdout, stderr, code), code, message);
           rej(potentialError);
         };
       });
@@ -256,11 +256,146 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
   const cwdSymbol = Symbol("cwd");
   const envSymbol = Symbol("env");
   const throwsSymbol = Symbol("throws");
+  const sandboxSymbol = Symbol("sandbox");
+
+  function validateStringArray(value, what: string): string[] | undefined {
+    if (value === undefined) return undefined;
+    if (!$isJSArray(value)) {
+      throw new TypeError(`$.sandbox: ${what} must be an array of strings`);
+    }
+    const out: string[] = [];
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i];
+      if (typeof item !== "string") {
+        throw new TypeError(`$.sandbox: ${what} must be an array of strings`);
+      }
+      out.push(item);
+    }
+    return out;
+  }
+
+  function validatePathArray(value, what: string): string[] | undefined {
+    const paths = validateStringArray(value, what);
+    if (paths === undefined) return undefined;
+    const { isAbsolute } = require("node:path");
+    for (const path of paths) {
+      if (path.length === 0 || !isAbsolute(path)) {
+        throw new TypeError(`$.sandbox: ${what} paths must be absolute, got ${JSON.stringify(path)}`);
+      }
+      if (path.includes("\0")) {
+        throw new TypeError(`$.sandbox: ${what} paths must not contain NUL bytes`);
+      }
+    }
+    return paths;
+  }
+
+  function validateLimit(value, what: string): number | undefined {
+    if (value === undefined) return undefined;
+    if (typeof value !== "number" || !Number.isInteger(value) || value <= 0) {
+      throw new TypeError(`$.sandbox: ${what} must be a positive integer`);
+    }
+    return value;
+  }
+
+  function validateKeys(object, allowed: string[], what: string) {
+    for (const key of Object.keys(object)) {
+      if (!allowed.includes(key)) {
+        throw new TypeError(`$.sandbox: unknown option '${what}${key}'`);
+      }
+    }
+  }
+
+  // Validates the `$.sandbox()` options object and deep-copies it into a
+  // frozen, null-prototype policy object (later mutation of the caller's
+  // object must not affect the sandbox). The native side
+  // (`ParsedShellScript.setSandbox`) re-validates, including builtin names
+  // in commands.allow/deny, which only it knows.
+  function normalizeSandboxOptions(options) {
+    if (typeof options !== "object" || options === null) {
+      throw new TypeError("$.sandbox: expected an options object");
+    }
+    validateKeys(options, ["commands", "fs", "network", "limits"], "");
+
+    const normalized: Record<string, any> = { __proto__: null };
+
+    const commands = options.commands;
+    if (commands !== undefined) {
+      if (typeof commands !== "object" || commands === null) {
+        throw new TypeError("$.sandbox: commands must be an object");
+      }
+      validateKeys(commands, ["allow", "deny"], "commands.");
+      normalized.commands = Object.freeze({
+        __proto__: null,
+        allow: validateStringArray(commands.allow, "commands.allow"),
+        deny: validateStringArray(commands.deny, "commands.deny"),
+      });
+    }
+
+    const fs = options.fs;
+    if (fs !== undefined) {
+      if (typeof fs !== "object" || fs === null) {
+        throw new TypeError("$.sandbox: fs must be an object");
+      }
+      validateKeys(fs, ["read", "write"], "fs.");
+      normalized.fs = Object.freeze({
+        __proto__: null,
+        read: validatePathArray(fs.read, "fs.read"),
+        write: validatePathArray(fs.write, "fs.write"),
+      });
+    }
+
+    const network = options.network;
+    if (network !== undefined) {
+      if (typeof network !== "boolean") {
+        throw new TypeError("$.sandbox: network must be a boolean");
+      }
+      if (network) {
+        throw new TypeError(
+          "$.sandbox: network access cannot be enabled yet; sandboxed shells run only builtin commands, none of which perform network I/O. The only supported value is false.",
+        );
+      }
+      normalized.network = false;
+    }
+
+    const limits = options.limits;
+    if (limits !== undefined) {
+      if (typeof limits !== "object" || limits === null) {
+        throw new TypeError("$.sandbox: limits must be an object");
+      }
+      validateKeys(limits, ["timeout", "maxOutputBytes"], "limits.");
+      normalized.limits = Object.freeze({
+        __proto__: null,
+        timeout: validateLimit(limits.timeout, "limits.timeout"),
+        maxOutputBytes: validateLimit(limits.maxOutputBytes, "limits.maxOutputBytes"),
+      });
+    }
+
+    return Object.freeze(normalized);
+  }
 
   class ShellPrototype {
     [cwdSymbol]: string | undefined;
     [envSymbol]: Record<string, string | undefined> | undefined;
     [throwsSymbol]: boolean = true;
+    [sandboxSymbol]: object | undefined;
+
+    sandbox(options) {
+      if (this[sandboxSymbol]) {
+        throw new Error("$.sandbox: this shell is already sandboxed; derive a new sandbox from an unsandboxed shell");
+      }
+      const normalized = normalizeSandboxOptions(options);
+
+      var Shell = function Shell(first, ...rest) {
+        return runShellTemplate(Shell, first, rest);
+      };
+      Object.setPrototypeOf(Shell, ShellPrototype.prototype);
+      Object.defineProperty(Shell, "name", { value: "Shell", configurable: true, enumerable: true });
+      Shell[cwdSymbol] = this[cwdSymbol];
+      Shell[envSymbol] = this[envSymbol];
+      Shell[throwsSymbol] = this[throwsSymbol];
+      Shell[sandboxSymbol] = normalized;
+      return Shell;
+    }
 
     env(newEnv: Record<string, string | undefined>) {
       if (typeof newEnv === "undefined" || newEnv === originalDefaultEnv) {
@@ -299,19 +434,28 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
   }
 
-  var BunShell = function BunShell(first, ...rest) {
+  // Shared tagged-template body for `Bun.$`, `new $.Shell()` instances, and
+  // `$.sandbox()` shells: `shell` is the template function itself, carrying
+  // its configuration under the symbol keys.
+  function runShellTemplate(shell, first, rest: any[]) {
     if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
     const parsed_shell_script = createParsedShellScript(first.raw, rest);
 
-    const cwd = BunShell[cwdSymbol];
-    const env = BunShell[envSymbol];
-    const throws = BunShell[throwsSymbol];
+    const cwd = shell[cwdSymbol];
+    const env = shell[envSymbol];
+    const throws = shell[throwsSymbol];
+    const sandbox = shell[sandboxSymbol];
 
     // cwd must be set before env or else it will be injected into env as "PWD=/"
     if (cwd) parsed_shell_script.setCwd(cwd);
     if (env) parsed_shell_script.setEnv(env);
+    if (sandbox) parsed_shell_script.setSandbox(sandbox);
 
     return new ShellPromise(parsed_shell_script, throws);
+  }
+
+  var BunShell = function BunShell(first, ...rest) {
+    return runShellTemplate(BunShell, first, rest);
   };
 
   function Shell() {
@@ -320,18 +464,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     }
 
     var Shell = function Shell(first, ...rest) {
-      if (first?.raw === undefined) throw new Error("Please use '$' as a tagged template function: $`cmd arg1 arg2`");
-      const parsed_shell_script = createParsedShellScript(first.raw, rest);
-
-      const cwd = Shell[cwdSymbol];
-      const env = Shell[envSymbol];
-      const throws = Shell[throwsSymbol];
-
-      // cwd must be set before env or else it will be injected into env as "PWD=/"
-      if (cwd) parsed_shell_script.setCwd(cwd);
-      if (env) parsed_shell_script.setEnv(env);
-
-      return new ShellPromise(parsed_shell_script, throws);
+      return runShellTemplate(Shell, first, rest);
     };
 
     Object.setPrototypeOf(Shell, ShellPrototype.prototype);

--- a/src/runtime/api/ParsedShellScript.classes.ts
+++ b/src/runtime/api/ParsedShellScript.classes.ts
@@ -25,6 +25,10 @@ export default [
         fn: "setQuiet",
         length: 1,
       },
+      setSandbox: {
+        fn: "setSandbox",
+        length: 1,
+      },
     },
   }),
 ];

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -565,6 +565,15 @@ fn run_task_cold(task: Task) {
             ShellRmDirTask::run_from_main_thread(t);
         }
         task_tag::ShellGlobTask => shell_dispatch!(ShellGlobTask),
+        task_tag::ShellYesTask => {
+            // `yes`'s no-IO write loop bounces through the event loop every
+            // few chunks; the task storage lives inside `Box<Yes>` in the
+            // interpreter arena (stable until the builtin is deinited).
+            // SAFETY: §Dispatch — tag identifies pointee; enqueued by
+            // `YesTask::enqueue` and alive until the builtin completes.
+            let t = unsafe { &*cast_ptr!(crate::shell::builtins::yes::YesTask) };
+            crate::shell::builtins::yes::YesTask::run_from_main_thread(t);
+        }
 
         // ── bake dev-server ──────────────────────────────────────────────
         task_tag::BakeHotReloadEvent => {
@@ -575,7 +584,7 @@ fn run_task_cold(task: Task) {
             unsafe { BakeHotReloadEvent::run(cast_ptr!(BakeHotReloadEvent)) };
         }
 
-        // ShellYesTask + any tag the hot path mis-routed: producer bug.
+        // Any tag the hot path mis-routed: producer bug.
         _ => panic!("Unexpected Task tag: {}", task.tag.0),
     }
 }
@@ -1047,6 +1056,13 @@ pub unsafe fn __bun_fire_timer(t: *mut EventLoopTimer, now: *const ElTimespec, v
         EventLoopTimerTag::SubprocessTimeout => {
             timer_arm!(Subprocess<'_>, event_loop_timer, |c, _now, _vm| (*c)
                 .timeout_callback())
+        }
+        EventLoopTimerTag::ShellInterpreterTimeout => {
+            timer_arm!(
+                crate::shell::Interpreter,
+                event_loop_timer,
+                |c, _now, _vm| (*c).on_sandbox_timeout()
+            )
         }
         EventLoopTimerTag::DevServerSweepSourceMaps => {
             // `sweep_weak_refs` takes the raw `*EventLoopTimer` and recovers

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -13,6 +13,7 @@ use crate::shell::interpreter::{
 use crate::shell::io::{InKind, OutFd, OutKind};
 use crate::shell::io_reader::IOReader;
 use crate::shell::io_writer::{self, IOWriter};
+use crate::shell::sandbox::SandboxAccess;
 use crate::shell::states::cmd::{Cmd, CmdState};
 use crate::shell::yield_::Yield;
 
@@ -94,6 +95,11 @@ macro_rules! shell_builtins {
             /// the experimental feature flag is set.
             pub const DISABLED_ON_POSIX: &'static [Kind] = &[ $( Kind::$PD ),* ];
 
+            /// Every builtin name, in `Kind` discriminant order (used by the
+            /// sandbox policy's allow/deny validation).
+            pub const ALL_NAMES: &'static [&'static str] =
+                &[ $( $u_name, )* $( $i_name, )* $( $b_name, )* ];
+
             /// Lowercase tag for error prefixes (`"{kind}: ..."`).
             pub fn as_str(self) -> &'static str {
                 match self {
@@ -112,7 +118,7 @@ macro_rules! shell_builtins {
             }
 
             /// argv[0] → `Kind`, no POSIX gating.
-            fn from_argv0_raw(s: &[u8]) -> Option<Kind> {
+            pub(crate) fn from_argv0_raw(s: &[u8]) -> Option<Kind> {
                 $( if s == $u_name.as_bytes() { return Some(Kind::$UV); } )*
                 $( if s == $i_name.as_bytes() { return Some(Kind::$IV); } )*
                 $( if s == $b_name.as_bytes() { return Some(Kind::$BV); } )*
@@ -162,6 +168,15 @@ macro_rules! shell_builtins {
                 written: usize,
                 err: Option<bun_sys::SystemError>,
             ) -> Yield {
+                // A cancelled sandboxed run surfaces as a write error so each
+                // builtin unwinds through its own error path (which releases
+                // registered readers etc.) instead of being torn down mid-state.
+                let err = match err {
+                    None if interp.sandbox_cancel_requested() => {
+                        Some(Interpreter::sandbox_cancel_error().to_shell_system_error())
+                    }
+                    e => e,
+                };
                 match Self::kind_of(interp, cmd) {
                     $( Kind::$UV => crate::shell::builtins::$u_mod::$UT::on_io_writer_chunk(interp, cmd, written, err), )*
                     $( Kind::$IV => crate::shell::builtins::$i_mod::$IT::on_io_writer_chunk(interp, cmd, written, err), )*
@@ -578,6 +593,25 @@ impl Builtin {
                 let cwd_fd = Self::cwd(interp, cmd);
                 let evtloop = interp.event_loop;
 
+                if let Some(policy) = interp.sandbox() {
+                    let access = if redirect.stdin() && !redirect.stdout() && !redirect.stderr() {
+                        SandboxAccess::Read
+                    } else {
+                        SandboxAccess::Write
+                    };
+                    if !policy.check_path(Self::shell(interp, cmd).cwd(), path.as_bytes(), access) {
+                        return Some(Self::cmd_write_failing_error(
+                            interp,
+                            cmd,
+                            format_args!(
+                                "bun: {}: {} access not permitted in sandbox\n",
+                                bstr::BStr::new(path.as_bytes()),
+                                access.verb(),
+                            ),
+                        ));
+                    }
+                }
+
                 // Regular files are not pollable on linux/macos.
                 let is_pollable_default: bool = cfg!(windows);
 
@@ -861,6 +895,34 @@ impl Builtin {
         interp.child_done(parent, cmd, 1)
     }
 
+    /// Check a path argument against the sandbox policy. `Err` carries the
+    /// formatted `"{kind}: {path}: ..."` message for the builtin's
+    /// failing-error path (exit code 1).
+    pub fn sandbox_check_path(
+        interp: &Interpreter,
+        cmd: NodeId,
+        kind: Kind,
+        path: &[u8],
+        access: SandboxAccess,
+    ) -> Result<(), Vec<u8>> {
+        let Some(policy) = interp.sandbox() else {
+            return Ok(());
+        };
+        if policy.check_path(Self::shell(interp, cmd).cwd(), path, access) {
+            return Ok(());
+        }
+        use std::io::Write as _;
+        let mut buf = Vec::new();
+        let _ = write!(
+            &mut buf,
+            "{}: {}: {} access not permitted in sandbox\n",
+            kind.as_str(),
+            bstr::BStr::new(path),
+            access.verb(),
+        );
+        Err(buf)
+    }
+
     /// Finish the builtin with `exit_code` and signal the owning Cmd.
     pub fn done(interp: &Interpreter, cmd: NodeId, exit_code: ExitCode) -> Yield {
         Self::of_mut(interp, cmd).exit_code = Some(exit_code);
@@ -918,6 +980,7 @@ impl Builtin {
         if buf.is_empty() {
             return Ok(0);
         }
+        interp.sandbox_count_output(buf.len())?;
         // Split-borrow the Cmd so `shell`
         // and the builtin's stdout/stderr are accessible simultaneously.
         let cmd_node = interp.as_cmd_mut(cmd);

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -1006,6 +1006,26 @@ impl IOWriter {
         }
     }
 
+    /// Count queued bytes against the sandbox output limit (no-op without a
+    /// sandbox policy). Exceeding the limit settles the promise with a
+    /// rejection; the chunk itself still completes, and the next
+    /// `Builtin::on_io_writer_chunk` dispatch delivers the cancellation.
+    fn sandbox_count_output(&self, n: usize) {
+        // End the `state()` borrow before entering the interpreter: the
+        // limit-exceeded path calls into JS (promise rejection), which must
+        // not overlap a live `&mut State`.
+        let interp: Option<*const Interpreter> = self
+            .state()
+            .interp
+            .as_ref()
+            .map(|p| core::ptr::from_ref(p.get()));
+        if let Some(interp) = interp {
+            // SAFETY: `set_interp` contract — the pointer is the live owning
+            // Interpreter; the shell is single-threaded.
+            let _ = unsafe { &*interp }.sandbox_count_output(n);
+        }
+    }
+
     /// Queue `buf` for writing; when the chunk completes (or errors),
     /// `child`'s `on_io_writer_chunk` fires.
     pub fn enqueue(&self, child: ChildPtr, bytelist: Option<*mut Vec<u8>>, buf: &[u8]) -> Yield {
@@ -1019,6 +1039,7 @@ impl IOWriter {
                 err: None,
             };
         }
+        self.sandbox_count_output(buf.len());
         let s = self.state();
         s.buf.extend_from_slice(buf);
         s.writers.push(Writer {
@@ -1067,6 +1088,8 @@ impl IOWriter {
             };
         }
         let end = s.buf.len();
+        self.sandbox_count_output(end - start);
+        let s = self.state();
         s.writers.push(Writer {
             ptr: child,
             len: end - start,

--- a/src/runtime/shell/ParsedShellScript.rs
+++ b/src/runtime/shell/ParsedShellScript.rs
@@ -9,6 +9,7 @@ use bun_jsc::{
 };
 
 use super::interpreter::ShellArgs;
+use super::sandbox::SandboxPolicy;
 use super::shell_body::{JsStrings, shell_cmd_from_js};
 use super::{EnvMap, EnvStr, Interpreter};
 
@@ -28,6 +29,7 @@ pub struct ParsedShellScript {
     pub export_env: JsCell<Option<EnvMap>>,
     pub quiet: Cell<bool>,
     pub cwd: Cell<Option<BunString>>,
+    pub sandbox: JsCell<Option<Box<SandboxPolicy>>>,
     /// Self-wrapper backref. `.classes.ts` has `finalize: true`, so the weak arm is
     /// sound: codegen calls `finalize()` which flips this to `.Finalized` before sweep.
     /// Read-only after construction; mutated only in `finalize(mut self: Box<Self>)`.
@@ -44,6 +46,7 @@ impl Default for ParsedShellScript {
             export_env: JsCell::new(None),
             quiet: Cell::new(false),
             cwd: Cell::new(None),
+            sandbox: JsCell::new(None),
             this_jsvalue: JsRef::empty(),
             estimated_size_for_gc: 0,
         }
@@ -61,6 +64,9 @@ impl ParsedShellScript {
         }
         if let Some(cwd) = self.cwd.get() {
             size += cwd.estimated_size();
+        }
+        if let Some(sandbox) = self.sandbox.get() {
+            size += sandbox.memory_cost();
         }
         size += self.jsobjs.get().capacity() * size_of::<JSValue>();
         size
@@ -84,13 +90,15 @@ impl ParsedShellScript {
         bool,
         Option<BunString>,
         Option<EnvMap>,
+        Option<Box<SandboxPolicy>>,
     ) {
         let args = self.args.replace(None).expect("args already taken");
         let jsobjs = self.jsobjs.replace(Vec::new());
         let quiet = self.quiet.get();
         let cwd = self.cwd.take();
         let export_env = self.export_env.replace(None);
-        (args, jsobjs, quiet, cwd, export_env)
+        let sandbox = self.sandbox.replace(None);
+        (args, jsobjs, quiet, cwd, export_env, sandbox)
     }
 
     /// Called from the generated C++ wrapper's `finalize()`. Runs on the mutator
@@ -131,6 +139,13 @@ impl ParsedShellScript {
     pub fn set_quiet(&self, _global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
         let arg = callframe.argument(0);
         self.quiet.set(arg.to_boolean());
+        Ok(JSValue::UNDEFINED)
+    }
+
+    #[bun_jsc::host_fn(method)]
+    pub fn set_sandbox(&self, global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+        let policy = SandboxPolicy::from_js(global, callframe.argument(0))?;
+        self.sandbox.set(Some(policy));
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -191,6 +191,16 @@ impl Cat {
                     *i += 1;
                 }
 
+                if let Err(msg) = Builtin::sandbox_check_path(
+                    interp,
+                    cmd,
+                    Kind::Cat,
+                    path.as_bytes(),
+                    crate::shell::sandbox::SandboxAccess::Read,
+                ) {
+                    return Self::write_failing_error(interp, cmd, &msg, 1);
+                }
+
                 let dir = Builtin::cwd(interp, cmd);
                 let fd = match shell_openat(dir, path, bun_sys::O::RDONLY, 0) {
                     Ok(fd) => fd,

--- a/src/runtime/shell/builtin/cd.rs
+++ b/src/runtime/shell/builtin/cd.rs
@@ -33,16 +33,31 @@ impl Cd {
 
         if args.len() == 1 {
             let first_arg = Builtin::of(interp, cmd).arg_bytes(0);
-            if first_arg == b"-" {
-                let prev = Builtin::shell(interp, cmd).prev_cwd().to_vec();
-                if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_prev_cwd() {
-                    return Self::handle_change_cwd_err(interp, cmd, &err, &prev);
-                }
+            let target = if first_arg == b"-" {
+                Builtin::shell(interp, cmd).prev_cwd().to_vec()
             } else {
-                let target = first_arg.to_vec();
-                if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_cwd(&target) {
+                first_arg.to_vec()
+            };
+            // The new cwd must be readable under the sandbox policy; every
+            // later relative path resolves against it and is checked again,
+            // but allowing a cd outside the policy would leak directory
+            // existence through the error messages.
+            if let Err(msg) = Builtin::sandbox_check_path(
+                interp,
+                cmd,
+                Kind::Cd,
+                &target,
+                crate::shell::sandbox::SandboxAccess::Read,
+            ) {
+                Self::state_mut(interp, cmd).state = State::WaitingIo;
+                return Builtin::write_failing_error(interp, cmd, &msg, 1);
+            }
+            if first_arg == b"-" {
+                if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_prev_cwd() {
                     return Self::handle_change_cwd_err(interp, cmd, &err, &target);
                 }
+            } else if let Err(err) = interp.as_cmd_mut(cmd).base.shell_mut().change_cwd(&target) {
+                return Self::handle_change_cwd_err(interp, cmd, &err, &target);
             }
         }
 

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -173,6 +173,39 @@ impl Cp {
                 let tgt = Builtin::of(interp, cmd).arg_bytes(target).to_vec();
                 let operands = 1 + (target - start);
                 let interp_ptr = interp.as_ctx_ptr();
+
+                // Sources are read, the target is written. `-R` traversal
+                // stays under the checked roots: the dereference flags
+                // (`-H`/`-L`) are rejected at parse time and the copy
+                // reproduces symlinks instead of following them.
+                {
+                    use crate::shell::sandbox::SandboxAccess;
+                    let mut denied = Builtin::sandbox_check_path(
+                        interp,
+                        cmd,
+                        Kind::Cp,
+                        &tgt,
+                        SandboxAccess::Write,
+                    )
+                    .err();
+                    if denied.is_none() {
+                        denied = (start..target).find_map(|i| {
+                            Builtin::sandbox_check_path(
+                                interp,
+                                cmd,
+                                Kind::Cp,
+                                Builtin::of(interp, cmd).arg_bytes(i),
+                                SandboxAccess::Read,
+                            )
+                            .err()
+                        });
+                    }
+                    if let Some(msg) = denied {
+                        Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
+                        return Builtin::write_failing_error(interp, cmd, &msg, 1);
+                    }
+                }
+
                 for i in start..target {
                     let src = Builtin::of(interp, cmd).arg_bytes(i).to_vec();
                     let task = ShellCpTask::create(

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -109,7 +109,13 @@ impl Ls {
                 {
                     use crate::shell::sandbox::SandboxAccess;
                     let check = |path: &[u8]| {
-                        Builtin::sandbox_check_path(interp, cmd, Kind::Ls, path, SandboxAccess::Read)
+                        Builtin::sandbox_check_path(
+                            interp,
+                            cmd,
+                            Kind::Ls,
+                            path,
+                            SandboxAccess::Read,
+                        )
                     };
                     let denied = match paths_start {
                         Some(start) => (start..argc)

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -101,6 +101,27 @@ impl Ls {
                     Some(start) => argc - start,
                     None => 1,
                 };
+
+                // Check every path operand (or the implicit ".") before any
+                // task is scheduled. `-R` recursion stays under these roots:
+                // the dirent-kind check in `run_from_thread_pool` never
+                // descends into symlinks.
+                {
+                    use crate::shell::sandbox::SandboxAccess;
+                    let check = |path: &[u8]| {
+                        Builtin::sandbox_check_path(interp, cmd, Kind::Ls, path, SandboxAccess::Read)
+                    };
+                    let denied = match paths_start {
+                        Some(start) => (start..argc)
+                            .find_map(|i| check(Builtin::of(interp, cmd).arg_bytes(i)).err()),
+                        None => check(b".").err(),
+                    };
+                    if let Some(msg) = denied {
+                        Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
+                        return Builtin::write_failing_error(interp, cmd, &msg, 1);
+                    }
+                }
+
                 Self::state_mut(interp, cmd).state = State::Exec(ExecState {
                     err: None,
                     task_count: AtomicUsize::new(task_count),

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -121,6 +121,19 @@ impl Mkdir {
                 if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                     exec.tasks_count = task_count;
                 }
+                for i in args_start..argc {
+                    let path = Builtin::of(interp, cmd).arg_bytes(i);
+                    if let Err(msg) = Builtin::sandbox_check_path(
+                        interp,
+                        cmd,
+                        Kind::Mkdir,
+                        path,
+                        crate::shell::sandbox::SandboxAccess::Write,
+                    ) {
+                        Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
+                        return Builtin::write_failing_error(interp, cmd, &msg, 1);
+                    }
+                }
                 let opts = Self::state_mut(interp, cmd).opts;
                 let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
                 let evtloop = Builtin::event_loop(interp, cmd);

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -108,6 +108,26 @@ impl Mv {
                 }
                 let cwd = Builtin::cwd(interp, cmd);
                 let target_idx = Self::state_mut(interp, cmd).args.target_idx;
+
+                // Renames unlink the source and create the target, so both
+                // need write access. Checked before the target-probe task so
+                // a denied mv does not even stat the target.
+                {
+                    let sources_start = Self::state_mut(interp, cmd).args.sources_start;
+                    for i in sources_start..=target_idx {
+                        let path = Builtin::of(interp, cmd).arg_bytes(i);
+                        if let Err(msg) = Builtin::sandbox_check_path(
+                            interp,
+                            cmd,
+                            Kind::Mv,
+                            path,
+                            crate::shell::sandbox::SandboxAccess::Write,
+                        ) {
+                            return Self::write_failing_error(interp, cmd, &msg, 1);
+                        }
+                    }
+                }
+
                 let target = ZBox::from_bytes(Builtin::of(interp, cmd).arg_bytes(target_idx));
                 let evtloop = Builtin::event_loop(interp, cmd);
                 let mut task = Box::new(ShellMvCheckTargetTask {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -320,6 +320,23 @@ impl Rm {
                             e.started = true;
                             (e.args_start, e.args_start + e.total_tasks)
                         };
+
+                        // Check every operand before any deletion task is
+                        // scheduled. `-r` traversal stays under these roots:
+                        // the worker unlinks with `O_NOFOLLOW`/`AT_REMOVEDIR`
+                        // semantics and never descends through symlinks.
+                        for i in args_start..argc {
+                            let root = Builtin::of(interp, cmd).arg_bytes(i);
+                            if let Err(msg) = Builtin::sandbox_check_path(
+                                interp,
+                                cmd,
+                                Kind::Rm,
+                                root,
+                                crate::shell::sandbox::SandboxAccess::Write,
+                            ) {
+                                return Self::write_failing_error(interp, cmd, &msg, 1);
+                            }
+                        }
                         let (sig, out_count) = match &Self::state_mut(interp, cmd).state {
                             RmState::Exec(e) => (
                                 bun_ptr::BackRef::new(&e.error_signal),

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -110,6 +110,19 @@ impl Touch {
                 if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
                     exec.tasks_count = argc - args_start;
                 }
+                for i in args_start..argc {
+                    let path = Builtin::of(interp, cmd).arg_bytes(i);
+                    if let Err(msg) = Builtin::sandbox_check_path(
+                        interp,
+                        cmd,
+                        Kind::Touch,
+                        path,
+                        crate::shell::sandbox::SandboxAccess::Write,
+                    ) {
+                        Self::state_mut(interp, cmd).state = State::WaitingWriteErr;
+                        return Builtin::write_failing_error(interp, cmd, &msg, 1);
+                    }
+                }
                 let opts = Self::state_mut(interp, cmd).opts;
                 let cwd = Builtin::shell(interp, cmd).cwd().to_vec();
                 let evtloop = Builtin::event_loop(interp, cmd);

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -51,7 +51,7 @@ impl Which {
             let mut had_not_found = false;
             for i in 0..argc {
                 let arg = Self::arg(interp, cmd, i);
-                match Self::resolve(&path_env, &cwd, &arg) {
+                match Self::resolve(interp, &path_env, &cwd, &arg) {
                     Some(resolved) => {
                         let buf = Builtin::fmt_error_arena(
                             interp,
@@ -102,7 +102,7 @@ impl Which {
 
         let arg = Self::arg(interp, cmd, arg_idx);
         let (path_env, cwd) = Self::path_and_cwd(interp, cmd);
-        let resolved = Self::resolve(&path_env, &cwd, &arg);
+        let resolved = Self::resolve(interp, &path_env, &cwd, &arg);
 
         let child = ChildPtr::new(cmd, WriterTag::Builtin);
         match resolved {
@@ -212,7 +212,20 @@ impl Which {
         Builtin::of(interp, cmd).arg_bytes(idx).to_vec()
     }
 
-    fn resolve(path_env: &[u8], cwd: &[u8], arg: &[u8]) -> Option<Vec<u8>> {
+    fn resolve(interp: &Interpreter, path_env: &[u8], cwd: &[u8], arg: &[u8]) -> Option<Vec<u8>> {
+        // Sandboxed shells never probe PATH (external binaries cannot run and
+        // stat'ing PATH entries would leak what exists on the host): the only
+        // resolvable commands are the policy-permitted builtins.
+        if let Some(policy) = interp.sandbox() {
+            use crate::shell::builtin::Kind;
+            return Kind::from_argv0(arg)
+                .filter(|kind| policy.builtin_allowed(*kind))
+                .map(|_| {
+                    let mut out = arg.to_vec();
+                    out.extend_from_slice(b": shell builtin");
+                    out
+                });
+        }
         let mut path_buf = bun_paths::path_buffer_pool::get();
         bun_which::which(&mut *path_buf, path_env, cwd, arg).map(|z| z.as_bytes().to_vec())
     }

--- a/src/runtime/shell/builtin/yes.rs
+++ b/src/runtime/shell/builtin/yes.rs
@@ -103,6 +103,12 @@ impl Yes {
             let chunk = &yes.buffer[..yes.buffer_used];
             let mut err = None;
             for _ in 0..4 {
+                // Zero-copy path bypasses `Builtin::write_no_io`, so the
+                // sandbox output accounting happens here.
+                if let Err(e) = interp.sandbox_count_output(chunk.len()) {
+                    err = Some(e);
+                    break;
+                }
                 // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd.
                 if let Err(e) = unsafe { stdout.write_no_io_to(shell, chunk) } {
                     err = Some(e);

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -331,6 +331,27 @@ pub struct Interpreter {
     pub cleanup_state: Cell<CleanupState>,
     pub estimated_size_for_gc: Cell<usize>,
 
+    /// Sandbox policy (`$.sandbox({...})`). `None` for ordinary shells, in
+    /// which case every sandbox hook below is a no-op.
+    pub sandbox: Option<Box<crate::shell::SandboxPolicy>>,
+    /// Set once when a sandbox limit aborts the run; checked at every
+    /// interpreter step boundary so in-flight state unwinds through normal
+    /// completion paths instead of being torn down mid-state.
+    sandbox_fault: Cell<Option<crate::shell::SandboxFault>>,
+    /// Wall-clock deadline mirror of the sandbox timeout timer, checked at
+    /// step boundaries so synchronous bursts that starve the event loop
+    /// still observe the timeout.
+    sandbox_deadline: Cell<Option<bun_core::Timespec>>,
+    /// Total bytes written to stdout/stderr/redirects, counted against
+    /// `limits.maxOutputBytes`.
+    sandbox_output_bytes: Cell<u64>,
+    /// True once the JS promise was settled by a sandbox fault; `finish()`
+    /// then skips the resolve call and only tears down.
+    promise_settled: Cell<bool>,
+    /// Intrusive timer node for `limits.timeout`. `JsCell` so `&self` can
+    /// hand `*mut EventLoopTimer` to the timer heap.
+    pub event_loop_timer: JsCell<crate::timer::EventLoopTimer>,
+
     /// Side-channel for `try_()`: lets init/setup paths use `?`-style cleanup
     /// while still surfacing the rich syscall error at the boundary.
     pub last_err: JsCell<Option<bun_sys::Error>>,
@@ -498,6 +519,7 @@ impl Interpreter {
         jsobjs: Vec<crate::jsc::JSValue>,
         export_env_: Option<EnvMap>,
         cwd_: Option<&[u8]>,
+        sandbox: Option<Box<crate::shell::SandboxPolicy>>,
     ) -> ShellResult<Box<Interpreter>> {
         // ── export_env ─────────────────────────────────────────────────────
         // On the `.js` event loop, take `export_env_` (or empty); on `.mini`,
@@ -610,6 +632,14 @@ impl Interpreter {
             this_jsvalue: Cell::new(crate::jsc::JSValue::ZERO),
             cleanup_state: Cell::new(CleanupState::NeedsFullCleanup),
             estimated_size_for_gc: Cell::new(0),
+            sandbox,
+            sandbox_fault: Cell::new(None),
+            sandbox_deadline: Cell::new(None),
+            sandbox_output_bytes: Cell::new(0),
+            promise_settled: Cell::new(false),
+            event_loop_timer: JsCell::new(crate::timer::EventLoopTimer::init_paused(
+                crate::timer::EventLoopTimerTag::ShellInterpreterTimeout,
+            )),
             last_err: JsCell::new(None),
             vm_args_utf8: JsCell::new(Vec::new()),
             command_ctx: ctx,
@@ -756,6 +786,7 @@ impl Interpreter {
             Vec::new(),
             None,
             cwd,
+            None,
         ) {
             Ok(i) => i,
             Err(e) => e.throw_mini(),
@@ -1160,6 +1191,173 @@ impl Interpreter {
         let _ = err.throw_js(global);
     }
 
+    // ── sandbox ($.sandbox) ────────────────────────────────────────────────
+
+    #[inline]
+    pub fn sandbox(&self) -> Option<&crate::shell::SandboxPolicy> {
+        self.sandbox.as_deref()
+    }
+
+    /// `true` once a sandbox fault (timeout / output limit) aborted the run.
+    /// Also checks the wall-clock deadline so synchronous bursts that starve
+    /// the event loop (and thus the timeout timer) still observe it. Checked
+    /// at step boundaries; each caller unwinds through its normal completion
+    /// path with a nonzero exit code.
+    #[inline]
+    pub fn sandbox_cancel_requested(&self) -> bool {
+        if self.sandbox.is_none() {
+            return false;
+        }
+        if self.sandbox_fault.get().is_some() {
+            return true;
+        }
+        if let Some(deadline) = self.sandbox_deadline.get() {
+            if bun_core::Timespec::now(bun_core::TimespecMockMode::AllowMockedTime)
+                .greater(&deadline)
+            {
+                self.trigger_sandbox_fault(crate::shell::SandboxFault::Timeout);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// The synthetic write error delivered to builtins whose IO loop is
+    /// interrupted by a sandbox fault.
+    pub fn sandbox_cancel_error() -> bun_sys::Error {
+        bun_sys::Error::from_code(bun_sys::E::ECANCELED, bun_sys::Tag::write)
+    }
+
+    /// Count `n` bytes of shell output against `limits.maxOutputBytes`.
+    /// Returns `Err(ECANCELED)` when the run is (or just became) cancelled so
+    /// write loops stop through their existing error handling.
+    pub fn sandbox_count_output(&self, n: usize) -> bun_sys::Result<()> {
+        let Some(policy) = self.sandbox() else {
+            return Ok(());
+        };
+        if self.sandbox_cancel_requested() {
+            return Err(Self::sandbox_cancel_error());
+        }
+        let Some(limit) = policy.max_output_bytes else {
+            return Ok(());
+        };
+        let total = self.sandbox_output_bytes.get().saturating_add(n as u64);
+        self.sandbox_output_bytes.set(total);
+        if total > limit {
+            self.trigger_sandbox_fault(crate::shell::SandboxFault::OutputLimit);
+            return Err(Self::sandbox_cancel_error());
+        }
+        Ok(())
+    }
+
+    /// Abort a sandboxed run: record the fault, settle the JS promise with a
+    /// descriptive rejection (carrying the output captured so far), and let
+    /// the state machine unwind at the `sandbox_cancel_requested` boundaries.
+    /// Does NOT tear down interpreter state — in-flight nodes still reference
+    /// it; `finish()` runs the teardown once they unwind.
+    fn trigger_sandbox_fault(&self, fault: crate::shell::SandboxFault) {
+        use crate::jsc::JSValue;
+        use crate::jsc::generated::JSShellInterpreter;
+
+        if self.sandbox_fault.get().is_some() {
+            return;
+        }
+        self.sandbox_fault.set(Some(fault));
+        self.disarm_sandbox_timer();
+
+        if !matches!(self.event_loop, EventLoopHandle::Js { .. }) || self.promise_settled.get() {
+            return;
+        }
+        self.promise_settled.set(true);
+        let this_jsvalue = self.this_jsvalue.get();
+        if this_jsvalue == JSValue::ZERO {
+            return;
+        }
+        let Some(reject) = JSShellInterpreter::reject_get_cached(this_jsvalue) else {
+            return;
+        };
+        let global_this = self
+            .global_this_ref()
+            .expect("global_this set on Js event-loop path");
+        let buffered_stdout = self.get_buffered_stdout(global_this);
+        let buffered_stderr = self.get_buffered_stderr(global_this);
+        // The caller no longer waits on this run; don't hold the event loop
+        // open for whatever is still unwinding.
+        self.keep_alive.with_mut(|k| k.disable());
+
+        let policy = self.sandbox().expect("fault requires a sandbox policy");
+        let message = match fault {
+            crate::shell::SandboxFault::Timeout => format!(
+                "Shell command timed out after {}ms (sandbox limits.timeout)",
+                policy.timeout_ms.unwrap_or(0)
+            ),
+            crate::shell::SandboxFault::OutputLimit => format!(
+                "Shell command output exceeded {} bytes (sandbox limits.maxOutputBytes)",
+                policy.max_output_bytes.unwrap_or(0)
+            ),
+        };
+        use bun_jsc::StringJsc as _;
+        let message_js = bun_core::String::clone_utf8(message.as_bytes())
+            .to_js(global_this)
+            .unwrap_or(JSValue::UNDEFINED);
+
+        let loop_ = self.event_loop;
+        let _entered = loop_.entered();
+        if let Err(err) = reject.call(
+            global_this,
+            JSValue::UNDEFINED,
+            &[
+                JSValue::js_number_from_int32(1),
+                buffered_stdout,
+                buffered_stderr,
+                message_js,
+            ],
+        ) {
+            global_this.report_active_exception_as_unhandled(err);
+        }
+        JSShellInterpreter::resolve_set_cached(this_jsvalue, global_this, JSValue::UNDEFINED);
+        JSShellInterpreter::reject_set_cached(this_jsvalue, global_this, JSValue::UNDEFINED);
+    }
+
+    /// `limits.timeout` timer fired (dispatched via
+    /// `EventLoopTimerTag::ShellInterpreterTimeout`).
+    pub(crate) fn on_sandbox_timeout(&self) {
+        use crate::timer::EventLoopTimerState;
+        if self.event_loop_timer.get().state == EventLoopTimerState::CANCELLED {
+            return;
+        }
+        self.event_loop_timer
+            .with_mut(|t| t.state = EventLoopTimerState::FIRED);
+        if self.flags.get().done() || self.exit_code.get().is_some() {
+            return;
+        }
+        self.trigger_sandbox_fault(crate::shell::SandboxFault::Timeout);
+    }
+
+    fn arm_sandbox_timer(&self, timeout_ms: u64) {
+        let ts = bun_core::Timespec::ms_from_now(
+            bun_core::TimespecMockMode::AllowMockedTime,
+            timeout_ms.min(i64::MAX as u64) as i64,
+        );
+        self.sandbox_deadline.set(Some(ts));
+        self.event_loop_timer.with_mut(|t| {
+            t.next = crate::timer::ElTimespec {
+                sec: ts.sec,
+                nsec: ts.nsec,
+            };
+        });
+        crate::jsc_hooks::timer_all_mut().insert(self.event_loop_timer.as_ptr());
+    }
+
+    fn disarm_sandbox_timer(&self) {
+        use crate::timer::EventLoopTimerState;
+        if self.event_loop_timer.get().state == EventLoopTimerState::ACTIVE {
+            crate::jsc_hooks::timer_all_mut().remove(self.event_loop_timer.as_ptr());
+            self.event_loop_timer
+                .with_mut(|t| t.state = EventLoopTimerState::CANCELLED);
+        }
+    }
+
     // ── run loop ───────────────────────────────────────────────────────────
 
     /// When `!quiet`, dup stdout/stderr (or open
@@ -1280,6 +1478,14 @@ impl Interpreter {
 
         if matches!(self.event_loop, EventLoopHandle::Js { .. }) {
             self.exit_code.set(Some(exit_code));
+            self.disarm_sandbox_timer();
+            if self.promise_settled.get() {
+                // A sandbox fault already rejected the promise (and cleared
+                // the cached resolve/reject); only the teardown remains.
+                self.keep_alive.with_mut(|k| k.disable());
+                self.deref_root_shell_and_io_if_needed(true);
+                return Yield::done();
+            }
             let this_jsvalue = self.this_jsvalue.get();
             if this_jsvalue != JSValue::ZERO {
                 if let Some(resolve) = JSShellInterpreter::resolve_get_cached(this_jsvalue) {
@@ -1347,6 +1553,10 @@ impl Interpreter {
             ));
         }
         Self::incr_pending_activity_flag(&self.has_pending_activity);
+
+        if let Some(timeout_ms) = self.sandbox().and_then(|p| p.timeout_ms) {
+            self.arm_sandbox_timer(timeout_ms);
+        }
 
         let shell = self.root_shell.as_ptr();
         let ast = &raw const self.args.get().script_ast;
@@ -1431,6 +1641,10 @@ impl Interpreter {
             &raw const *this as usize,
             <&'static str>::from(this.cleanup_state.get()),
         );
+
+        // The sandbox timeout timer holds a raw pointer into this allocation;
+        // it must leave the heap before the box drops.
+        this.disarm_sandbox_timer();
 
         match this.cleanup_state.get() {
             CleanupState::NeedsFullCleanup => {
@@ -3054,7 +3268,7 @@ pub fn create_shell_interpreter(
         )));
     }
 
-    let (shargs, jsobjs, quiet, cwd, export_env) = parsed_shell_script.take(global);
+    let (shargs, jsobjs, quiet, cwd, export_env, sandbox) = parsed_shell_script.take(global);
 
     let cwd = cwd.map(bun_core::OwnedString::new);
     let cwd_slice = cwd.as_deref().map(|c| c.to_utf8());
@@ -3070,6 +3284,7 @@ pub fn create_shell_interpreter(
         jsobjs,
         export_env,
         cwd_slice.as_ref().map(|c| c.slice()),
+        sandbox,
     ) {
         ShellResult::Ok(i) => i,
         ShellResult::Err(e) => {

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -120,10 +120,10 @@ pub mod builtins {
 pub use env_map::EnvMap;
 pub use env_str::EnvStr;
 pub use interpreter::{ExitCode, Interpreter, Node, NodeId, ShellExecEnv};
-pub use sandbox::{SandboxAccess, SandboxFault, SandboxPolicy};
 pub use io::IO;
 pub use io_writer as IOWriter;
 pub use ref_counted_str::RefCountedStr;
+pub use sandbox::{SandboxAccess, SandboxFault, SandboxPolicy};
 pub use yield_::Yield;
 
 /// Forward-decl task payloads for `runtime::dispatch::run_task` arms whose

--- a/src/runtime/shell/mod.rs
+++ b/src/runtime/shell/mod.rs
@@ -42,6 +42,7 @@ pub mod io_reader;
 pub mod io_writer;
 #[path = "ParsedShellScript.rs"]
 pub mod parsed_shell_script;
+pub mod sandbox;
 #[path = "Yield.rs"]
 pub mod yield_;
 
@@ -119,6 +120,7 @@ pub mod builtins {
 pub use env_map::EnvMap;
 pub use env_str::EnvStr;
 pub use interpreter::{ExitCode, Interpreter, Node, NodeId, ShellExecEnv};
+pub use sandbox::{SandboxAccess, SandboxFault, SandboxPolicy};
 pub use io::IO;
 pub use io_writer as IOWriter;
 pub use ref_counted_str::RefCountedStr;

--- a/src/runtime/shell/sandbox.rs
+++ b/src/runtime/shell/sandbox.rs
@@ -1,0 +1,367 @@
+//! Sandbox policy for `Bun.$` (`$.sandbox({...})`).
+//!
+//! A `SandboxPolicy` is parsed from the JS options object once per
+//! invocation (`ParsedShellScript.setSandbox`) and moved onto the
+//! [`Interpreter`](crate::shell::Interpreter), where every state node can
+//! reach it. Enforcement happens inside the interpreter, before any effect:
+//!
+//! - **Commands**: only shell builtins may run (external binaries never
+//!   spawn), filtered further by `commands.allow` / `commands.deny`
+//!   (checked in `Cmd::transition_to_exec`). The available builtin set is
+//!   the same as for an unsandboxed shell (`Kind::from_argv0`, including its
+//!   POSIX gating of cat/cp); allow/deny entries are validated against the
+//!   full name table so policies stay portable across platforms.
+//! - **Filesystem**: every path a builtin, redirect, glob walk, or `[[ -f x ]]`
+//!   test touches is resolved against the shell's cwd, symlink-resolved via
+//!   `realpath` of its deepest existing ancestor, and prefix-matched against
+//!   `fs.read` / `fs.write`. A `fs.write` prefix implies read access.
+//! - **Limits**: `limits.timeout` arms an `EventLoopTimer` and a wall-clock
+//!   deadline checked at interpreter step boundaries; `limits.maxOutputBytes`
+//!   is counted at the two output choke points (`Builtin::write_no_io` and
+//!   `IOWriter::enqueue`).
+//!
+//! Path checks run on the JS thread at the point where a path argument is
+//! consumed (builtin start / redirect open / glob-walk creation), not inside
+//! worker-pool traversal. Traversal stays underneath a checked root because
+//! neither `ls -R` (dirent kind) nor `rm -r` (`O_NOFOLLOW`) nor the glob
+//! walker (`follow_symlinks = false`) follows symlinks, and `cp` flags that
+//! would follow source symlinks during traversal (`-L`/`-H`) are rejected in
+//! sandboxed shells.
+
+use bun_core::strings;
+use bun_jsc::{JSGlobalObject, JSValue, JsResult};
+
+use crate::shell::builtin::Kind;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SandboxAccess {
+    Read,
+    Write,
+}
+
+impl SandboxAccess {
+    pub fn verb(self) -> &'static str {
+        match self {
+            SandboxAccess::Read => "read",
+            SandboxAccess::Write => "write",
+        }
+    }
+}
+
+/// Reason a sandboxed run was aborted before normal completion.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SandboxFault {
+    Timeout,
+    OutputLimit,
+}
+
+pub struct SandboxPolicy {
+    /// Bit `Kind as u8` set ⇒ that builtin may run.
+    allowed_builtins: u32,
+    /// Canonicalized absolute prefixes (no trailing separator except a bare
+    /// filesystem root).
+    read_prefixes: Vec<Box<[u8]>>,
+    write_prefixes: Vec<Box<[u8]>>,
+    pub timeout_ms: Option<u64>,
+    pub max_output_bytes: Option<u64>,
+}
+
+const ALL_BUILTINS_MASK: u32 = {
+    assert!(Kind::ALL_NAMES.len() <= 32);
+    (1u32 << Kind::ALL_NAMES.len()) - 1
+};
+
+impl SandboxPolicy {
+    #[inline]
+    pub fn builtin_allowed(&self, kind: Kind) -> bool {
+        self.allowed_builtins & (1u32 << (kind as u8)) != 0
+    }
+
+    /// `true` when `path` (absolute, or relative to `cwd`) is within the
+    /// policy's prefixes for `access`. Write prefixes also grant read.
+    pub fn check_path(&self, cwd: &[u8], path: &[u8], access: SandboxAccess) -> bool {
+        let canonical = canonicalize_path(cwd, path);
+        let write_ok = self
+            .write_prefixes
+            .iter()
+            .any(|p| prefix_matches(p, &canonical));
+        match access {
+            SandboxAccess::Write => write_ok,
+            SandboxAccess::Read => {
+                write_ok
+                    || self
+                        .read_prefixes
+                        .iter()
+                        .any(|p| prefix_matches(p, &canonical))
+            }
+        }
+    }
+
+    /// Parse the normalized options object produced by `$.sandbox()` in
+    /// `shell.ts`. Throws a TypeError on anything malformed so a bad policy
+    /// never half-applies.
+    pub fn from_js(global: &JSGlobalObject, options: JSValue) -> JsResult<Box<SandboxPolicy>> {
+        if !options.is_object() {
+            return Err(global
+                .throw_invalid_arguments(format_args!("sandbox: expected an options object")));
+        }
+
+        let mut policy = Box::new(SandboxPolicy {
+            allowed_builtins: ALL_BUILTINS_MASK,
+            read_prefixes: Vec::new(),
+            write_prefixes: Vec::new(),
+            timeout_ms: None,
+            max_output_bytes: None,
+        });
+
+        if let Some(commands) = options.get(global, "commands")? {
+            if !commands.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sandbox: commands must be an object"
+                )));
+            }
+            if let Some(allow) = commands.get(global, "allow")? {
+                policy.allowed_builtins = parse_command_mask(global, allow, "commands.allow")?;
+            }
+            if let Some(deny) = commands.get(global, "deny")? {
+                policy.allowed_builtins &= !parse_command_mask(global, deny, "commands.deny")?;
+            }
+        }
+
+        if let Some(fs) = options.get(global, "fs")? {
+            if !fs.is_object() {
+                return Err(
+                    global.throw_invalid_arguments(format_args!("sandbox: fs must be an object"))
+                );
+            }
+            if let Some(read) = fs.get(global, "read")? {
+                policy.read_prefixes = parse_path_prefixes(global, read, "fs.read")?;
+            }
+            if let Some(write) = fs.get(global, "write")? {
+                policy.write_prefixes = parse_path_prefixes(global, write, "fs.write")?;
+            }
+        }
+
+        if let Some(network) = options.get(global, "network")? {
+            if !network.is_boolean() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sandbox: network must be a boolean"
+                )));
+            }
+            if network.to_boolean() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sandbox: network access cannot be enabled yet; sandboxed shells run only builtin commands, none of which perform network I/O. The only supported value is false."
+                )));
+            }
+        }
+
+        if let Some(limits) = options.get(global, "limits")? {
+            if !limits.is_object() {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sandbox: limits must be an object"
+                )));
+            }
+            if let Some(timeout) = limits.get(global, "timeout")? {
+                policy.timeout_ms = Some(parse_positive_int(global, timeout, "limits.timeout")?);
+            }
+            if let Some(max_output) = limits.get(global, "maxOutputBytes")? {
+                policy.max_output_bytes = Some(parse_positive_int(
+                    global,
+                    max_output,
+                    "limits.maxOutputBytes",
+                )?);
+            }
+        }
+
+        Ok(policy)
+    }
+
+    pub fn memory_cost(&self) -> usize {
+        core::mem::size_of::<SandboxPolicy>()
+            + self
+                .read_prefixes
+                .iter()
+                .chain(self.write_prefixes.iter())
+                .map(|p| p.len())
+                .sum::<usize>()
+    }
+}
+
+fn parse_command_mask(global: &JSGlobalObject, list: JSValue, what: &str) -> JsResult<u32> {
+    let mut iter = list.array_iterator(global).map_err(|_| {
+        global.throw_invalid_arguments(format_args!("sandbox: {what} must be an array of strings"))
+    })?;
+    let mut mask = 0u32;
+    while let Some(item) = iter.next()? {
+        if !item.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "sandbox: {what} must be an array of strings"
+            )));
+        }
+        let name = item.get_zig_string(global)?.to_owned_slice();
+        match Kind::from_argv0_raw(&name) {
+            Some(kind) => mask |= 1u32 << (kind as u8),
+            None => {
+                return Err(global.throw_invalid_arguments(format_args!(
+                    "sandbox: unknown command {:?} in {what}. Sandboxed shells can only run builtin commands: {}",
+                    bstr::BStr::new(&name),
+                    Kind::ALL_NAMES.join(", "),
+                )));
+            }
+        }
+    }
+    Ok(mask)
+}
+
+fn parse_path_prefixes(
+    global: &JSGlobalObject,
+    list: JSValue,
+    what: &str,
+) -> JsResult<Vec<Box<[u8]>>> {
+    let mut iter = list.array_iterator(global).map_err(|_| {
+        global.throw_invalid_arguments(format_args!("sandbox: {what} must be an array of strings"))
+    })?;
+    let mut prefixes: Vec<Box<[u8]>> = Vec::with_capacity(iter.len as usize);
+    while let Some(item) = iter.next()? {
+        if !item.is_string() {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "sandbox: {what} must be an array of strings"
+            )));
+        }
+        let path = item.get_zig_string(global)?.to_owned_slice();
+        if path.is_empty() || !bun_paths::is_absolute(&path) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "sandbox: {what} paths must be absolute, got {:?}",
+                bstr::BStr::new(&path),
+            )));
+        }
+        if path.contains(&0) {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "sandbox: {what} paths must not contain NUL bytes"
+            )));
+        }
+        // Canonicalize now so symlinked prefixes compare equal to the
+        // canonical paths produced by `check_path` at enforcement time.
+        prefixes.push(canonicalize_path(b"/", &path).into_boxed_slice());
+    }
+    Ok(prefixes)
+}
+
+fn parse_positive_int(global: &JSGlobalObject, value: JSValue, what: &str) -> JsResult<u64> {
+    if !value.is_number() {
+        return Err(
+            global.throw_invalid_arguments(format_args!("sandbox: {what} must be a number"))
+        );
+    }
+    let n = value.as_number();
+    if !n.is_finite() || n <= 0.0 || n.fract() != 0.0 || n > u64::MAX as f64 {
+        return Err(global.throw_invalid_arguments(format_args!(
+            "sandbox: {what} must be a positive integer"
+        )));
+    }
+    Ok(n as u64)
+}
+
+/// Resolve `path` against `cwd` (`path.resolve` semantics: `.`/`..`
+/// collapsed, absolute `path` wins), then resolve symlinks by `realpath`-ing
+/// the deepest existing ancestor and re-appending the non-existing suffix.
+/// Returns an absolute path with no trailing separator (except a bare root).
+///
+/// Symlink resolution is what defeats `ln -s /etc escape; cat escape/passwd`
+/// style escapes: the comparison always happens on the physical path.
+pub fn canonicalize_path(cwd: &[u8], path: &[u8]) -> Vec<u8> {
+    use bun_paths::resolve_path as rp;
+
+    let resolved: Vec<u8> = rp::join_abs_string_z::<rp::platform::Auto>(cwd, &[path])
+        .as_bytes()
+        .to_vec();
+    let resolved = strip_trailing_sep(resolved);
+
+    let mut zbuf = bun_paths::path_buffer_pool::get();
+    let mut realbuf = bun_paths::path_buffer_pool::get();
+
+    let root_len = filesystem_root_len(&resolved);
+    let mut end = resolved.len();
+    loop {
+        let z = rp::z(&resolved[..end], &mut zbuf);
+        match bun_sys::realpath(z, &mut realbuf) {
+            Ok(real) => {
+                let mut out = real.to_vec();
+                if end < resolved.len() {
+                    // `resolved[end]` is the separator we cut at.
+                    if out.last().is_some_and(|&c| is_sep(c)) {
+                        out.pop();
+                    }
+                    out.extend_from_slice(&resolved[end..]);
+                }
+                return strip_trailing_sep(out);
+            }
+            Err(_) => {
+                // Strip the last component and retry on the parent.
+                let parent_end = match resolved[..end]
+                    .iter()
+                    .rposition(|&c| is_sep(c))
+                {
+                    Some(i) if i >= root_len => i,
+                    _ => return resolved,
+                };
+                if parent_end < root_len.max(1) {
+                    return resolved;
+                }
+                end = parent_end;
+            }
+        }
+    }
+}
+
+fn filesystem_root_len(path: &[u8]) -> usize {
+    if cfg!(windows) {
+        bun_paths::resolve_path::windows_filesystem_root(path).len()
+    } else {
+        1
+    }
+}
+
+#[inline]
+fn is_sep(c: u8) -> bool {
+    if cfg!(windows) {
+        c == b'/' || c == b'\\'
+    } else {
+        c == b'/'
+    }
+}
+
+fn strip_trailing_sep(mut path: Vec<u8>) -> Vec<u8> {
+    let root_len = filesystem_root_len(&path).max(1);
+    while path.len() > root_len && path.last().is_some_and(|&c| is_sep(c)) {
+        path.pop();
+    }
+    path
+}
+
+/// Case sensitivity follows the platform default filesystem, matching
+/// `bun_paths::resolve_path::is_parent_or_equal`.
+#[inline]
+fn path_bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        strings::eql(a, b)
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        strings::eql_case_insensitive_ascii_check_length(a, b)
+    }
+}
+
+fn prefix_matches(prefix: &[u8], canonical: &[u8]) -> bool {
+    if prefix.is_empty() || canonical.len() < prefix.len() {
+        return false;
+    }
+    if !path_bytes_eq(&canonical[..prefix.len()], prefix) {
+        return false;
+    }
+    canonical.len() == prefix.len()
+        // A prefix that still ends in a separator is a bare filesystem root.
+        || is_sep(prefix[prefix.len() - 1])
+        || is_sep(canonical[prefix.len()])
+}

--- a/src/runtime/shell/sandbox.rs
+++ b/src/runtime/shell/sandbox.rs
@@ -102,8 +102,9 @@ impl SandboxPolicy {
     /// never half-applies.
     pub fn from_js(global: &JSGlobalObject, options: JSValue) -> JsResult<Box<SandboxPolicy>> {
         if !options.is_object() {
-            return Err(global
-                .throw_invalid_arguments(format_args!("sandbox: expected an options object")));
+            return Err(
+                global.throw_invalid_arguments(format_args!("sandbox: expected an options object"))
+            );
         }
 
         let mut policy = Box::new(SandboxPolicy {
@@ -116,9 +117,8 @@ impl SandboxPolicy {
 
         if let Some(commands) = options.get(global, "commands")? {
             if !commands.is_object() {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "sandbox: commands must be an object"
-                )));
+                return Err(global
+                    .throw_invalid_arguments(format_args!("sandbox: commands must be an object")));
             }
             if let Some(allow) = commands.get(global, "allow")? {
                 policy.allowed_builtins = parse_command_mask(global, allow, "commands.allow")?;
@@ -144,9 +144,8 @@ impl SandboxPolicy {
 
         if let Some(network) = options.get(global, "network")? {
             if !network.is_boolean() {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "sandbox: network must be a boolean"
-                )));
+                return Err(global
+                    .throw_invalid_arguments(format_args!("sandbox: network must be a boolean")));
             }
             if network.to_boolean() {
                 return Err(global.throw_invalid_arguments(format_args!(
@@ -157,9 +156,8 @@ impl SandboxPolicy {
 
         if let Some(limits) = options.get(global, "limits")? {
             if !limits.is_object() {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "sandbox: limits must be an object"
-                )));
+                return Err(global
+                    .throw_invalid_arguments(format_args!("sandbox: limits must be an object")));
             }
             if let Some(timeout) = limits.get(global, "timeout")? {
                 policy.timeout_ms = Some(parse_positive_int(global, timeout, "limits.timeout")?);
@@ -255,9 +253,8 @@ fn parse_positive_int(global: &JSGlobalObject, value: JSValue, what: &str) -> Js
     }
     let n = value.as_number();
     if !n.is_finite() || n <= 0.0 || n.fract() != 0.0 || n > u64::MAX as f64 {
-        return Err(global.throw_invalid_arguments(format_args!(
-            "sandbox: {what} must be a positive integer"
-        )));
+        return Err(global
+            .throw_invalid_arguments(format_args!("sandbox: {what} must be a positive integer")));
     }
     Ok(n as u64)
 }
@@ -298,10 +295,7 @@ pub fn canonicalize_path(cwd: &[u8], path: &[u8]) -> Vec<u8> {
             }
             Err(_) => {
                 // Strip the last component and retry on the parent.
-                let parent_end = match resolved[..end]
-                    .iter()
-                    .rposition(|&c| is_sep(c))
-                {
+                let parent_end = match resolved[..end].iter().rposition(|&c| is_sep(c)) {
                     Some(i) if i >= root_len => i,
                     _ => return resolved,
                 };

--- a/src/runtime/shell/states/Binary.rs
+++ b/src/runtime/shell/states/Binary.rs
@@ -49,6 +49,11 @@ impl Binary {
             return interp.child_done(parent, this, right);
         }
 
+        // Sandbox cancellation: don't start (or continue past) either side.
+        if interp.sandbox_cancel_requested() {
+            return interp.child_done(parent, this, 1);
+        }
+
         if let Some(left) = left_exit {
             // Short-circuit: `&&` stops on nonzero, `||` stops on zero.
             let short = match n.op {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -225,6 +225,19 @@ impl Cmd {
 
     pub fn next(interp: &Interpreter, this: NodeId) -> Yield {
         loop {
+            // A cancelled sandboxed run stops scheduling new work; states that
+            // are already waiting on IO unwind through their own callbacks.
+            if interp.sandbox_cancel_requested()
+                && !matches!(
+                    interp.as_cmd(this).state,
+                    CmdState::Done | CmdState::WaitingWriteErr
+                )
+                && matches!(interp.as_cmd(this).exec, Exec::None)
+            {
+                let me = interp.as_cmd_mut(this);
+                me.exit_code = Some(1);
+                me.state = CmdState::Done;
+            }
             let (shell, node) = {
                 let me = interp.as_cmd(this);
                 (me.base.shell, me.node)
@@ -458,12 +471,37 @@ impl Cmd {
         };
 
         if let Some(kind) = BuiltinKind::from_argv0(&first_arg) {
+            if let Some(policy) = interp.sandbox() {
+                if !policy.builtin_allowed(kind) {
+                    return Builtin::cmd_write_failing_error(
+                        interp,
+                        this,
+                        format_args!(
+                            "bun: {}: command not permitted in sandbox\n",
+                            bstr::BStr::new(&first_arg)
+                        ),
+                    );
+                }
+            }
             log!("Cmd {} exec builtin={:?}", this, kind);
             if let Some(y) = Builtin::init(interp, this, kind) {
                 return y;
             }
             debug_assert!(matches!(interp.as_cmd(this).exec, Exec::Builtin(_)));
             return Builtin::start(interp, this);
+        }
+
+        if interp.sandbox().is_some() {
+            // Blocked before any PATH probing so a sandboxed script cannot
+            // learn what exists on the host filesystem.
+            return Builtin::cmd_write_failing_error(
+                interp,
+                this,
+                format_args!(
+                    "bun: {}: external commands are not permitted in sandbox\n",
+                    bstr::BStr::new(&first_arg)
+                ),
+            );
         }
 
         // ── Subprocess path ─────────────────────────────────────────────────

--- a/src/runtime/shell/states/CondExpr.rs
+++ b/src/runtime/shell/states/CondExpr.rs
@@ -108,6 +108,28 @@ impl CondExpr {
                 if path_empty {
                     return interp.child_done(parent, this, 1);
                 }
+                // File tests outside the sandbox's readable prefixes answer
+                // as if the path does not exist (exit 1) without touching the
+                // filesystem, so `[[ -e ... ]]` cannot probe the host tree.
+                if let Some(policy) = interp.sandbox() {
+                    let denied = {
+                        let me = interp.as_condexpr(this);
+                        let arg = &me.args[0][..];
+                        // May already carry a trailing NUL (see below).
+                        let arg = match arg.last() {
+                            Some(&0) => &arg[..arg.len() - 1],
+                            _ => arg,
+                        };
+                        !policy.check_path(
+                            me.base.shell().cwd(),
+                            arg,
+                            crate::shell::sandbox::SandboxAccess::Read,
+                        )
+                    };
+                    if denied {
+                        return interp.child_done(parent, this, 1);
+                    }
+                }
                 // Post a
                 // `ShellCondExprStatTask` to the thread pool; the result comes
                 // back on the main thread via `on_stat_task_done`.

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -432,6 +432,37 @@ impl Expansion {
             pattern = Self::neutralize_glob_metachars(&me.current_out, &me.meta_offsets);
             cwd = me.base.shell().cwd().to_vec();
         }
+        if let Some(policy) = interp.sandbox() {
+            // The walker's literal root is everything before the first glob
+            // metachar (escaped literals were neutralized into `[x]` classes
+            // above, so cutting at `[`/`*`/`?`/`{` matches the walker's own
+            // root). Traversal below the root never follows symlinks
+            // (`follow_symlinks = false` in the init call), so a readable
+            // root keeps enumeration inside the policy.
+            let root = glob_literal_root(&pattern);
+            let denied = match root {
+                Some(root) => !policy.check_path(
+                    &cwd,
+                    root,
+                    crate::shell::sandbox::SandboxAccess::Read,
+                ),
+                // Pattern has no literal directory prefix: the walk starts
+                // at the shell cwd.
+                None => !policy.check_path(
+                    &cwd,
+                    b".",
+                    crate::shell::sandbox::SandboxAccess::Read,
+                ),
+            };
+            if denied {
+                let mut msg = Vec::new();
+                msg.extend_from_slice(&pattern);
+                msg.extend_from_slice(b": read access not permitted in sandbox");
+                interp.as_expansion_mut(this).state =
+                    ExpansionState::Err(Box::new(ShellErr::Custom(msg.into_boxed_slice())));
+                return Yield::Next(this);
+            }
+        }
         let walker = match bun_glob::BunGlobWalkerZ::init_with_cwd(
             &pattern, &cwd, false, false, false, false, false, None,
         ) {
@@ -738,4 +769,24 @@ impl Expansion {
         out.has_quoted_empty = me.has_quoted_empty;
         out
     }
+}
+
+/// Longest literal directory prefix of a glob pattern: everything before the
+/// first glob metachar, truncated to the last path separator. `None` when the
+/// pattern has no literal directory part (walk starts at the cwd).
+fn glob_literal_root(pattern: &[u8]) -> Option<&[u8]> {
+    let meta = pattern
+        .iter()
+        .position(|&c| matches!(c, b'*' | b'?' | b'[' | b'{'))
+        .unwrap_or(pattern.len());
+    let is_sep = |c: u8| {
+        if cfg!(windows) {
+            c == b'/' || c == b'\\'
+        } else {
+            c == b'/'
+        }
+    };
+    let sep = pattern[..meta].iter().rposition(|&c| is_sep(c))?;
+    // Keep the separator for a bare root (`/*` → `/`).
+    Some(&pattern[..sep.max(1)])
 }

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -441,18 +441,12 @@ impl Expansion {
             // root keeps enumeration inside the policy.
             let root = glob_literal_root(&pattern);
             let denied = match root {
-                Some(root) => !policy.check_path(
-                    &cwd,
-                    root,
-                    crate::shell::sandbox::SandboxAccess::Read,
-                ),
+                Some(root) => {
+                    !policy.check_path(&cwd, root, crate::shell::sandbox::SandboxAccess::Read)
+                }
                 // Pattern has no literal directory prefix: the walk starts
                 // at the shell cwd.
-                None => !policy.check_path(
-                    &cwd,
-                    b".",
-                    crate::shell::sandbox::SandboxAccess::Read,
-                ),
+                None => !policy.check_path(&cwd, b".", crate::shell::sandbox::SandboxAccess::Read),
             };
             if denied {
                 let mut msg = Vec::new();

--- a/src/runtime/shell/states/Script.rs
+++ b/src/runtime/shell/states/Script.rs
@@ -61,6 +61,11 @@ impl Script {
     }
 
     pub(crate) fn next(interp: &Interpreter, this: NodeId) -> Yield {
+        // Sandbox cancellation: stop scheduling further statements (also
+        // covers subshell and command-substitution bodies, which run Scripts).
+        if interp.sandbox_cancel_requested() {
+            return Self::finish(interp, this, 1);
+        }
         let (idx, shell) = {
             let me = interp.as_script_mut(this);
             let len = Self::stmt_count_of(me);

--- a/test/js/bun/shell/bunshell-sandbox.test.ts
+++ b/test/js/bun/shell/bunshell-sandbox.test.ts
@@ -1,0 +1,496 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import fs from "node:fs";
+import { join } from "node:path";
+
+// $.sandbox() — sandboxed shells (experimental).
+//
+// Blocked operations exit with code 1 and a "... not permitted in sandbox"
+// message on stderr; exceeded limits reject the promise with a descriptive
+// message. These exact strings are part of the contract under test.
+
+function sandboxDir() {
+  return tempDir("shell-sandbox", {
+    "data/file.txt": "hello sandbox\n",
+    "data/other.txt": "other\n",
+    "secret.txt": "SECRET\n",
+  });
+}
+
+describe("$.sandbox", () => {
+  describe("option validation", () => {
+    test("rejects non-object options", () => {
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox()).toThrow(TypeError);
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox("abc")).toThrow(TypeError);
+      expect(() => $.sandbox(null)).toThrow(TypeError);
+    });
+
+    test("rejects unknown keys", () => {
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ commandz: {} })).toThrow("$.sandbox: unknown option 'commandz'");
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ commands: { allowed: [] } })).toThrow("$.sandbox: unknown option 'commands.allowed'");
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ fs: { readonly: true } })).toThrow("$.sandbox: unknown option 'fs.readonly'");
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ limits: { timeoutMs: 5 } })).toThrow("$.sandbox: unknown option 'limits.timeoutMs'");
+    });
+
+    test("rejects malformed command lists", () => {
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ commands: { allow: "echo" } })).toThrow(
+        "$.sandbox: commands.allow must be an array of strings",
+      );
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ commands: { deny: [1] } })).toThrow(
+        "$.sandbox: commands.deny must be an array of strings",
+      );
+    });
+
+    test("rejects unknown command names at invocation", () => {
+      const box = $.sandbox({ commands: { allow: ["curl"] } });
+      expect(() => box`echo hi`).toThrow(/unknown command "curl" in commands\.allow/);
+      const box2 = $.sandbox({ commands: { deny: ["not-a-builtin"] } });
+      expect(() => box2`echo hi`).toThrow(/unknown command "not-a-builtin" in commands\.deny/);
+    });
+
+    test("rejects relative and NUL-containing fs paths", () => {
+      expect(() => $.sandbox({ fs: { read: ["relative/path"] } })).toThrow(
+        '$.sandbox: fs.read paths must be absolute, got "relative/path"',
+      );
+      expect(() => $.sandbox({ fs: { write: [""] } })).toThrow("$.sandbox: fs.write paths must be absolute");
+      expect(() => $.sandbox({ fs: { read: ["/a\0b"] } })).toThrow("$.sandbox: fs.read paths must not contain NUL");
+    });
+
+    test("network can only be false", () => {
+      expect(() => $.sandbox({ network: false })).not.toThrow();
+      expect(() => $.sandbox({ network: true })).toThrow(/network access cannot be enabled yet/);
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ network: "on" })).toThrow("$.sandbox: network must be a boolean");
+    });
+
+    test("rejects non-positive-integer limits", () => {
+      for (const bad of [0, -5, 1.5, NaN, Infinity]) {
+        expect(() => $.sandbox({ limits: { timeout: bad } })).toThrow(
+          "$.sandbox: limits.timeout must be a positive integer",
+        );
+        expect(() => $.sandbox({ limits: { maxOutputBytes: bad } })).toThrow(
+          "$.sandbox: limits.maxOutputBytes must be a positive integer",
+        );
+      }
+      // @ts-expect-error intentionally wrong
+      expect(() => $.sandbox({ limits: { timeout: "100" } })).toThrow(
+        "$.sandbox: limits.timeout must be a positive integer",
+      );
+    });
+
+    test("policy is copied: later mutation of the options object has no effect", async () => {
+      using dir = sandboxDir();
+      const options = { fs: { read: [] as string[] } };
+      const box = $.sandbox(options);
+      options.fs.read.push(String(dir));
+      const result = await box`ls ${join(String(dir), "data")}`.quiet().nothrow();
+      expect(result.stderr.toString()).toContain("read access not permitted in sandbox");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("command policy", () => {
+    test("external commands are blocked, even nonexistent ones", async () => {
+      const box = $.sandbox({});
+      for (const cmd of ["git", "definitely-not-a-real-command-12345", "bun"]) {
+        const result = await box`${{ raw: cmd }} --version`.quiet().nothrow();
+        expect(result.stderr.toString()).toBe(`bun: ${cmd}: external commands are not permitted in sandbox\n`);
+        expect(result.stdout.toString()).toBe("");
+        expect(result.exitCode).toBe(1);
+      }
+    });
+
+    test("deny blocks a builtin, others still run", async () => {
+      using dir = sandboxDir();
+      const box = $.sandbox({ commands: { deny: ["rm"] }, fs: { write: [String(dir)] } });
+      const denied = await box`rm ${join(String(dir), "data", "file.txt")}`.quiet().nothrow();
+      expect(denied.stderr.toString()).toBe("bun: rm: command not permitted in sandbox\n");
+      expect(denied.exitCode).toBe(1);
+      expect(fs.existsSync(join(String(dir), "data", "file.txt"))).toBe(true);
+
+      const allowed = await box`echo still works`.quiet();
+      expect(allowed.stdout.toString()).toBe("still works\n");
+      expect(allowed.exitCode).toBe(0);
+    });
+
+    test("allow restricts to the listed builtins", async () => {
+      const box = $.sandbox({ commands: { allow: ["echo", "true"] } });
+      expect((await box`echo hi && true`.quiet()).stdout.toString()).toBe("hi\n");
+
+      const blocked = await box`pwd`.quiet().nothrow();
+      expect(blocked.stderr.toString()).toBe("bun: pwd: command not permitted in sandbox\n");
+      expect(blocked.exitCode).toBe(1);
+    });
+
+    test("deny wins over allow", async () => {
+      const box = $.sandbox({ commands: { allow: ["echo"], deny: ["echo"] } });
+      const result = await box`echo hi`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe("bun: echo: command not permitted in sandbox\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    test("environment assignments cannot re-enable external commands", async () => {
+      const box = $.sandbox({});
+      const result = await box`PATH=/usr/bin:/bin git status`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe("bun: git: external commands are not permitted in sandbox\n");
+      expect(result.exitCode).toBe(1);
+
+      const exported = await box`export PATH=/usr/bin:/bin && git status`.quiet().nothrow();
+      expect(exported.stderr.toString()).toBe("bun: git: external commands are not permitted in sandbox\n");
+      expect(exported.exitCode).toBe(1);
+    });
+
+    test("which resolves permitted builtins only and never probes PATH", async () => {
+      const box = $.sandbox({ commands: { deny: ["rm"] } });
+      expect((await box`which echo`.quiet()).stdout.toString()).toBe("echo: shell builtin\n");
+
+      const denied = await box`which rm`.quiet().nothrow();
+      expect(denied.stdout.toString()).toBe("which: rm not found\n");
+      expect(denied.exitCode).toBe(1);
+
+      // `bun` exists on PATH in every test environment; the sandbox must not
+      // reveal it.
+      const external = await box`which bun`.quiet().nothrow();
+      expect(external.stdout.toString()).toBe("which: bun not found\n");
+      expect(external.exitCode).toBe(1);
+    });
+  });
+
+  describe("filesystem policy", () => {
+    test("no fs grants: commands that touch no files still work", async () => {
+      const box = $.sandbox({});
+      const result = await box`echo a && basename /x/y.txt && seq 2`.quiet();
+      expect(result.stdout.toString()).toBe("a\ny.txt\n1\n2\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("no fs grants: listing the cwd is denied", async () => {
+      using dir = sandboxDir();
+      const box = $.sandbox({});
+      const result = await box.cwd(String(dir))`ls`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe("ls: .: read access not permitted in sandbox\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    test("read grant allows inside, denies outside and the parent", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      const inside = await box`ls ${data}`.quiet();
+      expect(
+        inside.stdout
+          .toString()
+          .split(/\r?\n/)
+          .filter(Boolean)
+          .sort(),
+      ).toEqual(["file.txt", "other.txt"]);
+
+      const parent = await box`ls ${String(dir)}`.quiet().nothrow();
+      expect(parent.stderr.toString()).toBe(`ls: ${String(dir)}: read access not permitted in sandbox\n`);
+      expect(parent.exitCode).toBe(1);
+    });
+
+    test("write grant implies read", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { write: [data] } });
+      const result = await box`ls ${data}`.quiet();
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("redirect writes respect the write prefixes", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { write: [data] } });
+
+      await box`echo content > ${join(data, "out.txt")}`.quiet();
+      expect(fs.readFileSync(join(data, "out.txt"), "utf8")).toBe("content\n");
+
+      const outside = join(String(dir), "evil.txt");
+      const denied = await box`echo stolen > ${outside}`.quiet().nothrow();
+      expect(denied.stderr.toString()).toBe(`bun: ${outside}: write access not permitted in sandbox\n`);
+      expect(denied.exitCode).toBe(1);
+      expect(fs.existsSync(outside)).toBe(false);
+
+      const append = await box`echo x >> ${outside}`.quiet().nothrow();
+      expect(append.stderr.toString()).toBe(`bun: ${outside}: write access not permitted in sandbox\n`);
+      expect(append.exitCode).toBe(1);
+    });
+
+    test("read grants do not allow writes", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+      const target = join(data, "new.txt");
+      const result = await box`echo x > ${target}`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe(`bun: ${target}: write access not permitted in sandbox\n`);
+      expect(result.exitCode).toBe(1);
+      expect(fs.existsSync(target)).toBe(false);
+    });
+
+    test("stdin redirects respect the read prefixes", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      expect((await box`echo ok < ${join(data, "file.txt")}`.quiet()).exitCode).toBe(0);
+
+      const secret = join(String(dir), "secret.txt");
+      const denied = await box`echo ok < ${secret}`.quiet().nothrow();
+      expect(denied.stderr.toString()).toBe(`bun: ${secret}: read access not permitted in sandbox\n`);
+      expect(denied.exitCode).toBe(1);
+    });
+
+    test("touch/mkdir/rm/mv are write-gated", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { write: [data] } });
+
+      // Inside the grant everything works.
+      const inside = await box`touch ${join(data, "a.txt")} && mkdir ${join(data, "sub")} && mv ${join(data, "a.txt")} ${join(data, "sub")} && rm -r ${join(data, "sub")}`
+        .quiet()
+        .nothrow();
+      expect(inside.stderr.toString()).toBe("");
+      expect(inside.exitCode).toBe(0);
+
+      const outside = String(dir);
+      const touch = await box`touch ${join(outside, "t.txt")}`.quiet().nothrow();
+      expect(touch.stderr.toString()).toBe(`touch: ${join(outside, "t.txt")}: write access not permitted in sandbox\n`);
+      expect(touch.exitCode).toBe(1);
+
+      const mkdir = await box`mkdir ${join(outside, "d")}`.quiet().nothrow();
+      expect(mkdir.stderr.toString()).toBe(`mkdir: ${join(outside, "d")}: write access not permitted in sandbox\n`);
+      expect(mkdir.exitCode).toBe(1);
+
+      const rm = await box`rm ${join(outside, "secret.txt")}`.quiet().nothrow();
+      expect(rm.stderr.toString()).toBe(`rm: ${join(outside, "secret.txt")}: write access not permitted in sandbox\n`);
+      expect(rm.exitCode).toBe(1);
+      expect(fs.existsSync(join(outside, "secret.txt"))).toBe(true);
+
+      // mv out of the sandbox is blocked on the target; mv in from outside is
+      // blocked on the source.
+      const mvOut = await box`mv ${join(data, "file.txt")} ${join(outside, "stolen.txt")}`.quiet().nothrow();
+      expect(mvOut.stderr.toString()).toBe(
+        `mv: ${join(outside, "stolen.txt")}: write access not permitted in sandbox\n`,
+      );
+      expect(mvOut.exitCode).toBe(1);
+      expect(fs.existsSync(join(data, "file.txt"))).toBe(true);
+
+      const mvIn = await box`mv ${join(outside, "secret.txt")} ${data}`.quiet().nothrow();
+      expect(mvIn.stderr.toString()).toBe(`mv: ${join(outside, "secret.txt")}: write access not permitted in sandbox\n`);
+      expect(mvIn.exitCode).toBe(1);
+    });
+
+    test("conditional file tests answer as nonexistent outside the grants", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      const allowed = await box`[[ -f ${join(data, "file.txt")} ]] && echo yes || echo no`.quiet();
+      expect(allowed.stdout.toString()).toBe("yes\n");
+
+      // secret.txt exists but is outside the read grant: the probe must not
+      // reveal it.
+      const denied = await box`[[ -f ${join(String(dir), "secret.txt")} ]] && echo yes || echo no`.quiet();
+      expect(denied.stdout.toString()).toBe("no\n");
+    });
+  });
+
+  describe("escape attempts", () => {
+    test("dot-dot traversal is canonicalized before the check", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      const sneaky = join(data, "..", "secret.txt");
+      const result = await box`echo ok < ${sneaky}`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe(`bun: ${sneaky}: read access not permitted in sandbox\n`);
+      expect(result.exitCode).toBe(1);
+
+      const lsDotDot = await box`ls ${join(data, "..")}`.quiet().nothrow();
+      expect(lsDotDot.stderr.toString()).toBe(`ls: ${join(data, "..")}: read access not permitted in sandbox\n`);
+      expect(lsDotDot.exitCode).toBe(1);
+    });
+
+    test("cd cannot leave the granted prefixes", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data], write: [data] } });
+
+      const up = await box.cwd(data)`cd .. && echo escaped > escaped.txt`.quiet().nothrow();
+      expect(up.stderr.toString()).toBe("cd: ..: read access not permitted in sandbox\n");
+      expect(up.exitCode).toBe(1);
+      expect(fs.existsSync(join(String(dir), "escaped.txt"))).toBe(false);
+
+      // cd within the grant, then relative operations resolve against it.
+      const inside = await box.cwd(data)`cd . && echo rel > rel.txt`.quiet();
+      expect(inside.exitCode).toBe(0);
+      expect(fs.readFileSync(join(data, "rel.txt"), "utf8")).toBe("rel\n");
+    });
+
+    test.skipIf(isWindows)("symlinks cannot smuggle reads outside the sandbox", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      fs.symlinkSync(String(dir), join(data, "updir"));
+      fs.symlinkSync(join(String(dir), "secret.txt"), join(data, "secret-link"));
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      // Enumerating through a symlinked directory is denied...
+      const viaDir = await box`ls ${join(data, "updir")}`.quiet().nothrow();
+      expect(viaDir.stderr.toString()).toBe(`ls: ${join(data, "updir")}: read access not permitted in sandbox\n`);
+      expect(viaDir.exitCode).toBe(1);
+
+      // ...as is reading through a symlinked file...
+      const viaFile = await box`echo ok < ${join(data, "secret-link")}`.quiet().nothrow();
+      expect(viaFile.stderr.toString()).toBe(
+        `bun: ${join(data, "secret-link")}: read access not permitted in sandbox\n`,
+      );
+      expect(viaFile.exitCode).toBe(1);
+
+      // ...and probing through one.
+      const probe = await box`[[ -f ${join(data, "secret-link")} ]] && echo yes || echo no`.quiet();
+      expect(probe.stdout.toString()).toBe("no\n");
+    });
+
+    test.skipIf(isWindows)("symlinked write targets are blocked", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      fs.symlinkSync(join(String(dir), "secret.txt"), join(data, "write-link"));
+      const box = $.sandbox({ fs: { write: [data] } });
+
+      const result = await box`echo overwritten > ${join(data, "write-link")}`.quiet().nothrow();
+      expect(result.stderr.toString()).toBe(
+        `bun: ${join(data, "write-link")}: write access not permitted in sandbox\n`,
+      );
+      expect(result.exitCode).toBe(1);
+      expect(fs.readFileSync(join(String(dir), "secret.txt"), "utf8")).toBe("SECRET\n");
+    });
+
+    test("glob expansion cannot enumerate outside the grants", async () => {
+      using dir = sandboxDir();
+      const data = join(String(dir), "data");
+      const box = $.sandbox({ fs: { read: [data] } });
+
+      // Inside: expands normally.
+      const inside = await box.cwd(data)`echo *.txt`.quiet();
+      expect(inside.stdout.toString().split(/\s+/).filter(Boolean).sort()).toEqual(["file.txt", "other.txt"]);
+
+      // Outside: the walk is refused before touching the filesystem.
+      const outside = await box`echo ${String(dir)}/*`.quiet().nothrow();
+      expect(outside.stderr.toString()).toContain("read access not permitted in sandbox");
+      expect(outside.stdout.toString()).not.toContain("secret");
+      expect(outside.exitCode).toBe(1);
+    });
+
+    test("subshells and command substitution inherit the policy", async () => {
+      using dir = sandboxDir();
+      const box = $.sandbox({ fs: { read: [join(String(dir), "data")] } });
+
+      const subshell = await box`(ls ${String(dir)})`.quiet().nothrow();
+      expect(subshell.stderr.toString()).toBe(`ls: ${String(dir)}: read access not permitted in sandbox\n`);
+      expect(subshell.exitCode).toBe(1);
+
+      // The inner command is denied, so the substitution expands to nothing
+      // (the outer echo still succeeds, matching POSIX semantics).
+      const subst = await box`echo $(ls ${String(dir)})`.quiet().nothrow();
+      expect(subst.stdout.toString()).toBe("\n");
+      expect(subst.stdout.toString()).not.toContain("secret");
+
+      const pipeline = await box`echo probe | ls ${String(dir)}`.quiet().nothrow();
+      expect(pipeline.stderr.toString()).toBe(`ls: ${String(dir)}: read access not permitted in sandbox\n`);
+      expect(pipeline.exitCode).toBe(1);
+    });
+  });
+
+  describe("limits", () => {
+    test("timeout rejects a runaway command", async () => {
+      const box = $.sandbox({ limits: { timeout: 300 } });
+      let error: any;
+      try {
+        await box`yes`.quiet();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error.message).toBe("Shell command timed out after 300ms (sandbox limits.timeout)");
+      expect(error.exitCode).toBe(1);
+    });
+
+    test("timeout does not fire for fast commands", async () => {
+      const box = $.sandbox({ limits: { timeout: 5000 } });
+      const result = await box`echo quick`.quiet();
+      expect(result.stdout.toString()).toBe("quick\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    test("maxOutputBytes rejects a command that emits too much", async () => {
+      const box = $.sandbox({ limits: { maxOutputBytes: 4096 } });
+      let error: any;
+      try {
+        await box`yes`.quiet();
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(error.message).toBe("Shell command output exceeded 4096 bytes (sandbox limits.maxOutputBytes)");
+      expect(error.exitCode).toBe(1);
+    });
+
+    test("maxOutputBytes allows output under the limit", async () => {
+      const box = $.sandbox({ limits: { maxOutputBytes: 4096 } });
+      const result = await box`seq 1 5`.quiet();
+      expect(result.stdout.toString()).toBe("1\n2\n3\n4\n5\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("API shape", () => {
+    test("returns a $-compatible tagged template function", async () => {
+      const box = $.sandbox({});
+      expect(typeof box).toBe("function");
+      expect(typeof box.cwd).toBe("function");
+      expect(typeof box.env).toBe("function");
+      expect(typeof box.nothrow).toBe("function");
+      expect((await box`echo shaped`.quiet()).stdout.toString()).toBe("shaped\n");
+    });
+
+    test("inherits cwd and env from the shell it derives from", async () => {
+      using dir = sandboxDir();
+      const parent = new $.Shell();
+      parent.cwd(String(dir));
+      parent.env({ SANDBOX_TEST_VAR: "inherited" });
+      const box = parent.sandbox({});
+      const result = await box`echo $SANDBOX_TEST_VAR && pwd`.quiet();
+      const [envLine, pwdLine] = result.stdout.toString().split(/\r?\n/);
+      expect(envLine).toBe("inherited");
+      expect(fs.realpathSync(pwdLine)).toBe(fs.realpathSync(String(dir)));
+    });
+
+    test("a sandboxed shell cannot be re-sandboxed", () => {
+      const box = $.sandbox({});
+      expect(() => box.sandbox({})).toThrow("$.sandbox: this shell is already sandboxed");
+    });
+
+    test("sandboxing does not affect the shell it derives from", async () => {
+      const shell = new $.Shell();
+      shell.sandbox({ commands: { deny: ["echo"] } });
+      expect((await shell`echo unaffected`.quiet()).stdout.toString()).toBe("unaffected\n");
+    });
+
+    test("text()/json() work on sandboxed shells", async () => {
+      const box = $.sandbox({});
+      expect(await box`echo '{"a": 1}'`.json()).toEqual({ a: 1 });
+      expect(await box`echo plain`.text()).toBe("plain\n");
+    });
+  });
+});

--- a/test/js/bun/shell/bunshell-sandbox.test.ts
+++ b/test/js/bun/shell/bunshell-sandbox.test.ts
@@ -187,13 +187,7 @@ describe("$.sandbox", () => {
       const box = $.sandbox({ fs: { read: [data] } });
 
       const inside = await box`ls ${data}`.quiet();
-      expect(
-        inside.stdout
-          .toString()
-          .split(/\r?\n/)
-          .filter(Boolean)
-          .sort(),
-      ).toEqual(["file.txt", "other.txt"]);
+      expect(inside.stdout.toString().split(/\r?\n/).filter(Boolean).sort()).toEqual(["file.txt", "other.txt"]);
 
       const parent = await box`ls ${String(dir)}`.quiet().nothrow();
       expect(parent.stderr.toString()).toBe(`ls: ${String(dir)}: read access not permitted in sandbox\n`);
@@ -257,9 +251,10 @@ describe("$.sandbox", () => {
       const box = $.sandbox({ fs: { write: [data] } });
 
       // Inside the grant everything works.
-      const inside = await box`touch ${join(data, "a.txt")} && mkdir ${join(data, "sub")} && mv ${join(data, "a.txt")} ${join(data, "sub")} && rm -r ${join(data, "sub")}`
-        .quiet()
-        .nothrow();
+      const inside =
+        await box`touch ${join(data, "a.txt")} && mkdir ${join(data, "sub")} && mv ${join(data, "a.txt")} ${join(data, "sub")} && rm -r ${join(data, "sub")}`
+          .quiet()
+          .nothrow();
       expect(inside.stderr.toString()).toBe("");
       expect(inside.exitCode).toBe(0);
 
@@ -287,7 +282,9 @@ describe("$.sandbox", () => {
       expect(fs.existsSync(join(data, "file.txt"))).toBe(true);
 
       const mvIn = await box`mv ${join(outside, "secret.txt")} ${data}`.quiet().nothrow();
-      expect(mvIn.stderr.toString()).toBe(`mv: ${join(outside, "secret.txt")}: write access not permitted in sandbox\n`);
+      expect(mvIn.stderr.toString()).toBe(
+        `mv: ${join(outside, "secret.txt")}: write access not permitted in sandbox\n`,
+      );
       expect(mvIn.exitCode).toBe(1);
     });
 


### PR DESCRIPTION
## What

`$.sandbox(options)` creates a restricted Bun Shell for safely running untrusted shell commands. Because Bun Shell implements its commands natively, the policy is enforced inside the interpreter, before any command or filesystem operation executes.

```ts
import { $ } from "bun";

const box = $.sandbox({
  commands: { deny: ["rm"] },
  fs: { read: ["/work/data"], write: ["/work/data/out"] },
  limits: { timeout: 5_000, maxOutputBytes: 1024 * 1024 },
});

await box`ls /work/data`;   // ok
await box`cat /etc/passwd`; // exit 1: "read access not permitted in sandbox"
await box`git status`;      // exit 1: "external commands are not permitted in sandbox"
```

The returned function is `$`-compatible (interpolation, `.cwd()`, `.env()`, `.quiet()`, `.text()`, ...) and inherits cwd/env/throws from the shell it derives from. Marked experimental; the option surface is validated strictly (unknown keys throw) so it can grow toward overlay filesystems and network allowlists without breaking existing callers.

## Policy surface

- **commands**: external binaries never run, blocked before any PATH lookup. `commands.allow` / `commands.deny` filter the builtin set; unknown names throw with the list of valid builtins. Deny wins over allow.
- **fs**: no filesystem access by default. `fs.read` / `fs.write` grant absolute path prefixes; a write prefix implies read, and omitting `write` gives a read-only sandbox. Every checked path is resolved against the shell cwd and through symlinks (realpath of the deepest existing ancestor) before the prefix comparison, and policy prefixes get the same canonicalization at parse time.
- **network**: structurally off. No builtin performs network I/O and external binaries cannot run, so the option is reserved: only `false` is accepted, `true` throws instead of silently doing nothing.
- **limits.timeout**: an `EventLoopTimer` plus a wall-clock deadline checked at interpreter step boundaries, so synchronous write bursts that starve the event loop still observe the timeout. Rejects with `Shell command timed out after <n>ms (sandbox limits.timeout)`.
- **limits.maxOutputBytes**: counted at the two output choke points (`Builtin::write_no_io` and `IOWriter::enqueue`), covering stdout, stderr, and file redirects. Rejects with `Shell command output exceeded <n> bytes (sandbox limits.maxOutputBytes)`. Both rejections carry the output captured so far.

## Enforcement points

- `Cmd::transition_to_exec` is the single command gate (builtin allow/deny, external block).
- Path checks sit at every place the interpreter touches the filesystem: `cat`/`ls`/`rm`/`mv`/`cp`/`touch`/`mkdir` operands, redirect opens (`<`, `>`, `>>`), `cd` targets, glob walk roots, and `[[ -f ... ]]` probes (which answer "does not exist" outside the grants).
- `which` never probes PATH in a sandbox; it resolves policy-permitted builtins only, so scripts cannot enumerate host binaries.
- Traversal stays under checked roots: `ls -R` descends by dirent kind, `rm -r` deletes with NOFOLLOW semantics, the glob walker runs with `follow_symlinks = false`, and `cp` rejects `-H`/`-L` at parse time. Subshells, pipelines, and command substitution share the same `Interpreter`, so the policy applies to them with no extra plumbing.
- On a limit fault the promise settles immediately and the state machine unwinds at step boundaries (`Script::next`, `Binary::next`, `Cmd::next`, the builtin IO-writer callback) via a synthetic `ECANCELED` write error, so builtins release their readers/writers through existing error paths instead of being torn down mid-state.

Blocked operations exit 1 with a `... not permitted in sandbox` message on stderr, so they compose with `&&`/`||`/`.nothrow()` like any failing command.

## Also fixed

`run_task_cold` had no dispatch arm for `ShellYesTask`, so the quiet-mode `yes` builtin panicked the event loop with `panic: Unexpected Task tag: 12` as soon as its write loop bounced through the task queue. The sandbox limit tests exercise exactly that path; the arm now routes to `YesTask::run_from_main_thread`.

## Out of scope, by design (documented)

- The available builtin set matches the regular shell: `cat`/`cp` are POSIX-disabled natively today, so inside a sandbox they are blocked like external commands on those platforms.
- JS objects interpolated into the command (`Bun.file()`, buffers, `Response`) come from the trusted caller, not the untrusted script, and are not policy-checked.
- A builtin blocked forever on a pipe that never receives data keeps its read poll active after a timeout; the promise still rejects and the caller regains control.
- Overlay/copy-on-write writes and host/domain network allowlists are follow-ups; the option shapes leave room for both.

## Verification

- New `test/js/bun/shell/bunshell-sandbox.test.ts`: 38 tests / 142 assertions covering option validation, allow/deny, the external-command block (including `bun` itself and `PATH=` tricks), read/write prefix matrices for every filesystem builtin and redirect form, and escape attempts: `..` traversal, symlinked directories, files, and write targets, subshells, command substitution, pipelines, glob enumeration, `cd`, and `[[ -f ]]` probes, plus timeout and output-limit behavior with exact error messages.
- Existing shell suite passes: `bunshell.test.ts` (376 pass), instance/default/throw/shelloutput/yield/lazy/exec/file-io/brace, and `commands/`. The only failures in this container are pre-existing and reproduce identically on a clean tree (ls permission-denied tests under root, shell-hang's 700ms spawn budget in a debug build).
- `bun run rust:check-all`: 10/10 target configurations compile.
- Docs: new "Sandboxed shells (experimental)" section in `docs/runtime/shell.mdx`; TypeScript declarations in `packages/bun-types/shell.d.ts` (bun-types integration test passes).
