### PR TITLE
Fix Windows use-after-free of the pipe reader buffer retained by in-flight libuv reads

### DIFF
--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1229,7 +1229,24 @@ impl WindowsBufferedReader {
         let limit = self.limit;
         // Never empty: reads are only issued while the limit has not been reached (`start_reading`, `on_read`), and libuv treats an empty buffer as an error.
         debug_assert!(!limit.reached());
-        self._buffer.reserve(limit.clamp_len(suggested_size));
+        let size = limit.clamp_len(suggested_size);
+        // Tty reads are served from the handle-owned scratch, not `_buffer`:
+        // a cooked-mode console line read hands this buffer to a worker
+        // thread that writes into it until `ReadConsoleW` returns, and a read
+        // cancelled by `uv_read_stop` is never returned through `read_cb` —
+        // so the buffer must outlive any reader teardown, which the tty does
+        // (see `uv::Tty::read_scratch`). Pipe reads complete synchronously
+        // inside `uv__pipe_read_data`, so `_buffer` is safe for them;
+        // `on_stream_read` stages tty chunks back into `_buffer`.
+        if matches!(self.source, Some(Source::Tty(_))) {
+            let scratch = self
+                .source
+                .as_mut()
+                .and_then(|s| s.tty_read_scratch(size))
+                .expect("tty source matched above");
+            return MaxBuf::clamp_read_buf(maxbuf, limit.clamp(scratch));
+        }
+        self._buffer.reserve(size);
         // SAFETY: returning spare capacity for libuv to write into; len updated in on_read.
         let buf = unsafe { bun_core::vec::spare_bytes_mut(&mut self._buffer) };
         MaxBuf::clamp_read_buf(maxbuf, limit.clamp(buf))
@@ -1392,7 +1409,26 @@ impl WindowsBufferedReader {
                 // (libuv's `read_cb` hands us `*const`).
                 let mut b = unsafe { *buf };
                 let slice = unsafe { b.slice_mut() };
-                this.on_read(sys::Result::Ok(len), &mut slice[..len], ReadState::Progress);
+                let data = &mut slice[..len];
+                if matches!(this.source, Some(Source::Tty(_))) {
+                    // Tty chunks arrive in the handle-owned scratch (see
+                    // get_read_buffer_with_stable_memory_address); stage them
+                    // into `_buffer`'s spare capacity so `on_read` commits
+                    // them exactly like a pipe chunk.
+                    this._buffer.reserve(len);
+                    // SAFETY: `_buffer` has at least `len` spare bytes and its
+                    // heap block is disjoint from both `this` and the tty
+                    // scratch; the raw round-trip matches the alloc_cb slice
+                    // libuv hands back for pipes.
+                    let staged = unsafe {
+                        let dst = bun_core::vec::spare_bytes_mut(&mut this._buffer).as_mut_ptr();
+                        core::ptr::copy_nonoverlapping(data.as_ptr(), dst, len);
+                        core::slice::from_raw_parts_mut(dst, len)
+                    };
+                    this.on_read(sys::Result::Ok(len), staged, ReadState::Progress);
+                } else {
+                    this.on_read(sys::Result::Ok(len), data, ReadState::Progress);
+                }
             }
         }
     }
@@ -1732,10 +1768,10 @@ impl WindowsBufferedReader {
                     if crate::source::stdin_tty::is_stdin_tty(p) {
                         // Node only ever closes stdin on process exit.
                     } else {
-                        // SAFETY: tty is a live heap-allocated uv_tty_t*.
+                        // SAFETY: tty is a live heap-allocated Tty*.
                         unsafe {
-                            (*p).data = p.cast::<c_void>();
-                            (*p).close(Self::on_tty_close);
+                            (*p).uv.data = p.cast::<c_void>();
+                            (*p).uv.close(Self::on_tty_close);
                         }
                     }
 
@@ -1779,24 +1815,26 @@ impl WindowsBufferedReader {
     /// before Drop; both paths are idempotent over an already-taken source.
     pub fn deinit(&mut self) {
         MaxBuf::remove_from_pipereader(&mut self.maxbuf);
-        self._buffer = Vec::new();
-        let Some(source) = self.source.take() else {
-            return;
-        };
-        if !source.is_closed() {
-            // closeImpl will take care of freeing the source.
-            // Dropping the `Box<Pipe>` here would free a uv_pipe_t still
-            // linked into the loop's handle queue → UAF. Restore the source so
-            // close_impl can do the proper take + hand-off to libuv
-            // (into_raw + uv_close).
-            self.source = Some(source);
-            self.close_impl::<false>();
-        } else {
-            // Already closing/closed: a uv close callback may still be pending
-            // on this allocation; dropping the Box would free memory libuv
-            // still owns, so leak it instead.
-            core::mem::forget(source);
+        if let Some(source) = self.source.take() {
+            if !source.is_closed() {
+                // closeImpl will take care of freeing the source.
+                // Dropping the `Box<Pipe>` here would free a uv_pipe_t still
+                // linked into the loop's handle queue → UAF. Restore the source
+                // so close_impl can do the proper take + hand-off to libuv
+                // (into_raw + uv_close). It also parks `_buffer` on the File
+                // when a uv_fs_read is still in flight (orphaned_read_buf), so
+                // the buffer must still be intact here — freeing it first
+                // would hand the threadpool write a dead block.
+                self.source = Some(source);
+                self.close_impl::<false>();
+            } else {
+                // Already closing/closed: a uv close callback may still be
+                // pending on this allocation; dropping the Box would free
+                // memory libuv still owns, so leak it instead.
+                core::mem::forget(source);
+            }
         }
+        self._buffer = Vec::new();
     }
 
     #[cfg(windows)]
@@ -1811,12 +1849,15 @@ impl WindowsBufferedReader {
     #[cfg(windows)]
     extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
         // `close_impl` set `handle.data = handle` and called `uv_close(handle)`;
-        // libuv passes the same pointer back, so `handle` *is* the tty ptr.
-        // Caller already gates on `!is_stdin_tty` before scheduling close, so
-        // `handle` is heap-allocated (open_tty heap::alloc). Reclaim and drop.
-        debug_assert!(!crate::source::stdin_tty::is_stdin_tty(handle));
+        // libuv passes the same pointer back, and `Tty::from_uv` recovers the
+        // owning `Tty`. Caller already gates on `!is_stdin_tty` before
+        // scheduling close, so `tty` is heap-allocated (open_tty). libuv only
+        // runs this callback once no requests are pending on the handle, so
+        // the read scratch dropped with the Box has no in-flight writer.
+        let tty = crate::source::Tty::from_uv(handle);
+        debug_assert!(!crate::source::stdin_tty::is_stdin_tty(tty));
         // SAFETY: non-stdin tty is heap-allocated; sole owner after uv_close.
-        drop(unsafe { bun_core::heap::take(handle) });
+        drop(unsafe { bun_core::heap::take(tty) });
     }
 
     fn on_read(&mut self, amount: sys::Result<usize>, slice: &mut [u8], has_more: ReadState) {

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1230,14 +1230,8 @@ impl WindowsBufferedReader {
         // Never empty: reads are only issued while the limit has not been reached (`start_reading`, `on_read`), and libuv treats an empty buffer as an error.
         debug_assert!(!limit.reached());
         let size = limit.clamp_len(suggested_size);
-        // Tty reads are served from the handle-owned scratch, not `_buffer`:
-        // a cooked-mode console line read hands this buffer to a worker
-        // thread that writes into it until `ReadConsoleW` returns, and a read
-        // cancelled by `uv_read_stop` is never returned through `read_cb` —
-        // so the buffer must outlive any reader teardown, which the tty does
-        // (see `uv::Tty::read_scratch`). Pipe reads complete synchronously
-        // inside `uv__pipe_read_data`, so `_buffer` is safe for them;
-        // `on_stream_read` stages tty chunks back into `_buffer`.
+        // Tty reads must not target `_buffer`: libuv can retain the pointer
+        // past reader teardown (see `uv::Tty::read_scratch` for the contract).
         if matches!(self.source, Some(Source::Tty(_))) {
             let scratch = self
                 .source
@@ -1411,15 +1405,11 @@ impl WindowsBufferedReader {
                 let slice = unsafe { b.slice_mut() };
                 let data = &mut slice[..len];
                 if matches!(this.source, Some(Source::Tty(_))) {
-                    // Tty chunks arrive in the handle-owned scratch (see
-                    // get_read_buffer_with_stable_memory_address); stage them
-                    // into `_buffer`'s spare capacity so `on_read` commits
-                    // them exactly like a pipe chunk.
+                    // Tty chunks arrive in the tty-owned scratch; stage them
+                    // into `_buffer` so `on_read` commits them like a pipe chunk.
                     this._buffer.reserve(len);
-                    // SAFETY: `_buffer` has at least `len` spare bytes and its
-                    // heap block is disjoint from both `this` and the tty
-                    // scratch; the raw round-trip matches the alloc_cb slice
-                    // libuv hands back for pipes.
+                    // SAFETY: `_buffer` has `len` spare bytes, disjoint from
+                    // `this` and the scratch.
                     let staged = unsafe {
                         let dst = bun_core::vec::spare_bytes_mut(&mut this._buffer).as_mut_ptr();
                         core::ptr::copy_nonoverlapping(data.as_ptr(), dst, len);
@@ -1821,10 +1811,9 @@ impl WindowsBufferedReader {
                 // Dropping the `Box<Pipe>` here would free a uv_pipe_t still
                 // linked into the loop's handle queue → UAF. Restore the source
                 // so close_impl can do the proper take + hand-off to libuv
-                // (into_raw + uv_close). It also parks `_buffer` on the File
-                // when a uv_fs_read is still in flight (orphaned_read_buf), so
-                // the buffer must still be intact here — freeing it first
-                // would hand the threadpool write a dead block.
+                // (into_raw + uv_close). close_impl also parks `_buffer` on
+                // the File for an in-flight uv_fs_read (orphaned_read_buf),
+                // which is why `_buffer` is freed after this, not before.
                 self.source = Some(source);
                 self.close_impl::<false>();
             } else {
@@ -1849,11 +1838,9 @@ impl WindowsBufferedReader {
     #[cfg(windows)]
     extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
         // `close_impl` set `handle.data = handle` and called `uv_close(handle)`;
-        // libuv passes the same pointer back, and `Tty::from_uv` recovers the
-        // owning `Tty`. Caller already gates on `!is_stdin_tty` before
-        // scheduling close, so `tty` is heap-allocated (open_tty). libuv only
-        // runs this callback once no requests are pending on the handle, so
-        // the read scratch dropped with the Box has no in-flight writer.
+        // libuv passes the same pointer back; `Tty::from_uv` recovers the
+        // owning `Tty`. Caller gates on `!is_stdin_tty`, so it is heap-owned,
+        // and no request is pending once this runs (`uv::Tty::read_scratch`).
         let tty = crate::source::Tty::from_uv(handle);
         debug_assert!(!crate::source::stdin_tty::is_stdin_tty(tty));
         // SAFETY: non-stdin tty is heap-allocated; sole owner after uv_close.

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -1758,10 +1758,12 @@ impl WindowsBufferedReader {
                     if crate::source::stdin_tty::is_stdin_tty(p) {
                         // Node only ever closes stdin on process exit.
                     } else {
-                        // SAFETY: tty is a live heap-allocated Tty*.
+                        // SAFETY: tty is a live heap-allocated Tty*;
+                        // `Tty::close` keeps whole-struct provenance so
+                        // on_tty_close may reclaim the Box.
                         unsafe {
                             (*p).uv.data = p.cast::<c_void>();
-                            (*p).uv.close(Self::on_tty_close);
+                            crate::source::Tty::close(p, Self::on_tty_close);
                         }
                     }
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1186,11 +1186,11 @@ pub trait BaseWindowsPipeWriter: Sized {
             }
             Source::Tty(tty) => {
                 let p = tty.as_ptr();
-                // SAFETY: tty is heap-allocated (via open_tty heap::alloc) or the
+                // SAFETY: tty is heap-allocated (via open_tty) or the
                 // process-static stdin tty; freed in on_tty_close (gated on is_stdin_tty).
-                unsafe { (*p).data = p.cast::<c_void>() };
+                unsafe { (*p).uv.data = p.cast::<c_void>() };
                 // SAFETY: tty is a live uv handle; libuv calls on_tty_close after close completes.
-                unsafe { (*p).close(on_tty_close) };
+                unsafe { (*p).uv.close(on_tty_close) };
             }
         }
         *self.source_mut() = None;
@@ -1322,11 +1322,12 @@ extern "C" fn on_pipe_close(handle: *mut uv::Pipe) {
 #[cfg(windows)]
 extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
     // `close()` set `handle.data = handle` and then called `uv_close(handle)`;
-    // libuv passes the same pointer back, so `handle` *is* the tty ptr.
-    // The stdin tty (fd 0) lives in static storage; never free it.
-    if !crate::source::stdin_tty::is_stdin_tty(handle) {
-        // SAFETY: non-stdin tty is heap-allocated (open_tty heap::alloc).
-        drop(unsafe { bun_core::heap::take(handle) });
+    // libuv passes the same pointer back, and `Tty::from_uv` recovers the
+    // owning `Tty`. The stdin tty (fd 0) lives in static storage; never free it.
+    let tty = crate::source::Tty::from_uv(handle);
+    if !crate::source::stdin_tty::is_stdin_tty(tty) {
+        // SAFETY: non-stdin tty is heap-allocated (open_tty).
+        drop(unsafe { bun_core::heap::take(tty) });
     }
 }
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1189,8 +1189,9 @@ pub trait BaseWindowsPipeWriter: Sized {
                 // SAFETY: tty is heap-allocated (via open_tty) or the
                 // process-static stdin tty; freed in on_tty_close (gated on is_stdin_tty).
                 unsafe { (*p).uv.data = p.cast::<c_void>() };
-                // SAFETY: tty is a live uv handle; libuv calls on_tty_close after close completes.
-                unsafe { (*p).uv.close(on_tty_close) };
+                // SAFETY: tty is a live uv handle; `Tty::close` keeps
+                // whole-struct provenance so on_tty_close may reclaim the Box.
+                unsafe { crate::source::Tty::close(p, on_tty_close) };
             }
         }
         *self.source_mut() = None;

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1322,8 +1322,8 @@ extern "C" fn on_pipe_close(handle: *mut uv::Pipe) {
 #[cfg(windows)]
 extern "C" fn on_tty_close(handle: *mut uv::uv_tty_t) {
     // `close()` set `handle.data = handle` and then called `uv_close(handle)`;
-    // libuv passes the same pointer back, and `Tty::from_uv` recovers the
-    // owning `Tty`. The stdin tty (fd 0) lives in static storage; never free it.
+    // libuv passes the same pointer back; `Tty::from_uv` recovers the owning
+    // `Tty`. The stdin tty (fd 0) lives in static storage; never free it.
     let tty = crate::source::Tty::from_uv(handle);
     if !crate::source::stdin_tty::is_stdin_tty(tty) {
         // SAFETY: non-stdin tty is heap-allocated (open_tty).

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -13,7 +13,7 @@ use bun_sys::ReturnCodeExt as _;
 bun_core::declare_scope!(PipeSource, hidden);
 
 pub type Pipe = uv::Pipe;
-pub type Tty = uv::uv_tty_t;
+pub use uv::Tty;
 
 pub enum Source {
     Pipe(Box<Pipe>),
@@ -253,10 +253,23 @@ impl Source {
         unsafe { tty.get_mut() }
     }
 
+    /// For a tty source, hand libuv the handle-owned read buffer (see
+    /// `uv::Tty::read_scratch`) with at least `size` spare bytes. `None` for
+    /// every other source.
+    pub(crate) fn tty_read_scratch(&mut self, size: usize) -> Option<&mut [u8]> {
+        let Source::Tty(tty) = self else { return None };
+        let scratch = &mut Self::tty_mut(tty).read_scratch;
+        scratch.clear();
+        scratch.reserve(size);
+        // SAFETY: spare capacity handed to libuv to write into; the read
+        // callback copies out the written prefix before anything reads it.
+        Some(unsafe { bun_core::vec::spare_bytes_mut(scratch) })
+    }
+
     pub fn is_closed(&self) -> bool {
         match self {
             Source::Pipe(pipe) => pipe.is_closed(),
-            Source::Tty(tty) => tty.is_closed(),
+            Source::Tty(tty) => tty.uv.is_closed(),
             Source::SyncFile(file) | Source::File(file) => file.file == -1,
         }
     }
@@ -264,14 +277,15 @@ impl Source {
     pub(crate) fn is_active(&self) -> bool {
         match self {
             Source::Pipe(pipe) => pipe.is_active(),
-            Source::Tty(tty) => tty.is_active(),
+            Source::Tty(tty) => tty.uv.is_active(),
             Source::SyncFile(_) | Source::File(_) => true,
         }
     }
 
     pub(crate) fn to_stream(&mut self) -> *mut uv::uv_stream_t {
         match self {
-            // SAFETY: uv::Pipe / uv::uv_tty_t embed uv_stream_t as their first member.
+            // SAFETY: uv::Pipe / `Tty` (via its first field, `uv::uv_tty_t`) embed
+            // uv_stream_t as their first member.
             // `&mut self` so the returned `*mut` carries write provenance.
             Source::Pipe(pipe) => core::ptr::from_mut::<Pipe>(pipe.as_mut()).cast(),
             Source::Tty(tty) => tty.as_ptr().cast(),
@@ -285,7 +299,7 @@ impl Source {
             // Windows); tag kind=system so callers can round-trip through
             // `Fd::native()`.
             Source::Pipe(pipe) => Fd::from_system(pipe.fd()),
-            Source::Tty(tty) => Fd::from_system(tty.fd()),
+            Source::Tty(tty) => Fd::from_system(tty.uv.fd()),
             Source::SyncFile(file) | Source::File(file) => Fd::from_uv(file.file),
         }
     }
@@ -293,7 +307,7 @@ impl Source {
     pub fn set_data(&mut self, data: *mut c_void) {
         match self {
             Source::Pipe(pipe) => pipe.data = data,
-            Source::Tty(tty) => Self::tty_mut(tty).data = data,
+            Source::Tty(tty) => Self::tty_mut(tty).uv.data = data,
             Source::SyncFile(file) | Source::File(file) => file.fs.data = data,
         }
     }
@@ -339,7 +353,7 @@ impl Source {
     pub fn ref_(&mut self) {
         match self {
             Source::Pipe(pipe) => pipe.ref_(),
-            Source::Tty(tty) => Self::tty_mut(tty).ref_(),
+            Source::Tty(tty) => Self::tty_mut(tty).uv.ref_(),
             Source::SyncFile(_) | Source::File(_) => {}
         }
     }
@@ -347,7 +361,7 @@ impl Source {
     pub fn unref(&mut self) {
         match self {
             Source::Pipe(pipe) => pipe.unref(),
-            Source::Tty(tty) => Self::tty_mut(tty).unref(),
+            Source::Tty(tty) => Self::tty_mut(tty).uv.unref(),
             Source::SyncFile(_) | Source::File(_) => {}
         }
     }
@@ -385,7 +399,12 @@ impl Source {
             return stdin_tty::get_stdin_tty(loop_);
         }
 
-        let mut tty: Box<Tty> = bun_core::boxed_zeroed();
+        // Not `boxed_zeroed`: `read_scratch` is a `Vec` (zeroed is UB); only
+        // the `uv` half is plain-old-data libuv fills in.
+        let mut tty: Box<Tty> = Box::new(Tty {
+            uv: bun_core::ffi::zeroed(),
+            read_scratch: Vec::new(),
+        });
         if let Some(err) = tty.init(loop_, uv_fd).to_error(bun_sys::Tag::open) {
             drop(tty);
             return bun_sys::Result::Err(err);
@@ -453,6 +472,7 @@ impl Source {
         match self {
             Source::Tty(tty) => {
                 if let Some(err) = Self::tty_mut(tty)
+                    .uv
                     .set_mode(if value {
                         uv::TtyMode::Raw
                     } else {
@@ -480,14 +500,14 @@ pub(crate) mod stdin_tty {
 
     // PORTING.md §Global mutable state: init guarded by `LOCK` + `INITIALIZED`;
     // afterwards only accessed by uv on the loop thread. RacyCell.
-    static DATA: bun_core::RacyCell<MaybeUninit<uv::uv_tty_t>> =
+    static DATA: bun_core::RacyCell<MaybeUninit<Tty>> =
         bun_core::RacyCell::new(MaybeUninit::uninit());
     static LOCK: bun_threading::Mutex = bun_threading::Mutex::new();
     static INITIALIZED: AtomicBool = AtomicBool::new(false);
 
     #[inline]
-    fn value() -> *mut uv::uv_tty_t {
-        DATA.get().cast::<uv::uv_tty_t>()
+    fn value() -> *mut Tty {
+        DATA.get().cast::<Tty>()
     }
 
     pub(crate) fn is_stdin_tty(tty: *const Tty) -> bool {
@@ -503,12 +523,18 @@ pub(crate) mod stdin_tty {
         let _guard = LOCK.lock_guard();
 
         if !INITIALIZED.swap(true, Ordering::Relaxed) {
-            // SAFETY: value() points to static storage sized for uv_tty_t; lock held.
-            let rc = unsafe { uv::uv_tty_init(loop_, value(), 0, 0) };
+            let p = value();
+            // SAFETY: value() points to static storage sized for Tty; lock
+            // held. uv_tty_init fills the `uv` half; `read_scratch` starts
+            // empty via a raw write (the storage is uninit, so a plain
+            // assignment would drop garbage).
+            let rc = unsafe { uv::uv_tty_init(loop_, core::ptr::addr_of_mut!((*p).uv), 0, 0) };
             if let Some(err) = rc.to_error(bun_sys::Tag::open) {
                 INITIALIZED.store(false, Ordering::Relaxed);
                 return bun_sys::Result::Err(err);
             }
+            // SAFETY: as above; lock held, first initialization.
+            unsafe { core::ptr::addr_of_mut!((*p).read_scratch).write(Vec::new()) };
         }
 
         // Destroy path must gate `heap::take` on `!is_stdin_tty(ptr)`.
@@ -537,6 +563,7 @@ extern "C" fn Source__setRawModeStdin(uv_loop: *mut uv::Loop, raw: bool) -> c_in
     // process — same invariant the `Source::Tty` arm relies on, so reuse the
     // shared `tty_mut` accessor.
     if let Some(err) = Source::tty_mut(&mut tty)
+        .uv
         .set_mode(if raw {
             uv::TtyMode::Vt
         } else {

--- a/src/io/source.rs
+++ b/src/io/source.rs
@@ -253,16 +253,15 @@ impl Source {
         unsafe { tty.get_mut() }
     }
 
-    /// For a tty source, hand libuv the handle-owned read buffer (see
-    /// `uv::Tty::read_scratch`) with at least `size` spare bytes. `None` for
-    /// every other source.
+    /// For a tty source, hand libuv the handle-owned read buffer with at
+    /// least `size` spare bytes (`uv::Tty::read_scratch`); `None` otherwise.
     pub(crate) fn tty_read_scratch(&mut self, size: usize) -> Option<&mut [u8]> {
         let Source::Tty(tty) = self else { return None };
         let scratch = &mut Self::tty_mut(tty).read_scratch;
         scratch.clear();
         scratch.reserve(size);
         // SAFETY: spare capacity handed to libuv to write into; the read
-        // callback copies out the written prefix before anything reads it.
+        // callback copies out the written prefix.
         Some(unsafe { bun_core::vec::spare_bytes_mut(scratch) })
     }
 
@@ -399,8 +398,7 @@ impl Source {
             return stdin_tty::get_stdin_tty(loop_);
         }
 
-        // Not `boxed_zeroed`: `read_scratch` is a `Vec` (zeroed is UB); only
-        // the `uv` half is plain-old-data libuv fills in.
+        // Not `boxed_zeroed`: a zeroed `Vec` is UB.
         let mut tty: Box<Tty> = Box::new(Tty {
             uv: bun_core::ffi::zeroed(),
             read_scratch: Vec::new(),

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1378,22 +1378,43 @@ impl Tty {
 
     #[inline]
     pub fn init(&mut self, loop_: *mut Loop, file: uv_file) -> ReturnCode {
-        self.uv.init(loop_, file)
+        // Init and register through a whole-struct pointer: the close paths
+        // reclaim the full `Tty` from this address, and `&mut self.uv` would
+        // narrow provenance to the field (same rule as `File::start_close`).
+        let uv_ptr = core::ptr::from_mut(self).cast::<uv_tty_t>();
+        // SAFETY: `uv` is the first `#[repr(C)]` field, sized for uv_tty_t.
+        let rc = unsafe { uv_tty_init(loop_, uv_ptr, file, 0) };
+        // fd 0 is the process-static stdin tty (never freed, shared across
+        // threads by design); everything else is a heap tty owned by this thread.
+        if rc.0 == 0 && file != 0 {
+            open_handles::add_tty(uv_ptr);
+        }
+        rc
+    }
+
+    /// `uv_close` through a whole-struct pointer so the close callback may
+    /// `Box::from_raw` the wrapper (`(*this).uv.close(..)` would autoref
+    /// `&mut uv_tty_t` and narrow provenance to the field).
+    ///
+    /// # Safety
+    /// `this` is a live, initialised tty that is not already closing.
+    pub unsafe fn close(this: *mut Self, cb: unsafe extern "C" fn(*mut uv_tty_t)) {
+        let handle = this.cast::<uv_handle_t>();
+        open_handles::remove(handle);
+        // SAFETY: `Tty` embeds `uv_handle_t` at offset 0; cb is ABI-identical.
+        unsafe {
+            uv_close(
+                handle,
+                Some(mem::transmute::<
+                    unsafe extern "C" fn(*mut uv_tty_t),
+                    unsafe extern "C" fn(*mut uv_handle_t),
+                >(cb)),
+            );
+        }
     }
 }
 
 impl uv_tty_t {
-    #[inline]
-    pub fn init(&mut self, loop_: *mut Loop, file: uv_file) -> ReturnCode {
-        // SAFETY: self is a valid `uv_tty_t`-sized allocation.
-        let rc = unsafe { uv_tty_init(loop_, self, file, 0) };
-        // fd 0 is the process-static stdin tty (never freed, shared across
-        // threads by design); everything else is a heap tty owned by this thread.
-        if rc.0 == 0 && file != 0 {
-            open_handles::add_tty(self);
-        }
-        rc
-    }
     #[inline]
     pub fn set_mode(&mut self, mode: TtyMode) -> ReturnCode {
         // SAFETY: tty was `init`ed.

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1350,6 +1350,42 @@ pub struct uv_tty_t {
     pub handle: HANDLE,
     tty: tty_u,
 }
+/// A console handle plus the read buffer whose lifetime libuv ties to the
+/// handle rather than to any reader.
+///
+/// `uv` must remain the first field of this `#[repr(C)]` struct: libuv
+/// callbacks and `open_handles` traffic in the inner `uv_tty_t*`, and
+/// [`Tty::from_uv`] plus the handle-subtype casts rely on both being the
+/// same address.
+#[repr(C)]
+pub struct Tty {
+    pub uv: uv_tty_t,
+
+    /// Destination buffer for this handle's console reads. A cooked-mode
+    /// line read stores the `alloc_cb` buffer and has a worker thread write
+    /// the typed (or cancellation-injected) line into it whenever
+    /// `ReadConsoleW` returns; a read cancelled by `uv_read_stop` is never
+    /// handed back through `read_cb`. The buffer therefore has to be owned
+    /// by something libuv guarantees outlives the read: this handle — its
+    /// close callback only runs once no requests are pending, and the
+    /// process-static stdin tty is never closed at all.
+    pub read_scratch: Vec<u8>,
+}
+
+impl Tty {
+    /// Recover the owning `Tty` from the `uv_tty_t*` libuv hands back
+    /// (`uv` is the first `#[repr(C)]` field, so both are the same address).
+    #[inline]
+    pub fn from_uv(handle: *mut uv_tty_t) -> *mut Tty {
+        handle.cast()
+    }
+
+    #[inline]
+    pub fn init(&mut self, loop_: *mut Loop, file: uv_file) -> ReturnCode {
+        self.uv.init(loop_, file)
+    }
+}
+
 impl uv_tty_t {
     #[inline]
     pub fn init(&mut self, loop_: *mut Loop, file: uv_file) -> ReturnCode {

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -1351,30 +1351,26 @@ pub struct uv_tty_t {
     tty: tty_u,
 }
 /// A console handle plus the read buffer whose lifetime libuv ties to the
-/// handle rather than to any reader.
-///
-/// `uv` must remain the first field of this `#[repr(C)]` struct: libuv
-/// callbacks and `open_handles` traffic in the inner `uv_tty_t*`, and
-/// [`Tty::from_uv`] plus the handle-subtype casts rely on both being the
-/// same address.
+/// handle rather than to any reader. `uv` must remain the first field
+/// (`#[repr(C)]`): callbacks and `open_handles` traffic in the inner
+/// `uv_tty_t*`, and [`Tty::from_uv`] relies on both being the same address.
 #[repr(C)]
 pub struct Tty {
     pub uv: uv_tty_t,
 
     /// Destination buffer for this handle's console reads. A cooked-mode
-    /// line read stores the `alloc_cb` buffer and has a worker thread write
-    /// the typed (or cancellation-injected) line into it whenever
-    /// `ReadConsoleW` returns; a read cancelled by `uv_read_stop` is never
-    /// handed back through `read_cb`. The buffer therefore has to be owned
-    /// by something libuv guarantees outlives the read: this handle — its
-    /// close callback only runs once no requests are pending, and the
-    /// process-static stdin tty is never closed at all.
+    /// line read parks a worker thread in `ReadConsoleW` writing into the
+    /// `alloc_cb` buffer, and a read cancelled by `uv_read_stop` is never
+    /// handed back through `read_cb` — so the buffer must be owned by
+    /// something libuv guarantees outlives the read. The handle is that
+    /// thing: its close callback only runs once no requests are pending,
+    /// and the process-static stdin tty is never closed at all.
     pub read_scratch: Vec<u8>,
 }
 
 impl Tty {
     /// Recover the owning `Tty` from the `uv_tty_t*` libuv hands back
-    /// (`uv` is the first `#[repr(C)]` field, so both are the same address).
+    /// (same address: `uv` is the first `#[repr(C)]` field).
     #[inline]
     pub fn from_uv(handle: *mut uv_tty_t) -> *mut Tty {
         handle.cast()

--- a/src/libuv_sys/open_handles.rs
+++ b/src/libuv_sys/open_handles.rs
@@ -204,11 +204,14 @@ pub fn stop_all_for_vm_teardown() {
             // SAFETY: listed ⇒ initialised on this thread and not closing; a
             // pipe/tty nobody adopted is a leaked Box handed to libuv here.
             (None, Kind::Pipe) => unsafe { Pipe::close_and_destroy_unlisted(handle.cast()) },
-            // SAFETY: as above (a leaked Box<uv_tty_t> nobody adopted).
+            // SAFETY: as above (a leaked Box<Tty> nobody adopted).
             (None, Kind::Tty) => unsafe {
                 unsafe extern "C" fn free_tty(t: *mut uv_tty_t) {
                     // SAFETY: heap tty (stdin's static tty is never listed).
-                    drop(unsafe { Box::from_raw(t) });
+                    // Every listed tty is a `Box<Tty>` whose `uv` field was
+                    // registered by `uv_tty_t::init`; `from_uv` recovers the
+                    // owning box.
+                    drop(unsafe { Box::from_raw(super::Tty::from_uv(t)) });
                 }
                 uv_close(
                     handle,

--- a/src/libuv_sys/open_handles.rs
+++ b/src/libuv_sys/open_handles.rs
@@ -207,10 +207,8 @@ pub fn stop_all_for_vm_teardown() {
             // SAFETY: as above (a leaked Box<Tty> nobody adopted).
             (None, Kind::Tty) => unsafe {
                 unsafe extern "C" fn free_tty(t: *mut uv_tty_t) {
-                    // SAFETY: heap tty (stdin's static tty is never listed).
-                    // Every listed tty is a `Box<Tty>` whose `uv` field was
-                    // registered by `uv_tty_t::init`; `from_uv` recovers the
-                    // owning box.
+                    // SAFETY: heap `Box<Tty>` (stdin's static tty is never
+                    // listed); `from_uv` recovers the owning box.
                     drop(unsafe { Box::from_raw(super::Tty::from_uv(t)) });
                 }
                 uv_close(

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -262,9 +262,9 @@ pub(crate) extern "C" fn Bun__ForceFileSinkToBeSynchronousForProcessObjectStdio(
                         }
                     }
                     bun_io::Source::Tty(tty) => {
-                        // SAFETY: `tty` is a live `NonNull<uv_tty_t>` (heap or static stdin tty);
-                        // `uv_tty_t` embeds `uv_stream_t` as its first field, so the cast is the
-                        // libuv handle-subtype downcast.
+                        // SAFETY: `tty` is a live `BackRef<Tty>` (heap or static stdin tty);
+                        // `Tty` (via its first field, `uv::uv_tty_t`) embeds `uv_stream_t` as
+                        // its first member, so the cast is the libuv handle-subtype downcast.
                         let rc = unsafe {
                             uv::uv_stream_set_blocking(tty.as_ptr().cast::<uv::uv_stream_t>(), 1)
                         };

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -518,15 +518,16 @@ describe("Bun.Terminal subprocess integration", () => {
   });
 
   // Regression test for a Windows-only use-after-free: cancelling a stdin
-  // stream while a cooked-mode console read is parked used to free the
+  // stream while a cooked-mode console read was parked used to free the
   // reader's buffer immediately (finish() shrink / Drop). libuv's line reads
   // block a worker thread in ReadConsoleW and convert the result into the
   // alloc_cb buffer from that thread; uv_read_stop cancels asynchronously by
-  // injecting a VK_RETURN, so the worker still writes "\r\n" through the
-  // stale pointer. The late write corrupted whatever mimalloc handed the
-  // freed 8 KiB block to next (seen in production as full-GC crashes in
-  // Heap::sweepArrayBuffers on clobbered ArrayBuffers). The child adopts the
-  // just-freed block with same-size ArrayBuffer probes and reports any
+  // injecting a VK_RETURN, so the worker still wrote "\r\n" through the
+  // stale pointer, corrupting whatever mimalloc handed the freed 8 KiB
+  // block to next (a plausible mechanism for production reports of full-GC
+  // crashes on clobbered ArrayBuffers). Fixed by serving tty reads from the
+  // handle-owned uv::Tty::read_scratch. The child adopts the
+  // previously-freed size class with ArrayBuffer probes and reports any
   // mutation.
   test.skipIf(!isWindows)("cancelling a parked console stdin read does not corrupt the heap", async () => {
     using dir = tempDir("conpty-stdin-read-cancel", {
@@ -540,8 +541,8 @@ describe("Bun.Terminal subprocess integration", () => {
         console.log("CHILD-READY");
         await warmup;
         // Arm the read under test; no more input arrives, so the libuv
-        // worker parks in ReadConsoleW with a pointer into the pipe
-        // reader's 8 KiB spare capacity.
+        // worker parks in ReadConsoleW holding the read buffer (pre-fix:
+        // the reader's spare capacity; post-fix: the tty-owned scratch).
         reader.read().catch(() => {});
         // The park itself is unobservable from JS; there is no condition to
         // await. With the machinery proven warm above, a short delay makes

--- a/test/js/bun/terminal/terminal-spawn.test.ts
+++ b/test/js/bun/terminal/terminal-spawn.test.ts
@@ -1,6 +1,6 @@
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isMusl, isWindows } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir } from "harness";
 import fs from "node:fs";
 
 // Cross-platform Bun.Terminal + Bun.spawn integration tests that don't rely
@@ -514,6 +514,100 @@ describe("Bun.Terminal subprocess integration", () => {
     const exitCode = await proc.exited;
     expect(terminal.localFlags & ICANON).not.toBe(0);
     expect(terminal.localFlags & ECHO).not.toBe(0);
+    expect(exitCode).toBe(0);
+  });
+
+  // Regression test for a Windows-only use-after-free: cancelling a stdin
+  // stream while a cooked-mode console read is parked used to free the
+  // reader's buffer immediately (finish() shrink / Drop). libuv's line reads
+  // block a worker thread in ReadConsoleW and convert the result into the
+  // alloc_cb buffer from that thread; uv_read_stop cancels asynchronously by
+  // injecting a VK_RETURN, so the worker still writes "\r\n" through the
+  // stale pointer. The late write corrupted whatever mimalloc handed the
+  // freed 8 KiB block to next (seen in production as full-GC crashes in
+  // Heap::sweepArrayBuffers on clobbered ArrayBuffers). The child adopts the
+  // just-freed block with same-size ArrayBuffer probes and reports any
+  // mutation.
+  test.skipIf(!isWindows)("cancelling a parked console stdin read does not corrupt the heap", async () => {
+    using dir = tempDir("conpty-stdin-read-cancel", {
+      "child-fixture.ts": `
+        const reader = Bun.stdin.stream().getReader();
+        // Warm-up round-trip: arm a cooked-mode console line read and await
+        // the line the parent writes once it sees CHILD-READY. Resolving
+        // proves the whole line-read machinery (libuv worker thread
+        // included) works end to end before cancellation is tested.
+        const warmup = reader.read();
+        console.log("CHILD-READY");
+        await warmup;
+        // Arm the read under test; no more input arrives, so the libuv
+        // worker parks in ReadConsoleW with a pointer into the pipe
+        // reader's 8 KiB spare capacity.
+        reader.read().catch(() => {});
+        // The park itself is unobservable from JS; there is no condition to
+        // await. With the machinery proven warm above, a short delay makes
+        // it overwhelmingly likely the worker is inside ReadConsoleW. If it
+        // is not yet, cancellation traps the read before any write and the
+        // run is vacuous rather than wrong.
+        await Bun.sleep(150);
+        await reader.cancel();
+        // Immediately adopt the 8 KiB block the buggy teardown just freed;
+        // mimalloc serves freshly freed blocks of a size class first.
+        const probes: Uint8Array[] = [];
+        for (let i = 0; i < 32; i++) {
+          const probe = new Uint8Array(new ArrayBuffer(8192));
+          probe.fill(0xaa);
+          probes.push(probe);
+        }
+        // Bounded window for the cancelled console read's late write to land.
+        const deadline = Date.now() + 600;
+        let corrupted = false;
+        while (Date.now() < deadline && !corrupted) {
+          for (const probe of probes) {
+            for (let i = 0; i < 64; i++) {
+              if (probe[i] !== 0xaa) corrupted = true;
+            }
+          }
+          Bun.gc(true);
+          await Bun.sleep(20);
+        }
+        console.log(corrupted ? "PROBE-CORRUPTED" : "PROBE-CLEAN");
+        process.exit(corrupted ? 42 : 0);
+      `,
+    });
+
+    const ready = Promise.withResolvers<void>();
+    const probeReported = Promise.withResolvers<void>();
+    const decoder = new TextDecoder();
+    let output = "";
+    await using terminal = new Bun.Terminal({
+      data(_, chunk: Uint8Array) {
+        output += decoder.decode(chunk, { stream: true });
+        if (output.includes("CHILD-READY")) ready.resolve();
+        if (output.includes("PROBE-")) probeReported.resolve();
+      },
+    });
+
+    const proc = Bun.spawn({
+      cmd: [bunExe(), "child-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      terminal,
+    });
+    // Fail fast with the child's output if it dies before the handshake.
+    proc.exited.then(code => ready.reject(new Error(`child exited before handshake: ${code}\n${output}`)));
+
+    await ready.promise;
+    terminal.write("warmup\r");
+
+    const exitCode = await proc.exited;
+    // The exit IOCP and the final ConPTY pipe-data IOCP are independent, so
+    // the verdict line can arrive after proc.exited resolves. The child
+    // prints PROBE-* before exit(0)/exit(42) on both paths, so the marker is
+    // guaranteed to arrive for those codes; on any other exit (crash) the
+    // marker may never come, so don't wait for it.
+    if (exitCode === 0 || exitCode === 42) await probeReported.promise;
+    expect(output).toContain("PROBE-CLEAN");
+    expect(output).not.toContain("PROBE-CORRUPTED");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows use-after-free: tearing down a pipe reader while a cooked-mode console read is in flight frees the buffer libuv's worker thread is still writing into.

### Problem

- On Windows, `WindowsBufferedReader` serves every libuv read from `_buffer`'s spare capacity. For a cooked-mode console read (the default for `process.stdin` / `Bun.stdin.stream()` on a console), libuv's `uv__tty_queue_read_line` stores that pointer and blocks a worker thread in `ReadConsoleW`; the worker converts the typed line into the buffer whenever `ReadConsoleW` returns (`uv_utf16_to_wtf8` into `read_line_buffer.base`), including when the read was cancelled mid-flight: `uv_read_stop` cancels asynchronously by injecting a VK_RETURN, and after read_stop the buffer is never handed back through `read_cb`.
- Reader teardown (`deinit()` / `Drop` / `finish()`'s `shrink_to_fit`) frees or moves `_buffer` regardless, so the worker's late write lands in freed mimalloc memory and corrupts whatever is allocated there next. The crash then surfaces arbitrarily far away, typically as a fault on the corrupted allocation's next owner.
- This is a plausible mechanism for the Windows-dominant Sentry crash family around `Heap::sweepArrayBuffers` -> `~ArrayBufferContents` -> `mi_free` (BUN-30T8 and siblings): the corrupted blocks are prime-size tenants for ArrayBuffer backing stores, and release-build `_mi_ptr_page` is unchecked only off macOS, matching the platform skew. No crash dump directly ties the family to this path, so that attribution is a hypothesis, not a claim.
- Separately, `deinit()` emptied `_buffer` before calling `close_impl`, so the `orphaned_read_buf` parking that #37075 added for in-flight `uv_fs_read` received an empty Vec and the threadpool write still targeted a freed block on that path.

### Fix

- Own the console read buffer by what libuv ties the read's lifetime to: the handle. `uv::Tty` becomes a `#[repr(C)]` wrapper over `uv_tty_t` (the same shape as `File` over `uv::fs_t`) with a `read_scratch: Vec<u8>`; `alloc_cb` serves tty reads from it, and `on_stream_read` stages delivered chunks into `_buffer` so commit/callback behavior is byte-identical to a pipe chunk.
- The scratch is freed with its handle: libuv only runs a handle's close callback once no requests are pending on it (the parked line read holds one), and the process-static stdin tty is never closed at all. Heap ttys drop the scratch with the `Box` in `on_tty_close` / the `open_handles` teardown path.
- Pipe reads complete synchronously inside `uv__pipe_read_data` on the loop thread and keep using `_buffer`; `uv_fs_read` keeps main's `orphaned_read_buf` parking. `HAS_INFLIGHT_READ` semantics are untouched, so `has_pending_read()` behaves exactly as on main (no per-chunk buffer churn for FileReader over a pipe).
- `deinit()` now frees `_buffer` after `close_impl`, so the `orphaned_read_buf` parking gets the real allocation.
- The tty scratch gets the same `ReadLimit` clamp main applies to `_buffer` (#39296), so a sliced read over a tty is cut at the limit exactly as over a pipe. This is the only change the rebase onto the PipeReader rework (#38886) needed; the staging copy in `on_stream_read` lands in `_buffer`'s spare capacity, which is what main's `on_read` / `on_read_chunk` commit and hand to the parent.

## How did you verify your code works?

- `test/js/bun/terminal/terminal-spawn.test.ts` "cancelling a parked console stdin read does not corrupt the heap" (Windows-only, ConPTY via `Bun.Terminal` so the child has a real console): the child proves the cooked-mode line-read machinery works with a parent round-trip, arms a read, cancels it while the worker is parked in `ReadConsoleW` (the pre-fix free point), immediately adopts the freed-size allocation with ArrayBuffer probes, and fails if the cancelled read's late write mutates one. The run is one-sidedly nondeterministic: a cycle where the worker had not yet entered `ReadConsoleW` is vacuous, never a false failure.
- Windows x64 debug build on the rebased base (main at 771c7e67e0): with only the test applied, the test fails 7 of 8 runs, each with the child tripping `mimalloc: error: corrupted free list entry of size 10240b` (the debug size class of libuv's 8 KiB line-read buffer); with the fix, 12 of 12 runs pass, the whole file passes (14 pass, 4 platform skips), and `terminal.test.ts`, `terminal-platform-gaps.test.ts`, `process-stdin.test.ts`, `stdin-fixtures.test.ts`, `spawn-streaming-stdin.test.ts`, `bun-stdin-slice.test.ts`, `tty.test.ts` and the tty regression tests pass (133 pass, 0 fail). A raw-mode ConPTY child (libuv's per-key-event read path through the same staging code) also received its input intact.
- `cargo check --workspace` passes for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`.

### Background

- libuv on Windows gives every stream read its buffer via `alloc_cb` and normally returns it through `read_cb` in the same loop iteration. The exception is the cooked-mode console line read: it parks a worker thread in `ReadConsoleW`, retains the `alloc_cb` buffer across loop iterations, and a cancellation via `uv_read_stop` never produces a `read_cb` for the in-flight read, so no reader-side completion point exists to free that buffer safely. The handle is the only object whose lifetime libuv guarantees covers the read.

<details>
<summary>Superseded earlier versions of this PR</summary>

Earlier revisions also (a) parked in-flight `uv_fs_read` buffers on the `File` and consumed `DEFER_DONE_CALLBACK` on normal completion after a lost `uv_cancel` race (both landed on main in a different shape via #37075), (b) redefined `HAS_INFLIGHT_READ` as a retention flag with clears moved to the read callbacks (dropped: it flipped `has_pending_read()` inside the chunk callback, causing a free+malloc per chunk for FileReader over a pipe), and (c) leaked one buffer per torn-down stdin reader, later reclaimed at the next `alloc_cb`, guarded by a `malloc_bins`-based leak test (dropped: the counters read 0 on release builds, making the test vacuous on CI, and the handle-owned scratch removes the leak outright).

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/terminal/terminal-spawn.test.ts

<!-- robobun:evidence:end -->
