### PR TITLE
Fix panic on lazy-export modules in bun build --format=internal_bake_dev

### DIFF
--- a/src/bundler/linker_context/generateCodeForLazyExport.rs
+++ b/src/bundler/linker_context/generateCodeForLazyExport.rs
@@ -36,7 +36,18 @@ pub fn generate_code_for_lazy_export(
     this: &mut LinkerContext,
     source_index: IndexInt,
 ) -> Result<(), AllocError> {
-    let exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
+    let mut exports_kind = this.graph.ast.items_exports_kind()[source_index as usize];
+    // The dev server's module format represents lazy-export modules (JSON,
+    // TOML, CSS modules, ...) as CommonJS modules evaluated by the HMR
+    // runtime, so always generate the `module.exports = ...` form below.
+    // The ESM form would synthesize `export` parts that
+    // `print_dev_server_module` cannot represent.
+    if this.options.output_format == crate::options::OutputFormat::InternalBakeDev
+        && exports_kind != bun_ast::ExportsKind::Cjs
+    {
+        exports_kind = bun_ast::ExportsKind::Cjs;
+        this.graph.ast.items_exports_kind_mut()[source_index as usize] = exports_kind;
+    }
     // Take `parts` as a raw pointer *before* the
     // long-lived immutable `items_css()` borrow below; re-borrowed again later as needed.
     let parts: *mut [Part] = this.graph.ast.items_parts_mut()[source_index as usize].as_mut_slice();

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -7003,8 +7003,18 @@ pub mod __gated_printer {
                 .expect("infallible: variant checked")
                 .func;
 
-            // Special-case lazy-export AST
-            if ast.has_lazy_export {
+            // Special-case lazy-export AST. The `SLazyExport` stmt is only
+            // still present when linking skipped `generate_code_for_lazy_export`
+            // (the dev server's incremental graph); the full `link()` used by
+            // `bun build --format=internal_bake_dev` rewrites it into a
+            // `module.exports = ...` assignment printed by the CommonJS branch
+            // below.
+            let body_stmts = slice_of(func.body.stmts);
+            if ast.has_lazy_export
+                && let Some(lazy) = body_stmts
+                    .first()
+                    .and_then(|stmt| stmt.data.s_lazy_export())
+            {
                 self.print_fn_args(
                     Some(func.open_parens_loc),
                     slice_of(func.args),
@@ -7013,8 +7023,6 @@ pub mod __gated_printer {
                 );
                 self.print_space();
                 self.print(b"{\n");
-                let body_stmts = slice_of(func.body.stmts);
-                let lazy = body_stmts[0].data.s_lazy_export().unwrap();
                 if !matches!(*lazy, ExprData::EUndefined(_)) {
                     self.indent();
                     self.print_indent();
@@ -7036,7 +7044,7 @@ pub mod __gated_printer {
                 return;
             }
             // ESM is represented by an array tuple [ dependencies, exports, starImports, load, async ];
-            else if ast.exports_kind == js_ast::ExportsKind::Esm {
+            if ast.exports_kind == js_ast::ExportsKind::Esm {
                 self.print(b": [ [");
                 // Print the dependencies.
                 if stmts.len() > 1 {

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -286,6 +286,26 @@ describe("bundler", async () => {
       },
     });
 
+    itBundled("bake-dev/loader-jsonc-default-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import data from "./data.jsonc";
+          console.log(data.value);
+        `,
+        "/data.jsonc": `{
+          // comment
+          "value": 1,
+        }`,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.jsonc"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = {");
+        expect(output).toContain("value: 1");
+      },
+    });
+
     itBundled("bake-dev/loader-toml-default-import", {
       format: "internal_bake_dev",
       files: {
@@ -301,6 +321,38 @@ describe("bundler", async () => {
         expect(output).toContain("module.exports = {");
         expect(output).toContain("value: 1");
         expect(output).toContain("import_data.default.value");
+      },
+    });
+
+    itBundled("bake-dev/loader-empty-cjs-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import x from "./empty.cjs";
+          console.log(x);
+        `,
+        "/empty.cjs": "",
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"empty.cjs"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = {}");
+      },
+    });
+
+    itBundled("bake-dev/loader-empty-mjs-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import x from "./empty.mjs";
+          console.log(x);
+        `,
+        "/empty.mjs": "",
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"empty.mjs"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = undefined");
       },
     });
 

--- a/test/bundler/bundler_loader.test.ts
+++ b/test/bundler/bundler_loader.test.ts
@@ -218,4 +218,111 @@ describe("bundler", async () => {
       });
     }
   });
+
+  // Lazy-export modules (JSON, TOML, CSS modules, ...) used to crash the
+  // printer when bundled with the dev server's module format.
+  // https://github.com/oven-sh/bun/issues/31943
+  describe("internal_bake_dev lazy exports", () => {
+    itBundled("bake-dev/loader-json-default-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import data from "./data.json";
+          console.log(data.value);
+        `,
+        "/data.json": `{"value": 1}`,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.json"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = { value: 1 }");
+        expect(output).toContain("import_data.default.value");
+      },
+    });
+
+    itBundled("bake-dev/loader-json-named-and-star-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import { value } from "./data.json";
+          import * as ns from "./data.json";
+          console.log(value, ns.value);
+        `,
+        "/data.json": `{"value": 1}`,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.json"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = { value: 1 }");
+      },
+    });
+
+    itBundled("bake-dev/loader-json-require", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          const data = require("./data.json");
+          console.log(data.value);
+        `,
+        "/data.json": `{"value": 1}`,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.json"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = { value: 1 }");
+      },
+    });
+
+    itBundled("bake-dev/loader-json-entry-point", {
+      format: "internal_bake_dev",
+      files: {
+        "/data.json": `{"value": 1}`,
+      },
+      entryPoints: ["/data.json"],
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.json"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = { value: 1 }");
+      },
+    });
+
+    itBundled("bake-dev/loader-toml-default-import", {
+      format: "internal_bake_dev",
+      files: {
+        "/entry.ts": /* js */ `
+          import data from "./data.toml";
+          console.log(data.value);
+        `,
+        "/data.toml": `value = 1`,
+      },
+      onAfterBundle(api) {
+        const output = api.readFile("/out.js");
+        expect(output).toContain('"data.toml"(hmr, module, exports) {');
+        expect(output).toContain("module.exports = {");
+        expect(output).toContain("value: 1");
+        expect(output).toContain("import_data.default.value");
+      },
+    });
+
+    // CSS imports are delivered out-of-band by the dev server, so the JS
+    // chunk only contains the importing module. This used to panic while
+    // linking the CSS file's lazy-export JS stub.
+    itBundled("bake-dev/loader-css-module-import", {
+      format: "internal_bake_dev",
+      outdir: "/out",
+      files: {
+        "/entry.ts": /* js */ `
+          import styles from "./styles.module.css";
+          console.log(styles.foo);
+        `,
+        "/styles.module.css": `.foo { color: red; }`,
+      },
+      onAfterBundle(api) {
+        const jsFile = readdirSync(api.outdir).find(x => x.endsWith(".js"))!;
+        expect(api.readFile(join("/out", jsFile))).toContain('"entry.ts"');
+        const cssFile = readdirSync(api.outdir).find(x => x.endsWith(".css"))!;
+        expect(api.readFile(join("/out", cssFile))).toContain("color: red");
+      },
+    });
+  });
 });


### PR DESCRIPTION
Fixes #31943

### Repro

```sh
echo '{"value":1}' > data.json
echo 'import data from "./data.json"; console.log(data.value)' > index.ts
bun build --format=internal_bake_dev index.ts
```

```
panic: index out of bounds: the len is 0 but the index is 0
Crashed while printing /tmp/repro/data.json
panic: called `Option::unwrap()` on a `None` value
Crashed while printing /tmp/repro/data.json
```

Every lazy-export loader hits this in the internal_bake_dev format: JSON/JSONC/TOML imports, `require()` of JSON, a JSON entry point, CSS module imports, and empty `.cjs`/`.mjs` files.

### Cause

The standalone CLI path runs the full `link()`, which calls `generate_code_for_lazy_export` for every module with a lazy-export AST. Both arms of that transform destroy the `SLazyExport` stmt: the CJS arm rewrites it into a `module.exports = ...` assignment, and the ESM arm empties the stmt list while synthesizing `export` parts. `ast.has_lazy_export` stays set, and `print_dev_server_module` unconditionally did `body_stmts[0].data.s_lazy_export().unwrap()` whenever that flag was set, so it panicked on either arm's output (index out of bounds for the ESM arm, unwrap on None for the CJS arm).

The dev server itself never hits this because it calls `LinkerContext::load` without the full link, so the `SLazyExport` stmt reaches the printer intact.

### Fix

- `generateCodeForLazyExport.rs`: when the output format is `internal_bake_dev`, force `exports_kind` to CommonJS so the transform always generates the `module.exports = ...` form. The HMR runtime evaluates lazy-export modules as CJS (the dev server prints them as `hmr.cjs.exports = ...`), and the ESM form would synthesize export parts the dev-server module printer cannot represent.
- `js_printer/lib.rs`: apply the lazy-export special case in `print_dev_server_module` only while the `SLazyExport` stmt is actually intact (the dev server path, unchanged output), and fall through to the regular CommonJS printing for the rewritten form.

A JSON module now prints as a plain CJS dev module, matching how the format already prints `.cjs` files:

```js
"data.json"(hmr, module, exports) {
  module.exports = { value: 1 };
},
```

CSS module imports no longer panic; like the dev server, the JS chunk omits the CSS stub (CSS is delivered out of band) and the CSS chunk is emitted correctly.

### Verification

New tests in `test/bundler/bundler_loader.test.ts` cover JSON default/named/star imports, `require()` of JSON, a JSON entry point, TOML, and CSS modules under `format: "internal_bake_dev"`. They crash the bundler without this change and pass with it. Dev server output is unchanged: `test/bake/dev/bundle.test.ts`, `esm.test.ts`, and `css.test.ts` pass, and a manual `Bun.serve` HMR probe still prints `hmr.cjs.exports = { value: 1 }; // bun .s_lazy_export` for JSON modules. `bundler_loader.test.ts`, `bundler_edgecase.test.ts`, and `css/css-modules.test.ts` all pass.