### PR TITLE
Serve fresh exports when CommonJS modules hot-reload in the dev server

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -303,6 +303,12 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
         require: mod.require.bind(mod),
       };
       mod.exports = null;
+    } else {
+      // Re-evaluating a stale CommonJS module: start from a fresh exports
+      // object so keys removed by the new version do not linger (matches
+      // first evaluation and the error path below, which performs the same
+      // reset after a failed evaluation).
+      mod.cjs.exports = {};
     }
     if (importer) {
       mod.importers.add(importer);
@@ -313,8 +319,20 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // Drop the cached ESM namespace view: `toESM` binds getters to the
+    // specific `cjs.exports` object it was given, so a view created during a
+    // previous evaluation would keep serving the old values forever (e.g. a
+    // hot-reloaded JSON file frozen at its first parse). getEsmExports()
+    // lazily rebuilds the view over the current `cjs.exports`, and
+    // patchImporters() then rebinds live ESM importers. This runs after the
+    // wrapper, not before it, so a re-entrant getEsmExports() during a
+    // circular evaluation cannot cache a view over the transient `{}`; a view
+    // cached mid-evaluation by a circular importer is dropped too, so it
+    // cannot outlive a reassigned `module.exports`.
+    mod.exports = null;
     mod.state = State.Loaded;
   } else {
     // ESM
@@ -403,6 +421,9 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         require: mod.require.bind(mod),
       };
       mod.exports = null;
+    } else {
+      // See the matching reset in loadModuleSync.
+      mod.cjs.exports = {};
     }
     if (importer) {
       mod.importers.add(importer);
@@ -413,8 +434,11 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // See the matching reset in loadModuleSync.
+    mod.exports = null;
     mod.state = State.Loaded;
     return mod;
   } else {
@@ -750,18 +774,36 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Reload all modules
+  // Reload all modules. Mark every module stale before reloading any of
+  // them: a reloading module can synchronously evaluate another module in
+  // the set through its imports, and that module must re-evaluate with its
+  // new code rather than serve the previous evaluation. Capture and clear
+  // accept handlers in the same pass so an evaluation triggered by an
+  // importer does not have its freshly registered handlers wiped below.
   const promises: Promise<HMRModule>[] = [];
+  const selfAccepts = new Map<HMRModule, HotAcceptFunction | null>();
   for (const mod of toReload) {
     mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
+    selfAccepts.set(mod, mod.selfAccept);
     mod.selfAccept = null;
     mod.depAccepts = null;
-
+  }
+  const deferredAccepts: [HMRModule, HotAcceptFunction][] = [];
+  for (const mod of toReload) {
+    const selfAccept = selfAccepts.get(mod)!;
     const modOrPromise = loadModuleAsync(mod.id, false, null);
     if (modOrPromise === mod) {
       if (selfAccept) {
-        selfAccept(getEsmExports(mod));
+        if (mod.state === State.Loaded) {
+          selfAccept(getEsmExports(mod));
+        } else {
+          // An earlier importer in this loop already started loading this
+          // module and it has top-level await: it is still Pending, so its
+          // namespace is not final yet. Its load promise is awaited through
+          // that importer's dependency chain below; invoke the accept
+          // callback after everything settles.
+          deferredAccepts.push([mod, selfAccept]);
+        }
       }
     } else {
       DEBUG.ASSERT(modOrPromise instanceof Promise);
@@ -777,6 +819,13 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   }
   if (promises.length > 0) {
     await Promise.all(promises);
+  }
+  for (const [mod, selfAccept] of deferredAccepts) {
+    // Skip modules that still did not finish loading (e.g. a failed or
+    // untracked in-flight load); their importers' rejections surface above.
+    if (mod.state === State.Loaded) {
+      selfAccept(getEsmExports(mod));
+    }
   }
   for (const mod of toReload) {
     const { selfAccept } = mod;

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -642,3 +642,127 @@ devTest("dev.write resolves only after the new module body has run", {
     expect(await c.js`globalThis.marker`).toBe("updated");
   },
 });
+devTest("editing an imported JSON file updates importers without a reload", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import data, { value } from "./data.json";
+      console.log("json:" + data.value + ":" + value);
+      globalThis.readJson = () => "live:" + data.value + ":" + value;
+      import.meta.hot.accept();
+    `,
+    "data.json": `{ "value": 1 }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("json:1:1");
+    await dev.patch("data.json", { find: "1", replace: "2" });
+    await c.expectMessage("json:2:2");
+    expect(await c.js<string>`readJson()`).toBe("live:2:2");
+    await dev.patch("data.json", { find: "2", replace: "3" });
+    await c.expectMessage("json:3:3");
+    expect(await c.js<string>`readJson()`).toBe("live:3:3");
+  },
+});
+devTest("editing a CommonJS module updates ESM importers without a reload", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import dep from "./dep.cjs";
+      console.log("cjs:" + dep.value);
+      globalThis.readCjs = () => "live:" + dep.value;
+      import.meta.hot.accept();
+    `,
+    "dep.cjs": `module.exports = { value: 1 };`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("cjs:1");
+    await dev.patch("dep.cjs", { find: "1", replace: "2" });
+    await c.expectMessage("cjs:2");
+    expect(await c.js<string>`readCjs()`).toBe("live:2");
+    await dev.patch("dep.cjs", { find: "2", replace: "3" });
+    await c.expectMessage("cjs:3");
+    expect(await c.js<string>`readCjs()`).toBe("live:3");
+  },
+});
+devTest("keys removed from a CommonJS module disappear after a hot update", {
+  // Unlike a wholesale `module.exports = {...}` assignment, incremental
+  // `exports.x = ...` modules mutate the same exports object across reloads
+  // unless the runtime resets it, so a deleted export would linger forever.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import * as dep from "./dep.cjs";
+      console.log("inc:" + dep.a + ":" + dep.b);
+      globalThis.readInc = () => "live:" + dep.a + ":" + (dep.b === undefined ? "gone" : dep.b);
+      import.meta.hot.accept();
+    `,
+    "dep.cjs": `
+      exports.a = 1;
+      exports.b = 2;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("inc:1:2");
+    await dev.write("dep.cjs", `exports.a = 10;`);
+    await c.expectMessage("inc:10:undefined");
+    expect(await c.js<string>`readInc()`).toBe("live:10:gone");
+  },
+});
+devTest("a module flipping between CommonJS and ESM across hot updates stays fresh", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { value } from "./dep.js";
+      console.log("flip:" + value);
+      globalThis.readFlip = () => "live:" + value;
+      import.meta.hot.accept();
+    `,
+    "dep.js": `module.exports = { value: 1 };`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("flip:1");
+    // CJS -> ESM
+    await dev.write("dep.js", `export const value = 2;`);
+    await c.expectMessage("flip:2");
+    expect(await c.js<string>`readFlip()`).toBe("live:2");
+    // ESM -> CJS
+    await dev.write("dep.js", `module.exports = { value: 3 };`);
+    await c.expectMessage("flip:3");
+    expect(await c.js<string>`readFlip()`).toBe("live:3");
+    // CJS again, exercising the stale-reset arm after a flip
+    await dev.write("dep.js", `module.exports = { value: 4 };`);
+    await c.expectMessage("flip:4");
+    expect(await c.js<string>`readFlip()`).toBe("live:4");
+  },
+});
+devTest("require() of a hot-reloaded ESM module sees fresh exports", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      const m = require("./esm.ts");
+      console.log("esm:" + m.x);
+      import.meta.hot.accept();
+    `,
+    "esm.ts": `export const x = 1;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("esm:1");
+    await dev.patch("esm.ts", { find: "1", replace: "2" });
+    await c.expectMessage("esm:2");
+  },
+});

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -702,6 +702,7 @@ devTest("keys removed from a CommonJS module disappear after a hot update", {
       import * as dep from "./dep.cjs";
       console.log("inc:" + dep.a + ":" + dep.b);
       globalThis.readInc = () => "live:" + dep.a + ":" + (dep.b === undefined ? "gone" : dep.b);
+      globalThis.incKeys = () => Object.keys(dep).sort().join(",");
       import.meta.hot.accept();
     `,
     "dep.cjs": `
@@ -712,9 +713,12 @@ devTest("keys removed from a CommonJS module disappear after a hot update", {
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("inc:1:2");
+    expect(await c.js<string>`incKeys()`).toBe("a,b,default");
     await dev.write("dep.cjs", `exports.a = 10;`);
     await c.expectMessage("inc:10:undefined");
     expect(await c.js<string>`readInc()`).toBe("live:10:gone");
+    // The deleted key is gone from the namespace shape, not merely undefined.
+    expect(await c.js<string>`incKeys()`).toBe("a,default");
   },
 });
 devTest("a module flipping between CommonJS and ESM across hot updates stays fresh", {
@@ -764,5 +768,52 @@ devTest("require() of a hot-reloaded ESM module sees fresh exports", {
     await c.expectMessage("esm:1");
     await dev.patch("esm.ts", { find: "1", replace: "2" });
     await c.expectMessage("esm:2");
+  },
+});
+devTest("self-accept of a top-level-await module is deferred until in-flight reloads settle", {
+  // `a.ts` and `b.ts` form an import cycle, so editing `a.ts` reloads both:
+  // `a.ts` as the changed module and `b.ts` as its self-accepting importer,
+  // in that order. Reloading `a.ts` starts loading stale `b.ts` through the
+  // import, and `b.ts` has top-level await, so when the reload loop reaches
+  // `b.ts` it is still pending: its accept callback must wait for the
+  // in-flight load instead of firing on a half-evaluated module. The eval
+  // counter proves `a.ts` re-evaluates against the re-evaluated `b.ts`.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { aValue } from "./a";
+      globalThis.readRoot = () => "root:" + aValue;
+      import.meta.hot.accept();
+    `,
+    "a.ts": `
+      import { bToken } from "./b";
+      export const aValue = 1;
+      console.log("a-eval:" + aValue + ":" + bToken);
+      globalThis.readA = () => "liveA:" + aValue + ":" + bToken;
+    `,
+    "b.ts": `
+      import { aValue } from "./a";
+      export const bToken = (globalThis.bEvalCount = (globalThis.bEvalCount ?? 0) + 1);
+      console.log("b-eval:" + bToken);
+      await Promise.resolve();
+      globalThis.readB = () => "liveB:" + bToken + ":" + aValue;
+      import.meta.hot.accept(m => console.log("b-accept:" + m.bToken));
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("b-eval:1", "a-eval:1:1");
+    await dev.patch("a.ts", { find: "aValue = 1", replace: "aValue = 2" });
+    await c.expectMessage("b-eval:2", "a-eval:2:2", "b-accept:2");
+    expect(await c.js<string>`readA()`).toBe("liveA:2:2");
+    expect(await c.js<string>`readB()`).toBe("liveB:2:2");
+    expect(await c.js<string>`readRoot()`).toBe("root:2");
+    await dev.patch("a.ts", { find: "aValue = 2", replace: "aValue = 3" });
+    await c.expectMessage("b-eval:3", "a-eval:3:3", "b-accept:3");
+    expect(await c.js<string>`readA()`).toBe("liveA:3:3");
+    expect(await c.js<string>`readB()`).toBe("liveB:3:3");
+    expect(await c.js<string>`readRoot()`).toBe("root:3");
   },
 });


### PR DESCRIPTION
### What does this PR do?

Fixes hot reload serving permanently stale data for imported `.json` files (and any CommonJS module consumed via ESM import) in the dev server: editing `data.json` fired an HMR update and re-evaluated the module, but the page kept rendering the value from the **first** bundle, frozen across every subsequent edit. Only a full page reload picked up changes.

Two defects in the HMR client runtime combined:

1. **Stale cached namespace view** (`src/runtime/bake/hmr-module.ts`, the fix line is the post-wrapper `mod.exports = null` in both CJS branches): the CJS reload path re-ran the wrapper but never invalidated `mod.exports`, the `toESM()` view cached on first load. `toESM()` binds getters to the *specific* `cjs.exports` object it was given, so after re-evaluation assigned a new object, `patchImporters()` and accept callbacks kept serving the view bound to the first evaluation's exports. JSON files are emitted as CJS lazy-export wrappers in dev, so every JSON edit hit this. Re-evaluation also now starts from a fresh exports object so keys removed by the new version don't linger.

2. **Reload-order staleness** (`replaceModules`): modules were marked stale one at a time inside the reload loop, so when the hot chunk listed an importer before its edited dep (which the asset invalidation path always produces for JSON), the importer re-evaluated against the still-loaded old dep. The reload is now two-pass: mark everything stale and capture accept handlers first, then reload. Accept callbacks for modules whose load was started by an earlier importer in the loop (possible with top-level await) are deferred until in-flight loads settle.

### How did you verify your code works?

Six new tests in `test/bake/dev/hot.test.ts` (17 total in the file, all passing on a debug build): JSON default+named imports across three successive edits, plain `module.exports` CJS, `exports.key` removal after edit (asserting the deleted key leaves the namespace shape, not just reads `undefined`), CJS<->ESM flips across reloads, `require()` of hot-reloaded ESM, and a top-level-await module in an import cycle whose self-accept callback goes through the new deferred queue (verified the deferred branch executes via a temporary marker log). Each asserts both eval-time output and post-patch live-binding reads, with no full page reload.

With `src/runtime/bake/hmr-module.ts` reverted to main and everything else unchanged, five of the six fail: the JSON test freezes at the first value, the CJS test freezes at `1`, the removed-key test shows the deleted export lingering, the flip test serves a stale value, and the top-level-await test shows the importer re-evaluating against the stale dep before the dep reloads. These are exactly the reported symptoms. The `require()`-of-ESM test passes both ways by design: it pins the mirror-direction cache (`mod.cjs` reset in `finishLoadModuleAsync`) that was already correct.

Deleting any load-bearing hunk (the fresh-exports reset, the post-wrapper invalidation, the two-pass marking, or the deferred accept queue) breaks at least one test.

### Rebase notes

Rebased onto main twice as it moved. Both times the only conflict was in `test/bake/dev/hot.test.ts`, where main appended a new `devTest` at the end of the file and so did this branch; resolved both times by keeping main's tests first and the six added here after them. No test content changed on either side.

`src/runtime/bake/hmr-module.ts` merged cleanly both times. Main has since fixed the `require: mod.require.bind(this)` bug in the ESM->CJS flip arms (#31942) that this PR's description previously flagged as pre-existing; that fix and the changes here are independent and both present. The runtime file has not changed on main since the first rebase, so the revert-to-main check above still applies. All 17 tests pass on the current base, including main's new test that awaits a top-level-await module body through `replaceModules`, which exercises the two-pass reload directly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->