### PR TITLE
Fix missing exception check on Bun.plugin target coercion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,8 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import { resolve } from "path";
 
 declare global {
@@ -364,6 +364,23 @@ describe("errors", () => {
     expect(() => {
       plugin(opts as any);
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
+  });
+
+  it("handles a 'target' whose toString throws", () => {
+    const setup = jest.fn();
+    const opts = {
+      setup,
+      target: {
+        toString() {
+          throw new Error("boom from target toString");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("boom from target toString");
+    expect(setup).not.toHaveBeenCalled();
   });
 
   it("invalid loaders throw", () => {


### PR DESCRIPTION
Fuzzing found a debug assertion failure (`ExceptionScope::assertNoException`, fingerprint `351df89ce3773a75`) in `Bun.plugin()`:

```js
const v0 = {};
function f1() { return v0; }
f1.toString = f1;
Bun.plugin({ target: f1, setup: ArrayBuffer });
```

### Root cause

`setupBunPlugin` in `src/jsc/bindings/BunPlugin.cpp` coerces the `target` option with `toStringOrNull()`, which can run user JS (`toString`/`valueOf`). When that coercion throws (here, `OrdinaryToPrimitive` fails with "No default value"), `toStringOrNull()` returns null, the validation block was skipped, and execution continued with the exception still pending: the builder object was constructed and `setup()` was invoked. Debug builds abort on the assertion when re-entering the VM; release builds incorrectly call `setup()` before the error finally surfaces.

### Fix

Add the two missing `RETURN_IF_EXCEPTION` checks after `toStringOrNull()` and `JSString::value()` so the exception propagates to the caller as a normal catchable error. The other string coercions in this file already check exceptions correctly.

### Test

Added `handles a 'target' whose toString throws` to `test/js/bun/plugin/plugins.test.ts`, next to the existing invalid-target test. It asserts the thrown error propagates and that `setup` is never invoked. On the unfixed build it fails with `setup` called once (release) or the assertion abort (debug); it passes with this fix.