### PR TITLE
Give decorator lowering temporaries file-unique names

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -4,6 +4,7 @@
 use bun_alloc::ArenaVecExt as _;
 
 use bun_collections::{HashMap, VecExt};
+use bun_core::{MutableString, UnwrapOrOom as _};
 
 use crate::lexer as js_lexer;
 use crate::p::P;
@@ -169,6 +170,57 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
         let ref_ = self.new_symbol(kind, name);
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
+        ref_
+    }
+
+    /// File-unique name for a lowering temporary.
+    ///
+    /// The runtime transpiler prints symbols with their original names (no
+    /// rename pass), and lowering chains both nest (a decorated class
+    /// expression inside another decorated class's relocated static
+    /// initializer) and outlive their own evaluation (constructors read
+    /// `_init`, private method calls read `_m_fn`), so two chains that share
+    /// spellings clobber each other's temps. First use of a base name keeps
+    /// it as-is; later uses get a numeric suffix (`_dec`, `_dec2`, ...),
+    /// matching `NumberScope::find_unused_name`.
+    fn temp_name(&mut self, base: &'a [u8]) -> &'a [u8] {
+        // Key-derived bases (`_` + private name or string key) can contain
+        // arbitrary bytes; sanitize them like the renamer does.
+        let valid = MutableString::ensure_valid_identifier(base).unwrap_or_oom();
+        let base: &'a [u8] = if *valid == *base {
+            base
+        } else {
+            self.arena.alloc_slice_copy(&valid)
+        };
+        let Some(&prev) = self.decorator_temp_names.get(base) else {
+            self.decorator_temp_names.put(base, 1).unwrap_or_oom();
+            return base;
+        };
+        let mut tries = prev + 1;
+        let mut name = self.bump_name(base, Some(tries as usize));
+        while self.decorator_temp_names.contains_key(name) {
+            tries += 1;
+            name = self.bump_name(base, Some(tries as usize));
+        }
+        self.decorator_temp_names.put(base, tries).unwrap_or_oom();
+        self.decorator_temp_names.put(name, 1).unwrap_or_oom();
+        name
+    }
+
+    /// Fresh lowering temporary: file-unique spelling (see `temp_name`) plus
+    /// a `DeclaredSymbol` entry so the bundler's chunk renamer can see it.
+    /// Symbols that only live in a module scope's `generated` list are never
+    /// assigned a name by the renamer and would collide across files in a
+    /// chunk.
+    fn temp_sym(&mut self, base: &'a [u8]) -> Ref {
+        let name = self.temp_name(base);
+        let ref_ = self.new_sym(js_ast::symbol::Kind::Other, name);
+        self.declared_symbols
+            .append(js_ast::DeclaredSymbol {
+                ref_,
+                is_top_level: true,
+            })
+            .unwrap_or_oom();
         ref_
     }
 
@@ -1124,7 +1176,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut expr_var_decls = BumpVec::<G::Decl>::new_in(bump);
 
         if is_expr {
-            let ecr = p.new_sym(js_ast::symbol::Kind::Other, b"_class");
+            let ecr = p.temp_sym(b"_class");
             expr_class_ref = Some(ecr);
             let binding = p.b(B::Identifier { r#ref: ecr }, loc);
             expr_var_decls.push(G::Decl {
@@ -1159,7 +1211,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .original_name
                 .slice();
             let name = p.bump_name2(b"_", cns);
-            inner_class_ref = p.new_sym(js_ast::symbol::Kind::Other, name);
+            inner_class_ref = p.temp_sym(name);
         }
 
         // `ExprNodeList = Vec<Expr>` owns its
@@ -1171,7 +1223,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             bun_alloc::AstAlloc::take(&mut class.ts_decorators);
         let class_decorators_len = class_decorators.len_u32() as usize;
 
-        let init_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_init");
+        let init_ref = p.temp_sym(b"_init");
         if is_expr {
             let binding = p.b(B::Identifier { r#ref: init_ref }, loc);
             expr_var_decls.push(G::Decl {
@@ -1182,7 +1234,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         let mut base_ref: Option<Ref> = None;
         if class.extends.is_some() {
-            let br = p.new_sym(js_ast::symbol::Kind::Other, b"_base");
+            let br = p.temp_sym(b"_base");
             base_ref = Some(br);
             if is_expr {
                 let binding = p.b(B::Identifier { r#ref: br }, loc);
@@ -1194,13 +1246,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // ── Phase 2: Pre-evaluate decorators/keys ────────
-        let mut dec_counter: usize = 0;
         let mut class_dec_ref: Option<Ref> = None;
         let mut class_dec_stmt: Stmt = Stmt::empty();
         let mut class_dec_assign_expr: Option<Expr> = None;
         if class_decorators_len > 0 {
-            dec_counter += 1;
-            let cdr = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
+            let cdr = p.temp_sym(b"_dec");
             class_dec_ref = Some(cdr);
             // Move ownership into the AST node — `class_decorators` is not read
             // again on this branch (Phase-5's else-arm only runs when
@@ -1228,7 +1278,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut prop_dec_refs: HashMap<usize, Ref> = HashMap::default();
         let mut computed_key_refs: HashMap<usize, Ref> = HashMap::default();
         let mut pre_eval_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut computed_key_counter: usize = 0;
 
         let props_slice: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice.iter_mut().enumerate() {
@@ -1236,21 +1285,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
             if prop.ts_decorators.len_u32() > 0 {
-                dec_counter += 1;
-                let dec_name: &'a [u8] = if dec_counter == 1 {
-                    b"_dec"
-                } else {
-                    p.bump_name(b"_dec", Some(dec_counter))
-                };
-                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, dec_name);
+                // In expression mode the `var` binding for this temp is added
+                // when the pre-eval statements are folded into
+                // `expr_var_decls` during output assembly; declaring it here
+                // too would emit `var _dec, _dec`.
+                let dec_ref = p.temp_sym(b"_dec");
                 prop_dec_refs.insert(prop_idx, dec_ref);
-                if is_expr {
-                    let binding = p.b(B::Identifier { r#ref: dec_ref }, loc);
-                    expr_var_decls.push(G::Decl {
-                        binding,
-                        value: None,
-                    });
-                }
                 // SAFETY: shallow-reborrow arena Vec.
                 let items: ExprNodeList = unsafe { core::ptr::read(&raw const prop.ts_decorators) };
                 let arr = p.new_expr(
@@ -1266,21 +1306,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && prop.key.is_some()
                 && prop.ts_decorators.len_u32() > 0
             {
-                computed_key_counter += 1;
-                let key_name: &'a [u8] = if computed_key_counter == 1 {
-                    b"_computedKey"
-                } else {
-                    p.bump_name(b"_computedKey", Some(computed_key_counter))
-                };
-                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, key_name);
+                let key_ref = p.temp_sym(b"_computedKey");
                 computed_key_refs.insert(prop_idx, key_ref);
-                if is_expr {
-                    let binding = p.b(B::Identifier { r#ref: key_ref }, loc);
-                    expr_var_decls.push(G::Decl {
-                        binding,
-                        value: None,
-                    });
-                }
                 let key_loc = prop.key.expect("infallible: prop has key").loc;
                 pre_eval_stmts.push(p.var_decl(key_ref, prop.key, loc));
                 prop.key = Some(p.use_ref(key_ref, key_loc));
@@ -1385,7 +1412,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
@@ -1452,7 +1478,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             ex.storage_ref
                         } else {
                             let nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                            p.new_sym(js_ast::symbol::Kind::Other, nm)
+                            p.temp_sym(nm)
                         };
                         let fn_nm = {
                             let mut v = BumpVec::<u8>::new_in(bump);
@@ -1461,7 +1487,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             v.extend_from_slice(Self::fn_suffix(nk));
                             v.into_bump_slice()
                         };
-                        let fn_ref = p.new_sym(js_ast::symbol::Kind::Other, fn_nm);
+                        let fn_ref = p.temp_sym(fn_nm);
 
                         let mut new_info =
                             existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
@@ -1510,7 +1536,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     } else {
                         // Non-decorated private field → WeakMap
                         let wm_nm = p.bump_name2(b"_", &npriv_orig[1..]);
-                        let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, wm_nm);
+                        let wm_ref = p.temp_sym(wm_nm);
                         private_lowered_map.insert(npriv_inner, PrivateLoweredInfo::new(wm_ref));
                         let wme = p.new_weak_map_expr(loc);
                         prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
@@ -1545,12 +1571,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 break 'brk p.bump_name2(b"_", &s.data);
                             }
                         }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
+                        b"_accessor_storage"
                     };
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                    let wm_ref = p.temp_sym(accessor_name);
                     let wme = p.new_weak_map_expr(loc);
                     prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));
 
@@ -1720,7 +1743,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ex.storage_ref
                     } else {
                         let nm = p.bump_name2(b"_", &private_orig[1..]);
-                        p.new_sym(js_ast::symbol::Kind::Other, nm)
+                        p.temp_sym(nm)
                     };
                     private_storage_ref = Some(ws_ref);
                     let fn_nm = {
@@ -1730,7 +1753,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         v.extend_from_slice(Self::fn_suffix(k));
                         v.into_bump_slice()
                     };
-                    let fn_ref = p.new_sym(js_ast::symbol::Kind::Other, fn_nm);
+                    let fn_ref = p.temp_sym(fn_nm);
                     private_method_fn_ref = Some(fn_ref);
 
                     let mut new_info = existing.unwrap_or_else(|| PrivateLoweredInfo::new(ws_ref));
@@ -1752,7 +1775,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_arg_count = 6;
                 } else if k == 5 {
                     let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, nm);
+                    let wm_ref = p.temp_sym(nm);
                     private_storage_ref = Some(wm_ref);
                     private_lowered_map.insert(priv_inner, PrivateLoweredInfo::new(wm_ref));
                     let wme = p.new_weak_map_expr(loc);
@@ -1760,7 +1783,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     dec_arg_count = 5;
                 } else if k == 4 {
                     let nm = p.bump_name2(b"_", &private_orig[1..]);
-                    let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, nm);
+                    let wm_ref = p.temp_sym(nm);
                     private_storage_ref = Some(wm_ref);
                     let acc_nm = {
                         let mut v = BumpVec::<u8>::new_in(bump);
@@ -1769,7 +1792,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         v.extend_from_slice(b"_acc");
                         v.into_bump_slice()
                     };
-                    let acc_ref = p.new_sym(js_ast::symbol::Kind::Other, acc_nm);
+                    let acc_ref = p.temp_sym(acc_nm);
                     private_method_fn_ref = Some(acc_ref);
                     private_lowered_map.insert(
                         priv_inner,
@@ -1793,11 +1816,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     {
                         break 'brk p.bump_name2(b"_", &s.data);
                     }
-                    let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                    accessor_storage_counter += 1;
-                    name
+                    b"_accessor_storage"
                 };
-                let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
+                let wm_ref = p.temp_sym(accessor_name);
                 private_extra_ref = Some(wm_ref);
                 let wme = p.new_weak_map_expr(loc);
                 prefix_stmts.push(p.var_decl(wm_ref, Some(wme), loc));

--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -173,16 +173,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         ref_
     }
 
-    /// File-unique name for a lowering temporary.
-    ///
-    /// The runtime transpiler prints symbols with their original names (no
-    /// rename pass), and lowering chains both nest (a decorated class
-    /// expression inside another decorated class's relocated static
-    /// initializer) and outlive their own evaluation (constructors read
-    /// `_init`, private method calls read `_m_fn`), so two chains that share
-    /// spellings clobber each other's temps. First use of a base name keeps
-    /// it as-is; later uses get a numeric suffix (`_dec`, `_dec2`, ...),
-    /// matching `NumberScope::find_unused_name`.
+    /// File-unique name for a lowering temporary: first use keeps `base`,
+    /// later uses get a numeric suffix (`_dec`, `_dec2`, ...), matching
+    /// `NumberScope::find_unused_name`. Chains read their temps after later
+    /// chains evaluate, and the runtime transpiler prints original names
+    /// with no rename pass, so shared spellings alias at runtime.
     fn temp_name(&mut self, base: &'a [u8]) -> &'a [u8] {
         // Key-derived bases (`_` + private name or string key) can contain
         // arbitrary bytes; sanitize them like the renamer does.
@@ -207,11 +202,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name
     }
 
-    /// Fresh lowering temporary: file-unique spelling (see `temp_name`) plus
-    /// a `DeclaredSymbol` entry so the bundler's chunk renamer can see it.
-    /// Symbols that only live in a module scope's `generated` list are never
-    /// assigned a name by the renamer and would collide across files in a
-    /// chunk.
+    /// `temp_name` + symbol creation + a `DeclaredSymbol` entry; without the
+    /// entry the chunk renamer never sees module-scope generated symbols and
+    /// temps collide across bundled files.
     fn temp_sym(&mut self, base: &'a [u8]) -> Ref {
         let name = self.temp_name(base);
         let ref_ = self.new_sym(js_ast::symbol::Kind::Other, name);
@@ -1285,10 +1278,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
             if prop.ts_decorators.len_u32() > 0 {
-                // In expression mode the `var` binding for this temp is added
-                // when the pre-eval statements are folded into
-                // `expr_var_decls` during output assembly; declaring it here
-                // too would emit `var _dec, _dec`.
+                // The `var` binding is added when pre-eval statements fold
+                // into `expr_var_decls`; declaring it here too emitted
+                // `var _dec, _dec`.
                 let dec_ref = p.temp_sym(b"_dec");
                 prop_dec_refs.insert(prop_idx, dec_ref);
                 // SAFETY: shallow-reborrow arena Vec.

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -536,6 +536,13 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
+    // Names already handed out to decorator-lowering temporaries in this
+    // file, mapped to the highest numeric suffix used for that base name.
+    // The runtime transpiler prints symbols by original name without a
+    // rename pass, so every lowering chain needs file-unique spellings.
+    // See `temp_name` in lower/lower_decorators.rs.
+    pub decorator_temp_names: StringHashMap<u32>,
+
     // When bundling, hoisted top-level local variables declared with "var" in
     // nested scopes are moved up to be declared in the top-level scope instead.
     // The old "var" statements are turned into regular assignments instead. This
@@ -8794,6 +8801,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             await_target: None,
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
+            decorator_temp_names: Default::default(),
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -536,11 +536,8 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
-    // Names already handed out to decorator-lowering temporaries in this
-    // file, mapped to the highest numeric suffix used for that base name.
-    // The runtime transpiler prints symbols by original name without a
-    // rename pass, so every lowering chain needs file-unique spellings.
-    // See `temp_name` in lower/lower_decorators.rs.
+    // Decorator-lowering temp names used in this file, mapped to the highest
+    // numeric suffix handed out. See `temp_name` in lower/lower_decorators.rs.
     pub decorator_temp_names: StringHashMap<u32>,
 
     // When bundling, hoisted top-level local variables declared with "var" in

--- a/test/bundler/bundler_edgecase.test.ts
+++ b/test/bundler/bundler_edgecase.test.ts
@@ -2698,6 +2698,62 @@ describe("bundler", () => {
       `);
     },
   });
+  // https://github.com/oven-sh/bun/issues/31929
+  itBundled("edgecase/DecoratorLoweringTempsAcrossModules", {
+    files: {
+      "/entry.js": /* js */ `
+        import { A } from './a.js';
+        import { B } from './b.js';
+        console.log(new A().a, new B().b);
+      `,
+      "/a.js": /* js */ `
+        function double(v, c) { return x => x * 2; }
+        export const A = class { @double a = 1; };
+      `,
+      "/b.js": /* js */ `
+        function triple(v, c) { return x => x * 3; }
+        export const B = class { @triple b = 1; };
+      `,
+    },
+    run: {
+      stdout: "2 3",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/30568
+  itBundled("edgecase/AccessorStorageTempsAcrossModules", {
+    files: {
+      "/entry.js": /* js */ `
+        import { ComponentA } from './a.js';
+        import { ComponentB } from './b.js';
+        console.log(new ComponentA().myData, new ComponentB().myData);
+      `,
+      "/a.js": /* js */ `
+        import { state } from './decorator.js';
+        export class ComponentA {
+          @state() accessor myData = 'A';
+        }
+      `,
+      "/b.js": /* js */ `
+        import { state } from './decorator.js';
+        export class ComponentB {
+          @state() accessor myData = 'B';
+        }
+      `,
+      "/decorator.js": /* js */ `
+        export function state() {
+          return function (target, context) {
+            return {
+              get() { return target.get.call(this); },
+              set(newValue) { target.set.call(this, newValue); },
+            };
+          };
+        }
+      `,
+    },
+    run: {
+      stdout: "A B",
+    },
+  });
   itBundled("edgecase/NonAsciiIdentifierPreserved", {
     files: {
       "/entry.js": /* js */ `

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -1210,4 +1210,177 @@ describe("ES Decorators", () => {
       expect(exitCode).toBe(0);
     });
   });
+
+  // https://github.com/oven-sh/bun/issues/31929
+  describe("lowering temps do not collide between chains", () => {
+    test("decorated class expression nested in another decorated class's static initializer", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, c) { return v; }
+        const C = class Outer {
+          @dec static s = (class { @dec static x = 42; }).x;
+        };
+        console.log(C.name, C.s);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("Outer 42\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("sibling decorated class expressions with instance fields", async () => {
+      // Constructors read the chain's _init array at construction time,
+      // after the sibling chain has already evaluated.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function double(v, c) { return x => x * 2; }
+        function triple(v, c) { return x => x * 3; }
+        const A = class { @double a = 1; };
+        const B = class { @triple b = 1; };
+        console.log(new A().a, new B().b);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("sibling decorated class statements with instance fields", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function double(v, c) { return x => x * 2; }
+        function triple(v, c) { return x => x * 3; }
+        class A { @double a = 1; }
+        class B { @triple b = 1; }
+        console.log(new A().a, new B().b);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("2 3\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("sibling classes with decorated private methods", async () => {
+      // Private method calls read the extracted _m_fn temp at call time.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function firstDec(v, c) { return function () { return "first"; }; }
+        function secondDec(v, c) { return function () { return "second"; }; }
+        const A = class { @firstDec #m() { return "a"; } call() { return this.#m(); } };
+        const B = class { @secondDec #m() { return "b"; } call() { return this.#m(); } };
+        console.log(new A().call(), new B().call());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("first second\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("sibling decorated classes with computed keys", async () => {
+      // Instance field assignment reads the chain's _computedKey temp inside
+      // the constructor.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, c) { return v; }
+        const ka = "a", kb = "b";
+        const A = class { @dec [ka] = 1; };
+        const B = class { @dec [kb] = 2; };
+        console.log(JSON.stringify(Object.keys(new A())), JSON.stringify(Object.keys(new B())));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe('["a"] ["b"]\n');
+      expect(exitCode).toBe(0);
+    });
+
+    test("accessor storage temp name is sanitized for non-identifier keys", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, c) { return v; }
+        class A { @dec accessor "x y" = 1; }
+        class B { @dec m() {} accessor "a b" = 2; }
+        console.log(new A()["x y"], new B()["a b"]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("class statement named like a lowering temp", async () => {
+      // Statement lowering captures the inner class binding in a "_" + name
+      // temp (here "_init"), which must not alias an expression chain's _init.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(v, c) { return v; }
+        function addX(v, c) { return x => 42; }
+        @dec class init { @dec m() { return init; } }
+        const C = class { @addX x = 1; };
+        console.log(new init().m() === init, new C().x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("true 42\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // https://github.com/oven-sh/bun/issues/29837
+    test("auto-accessor in subclass does not collide with base class storage", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        class A {
+          accessor name = "A"
+        }
+        class B extends A {
+          accessor name = "B"
+          logName() {
+            console.log(this.name)
+            console.log(super.name)
+          }
+        }
+        new B().logName()
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("B\nA\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("same-named auto-accessor storage is per class: brand check, subclass, static siblings", async () => {
+      // Each auto-accessor owns a distinct private storage slot, so a
+      // getter borrowed from one class must throw on another class's
+      // instance, a subclass can shadow the base accessor, and sibling
+      // static accessors keep independent values.
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const t = (f) => { try { return f(); } catch (e) { return "THROW:" + e.constructor.name; } };
+        class Config { accessor value = "config-storage"; static readVia(o) { return t(() => Object.getOwnPropertyDescriptor(Config.prototype, "value").get.call(o)); } }
+        class Widget { accessor value = "widget-storage"; }
+        console.log(Config.readVia(new Widget()));
+        class Base { accessor x = 1; }
+        class Derived extends Base { accessor x = 100; }
+        console.log(t(() => new Derived().x));
+        class P { static accessor s = "P-value"; }
+        class Q { static accessor s = "Q-value"; }
+        console.log(t(() => P.s), Q.s);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("THROW:TypeError\n100\nP-value Q-value\n");
+      expect(exitCode).toBe(0);
+    });
+
+    // https://github.com/oven-sh/bun/issues/28010
+    test("field decorators in a subclass do not remap base class initializers", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function decorate(name) {
+          return function (_value, context) {
+            return function (initialValue) {
+              console.log(name, String(context.name), initialValue);
+              return initialValue;
+            }
+          }
+        }
+        class Parent {
+          @decorate('Parent.foo') foo = 'parent_foo';
+          @decorate('Parent.shared') shared = 'parent_shared';
+        }
+        class Child extends Parent {
+          @decorate('Child.foo') foo = 'child_foo';
+          @decorate('Child.childOnly') childOnly = 'child_childOnly';
+        }
+        new Child();
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(
+        "Parent.foo foo parent_foo\n" +
+          "Parent.shared shared parent_shared\n" +
+          "Child.foo foo child_foo\n" +
+          "Child.childOnly childOnly child_childOnly\n",
+      );
+      expect(exitCode).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Fixes #31929
Fixes #28010
Fixes #28316
Fixes #30326
Fixes #30568
Fixes #31965
Fixes #30420

## Repro

```js
function dec(v, c) { return v; }
const C = class Outer {
  @dec static s = (class { @dec static x = 42; }).x;
};
console.log(C.name, C.s);
// bun:            _class undefined
// esbuild + node: Outer 42
```

## Root cause

Standard-decorator lowering temps (`_class`/`_init`/`_dec`) collide when lowering chains share a scope. Every `lower_impl` invocation creates fresh `Ref`s but reuses the same spellings, and the runtime transpiler prints symbols by original name with no rename pass (`NoOpRenamer`), so identical spellings alias at runtime.

The bug class is wider than the nested repro above. Any temp read after the chain's own evaluation is corrupted by a later chain with the same spellings:

- constructors read `_init` at construction time, so sibling or parent/child decorated classes apply each other's field initializers (#28010, #28316, #30326)
- `accessor` storage WeakMaps (and the `_name` WeakMaps of lowered `#name` members) collide between base and subclass, throwing "Cannot add the same private member more than once". For classes without any decorators this is #29837, which #31926 now fixes by lowering those classes in place; this PR is what the decorated variant from the #29837 comment thread (a `#name` field plus a decorated getter in both base and subclass) needs, verified against current `main`. Refs #29837.
- private method calls read `_m_fn` at call time
- computed field names read `_computedKey` inside the constructor

The bundler was affected too: these symbols only live in a scope's `generated` list, which the chunk renamer never visits for unwrapped module scopes, so two bundled files each using `_myData` collided in the output chunk (#30568; there is an existing TODO about this renamer gap at `p.rs` `generate_temp_ref`).

Two adjacent warts from the same name construction: a single chain declared `_dec` twice (`var _class, _init, _dec, _dec;`), and string-keyed accessors emitted invalid identifiers (`class A { @dec accessor "x y" = 1 }` produced `var _x y = new WeakMap;`).

## Fix

`src/js_parser/lower/lower_decorators.rs`, `src/js_parser/p.rs`:

- Add a per-file name table on the parser (`decorator_temp_names`) and route every lowering temp through a new `temp_sym` helper. First use of a base name keeps it; later uses get a numeric suffix (`_dec`, `_dec2`, ...), same convention as `NumberScope::find_unused_name`. Single-class files keep their existing output.
- Sanitize key-derived bases with `MutableString::ensure_valid_identifier`, like the renamer does.
- Register each temp as a `DeclaredSymbol` so the bundler's chunk renamer assigns it a name and cross-file chains stop colliding (same pattern as the react-refresh signature temp).
- Drop the duplicate `var` entry for member decorator and computed key temps in expression mode; their binding is already added when pre-eval statements are folded into the hoisted declaration list.

Supersedes #30329, which fixed a subset of this on a pre-Rust-port base.

Related: #31926 (in-place lowering for classes with no decorators; the two auto-accessor tests in this PR overlap with it and are kept as coverage of the decorated-path naming) and #35708 (class-body placement of undecorated accessor storage and lowered privates inside decorated classes). All three touch different aspects of `lower_decorators.rs`; this one merges cleanly against current `main` and its suite passes there.

## Verification

New tests fail on the unfixed build and pass with the fix:

- `test/bundler/transpiler/es-decorators.test.ts`, "lowering temps do not collide between chains" (9 tests): nested chain, sibling expressions, sibling statements, decorated private methods, computed keys, non-identifier accessor keys, a class statement named `init` whose capture temp aliased the expression chain's `_init`, auto-accessor base/subclass collision (#29837), and subclass field decorator remapping (#28010)
- `test/bundler/bundler_edgecase.test.ts`: `DecoratorLoweringTempsAcrossModules` (two bundled modules with decorated classes) and `AccessorStorageTempsAcrossModules` (#30568's repro)

The repros from #28010, #28316, #29837, #30326, and #30568 were each run against the unfixed build (reproduced) and this branch (matches tsc/esbuild+node output).

Existing suites pass: es-decorators (52), es-decorators-esbuild (147), decorators, decorator-metadata, bundler_decorator_metadata, bundler_edgecase (121), transpiler.test.js (188), esbuild/ts, esbuild/lower, esbuild/default. Verified `--minify` output by running it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_edgecase.test.ts

<!-- robobun:evidence:end -->
