### PR TITLE
Fix use-after-free of stream error objects parked in ByteStream

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3022,30 +3022,10 @@ where
         this.do_render_blob();
     }
 
-    pub fn on_pipe(this: &mut Self, mut stream: WebCore::streams::Result) {
-        let stream_needs_deinit = matches!(
-            stream,
-            WebCore::streams::Result::Owned(_) | WebCore::streams::Result::OwnedAndDone(_)
-        );
+    pub fn on_pipe(this: &mut Self, stream: &WebCore::streams::Result) {
         let is_done = stream.is_done();
-        // NOTE: reshaped for borrowck — the defer reads `stream` through a
-        // raw ptr so the body below can keep borrowing it.
-        let stream_ptr: *mut WebCore::streams::Result = &raw mut stream;
         // Drop one ref only when the stream signals completion.
         let _ref = is_done.then(|| RequestContextRef(std::ptr::from_mut::<Self>(this)));
-        scopeguard::defer! {
-            if stream_needs_deinit {
-                // SAFETY: stream lives on the caller's stack frame past the guard.
-                match unsafe { &mut *stream_ptr } {
-                    WebCore::streams::Result::OwnedAndDone(owned)
-                    | WebCore::streams::Result::Owned(owned) => {
-                        // Vec::deinit → Drop in Rust.
-                        *owned = Vec::<u8>::default();
-                    }
-                    _ => unreachable!(),
-                }
-            }
-        }
 
         if this.is_aborted_or_ended() {
             return;
@@ -3628,11 +3608,9 @@ where
                     let mut err = Body::ValueError::Message(BunString::static_(
                         "Request body exceeded maxRequestBodySize",
                     ));
-                    let js_err = err.to_js(global_this);
-                    js_err.ensure_still_alive();
                     // TODO: properly propagate exception upwards
                     let _ = bytes.on_data(WebCore::streams::Result::Err(
-                        WebCore::streams::StreamError::JSValue(js_err),
+                        err.to_stream_error(global_this),
                     ));
                     err.reset();
                 }
@@ -4088,7 +4066,7 @@ where
     fn on_pipe(&mut self, stream: WebCore::streams::Result) {
         // Forward to the inherent associated fn (not method-dispatched to avoid
         // recursing into this trait impl).
-        RequestContext::on_pipe(self, stream)
+        RequestContext::on_pipe(self, &stream)
     }
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -628,7 +628,10 @@ impl ValueError {
     ) -> streams::result::StreamError {
         match self {
             ValueError::AbortReason(reason) => streams::result::StreamError::AbortReason(*reason),
-            _ => streams::result::StreamError::JSValue(self.to_js(global_object)),
+            _ => streams::result::StreamError::JSValue(jsc::strong::Optional::create(
+                self.to_js(global_object),
+                global_object,
+            )),
         }
     }
 
@@ -2307,29 +2310,14 @@ impl<'a> ValueBufferer<'a> {
         }
     }
 
-    fn on_stream_pipe(&mut self, stream: streams::Result) {
-        let stream_ = stream;
-        let stream_needs_deinit = matches!(
-            stream_,
-            streams::Result::Owned(_) | streams::Result::OwnedAndDone(_)
-        );
-
-        let chunk = stream_.slice();
+    fn on_stream_pipe(&mut self, stream: &streams::Result) {
+        let chunk = stream.slice();
         bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe chunk {}", chunk.len());
         let _ = self.stream_buffer.write(chunk);
-        if stream_.is_done() {
+        if stream.is_done() {
             let bytes = self.stream_buffer.list.as_slice();
             bun_core::scoped_log!(BodyValueBufferer, "onStreamPipe done {}", bytes.len());
             (self.on_finished_buffering)(self.ctx, bytes, None, true);
-        }
-
-        if stream_needs_deinit {
-            match stream_ {
-                streams::Result::OwnedAndDone(owned) | streams::Result::Owned(owned) => {
-                    drop(owned);
-                }
-                _ => unreachable!(),
-            }
         }
     }
 
@@ -2531,7 +2519,7 @@ impl<'a> ValueBufferer<'a> {
 // `webcore::Wrap<T>` requires `T: PipeHandler`.
 impl<'a> crate::webcore::PipeHandler for ValueBufferer<'a> {
     fn on_pipe(&mut self, stream: streams::Result) {
-        self.on_stream_pipe(stream)
+        self.on_stream_pipe(&stream)
     }
 }
 

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -158,7 +158,7 @@ impl ByteStream {
         });
     }
 
-    pub(crate) fn on_data(&self, stream: streams::Result) -> Result<(), bun_jsc::JsTerminated> {
+    pub(crate) fn on_data(&self, mut stream: streams::Result) -> Result<(), bun_jsc::JsTerminated> {
         bun_jsc::mark_binding!();
         if self.done.get() {
             // The owned `Vec<u8>`/`Vec`
@@ -285,6 +285,7 @@ impl ByteStream {
             let pending_buffer_len = pending_buf.len();
             debug_assert!(pending_buf.as_ptr() != chunk.as_ptr());
             pending_buf[..to_copy_len].copy_from_slice(&chunk[..to_copy_len]);
+            let has_remaining = chunk.len() > to_copy_len;
             self.pending_buffer.set(Self::empty_pending_buffer());
 
             let is_really_done =
@@ -294,9 +295,9 @@ impl ByteStream {
                 self.done.set(true);
 
                 if to_copy_len == 0 {
-                    if let streams::Result::Err(err) = &stream {
-                        self.pending
-                            .with_mut(|p| p.result = streams::Result::Err(err.clone()));
+                    if matches!(stream, streams::Result::Err(_)) {
+                        let err = core::mem::replace(&mut stream, streams::Result::Done);
+                        self.pending.with_mut(|p| p.result = err);
                     } else {
                         self.pending.with_mut(|p| p.result = streams::Result::Done);
                     }
@@ -319,10 +320,7 @@ impl ByteStream {
                 });
             }
 
-            let remaining = &chunk[to_copy_len..];
-            if !remaining.is_empty() && !chunk.is_empty() {
-                // `chunk` borrows `stream`; passing both requires re-slicing inside
-                // `append`.
+            if has_remaining {
                 self.append(stream, to_copy_len)
                     .unwrap_or_else(|_| panic!("Out of memory while copying request body"));
             }
@@ -577,8 +575,9 @@ impl ByteStream {
         }
 
         if let streams::Result::Err(err) = &self.pending.get().result {
-            let (err_js, _) = err.to_js_weak(global_this);
-            self.pending.with_mut(|p| p.result.release());
+            let err_js = err.to_js(global_this);
+            err_js.ensure_still_alive();
+            self.pending.with_mut(|p| p.result = streams::Result::Done);
             self.done.set(true);
             self.buffer.with_mut(|b| {
                 b.clear();

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -1018,21 +1018,11 @@ impl<C: SourceContext> NewSource<C> {
         mut result: streams::Result,
     ) -> JsResult<JSValue> {
         match &result {
-            streams::Result::Err(err) => match err {
-                streams::StreamError::Error(e) => {
-                    Err(global_this.throw_value(e.to_js(global_this)))
-                }
-                // Always throw on `.err`: `to_js_weak` handles all four variants
-                // and reports whether the value was strong-protected (needs `unprotect()`).
-                _ => {
-                    let (js_err, was_strong) = err.to_js_weak(global_this);
-                    js_err.ensure_still_alive();
-                    if was_strong == streams::WasStrong::Strong {
-                        js_err.unprotect();
-                    }
-                    Err(global_this.throw_value(js_err))
-                }
-            },
+            streams::Result::Err(err) => {
+                let js_err = err.to_js(global_this);
+                js_err.ensure_still_alive();
+                Err(global_this.throw_value(js_err))
+            }
             streams::Result::Pending(_) => {
                 let out = result.to_js(global_this)?;
                 <Self as NewSourceCodegen>::pending_promise_set_cached(

--- a/src/runtime/webcore/ResumableSink.rs
+++ b/src/runtime/webcore/ResumableSink.rs
@@ -200,11 +200,8 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
                     let err: Option<JSValue> = 'brk_err: {
                         let pending = &byte_stream.pending.get().result;
                         if let StreamResult::Err(e) = pending {
-                            let (js_err, was_strong) = e.to_js_weak(global_this);
+                            let js_err = e.to_js(global_this);
                             js_err.ensure_still_alive();
-                            if was_strong == crate::webcore::streams::WasStrong::Strong {
-                                js_err.unprotect();
-                            }
                             break 'brk_err Some(js_err);
                         }
                         None
@@ -483,11 +480,8 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
         if is_done {
             let err: Option<JSValue> = 'brk_err: {
                 if let StreamResult::Err(e) = &stream {
-                    let (js_err, was_strong) = e.to_js_weak(self.global_this.get());
+                    let js_err = e.to_js(self.global_this.get());
                     js_err.ensure_still_alive();
-                    if was_strong == crate::webcore::streams::WasStrong::Strong {
-                        js_err.unprotect();
-                    }
                     break 'brk_err Some(js_err);
                 }
                 None

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -667,7 +667,9 @@ impl FetchTasklet {
                 if let Some(bytes) = readable.ptr.bytes() {
                     js_err = err.to_js(&global_this);
                     js_err.ensure_still_alive();
-                    bytes.on_data(StreamResult::Err(StreamError::JSValue(js_err)))?;
+                    bytes.on_data(StreamResult::Err(StreamError::JSValue(
+                        bun_jsc::strong::Optional::create(js_err, &global_this),
+                    )))?;
                 }
             }
             // A failure result is terminal (`to_result` forces `has_more =

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -798,10 +798,7 @@ pub fn upload_stream(
                     result: crate::webcore::streams::StreamResult::Done,
                     ..Default::default()
                 });
-                let (js_err, was_strong) = err.to_js_weak(global_this);
-                if was_strong == crate::webcore::streams::WasStrong::Strong {
-                    js_err.unprotect();
-                }
+                let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
                 credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
@@ -826,10 +823,7 @@ pub fn upload_stream(
                     result: crate::webcore::streams::StreamResult::Done,
                     ..Default::default()
                 });
-                let (js_err, was_strong) = err.to_js_weak(global_this);
-                if was_strong == crate::webcore::streams::WasStrong::Strong {
-                    js_err.unprotect();
-                }
+                let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
                 credentials.deref();
                 return Ok(bun_jsc::JSPromise::rejected_promise(global_this, js_err).to_js());
@@ -1151,11 +1145,12 @@ pub fn readable_stream(
                 if let Some(bytes) = readable.ptr.bytes() {
                     if let Some(err) = request_err {
                         bytes.on_data(crate::webcore::streams::StreamResult::Err(
-                            crate::webcore::streams::StreamError::JSValue(s3_error_to_js(
-                                &err,
-                                &self_.global,
-                                Some(&self_.path),
-                            )),
+                            crate::webcore::streams::StreamError::JSValue(
+                                bun_jsc::strong::Optional::create(
+                                    s3_error_to_js(&err, &self_.global, Some(&self_.path)),
+                                    &self_.global,
+                                ),
+                            ),
                         ))?;
                         return Ok(());
                     }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -319,48 +319,29 @@ pub enum StreamResult {
 }
 
 impl StreamResult {
-    // Intentionally not Drop — Result is bitwise-copied in the to_js() shutdown path, so
-    // ownership is contextual and a Drop impl would double-free.
-    // Named `release` (not `deinit`) per PORTING.md — `pub fn deinit` is forbidden as a public API.
     pub fn release(&mut self) {
         match self {
-            StreamResult::Owned(owned) => owned.clear_and_free(),
-            StreamResult::OwnedAndDone(owned_and_done) => owned_and_done.clear_and_free(),
-            StreamResult::Err(err) => {
-                if let StreamError::JSValue(v) = err {
-                    v.unprotect();
-                }
+            StreamResult::Owned(owned) | StreamResult::OwnedAndDone(owned) => {
+                owned.clear_and_free()
             }
+            StreamResult::Err(StreamError::JSValue(s)) => s.deinit(),
             _ => {}
         }
     }
 }
 
-#[derive(Clone)]
 pub enum StreamError {
     Error(SysError),
     AbortReason(CommonAbortReason),
-    // TODO: use an explicit jsc.Strong.Optional here.
-    JSValue(JSValue),
-    WeakJSValue(JSValue),
-}
-
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub enum WasStrong {
-    Strong,
-    Weak,
+    JSValue(jsc::strong::Optional),
 }
 
 impl StreamError {
-    pub fn to_js_weak(&self, global_object: &JSGlobalObject) -> (JSValue, WasStrong) {
+    pub fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
         match self {
-            StreamError::Error(err) => (err.to_js(global_object), WasStrong::Weak),
-            StreamError::JSValue(v) => (*v, WasStrong::Strong),
-            StreamError::WeakJSValue(v) => (*v, WasStrong::Weak),
-            StreamError::AbortReason(reason) => {
-                let value = reason.to_js(global_object);
-                (value, WasStrong::Weak)
-            }
+            StreamError::Error(err) => err.to_js(global_object),
+            StreamError::JSValue(v) => v.get().unwrap_or(JSValue::UNDEFINED),
+            StreamError::AbortReason(reason) => reason.to_js(global_object),
         }
     }
 }
@@ -817,14 +798,8 @@ impl StreamResult {
 
         match result {
             StreamResult::Err(err) => {
-                let value = 'brk: {
-                    let (js_err, was_strong) = err.to_js_weak(global_this);
-                    js_err.ensure_still_alive();
-                    if was_strong == WasStrong::Strong {
-                        js_err.unprotect();
-                    }
-                    break 'brk js_err;
-                };
+                let value = err.to_js(global_this);
+                value.ensure_still_alive();
                 *result = StreamResult::Temporary(RawSlice::EMPTY);
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut`
                 // deref. Fresh temp `&mut` is the sole borrow across this
@@ -909,10 +884,7 @@ impl StreamResult {
                 Ok(promise_js)
             }
             StreamResult::Err(err) => {
-                let (js_err, was_strong) = err.to_js_weak(global_this);
-                if was_strong == WasStrong::Strong {
-                    js_err.unprotect();
-                }
+                let js_err = err.to_js(global_this);
                 js_err.ensure_still_alive();
                 Ok(JSPromise::rejected_promise(global_this, js_err).to_js())
             }
@@ -2507,7 +2479,7 @@ impl BufferAction {
         err: &StreamError,
     ) -> core::result::Result<(), jsc::JsTerminated> {
         // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*mut → &mut` deref.
-        JSPromise::opaque_mut(self.swap()).reject(global, Ok(err.to_js_weak(global).0))
+        JSPromise::opaque_mut(self.swap()).reject(global, Ok(err.to_js(global)))
     }
 
     pub fn resolve(

--- a/test/js/bun/s3/s3-stream-error-gc.test.ts
+++ b/test/js/bun/s3/s3-stream-error-gc.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot } from "harness";
+
+test("S3 stream error parked before consumption survives GC", async () => {
+  const fixture = `
+    const stream = Bun.S3Client.file("some-key").stream();
+    Bun.gc(true);
+    const decoys = [];
+    for (let i = 0; i < 100; i++) decoys.push(new TypeError("decoy " + i));
+    let err = null;
+    try {
+      await stream.text();
+    } catch (e) {
+      err = e;
+    }
+    if (err === null) throw new Error("expected rejection");
+    if (String(err.message).includes("decoy")) throw new Error("rejected with a recycled object: " + err);
+    console.log(err.code);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: {
+      ...bunEnv,
+      S3_ACCESS_KEY_ID: undefined,
+      S3_SECRET_ACCESS_KEY: undefined,
+      S3_REGION: undefined,
+      S3_ENDPOINT: undefined,
+      S3_BUCKET: undefined,
+      S3_SESSION_TOKEN: undefined,
+      AWS_ACCESS_KEY_ID: undefined,
+      AWS_SECRET_ACCESS_KEY: undefined,
+      AWS_REGION: undefined,
+      AWS_ENDPOINT: undefined,
+      AWS_BUCKET: undefined,
+      AWS_SESSION_TOKEN: undefined,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({
+    stdout: normalizeBunSnapshot(stdout),
+    stderr: normalizeBunSnapshot(stderr),
+    exitCode,
+  }).toMatchInlineSnapshot(`
+    {
+      "exitCode": 0,
+      "stderr": "",
+      "stdout": "ERR_S3_MISSING_CREDENTIALS",
+    }
+  `);
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a use-after-free found by Fuzzilli (fingerprint `StructureID.h(93)`, `ASSERTION FAILED: decontaminate()` in `StructureID::decode()`).

`StreamError::JSValue` held a raw `JSValue` with no GC root. When an S3 download stream failed before a consumer attached (missing credentials fail synchronously inside `.stream()`), the error object was parked in `ByteStream.pending.result` across event-loop turns. A GC before the stream was consumed freed it, so `.text()` rejected with whatever now lived in the recycled cell, or crashed on a dead cell. Deterministic on an unfixed build:

```js
const stream = Bun.S3Client.file("some-key").stream();
Bun.gc(true);
for (let i = 0; i < 100; i++) new TypeError("decoy " + i);
await stream.text().catch(e => e); // rejects with TypeError: decoy 0 (recycled cell)
```

The fetch, request body size limit, and `Body::ValueError::to_stream_error` producers had the same shape.

### The fix

`StreamError::JSValue` now holds `jsc::strong::Optional`, which keeps the value rooted while held and releases it on `Drop` (implements the existing TODO on the variant).

This deletes most of the surrounding machinery: `to_js_weak` becomes `to_js`, the `WasStrong` enum and every consumer-side `if was_strong == Strong { unprotect() }` branch are gone, the unused `WeakJSValue` variant is gone, `StreamError` is no longer `Clone`, `RequestContext::on_pipe` drops its raw-pointer `scopeguard::defer!`/`unsafe` block (the by-value result drops naturally in the trait impl), and `ByteStream::on_data` moves a parked error instead of cloning it.

### How did you verify your code works?

- New test `test/js/bun/s3/s3-stream-error-gc.test.ts` fails on the unfixed build (rejects with a recycled decoy object) and passes with this change.
- The original fuzzer script no longer asserts.
- Ran the S3 test directory, `test/js/web/streams/streams.test.js`, `test/js/web/fetch/{body-stream,body-mixin-errors,fetch.stream}.test.ts`, `test/js/web/streams/readable-stream-blob-consumed.test.ts`, and `test/js/bun/http/serve-pending-promise-abort-leak.test.ts` against the debug build; only behavioral delta vs an unmodified build is the new test passing (the remaining failures are pre-existing 5s debug+ASAN timeouts that reproduce identically on the unmodified debug build).
- `cargo clippy -p bun_runtime` and `bun run rust:check-all` pass.
