### PR TITLE
fix(node:net): flush parent->child writes on synchronously-adopted fd…

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -885,6 +885,14 @@ Socket.prototype.connect = function connect(...args) {
       connection = socket;
     }
     if (fd) {
+      // Adopting an existing fd can complete synchronously — on Windows a pipe
+      // fd is opened with uv_pipe_open inside doConnect(), which fires
+      // SocketHandlers.open (clearing `connecting` and emitting "connect")
+      // before doConnect() returns. Set `connecting` BEFORE the call so a
+      // synchronous open can clear it; setting it afterwards (as the non-fd
+      // path does below) would clobber the already-completed connection and
+      // strand every subsequent write waiting for a "connect" that already fired.
+      this.connecting = true;
       doConnect(this._handle, {
         data: this,
         fd: fd,
@@ -904,7 +912,9 @@ Socket.prototype.connect = function connect(...args) {
       process.nextTick(() => {
         this.resume();
       });
-      this.connecting = true;
+      // For the fd path `connecting` was already set above (before doConnect),
+      // so a synchronous open could clear it — don't re-set it here.
+      if (!fd) this.connecting = true;
     }
     if (fd) {
       return this;

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import path from "path";
@@ -469,4 +469,53 @@ it("spawnSync(does-not-exist)", () => {
   expect(x.output).toEqual([null, null, null]);
   expect(x.stdout).toEqual(null);
   expect(x.stderr).toEqual(null);
+});
+
+describe("extra stdio pipes (fd >= 3)", () => {
+  // A child that reads everything sent to one extra fd and writes back what it
+  // received (prefixed) on another extra fd. Exercises BOTH directions of an
+  // extra duplex pipe: parent->child (read fd) and child->parent (write fd).
+  const echoFixture = (readFd: number, writeFd: number) => `
+    const fs = require("node:fs");
+    let buf = "";
+    const r = fs.createReadStream(null, { fd: ${readFd} });
+    const w = fs.createWriteStream(null, { fd: ${writeFd} });
+    r.on("data", d => (buf += d));
+    r.on("end", () => { w.write("ECHO:" + buf); w.end(); });
+  `;
+
+  // Regression: on Windows, adopting the extra pipe fd completed synchronously
+  // inside net.connect(), then connect() re-set `connecting = true`, stranding
+  // every parent->child write (the "connect" event had already fired). The
+  // child->parent direction always worked. See net.ts Socket.prototype.connect.
+  // This passed on POSIX before the fix; on Windows it failed (parent->child
+  // write dropped -> child never ends -> no echo).
+  it("parent can write to an extra pipe and read the child's reply (fd3 in, fd4 out)", async () => {
+    using dir = tempDir("extra-fd-write", {
+      "child.js": echoFixture(3, 4),
+    });
+
+    const child = spawn(bunExe(), [path.join(String(dir), "child.js")], {
+      env: bunEnv,
+      stdio: ["ignore", "pipe", "pipe", "pipe", "pipe"],
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    let fd4 = "";
+    let stderr = "";
+    // The child's reply comes back over fd4 (child->parent direction).
+    child.stdio[4]!.on("data", d => (fd4 += d));
+    child.stderr!.on("data", d => (stderr += d));
+    child.on("error", reject);
+    child.on("close", code => {
+      if (code !== 0) reject(new Error(`child exited code=${code} stderr=${stderr} fd4=${JSON.stringify(fd4)}`));
+      else resolve(fd4);
+    });
+
+    // The bug stranded exactly this write.
+    child.stdio[3]!.write("payload-from-parent");
+    child.stdio[3]!.end();
+
+    expect(await promise).toBe("ECHO:payload-from-parent");
+  });
 });


### PR DESCRIPTION
### What does this PR do?

Fixes parent→child writes silently dropping on extra `child_process` stdio
pipes (fd ≥ 3) on **Windows**. This is the root cause of Playwright's
`chromium.launch()` hanging under Bun on Windows: Playwright defaults to
`--remote-debugging-pipe` and writes CDP commands to the browser's **fd3**,
and under Bun those writes never arrived.

#### Root cause

`Socket.prototype.connect` in `src/js/node/net.ts` set `this.connecting = true`
**after** calling `doConnect()`. On Windows, adopting an existing pipe f
completes **synchronously** inside `doConnect()`:

doConnect() → uv_pipe_open → on_connect → SocketHandlers.open
            → clears connecting, emits "connect"   ← all before doConnec

The post-hoc assignment then clobbered `connecting` back to `true`, so e
subsequent `socket.write()` buffered in `_pendingData` waiting for a `"connect"`
event that had **already fired** — stranding the write forever.

`child→parent` and TCP / `host:port` connects are unaffected because the
connect is genuinely async (it completes *after* the assignment), which is why
this went unnoticed.

#### The fix

`src/js/node/net.ts`: set `this.connecting = true` **before** `doConnect
(so a synchronous open can legitimately clear it) and guard the later
assignment with `if (!fd)`. **+11 / −1**, plus a regression test.

### How did you verify your code works?

Validated at four levels:

1. **Instrumented trace** — `_write` observed `connecting=true` *after*
   `SocketHandlers.open` had already fired → confirmed the clobber.
2. **Three isolated repros** (parent→fd3, parent→fd4, bidirectional fd3-
   — all flip from `*_TIMEOUT` → `CHILD_GOT:PING` / `PING4` / `PONG:PING`.
3. **Regression test** — `test/js/node/child_process/child_process.test.
   → *"extra stdio pipes (fd ≥ 3)"*. Spawns a child with extra duplex pipes,
   writes a payload from the parent on **fd3**, asserts the child echoes
   **fd4**. **Passes** with the fix; **fails** on `USE_SYSTEM_BUN=1`
   (5s timeout on Windows) — the discriminator Bun requires.
4. **Real Playwright** — `chromium.launch()` + `newPage()` + `goto()` +
   `evaluate()` under the patched build returned `42`. ✅

<details>
<summary>Reproducing the build locally on Windows (toolchain notes)</summary>

Building Bun from source on Windows to verify the fix:

- **VS 2022** with the **Desktop development with C++** workload + a
  **Windows 11 SDK** (10.0.22621 / 26100). The MSVC toolset alone isn't
  `vcvarsall.bat` and the registered `VC.Tools` component are required.
- **LLVM 21.1.8 exactly** (Bun enforces it; 22.x is rejected) —
  `scoop install llvm@21.1.8`.
- **rustup** + the pinned nightly from `rust-toolchain.toml` (currently
  `nightly-2026-05-06`). Run `rustup set auto-self-update disable` first — a
  mid-build rustup self-update swaps `cargo.exe` and causes a transient
  `Access is denied (os error 5)`.
- `cmake`, `ninja`, `go`, `nasm`, `perl`, `ccache` via scoop.
- **Endpoint security:** the build compiles & executes many fresh binaries
  (build-scripts, codegen tools, the final `bun-debug.exe`). WatchGuard
  Panda Advanced Protection must be in **Audit mode** during the build —
  *folder exclusions only suppress AV scanning, not execution blocking*,
  Lock/Hardening mode blocks the build with `Access is denied`.
- Build with `bun bd` (do **not** invoke `build/debug/bun-debug.exe` dir
  Test with `bun bd test <file>`. First build pulls prebuilt WebKit (~GB) —
  expect 30–90 min cold.

</details>

### Related issues

Fixes #27977
Fixes #15679
Fixes #17989

Related: #23826 (closed as a duplicate of #15679).
`#13543` (Playwright-on-Windows, `ENOENT` symptom) is likely a separate issue
and is **not** claimed fixed here.
