### PR TITLE
Don't panic when auto-install can't read the top-level directory

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -404,9 +404,12 @@ impl<'a> Transpiler<'a> {
         self.macro_context = Some(js_ast::Macro::MacroContext::init(self));
     }
 
-    /// Returns the resolver's auto-install package-manager handle.
+    /// Returns the resolver's auto-install package-manager handle. Errs when
+    /// the one-time init fails (e.g. unreadable top-level directory).
     #[inline]
-    pub fn get_package_manager(&mut self) -> *mut dyn bun_resolver::install_types::AutoInstaller {
+    pub fn get_package_manager(
+        &mut self,
+    ) -> Result<*mut dyn bun_resolver::install_types::AutoInstaller, bun_core::Error> {
         self.resolver.get_package_manager()
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2263,11 +2263,23 @@ pub(crate) fn init_with_runtime(
     bun_install: Option<&Api::BunInstall>,
     cli: CommandLineArguments,
     env: &mut dot_env::Loader<'static>,
-) -> *mut PackageManager {
-    bun_core::run_once! {{
-        init_with_runtime_once(log, bun_install, cli, env);
-    }}
-    get()
+) -> Result<*mut PackageManager, bun_core::Error> {
+    // NB: not `bun_core::run_once!` — the body is fallible (reading the root
+    // directory hits ENOENT/EACCES at runtime when the cwd was deleted or is
+    // unreadable), and the failure must be sticky: `holder::RAW_PTR` stays
+    // null on failure, so later callers have to see the error instead of a
+    // null singleton.
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    static INIT_ERROR: core::sync::atomic::AtomicU16 = core::sync::atomic::AtomicU16::new(0);
+    ONCE.call_once(|| {
+        if let Err(err) = init_with_runtime_once(log, bun_install, cli, env) {
+            INIT_ERROR.store(err.as_u16(), core::sync::atomic::Ordering::Release);
+        }
+    });
+    match INIT_ERROR.load(core::sync::atomic::Ordering::Acquire) {
+        0 => Ok(get()),
+        code => Err(bun_core::Error::from_raw(code)),
+    }
 }
 
 pub(crate) fn init_with_runtime_once(
@@ -2275,10 +2287,23 @@ pub(crate) fn init_with_runtime_once(
     bun_install: Option<&Api::BunInstall>,
     cli: CommandLineArguments,
     env: &mut dot_env::Loader<'static>,
-) {
+) -> Result<(), bun_core::Error> {
     if env.get(b"BUN_INSTALL_VERBOSE").is_some() {
         PackageManager::set_verbose_install(true);
     }
+
+    // Read the root directory BEFORE allocating the singleton. This is
+    // user-reachable failure (the cwd may have been deleted out from under the
+    // process, or be unreadable: ENOENT/EACCES/ENOTDIR), and bailing out here
+    // leaves `holder::RAW_PTR` null rather than pointing at an uninitialized
+    // manager. Returns the resolver's BSSMap-owned `*EntriesOption` slot.
+    let fs_instance = FileSystem::instance();
+    let root_dir = match fs_instance.read_directory(fs_instance.top_level_dir(), 0, true)? {
+        // SAFETY: the BSSMap singleton owns `*e` for the process lifetime,
+        // and runtime init runs once on the main thread before any other access.
+        fs::EntriesOption::Entries(e) => unsafe { &mut *std::ptr::from_mut::<fs::DirEntry>(*e) },
+        fs::EntriesOption::Err(e) => return Err(e.canonical_error),
+    };
 
     let cpu_count: u32 = u32::from(bun_core::get_thread_count());
     allocate_package_manager();
@@ -2291,38 +2316,6 @@ pub(crate) fn init_with_runtime_once(
     // initialized it.
     let manager_ptr: *mut PackageManager =
         holder::RAW_PTR.load(core::sync::atomic::Ordering::Acquire);
-    // Returns the resolver's BSSMap-owned
-    // `*EntriesOption` slot. On error, `Output::err` then panic:
-    // this is the runtime auto-install path
-    // where the resolver already opened `top_level_dir`, so failure is a
-    // programmer-error / fs-disappeared edge.
-    let fs_instance = FileSystem::instance();
-    let root_dir = match fs_instance
-        .read_directory(fs_instance.top_level_dir(), 0, true)
-        .map(|r| &mut *r)
-    {
-        // SAFETY: the BSSMap singleton owns `*e` for the process lifetime,
-        // and runtime init runs once on the main thread before any other access.
-        Ok(fs::EntriesOption::Entries(e)) => unsafe {
-            &mut *std::ptr::from_mut::<fs::DirEntry>(*e)
-        },
-        Ok(fs::EntriesOption::Err(e)) => {
-            Output::err(
-                e.canonical_error,
-                "failed to read root directory: '{s}'",
-                (bstr::BStr::new(fs_instance.top_level_dir()),),
-            );
-            panic!("Failed to initialize package manager");
-        }
-        Err(err) => {
-            Output::err(
-                err,
-                "failed to read root directory: '{s}'",
-                (bstr::BStr::new(fs_instance.top_level_dir()),),
-            );
-            panic!("Failed to initialize package manager");
-        }
-    };
 
     // var progress = Progress{};
     // var node = progress.start(name: []const u8, estimated_total_items: usize)
@@ -2556,4 +2549,6 @@ pub(crate) fn init_with_runtime_once(
     } else {
         manager.lockfile.init_empty();
     }
+
+    Ok(())
 }

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2270,6 +2270,8 @@ pub(crate) fn init_with_runtime(
     // null on failure, so later callers have to see the error instead of a
     // null singleton.
     static ONCE: std::sync::Once = std::sync::Once::new();
+    // `0` = initialized without error; `bun_core::Error` is a `NonZeroU16`, so
+    // every real code round-trips exactly through `as_u16`/`from_raw`.
     static INIT_ERROR: core::sync::atomic::AtomicU16 = core::sync::atomic::AtomicU16::new(0);
     ONCE.call_once(|| {
         if let Err(err) = init_with_runtime_once(log, bun_install, cli, env) {

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -456,7 +456,7 @@ pub(crate) unsafe fn __bun_resolver_init_package_manager(
     mut log: core::ptr::NonNull<bun_ast::Log>,
     install: Option<core::ptr::NonNull<crate::bun_schema::api::BunInstall>>,
     mut env: core::ptr::NonNull<bun_dotenv::Loader<'static>>,
-) -> core::ptr::NonNull<dyn hooks::AutoInstaller> {
+) -> Result<core::ptr::NonNull<dyn hooks::AutoInstaller>, bun_core::Error> {
     // Idempotent.
     bun_http::http_thread::init(&Default::default());
 
@@ -474,9 +474,9 @@ pub(crate) unsafe fn __bun_resolver_init_package_manager(
         bun_install,
         crate::package_manager::CommandLineArguments::default(),
         env_ref,
-    );
-    // `init_with_runtime` returns the non-null `holder::RAW_PTR` singleton;
-    // upcast to the trait object the resolver stores.
-    core::ptr::NonNull::new(pm as *mut dyn hooks::AutoInstaller)
-        .expect("init_with_runtime returns the holder::RAW_PTR singleton")
+    )?;
+    // On success `init_with_runtime` returns the non-null `holder::RAW_PTR`
+    // singleton; upcast to the trait object the resolver stores.
+    Ok(core::ptr::NonNull::new(pm as *mut dyn hooks::AutoInstaller)
+        .expect("init_with_runtime returns the holder::RAW_PTR singleton"))
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3438,15 +3438,25 @@ impl VirtualMachine {
     /// the concrete `bun_install::PackageManager` here — the resolver's
     /// `PackageManager` is exactly that struct, just type-erased at a lower
     /// tier.
+    ///
+    /// Panics when the lazy init fails (unreadable top-level dir). Production
+    /// callers (AsyncModule's pending-task machinery) only run after a pending
+    /// dependency was enqueued, which requires a previously successful
+    /// `get_package_manager`, so the init error is surfaced as a resolve
+    /// failure in `Resolver::load_node_modules` long before reaching here.
     #[inline]
     pub fn package_manager(&mut self) -> &mut bun_install::PackageManager {
-        let pm = self.transpiler.get_package_manager();
+        let pm = self
+            .transpiler
+            .get_package_manager()
+            .expect("package manager init already succeeded when the pending task was enqueued");
         // SAFETY: `bun_resolver::package_json::PackageManager` is an opaque
         // forward-decl of `bun_install::PackageManager`; the pointer was
         // produced by `PackageManager::init_with_runtime` (the install crate)
         // and only ever names that one type, so the concrete 64-byte alignment
-        // is preserved through the `dyn` erasure. `get_package_manager` never
-        // returns null (it lazy-inits the process-static singleton).
+        // is preserved through the `dyn` erasure. On success
+        // `get_package_manager` never returns null (it lazy-inits the
+        // process-static singleton).
         unsafe {
             &mut *NonNull::new_unchecked(pm)
                 .cast::<bun_install::PackageManager>()

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3444,6 +3444,9 @@ impl VirtualMachine {
     /// dependency was enqueued, which requires a previously successful
     /// `get_package_manager`, so the init error is surfaced as a resolve
     /// failure in `Resolver::load_node_modules` long before reaching here.
+    /// The one caller outside that machinery is the `bun:internal-for-testing`
+    /// `parseLockfile` binding (`install_jsc/install_binding.rs`), which may
+    /// lazy-init here and accepts the panic on its test-only surface.
     #[inline]
     pub fn package_manager(&mut self) -> &mut bun_install::PackageManager {
         let pm = self

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -545,13 +545,11 @@ pub struct Resolver<'a> {
 
     /// Auto-install backend. `bun_install::PackageManager` implements
     /// [`AutoInstaller`]; the resolver only sees the trait object so it stays
-    /// below `bun_install` in the dep graph. The runtime/bundler that enables
-    /// auto-install (`opts.global_cache != .disable`) is responsible for
-    /// constructing the `PackageManager`
-    /// and assigning it here BEFORE resolution; the resolver does not
-    /// construct it lazily — that would require depending on `bun_install`,
-    /// which depends on us. When `None`, [`get_package_manager`] panics if the
-    /// auto-install path is reached.
+    /// below `bun_install` in the dep graph. `None` until the auto-install
+    /// path is first reached: [`get_package_manager`] then initializes the
+    /// singleton through the link-time `__bun_resolver_init_package_manager`
+    /// factory and caches the pointer here. A failed init (e.g. unreadable
+    /// top-level directory) is returned as an error and leaves this `None`.
     pub package_manager: Option<NonNull<dyn AutoInstaller>>,
     pub on_wake_package_manager: Install::WakeHandler,
     // Stored as `NonNull` (not `&'a Loader`) because the same allocation is

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -36,11 +36,13 @@ unsafe extern "Rust" {
     /// reborrows `&mut *log` / `&mut *env` and reads `*install` if non-null.
     /// All three must point at process-lifetime Transpiler-owned storage; the
     /// returned `NonNull` names the `'static` `PackageManager` singleton.
+    /// Errs when the one-time init fails (e.g. the top-level directory is
+    /// unreadable); the failure is sticky across calls.
     fn __bun_resolver_init_package_manager(
         log: NonNull<bun_ast::Log>,
         install: Option<NonNull<bun_options_types::schema::api::BunInstall>>,
         env: NonNull<bun_dotenv::Loader<'static>>,
-    ) -> NonNull<dyn AutoInstaller>;
+    ) -> core::result::Result<NonNull<dyn AutoInstaller>, bun_core::Error>;
 }
 use crate::cache::Set as CacheSet;
 use ::bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
@@ -877,10 +879,15 @@ impl<'a> Resolver<'a> {
     /// process-static singleton as a `dyn AutoInstaller`. We then wire
     /// `on_wake` and cache the pointer. Reached from
     /// the auto-install path (`load_node_modules` global-cache block) when
-    /// [`use_package_manager`] is `true`.
-    pub fn get_package_manager(&mut self) -> *mut dyn AutoInstaller {
+    /// [`use_package_manager`] is `true`. Errs (without caching, but sticky
+    /// inside the factory) when the one-time init fails, e.g. the top-level
+    /// directory was deleted or is unreadable — callers surface that as a
+    /// resolve failure rather than panicking.
+    pub fn get_package_manager(
+        &mut self,
+    ) -> core::result::Result<*mut dyn AutoInstaller, bun_core::Error> {
         if let Some(pm) = self.package_manager {
-            return pm.as_ptr();
+            return Ok(pm.as_ptr());
         }
         // SAFETY: `DotEnv::Loader<'a>` is layout-identical across `'a`;
         // `init_with_runtime` only borrows it for the synchronous init (the
@@ -895,11 +902,11 @@ impl<'a> Resolver<'a> {
         // process-lifetime storage (Transpiler-owned). The returned pointer
         // names the `PackageManager` singleton (`'static`).
         let pm: NonNull<dyn AutoInstaller> =
-            unsafe { __bun_resolver_init_package_manager(self.log, self.opts.install, env) };
+            unsafe { __bun_resolver_init_package_manager(self.log, self.opts.install, env) }?;
         // SAFETY: `pm` is the just-initialized singleton; sole `&mut` here.
         unsafe { (*pm.as_ptr()).set_on_wake(self.on_wake_package_manager) };
         self.package_manager = Some(pm);
-        pm.as_ptr()
+        Ok(pm.as_ptr())
     }
 
     /// Safe accessor for the optional [`AutoInstaller`] back-reference.
@@ -3001,7 +3008,34 @@ impl<'a> Resolver<'a> {
                 // `log()`. The PackageManager lives in a separate allocation, so
                 // derive a raw pointer once and re-borrow per use — disjoint
                 // from `self`'s storage.
-                let manager_ptr: *mut dyn AutoInstaller = self.get_package_manager();
+                let manager_ptr: *mut dyn AutoInstaller = match self.get_package_manager() {
+                    Ok(pm) => pm,
+                    Err(err) => {
+                        // One-time init reads the top-level directory, which
+                        // can fail at runtime (cwd deleted, EACCES, a dropped
+                        // network drive). Report it as a catchable resolve
+                        // error; the `Metadata::Resolve` msg carries the text
+                        // for `import.meta.resolveSync` & co.
+                        let top_level_dir = self.fs_ref().top_level_dir;
+                        self.log_mut().add_resolve_error(
+                            None,
+                            bun_ast::Range::NONE,
+                            format_args!(
+                                "Cannot read directory \"{}\": {} while resolving \"{}\"",
+                                bstr::BStr::new(top_level_dir),
+                                bstr::BStr::new(err.name()),
+                                bstr::BStr::new(import_path)
+                            ),
+                            import_path,
+                            kind,
+                            err,
+                        );
+                        if let Some(d) = self.debug_logs.as_mut() {
+                            d.decrease_indent();
+                        }
+                        return MatchStatus::Failure(err);
+                    }
+                };
                 macro_rules! manager {
                     () => {
                         // SAFETY: re-borrowed narrowly per use; PackageManager outlives resolver.
@@ -3615,7 +3649,13 @@ impl<'a> Resolver<'a> {
         let input_package_id = *input_package_id_;
         // NOTE: see `manager_ptr` note in `load_node_modules` — split the
         // `&mut self` borrow by holding the PackageManager via raw pointer.
-        let pm_ptr: *mut dyn AutoInstaller = self.get_package_manager();
+        // Init failure is unreachable in practice (`load_node_modules`
+        // initialized the manager before calling here), but propagate rather
+        // than unwrap so the invariant isn't load-bearing for safety.
+        let pm_ptr: *mut dyn AutoInstaller = match self.get_package_manager() {
+            Ok(pm) => pm,
+            Err(err) => return DependencyToResolve::Failure(err),
+        };
         macro_rules! pm {
             () => {
                 // SAFETY: PackageManager lives in a separate allocation; disjoint from `self`.

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -740,6 +740,75 @@ describe.if(isWindows)("#30839 - imports entry pointing at a scoped package", ()
       } catch {}
     }
   });
+
+  // The runtime auto-installer's one-time init reads the top-level directory
+  // (the cwd). When that read fails — cwd on a dead network drive, permissions
+  // revoked, directory deleted — the whole process used to die with
+  // "panic: Failed to initialize package manager" instead of surfacing a
+  // resolution error the caller can catch.
+  //
+  // The cwd must be unlistable from process start (the startup dir walk
+  // otherwise caches its entries, and the cached listing satisfies the
+  // package-manager init even if the directory disappears later), and the
+  // script must live in a readable directory so the resolver reaches the
+  // auto-install path at all.
+  it.skipIf(!canTriggerEACCES)("auto-install init failure from an unreadable cwd is a catchable error", async () => {
+    using dir = tempDir("autoinstall-unreadable-cwd", {
+      // Dynamic specifier so the transpiler can't resolve it at build time;
+      // the resolve must happen at runtime, through the auto-install path.
+      "app/main.js": `
+        console.log("start");
+        const spec = ["left", "pad"].join("-");
+        try {
+          const r = import.meta.resolveSync(spec);
+          console.log("resolved:", r);
+        } catch (e) {
+          console.log("caught:", String(e && e.message));
+        }
+        console.log("end");
+      `,
+      "work/.keep": "",
+    });
+    const root = String(dir);
+    const work = join(root, "work");
+
+    let cmd: string[];
+    if (canUseRunuser) {
+      // Let `nobody` traverse and read everything except the cwd.
+      for (const p of [root, join(root, "app"), join(root, "app", "main.js")]) {
+        chmodSync(p, 0o777);
+      }
+      cmd = ["runuser", "-u", "nobody", "--", bunExe(), join(root, "app", "main.js")];
+    } else {
+      cmd = [bunExe(), join(root, "app", "main.js")];
+    }
+    // Execute-only: the spawn can chdir into it, but listing it fails.
+    chmodSync(work, 0o111);
+
+    try {
+      await using proc = Bun.spawn({
+        cmd,
+        env: bunEnv,
+        cwd: work,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: expect.stringMatching(
+          /^start\ncaught: Cannot read directory "[^"]+": E[A-Z]+ while resolving "left-pad"\nend\n$/,
+        ),
+        stderr: "",
+        exitCode: 0,
+      });
+    } finally {
+      // Ensure tempDir cleanup can delete work/.keep.
+      try {
+        chmodSync(work, 0o755);
+      } catch {}
+    }
+  });
 }
 
 describe("resolving external URL specifiers with non-ASCII characters", () => {


### PR DESCRIPTION
### Crash

Sentry BUN-34PN: ~120 events, 100% Windows x64, `bun <script>` / `bun -e`, bun 1.3.8 through 1.3.14.

```
panic: access of union field 'entries' while field 'err' is active
```

in `initWithRuntimeOnce` (PackageManager runtime init), reached from `import.meta.resolveSync` via the resolver's auto-install path. On current main the same path still crashes, with the message `panic: Failed to initialize package manager`.

### Repro

The cwd must be unlistable from process start (if it is readable at startup, the dir walk caches its entries and the cached listing satisfies the later init), and the script must live in a readable directory so the resolver reaches the auto-install path:

```sh
mkdir -p /tmp/t/app /tmp/t/cwd
cat > /tmp/t/app/main.js <<'JS'
const spec = ["left", "pad"].join("-");   // dynamic so the transpiler can't pre-resolve it
try { console.log(import.meta.resolveSync(spec)); }
catch (e) { console.log("caught:", e.message); }
JS
chmod 111 /tmp/t/cwd        # execute-only: chdir works, listing fails (run as non-root)
cd /tmp/t/cwd && bun /tmp/t/app/main.js
```

Before:

```
ENOENT: failed to read root directory: '/tmp/t/cwd'
panic: Failed to initialize package manager
```

(exit 132, crash report). This matches the field population: cwd on a dead mapped drive or with revoked permissions.

### Fix

The runtime auto-installer's one-time init read the top-level directory and panicked on failure. That failure is user-reachable, so it is now a recoverable error:

- `init_with_runtime` / `init_with_runtime_once` (src/install/PackageManager.rs) return `Result`. The directory read happens before the singleton allocation, so a failure leaves `holder::RAW_PTR` null instead of pointing at an uninitialized manager. The failure is sticky across calls (same `Once` semantics as before).
- `__bun_resolver_init_package_manager` (src/install/auto_installer.rs) and `Resolver::get_package_manager` (src/resolver/resolver.rs) propagate the error.
- `load_node_modules` turns it into `MatchStatus::Failure` with a `Metadata::Resolve` log message, so JS gets a catchable `ResolveMessage`.
- `VirtualMachine::package_manager` keeps its infallible signature; its production callers (AsyncModule pending-task machinery) only run after a successful init, documented at the `expect`.

After:

```
caught: Cannot read directory "/tmp/t/cwd": ENOENT while resolving "left-pad"
```

exit 0, execution continues, repeated resolves rethrow the same error.

The `bun install` CLI init path already returned `Err(e.canonical_error)` for this case and is unchanged.

### Verification

- New test in `test/js/bun/resolve/resolve.test.ts` (`auto-install init failure from an unreadable cwd is a catchable error`), next to the existing entries-cache EACCES test and reusing its root/`runuser` scaffolding. Fails on the unfixed build (panic, exit 132), passes with the fix.
- `bun bd test test/js/bun/resolve/resolve.test.ts`: 39 pass, 0 fail.
- `bun bd test test/cli/run/run-autoinstall.test.ts test/cli/run/run-autoinstall-abs-path.test.ts test/cli/run/autoinstall-cached-manifest.test.ts`: 13 pass, 0 fail.
- Happy path intact: auto-install resolve with a readable cwd still works; `bun install` CLI unaffected; `await import()` on the broken-cwd path rejects with the same catchable error.
