### PR TITLE
Fix quadratic backtracking in TypeScript type-argument speculation

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -397,6 +397,19 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// binary search.
     pub(crate) ts_conditional_arrow_attempts: Vec<u32>,
 
+    /// Byte offsets of `<` tokens where a type-context `skip_type_script_type_arguments`
+    /// scan failed during speculative parsing. The scan only consumes tokens, so its
+    /// outcome depends only on the offset, and a repeated scan can fail at once. In
+    /// `a<T<T<T<...` the expression parser asks "is this a type argument list?" at
+    /// each `<`; every attempt scans the rest of the chain as nested lists before it
+    /// fails, which is quadratic without the memo (found by fuzzing). A failing scan
+    /// records every nested level as it unwinds, in descending offset order, so this
+    /// is a hash set and not a sorted `Vec` like the two memos above. One `u32` per
+    /// failed nested list: it stays empty (no allocation) for ordinary comparisons
+    /// like `a < b`, and gets entries for shapes like `a < b < c`.
+    pub(crate) ts_type_args_backtracks:
+        bun_collections::hashbrown::HashSet<u32, bun_wyhash::BuildHasher>,
+
     /// When this flag is enabled, we attempt to fold all expressions that
     /// TypeScript would consider to be "constant expressions". This flag is
     /// enabled inside each enum body block since TypeScript requires numeric
@@ -9698,6 +9711,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             reported_stack_overflow: core::cell::Cell::new(false),
             ts_infer_constraint_backtracks: Vec::new(),
             ts_conditional_arrow_attempts: Vec::new(),
+            ts_type_args_backtracks: Default::default(),
             arena,
             then_catch_chain: ThenCatchChain {
                 next_target: null_expr_data(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -397,16 +397,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// binary search.
     pub(crate) ts_conditional_arrow_attempts: Vec<u32>,
 
-    /// Byte offsets of `<` tokens where a type-context `skip_type_script_type_arguments`
-    /// scan failed during speculative parsing. The scan only consumes tokens, so its
-    /// outcome depends only on the offset, and a repeated scan can fail at once. In
-    /// `a<T<T<T<...` the expression parser asks "is this a type argument list?" at
-    /// each `<`; every attempt scans the rest of the chain as nested lists before it
-    /// fails, which is quadratic without the memo (found by fuzzing). A failing scan
-    /// records every nested level as it unwinds, in descending offset order, so this
-    /// is a hash set and not a sorted `Vec` like the two memos above. One `u32` per
-    /// failed nested list: it stays empty (no allocation) for ordinary comparisons
-    /// like `a < b`, and gets entries for shapes like `a < b < c`.
+    /// Offsets of `<` tokens where a type-context `skip_type_script_type_arguments` scan
+    /// failed while speculating (log disabled, so a caller restores the lexer and drops
+    /// the error). The outcome depends only on the offset, so a repeat fails at once.
+    /// Without it, each `<` in `a<T<T<T<...` re-scans the rest of the chain (quadratic,
+    /// found by fuzzing). A hash set, not a sorted `Vec`: a failing chain records its
+    /// offsets innermost first. Empty for plain `a < b`: the expression-level variant
+    /// (stricter closer, retried at most once per precedence level) is not recorded.
     pub(crate) ts_type_args_backtracks:
         bun_collections::hashbrown::HashSet<u32, bun_wyhash::BuildHasher>,
 

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1409,16 +1409,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        // Memoize failures of the type-context variant while speculating (the
-        // log is disabled, so a caller above restores the lexer and discards the
-        // error, and failing early loses no diagnostic). The expression variant
-        // stays out: the expression parser retries it at one offset only a
-        // bounded number of times, it accepts fewer closing tokens than this
-        // variant so the two could not share entries, and leaving it out keeps
-        // the set empty for ordinary comparisons like `a < b`. The JSX element
-        // variant lexes the closing `>` differently and stays out too.
-        // `expect_less_than` bumps `lexer.start` when it splits a compound
-        // token like `<<`, so the offset alone identifies the scan.
+        // See `P::ts_type_args_backtracks`. The JSX element variant lexes its `>` differently.
         let memoize = !IS_INSIDE_JSX_ELEMENT
             && !IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION
             && self.lexer.is_log_disabled;

--- a/src/js_parser/parse/parse_skip_typescript.rs
+++ b/src/js_parser/parse/parse_skip_typescript.rs
@@ -1409,6 +1409,46 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // Memoize failures of the type-context variant while speculating (the
+        // log is disabled, so a caller above restores the lexer and discards the
+        // error, and failing early loses no diagnostic). The expression variant
+        // stays out: the expression parser retries it at one offset only a
+        // bounded number of times, it accepts fewer closing tokens than this
+        // variant so the two could not share entries, and leaving it out keeps
+        // the set empty for ordinary comparisons like `a < b`. The JSX element
+        // variant lexes the closing `>` differently and stays out too.
+        // `expect_less_than` bumps `lexer.start` when it splits a compound
+        // token like `<<`, so the offset alone identifies the scan.
+        let memoize = !IS_INSIDE_JSX_ELEMENT
+            && !IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION
+            && self.lexer.is_log_disabled;
+        debug_assert!(self.lexer.start <= u32::MAX as usize);
+        let offset = self.lexer.start as u32;
+        if memoize && self.ts_type_args_backtracks.contains(&offset) {
+            return Err(Error::Backtrack);
+        }
+
+        let result = self.skip_type_script_type_arguments_inner::<
+            IS_INSIDE_JSX_ELEMENT,
+            IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION,
+        >();
+        match result {
+            // Stack and memory exhaustion are not properties of the offset
+            Ok(_) | Err(Error::StackOverflow | Error::Alloc(_)) => {}
+            Err(_) if memoize => {
+                self.ts_type_args_backtracks.insert(offset);
+            }
+            Err(_) => {}
+        }
+        result
+    }
+
+    fn skip_type_script_type_arguments_inner<
+        const IS_INSIDE_JSX_ELEMENT: bool,
+        const IS_PARSE_TYPE_ARGUMENTS_IN_EXPRESSION: bool,
+    >(
+        &mut self,
+    ) -> Result<bool, Error> {
         self.lexer.expect_less_than::<false>()?;
 
         loop {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -901,7 +901,9 @@ describe("Bun.Transpiler", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect(stderr).toBe("");
-      const best = JSON.parse(stdout || "{}");
+      // A signal here means the 30s timeout killed a parse that hung.
+      expect(proc.signalCode).toBeNull();
+      const best = JSON.parse(stdout);
       // ~1 when linear, ~4 when quadratic.
       expect(best.long / best.short).toBeLessThan(2.5);
       expect(exitCode).toBe(0);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, hideFromStackTrace, tempDir } from "harness";
+import { bunEnv, bunExe, hideFromStackTrace, isASAN, isDebug, tempDir } from "harness";
 import { join } from "path";
 
 describe("Bun.Transpiler", () => {
@@ -842,6 +842,70 @@ describe("Bun.Transpiler", () => {
       expect(stdout).toContain("DONE");
       expect(exitCode).toBe(0);
     }, 90_000);
+
+    it("speculative type argument scans over an unclosed `<` chain take linear time", async () => {
+      // In expression position, every `<` after an identifier starts a speculative
+      // "is this a type argument list?" scan. In `A<Promise<T<T<T...` every scan
+      // consumed the whole rest of the chain before it failed, so the parse was
+      // quadratic in the chain length (found by fuzzing). Failed scans are now
+      // memoized by the offset of their `<`. Both synthetic inputs hold the same
+      // number of `<T` units, so with the memo they take the same time, and without
+      // it the 4x longer chains take ~4x as long. The ratio does not depend on
+      // machine or build speed. These chains stay far below the parser's stack
+      // check, whose failures the memo does not record. The exact fuzz input (one
+      // chain, ~10,500 levels deep) nests past that check on debug and ASAN builds,
+      // so only release builds parse it here.
+      using dir = tempDir("ts-type-args-speculation", {
+        "fuzz-input.gz.b64":
+          "H4sIAAAAAAACA+3QwQnAIBAAwbepSQ6ugzxswUceIsT+IWVEkmELWJis5z3HtXptf6q8ND6SN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5s2bN2/evHnz5v157+0kIh4umLOXg1IAAA==",
+        "check.ts": `
+          const fill = (n: number, unit: string) => Buffer.alloc(n * unit.length, unit).toString();
+          const source = (chains: number, units: number) => fill(chains, "A<Promise" + fill(units, "<T") + ">>;\\n");
+          // Only the innermost "T<T<T>>" of a chain is a valid type argument list (and
+          // is erased). Every "<" before it fails the scan and prints as a comparison.
+          const expected = (chains: number, units: number) => fill(chains, "A < Promise" + fill(units - 2, " < T") + ";\\n");
+
+          const transpiler = new Bun.Transpiler({ loader: "tsx" });
+          const inputs = { short: [24, 250], long: [6, 1000] };
+          const best = { short: Infinity, long: Infinity };
+          for (let run = 0; run < 5; run++) {
+            for (const [name, [chains, units]] of Object.entries(inputs)) {
+              const input = source(chains, units);
+              const start = performance.now();
+              const output = transpiler.transformSync(input);
+              best[name] = Math.min(best[name], performance.now() - start);
+              if (output !== expected(chains, units)) throw new Error(name + ": unexpected output: " + output.slice(0, 100));
+            }
+          }
+
+          if (process.argv[2] === "with-fuzz-input") {
+            const b64 = await Bun.file("fuzz-input.gz.b64").text();
+            const input = Buffer.from(Bun.gunzipSync(Buffer.from(b64, "base64"))).toString("latin1");
+            // 57 lines of "A<Promise<T...<T<", then "T<T...<T>>": one expression.
+            if (!input.endsWith("<T<T>>")) throw new Error("unexpected fuzz input");
+            const expected = input.slice(0, -"<T<T>>".length).replace(/[\\t\\n]/g, "").replaceAll("<", " < ") + ";\\n";
+            if (transpiler.transformSync(input) !== expected) throw new Error("fuzz input: unexpected output");
+          }
+          console.log(JSON.stringify(best));
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "check.ts", isDebug || isASAN ? "synthetic-only" : "with-fuzz-input"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: 30_000,
+        killSignal: "SIGKILL",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      const best = JSON.parse(stdout || "{}");
+      // ~1 when linear, ~4 when quadratic.
+      expect(best.long / best.short).toBeLessThan(2.5);
+      expect(exitCode).toBe(0);
+    });
 
     it("type arguments in expression require a bare '>' closer", () => {
       // TypeScript's "parseTypeArgumentsInExpression" only accepts a bare ">"


### PR DESCRIPTION
### Problem
- A 21 KB TSX fuzz input, `A<Promise` followed by about 10,500 unclosed `<T` units, takes 4 s to transpile.
- Each `<` after an identifier in an expression starts a speculative type-argument scan (`skip_type_script_type_arguments_with_backtracking`, `src/js_parser/parse/parse_skip_typescript.rs`). In the chain, every scan consumes the rest of the input as nested lists before it fails: quadratic.

### Fix
- `skip_type_script_type_arguments` records in `ts_type_args_backtracks` the `<` offset of each nested (type-context) list whose scan fails during speculation, at every nested level as the failure unwinds. A repeated scan at a recorded offset fails at once.
- Correct because the scan only consumes tokens, so its outcome depends only on the offset. `StackOverflow` and `Alloc` are not recorded. Only speculative scans (lexer log disabled) take part: there a caller restores the lexer and drops the error. The expression-level variant accepts fewer closing tokens and stays out.
- Reworked after review: rebased, one memoized variant instead of a variant bit in the key, and a test that fails unfixed on release builds too.
- Verified: `test/bundler/transpiler/transpiler.test.js` (new test), `test/bundler/esbuild/ts.test.ts`, the stack-overflow tests, and 32 disambiguation cases that print as on bun 1.4.3.

### Background
- TypeScript cannot tell `f<T>(x)` from `f < T > (x)` without trying. The parser snapshots the lexer, scans a candidate list, and restores it on failure.
- The parser has two memos of this kind: `ts_infer_constraint_backtracks` (#31307) and `ts_conditional_arrow_attempts` (#40818).
- A stack check stops very deep nesting with `StackOverflow`. A deeper chain still re-scans up to that depth per `<` (see Notes).

<details><summary>Notes</summary>

- Repro: `new Bun.Transpiler({loader:"tsx"}).transformSync(...)` on the gzip+base64 input in the test. Decoded, it is 57 lines of `A<Promise` + 178 `<T` units ending in `<`, then `T` + 72 `<T` units + `>>`: one expression, one chain.
- Scaling on bun 1.4.3 (release): 500 units 9 ms, 1,000 units 36 ms, 2,000 units 133 ms, 4,000 units 531 ms, 8,000 units 2.1 s. With the memo (debug build): 15 to 20 us per unit, flat from 1,000 to 4,000 units.
- Memory: one `u32` per failed nested list. The set stays empty, with no allocation, for ordinary comparisons (`a < b`, `i < n`, `x < y && ...`), because the expression-level attempt itself is not recorded. It gets entries for shapes like `a < b < c`, where the speculation at the first `<` scans `b<c` as a nested list that fails. It is a hash set and not a sorted `Vec<u32>` like the two sibling memos (#31307 switched to a sorted `Vec` because `infer` backtracks are rare): a failing chain records its offsets innermost first, in descending order, so every insert into an ascending `Vec` would shift the whole vector, which is quadratic again on exactly the input this fixes.
- Why the expression-level variant stays out: the expression parser retries it at one offset only a bounded number of times (once per enclosing precedence level), so recording it saves a constant. The quadratic comes from the nested lists, which were re-scanned once per enclosing `<`. Since #34224 that variant also accepts only a bare `>` as the closer, so it can fail where the type-context variant succeeds (`f<x>=g<y>;`); with one variant in the memo no entry can be read by the other.
- The JSX element variant (`<Foo<T> ...>`) lexes its closing `>` with the JSX lexer and does not use the memo. Lists nested inside it are ordinary type-context scans.
- The new test measures the best of five parses for two inputs with the same number of `<T` units: 24 chains of 250 units and 6 chains of 1,000 units. The ratio long/short is 0.97 to 1.08 with the memo and 3.7 to 4.5 without it (bun 1.4.3 release: `Expected: < 2.5, Received: 4.02`; unfixed debug build: the same, or the 5 s default test timeout first). It also asserts the exact printed output, so the speculation outcomes are unchanged. Chains of 1,000 stay far below the stack check on every build. The verbatim fuzz input nests past the stack check on debug and ASAN builds (28 s there), so the test parses it only on release builds and checks its output.
- Earlier version of this PR (June): keyed by offset for both variants, used the since-removed `err!` macro, and had a time-budget test that passed without the fix on release builds.

</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
ninja: Entering directory `/workspace/bun/build/debug'
[1/162] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/162] gen cpp.rs (cppbind)
[2/162] cargo bun_runtime → libbun_runtime.a
FAILED: rust-target/x86_64-unknown-linux-gnu/debug/libbun_runtime.a 
/workspace/bun/build/release/bun /workspace/bun/scripts/build/stream.ts rust --console --cwd=/workspace/bun --env=CARGO_TERM_COLOR=always --env=BUN_CODEGEN_DIR=/workspace/bun/build/debug/codegen --env=CC=/usr/lib/llvm-21/bin/clang --env=CXX=/usr/lib/llvm-21/bin/clang++ --env=AR=/usr/lib/llvm-21/bin/llvm-ar --env=CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=/usr/lib/llvm-21/bin/clang++ --env=CARGO_HOME=/root/.cargo --env=RUSTUP_HOME=/root/.rustup --env=RUSTUP_TOOLCHAIN=nightly-2026-07-20 --env=CARGO_PROFILE_RELEASE_LTO=off --env=CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 --env=CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS=true --env=CARGO_ENCODED_RUSTFLAGS='-Crelocati
... (truncated)

release without fix: 22 skipped
bun test v1.4.3-canary.1 (cd517ef35)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [0.14ms]
(pass) Bun.Transpiler > normalizes \r\n [0.23ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [0.10ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [0.15ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [0.04ms]
(pass) Bun.Transpiler > property access inlining > works [0.03ms]
(pass) Bun.Transpiler > property access inlining > works nested [0.03ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [1.05ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [0.37ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [8.24ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-chain index into enum [0.48ms]
(pass) Bun.Transpiler > TypeScript > import Foo = Baz.Bar [0.09ms]
(pass) Bun.Transpiler > TypeScript > ternary should parse correctly when
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 22 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/bundler/transpiler/transpiler.test.js
bun test v1.4.3 (f42e98025)

test/bundler/transpiler/transpiler.test.js:
(pass) Bun.Transpiler > handles errors when parsing macros [5.33ms]
(pass) Bun.Transpiler > normalizes \r\n [6.07ms]
1
(pass) Bun.Transpiler > doesn't hang indefinitely #2746 [3.95ms]
(pass) Bun.Transpiler > property access inlining > bails out with spread [9.00ms]
(pass) Bun.Transpiler > property access inlining > bails out with multiple items [2.63ms]
(pass) Bun.Transpiler > property access inlining > works [2.60ms]
(pass) Bun.Transpiler > property access inlining > works nested [2.61ms]
(pass) Bun.Transpiler > property access inlining > bails out when the array item is an optional chain [51.83ms]
(pass) Bun.Transpiler > property access inlining > bails out or strips `this` when the index is a call/assignment target [24.14ms]
(pass) Bun.Transpiler > property access inlining > preserves runtime semantics when inlining from a literal index [287.59ms]
(pass) Bun.Transpiler > property access inlining > bails out on optional-
... (truncated)

release with fix: 22 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 811ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/123] gen generated_host_exports.rs
generated_host_exports.rs: 122 exports (host=5, lazy=10, generic=107, rust=0); 242 extern-C blocks audited
[2/123] gen cpp.rs (cppbind)
[2/123] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_base64 v0.0.0 (/workspace/bun/src/base64)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_parser/p.rs                           | 11 +++++
 src/js_parser/parse/parse_skip_typescript.rs | 31 +++++++++++++
 test/bundler/transpiler/transpiler.test.js   | 68 +++++++++++++++++++++++++++-
 3 files changed, 109 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/js_parser/p.rs                                5      6     20
src/js_parser/parse/parse_skip_typescript.rs      5      6     20
test/bundler/transpiler/transpiler.test.js        4      6     19
```

</details>

**root cause** · written by the author bot

In TSX exp ­ression position each `<` following an identifier begins a speculative scan to decide whether it opens a type argument list, and on a long chain of unclosed `<T` sequences every one of those scans walked the entire remaining chain before failing, so parsing cost grew quadratically with the chain length and a ~21KB input appeared to hang. The fix memoizes failed type argument scans by the source offset of their `<`, so a position that has already been proven not to start a type argument list is rejected immediately instead of re-scanning the suffix, bringing the worst case back …

<!-- robobun:evidence:end -->