### PR TITLE
fix(s3): correct checksumAlgorithm property name

### DIFF
--- a/src/runtime/webcore/s3/list_objects.zig
+++ b/src/runtime/webcore/s3/list_objects.zig
@@ -36,7 +36,7 @@ const S3ListObjectsContents = struct {
     key: []const u8,
     etag: ?bun.ptr.OwnedIn([]const u8, bun.allocators.MaybeOwned(bun.DefaultAllocator)),
     checksum_type: ?[]const u8,
-    checksum_algorithme: ?[]const u8,
+    checksum_algorithm: ?[]const u8,
     last_modified: ?[]const u8,
     object_size: ?i64,
     storage_class: ?[]const u8,
@@ -125,8 +125,8 @@ pub const S3ListObjectsV2Result = struct {
                     objectInfo.put(globalObject, jsc.ZigString.static("eTag"), try bun.String.createUTF8ForJS(globalObject, etag.get()));
                 }
 
-                if (item.checksum_algorithme) |checksum_algorithme| {
-                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithme"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithme));
+                if (item.checksum_algorithm) |checksum_algorithm| {
+                    objectInfo.put(globalObject, jsc.ZigString.static("checksumAlgorithm"), try bun.String.createUTF8ForJS(globalObject, checksum_algorithm));
                 }
 
                 if (item.checksum_type) |checksum_type| {
@@ -225,7 +225,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                     var etag: ?[]const u8 = null;
                     var etag_owned: bool = false;
                     var checksum_type: ?[]const u8 = null;
-                    var checksum_algorithme: ?[]const u8 = null;
+                    var checksum_algorithm: ?[]const u8 = null;
                     var owner_id: ?[]const u8 = null;
                     var owner_display_name: ?[]const u8 = null;
                     var is_restore_in_progress: ?bool = null;
@@ -273,7 +273,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ChecksumAlgorithm")) {
                                     if (strings.indexOf(xml[i..], "</ChecksumAlgorithm>")) |__tag_end| {
-                                        checksum_algorithme = xml[i .. i + __tag_end];
+                                        checksum_algorithm = xml[i .. i + __tag_end];
                                         i = i + __tag_end + 20;
                                     }
                                 } else if (strings.eql(inner_tag_name_or_tag_end, "ETag")) {
@@ -383,7 +383,7 @@ pub fn parseS3ListObjectsResult(xml: []const u8) !S3ListObjectsV2Result {
                             .key = object_key_val,
                             .etag = if (etag) |etag_| if (etag_owned) .fromRawIn(etag_, .init()) else .fromRawIn(etag_, .initBorrowed()) else null,
                             .checksum_type = checksum_type,
-                            .checksum_algorithme = checksum_algorithme,
+                            .checksum_algorithm = checksum_algorithm,
                             .last_modified = last_modified,
                             .object_size = object_size,
                             .storage_class = storage_class,


### PR DESCRIPTION
This is an independent contribution made by an individual developer. This work is not associated with any hackathon, competition, or coordinated PR campaign.

## Summary

Fixes #19142

The S3 list objects response (S3ListObjectsResponse.contents) exposes a property named checksumAlgorithme — a misspelling (French: "algorithme"). The correct English name is checksumAlgorithm, which is what the TypeScript types (packages/bun-types/s3.d.ts) already declare.

## Root Cause

In src/runtime/webcore/s3/list_objects.zig, the struct field, parser variable, and JS property name all used the French spelling algorithme instead of the English algorithm. The XML tag parsing correctly reads <ChecksumAlgorithm> (AWS S3 uses English), but the value was stored and exposed under the French spelling.

## Fix

Renamed all 6 occurrences of checksum_algorithme to checksum_algorithm, and the JS property from "checksumAlgorithme" to "checksumAlgorithm". The TypeScript type definition already uses checksumAlgorithm, so no type changes needed.

## Changes

- src/runtime/webcore/s3/list_objects.zig: 6 lines changed (+6 -6)

## Testing

- The renamed field correctly receives the value parsed from the <ChecksumAlgorithm> XML tag (unchanged parsing logic)
- The JS property is now exposed as checksumAlgorithm, matching the TypeScript type declaration in packages/bun-types/s3.d.ts
