### PR TITLE
dev server: fix require binding when a module flips from ESM to CJS

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -298,7 +298,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
       mod.cjs = {
         id,
         exports: {},
-        require: mod.require.bind(this),
+        require: mod.require.bind(mod),
       };
       mod.exports = null;
     }
@@ -398,7 +398,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
       mod.cjs = {
         id,
         exports: {},
-        require: mod.require.bind(this),
+        require: mod.require.bind(mod),
       };
       mod.exports = null;
     }

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -273,6 +273,58 @@ devTest("ESM <-> CJS (async)", {
     await c.expectMessage("PASS");
   },
 });
+devTest("importer tracking survives flipping a module from ESM to CJS", {
+  // https://github.com/oven-sh/bun/issues/31942
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import './dep';
+      import.meta.hot.data.runs = (import.meta.hot.data.runs ?? 0) + 1;
+      console.log('index run ' + import.meta.hot.data.runs);
+      import.meta.hot.accept();
+    `,
+    "dep.ts": `
+      export const value = 'esm';
+    `,
+    "leaf.ts": `
+      console.log('leaf 1');
+      export const value = 'leaf1';
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("index run 1");
+    // Flip `dep` from ESM to CJS. The dead branch gets `leaf` bundled (direct
+    // `require` calls are statically rewritten to `hmr.require`, which binds
+    // `this` correctly), while the indirect `m.require(...)` call is emitted
+    // verbatim and goes through the `require` function bound onto the
+    // replacement CJS module object, which must record `dep` as an importer
+    // of `leaf`.
+    await dev.write(
+      "dep.ts",
+      `
+        if (globalThis.__never_set) require('./leaf');
+        const m = module;
+        module.exports = { value: m.require(module.id.replace('dep', 'leaf')).value };
+      `,
+    );
+    await c.expectMessage("leaf 1", "index run 2");
+    // Editing `leaf` must propagate through the flipped module up to the
+    // self-accepting root as a hot update. If the importer edge was dropped,
+    // the dev server forces a full page reload instead (the client harness
+    // fails on unexpected reloads).
+    await dev.write(
+      "leaf.ts",
+      `
+        console.log('leaf 2');
+        export const value = 'leaf2';
+      `,
+    );
+    await c.expectMessage("leaf 2", "index run 3");
+  },
+});
 devTest("cannot require a module with top level await", {
   // TODO: after the module-loader rewrite the dev server's /_bun/report_error
   // handler can hang (never responds), so the client overlay never mounts and


### PR DESCRIPTION
Fixes #31942

### Problem

In `src/runtime/bake/hmr-module.ts`, the ESM->CJS flip arms of `loadModuleSync` and `loadModuleAsync` built the replacement CJS module object with:

```ts
require: mod.require.bind(this),
```

`this` inside those plain exported functions is not the `HMRModule`: it is `undefined` in strict mode, `globalThis` in sloppy mode. Either way, once a module flips from ESM to CJS across a hot update, calls through its `require` pass a bogus `importer` into the module loader:

- strict (`<script type="module">` in a real browser): `loadModuleSync(id, true, undefined)`, so `mod.importers.add(importer)` never runs and the importer edge is silently dropped. The next edit to that dependency finds `importers.size === 0` on a non-accepting module and forces a full page reload instead of a hot update.
- sloppy (chunks evaluated via indirect `eval`, e.g. the bake test harness): `window` is truthy, so it gets added to `importers`, and the next boundary walk crashes with `TypeError: Cannot convert undefined or null to object` at `Object.keys(mod.data)` in `replaceModules`, which then triggers a full reload.

The first-construction path in the `HMRModule` constructor (and the `toCommonJS` path) correctly use `this.require.bind(this)`; only the two flip arms were affected.

Note the trigger requires a require call that is not statically rewritten: direct `require('./x')` (and even `module.require('./x')`) in a CJS module is rewritten by the parser to `hmr.require("x.ts")`, a method call with correct `this`. Indirect access (`const m = module; m.require(...)`) keeps the runtime-bound function and hits the bug.

### Fix

Bind `require` to `mod` in both flip arms, matching the constructor.

### Test

`test/bake/dev/esm.test.ts`: "importer tracking survives flipping a module from ESM to CJS". A self-accepting root imports `dep`; `dep` is edited from ESM to a CJS module that requires `leaf` through an indirectly-accessed `module.require`; then `leaf` is edited. With the fix the edit propagates as a hot update to the accepting root. Without the fix the client crashes with the `TypeError` above and attempts a full reload, which the harness rejects:

```
TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at replaceModules (http://localhost:33453/_bun/client/index-00000000dc9372ec.js:2452:29)
```

Fails on unfixed main (`bun bd test` with `src/` stashed) and on `USE_SYSTEM_BUN=1`; passes with the fix. Full `test/bake/dev/esm.test.ts` (17/17) and `test/bake/dev/hot.test.ts` (9/9) pass.

A related but separate defect (stale CJS exports when a hot update propagates through an already-loaded CJS module without re-executing it) is intentionally not addressed here; the test asserts importer tracking rather than the re-executed value so it stays valid when that lands.
