### PR TITLE
spawn: respect Blob offset/size when a sliced Bun.file is used as stdin

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -1,5 +1,5 @@
 use bun_collections::VecExt;
-use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult};
+use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsResult, SysErrorJsc as _};
 #[cfg(windows)]
 use bun_sys::windows::libuv as uv;
 use bun_sys::{self as sys, Fd, FdExt as _};
@@ -549,45 +549,89 @@ impl Stdio {
         let fd = FdStdio::from_int(i).unwrap().fd();
 
         if blob.needs_to_read_file() {
-            if let Some(store) = blob.store() {
-                if let StoreData::File(ref file) = store.data {
-                    match file.pathlike {
-                        PathOrFileDescriptor::Fd(store_fd) => {
-                            if store_fd == fd {
-                                *self = Stdio::Inherit;
-                            } else {
-                                // TODO: is this supposed to be `store.data.file.pathlike.fd`?
-                                if let Some(tag) = FdStdio::from_int(i) {
-                                    match tag {
-                                        FdStdio::StdIn => {
-                                            if i == 1 || i == 2 {
-                                                return Err(global.throw_invalid_arguments(
-                                                    format_args!(
-                                                        "stdin cannot be used for stdout or stderr"
-                                                    ),
-                                                ));
+            if let webcore::blob::Any::Blob(ref b) = blob {
+                if let Some(store) = b.store() {
+                    if let StoreData::File(ref file) = store.data {
+                        // A sliced file blob can't be handed to the child as a raw fd/path —
+                        // the child would read the whole file. Buffer the window instead.
+                        let offset = b.offset.get();
+                        let size = b.size.get();
+                        let is_entire_file = offset == 0 && size == webcore::blob::MAX_SIZE;
+
+                        match file.pathlike {
+                            PathOrFileDescriptor::Fd(store_fd) => {
+                                if is_entire_file {
+                                    if store_fd == fd {
+                                        *self = Stdio::Inherit;
+                                    } else {
+                                        // TODO: is this supposed to be `store.data.file.pathlike.fd`?
+                                        if let Some(tag) = FdStdio::from_int(i) {
+                                            match tag {
+                                                FdStdio::StdIn => {
+                                                    if i == 1 || i == 2 {
+                                                        return Err(global
+                                                            .throw_invalid_arguments(format_args!(
+                                                            "stdin cannot be used for stdout or stderr"
+                                                        )));
+                                                    }
+                                                }
+                                                FdStdio::StdOut | FdStdio::StdErr => {
+                                                    if i == 0 {
+                                                        return Err(global
+                                                            .throw_invalid_arguments(format_args!(
+                                                            "stdout and stderr cannot be used for stdin"
+                                                        )));
+                                                    }
+                                                }
                                             }
                                         }
-                                        FdStdio::StdOut | FdStdio::StdErr => {
-                                            if i == 0 {
-                                                return Err(global.throw_invalid_arguments(
-                                                    format_args!(
-                                                        "stdout and stderr cannot be used for stdin"
-                                                    ),
-                                                ));
-                                            }
-                                        }
+
+                                        *self = Stdio::Fd(store_fd);
                                     }
+                                    return Ok(());
                                 }
 
-                                *self = Stdio::Fd(store_fd);
+                                if i == 1 || i == 2 {
+                                    return Err(global.throw_invalid_arguments(format_args!(
+                                        "Blobs are immutable, and cannot be used for stdout/stderr"
+                                    )));
+                                }
+                                let bytes = read_file_slice(global, store_fd, offset, size)?;
+                                *self = if bytes.is_empty() {
+                                    Stdio::Ignore
+                                } else {
+                                    Stdio::Blob(webcore::blob::Any::from_owned_slice(bytes))
+                                };
+                                return Ok(());
                             }
+                            PathOrFileDescriptor::Path(ref path) => {
+                                if is_entire_file {
+                                    *self = Stdio::Path(path.clone());
+                                    return Ok(());
+                                }
 
-                            return Ok(());
-                        }
-                        PathOrFileDescriptor::Path(ref path) => {
-                            *self = Stdio::Path(path.clone());
-                            return Ok(());
+                                if i == 1 || i == 2 {
+                                    return Err(global.throw_invalid_arguments(format_args!(
+                                        "Blobs are immutable, and cannot be used for stdout/stderr"
+                                    )));
+                                }
+                                let opened = match sys::File::openat(
+                                    Fd::cwd(),
+                                    path.slice(),
+                                    sys::O::RDONLY,
+                                    0,
+                                ) {
+                                    Ok(f) => f,
+                                    Err(err) => return Err(global.throw_value(err.to_js(global))),
+                                };
+                                let bytes = read_file_slice(global, opened.fd(), offset, size)?;
+                                *self = if bytes.is_empty() {
+                                    Stdio::Ignore
+                                } else {
+                                    Stdio::Blob(webcore::blob::Any::from_owned_slice(bytes))
+                                };
+                                return Ok(());
+                            }
                         }
                     }
                 }
@@ -609,6 +653,40 @@ impl Stdio {
         *self = Stdio::Blob(blob);
         Ok(())
     }
+}
+
+/// Read up to `size` bytes from `fd` starting at `offset`. Used for sliced
+/// file blobs as stdin, where the fd/path fast path would feed the whole file.
+fn read_file_slice(
+    global: &JSGlobalObject,
+    fd: Fd,
+    offset: webcore::blob::SizeType,
+    size: webcore::blob::SizeType,
+) -> JsResult<Vec<u8>> {
+    let want = usize::try_from(size).unwrap_or(usize::MAX);
+    let mut buf = Vec::<u8>::new();
+    let mut pos = i64::try_from(offset).unwrap_or(i64::MAX);
+    while buf.len() < want {
+        let remaining = want - buf.len();
+        let old_len = buf.len();
+        buf.resize(old_len + remaining.min(64 * 1024), 0);
+        match sys::pread(fd, &mut buf[old_len..], pos) {
+            Ok(0) => {
+                buf.truncate(old_len);
+                break;
+            }
+            Ok(n) => {
+                buf.truncate(old_len + n);
+                pos = pos.saturating_add(i64::try_from(n).expect("int cast"));
+            }
+            Err(err) if err.get_errno() == sys::E::EINTR => {
+                buf.truncate(old_len);
+                continue;
+            }
+            Err(err) => return Err(global.throw_value(err.to_js(global))),
+        }
+    }
+    Ok(buf)
 }
 
 impl Drop for Stdio {

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -309,6 +309,80 @@ for (let [gcTick, label] of [
         expect(await readableStreamToText(stdout!)).toBe("hello there!");
       });
 
+      it("Bun.file().slice() works as stdin (path-backed)", async () => {
+        const stdinPath = join(tmpdirSync(), "stdin.txt");
+        writeFileSync(stdinPath, "0123456789abcdef");
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: Bun.file(stdinPath).slice(5, 10),
+          env: bunEnv,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "56789", stderr: "", exitCode: 0 });
+      });
+
+      it("Bun.file().slice() works as stdin (fd-backed)", async () => {
+        const stdinPath = join(tmpdirSync(), "stdin.txt");
+        writeFileSync(stdinPath, "0123456789abcdef");
+        const fd = openSync(stdinPath, "r");
+        try {
+          await using proc = spawn({
+            cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+            stdout: "pipe",
+            stderr: "pipe",
+            stdin: Bun.file(fd).slice(5, 10),
+            env: bunEnv,
+          });
+          const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+          expect({ stdout, stderr, exitCode }).toEqual({ stdout: "56789", stderr: "", exitCode: 0 });
+        } finally {
+          closeSync(fd);
+        }
+      });
+
+      it("Bun.file().slice(0) works as stdin (full-file slice still uses fd fast path)", async () => {
+        const stdinPath = join(tmpdirSync(), "stdin.txt");
+        writeFileSync(stdinPath, "0123456789abcdef");
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: Bun.file(stdinPath).slice(0),
+          env: bunEnv,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "0123456789abcdef", stderr: "", exitCode: 0 });
+      });
+
+      it("Bun.file().slice() past EOF works as stdin", async () => {
+        const stdinPath = join(tmpdirSync(), "stdin.txt");
+        writeFileSync(stdinPath, "0123456789abcdef");
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+          stdout: "pipe",
+          stderr: "pipe",
+          stdin: Bun.file(stdinPath).slice(10, 1000),
+          env: bunEnv,
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "abcdef", stderr: "", exitCode: 0 });
+      });
+
+      it("Bun.file().slice() works as stdin via spawnSync", () => {
+        const stdinPath = join(tmpdirSync(), "stdin.txt");
+        writeFileSync(stdinPath, "0123456789abcdef");
+        const { stdout, exitCode } = spawnSync({
+          cmd: [bunExe(), "-e", "process.stdin.pipe(process.stdout)"],
+          stdout: "pipe",
+          stdin: Bun.file(stdinPath).slice(5, 10),
+          env: bunEnv,
+        });
+        expect(stdout.toString()).toBe("56789");
+        expect(exitCode).toBe(0);
+      });
+
       it("Bun.file() works as stdin and stdout", async () => {
         const stdinPath = join(tmpdirSync(), "stdout.txt");
         writeFileSync(stdinPath, "hello!");


### PR DESCRIPTION
## What

`Bun.spawn({ stdin: Bun.file(path).slice(5, 10) })` was feeding the **entire file** to the child's stdin instead of just bytes `5..10`. Same for `Bun.file(fd).slice(...)` and `spawnSync`.

## Why

`extract_blob` in [src/runtime/api/bun/spawn/stdio.rs](src/runtime/api/bun/spawn/stdio.rs) saw a file-backed Blob and converted it directly to `Stdio::Fd(store_fd)` / `Stdio::Path(path)` without consulting the Blob's `offset`/`size` fields. The child then received a raw fd/path and read the whole file.

## Fix

When the Blob's `offset != 0` or `size != MAX_SIZE` (i.e., it's a slice), read the requested byte window into memory via `pread` and feed it through the normal buffered/memfd pipe path. The whole-file fast path (raw fd/path handed to the child) is unchanged for un-sliced `Bun.file(...)` and `Bun.file(...).slice(0)`.

For the path-backed case the file is opened `O_RDONLY` and closed after reading. For the fd-backed case `pread` is used so the user's fd position is not disturbed.

## Tests

Added in `test/js/bun/spawn/spawn.test.ts`:
- path-backed `Bun.file(path).slice(5, 10)`
- fd-backed `Bun.file(fd).slice(5, 10)`
- `.slice(0)` (whole file — still takes the fd/path fast path)
- `.slice(10, 1000)` past EOF (truncates to actual file end)
- `spawnSync` with a sliced file

All five fail on `main` (child receives `"0123456789abcdef"` instead of `"56789"`); all pass with this change. Full `spawn.test.ts` (120 tests) passes; `rust:check-all` clean on all 10 targets.