### PR TITLE
libarchive: make explicit-free methods unsafe fn

### DIFF
--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -172,8 +172,18 @@ pub mod lib {
             // SAFETY: self came from archive_read_new().
             unsafe { archive_read_close(self.as_mut_ptr()) }
         }
-        pub fn read_free(&self) -> Result {
-            // SAFETY: self came from archive_read_new(); not used after this.
+        /// Frees the handle via `archive_read_free`, which destroys the
+        /// archive (and its error string) even when it reports an error:
+        /// the handle is gone on every return path, so the returned
+        /// [`Result`] carries no retrievable detail.
+        ///
+        /// # Safety
+        /// `self` must be a live handle from [`Archive::read_new`] that no
+        /// other owner frees (in particular not a [`ReadArchive`], whose
+        /// `Drop` frees it again), and it must not be used in any way after
+        /// this call.
+        pub unsafe fn read_free(&self) -> Result {
+            // SAFETY: caller guarantees this is the handle's final use.
             unsafe { archive_read_free(self.as_mut_ptr()) }
         }
         pub fn read_support_format_tar(&self) -> Result {
@@ -370,8 +380,18 @@ pub mod lib {
             // SAFETY: FFI call with no preconditions.
             unsafe { archive_write_new() }
         }
-        pub fn write_free(&self) -> Result {
-            // SAFETY: self came from archive_write_new(); not used after this.
+        /// Frees the handle via `archive_write_free`, which destroys the
+        /// archive (and its error string) even when it reports an error:
+        /// the handle is gone on every return path, so the returned
+        /// [`Result`] carries no retrievable detail.
+        ///
+        /// # Safety
+        /// `self` must be a live handle from [`Archive::write_new`] that no
+        /// other owner frees (in particular not a [`WriteArchive`], whose
+        /// `Drop` frees it again), and it must not be used in any way after
+        /// this call.
+        pub unsafe fn write_free(&self) -> Result {
+            // SAFETY: caller guarantees this is the handle's final use.
             unsafe { archive_write_free(self.as_mut_ptr()) }
         }
         pub fn write_close(&self) -> Result {
@@ -469,8 +489,16 @@ pub mod lib {
             // SAFETY: `archive` is a live handle (opaque_ffi! `&self → *mut Self`).
             unsafe { archive_entry_new2(archive.as_mut_ptr()) }
         }
-        pub fn free(&self) {
-            // SAFETY: self came from Entry::new(); not used after this.
+        /// Frees the entry via `archive_entry_free`.
+        ///
+        /// # Safety
+        /// `self` must be an entry from [`Entry::new`] / [`Entry::new2`]
+        /// that no other owner frees (in particular not an [`OwnedEntry`],
+        /// whose `Drop` frees it again, and not an archive-owned entry from
+        /// `read_next_header`, which libarchive frees itself), and it must
+        /// not be used in any way after this call.
+        pub unsafe fn free(&self) {
+            // SAFETY: caller guarantees this is the entry's final use.
             unsafe { archive_entry_free(self.as_mut_ptr()) }
         }
         pub fn clear(&self) -> *mut Entry {
@@ -734,12 +762,13 @@ pub mod lib {
                 }
                 _ => {}
             }
-            match a.read_free() {
-                Result::Failed | Result::Fatal | Result::Warn => {
-                    return IteratorResult::init_err(self.archive, b"failed to free archive read");
-                }
-                _ => {}
-            }
+            // `archive_read_free` destroys the handle and its error string
+            // even when it reports an error, so a failure here has nothing
+            // to report and no handle left to hand to the caller; real
+            // errors surface through `read_close` above.
+            // SAFETY: `close` consumes `self` and nothing else frees
+            // `self.archive`, so this is the handle's final use.
+            let _ = unsafe { a.read_free() };
             IteratorResult::init_res(())
         }
     }
@@ -983,7 +1012,9 @@ impl BufferReadStream {
 impl Drop for BufferReadStream {
     fn drop(&mut self) {
         let _ = self.archive().read_close();
-        let _ = self.archive().read_free();
+        // SAFETY: `self.archive` came from `Archive::read_new()` in `init`,
+        // is owned solely by this stream, and this is its final use.
+        let _ = unsafe { self.archive().read_free() };
     }
 }
 

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -762,10 +762,6 @@ pub mod lib {
                 }
                 _ => {}
             }
-            // `archive_read_free` destroys the handle and its error string
-            // even when it reports an error, so a failure here has nothing
-            // to report and no handle left to hand to the caller; real
-            // errors surface through `read_close` above.
             // SAFETY: `close` consumes `self` and nothing else frees
             // `self.archive`, so this is the handle's final use.
             let _ = unsafe { a.read_free() };

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -2774,9 +2774,6 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         _ => {}
     }
 
-    // `archive_write_free` destroys the handle and its error string even
-    // when it reports an error, so a failure here has nothing to report;
-    // real errors surface through `write_close` above.
     // SAFETY: `archive` is freed exactly once here and not used afterwards.
     let _ = unsafe { archive.write_free() };
 
@@ -4138,9 +4135,6 @@ pub mod bindings {
             }
             _ => {}
         }
-        // `archive_read_free` destroys the handle and its error string even
-        // when it reports an error, so a failure here has nothing to report;
-        // real errors surface through `read_close` above.
         // SAFETY: `archive` is freed exactly once here and not used afterwards.
         let _ = unsafe { archive.read_free() };
 

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -1703,7 +1703,10 @@ trait ArchivePtrExt {
     fn write_set_options(self, opts: &ZStr) -> ArchiveResult;
     fn write_open_filename(self, path: &ZStr) -> ArchiveResult;
     fn write_close(self) -> ArchiveResult;
-    fn write_free(self) -> ArchiveResult;
+    /// # Safety
+    /// See [`Archive::write_free`]: `self` must be a live handle that no
+    /// other owner frees, and it must not be used after this call.
+    unsafe fn write_free(self) -> ArchiveResult;
     fn error_string(self) -> &'static [u8];
     fn read_support_format_tar(self) -> ArchiveResult;
     fn read_support_format_gnutar(self) -> ArchiveResult;
@@ -1713,7 +1716,10 @@ trait ArchivePtrExt {
     fn read_next_header(self, entry: &mut *mut ArchiveEntry) -> ArchiveResult;
     fn read_data(self, buf: &mut [u8]) -> isize;
     fn read_close(self) -> ArchiveResult;
-    fn read_free(self) -> ArchiveResult;
+    /// # Safety
+    /// See [`Archive::read_free`]: `self` must be a live handle that no
+    /// other owner frees, and it must not be used after this call.
+    unsafe fn read_free(self) -> ArchiveResult;
 }
 impl ArchivePtrExt for *mut Archive {
     #[inline]
@@ -1746,8 +1752,9 @@ impl ArchivePtrExt for *mut Archive {
         Archive::opaque_ref(self).write_close()
     }
     #[inline]
-    fn write_free(self) -> ArchiveResult {
-        Archive::opaque_ref(self).write_free()
+    unsafe fn write_free(self) -> ArchiveResult {
+        // SAFETY: forwarded to the caller.
+        unsafe { Archive::opaque_ref(self).write_free() }
     }
     #[inline]
     fn error_string(self) -> &'static [u8] {
@@ -1789,8 +1796,9 @@ impl ArchivePtrExt for *mut Archive {
         Archive::opaque_ref(self).read_close()
     }
     #[inline]
-    fn read_free(self) -> ArchiveResult {
-        Archive::opaque_ref(self).read_free()
+    unsafe fn read_free(self) -> ArchiveResult {
+        // SAFETY: forwarded to the caller.
+        unsafe { Archive::opaque_ref(self).read_free() }
     }
 }
 
@@ -2751,7 +2759,9 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         }
     }
 
-    ArchiveEntry::opaque_ref(entry).free();
+    // SAFETY: `entry` is the `archive_entry_new2` handle created at the top
+    // of this function; it is freed exactly once here and not used again.
+    unsafe { ArchiveEntry::opaque_ref(entry).free() };
 
     match archive.write_close() {
         ArchiveResult::Failed | ArchiveResult::Fatal | ArchiveResult::Warn => {
@@ -2764,16 +2774,11 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         _ => {}
     }
 
-    match archive.write_free() {
-        ArchiveResult::Failed | ArchiveResult::Fatal | ArchiveResult::Warn => {
-            Output::err_generic(
-                "failed to free archive: {}",
-                format_args!("{}", bstr::BStr::new(archive.error_string())),
-            );
-            Global::crash();
-        }
-        _ => {}
-    }
+    // `archive_write_free` destroys the handle and its error string even
+    // when it reports an error, so a failure here has nothing to report;
+    // real errors surface through `write_close` above.
+    // SAFETY: `archive` is freed exactly once here and not used afterwards.
+    let _ = unsafe { archive.write_free() };
 
     let mut shasum: [u8; sha::SHA1::DIGEST] = [0; sha::SHA1::DIGEST];
     let mut integrity: [u8; sha::SHA512::DIGEST] = [0; sha::SHA512::DIGEST];
@@ -4133,15 +4138,11 @@ pub mod bindings {
             }
             _ => {}
         }
-        match archive.read_free() {
-            ArchiveResult::Failed | ArchiveResult::Fatal | ArchiveResult::Warn => {
-                return Err(global.throw(format_args!(
-                    "failed to close read archive: {}",
-                    bstr::BStr::new(archive.error_string())
-                )));
-            }
-            _ => {}
-        }
+        // `archive_read_free` destroys the handle and its error string even
+        // when it reports an error, so a failure here has nothing to report;
+        // real errors surface through `read_close` above.
+        // SAFETY: `archive` is freed exactly once here and not used afterwards.
+        let _ = unsafe { archive.read_free() };
 
         let entries = JSArray::create_empty(global, entries_info.len())?;
 

--- a/test/internal/libarchive-free-safety.test.ts
+++ b/test/internal/libarchive-free-safety.test.ts
@@ -1,0 +1,25 @@
+// https://github.com/oven-sh/bun/issues/31972
+//
+// The libarchive RAII owners (ReadArchive/WriteArchive/OwnedEntry) deref to
+// the opaque Archive/Entry handle types and free the handle on Drop. If those
+// handle types expose SAFE explicit-free methods taking `&self`, safe Rust can
+// free a handle through an owner and then Drop frees it again: a double free
+// with no `unsafe` anywhere. The explicit-free methods must therefore be
+// `unsafe fn` (a `&self` receiver cannot express that the call invalidates
+// the handle).
+import { expect, test } from "bun:test";
+import path from "path";
+
+const source = await Bun.file(path.join(import.meta.dir, "..", "..", "src", "libarchive", "lib.rs")).text();
+
+test.each(["read_free", "write_free", "free"])("libarchive `%s(&self)` is an unsafe fn", name => {
+  const decls = [
+    ...source.matchAll(new RegExp(String.raw`(?:pub\s+)?(?:unsafe\s+)?fn\s+${name}\s*\(\s*&(?:mut\s+)?self`, "g")),
+  ];
+  // The method must exist (so a rename can't make this test pass vacuously),
+  // and every declaration of it must be `unsafe`.
+  expect(decls.length).toBeGreaterThan(0);
+  for (const decl of decls) {
+    expect(decl[0]).toInclude("unsafe");
+  }
+});


### PR DESCRIPTION
Fixes #31972

### Problem

`ReadArchive`, `WriteArchive`, and `OwnedEntry` in `src/libarchive/lib.rs` are RAII owners that `Deref` to the opaque `Archive`/`Entry` handle types. Those types exposed safe explicit-free methods taking `&self` (`Archive::read_free`, `Archive::write_free`, `Entry::free`), so safe Rust could free a handle through an owner and `Drop` would free it again:

```rust
let read = ReadArchive::new();
let _ = read.read_free(); // resolves via Deref
drop(read);               // Drop calls archive_read_free again
```

Linked against the ASAN-instrumented libarchive objects, this reports `AddressSanitizer: heap-use-after-free` in `archive_read_free` called from `ReadArchive::drop`, with the prior free in `Archive::read_free`. `WriteArchive`/`OwnedEntry` follow the identical pattern. No production call site hits this today; it is latent API unsoundness.

### Fix

- `Archive::read_free`, `Archive::write_free`, and `Entry::free` are now `unsafe fn` with a `# Safety` contract: the handle must not be owned by an RAII owner and must not be used after the call. A `&self` receiver cannot express that the call invalidates the handle, so the repro above is now a compile error (E0133) on all three calls.
- Raw-handle call sites (`ArchiveIterator::close`, `BufferReadStream::drop`, `pack_command`'s pointer extension trait; `TarballStream` was already in `unsafe` blocks) discharge the contract with SAFETY comments.
- Same-class cleanup: `archive_read_free`/`archive_write_free` destroy the handle and its error string even when they report an error (`_archive_read_free` and `_archive_write_free` both end in an unconditional `free(a)`), so the error branches that called `error_string()` after a failed free were themselves use-after-free. They are removed; they were also unreachable, because after the separately-checked `*_close` succeeds the free cannot fail on these paths (read side: no extract cleanup is registered on read-from-memory paths; write side: pax `format_free` always returns `ARCHIVE_OK`). Close errors are still checked and reported while the handle is live.

### Verification

- `test/internal/libarchive-free-safety.test.ts` asserts every borrowed-handle free method in the wrapper is `unsafe fn` (same source-invariant style as `dead-code-escapes.test.ts`). It fails on the unfixed tree (3 fail) and passes with the fix.
- The issue's repro crate no longer compiles: `error[E0133]: call to unsafe function Archive::read_free is unsafe and requires unsafe block` (and the same for `write_free`/`Entry::free`).
- `cargo check`/`clippy` clean; full debug build links.
- `bun bd test test/js/bun/archive.test.ts` (106 pass), `bun bd test test/cli/install/bun-pack.test.ts` (80 pass, exercises both pack_command free sites including `readTarball`), and a manual `bun pm pack` + `bun publish <tarball> --dry-run` smoke for the `ArchiveIterator::close` path.

<details>
<summary>History: earlier revisions of this PR</summary>

The original revision (d2674a71, reviewed by bots above) additionally deleted `lib::Iterator`/`IterResult`/`IteratorEntry`/`IteratorError`, an unused duplicate of `ArchiveIterator` (~200 lines). Main later removed that dead block independently (#36903), so after reapplying this change on current main the deletion is no longer part of this diff; the PR is now the `unsafe fn` conversion, the call-site updates, and the regression test (96+/39-).

An earlier rebase (181e087d) resolved a conflict with #33166, which had modified the then-still-present dead block; the resolution kept the deletion after verifying zero callers.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/libarchive-free-safety.test.ts
bun test v1.4.0 (07d38c171)

test/internal/libarchive-free-safety.test.ts:
18 |   ];
19 |   // The method must exist (so a rename can't make this test pass vacuously),
20 |   // and every declaration of it must be `unsafe`.
21 |   expect(decls.length).toBeGreaterThan(0);
22 |   for (const decl of decls) {
23 |     expect(decl[0]).toInclude("unsafe");
                         ^
error: expect(received).toInclude(expected)

Expected to include: "unsafe"
Received: "pub fn read_free(&self"

      at <anonymous> (/workspace/bun/test/internal/libarchive-free-safety.test.ts:23:21)
(fail) libarchive `read_free(&self)` is an unsafe fn [14.65ms]
18 |   ];
19 |   // The method must exist (so a rename can't make this test pass vacuously),
20 |   // and every declaration of it must be `unsafe`.
21 |   expect(decls.length).toBeGreaterThan(0);
22 |   for (const decl of decls) {
23 |     expect(decl[0]).toInclude("unsafe");
                         ^
error: expect(received).toInclude(expected)

Expected to i
... (truncated)

release without fix: 3 FAILED
bun test v1.3.14 (0d9b296a)

test/internal/libarchive-free-safety.test.ts:
18 |   ];
19 |   // The method must exist (so a rename can't make this test pass vacuously),
20 |   // and every declaration of it must be `unsafe`.
21 |   expect(decls.length).toBeGreaterThan(0);
22 |   for (const decl of decls) {
23 |     expect(decl[0]).toInclude("unsafe");
                         ^
error: expect(received).toInclude(expected)

Expected to include: "unsafe"
Received: "pub fn read_free(&self"

      at <anonymous> (/workspace/bun/test/internal/libarchive-free-safety.test.ts:23:21)
(fail) libarchive `read_free(&self)` is an unsafe fn [9.42ms]
18 |   ];
19 |   // The method must exist (so a rename can't make this test pass vacuously),
20 |   // and every declaration of it must be `unsafe`.
21 |   expect(decls.length).toBeGreaterThan(0);
22 |   for (const decl of decls) {
23 |     expect(decl[0]).toInclude("unsafe");
                         ^
error: expect(received).toInclude(expected)

Expected to include: "unsafe"
Received: "pub fn write_free(&self"

      at <anonymous> (/workspace/bun/test/internal/libarchive-free-safety.test.ts:23:21)
(fail) libarchive `write_free(&self)
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/libarchive-free-safety.test.ts
bun test v1.4.0 (07d38c171)

test/internal/libarchive-free-safety.test.ts:
(pass) libarchive `read_free(&self)` is an unsafe fn [28.43ms]
(pass) libarchive `write_free(&self)` is an unsafe fn [3.42ms]
(pass) libarchive `free(&self)` is an unsafe fn [2.21ms]

 3 pass
 0 fail
 6 expect() calls
Ran 3 tests across 1 file. [2.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
rustup spent 9s installing the pinned toolchain (nightly-2026-07-20); it was missing or incomplete on this machine
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     aa606e8cfb
  features     baseline

22 deps, 120 codegen, 1175 objects in 9164ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1240] mkdir codegen
[2/1240] mkdir stamps
[3/1240] mkdir pch
[4/1240] mkdir obj
[5/1240] gen ErrorCode+*.h
[6/1240] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1240] fetch zlib
[zlib] up to date
[8/1240] fetch tinycc
[tinycc] up to date
[9/1240] gen bindgenv2
[10/1240] gen .bind.ts → GeneratedBindings.cpp
[11/1240] fetch picohttpparser
[picohttpparser] up to date
[12/1240] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[13/1240] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[14/1240] fetch nodejs (prebuilt)
[nodejs
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/libarchive/lib.rs                        | 53 +++++++++++++++++++++-------
 src/runtime/cli/pack_command.rs              | 47 +++++++++++-------------
 test/internal/libarchive-free-safety.test.ts | 25 +++++++++++++
 3 files changed, 86 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/libarchive/lib.rs                             9      8      5
src/runtime/cli/pack_command.rs                   3      4      7
test/internal/libarchive-free-safety.test.ts      0      1      5
```

</details>

**root cause** · written by the author bot

The libarchive RAII wrappers ReadArchive, WriteArchive, and OwnedEntry dereferenced to the underlying handle types, whose safe explicit-free methods took &self rather than consuming ownership, so safe code could free a handle that the owner's Drop implementation would later free again, causing a double free. The fix marks read_free, write_free, and free as unsafe with documented safety contracts requiring the caller to own the handle and not use it afterward, making it impossible to trigger the double free from safe Rust. All internal call sites in the iterator, stream, and pack command cle…

<!-- robobun:evidence:end -->