### PR TITLE
css: budget selector expansion and nesting substitution by bytes

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -2408,6 +2408,8 @@ mod stylesheet_impl {
                 err: None,
                 selector_expansion_multiplier: 1,
                 selector_expansion_total: 0,
+                selector_expansion_chain_bytes: 0,
+                selector_expansion_bytes_total: 0,
             };
 
             if self.rules.minify(&mut minify_ctx, false).is_err() {

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -494,9 +494,7 @@ pub enum MinifyErrorKind {
     /// Compiling nested rules for the configured browser targets would expand to
     /// more than [`crate::css_rules::MAX_SELECTOR_EXPANSION`] selectors.
     selector_expansion_limit_exceeded,
-    /// Compiling nested rules for the configured browser targets would expand
-    /// selectors into more than
-    /// [`crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES`] estimated bytes.
+    /// Same expansion, bounded by [`crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES`] estimated bytes.
     selector_expansion_bytes_limit_exceeded,
     /// Rule minification failed without recording a more specific diagnostic on
     /// `MinifyContext::err`. Defensive fallback — every failing path is expected

--- a/src/css/error.rs
+++ b/src/css/error.rs
@@ -494,6 +494,10 @@ pub enum MinifyErrorKind {
     /// Compiling nested rules for the configured browser targets would expand to
     /// more than [`crate::css_rules::MAX_SELECTOR_EXPANSION`] selectors.
     selector_expansion_limit_exceeded,
+    /// Compiling nested rules for the configured browser targets would expand
+    /// selectors into more than
+    /// [`crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES`] estimated bytes.
+    selector_expansion_bytes_limit_exceeded,
     /// Rule minification failed without recording a more specific diagnostic on
     /// `MinifyContext::err`. Defensive fallback — every failing path is expected
     /// to record one before returning an error.
@@ -518,6 +522,11 @@ impl fmt::Display for MinifyErrorKind {
                 f,
                 "Nested CSS rules expand to more than {} selectors when compiled for the configured browser targets. Reduce the nesting depth or the number of selectors per rule, or target browsers that support CSS nesting.",
                 crate::css_rules::MAX_SELECTOR_EXPANSION,
+            ),
+            Self::selector_expansion_bytes_limit_exceeded => write!(
+                f,
+                "Nested CSS rules expand to more than {} bytes of selectors when compiled for the configured browser targets. Reduce the nesting depth, the number or size of selectors per rule, or target browsers that support CSS nesting.",
+                crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES,
             ),
             Self::unknown => write!(f, "CSS minification failed"),
         }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -147,6 +147,17 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub(crate) nesting_expansions: u32,
+    /// Running total of bytes emitted by `&` parent-selector substitutions
+    /// (accumulated across the whole stylesheet, never reset). Complements
+    /// `nesting_expansions`: the count bounds how many substitutions happen,
+    /// this bounds what they emit: each substitution writes the parent
+    /// selector list, whose size is input-controlled. Bounded in
+    /// `serialize::serialize_nesting`.
+    pub(crate) nesting_expansion_bytes: usize,
+    /// Recursion depth of in-progress `serialize_nesting` substitutions; only
+    /// the outermost one measures its byte span into
+    /// `nesting_expansion_bytes` (inner substitutions are contained in it).
+    pub(crate) nesting_expansion_meter_depth: u32,
     /// Running total of bytes emitted by duplicate vendor-prefix passes. A rule
     /// whose selector list carries more than one vendor prefix (e.g. a list
     /// mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a single
@@ -310,6 +321,8 @@ impl<'a> Printer<'a> {
             css_module: None,
             ctx: None,
             nesting_expansions: 0,
+            nesting_expansion_bytes: 0,
+            nesting_expansion_meter_depth: 0,
             prefix_expansion_bytes: 0,
             error_kind: None,
         }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -147,17 +147,10 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub(crate) nesting_expansions: u32,
-    /// Running total of bytes emitted by `&` parent-selector substitutions
-    /// (accumulated across the whole stylesheet, never reset). Complements
-    /// `nesting_expansions`: the count bounds how many substitutions happen,
-    /// this bounds what they emit: each substitution writes the parent
-    /// selector list, whose size is input-controlled. Bounded in
-    /// `serialize::serialize_nesting`.
+    /// Stylesheet-wide bytes written by completed `&` substitutions; bounded in `serialize::serialize_nesting`.
     pub(crate) nesting_expansion_bytes: usize,
-    /// Recursion depth of in-progress `serialize_nesting` substitutions; only
-    /// the outermost one measures its byte span into
-    /// `nesting_expansion_bytes` (inner substitutions are contained in it).
-    pub(crate) nesting_expansion_meter_depth: u32,
+    /// `bytes_written()` when the outermost in-progress `&` substitution began, if any.
+    pub(crate) nesting_expansion_span_start: Option<usize>,
     /// Running total of bytes emitted by duplicate vendor-prefix passes. A rule
     /// whose selector list carries more than one vendor prefix (e.g. a list
     /// mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a single
@@ -322,7 +315,7 @@ impl<'a> Printer<'a> {
             ctx: None,
             nesting_expansions: 0,
             nesting_expansion_bytes: 0,
-            nesting_expansion_meter_depth: 0,
+            nesting_expansion_span_start: None,
             prefix_expansion_bytes: 0,
             error_kind: None,
         }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1207,6 +1207,22 @@ pub struct StyleContext<'a> {
 /// instead.
 pub(crate) const MAX_SELECTOR_EXPANSION: u32 = 65_536;
 
+/// Upper bound on the estimated serialized bytes of the selectors that
+/// compiling nested rules away for the configured targets may expand a
+/// stylesheet into.
+///
+/// [`MAX_SELECTOR_EXPANSION`] bounds how many selectors the expansion
+/// produces, but each expanded selector repeats its ancestor chain, whose
+/// per-level size is input-controlled (long identifiers, multi-argument
+/// `:lang()`, raw custom pseudo-class arguments). Count × size lets a few KB
+/// of input expand into hundreds of megabytes of cloned rules and output while
+/// staying under the count cap, so the expansion is also charged by estimated
+/// bytes ([`selector::selector_list_weight`](crate::selectors::selector)).
+/// Exceeding this is reported as a `selector_expansion_bytes_limit_exceeded`
+/// minify error. The thresholds are ordered so that stylesheets with
+/// ordinary-sized selectors keep hitting the count limit first.
+pub(crate) const MAX_SELECTOR_EXPANSION_BYTES: u64 = 64 << 20;
+
 /// Per-stylesheet minification state threaded through `CssRuleList::minify`
 /// and every leaf rule's `minify`.
 ///
@@ -1242,4 +1258,13 @@ pub struct MinifyContext<'a, 'bump> {
     /// Running total of selectors that compiling nested rules for the targets
     /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
     pub(crate) selector_expansion_total: u32,
+    /// Estimated serialized bytes one expanded selector's ancestor chain
+    /// contributes: the sum over the enclosing (compiled) style rules of the
+    /// average selector weight of their lists. `0` at the top level;
+    /// maintained alongside `selector_expansion_multiplier` in
+    /// `StyleRule::minify_nested_rules`.
+    pub(crate) selector_expansion_chain_bytes: u32,
+    /// Running estimate of the serialized bytes the expansion will produce,
+    /// checked against [`MAX_SELECTOR_EXPANSION_BYTES`].
+    pub(crate) selector_expansion_bytes_total: u64,
 }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1263,7 +1263,7 @@ pub struct MinifyContext<'a, 'bump> {
     /// average selector weight of their lists. `0` at the top level;
     /// maintained alongside `selector_expansion_multiplier` in
     /// `StyleRule::minify_nested_rules`.
-    pub(crate) selector_expansion_chain_bytes: u32,
+    pub(crate) selector_expansion_chain_bytes: u64,
     /// Running estimate of the serialized bytes the expansion will produce,
     /// checked against [`MAX_SELECTOR_EXPANSION_BYTES`].
     pub(crate) selector_expansion_bytes_total: u64,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1207,20 +1207,7 @@ pub struct StyleContext<'a> {
 /// instead.
 pub(crate) const MAX_SELECTOR_EXPANSION: u32 = 65_536;
 
-/// Upper bound on the estimated serialized bytes of the selectors that
-/// compiling nested rules away for the configured targets may expand a
-/// stylesheet into.
-///
-/// [`MAX_SELECTOR_EXPANSION`] bounds how many selectors the expansion
-/// produces, but each expanded selector repeats its ancestor chain, whose
-/// per-level size is input-controlled (long identifiers, multi-argument
-/// `:lang()`, raw custom pseudo-class arguments). Count × size lets a few KB
-/// of input expand into hundreds of megabytes of cloned rules and output while
-/// staying under the count cap, so the expansion is also charged by estimated
-/// bytes ([`selector::selector_list_weight`](crate::selectors::selector)).
-/// Exceeding this is reported as a `selector_expansion_bytes_limit_exceeded`
-/// minify error. The thresholds are ordered so that stylesheets with
-/// ordinary-sized selectors keep hitting the count limit first.
+/// Byte companion of [`MAX_SELECTOR_EXPANSION`]: caps the expansion's estimated serialized size, since per-selector size is input-controlled.
 pub(crate) const MAX_SELECTOR_EXPANSION_BYTES: u64 = 64 << 20;
 
 /// Per-stylesheet minification state threaded through `CssRuleList::minify`
@@ -1258,13 +1245,8 @@ pub struct MinifyContext<'a, 'bump> {
     /// Running total of selectors that compiling nested rules for the targets
     /// will expand to, checked against [`MAX_SELECTOR_EXPANSION`].
     pub(crate) selector_expansion_total: u32,
-    /// Estimated serialized bytes one expanded selector's ancestor chain
-    /// contributes: the sum over the enclosing (compiled) style rules of the
-    /// average selector weight of their lists. `0` at the top level;
-    /// maintained alongside `selector_expansion_multiplier` in
-    /// `StyleRule::minify_nested_rules`.
+    /// Sum of the enclosing compiled style rules' average selector weights. `0` at the top level.
     pub(crate) selector_expansion_chain_bytes: u64,
-    /// Running estimate of the serialized bytes the expansion will produce,
-    /// checked against [`MAX_SELECTOR_EXPANSION_BYTES`].
+    /// Running byte estimate of the expansion, checked against [`MAX_SELECTOR_EXPANSION_BYTES`].
     pub(crate) selector_expansion_bytes_total: u64,
 }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -385,19 +385,43 @@ impl<R> StyleRule<R> {
     /// otherwise a few hundred bytes of deeply nested multi-selector rules
     /// expand into gigabytes of cloned rules and output. See
     /// [`css_rules::MAX_SELECTOR_EXPANSION`](super::MAX_SELECTOR_EXPANSION).
+    ///
+    /// The expansion is charged twice, in this order: by selector count
+    /// (bounds how many rules/selectors materialize) and by estimated
+    /// serialized bytes (bounds their size; per-selector size is
+    /// input-controlled, so a few fat selectors could otherwise expand into
+    /// hundreds of megabytes while staying under the count cap). See
+    /// [`css_rules::MAX_SELECTOR_EXPANSION_BYTES`](super::MAX_SELECTOR_EXPANSION_BYTES).
     pub(crate) fn charge_selector_expansion(
         &self,
         context: &mut MinifyContext<'_, '_>,
     ) -> Result<(), MinifyErr> {
         if context.selector_expansion_multiplier > 1 {
-            context.selector_expansion_total = context.selector_expansion_total.saturating_add(
-                context
-                    .selector_expansion_multiplier
-                    .saturating_mul(self.selectors.v.len().max(1)),
-            );
+            let len = self.selectors.v.len().max(1);
+            context.selector_expansion_total = context
+                .selector_expansion_total
+                .saturating_add(context.selector_expansion_multiplier.saturating_mul(len));
             if context.selector_expansion_total > super::MAX_SELECTOR_EXPANSION {
                 context.err = Some(crate::error::MinifyError {
                     kind: crate::error::MinifyErrorKind::selector_expansion_limit_exceeded,
+                    loc: self.loc,
+                });
+                return Err(MinifyErr::minify_err);
+            }
+
+            // Every expanded copy of one of this rule's selectors also repeats
+            // its ancestor chain, so charge chain bytes once per copy.
+            let own_bytes = selector::selector_list_weight(self.selectors.v.slice()) as u64;
+            let chain_bytes =
+                (context.selector_expansion_chain_bytes as u64).saturating_mul(len as u64);
+            context.selector_expansion_bytes_total =
+                context.selector_expansion_bytes_total.saturating_add(
+                    (context.selector_expansion_multiplier as u64)
+                        .saturating_mul(own_bytes.saturating_add(chain_bytes)),
+                );
+            if context.selector_expansion_bytes_total > super::MAX_SELECTOR_EXPANSION_BYTES {
+                context.err = Some(crate::error::MinifyError {
+                    kind: crate::error::MinifyErrorKind::selector_expansion_bytes_limit_exceeded,
                     loc: self.loc,
                 });
                 return Err(MinifyErr::minify_err);
@@ -432,6 +456,7 @@ impl<R> StyleRule<R> {
         // nesting is compiled away the printed output still fans out per
         // selector, which is why the nesting branch bumps unconditionally.
         let saved_expansion_multiplier = context.selector_expansion_multiplier;
+        let saved_expansion_chain_bytes = context.selector_expansion_chain_bytes;
         let selectors_incompatible = self.selectors.v.len() > 1
             && context.targets.should_compile_selectors()
             && !self.is_compatible(context.targets);
@@ -440,9 +465,17 @@ impl<R> StyleRule<R> {
                 && !self.selectors.any_has_pseudo_element()
                 && self.selectors.specifities_all_equal());
         if context.targets.should_compile_same(css::Feature::Nesting) || splits_selectors {
-            context.selector_expansion_multiplier = context
-                .selector_expansion_multiplier
-                .saturating_mul(self.selectors.v.len().max(1));
+            let len = self.selectors.v.len().max(1);
+            context.selector_expansion_multiplier =
+                context.selector_expansion_multiplier.saturating_mul(len);
+            // Each expanded descendant selector is prefixed with one selector
+            // from this level; track the level's average selector weight as
+            // the chain-bytes contribution.
+            let avg_weight =
+                (selector::selector_list_weight(self.selectors.v.slice()) / len).max(1);
+            context.selector_expansion_chain_bytes = context
+                .selector_expansion_chain_bytes
+                .saturating_add(avg_weight);
         }
 
         let mut handler_context = context.handler_context.child(DeclarationContext::StyleRule);
@@ -456,6 +489,7 @@ impl<R> StyleRule<R> {
             &mut handler_context,
         );
         context.selector_expansion_multiplier = saved_expansion_multiplier;
+        context.selector_expansion_chain_bytes = saved_expansion_chain_bytes;
         result
     }
 

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -411,9 +411,10 @@ impl<R> StyleRule<R> {
 
             // Every expanded copy of one of this rule's selectors also repeats
             // its ancestor chain, so charge chain bytes once per copy.
-            let own_bytes = selector::selector_list_weight(self.selectors.v.slice()) as u64;
-            let chain_bytes =
-                (context.selector_expansion_chain_bytes as u64).saturating_mul(len as u64);
+            let own_bytes = selector::selector_list_weight(self.selectors.v.slice());
+            let chain_bytes = context
+                .selector_expansion_chain_bytes
+                .saturating_mul(len as u64);
             context.selector_expansion_bytes_total =
                 context.selector_expansion_bytes_total.saturating_add(
                     (context.selector_expansion_multiplier as u64)
@@ -472,7 +473,7 @@ impl<R> StyleRule<R> {
             // from this level; track the level's average selector weight as
             // the chain-bytes contribution.
             let avg_weight =
-                (selector::selector_list_weight(self.selectors.v.slice()) / len).max(1);
+                (selector::selector_list_weight(self.selectors.v.slice()) / len as u64).max(1);
             context.selector_expansion_chain_bytes = context
                 .selector_expansion_chain_bytes
                 .saturating_add(avg_weight);

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -385,13 +385,7 @@ impl<R> StyleRule<R> {
     /// otherwise a few hundred bytes of deeply nested multi-selector rules
     /// expand into gigabytes of cloned rules and output. See
     /// [`css_rules::MAX_SELECTOR_EXPANSION`](super::MAX_SELECTOR_EXPANSION).
-    ///
-    /// The expansion is charged twice, in this order: by selector count
-    /// (bounds how many rules/selectors materialize) and by estimated
-    /// serialized bytes (bounds their size; per-selector size is
-    /// input-controlled, so a few fat selectors could otherwise expand into
-    /// hundreds of megabytes while staying under the count cap). See
-    /// [`css_rules::MAX_SELECTOR_EXPANSION_BYTES`](super::MAX_SELECTOR_EXPANSION_BYTES).
+    /// Charged by count first, then by estimated bytes ([`super::MAX_SELECTOR_EXPANSION_BYTES`]).
     pub(crate) fn charge_selector_expansion(
         &self,
         context: &mut MinifyContext<'_, '_>,
@@ -409,8 +403,7 @@ impl<R> StyleRule<R> {
                 return Err(MinifyErr::minify_err);
             }
 
-            // Every expanded copy of one of this rule's selectors also repeats
-            // its ancestor chain, so charge chain bytes once per copy.
+            // Each expanded copy also repeats its ancestor chain: charge chain bytes once per copy.
             let own_bytes = selector::selector_list_weight(self.selectors.v.slice());
             let chain_bytes = context
                 .selector_expansion_chain_bytes
@@ -469,9 +462,7 @@ impl<R> StyleRule<R> {
             let len = self.selectors.v.len().max(1);
             context.selector_expansion_multiplier =
                 context.selector_expansion_multiplier.saturating_mul(len);
-            // Each expanded descendant selector is prefixed with one selector
-            // from this level; track the level's average selector weight as
-            // the chain-bytes contribution.
+            // Every expanded descendant is prefixed with one selector from this level.
             let avg_weight =
                 (selector::selector_list_weight(self.selectors.v.slice()) / len as u64).max(1);
             context.selector_expansion_chain_bytes = context

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -222,16 +222,7 @@ fn lang_list_to_selectors<'bump>(_bump: &'bump Bump, langs: &[&'static [u8]]) ->
     selectors.into_boxed_slice()
 }
 
-/// Estimated serialized byte size of every selector in `selectors`, for
-/// weighting the selector-expansion budget
-/// ([`MAX_SELECTOR_EXPANSION_BYTES`](crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES)).
-///
-/// Counting expanded *selectors* alone does not bound the expansion's size:
-/// a selector's serialized form is input-controlled (long identifiers,
-/// multi-argument `:lang()`, raw custom pseudo-class arguments), so a few fat
-/// selectors multiplied through compiled nesting can reach hundreds of
-/// megabytes while staying under the count cap. This estimate only needs to
-/// be proportional to the serialized size, not exact.
+/// Rough serialized byte size of `selectors` (proportional, not exact), for [`crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES`].
 pub(crate) fn selector_list_weight(selectors: &[Selector]) -> u64 {
     let mut weight: u64 = 0;
     for selector in selectors {
@@ -303,13 +294,11 @@ fn ident_or_ref_weight(ident: css::css_values::ident::IdentOrRef) -> u64 {
 }
 
 fn pseudo_class_weight(pseudo: &PseudoClass) -> u64 {
-    // Longest built-in pseudo-class names are ~24 bytes (vendor prefixes
-    // included); variants carrying input-controlled payloads are measured.
+    // ~Longest built-in name with vendor prefix; input-controlled payloads are measured instead.
     const NAME: u64 = 24;
     match pseudo {
         PseudoClass::Lang { languages } => {
-            // Downleveling multiplies each language into its own `:lang()`
-            // inside `:is()`, so charge per-language overhead too.
+            // Downleveling wraps each language in its own `:lang()`, hence the per-language overhead.
             let mut w: u64 = 0;
             for lang in languages {
                 w = w.saturating_add(lang.len() as u64).saturating_add(8);
@@ -332,6 +321,17 @@ fn pseudo_element_weight(pseudo: &PseudoElement) -> u64 {
     match pseudo {
         PseudoElement::CueFunction { selector } | PseudoElement::CueRegionFunction { selector } => {
             NAME.saturating_add(selector_weight(selector))
+        }
+        PseudoElement::ViewTransitionGroup { part_name }
+        | PseudoElement::ViewTransitionImagePair { part_name }
+        | PseudoElement::ViewTransitionOld { part_name }
+        | PseudoElement::ViewTransitionNew { part_name } => NAME.saturating_add(match part_name {
+            parser::ViewTransitionPartName::All => 1,
+            parser::ViewTransitionPartName::Name(ident)
+            | parser::ViewTransitionPartName::Class(ident) => ident.v.len() as u64,
+        }),
+        PseudoElement::PickerFunction { identifier } => {
+            NAME.saturating_add(identifier.v.len() as u64)
         }
         PseudoElement::Custom { name } => NAME.saturating_add(name.len() as u64),
         PseudoElement::CustomFunction { name, arguments } => NAME
@@ -382,8 +382,7 @@ fn token_weight(token: &css::Token) -> u64 {
         | Token::BadUrl(v)
         | Token::Whitespace(v)
         | Token::Comment(v) => v.len() as u64,
-        // Numeric tokens serialize through dtoa's shortest round-trip
-        // form, which is bounded (<= ~17 bytes), so a constant covers them.
+        // Numerics print via dtoa's shortest round-trip form, which is at most ~17 bytes.
         Token::Number(_) => NUMERIC,
         Token::Percentage { .. } => NUMERIC.saturating_add(1),
         Token::Dimension(dim) => (dim.unit.len() as u64).saturating_add(NUMERIC),
@@ -1461,18 +1460,7 @@ pub(crate) mod serialize {
     /// bound.
     const MAX_NESTING_EXPANSIONS: u32 = 65_536;
 
-    /// Maximum number of bytes parent-selector substitutions may emit across
-    /// a whole stylesheet.
-    ///
-    /// [`MAX_NESTING_EXPANSIONS`] bounds how many times `&` is substituted,
-    /// but each substitution writes the parent selector list, whose size is
-    /// input-controlled (long identifiers, long pseudo-class argument lists).
-    /// Substitution count × parent size lets a few KB of input print hundreds
-    /// of megabytes while staying under the count limit, so the bytes emitted
-    /// by substitutions are budgeted as well. Same judgment as
-    /// `MAX_PREFIX_EXPANSION_BYTES` (`rules/style.rs`): real stylesheets
-    /// substitute a tiny fraction of this; anything past it is a runaway
-    /// expansion.
+    /// Byte companion of [`MAX_NESTING_EXPANSIONS`], stylesheet-wide: the substituted parent list's size is input-controlled.
     const MAX_NESTING_EXPANSION_BYTES: usize = 64 << 20;
 
     fn serialize_nesting(
@@ -1498,25 +1486,33 @@ pub(crate) mod serialize {
                 None,
             );
         }
-        // Meter the bytes this substitution emits. Only the outermost
-        // substitution measures: recursive substitutions (the parent's own
-        // `&` referring to the grandparent) are contained in the outer span,
-        // so measuring them too would double-count.
-        let outermost = dest.nesting_expansion_meter_depth == 0;
-        let bytes_before = if outermost { dest.bytes_written() } else { 0 };
-        dest.nesting_expansion_meter_depth += 1;
-        let result = serialize_nesting_substitution(dest, ctx, first);
-        dest.nesting_expansion_meter_depth -= 1;
-        result?;
+        // The outermost substitution opens the metered span; every nested return re-checks it so the cap trips mid-expansion.
+        let outermost = dest.nesting_expansion_span_start.is_none();
         if outermost {
-            let emitted = dest.bytes_written().saturating_sub(bytes_before);
-            dest.nesting_expansion_bytes = dest.nesting_expansion_bytes.saturating_add(emitted);
-            if dest.nesting_expansion_bytes > MAX_NESTING_EXPANSION_BYTES {
-                return dest.new_error(
-                    crate::error::PrinterErrorKind::maximum_nesting_expansion,
-                    None,
-                );
-            }
+            dest.nesting_expansion_span_start = Some(dest.bytes_written());
+        }
+        let result = serialize_nesting_substitution(dest, ctx, first)
+            .and_then(|()| charge_nesting_expansion_bytes(dest, outermost));
+        if outermost {
+            dest.nesting_expansion_span_start = None;
+        }
+        result
+    }
+
+    fn charge_nesting_expansion_bytes(dest: &mut Printer, commit: bool) -> Result<(), PrintErr> {
+        let written = dest.bytes_written();
+        let span_start = dest.nesting_expansion_span_start.unwrap_or(written);
+        let total = dest
+            .nesting_expansion_bytes
+            .saturating_add(written.saturating_sub(span_start));
+        if total > MAX_NESTING_EXPANSION_BYTES {
+            return dest.new_error(
+                crate::error::PrinterErrorKind::maximum_nesting_expansion,
+                None,
+            );
+        }
+        if commit {
+            dest.nesting_expansion_bytes = total;
         }
         Ok(())
     }
@@ -1526,10 +1522,7 @@ pub(crate) mod serialize {
         ctx: &StyleContext,
         first: bool,
     ) -> Result<(), PrintErr> {
-        // If there's only one simple selector, just serialize it directly.
-        // Otherwise, use an :is() pseudo class.
-        // Type selectors are only allowed at the start of a compound selector,
-        // so use :is() if that is not the case.
+        // A lone simple selector serializes directly; otherwise wrap in :is() (type selectors must lead a compound).
         if ctx.selectors.v.len() == 1
             && (first
                 || (!has_type_selector(ctx.selectors.v.at(0)) && is_simple(ctx.selectors.v.at(0))))

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -232,43 +232,43 @@ fn lang_list_to_selectors<'bump>(_bump: &'bump Bump, langs: &[&'static [u8]]) ->
 /// selectors multiplied through compiled nesting can reach hundreds of
 /// megabytes while staying under the count cap. This estimate only needs to
 /// be proportional to the serialized size, not exact.
-pub(crate) fn selector_list_weight(selectors: &[Selector]) -> u32 {
-    let mut weight: u32 = 0;
+pub(crate) fn selector_list_weight(selectors: &[Selector]) -> u64 {
+    let mut weight: u64 = 0;
     for selector in selectors {
         weight = weight.saturating_add(selector_weight(selector));
     }
     weight
 }
 
-pub(crate) fn selector_weight(selector: &Selector) -> u32 {
-    let mut weight: u32 = 0;
+pub(crate) fn selector_weight(selector: &Selector) -> u64 {
+    let mut weight: u64 = 0;
     for component in selector.components.iter() {
         weight = weight.saturating_add(component_weight(component));
     }
     weight
 }
 
-fn component_weight(component: &Component) -> u32 {
-    const BASE: u32 = 4;
-    let payload: u32 = match component {
-        Component::DefaultNamespace(url) => url.len() as u32,
+fn component_weight(component: &Component) -> u64 {
+    const BASE: u64 = 4;
+    let payload: u64 = match component {
+        Component::DefaultNamespace(url) => url.len() as u64,
         Component::Namespace { prefix, url } => {
-            (prefix.v.len() as u32).saturating_add(url.len() as u32)
+            (prefix.v.len() as u64).saturating_add(url.len() as u64)
         }
-        Component::LocalName(name) => name.name.v.len() as u32,
+        Component::LocalName(name) => name.name.v.len() as u64,
         Component::Id(ident) | Component::Class(ident) => ident_or_ref_weight(*ident),
-        Component::AttributeInNoNamespaceExists { local_name, .. } => local_name.v.len() as u32,
+        Component::AttributeInNoNamespaceExists { local_name, .. } => local_name.v.len() as u64,
         Component::AttributeInNoNamespace {
             local_name, value, ..
-        } => (local_name.v.len() as u32).saturating_add(value.len() as u32),
+        } => (local_name.v.len() as u64).saturating_add(value.len() as u64),
         Component::AttributeOther(attr) => {
             let op_len = match &attr.operation {
                 parser::attrs::ParsedAttrSelectorOperation::Exists => 0,
                 parser::attrs::ParsedAttrSelectorOperation::WithValue {
                     expected_value, ..
-                } => expected_value.len() as u32,
+                } => expected_value.len() as u64,
             };
-            (attr.local_name.v.len() as u32).saturating_add(op_len)
+            (attr.local_name.v.len() as u64).saturating_add(op_len)
         }
         Component::Negation(list)
         | Component::Where(list)
@@ -281,9 +281,9 @@ fn component_weight(component: &Component) -> u32 {
         Component::Slotted(selector) => selector_weight(selector),
         Component::Host(selector) => selector.as_ref().map_or(0, selector_weight),
         Component::Part(names) => {
-            let mut w: u32 = 0;
+            let mut w: u64 = 0;
             for name in names.iter() {
-                w = w.saturating_add(name.v.len() as u32);
+                w = w.saturating_add(name.v.len() as u64);
             }
             w
         }
@@ -294,56 +294,56 @@ fn component_weight(component: &Component) -> u32 {
     BASE.saturating_add(payload)
 }
 
-fn ident_or_ref_weight(ident: css::css_values::ident::IdentOrRef) -> u32 {
+fn ident_or_ref_weight(ident: css::css_values::ident::IdentOrRef) -> u64 {
     // CSS-modules refs resolve through the symbol table; use a flat estimate.
     match ident.as_ident() {
-        Some(ident) => ident.v.len() as u32,
+        Some(ident) => ident.v.len() as u64,
         None => 16,
     }
 }
 
-fn pseudo_class_weight(pseudo: &PseudoClass) -> u32 {
+fn pseudo_class_weight(pseudo: &PseudoClass) -> u64 {
     // Longest built-in pseudo-class names are ~24 bytes (vendor prefixes
     // included); variants carrying input-controlled payloads are measured.
-    const NAME: u32 = 24;
+    const NAME: u64 = 24;
     match pseudo {
         PseudoClass::Lang { languages } => {
             // Downleveling multiplies each language into its own `:lang()`
             // inside `:is()`, so charge per-language overhead too.
-            let mut w: u32 = 0;
+            let mut w: u64 = 0;
             for lang in languages {
-                w = w.saturating_add(lang.len() as u32).saturating_add(8);
+                w = w.saturating_add(lang.len() as u64).saturating_add(8);
             }
             w
         }
         PseudoClass::Local { selector } | PseudoClass::Global { selector } => {
             selector_weight(selector)
         }
-        PseudoClass::Custom { name } => NAME.saturating_add(name.len() as u32),
+        PseudoClass::Custom { name } => NAME.saturating_add(name.len() as u64),
         PseudoClass::CustomFunction { name, arguments } => NAME
-            .saturating_add(name.len() as u32)
+            .saturating_add(name.len() as u64)
             .saturating_add(token_list_weight(arguments)),
         _ => NAME,
     }
 }
 
-fn pseudo_element_weight(pseudo: &PseudoElement) -> u32 {
-    const NAME: u32 = 24;
+fn pseudo_element_weight(pseudo: &PseudoElement) -> u64 {
+    const NAME: u64 = 24;
     match pseudo {
         PseudoElement::CueFunction { selector } | PseudoElement::CueRegionFunction { selector } => {
             NAME.saturating_add(selector_weight(selector))
         }
-        PseudoElement::Custom { name } => NAME.saturating_add(name.len() as u32),
+        PseudoElement::Custom { name } => NAME.saturating_add(name.len() as u64),
         PseudoElement::CustomFunction { name, arguments } => NAME
-            .saturating_add(name.len() as u32)
+            .saturating_add(name.len() as u64)
             .saturating_add(token_list_weight(arguments)),
         _ => NAME,
     }
 }
 
-fn token_list_weight(list: &crate::properties::custom::TokenList) -> u32 {
+fn token_list_weight(list: &crate::properties::custom::TokenList) -> u64 {
     use crate::properties::custom::TokenOrValue;
-    let mut weight: u32 = 0;
+    let mut weight: u64 = 0;
     for token_or_value in &list.v {
         let w = match token_or_value {
             TokenOrValue::Token(token) => token_weight(token),
@@ -358,7 +358,7 @@ fn token_list_weight(list: &crate::properties::custom::TokenList) -> u32 {
                 .map_or(0, token_list_weight)
                 .saturating_add(16),
             TokenOrValue::Function(func) => {
-                (func.name.v.len() as u32).saturating_add(token_list_weight(&func.arguments))
+                (func.name.v.len() as u64).saturating_add(token_list_weight(&func.arguments))
             }
             _ => 16,
         };
@@ -367,8 +367,9 @@ fn token_list_weight(list: &crate::properties::custom::TokenList) -> u32 {
     weight
 }
 
-fn token_weight(token: &css::Token) -> u32 {
+fn token_weight(token: &css::Token) -> u64 {
     use css::Token;
+    const NUMERIC: u64 = 17;
     match token {
         Token::Ident(v)
         | Token::Function(v)
@@ -380,8 +381,12 @@ fn token_weight(token: &css::Token) -> u32 {
         | Token::UnquotedUrl(v)
         | Token::BadUrl(v)
         | Token::Whitespace(v)
-        | Token::Comment(v) => v.len() as u32,
-        Token::Dimension(dim) => dim.unit.len() as u32,
+        | Token::Comment(v) => v.len() as u64,
+        // Numeric tokens serialize through dtoa's shortest round-trip
+        // form, which is bounded (<= ~17 bytes), so a constant covers them.
+        Token::Number(_) => NUMERIC,
+        Token::Percentage { .. } => NUMERIC.saturating_add(1),
+        Token::Dimension(dim) => (dim.unit.len() as u64).saturating_add(NUMERIC),
         _ => 8,
     }
 }

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -222,6 +222,170 @@ fn lang_list_to_selectors<'bump>(_bump: &'bump Bump, langs: &[&'static [u8]]) ->
     selectors.into_boxed_slice()
 }
 
+/// Estimated serialized byte size of every selector in `selectors`, for
+/// weighting the selector-expansion budget
+/// ([`MAX_SELECTOR_EXPANSION_BYTES`](crate::css_rules::MAX_SELECTOR_EXPANSION_BYTES)).
+///
+/// Counting expanded *selectors* alone does not bound the expansion's size:
+/// a selector's serialized form is input-controlled (long identifiers,
+/// multi-argument `:lang()`, raw custom pseudo-class arguments), so a few fat
+/// selectors multiplied through compiled nesting can reach hundreds of
+/// megabytes while staying under the count cap. This estimate only needs to
+/// be proportional to the serialized size, not exact.
+pub(crate) fn selector_list_weight(selectors: &[Selector]) -> u32 {
+    let mut weight: u32 = 0;
+    for selector in selectors {
+        weight = weight.saturating_add(selector_weight(selector));
+    }
+    weight
+}
+
+pub(crate) fn selector_weight(selector: &Selector) -> u32 {
+    let mut weight: u32 = 0;
+    for component in selector.components.iter() {
+        weight = weight.saturating_add(component_weight(component));
+    }
+    weight
+}
+
+fn component_weight(component: &Component) -> u32 {
+    const BASE: u32 = 4;
+    let payload: u32 = match component {
+        Component::DefaultNamespace(url) => url.len() as u32,
+        Component::Namespace { prefix, url } => {
+            (prefix.v.len() as u32).saturating_add(url.len() as u32)
+        }
+        Component::LocalName(name) => name.name.v.len() as u32,
+        Component::Id(ident) | Component::Class(ident) => ident_or_ref_weight(*ident),
+        Component::AttributeInNoNamespaceExists { local_name, .. } => local_name.v.len() as u32,
+        Component::AttributeInNoNamespace {
+            local_name, value, ..
+        } => (local_name.v.len() as u32).saturating_add(value.len() as u32),
+        Component::AttributeOther(attr) => {
+            let op_len = match &attr.operation {
+                parser::attrs::ParsedAttrSelectorOperation::Exists => 0,
+                parser::attrs::ParsedAttrSelectorOperation::WithValue {
+                    expected_value, ..
+                } => expected_value.len() as u32,
+            };
+            (attr.local_name.v.len() as u32).saturating_add(op_len)
+        }
+        Component::Negation(list)
+        | Component::Where(list)
+        | Component::Is(list)
+        | Component::Any {
+            selectors: list, ..
+        }
+        | Component::Has(list) => selector_list_weight(list),
+        Component::NthOf(nth) => selector_list_weight(&nth.selectors),
+        Component::Slotted(selector) => selector_weight(selector),
+        Component::Host(selector) => selector.as_ref().map_or(0, selector_weight),
+        Component::Part(names) => {
+            let mut w: u32 = 0;
+            for name in names.iter() {
+                w = w.saturating_add(name.v.len() as u32);
+            }
+            w
+        }
+        Component::NonTsPseudoClass(pseudo) => pseudo_class_weight(pseudo),
+        Component::PseudoElement(pseudo) => pseudo_element_weight(pseudo),
+        _ => BASE,
+    };
+    BASE.saturating_add(payload)
+}
+
+fn ident_or_ref_weight(ident: css::css_values::ident::IdentOrRef) -> u32 {
+    // CSS-modules refs resolve through the symbol table; use a flat estimate.
+    match ident.as_ident() {
+        Some(ident) => ident.v.len() as u32,
+        None => 16,
+    }
+}
+
+fn pseudo_class_weight(pseudo: &PseudoClass) -> u32 {
+    // Longest built-in pseudo-class names are ~24 bytes (vendor prefixes
+    // included); variants carrying input-controlled payloads are measured.
+    const NAME: u32 = 24;
+    match pseudo {
+        PseudoClass::Lang { languages } => {
+            // Downleveling multiplies each language into its own `:lang()`
+            // inside `:is()`, so charge per-language overhead too.
+            let mut w: u32 = 0;
+            for lang in languages {
+                w = w.saturating_add(lang.len() as u32).saturating_add(8);
+            }
+            w
+        }
+        PseudoClass::Local { selector } | PseudoClass::Global { selector } => {
+            selector_weight(selector)
+        }
+        PseudoClass::Custom { name } => NAME.saturating_add(name.len() as u32),
+        PseudoClass::CustomFunction { name, arguments } => NAME
+            .saturating_add(name.len() as u32)
+            .saturating_add(token_list_weight(arguments)),
+        _ => NAME,
+    }
+}
+
+fn pseudo_element_weight(pseudo: &PseudoElement) -> u32 {
+    const NAME: u32 = 24;
+    match pseudo {
+        PseudoElement::CueFunction { selector } | PseudoElement::CueRegionFunction { selector } => {
+            NAME.saturating_add(selector_weight(selector))
+        }
+        PseudoElement::Custom { name } => NAME.saturating_add(name.len() as u32),
+        PseudoElement::CustomFunction { name, arguments } => NAME
+            .saturating_add(name.len() as u32)
+            .saturating_add(token_list_weight(arguments)),
+        _ => NAME,
+    }
+}
+
+fn token_list_weight(list: &crate::properties::custom::TokenList) -> u32 {
+    use crate::properties::custom::TokenOrValue;
+    let mut weight: u32 = 0;
+    for token_or_value in &list.v {
+        let w = match token_or_value {
+            TokenOrValue::Token(token) => token_weight(token),
+            TokenOrValue::Var(var) => var
+                .fallback
+                .as_ref()
+                .map_or(0, token_list_weight)
+                .saturating_add(16),
+            TokenOrValue::Env(env) => env
+                .fallback
+                .as_ref()
+                .map_or(0, token_list_weight)
+                .saturating_add(16),
+            TokenOrValue::Function(func) => {
+                (func.name.v.len() as u32).saturating_add(token_list_weight(&func.arguments))
+            }
+            _ => 16,
+        };
+        weight = weight.saturating_add(w).saturating_add(4);
+    }
+    weight
+}
+
+fn token_weight(token: &css::Token) -> u32 {
+    use css::Token;
+    match token {
+        Token::Ident(v)
+        | Token::Function(v)
+        | Token::AtKeyword(v)
+        | Token::UnrestrictedHash(v)
+        | Token::IdHash(v)
+        | Token::QuotedString(v)
+        | Token::BadString(v)
+        | Token::UnquotedUrl(v)
+        | Token::BadUrl(v)
+        | Token::Whitespace(v)
+        | Token::Comment(v) => v.len() as u32,
+        Token::Dimension(dim) => dim.unit.len() as u32,
+        _ => 8,
+    }
+}
+
 /// Returns the vendor prefix (if any) used in the given selector list.
 /// If multiple vendor prefixes are seen, this is invalid, and an empty result is returned.
 pub(crate) fn get_prefix(selectors: &SelectorList) -> VendorPrefix {
@@ -1292,35 +1456,26 @@ pub(crate) mod serialize {
     /// bound.
     const MAX_NESTING_EXPANSIONS: u32 = 65_536;
 
+    /// Maximum number of bytes parent-selector substitutions may emit across
+    /// a whole stylesheet.
+    ///
+    /// [`MAX_NESTING_EXPANSIONS`] bounds how many times `&` is substituted,
+    /// but each substitution writes the parent selector list, whose size is
+    /// input-controlled (long identifiers, long pseudo-class argument lists).
+    /// Substitution count × parent size lets a few KB of input print hundreds
+    /// of megabytes while staying under the count limit, so the bytes emitted
+    /// by substitutions are budgeted as well. Same judgment as
+    /// `MAX_PREFIX_EXPANSION_BYTES` (`rules/style.rs`): real stylesheets
+    /// substitute a tiny fraction of this; anything past it is a runaway
+    /// expansion.
+    const MAX_NESTING_EXPANSION_BYTES: usize = 64 << 20;
+
     fn serialize_nesting(
         dest: &mut Printer,
         context: Option<&StyleContext>,
         first: bool,
     ) -> Result<(), PrintErr> {
-        if let Some(ctx) = context {
-            dest.nesting_expansions += 1;
-            if dest.nesting_expansions > MAX_NESTING_EXPANSIONS {
-                return dest.new_error(
-                    crate::error::PrinterErrorKind::maximum_nesting_expansion,
-                    None,
-                );
-            }
-            // If there's only one simple selector, just serialize it directly.
-            // Otherwise, use an :is() pseudo class.
-            // Type selectors are only allowed at the start of a compound selector,
-            // so use :is() if that is not the case.
-            if ctx.selectors.v.len() == 1
-                && (first
-                    || (!has_type_selector(ctx.selectors.v.at(0))
-                        && is_simple(ctx.selectors.v.at(0))))
-            {
-                serialize_selector(ctx.selectors.v.at(0), dest, ctx.parent, false)?;
-            } else {
-                dest.write_str(b":is(")?;
-                serialize_selector_list(ctx.selectors.v.slice(), dest, ctx.parent, false)?;
-                dest.write_char(b')')?;
-            }
-        } else {
+        let Some(ctx) = context else {
             // If there is no context, we are at the root if nesting is supported. This is equivalent to :scope.
             // Otherwise, if nesting is supported, serialize the nesting selector directly.
             if dest.targets.should_compile_same(Feature::Nesting) {
@@ -1328,8 +1483,58 @@ pub(crate) mod serialize {
             } else {
                 dest.write_char(b'&')?;
             }
+            return Ok(());
+        };
+
+        dest.nesting_expansions += 1;
+        if dest.nesting_expansions > MAX_NESTING_EXPANSIONS {
+            return dest.new_error(
+                crate::error::PrinterErrorKind::maximum_nesting_expansion,
+                None,
+            );
+        }
+        // Meter the bytes this substitution emits. Only the outermost
+        // substitution measures: recursive substitutions (the parent's own
+        // `&` referring to the grandparent) are contained in the outer span,
+        // so measuring them too would double-count.
+        let outermost = dest.nesting_expansion_meter_depth == 0;
+        let bytes_before = if outermost { dest.bytes_written() } else { 0 };
+        dest.nesting_expansion_meter_depth += 1;
+        let result = serialize_nesting_substitution(dest, ctx, first);
+        dest.nesting_expansion_meter_depth -= 1;
+        result?;
+        if outermost {
+            let emitted = dest.bytes_written().saturating_sub(bytes_before);
+            dest.nesting_expansion_bytes = dest.nesting_expansion_bytes.saturating_add(emitted);
+            if dest.nesting_expansion_bytes > MAX_NESTING_EXPANSION_BYTES {
+                return dest.new_error(
+                    crate::error::PrinterErrorKind::maximum_nesting_expansion,
+                    None,
+                );
+            }
         }
         Ok(())
+    }
+
+    fn serialize_nesting_substitution(
+        dest: &mut Printer,
+        ctx: &StyleContext,
+        first: bool,
+    ) -> Result<(), PrintErr> {
+        // If there's only one simple selector, just serialize it directly.
+        // Otherwise, use an :is() pseudo class.
+        // Type selectors are only allowed at the start of a compound selector,
+        // so use :is() if that is not the case.
+        if ctx.selectors.v.len() == 1
+            && (first
+                || (!has_type_selector(ctx.selectors.v.at(0)) && is_simple(ctx.selectors.v.at(0))))
+        {
+            serialize_selector(ctx.selectors.v.at(0), dest, ctx.parent, false)
+        } else {
+            dest.write_str(b":is(")?;
+            serialize_selector_list(ctx.selectors.v.slice(), dest, ctx.parent, false)?;
+            dest.write_char(b')')
+        }
     }
 }
 

--- a/test/js/bun/css/selector-expansion-bytes.test.ts
+++ b/test/js/bun/css/selector-expansion-bytes.test.ts
@@ -1,0 +1,119 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { expect, test } from "bun:test";
+
+// Regression test for unbounded memory growth when compiling CSS selectors
+// for older browser targets (found by CSS fuzzing, crash signature
+// `oom:css:…Write…write_all…|…css_parser…`).
+//
+// The selector-expansion limits added for earlier fuzz reports bound how many
+// selectors compiling nesting away produces (MAX_SELECTOR_EXPANSION) and how
+// many `&` substitutions the printer performs (MAX_NESTING_EXPANSIONS), but
+// both counted units, not bytes. The size of each expanded selector is
+// input-controlled (long identifiers, multi-argument `:lang()`, `::part()`),
+// so a ~30 KB stylesheet could stay under both count limits while expanding
+// to hundreds of MB of cloned rules and output (over 1 GB RSS in debug
+// builds). The expansion is now also budgeted by estimated serialized bytes
+// (MAX_SELECTOR_EXPANSION_BYTES on the minify side,
+// MAX_NESTING_EXPANSION_BYTES on the printer side) and reports an error
+// instead of materializing the blowup.
+
+const CHROME_80 = { chrome: 80 << 16 };
+
+/** Runs minifyTest and folds the outcome into a short string so a failing
+ * assertion reports the output's size instead of printing 100+ MB of CSS. */
+function minifyOutcome(css: string): string {
+  try {
+    return `output:${cssInternals.minifyTest(css, "", CHROME_80).length} bytes`;
+  } catch (e) {
+    return `error:${(e as Error).message}`;
+  }
+}
+
+// The minimized fuzz input: multi-argument :lang() with an invalid
+// declaration, compiled for a target without :lang(a, b) or :is() support.
+// Its downlevel output is small and stays small; this locks that in.
+test("multi-argument :lang() downlevel output stays small", () => {
+  const input = "a:lang(en, fr) {\n        color: 0red;\n      }";
+
+  expect(cssInternals.minifyTest(input, "", CHROME_80)).toBe(
+    "a:-webkit-any(:lang(en),:lang(fr)){color:0red}a:is(:lang(en),:lang(fr)){color:0red}",
+  );
+  expect(cssInternals._test(input, "", CHROME_80)).toBe(
+    "a:-webkit-any(:lang(en), :lang(fr)) {\n  color: 0red;\n}\n\na:is(:lang(en), :lang(fr)) {\n  color: 0red;\n}\n",
+  );
+  expect(cssInternals.prefixTest(input, "", CHROME_80)).toBe(
+    "a:-webkit-any(:lang(en), :lang(fr)) {\n  color: 0red;\n}\n\na:is(:lang(en), :lang(fr)) {\n  color: 0red;\n}\n",
+  );
+  // No targets: nothing to downlevel.
+  expect(cssInternals.minifyTest(input, "")).toBe("a:lang(en,fr){color:0red}");
+});
+
+/** Unclosed nested rules with two fat selectors per level: the selector count
+ * stays under MAX_SELECTOR_EXPANSION (2^15 leaves), but each expanded
+ * selector repeats its ancestor chain of `identLength`-byte identifiers. */
+function fatNestedList(
+  depth: number,
+  identLength: number,
+  selector: (ident: string, i: number) => string,
+): string {
+  const ident = Buffer.alloc(identLength, "x").toString();
+  let css = "";
+  for (let i = 0; i < depth; i++) {
+    css += `${selector(ident + "a", i)}, ${selector(ident + "b", i)} {\n`;
+  }
+  css += "color: red;\n}";
+  return css;
+}
+
+test("fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB", () => {
+  // 30 KB input; expanded to ~265 MB of output before the byte budget existed.
+  const css = fatNestedList(15, 1000, (ident, i) => `.${ident}${i}::part(p)`);
+  expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
+  // Without targets the nesting is preserved, so the same input stays small.
+  expect(cssInternals.minifyTest(css, "").length).toBeLessThan(2 * css.length);
+});
+
+test("fat multi-argument :lang() selectors under the expansion count cap error instead of expanding", () => {
+  // ~5 KB input; expanded to ~120 MB of output before the byte budget existed.
+  const langs = Array.from({ length: 8 }, (_, i) => "l" + i).join(", ");
+  const css = fatNestedList(15, 250, (ident, i) => `.${ident}${i} :lang(${langs})`);
+  expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
+});
+
+test("fat `&` parent-selector substitution errors instead of printing hundreds of MB", () => {
+  // 13 KB input; 2^16 substitutions of an 800-byte parent printed ~107 MB
+  // before the byte budget existed.
+  const ident = Buffer.alloc(800, "y").toString();
+  let css = "";
+  for (let i = 0; i < 16; i++) {
+    css += `&:is(.${ident}${i}, &.z${i}) {\n`;
+  }
+  css += "color: red;\n";
+  css += "}\n".repeat(16);
+  expect(minifyOutcome(css)).toMatch(/^error:Maximum nesting expansion exceeded/);
+});
+
+test("mid-size expansions below the byte budget still compile", () => {
+  // 2^13 expanded selectors with short names stay well under the byte budget.
+  let css = "";
+  for (let i = 0; i < 13; i++) {
+    css += "co :lang(en, fr), .bar :lang(fr, de) {\n";
+  }
+  css += "color: red;\n}";
+  expect(minifyOutcome(css)).toMatch(/^output:\d{6,} bytes$/);
+});
+
+test("thin-selector deep nesting still reports the selector count limit", () => {
+  let css = "";
+  for (let i = 0; i < 23; i++) {
+    css += "co :is(.bar), .bar :is(.baz) {\n";
+  }
+  css += "color: red;\n}";
+  expect(minifyOutcome(css)).toMatch(/^error:.*65536 selectors/);
+});
+
+test("ordinary nesting compiled for old targets is unaffected", () => {
+  expect(cssInternals.minifyTest("a { .x { color: red; } .y { color: blue; } }", "", CHROME_80)).toBe(
+    "a .x{color:red}a .y{color:#00f}",
+  );
+});

--- a/test/js/bun/css/selector-expansion-bytes.test.ts
+++ b/test/js/bun/css/selector-expansion-bytes.test.ts
@@ -51,11 +51,7 @@ test("multi-argument :lang() downlevel output stays small", () => {
 /** Unclosed nested rules with two fat selectors per level: the selector count
  * stays under MAX_SELECTOR_EXPANSION (2^15 leaves), but each expanded
  * selector repeats its ancestor chain of `identLength`-byte identifiers. */
-function fatNestedList(
-  depth: number,
-  identLength: number,
-  selector: (ident: string, i: number) => string,
-): string {
+function fatNestedList(depth: number, identLength: number, selector: (ident: string, i: number) => string): string {
   const ident = Buffer.alloc(identLength, "x").toString();
   let css = "";
   for (let i = 0; i < depth; i++) {

--- a/test/js/bun/css/selector-expansion-bytes.test.ts
+++ b/test/js/bun/css/selector-expansion-bytes.test.ts
@@ -18,12 +18,14 @@ import { expect, test } from "bun:test";
 // instead of materializing the blowup.
 
 const CHROME_80 = { chrome: 80 << 16 };
+// Supports :is() (no vendor-prefix passes) but not CSS nesting, so nesting is compiled away.
+const CHROME_100 = { chrome: 100 << 16 };
 
 /** Runs minifyTest and folds the outcome into a short string so a failing
  * assertion reports the output's size instead of printing 100+ MB of CSS. */
-function minifyOutcome(css: string): string {
+function minifyOutcome(css: string, targets: object = CHROME_80): string {
   try {
-    return `output:${cssInternals.minifyTest(css, "", CHROME_80).length} bytes`;
+    return `output:${cssInternals.minifyTest(css, "", targets).length} bytes`;
   } catch (e) {
     return `error:${(e as Error).message}`;
   }
@@ -76,6 +78,14 @@ test("fat multi-argument :lang() selectors under the expansion count cap error i
   expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
 });
 
+test("fat functional pseudo-element arguments are weighed like ::part() names", () => {
+  // ~31 KB inputs; each expanded to ~500 MB of output before these payloads were measured.
+  for (const pseudo of ["view-transition-group", "view-transition-old", "picker"]) {
+    const css = fatNestedList(15, 1000, (ident, i) => `.a${i}::${pseudo}(${ident})`);
+    expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
+  }
+});
+
 test("fat `&` parent-selector substitution errors instead of printing hundreds of MB", () => {
   // 13 KB input; 2^16 substitutions of an 800-byte parent printed ~107 MB
   // before the byte budget existed.
@@ -87,6 +97,19 @@ test("fat `&` parent-selector substitution errors instead of printing hundreds o
   css += "color: red;\n";
   css += "}\n".repeat(16);
   expect(minifyOutcome(css)).toMatch(/^error:Maximum nesting expansion exceeded/);
+});
+
+test("a single `&` substitution that expands a fat ancestor chain is bounded mid-expansion", () => {
+  // The ancestors have no declarations, so only the innermost `&` prelude is
+  // printed: one outermost substitution performing 2^16 - 1 nested ones.
+  // 33 KB input; printed ~135 MB before the byte budget existed.
+  const ident = Buffer.alloc(2048, "k").toString();
+  let css = "";
+  for (let i = 0; i < 16; i++) {
+    css += `&:is(.${ident}${i}, &.z${i}) {\n`;
+  }
+  css += "& { color: red; }\n" + "}\n".repeat(16);
+  expect(minifyOutcome(css, CHROME_100)).toMatch(/^error:Maximum nesting expansion exceeded/);
 });
 
 test("mid-size expansions below the byte budget still compile", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS minifier OOM family found by fuzzing (signature `oom:css:_RNvXs1_NtNtC8bun_core4util2ioINtNtC5alloc3vec3VechENtB5_5Write9write_allC11bun_css_jsc|_RNvMNtC7bun_css10css_pa…`, i.e. `<Vec<u8> as Write>::write_all` growing the output buffer under a `css_parser` frame, on 1.4.0-canary.1+d2a6506df).

The minimized 45-byte input from the report (`a:lang(en, fr) { color: 0red; }` with a chrome 80 target) does not reproduce on its own: its downlevel output is 83 bytes and a fixed point under re-minification, verified at the exact reported revision under ASAN. Like the sibling report fixed in #31277, the published repro lost the context that makes the family blow up. The real trigger is the same `:lang()`/`::part()` downlevel path inside nested rules with fat selectors.

#### Root cause

The selector-expansion limits added for earlier fuzz reports bound expansion by **count**, not **bytes**:

- `MAX_SELECTOR_EXPANSION` (65,536) counts how many selectors compiling nesting away produces (#31277, #31482).
- `MAX_NESTING_EXPANSIONS` (65,536) counts how many `&` parent-selector substitutions the printer performs per rule prelude (#31276).

Each counted unit's serialized size is input-controlled: long identifiers, multi-argument `:lang()` (which downlevels to `:is(:lang(a), :lang(b))` / `:-webkit-any(...)` for old targets), `::part()`, raw custom pseudo-class arguments. Count x size stays under every cap while the output explodes. On current main (all existing caps intact, release build):

```js
// minify side: 30 KB in -> 265,879,552 bytes out, 581 MB RSS, no error
// (1.2 GB peak RSS on a debug/ASAN build)
const c = require("bun:internal-for-testing").cssInternals;
const id = "x".repeat(1000);
let css = "";
for (let i = 0; i < 15; i++) css += `.${id}a${i}::part(p), .${id}b${i}::part(p) {\n`;
css += "color: red;\n}";
c.minifyTest(css, "", { chrome: 80 << 16 });
```

```js
// print side: 13 KB in -> 107,674,291 bytes out, no error
const idy = "y".repeat(800);
let css2 = "";
for (let i = 0; i < 16; i++) css2 += `&:is(.${idy}${i}, &.z${i}) {\n`;
css2 += "color: red;\n" + "}\n".repeat(16);
c.minifyTest(css2, "", { chrome: 80 << 16 });
```

The same shapes reach the same paths through `bun build --minify` (default browser targets compile nesting away). In a fuzzing session with a memory cap, allocation fails while the printer grows its output `Vec`, which is exactly the reported crash stack.

#### Fix

Budget both expansions by estimated serialized bytes, alongside the existing count caps (checked second, so ordinary-sized selectors keep reporting the existing count errors):

- **Minify side**: `charge_selector_expansion` now also charges `multiplier x (own list weight + ancestor chain weight)` against `MAX_SELECTOR_EXPANSION_BYTES` (64 MB, matching `MAX_PREFIX_EXPANSION_BYTES` from #31642). The chain weight is tracked next to the multiplier in `MinifyContext`. Selector weights are estimated by `selector_list_weight` (identifier/payload byte lengths, recursing into `:is()`/`:not()`/`:nth-child(of)`, custom pseudo-class token lists, and the identifier arguments of `::part()`, `::view-transition-*()` and `::picker()`). Reported as a new `selector_expansion_bytes_limit_exceeded` minify error.
- **Print side**: `serialize_nesting` records `bytes_written()` when the outermost `&` substitution begins and re-checks the stylesheet-wide `Printer.nesting_expansion_bytes` plus the in-progress span against `MAX_NESTING_EXPANSION_BYTES` (64 MB) as every nested substitution returns, so the cap trips mid-expansion (a lone `&` under declaration-less ancestors performs all 2^16 - 1 nested substitutions inside one outermost call). Reported with the existing `maximum_nesting_expansion` printer error.

The weight walk only runs for rules inside compiled nesting (`selector_expansion_multiplier > 1` or a bumping level), so flat stylesheets and modern targets pay nothing.

Relationship to #31913 (same fuzzing campaign, different signature `hang:css:…PropertyIdTag…`): that PR bounds the payload (declarations, nested subtrees, token lists) deep-cloned when splitting target-incompatible selector lists. It does not bound the printer's `&` substitution path (the second repro above stays exponential under it: no splits happen, the multiplier stays 1, and no clones are made), and its declaration-payload shapes stay under this PR's selector-weight budgets, so the two are complementary. Textual conflicts in `error.rs`/`rules/mod.rs`/`css_parser.rs` are expected with whichever lands second.

#### Verification

- New tests in `test/js/bun/css/selector-expansion-bytes.test.ts`. On an unfixed build the five blowup tests fail (the 265 MB / 120 MB / 500 MB / 107 MB / 135 MB outputs are returned instead of errors); on this branch all 9 pass.
- The reported 45-byte fuzz input's downlevel output is asserted byte-for-byte for `minifyTest`, `_test`, and `prefixTest` with the chrome 80 target.
- Below the budgets output is unchanged: a 2^13-selector expansion still compiles (asserted), valid multi-arg `:lang()` and `:dir()` downlevel outputs are byte-identical, and the thin-selector deep-nesting case still reports the existing 65,536-selector count error.
- `test/js/bun/css/` (2135 pass; the 5 `css-fuzz.test.ts`/`fuzz ansi256` debug-build timeouts are pre-existing, reproduced on an unfixed debug build) and `test/bundler/css/` (167 pass).

#### Rebase notes

Rebased onto current main (~2200 commits). The conflicts were mechanical: main narrowed `pub` items in `printer.rs`, `rules/mod.rs` and `selectors/selector.rs` to `pub(crate)`/private, so the new fields, constants, and `serialize_nesting` follow that visibility. No logic changed in the resolution. Review follow-ups since the first revision: weights are `u64` end to end with numeric tokens charged, functional pseudo-element identifier arguments are weighed, and the printer budget is enforced mid-expansion (see above).

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 4 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/selector-expansion-bytes.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/selector-expansion-bytes.test.ts:
(pass) multi-argument :lang() downlevel output stays small [15.45ms]
64 | }
65 | 
66 | test("fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB", () => {
67 |   // 30 KB input; expanded to ~265 MB of output before the byte budget existed.
68 |   const css = fatNestedList(15, 1000, (ident, i) => `.${ident}${i}::part(p)`);
69 |   expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
                                  ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /^error:.*bytes of selectors/
Received: "output:265879552 bytes"

      at <anonymous> (/workspace/bun/test/js/bun/css/selector-expansion-bytes.test.ts:69:30)
(fail) fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB [12567.65ms]
  ^ this test timed out after 5000ms.
73 | 
74 | test("fat multi-argument :lang() selectors u
... (truncated)

release without fix: 5 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/bun/css/selector-expansion-bytes.test.ts:
(pass) multi-argument :lang() downlevel output stays small [0.40ms]
64 | }
65 | 
66 | test("fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB", () => {
67 |   // 30 KB input; expanded to ~265 MB of output before the byte budget existed.
68 |   const css = fatNestedList(15, 1000, (ident, i) => `.${ident}${i}::part(p)`);
69 |   expect(minifyOutcome(css)).toMatch(/^error:.*bytes of selectors/);
                                  ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /^error:.*bytes of selectors/
Received: "output:265879552 bytes"

      at <anonymous> (/workspace/bun/test/js/bun/css/selector-expansion-bytes.test.ts:69:30)
(fail) fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB [951.52ms]
73 | 
74 | test("fat multi-argument :lang() selectors under the expansion count cap error instead of expanding", () => {
75 |   // ~5 KB input; expanded to ~120 MB of output before the byte budget existed.
76 |   const langs = Array.from({ length: 8 }, (_, i) => "l" +
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/bun/css/selector-expansion-bytes.test.ts
bun test v1.4.3 (f42e98025)

test/js/bun/css/selector-expansion-bytes.test.ts:
(pass) multi-argument :lang() downlevel output stays small [15.22ms]
(pass) fat ::part() selectors under the expansion count cap error instead of expanding to hundreds of MB [38.98ms]
(pass) fat multi-argument :lang() selectors under the expansion count cap error instead of expanding [18.33ms]
(pass) fat functional pseudo-element arguments are weighed like ::part() names [31.55ms]
(pass) fat `&` parent-selector substitution errors instead of printing hundreds of MB [2993.23ms]
(pass) a single `&` substitution that expands a fat ancestor chain is bounded mid-expansion [2307.00ms]
(pass) mid-size expansions below the byte budget still compile [1845.99ms]
(pass) thin-selector deep nesting still reports the selector count limit [8.44ms]
(pass) ordinary nesting compiled for old targets is unaffected [2.94ms]

 9 pass
 0 fail
 15 expect() calls
Ran 9 tests across 1 file. [9.44s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     96b22f46d0
  features     baseline

23 deps, 131 codegen, 1172 objects in 725ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [8.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [10.00ms]
[6/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[7/1244] fetch zlib
[zlib] up to date
[8/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1217] fetch tinycc
[tinycc] up to date
[10/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[11/1216] gen .bind.ts → Gen
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs                            |   2 +
 src/css/error.rs                                 |   7 +
 src/css/printer.rs                               |   6 +
 src/css/rules/mod.rs                             |   7 +
 src/css/rules/style.rs                           |  42 +++-
 src/css/selectors/selector.rs                    | 251 ++++++++++++++++++++---
 test/js/bun/css/selector-expansion-bytes.test.ts | 138 +++++++++++++
 7 files changed, 421 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/css/css_parser.rs                                 3      1     16
src/css/error.rs                                      2      4     16
src/css/printer.rs                                    4      5     16
src/css/rules/mod.rs                                  6      7     16
src/css/rules/style.rs                                3      6     16
src/css/selectors/selector.rs                         9      9     16
test/js/bun/css/selector-expansion-bytes.test.ts      2      5     16
```

</details>

**root cause** · written by the author bot

The parser's downlevel path for multi-argument `:lang()` expanded each argument into a separate selector alternative and then re-expanded the result through nested-rule selector compilation, so the `&` parent-selector substitution multiplied against the ancestor chain on every level and produced output whose size grew without bound before any existing selector-count cap could stop it; the invalid `0red` declaration kept the rule alive through error recovery, so the expansion ran to completion instead of being discarded. The fix meters the expansion in bytes rather than only in selector coun…

<!-- robobun:evidence:end -->