### PR TITLE
Fall back to source when a compiled executable's embedded bytecode is corrupted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2026,6 +2026,7 @@ dependencies = [
  "bun_sys",
  "bun_threading",
  "bun_url",
+ "bun_wyhash",
  "bun_zlib",
  "bun_zstd",
  "const_format",

--- a/src/ast/loader.rs
+++ b/src/ast/loader.rs
@@ -21,6 +21,7 @@ use enum_map::Enum;
     Debug,
     Hash,
     Enum,
+    strum::FromRepr,
     strum::IntoStaticStr,
     strum::VariantNames,
 )]

--- a/src/standalone_graph/Cargo.toml
+++ b/src/standalone_graph/Cargo.toml
@@ -39,5 +39,6 @@ bun_sourcemap.workspace = true
 bun_sys.workspace = true
 bun_threading.workspace = true
 bun_url.workspace = true
+bun_wyhash.workspace = true
 bun_zlib.workspace = true
 bun_zstd.workspace = true

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -255,7 +255,7 @@ pub(crate) struct CompiledModuleGraphFile {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum FileSide {
     #[default]
     Server = 0,
@@ -263,7 +263,7 @@ pub enum FileSide {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum Encoding {
     Binary = 0,
     #[default]
@@ -273,7 +273,7 @@ pub enum Encoding {
 }
 
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, PartialEq, Eq, Default, strum::FromRepr)]
 pub enum ModuleFormat {
     #[default]
     None = 0,
@@ -584,7 +584,7 @@ impl StandaloneModuleGraph {
         // is just as out of bounds as `> count`.
         if offsets.entry_point_id as usize >= modules_list_count {
             return Err(err!(
-                "Corrupted module graph: entry point ID is greater than module list count"
+                "Corrupted module graph: entry point ID is out of bounds"
             ));
         }
 
@@ -592,13 +592,40 @@ impl StandaloneModuleGraph {
         modules.reserve(modules_list_count);
         for i in 0..modules_list_count {
             // SAFETY: index < count derived from byte length above; bytes live for 'static.
-            let module: CompiledModuleGraphFile = unsafe {
-                core::ptr::read_unaligned(
-                    modules_list_base
-                        .add(i * size_of::<CompiledModuleGraphFile>())
-                        .cast::<CompiledModuleGraphFile>(),
-                )
-            };
+            let record_base =
+                unsafe { modules_list_base.add(i * size_of::<CompiledModuleGraphFile>()) };
+
+            // The record's `#[repr(u8)]` enum fields come from the untrusted
+            // blob, and materializing an enum from an out-of-range discriminant
+            // is UB, so validate the raw bytes before `read_unaligned` produces
+            // the typed record.
+            {
+                // SAFETY: `offset < size_of::<CompiledModuleGraphFile>()` and the
+                // whole record is in-bounds per above; u8 reads need no alignment.
+                let enum_byte = |offset: usize| -> u8 { unsafe { record_base.add(offset).read() } };
+                use core::mem::offset_of;
+                if Loader::from_repr(enum_byte(offset_of!(CompiledModuleGraphFile, loader)))
+                    .is_none()
+                    || Encoding::from_repr(enum_byte(offset_of!(CompiledModuleGraphFile, encoding)))
+                        .is_none()
+                    || ModuleFormat::from_repr(enum_byte(offset_of!(
+                        CompiledModuleGraphFile,
+                        module_format
+                    )))
+                    .is_none()
+                    || FileSide::from_repr(enum_byte(offset_of!(CompiledModuleGraphFile, side)))
+                        .is_none()
+                {
+                    return Err(err!(
+                        "Corrupted module graph: invalid enum value in module record"
+                    ));
+                }
+            }
+
+            // SAFETY: record is in-bounds per above and every enum discriminant
+            // was just validated.
+            let module: CompiledModuleGraphFile =
+                unsafe { core::ptr::read_unaligned(record_base.cast::<CompiledModuleGraphFile>()) };
             let module = &module;
 
             check_ptr(raw_len, module.name, true)?;

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -557,7 +557,8 @@ impl StandaloneModuleGraph {
         // must not hold a long-lived `&[u8]` that *spans* a writable subrange (a foreign write
         // would invalidate it under Stacked/Tree Borrows). Keep `(raw_ptr, raw_len)` raw and
         // derive every read-only `&'static [u8]` per-call over its own disjoint subrange only;
-        // the bytecode/module_info regions never have a shared reference formed over them.
+        // the bytecode/module_info regions only get a short-lived `&[u8]` during the hash
+        // check below, dropped before `slice_to_mut` derives their `*mut`.
         let raw_const: *const u8 = raw_ptr;
 
         // Every offset/length below comes straight from the (possibly
@@ -567,8 +568,8 @@ impl StandaloneModuleGraph {
         if offsets.byte_count > raw_len {
             return Err(err!("Corrupted module graph: byte count is out of bounds"));
         }
-        check_ptr(raw_len, offsets.modules_ptr, false)?;
-        check_ptr(raw_len, offsets.compile_exec_argv_ptr, true)?;
+        check_ptr(raw_const, raw_len, offsets.modules_ptr, false)?;
+        check_ptr(raw_const, raw_len, offsets.compile_exec_argv_ptr, true)?;
 
         // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)` disjoint
         // from bytecode/module_info, serialized by `to_bytes`.
@@ -577,6 +578,11 @@ impl StandaloneModuleGraph {
         // `&[CompiledModuleGraphFile]` would require natural alignment (StringPointer's u32 fields
         // → 4-byte). We instead iterate by index and `read_unaligned` each fixed-size record into a
         // local (`CompiledModuleGraphFile` is `Copy`/POD), so no `&T` ever points at unaligned memory.
+        // The writer always emits an exact multiple of the record size, so a
+        // remainder means the table was truncated or rewritten.
+        if modules_list_bytes.len() % size_of::<CompiledModuleGraphFile>() != 0 {
+            return Err(err!("Corrupted module graph: module table is truncated"));
+        }
         let modules_list_count = modules_list_bytes.len() / size_of::<CompiledModuleGraphFile>();
         let modules_list_base = modules_list_bytes.as_ptr();
 
@@ -628,12 +634,12 @@ impl StandaloneModuleGraph {
                 unsafe { core::ptr::read_unaligned(record_base.cast::<CompiledModuleGraphFile>()) };
             let module = &module;
 
-            check_ptr(raw_len, module.name, true)?;
-            check_ptr(raw_len, module.contents, true)?;
-            check_ptr(raw_len, module.sourcemap, false)?;
-            check_ptr(raw_len, module.bytecode, false)?;
-            check_ptr(raw_len, module.module_info, false)?;
-            check_ptr(raw_len, module.bytecode_origin_path, true)?;
+            check_ptr(raw_const, raw_len, module.name, true)?;
+            check_ptr(raw_const, raw_len, module.contents, true)?;
+            check_ptr(raw_const, raw_len, module.sourcemap, false)?;
+            check_ptr(raw_const, raw_len, module.bytecode, false)?;
+            check_ptr(raw_const, raw_len, module.module_info, false)?;
+            check_ptr(raw_const, raw_len, module.bytecode_origin_path, true)?;
 
             // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is in-bounds
             // (checked above) and disjoint from the writable bytecode/module_info
@@ -685,6 +691,18 @@ impl StandaloneModuleGraph {
                     module_info_ptr = StringPointer::default();
                     bytecode_origin_path = b"";
                 }
+            } else if module_info_ptr.length > 0 || !bytecode_origin_path.is_empty() {
+                // The writer only emits module_info/bytecode_origin_path
+                // alongside bytecode, so a record carrying either without
+                // bytecode is corrupt (e.g. only the bytecode length field was
+                // stomped, skipping the hash check above). Drop them so the
+                // module falls back to plain source like the mismatch arm.
+                bun_core::debug_warn!(
+                    "module record for {} has module_info without bytecode; falling back to source",
+                    bstr::BStr::new(name.as_bytes())
+                );
+                module_info_ptr = StringPointer::default();
+                bytecode_origin_path = b"";
             }
 
             let _ = modules.put(
@@ -747,11 +765,18 @@ impl StandaloneModuleGraph {
 }
 
 /// Bounds check for a blob-controlled `StringPointer` read from the embedded
-/// section. The `slice_to*` helpers below only `debug_assert!` their bounds,
-/// so `from_bytes` calls this first: a corrupted executable must fail with an
-/// error in release builds, not read out of bounds. `nul_terminated` subranges
-/// additionally require the trailing NUL written by `append_count_z`.
-fn check_ptr(len: usize, ptr: StringPointer, nul_terminated: bool) -> Result<(), BunError> {
+/// section at `base`. The `slice_to*` helpers below only `debug_assert!` their
+/// bounds, so `from_bytes` calls this first: a corrupted executable must fail
+/// with an error in release builds, not read out of bounds. `nul_terminated`
+/// subranges additionally require the trailing NUL written by `append_count_z`
+/// to be in-bounds and actually zero, so the `ZStr` invariant holds for C
+/// string consumers.
+fn check_ptr(
+    base: *const u8,
+    len: usize,
+    ptr: StringPointer,
+    nul_terminated: bool,
+) -> Result<(), BunError> {
     // Zero-length pointers are never dereferenced (`slice_to*` return empty).
     if ptr.length == 0 {
         return Ok(());
@@ -760,6 +785,14 @@ fn check_ptr(len: usize, ptr: StringPointer, nul_terminated: bool) -> Result<(),
     let end = u64::from(ptr.offset) + u64::from(ptr.length) + u64::from(nul_terminated);
     if end > len as u64 {
         return Err(err!("Corrupted module graph: file data is out of bounds"));
+    }
+    if nul_terminated {
+        // SAFETY: `offset + length < len` per the check above; u8 reads need
+        // no alignment.
+        let terminator = unsafe { base.add(ptr.offset as usize + ptr.length as usize).read() };
+        if terminator != 0 {
+            return Err(err!("Corrupted module graph: string is not NUL terminated"));
+        }
     }
     Ok(())
 }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -676,10 +676,16 @@ impl StandaloneModuleGraph {
                         raw_const.add(bytecode_ptr.offset as usize),
                         bytecode_ptr.length as usize,
                     );
-                    let mi = core::slice::from_raw_parts(
-                        raw_const.add(module_info_ptr.offset as usize),
-                        module_info_ptr.length as usize,
-                    );
+                    // `check_ptr` skips zero-length pointers, so their offset is
+                    // unvalidated; don't even compute `add(offset)` for them.
+                    let mi: &[u8] = if module_info_ptr.length > 0 {
+                        core::slice::from_raw_parts(
+                            raw_const.add(module_info_ptr.offset as usize),
+                            module_info_ptr.length as usize,
+                        )
+                    } else {
+                        b""
+                    };
                     bun_wyhash::hash_with_seed(bun_wyhash::hash(bc), mi)
                 };
                 if actual != u64::from_le_bytes(module.bytecode_hash) {
@@ -744,6 +750,13 @@ impl StandaloneModuleGraph {
                     wtf_string: BunString::empty(),
                 },
             );
+        }
+
+        // The writer never emits duplicate module names, and `entry_point_id`
+        // was validated against the record count while it indexes this
+        // (deduplicating) map, so any `put` overwrite above means corruption.
+        if modules.count() != modules_list_count {
+            return Err(err!("Corrupted module graph: duplicate module name"));
         }
 
         modules.lock_pointers(); // make the pointers stable forever

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -704,7 +704,7 @@ impl StandaloneModuleGraph {
                 // stomped, skipping the hash check above). Drop them so the
                 // module falls back to plain source like the mismatch arm.
                 bun_core::debug_warn!(
-                    "module record for {} has module_info without bytecode; falling back to source",
+                    "module record for {} has bytecode metadata without bytecode; falling back to source",
                     bstr::BStr::new(name.as_bytes())
                 );
                 module_info_ptr = StringPointer::default();

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -240,6 +240,14 @@ pub(crate) struct CompiledModuleGraphFile {
     /// The file path used when generating bytecode (e.g., "B:/~BUN/root/app.js").
     /// Must match exactly at runtime for bytecode cache hits.
     pub bytecode_origin_path: StringPointer,
+    /// wyhash over the serialized `bytecode` range chained with the
+    /// `module_info` range; all-zero when there is no bytecode. JSC's bytecode
+    /// decoder trusts interior offsets/sizes, so a corrupted executable must be
+    /// detected before the blob reaches it (`from_bytes` falls back to the
+    /// embedded source on mismatch). Stored as little-endian bytes: a `u64`
+    /// field would add struct padding that leaks uninitialized memory when the
+    /// record is serialized with `sliceAsBytes`.
+    pub bytecode_hash: [u8; 8],
     pub encoding: Encoding,
     pub loader: Loader,
     pub module_format: ModuleFormat,
@@ -552,6 +560,16 @@ impl StandaloneModuleGraph {
         // the bytecode/module_info regions never have a shared reference formed over them.
         let raw_const: *const u8 = raw_ptr;
 
+        // Every offset/length below comes straight from the (possibly
+        // corrupted or truncated) executable, and the `slice_to*` helpers only
+        // debug_assert their bounds, so validate here and make release builds fail
+        // with an error instead of reading out of bounds.
+        if offsets.byte_count > raw_len {
+            return Err(err!("Corrupted module graph: byte count is out of bounds"));
+        }
+        check_ptr(raw_len, offsets.modules_ptr, false)?;
+        check_ptr(raw_len, offsets.compile_exec_argv_ptr, true)?;
+
         // SAFETY: modules metadata blob is a read-only subrange of `[0, raw_len)` disjoint
         // from bytecode/module_info, serialized by `to_bytes`.
         let modules_list_bytes = unsafe { slice_to(raw_const, raw_len, offsets.modules_ptr) };
@@ -562,7 +580,9 @@ impl StandaloneModuleGraph {
         let modules_list_count = modules_list_bytes.len() / size_of::<CompiledModuleGraphFile>();
         let modules_list_base = modules_list_bytes.as_ptr();
 
-        if offsets.entry_point_id as usize > modules_list_count {
+        // `>=`: the ID indexes the module list (`entry_point()`), so `== count`
+        // is just as out of bounds as `> count`.
+        if offsets.entry_point_id as usize >= modules_list_count {
             return Err(err!(
                 "Corrupted module graph: entry point ID is greater than module list count"
             ));
@@ -580,8 +600,16 @@ impl StandaloneModuleGraph {
                 )
             };
             let module = &module;
+
+            check_ptr(raw_len, module.name, true)?;
+            check_ptr(raw_len, module.contents, true)?;
+            check_ptr(raw_len, module.sourcemap, false)?;
+            check_ptr(raw_len, module.bytecode, false)?;
+            check_ptr(raw_len, module.module_info, false)?;
+            check_ptr(raw_len, module.bytecode_origin_path, true)?;
+
             // SAFETY: each name/contents/sourcemap/bytecode_origin_path subrange is in-bounds
-            // (serialized by `to_bytes`) and disjoint from the writable bytecode/module_info
+            // (checked above) and disjoint from the writable bytecode/module_info
             // subranges; section bytes are a live 'static allocation.
             let (name, contents, sourcemap_bytes, bytecode_origin) = unsafe {
                 (
@@ -591,6 +619,47 @@ impl StandaloneModuleGraph {
                     slice_to_z(raw_const, raw_len, module.bytecode_origin_path),
                 )
             };
+
+            // Verify the embedded bytecode (and its module_info, which is
+            // parsed with the same level of trust) against the hash recorded
+            // by `to_bytes`. JSC's bytecode decoder trusts interior
+            // offsets/sizes, so a blob corrupted after compilation (partial
+            // download, disk corruption, binary rewriters) would crash it.
+            // Fall back to parsing the embedded source instead.
+            let mut bytecode_ptr = module.bytecode;
+            let mut module_info_ptr = module.module_info;
+            let mut bytecode_origin_path = if module.bytecode_origin_path.length > 0 {
+                bytecode_origin.as_bytes()
+            } else {
+                b""
+            };
+            if bytecode_ptr.length > 0 {
+                // SAFETY: both subranges are in-bounds (checked above). These
+                // shared references die inside this block; JSC's in-place
+                // writes to the bytecode/module_info regions can only happen
+                // after `from_bytes` returns.
+                let actual = unsafe {
+                    let bc = core::slice::from_raw_parts(
+                        raw_const.add(bytecode_ptr.offset as usize),
+                        bytecode_ptr.length as usize,
+                    );
+                    let mi = core::slice::from_raw_parts(
+                        raw_const.add(module_info_ptr.offset as usize),
+                        module_info_ptr.length as usize,
+                    );
+                    bun_wyhash::hash_with_seed(bun_wyhash::hash(bc), mi)
+                };
+                if actual != u64::from_le_bytes(module.bytecode_hash) {
+                    bun_core::debug_warn!(
+                        "embedded bytecode for {} failed its integrity check; falling back to source",
+                        bstr::BStr::new(name.as_bytes())
+                    );
+                    bytecode_ptr = StringPointer::default();
+                    module_info_ptr = StringPointer::default();
+                    bytecode_origin_path = b"";
+                }
+            }
+
             let _ = modules.put(
                 name.as_bytes(),
                 File {
@@ -607,26 +676,22 @@ impl StandaloneModuleGraph {
                     } else {
                         LazySourceMap::None
                     },
-                    bytecode: if module.bytecode.length > 0 {
+                    bytecode: if bytecode_ptr.length > 0 {
                         // SAFETY: section bytes are a writable 'static allocation; JSC mutates
-                        // bytecode in place. Subrange is in-bounds (serialized by to_bytes) and
+                        // bytecode in place. Subrange is in-bounds (checked above) and
                         // disjoint from every read-only subslice handed out above — no
-                        // `&[u8]` is ever formed over this range.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.bytecode) }
+                        // `&[u8]` outlives the hash check over this range.
+                        unsafe { slice_to_mut(raw_ptr, raw_len, bytecode_ptr) }
                     } else {
                         std::ptr::from_mut::<[u8]>(&mut [])
                     },
-                    module_info: if module.module_info.length > 0 {
+                    module_info: if module_info_ptr.length > 0 {
                         // SAFETY: see bytecode above.
-                        unsafe { slice_to_mut(raw_ptr, raw_len, module.module_info) }
+                        unsafe { slice_to_mut(raw_ptr, raw_len, module_info_ptr) }
                     } else {
                         std::ptr::from_mut::<[u8]>(&mut [])
                     },
-                    bytecode_origin_path: if module.bytecode_origin_path.length > 0 {
-                        bytecode_origin.as_bytes()
-                    } else {
-                        b""
-                    },
+                    bytecode_origin_path,
                     module_format: module.module_format,
                     side: module.side,
                     cached_blob: None,
@@ -652,6 +717,24 @@ impl StandaloneModuleGraph {
             flags: offsets.flags,
         })
     }
+}
+
+/// Bounds check for a blob-controlled `StringPointer` read from the embedded
+/// section. The `slice_to*` helpers below only `debug_assert!` their bounds,
+/// so `from_bytes` calls this first: a corrupted executable must fail with an
+/// error in release builds, not read out of bounds. `nul_terminated` subranges
+/// additionally require the trailing NUL written by `append_count_z`.
+fn check_ptr(len: usize, ptr: StringPointer, nul_terminated: bool) -> Result<(), BunError> {
+    // Zero-length pointers are never dereferenced (`slice_to*` return empty).
+    if ptr.length == 0 {
+        return Ok(());
+    }
+    // u64 arithmetic: `offset + length + 1` can overflow u32 but not u64.
+    let end = u64::from(ptr.offset) + u64::from(ptr.length) + u64::from(nul_terminated);
+    if end > len as u64 {
+        return Err(err!("Corrupted module graph: file data is out of bounds"));
+    }
+    Ok(())
 }
 
 /// Read-only subslice helper. Builds a `&'static [u8]` over the *subrange only* so no
@@ -819,8 +902,12 @@ pub(crate) fn to_bytes(
                 let writable_after_padding = string_builder.writable();
                 writable_after_padding[0..bytecode.len()]
                     .copy_from_slice(&bytecode[0..bytecode.len()]);
-                let unaligned_space = &writable_after_padding[bytecode.len()..];
-                let len = bytecode.len() + unaligned_space.len().min(128);
+                // Zero the trailing slack included in the stored length so the
+                // range hashes deterministically and no uninitialized heap
+                // bytes leak into the emitted executable.
+                let slack = (writable_after_padding.len() - bytecode.len()).min(128);
+                writable_after_padding[bytecode.len()..bytecode.len() + slack].fill(0);
+                let len = bytecode.len() + slack;
                 string_builder.len += len;
                 break 'brk StringPointer {
                     offset: aligned_offset as u32,
@@ -847,6 +934,19 @@ pub(crate) fn to_bytes(
                 };
             }
             break 'brk StringPointer::default();
+        };
+
+        // Both ranges are final at this point (the builder only appends), so
+        // hash them now for the runtime integrity check in `from_bytes`.
+        let bytecode_hash: [u8; 8] = if bytecode.length > 0 {
+            let written = string_builder.written_slice();
+            bun_wyhash::hash_with_seed(
+                bun_wyhash::hash(bytecode.slice(written)),
+                module_info.slice(written),
+            )
+            .to_le_bytes()
+        } else {
+            [0; 8]
         };
 
         // Note: `src/sys/File.rs` is still cfg-gated upstream, so the
@@ -940,6 +1040,7 @@ pub(crate) fn to_bytes(
             bytecode,
             module_info,
             bytecode_origin_path,
+            bytecode_hash,
             side: match output_file.side.unwrap_or(options::Side::Server) {
                 options::Side::Server => FileSide::Server,
                 options::Side::Client => FileSide::Client,

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -730,7 +730,13 @@ describe("compiled executable bytecode integrity", () => {
       }
       cmdOff += exe.readUInt32LE(cmdOff + 4);
     }
-    expect(sigOff).toBeGreaterThan(0);
+    if (sigOff === 0) {
+      // Bun only ad-hoc signs arm64 Mach-O output; unsigned x64 binaries run
+      // fine with modified bytes. On arm64 a missing signature would get the
+      // corrupted copy killed by the kernel, so insist on one there.
+      expect(isArm64).toBe(false);
+      return;
+    }
 
     // Code-signature blobs use big-endian fields.
     expect(exe.readUInt32BE(sigOff)).toBe(0xfade0cc0); // CSMAGIC_EMBEDDED_SIGNATURE

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -709,10 +709,62 @@ describe("compiled executable bytecode integrity", () => {
     return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
-  async function runQuiet(cmd: string[]): Promise<{ stderr: string; exitCode: number }> {
-    await using proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "pipe" });
-    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode };
+  // Bun signs macOS --compile output itself (MachoSigner in
+  // src/exe_format/macho.rs): an ad-hoc signature whose CodeDirectory holds a
+  // SHA-256 hash per 4096-byte page. Corrupting section bytes invalidates the
+  // touched pages' hashes and the arm64 kernel kills the process at page-in.
+  // Apple's codesign cannot be used to re-sign here (newer releases reject the
+  // binary with "main executable failed strict validation"), so recompute the
+  // page hashes and patch them into the existing CodeDirectory instead, which
+  // keeps the ad-hoc signature valid on every macOS version.
+  function patchMachoAdhocSignature(exe: Buffer): void {
+    expect(exe.readUInt32LE(0)).toBe(0xfeedfacf); // thin 64-bit Mach-O
+    const ncmds = exe.readUInt32LE(16);
+    let sigOff = 0;
+    let cmdOff = 32;
+    for (let i = 0; i < ncmds; i++) {
+      if (exe.readUInt32LE(cmdOff) === 0x1d) {
+        // LC_CODE_SIGNATURE: linkedit_data_command { cmd, cmdsize, dataoff, datasize }
+        sigOff = exe.readUInt32LE(cmdOff + 8);
+        break;
+      }
+      cmdOff += exe.readUInt32LE(cmdOff + 4);
+    }
+    expect(sigOff).toBeGreaterThan(0);
+
+    // Code-signature blobs use big-endian fields.
+    expect(exe.readUInt32BE(sigOff)).toBe(0xfade0cc0); // CSMAGIC_EMBEDDED_SIGNATURE
+    const blobCount = exe.readUInt32BE(sigOff + 8);
+    let cdOff = 0;
+    for (let i = 0; i < blobCount; i++) {
+      if (exe.readUInt32BE(sigOff + 12 + i * 8) === 0) {
+        // CSSLOT_CODEDIRECTORY
+        cdOff = sigOff + exe.readUInt32BE(sigOff + 12 + i * 8 + 4);
+        break;
+      }
+    }
+    expect(cdOff).toBeGreaterThan(0);
+    expect(exe.readUInt32BE(cdOff)).toBe(0xfade0c02); // CSMAGIC_CODEDIRECTORY
+
+    const hashOffset = exe.readUInt32BE(cdOff + 16);
+    const nCodeSlots = exe.readUInt32BE(cdOff + 28);
+    const codeLimit = exe.readUInt32BE(cdOff + 32);
+    const hashSize = exe[cdOff + 36];
+    const hashType = exe[cdOff + 37];
+    const pageSize = 1 << exe[cdOff + 39];
+    expect({ hashSize, hashType }).toEqual({ hashSize: 32, hashType: 2 }); // SHA-256
+
+    for (let i = 0; i < nCodeSlots; i++) {
+      const start = i * pageSize;
+      // MachoSigner hashes the final partial page zero-padded to a full page.
+      let page: Buffer = exe.subarray(start, start + pageSize);
+      if (start + pageSize > codeLimit) {
+        page = Buffer.alloc(pageSize);
+        exe.copy(page, 0, start, codeLimit);
+      }
+      const digest = new Bun.CryptoHasher("sha256").update(page).digest();
+      exe.set(digest, cdOff + hashOffset + i * hashSize);
+    }
   }
 
   // Writes the corrupted executable to a sibling path: overwriting the
@@ -720,25 +772,11 @@ describe("compiled executable bytecode integrity", () => {
   // from the pristine run.
   async function writeCorrupted(exePath: string, exe: Buffer): Promise<string> {
     const corruptedPath = isWindows ? exePath.replace(/\.exe$/, "-corrupted.exe") : `${exePath}-corrupted`;
+    if (isMacOS) {
+      patchMachoAdhocSignature(exe);
+    }
     await Bun.write(corruptedPath, exe);
     chmodSync(corruptedPath, 0o755);
-    if (isMacOS) {
-      // Re-sign so the ad-hoc code signature covers the corrupted bytes;
-      // otherwise the kernel kills the process before it can start. Newer
-      // codesign versions can refuse to force-replace a signature that no
-      // longer matches the file, so strip it and sign fresh when that fails.
-      const force = await runQuiet(["codesign", "--force", "--sign", "-", corruptedPath]);
-      if (force.exitCode !== 0) {
-        const remove = await runQuiet(["codesign", "--remove-signature", corruptedPath]);
-        const sign = await runQuiet(["codesign", "--sign", "-", corruptedPath]);
-        // `force` is mirrored so its stderr shows up in the failure diff.
-        expect({ force, remove, sign }).toEqual({
-          force,
-          remove: { stderr: expect.any(String), exitCode: 0 },
-          sign: { stderr: expect.any(String), exitCode: 0 },
-        });
-      }
-    }
     return corruptedPath;
   }
 

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -696,7 +696,9 @@ describe("compiled executable bytecode integrity", () => {
     return join(dir, isWindows ? "app.exe" : "app");
   }
 
-  async function runExecutable(exePath: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  async function runExecutable(
+    exePath: string,
+  ): Promise<{ stdout: string; stderr: string; exitCode: number; signalCode: string | null }> {
     await using proc = Bun.spawn({
       cmd: [exePath],
       env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
@@ -704,7 +706,7 @@ describe("compiled executable bytecode integrity", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
   // Writes the corrupted executable to a sibling path: overwriting the
@@ -795,6 +797,40 @@ describe("compiled executable bytecode integrity", () => {
     const corrupted = await runExecutable(corruptedPath);
     expect(corrupted.stdout).not.toContain("record-enum-integrity-marker");
     expect(corrupted.stderr).toContain("Corrupted module graph");
+    // Rejected with an error, not a crash: the process exited on its own.
+    expect(corrupted.signalCode).toBeNull();
     expect(corrupted.exitCode).not.toBe(0);
+  }, 60_000);
+
+  test("module_info without bytecode is discarded", async () => {
+    using dir = tempDir("module-info-orphan", {
+      "app.js": `console.log("module-info-orphan-marker");`,
+    });
+    const exePath = await buildExecutable(String(dir), "esm");
+
+    const exe = Buffer.from(await Bun.file(exePath).arrayBuffer());
+    const graph = findModuleGraph(exe);
+    expect(graph).not.toBeNull();
+    // Zero the bytecode length field so the hash check is skipped, then
+    // corrupt the module_info payload. The writer only emits module_info
+    // alongside bytecode, so the orphaned (and here corrupted) module_info is
+    // discarded with the rest of the pair instead of being parsed; this pins
+    // the fallback semantics: the app still runs from source, no error, no
+    // bytecode cache.
+    const rec = graph!.records[0];
+    const bytecodeLength = exe.readUInt32LE(rec + RECORD_BYTECODE_OFFSET + 4);
+    expect(bytecodeLength).toBeGreaterThan(0);
+    exe.writeUInt32LE(0, rec + RECORD_BYTECODE_OFFSET + 4);
+    const miOffset = exe.readUInt32LE(rec + RECORD_MODULE_INFO_OFFSET);
+    const miLength = exe.readUInt32LE(rec + RECORD_MODULE_INFO_OFFSET + 4);
+    expect(miLength).toBeGreaterThan(0);
+    for (let i = 0; i < Math.min(64, miLength); i++) exe[graph!.base + miOffset + i] ^= 0xa5;
+    const corruptedPath = await writeCorrupted(exePath, exe);
+
+    const corrupted = await runExecutable(corruptedPath);
+    expect(corrupted.stdout).toContain("module-info-orphan-marker");
+    expect(corrupted.stderr).not.toContain("Cache hit for sourceCode");
+    expect(corrupted.signalCode).toBeNull();
+    expect(corrupted.exitCode).toBe(0);
   }, 60_000);
 });

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -579,3 +579,193 @@ describe("compiled binary in a deleted cwd", () => {
 });
 
 // file command test works well
+
+// A `bun build --compile --bytecode` executable embeds both the bundled source
+// and its JSC bytecode. JSC's bytecode decoder trusts interior offsets/sizes,
+// so if the embedded bytecode is modified after compilation (partial download,
+// disk corruption, binary rewriters like rcedit/signtool), feeding it to the
+// decoder crashes the process at startup. The StandaloneModuleGraph records a
+// hash of each module's bytecode + module_info at build time and falls back to
+// parsing the embedded source when it no longer matches.
+describe("compiled executable bytecode integrity", () => {
+  // Container layout from src/standalone_graph/StandaloneModuleGraph.rs: the
+  // embedded payload ends with [Offsets struct][16-byte trailer], and every
+  // StringPointer inside is relative to the payload start.
+  const TRAILER = Buffer.from("\n---- Bun! ----\n");
+  // #[repr(C)] Offsets { byte_count: usize, modules_ptr: StringPointer,
+  //   entry_point_id: u32, compile_exec_argv_ptr: StringPointer, flags: u32 }
+  const OFFSETS_SIZE = 32;
+  // #[repr(C)] CompiledModuleGraphFile: 6 StringPointers (name, contents,
+  // sourcemap, bytecode, module_info, bytecode_origin_path), bytecode_hash
+  // ([u8; 8]), then 4 one-byte enums. 52 is the pre-hash record size, kept so
+  // the locator also works on older builds (where the run then crashes).
+  const RECORD_SIZES = [60, 52];
+  const RECORD_BYTECODE_OFFSET = 24;
+  const RECORD_MODULE_INFO_OFFSET = 32;
+
+  interface GraphLocation {
+    base: number;
+    records: number[];
+  }
+
+  // The trailer string also lives in the bun binary's read-only data, so every
+  // occurrence is validated structurally and the last valid one (the embedded
+  // graph, which is placed after the runtime's own bytes) wins.
+  function findModuleGraph(exe: Buffer): GraphLocation | null {
+    let result: GraphLocation | null = null;
+    let pos = -1;
+    while ((pos = exe.indexOf(TRAILER, pos + 1)) !== -1) {
+      const offsetsPos = pos - OFFSETS_SIZE;
+      if (offsetsPos < 0) continue;
+      const byteCountBig = exe.readBigUInt64LE(offsetsPos);
+      if (byteCountBig === 0n || byteCountBig > BigInt(offsetsPos)) continue;
+      const byteCount = Number(byteCountBig);
+      const base = offsetsPos - byteCount;
+      const modulesOffset = exe.readUInt32LE(offsetsPos + 8);
+      const modulesLength = exe.readUInt32LE(offsetsPos + 12);
+      const entryPointId = exe.readUInt32LE(offsetsPos + 16);
+      if (modulesLength === 0 || modulesOffset + modulesLength > byteCount) continue;
+      const recordSize = RECORD_SIZES.find(size => modulesLength % size === 0);
+      if (recordSize === undefined) continue;
+      const count = modulesLength / recordSize;
+      if (entryPointId >= count) continue;
+
+      const records: number[] = [];
+      let valid = true;
+      for (let i = 0; i < count; i++) {
+        const rec = base + modulesOffset + i * recordSize;
+        const nameOffset = exe.readUInt32LE(rec);
+        const nameLength = exe.readUInt32LE(rec + 4);
+        const contentsOffset = exe.readUInt32LE(rec + 8);
+        const contentsLength = exe.readUInt32LE(rec + 12);
+        if (nameLength === 0 || nameOffset + nameLength > byteCount) {
+          valid = false;
+          break;
+        }
+        if (contentsOffset + contentsLength > byteCount) {
+          valid = false;
+          break;
+        }
+        records.push(rec);
+      }
+      if (valid) result = { base, records };
+    }
+    return result;
+  }
+
+  // XORs 64 bytes in the middle of each module's region (bytecode or
+  // module_info), far past the 4-byte JSC cache-version header at the start,
+  // which is the only part the decoder checks before trusting the rest.
+  function corruptRegions(exe: Buffer, fieldOffset: number): number {
+    const graph = findModuleGraph(exe);
+    expect(graph).not.toBeNull();
+    let corrupted = 0;
+    for (const rec of graph!.records) {
+      const offset = exe.readUInt32LE(rec + fieldOffset);
+      const length = exe.readUInt32LE(rec + fieldOffset + 4);
+      if (length === 0) continue;
+      const start = graph!.base + offset + (length >> 1);
+      const n = Math.min(64, length - (length >> 1));
+      for (let i = 0; i < n; i++) exe[start + i] ^= 0xa5;
+      corrupted++;
+    }
+    return corrupted;
+  }
+
+  async function buildExecutable(dir: string, format: "cjs" | "esm"): Promise<string> {
+    await using build = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--compile",
+        "--bytecode",
+        `--format=${format}`,
+        join(dir, "app.js"),
+        "--outfile",
+        join(dir, "app"),
+      ],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, buildStderr, buildExit] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+    expect(buildStderr).not.toContain("error:");
+    expect(buildExit).toBe(0);
+    return join(dir, isWindows ? "app.exe" : "app");
+  }
+
+  async function runExecutable(exePath: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    await using proc = Bun.spawn({
+      cmd: [exePath],
+      env: { ...bunEnv, BUN_JSC_verboseDiskCache: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // Writes the corrupted executable to a sibling path: overwriting the
+  // original in place can hit ETXTBSY while the kernel still holds it open
+  // from the pristine run.
+  async function corruptExecutable(exePath: string, fieldOffset: number): Promise<string> {
+    const exe = Buffer.from(await Bun.file(exePath).arrayBuffer());
+    expect(corruptRegions(exe, fieldOffset)).toBeGreaterThan(0);
+    const corruptedPath = isWindows ? exePath.replace(/\.exe$/, "-corrupted.exe") : `${exePath}-corrupted`;
+    await Bun.write(corruptedPath, exe);
+    chmodSync(corruptedPath, 0o755);
+    if (isMacOS) {
+      // Re-sign so the ad-hoc code signature covers the corrupted bytes;
+      // otherwise the kernel kills the process before it can start.
+      await using sign = Bun.spawn({
+        cmd: ["codesign", "--force", "--sign", "-", corruptedPath],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(await sign.exited).toBe(0);
+    }
+    return corruptedPath;
+  }
+
+  for (const format of ["cjs", "esm"] as const) {
+    test(`corrupted embedded bytecode falls back to source (${format})`, async () => {
+      using dir = tempDir(`bytecode-integrity-${format}`, {
+        "app.js": `console.log("bytecode-integrity-marker");`,
+      });
+      const exePath = await buildExecutable(String(dir), format);
+
+      // Pristine executable: the bytecode hash matches, so JSC decodes the
+      // embedded bytecode instead of parsing source.
+      const clean = await runExecutable(exePath);
+      expect(clean.stdout).toContain("bytecode-integrity-marker");
+      expect(clean.stderr).toContain("Cache hit for sourceCode");
+      expect(clean.exitCode).toBe(0);
+
+      const corruptedPath = await corruptExecutable(exePath, RECORD_BYTECODE_OFFSET);
+
+      // Corrupted bytecode must be rejected before it reaches JSC's decoder,
+      // falling back to the embedded source. Not a crash, not a silent decode.
+      const corrupted = await runExecutable(corruptedPath);
+      expect(corrupted.stdout).toContain("bytecode-integrity-marker");
+      expect(corrupted.stderr).not.toContain("Cache hit for sourceCode");
+      expect(corrupted.exitCode).toBe(0);
+    }, 60_000);
+  }
+
+  test("corrupted embedded module_info falls back to source (esm)", async () => {
+    using dir = tempDir("module-info-integrity", {
+      "app.js": `console.log("module-info-integrity-marker");`,
+    });
+    const exePath = await buildExecutable(String(dir), "esm");
+
+    // module_info is covered by the same hash as the bytecode: both are
+    // produced together at build time and parsed with the same trust.
+    const corruptedPath = await corruptExecutable(exePath, RECORD_MODULE_INFO_OFFSET);
+
+    const corrupted = await runExecutable(corruptedPath);
+    expect(corrupted.stdout).toContain("module-info-integrity-marker");
+    expect(corrupted.stderr).not.toContain("Cache hit for sourceCode");
+    expect(corrupted.exitCode).toBe(0);
+  }, 60_000);
+});

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -605,6 +605,7 @@ describe("compiled executable bytecode integrity", () => {
 
   interface GraphLocation {
     base: number;
+    recordSize: number;
     records: number[];
   }
 
@@ -648,7 +649,7 @@ describe("compiled executable bytecode integrity", () => {
         }
         records.push(rec);
       }
-      if (valid) result = { base, records };
+      if (valid) result = { base, recordSize, records };
     }
     return result;
   }
@@ -709,9 +710,7 @@ describe("compiled executable bytecode integrity", () => {
   // Writes the corrupted executable to a sibling path: overwriting the
   // original in place can hit ETXTBSY while the kernel still holds it open
   // from the pristine run.
-  async function corruptExecutable(exePath: string, fieldOffset: number): Promise<string> {
-    const exe = Buffer.from(await Bun.file(exePath).arrayBuffer());
-    expect(corruptRegions(exe, fieldOffset)).toBeGreaterThan(0);
+  async function writeCorrupted(exePath: string, exe: Buffer): Promise<string> {
     const corruptedPath = isWindows ? exePath.replace(/\.exe$/, "-corrupted.exe") : `${exePath}-corrupted`;
     await Bun.write(corruptedPath, exe);
     chmodSync(corruptedPath, 0o755);
@@ -723,9 +722,16 @@ describe("compiled executable bytecode integrity", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      expect(await sign.exited).toBe(0);
+      const [, , signExit] = await Promise.all([sign.stdout.text(), sign.stderr.text(), sign.exited]);
+      expect(signExit).toBe(0);
     }
     return corruptedPath;
+  }
+
+  async function corruptExecutable(exePath: string, fieldOffset: number): Promise<string> {
+    const exe = Buffer.from(await Bun.file(exePath).arrayBuffer());
+    expect(corruptRegions(exe, fieldOffset)).toBeGreaterThan(0);
+    return writeCorrupted(exePath, exe);
   }
 
   for (const format of ["cjs", "esm"] as const) {
@@ -767,5 +773,28 @@ describe("compiled executable bytecode integrity", () => {
     expect(corrupted.stdout).toContain("module-info-integrity-marker");
     expect(corrupted.stderr).not.toContain("Cache hit for sourceCode");
     expect(corrupted.exitCode).toBe(0);
+  }, 60_000);
+
+  test("out-of-range enum byte in a module record is rejected as corruption", async () => {
+    using dir = tempDir("record-enum-integrity", {
+      "app.js": `console.log("record-enum-integrity-marker");`,
+    });
+    const exePath = await buildExecutable(String(dir), "cjs");
+
+    const exe = Buffer.from(await Bun.file(exePath).arrayBuffer());
+    const graph = findModuleGraph(exe);
+    expect(graph).not.toBeNull();
+    // Stomp the record's loader byte (after the StringPointers and, in the
+    // current format, the 8-byte bytecode hash). Materializing a #[repr(u8)]
+    // enum from an out-of-range discriminant is UB, so the loader must treat
+    // it as graph corruption and refuse to start, not read garbage.
+    const loaderOffset = graph!.recordSize === 60 ? 57 : 49;
+    exe[graph!.records[0] + loaderOffset] = 0xff;
+    const corruptedPath = await writeCorrupted(exePath, exe);
+
+    const corrupted = await runExecutable(corruptedPath);
+    expect(corrupted.stdout).not.toContain("record-enum-integrity-marker");
+    expect(corrupted.stderr).toContain("Corrupted module graph");
+    expect(corrupted.exitCode).not.toBe(0);
   }, 60_000);
 });

--- a/test/bundler/bun-build-compile.test.ts
+++ b/test/bundler/bun-build-compile.test.ts
@@ -709,6 +709,12 @@ describe("compiled executable bytecode integrity", () => {
     return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
+  async function runQuiet(cmd: string[]): Promise<{ stderr: string; exitCode: number }> {
+    await using proc = Bun.spawn({ cmd, stdout: "pipe", stderr: "pipe" });
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
   // Writes the corrupted executable to a sibling path: overwriting the
   // original in place can hit ETXTBSY while the kernel still holds it open
   // from the pristine run.
@@ -718,14 +724,20 @@ describe("compiled executable bytecode integrity", () => {
     chmodSync(corruptedPath, 0o755);
     if (isMacOS) {
       // Re-sign so the ad-hoc code signature covers the corrupted bytes;
-      // otherwise the kernel kills the process before it can start.
-      await using sign = Bun.spawn({
-        cmd: ["codesign", "--force", "--sign", "-", corruptedPath],
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, , signExit] = await Promise.all([sign.stdout.text(), sign.stderr.text(), sign.exited]);
-      expect(signExit).toBe(0);
+      // otherwise the kernel kills the process before it can start. Newer
+      // codesign versions can refuse to force-replace a signature that no
+      // longer matches the file, so strip it and sign fresh when that fails.
+      const force = await runQuiet(["codesign", "--force", "--sign", "-", corruptedPath]);
+      if (force.exitCode !== 0) {
+        const remove = await runQuiet(["codesign", "--remove-signature", corruptedPath]);
+        const sign = await runQuiet(["codesign", "--sign", "-", corruptedPath]);
+        // `force` is mirrored so its stderr shows up in the failure diff.
+        expect({ force, remove, sign }).toEqual({
+          force,
+          remove: { stderr: expect.any(String), exitCode: 0 },
+          sign: { stderr: expect.any(String), exitCode: 0 },
+        });
+      }
     }
     return corruptedPath;
   }


### PR DESCRIPTION
### What does this PR do?

Fixes startup crashes in `bun build --compile --bytecode` executables whose embedded bytecode was corrupted after the build (partial/interrupted download, disk corruption, antivirus or binary rewriters such as rcedit/signtool). Sentry issues, Windows-dominant on bun 1.3.14:

- BUN-2V6A: segfault at wild addresses in `JSC::CachedUniquedStringImplBase<WTF::UniquedStringImpl>::decode` (CachedTypes.cpp) while decoding `CachedFunctionExecutable` identifiers.
- BUN-37MT (+ same-stack siblings BUN-37N4, BUN-37MV, BUN-385Y): IllegalInstruction via `pas_allocation_result_crash_on_error`, allocating from `JSC::CachedFunctionExecutableRareData::decode` / `CachedVector::decode` inside `CachedCodeBlock<UnlinkedModuleProgramCodeBlock>::decode`. 800+ events/day.

Related but distinct from #31787, which validates the outer container length (BUN-2V2F, crash while locating the graph). This PR validates the payload interior: the crashes above happen after the container parses fine, inside JSC's decoder.

### Root cause

The embedded bytecode blob is a raw slice of the mapped executable image, wired through the standalone module graph into `JSC::CachedBytecode::create` unvalidated. The only pre-decode gate is JSC's 4-byte cache-version compare; everything after those bytes is trusted (raw offsets, raw sizes, debug-only asserts). Interior corruption sails straight into the decoder, which reads blob-controlled offsets (shape 1) or allocates blob-controlled sizes (shape 2).

docs/bundler/bytecode.mdx documents that corrupted bytecode "fails open" and falls back to parsing the source. That was only true for the version field, not interior corruption.

Additionally, `from_bytes` trusted every `StringPointer` in the graph metadata with `debug_assert!`-only bounds checks (compiled out in release), and accepted `entry_point_id == module count` (later indexes the module list).

### Fix

- `to_bytes` records a wyhash of each module's serialized bytecode range chained with its `module_info` range (the two are produced and consumed together) in `CompiledModuleGraphFile`.
- `from_bytes` verifies the hash before the blob can reach JSC. On mismatch it clears `bytecode`, `module_info` and `bytecode_origin_path`, so the module loads from the embedded source text that is always present alongside. Matches the documented fail-open behavior; a `debug_warn` surfaces it in debug builds.
- The trailing slack included in the stored bytecode length is now zeroed: needed for deterministic hashing, and it stops up to 128 uninitialized heap bytes leaking into every emitted executable.
- `from_bytes` bounds-checks every `StringPointer` read from the executable in release builds and rejects `entry_point_id >= count`.
- `from_bytes` validates the record's `#[repr(u8)]` enum discriminants (`loader`, `encoding`, `module_format`, `side`) via `strum::FromRepr` before `read_unaligned` materializes the typed record; an out-of-range byte was previously language-level UB (review finding).
- Further review hardening: `check_ptr` also verifies the trailing NUL byte for z-strings, module tables whose length is not a record-size multiple are rejected, duplicate module names are rejected (a `put` overwrite would shrink the list `entry_point_id` indexes), and a record carrying `module_info` or `bytecode_origin_path` without bytecode has both discarded (the writer only emits them together, so stomping just the bytecode length field cannot route unverified module_info past the hash check).

Compile-time writer and runtime reader change together in this PR (the module record grows from 52 to 60 bytes). This is corruption detection, not tamper-proofing: anyone who can rewrite the executable can rewrite the hash.

Not covered: the `.jsc` sidecar path (`bun build --bytecode` without `--compile`) still trusts the sidecar file contents. That requires an on-disk format change for standalone `.jsc` files and is left as a follow-up.

### How did you verify your code works?

New tests in `test/bundler/bun-build-compile.test.ts` ("compiled executable bytecode integrity"): compile a hello world (cjs and esm), locate the embedded graph through the trailer/offsets structure, XOR 64 bytes in the middle of the bytecode region (past the 4-byte version header), and run the corrupted executable. A third test corrupts the `module_info` region instead (proves the chained part of the hash is load-bearing), a fourth stomps a record's loader enum byte and asserts the executable refuses to start with "Corrupted module graph" and no signal (rejected, not crashed), and a fifth zeroes the bytecode length field and corrupts `module_info` to pin the orphaned-module_info discard semantics (runs from source, exit 0, no bytecode cache). Pristine executables must print `[Disk Cache] Cache hit for sourceCode` under `BUN_JSC_verboseDiskCache=1` (proves the hash matches on valid binaries and bytecode is actually used); corrupted ones must produce the same stdout, exit 0, and no cache hit (proves the fallback ran).

On the unfixed build the corrupted cjs/esm executables crash with empty stdout, and the corrupted module_info binary keeps decoding bytecode; with the fix the corruption is detected:

```
USE_SYSTEM_BUN=1: 4 of the 5 integrity tests fail (corrupted exe stdout is "" for cjs/esm; "Cache hit" still present for module_info; enum byte reads garbage). The orphaned-module_info test passes both ways by design: that parser was already bounds-checked, the test pins the discard semantics.
bun bd test:       5 pass (17/17 for the whole file)
```

`bun-build-compile.test.ts` (15/15), `bundler_compile.test.ts` bytecode tests, `bundler_compile_splitting.test.ts`, `compile-argv.test.ts`, `bundler_compile_autoload.test.ts`, and `bun-build-compile-sourcemap.test.ts` (45/45) pass with the fix, so no valid binary is rejected. (Five `bundler_compile.test.ts` bytecode tests fail identically on main under debug builds due to an unrelated `hintSourcePagesDontNeed` debug warn in their exact-stderr assertions.)



