### PR TITLE
markdown: add mailto:/http:// autolink prefixes to react and render hrefs

### DIFF
--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -21,6 +21,24 @@ fn js_array_push(arr: JSValue, global: &JSGlobalObject, item: JSValue) -> JsResu
     arr.push(global, item)
 }
 
+/// Owned href bytes for a span, prepending the autolink scheme prefix
+/// (`mailto:` for emails, `http://` for www) that the HTML renderer adds.
+/// Non-autolink spans keep the raw href; an empty href stays unallocated.
+fn href_bytes_with_prefix(detail: &md::SpanDetail<'_>) -> Box<[u8]> {
+    if !detail.autolink_email && !detail.autolink_www {
+        return Box::from(detail.href);
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    if detail.autolink_email {
+        buf.extend_from_slice(b"mailto:");
+    }
+    if detail.autolink_www {
+        buf.extend_from_slice(b"http://");
+    }
+    buf.extend_from_slice(detail.href);
+    buf.into_boxed_slice()
+}
+
 /// Map a host-fn `JsError` back into the parser's error enum so it can
 /// bubble through `md::render_with_renderer` and be re-thrown at the top.
 #[inline]
@@ -824,7 +842,7 @@ impl<'a> ParseRenderer<'a> {
         self.marked_args.append(array);
         self.stack.push(ParseStackEntry {
             children: array,
-            href: Box::from(detail.href),
+            href: href_bytes_with_prefix(&detail),
             title: Box::from(detail.title),
             ..Default::default()
         });
@@ -1286,7 +1304,7 @@ impl<'a> JsCallbackRenderer<'a> {
             return Err(self.global_object.throw_stack_overflow());
         }
         self.stack.push(CallbackStackEntry {
-            href: Box::from(detail.href),
+            href: href_bytes_with_prefix(&detail),
             title: Box::from(detail.title),
             ..Default::default()
         });

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -79,6 +79,37 @@ describe("Bun.markdown.react", () => {
     expect(link.props.children).toEqual(["click"]);
   });
 
+  // https://github.com/oven-sh/bun/issues/31936
+  test("email autolink href has mailto: prefix", () => {
+    const link = children("<email@example.com>\n")[0].props.children[0];
+    expect(link.type).toBe("a");
+    expect(link.props.href).toBe("mailto:email@example.com");
+    expect(link.props.children).toEqual(["email@example.com"]);
+  });
+
+  test("URL autolink href has no prefix", () => {
+    const link = children("<https://example.com>\n")[0].props.children[0];
+    expect(link.props.href).toBe("https://example.com");
+  });
+
+  test("permissive email autolink href has mailto: prefix", () => {
+    const link = children("email@example.com\n", undefined, { autolinks: true })[0].props.children[0];
+    expect(link.type).toBe("a");
+    expect(link.props.href).toBe("mailto:email@example.com");
+    expect(link.props.children).toEqual(["email@example.com"]);
+  });
+
+  test("permissive www autolink href has http:// prefix", () => {
+    const link = children("www.example.com\n", undefined, { autolinks: true })[0].props.children[0];
+    expect(link.props.href).toBe("http://www.example.com");
+    expect(link.props.children).toEqual(["www.example.com"]);
+  });
+
+  test("permissive URL autolink href has no prefix", () => {
+    const link = children("https://example.com\n", undefined, { autolinks: true })[0].props.children[0];
+    expect(link.props.href).toBe("https://example.com");
+  });
+
   test("image has src and alt in props", () => {
     const img = children("![alt](img.png)\n")[0].props.children[0];
     expect(img.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -375,6 +375,28 @@ describe("Bun.markdown.render", () => {
     expect(result).toContain("[www.example.com]");
   });
 
+  // https://github.com/oven-sh/bun/issues/31936
+  test("autolink href meta includes mailto:/http:// prefix", () => {
+    const hrefs: string[] = [];
+    Markdown.render(
+      "<email@example.com>\n\nemail@example.com\n\nwww.example.com\n\nhttps://example.com\n",
+      {
+        link: (children: string, { href }: any) => {
+          hrefs.push(href);
+          return children;
+        },
+        paragraph: (children: string) => children,
+      },
+      { autolinks: true },
+    );
+    expect(hrefs).toEqual([
+      "mailto:email@example.com",
+      "mailto:email@example.com",
+      "http://www.example.com",
+      "https://example.com",
+    ]);
+  });
+
   test("headings option provides id in heading meta", () => {
     const result = Markdown.render(
       "## Hello World\n",


### PR DESCRIPTION
Fixes #31936

`Bun.markdown.react()` and `Bun.markdown.render()` returned autolink hrefs without the `mailto:`/`http://` prefix that `Bun.markdown.html()` adds:

```js
const s = "email@example.com";
Bun.markdown.html(s, { autolinks: true });
// <p><a href="mailto:email@example.com">email@example.com</a></p>
Bun.markdown.react(s, {}, { autolinks: true });
// a element had href: "email@example.com" (missing mailto:)
```

Standard angle-bracket email autolinks (`<email@example.com>`, no option needed) and permissive www autolinks (`www.example.com`, missing `http://`) were affected the same way.

### Cause

The markdown span detail carries the raw matched text as `href` plus `autolink_email`/`autolink_www` flags; each renderer is responsible for prepending `mailto:`/`http://`. The HTML and ANSI renderers do this, but `MarkdownObject.rs` used `detail.href` directly when building the react element `href` prop and the `render()` link callback `href` metadata.

### Fix

Add a `href_bytes_with_prefix` helper in `MarkdownObject.rs` that builds the owned href bytes, prepending the prefixes based on the span detail flags (matching `html_renderer.rs`). Both the react renderer (`ParseStackEntry`) and callback renderer (`CallbackStackEntry`) now build their stored `href` box through it at `enter_span` time. Image `src` and wikilink `target` carry no autolink flags, so they are unchanged, matching the HTML renderer.

### Verification

New tests in `test/js/bun/md/md-react.test.ts` and `test/js/bun/md/md-render-callback.test.ts` cover standard email autolinks, permissive email/www/url autolinks, and that non-email URL autolinks get no prefix. They fail on the unfixed build (href comes back without the prefix) and pass with this change; the full `test/js/bun/md/` suite (1068 tests) passes.

### Rebase note

Rebased onto main after #32671 (reference-link href/title use-after-free fix) landed in the same two `SpanType::A` sites. That PR replaced the stored `SpanDetail` with owned `href`/`title` `Box<[u8]>` copies built at `enter_span` time. Resolved by building the autolink prefix into that owned `href` box (where the `autolink_email`/`autolink_www` flags are still in scope) rather than at leave time, which keeps the #32671 ownership model intact. Verified the #32671 reference-link repro still returns uncorrupted href/title.
