### PR TITLE
test: strip inherited npm_config_user_agent from bunEnv

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -66,6 +66,11 @@ export const bunEnv: NodeJS.Dict<string> = {
   // Strip ad-hoc JSC debug options that may be set on CI agents — they leak
   // a "WARNING: failed to parse" line to stderr that breaks snapshot tests.
   JSC_useJIT: undefined,
+  // Strip the user agent injected by an outer `bun run` (e.g. when the suite
+  // is launched via `bun bd test`). Spawned buns honor a pre-existing value
+  // (put_default in run_command.rs), so tests asserting on the user agent
+  // would otherwise see the outer bun's version instead of bunExe()'s.
+  npm_config_user_agent: undefined,
   GITHUB_ACTIONS: "false",
   BUN_DEBUG_QUIET_LOGS: "1",
   NO_COLOR: "1",


### PR DESCRIPTION
Fixes #31925

### Repro

On a clean tree:

```sh
bun bd test test/cli/install/bunx.test.ts -t "npm_config_user_agent"
```

```
397 |   expect(out.trim()).toContain(`bun/${Bun.version}`);
error: expect(received).toContain(expected)
Expected to contain: "bun/1.4.0-debug"
Received: "bun/1.4.0 npm/? node/v24.3.0 linux x64"
(fail) should set "npm_config_user_agent" to bun
```

### Cause

The issue's diagnosis (user agent built from an unsuffixed version) is not what happens: the user agent and `Bun.version` are built from the same `Global::package_json_version` constant, suffix included. The real mechanism is environment inheritance:

1. `bun bd test ...` runs the `bd` script under the system bun, whose run_command sets `npm_config_user_agent=bun/1.4.0 npm/? node/v24.3.0 linux x64` into the script environment.
2. The build script execs the debug test runner, which inherits the variable, and `bunEnv` in `test/harness.ts` spreads `process.env` without stripping it.
3. The spawned `bun x print-pm` sees a pre-existing `npm_config_user_agent` and keeps it (`put_default` in `src/runtime/cli/run_command.rs` and `src/install/lib.rs`, intentional inherit-if-set behavior dating back to the Zig implementation).

So the test compares the outer bun's user agent against the inner bun's `Bun.version` and fails deterministically whenever the two versions differ, i.e. for anyone running the suite through `bun bd test` / `bun run`. In CI the runner is launched by node, the variable is absent, and the test passes, so this never showed up there.

### Fix

Strip `npm_config_user_agent` in `bunEnv` (test/harness.ts), next to the existing `JSC_useJIT` / `FORCE_COLOR` strips. Spawned buns then set their own user agent. No runtime change: the inherit-if-set behavior is deliberate and stays as is.

### Verification

- Before (clean main, debug build): the repro command above fails with the exact output quoted.
- After: passes.
- `test/cli/run/env.test.ts`, `test/cli/run/run-process-env.test.ts`, and the rest of `bunx.test.ts` behave the same before and after (remaining local failures are pre-existing on clean main: the node-24 `@angular/cli` test, tracked by #31818 / #31820, and container TLS noise on the github tarball tests).

Note: the CI-lane failures on `bunx.test.ts` mentioned in the issue are the `should handle package that requires node 24` test, not this assertion; those are owned by #31818 / #31820.