### PR TITLE
markdown: fix quadratic rendering of nested link/image labels without a depth cap

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -1,11 +1,25 @@
 use crate::autolinks::{find_permissive_autolink, is_emph_boundary_resolved};
 use crate::helpers;
-use crate::links::BracketMatches;
+use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
 use crate::types::{OFF, SpanType, TextType, VerbatimLine};
 
 /// Emphasis delimiter entry for CommonMark emphasis algorithm.
 pub const MAX_EMPH_MATCHES: usize = 6;
+
+/// Snapshot of an enclosing slice's walk state while one of its link/image/
+/// wikilink labels is rendered. `base..end` locate the enclosing slice
+/// within the block's inline content; `i`/`text_start`/`delim_cursor` are
+/// local to that slice. See `process_inline_content`.
+pub struct LabelFrame {
+    base: usize,
+    end: usize,
+    i: usize,
+    text_start: usize,
+    resolved: Vec<EmphDelim>,
+    delim_cursor: usize,
+    leave: LabelLeave,
+}
 
 #[derive(Clone, Copy)]
 pub struct EmphDelim {
@@ -145,13 +159,12 @@ impl Parser<'_> {
                 merged_len -= 1;
             }
         }
-        // take() the Vec out so process_inline_content (and any recursive
-        // call via process_link) gets a fresh self.buffer to scribble on without
-        // aliasing. Verified: nothing reachable from process_inline_content
-        // (including recursive process_link -> process_inline_content calls, which
-        // operate solely on the `content`/label slices) touches `self.buffer`; its
-        // other users (ref-def merging in blocks.rs/ref_defs.rs) run during the
-        // block phase, never re-entrantly from here.
+        // take() the Vec out so process_inline_content gets a fresh
+        // self.buffer to scribble on without aliasing. Verified: nothing
+        // reachable from process_inline_content (label frames operate solely
+        // on `content` subslices) touches `self.buffer`; its other users
+        // (ref-def merging in blocks.rs/ref_defs.rs) run during the block
+        // phase, never re-entrantly from here.
         let merged = core::mem::take(&mut self.buffer);
         let ret = self.process_inline_content(&merged[..merged_len], block_lines[0].beg);
         self.buffer = merged;
@@ -161,7 +174,7 @@ impl Parser<'_> {
     pub fn process_inline_content(
         &mut self,
         content: &[u8],
-        base_off: OFF,
+        _base_off: OFF,
     ) -> Result<(), parser::Error> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(parser::Error::StackOverflow);
@@ -169,327 +182,412 @@ impl Parser<'_> {
 
         // Failed HTML terminator searches recorded for another slice must not
         // leak into this one (the merged-line buffer is recycled across blocks,
-        // so a stale entry could alias a new slice of the same length). The
-        // caller's memo is restored on return so a recursive call for a link
-        // label does not throw away what the enclosing slice already learned.
+        // so a stale entry could alias a new slice of the same length).
+        // Label frames below are subslices of `content`, so the memo stays
+        // valid for them via `offset_within`.
         let outer_html_scan_memo = self.html_scan_memo.replace(HtmlScanMemo::EMPTY);
 
-        // Bracket-pair map for this slice: link processing looks up the ']'
-        // matching a '[' here instead of rescanning the rest of the slice for
-        // every opener. The backing storage is recycled via self.bracket_pairs
-        // (recursive calls for link labels simply build their own small map).
+        // Bracket-pair map for the whole slice: link processing looks up the
+        // ']' matching a '[' here instead of rescanning the rest of the slice
+        // for every opener. Label frames share this map (with their offset as
+        // `base`) instead of rebuilding it per nesting level; a per-level
+        // rebuild costs O(label) each and is quadratic on inputs like
+        // `"![".repeat(n) + "](u)".repeat(n)`. The backing storage is
+        // recycled via self.bracket_pairs.
         let bracket_storage = core::mem::take(&mut self.bracket_pairs);
         let brackets = self.compute_bracket_matches(content, bracket_storage);
 
+        // A link/image/wikilink label is rendered as inline content of its
+        // own: emphasis pairs within the label, and nested constructs inside
+        // it are rendered recursively. That recursion is driven iteratively
+        // with this frame stack so nesting depth is bounded by the heap, not
+        // the native stack. Each frame snapshots the enclosing slice's walk
+        // state plus the close action for the label being entered. The
+        // backing vec is recycled through `Parser.label_frames` so blocks
+        // with links do not allocate a stack per block in steady state.
+        let mut frames: Vec<LabelFrame> = core::mem::take(&mut self.label_frames);
+        debug_assert!(frames.is_empty());
+
+        // Walk state for the current (innermost) slice. `base` is the
+        // slice's offset within `content`, which `brackets` was built for
+        // (`cur` is always `content[base..base + cur.len()]`).
+        let mut cur: &[u8] = content;
+        let mut base: usize = 0;
+
         // Phase 1: Collect and resolve emphasis delimiters
-        self.collect_emphasis_delimiters(content, &brackets);
+        self.collect_emphasis_delimiters(cur, &brackets, base);
         self.resolve_emphasis_delimiters();
 
-        // Copy resolved delimiters locally (recursive calls may modify emph_delims)
-        let resolved: Vec<EmphDelim> = self.emph_delims.clone();
+        // Copy resolved delimiters locally (label frames reuse emph_delims)
+        let mut resolved: Vec<EmphDelim> = self.emph_delims.clone();
 
         // Phase 2: Emit content using resolved emphasis info
         let mut i: usize = 0;
         let mut text_start: usize = 0;
         let mut delim_cursor: usize = 0;
 
-        while i < content.len() {
-            let c = content[i];
+        // Enter the label of a just-parsed link/image/wikilink: snapshot the
+        // current walk state and restart the walk on the label slice.
+        macro_rules! enter_label {
+            ($parse:expr) => {{
+                let parse = $parse;
+                frames.push(LabelFrame {
+                    base,
+                    end: base + cur.len(),
+                    i: parse.link_end,
+                    text_start: parse.link_end,
+                    resolved: core::mem::take(&mut resolved),
+                    delim_cursor,
+                    leave: parse.leave,
+                });
+                base += parse.label_start;
+                cur = &cur[parse.label_start..parse.label_end];
+                self.collect_emphasis_delimiters(cur, &brackets, base);
+                self.resolve_emphasis_delimiters();
+                resolved = self.emph_delims.clone();
+                i = 0;
+                text_start = 0;
+                delim_cursor = 0;
+            }};
+        }
 
-            // Fast path: character has no special meaning, skip it
-            if !self.mark_char_map.is_set(c as usize) {
-                i += 1;
-                continue;
-            }
+        'frames: loop {
+            while i < cur.len() {
+                let content = cur;
+                let c = content[i];
 
-            // Newline from merged lines — check for hard break
-            if c == b'\n' {
-                let mut emit_end = i;
-                let mut is_hard = false;
-                if emit_end > text_start && content[emit_end - 1] == b'\\' {
-                    emit_end -= 1;
-                    is_hard = true;
-                } else {
-                    let mut sp = emit_end;
-                    while sp > text_start && content[sp - 1] == b' ' {
-                        sp -= 1;
-                    }
-                    if emit_end - sp >= 2 {
-                        // Also strip any trailing tabs/spaces before the space run
-                        while sp > text_start
-                            && (content[sp - 1] == b' ' || content[sp - 1] == b'\t')
-                        {
+                // Fast path: character has no special meaning, skip it
+                if !self.mark_char_map.is_set(c as usize) {
+                    i += 1;
+                    continue;
+                }
+
+                // Newline from merged lines — check for hard break
+                if c == b'\n' {
+                    let mut emit_end = i;
+                    let mut is_hard = false;
+                    if emit_end > text_start && content[emit_end - 1] == b'\\' {
+                        emit_end -= 1;
+                        is_hard = true;
+                    } else {
+                        let mut sp = emit_end;
+                        while sp > text_start && content[sp - 1] == b' ' {
                             sp -= 1;
                         }
-                        emit_end = sp;
-                        is_hard = true;
-                    }
-                }
-                if emit_end > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..emit_end])?;
-                }
-                if is_hard {
-                    self.emit_text(TextType::Br, b"")?;
-                } else {
-                    self.emit_text(TextType::Softbr, b"")?;
-                }
-                i += 1;
-                text_start = i;
-                continue;
-            }
-
-            // Check for backslash escape
-            if c == b'\\' && i + 1 < content.len() && helpers::is_ascii_punctuation(content[i + 1])
-            {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
-                }
-                i += 1;
-                self.emit_text(TextType::Normal, &content[i..i + 1])?;
-                i += 1;
-                text_start = i;
-                continue;
-            }
-
-            // Code span
-            if c == b'`' {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
-                }
-                let count = count_backticks(content, i);
-                if let Some(end_pos) = self.find_code_span_end(content, i + count, count) {
-                    self.enter_span(SpanType::Code)?;
-                    let code_content =
-                        self.normalize_code_span_content(&content[i + count..end_pos]);
-                    self.emit_text(TextType::Code, code_content)?;
-                    self.leave_span(SpanType::Code)?;
-                    i = end_pos + count;
-                } else {
-                    // No matching closer found — emit the entire backtick run as literal text
-                    self.emit_text(TextType::Normal, &content[i..i + count])?;
-                    i += count;
-                }
-                text_start = i;
-                continue;
-            }
-
-            // Emphasis/strikethrough with * or _ or ~ — use resolved delimiters
-            if c == b'*' || c == b'_' || (c == b'~' && self.flags.strikethrough) {
-                // Find the corresponding resolved delimiter
-                while delim_cursor < resolved.len() && resolved[delim_cursor].pos < i {
-                    delim_cursor += 1;
-                }
-
-                if delim_cursor < resolved.len() && resolved[delim_cursor].pos == i {
-                    if i > text_start {
-                        self.emit_text(TextType::Normal, &content[text_start..i])?;
-                    }
-
-                    let d = &resolved[delim_cursor];
-                    let run_end = d.pos + d.count;
-
-                    // Emit closing tags first (innermost to outermost)
-                    if d.emph_char == b'~' {
-                        if d.close_count > 0 {
-                            self.leave_span(SpanType::Del)?;
+                        if emit_end - sp >= 2 {
+                            // Also strip any trailing tabs/spaces before the space run
+                            while sp > text_start
+                                && (content[sp - 1] == b' ' || content[sp - 1] == b'\t')
+                            {
+                                sp -= 1;
+                            }
+                            emit_end = sp;
+                            is_hard = true;
                         }
+                    }
+                    if emit_end > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..emit_end])?;
+                    }
+                    if is_hard {
+                        self.emit_text(TextType::Br, b"")?;
                     } else {
-                        self.emit_emph_close_tags(&d.close_sizes[0..d.close_num as usize])?;
+                        self.emit_text(TextType::Softbr, b"")?;
                     }
-
-                    // Emit remaining delimiter chars as text
-                    let text_chars = d.count.saturating_sub(d.open_count + d.close_count);
-                    if text_chars > 0 {
-                        self.emit_text(TextType::Normal, &content[i..i + text_chars])?;
-                    }
-
-                    // Emit opening tags (outermost to innermost)
-                    if d.emph_char == b'~' {
-                        if d.open_count > 0 {
-                            self.enter_span(SpanType::Del)?;
-                        }
-                    } else {
-                        self.emit_emph_open_tags(&d.open_sizes[0..d.open_num as usize])?;
-                    }
-
-                    delim_cursor += 1;
-                    i = run_end;
-                    text_start = i;
-                    continue;
-                }
-                // No resolved delimiter found, just advance
-                i += 1;
-                continue;
-            }
-
-            // HTML entity
-            if c == b'&' {
-                if let Some(end_pos) = self.find_entity(content, i) {
-                    if i > text_start {
-                        self.emit_text(TextType::Normal, &content[text_start..i])?;
-                    }
-                    self.emit_text(TextType::Entity, &content[i..end_pos])?;
-                    i = end_pos;
-                    text_start = i;
-                    continue;
-                }
-            }
-
-            // HTML tag
-            if c == b'<' && !self.flags.no_html_spans {
-                if let Some(tag_end) = self.find_html_tag(content, i) {
-                    if i > text_start {
-                        self.emit_text(TextType::Normal, &content[text_start..i])?;
-                    }
-                    self.emit_text(TextType::Html, &content[i..tag_end])?;
-                    i = tag_end;
-                    text_start = i;
-                    continue;
-                }
-                if let Some(autolink) = self.find_autolink(content, i) {
-                    if i > text_start {
-                        self.emit_text(TextType::Normal, &content[text_start..i])?;
-                    }
-                    self.render_autolink(&content[i + 1..autolink.end_pos - 1], autolink.is_email)?;
-                    i = autolink.end_pos;
-                    text_start = i;
-                    continue;
-                }
-            }
-
-            // Wiki links: [[destination]] or [[destination|label]]
-            if c == b'[' && self.flags.wiki_links && i + 1 < content.len() && content[i + 1] == b'['
-            {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
-                }
-                if let Some(end_pos) = self.process_wiki_link(content, i)? {
-                    i = end_pos;
-                    text_start = i;
-                    continue;
-                }
-                // No wikilink matched: restore text_start so preceding text
-                // isn't double-emitted by the next span branch.
-                text_start = i;
-            }
-
-            // Links: [text](url) or [text][ref]
-            if c == b'[' {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
-                }
-                if let Some(end_pos) = self.process_link(content, i, base_off, false, &brackets)? {
-                    i = end_pos;
-                } else {
-                    self.emit_text(TextType::Normal, b"[")?;
                     i += 1;
+                    text_start = i;
+                    continue;
                 }
-                text_start = i;
-                continue;
-            }
 
-            // Images: ![text](url)
-            if c == b'!' && i + 1 < content.len() && content[i + 1] == b'[' {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
-                }
-                if let Some(end_pos) =
-                    self.process_link(content, i + 1, base_off, true, &brackets)?
+                // Check for backslash escape
+                if c == b'\\'
+                    && i + 1 < content.len()
+                    && helpers::is_ascii_punctuation(content[i + 1])
                 {
-                    i = end_pos;
-                } else {
-                    self.emit_text(TextType::Normal, b"!")?;
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
                     i += 1;
-                }
-                text_start = i;
-                continue;
-            }
-
-            // Note: Strikethrough (~) is handled above via the resolved delimiter system
-
-            // Permissive autolinks: detect URL, email, and WWW autolinks
-            // Suppress inside explicit links to avoid double-wrapping (md4c issue #152)
-            if self.link_nesting_level == 0
-                && ((c == b':' && self.flags.permissive_url_autolinks)
-                    || (c == b'@' && self.flags.permissive_email_autolinks)
-                    || (c == b'.' && self.flags.permissive_www_autolinks))
-            {
-                // First try with strict boundaries, then with relaxed (emphasis-aware)
-                let mut al = find_permissive_autolink(content, i, false);
-                if al.is_none() {
-                    al = find_permissive_autolink(content, i, true);
-                    if let Some(a) = al {
-                        if !is_emph_boundary_resolved(content, a, &resolved) {
-                            al = None;
-                        }
-                    }
-                }
-                if let Some(a) = al {
-                    if a.beg > text_start {
-                        self.emit_text(TextType::Normal, &content[text_start..a.beg])?;
-                    }
-
-                    // Determine URL prefix and render through the renderer
-                    let link_text = &content[a.beg..a.end];
-                    if c == b'@' {
-                        self.renderer.enter_span(
-                            SpanType::A,
-                            crate::types::SpanDetail {
-                                href: link_text,
-                                permissive_autolink: true,
-                                autolink_email: true,
-                                ..Default::default()
-                            },
-                        )?;
-                        self.emit_text(TextType::Normal, link_text)?;
-                        self.renderer.leave_span(SpanType::A)?;
-                    } else if c == b'.' {
-                        self.renderer.enter_span(
-                            SpanType::A,
-                            crate::types::SpanDetail {
-                                href: link_text,
-                                permissive_autolink: true,
-                                autolink_www: true,
-                                ..Default::default()
-                            },
-                        )?;
-                        self.emit_text(TextType::Normal, link_text)?;
-                        self.renderer.leave_span(SpanType::A)?;
-                    } else {
-                        self.renderer.enter_span(
-                            SpanType::A,
-                            crate::types::SpanDetail {
-                                href: link_text,
-                                permissive_autolink: true,
-                                ..Default::default()
-                            },
-                        )?;
-                        self.emit_text(TextType::Normal, link_text)?;
-                        self.renderer.leave_span(SpanType::A)?;
-                    }
-                    i = a.end;
+                    self.emit_text(TextType::Normal, &content[i..i + 1])?;
+                    i += 1;
                     text_start = i;
                     continue;
                 }
-            }
 
-            // Null character
-            if c == 0 {
-                if i > text_start {
-                    self.emit_text(TextType::Normal, &content[text_start..i])?;
+                // Code span
+                if c == b'`' {
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    let count = count_backticks(content, i);
+                    if let Some(end_pos) = self.find_code_span_end(content, i + count, count) {
+                        self.enter_span(SpanType::Code)?;
+                        let code_content =
+                            self.normalize_code_span_content(&content[i + count..end_pos]);
+                        self.emit_text(TextType::Code, code_content)?;
+                        self.leave_span(SpanType::Code)?;
+                        i = end_pos + count;
+                    } else {
+                        // No matching closer found — emit the entire backtick run as literal text
+                        self.emit_text(TextType::Normal, &content[i..i + count])?;
+                        i += count;
+                    }
+                    text_start = i;
+                    continue;
                 }
-                self.emit_text(TextType::NullChar, b"")?;
+
+                // Emphasis/strikethrough with * or _ or ~ — use resolved delimiters
+                if c == b'*' || c == b'_' || (c == b'~' && self.flags.strikethrough) {
+                    // Find the corresponding resolved delimiter
+                    while delim_cursor < resolved.len() && resolved[delim_cursor].pos < i {
+                        delim_cursor += 1;
+                    }
+
+                    if delim_cursor < resolved.len() && resolved[delim_cursor].pos == i {
+                        if i > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..i])?;
+                        }
+
+                        let d = &resolved[delim_cursor];
+                        let run_end = d.pos + d.count;
+
+                        // Emit closing tags first (innermost to outermost)
+                        if d.emph_char == b'~' {
+                            if d.close_count > 0 {
+                                self.leave_span(SpanType::Del)?;
+                            }
+                        } else {
+                            self.emit_emph_close_tags(&d.close_sizes[0..d.close_num as usize])?;
+                        }
+
+                        // Emit remaining delimiter chars as text
+                        let text_chars = d.count.saturating_sub(d.open_count + d.close_count);
+                        if text_chars > 0 {
+                            self.emit_text(TextType::Normal, &content[i..i + text_chars])?;
+                        }
+
+                        // Emit opening tags (outermost to innermost)
+                        if d.emph_char == b'~' {
+                            if d.open_count > 0 {
+                                self.enter_span(SpanType::Del)?;
+                            }
+                        } else {
+                            self.emit_emph_open_tags(&d.open_sizes[0..d.open_num as usize])?;
+                        }
+
+                        delim_cursor += 1;
+                        i = run_end;
+                        text_start = i;
+                        continue;
+                    }
+                    // No resolved delimiter found, just advance
+                    i += 1;
+                    continue;
+                }
+
+                // HTML entity
+                if c == b'&' {
+                    if let Some(end_pos) = self.find_entity(content, i) {
+                        if i > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..i])?;
+                        }
+                        self.emit_text(TextType::Entity, &content[i..end_pos])?;
+                        i = end_pos;
+                        text_start = i;
+                        continue;
+                    }
+                }
+
+                // HTML tag
+                if c == b'<' && !self.flags.no_html_spans {
+                    if let Some(tag_end) = self.find_html_tag(content, i) {
+                        if i > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..i])?;
+                        }
+                        self.emit_text(TextType::Html, &content[i..tag_end])?;
+                        i = tag_end;
+                        text_start = i;
+                        continue;
+                    }
+                    if let Some(autolink) = self.find_autolink(content, i) {
+                        if i > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..i])?;
+                        }
+                        self.render_autolink(
+                            &content[i + 1..autolink.end_pos - 1],
+                            autolink.is_email,
+                        )?;
+                        i = autolink.end_pos;
+                        text_start = i;
+                        continue;
+                    }
+                }
+
+                // Wiki links: [[destination]] or [[destination|label]]
+                if c == b'['
+                    && self.flags.wiki_links
+                    && i + 1 < content.len()
+                    && content[i + 1] == b'['
+                {
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    if let Some(parse) = self.process_wiki_link(content, i)? {
+                        enter_label!(parse);
+                        continue;
+                    }
+                    // No wikilink matched: restore text_start so preceding text
+                    // isn't double-emitted by the next span branch.
+                    text_start = i;
+                }
+
+                // Links: [text](url) or [text][ref]
+                if c == b'[' {
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    if let Some(parse) = self.process_link(content, i, false, &brackets, base)? {
+                        enter_label!(parse);
+                    } else {
+                        self.emit_text(TextType::Normal, b"[")?;
+                        i += 1;
+                        text_start = i;
+                    }
+                    continue;
+                }
+
+                // Images: ![text](url)
+                if c == b'!' && i + 1 < content.len() && content[i + 1] == b'[' {
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    if let Some(parse) = self.process_link(content, i + 1, true, &brackets, base)? {
+                        enter_label!(parse);
+                    } else {
+                        self.emit_text(TextType::Normal, b"!")?;
+                        i += 1;
+                        text_start = i;
+                    }
+                    continue;
+                }
+
+                // Note: Strikethrough (~) is handled above via the resolved delimiter system
+
+                // Permissive autolinks: detect URL, email, and WWW autolinks
+                // Suppress inside explicit links to avoid double-wrapping (md4c issue #152)
+                if self.link_nesting_level == 0
+                    && ((c == b':' && self.flags.permissive_url_autolinks)
+                        || (c == b'@' && self.flags.permissive_email_autolinks)
+                        || (c == b'.' && self.flags.permissive_www_autolinks))
+                {
+                    // First try with strict boundaries, then with relaxed (emphasis-aware)
+                    let mut al = find_permissive_autolink(content, i, false);
+                    if al.is_none() {
+                        al = find_permissive_autolink(content, i, true);
+                        if let Some(a) = al {
+                            if !is_emph_boundary_resolved(content, a, &resolved) {
+                                al = None;
+                            }
+                        }
+                    }
+                    if let Some(a) = al {
+                        if a.beg > text_start {
+                            self.emit_text(TextType::Normal, &content[text_start..a.beg])?;
+                        }
+
+                        // Determine URL prefix and render through the renderer
+                        let link_text = &content[a.beg..a.end];
+                        if c == b'@' {
+                            self.renderer.enter_span(
+                                SpanType::A,
+                                crate::types::SpanDetail {
+                                    href: link_text,
+                                    permissive_autolink: true,
+                                    autolink_email: true,
+                                    ..Default::default()
+                                },
+                            )?;
+                            self.emit_text(TextType::Normal, link_text)?;
+                            self.renderer.leave_span(SpanType::A)?;
+                        } else if c == b'.' {
+                            self.renderer.enter_span(
+                                SpanType::A,
+                                crate::types::SpanDetail {
+                                    href: link_text,
+                                    permissive_autolink: true,
+                                    autolink_www: true,
+                                    ..Default::default()
+                                },
+                            )?;
+                            self.emit_text(TextType::Normal, link_text)?;
+                            self.renderer.leave_span(SpanType::A)?;
+                        } else {
+                            self.renderer.enter_span(
+                                SpanType::A,
+                                crate::types::SpanDetail {
+                                    href: link_text,
+                                    permissive_autolink: true,
+                                    ..Default::default()
+                                },
+                            )?;
+                            self.emit_text(TextType::Normal, link_text)?;
+                            self.renderer.leave_span(SpanType::A)?;
+                        }
+                        i = a.end;
+                        text_start = i;
+                        continue;
+                    }
+                }
+
+                // Null character
+                if c == 0 {
+                    if i > text_start {
+                        self.emit_text(TextType::Normal, &content[text_start..i])?;
+                    }
+                    self.emit_text(TextType::NullChar, b"")?;
+                    i += 1;
+                    text_start = i;
+                    continue;
+                }
+
                 i += 1;
-                text_start = i;
-                continue;
             }
 
-            i += 1;
+            // Current slice fully walked: flush its trailing text, then
+            // either close the finished label and resume its enclosing
+            // slice, or, for the outermost slice, finish.
+            if text_start < cur.len() {
+                self.emit_text(TextType::Normal, &cur[text_start..])?;
+            }
+            match frames.pop() {
+                Some(frame) => {
+                    match frame.leave {
+                        LabelLeave::AltText => {}
+                        LabelLeave::Image => {
+                            self.image_nesting_level -= 1;
+                            self.renderer.leave_span(SpanType::Img)?;
+                        }
+                        LabelLeave::Link => {
+                            self.link_nesting_level -= 1;
+                            self.renderer.leave_span(SpanType::A)?;
+                        }
+                        LabelLeave::Wikilink => {
+                            self.renderer.leave_span(SpanType::Wikilink)?;
+                        }
+                    }
+                    cur = &content[frame.base..frame.end];
+                    base = frame.base;
+                    i = frame.i;
+                    text_start = frame.text_start;
+                    resolved = frame.resolved;
+                    delim_cursor = frame.delim_cursor;
+                }
+                None => break 'frames,
+            }
         }
 
-        if text_start < content.len() {
-            self.emit_text(TextType::Normal, &content[text_start..])?;
-        }
+        // Hand the frame storage back for reuse by the next block.
+        self.label_frames = frames;
+
         // Hand the bracket-map storage back for reuse by the next block.
         self.bracket_pairs = brackets.into_storage();
         // Restore the enclosing slice's memo (the entries built for this slice
@@ -575,8 +673,15 @@ impl Parser<'_> {
         content
     }
 
-    /// Collect emphasis delimiter runs from content, skipping code spans and HTML tags.
-    pub fn collect_emphasis_delimiters(&mut self, content: &[u8], brackets: &BracketMatches) {
+    /// Collect emphasis delimiter runs from content, skipping code spans and
+    /// HTML tags. `base` is the offset of `content` within the slice
+    /// `brackets` was built for.
+    pub fn collect_emphasis_delimiters(
+        &mut self,
+        content: &[u8],
+        brackets: &BracketMatches,
+        base: usize,
+    ) {
         self.emph_delims.clear();
         let mut i: usize = 0;
         while i < content.len() {
@@ -614,13 +719,14 @@ impl Parser<'_> {
             if c == b'[' || (c == b'!' && i + 1 < content.len() && content[i + 1] == b'[') {
                 let is_img = c == b'!';
                 let bracket_start = if is_img { i + 1 } else { i };
-                let link_result = self.try_match_bracket_link(content, bracket_start, brackets, 0);
+                let link_result =
+                    self.try_match_bracket_link(content, bracket_start, brackets, base);
                 if link_result.is_link {
                     // Link nesting prohibition: links cannot contain other links (CommonMark §6.7)
                     // Images CAN contain links in alt text, so only check for non-images
                     if !is_img {
                         let label = &content[bracket_start + 1..link_result.label_end];
-                        if self.label_contains_link(label, brackets, bracket_start + 1) {
+                        if self.label_contains_link(label, brackets, base + bracket_start + 1) {
                             // Label contains inner links — this can't form a link
                             i += 1;
                             continue;

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -90,9 +90,9 @@ pub const HTML_SCAN_KIND_COUNT: usize = 4;
 /// after position P of the paragraph" covers every later position of every
 /// label inside it. Sub-slice scans never overwrite the enclosing slice's
 /// entry (they prove nothing beyond their own extent), and
-/// `process_inline_content` starts each slice from an empty memo and restores
-/// the caller's on return, so recycled merged-line buffers and transient
-/// table-cell buffers can never alias a previous slice's entry.
+/// `process_inline_content` starts each block's slice from an empty memo, so
+/// recycled merged-line buffers and transient table-cell buffers can never
+/// alias a previous slice's entry.
 #[derive(Clone, Copy)]
 pub struct HtmlScanMemo {
     slice_addr: usize,
@@ -181,7 +181,7 @@ impl Parser<'_> {
         // so a stale entry could alias a new slice of the same length).
         // Label frames below are subslices of `content`, so the memo stays
         // valid for them via `offset_within`.
-        let outer_html_scan_memo = self.html_scan_memo.replace(HtmlScanMemo::EMPTY);
+        self.html_scan_memo.set(HtmlScanMemo::EMPTY);
 
         // Bracket-pair map for the whole slice: link processing looks up the
         // ']' matching a '[' here instead of rescanning the rest of the slice
@@ -586,9 +586,6 @@ impl Parser<'_> {
 
         // Hand the bracket-map storage back for reuse by the next block.
         self.bracket_pairs = brackets.into_storage();
-        // Restore the enclosing slice's memo (the entries built for this slice
-        // are meaningless to the caller).
-        self.html_scan_memo.set(outer_html_scan_memo);
         Ok(())
     }
 

--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -2,7 +2,7 @@ use crate::autolinks::{find_permissive_autolink, is_emph_boundary_resolved};
 use crate::helpers;
 use crate::links::{BracketMatches, LabelLeave};
 use crate::parser::{self, Parser};
-use crate::types::{OFF, SpanType, TextType, VerbatimLine};
+use crate::types::{SpanType, TextType, VerbatimLine};
 
 /// Emphasis delimiter entry for CommonMark emphasis algorithm.
 pub const MAX_EMPH_MATCHES: usize = 6;
@@ -166,16 +166,12 @@ impl Parser<'_> {
         // (ref-def merging in blocks.rs/ref_defs.rs) run during the block
         // phase, never re-entrantly from here.
         let merged = core::mem::take(&mut self.buffer);
-        let ret = self.process_inline_content(&merged[..merged_len], block_lines[0].beg);
+        let ret = self.process_inline_content(&merged[..merged_len]);
         self.buffer = merged;
         ret
     }
 
-    pub fn process_inline_content(
-        &mut self,
-        content: &[u8],
-        _base_off: OFF,
-    ) -> Result<(), parser::Error> {
+    pub fn process_inline_content(&mut self, content: &[u8]) -> Result<(), parser::Error> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(parser::Error::StackOverflow);
         }

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -22,6 +22,14 @@ const MAX_LINK_DEST_PAREN_DEPTH: u32 = 32;
 /// wiki links are enabled, e.g. via `Bun.markdown.ansi`).
 const MAX_WIKI_BRACKET_DEPTH: u32 = 32;
 
+/// Maximum depth of link/image-label recursion. Rendering a label re-parses
+/// the label slice from scratch (`process_inline_content` rebuilds the
+/// bracket map and emphasis state per call), so each nesting level costs
+/// O(label). Unbounded nesting is quadratic on inputs like
+/// `"![".repeat(n) + "](u)".repeat(n)`; past the cap a label is emitted as
+/// plain text instead of recursing.
+const MAX_LABEL_NESTING_DEPTH: u32 = 32;
+
 /// Result of `try_match_bracket_link`.
 pub struct BracketLinkMatch {
     pub is_link: bool,
@@ -281,6 +289,19 @@ impl Parser<'_> {
         })
     }
 
+    /// Render the inline content of a link/image/wikilink label. All label
+    /// recursion funnels through here so the depth cap cannot be bypassed by
+    /// one of the call sites.
+    fn process_label_content(&mut self, label: &[u8]) -> Result<(), parser::Error> {
+        if self.label_nesting_level >= MAX_LABEL_NESTING_DEPTH {
+            return self.emit_text(TextType::Normal, label);
+        }
+        self.label_nesting_level += 1;
+        let ret = self.process_inline_content(label, 0);
+        self.label_nesting_level -= 1;
+        ret
+    }
+
     pub fn process_link(
         &mut self,
         content: &[u8],
@@ -441,7 +462,7 @@ impl Parser<'_> {
 
                 if self.image_nesting_level > 0 {
                     // Inside image alt text — emit only text, no HTML tags
-                    self.process_inline_content(label, 0)?;
+                    self.process_label_content(label)?;
                 } else if is_image {
                     self.renderer.enter_span(
                         Span::Img,
@@ -452,7 +473,7 @@ impl Parser<'_> {
                         },
                     )?;
                     self.image_nesting_level += 1;
-                    self.process_inline_content(label, 0)?;
+                    self.process_label_content(label)?;
                     self.image_nesting_level -= 1;
                     self.renderer.leave_span(Span::Img)?;
                 } else {
@@ -465,7 +486,7 @@ impl Parser<'_> {
                         },
                     )?;
                     self.link_nesting_level += 1;
-                    self.process_inline_content(label, 0)?;
+                    self.process_label_content(label)?;
                     self.link_nesting_level -= 1;
                     self.renderer.leave_span(Span::A)?;
                 }
@@ -853,7 +874,7 @@ impl Parser<'_> {
                 ..Default::default()
             },
         )?;
-        self.process_inline_content(label, 0)?;
+        self.process_label_content(label)?;
         self.renderer.leave_span(Span::Wikilink)?;
 
         Ok(Some(pos + 2)) // skip both ']'
@@ -869,7 +890,7 @@ impl Parser<'_> {
     ) -> Result<(), parser::Error> {
         if self.image_nesting_level > 0 {
             // Inside image alt text — emit only text, no HTML tags
-            self.process_inline_content(label_content, 0)?;
+            self.process_label_content(label_content)?;
         } else if is_image {
             self.renderer.enter_span(
                 Span::Img,
@@ -880,7 +901,7 @@ impl Parser<'_> {
                 },
             )?;
             self.image_nesting_level += 1;
-            self.process_inline_content(label_content, 0)?;
+            self.process_label_content(label_content)?;
             self.image_nesting_level -= 1;
             self.renderer.leave_span(Span::Img)?;
         } else {
@@ -893,7 +914,7 @@ impl Parser<'_> {
                 },
             )?;
             self.link_nesting_level += 1;
-            self.process_inline_content(label_content, 0)?;
+            self.process_label_content(label_content)?;
             self.link_nesting_level -= 1;
             self.renderer.leave_span(Span::A)?;
         }

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -755,14 +755,19 @@ impl Parser<'_> {
             }
         }
 
-        // Shortcut reference
-        let inner_label = &content[start + 1..label_end];
-        if self.lookup_ref_def(inner_label).is_some() {
-            return BracketLinkMatch {
-                is_link: true,
-                label_end,
-                link_end: label_end + 1,
-            };
+        // Shortcut reference: like process_link, a shortcut must not be
+        // followed by '[' (the lookahead and the parser must agree on what
+        // is a link or label_contains_link rejects constructs the parser
+        // renders)
+        if content.get(label_end + 1) != Some(&b'[') {
+            let inner_label = &content[start + 1..label_end];
+            if self.lookup_ref_def(inner_label).is_some() {
+                return BracketLinkMatch {
+                    is_link: true,
+                    label_end,
+                    link_end: label_end + 1,
+                };
+            }
         }
 
         BracketLinkMatch {

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -507,7 +507,12 @@ impl Parser<'_> {
             }
         }
 
-        // Reference link: [text][ref] or [text][] or shortcut [text]
+        // Reference link: [text][ref] or [text][] or shortcut [text].
+        // A reference label must start immediately after the closing ']'; a
+        // failed inline-link parse above may have advanced `pos` onto a later
+        // '[' (e.g. "[foo](bar [ref])"), which must not be read as the
+        // reference (try_match_bracket_link checks the byte after ']' too).
+        pos = label_end + 1;
         if pos < content.len() && content[pos] == b'[' {
             pos += 1;
             let ref_start = pos;

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -626,12 +626,15 @@ impl Parser<'_> {
             {
                 p += 1;
             }
-            // Parse dest
+            // Parse dest (no line endings or unescaped '<' allowed, matching
+            // process_link: the lookahead and the parser must agree on what
+            // is a link or emphasis collection desyncs from rendering)
             if p < content.len() && content[p] == b'<' {
                 p += 1;
                 while p < content.len()
                     && content[p] != b'>'
                     && content[p] != b'\n'
+                    && content[p] != b'\r'
                     && content[p] != b'<'
                 {
                     if content[p] == b'\\' && p + 1 < content.len() {

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -7,7 +7,6 @@ use crate::types::{OFF, SpanDetail, SpanType, TextType};
 // `SpanAttrs` in the original implementation).
 type Span = SpanType;
 type SpanAttrs<'a> = SpanDetail<'a>;
-type Off = OFF;
 
 /// Maximum parenthesis nesting depth inside a bare inline-link destination.
 /// CommonMark allows implementations to impose such a limit ("at least three
@@ -22,19 +21,33 @@ const MAX_LINK_DEST_PAREN_DEPTH: u32 = 32;
 /// wiki links are enabled, e.g. via `Bun.markdown.ansi`).
 const MAX_WIKI_BRACKET_DEPTH: u32 = 32;
 
-/// Maximum depth of link/image-label recursion. Rendering a label re-parses
-/// the label slice from scratch (`process_inline_content` rebuilds the
-/// bracket map and emphasis state per call), so each nesting level costs
-/// O(label). Unbounded nesting is quadratic on inputs like
-/// `"![".repeat(n) + "](u)".repeat(n)`; past the cap a label is emitted as
-/// plain text instead of recursing.
-const MAX_LABEL_NESTING_DEPTH: u32 = 32;
-
 /// Result of `try_match_bracket_link`.
 pub struct BracketLinkMatch {
     pub is_link: bool,
     pub label_end: usize,
     pub link_end: usize,
+}
+
+/// A successfully parsed link/image/wikilink whose opening span has been
+/// emitted. The caller renders `content[label_start..label_end]` as inline
+/// content, performs `leave`, and resumes at `link_end`. Returning this
+/// instead of recursing keeps label nesting iterative (arbitrary depth, no
+/// native stack growth).
+pub struct LabelParse {
+    pub label_start: usize,
+    pub label_end: usize,
+    pub link_end: usize,
+    pub leave: LabelLeave,
+}
+
+/// Close action matching the span opened by `enter_label_span` /
+/// `process_wiki_link`.
+pub enum LabelLeave {
+    /// Inside image alt text: no span was opened.
+    AltText,
+    Image,
+    Link,
+    Wikilink,
 }
 
 /// Result of `find_autolink`.
@@ -289,30 +302,54 @@ impl Parser<'_> {
         })
     }
 
-    /// Render the inline content of a link/image/wikilink label. All label
-    /// recursion funnels through here so the depth cap cannot be bypassed by
-    /// one of the call sites.
-    fn process_label_content(&mut self, label: &[u8]) -> Result<(), parser::Error> {
-        if self.label_nesting_level >= MAX_LABEL_NESTING_DEPTH {
-            return self.emit_text(TextType::Normal, label);
+    /// Emit the opening span for a link/image whose label is about to be
+    /// rendered, and return the matching close action for the caller to run
+    /// once the label content has been emitted.
+    fn enter_label_span(
+        &mut self,
+        dest: &[u8],
+        title: &[u8],
+        is_image: bool,
+    ) -> Result<LabelLeave, parser::Error> {
+        if self.image_nesting_level > 0 {
+            // Inside image alt text: emit only text, no HTML tags
+            Ok(LabelLeave::AltText)
+        } else if is_image {
+            self.renderer.enter_span(
+                Span::Img,
+                SpanAttrs {
+                    href: dest,
+                    title,
+                    ..Default::default()
+                },
+            )?;
+            self.image_nesting_level += 1;
+            Ok(LabelLeave::Image)
+        } else {
+            self.renderer.enter_span(
+                Span::A,
+                SpanAttrs {
+                    href: dest,
+                    title,
+                    ..Default::default()
+                },
+            )?;
+            self.link_nesting_level += 1;
+            Ok(LabelLeave::Link)
         }
-        self.label_nesting_level += 1;
-        let ret = self.process_inline_content(label, 0);
-        self.label_nesting_level -= 1;
-        ret
     }
 
     pub fn process_link(
         &mut self,
         content: &[u8],
         start: usize,
-        _base_off: Off,
         is_image: bool,
         brackets: &BracketMatches,
-    ) -> Result<Option<usize>, parser::Error> {
+        base: usize,
+    ) -> Result<Option<LabelParse>, parser::Error> {
         // start points at '['
         // Find matching ']', skipping code spans and HTML tags (which take precedence)
-        let Some(bracket) = self.match_bracket(content, start, brackets, 0) else {
+        let Some(bracket) = self.match_bracket(content, start, brackets, base) else {
             return Ok(None);
         };
         let has_inner_bracket = bracket.has_inner_bracket;
@@ -455,43 +492,18 @@ impl Parser<'_> {
                 // Link nesting prohibition: links cannot contain other links (CommonMark §6.7)
                 if !is_image
                     && has_inner_bracket
-                    && self.label_contains_link(label, brackets, start + 1)
+                    && self.label_contains_link(label, brackets, base + start + 1)
                 {
                     return Ok(None);
                 }
 
-                if self.image_nesting_level > 0 {
-                    // Inside image alt text — emit only text, no HTML tags
-                    self.process_label_content(label)?;
-                } else if is_image {
-                    self.renderer.enter_span(
-                        Span::Img,
-                        SpanAttrs {
-                            href: dest,
-                            title,
-                            ..Default::default()
-                        },
-                    )?;
-                    self.image_nesting_level += 1;
-                    self.process_label_content(label)?;
-                    self.image_nesting_level -= 1;
-                    self.renderer.leave_span(Span::Img)?;
-                } else {
-                    self.renderer.enter_span(
-                        Span::A,
-                        SpanAttrs {
-                            href: dest,
-                            title,
-                            ..Default::default()
-                        },
-                    )?;
-                    self.link_nesting_level += 1;
-                    self.process_label_content(label)?;
-                    self.link_nesting_level -= 1;
-                    self.renderer.leave_span(Span::A)?;
-                }
-
-                return Ok(Some(pos));
+                let leave = self.enter_label_span(dest, title, is_image)?;
+                return Ok(Some(LabelParse {
+                    label_start: start + 1,
+                    label_end,
+                    link_end: pos,
+                    leave,
+                }));
             }
         }
 
@@ -524,12 +536,17 @@ impl Parser<'_> {
                     // Link nesting prohibition
                     if !is_image
                         && has_inner_bracket
-                        && self.label_contains_link(label, brackets, start + 1)
+                        && self.label_contains_link(label, brackets, base + start + 1)
                     {
                         return Ok(None);
                     }
-                    self.render_ref_link(label, &dest, &title, is_image)?;
-                    return Ok(Some(pos));
+                    let leave = self.enter_label_span(&dest, &title, is_image)?;
+                    return Ok(Some(LabelParse {
+                        label_start: start + 1,
+                        label_end,
+                        link_end: pos,
+                        leave,
+                    }));
                 }
             }
         }
@@ -551,12 +568,17 @@ impl Parser<'_> {
                 // Link nesting prohibition
                 if !is_image
                     && has_inner_bracket
-                    && self.label_contains_link(label, brackets, start + 1)
+                    && self.label_contains_link(label, brackets, base + start + 1)
                 {
                     return Ok(None);
                 }
-                self.render_ref_link(label, &dest, &title, is_image)?;
-                return Ok(Some(label_end + 1));
+                let leave = self.enter_label_span(&dest, &title, is_image)?;
+                return Ok(Some(LabelParse {
+                    label_start: start + 1,
+                    label_end,
+                    link_end: label_end + 1,
+                    leave,
+                }));
             }
         }
 
@@ -809,7 +831,7 @@ impl Parser<'_> {
         &mut self,
         content: &[u8],
         start: usize,
-    ) -> Result<Option<usize>, parser::Error> {
+    ) -> Result<Option<LabelParse>, parser::Error> {
         // start points at first '[', next char is also '['
         let mut pos = start + 2;
 
@@ -849,14 +871,9 @@ impl Parser<'_> {
 
         let inner_end = pos;
 
-        // Determine target and label
+        // Determine the target
         let target = if let Some(pp) = pipe_pos {
             &content[inner_start..pp]
-        } else {
-            &content[inner_start..inner_end]
-        };
-        let label = if let Some(pp) = pipe_pos {
-            &content[pp + 1..inner_end]
         } else {
             &content[inner_start..inner_end]
         };
@@ -874,51 +891,17 @@ impl Parser<'_> {
                 ..Default::default()
             },
         )?;
-        self.process_label_content(label)?;
-        self.renderer.leave_span(Span::Wikilink)?;
-
-        Ok(Some(pos + 2)) // skip both ']'
-    }
-
-    /// Render a reference link/image given the resolved ref def.
-    pub fn render_ref_link(
-        &mut self,
-        label_content: &[u8],
-        dest: &[u8],
-        title: &[u8],
-        is_image: bool,
-    ) -> Result<(), parser::Error> {
-        if self.image_nesting_level > 0 {
-            // Inside image alt text — emit only text, no HTML tags
-            self.process_label_content(label_content)?;
-        } else if is_image {
-            self.renderer.enter_span(
-                Span::Img,
-                SpanAttrs {
-                    href: dest,
-                    title,
-                    ..Default::default()
-                },
-            )?;
-            self.image_nesting_level += 1;
-            self.process_label_content(label_content)?;
-            self.image_nesting_level -= 1;
-            self.renderer.leave_span(Span::Img)?;
+        let label_start = if let Some(pp) = pipe_pos {
+            pp + 1
         } else {
-            self.renderer.enter_span(
-                Span::A,
-                SpanAttrs {
-                    href: dest,
-                    title,
-                    ..Default::default()
-                },
-            )?;
-            self.link_nesting_level += 1;
-            self.process_label_content(label_content)?;
-            self.link_nesting_level -= 1;
-            self.renderer.leave_span(Span::A)?;
-        }
-        Ok(())
+            inner_start
+        };
+        Ok(Some(LabelParse {
+            label_start,
+            label_end: inner_end,
+            link_end: pos + 2, // skip both ']'
+            leave: LabelLeave::Wikilink,
+        }))
     }
 
     pub fn find_autolink(&self, content: &[u8], start: usize) -> Option<Autolink> {

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -39,9 +39,6 @@ pub struct Parser<'a> {
     pub renderer: Renderer<'a>,
     pub image_nesting_level: u32,
     pub link_nesting_level: u32,
-    // Depth of link/image-label recursion, capped in process_label_content
-    // (links.rs) to keep nested-label rendering linear.
-    pub label_nesting_level: u32,
 
     // Code indent offset: 4 normally, maxInt if no_indented_code_blocks
     pub code_indent_offset: u32,
@@ -65,6 +62,9 @@ pub struct Parser<'a> {
     // Scratch storage recycled by compute_bracket_matches (links.rs) so inline
     // processing does not allocate a bracket-pair map per block.
     pub bracket_pairs: Vec<(OFF, OFF)>,
+    // Label-frame stack recycled by process_inline_content (inlines.rs) so
+    // blocks with links do not allocate a frame stack per block.
+    pub label_frames: Vec<crate::inlines::LabelFrame>,
     // Memo of failed closing-delimiter searches in find_html_tag (inlines.rs).
     // Cell because find_html_tag is a &self query reached from both &self and
     // &mut self scanners.
@@ -183,7 +183,6 @@ impl<'a> Parser<'a> {
             renderer: rend,
             image_nesting_level: 0,
             link_nesting_level: 0,
-            label_nesting_level: 0,
             code_indent_offset: if flags.no_indented_code_blocks {
                 u32::MAX
             } else {
@@ -197,6 +196,7 @@ impl<'a> Parser<'a> {
             buffer: Vec::new(),
             emph_delims: Vec::new(),
             bracket_pairs: Vec::new(),
+            label_frames: Vec::new(),
             html_scan_memo: Cell::new(HtmlScanMemo::EMPTY),
             n_containers: 0,
             current_block: None,

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -300,8 +300,10 @@ impl<'a> Parser<'a> {
     //   find_html_tag
     //
     // links.rs — impl Parser:
-    //   process_link, try_match_bracket_link, label_contains_link,
-    //   process_wiki_link, render_ref_link, find_autolink, render_autolink
+    //   compute_bracket_matches, match_bracket, scan_bracket_close,
+    //   enter_label_span, process_link, try_match_bracket_link,
+    //   label_contains_link, process_wiki_link, find_autolink,
+    //   render_autolink
     //
     // line_analysis.rs — impl Parser:
     //   is_setext_underline, is_hr_line, is_atx_header_line,

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -39,6 +39,9 @@ pub struct Parser<'a> {
     pub renderer: Renderer<'a>,
     pub image_nesting_level: u32,
     pub link_nesting_level: u32,
+    // Depth of link/image-label recursion, capped in process_label_content
+    // (links.rs) to keep nested-label rendering linear.
+    pub label_nesting_level: u32,
 
     // Code indent offset: 4 normally, maxInt if no_indented_code_blocks
     pub code_indent_offset: u32,
@@ -180,6 +183,7 @@ impl<'a> Parser<'a> {
             renderer: rend,
             image_nesting_level: 0,
             link_nesting_level: 0,
+            label_nesting_level: 0,
             code_indent_offset: if flags.no_indented_code_blocks {
                 u32::MAX
             } else {

--- a/src/md/render_blocks.rs
+++ b/src/md/render_blocks.rs
@@ -1,6 +1,6 @@
 use super::helpers;
 use super::parser::{Error as ParserError, Parser};
-use super::types::{self, BlockType, JsResult, OFF, TextType, VerbatimLine};
+use super::types::{self, BlockType, JsResult, TextType, VerbatimLine};
 
 impl Parser<'_> {
     pub fn enter_block(&mut self, block_type: BlockType, data: u32, flags: u32) -> JsResult<()> {
@@ -168,15 +168,9 @@ impl Parser<'_> {
                     } else {
                         cell_content
                     };
-                    self.process_inline_content(
-                        unescaped,
-                        vline.beg + OFF::try_from(cell_beg).expect("int cast"),
-                    )?;
+                    self.process_inline_content(unescaped)?;
                 } else {
-                    self.process_inline_content(
-                        cell_content,
-                        vline.beg + OFF::try_from(cell_beg).expect("int cast"),
-                    )?;
+                    self.process_inline_content(cell_content)?;
                 }
             }
             self.leave_block(cell_type, 0)?;

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -739,6 +739,12 @@ describe("pathological bracket inputs", () => {
     );
     // Control: plain shortcut references still resolve.
     expect(Markdown.html("[foo]: /u\n\n[foo]\n")).toBe('<p><a href="/u">foo</a></p>\n');
+    // A reference label must start immediately after the closing ']': a
+    // failed inline-link parse must not leave the scan position on a later
+    // '[' and read it as the reference.
+    expect(Markdown.html("[ref]: /u\n\n[foo](bar [ref])\n")).toBe('<p>[foo](bar <a href="/u">ref</a>)</p>\n');
+    expect(Markdown.html("[ref]: /u\n\n[foo][ref]\n")).toBe('<p><a href="/u">foo</a></p>\n');
+    expect(Markdown.html("[ref]: /u\n\n[foo](/x)[ref]\n")).toBe('<p><a href="/x">foo</a><a href="/u">ref</a></p>\n');
   });
 });
 

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -725,6 +725,21 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html("![\\[escaped\\]](u)\n")).toBe('<p><img src="u" alt="[escaped]" /></p>\n');
     expect(Markdown.ansi("[[target|wiki *label*]]", { colors: false })).toBe("[[wiki label]]\n");
   });
+
+  test("link-validity lookahead agrees with the link parser", () => {
+    // [foo][x] with x undefined is not a link: the full reference fails and
+    // the shortcut form may not be followed by '['. The lookahead used by
+    // label_contains_link and the emphasis collector must agree, or the
+    // outer link is wrongly rejected as containing a link.
+    const doc = "[foo]: /u\n\n[outer [foo][x] text](dest)\n";
+    expect(Markdown.html(doc)).toBe('<p><a href="dest">outer [foo][x] text</a></p>\n');
+    // Control: a real inner link still rejects the outer candidate.
+    expect(Markdown.html("[foo]: /u\n\n[outer [foo] text](dest)\n")).toBe(
+      '<p>[outer <a href="/u">foo</a> text](dest)</p>\n',
+    );
+    // Control: plain shortcut references still resolve.
+    expect(Markdown.html("[foo]: /u\n\n[foo]\n")).toBe('<p><a href="/u">foo</a></p>\n');
+  });
 });
 
 // ============================================================================

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -686,20 +686,24 @@ describe("pathological bracket inputs", () => {
   // ~256 KB). Label recursion is now capped at depth 32; deeper labels are
   // emitted as plain text.
   test("nested image/link labels render in linear time", async () => {
+    // The first case's alt="![ check fails deterministically on the unfixed
+    // build (a label was never emitted verbatim), independent of the 30s
+    // kill, so the sizes only need to be large enough to make the quadratic
+    // visible, not to outlast the timeout.
     await expectRendersQuickly(`
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
         const cases = [
-          ["nested inline images", fill(20000, "![") + fill(20000, "](u)"), out => out.includes('<img src="u"') && out.includes('alt="![')],
-          ["link/image alternation", fill(18000, "[![") + fill(18000, "](u)"), out => out.includes('<a href="u"')],
-          ["nested reference images", "[r]: /u\\n\\n" + fill(20000, "![") + fill(20000, "][r]"), out => out.includes('<img src="/u"')],
-          ["nested images, unclosed tail", fill(30000, "![") + "x", out => out.includes("![![")],
+          ["nested inline images", fill(10000, "![") + fill(10000, "](u)"), out => out.includes('<img src="u"') && out.includes('alt="![')],
+          ["link/image alternation", fill(9000, "[![") + fill(9000, "](u)"), out => out.includes('<a href="u"')],
+          ["nested reference images", "[r]: /u\\n\\n" + fill(10000, "![") + fill(10000, "][r]"), out => out.includes('<img src="/u"')],
+          ["nested images, unclosed tail", fill(15000, "![") + "x", out => out.includes("![![")],
         ];
         for (const [name, input, check] of cases) {
           const out = Bun.markdown.html(input);
           if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
           console.log("OK " + name);
         }
-        Bun.markdown.ansi(fill(20000, "![") + fill(20000, "](u)"), { colors: false });
+        Bun.markdown.ansi(fill(10000, "![") + fill(10000, "](u)"), { colors: false });
         console.log("OK ansi nested images");
         console.log("DONE");
       `);

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -680,45 +680,44 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html(wiki(40), { wikiLinks: true })).not.toContain('data-target="t"');
   });
 
-  // Rendering a link/image label re-parses the label slice, so constructs
-  // nested inside their own labels used to cost O(label) per level: a flood
-  // of "![" openers closed by "](u)" repeats was O(n²) (fuzzer-found hang at
-  // ~256 KB). Label recursion is now capped at depth 32; deeper labels are
-  // emitted as plain text.
+  // Rendering a link/image label used to recurse: each nesting level
+  // re-tokenized its whole label (bracket map, emphasis state), so a flood
+  // of "![" openers closed by "](u)" repeats was O(n²) — a fuzzer-found
+  // ~256 KB input hung for ~30s and deeper inputs aborted with OOM. Label
+  // frames now share the slice's bracket map and are driven iteratively, so
+  // rendering is linear and nesting depth is unlimited. The exact-output
+  // assertions double as the regression check: only a full (non-truncated,
+  // non-capped) parse of the 250 KB nesting chain flattens to these strings.
   test("nested image/link labels render in linear time", async () => {
-    // The first case's alt="![ check fails deterministically on the unfixed
-    // build (a label was never emitted verbatim), independent of the 30s
-    // kill, so the sizes only need to be large enough to make the quadratic
-    // visible, not to outlast the timeout.
     await expectRendersQuickly(`
         const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
         const cases = [
-          ["nested inline images", fill(10000, "![") + fill(10000, "](u)"), out => out.includes('<img src="u"') && out.includes('alt="![')],
-          ["link/image alternation", fill(9000, "[![") + fill(9000, "](u)"), out => out.includes('<a href="u"')],
-          ["nested reference images", "[r]: /u\\n\\n" + fill(10000, "![") + fill(10000, "][r]"), out => out.includes('<img src="/u"')],
-          ["nested images, unclosed tail", fill(15000, "![") + "x", out => out.includes("![![")],
+          ["nested inline images", fill(43000, "![") + fill(43000, "](u)"), out => out === '<p><img src="u" alt="" /></p>\\n'],
+          ["link/image alternation", fill(36000, "[![") + fill(36000, "](u)"), out => out.endsWith('<a href="u"><img src="u" alt="" /></a></p>\\n')],
+          ["nested reference images", "[r]: /u\\n\\n" + fill(40000, "![") + fill(40000, "][r]"), out => out === '<p><img src="/u" alt="" /></p>\\n'],
+          ["nested images, unclosed tail", fill(60000, "![") + "x", out => out.includes("![![")],
         ];
         for (const [name, input, check] of cases) {
           const out = Bun.markdown.html(input);
           if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
           console.log("OK " + name);
         }
-        Bun.markdown.ansi(fill(10000, "![") + fill(10000, "](u)"), { colors: false });
+        const ansi = Bun.markdown.ansi(fill(43000, "![") + fill(43000, "](u)"), { colors: false });
+        if (ansi !== "[img] (image)\\n") throw new Error("unexpected ansi output: " + JSON.stringify(ansi.slice(0, 200)));
         console.log("OK ansi nested images");
         console.log("DONE");
       `);
   }, 90_000);
 
-  test("image and link label nesting within the cap is unchanged", () => {
-    const nest = (depth: number) => "![".repeat(depth) + "x" + "](u)".repeat(depth);
-    // Nested image alt text flattens to the innermost text.
+  test("deeply nested image/link labels flatten exactly at any depth", () => {
+    const nest = (depth: number) =>
+      Buffer.alloc(depth * 2, "![").toString() + "x" + Buffer.alloc(depth * 4, "](u)").toString();
+    // Nested image alt text flattens to the innermost text, regardless of
+    // depth: there is no nesting cap and no native-stack recursion.
     expect(Markdown.html(nest(2))).toBe('<p><img src="u" alt="x" /></p>\n');
-    expect(Markdown.html(nest(33))).toBe('<p><img src="u" alt="x" /></p>\n');
-    // Past the cap the construct is still an image, but the label at the cap
-    // is alt text verbatim instead of being flattened further.
-    const over = Markdown.html(nest(40));
-    expect(over).toContain('<img src="u"');
-    expect(over).toContain('alt="![');
+    expect(Markdown.html(nest(40))).toBe('<p><img src="u" alt="x" /></p>\n');
+    expect(Markdown.html(nest(20000))).toBe('<p><img src="u" alt="x" /></p>\n');
+    expect(Markdown.ansi(nest(5000), { colors: false })).toBe("[img] x\n");
     // Image inside a link, link inside an image alt: normal nesting depths.
     expect(Markdown.html("[![alt](i.png)](p)\n")).toBe('<p><a href="p"><img src="i.png" alt="alt" /></a></p>\n');
     expect(Markdown.html("![a ![b](u2) c](u1)\n")).toBe('<p><img src="u1" alt="a b c" /></p>\n');

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -679,6 +679,49 @@ describe("pathological bracket inputs", () => {
     // Past the cap the outer candidate is rejected.
     expect(Markdown.html(wiki(40), { wikiLinks: true })).not.toContain('data-target="t"');
   });
+
+  // Rendering a link/image label re-parses the label slice, so constructs
+  // nested inside their own labels used to cost O(label) per level: a flood
+  // of "![" openers closed by "](u)" repeats was O(n²) (fuzzer-found hang at
+  // ~256 KB). Label recursion is now capped at depth 32; deeper labels are
+  // emitted as plain text.
+  test("nested image/link labels render in linear time", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const cases = [
+          ["nested inline images", fill(20000, "![") + fill(20000, "](u)"), out => out.includes('<img src="u"') && out.includes('alt="![')],
+          ["link/image alternation", fill(18000, "[![") + fill(18000, "](u)"), out => out.includes('<a href="u"')],
+          ["nested reference images", "[r]: /u\\n\\n" + fill(20000, "![") + fill(20000, "][r]"), out => out.includes('<img src="/u"')],
+          ["nested images, unclosed tail", fill(30000, "![") + "x", out => out.includes("![![")],
+        ];
+        for (const [name, input, check] of cases) {
+          const out = Bun.markdown.html(input);
+          if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK " + name);
+        }
+        Bun.markdown.ansi(fill(20000, "![") + fill(20000, "](u)"), { colors: false });
+        console.log("OK ansi nested images");
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("image and link label nesting within the cap is unchanged", () => {
+    const nest = (depth: number) => "![".repeat(depth) + "x" + "](u)".repeat(depth);
+    // Nested image alt text flattens to the innermost text.
+    expect(Markdown.html(nest(2))).toBe('<p><img src="u" alt="x" /></p>\n');
+    expect(Markdown.html(nest(33))).toBe('<p><img src="u" alt="x" /></p>\n');
+    // Past the cap the construct is still an image, but the label at the cap
+    // is alt text verbatim instead of being flattened further.
+    const over = Markdown.html(nest(40));
+    expect(over).toContain('<img src="u"');
+    expect(over).toContain('alt="![');
+    // Image inside a link, link inside an image alt: normal nesting depths.
+    expect(Markdown.html("[![alt](i.png)](p)\n")).toBe('<p><a href="p"><img src="i.png" alt="alt" /></a></p>\n');
+    expect(Markdown.html("![a ![b](u2) c](u1)\n")).toBe('<p><img src="u1" alt="a b c" /></p>\n');
+    expect(Markdown.html("[`code` *em*](u)\n")).toBe('<p><a href="u"><code>code</code> <em>em</em></a></p>\n');
+    expect(Markdown.html("![\\[escaped\\]](u)\n")).toBe('<p><img src="u" alt="[escaped]" /></p>\n');
+    expect(Markdown.ansi("[[target|wiki *label*]]", { colors: false })).toBe("[[wiki label]]\n");
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
Fixes a fuzzer-found hang in `Bun.markdown` (signature: `hang:markdown:...Parser13find_autolink`, a ~256 KB nested-bracket input).

### Repro

```js
// before: ~30s at 256 KB, OOM beyond that
Bun.markdown.html("![".repeat(43000) + "](u)".repeat(43000));
```

Scaling before the fix (release): 8 KB 30ms, 16 KB 114ms, 32 KB 453ms, 64 KB 1.8s, 4x per doubling. The same blowup existed for reference-style nested images (`"![".repeat(n) + "][r]".repeat(n)`) and link/image alternation (`"[![".repeat(n) + "](u)".repeat(n)`).

### Cause

Rendering a link/image/wikilink label called `process_inline_content` recursively on the label slice, and every recursion level rebuilt the bracket-pair map and emphasis state for its whole label. Nested images are labels inside labels, so an n-deep chain did n passes over shrinking slices: O(n^2) total, with unbounded native recursion on top (deep inputs aborted with OOM).

### Fix

No depth cap (an earlier revision of this PR used one; review asked for the code to be faster instead). Label rendering is now iterative over state computed once:

- `process_inline_content` builds the bracket-pair map once per block. Label rendering shares it through a `base` offset instead of rebuilding it per nesting level. The map lookup helpers already supported `base`; the rebuild was the quadratic part.
- `process_link` / `process_wiki_link` no longer recurse. They parse the construct, emit the opening span, and return the label range plus a close action (`LabelParse`). The walk in `process_inline_content` pushes its state on an explicit frame stack and continues inside the label, popping and closing the span when the label ends.

Each nesting level now only walks its own direct text and children (nested constructs are skipped via their end position), so total work is linear in the input. Nesting depth is bounded by the heap, not the native stack: there is no cap and no stack overflow, and a 50,000-deep chain flattens correctly.

Output is unchanged. Sharing the map is sound because a code span, HTML span or autolink that starts inside a label cannot extend past the label's closing bracket: that bracket is visible to the same tokenization that paired it, so per-label re-tokenization and the shared map agree. Verified byte-identical output against the previous implementation on nested/escaped/code-span/wikilink bracket cases and the full spec suites.

### Performance (release, x64 Linux)

| input | before | with cap (reverted) | now |
|---|---|---|---|
| nested images 256 KB | ~30s | 41ms | 6.9ms |
| nested images 1 MB | OOM | 165ms | 31ms |
| nested images 4 MB | OOM | 685ms | 137ms |
| 188 KB ordinary document | 3.1ms | 3.1ms | 3.2ms (within run-to-run noise; link-heavy docs show a smaller delta than no-link docs, so the delta tracks binary layout, not the change) |

### Tests

In `test/js/bun/md/md-edge-cases.test.ts`:

- `nested image/link labels render in linear time`: ~250 KB floods of all three quadratic shapes plus an unclosed-tail variant, with exact-output assertions (`<p><img src="u" alt="" /></p>`) that only a full non-truncated parse of the nesting chain produces, through both `Bun.markdown.html` and `Bun.markdown.ansi`. Fails on the unfixed build (hang/OOM).
- `deeply nested image/link labels flatten exactly at any depth`: exact output for depths 2, 40, and 20,000, plus image-in-link, image-in-image-alt, code span/emphasis/escapes in labels, and wikilink labels.

Full `test/js/bun/md/` suite (1054 tests, includes the CommonMark and GFM spec conformance files) passes.



### Related consistency fixes surfaced during review

`try_match_bracket_link` (the lookahead used by the emphasis collector and `label_contains_link`) and `process_link` (the renderer) must agree on what is a link. Review found three pre-existing disagreements in this pair, fixed here since the PR reworks exactly these functions:

- The lookahead's angle-bracket destination did not reject CR like the parser does (10ac5a521c; not currently reachable from document input, since block parsing normalizes line endings).
- The lookahead's shortcut-reference fallback lacked the parser's "not followed by [" rule, so `[outer [foo][x] text](dest)` (foo defined, x not) wrongly rendered entirely as literal text (ed5e20bbac, tested).
- The parser's reference branch read the scan position left over from a failed inline-link parse instead of the byte after `]`, so `[foo](bar [ref])` consumed through `[ref]` and rendered `[foo]` with ref's destination (83f68bfdba, tested; now matches cmark).
