### PR TITLE
css: bound the payload cloned when splitting target-incompatible selectors

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2595,6 +2595,7 @@ mod stylesheet_impl {
                 err: None,
                 selector_expansion_multiplier: 1,
                 selector_expansion_total: 0,
+                split_clone_weight_total: 0,
             };
 
             if self.rules.minify(&mut minify_ctx, false).is_err() {

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -515,6 +515,11 @@ pub enum MinifyErrorKind {
     /// Compiling nested rules for the configured browser targets would expand to
     /// more than [`crate::css_rules::MAX_SELECTOR_EXPANSION`] selectors.
     selector_expansion_limit_exceeded,
+    /// Splitting a rule's selectors for the configured browser targets clones
+    /// the rule's declarations and nested rules once per split-off selector,
+    /// and the cumulative weight of those clones exceeded
+    /// [`crate::css_rules::MAX_SELECTOR_SPLIT_CLONE_WEIGHT`].
+    selector_split_clone_limit_exceeded,
     /// Rule minification failed without recording a more specific diagnostic on
     /// `MinifyContext::err`. Defensive fallback — every failing path is expected
     /// to record one before returning an error.
@@ -539,6 +544,10 @@ impl fmt::Display for MinifyErrorKind {
                 f,
                 "Nested CSS rules expand to more than {} selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.",
                 crate::css_rules::MAX_SELECTOR_EXPANSION,
+            ),
+            Self::selector_split_clone_limit_exceeded => write!(
+                f,
+                "Splitting nested CSS rules with selectors unsupported by the configured browser targets duplicates too much CSS. Reduce the nesting depth or the number of selectors per rule, or target browsers that support these selectors.",
             ),
             Self::unknown => write!(f, "CSS minification failed"),
         }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -126,7 +126,10 @@ pub struct Printer<'a> {
     pub sources: Option<&'a Vec<Box<[u8]>>>,
     pub dest: &'a mut dyn Write,
     pub loc: Location,
-    pub indent_amt: u8,
+    /// Two per nesting level. `u32` because valid stylesheets can nest rules
+    /// hundreds of levels deep (bounded only by input size), which overflows a
+    /// `u8` at 128 levels.
+    pub indent_amt: u32,
     pub line: u32,
     pub col: u32,
     pub minify: bool,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -922,7 +922,10 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 /// rules, declarations, selector components (recursing into selector-list
 /// arguments), and raw token lists (token count plus borrowed text length —
 /// the text is borrowed by the clone but re-emitted per clone when printed).
-/// Parsed leaf values are charged a flat constant per declaration: their
+/// Every token variant that stores its text inline is charged that text,
+/// including dimension units, dashed idents, and var()/env()/function names.
+/// Parsed leaf values and `url()` (whose text lives in the stylesheet's
+/// import records, not reachable here) are charged a flat constant: their
 /// per-rule size is bounded by the input, and the number of clones is bounded
 /// by [`MAX_SELECTOR_EXPANSION`]. The walk runs once per split rule, so its
 /// own cost stays proportional to the weight it charges.
@@ -1034,14 +1037,40 @@ mod clone_weight {
             .map(|t| {
                 TOKEN.saturating_add(match t {
                     TokenOrValue::Token(token) => token_text_len(token),
-                    TokenOrValue::Var(var) => var.fallback.as_ref().map_or(0, token_list),
-                    TokenOrValue::Env(env) => env.fallback.as_ref().map_or(0, token_list),
-                    TokenOrValue::Function(f) => token_list(&f.arguments),
+                    TokenOrValue::Var(var) => (var.name.ident.v().len() as u64)
+                        .saturating_add(var.fallback.as_ref().map_or(0, token_list)),
+                    TokenOrValue::Env(env) => env_name_len(&env.name)
+                        .saturating_add(env.fallback.as_ref().map_or(0, token_list)),
+                    TokenOrValue::Function(f) => {
+                        (f.name.v().len() as u64).saturating_add(token_list(&f.arguments))
+                    }
                     TokenOrValue::UnresolvedColor(color) => unresolved_color(color),
+                    TokenOrValue::DashedIdent(ident) => ident.v().len() as u64,
+                    TokenOrValue::AnimationName(name) => animation_name_len(name),
+                    // `Url` stores only an import-record index; see the module
+                    // doc. Remaining variants are fixed-size parsed values.
                     _ => 0,
                 })
             })
             .fold(0u64, u64::saturating_add)
+    }
+
+    fn env_name_len(name: &css::properties::custom::EnvironmentVariableName) -> u64 {
+        use css::properties::custom::EnvironmentVariableName;
+        match name {
+            EnvironmentVariableName::Ua(_) => 0,
+            EnvironmentVariableName::Custom(reference) => reference.ident.v().len() as u64,
+            EnvironmentVariableName::Unknown(ident) => ident.v().len() as u64,
+        }
+    }
+
+    fn animation_name_len(name: &css::properties::animation::AnimationName) -> u64 {
+        use css::properties::animation::AnimationName;
+        match name {
+            AnimationName::None => 0,
+            AnimationName::Ident(ident) => ident.v().len() as u64,
+            AnimationName::String(s) => s.len() as u64,
+        }
     }
 
     fn unresolved_color(color: &css::properties::custom::UnresolvedColor) -> u64 {
@@ -1070,6 +1099,9 @@ mod clone_weight {
             | Token::BadUrl(v)
             | Token::Whitespace(v)
             | Token::Comment(v) => v.len() as u64,
+            // The unit of an unknown dimension is arbitrary-length ident text
+            // (e.g. `1aaaa...`), kept as a raw token.
+            Token::Dimension(d) => d.unit.len() as u64,
             _ => 0,
         }
     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -793,6 +793,29 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         supports: Vec<CssRule<R>>,
         logical: Vec<CssRule<R>>,
     }
+    if incompatible.len() > 0 {
+        // Each split-off selector clones this rule's declarations and entire
+        // nested-rule subtree (loop below). The subtree already contains the
+        // clones split off while minifying deeper levels, so under nesting the
+        // cloned payload compounds exponentially with depth.
+        // `charge_selector_expansion` bounds how many rules this produces but
+        // not their size; bound the cumulative cloned payload too, so huge
+        // token lists or declaration blocks can't multiply into gigabytes
+        // while staying under the selector-count cap.
+        let per_clone = clone_weight::RULE
+            .saturating_add(clone_weight::decl_block(&sty.declarations))
+            .saturating_add(clone_weight::rule_list(&sty.rules));
+        context.split_clone_weight_total = context
+            .split_clone_weight_total
+            .saturating_add(per_clone.saturating_mul(incompatible.len() as u64));
+        if context.split_clone_weight_total > MAX_SELECTOR_SPLIT_CLONE_WEIGHT {
+            context.err = Some(crate::error::MinifyError {
+                kind: crate::error::MinifyErrorKind::selector_split_clone_limit_exceeded,
+                loc: sty.loc,
+            });
+            return Err(MinifyErr::minify_err);
+        }
+    }
     let mut incompatible_rules: SmallList<IncompatibleRuleEntry<R>, 1> =
         SmallList::init_capacity(incompatible.len());
     while incompatible.len() > 0 {
@@ -889,6 +912,167 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     }
 
     Ok(())
+}
+
+/// Weight estimate for the rule clones made by `minify_style_arm`'s
+/// incompatible-selector split, in roughly byte-sized units, charged against
+/// [`MAX_SELECTOR_SPLIT_CLONE_WEIGHT`].
+///
+/// The walk counts the structures whose count or size scales with user input:
+/// rules, declarations, selector components (recursing into selector-list
+/// arguments), and raw token lists (token count plus borrowed text length —
+/// the text is borrowed by the clone but re-emitted per clone when printed).
+/// Parsed leaf values are charged a flat constant per declaration: their
+/// per-rule size is bounded by the input, and the number of clones is bounded
+/// by [`MAX_SELECTOR_EXPANSION`]. The walk runs once per split rule, so its
+/// own cost stays proportional to the weight it charges.
+mod clone_weight {
+    use super::{CssRule, CssRuleList};
+    use crate as css;
+    use css::properties::Property;
+    use css::properties::custom::{TokenList, TokenOrValue};
+    use css::selectors::{Component, PseudoClass, PseudoElement, Selector, SelectorList};
+
+    /// Flat weight of one rule (struct + bookkeeping).
+    pub(super) const RULE: u64 = 64;
+    /// Flat weight of one declaration.
+    const DECL: u64 = 64;
+    const COMPONENT: u64 = 16;
+    const TOKEN: u64 = 16;
+
+    pub(super) fn rule_list<R>(rules: &CssRuleList<R>) -> u64 {
+        rules.v.iter().map(rule).fold(0u64, u64::saturating_add)
+    }
+
+    fn rule<R>(rule: &CssRule<R>) -> u64 {
+        let nested = match rule {
+            CssRule::Style(sty) => selector_list(&sty.selectors)
+                .saturating_add(decl_block(&sty.declarations))
+                .saturating_add(rule_list(&sty.rules)),
+            CssRule::Media(r) => rule_list(&r.rules),
+            CssRule::Supports(r) => rule_list(&r.rules),
+            CssRule::Container(r) => rule_list(&r.rules),
+            CssRule::LayerBlock(r) => rule_list(&r.rules),
+            CssRule::MozDocument(r) => rule_list(&r.rules),
+            CssRule::Scope(r) => rule_list(&r.rules),
+            CssRule::StartingStyle(r) => rule_list(&r.rules),
+            CssRule::Nesting(r) => selector_list(&r.style.selectors)
+                .saturating_add(decl_block(&r.style.declarations))
+                .saturating_add(rule_list(&r.style.rules)),
+            CssRule::Keyframes(r) => r
+                .keyframes
+                .iter()
+                .map(|k| decl_block(&k.declarations))
+                .fold(0u64, u64::saturating_add),
+            CssRule::Unknown(r) => {
+                token_list(&r.prelude).saturating_add(r.block.as_ref().map_or(0, token_list))
+            }
+            // Remaining rules can't contain nested style rules; their payload
+            // is bounded per rule by the input.
+            _ => 0,
+        };
+        RULE.saturating_add(nested)
+    }
+
+    pub(super) fn decl_block(decls: &css::DeclarationBlock) -> u64 {
+        decls
+            .declarations
+            .iter()
+            .chain(decls.important_declarations.iter())
+            .map(property)
+            .fold(0u64, u64::saturating_add)
+    }
+
+    fn property(property: &Property) -> u64 {
+        DECL.saturating_add(match property {
+            Property::Custom(c) => token_list(&c.value),
+            Property::Unparsed(u) => token_list(&u.value),
+            _ => 0,
+        })
+    }
+
+    pub(super) fn selector_list(list: &SelectorList) -> u64 {
+        selector_slice(list.v.slice())
+    }
+
+    fn selector_slice(selectors: &[Selector]) -> u64 {
+        selectors
+            .iter()
+            .map(|sel| {
+                sel.components
+                    .iter()
+                    .map(component)
+                    .fold(0u64, u64::saturating_add)
+            })
+            .fold(0u64, u64::saturating_add)
+    }
+
+    fn component(component: &Component) -> u64 {
+        COMPONENT.saturating_add(match component {
+            Component::Negation(list)
+            | Component::Where(list)
+            | Component::Is(list)
+            | Component::Has(list)
+            | Component::Any {
+                selectors: list, ..
+            } => selector_slice(list),
+            Component::NthOf(data) => selector_slice(&data.selectors),
+            Component::Slotted(sel) => selector_slice(core::slice::from_ref(sel)),
+            Component::Host(Some(sel)) => selector_slice(core::slice::from_ref(sel)),
+            Component::NonTsPseudoClass(PseudoClass::CustomFunction { arguments, .. })
+            | Component::PseudoElement(PseudoElement::CustomFunction { arguments, .. }) => {
+                token_list(arguments)
+            }
+            _ => 0,
+        })
+    }
+
+    fn token_list(tokens: &TokenList) -> u64 {
+        tokens
+            .v
+            .iter()
+            .map(|t| {
+                TOKEN.saturating_add(match t {
+                    TokenOrValue::Token(token) => token_text_len(token),
+                    TokenOrValue::Var(var) => var.fallback.as_ref().map_or(0, token_list),
+                    TokenOrValue::Env(env) => env.fallback.as_ref().map_or(0, token_list),
+                    TokenOrValue::Function(f) => token_list(&f.arguments),
+                    TokenOrValue::UnresolvedColor(color) => unresolved_color(color),
+                    _ => 0,
+                })
+            })
+            .fold(0u64, u64::saturating_add)
+    }
+
+    fn unresolved_color(color: &css::properties::custom::UnresolvedColor) -> u64 {
+        use css::properties::custom::UnresolvedColor;
+        match color {
+            UnresolvedColor::RGB { alpha, .. } | UnresolvedColor::HSL { alpha, .. } => {
+                token_list(alpha)
+            }
+            UnresolvedColor::LightDark { light, dark } => {
+                token_list(light).saturating_add(token_list(dark))
+            }
+        }
+    }
+
+    fn token_text_len(token: &css::Token) -> u64 {
+        use css::Token;
+        match token {
+            Token::Ident(v)
+            | Token::Function(v)
+            | Token::AtKeyword(v)
+            | Token::UnrestrictedHash(v)
+            | Token::IdHash(v)
+            | Token::QuotedString(v)
+            | Token::BadString(v)
+            | Token::UnquotedUrl(v)
+            | Token::BadUrl(v)
+            | Token::Whitespace(v)
+            | Token::Comment(v) => v.len() as u64,
+            _ => 0,
+        }
+    }
 }
 
 // ─── StyleRuleKey ──────────────────────────────────────────────────────────
@@ -1069,6 +1253,21 @@ pub struct StyleContext<'a> {
 /// instead.
 pub const MAX_SELECTOR_EXPANSION: u32 = 65_536;
 
+/// Upper bound on the cumulative weight (roughly bytes of AST payload) of
+/// style-rule clones produced by splitting selector lists that are
+/// incompatible with the configured targets.
+///
+/// `minify_style_arm` clones a rule's declarations and its entire nested-rule
+/// subtree once per split-off selector. Under CSS nesting the subtree at each
+/// level already contains the clones split off at deeper levels, so the cloned
+/// payload compounds exponentially with nesting depth. [`MAX_SELECTOR_EXPANSION`]
+/// bounds how many rules the split can produce but not their size: each clone
+/// can carry arbitrarily large token lists or declaration blocks, so a few
+/// hundred kilobytes of adversarial input could otherwise clone (and later
+/// print) gigabytes while staying under the selector-count cap. Real-world
+/// stylesheets duplicate at most a few kilobytes here.
+pub const MAX_SELECTOR_SPLIT_CLONE_WEIGHT: u64 = 64 << 20;
+
 /// Per-stylesheet minification state threaded through `CssRuleList::minify`
 /// and every leaf rule's `minify`.
 ///
@@ -1104,4 +1303,8 @@ pub struct MinifyContext<'a, 'bump> {
     /// Running total of selectors that compiling nested rules for the targets
     /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
     pub selector_expansion_total: u32,
+    /// Running total of the weight of rule clones made when splitting
+    /// target-incompatible selector lists, checked against
+    /// [`MAX_SELECTOR_SPLIT_CLONE_WEIGHT`].
+    pub split_clone_weight_total: u64,
 }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1178,7 +1178,15 @@ mod clone_weight {
                 local_name, value, ..
             } => (local_name.v().len() as u64).saturating_add(value.len() as u64),
             Component::AttributeOther(attr) => {
-                (attr.local_name.v().len() as u64).saturating_add(match &attr.operation {
+                use css::selectors::parser::attrs::NamespaceConstraint;
+                (match &attr.namespace {
+                    Some(NamespaceConstraint::Specific(ns)) => {
+                        (ns.prefix.v().len() as u64).saturating_add(ns.url.len() as u64)
+                    }
+                    _ => 0,
+                })
+                .saturating_add(attr.local_name.v().len() as u64)
+                .saturating_add(match &attr.operation {
                     ParsedAttrSelectorOperation::WithValue { expected_value, .. } => {
                         expected_value.len() as u64
                     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -922,8 +922,10 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 /// rules, declarations, selector components (recursing into selector-list
 /// arguments), and raw token lists (token count plus borrowed text length —
 /// the text is borrowed by the clone but re-emitted per clone when printed).
-/// Every token variant that stores its text inline is charged that text,
-/// including dimension units, dashed idents, and var()/env()/function names.
+/// Every variant that stores its text inline is charged that text: token
+/// payloads (including dimension units and dashed idents), var()/env()/
+/// function and pseudo-class names, custom-property names, and selector
+/// text (classes, ids, element and attribute names, attribute values).
 /// Parsed leaf values and `url()` (whose text lives in the stylesheet's
 /// import records, not reachable here) are charged a flat constant: their
 /// per-rule size is bounded by the input, and the number of clones is bounded
@@ -987,8 +989,15 @@ mod clone_weight {
     }
 
     fn property(property: &Property) -> u64 {
+        use css::properties::custom::CustomPropertyName;
         DECL.saturating_add(match property {
-            Property::Custom(c) => token_list(&c.value),
+            Property::Custom(c) => {
+                let name_len = match &c.name {
+                    CustomPropertyName::Custom(ident) => ident.v().len(),
+                    CustomPropertyName::Unknown(ident) => ident.v().len(),
+                };
+                (name_len as u64).saturating_add(token_list(&c.value))
+            }
             Property::Unparsed(u) => token_list(&u.value),
             _ => 0,
         })
@@ -1011,6 +1020,7 @@ mod clone_weight {
     }
 
     fn component(component: &Component) -> u64 {
+        use css::selectors::parser::attrs::ParsedAttrSelectorOperation;
         COMPONENT.saturating_add(match component {
             Component::Negation(list)
             | Component::Where(list)
@@ -1022,12 +1032,62 @@ mod clone_weight {
             Component::NthOf(data) => selector_slice(&data.selectors),
             Component::Slotted(sel) => selector_slice(core::slice::from_ref(sel)),
             Component::Host(Some(sel)) => selector_slice(core::slice::from_ref(sel)),
-            Component::NonTsPseudoClass(PseudoClass::CustomFunction { arguments, .. })
-            | Component::PseudoElement(PseudoElement::CustomFunction { arguments, .. }) => {
-                token_list(arguments)
+            Component::NonTsPseudoClass(pseudo) => pseudo_class(pseudo),
+            Component::PseudoElement(pseudo) => pseudo_element(pseudo),
+            // CSS-modules locals (`IdentOrRef::is_ref`) print a symbol-table
+            // name instead of inline text; they are charged the flat constant.
+            Component::Id(ident) | Component::Class(ident) => {
+                ident.as_ident().map_or(0, |i| i.v().len() as u64)
+            }
+            Component::LocalName(name) => name.name.v().len() as u64,
+            Component::Namespace { prefix, url } => {
+                (prefix.v().len() as u64).saturating_add(url.len() as u64)
+            }
+            Component::DefaultNamespace(url) => url.len() as u64,
+            Component::Part(idents) => idents
+                .iter()
+                .map(|i| i.v().len() as u64)
+                .fold(0u64, u64::saturating_add),
+            Component::AttributeInNoNamespaceExists { local_name, .. } => {
+                local_name.v().len() as u64
+            }
+            Component::AttributeInNoNamespace {
+                local_name, value, ..
+            } => (local_name.v().len() as u64).saturating_add(value.len() as u64),
+            Component::AttributeOther(attr) => {
+                (attr.local_name.v().len() as u64).saturating_add(match &attr.operation {
+                    ParsedAttrSelectorOperation::WithValue { expected_value, .. } => {
+                        expected_value.len() as u64
+                    }
+                    ParsedAttrSelectorOperation::Exists => 0,
+                })
             }
             _ => 0,
         })
+    }
+
+    fn pseudo_class(pseudo: &PseudoClass) -> u64 {
+        match pseudo {
+            PseudoClass::CustomFunction { name, arguments } => {
+                (name.len() as u64).saturating_add(token_list(arguments))
+            }
+            PseudoClass::Custom { name } => name.len() as u64,
+            PseudoClass::Lang { languages } => languages
+                .iter()
+                .map(|l| l.len() as u64)
+                .fold(0u64, u64::saturating_add),
+            _ => 0,
+        }
+    }
+
+    fn pseudo_element(pseudo: &PseudoElement) -> u64 {
+        match pseudo {
+            PseudoElement::CustomFunction { name, arguments } => {
+                (name.len() as u64).saturating_add(token_list(arguments))
+            }
+            PseudoElement::Custom { name } => name.len() as u64,
+            _ => 0,
+        }
     }
 
     fn token_list(tokens: &TokenList) -> u64 {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -954,12 +954,27 @@ mod clone_weight {
             CssRule::Style(sty) => selector_list(&sty.selectors)
                 .saturating_add(decl_block(&sty.declarations))
                 .saturating_add(rule_list(&sty.rules)),
-            CssRule::Media(r) => rule_list(&r.rules),
-            CssRule::Supports(r) => rule_list(&r.rules),
-            CssRule::Container(r) => rule_list(&r.rules),
-            CssRule::LayerBlock(r) => rule_list(&r.rules),
+            CssRule::Media(r) => media_list(&r.query).saturating_add(rule_list(&r.rules)),
+            CssRule::Supports(r) => {
+                supports_condition(&r.condition).saturating_add(rule_list(&r.rules))
+            }
+            CssRule::Container(r) => (r.name.as_ref().map_or(0, |n| n.v.v().len() as u64))
+                .saturating_add(container_condition(&r.condition))
+                .saturating_add(rule_list(&r.rules)),
+            CssRule::LayerBlock(r) => r
+                .name
+                .as_ref()
+                .map_or(0, |n| {
+                    n.v.slice()
+                        .iter()
+                        .map(|segment| segment.len() as u64)
+                        .fold(0u64, u64::saturating_add)
+                })
+                .saturating_add(rule_list(&r.rules)),
             CssRule::MozDocument(r) => rule_list(&r.rules),
-            CssRule::Scope(r) => rule_list(&r.rules),
+            CssRule::Scope(r) => (r.scope_start.as_ref().map_or(0, selector_list))
+                .saturating_add(r.scope_end.as_ref().map_or(0, selector_list))
+                .saturating_add(rule_list(&r.rules)),
             CssRule::StartingStyle(r) => rule_list(&r.rules),
             CssRule::Nesting(r) => selector_list(&r.style.selectors)
                 .saturating_add(decl_block(&r.style.declarations))
@@ -969,14 +984,122 @@ mod clone_weight {
                 .iter()
                 .map(|k| decl_block(&k.declarations))
                 .fold(0u64, u64::saturating_add),
-            CssRule::Unknown(r) => {
-                token_list(&r.prelude).saturating_add(r.block.as_ref().map_or(0, token_list))
-            }
+            CssRule::Unknown(r) => (r.name.len() as u64)
+                .saturating_add(token_list(&r.prelude))
+                .saturating_add(r.block.as_ref().map_or(0, token_list)),
             // Remaining rules can't contain nested style rules; their payload
             // is bounded per rule by the input.
             _ => 0,
         };
         RULE.saturating_add(nested)
+    }
+
+    fn media_list(list: &css::media_query::MediaList) -> u64 {
+        use css::media_query::MediaType;
+        list.media_queries
+            .iter()
+            .map(|q| {
+                (match q.media_type {
+                    // SAFETY: arena-owned slice; only its length is read.
+                    MediaType::Custom(name) => name.len() as u64,
+                    _ => 0,
+                })
+                .saturating_add(q.condition.as_ref().map_or(0, media_condition))
+            })
+            .fold(0u64, u64::saturating_add)
+    }
+
+    fn media_condition(condition: &css::media_query::MediaCondition) -> u64 {
+        use css::media_query::MediaCondition;
+        match condition {
+            MediaCondition::Feature(feature) => query_feature(feature),
+            MediaCondition::Not(inner) => media_condition(inner),
+            MediaCondition::Operation { conditions, .. } => conditions
+                .iter()
+                .map(media_condition)
+                .fold(0u64, u64::saturating_add),
+        }
+    }
+
+    fn query_feature<F: css::media_query::FeatureIdTrait>(
+        feature: &css::media_query::QueryFeature<F>,
+    ) -> u64 {
+        use css::media_query::QueryFeature;
+        match feature {
+            QueryFeature::Plain { name, value } | QueryFeature::Range { name, value, .. } => {
+                feature_name(name).saturating_add(feature_value(value))
+            }
+            QueryFeature::Boolean { name } => feature_name(name),
+            QueryFeature::Interval {
+                name, start, end, ..
+            } => feature_name(name)
+                .saturating_add(feature_value(start))
+                .saturating_add(feature_value(end)),
+        }
+    }
+
+    fn feature_name<F: css::media_query::FeatureIdTrait>(
+        name: &css::media_query::MediaFeatureName<F>,
+    ) -> u64 {
+        use css::media_query::MediaFeatureName;
+        match name {
+            MediaFeatureName::Standard(_) => 0,
+            MediaFeatureName::Custom(ident) => ident.v().len() as u64,
+            MediaFeatureName::Unknown(ident) => ident.v().len() as u64,
+        }
+    }
+
+    fn feature_value(value: &css::media_query::MediaFeatureValue) -> u64 {
+        use css::media_query::MediaFeatureValue;
+        match value {
+            MediaFeatureValue::Ident(ident) => ident.v().len() as u64,
+            MediaFeatureValue::Env(env) => {
+                env_name_len(&env.name).saturating_add(env.fallback.as_ref().map_or(0, token_list))
+            }
+            _ => 0,
+        }
+    }
+
+    fn supports_condition(condition: &super::supports::SupportsCondition) -> u64 {
+        use super::supports::SupportsCondition;
+        match condition {
+            SupportsCondition::Not(inner) => supports_condition(inner),
+            SupportsCondition::And(conditions) | SupportsCondition::Or(conditions) => conditions
+                .iter()
+                .map(supports_condition)
+                .fold(0u64, u64::saturating_add),
+            SupportsCondition::Declaration(decl) => {
+                (decl.property_id.name().len() as u64).saturating_add(decl.value.len() as u64)
+            }
+            SupportsCondition::Selector(text) | SupportsCondition::Unknown(text) => {
+                text.len() as u64
+            }
+        }
+    }
+
+    fn container_condition(condition: &super::container::ContainerCondition) -> u64 {
+        use super::container::ContainerCondition;
+        match condition {
+            ContainerCondition::Feature(feature) => query_feature(feature),
+            ContainerCondition::Not(inner) => container_condition(inner),
+            ContainerCondition::Operation { conditions, .. } => conditions
+                .iter()
+                .map(container_condition)
+                .fold(0u64, u64::saturating_add),
+            ContainerCondition::Style(query) => style_query(query),
+        }
+    }
+
+    fn style_query(query: &super::container::StyleQuery) -> u64 {
+        use super::container::StyleQuery;
+        match query {
+            StyleQuery::Feature(feature) => property(feature),
+            StyleQuery::Not(inner) => style_query(inner),
+            StyleQuery::Operation { conditions, .. } => conditions
+                .iter()
+                .map(style_query)
+                .fold(0u64, u64::saturating_add),
+        }
     }
 
     pub(super) fn decl_block(decls: &css::DeclarationBlock) -> u64 {
@@ -1076,16 +1199,33 @@ mod clone_weight {
                 .iter()
                 .map(|l| l.len() as u64)
                 .fold(0u64, u64::saturating_add),
+            PseudoClass::Local { selector } | PseudoClass::Global { selector } => {
+                selector_slice(core::slice::from_ref(&**selector))
+            }
             _ => 0,
         }
     }
 
     fn pseudo_element(pseudo: &PseudoElement) -> u64 {
+        use css::selectors::parser::ViewTransitionPartName;
         match pseudo {
             PseudoElement::CustomFunction { name, arguments } => {
                 (name.len() as u64).saturating_add(token_list(arguments))
             }
             PseudoElement::Custom { name } => name.len() as u64,
+            PseudoElement::CueFunction { selector }
+            | PseudoElement::CueRegionFunction { selector } => {
+                selector_slice(core::slice::from_ref(&**selector))
+            }
+            PseudoElement::ViewTransitionGroup { part_name }
+            | PseudoElement::ViewTransitionImagePair { part_name }
+            | PseudoElement::ViewTransitionOld { part_name }
+            | PseudoElement::ViewTransitionNew { part_name } => match part_name {
+                ViewTransitionPartName::All => 0,
+                ViewTransitionPartName::Name(ident) | ViewTransitionPartName::Class(ident) => {
+                    ident.v().len() as u64
+                }
+            },
             _ => 0,
         }
     }

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -132,7 +132,7 @@ test("bun build reports an error instead of exploding on deeply nested multi-sel
     timeout: 20_000,
     killSignal: "SIGKILL",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toContain(LIMIT_ERROR);
   expect(exitCode).toBe(1);
   // The build must fail before emitting the (multi-megabyte) expanded output.
@@ -371,7 +371,7 @@ test("bun build does not hang on deeply nested multi-selector css spanning @star
     timeout: 20_000,
     killSignal: "SIGKILL",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   // Must terminate on its own (reporting the limit error), not be SIGKILLed.
   expect(proc.signalCode).toBeNull();
   expect(stderr).toContain(LIMIT_ERROR);

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -435,6 +435,39 @@ test("the minimized fuzzer input terminates across minify, nesting-compile, and 
   expect(() => prefixTest(input, "", { safari: (13 << 16) | (2 << 8) })).toThrow(boundedError);
 });
 
+test("the ::part()-nested fuzzer input with large token-list declarations is bounded", () => {
+  // 16.5 KB fuzzer-generated input: a `>`-combinator-flooded top-level rule
+  // wrapping ~12 levels of two-selector `::part()`-bearing nested rules whose
+  // deepest declaration value is an unclosed `olor-mix(` swallowing several KB
+  // of trailing text (including a `border-right-color: lab(...)` that stages
+  // an `@supports` fallback). For a chrome 80 target every nested level has
+  // `&` (so is incompatible), cannot wrap in `:is()` (no `:is()` support), and
+  // therefore splits into per-selector clones of the whole subtree, payload
+  // included. Before the clone-weight budget this produced ~155 MB of output
+  // and ~2.3 GB of RSS; the `@supports` fallback for `lab()` was cloned along
+  // with the subtree and accounted for roughly half of that. With the budget
+  // both the nesting-compile and prefix passes now report the clone-limit
+  // error instead.
+  const input = Buffer.from(
+    Bun.gunzipSync(
+      Buffer.from(
+        "H4sICCgOMmoCA2Z1enotaW5wdXQuY3NzAO2bzW7bNhzAd+2AvMBOBIYAdmGmkuWPRsZ6aBID2TqjSZcNA3qhJErmQpECRVl2jAB9g71Cj+0z9BCgj9IX6KX3lpLspUnhNm3ioPb+4oEy/x8/in9+wSAfoAeQVi4tFj29todlmi4rcZZqnOoJp5jFJKKfqnwf0YH0naQ7q13997cIS2TKNJMCptplKYScjnGkZH69moZSFJOgotofXpK9fg5j/tpp4yadjSTzKQ5JzPhkbZts44qKERVUMR+XjWJWcxrqnKggRQhJ102I0rUhJQFV9QbaCmVR5lOhqSokngwmdTT9cbEu+bTkanbnWu/+PTtbQ82iGE3LmcNFQqqY8Hm2L0ImmJ6kVGOPS//YTC3G3EV4LknGPePAfR9KP7uTSjn1pDI0nLNAD10LO00HWchOxqefUbPvt1qdbqtldZ2utd1u2x27/WUr66tUym8kaUJ9jRUxa5mL2tRUr4XuIQeRTEu0Tmoe8Y/NapKJwAQrp94xMzY0ocZMRJgzQYkyyw0JmBlDtQnlXObItpJxA3k8o6htXuvr0iI304PWT6VoPjNRVM+8l3hyjIvNiIvs3rkwlieLJGlZiKst4ohelM6cznc3P+QXxP9tespSCNQyVZa2yLx59vKG3X7tHmNBT9Z0bPbC7IRiEvyTpeXqJmhv3vHn2ShmoppJfMmlctEOKnIcs3GNCUTjYe4hLkVEFdoYZrTx+OCo//jR3qCo68ODo9+7h0f93T/YeGDKB4/2/tw92ovSJ1b/4eGJ3j3s9w/2Wf7bzpNfs7//srk/2e/s93WwI6xf0N17gAf8auNdmRT/DBAOUQA84AEPeMB/E/5pNrVtyzynt16RGMIAeMCvPv7tqzNof8ADHvCABzzgF+OhWQEP+P8lfrW+Zwrh/Gb8qvmFsQ94wAP+lvFTaH3AryW+PAQTUF+W5+NEdUEGIgJ4wAMe8IAH/JLxr59XFUCmqGaNw+pJmPaH1WuE3jx74VibqGVt1is1x7ECGqGyEG3Wi5P489OtMWlGTGAmikP8WLpuyDjFKeW0XOp9GXuFIEsUi4ba16ZSXkYEi6v1P6CcTCKtpfjoxGxM1MznRY8z60vackRVyGWOc0WSc9OqOr0vGF/WXwQjLiep+Zwh4wHVmqpp1dCKBqcLnf1UOtuY3wzQMnGRT7hfM9GqDchA0bgxuyEwyhuoZX7X0V2E7Y+uOqyV0VWPRM/1ZkfHy66DZz37Z89pmlQpJf4FWZnVAuZKwSdVsNLEdDCcOGir0zLd+D7asrebrXbb5J1u127WP0/jxKuZcYDana0OcrbrvQ/3GCU6nUAAAA==",
+        "base64",
+      ),
+    ),
+  ).toString("latin1");
+
+  expect(input.length).toBe(16541);
+  // `minifyTest` has no browser targets, so nothing splits; the output stays
+  // roughly input-sized.
+  const minified = minifyTest(input, "");
+  expect(minified.length).toBeLessThan(20_000);
+  // With a chrome 80 target both the nesting-compile and prefix passes split
+  // at every nested level; the clone-weight budget must cut them off.
+  expect(() => cssInternals._test(input, "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
+  expect(() => prefixTest(input, "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
+});
+
 // ── combinator token floods stay linear ──────────────────────────────────────
 
 test("a '>' combinator flood in an invalid selector minifies in linear time", () => {

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -287,16 +287,24 @@ test.each([
   ["class-selector", ".PAD { color: red }"],
   ["type-selector", "PAD { color: red }"],
   ["attribute-value", '[d="PAD"] { color: red }'],
+  ["view-transition-part-name", "::view-transition-group(PAD) { color: red }"],
+  ["cue-selector", '::cue([d="PAD"]) { color: red }'],
+  ["unknown-at-rule-name", "@PAD;"],
+  ["media-feature-name", "@media (PAD: 1) { color: red }"],
+  ["supports-condition", "@supports (PAD: PAD) { color: red }"],
+  ["layer-name", "@layer PAD { color: red }"],
+  ["scope-selector", "@scope (.PAD) { color: red }"],
+  ["container-name", "@container PAD (width > 1px) { color: red }"],
 ])("the clone weight counts %s text, not just plain idents", (_name, body) => {
   // Every construct that carries input-sized borrowed text must be charged its
-  // text length. E.g. prepending a digit to the padding turns the ident into a
-  // dimension token whose unit is the full 2 KB text, and moving the padding
-  // into the property name or a nested rule's selector stores the same bytes
-  // outside any token list; if only plain idents were counted, each of these
-  // one-character moves would bypass the budget and restore the multi-gigabyte
-  // amplification.
+  // text length: raw-token payloads, property names, selector text, wrapped
+  // pseudo-element selectors and part names, and the names/preludes/conditions
+  // of every at-rule that can nest inside a style rule. If any of them were
+  // charged only the flat constant, moving the padding there would bypass the
+  // budget and restore the multi-gigabyte amplification (each of these shapes
+  // produced a 33+ MB output from ~30 KB of input before it was counted).
   const pad = Buffer.alloc(2048, "a").toString();
-  const src = `.a, .b { ${body.replace("PAD", pad)}\n`.repeat(14) + "color: red;\n" + "}".repeat(14);
+  const src = `.a, .b { ${body.replace(/PAD/g, pad)}\n`.repeat(14) + "color: red;\n" + "}".repeat(14);
   expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
 });
 

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -295,6 +295,7 @@ test.each([
   ["layer-name", "@layer PAD { color: red }"],
   ["scope-selector", "@scope (.PAD) { color: red }"],
   ["container-name", "@container PAD (width > 1px) { color: red }"],
+  ["attribute-namespace-prefix", "[PAD|d] { color: red }"],
 ])("the clone weight counts %s text, not just plain idents", (_name, body) => {
   // Every construct that carries input-sized borrowed text must be charged its
   // text length: raw-token payloads, property names, selector text, wrapped
@@ -345,7 +346,7 @@ test("bun build reports the clone limit instead of writing a multi-megabyte file
     timeout: 20_000,
     killSignal: "SIGKILL",
   });
-  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  const [_stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(proc.signalCode).toBeNull();
   expect(stderr).toContain(CLONE_LIMIT_ERROR);
   expect(exitCode).toBe(1);

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -277,19 +277,26 @@ test("the mixed vendor-prefix fuzzer shape with large payloads is bounded too", 
 });
 
 test.each([
-  ["dimension-unit", "--p: 1PAD"],
-  ["dashed-ident", "--p: --PAD"],
-  ["var-name", "--p: var(--PAD)"],
-  ["env-name", "--p: env(--PAD)"],
-  ["function-name", "--p: PAD(x)"],
+  ["dimension-unit", "--p: 1PAD;"],
+  ["dashed-ident", "--p: --PAD;"],
+  ["var-name", "--p: var(--PAD);"],
+  ["env-name", "--p: env(--PAD);"],
+  ["function-name", "--p: PAD(x);"],
+  ["custom-property-name", "--PAD: 1;"],
+  ["unknown-pseudo-class-name", ":PAD { color: red }"],
+  ["class-selector", ".PAD { color: red }"],
+  ["type-selector", "PAD { color: red }"],
+  ["attribute-value", '[d="PAD"] { color: red }'],
 ])("the clone weight counts %s text, not just plain idents", (_name, body) => {
-  // Every raw-token variant that carries input-sized text must be charged its
+  // Every construct that carries input-sized borrowed text must be charged its
   // text length. E.g. prepending a digit to the padding turns the ident into a
-  // dimension token whose unit is the full 2 KB text; if only idents were
-  // counted, that one-character change would bypass the budget and restore the
-  // multi-gigabyte amplification.
+  // dimension token whose unit is the full 2 KB text, and moving the padding
+  // into the property name or a nested rule's selector stores the same bytes
+  // outside any token list; if only plain idents were counted, each of these
+  // one-character moves would bypass the budget and restore the multi-gigabyte
+  // amplification.
   const pad = Buffer.alloc(2048, "a").toString();
-  const src = `.a, .b { ${body.replace("PAD", pad)};\n`.repeat(14) + "color: red;\n" + "}".repeat(14);
+  const src = `.a, .b { ${body.replace("PAD", pad)}\n`.repeat(14) + "color: red;\n" + "}".repeat(14);
   expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
 });
 

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -238,6 +238,88 @@ test("shallow nesting spanning @scope still compiles for old targets", () => {
   expect(out).toContain("@scope");
 });
 
+// ── selector-split clone weight ──────────────────────────────────────────────
+//
+// The selector-count cap above bounds how many rules the incompatible-selector
+// split can produce, but not their size: each split-off selector deep-clones
+// the rule's declarations and entire nested-rule subtree, and under nesting
+// the subtree already contains the clones made at deeper levels. A large
+// custom-property payload repeated across a dozen two-selector nesting levels
+// therefore cloned (and later printed) gigabytes while staying well under
+// 65,536 selectors — e.g. 449 KB of input produced a 1.08 GB minified output.
+// The minifier now also bounds the cumulative weight of those clones.
+
+const CLONE_LIMIT_ERROR = "duplicates too much CSS";
+
+/** `depth` nested two-selector rules, each carrying a `payload`-sized custom property. */
+function nestedPayloadRules(depth: number, payload: number): string {
+  const pad = Buffer.alloc(payload, "a").toString();
+  return `.a, .b { --p: ${pad};\n`.repeat(depth) + "color: red;\n" + "}".repeat(depth);
+}
+
+test("splitting nested rules with large payloads errors instead of cloning gigabytes", () => {
+  // 14 levels of two-selector rules with a 2 KB payload each: ~16K selector
+  // combinations (well under the selector-count cap) but each split clones the
+  // payload-bearing subtree, compounding to ~70 MB of cloned weight (33 MB of
+  // output before the fix, gigabytes at slightly larger payloads).
+  expect(() => minifyTest(nestedPayloadRules(14, 2048), "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
+});
+
+test("the mixed vendor-prefix fuzzer shape with large payloads is bounded too", () => {
+  // Same shape as the fuzzer's hang input but with a fat custom property per
+  // level: mixed-compat selector lists split at every nesting level, cloning
+  // the payload into every branch. 97 KB of input produced a 69 MB output
+  // before the fix.
+  const pad = Buffer.alloc(8192, "a").toString();
+  const src =
+    `.a:placeholder-shown .x, .b:-webkit-autofill .y { --p: ${pad};\n`.repeat(12) + "color: red" + "}".repeat(12);
+  expect(() => minifyTest(src, "", { safari: (13 << 16) | (2 << 8) })).toThrow(CLONE_LIMIT_ERROR);
+});
+
+test("nested rules with payloads below the clone limit still compile byte-for-byte", () => {
+  // Two levels below the throwing depth: the split path runs and its output is
+  // unchanged by the budget.
+  const out = minifyTest(nestedPayloadRules(12, 2048), "", OLD_TARGETS);
+  expect(out.length).toBe(8595441);
+  expect(out).toContain("color:red");
+});
+
+test("shallow incompatible splits still produce the full split output", () => {
+  const out = minifyTest(".a, .b { --p: x;\n".repeat(3) + "color: red;\n" + "}".repeat(3), "", OLD_TARGETS);
+  expect(out).toBe(
+    ".a,.b{--p:x}" +
+      ":is(.a,.b) .a{--p:x}" +
+      ":is(.a,.b) .a .a{--p:x;color:red}" +
+      ":is(.a,.b) .a .b{--p:x;color:red}" +
+      ":is(.a,.b) .b{--p:x}" +
+      ":is(.a,.b) .b .a{--p:x;color:red}" +
+      ":is(.a,.b) .b .b{--p:x;color:red}",
+  );
+});
+
+test("bun build reports the clone limit instead of writing a multi-megabyte file", async () => {
+  using dir = tempDir("css-split-clone-weight", {
+    "input.css": nestedPayloadRules(14, 2048),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "input.css", "--outdir", "out", "--minify"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: before the fix this build wrote ~33 MB (gigabytes at larger
+    // payloads). Let the child terminate itself so a regression fails the
+    // assertions below instead of hanging the runner.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(proc.signalCode).toBeNull();
+  expect(stderr).toContain(CLONE_LIMIT_ERROR);
+  expect(exitCode).toBe(1);
+  expect(await Bun.file(`${dir}/out/input.css`).exists()).toBe(false);
+});
+
 test("bun build does not hang on deeply nested multi-selector css spanning @starting-style", async () => {
   using dir = tempDir("css-starting-style-expansion", {
     // The fuzzer's depth (14 outer + 11 inner): without the fix this hangs for
@@ -262,4 +344,80 @@ test("bun build does not hang on deeply nested multi-selector css spanning @star
   expect(stderr).toContain(LIMIT_ERROR);
   expect(exitCode).toBe(1);
   expect(await Bun.file(`${dir}/out/input.css`).exists()).toBe(false);
+});
+
+// ── printer indent counter ───────────────────────────────────────────────────
+
+test("pretty-printing 128+ levels of nested rules does not crash", async () => {
+  // The printer's indent counter was a u8 incremented by 2 per nesting level,
+  // so pretty-printing a valid stylesheet with 128+ nested rules overflowed it
+  // (a panic in debug builds). Run in a subprocess so a regression is an exit
+  // code, not a dead test runner.
+  const script = `
+    const { cssInternals } = require("bun:internal-for-testing");
+    const css = ".a {\\n".repeat(200) + "color: red;\\n" + "}".repeat(200);
+    const out = cssInternals.prefixTest(css, "", { chrome: 130 << 16 });
+    console.log(out.length);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    indentedLength: parseInt(stdout, 10) > 1000,
+    exitCode,
+    stderr: stderr.includes("panic") ? stderr : "",
+  }).toEqual({
+    indentedLength: true,
+    exitCode: 0,
+    stderr: "",
+  });
+});
+
+// ── minimized fuzzer input ───────────────────────────────────────────────────
+
+test("the minimized fuzzer input terminates across minify, nesting-compile, and prefix passes", () => {
+  // 11.6 KB fuzzer-generated input combining `>`-combinator token floods inside
+  // invalid rules with ~20 levels of unclosed mixed-compat two-selector nesting.
+  // Before the expansion bounds, minifying it for old targets cloned and
+  // re-serialized the nested subtree once per incompatible selector per level,
+  // hanging or OOMing (6+ GB). Every pass must now finish quickly, either
+  // returning output or reporting one of the bounded-expansion errors.
+  const input = Buffer.from(
+    Bun.gunzipSync(
+      Buffer.from(
+        "H4sIAAAAAAACA+1azW4bNxDu2U9BIBAgFaKwsiXLpoDcc3GB3AL4UO7u7C4hityQ1F8FAXqDvkKP7a1vkCKPkpx76z2dXf04VhzbcSTZVrgCJJMz/GY45HDWnGkkWpMpsRGXwMgrlQgl3KRC+L9/z5Xocye0orEwEDkR8qiX8AjoUFgRComMWlXIBb+ozI5ekls/qRExTXl+OxvTA0d1Qg1XKaw6GwsVHXZuDcgm2vTZYtpVupq2qnVXlgjInqZ0TZOTzxRotFGFgpHlH+Z/SrR7pmUMhtpMjxRphNzUSyBGRxDmYGxeLNIQpstRdw3pCUf5wOlESMmiDKIexAXPb2R6RPDZqoCdA/uRhzVypztw9dy/O9SmkCKUFAqoddw4OhKxyxg5zsfdNZ8egsFzAWikpTaWkSYZclOlFFWq1ckJkTystoPG+flZhTSP2412cEoodnSCzlnN43icr+L8cn+c2fKXZQVenbBERwO7iNsS1tv6e8iJhDEdGZ4zUnx3tyJx7Wehdk5jWGzmY2K1FDEJ0dd73U2+pQv2+bh6HL0dJVqhW4JIM4deWXuwUqEB3qMhYGyG++lfHDnTUnzCOIzIa93njbrlRFlqUUvNLhEzRosJB4x60rMhzZ6UilJYh+FnIoG6SQ43ci59A08QyXMLT8eiv9532FeALg94z3nX2y1pf9Kivrf+95EOZT5HP8Ya+q28T9J/v7979ywmcHSwK7P4j2xcJ0HN78dvJ3mzHDrpn/mXxA/zv3apy0187//YAsjWVHQwdniBGINyfq9siYSZmz22skmegbI3suxZlasWX6Xptgj9GMa93vo4nz+qArNHnr9v7be1vDMzxdXx4n5t21J+3qD95M3/sBZmw5/ATsFDN8VEoB6YCO4alWuBp7OhMMTYb++StS67ULzvl/3LFsPkawpuV4LKShBM6ZbJHOsMuChjmGmrzK4leQgvMtEbqZ5PdFS+o3z2ihJsQpXjYFHk0QyCbyq1CZZKXFXsPHOEgiM1eqBiRiKtRERTw2OBblLljpz75wFPhbSDSlmchBmgQV8VNUp18iIJTuskxWKJ2rKuiCzJZoDJpDKR6tfjUdfDm9+b/8DNz6VIFSY7ZXLrQmwGFnwbxwCKZTE/apz0CHtC+HQXxPSqaLf8S3IHb6rNs1brtNNqBZ2TTnDebjdPm20sQFpLLWtsyQSk1KMumf0PJ9zOf3YtAAA=",
+        "base64",
+      ),
+    ),
+  ).toString("latin1");
+
+  const boundedError = /expand|expansion|duplicates too much CSS/;
+  expect(() => minifyTest(input, "")).toThrow(boundedError);
+  expect(() => minifyTest(input, "", { safari: (13 << 16) | (2 << 8) })).toThrow(boundedError);
+  expect(() => prefixTest(input, "", { safari: (13 << 16) | (2 << 8) })).toThrow(boundedError);
+});
+
+// ── combinator token floods stay linear ──────────────────────────────────────
+
+test("a '>' combinator flood in an invalid selector minifies in linear time", () => {
+  // The fuzzer input floods tens of thousands of `>` delimiter tokens inside
+  // invalid rules. Parsing collapses consecutive combinators, so this must
+  // complete quickly with a tiny output rather than being cloned or
+  // re-serialized per token.
+  const flood = Buffer.alloc(80_000, "> ").toString();
+  expect(minifyTest(`${flood}.foo { color: red }`, "")).toBe(">>.foo>{color:red}");
+});
+
+test("a '>' combinator flood in an unknown declaration value stays linear", () => {
+  // Unknown declarations keep their value as a raw token list; a 40K-token
+  // flood must round-trip in linear time and size.
+  const flood = Buffer.alloc(80_000, "> ").toString();
+  const out = minifyTest(`.a { notaprop: ${flood} }`, "");
+  expect(out.length).toBeGreaterThan(40_000);
+  expect(out.length).toBeLessThan(81_000);
+  expect(out).toStartWith(".a{notaprop:>");
 });

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -277,6 +277,7 @@ test("the mixed vendor-prefix fuzzer shape with large payloads is bounded too", 
 });
 
 test.each([
+  ["unparsed-property-value", "box-shadow: PAD;"],
   ["dimension-unit", "--p: 1PAD;"],
   ["dashed-ident", "--p: --PAD;"],
   ["var-name", "--p: var(--PAD);"],

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -276,6 +276,23 @@ test("the mixed vendor-prefix fuzzer shape with large payloads is bounded too", 
   expect(() => minifyTest(src, "", { safari: (13 << 16) | (2 << 8) })).toThrow(CLONE_LIMIT_ERROR);
 });
 
+test.each([
+  ["dimension-unit", "--p: 1PAD"],
+  ["dashed-ident", "--p: --PAD"],
+  ["var-name", "--p: var(--PAD)"],
+  ["env-name", "--p: env(--PAD)"],
+  ["function-name", "--p: PAD(x)"],
+])("the clone weight counts %s text, not just plain idents", (_name, body) => {
+  // Every raw-token variant that carries input-sized text must be charged its
+  // text length. E.g. prepending a digit to the padding turns the ident into a
+  // dimension token whose unit is the full 2 KB text; if only idents were
+  // counted, that one-character change would bypass the budget and restore the
+  // multi-gigabyte amplification.
+  const pad = Buffer.alloc(2048, "a").toString();
+  const src = `.a, .b { ${body.replace("PAD", pad)};\n`.repeat(14) + "color: red;\n" + "}".repeat(14);
+  expect(() => minifyTest(src, "", OLD_TARGETS)).toThrow(CLONE_LIMIT_ERROR);
+});
+
 test("nested rules with payloads below the clone limit still compile byte-for-byte", () => {
   // Two levels below the throwing depth: the split path runs and its output is
   // unchanged by the budget.


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS minifier hang/OOM family found by fuzzing (signature: `hang:css:...PropertyIdTag::name`, an 11.6 KB input that hung or ate 6+ GB on the canary it was found on), and a related debug-build panic.

#### Root cause

When a style rule's selector list is incompatible with the configured browser targets (and cannot be collapsed into `:is()`), `minify_style_arm` (src/css/rules/mod.rs) splits it: each split-off selector gets a deep clone of the rule's declarations and its **entire nested-rule subtree**:

```rust
rules: sty.rules.deep_clone(context.arena),
```

Minify recurses bottom-up, so at each nesting level the subtree already contains the clones split off at deeper levels. With two-selector lists the cloned payload doubles per level: exponential time and memory in nesting depth. Caught live under gdb on the fuzzer input: the stack is `CssRuleList::deep_clone` recursing into `TokenList` clones from `minify_style_arm`.

The existing caps don't bound this. `MAX_SELECTOR_EXPANSION` (65,536) counts *selectors*, not bytes; each cloned rule can carry arbitrarily large token lists. On current main (all caps intact, release build):

```js
// 449 KB in -> 1,083,588,618 bytes out, 2.1 GB RSS, no error
const pad = "a".repeat(32 * 1024);
const css = `.a:placeholder-shown .x, .b:-webkit-autofill .y { --p: ${pad};\n`.repeat(14)
  + "color: red" + "}".repeat(14);
require("bun:internal-for-testing").cssInternals._test(css, "", { safari: (13<<16)|(2<<8) });
```

The same shape reaches the same path through `bun build --minify` (default browser targets compile nesting away), so the bundler amplifies identically.

#### Fix

Charge a weight estimate of each split's clones against a per-stylesheet budget, `MAX_SELECTOR_SPLIT_CLONE_WEIGHT = 64 MB`, before cloning. The weight walk counts every structure whose count or size scales with user input: rules, declarations, raw token lists with their text (including dimension units and dashed idents), custom-property and var()/env()/function/pseudo names, selector text (classes, ids, element, attribute and namespace names, attribute values, wrapped `::cue()`/`:local()`/view-transition selectors), and the names, preludes, and conditions of every at-rule that can nest inside a style rule (@media, @supports, @container, @layer, @scope, unknown at-rules). Past the budget, minification reports a catchable error ("Splitting nested CSS rules with selectors unsupported by the configured browser targets duplicates too much CSS."), mirroring the existing `MAX_SELECTOR_EXPANSION` and `MAX_PREFIX_EXPANSION_BYTES` (#31642) bounds. The weight walk only runs for rules that actually split, so stylesheets that never split pay nothing, and its cost is proportional to what it charges.

Also fixes a bug in the same input family: the printer's indent counter was a `u8` incremented by 2 per nesting level, so pretty-printing a valid stylesheet with 128+ nested levels overflowed it; that is a panic ("attempt to add with overflow") in debug builds. Widened to `u32`.

Not changed: the `>`-combinator token floods from the fuzzer input parse and minify in linear time already (consecutive combinators collapse during selector parsing; raw token lists in unknown declarations round-trip linearly); tests now pin that down.

#### Verification

- The 11.6 KB minimized fuzzer input terminates quickly on all passes (minify, nesting compile, prefix), reporting bounded-expansion errors; embedded (gzip+base64) as a regression test.
- The 449 KB repro above now errors in ~60 ms instead of producing a 1 GB output.
- Output below the budget is byte-for-byte unchanged: asserted for the split path at depth 12 (8,595,441 identical bytes pre/post fix), plus `css.test.ts` (1093), `nested-selector-list-expansion.test.ts`, `nested-selector-expansion.test.ts`, `nested-vendor-prefix-duplication.test.ts`, `doesnt_crash.test.ts`, `test/bundler/css/` (164), `test/bundler/esbuild/css.test.ts` (53) all pass.
- New tests in `test/js/bun/css/nested-selector-list-expansion.test.ts`, including a 19-case `test.each` matrix moving the payload into every chargeable text carrier. On an unfixed build: the clone-budget tests fail (33 MB / 69 MB outputs are returned instead of the error, `bun build` writes the file), and the indent test fails on unfixed debug builds with the overflow panic.

(`css-fuzz.test.ts` debug-build timeouts are pre-existing on main and the file is skipped on CI.)

