### PR TITLE
tls: enforce the SSLContextCache owning-thread invariant with debug assertions

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -360,7 +360,8 @@ static void ssl_flush_pending_session(struct us_socket_t *s) {
 
 /* Defined in `src/runtime/api/bun/SSLContextCache.rs`: tombstones the cache entry on
  * SSL_CTX refcount→0 so the per-VM weak SSL_CTX cache learns the pointer is
- * dead without holding a ref of its own. */
+ * dead without holding a ref of its own. Runs on whichever thread dropped the
+ * last ref; the Rust side asserts that is the cache's owning JS thread. */
 extern void bun_ssl_ctx_cache_on_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                                       int index, long argl, void *argp);
 

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -10,9 +10,18 @@
 //! thread: every consumer's `SSL_CTX_free` (socket close, `owned_ssl_ctx`
 //! deinit, `SecureContext.finalize`) runs there — JSC sweeps destructible
 //! objects on the mutator, not heap-helper, thread. The mutex makes the
-//! tombstone-write / `get_or_create`-load+`up_ref` ordering explicit and
-//! protects against any future caller that does free off-thread; the lock is
-//! uncontended in practice.
+//! tombstone-write / `get_or_create`-load+`up_ref` ordering explicit; the
+//! lock is uncontended in practice.
+//!
+//! The mutex can NOT make an off-thread `SSL_CTX_free` safe: BoringSSL drops
+//! `references` to 0 *before* `CRYPTO_free_ex_data` reaches
+//! `bun_ssl_ctx_cache_on_free`, so between the decrement and the tombstone
+//! write a concurrent `get_or_create` would still see `entry.ctx != null` and
+//! `SSL_CTX_up_ref` 0→1, resurrecting a ctx whose destruction already
+//! committed (use-after-free). Keeping every last-ref free on the owning JS
+//! thread is therefore a hard invariant, enforced by `debug_assert` in
+//! `get_or_create_digest` / `bun_ssl_ctx_cache_on_free`; a consumer that
+//! ships a cache-descended ref to another thread must marshal the free back.
 //!
 //! This subsumes the per-consumer `createSSLContext` calls (Postgres, MySQL,
 //! Valkey, `Bun.connect`, `upgradeTLS`, WebSocket client) and the JS-side
@@ -31,11 +40,32 @@ use bun_uws::create_bun_socket_error_t;
 // `jsc.API.ServerConfig.SSLConfig` — re-exported from src/runtime/socket/SSLConfig.rs
 use crate::api::server::server_config::SSLConfig;
 
-#[derive(Default)]
 pub struct SSLContextCache {
     map: ArrayHashMap<Digest, *mut Entry, DigestContext>,
     mutex: Mutex,
     ops_since_compact: u32,
+    /// The owning VM's JS thread, captured at construction
+    /// (`init_runtime_state` runs on it). See the module doc: last-ref
+    /// `SSL_CTX_free` of a cache-managed ctx off this thread is a
+    /// use-after-free window the mutex cannot close.
+    #[cfg(debug_assertions)]
+    owner_thread: std::thread::ThreadId,
+    #[cfg(not(debug_assertions))]
+    owner_thread: (),
+}
+
+impl Default for SSLContextCache {
+    fn default() -> Self {
+        Self {
+            map: ArrayHashMap::default(),
+            mutex: Mutex::default(),
+            ops_since_compact: 0,
+            #[cfg(debug_assertions)]
+            owner_thread: std::thread::current().id(),
+            #[cfg(not(debug_assertions))]
+            owner_thread: (),
+        }
+    }
 }
 
 pub type Digest = [u8; 32];
@@ -99,6 +129,7 @@ impl SSLContextCache {
         d: Digest,
         err: &mut create_bun_socket_error_t,
     ) -> Option<*mut boringssl::SSL_CTX> {
+        self.debug_assert_owner_thread();
         {
             let _guard = self.mutex.lock_guard();
             if let Some(entry) = self.map.get(&d) {
@@ -189,6 +220,21 @@ impl SSLContextCache {
         Some(ctx)
     }
 
+    /// Enforces the module-doc invariant. Meaningful for the *free* side:
+    /// `bun_ssl_ctx_cache_on_free` runs on whichever thread dropped the last
+    /// ref, and an off-thread drop races `get_or_create`'s `up_ref` into a
+    /// resurrection use-after-free regardless of the mutex.
+    #[inline]
+    fn debug_assert_owner_thread(&self) {
+        #[cfg(debug_assertions)]
+        assert!(
+            std::thread::current().id() == self.owner_thread,
+            "SSLContextCache touched off its owning JS thread; an off-thread \
+             SSL_CTX_free of a cache-managed ctx can resurrect a dying SSL_CTX \
+             (see module doc). Marshal the free back to the owning thread."
+        );
+    }
+
     /// Reclaim tombstoned entries. Locked variant — callers hold `self.mutex`.
     fn compact_locked(&mut self) {
         let mut i: usize = 0;
@@ -237,6 +283,7 @@ pub extern "C" fn bun_ssl_ctx_cache_on_free(
     // SAFETY: non-null ptr is the *Entry we stored via SSL_CTX_set_ex_data; the
     // owning cache outlives every SSL_CTX it hands out (Drop clears ex_data first).
     let entry: &mut Entry = unsafe { bun_ptr::callback_ctx::<Entry>(ptr) };
+    entry.owner.debug_assert_owner_thread();
     let _guard = entry.owner.mutex.lock_guard();
     entry.ctx = ptr::null_mut();
 }
@@ -247,6 +294,7 @@ impl Drop for SSLContextCache {
     /// dereference the freed `Entry`/map. Map itself holds no refs, so no
     /// `SSL_CTX_free` here.
     fn drop(&mut self) {
+        self.debug_assert_owner_thread();
         let _guard = self.mutex.lock_guard();
         for &entry in self.map.values() {
             // SAFETY: map values are live heap Entries; we hold the mutex.

--- a/src/runtime/api/bun/SSLContextCache.rs
+++ b/src/runtime/api/bun/SSLContextCache.rs
@@ -50,8 +50,6 @@ pub struct SSLContextCache {
     /// use-after-free window the mutex cannot close.
     #[cfg(debug_assertions)]
     owner_thread: std::thread::ThreadId,
-    #[cfg(not(debug_assertions))]
-    owner_thread: (),
 }
 
 impl Default for SSLContextCache {
@@ -62,8 +60,6 @@ impl Default for SSLContextCache {
             ops_since_compact: 0,
             #[cfg(debug_assertions)]
             owner_thread: std::thread::current().id(),
-            #[cfg(not(debug_assertions))]
-            owner_thread: (),
         }
     }
 }

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -197,13 +197,16 @@ test("rebuilding a config after its SSL_CTX was reclaimed reuses the tombstoned 
     if (sslCtxLiveCount() <= before) break;
   }
   expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
+  // Re-capture after the loop: the sweeps above may also reclaim stragglers
+  // from earlier tests, so `before` is no longer the right baseline.
+  const drained = sslCtxLiveCount();
 
   // Same digest again: the cache must rebuild exactly one CTX (adopting the
   // tombstoned entry) and the follow-up create must dedupe onto it.
   sc = tls.createSecureContext(opts);
   const again = tls.createSecureContext({ ...opts });
   expect(again.context).toBe(sc.context);
-  expect(sslCtxLiveCount()).toBe(before + 1);
+  expect(sslCtxLiveCount()).toBe(drained + 1);
 });
 
 // https://github.com/oven-sh/bun/issues/31881: node:http2 churn (a new

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -227,17 +227,29 @@ test("node:http2 session churn with GC shares one SSL_CTX and completes every re
 
   async function oneSession() {
     const session = http2.connect(`https://localhost:${port}`, clientOpts);
+    // Armed before anything can fail so the finally below never misses the event.
+    const closed = once(session, "close");
     const { promise, resolve, reject } = Promise.withResolvers<number>();
-    session.on("error", reject);
+    session.once("error", reject);
     const req = session.request({ ":path": "/" });
-    req.on("error", reject);
-    req.on("response", headers => resolve(headers[":status"] as number));
+    req.once("error", reject);
+    let statusCode: number | undefined;
+    req.once("response", headers => {
+      statusCode = headers[":status"] as unknown as number;
+    });
+    // Resolve on full request completion, not just headers.
+    req.once("end", () => {
+      if (statusCode == null) reject(new Error("request ended without a :status header"));
+      else resolve(statusCode);
+    });
     req.resume();
     req.end();
-    const status = await promise;
-    session.close();
-    await once(session, "close");
-    return status;
+    try {
+      return await promise;
+    } finally {
+      session.close();
+      await closed;
+    }
   }
 
   try {

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -5,6 +5,7 @@
 // real owner drops, BoringSSL's ex_data free callback tombstones the entry.
 import { expect, test } from "bun:test";
 import { once } from "node:events";
+import http2 from "node:http2";
 import tls from "node:tls";
 // @ts-expect-error - debug-only export
 import { sslCtxLiveCount } from "bun:internal-for-testing";
@@ -170,6 +171,95 @@ test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
       },
     });
     await promise;
+  }
+});
+
+// Tombstone-adopt path: after the last owner drops and the entry is
+// tombstoned (ctx nulled, digest still mapped), the next get_or_create for
+// the same digest must adopt the rebuilt CTX into the existing slot: one
+// allocation, and subsequent identical configs are cache hits again.
+test("rebuilding a config after its SSL_CTX was reclaimed reuses the tombstoned slot", async () => {
+  // Drain leftovers so `before` is stable (same preamble as the weak-cache test).
+  Bun.gc(true);
+  await new Promise<void>(r => setImmediate(r));
+  Bun.gc(true);
+  const before = sslCtxLiveCount();
+
+  // Unique digest via a distinctive cipher list so nothing else shares it.
+  const opts = { ciphers: "ECDHE-RSA-AES256-GCM-SHA384" };
+  let sc: any = tls.createSecureContext(opts);
+  expect(sslCtxLiveCount()).toBe(before + 1);
+  sc = undefined;
+
+  for (let i = 0; i < 50; i++) {
+    Bun.gc(true);
+    await new Promise<void>(r => setImmediate(r));
+    if (sslCtxLiveCount() <= before) break;
+  }
+  expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
+
+  // Same digest again: the cache must rebuild exactly one CTX (adopting the
+  // tombstoned entry) and the follow-up create must dedupe onto it.
+  sc = tls.createSecureContext(opts);
+  const again = tls.createSecureContext({ ...opts });
+  expect(again.context).toBe(sc.context);
+  expect(sslCtxLiveCount()).toBe(before + 1);
+});
+
+// https://github.com/oven-sh/bun/issues/31881: node:http2 churn (a new
+// session per request, firebase-admin's pattern) over the weak cache, with GC
+// pressure interleaved so reclaim/tombstone/rebuild overlap the session
+// lifecycle on the event loop. Debug builds additionally assert (in
+// bun_ssl_ctx_cache_on_free) that every last-ref SSL_CTX_free stays on the
+// owning JS thread, the invariant that keeps getOrCreate's up_ref from
+// resurrecting a dying ctx.
+test("node:http2 session churn with GC shares one SSL_CTX and completes every request", async () => {
+  const server = http2.createSecureServer({ ...tlsCerts });
+  server.on("stream", stream => {
+    stream.respond({ ":status": 200 });
+    stream.end("ok");
+  });
+  server.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as import("net").AddressInfo;
+
+  const clientOpts = { ca: tlsCerts.cert, rejectUnauthorized: false };
+
+  async function oneSession() {
+    const session = http2.connect(`https://localhost:${port}`, clientOpts);
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    session.on("error", reject);
+    const req = session.request({ ":path": "/" });
+    req.on("error", reject);
+    req.on("response", headers => resolve(headers[":status"] as number));
+    req.resume();
+    req.end();
+    const status = await promise;
+    session.close();
+    await once(session, "close");
+    return status;
+  }
+
+  try {
+    // Warm: server CTX + first client CTX + any lazy defaults.
+    expect(await oneSession()).toBe(200);
+    Bun.gc(true);
+    await new Promise<void>(r => setImmediate(r));
+    const before = sslCtxLiveCount();
+
+    for (let round = 0; round < 6; round++) {
+      const statuses = await Promise.all([oneSession(), oneSession(), oneSession(), oneSession(), oneSession()]);
+      expect(statuses).toEqual([200, 200, 200, 200, 200]);
+      Bun.gc(true);
+      await new Promise<void>(r => setImmediate(r));
+    }
+
+    // 30 sessions later: same client config = same digest = no per-session
+    // CTX growth (headroom for defaults lazily built mid-run).
+    expect(sslCtxLiveCount() - before).toBeLessThanOrEqual(2);
+  } finally {
+    server.close();
+    await once(server, "close");
   }
 });
 

--- a/test/js/node/tls/ssl-ctx-cache.test.ts
+++ b/test/js/node/tls/ssl-ctx-cache.test.ts
@@ -174,41 +174,6 @@ test("Bun.connect with inline ca shares SSL_CTX across calls", async () => {
   }
 });
 
-// Tombstone-adopt path: after the last owner drops and the entry is
-// tombstoned (ctx nulled, digest still mapped), the next get_or_create for
-// the same digest must adopt the rebuilt CTX into the existing slot: one
-// allocation, and subsequent identical configs are cache hits again.
-test("rebuilding a config after its SSL_CTX was reclaimed reuses the tombstoned slot", async () => {
-  // Drain leftovers so `before` is stable (same preamble as the weak-cache test).
-  Bun.gc(true);
-  await new Promise<void>(r => setImmediate(r));
-  Bun.gc(true);
-  const before = sslCtxLiveCount();
-
-  // Unique digest via a distinctive cipher list so nothing else shares it.
-  const opts = { ciphers: "ECDHE-RSA-AES256-GCM-SHA384" };
-  let sc: any = tls.createSecureContext(opts);
-  expect(sslCtxLiveCount()).toBe(before + 1);
-  sc = undefined;
-
-  for (let i = 0; i < 50; i++) {
-    Bun.gc(true);
-    await new Promise<void>(r => setImmediate(r));
-    if (sslCtxLiveCount() <= before) break;
-  }
-  expect(sslCtxLiveCount()).toBeLessThanOrEqual(before);
-  // Re-capture after the loop: the sweeps above may also reclaim stragglers
-  // from earlier tests, so `before` is no longer the right baseline.
-  const drained = sslCtxLiveCount();
-
-  // Same digest again: the cache must rebuild exactly one CTX (adopting the
-  // tombstoned entry) and the follow-up create must dedupe onto it.
-  sc = tls.createSecureContext(opts);
-  const again = tls.createSecureContext({ ...opts });
-  expect(again.context).toBe(sc.context);
-  expect(sslCtxLiveCount()).toBe(drained + 1);
-});
-
 // https://github.com/oven-sh/bun/issues/31881: node:http2 churn (a new
 // session per request, firebase-admin's pattern) over the weak cache, with GC
 // pressure interleaved so reclaim/tombstone/rebuild overlap the session


### PR DESCRIPTION
## What

Hardens the per-VM weak `SSL_CTX` cache (`SSLContextCache.rs`, added in #30024) around the invariant its safety actually rests on, prompted by the analysis in #31883 / #31881.

- Corrects the module doc comment. It claimed the mutex "protects against any future caller that does free off-thread". It cannot: `SSL_CTX_free` drops `references` to 0 *before* `CRYPTO_free_ex_data` reaches `bun_ssl_ctx_cache_on_free`, so between the decrement and the tombstone write a concurrent `get_or_create` on the JS thread would still see `entry.ctx != null` and `SSL_CTX_up_ref` 0 to 1, resurrecting a ctx whose destruction already committed (use-after-free). The mutex only orders the tombstone write against the load+up_ref; it cannot undo a refcount that already hit 0.
- Encodes the real invariant as debug assertions: `get_or_create_digest`, `bun_ssl_ctx_cache_on_free` (which runs on whichever thread drops the last ref), and `Drop` now assert they run on the thread that constructed the cache (`init_runtime_state`, i.e. the owning VM's JS thread). Same pattern as `VirtualMachine.debug_thread_id` / `timer::All.thread_id`. Release builds are unchanged.
- Documents the callback's threading contract in `openssl.c` next to the `bun_ssl_ctx_cache_on_free` declaration.

## Is the resurrection race reachable today?

No, as far as a full consumer audit can tell, which is why this is an assertion and not a behavior change. #31883 proposes making the cache hold strong refs to close the race, but patches the (since removed) `SSLContextCache.zig` porting-reference file, and the premise (a `node:http2` teardown dropping the last ref off the JS thread) does not hold on main or on v1.3.14:

- All ten cache consumers (`Bun.connect`/node:net, `upgradeTLS`, `upgradeDuplexToTLS`, `SecureContext`/`tls.connect`, `defaultClientSslCtx`, WebSocket client, SNI `addServerName`, Valkey, Postgres, MySQL) release their ref on the VM loop thread or in a JSC finalizer (mutator thread, same thread).
- The fetch/HTTP thread and h3 build their own contexts directly (`HTTPContext.rs`), never through the per-VM cache; their ex_data slot is null so the tombstone callback no-ops.
- The DNS threadpool only enqueues and wakes the loop; the connecting-socket `SSL_CTX` unref runs in the loop drain.
- usockets frees the per-socket `SSL` synchronously in `us_internal_ssl_detach` on the loop thread; there is no deferred `SSL_CTX` free list.

The assertions make that audit permanent: any future consumer that ships a cache-descended ref to another thread trips the assert in every debug/ASAN run instead of shipping a heisen-UAF. Strong refs were not adopted because they would also pin one `SSL_CTX` (cert chain, CA store) per distinct config for the VM's lifetime, a real cost for per-hostname cert servers using `addServerName`, to close a window that is currently unreachable.

## Tests

Adds a `node:http2` new-session-per-request churn test to `test/js/node/tls/ssl-ctx-cache.test.ts` (30 sessions, 5 concurrent) with interleaved `Bun.gc(true)`, the firebase-admin pattern from #31881, asserting every request completes and the live `SSL_CTX` count stays flat. `http2.connect` goes through `tls.connect`, which still takes the internal `intern` path through the per-digest cache, so this covers the cache's tombstone/rebuild lifecycle and exercises the new assertions on every last-ref free in debug builds.

This is a regression canary for the cache lifecycle, not a fail-before test: the assertion added here is not reachable from JS today (that is the point of the audit above), so the test passes on current release builds as well. On debug builds it additionally exercises the assertion on every tombstone.

## Rebases

- Onto #31155: it routes user-facing `tls.createSecureContext()` through a private, uncached path (so `addCACert` on one context cannot affect another) while the internal connect paths keep using the per-digest cache. The `openssl.c` conflict was the new session/keylog code inserted just above the `bun_ssl_ctx_cache_on_free` declaration; resolved by keeping both. A tombstone-adopt test this PR originally added via `createSecureContext` was dropped: that entry point no longer goes through the cache, so it cannot reach the tombstone path; the http2 churn test (which uses the cached internal path) covers the same lifecycle.
- Onto the `.zig`-reference removal (#32621) and the comment-path sweep: main independently fixed the stale "Defined in Zig" text in `openssl.c`, so this PR's `openssl.c` diff is now just the added sentence documenting which thread runs the callback.

Verification: full `test/js/node/tls/` and `test/js/node/http2/` suites run against this change on a debug (ASAN) build; the assertion never fires. The two failures in those suites reproduce identically on clean main: a hostname-verification test failure, and a SEGV in `BIO_ctrl` from the upgraded-duplex teardown already fixed by #31364.
