### PR TITLE
Make the HMR module loader iterative to survive large hot updates

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -269,8 +269,55 @@ HMRModule.prototype.indirectHot = new Proxy({}, {
   },
 });
 
-// TODO: This function is currently recursive.
-export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModule | null): HMRModule {
+/** Heap-allocated continuation frame for the iterative ESM dependency
+ * traversal in `loadModuleSync` and `loadModuleAsync`. The runtime's
+ * dependency-closure walk must not consume native stack per import edge: a
+ * hot update can re-evaluate an arbitrarily large stale subgraph (see
+ * `replaceModules`), and a recursive walk overflows the call stack there.
+ *
+ * Re-entrancy invariant: a module has at most one live frame across all
+ * traversals. A frame is only created when a module transitions into
+ * `State.Pending` (new or Stale), and every other lookup — including
+ * re-entrant entries into the loader from user code mid-evaluation, i.e.
+ * `mod.require()` / `mod.dynamicImport()` inside a CommonJS wrapper or an
+ * ESM load function — observes `State.Pending` in the registry and receives
+ * the partially-initialized module, preserving circular-import semantics.
+ * Note this also means a module that is Pending because its top-level-await
+ * load is still in flight is indistinguishable from an in-cycle module:
+ * importers discovered later receive its unfinished namespace synchronously —
+ * identical to the old recursive code.
+ * Those re-entrant calls run their own traversal loop to completion
+ * synchronously, so native stack growth is bounded by user `require()`
+ * nesting depth (as in Node), not by importer fan-out or graph depth. */
+interface LoadFrame {
+  mod: HMRModule;
+  /** `UnloadedESM[ESMProps.imports]`: the encoded dependency array. */
+  deps: EncodedDependencyArray;
+  load: UnloadedESM[3];
+  /** Cursor into `deps`. Always points at a dependency Id (or past the end). */
+  i: number;
+  /** Dependency load results in import order. `Promise` entries only occur
+   * under `loadModuleAsync`. */
+  list: (HMRModule | Promise<HMRModule>)[];
+  /** Whether any dependency produced a Promise (only under `loadModuleAsync`). */
+  isAsync: boolean;
+  /** Frame that receives `mod` when this one completes; null for the root. */
+  parent: LoadFrame | null;
+}
+
+/** Shared prologue of `loadModuleSync` / `loadModuleAsync` for one module.
+ * Returns the module itself when it is usable as-is (registry hit) or when it
+ * is CommonJS (evaluated immediately; nested `require` calls inside the
+ * wrapper re-enter the public loader). Returns a `LoadFrame` for an ESM
+ * module whose dependency closure must be traversed first. Returns null only
+ * for `sync === false` with `isUserDynamic` when the module is not bundled,
+ * so `dynamicImport` can fall back to a native `import()`. */
+function beginModuleLoad(
+  id: Id,
+  isUserDynamic: boolean,
+  importer: HMRModule | null,
+  sync: boolean,
+): HMRModule | LoadFrame | null {
   // First, try and re-use an existing module.
   let mod = registry.get(id);
   if (mod) {
@@ -286,7 +333,10 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     }
   }
   const loadOrEsmModule = unloadedModuleRegistry[id];
-  if (!loadOrEsmModule) throwNotFound(id, isUserDynamic);
+  if (!loadOrEsmModule) {
+    if (!sync && isUserDynamic) return null;
+    throwNotFound(id, isUserDynamic);
+  }
 
   if (typeof loadOrEsmModule === "function") {
     // CommonJS
@@ -332,6 +382,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     // cannot outlive a reassigned `module.exports`.
     mod.exports = null;
     mod.state = State.Loaded;
+    return mod;
   } else {
     // ESM
     if (IS_BUN_DEVELOPMENT) {
@@ -347,7 +398,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
       }
     }
     const { [ESMProps.imports]: deps, [ESMProps.load]: load, [ESMProps.isAsync]: isAsync } = loadOrEsmModule;
-    if (isAsync) {
+    if (sync && isAsync) {
       throw new AsyncImportError(id);
     }
     if (!mod) {
@@ -361,113 +412,145 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     if (importer) {
       mod.importers.add(importer);
     }
+    return { mod, deps, load, i: 0, list: [], isAsync: false, parent: null };
+  }
+}
 
-    const { list: depsList } = parseEsmDependencies(mod, deps, loadModuleSync);
+/** Record one finished dependency on `frame` and advance the cursor past the
+ * dependency's encoded export keys (see `EncodedDependencyArray`: each entry
+ * is `dep Id, key count, ...export keys`; CommonJS dependencies skip their
+ * key range wholesale). */
+function advanceDep(frame: LoadFrame, promiseOrModule: HMRModule | Promise<HMRModule>) {
+  const { deps, list } = frame;
+  let i = frame.i;
+  const dep = deps[i] as string;
+  let expectedExportKeyEnd = i + 2 + (deps[i + 1] as number);
+  list.push(promiseOrModule);
+
+  const unloadedModule = unloadedModuleRegistry[dep];
+  if (!unloadedModule) {
+    throwNotFound(dep, false);
+  }
+  if (typeof unloadedModule !== "function") {
+    const availableExportKeys = unloadedModule[ESMProps.exports];
+    i += 2;
+    while (i < expectedExportKeyEnd) {
+      const key = deps[i] as string;
+      DEBUG.ASSERT(typeof key === "string");
+      // TODO: there is a bug in the way exports are verified. Additionally a
+      // possible performance issue. For the meantime, this is disabled since
+      // it was not shipped in the initial 1.2.3 HMR, and real issues will
+      // just throw 'undefined is not a function' or so on.
+
+      // if (!availableExportKeys.includes(key)) {
+      //   if (!hasExportStar(unloadedModule[ESMProps.stars], key)) {
+      //     throw new SyntaxError(`Module "${dep}" does not export key "${key}"`);
+      //   }
+      // }
+      i++;
+    }
+    frame.isAsync ||= promiseOrModule instanceof Promise;
+  } else {
+    DEBUG.ASSERT(!registry.get(dep)?.esm);
+    i = expectedExportKeyEnd;
+
+    if (IS_BUN_DEVELOPMENT) {
+      DEBUG.ASSERT((list[list.length - 1] as any) instanceof HMRModule);
+    }
+  }
+  frame.i = i;
+}
+
+export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModule | null): HMRModule {
+  const start = beginModuleLoad(id, isUserDynamic, importer, true);
+  if (start instanceof HMRModule) return start;
+
+  // Iterative depth-first post-order traversal of the ESM dependency
+  // closure: dependencies evaluate before dependents, shared (diamond)
+  // dependencies evaluate once via the registry state check in
+  // `beginModuleLoad`. Frames live on the heap so stack depth does not scale
+  // with the size of the graph.
+  // null is impossible here: beginModuleLoad only returns null when
+  // sync === false && isUserDynamic.
+  let frame = start as LoadFrame;
+  while (true) {
+    const { deps } = frame;
+    if (frame.i < deps.length) {
+      const dep = deps[frame.i] as string;
+      DEBUG.ASSERT(typeof dep === "string");
+      DEBUG.ASSERT(typeof deps[frame.i + 1] === "number");
+      const next = beginModuleLoad(dep, false, frame.mod, true);
+      if (next instanceof HMRModule) {
+        advanceDep(frame, next);
+      } else {
+        (next as LoadFrame).parent = frame;
+        frame = next as LoadFrame;
+      }
+      continue;
+    }
+    // All dependencies are evaluated; evaluate this module's body. A thrown
+    // load propagates to the caller and abandons every frame still on the
+    // chain: ancestors stay in State.Pending, exactly as native stack
+    // unwinding left them in the old recursive code. On this sync path the
+    // throwing module ALSO stays Pending with no failure recorded — the old
+    // loadModuleSync had no try/catch around load() either. Only the
+    // CommonJS catch in beginModuleLoad and the async path
+    // (finishLoadModuleAsync / the Promise.all reject arm) record
+    // Stale/Error states. Do not "fix" this to set State.Error: a Pending
+    // module is retried by the next load, an Error one rethrows forever.
+    const mod = frame.mod;
+    const depsList = frame.list as HMRModule[];
     const exportsBefore = mod.exports;
     mod.imports = depsList.map(getEsmExports);
-    load(mod);
+    frame.load(mod);
     mod.imports = depsList;
     if (mod.exports === exportsBefore) mod.exports = {};
     mod.cjs = null;
     mod.state = State.Loaded;
+    const { parent } = frame;
+    if (!parent) return mod;
+    advanceDep(parent, mod);
+    frame = parent;
   }
-
-  return mod;
 }
 
 // Do not add the `async` keyword to this function, that way the list of
 // `HMRModule`s can be created synchronously, even if evaluation is not.
 // Returns `null` if the module is not found in dynamic mode, so that the caller
 // can use the `import` keyword instead.
-// TODO: This function is currently recursive.
 export function loadModuleAsync<IsUserDynamic extends boolean>(
   id: Id,
   isUserDynamic: IsUserDynamic,
   importer: HMRModule | null,
 ): (IsUserDynamic extends true ? null : never) | Promise<HMRModule> | HMRModule {
-  // First, try and re-use an existing module.
-  let mod = registry.get(id)!;
-  if (mod) {
-    const { state } = mod;
-    if (state === State.Error) throw mod.failure;
-    if (state === State.Stale) {
-      mod.state = State.Pending;
-      isUserDynamic = false as IsUserDynamic;
-    } else {
-      if (importer) {
-        mod.importers.add(importer);
+  const start = beginModuleLoad(id, isUserDynamic, importer, false);
+  if (start === null) return null!;
+  if (start instanceof HMRModule) return start;
+
+  // Same iterative traversal as `loadModuleSync`, except a frame's result may
+  // be a `Promise<HMRModule>` when its dependency closure contains top-level
+  // await. Promise continuations run on the microtask queue with a fresh
+  // native stack, so only synchronous closures consume frames here.
+  let frame = start as LoadFrame;
+  while (true) {
+    const { deps } = frame;
+    if (frame.i < deps.length) {
+      const dep = deps[frame.i] as string;
+      DEBUG.ASSERT(typeof dep === "string");
+      DEBUG.ASSERT(typeof deps[frame.i + 1] === "number");
+      const next = beginModuleLoad(dep, false, frame.mod, false);
+      if (next instanceof HMRModule) {
+        advanceDep(frame, next);
+      } else {
+        // `null` is impossible: dependencies pass isUserDynamic=false.
+        (next as LoadFrame).parent = frame;
+        frame = next as LoadFrame;
       }
-      return mod;
+      continue;
     }
-  }
-  const loadOrEsmModule = unloadedModuleRegistry[id];
-  if (!loadOrEsmModule) {
-    if (isUserDynamic) return null!;
-    throwNotFound(id, isUserDynamic);
-  }
-
-  if (typeof loadOrEsmModule === "function") {
-    // CommonJS
-    if (!mod) {
-      mod = new HMRModule(id, true);
-      registry.set(id, mod);
-    } else if (mod.esm) {
-      mod.esm = false;
-      mod.cjs = {
-        id,
-        exports: {},
-        require: mod.require.bind(this),
-      };
-      mod.exports = null;
-    } else {
-      // See the matching reset in loadModuleSync.
-      mod.cjs.exports = {};
-    }
-    if (importer) {
-      mod.importers.add(importer);
-    }
-    try {
-      const cjs = mod.cjs;
-      loadOrEsmModule(mod, cjs, cjs.exports);
-    } catch (e) {
-      mod.state = State.Stale;
-      mod.cjs.exports = {};
-      mod.exports = null;
-      throw e;
-    }
-    // See the matching reset in loadModuleSync.
-    mod.exports = null;
-    mod.state = State.Loaded;
-    return mod;
-  } else {
-    // ESM
-    if (IS_BUN_DEVELOPMENT) {
-      try {
-        DEBUG.ASSERT(Array.isArray(loadOrEsmModule[0]));
-        DEBUG.ASSERT(Array.isArray(loadOrEsmModule[1]));
-        DEBUG.ASSERT(Array.isArray(loadOrEsmModule[2]));
-        DEBUG.ASSERT(typeof loadOrEsmModule[3] === "function");
-        DEBUG.ASSERT(typeof loadOrEsmModule[4] === "boolean");
-      } catch (e) {
-        console.warn(id, loadOrEsmModule);
-        throw e;
-      }
-    }
-    const [deps /* exports */ /* stars */, , , load /* isAsync */] = loadOrEsmModule;
-
-    if (!mod) {
-      mod = new HMRModule(id, false);
-      registry.set(id, mod);
-    } else if (!mod.esm) {
-      mod.esm = true;
-      mod.exports = null;
-      mod.cjs = null;
-    }
-    if (importer) {
-      mod.importers.add(importer);
-    }
-
-    const { list, isAsync } = parseEsmDependencies(mod, deps, loadModuleAsync<false>);
+    // All dependencies are evaluated or in flight; finish this module.
+    const mod = frame.mod;
+    const { list, isAsync, load, parent } = frame;
     DEBUG.ASSERT(
       isAsync //
         ? list.some(x => x instanceof Promise)
@@ -476,7 +559,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
 
     // Running finishLoadModuleAsync synchronously when there are no promises is
     // not a performance optimization but a behavioral correctness issue.
-    return isAsync
+    const result = isAsync
       ? Promise.all(list).then(
           list => finishLoadModuleAsync(mod, load, list),
           e => {
@@ -490,6 +573,12 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
           load,
           list as HMRModule[], // no promises as by assert above
         );
+    if (!parent) return result;
+    // The parent observes `result instanceof Promise` in `advanceDep`, which
+    // is how asyncness propagates up the dependency chain (a module is async
+    // iff its own body has top-level await or any dependency is async).
+    advanceDep(parent, result);
+    frame = parent;
   }
 }
 
@@ -519,60 +608,6 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
     mod.failure = e;
     throw e;
   }
-}
-
-type GenericModuleLoader<R> = (id: Id, isUserDynamic: false, importer: HMRModule) => R;
-// TODO: This function is currently recursive.
-function parseEsmDependencies<T extends GenericModuleLoader<any>>(
-  parent: HMRModule,
-  deps: (string | number)[],
-  enqueueModuleLoad: T,
-) {
-  let i = 0;
-  let list: ReturnType<T>[] = [];
-  let isAsync = false;
-  const { length } = deps;
-  while (i < length) {
-    const dep = deps[i] as string;
-    DEBUG.ASSERT(typeof dep === "string");
-    let expectedExportKeyEnd = i + 2 + (deps[i + 1] as number);
-    DEBUG.ASSERT(typeof deps[i + 1] === "number");
-    const promiseOrModule = enqueueModuleLoad(dep, false, parent);
-    list.push(promiseOrModule);
-
-    const unloadedModule = unloadedModuleRegistry[dep];
-    if (!unloadedModule) {
-      throwNotFound(dep, false);
-    }
-    if (typeof unloadedModule !== "function") {
-      const availableExportKeys = unloadedModule[ESMProps.exports];
-      i += 2;
-      while (i < expectedExportKeyEnd) {
-        const key = deps[i] as string;
-        DEBUG.ASSERT(typeof key === "string");
-        // TODO: there is a bug in the way exports are verified. Additionally a
-        // possible performance issue. For the meantime, this is disabled since
-        // it was not shipped in the initial 1.2.3 HMR, and real issues will
-        // just throw 'undefined is not a function' or so on.
-
-        // if (!availableExportKeys.includes(key)) {
-        //   if (!hasExportStar(unloadedModule[ESMProps.stars], key)) {
-        //     throw new SyntaxError(`Module "${dep}" does not export key "${key}"`);
-        //   }
-        // }
-        i++;
-      }
-      isAsync ||= promiseOrModule instanceof Promise;
-    } else {
-      DEBUG.ASSERT(!registry.get(dep)?.esm);
-      i = expectedExportKeyEnd;
-
-      if (IS_BUN_DEVELOPMENT) {
-        DEBUG.ASSERT((list[list.length - 1] as any) instanceof HMRModule);
-      }
-    }
-  }
-  return { list, isAsync };
 }
 
 function hasExportStar(starImports: Id[], key: string) {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -301,6 +301,12 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
         require: mod.require.bind(this),
       };
       mod.exports = null;
+    } else {
+      // Re-evaluating a stale CommonJS module: start from a fresh exports
+      // object so keys removed by the new version do not linger (matches
+      // first evaluation and the error path below, which performs the same
+      // reset after a failed evaluation).
+      mod.cjs.exports = {};
     }
     if (importer) {
       mod.importers.add(importer);
@@ -311,8 +317,20 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // Drop the cached ESM namespace view: `toESM` binds getters to the
+    // specific `cjs.exports` object it was given, so a view created during a
+    // previous evaluation would keep serving the old values forever (e.g. a
+    // hot-reloaded JSON file frozen at its first parse). getEsmExports()
+    // lazily rebuilds the view over the current `cjs.exports`, and
+    // patchImporters() then rebinds live ESM importers. This runs after the
+    // wrapper, not before it, so a re-entrant getEsmExports() during a
+    // circular evaluation cannot cache a view over the transient `{}`; a view
+    // cached mid-evaluation by a circular importer is dropped too, so it
+    // cannot outlive a reassigned `module.exports`.
+    mod.exports = null;
     mod.state = State.Loaded;
   } else {
     // ESM
@@ -401,6 +419,9 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         require: mod.require.bind(this),
       };
       mod.exports = null;
+    } else {
+      // See the matching reset in loadModuleSync.
+      mod.cjs.exports = {};
     }
     if (importer) {
       mod.importers.add(importer);
@@ -411,8 +432,11 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     } catch (e) {
       mod.state = State.Stale;
       mod.cjs.exports = {};
+      mod.exports = null;
       throw e;
     }
+    // See the matching reset in loadModuleSync.
+    mod.exports = null;
     mod.state = State.Loaded;
     return mod;
   } else {
@@ -748,18 +772,36 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Reload all modules
+  // Reload all modules. Mark every module stale before reloading any of
+  // them: a reloading module can synchronously evaluate another module in
+  // the set through its imports, and that module must re-evaluate with its
+  // new code rather than serve the previous evaluation. Capture and clear
+  // accept handlers in the same pass so an evaluation triggered by an
+  // importer does not have its freshly registered handlers wiped below.
   const promises: Promise<HMRModule>[] = [];
+  const selfAccepts = new Map<HMRModule, HotAcceptFunction | null>();
   for (const mod of toReload) {
     mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
+    selfAccepts.set(mod, mod.selfAccept);
     mod.selfAccept = null;
     mod.depAccepts = null;
-
+  }
+  const deferredAccepts: [HMRModule, HotAcceptFunction][] = [];
+  for (const mod of toReload) {
+    const selfAccept = selfAccepts.get(mod)!;
     const modOrPromise = loadModuleAsync(mod.id, false, null);
     if (modOrPromise === mod) {
       if (selfAccept) {
-        selfAccept(getEsmExports(mod));
+        if (mod.state === State.Loaded) {
+          selfAccept(getEsmExports(mod));
+        } else {
+          // An earlier importer in this loop already started loading this
+          // module and it has top-level await: it is still Pending, so its
+          // namespace is not final yet. Its load promise is awaited through
+          // that importer's dependency chain below; invoke the accept
+          // callback after everything settles.
+          deferredAccepts.push([mod, selfAccept]);
+        }
       }
     } else {
       DEBUG.ASSERT(modOrPromise instanceof Promise);
@@ -775,6 +817,13 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   }
   if (promises.length > 0) {
     await Promise.all(promises);
+  }
+  for (const [mod, selfAccept] of deferredAccepts) {
+    // Skip modules that still did not finish loading (e.g. a failed or
+    // untracked in-flight load); their importers' rejections surface above.
+    if (mod.state === State.Loaded) {
+      selfAccept(getEsmExports(mod));
+    }
   }
   for (const mod of toReload) {
     const { selfAccept } = mod;

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -527,3 +527,127 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
     }
   },
 });
+devTest("editing an imported JSON file updates importers without a reload", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import data, { value } from "./data.json";
+      console.log("json:" + data.value + ":" + value);
+      globalThis.readJson = () => "live:" + data.value + ":" + value;
+      import.meta.hot.accept();
+    `,
+    "data.json": `{ "value": 1 }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("json:1:1");
+    await dev.patch("data.json", { find: "1", replace: "2" });
+    await c.expectMessage("json:2:2");
+    expect(await c.js<string>`readJson()`).toBe("live:2:2");
+    await dev.patch("data.json", { find: "2", replace: "3" });
+    await c.expectMessage("json:3:3");
+    expect(await c.js<string>`readJson()`).toBe("live:3:3");
+  },
+});
+devTest("editing a CommonJS module updates ESM importers without a reload", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import dep from "./dep.cjs";
+      console.log("cjs:" + dep.value);
+      globalThis.readCjs = () => "live:" + dep.value;
+      import.meta.hot.accept();
+    `,
+    "dep.cjs": `module.exports = { value: 1 };`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("cjs:1");
+    await dev.patch("dep.cjs", { find: "1", replace: "2" });
+    await c.expectMessage("cjs:2");
+    expect(await c.js<string>`readCjs()`).toBe("live:2");
+    await dev.patch("dep.cjs", { find: "2", replace: "3" });
+    await c.expectMessage("cjs:3");
+    expect(await c.js<string>`readCjs()`).toBe("live:3");
+  },
+});
+devTest("keys removed from a CommonJS module disappear after a hot update", {
+  // Unlike a wholesale `module.exports = {...}` assignment, incremental
+  // `exports.x = ...` modules mutate the same exports object across reloads
+  // unless the runtime resets it, so a deleted export would linger forever.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import * as dep from "./dep.cjs";
+      console.log("inc:" + dep.a + ":" + dep.b);
+      globalThis.readInc = () => "live:" + dep.a + ":" + (dep.b === undefined ? "gone" : dep.b);
+      import.meta.hot.accept();
+    `,
+    "dep.cjs": `
+      exports.a = 1;
+      exports.b = 2;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("inc:1:2");
+    await dev.write("dep.cjs", `exports.a = 10;`);
+    await c.expectMessage("inc:10:undefined");
+    expect(await c.js<string>`readInc()`).toBe("live:10:gone");
+  },
+});
+devTest("a module flipping between CommonJS and ESM across hot updates stays fresh", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { value } from "./dep.js";
+      console.log("flip:" + value);
+      globalThis.readFlip = () => "live:" + value;
+      import.meta.hot.accept();
+    `,
+    "dep.js": `module.exports = { value: 1 };`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("flip:1");
+    // CJS -> ESM
+    await dev.write("dep.js", `export const value = 2;`);
+    await c.expectMessage("flip:2");
+    expect(await c.js<string>`readFlip()`).toBe("live:2");
+    // ESM -> CJS
+    await dev.write("dep.js", `module.exports = { value: 3 };`);
+    await c.expectMessage("flip:3");
+    expect(await c.js<string>`readFlip()`).toBe("live:3");
+    // CJS again, exercising the stale-reset arm after a flip
+    await dev.write("dep.js", `module.exports = { value: 4 };`);
+    await c.expectMessage("flip:4");
+    expect(await c.js<string>`readFlip()`).toBe("live:4");
+  },
+});
+devTest("require() of a hot-reloaded ESM module sees fresh exports", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      const m = require("./esm.ts");
+      console.log("esm:" + m.x);
+      import.meta.hot.accept();
+    `,
+    "esm.ts": `export const x = 1;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("esm:1");
+    await dev.patch("esm.ts", { find: "1", replace: "2" });
+    await c.expectMessage("esm:2");
+  },
+});

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -632,6 +632,74 @@ devTest("a module flipping between CommonJS and ESM across hot updates stays fre
     expect(await c.js<string>`readFlip()`).toBe("live:4");
   },
 });
+// Long enough that the module loader's old recursive dependency walk
+// (loadModuleSync/loadModuleAsync <-> parseEsmDependencies, ~2 fat native
+// frames per import edge) exceeds the V8 call-stack limit in the node-based
+// client fixture, both at initial page load and when the whole chain is
+// stale in one hot update. The loader must traverse the dependency closure
+// iteratively for this to pass. The chain uses side-effect imports plus a
+// globalThis side channel (not re-export live bindings) so that on the fixed
+// build no user-level getter chain scales with the constant: only the
+// loader's own traversal sees the depth, and DEEP_CHAIN_LENGTH can be raised
+// freely if engine stack limits grow. Bundle time inside the fixed
+// per-message wait window (2000 * WAIT_MULTIPLIER in bake-harness.ts; NOT
+// scaled by timeoutMultiplier) is the only upper bound on the constant.
+const DEEP_CHAIN_LENGTH = 2500;
+const deepChainFiles: Record<string, string> = {
+  "index.html": emptyHtmlFile({
+    scripts: ["index.ts"],
+  }),
+  "index.ts": `
+    import "./a0";
+    console.log("chain:" + globalThis.chainValue);
+    globalThis.readChain = () => "live:" + globalThis.chainValue;
+    import.meta.hot.accept();
+  `,
+  [`a${DEEP_CHAIN_LENGTH}.ts`]: `globalThis.chainValue = 1;`,
+};
+for (let i = 0; i < DEEP_CHAIN_LENGTH; i++) {
+  deepChainFiles[`a${i}.ts`] = `import "./a${i + 1}";`;
+}
+devTest("hot update applies across a deep import chain without a page reload", {
+  // Protects the outer test timeout for the two ~2500-file bundles; the
+  // per-message wait window is fixed and cannot be extended, so if this test
+  // times out waiting for a message, shrink DEEP_CHAIN_LENGTH (keeping the
+  // USE_SYSTEM_BUN=1 run failing) instead of touching timeouts.
+  timeoutMultiplier: 5,
+  files: deepChainFiles,
+  async test(dev) {
+    await using c = await dev.client("/");
+    // On the unfixed build the recursive initial-load walk of all
+    // DEEP_CHAIN_LENGTH+1 modules overflows the stack here.
+    await c.expectMessage("chain:1");
+
+    // Editing the leaf re-evaluates only the leaf and the self-accepting
+    // entry (replaceModules marks only payload modules and accepting
+    // boundaries stale); the leaf reloads first by Set insertion order. No
+    // full page reload may occur (the client fixture fails the test on an
+    // unexpected location.reload()).
+    await dev.patch(`a${DEEP_CHAIN_LENGTH}.ts`, { find: "= 1", replace: "= 2" });
+    await c.expectMessage("chain:2");
+    expect(await c.js<string>`readChain()`).toBe("live:2");
+
+    // Touch every module in the chain in a single batch so one hot update
+    // marks the entire chain stale: the first reloaded root's traversal then
+    // re-evaluates the whole cone through the loader in one synchronous
+    // pass, which is the depth that used to RangeError. Each rewrite is
+    // semantically distinct from the loaded version so no current or future
+    // content-dedup can drop it from the update payload. dev.write (not raw
+    // writeFileSync) re-arms the batch's SeenFiles synchronization per file.
+    {
+      await using _batch = await dev.batchChanges();
+      await dev.write(`a${DEEP_CHAIN_LENGTH}.ts`, `globalThis.chainValue = 3;`);
+      for (let i = 0; i < DEEP_CHAIN_LENGTH; i++) {
+        await dev.write(`a${i}.ts`, `import "./a${i + 1}"; globalThis.touched = ${i};`);
+      }
+    }
+    await c.expectMessage("chain:3");
+    expect(await c.js<string>`readChain()`).toBe("live:3");
+  },
+});
 devTest("require() of a hot-reloaded ESM module sees fresh exports", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### What does this PR do?

Stacked on #31944 (the base branch); only the second commit is new here.

Fixes `RangeError: Maximum call stack size exceeded` in the dev server's HMR runtime when a hot update touches a module with very high fan-in, or a page loads through a deep import chain. The error was caught by the update handler and recovered via a full page reload, so the symptom was an alarming console error plus losing the hot update.

The loader's dependency walk in `src/runtime/bake/hmr-module.ts` was mutually recursive (`loadModuleSync`/`loadModuleAsync` -> `parseEsmDependencies` -> back into the loaders), consuming native stack frames per edge of the stale subgraph with user module evaluation frames interleaved — all three functions carried `// TODO: This function is currently recursive.`

Now the dependency-closure walk is iterative: a shared `beginModuleLoad` prologue (registry state handling, CJS evaluation, ESM frame creation), per-module `LoadFrame` continuations forming an explicit heap-linked parent chain, and flat driver loops that evaluate completed frames. Native stack depth no longer scales with graph depth or fan-out.

What deliberately stays recursive: a module body calling `require()` or a synchronous dynamic import mid-evaluation is a fresh entry into the loader that must return synchronously inside the live user frame. That's bounded by user require-nesting depth (Node recurses identically), not by importer fan-out, and each such entry runs its own complete iterative traversal, converging with the outer one through the `Pending` registry state.

Observable semantics preserved: evaluation order, `Pending`-based circular-import handling, top-level-await promise composition (synchronous closures still complete synchronously — the load-bearing comment is kept), `AsyncImportError` throw points, error propagation, ESM<->CJS flips, and accept/dispose/`patchImporters` timing.

### How did you verify your code works?

New test in `test/bake/dev/hot.test.ts`: bundles a 2500-module import chain, asserts the initial load works, a leaf edit hot-applies without a page reload (eval-time output + live-binding read), and a full-chain rewrite hot-applies. On the unfixed build (`USE_SYSTEM_BUN=1`) the test fails at the initial load — the recursive walk overflows the stack (repeated runtime frames in the trace) and the runtime falls back to a full reload.

All 14 pre-existing hot tests (including the five from #31944) pass unchanged on a debug build; the test-file diff is pure addition.