### PR TITLE
ci: update the process.versions test hash in dep update workflows

### DIFF
--- a/.github/workflows/update-cares.yml
+++ b/.github/workflows/update-cares.yml
@@ -79,6 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const CARES_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/cares.ts
+          # process.versions pins the same commit (key "ares"); update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*ares: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "ares: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -87,6 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/cares.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update c-ares to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update c-ares to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-libarchive.yml
+++ b/.github/workflows/update-libarchive.yml
@@ -79,6 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const LIBARCHIVE_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/libarchive.ts
+          # process.versions pins the same commit; update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*libarchive: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "libarchive: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -87,6 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/libarchive.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update libarchive to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libarchive to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-libdeflate.yml
+++ b/.github/workflows/update-libdeflate.yml
@@ -79,6 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const LIBDEFLATE_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/libdeflate.ts
+          # process.versions pins the same commit; update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*libdeflate: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "libdeflate: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -87,6 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/libdeflate.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update libdeflate to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-lolhtml.yml
+++ b/.github/workflows/update-lolhtml.yml
@@ -91,6 +91,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const LOLHTML_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/lolhtml.ts
+          # process.versions pins the same commit; update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*lolhtml: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "lolhtml: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -99,6 +102,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/lolhtml.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lolhtml to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-lshpack.yml
+++ b/.github/workflows/update-lshpack.yml
@@ -96,6 +96,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const LSHPACK_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/lshpack.ts
+          # process.versions pins the same commit; update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*lshpack: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "lshpack: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -104,6 +107,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/lshpack.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update lshpack to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update lshpack to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true

--- a/.github/workflows/update-zstd.yml
+++ b/.github/workflows/update-zstd.yml
@@ -79,6 +79,9 @@ jobs:
         run: |
           set -euo pipefail
           sed -i -E 's/^(const ZSTD_COMMIT = ")[0-9a-f]{40}(";)$/\1'"$LATEST"'\2/' scripts/build/deps/zstd.ts
+          # process.versions pins the same commit; update it or the process.versions test fails
+          sed -i -E 's/^([[:space:]]*zstd: ")[0-9a-f]{40}(",)$/\1'"$LATEST"'\2/' test/js/node/process/process.test.js
+          grep -qF "zstd: \"$LATEST\"" test/js/node/process/process.test.js
 
       - name: Create Pull Request
         if: success() && steps.check-version.outputs.current != steps.check-version.outputs.latest
@@ -87,6 +90,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           add-paths: |
             scripts/build/deps/zstd.ts
+            test/js/node/process/process.test.js
           commit-message: "deps: update zstd to ${{ steps.check-version.outputs.tag }} (${{ steps.check-version.outputs.latest }})"
           title: "deps: update zstd to ${{ steps.check-version.outputs.tag }}"
           delete-branch: true


### PR DESCRIPTION
## What does this PR do?

The dep auto-update workflows (c-ares, libarchive, libdeflate, lolhtml, lshpack, zstd) bump the commit in `scripts/build/deps/<name>.ts` but not the matching pinned hash in `test/js/node/process/process.test.js`, so every PR they open fails the `process.versions` test on all test lanes. The test pins these hashes on purpose (its comment says bumping a dep requires updating it too).

This bit #31315: the lshpack test lanes were red, and because the workflow regenerates its branch with `add-paths` limited to the dep file, a manually pushed test fix was wiped by the next force-push. It had to be re-applied three times.

Fix, in each of the six workflows:
- the update step also rewrites the matching key in `process.test.js` (key `ares` for c-ares)
- a `grep` right after verifies the new hash landed in the test file, so the job fails loudly if the test file's shape ever drifts instead of regressing to broken auto-PRs
- `add-paths` includes the test file so the change is committed

Workflows for deps not pinned in the test (hdrhistogram, highway, sqlite3, root-certs, vendor) are unchanged.

## How did you verify your code works?

Simulated the new step locally for each of the six keys against the real test file: the sed rewrites exactly one line and the grep passes. Also exercised the failure path: with the key renamed so the sed cannot match, the grep exits 1, which fails the step under `set -euo pipefail`. All six YAML files validated with a YAML parser.