### PR TITLE
Propagate exception from Bun.plugin target string conversion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,12 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        String targetString = targetValue.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import { resolve } from "path";
 
 declare global {
@@ -364,6 +364,23 @@ describe("errors", () => {
     expect(() => {
       plugin(opts as any);
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
+  });
+
+  it("handles 'target' that fails string conversion", () => {
+    const setup = jest.fn();
+    const opts = {
+      setup,
+      target: {
+        toString() {
+          return {};
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("No default value");
+    expect(setup).not.toHaveBeenCalled();
   });
 
   it("invalid loaders throw", () => {


### PR DESCRIPTION
Fuzzing found a deterministic debug assertion crash in `Bun.plugin()` (fingerprint `93b5581fa4549ef5`):

```js
Bun.plugin({
  setup() {},
  target: { toString() { return {}; } },
});
```

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: No default value
!exception()
JavaScriptCore/ExceptionScope.h(61) : void JSC::ExceptionScope::assertNoException()
```

### Root cause

`setupBunPlugin` in `src/jsc/bindings/BunPlugin.cpp` converted the `target` option with `targetValue.toStringOrNull(globalObject)`. That conversion can run user JS (`toString`/`valueOf` via ToPrimitive) and throw, for example the "No default value" TypeError when ToPrimitive yields no primitive. On failure `toStringOrNull()` returns null with the exception left pending, the null case was silently skipped, and execution continued into `constructEmptyObject` and the `setup` call with a live exception, which trips `assertNoException` in debug builds.

### Fix

Convert with `toWTFString()` followed by `RETURN_IF_EXCEPTION` (the added `RETURN_IF_EXCEPTION(throwScope, {});` line is the fix), matching how the other option reads in this file handle conversions. The conversion error now propagates to the caller as a normal TypeError before `setup` runs. Non-throwing inputs behave exactly as before, including the existing invalid-target error path.

### Test

Added `errors > handles 'target' that fails string conversion` to `test/js/bun/plugin/plugins.test.ts`. On the unfixed debug build the test run aborts with the assertion (SIGABRT) at exactly this test; with the fix the whole file passes and the test asserts `plugin()` throws "No default value" without calling `setup`. The assertion is compiled out of release builds, so the unfixed release binary already reports the error; the debug assert is the failure mode this guards.