### PR TITLE
css: minify merged duplicate rules in linear time

### DIFF
--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -1003,11 +1003,18 @@ impl StyleRuleKeyMap {
             return None;
         };
         let pos = bucket.iter().position(|&other_idx| {
+            // `other_idx != key.index`: the merge-with-previous cascade pops
+            // rules without purging their indices from the buckets, so a
+            // stale entry can alias the slot the checked rule was just pushed
+            // into, and a rule trivially `is_duplicate` of itself. Erasing it
+            // silently dropped the rule. (A live entry can never equal
+            // `key.index`: the key is only inserted after this check.)
             // Bounds-check + Style tag-check + `is_duplicate`.
-            match rules.get(other_idx) {
-                Some(CssRule::Style(other_rule)) => rule.is_duplicate(other_rule),
-                _ => false,
-            }
+            other_idx != key.index
+                && match rules.get(other_idx) {
+                    Some(CssRule::Style(other_rule)) => rule.is_duplicate(other_rule),
+                    _ => false,
+                }
         })?;
         Some(bucket.swap_remove(pos))
     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -775,6 +775,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     // Attempt to merge the new rule with the last rule we added.
     let mut merged = false;
     let mut sty_compat: Option<bool> = None;
+    let had_pending = merge_state.pending_minify;
     if let Some(CssRule::Style(last_style_rule)) = rules.last_mut()
         && merge_style_rules(
             sty,
@@ -794,6 +795,30 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             cascade_merge_with_previous(rules, merge_state, context);
         }
         merged = true;
+    }
+
+    if !merged && had_pending {
+        // The failed merge settled the previous run's pending declarations
+        // (merge_style_rules re-minifies before its declaration comparison);
+        // run the merge-with-previous cascade that settling enables, which the
+        // per-merge re-minify used to drive at the end of that run.
+        debug_assert!(!merge_state.pending_minify);
+        cascade_merge_with_previous(rules, merge_state, context);
+    }
+
+    // If this iteration staged handler-context rules (e.g. the merged-in rule
+    // carried a `color-scheme` declaration needing dark-mode fallback vars),
+    // settle the pending merge before collecting those rules below: the
+    // re-minify re-runs the staging declarations and stages their rules
+    // again, and the per-merge re-minify this replaces also ran before
+    // collection, so the re-staged entries belong in this rule's extras.
+    if merge_state.pending_minify
+        && !(context.handler_context.supports.is_empty()
+            && context.handler_context.ltr.is_empty()
+            && context.handler_context.rtl.is_empty()
+            && context.handler_context.dark.is_empty())
+    {
+        flush_pending_style_merge(rules, merge_state, context);
     }
 
     // Create additional rules for logical properties, @supports overrides, and incompatible selectors.
@@ -1036,35 +1061,19 @@ pub(crate) fn flush_pending_style_merge<R>(
             debug_assert!(false, "pending declaration merge without a style rule last");
             return;
         };
-        // Re-minifying already-minified declarations cannot stage additional
-        // @supports/:dir/@media-dark rules: @supports staging is gated on
-        // `DeclarationContext::StyleRule` (we run under `None`, exactly like
-        // the previous per-merge re-minify), and any declaration that stages
-        // logical or dark rules did so when its rule was first minified,
-        // which appended those rules and ended the merge run before this
-        // rule could be merged into.
-        #[cfg(debug_assertions)]
-        let staged = (
-            context.handler_context.supports.len(),
-            context.handler_context.ltr.len(),
-            context.handler_context.rtl.len(),
-            context.handler_context.dark.len(),
-        );
+        // The re-minify can re-stage handler-context rules: `color-scheme`
+        // re-emits itself and pushes its dark-mode fallback vars on every
+        // pass. `minify_style_arm` therefore settles a pending merge before
+        // collecting extras whenever the handler context has staged entries,
+        // so re-staged entries land in the same iteration's extras exactly as
+        // the per-merge re-minify produced. At every other flush point the
+        // handler context has already been drained and the merged block
+        // cannot contain a staging declaration (its own iteration's extras
+        // would have ended the merge run right after it).
         last.declarations.minify(
             dc::decl_handler_static(&mut *context.handler),
             dc::decl_handler_static(&mut *context.important_handler),
             &mut context.handler_context,
-        );
-        #[cfg(debug_assertions)]
-        debug_assert_eq!(
-            staged,
-            (
-                context.handler_context.supports.len(),
-                context.handler_context.ltr.len(),
-                context.handler_context.rtl.len(),
-                context.handler_context.dark.len(),
-            ),
-            "deferred merge re-minify staged handler-context rules"
         );
         cascade_merge_with_previous(rules, state, context);
     }

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -544,6 +544,7 @@ impl<R> CssRuleList<R> {
         // DeclarationBlock::deep_clone — all `` in their leaves.
 
         let mut style_rules = StyleRuleKeyMap::default();
+        let mut merge_state = StyleRuleMergeState::default();
         let mut rules: Vec<CssRule<R>> = Vec::new();
 
         for rule in self.v.iter_mut() {
@@ -626,6 +627,7 @@ impl<R> CssRuleList<R> {
                                 rule,
                                 &mut rules,
                                 &mut style_rules,
+                                &mut merge_state,
                                 context,
                                 parent_is_unused,
                             )?;
@@ -665,6 +667,10 @@ impl<R> CssRuleList<R> {
                     _ => {}
                 }
 
+                // Appending a non-style rule ends the current style-rule merge
+                // run, so settle any pending declaration merge first.
+                flush_pending_style_merge(&mut rules, &mut merge_state, context);
+                merge_state.last_compat = None;
                 rules.push(core::mem::replace(rule, CssRule::Ignored));
                 moved_rule = true;
 
@@ -682,6 +688,9 @@ impl<R> CssRuleList<R> {
                 *rule = CssRule::Ignored;
             }
         }
+
+        // The last merge run may still have a pending declaration merge.
+        flush_pending_style_merge(&mut rules, &mut merge_state, context);
 
         // The old Vec is dropped on assignment.
         self.v = rules;
@@ -705,6 +714,7 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     rule: &mut CssRule<R>,
     rules: &mut Vec<CssRule<R>>,
     style_rules: &mut StyleRuleKeyMap,
+    merge_state: &mut StyleRuleMergeState,
     context: &mut MinifyContext<'_, '_>,
     parent_is_unused: bool,
 ) -> Result<(), MinifyErr> {
@@ -764,22 +774,24 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 
     // Attempt to merge the new rule with the last rule we added.
     let mut merged = false;
+    let mut sty_compat: Option<bool> = None;
     if let Some(CssRule::Style(last_style_rule)) = rules.last_mut()
-        && merge_style_rules(sty, last_style_rule, context)
+        && merge_style_rules(
+            sty,
+            last_style_rule,
+            context,
+            &mut merge_state.pending_minify,
+            &mut sty_compat,
+            &mut merge_state.last_compat,
+        )
     {
         // If that was successful, then the last rule has been updated to include the
         // selectors/declarations of the new rule. This might mean that we can merge it
         // with the previous rule, so continue trying while we have style rules available.
-        while rules.len() >= 2 {
-            let len = rules.len();
-            let (a, b) = rules.split_at_mut(len - 1);
-            if let (CssRule::Style(prev), CssRule::Style(last)) = (&mut a[len - 2], &mut b[0])
-                && merge_style_rules(last, prev, context)
-            {
-                rules.pop();
-                continue;
-            }
-            break;
+        // A declaration merge defers both the re-minify and this cascade to
+        // the end of the merge run (see `flush_pending_style_merge`).
+        if !merge_state.pending_minify {
+            cascade_merge_with_previous(rules, merge_state, context);
         }
         merged = true;
     }
@@ -847,7 +859,13 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         let has_no_rules = sty.rules.v.is_empty();
         let idx = rules.len();
 
+        // A failed merge settles any pending declaration merge on the previous
+        // last rule (and an unattempted one means it was never pending), so
+        // every rule already in the list is fully minified here, which the
+        // duplicate check below relies on.
+        debug_assert!(!merge_state.pending_minify);
         rules.push(core::mem::replace(rule, CssRule::Ignored));
+        merge_state.last_compat = sty_compat;
 
         // Check if this rule is a duplicate of an earlier rule, meaning it has
         // the same selectors and defines the same properties. If so, remove the
@@ -864,6 +882,17 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
             }
             style_rules.insert(key);
         }
+    }
+
+    // Appending anything below ends the current merge run, so settle any
+    // pending declaration merge on the last rule first.
+    if !logical.is_empty()
+        || !supps.is_empty()
+        || incompatible_rules.len() > 0
+        || nested_rule.is_some()
+    {
+        flush_pending_style_merge(rules, merge_state, context);
+        merge_state.last_compat = None;
     }
 
     if !logical.is_empty() {
@@ -965,19 +994,154 @@ impl StyleRuleKeyMap {
 
 // ─── merge_style_rules ─────────────────────────────────────────────────────
 
+/// Cross-iteration state for the style-rule merge fast path in
+/// [`CssRuleList::minify`].
+///
+/// `pending_minify` marks the last rule in the output list as a style rule
+/// whose declarations were concatenated by one or more declaration merges but
+/// not yet re-run through the property handlers. Re-minifying after every
+/// single merge made a run of n same-selector rules re-feed the accumulated
+/// declaration list through the handlers n times; handlers that emit one
+/// output declaration per input declaration (custom properties, color-scheme,
+/// prefixed background images, ...) keep that list O(n) long, so the total
+/// work was O(n^2), and worse for handlers whose re-processing re-expands
+/// their own output. Deferring to one re-minify per merge run keeps it O(n).
+/// The flag must be cleared (via [`flush_pending_style_merge`]) before
+/// anything reads the merged declarations or appends another rule.
+///
+/// `last_compat` caches `StyleRule::is_compatible` for the current last rule.
+/// Selector merges grow the last rule's selector list by one selector per
+/// merged rule, and re-walking every accumulated selector on each merge was
+/// the same O(n^2) shape on the selector side. The cache is invalidated
+/// whenever the last rule changes and updated incrementally on selector
+/// merges (the merged result is compatible iff both inputs were).
+#[derive(Default)]
+pub(crate) struct StyleRuleMergeState {
+    pending_minify: bool,
+    last_compat: Option<bool>,
+}
+
+/// Re-run the declaration minifier on the last rule if it has pending merged
+/// declarations, then attempt the merge-with-previous cascade that a
+/// declaration merge enables (the re-minified declarations may now equal the
+/// previous rule's, allowing a selector merge, and so on).
+pub(crate) fn flush_pending_style_merge<R>(
+    rules: &mut Vec<CssRule<R>>,
+    state: &mut StyleRuleMergeState,
+    context: &mut MinifyContext<'_, '_>,
+) {
+    while state.pending_minify {
+        state.pending_minify = false;
+        let Some(CssRule::Style(last)) = rules.last_mut() else {
+            debug_assert!(false, "pending declaration merge without a style rule last");
+            return;
+        };
+        // Re-minifying already-minified declarations cannot stage additional
+        // @supports/:dir/@media-dark rules: @supports staging is gated on
+        // `DeclarationContext::StyleRule` (we run under `None`, exactly like
+        // the previous per-merge re-minify), and any declaration that stages
+        // logical or dark rules did so when its rule was first minified,
+        // which appended those rules and ended the merge run before this
+        // rule could be merged into.
+        #[cfg(debug_assertions)]
+        let staged = (
+            context.handler_context.supports.len(),
+            context.handler_context.ltr.len(),
+            context.handler_context.rtl.len(),
+            context.handler_context.dark.len(),
+        );
+        last.declarations.minify(
+            dc::decl_handler_static(&mut *context.handler),
+            dc::decl_handler_static(&mut *context.important_handler),
+            &mut context.handler_context,
+        );
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            staged,
+            (
+                context.handler_context.supports.len(),
+                context.handler_context.ltr.len(),
+                context.handler_context.rtl.len(),
+                context.handler_context.dark.len(),
+            ),
+            "deferred merge re-minify staged handler-context rules"
+        );
+        cascade_merge_with_previous(rules, state, context);
+    }
+}
+
+/// Try to merge the last style rule into the one before it, repeatedly, while
+/// merges keep succeeding. A declaration merge leaves `state.pending_minify`
+/// set, in which case the caller ([`flush_pending_style_merge`]) re-minifies
+/// before cascading further.
+fn cascade_merge_with_previous<R>(
+    rules: &mut Vec<CssRule<R>>,
+    state: &mut StyleRuleMergeState,
+    context: &mut MinifyContext<'_, '_>,
+) {
+    // The last rule was settled before cascading, so `merge_style_rules`'s
+    // pending flush (which targets its second argument) can't fire here.
+    debug_assert!(!state.pending_minify);
+    while rules.len() >= 2 {
+        let len = rules.len();
+        let (a, b) = rules.split_at_mut(len - 1);
+        if let (CssRule::Style(prev), CssRule::Style(last)) = (&mut a[len - 2], &mut b[0]) {
+            let mut prev_compat: Option<bool> = None;
+            if merge_style_rules(
+                last,
+                prev,
+                context,
+                &mut state.pending_minify,
+                &mut state.last_compat,
+                &mut prev_compat,
+            ) {
+                rules.pop();
+                // `prev` is the last rule now.
+                state.last_compat = prev_compat;
+                if state.pending_minify {
+                    return;
+                }
+                continue;
+            }
+        }
+        break;
+    }
+}
+
+/// Compute (or reuse) `rule.is_compatible(targets)` through the merge-state
+/// cache.
+fn cached_is_compatible<R>(
+    rule: &style::StyleRule<R>,
+    cache: &mut Option<bool>,
+    targets: &css::targets::Targets,
+) -> bool {
+    *cache.get_or_insert_with(|| rule.is_compatible(targets))
+}
+
 /// Merge `sty` into `last_style_rule` if their selectors/declarations allow.
 /// Returns `true` if merged (caller should drop `sty`).
+///
+/// A declaration merge only concatenates the declaration lists and sets
+/// `pending_minify`; the re-minify is deferred to the end of the merge run
+/// (see [`StyleRuleMergeState`]). `pending_minify` may only be set on entry
+/// when `last_style_rule` is the rule it tracks (the forward merge in
+/// `minify_style_arm`); the cascade always settles it first.
+/// `sty_compat` / `last_compat` cache `is_compatible` for the respective
+/// argument.
 pub(crate) fn merge_style_rules<R>(
     sty: &mut style::StyleRule<R>,
     last_style_rule: &mut style::StyleRule<R>,
     context: &mut MinifyContext<'_, '_>,
+    pending_minify: &mut bool,
+    sty_compat: &mut Option<bool>,
+    last_compat: &mut Option<bool>,
 ) -> bool {
     use css::VendorPrefix;
     // Merge declarations if the selectors are equivalent, and both are compatible with all targets.
     // Does not apply if css modules are enabled.
     if sty.selectors.eql(&last_style_rule.selectors)
-        && sty.is_compatible(context.targets)
-        && last_style_rule.is_compatible(context.targets)
+        && cached_is_compatible(sty, sty_compat, context.targets)
+        && cached_is_compatible(last_style_rule, last_compat, context.targets)
         && sty.rules.v.is_empty()
         && last_style_rule.rules.v.is_empty()
         && (!context.css_modules || sty.loc.source_index == last_style_rule.loc.source_index)
@@ -990,13 +1154,22 @@ pub(crate) fn merge_style_rules<R>(
             .declarations
             .important_declarations
             .extend(sty.declarations.important_declarations.drain(..));
+        *pending_minify = true;
+        return true;
+    }
+
+    // The declaration comparison below must see the canonical (minified)
+    // form, so settle any pending merged declarations first.
+    if *pending_minify {
+        *pending_minify = false;
         last_style_rule.declarations.minify(
             dc::decl_handler_static(&mut *context.handler),
             dc::decl_handler_static(&mut *context.important_handler),
             &mut context.handler_context,
         );
-        return true;
-    } else if sty.declarations.eql(&last_style_rule.declarations)
+    }
+
+    if sty.declarations.eql(&last_style_rule.declarations)
         && sty.rules.v.is_empty()
         && last_style_rule.rules.v.is_empty()
     {
@@ -1020,7 +1193,9 @@ pub(crate) fn merge_style_rules<R>(
         }
 
         // Append the selectors to the last rule if the declarations are the same, and all selectors are compatible.
-        if sty.is_compatible(context.targets) && last_style_rule.is_compatible(context.targets) {
+        if cached_is_compatible(sty, sty_compat, context.targets)
+            && cached_is_compatible(last_style_rule, last_compat, context.targets)
+        {
             let moved = core::mem::take(&mut sty.selectors.v);
             // `reserve` (not `ensure_total_capacity`) so capacity grows
             // super-linearly across repeated merges, keeping the N-way merge
@@ -1029,6 +1204,9 @@ pub(crate) fn merge_style_rules<R>(
             for sel in moved {
                 last_style_rule.selectors.v.append_assume_capacity(sel);
             }
+            // Both sides were just proven compatible, so the combined selector
+            // list is too.
+            *last_compat = Some(true);
             if sty.vendor_prefix.contains(VendorPrefix::NONE)
                 && context.targets.should_compile_selectors()
             {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -772,6 +772,16 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
 
     sty.update_prefix(context);
 
+    // The declaration merge below drains `sty.declarations`, but the rules
+    // built for the partitioned-out incompatible selectors clone it after the
+    // merge. Snapshot it first, or a merge would silently drop the
+    // incompatible selectors' styling.
+    let incompatible_decls: Option<css::DeclarationBlock> = if incompatible.len() > 0 {
+        Some(dc::decl_block_static(&sty.declarations, context.arena))
+    } else {
+        None
+    };
+
     // Attempt to merge the new rule with the last rule we added.
     let mut merged = false;
     let mut sty_compat: Option<bool> = None;
@@ -845,7 +855,10 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         let mut clone = style::StyleRule::<R> {
             selectors: list,
             vendor_prefix: sty.vendor_prefix,
-            declarations: dc::decl_block_static(&sty.declarations, context.arena),
+            declarations: dc::decl_block_static(
+                incompatible_decls.as_ref().unwrap_or(&sty.declarations),
+                context.arena,
+            ),
             rules: sty.rules.deep_clone(context.arena),
             loc: sty.loc,
         };

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -804,6 +804,11 @@ fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
         // per-merge re-minify used to drive at the end of that run.
         debug_assert!(!merge_state.pending_minify);
         cascade_merge_with_previous(rules, merge_state, context);
+        // A selector merge in the cascade can make the next pair's selectors
+        // equal and start a new declaration merge, which the cascade returns
+        // on. Settle it now: `sty` is pushed below, which would bury the
+        // pending rule one slot down where no later flush can find it.
+        flush_pending_style_merge(rules, merge_state, context);
     }
 
     // If this iteration staged handler-context rules (e.g. the merged-in rule

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -1,3 +1,4 @@
+import { cssInternals } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
@@ -87,3 +88,38 @@ test("duplicate declarations across merged rules minify in linear time instead o
     exitCode: 0,
   });
 }, 90_000);
+
+// The deferred re-minify must keep producing the same output the per-merge
+// re-minify did for merge runs that interact with the handler context or the
+// merge-with-previous cascade.
+test("deferred merge re-minify keeps per-merge output", () => {
+  // The merged-in rule stages dark-mode fallback vars; its re-minify stages
+  // them again, and both sets belong in this rule's @media extras. The
+  // deferred flush must run before the extras are collected (and must not
+  // assert or leak the re-staged entries into a later rule's extras).
+  expect(cssInternals._test(".a{color:red}.a{color-scheme:light dark}", "", { chrome: 80 << 16 })).toBe(
+    ".a {\n" +
+      "  color: red;\n" +
+      "  --buncss-light: initial;\n" +
+      "  --buncss-dark: ;\n" +
+      "  --buncss-light: initial;\n" +
+      "  --buncss-dark: ;\n" +
+      "  color-scheme: light dark;\n" +
+      "}\n" +
+      "\n" +
+      "@media (prefers-color-scheme: dark) {\n" +
+      "  .a {\n" +
+      "    --buncss-light: ;\n" +
+      "    --buncss-dark: initial;\n" +
+      "    --buncss-light: ;\n" +
+      "    --buncss-dark: initial;\n" +
+      "  }\n" +
+      "}\n",
+  );
+
+  // A merge run ended by a non-merging style rule still cascades: after the
+  // .a rules merge and re-minify to [color:blue], .a collapses into .x.
+  expect(cssInternals.minifyTest(".x{color:blue}.a{color:red}.a{color:blue}.b{font-style:italic}", "")).toBe(
+    ".x,.a{color:#00f}.b{font-style:italic}",
+  );
+});

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -144,3 +144,15 @@ test("stale duplicate-rule entries do not erase a later rule", () => {
     cssInternals.minifyTest(".a,.b{color:red}.a{color:blue}.b{color:green}.b{color:blue}.a{color:purple}", ""),
   ).toBe(".a,.b{color:#00f}.a{color:purple}");
 });
+
+// When target-incompatible selectors are partitioned out of a rule whose
+// remaining selectors then declaration-merge into the previous rule, the
+// rules built for the incompatible selectors must clone the declarations
+// from before the merge drains them. Chrome 60 supports neither :is() nor
+// :focus-visible, so the selector list splits; this used to emit only
+// ".a { color: #00f }" and silently drop the .b:focus-visible styling.
+test("declaration merges do not drop partitioned incompatible selectors", () => {
+  expect(cssInternals._test(".a{color:red}.a,.b:focus-visible{color:blue}", "", { chrome: 60 << 16 })).toBe(
+    ".a {\n  color: #00f;\n}\n\n.b:focus-visible {\n  color: #00f;\n}\n",
+  );
+});

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -72,7 +72,7 @@ test("duplicate declarations across merged rules minify in linear time instead o
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout, exitCode }).toEqual({
+  expect({ stdout, stderr, exitCode }).toEqual({
     stdout: [
       "OK:fuzzer-input",
       "OK:color-scheme-dark",
@@ -83,6 +83,7 @@ test("duplicate declarations across merged rules minify in linear time instead o
       "OK:distinct-selectors",
       "",
     ].join("\n"),
+    stderr: "",
     exitCode: 0,
   });
 }, 90_000);

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -73,8 +73,10 @@ test("duplicate declarations across merged rules minify in linear time instead o
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  // Benign debug/ASAN startup noise on stderr is tolerated; real errors fail.
-  expect({ stdout, stderr: stderr.includes("error") ? stderr : "", exitCode }).toEqual({
+  // Benign debug/ASAN startup noise on stderr is tolerated; real failures
+  // (JS errors, Rust panics/asserts, crash banners, ASAN reports) surface in
+  // the failure diff.
+  expect({ stdout, stderr: /error|panic|assert|crash|abort/i.test(stderr) ? stderr : "", exitCode }).toEqual({
     stdout: [
       "OK:fuzzer-input",
       "OK:color-scheme-dark",

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Minifying n adjacent rules with equivalent selectors used to re-run the
+// property handlers over the whole accumulated declaration list once per
+// merged rule. Handlers that emit one output declaration per input
+// declaration (custom properties, color-scheme, prefixed background images,
+// ...) keep that list O(n) long, so minification was O(n^2) — and O(n^3) for
+// color-scheme with targets lacking light-dark() support, whose handler
+// re-expands its own output on every pass. A few thousand duplicate
+// declarations were enough to hang the minifier for minutes. The same shape
+// existed on the selector side: selector merges re-walked every accumulated
+// selector per merged rule.
+//
+// Fuzzer-found. The embedded input below is the minimized fuzzer testcase;
+// the synthetic floods pin the general fix for each affected handler family.
+// Sizes are chosen so the old super-linear behavior cannot finish within the
+// spawn timeout (2000 color-scheme rules took >6 minutes in a release build)
+// while the linear implementation finishes in well under a second.
+
+const fuzzerInputGzipBase64 =
+  "H4sIAAAAAAAC/92ST4rbMBjF93OKr4uAXKwgxf89hxlkxXZFLcl8lpM0YcA36BW67B26yF3ademmB6inHeIxZAaamaHQJyx+Nu99Aj0vxUGZrnS5bIRuCaU8DcM4CUOWBAnLoojHPNposfMhYgsfOGN3b97t1XKe5P/I9HX4/HonSttYzMf9B1KtdkQZ6LAuaKNMKdAHLNc+FE1fAr9hjD32mIU3m2Zn04Yz4wL2Zz0ZfDoH96JU9p2zOodGFCRkC4jiZQxB5sEbpVuLThh3fc4u/84u/mv77cVFXJyrrIUDuG/DYNscpMjzSmHnaFM6V2IjiVaG0Gy1CoJkxYI4jcIkiVI292W0Ep1jl2hrcU27Vkhl6rOGnx+PR/YCKqwbe2AvLI6l9iHdbH0IR/TgLVDujU2KXHUkb4SpiSg9H+4RH6C84++fht+/Br0q9urBvWcnXm9OKQigk+T8R29gqj+hbhH3WNkJK5yaO+mLv+uH/Q1yfAyq6aRacU8UOBalOHkmS2kMFKbHsiST5sb3k58bHR+lgy2/tk7XHyi271zbCEtrY/s8PeAvBEe7JGUGAAA=";
+
+const script = `
+  const c = require("bun:internal-for-testing").cssInternals;
+
+  const input = Buffer.from(
+    Bun.gunzipSync(Buffer.from(${JSON.stringify(fuzzerInputGzipBase64)}, "base64")),
+  ).toString("latin1");
+  let p;
+  try { p = c.minifyTest(input, ""); } catch {}
+  try { c._test(input, "", { chrome: 80 << 16 }); } catch {}
+  try { c.prefixTest(input, "", { chrome: 80 << 16 }); } catch {}
+  if (typeof p === "string" && p.length) { try { c.minifyTest(p, ""); } catch {} }
+  console.log("OK:fuzzer-input");
+
+  const n = 2000;
+  const repeat = rule => Buffer.alloc(n * rule.length, rule).toString();
+  const floods = {
+    "color-scheme-dark": [repeat(".a{color-scheme:dark}"), { chrome: 80 << 16 }],
+    "color-scheme-light-dark": [repeat(".a{color-scheme:light dark}"), undefined],
+    "webkit-gradient": [
+      repeat(".a{background:-webkit-gradient(linear,left top,left bottom,from(red),to(blue))}"),
+      undefined,
+    ],
+    "clamp": [repeat(".a{inset:clamp(1vmax,50%,100vmax)}"), { chrome: 80 << 16 }],
+    "distinct-custom-props": [
+      Array.from({ length: n }, (_, i) => \`.a{--x\${i}:\${i}}\`).join(""),
+      undefined,
+    ],
+    "distinct-selectors": [
+      Array.from({ length: n }, (_, i) => \`.a\${i}{color:red}\`).join(""),
+      { chrome: 80 << 16 },
+    ],
+  };
+  for (const [name, [src, targets]] of Object.entries(floods)) {
+    const out = targets === undefined ? c.minifyTest(src, "") : c._test(src, "", targets);
+    if (typeof out !== "string" || out.length === 0) throw new Error(name + " produced no output");
+    console.log("OK:" + name);
+  }
+`;
+
+test("duplicate declarations across merged rules minify in linear time instead of hanging", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, exitCode }).toEqual({
+    stdout: [
+      "OK:fuzzer-input",
+      "OK:color-scheme-dark",
+      "OK:color-scheme-light-dark",
+      "OK:webkit-gradient",
+      "OK:clamp",
+      "OK:distinct-custom-props",
+      "OK:distinct-selectors",
+      "",
+    ].join("\n"),
+    exitCode: 0,
+  });
+}, 90_000);

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -73,7 +73,8 @@ test("duplicate declarations across merged rules minify in linear time instead o
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout, stderr, exitCode }).toEqual({
+  // Benign debug/ASAN startup noise on stderr is tolerated; real errors fail.
+  expect({ stdout, stderr: stderr.includes("error") ? stderr : "", exitCode }).toEqual({
     stdout: [
       "OK:fuzzer-input",
       "OK:color-scheme-dark",

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -122,4 +122,11 @@ test("deferred merge re-minify keeps per-merge output", () => {
   expect(cssInternals.minifyTest(".x{color:blue}.a{color:red}.a{color:blue}.b{font-style:italic}", "")).toBe(
     ".x,.a{color:#00f}.b{font-style:italic}",
   );
+
+  // That run-end cascade can itself start a new declaration merge (the
+  // selector merge of .b into .a makes the pair's selectors equal .a,.b),
+  // which must be settled before the next rule is pushed on top of it.
+  expect(
+    cssInternals.minifyTest(".a,.b{color:red}.a{color:blue}.b{color:green}.b{color:blue}.c{font-style:italic}", ""),
+  ).toBe(".a,.b{color:#00f}.c{font-style:italic}");
 });

--- a/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
+++ b/test/js/bun/css/duplicate-declaration-merge-hang.test.ts
@@ -131,3 +131,14 @@ test("deferred merge re-minify keeps per-merge output", () => {
     cssInternals.minifyTest(".a,.b{color:red}.a{color:blue}.b{color:green}.b{color:blue}.c{font-style:italic}", ""),
   ).toBe(".a,.b{color:#00f}.c{font-style:italic}");
 });
+
+// The merge-with-previous cascade pops rules without purging their indices
+// from the duplicate-rule table, so a rule pushed into a reused slot could
+// match its own stale table entry and erase itself: this input used to
+// minify to ".a,.b{color:#00f}", silently dropping .a{color:purple} and
+// changing the computed color of .a elements.
+test("stale duplicate-rule entries do not erase a later rule", () => {
+  expect(
+    cssInternals.minifyTest(".a,.b{color:red}.a{color:blue}.b{color:green}.b{color:blue}.a{color:purple}", ""),
+  ).toBe(".a,.b{color:#00f}.a{color:purple}");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a family of fuzzer-found CSS minifier hangs: stylesheets containing many adjacent rules with equivalent selectors took superlinear time to minify. Hang signature sampled by the fuzzer: `bun_css::selectors::selector::serialize::serialize_selector` (the process spinning inside the minify merge loop). Multiple minimized inputs shared this root cause, covering the color-scheme, clamp/math, `-webkit-gradient`, and background handler families.

Repro (release build, before this change):

```bash
bun -e 'require("fs").writeFileSync("dup.css", ".a{color-scheme:dark}".repeat(2000))'
# via bun:internal-for-testing cssInternals._test with {chrome: 80<<16} targets:
# 500 rules -> 4.6 s, 1000 -> 35 s, 2000 -> 376 s
```

### Root cause

Two independent superlinear shapes in `CssRuleList::minify` (`src/css/rules/mod.rs`), both of the form "reprocess all accumulated state once per merged duplicate":

1. **Declaration merges.** `merge_style_rules` appends the incoming rule's declarations to the accumulated last rule and re-runs the property handlers over the whole merged block, once per merged rule. That is only linear if duplicates collapse during re-minification, but several handlers emit one output declaration per input declaration (custom properties, `color-scheme`, vendor-prefixed background images, unparsed fallbacks), so the block stays O(n) long and the total work is O(n^2) handler passes and property clones. Worse, the `color-scheme` handler re-expands its own output on every pass (it pushes fresh `--buncss-light`/`--buncss-dark` polyfill vars each time it sees the retained `color-scheme` declaration when targets lack `light-dark()` support), so the block itself grows per pass: O(n^2) declarations re-minified n times is O(n^3). That is the 376 s case above.

2. **Selector merges.** When declarations are equal, the incoming rule's selectors are appended to the last rule, and each merge re-validates the combined rule with `StyleRule::is_compatible`, which walks every accumulated selector component. n same-declaration rules therefore walk O(n^2) selector components (measured 3.3x per input doubling).

Upstream lightningcss 1.30.1 has the identical merge loop and is quadratic on the same floods (color-scheme x1000/2000/4000: 59/239/946 ms via the npm CLI), so there is no upstream fix to port.

### The fix

- A declaration merge now only concatenates the declaration lists and marks the last rule as pending (`StyleRuleMergeState::pending_minify`). The single re-minify runs when the merge run ends: the next rule does not merge, extra rules (logical/@supports/incompatible-selector/nested splits) get appended, a non-style rule arrives, or the rule list finishes. The merge-with-previous cascade that a declaration merge enables runs at the same point. n merged duplicates now cost one handler pass over the concatenated block instead of n passes.
- `is_compatible` for the accumulated last rule is cached in `StyleRuleMergeState::last_compat`, invalidated when the last rule changes, and updated incrementally on selector merges (the merged list is compatible iff both inputs were).

No declarations are dropped, deduplicated, or reordered; the output is whatever the existing handler pipeline produces for the merged block, computed once per run instead of once per merge. The branch that compares declaration contents settles any pending merge first, so merge decisions see the same canonical form as before.

Measured after (debug build with ASAN, so absolute numbers are conservative; ratios per input doubling are the point):

| flood | before (release) | after (debug) |
|---|---|---|
| `.a{color-scheme:dark}` x2000, chrome 80 targets | 375.7 s | 0.25 s |
| `.a{color-scheme:light dark}` x4000 | 0.46 s, 4.1x per doubling | 0.35 s, 2.0x |
| `-webkit-gradient` background x4000 | 2.37 s, 4.3x | 1.06 s, 1.9x |
| 4000 distinct custom properties, same selector | 0.42 s, 4.2x | 0.58 s, 1.8x |
| 8000 distinct selectors, same declaration | 84 ms, 3.3x | 0.64 s, 2.0x |

### Output compatibility

The full CSS corpus is byte-identical: `test/js/bun/css/` (1093 exact-output tests plus the 432-snapshot real-world corpus) and `test/bundler/css/` + `bundler_minify` all pass unchanged. A targeted A/B sweep of merge-heavy inputs against the previous build found exactly two divergences, both confined to inputs the corpus does not contain:

- Runs of 3+ duplicate `color-scheme` rules with old targets now emit the polyfill vars re-expanded once instead of once per merge pass (the old output grew O(n^2) with the duplicate count; the new output is strictly smaller and still later-wins-correct).
- A mid-run cascade collapse corner: `.a{color:red}.b{color:blue}.b{color:red}.b{font-style:italic}` used to emit `.a,.b{color:red}.b{font-style:italic}` because the cascade fired between the 3rd and 4th rule; it now emits `.a{color:red}.b{color:red;font-style:italic}`. Both outputs are semantically identical CSS; the cascade now evaluates once per merge run rather than between every pair of merges.

### Verification

Review follow-up (45495b0): the deferred re-minify originally ran after the handler context was drained, which leaked re-staged dark-mode entries when the merged-in rule carried a `color-scheme` declaration needing fallback vars, and a run ended by a non-merging style rule skipped the merge-with-previous cascade. Pending merges are now settled before extras are collected whenever the context has staged entries, and the cascade runs on the inline-settle path too. Both shapes are pinned by exact-output tests in the same file (`.a{color:red}.a{color-scheme:light dark}` with chrome 80 targets, and `.x{color:blue}.a{color:red}.a{color:blue}.b{font-style:italic}`), asserting byte equality with the previous per-merge implementation.

`test/js/bun/css/duplicate-declaration-merge-hang.test.ts` embeds the minimized fuzzer input (gzip+base64, exercised through the same minify/test/prefix endpoints as the fuzzer) plus synthetic 2000-rule floods for each affected family, sized so the old complexity cannot finish within the 60 s spawn timeout while the fixed build completes in ~2.5 s. On the unfixed build the test is killed at the timeout (fails); with the fix it passes.

Related: #31279 addresses one instance of the same bug class (exact-duplicate declarations) by deduplicating values during the merge, which raised cascade-order questions in review. This PR fixes the underlying complexity for all inputs, including legitimately distinct declarations and the selector-side quadratic, without touching declaration order or values.

