### PR TITLE
Fix standard-decorator lowering temp name collisions between sibling classes

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -165,11 +165,50 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.call_runtime(l, name, list)
     }
 
-    /// newSymbol + scope.generated.append in one call.
+    /// newSymbol + scope.generated.append in one call, for temps that become
+    /// `var`s in the enclosing scope. The name is uniqued across the file
+    /// (`_init`, `_init2`, ...): the transpile-only path never runs a renamer,
+    /// so sibling decorated classes would otherwise declare the same names and
+    /// clobber each other's state. The symbol is also recorded as declared so
+    /// the bundler's renamer can fix collisions across files in a chunk.
     fn new_sym(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
+        let name = self.dedupe_decorator_temp_name(name);
+        let ref_ = self.new_symbol(kind, name).expect("unreachable");
+        self.record_declared_symbol(ref_);
+        VecExt::append(&mut self.current_scope_mut().generated, ref_);
+        ref_
+    }
+
+    /// `new_sym` without the file-wide uniquing or declaration record, for
+    /// names scoped to a synthesized inner function or class that can never
+    /// collide with sibling lowerings (setter parameters, anonymous class
+    /// expression names — the latter are observable via `Class.name` and must
+    /// be emitted verbatim).
+    fn new_sym_scoped(&mut self, kind: js_ast::symbol::Kind, name: &'a [u8]) -> Ref {
         let ref_ = self.new_symbol(kind, name).expect("unreachable");
         VecExt::append(&mut self.current_scope_mut().generated, ref_);
         ref_
+    }
+
+    /// Returns `base` the first time it is requested and `base<N>` (N >= 2)
+    /// after that, skipping suffixed names an earlier request already took
+    /// verbatim (e.g. a class named `init2` mints `_init2` before a second
+    /// `_init` is requested).
+    fn dedupe_decorator_temp_name(&mut self, base: &'a [u8]) -> &'a [u8] {
+        let Some(&last) = self.decorator_temp_name_counts.get(base) else {
+            self.decorator_temp_name_counts.insert(base, 1);
+            return base;
+        };
+        let mut tries = last + 1;
+        loop {
+            let candidate = self.bump_name(base, Some(tries as usize));
+            if !self.decorator_temp_name_counts.contains_key(candidate) {
+                self.decorator_temp_name_counts.insert(base, tries);
+                self.decorator_temp_name_counts.insert(candidate, 1);
+                return candidate;
+            }
+            tries += 1;
+        }
     }
 
     /// Single var declaration statement.
@@ -1137,7 +1176,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && can_be_class_binding_name(name)
                 {
                     class.class_name = Some(js_ast::LocRef {
-                        ref_: Some(p.new_sym(js_ast::symbol::Kind::Other, name)),
+                        ref_: Some(p.new_sym_scoped(js_ast::symbol::Kind::Other, name)),
                         loc,
                     });
                 }
@@ -1194,12 +1233,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         // ── Phase 2: Pre-evaluate decorators/keys ────────
-        let mut dec_counter: usize = 0;
         let mut class_dec_ref: Option<Ref> = None;
         let mut class_dec_stmt: Stmt = Stmt::empty();
         let mut class_dec_assign_expr: Option<Expr> = None;
         if class_decorators_len > 0 {
-            dec_counter += 1;
             let cdr = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
             class_dec_ref = Some(cdr);
             // Move ownership into the AST node — `class_decorators` is not read
@@ -1228,7 +1265,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let mut prop_dec_refs: HashMap<usize, Ref> = HashMap::default();
         let mut computed_key_refs: HashMap<usize, Ref> = HashMap::default();
         let mut pre_eval_stmts = BumpVec::<Stmt>::new_in(bump);
-        let mut computed_key_counter: usize = 0;
 
         let props_slice: &mut [Property] = class.properties.slice_mut();
         for (prop_idx, prop) in props_slice.iter_mut().enumerate() {
@@ -1236,13 +1272,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 continue;
             }
             if prop.ts_decorators.len_u32() > 0 {
-                dec_counter += 1;
-                let dec_name: &'a [u8] = if dec_counter == 1 {
-                    b"_dec"
-                } else {
-                    p.bump_name(b"_dec", Some(dec_counter))
-                };
-                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, dec_name);
+                let dec_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_dec");
                 prop_dec_refs.insert(prop_idx, dec_ref);
                 if is_expr {
                     let binding = p.b(B::Identifier { r#ref: dec_ref }, loc);
@@ -1266,13 +1296,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 && prop.key.is_some()
                 && prop.ts_decorators.len_u32() > 0
             {
-                computed_key_counter += 1;
-                let key_name: &'a [u8] = if computed_key_counter == 1 {
-                    b"_computedKey"
-                } else {
-                    p.bump_name(b"_computedKey", Some(computed_key_counter))
-                };
-                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, key_name);
+                let key_ref = p.new_sym(js_ast::symbol::Kind::Other, b"_computedKey");
                 computed_key_refs.insert(prop_idx, key_ref);
                 if is_expr {
                     let binding = p.b(B::Identifier { r#ref: key_ref }, loc);
@@ -1385,7 +1409,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             BumpVec::<js_ast::StoreRef<G::ClassStaticBlock>>::new_in(bump);
         let mut prefix_stmts = BumpVec::<Stmt>::new_in(bump);
         let mut private_lowered_map: PrivateLoweredMap = PrivateLoweredMap::default();
-        let mut accessor_storage_counter: usize = 0;
         let mut emitted_private_adds: HashMap<u32, ()> = HashMap::default();
         let mut static_private_add_blocks = BumpVec::<Property>::new_in(bump);
 
@@ -1543,10 +1566,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 break 'brk p.bump_name2(b"_", &s.data);
                             }
                         }
-                        let name =
-                            p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                        accessor_storage_counter += 1;
-                        name
+                        b"_accessor_storage"
                     };
                     let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
                     let wme = p.new_weak_map_expr(loc);
@@ -1571,7 +1591,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     };
 
                     // Setter: set foo(v) { __privateSet(this, _foo, v); }
-                    let setter_param_ref = p.new_sym(js_ast::symbol::Kind::Other, b"v");
+                    let setter_param_ref = p.new_sym_scoped(js_ast::symbol::Kind::Other, b"v");
                     let this_e2 = p.new_expr(E::This {}, loc);
                     let wm_e2 = p.use_ref(wm_ref, loc);
                     let v_e = p.use_ref(setter_param_ref, loc);
@@ -1789,9 +1809,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     if let js_ast::ExprData::EString(s) = &key_expr.data {
                         break 'brk p.bump_name2(b"_", &s.data);
                     }
-                    let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));
-                    accessor_storage_counter += 1;
-                    name
+                    b"_accessor_storage"
                 };
                 let wm_ref = p.new_sym(js_ast::symbol::Kind::Other, accessor_name);
                 private_extra_ref = Some(wm_ref);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -541,6 +541,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub temp_refs_to_declare: List<'a, TempRef>,
     pub temp_ref_count: i32,
 
+    /// Tracks the `var` temp names minted by the standard-decorator lowering
+    /// (`_init`, `_dec`, ...) so each name is only used once per file. The
+    /// transpile-only path never runs a renamer, so sibling decorated classes
+    /// would otherwise emit colliding declarations in the enclosing scope that
+    /// clobber each other's state. Maps a name to the last numeric suffix
+    /// handed out for it (1 = the bare name).
+    pub decorator_temp_name_counts: HashMap<&'a [u8], u32>,
+
     // When bundling, hoisted top-level local variables declared with "var" in
     // nested scopes are moved up to be declared in the top-level scope instead.
     // The old "var" statements are turned into regular assignments instead. This
@@ -9219,6 +9227,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             await_target: None,
             temp_refs_to_declare: BumpVec::new_in(arena),
             temp_ref_count: 0,
+            decorator_temp_name_counts: Default::default(),
             relocated_top_level_vars: BumpVec::new_in(arena),
             after_arrow_body_loc: bun_ast::Loc::EMPTY,
             const_values: Default::default(),

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -366,6 +366,158 @@ describe("ES Decorators", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/31965
+  describe("sibling decorated classes don't share lowering temps", () => {
+    test("superclass addInitializer fires for subclass instances", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const order = [];
+        function trace(name) {
+          return function (target, ctx) {
+            ctx.addInitializer(function () {
+              order.push(name + " on " + this.constructor.name);
+            });
+            return target;
+          };
+        }
+        class A {
+          @trace("A.field") accessor counter = 0;
+          @trace("A.foo") get foo() { return 1; }
+        }
+        class B extends A {
+          @trace("B.bar") get bar() { return 2; }
+        }
+        new A();
+        order.push("--");
+        new B();
+        console.log(order.join(","));
+      `);
+      expect(stderr).toBe("");
+      // Initializer order matches tsc --target es2022 and esbuild: within a
+      // class, getter/method extra initializers run before accessor initializers.
+      expect(stdout).toBe("A.foo on A,A.field on A,--,A.foo on B,A.field on B,B.bar on B\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("each class's addInitializer fires exactly once for its own class", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const order = [];
+        function trace(name) {
+          return function (target, ctx) {
+            ctx.addInitializer(function () { order.push(name); });
+            return target;
+          };
+        }
+        class A { @trace("A.foo") get foo() { return 1; } }
+        class B { @trace("B.bar") get bar() { return 2; } }
+        new A();
+        new B();
+        console.log(order.join(","));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("A.foo,B.bar\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("same-named accessors in two classes use separate storage", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(target, ctx) { return target; }
+        class A { @dec accessor x = 1 }
+        class B { @dec accessor x = 2 }
+        const a = new A();
+        const b = new B();
+        console.log(a.x, b.x);
+        a.x = 10;
+        console.log(a.x, b.x);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2\n10 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("same-named decorated private fields in two classes use separate storage", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(target, ctx) { return target; }
+        class A { @dec #x = 1; getX() { return this.#x; } }
+        const a = new A();
+        class B { @dec #x = 2; getX() { return this.#x; } }
+        const b = new B();
+        console.log(a.getX(), b.getX());
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("1 2\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated class expressions keep separate state and names", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        const order = [];
+        function trace(name) {
+          return function (target, ctx) {
+            ctx.addInitializer(function () { order.push(name); });
+            return target;
+          };
+        }
+        const A = class { @trace("A.foo") get foo() { return 1; } };
+        const B = class { @trace("B.bar") get bar() { return 2; } };
+        new A();
+        new B();
+        console.log(A.name, B.name, order.join(","));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("A B A.foo,B.bar\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated classes in two bundled files keep separate state", async () => {
+      using dir = tempDir("es-dec-bundle", {
+        "a.js": `
+          export const order = [];
+          function dec(target, ctx) {
+            ctx.addInitializer(function () { order.push("A.foo on " + this.constructor.name); });
+            return target;
+          }
+          export class A { @dec get foo() { return 1; } }
+        `,
+        "b.js": `
+          import { order } from "./a.js";
+          function dec(target, ctx) {
+            ctx.addInitializer(function () { order.push("B.bar on " + this.constructor.name); });
+            return target;
+          }
+          export class B { @dec get bar() { return 2; } }
+        `,
+        "index.js": `
+          import { A, order } from "./a.js";
+          import { B } from "./b.js";
+          new A();
+          new B();
+          console.log(order.join(","));
+        `,
+      });
+
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "index.js", "--outfile=bundle.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [buildStderr, buildExitCode] = await Promise.all([build.stderr.text(), build.exited]);
+      expect(filterStderr(buildStderr)).toBe("");
+      expect(buildExitCode).toBe(0);
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "bundle.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(filterStderr(rawStderr)).toBe("");
+      expect(stdout).toBe("A.foo on A,B.bar on B\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("standard vs experimental mode switching", () => {
     test("JS files use standard decorators by default", async () => {
       // JS files always use standard decorators, even when


### PR DESCRIPTION
Fixes #31965

Every instance of class A ran class B's initializers:

```ts
class A {
  @trace("A.field") accessor counter = 0
  @trace("A.foo") get foo() { return 1 }
}
class B extends A {
  @trace("B.bar") get bar() { return 2 }
}
new A() // fires "B.bar" instead of A.field / A.foo
new B() // fires "B.bar" twice, A's initializers never fire
```

Real-world impact: mobx 6 `@computed` relies on `addInitializer`, so the first property read crashes with `values_.get(key).get of undefined`.

### Cause

The standard (TC39) decorator lowering named its temp vars (`_init`, `_dec`, `_computedKey`, `_accessor_storage`, `_base`, private storage WeakMaps) with counters local to a single class lowering. With two or more decorated classes in the same scope the second lowering redeclared the first class's `var`s:

```js
var _init = __decoratorStart(undefined);
class A { constructor() { __runInitializers(_init, 5, this); ... } }
...
var _init = __decoratorStart(_base); // clobbers A's _init
class B extends _base { ... }
```

Constructors read `_init` lazily, so `new A()` ran B's initializers and A's never fired. The same collision made two classes with a same-named `accessor` share one storage WeakMap, throwing `TypeError: Cannot read from private field`, and corrupted same-named decorated private fields (`#x`) across classes.

The transpile-only path (`bun run`) never runs a renamer, so generated names must be unique at generation time. In bundle mode the renamer also never saw these symbols: top-level names come from `part.declared_symbols`, which the lowering never recorded, so collisions survived across files in a chunk too.

### Fix

- `new_sym` now uniques the requested name through a per-file map on the parser: the first request keeps the bare name, later ones get `_init2`, `_init3`, ... (matching esbuild's output style). The per-class `dec_counter` / `computed_key_counter` / `accessor_storage_counter` locals are replaced by this map.
- `new_sym` also records the symbol via `record_declared_symbol` so the bundler's renamer dedupes collisions across files in a chunk, like any other top-level symbol.
- Setter parameters and inferred anonymous class expression names (observable via `Class.name`) keep their exact names via a non-uniquing variant.

### Verification

New tests in `test/bundler/transpiler/es-decorators.test.ts` cover the issue repro (initializer firing order matches `tsc --target es2022` and esbuild), sibling classes without inheritance, same-named accessors and decorated private fields across classes, decorated class expressions (including `Class.name`), and two decorated classes bundled from separate files. All 6 fail on the unfixed build and pass with the fix.

Existing suites pass: `es-decorators.test.ts` (49), `es-decorators-esbuild.test.ts` (147), `decorators.test.ts` (22), `decorator-metadata.test.ts` (5), `bundler_decorator_metadata.test.ts` (2), `bundler_minify.test.ts` (39), `bundler_splitting.test.ts` (10), `bundler_edgecase.test.ts` (119).
