### PR TITLE
Report connection resets during the TLS handshake as ECONNRESET instead of a certificate error

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -270,6 +270,15 @@ impl<'a> AsyncHTTP<'a> {
             .cast::<AsyncHTTP<'static>>()
     }
 
+    /// Whether any hop of this request performs a TLS handshake: the target
+    /// URL directly, or the proxy connection when one is configured.
+    ///
+    /// **Not thread safe while request is in-flight** (same caveat as
+    /// [`HTTPClient::is_https`]).
+    pub fn used_tls(&self) -> bool {
+        self.url.is_https() || self.client.is_https()
+    }
+
     /// Accessor for the global concurrent-request cap. Returned as a static
     /// so callers can `.load()` / `.store()` directly.
     #[inline]

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1473,14 +1473,18 @@ fn write_to_socket_with_buffer_fallback<const IS_SSL: bool>(
 // this file doesn't grow a dep on a header-generated const set.
 pub(crate) fn get_cert_error_from_no(error_no: i32) -> crate::Error {
     use crate::error::CertError;
-    // A connection reset/closed before the TLS handshake completes is
-    // delivered as a synthesized verify error with a negative `error_no`
-    // (`ssl_trigger_handshake_econnreset` in
-    // packages/bun-usockets/src/crypto/openssl.c: error -46, code
-    // "ECONNRESET"). `X509_V_ERR_*` codes are all non-negative, so a negative
-    // value is never a certificate problem; report the connection error
-    // (Node surfaces this case as ECONNRESET too) instead of
+    // uSockets synthesizes negative `error_no` sentinels for handshake
+    // failures that are not certificate problems (`X509_V_ERR_*` codes are
+    // all non-negative): -71/"EPROTO" for a fatal TLS protocol error
+    // (`ssl_dispatch_parked_reason`) and -46/"ECONNRESET" for a connection
+    // reset/closed before the handshake completed
+    // (`ssl_trigger_handshake_econnreset`), both in
+    // packages/bun-usockets/src/crypto/openssl.c. Report them with Node's
+    // codes for the same cases instead of
     // UNKNOWN_CERTIFICATE_VERIFICATION_ERROR.
+    if error_no == -71 {
+        return crate::Error::Sys(bun_errno::SystemErrno::EPROTO);
+    }
     if error_no < 0 {
         return crate::Error::Sys(bun_errno::SystemErrno::ECONNRESET);
     }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1464,7 +1464,7 @@ fn write_to_socket_with_buffer_fallback<const IS_SSL: bool>(
 //    and ProxyTunnel.rs.
 // ────────────────────────────────────────────────────────────────────────
 
-/// Maps an X509 verify code
+/// Maps the `error_no` of the uSockets handshake verify error
 /// onto a `crate::Error` whose name is the upper-snake error tag
 /// (e.g. `CERT_HAS_EXPIRED`). JS-side `error.code` matches on this exact
 /// string, so do NOT substitute `X509_verify_cert_error_string` output here.
@@ -1473,6 +1473,17 @@ fn write_to_socket_with_buffer_fallback<const IS_SSL: bool>(
 // this file doesn't grow a dep on a header-generated const set.
 pub(crate) fn get_cert_error_from_no(error_no: i32) -> crate::Error {
     use crate::error::CertError;
+    // A connection reset/closed before the TLS handshake completes is
+    // delivered as a synthesized verify error with a negative `error_no`
+    // (`ssl_trigger_handshake_econnreset` in
+    // packages/bun-usockets/src/crypto/openssl.c: error -46, code
+    // "ECONNRESET"). `X509_V_ERR_*` codes are all non-negative, so a negative
+    // value is never a certificate problem; report the connection error
+    // (Node surfaces this case as ECONNRESET too) instead of
+    // UNKNOWN_CERTIFICATE_VERIFICATION_ERROR.
+    if error_no < 0 {
+        return crate::Error::Sys(bun_errno::SystemErrno::ECONNRESET);
+    }
     crate::Error::Cert(match error_no {
         0 => CertError::OK, // X509_V_OK
         2 => CertError::UNABLE_TO_GET_ISSUER_CERT,

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1352,13 +1352,7 @@ impl FetchTasklet {
         // sendfile body path surfacing the raw errno (`SendFile::write`,
         // which is `url.is_http()`-only). Only emit the TLS-specific message
         // when some hop of this request actually performs a TLS handshake.
-        let used_tls = self.http.as_ref().is_some_and(|http_| {
-            http_.url.is_https()
-                || http_
-                    .http_proxy
-                    .as_ref()
-                    .is_some_and(|proxy| proxy.is_https())
-        });
+        let used_tls = self.http.as_ref().is_some_and(|http_| http_.used_tls());
 
         let message = match fail {
             http::Error::ConnectionClosed => BunString::static_(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1347,9 +1347,27 @@ impl FetchTasklet {
             BunString::static_(fail.name())
         };
 
+        // `Error::Sys(ECONNRESET)` has two producers: the mid-TLS-handshake
+        // reset sentinel (`get_cert_error_from_no`) and the plain-HTTP
+        // sendfile body path surfacing the raw errno (`SendFile::write`,
+        // which is `url.is_http()`-only). Only emit the TLS-specific message
+        // when some hop of this request actually performs a TLS handshake.
+        let used_tls = self.http.as_ref().is_some_and(|http_| {
+            http_.url.is_https()
+                || http_
+                    .http_proxy
+                    .as_ref()
+                    .is_some_and(|proxy| proxy.is_https())
+        });
+
         let message = match fail {
             http::Error::ConnectionClosed => BunString::static_(
                 "The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()",
+            ),
+            // Connection reset/closed before the TLS handshake completed;
+            // message matches Node's ConnResetException for the same case.
+            http::Error::Sys(bun_errno::SystemErrno::ECONNRESET) if used_tls => BunString::static_(
+                "Client network socket disconnected before secure TLS connection was established",
             ),
             http::Error::FailedToOpenSocket => {
                 BunString::static_("Was there a typo in the url or port?")

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -78,19 +78,22 @@ test("bun install times out when the registry accepts TCP but never completes th
 
 // https://github.com/oven-sh/bun/issues/31949
 //
-// A registry connection that is reset during the TLS handshake involves no
-// certificate at all, so `bun install` must report it as ECONNRESET (the code
-// Node and npm surface), not as UNKNOWN_CERTIFICATE_VERIFICATION_ERROR, which
-// sends users hunting through CA stores for a network problem.
-test("bun install reports ECONNRESET when the registry resets the connection during the TLS handshake", async () => {
+// A registry connection that dies during the TLS handshake involves no
+// certificate at all, so `bun install` must report it as a connection error
+// (ECONNRESET, the code Node and npm surface), never as
+// UNKNOWN_CERTIFICATE_VERIFICATION_ERROR, which sends users hunting through
+// CA stores for a network problem. A FIN (socket.destroy) reaches the SSL
+// close path and its mid-handshake sentinel; a peer RST raw-closes the
+// socket before the SSL layer sees it and reports ConnectionClosed instead.
+test("bun install reports a connection error when the registry closes the connection during the TLS handshake", async () => {
   // Raw TCP listener: accepts the connection, reads the ClientHello, and
-  // resets the socket without ever writing a TLS byte back.
+  // closes the socket without ever writing a TLS byte back.
   const sockets = new Set<net.Socket>();
   const server = net.createServer(socket => {
     sockets.add(socket);
     socket.on("close", () => sockets.delete(socket));
     socket.on("error", () => {});
-    socket.once("data", () => socket.resetAndDestroy());
+    socket.once("data", () => socket.destroy());
   });
   const { promise: listening, resolve: onListening, reject: onListenError } = Promise.withResolvers<void>();
   // Left attached after listen succeeds: rejecting a settled promise is a
@@ -128,8 +131,10 @@ test("bun install reports ECONNRESET when the registry resets the connection dur
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     const combined = stdout + stderr;
-    expect(combined).toContain("ECONNRESET downloading package manifest left-pad");
     expect(combined).not.toContain("UNKNOWN_CERTIFICATE_VERIFICATION_ERROR");
+    // ECONNRESET from the handshake sentinel; ConnectionClosed when the
+    // platform's event loop raw-closes the socket before the SSL layer runs.
+    expect(combined).toMatch(/error: (ECONNRESET|ConnectionClosed) downloading package manifest left-pad/);
     expect(exitCode).not.toBe(0);
   } finally {
     for (const s of sockets) s.destroy();

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -92,7 +92,10 @@ test("bun install reports ECONNRESET when the registry resets the connection dur
     socket.on("error", () => {});
     socket.once("data", () => socket.resetAndDestroy());
   });
-  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const { promise: listening, resolve: onListening, reject: onListenError } = Promise.withResolvers<void>();
+  server.once("error", onListenError);
+  server.listen(0, "127.0.0.1", onListening);
+  await listening;
   const port = (server.address() as net.AddressInfo).port;
 
   try {

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -13,6 +13,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import * as net from "node:net";
+import { join } from "node:path";
 
 test("bun install times out when the registry accepts TCP but never completes the TLS handshake", async () => {
   // Raw TCP listener: accepts the connection, reads (and discards) the
@@ -74,3 +75,59 @@ test("bun install times out when the registry accepts TCP but never completes th
     await new Promise<void>(resolve => server.close(() => resolve()));
   }
 }, 60_000);
+
+// https://github.com/oven-sh/bun/issues/31949
+//
+// A registry connection that is reset during the TLS handshake involves no
+// certificate at all, so `bun install` must report it as ECONNRESET (the code
+// Node and npm surface), not as UNKNOWN_CERTIFICATE_VERIFICATION_ERROR, which
+// sends users hunting through CA stores for a network problem.
+test("bun install reports ECONNRESET when the registry resets the connection during the TLS handshake", async () => {
+  // Raw TCP listener: accepts the connection, reads the ClientHello, and
+  // resets the socket without ever writing a TLS byte back.
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer(socket => {
+    sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    socket.on("error", () => {});
+    socket.once("data", () => socket.resetAndDestroy());
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as net.AddressInfo).port;
+
+  try {
+    using dir = tempDir("install-handshake-reset", {
+      "package.json": JSON.stringify({
+        name: "reset-repro",
+        version: "1.0.0",
+        dependencies: { "left-pad": "1.3.0" },
+      }),
+      "bunfig.toml": `[install]\nregistry = "https://127.0.0.1:${port}/"\n`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "install"],
+      env: {
+        ...bunEnv,
+        // Keep the manifest lookup off any shared cache so the request always
+        // hits the failing registry.
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+        // One failed attempt is enough to observe the error.
+        BUN_CONFIG_HTTP_RETRY_COUNT: "0",
+      },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const combined = stdout + stderr;
+    expect(combined).toContain("ECONNRESET downloading package manifest left-pad");
+    expect(combined).not.toContain("UNKNOWN_CERTIFICATE_VERIFICATION_ERROR");
+    expect(exitCode).not.toBe(0);
+  } finally {
+    for (const s of sockets) s.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+});

--- a/test/cli/install/bun-install-stalled-tls.test.ts
+++ b/test/cli/install/bun-install-stalled-tls.test.ts
@@ -93,6 +93,8 @@ test("bun install reports ECONNRESET when the registry resets the connection dur
     socket.once("data", () => socket.resetAndDestroy());
   });
   const { promise: listening, resolve: onListening, reject: onListenError } = Promise.withResolvers<void>();
+  // Left attached after listen succeeds: rejecting a settled promise is a
+  // no-op, and it keeps a later server-level "error" from crashing the test.
   server.once("error", onListenError);
   server.listen(0, "127.0.0.1", onListening);
   await listening;

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -513,9 +513,15 @@ describe.concurrent("fetch-tls", () => {
   // A connection reset/closed mid-TLS-handshake involves no certificate at
   // all, so it must surface as ECONNRESET (like Node), not as a certificate
   // verification error. https://github.com/oven-sh/bun/issues/31949
-  for (const [closeMode, closeSocket] of [
-    ["resets (RST)", (socket: net.Socket) => socket.resetAndDestroy()],
-    ["closes (FIN)", (socket: net.Socket) => socket.destroy()],
+  //
+  // The two variants take different paths: a FIN reaches the SSL close path
+  // and its mid-handshake sentinel, while a peer RST raw-closes the socket
+  // (see the POLL_TYPE_SOCKET error arm in packages/bun-usockets/src/loop.c)
+  // and surfaces as the generic connection-closed failure. Both carry the
+  // ECONNRESET code; only the FIN path has Node's handshake-specific message.
+  for (const [closeMode, closeSocket, viaHandshakeSentinel] of [
+    ["resets (RST)", (socket: net.Socket) => socket.resetAndDestroy(), false],
+    ["closes (FIN)", (socket: net.Socket) => socket.destroy(), true],
   ] as const) {
     it(`fetch reports ECONNRESET when the server ${closeMode} the connection during the TLS handshake`, async () => {
       // Raw TCP listener: accepts the connection, reads the ClientHello, and
@@ -548,7 +554,7 @@ describe.concurrent("fetch-tls", () => {
         // The load-bearing invariant: a mid-handshake reset is a connection
         // error, never a certificate error.
         expect(err.code).toBe("ECONNRESET");
-        if (!isWindows) {
+        if (viaHandshakeSentinel && !isWindows) {
           // Node's exact message for this case. On Windows CI the error
           // carries a different (still ECONNRESET-coded) message, so the
           // exact-text assertion is POSIX-only.

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
 import { readFileSync } from "node:fs";
+import net from "node:net";
 import { join } from "node:path";
 import tls from "node:tls";
 
@@ -508,6 +509,49 @@ describe.concurrent("fetch-tls", () => {
       );
     });
   });
+
+  // A connection reset/closed mid-TLS-handshake involves no certificate at
+  // all, so it must surface as ECONNRESET (like Node), not as a certificate
+  // verification error. https://github.com/oven-sh/bun/issues/31949
+  for (const [closeMode, closeSocket] of [
+    ["resets (RST)", (socket: net.Socket) => socket.resetAndDestroy()],
+    ["closes (FIN)", (socket: net.Socket) => socket.destroy()],
+  ] as const) {
+    it(`fetch reports ECONNRESET when the server ${closeMode} the connection during the TLS handshake`, async () => {
+      // Raw TCP listener: accepts the connection, reads the ClientHello, and
+      // kills the socket without ever writing a TLS byte back.
+      const sockets = new Set<net.Socket>();
+      const server = net.createServer(socket => {
+        sockets.add(socket);
+        socket.on("close", () => sockets.delete(socket));
+        socket.on("error", () => {});
+        socket.once("data", () => closeSocket(socket));
+      });
+      const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+      server.listen(0, "127.0.0.1", onListening);
+      try {
+        await listening;
+        const port = (server.address() as net.AddressInfo).port;
+
+        let err: any;
+        try {
+          await fetch(`https://127.0.0.1:${port}/`, { keepalive: false });
+          expect.unreachable();
+        } catch (e) {
+          err = e;
+        }
+
+        expect(err).toBeInstanceOf(Error);
+        expect({ code: err.code, message: err.message }).toEqual({
+          code: "ECONNRESET",
+          message: "Client network socket disconnected before secure TLS connection was established",
+        });
+      } finally {
+        for (const s of sockets) s.destroy();
+        server.close();
+      }
+    });
+  }
 
   it("fetch with checkServerIdentity failing should throw", async () => {
     await createServer(CERT_LOCALHOST_IP, async port => {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -527,7 +527,10 @@ describe.concurrent("fetch-tls", () => {
         socket.on("error", () => {});
         socket.once("data", () => closeSocket(socket));
       });
-      const { promise: listening, resolve: onListening } = Promise.withResolvers<void>();
+      const { promise: listening, resolve: onListening, reject: onListenError } = Promise.withResolvers<void>();
+      // Left attached after listen succeeds: rejecting a settled promise is a
+      // no-op, and it keeps a later server-level "error" from crashing the test.
+      server.once("error", onListenError);
       server.listen(0, "127.0.0.1", onListening);
       try {
         await listening;

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -552,9 +552,7 @@ describe.concurrent("fetch-tls", () => {
           // Node's exact message for this case. On Windows CI the error
           // carries a different (still ECONNRESET-coded) message, so the
           // exact-text assertion is POSIX-only.
-          expect(err.message).toBe(
-            "Client network socket disconnected before secure TLS connection was established",
-          );
+          expect(err.message).toBe("Client network socket disconnected before secure TLS connection was established");
         }
       } finally {
         for (const s of sockets) s.destroy();

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -567,6 +567,29 @@ describe.concurrent("fetch-tls", () => {
     });
   }
 
+  // A fatal TLS protocol error (the peer answers the ClientHello with
+  // non-TLS bytes) is the other non-certificate handshake failure: uSockets
+  // reports it as the -71/"EPROTO" sentinel (ssl_dispatch_parked_reason),
+  // and it must surface as EPROTO like Node, not as a certificate error.
+  it("fetch reports EPROTO when the server speaks plain HTTP during the TLS handshake", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("ok"),
+    });
+
+    let err: any;
+    try {
+      await fetch(`https://127.0.0.1:${server.port}/`, { keepalive: false });
+      expect.unreachable();
+    } catch (e) {
+      err = e;
+    }
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe("EPROTO");
+  });
+
   it("fetch with checkServerIdentity failing should throw", async () => {
     await createServer(CERT_LOCALHOST_IP, async port => {
       try {

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isASAN, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, tmpdirSync } from "harness";
 import { readFileSync } from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -545,10 +545,17 @@ describe.concurrent("fetch-tls", () => {
         }
 
         expect(err).toBeInstanceOf(Error);
-        expect({ code: err.code, message: err.message }).toEqual({
-          code: "ECONNRESET",
-          message: "Client network socket disconnected before secure TLS connection was established",
-        });
+        // The load-bearing invariant: a mid-handshake reset is a connection
+        // error, never a certificate error.
+        expect(err.code).toBe("ECONNRESET");
+        if (!isWindows) {
+          // Node's exact message for this case. On Windows CI the error
+          // carries a different (still ECONNRESET-coded) message, so the
+          // exact-text assertion is POSIX-only.
+          expect(err.message).toBe(
+            "Client network socket disconnected before secure TLS connection was established",
+          );
+        }
       } finally {
         for (const s of sockets) s.destroy();
         server.close();


### PR DESCRIPTION
Fixes #31949

### Symptom

`bun install` against a registry whose connections die mid-TLS-handshake reports:

```
error: UNKNOWN_CERTIFICATE_VERIFICATION_ERROR downloading package manifest vite
```

while `curl`, `openssl s_client`, `npm`, and a single `fetch()` against the same host all verify the chain fine, and no CA knob (`--use-system-ca`, `NODE_USE_SYSTEM_CA`, `NODE_EXTRA_CA_CERTS`) changes anything.

### Root cause

This is not a certificate problem. When a connection is reset or closed before the TLS handshake completes, uSockets synthesizes a verify error with `error = -46` and code `ECONNRESET` (`ssl_trigger_handshake_econnreset` in `packages/bun-usockets/src/crypto/openssl.c`). The HTTP client's handshake handlers treat any nonzero `error_no` as an X509 verify code and funnel it through `get_cert_error_from_no`, where `-46` falls through to `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`.

That label sent the reporter on a multi-day CA-store hunt for what is actually a network appliance killing connections (their hardened CI; `bun install` opens up to 64 parallel connections while curl/npm/fetch open one, which is why only install tripped it).

Reproducible with no certificates involved at all, with a plain TCP server that accepts, reads the ClientHello, and resets the socket:

```
$ bun install          # registry pointed at the reset server
error: UNKNOWN_CERTIFICATE_VERIFICATION_ERROR downloading package manifest left-pad

$ bun -e "fetch('https://127.0.0.1:<port>/').catch(e => console.log(e.code, '|', e.message))"
UNKNOWN_CERTIFICATE_VERIFICATION_ERROR | unknown certificate verification error
```

Node reports the identical scenario as `ECONNRESET` with "Client network socket disconnected before secure TLS connection was established".

### Fix

- `src/http/lib.rs`: `get_cert_error_from_no` maps negative `error_no` to `ECONNRESET`. `X509_V_ERR_*` codes are all non-negative, so a negative value is never a certificate error; the only producer is the uSockets mid-handshake reset sentinel. This is the shared helper behind all handshake handlers (`HTTPContext::on_handshake` and both `ProxyTunnel::on_handshake` sites), so every caller is fixed at once.
- `src/runtime/webcore/fetch/FetchTasklet.rs`: map the `ECONNRESET` failure to Node's message for this case, "Client network socket disconnected before secure TLS connection was established". The message is gated on the request (or its proxy) using TLS, because the plain-HTTP sendfile body path also surfaces a raw `ECONNRESET` errno for mid-upload resets; those keep the generic message. The error `code` is `ECONNRESET` in both cases.

After the fix:

```
$ bun install
error: ECONNRESET downloading package manifest left-pad
```

`bun install` retry behavior is unchanged (manifest retries key on missing metadata, not the error name). The WebSocket client's handshake handler already reports a generic TLS handshake failure rather than a certificate error, so it is not touched.

### Tests

- `test/js/web/fetch/fetch.tls.test.ts`: fetch against a server that resets (RST) or closes (FIN) the connection during the handshake must reject with `code: "ECONNRESET"`; the FIN variant additionally asserts the Node-parity message on POSIX. The two variants take different paths: a FIN reaches the SSL close path and the mid-handshake sentinel this PR fixes, while a peer RST raw-closes the socket before the SSL layer runs (the POLL_TYPE_SOCKET error arm in packages/bun-usockets/src/loop.c) and surfaces as the generic connection-closed failure, which already carried the ECONNRESET code.
- `test/cli/install/bun-install-stalled-tls.test.ts`: `bun install` against a registry that closes the connection mid-handshake must print a connection error (`ECONNRESET` via the sentinel, or `ConnectionClosed` on platforms whose event loop raw-closes first) and never `UNKNOWN_CERTIFICATE_VERIFICATION_ERROR`.

The FIN-driven tests fail on the unfixed build with exactly the mislabel from the issue and pass with this change.

### Rebase notes

Rebased over the error-handling refactor that replaced interned error names with per-crate thiserror enums (#33909). The fix is the same shape in the new idiom: `get_cert_error_from_no` returns `Error::Sys(SystemErrno::ECONNRESET)` for negative `error_no`, and the fetch message arm matches that variant. The sendfile collision gate is unchanged (that path now produces the same `Error::Sys` value via `bun_errno::from_errno`). Upstream also changed peer-RST handling to raw-close the socket before the SSL layer runs (#32681), so the RST variants no longer exercise the sentinel; the tests were adjusted as described above, and fail-before was re-verified against the new base.

A later rebase dropped the timeout-test fixture commit (main adopted an equivalent 127.0.0.1 binding fix) and adapted the message gate to the per-hop proxy refactor: `http_proxy` moved to `HTTPClient` as crate-private, so the gate now uses a small `AsyncHTTP::used_tls()` helper covering both the target URL and the proxy hop.

The rebase also picked up a second negative sentinel added upstream in #33390: -71/EPROTO for fatal TLS protocol errors (`ssl_dispatch_parked_reason`). It is mapped to EPROTO (Node parity) rather than being swallowed by the reset mapping, with a regression test (https fetch against a plain-HTTP listener must reject with `code: "EPROTO"`, not a certificate error).

One pre-existing test in the same file, `fetch timeout works on tls`, failed on some hosts independently of this change: its server used `hostname: "localhost"`, which binds ::1 only on hosts whose resolver returns the IPv6 loopback first, while fetch connects to 127.0.0.1, so the request died with ConnectionRefused before the timeout under test could fire. The fixture now binds 127.0.0.1 explicitly; the assertions are unchanged. With that, both test files pass fully.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 10 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/fetch/fetch.tls.test.ts

<!-- robobun:evidence:end -->

