### PR TITLE
Remove unsound ErasedBox and the dead websocket_deflate RareData slot

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1502,8 +1502,6 @@ impl<const SSL: bool> WebSocket<SSL> {
         secure: Option<*mut SslCtx>,
         proxy_tunnel: Option<NonNull<WebSocketProxyTunnel>>,
     ) -> *mut Self {
-        // outlives this call.
-        let vm = global_this.bun_vm().as_mut();
         let ws = bun_core::heap::into_raw(Box::new(WebSocket::<SSL> {
             ref_count: Cell::new(1),
             tcp: Cell::new(Socket::<SSL>::detached()),
@@ -1525,7 +1523,6 @@ impl<const SSL: bool> WebSocket<SSL> {
             payload_length_frame_bytes: Cell::new([0u8; 8]),
             payload_length_frame_len: Cell::new(0),
             initial_data_handler: Cell::new(None),
-            // re-derived from `global_this` so `vm` stays usable below
             // SAFETY: bun_vm() never returns null; event_loop ptr is live for VM lifetime.
             event_loop: global_this.bun_vm().event_loop_mut(),
             deflate: RefCell::new(None),
@@ -1539,7 +1536,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         let ws_ref = unsafe { &mut *ws };
 
         if let Some(params) = deflate_params {
-            *ws_ref.deflate.get_mut() = WebSocketDeflate::init(*params, vm.rare_data()).ok();
+            *ws_ref.deflate.get_mut() = WebSocketDeflate::init(*params).ok();
         }
 
         ws

--- a/src/http_jsc/websocket_client/WebSocketDeflate.rs
+++ b/src/http_jsc/websocket_client/WebSocketDeflate.rs
@@ -3,7 +3,6 @@
 use core::ffi::c_int;
 
 use bun_core::feature_flag;
-use bun_jsc::rare_data::RareData as JscRareData;
 use bun_libdeflate_sys::libdeflate as libdeflate_sys;
 use bun_zlib as zlib;
 
@@ -66,10 +65,10 @@ pub struct PerMessageDeflate {
     pub decompress_stream: zlib::InflateDecoder,
     pub params: Params,
     // VM `bun_jsc::RareData` would be the natural owner (pooled libdeflate
-    // handles, shared across connections), but `bun_jsc::RareData::websocket_deflate()`
-    // returns an opaque placeholder (the real type is *this* `RareData`, which
-    // would be a dep cycle), so each connection owns a fresh instance instead —
-    // a per-connection libdeflate allocation, not a correctness divergence.
+    // handles, shared across connections), but the concrete type is *this*
+    // `RareData`, which `bun_jsc` cannot name without a dep cycle, so each
+    // connection owns a fresh instance instead: a per-connection libdeflate
+    // allocation, not a correctness divergence.
     pub rare_data: RareData,
 }
 
@@ -108,10 +107,7 @@ pub enum CompressError {
 bun_core::named_error_set!(DecompressError, CompressError);
 
 impl PerMessageDeflate {
-    pub(crate) fn init(
-        params: Params,
-        rare_data: &mut JscRareData,
-    ) -> Result<Box<Self>, bun_core::Error> {
+    pub(crate) fn init(params: Params) -> Result<Box<Self>, bun_core::Error> {
         // Initialize compressor (deflate)
         // We use negative window bits for raw DEFLATE, as required by RFC 7692.
         let compress_stream = zlib::DeflateEncoder::new(
@@ -131,14 +127,8 @@ impl PerMessageDeflate {
             params,
             compress_stream,
             decompress_stream,
-            // `rare_data.websocket_deflate()` returns an opaque `{ _opaque: () }`
-            // placeholder in bun_jsc (the real type is `self::RareData`, which
-            // bun_jsc cannot import without a dep cycle), so use a fresh
-            // per-connection instance — see the `rare_data` field note.
-            rare_data: {
-                let _ = rare_data;
-                RareData::default()
-            },
+            // Fresh per-connection instance; see the `rare_data` field note.
+            rare_data: RareData::default(),
         }))
     }
 

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -31,7 +31,7 @@ use super::uuid::UUID;
 //
 //   - `mysql_context` / `postgresql_context` / `ssl_ctx_cache` / `editor_context`
 //     → moved to `bun_runtime::jsc_hooks::RuntimeState` (already there).
-//   - `cron_jobs` / `node_fs_stat_watcher_scheduler` / `websocket_deflate`
+//   - `cron_jobs` / `node_fs_stat_watcher_scheduler`
 //     → erased `*mut c_void` slots; high tier lazy-inits.
 //   - the `bun test --isolate` watcher/server registries → moved to
 //     `bun_runtime::jsc_hooks::IsolationHandles` so the entries keep their
@@ -192,26 +192,11 @@ impl CleanupHook {
     }
 }
 
-/// Erased high-tier slot with paired destructor (e.g. `WebSocketDeflate::RareData`).
-pub struct ErasedBox {
-    pub ptr: NonNull<c_void>,
-    pub dtor: unsafe fn(*mut c_void),
-}
-impl Drop for ErasedBox {
-    fn drop(&mut self) {
-        // SAFETY: `dtor` was supplied by the same high-tier code that allocated `ptr`.
-        unsafe { (self.dtor)(self.ptr.as_ptr()) };
-    }
-}
-
 // ──────────────────────────────────────────────────────────────────────────
 // RareData
 // ──────────────────────────────────────────────────────────────────────────
 
 pub struct RareData {
-    /// `bun_http_jsc::WebSocketDeflate::RareData` — erased; lazy-init in
-    /// `bun_http_jsc::WebSocketDeflate::rare_data()`.
-    pub websocket_deflate: Option<ErasedBox>,
     pub boring_ssl_engine: Option<*mut boring::ENGINE>,
 
     /// Erased `*mut webcore::blob::Store` (intrusive-refcounted on the runtime
@@ -310,7 +295,6 @@ pub(crate) type FilePollStore = Async::file_poll::Store;
 impl Default for RareData {
     fn default() -> Self {
         Self {
-            websocket_deflate: None,
             boring_ssl_engine: None,
             stderr_store: None,
             stderr_mode: 0,
@@ -649,12 +633,6 @@ impl RareData {
     #[inline]
     pub fn memory_pressure_watcher_slot(&mut self) -> &mut Option<NonNull<c_void>> {
         &mut self.memory_pressure_watcher
-    }
-
-    /// Raw slot — lazy-init body lives in `bun_http_jsc::WebSocketDeflate`.
-    #[inline]
-    pub fn websocket_deflate_slot(&mut self) -> &mut Option<ErasedBox> {
-        &mut self.websocket_deflate
     }
 
     // ── lazy-init: hot_map ─────────────────────────────────────────────────
@@ -1069,9 +1047,9 @@ fn get_tls_default_ciphers_from_js(
 
 impl Drop for RareData {
     fn drop(&mut self) {
-        // temp_pipe_read_buffer / spawn_sync_event_loop_ / aws_signature_cache /
-        // s3_default_client / default_csrf_secret / cleanup_hooks / cron_jobs /
-        // path_buf / websocket_deflate / tls_default_ciphers:
+        // temp_pipe_read_buffer / spawn_sync_event_loop_ / s3_default_client /
+        // default_csrf_secret / cleanup_hooks / cron_jobs / path_buf /
+        // tls_default_ciphers:
         // all dropped automatically via field Drop.
 
         if let Some(engine) = self.boring_ssl_engine.take() {

--- a/test/internal/unsound-erased-box.test.ts
+++ b/test/internal/unsound-erased-box.test.ts
@@ -1,0 +1,48 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import path from "path";
+import { globAllSources } from "../../scripts/glob-sources.ts";
+
+// https://github.com/oven-sh/bun/issues/31976
+//
+// `bun_jsc::rare_data::ErasedBox` paired a `pub ptr: NonNull<c_void>` with a
+// `pub dtor: unsafe fn(*mut c_void)` and called `dtor(ptr)` from a safe `Drop`.
+// Because both fields were public, fully-safe code could forge an arbitrary
+// pointer/destructor pair via a struct literal and get UB on drop. The type
+// (and the never-populated `RareData.websocket_deflate` slot holding it) was
+// dead code and was deleted. An erased owner whose destructor runs in a safe
+// `Drop` must keep its fields private and gate construction behind an
+// `unsafe fn`, so the pairing invariant is acknowledged at every call site.
+
+const root = path.resolve(import.meta.dir, "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Read and preprocess each file once; both tests scan the cache.
+const sources = new Map<string, string>();
+for (const abs of rustSources) {
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions don't count.
+  const stripped = content.replace(/^\s*\/\/.*$/gm, "");
+  sources.set(path.relative(root, abs).replaceAll(path.sep, "/"), stripped);
+}
+
+function scan(pattern: RegExp): string[] {
+  const offenders: string[] = [];
+  for (const [source, stripped] of sources) {
+    if (pattern.test(stripped)) {
+      offenders.push(source);
+    }
+  }
+  return offenders;
+}
+
+test("ErasedBox (safe-forgeable ptr/dtor pair) stays deleted", () => {
+  expect(scan(/\bErasedBox\b/)).toEqual([]);
+});
+
+test("no pub destructor function-pointer fields", () => {
+  // A `pub dtor: unsafe fn(..)` field lets safe code in any crate swap in an
+  // arbitrary destructor; whatever later calls it (typically a safe `Drop`)
+  // then runs a forged function on a forged pointer.
+  expect(scan(/\bpub\s+dtor\s*:\s*unsafe\s+fn\b/)).toEqual([]);
+});

--- a/test/internal/unsound-erased-box.test.ts
+++ b/test/internal/unsound-erased-box.test.ts
@@ -55,6 +55,13 @@ function scan(pattern: RegExp): string[] {
   return offenders;
 }
 
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing (e.g. a
+  // symlinked checkout root) and leaving nothing to scan, which would make the
+  // assertions below pass vacuously.
+  expect(sources.size).toBeGreaterThan(0);
+});
+
 test("ErasedBox (safe-forgeable ptr/dtor pair) stays deleted", () => {
   expect(scan(/\bErasedBox\b/)).toEqual([]);
 });

--- a/test/internal/unsound-erased-box.test.ts
+++ b/test/internal/unsound-erased-box.test.ts
@@ -1,5 +1,6 @@
 import { file } from "bun";
 import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../scripts/glob-sources.ts";
 
@@ -17,13 +18,31 @@ import { globAllSources } from "../../scripts/glob-sources.ts";
 const root = path.resolve(import.meta.dir, "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
 
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
 // Read and preprocess each file once; both tests scan the cache.
 const sources = new Map<string, string>();
 for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
   const content = await file(abs).text();
   // Strip full-line comments so prose mentions don't count.
   const stripped = content.replace(/^\s*\/\/.*$/gm, "");
-  sources.set(path.relative(root, abs).replaceAll(path.sep, "/"), stripped);
+  sources.set(source, stripped);
 }
 
 function scan(pattern: RegExp): string[] {


### PR DESCRIPTION
Fixes #31976

### Problem

`bun_jsc::rare_data::ErasedBox` declared both fields `pub`:

```rust
pub struct ErasedBox {
    pub ptr: NonNull<c_void>,
    pub dtor: unsafe fn(*mut c_void),
}
impl Drop for ErasedBox {
    fn drop(&mut self) {
        // SAFETY: `dtor` was supplied by the same high-tier code that allocated `ptr`.
        unsafe { (self.dtor)(self.ptr.as_ptr()) };
    }
}
```

A struct literal needs no `unsafe`, and naming an `unsafe fn` as a value needs no `unsafe` either, so fully safe code in any crate could forge an arbitrary pointer/destructor pair and the safe `Drop` would invoke it: undefined behavior with zero `unsafe` blocks on the caller's side. The SAFETY comment asserted an invariant no constructor enforced.

No shipped behavior was affected: `ErasedBox` was never constructed anywhere in the tree. The `RareData.websocket_deflate` slot holding it was only ever written as `None`, and `websocket_deflate_slot()` had no callers. The lazy init it was reserved for never happened because the concrete payload type lives in `bun_http_jsc` (a dep cycle for `bun_jsc`), so `PerMessageDeflate` stores its libdeflate handles per connection instead.

### Fix

Delete the dead code rather than keep an unsound reserved slot:

- `ErasedBox`, the `websocket_deflate` field, and `websocket_deflate_slot()` in `src/jsc/rare_data.rs`
- the discarded `rare_data: &mut JscRareData` parameter of `PerMessageDeflate::init` (its body was `let _ = rare_data;`) and the comments referencing the deleted slot in `src/http_jsc/websocket_client/WebSocketDeflate.rs`, plus the two call sites in `src/http_jsc/websocket_client.rs` (the `vm` binding in `init_with_tunnel` existed only for this argument)

### Test

The unsoundness has no runtime-observable behavior (the type was dead code), so the guard is a source-scan test, `test/internal/unsound-erased-box.test.ts`, following the existing `ban-words` / `dead-code-escapes` pattern there. It scans tracked Rust sources and asserts:

1. `ErasedBox` stays deleted
2. no `pub dtor: unsafe fn` field exists anywhere (the forgeable-destructor shape, independent of the struct name)

Both assertions fail on the unfixed tree (offender: `src/jsc/rare_data.rs`) and pass with this change.

Verified `cargo check -p bun_jsc -p bun_http_jsc`, a full debug build, and the websocket permessage-deflate suites (`websocket-permessage-deflate*.test.ts`, 13 pass / 1 skip) since `PerMessageDeflate::init`'s signature changed.

### Rebase note

Rebased onto current main and resolved a conflict in `websocket_client.rs`, where #32681 consolidated the two WebSocket `init` paths into a single `new_raw` helper (fields now wrapped in `Cell`/`RefCell`) that still carried the dead `vm.rare_data()` argument to `WebSocketDeflate::init`. Re-applied the argument removal on top of `new_raw`, dropping the now-unused `vm` binding and its stale borrow comment. `rare_data.rs` and `WebSocketDeflate.rs` applied without conflict.

Re-verified: `cargo check -p bun_jsc -p bun_http_jsc`, full debug build, the source-scan test (fails with src stashed, passes with the fix), and `websocket-permessage-deflate*.test.ts` (15 pass / 1 skip).
