### PR TITLE
Preserve optional chain short-circuiting through lowered private members in decorated classes

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -833,6 +833,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // capture the receiver so `.call(...)` re-reads it without side
             // effects.
             js_ast::ExprData::EDot(mut e) => {
+                // `super.m?.()`: bare `super` is not an expression, so it
+                // cannot be captured; per MakeSuperPropertyReference the
+                // call's `this` value is the current `this`.
+                if matches!(e.target.data, js_ast::ExprData::ESuper(_)) {
+                    return (callee, Some(self.new_expr(E::This {}, l)));
+                }
                 let mut target = e.target;
                 self.rewrite_private_accesses_in_expr(&mut target, map);
                 let (recv_write, recv_read) = self.capture_expr_for_reuse(target, l);
@@ -840,13 +846,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 (callee, Some(recv_read))
             }
             js_ast::ExprData::EIndex(mut e) => {
+                let mut idx = e.index;
+                self.rewrite_private_accesses_in_expr(&mut idx, map);
+                e.index = idx;
+                // `super[k]?.()`: same as `super.m?.()` above.
+                if matches!(e.target.data, js_ast::ExprData::ESuper(_)) {
+                    return (callee, Some(self.new_expr(E::This {}, l)));
+                }
                 let mut target = e.target;
                 self.rewrite_private_accesses_in_expr(&mut target, map);
                 let (recv_write, recv_read) = self.capture_expr_for_reuse(target, l);
                 e.target = recv_write;
-                let mut idx = e.index;
-                self.rewrite_private_accesses_in_expr(&mut idx, map);
-                e.index = idx;
                 (callee, Some(recv_read))
             }
             // Not a member access: the call's `this` is undefined.

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -699,8 +699,347 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
+    /// Re-read `value` without re-running side effects: identifiers and
+    /// `this` are repeated directly (class bodies are strict mode code, so
+    /// no `with` scope can turn an identifier read into a getter call);
+    /// anything else is captured in a temporary that is declared by
+    /// `declare_capture_temps_in_fn_body` (temps created inside a rewritten
+    /// function body) or `drain_capture_temp_decls` (everything else).
+    /// Returns the expression to evaluate in place of `value` plus the
+    /// side-effect-free re-read.
+    fn capture_expr_for_reuse(&mut self, value: Expr, l: bun_ast::Loc) -> (Expr, Expr) {
+        match value.data {
+            js_ast::ExprData::EIdentifier(id) => (value, self.use_ref(id.ref_, l)),
+            js_ast::ExprData::EThis(_) => (value, self.new_expr(E::This {}, l)),
+            _ => {
+                let tmp_ref = self.generate_temp_ref(Some(b"_chain"));
+                let write = self.assign_to(tmp_ref, value, l);
+                let read = self.use_ref(tmp_ref, l);
+                (write, read)
+            }
+        }
+    }
+
+    fn lowered_private_index_info(
+        expr: &Expr,
+        map: &PrivateLoweredMap,
+    ) -> Option<PrivateLoweredInfo> {
+        if let js_ast::ExprData::EIndex(e) = &expr.data
+            && let js_ast::ExprData::EPrivateIdentifier(pi) = &e.index.data
+        {
+            return map.get(&pi.ref_.inner_index()).copied();
+        }
+        None
+    }
+
+    /// Whether `expr`, the outermost link of an optional chain, needs the
+    /// chain flattened because a private access that is being lowered
+    /// participates in it. Only this segment is examined (the links up to and
+    /// including the one flagged `Start`); a chain in the segment's base is a
+    /// separate segment that the rewrite inspects when it recurses into it.
+    fn optional_chain_needs_private_lowering(expr: &Expr, map: &PrivateLoweredMap) -> bool {
+        let mut cur = *expr;
+        loop {
+            match &cur.data {
+                js_ast::ExprData::EIndex(e) if e.optional_chain.is_some() => {
+                    if Self::lowered_private_index_info(&cur, map).is_some() {
+                        return true;
+                    }
+                    if e.optional_chain == Some(js_ast::OptionalChain::Start) {
+                        return false;
+                    }
+                    cur = e.target;
+                }
+                js_ast::ExprData::EDot(e) if e.optional_chain.is_some() => {
+                    if e.optional_chain == Some(js_ast::OptionalChain::Start) {
+                        return false;
+                    }
+                    cur = e.target;
+                }
+                js_ast::ExprData::ECall(e) if e.optional_chain.is_some() => {
+                    if e.optional_chain == Some(js_ast::OptionalChain::Start) {
+                        // `callee?.()` where the callee ends in a lowered
+                        // private access: rewriting the callee into a
+                        // `__privateGet(..)` helper call would otherwise
+                        // swallow the nullish test on the callee value.
+                        return Self::lowered_private_index_info(&e.target, map).is_some();
+                    }
+                    cur = e.target;
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// Point `call` at `callee.call(this_read, ...original args)`, rewriting
+    /// the original arguments in place as they move.
+    fn retarget_call_through_dot_call(
+        &mut self,
+        mut call: js_ast::StoreRef<E::Call>,
+        callee: Expr,
+        this_read: Expr,
+        map: &PrivateLoweredMap,
+        l: bun_ast::Loc,
+    ) {
+        let call_target = self.new_expr(
+            E::Dot {
+                target: callee,
+                name: b"call".into(),
+                name_loc: l,
+                ..Default::default()
+            },
+            l,
+        );
+        let bump = self.arena;
+        let orig_args = call.args.slice_mut();
+        let mut new_args = BumpVec::with_capacity_in(1 + orig_args.len(), bump);
+        new_args.push(this_read);
+        for arg in orig_args.iter_mut() {
+            self.rewrite_private_accesses_in_expr(arg, map);
+            new_args.push(*arg);
+        }
+        call.target = call_target;
+        call.args = ExprNodeList::from_bump_vec(new_args);
+        call.optional_chain = None;
+    }
+
+    /// Rewrite the callee of an optional call (`callee?.(...)`) whose segment
+    /// is being flattened. Returns the expression producing the callee value
+    /// and, when the callee is a member access, a side-effect-free re-read of
+    /// its receiver for use as the call's `this`.
+    fn rewrite_optional_callee(
+        &mut self,
+        callee: Expr,
+        map: &PrivateLoweredMap,
+    ) -> (Expr, Option<Expr>) {
+        let l = callee.loc;
+        if callee.is_optional_chain() {
+            // `o?.a.#m?.()` / `o?.a.b?.()`: flatten the callee's own segment
+            // to surface both its nullish tests and its `this` value.
+            return self.lower_optional_chain_with_private(callee, map, true);
+        }
+        // `o.#m?.()`: the callee itself is a lowered private access.
+        if let Some(info) = Self::lowered_private_index_info(&callee, map) {
+            let js_ast::ExprData::EIndex(e) = callee.data else {
+                unreachable!()
+            };
+            let mut recv = e.target;
+            self.rewrite_private_accesses_in_expr(&mut recv, map);
+            let (recv_write, recv_read) = self.capture_expr_for_reuse(recv, l);
+            return (self.private_get_expr(recv_write, &info, l), Some(recv_read));
+        }
+        match callee.data {
+            // `o.x?.()` (with a lowered private elsewhere in the segment):
+            // capture the receiver so `.call(...)` re-reads it without side
+            // effects.
+            js_ast::ExprData::EDot(mut e) => {
+                let mut target = e.target;
+                self.rewrite_private_accesses_in_expr(&mut target, map);
+                let (recv_write, recv_read) = self.capture_expr_for_reuse(target, l);
+                e.target = recv_write;
+                (callee, Some(recv_read))
+            }
+            js_ast::ExprData::EIndex(mut e) => {
+                let mut target = e.target;
+                self.rewrite_private_accesses_in_expr(&mut target, map);
+                let (recv_write, recv_read) = self.capture_expr_for_reuse(target, l);
+                e.target = recv_write;
+                let mut idx = e.index;
+                self.rewrite_private_accesses_in_expr(&mut idx, map);
+                e.index = idx;
+                (callee, Some(recv_read))
+            }
+            // Not a member access: the call's `this` is undefined.
+            _ => {
+                let mut c = callee;
+                self.rewrite_private_accesses_in_expr(&mut c, map);
+                (c, None)
+            }
+        }
+    }
+
+    /// Flatten one optional-chain segment so its `?.` nullish tests survive
+    /// the private-access rewrite: `o?.a.#m()` becomes
+    /// `o == null ? void 0 : __privateGet(_a = o.a, _m).call(_a)`.
+    ///
+    /// When `want_this_value` is set the caller is about to `.call()` the
+    /// result (`o?.a.#m?.()`), and the second return value re-reads the
+    /// receiver of the segment's final member access without side effects
+    /// (`None` when the segment ends in a call, whose result is then called
+    /// with an undefined `this`).
+    fn lower_optional_chain_with_private(
+        &mut self,
+        expr: Expr,
+        map: &PrivateLoweredMap,
+        want_this_value: bool,
+    ) -> (Expr, Option<Expr>) {
+        let l = expr.loc;
+        let bump = self.arena;
+
+        // Collect the segment's links from the outside in; the link flagged
+        // `Start` carries the `?.` and its target is the segment's base.
+        let mut links = BumpVec::<Expr>::new_in(bump);
+        let mut cur = expr;
+        let base = loop {
+            links.push(cur);
+            let (oc, target) = match &cur.data {
+                js_ast::ExprData::EDot(e) => (e.optional_chain, e.target),
+                js_ast::ExprData::EIndex(e) => (e.optional_chain, e.target),
+                js_ast::ExprData::ECall(e) => (e.optional_chain, e.target),
+                _ => unreachable!("optional chain links are EDot/EIndex/ECall"),
+            };
+            if oc == Some(js_ast::OptionalChain::Start) {
+                break target;
+            }
+            debug_assert_eq!(oc, Some(js_ast::OptionalChain::Continuation));
+            cur = target;
+        };
+
+        let mut tail_this: Option<Expr> = None;
+        let start_link = links[links.len() - 1];
+
+        // Hoist the segment's nullish test into `test_expr` and rebuild the
+        // links bottom-up on `acc` (as plain, non-optional accesses).
+        let (test_expr, mut acc, mut i) = if matches!(&start_link.data, js_ast::ExprData::ECall(_))
+        {
+            // The segment starts with `callee?.(...)`: the callee value is
+            // what gets nullish-tested, and calling it through `.call(...)`
+            // keeps the `this` binding its member structure would have
+            // provided.
+            let (callee_value, this_value) = self.rewrite_optional_callee(base, map);
+            let (test_expr, callee_read) = self.capture_expr_for_reuse(callee_value, l);
+            let js_ast::ExprData::ECall(mut ce) = start_link.data else {
+                unreachable!()
+            };
+            if let Some(this_read) = this_value {
+                self.retarget_call_through_dot_call(ce, callee_read, this_read, map, l);
+            } else {
+                ce.target = callee_read;
+                ce.optional_chain = None;
+                for arg in ce.args.slice_mut() {
+                    self.rewrite_private_accesses_in_expr(arg, map);
+                }
+            }
+            (test_expr, start_link, links.len() as isize - 2)
+        } else {
+            let mut base = base;
+            if base.is_optional_chain() && Self::optional_chain_needs_private_lowering(&base, map) {
+                let (lowered, _) = self.lower_optional_chain_with_private(base, map, false);
+                base = lowered;
+            } else {
+                self.rewrite_private_accesses_in_expr(&mut base, map);
+            }
+            let (test_expr, base_read) = self.capture_expr_for_reuse(base, l);
+            (test_expr, base_read, links.len() as isize - 1)
+        };
+
+        while i >= 0 {
+            let link = links[i as usize];
+            let capture_tail_this = i == 0 && want_this_value;
+            match link.data {
+                js_ast::ExprData::EIndex(mut e) => {
+                    if let Some(info) = Self::lowered_private_index_info(&link, map) {
+                        // `...#m(...)`: pair the private access with the call
+                        // link right above it so the receiver can be passed to
+                        // `.call(...)`, evaluated once.
+                        if i > 0
+                            && let js_ast::ExprData::ECall(ce) = links[(i - 1) as usize].data
+                        {
+                            let (recv_write, recv_read) = self.capture_expr_for_reuse(acc, l);
+                            let private_access = self.private_get_expr(recv_write, &info, l);
+                            self.retarget_call_through_dot_call(
+                                ce,
+                                private_access,
+                                recv_read,
+                                map,
+                                l,
+                            );
+                            acc = links[(i - 1) as usize];
+                            i -= 2;
+                            continue;
+                        }
+                        let obj = if capture_tail_this {
+                            let (recv_write, recv_read) = self.capture_expr_for_reuse(acc, l);
+                            tail_this = Some(recv_read);
+                            recv_write
+                        } else {
+                            acc
+                        };
+                        acc = self.private_get_expr(obj, &info, l);
+                        i -= 1;
+                        continue;
+                    }
+                    let mut idx = e.index;
+                    self.rewrite_private_accesses_in_expr(&mut idx, map);
+                    e.index = idx;
+                    e.target = if capture_tail_this {
+                        let (recv_write, recv_read) = self.capture_expr_for_reuse(acc, l);
+                        tail_this = Some(recv_read);
+                        recv_write
+                    } else {
+                        acc
+                    };
+                    e.optional_chain = None;
+                    acc = link;
+                    i -= 1;
+                }
+                js_ast::ExprData::EDot(mut e) => {
+                    e.target = if capture_tail_this {
+                        let (recv_write, recv_read) = self.capture_expr_for_reuse(acc, l);
+                        tail_this = Some(recv_read);
+                        recv_write
+                    } else {
+                        acc
+                    };
+                    e.optional_chain = None;
+                    acc = link;
+                    i -= 1;
+                }
+                js_ast::ExprData::ECall(mut e) => {
+                    // A plain call continuing the chain (`o?.a.b(...)`): the
+                    // rebuilt member target supplies its `this`.
+                    e.target = acc;
+                    e.optional_chain = None;
+                    for arg in e.args.slice_mut() {
+                        self.rewrite_private_accesses_in_expr(arg, map);
+                    }
+                    acc = link;
+                    i -= 1;
+                }
+                _ => unreachable!("optional chain links are EDot/EIndex/ECall"),
+            }
+        }
+
+        let null = self.new_expr(E::Null {}, l);
+        let test_ = self.new_expr(
+            E::Binary {
+                op: js_ast::OpCode::BinLooseEq,
+                left: test_expr,
+                right: null,
+            },
+            l,
+        );
+        let yes = self.new_expr(E::Undefined {}, l);
+        let result = self.new_expr(
+            E::If {
+                test_,
+                yes,
+                no: acc,
+            },
+            l,
+        );
+        (result, tail_this)
+    }
+
     fn rewrite_private_accesses_in_expr(&mut self, expr: &mut Expr, map: &PrivateLoweredMap) {
         let expr_loc = expr.loc;
+        // Rewriting a private access inside an optional chain must not lose
+        // the chain's short-circuiting: hoist the nullish tests out first.
+        if expr.is_optional_chain() && Self::optional_chain_needs_private_lowering(expr, map) {
+            let (lowered, _) = self.lower_optional_chain_with_private(*expr, map, false);
+            *expr = lowered;
+            return;
+        }
         match &mut expr.data {
             js_ast::ExprData::EIndex(e) => {
                 let mut tgt = e.target;
@@ -762,21 +1101,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             // temporary so its side effects run once and nested private
                             // calls don't duplicate the whole subtree (the duplication is
                             // exponential in the length of a chain like `o.#m().#m().#m()`).
-                            let (get_obj, this_arg) = match &obj_expr.data {
-                                js_ast::ExprData::EIdentifier(id) => {
-                                    let obj_ref = id.ref_;
-                                    (obj_expr, self.use_ref(obj_ref, obj_expr.loc))
-                                }
-                                js_ast::ExprData::EThis(_) => {
-                                    (obj_expr, self.new_expr(E::This {}, obj_expr.loc))
-                                }
-                                _ => {
-                                    let tmp_ref = self.generate_temp_ref(Some(b"_obj"));
-                                    let write = self.assign_to(tmp_ref, obj_expr, expr_loc);
-                                    let read = self.use_ref(tmp_ref, expr_loc);
-                                    (write, read)
-                                }
-                            };
+                            let (get_obj, this_arg) =
+                                self.capture_expr_for_reuse(obj_expr, expr_loc);
                             let private_access = self.private_get_expr(get_obj, &info, expr_loc);
                             let call_target = self.new_expr(
                                 E::Dot {

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -762,7 +762,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         // private access: rewriting the callee into a
                         // `__privateGet(..)` helper call would otherwise
                         // swallow the nullish test on the callee value.
-                        return Self::lowered_private_index_info(&e.target, map).is_some();
+                        if Self::lowered_private_index_info(&e.target, map).is_some() {
+                            return true;
+                        }
+                        // `o?.#f.b?.()`: the callee is a chain segment with a
+                        // lowered private deeper in. Flattening it in place
+                        // would turn the callee into a ternary value and drop
+                        // the call's `this`; route the call through the
+                        // flattener so the receiver is captured instead.
+                        return e.target.is_optional_chain()
+                            && Self::optional_chain_needs_private_lowering(&e.target, map);
                     }
                     cur = e.target;
                 }
@@ -1043,6 +1052,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     fn rewrite_private_accesses_in_expr(&mut self, expr: &mut Expr, map: &PrivateLoweredMap) {
         let expr_loc = expr.loc;
+        // `delete o?.#f.x`: a flattened chain is a ternary value, and
+        // `delete` of a non-reference is a silent no-op. Push the `delete`
+        // into the non-null branch (`o == null ? true : delete
+        // __privateGet(o, _f).x`) so it still removes the property, and
+        // yield `true` when the chain short-circuits, matching the spec.
+        if let js_ast::ExprData::EUnary(mut ue) = expr.data
+            && ue.op == js_ast::OpCode::UnDelete
+            && ue.value.is_optional_chain()
+            && Self::optional_chain_needs_private_lowering(&ue.value, map)
+        {
+            let (lowered, _) = self.lower_optional_chain_with_private(ue.value, map, false);
+            let js_ast::ExprData::EIf(mut ie) = lowered.data else {
+                unreachable!()
+            };
+            ue.value = ie.no;
+            ie.yes = self.new_expr(E::Boolean { value: true }, expr_loc);
+            ie.no = *expr;
+            *expr = lowered;
+            return;
+        }
         // Rewriting a private access inside an optional chain must not lose
         // the chain's short-circuiting: hoist the nullish tests out first.
         if expr.is_optional_chain() && Self::optional_chain_needs_private_lowering(expr, map) {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1108,6 +1108,40 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("7 undefined 7\n");
       expect(exitCode).toBe(0);
     });
+
+    test("optional call keeps `this` when the callee chain has a private deeper in", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        let captured = null;
+        class Foo {
+          static #f = { b() { captured = this; return 1; } };
+          @dec() go(o) { return o?.#f.b?.(); }
+          @dec() isCaptured(o) { return captured === o?.#f; }
+          @dec() goMissing(o) { return o?.#f.missing?.(); }
+        }
+        const f = new Foo();
+        console.log(f.go(Foo), f.isCaptured(Foo), f.go(undefined), f.goMissing(Foo));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 true undefined undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("delete through a lowered private chain removes the property", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #f = { x: 1 };
+          @dec() del(o) { return delete o?.#f.x; }
+          @dec() has() { return "x" in Foo.#f; }
+        }
+        const f = new Foo();
+        console.log(f.del(undefined), f.has(), f.del(Foo), f.has());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true true true false\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("accessor with TypeScript annotations", () => {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -925,6 +925,171 @@ describe("ES Decorators", () => {
     });
   });
 
+  // When a class has decorated members, private accesses are rewritten into
+  // __privateGet/__privateMethod helper calls. The `?.` tests guarding those
+  // accesses must be hoisted out of the chain so a nullish base still
+  // short-circuits the whole chain instead of reaching the helper.
+  // https://github.com/oven-sh/bun/issues/31910
+  describe.concurrent("optional chains through lowered private members", () => {
+    test("nullish base short-circuits lowered private gets and calls", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #f = 123;
+          static #m = function () { return { Foo }; };
+          @dec() direct(o) { return o?.#f; }
+          @dec() viaProp(o) { return o?.a.#f; }
+          @dec() callViaProp(o) { return o?.Foo.#m(); }
+          @dec() directCall(o) { return o?.#m(); }
+          @dec() afterGet(o) { return o?.a.#f.x; }
+        }
+        const f = new Foo();
+        console.log(f.direct(null), f.viaProp(undefined), f.callViaProp(null), f.directCall(undefined), f.afterGet(null));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined undefined undefined undefined undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("non-nullish chains produce the right values and `this`", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #f = 123;
+          static #m = function (...args) { return [this === Foo, args]; };
+          @dec() viaProp(o) { return o?.a.#f; }
+          @dec() callViaProp(o) { return o?.a.#m(1, 2); }
+          @dec() direct(o) { return o?.#f; }
+          @dec() directCall(o) { return o?.#m(3); }
+        }
+        const f = new Foo();
+        console.log(JSON.stringify([f.viaProp({ a: Foo }), f.callViaProp({ a: Foo }), f.direct(Foo), f.directCall(Foo)]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[123,[true,[1,2]],123,[true,[3]]]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("optional call of a lowered private tests the function value and keeps `this`", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #fn = null;
+          static #m = function (...args) { return [this === Foo, args]; };
+          @dec() nullishFn(o) { return o.#fn?.(1); }
+          @dec() optCall(o) { return o.#m?.(2); }
+          @dec() chainOptCall(o) { return o?.a.#m?.(3); }
+        }
+        const f = new Foo();
+        console.log(JSON.stringify([f.nullishFn(Foo), f.optCall(Foo), f.chainOptCall({ a: Foo }), f.chainOptCall(undefined)]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[null,[true,[2]],[true,[3]],null]\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("chain base and computed keys evaluate exactly once and stay lazy", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        let baseEvals = 0;
+        let keyEvals = 0;
+        class Counter {
+          static #f = 5;
+          static #m = function (x) { return [this === Counter, x]; };
+          @dec() callChain(o) { return getBase(o)?.a.#m(42); }
+          @dec() computed(o, k) { return o?.[k()].#f; }
+        }
+        function getBase(o) { baseEvals++; return o; }
+        function key() { keyEvals++; return "k"; }
+        const c = new Counter();
+        const r1 = c.callChain({ a: Counter });
+        const r2 = c.callChain(undefined);
+        const r3 = c.computed({ k: Counter }, key);
+        const r4 = c.computed(null, () => { throw new Error("must not evaluate"); });
+        console.log(JSON.stringify([r1, r2, r3, r4]), baseEvals, keyEvals);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[[true,42],null,5,null] 2 1\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("each `?.` in a multi-segment chain keeps its own test", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #f = 123;
+          static #g = { b: Foo };
+          static #n = null;
+          static #m = function (x) { return x * 2; };
+          @dec() twoOpt(o) { return o?.a?.b.#f; }
+          @dec() segHit(o) { return o?.a.#g?.b.#m(21); }
+          @dec() segNull(o) { return o?.a.#n?.b.#m(21); }
+        }
+        const f = new Foo();
+        console.log(f.twoOpt(null), f.twoOpt({ a: null }), f.twoOpt({ a: { b: Foo } }), f.segHit({ a: Foo }), f.segNull({ a: Foo }));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined undefined 123 42 undefined\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("optional call at the segment start with a private access above it", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          static #f = 7;
+          @dec() callThenGet(o) { return o.x?.().#f; }
+          @dec() chainCallThenGet(o) { return o?.a.b?.().#f; }
+        }
+        const f = new Foo();
+        const withThis = { val: Foo, x() { return this.val; } };
+        console.log(
+          f.callThenGet({}),
+          f.callThenGet(withThis),
+          f.chainCallThenGet(undefined),
+          f.chainCallThenGet({ a: {} }),
+          f.chainCallThenGet({ a: { b: () => Foo } }),
+        );
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined 7 undefined undefined 7\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated class expressions declare the chain temporaries", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        let evals = 0;
+        const C = class {
+          static #m = function () { return { C, n: ++evals }; };
+          @dec() go(o) { return o?.C.#m().n; }
+        };
+        const c = new C();
+        console.log(c.go(undefined), c.go({ C }), evals);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("undefined 1 1\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("private instance methods and getters short-circuit in chains", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Foo {
+          #p(n) { return [this instanceof Foo, n]; }
+          get #g() { return 9; }
+          @dec() method(o) { return o?.x.#p(1); }
+          @dec() getter(o) { return o?.x.#g; }
+        }
+        const f = new Foo();
+        console.log(JSON.stringify([f.method(null), f.method({ x: f }), f.getter(undefined), f.getter({ x: f })]));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("[null,[true,1],null,9]\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("accessor with TypeScript annotations", () => {
     test("accessor with definite assignment assertion (!)", async () => {
       using dir = tempDir("es-dec-accessor-bang", {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1088,6 +1088,26 @@ describe("ES Decorators", () => {
       expect(stdout).toBe("[null,[true,1],null,9]\n");
       expect(exitCode).toBe(0);
     });
+
+    test("optional call of a super property keeps valid syntax and `this`", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec() { return (v, ctx) => {}; }
+        class Base {
+          hit() { return this; }
+        }
+        class Sub extends Base {
+          #f = 7;
+          @dec() go() { return super.hit?.().#f; }
+          @dec() goMissing() { return super.missing?.().#f; }
+          @dec() goComputed(k) { return super[k]?.().#f; }
+        }
+        const s = new Sub();
+        console.log(s.go(), s.goMissing(), s.goComputed("hit"));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("7 undefined 7\n");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("accessor with TypeScript annotations", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes #31910. Optional chains that pass through a lowered private member access in a decorated class lose their short-circuiting: the `?.` nullish check is dropped by the rewrite, so the `__privateGet`/`__privateMethod` helper is called with `undefined` and throws `TypeError: Cannot read from private field` instead of the chain evaluating to `undefined`.

```js
function decorator() { return (v, ctx) => {}; }
class Foo {
  static #m = function () { return { Foo }; };
  @decorator() test(o) { return o?.Foo.#m(); }
}
new Foo().test(undefined); // expected: undefined; before this PR: TypeError
```

### Cause

`rewrite_private_accesses_in_expr` in `src/js_parser/lower/lower_decorators.rs` rewrites `EIndex`/`ECall` nodes with private identifiers into helper calls without looking at the `optional_chain` flags, emitting

```js
__privateGet(o?.Foo, _m).call(o?.Foo)
```

where `o?.Foo` evaluates to `undefined` without short-circuiting the enclosing call.

### Fix

Before rewriting, detect optional-chain segments whose spine contains a lowered private access (or whose `?.()` callee ends in one) and flatten the segment, hoisting the nullish test out, the way esbuild's decorator lowering does:

```js
o == null ? void 0 : __privateGet(_a = o.Foo, _m).call(_a)
```

- Receivers of private method calls, optional callees, and effectful chain bases are captured in temporaries so they evaluate exactly once. The temporaries are declared in a `var` statement emitted with the other lowering variables (WeakMaps, `_dec`, `_init`), covering both class statements and class expressions.
- `callee?.()` segments preserve the `this` binding of the callee's member access via `.call(recv)`, including across nested segments (`o?.a.#m?.()` calls `#m` with `this === o.a`; esbuild drops `this` here, Node keeps it, this PR matches Node).
- Segments without a lowered private are left as native `?.` syntax.
- `delete` of a chain containing a lowered private pushes the `delete` into the non-null branch (`o == null ? true : delete __privateGet(o, _f).x`) so the property reference survives.
- `super.m?.()` / `super[k]?.()` callees stay intact (bare `super` cannot be captured in a temporary) and call with the current `this`.
- Each `?.` in a multi-segment chain keeps its own test; inner segments are lowered recursively only when needed.

The lowered output matches esbuild's decorator lowering shape for the common forms (`o?.#f`, `o?.a.#f`, `o?.a.#m()`, `o.#m?.()`, `g()?.a.#f`, `o?.a?.b.#f`, ...).

### Verification

New tests in `test/bundler/transpiler/es-decorators.test.ts` ("optional chains through lowered private members"): nullish short-circuit for field gets / method calls / direct accesses, non-null paths with exact values and `this`, optional calls of private members, multi-segment chains, evaluate-once + laziness of bases and computed keys, `?.()` at segment start with a private above it, decorated class expressions, and private instance methods/getters.

`bun bd test test/bundler/transpiler/es-decorators.test.ts`: 43 pass with the fix; 7 of the 8 new tests fail with `USE_SYSTEM_BUN=1` (the remaining one guards non-null path values, which already worked). Also ran `es-decorators-esbuild.test.ts` (147), `decorators.test.ts` (22), `decorator-metadata.test.ts` (5), `bundler_decorator_metadata.test.ts` (2), and `transpiler.test.js` (188): no regressions.

A 37-case differential fixture (every chain form above, nullish at each position plus hit paths, with side-effect counters) produces byte-identical output between Node (undecorated, native semantics) and this branch's lowering; 18 of the 37 cases throw `TypeError` on the unfixed build.

Rebased on main after #31426 (evaluate private method call receivers once) merged; it touches the same function. Resolution: kept main's temp-declaration machinery (`drain_capture_temp_decls` and the per-function-body declarations, which also make the temps reentrancy-safe) and dropped this PR's duplicate class-level drain block, and the receiver capture in the non-chain `ECall` arm now goes through this PR's `capture_expr_for_reuse` helper instead of an identical inline match. Both PRs' test suites pass together (54 tests in `es-decorators.test.ts`).