### PR TITLE
dev server: flag re-bundled HTML route modules as route updates in hot update payloads

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4197,6 +4197,14 @@ pub(super) fn finalize_bundle(
         }
     }
 
+    // HTML routes whose generated JS module was re-emitted into this bundle's
+    // hot chunk. These are collected independently of the dependency traces:
+    // `html_routes_hard_affected` can miss a re-bundled route when another
+    // trace visits the HTML file first (the `gts` bitset makes
+    // `trace_dependencies` order-dependent), and List 1 below must flag every
+    // route whose root module ships in the chunk.
+    let mut html_routes_rebundled: Vec<route_bundle::Index> =
+        Vec::with_capacity(html_chunks_mut.len());
     for chunk in html_chunks_mut.iter_mut() {
         let index = bun_ast::Index::init(chunk.entry_point.source_index());
         let bundler::CompileResult::Html {
@@ -4228,6 +4236,7 @@ pub(super) fn finalize_bundle(
             .unwrap::<{ bake::Side::Client }>()
             .expect("unresolved index");
         let route_bundle_index = dev.client_graph.html_route_bundle_index(client_index);
+        html_routes_rebundled.push(route_bundle_index);
         let route_bundle = dev.route_bundle_ptr(route_bundle_index);
         debug_assert!(route_bundle.data.html().bundled_file == client_index);
         // Note: split borrow — `invalidate_client_bundle` needs `&mut RouteBundle`
@@ -4470,25 +4479,43 @@ pub(super) fn finalize_bundle(
     let will_hear_hot_update = hot_update_subscribers > 0;
 
     // This list of routes affected excludes client code.
-    if will_hear_hot_update
-        && current_bundle!().had_reload_event
+    // The affected-route lists are only announced for watcher-triggered
+    // bundles that completed without failures; viewers of a broken route keep
+    // the current page and the error overlay instead of reloading into an
+    // error page.
+    let announce_affected_routes = current_bundle!().had_reload_event
         && (dev.incremental_result.framework_routes_affected.len()
             + dev.incremental_result.html_routes_hard_affected.len())
             > 0
-        && dev.bundling_failures.is_empty()
-    {
+        && dev.bundling_failures.is_empty();
+    // HTML routes whose root JS module ships in this bundle's hot chunk are
+    // announced unconditionally: the HMR client can never hot-apply an HTML
+    // root module (`replaceModules` expects the route reload to happen
+    // first), so sending the module without flagging the route would push
+    // viewers through the "hot update was not accepted" full-reload fallback.
+    if will_hear_hot_update && (announce_affected_routes || !html_routes_rebundled.is_empty()) {
         has_route_bits_set = true;
 
-        for request in &dev.incremental_result.framework_routes_affected {
-            let route = dev.router.route_ptr(request.route_index());
-            if let Some(id) = route.bundle {
-                route_bits.set(id.get() as usize);
+        if announce_affected_routes {
+            for request in &dev.incremental_result.framework_routes_affected {
+                let route = dev.router.route_ptr(request.route_index());
+                if let Some(id) = route.bundle {
+                    route_bits.set(id.get() as usize);
+                }
+                if request.should_recurse_when_visiting() {
+                    mark_all_route_children(
+                        &dev.router,
+                        &mut [&mut route_bits],
+                        request.route_index(),
+                    );
+                }
             }
-            if request.should_recurse_when_visiting() {
-                mark_all_route_children(&dev.router, &mut [&mut route_bits], request.route_index());
+            for route_bundle_index in &dev.incremental_result.html_routes_hard_affected {
+                route_bits.set(route_bundle_index.get() as usize);
+                route_bits_client.set(route_bundle_index.get() as usize);
             }
         }
-        for route_bundle_index in &dev.incremental_result.html_routes_hard_affected {
+        for route_bundle_index in &html_routes_rebundled {
             route_bits.set(route_bundle_index.get() as usize);
             route_bits_client.set(route_bundle_index.get() as usize);
         }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3003,7 +3003,9 @@ impl DevServer {
                 if !loaders[import.source_index.get() as usize].is_javascript_like() {
                     continue; // ignore non-JavaScript imports
                 }
-                input_file_sources[import.source_index.get() as usize].path.pretty
+                input_file_sources[import.source_index.get() as usize]
+                    .path
+                    .pretty
             } else {
                 // Find the in-graph import.
                 let Some(file) = self.client_graph.bundled_files.get(import.path.text) else {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2994,10 +2994,16 @@ impl DevServer {
         w.extend_from_slice(b": [ [");
         let mut any = false;
         for import in import_records[index.get() as usize].as_slice() {
-            if import.source_index.is_valid() {
+            // The emitted key must match the target module's own key, which
+            // the printer derives from the source's `pretty` path. The
+            // record's `pretty` is not rewritten when the import target is
+            // also an entry point of this bundle, leaving the raw specifier
+            // or an absolute path behind (#31923).
+            let key: &[u8] = if import.source_index.is_valid() {
                 if !loaders[import.source_index.get() as usize].is_javascript_like() {
                     continue; // ignore non-JavaScript imports
                 }
+                input_file_sources[import.source_index.get() as usize].path.pretty
             } else {
                 // Find the in-graph import.
                 let Some(file) = self.client_graph.bundled_files.get(import.path.text) else {
@@ -3006,16 +3012,14 @@ impl DevServer {
                 if !matches!(file.content, incremental_graph::Content::Js(_)) {
                     continue;
                 }
-            }
+                import.path.pretty
+            };
             if !any {
                 any = true;
                 w.extend_from_slice(b"\n");
             }
             w.extend_from_slice(b"    ");
-            bun_js_printer::write_json_string::<_, { bun_js_printer::Encoding::Utf8 }>(
-                import.path.pretty,
-                w,
-            )?;
+            bun_js_printer::write_json_string::<_, { bun_js_printer::Encoding::Utf8 }>(key, w)?;
             w.extend_from_slice(b", 0,\n");
         }
         if any {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -1044,7 +1044,11 @@ export class Client extends EventEmitter {
       this.suppressInteractivePrompt = true;
       let retries = 0;
       let hasVisibleModal = false;
-      while (retries < 5) {
+      // When errors are expected, wait for the modal with the same headroom
+      // as the other harness waits. When none are expected the modal never
+      // appears on the happy path, so keep the short window.
+      const maxRetries = errors && errors.length > 0 ? 5 * WAIT_MULTIPLIER : 5;
+      while (retries < maxRetries) {
         hasVisibleModal = await this.js`document.querySelector("bun-hmr")?.style.display === "block"`;
         if (hasVisibleModal) break;
         await Bun.sleep(200);

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -370,3 +370,52 @@ devTest("error report endpoint blanks stray non-text bytes in reported frames", 
     await dev.fetch("/").expect.toInclude("<h1>Frame Bytes</h1>");
   },
 });
+
+// https://github.com/oven-sh/bun/issues/31908
+// A request for a route with bundling failures re-bundles the route's HTML
+// module into the hot update chunk. The update must be flagged as a route
+// update (List 1) so connected clients reload; the client can never apply an
+// HTML root module through `replaceModules`.
+devTest("connected client reloads when a broken route is re-bundled", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["script.ts"],
+      body: "<h1>Hello</h1>",
+    }),
+    "script.ts": `
+      console.log("v1");
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
+    await using c = await dev.client("/", { allowUnlimitedReloads: true });
+    await c.expectMessage("v1");
+    await dev.write(
+      "script.ts",
+      `
+        import "./missing.ts";
+        console.log("v2");
+      `,
+      {
+        errors: ['script.ts:1:8: error: Could not resolve: "./missing.ts"'],
+      },
+    );
+    // Requesting the broken route re-bundles its HTML module; the hot update
+    // carrying that module must tell viewers to reload.
+    await c.expectReload(async () => {
+      expect((await dev.fetch("/")).status).toBe(500);
+    });
+    await dev.write(
+      "script.ts",
+      `
+        console.log("v2");
+      `,
+    );
+    // The client converges on the healthy page. Depending on when its reload
+    // request lands, it may pass through the bundling error page first and
+    // reload once more when the errors clear.
+    await c.output.waitForLine(/\[Bun\] (Live|Hot-module)-reloading socket connected/);
+    await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
+    await c.expectMessage("v2");
+  },
+});

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -410,9 +410,6 @@ devTest("connected client reloads when a broken route is re-bundled", {
     // The reload lands on the bundling error page (the route is still
     // broken). Wait for the client to settle there so the recovery below
     // deterministically reloads it through the error page.
-    while (!(await c.js<boolean>`document.querySelector("bun-hmr")?.style.display === "block"`.catch(() => false))) {
-      await Bun.sleep(50);
-    }
     await c.expectErrorOverlay(['script.ts:1:8: error: Could not resolve: "./missing.ts"']);
     await c.expectReload(async () => {
       await dev.write(
@@ -423,6 +420,51 @@ devTest("connected client reloads when a broken route is re-bundled", {
       );
     });
     await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
+    await c.expectMessage("v2");
+  },
+});
+
+// https://github.com/oven-sh/bun/issues/31908
+// Editing the HTML file and one of its scripts in the same watch batch
+// re-emits the HTML module into the hot chunk, but the dependency trace from
+// the script visits the HTML file first, so `html_routes_hard_affected`
+// misses the route. The re-bundled HTML module must still be announced as a
+// route update.
+// The reloaded page also covers https://github.com/oven-sh/bun/issues/31923:
+// the HTML module stored by the combined rebuild must reference the script by
+// its module key, or the regenerated route bundle fails to load.
+devTest("combined html and script edit in one batch performs a route reload", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["script.ts"],
+      body: "<h1>Hello</h1>",
+    }),
+    "script.ts": `
+      console.log("v1");
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
+    await using c = await dev.client("/");
+    await c.expectMessage("v1");
+    await c.expectReload(async () => {
+      await using _batch = await dev.batchChanges();
+      await dev.write(
+        "index.html",
+        emptyHtmlFile({
+          scripts: ["script.ts"],
+          body: "<h1>World</h1>",
+        }),
+      );
+      await dev.write(
+        "script.ts",
+        `
+          console.log("v2");
+        `,
+      );
+    });
+    await c.output.waitForLine(/\[Bun\] Server-side code changed, reloading!/);
+    await dev.fetch("/").expect.toInclude("<h1>World</h1>");
     await c.expectMessage("v2");
   },
 });

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -388,7 +388,7 @@ devTest("connected client reloads when a broken route is re-bundled", {
   },
   async test(dev) {
     await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
-    await using c = await dev.client("/", { allowUnlimitedReloads: true });
+    await using c = await dev.client("/");
     await c.expectMessage("v1");
     await dev.write(
       "script.ts",
@@ -401,20 +401,27 @@ devTest("connected client reloads when a broken route is re-bundled", {
       },
     );
     // Requesting the broken route re-bundles its HTML module; the hot update
-    // carrying that module must tell viewers to reload.
+    // carrying that module must tell viewers to perform a route reload
+    // instead of delivering "index.html" through `replaceModules`.
     await c.expectReload(async () => {
       expect((await dev.fetch("/")).status).toBe(500);
     });
-    await dev.write(
-      "script.ts",
-      `
-        console.log("v2");
-      `,
-    );
-    // The client converges on the healthy page. Depending on when its reload
-    // request lands, it may pass through the bundling error page first and
-    // reload once more when the errors clear.
-    await c.output.waitForLine(/\[Bun\] (Live|Hot-module)-reloading socket connected/);
+    await c.output.waitForLine(/\[Bun\] Server-side code changed, reloading!/);
+    // The reload lands on the bundling error page (the route is still
+    // broken). Wait for the client to settle there so the recovery below
+    // deterministically reloads it through the error page.
+    while (!(await c.js<boolean>`document.querySelector("bun-hmr")?.style.display === "block"`.catch(() => false))) {
+      await Bun.sleep(50);
+    }
+    await c.expectErrorOverlay(['script.ts:1:8: error: Could not resolve: "./missing.ts"']);
+    await c.expectReload(async () => {
+      await dev.write(
+        "script.ts",
+        `
+          console.log("v2");
+        `,
+      );
+    });
     await dev.fetch("/").expect.toInclude("<h1>Hello</h1>");
     await c.expectMessage("v2");
   },


### PR DESCRIPTION
### What does this PR do?

Fixes #31908. Fixes #31923.

#### Route updates for re-bundled HTML modules (#31908)

The dev server's hot update payload starts with a list of routes that require a page reload (List 1 in `finalize_bundle`). That list was only written for watcher-triggered bundles with zero bundling failures, but the JS chunk in the same payload can carry an HTML route's generated root module outside those conditions. The HMR client can never hot-apply an HTML root module through `replaceModules`:

- debug builds of the HMR runtime crash on `DEBUG.ASSERT(!boundary.endsWith(".html")); // caller should have already reloaded` (`src/runtime/bake/hmr-module.ts`), observed as `error: Client exited: "Assertion failed"` with `at replaceModules` in the trace
- release builds print the misleading `Hot update was not accepted because it or its importers do not call import.meta.hot.accept` warning (nothing in an HTML file can call that) and fall back to a full reload

Two reachable cases ship the HTML module with List 1 empty:

1. Requesting a route that has bundling failures: `check_route_failures` cache-busts everything reachable and re-bundles the route (`had_reload_event` false, failures non-empty). This is the scenario from the issue: CSS root fails on hot reload, the page is fetched (500), and connected clients crash.
2. A clean rebuild that re-emits the HTML module but whose dependency trace visits the HTML file from another changed file first: the `gts` visited bitset makes `trace_dependencies` order-dependent, so the `html_routes_hard_affected` entry is swallowed (editing the HTML file and one of its scripts in the same watch batch).

Fix: collect the route bundle indices whose HTML chunk was emitted during `finalize_bundle` (`html_routes_rebundled`) and always include them in List 1. Framework routes keep the existing gating. Viewers of the route now perform a route reload, which is what the payload format documents for List 1.

#### HTML module import keys (#31923, found while testing scenario 2)

`generate_javascript_code_for_html_file` wrote each import's `record.path.pretty` as the module key. When the import target is also an entry point of the same rebuild (the combined watch batch above), the record's pretty path is not rewritten and keeps the raw specifier or an absolute path, so the stored HTML module referenced a key that does not exist in the client module registry and the regenerated route bundle failed to boot with `Failed to load bundled module '/abs/path/script.ts'`. Fix: emit the key from the resolved source's pretty path, the same field the printer derives the target module's own key from.

#### Test harness

`expectErrorOverlay`'s retry budget now scales with `WAIT_MULTIPLIER` when errors are expected, matching the other harness waits; the no-errors branch keeps the short window because it runs on every `dev.write` with a connected client and the modal never appears on the happy path.

### Verification

Two new tests in `test/bake/dev/html.test.ts`:

- `connected client reloads when a broken route is re-bundled` (scenario 1): break a script import, fetch the route (500, triggers the re-bundle), assert the client performs a route reload (`[Bun] Server-side code changed, reloading!`), lands on the error page, and converges on the healthy page after the fix.
- `combined html and script edit in one batch performs a route reload` (scenario 2): edit `index.html` and `script.ts` in one `dev.batchChanges()` batch, assert the route reload and that the reloaded page boots and runs the new script (covers #31923).

On main, scenario 1 fails with `error: Client exited: "Assertion failed"` (debug) and `Timeout waiting for line "[Bun] Server-side code changed, reloading!"` (release); scenario 2 fails with the same assert plus the `Failed to load bundled module` boot failure. Both pass with the fixes on debug (ASAN) and release builds; `test/bake/dev/{html,hot,esm,css,bundle,react-spa,react-response,sourcemap}.test.ts` pass (except two css failures that reproduce identically on plain main and are #31903, fixed by #31905).

Note: the exact CSS repro from #31908 additionally requires #31905, without which the dev server crashes first (#31903, `assertion failed: !chunk.content.is_css()`). The regression tests here use failed or co-edited JS instead, which reach the same payload path on current main. The CSS scenario (connected client + `url()` resolve error + recovery) was verified locally to pass with this fix applied on top of #31905.
