### PR TITLE
bun_alloc: make buffer-consuming allocator methods unsafe fn

### DIFF
--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -92,22 +92,33 @@ impl Default for StdAllocator {
 }
 
 impl StdAllocator {
+    /// # Safety
+    /// `buf` must describe a live allocation obtained from this allocator, and
+    /// `alignment`/`ra` must satisfy this allocator's vtable contract for it.
+    /// The allocation is freed exactly once; its memory must not be accessed
+    /// after this call.
     #[inline]
-    pub(crate) fn raw_free(&self, buf: &mut [u8], alignment: Alignment, ra: usize) {
-        // SAFETY: vtable invariant — `free` callee respects the (ptr, buf, alignment, ra) contract.
+    pub(crate) unsafe fn raw_free(&self, buf: &mut [u8], alignment: Alignment, ra: usize) {
+        // SAFETY: caller contract matches the vtable `free` contract.
         unsafe { (self.vtable.free)(self.ptr, buf, alignment, ra) }
     }
-    /// `raw_free` with `ret_addr = 0`, byte-aligned.
+    /// [`Self::raw_free`] with `ret_addr = 0`, byte-aligned. A null `ptr` or
+    /// zero `len` is a no-op.
+    ///
+    /// # Safety
+    /// `ptr` must be null or point to a live allocation of `len` bytes
+    /// obtained from this allocator. The allocation is freed exactly once; its
+    /// memory must not be accessed after this call.
     #[inline]
-    pub fn free(&self, bytes: &[u8]) {
-        if bytes.is_empty() {
+    pub unsafe fn free(&self, ptr: *mut u8, len: usize) {
+        if ptr.is_null() || len == 0 {
             return;
         }
-        // SAFETY: `bytes` is reborrowed mutably only for the vtable signature; the
-        // callee treats it as opaque.
-        let buf =
-            unsafe { core::slice::from_raw_parts_mut(bytes.as_ptr().cast_mut(), bytes.len()) };
-        self.raw_free(buf, Alignment::from_byte_units(1), 0);
+        // SAFETY: caller contract — `ptr[..len]` is a live allocation owned by
+        // this allocator; the slice exists only to satisfy the vtable signature.
+        let buf = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
+        // SAFETY: caller contract — see the `# Safety` section above.
+        unsafe { self.raw_free(buf, Alignment::from_byte_units(1), 0) };
     }
 }
 

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -93,31 +93,24 @@ impl Default for StdAllocator {
 
 impl StdAllocator {
     /// # Safety
-    /// `buf` must describe a live allocation obtained from this allocator, and
-    /// `alignment`/`ra` must satisfy this allocator's vtable contract for it.
-    /// The allocation is freed exactly once; its memory must not be accessed
-    /// after this call.
+    /// `buf` must be a live allocation from this allocator with `alignment`. Freed exactly once.
     #[inline]
     pub(crate) unsafe fn raw_free(&self, buf: &mut [u8], alignment: Alignment, ra: usize) {
-        // SAFETY: caller contract matches the vtable `free` contract.
+        // SAFETY: caller contract.
         unsafe { (self.vtable.free)(self.ptr, buf, alignment, ra) }
     }
-    /// [`Self::raw_free`] with `ret_addr = 0`, byte-aligned. A null `ptr` or
-    /// zero `len` is a no-op.
+    /// [`Self::raw_free`] with `ret_addr = 0`, byte-aligned. Null `ptr` or zero `len` is a no-op.
     ///
     /// # Safety
-    /// `ptr` must be null or point to a live allocation of `len` bytes
-    /// obtained from this allocator. The allocation is freed exactly once; its
-    /// memory must not be accessed after this call.
+    /// `ptr` must be null or a live allocation of `len` bytes from this allocator. Freed exactly once.
     #[inline]
     pub unsafe fn free(&self, ptr: *mut u8, len: usize) {
         if ptr.is_null() || len == 0 {
             return;
         }
-        // SAFETY: caller contract — `ptr[..len]` is a live allocation owned by
-        // this allocator; the slice exists only to satisfy the vtable signature.
+        // SAFETY: caller contract — `ptr[..len]` is live and owned by this allocator.
         let buf = unsafe { core::slice::from_raw_parts_mut(ptr, len) };
-        // SAFETY: caller contract — see the `# Safety` section above.
+        // SAFETY: caller contract.
         unsafe { self.raw_free(buf, Alignment::from_byte_units(1), 0) };
     }
 }

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -771,11 +771,8 @@ pub mod store {
             // `stored_name` is a `Box<[u8]>`, so its field `Drop` frees it;
             // only the custom-allocator buffer needs an explicit free here.
             if let Some(p) = self.ptr {
-                // SAFETY: `ptr[..cap]` is the live allocation owned by
-                // `self.allocator` (`init`/`from_raw_parts` contract), freed
-                // exactly once here — `drop` runs once and nothing reads
-                // through `self.ptr` afterwards. A dangling `cap == 0`
-                // pointer (`Bytes::init(Vec::new())`) is a no-op in `free`.
+                // SAFETY: `ptr[..cap]` is owned by `self.allocator` (`init`/`from_raw_parts`
+                // contract) and `drop` runs once. A dangling `cap == 0` pointer is a no-op.
                 unsafe { self.allocator.free(p.as_ptr(), self.cap as usize) };
             }
         }

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -770,13 +770,14 @@ pub mod store {
         fn drop(&mut self) {
             // `stored_name` is a `Box<[u8]>`, so its field `Drop` frees it;
             // only the custom-allocator buffer needs an explicit free here.
-            // Route through the existing accessor instead of re-deriving the
-            // slice from raw parts here: `allocated_slice` already encapsulates
-            // the `(ptr, cap)` → `&[u8]` invariant (and the `None` ⇒ `&[]`
-            // case), and `StdAllocator::free` is `raw_free` with byte alignment
-            // plus an empty-slice early-out — identical to the previous
-            // open-coded `raw_free(.., Alignment::of::<u8>(), 0)`.
-            self.allocator.free(self.allocated_slice());
+            if let Some(p) = self.ptr {
+                // SAFETY: `ptr[..cap]` is the live allocation owned by
+                // `self.allocator` (`init`/`from_raw_parts` contract), freed
+                // exactly once here — `drop` runs once and nothing reads
+                // through `self.ptr` afterwards. A dangling `cap == 0`
+                // pointer (`Bytes::init(Vec::new())`) is a no-op in `free`.
+                unsafe { self.allocator.free(p.as_ptr(), self.cap as usize) };
+            }
         }
     }
 

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -493,9 +493,8 @@ impl BytesExt for Bytes {
             // — same path `Bytes::drop` takes.
             let copy = self.slice().to_vec();
             if let Some(p) = self.ptr.take() {
-                // SAFETY: `ptr[..cap]` is the live allocation owned by
-                // `self.allocator` (`from_raw_parts` contract); `take()`
-                // cleared `self.ptr`, so nothing reads or frees it again.
+                // SAFETY: `ptr[..cap]` is owned by `self.allocator` (`from_raw_parts`
+                // contract); `take()` cleared `self.ptr`, so it is freed once.
                 unsafe { self.allocator.free(p.as_ptr(), self.cap as usize) };
             }
             copy

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -490,10 +490,14 @@ impl BytesExt for Bytes {
         } else {
             // Non-global allocator (e.g. memfd → munmap): copy through the
             // safe `Bytes::slice()` accessor, then free via the owning vtable
-            // — same path `Bytes::drop` takes (`allocator.free(allocated_slice())`).
+            // — same path `Bytes::drop` takes.
             let copy = self.slice().to_vec();
-            self.allocator.free(self.allocated_slice());
-            self.ptr = None;
+            if let Some(p) = self.ptr.take() {
+                // SAFETY: `ptr[..cap]` is the live allocation owned by
+                // `self.allocator` (`from_raw_parts` contract); `take()`
+                // cleared `self.ptr`, so nothing reads or frees it again.
+                unsafe { self.allocator.free(p.as_ptr(), self.cap as usize) };
+            }
             copy
         };
         self.len = 0;

--- a/test/internal/bun-alloc-unsafe-free.test.ts
+++ b/test/internal/bun-alloc-unsafe-free.test.ts
@@ -1,0 +1,67 @@
+// Guards the soundness contract from https://github.com/oven-sh/bun/issues/31967
+//
+// `StdAllocator::free(&self, bytes: &[u8])` was a safe public method: safe
+// Rust could hand it any shared byte slice (stack, static, borrowed) and it
+// would cast the slice to `&mut [u8]` and forward it to the allocator vtable's
+// `free` — i.e. `mi_free` on a stack pointer, reachable with zero `unsafe`.
+//
+// The fix makes `free` (and the `raw_free` it forwards to) `unsafe fn` with a
+// documented precondition, and `free` now takes `(*mut u8, len)` so the
+// aliasing `&[u8] -> &mut [u8]` cast is gone. Soundness is enforced at the
+// type level, not at runtime — no observable behavior change is reachable
+// from JS — so this test statically inspects the Rust source to keep a future
+// refactor from silently reintroducing a safe deallocation entry point.
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+
+function strippedSource(relative: string): string {
+  const source = readFileSync(join(ROOT, relative), "utf-8");
+  // Strip // line comments (incl. /// docs) and /* */ block comments so
+  // prose mentioning the old signatures doesn't false-match.
+  return source.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+// Extract the body of the inherent `impl <Type> { ... }` block so assertions
+// don't leak onto other types in the same file. Works on comment-stripped
+// source; the impl block under test contains no string literals, so brace
+// counting is exact.
+function implBlock(src: string, header: string): string {
+  const start = src.indexOf(header);
+  expect(start).toBeGreaterThan(-1);
+  let depth = 0;
+  let i = src.indexOf("{", start);
+  const open = i;
+  for (; i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return src.slice(open, i + 1);
+}
+
+// A safe `pub fn <name>(` / `pub(crate) fn <name>(` declaration. `unsafe fn`
+// never matches: `fn` must directly follow the visibility (modulo whitespace).
+// `\(` keeps `free(` from matching e.g. `free_only(`.
+const VIS = "pub(?:\\s*\\([^)]*\\))?";
+const safeDecl = (name: string) => new RegExp(`\\b${VIS}\\s+fn\\s+${name}\\s*\\(`);
+const unsafeDecl = (name: string) => new RegExp(`\\b${VIS}\\s+unsafe\\s+fn\\s+${name}\\s*\\(`);
+
+test("StdAllocator buffer-consuming methods are unsafe fn", () => {
+  const src = implBlock(strippedSource("src/bun_alloc/lib.rs"), "impl StdAllocator");
+  for (const name of ["free", "raw_free"]) {
+    expect(src).not.toMatch(safeDecl(name));
+    expect(src).toMatch(unsafeDecl(name));
+  }
+});
+
+test("StdAllocator::free takes a raw pointer, not a borrowed slice", () => {
+  const src = implBlock(strippedSource("src/bun_alloc/lib.rs"), "impl StdAllocator");
+  expect(src).toMatch(/unsafe\s+fn\s+free\s*\(\s*&self\s*,\s*ptr\s*:\s*\*mut\s+u8\s*,\s*len\s*:\s*usize\s*\)/);
+  // The old shape minted a `&mut [u8]` from a shared borrow's pointer.
+  expect(src).not.toMatch(/fn\s+free\s*\(\s*&self\s*,\s*\w+\s*:\s*&\s*\[u8\]\s*\)/);
+});

--- a/test/internal/source-lints/bun-alloc-unsafe-free.test.ts
+++ b/test/internal/source-lints/bun-alloc-unsafe-free.test.ts
@@ -15,7 +15,7 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const ROOT = join(import.meta.dir, "..", "..");
+const ROOT = join(import.meta.dir, "..", "..", "..");
 
 function strippedSource(relative: string): string {
   const source = readFileSync(join(ROOT, relative), "utf-8");


### PR DESCRIPTION
### Problem
- `StdAllocator::free(&self, bytes: &[u8])` in `src/bun_alloc/lib.rs:102` is a safe public method. Safe Rust can pass it any shared slice (stack, static, borrowed). It mints a `&mut [u8]` from the shared borrow and forwards it to the vtable `free`, so `mi_free` on a stack pointer is reachable with zero `unsafe`. A zero-`unsafe` crate that calls `StdAllocator::default().free(&[1u8, 2, 3, 4])` compiles and segfaults in `mi_free`.
- `raw_free` (`lib.rs:96`) has the same shape: a safe signature over a vtable call whose "allocated by this allocator" contract is not encoded.

### Fix
- `StdAllocator::raw_free` is now `unsafe fn`. `StdAllocator::free` is now `unsafe fn free(&self, ptr: *mut u8, len: usize)`, the same shape as the existing `default_alloc::free`. Taking a raw pointer also deletes the `&[u8] -> &mut [u8]` cast. Null `ptr` or zero `len` stays a no-op.
- The two callers, `Bytes::drop` (`src/jsc/webcore_types.rs`) and `Bytes::to_internal_blob` (`src/runtime/webcore/blob/Store.rs`), pass their owned `(ptr, cap)` pair under an `unsafe` block that states the provenance. `to_internal_blob` uses `ptr.take()`, which keeps the single-free invariant the old `self.ptr = None` gave.
- Correct because the only memory that reaches the vtable is memory the `Bytes` recorded at `init`/`from_raw_parts`, and each path frees it once. The issue's repro now fails to compile (`E0133`).
- Verified: `test/internal/source-lints/bun-alloc-unsafe-free.test.ts` (both tests fail on the unfixed source). Also `cargo check --workspace`, `blob.test.ts`, `blob-write.test.ts`, `blob-cow.test.ts` on the ASAN debug build.

### Background
- `StdAllocator` is a `{ptr, vtable}` fat handle over an `AllocatorVTable`. Its `free` entry takes `&mut [u8]` because the vtable signature is shared with allocators that need the length (for example the `munmap` vtable in `Store.rs`).
- `Bytes` is the in-memory store behind a `Blob`. It keeps `(ptr, len, cap, allocator)` instead of a `Vec<u8>` so a memfd- or mmap-backed buffer can carry its own `free` vtable.
- The guard test is a source lint, the pattern `test/internal/source-lints/` uses for type-level invariants with no runtime behavior to observe.

<details><summary>Notes</summary>

Rebase: main deleted `NullableAllocator.rs`, `fallback.rs`, `fallback/z.rs`, and `BufferFallbackAllocator.rs` (#36903, #34767) and dropped `raw_resize`/`raw_remap`/`default_free` from `StdAllocator`. The first version of this PR also made those `unsafe fn`. After the rebase only `free` and `raw_free` remain, so the diff is now three source files and the test. No conflict text was hand-merged: the branch was reset to main and the fix re-applied against the current surface.

`missing_safety_doc` is `allow` in this workspace, so the `# Safety` sections are convention, not a build requirement. They match the 8 existing `unsafe fn`s in `lib.rs`.

CI on the rebased branch: `test/js/node/test/parallel/test-crypto-dh-leak.js` fails on the `debian-13-x64-asan` lane (RSS delta 23 MB against a 20 MB bound). It fails identically on an ASAN build of main without this change (verified locally, delta 24 MB). The test itself skips under Node's ASAN detection for this reason. Reported to main-break triage.
</details>

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 8 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/bun-alloc-unsafe-free.test.ts
bun test v1.4.3 (f42e98025)

test/internal/source-lints/bun-alloc-unsafe-free.test.ts:
52 | const unsafeDecl = (name: string) => new RegExp(`\\b${VIS}\\s+unsafe\\s+fn\\s+${name}\\s*\\(`);
53 | 
54 | test("StdAllocator buffer-consuming methods are unsafe fn", () => {
55 |   const src = implBlock(strippedSource("src/bun_alloc/lib.rs"), "impl StdAllocator");
56 |   for (const name of ["free", "raw_free"]) {
57 |     expect(src).not.toMatch(safeDecl(name));
                         ^
error: expect(received).not.toMatch(expected)

Expected substring or pattern: not /\bpub(?:\s*\([^)]*\))?\s+fn\s+free\s*\(/
Received: "{\n    #[inline]\n    pub(crate) fn raw_free(&self, buf: &mut [u8], alignment: Alignment, ra: usize) {\n        \n        unsafe { (self.vtable.free)(self.ptr, buf, alignment, ra) }\n    }\n    \n    #[inline]\n    pub fn free(&self, bytes: &[u8]) {\n        if bytes.is_empty() {\n            return;\n        }\n        \n        \n        let buf =\n            unsafe { c
... (truncated)

release without fix: 2 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/internal/source-lints/bun-alloc-unsafe-free.test.ts:
52 | const unsafeDecl = (name: string) => new RegExp(`\\b${VIS}\\s+unsafe\\s+fn\\s+${name}\\s*\\(`);
53 | 
54 | test("StdAllocator buffer-consuming methods are unsafe fn", () => {
55 |   const src = implBlock(strippedSource("src/bun_alloc/lib.rs"), "impl StdAllocator");
56 |   for (const name of ["free", "raw_free"]) {
57 |     expect(src).not.toMatch(safeDecl(name));
                         ^
error: expect(received).not.toMatch(expected)

Expected substring or pattern: not /\bpub(?:\s*\([^)]*\))?\s+fn\s+free\s*\(/
Received: "{\n    #[inline]\n    pub(crate) fn raw_free(&self, buf: &mut [u8], alignment: Alignment, ra: usize) {\n        \n        unsafe { (self.vtable.free)(self.ptr, buf, alignment, ra) }\n    }\n    \n    #[inline]\n    pub fn free(&self, bytes: &[u8]) {\n        if bytes.is_empty() {\n            return;\n        }\n        \n        \n        let buf =\n            unsafe { core::slice::from_raw_parts_mut(bytes.as_ptr().cast_mut(), bytes.len()) };\n        self.raw_free(buf, Alignment::from_byte_units(1), 0);\n    }\n}"

      at <anonymous> (/workspac
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/internal/source-lints/bun-alloc-unsafe-free.test.ts
bun test v1.4.3 (f42e98025)

test/internal/source-lints/bun-alloc-unsafe-free.test.ts:
(pass) StdAllocator buffer-consuming methods are unsafe fn [82.87ms]
(pass) StdAllocator::free takes a raw pointer, not a borrowed slice [18.24ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [2.18s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f1f23be0d0
  features     baseline

23 deps, 131 codegen, 1172 objects in 818ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.3-canary.1 (f42e98025)

Checked 22 installs across 61 packages (no changes) [9.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.3-canary.1 (f42e98025)

Checked 1 install across 2 packages (no changes) [4.00ms]
[3/1244] gen ErrorCode+*.h
[4/1244] gen bindgenv2
[5/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.3-canary.1 (f42e98025)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1244] fetch zlib
[zlib] up to date
[7/1244] gen node-fallbacks/react-refresh.js
Bundled 1 module in 5ms

  react-refresh.js  4.81 KB  (entry point)

[8/1244] fetch tinycc
[tinycc] up to date
[9/1243] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1216] gen .bind.ts → GeneratedBindings.cpp
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_alloc/lib.rs                               | 24 ++++----
 src/jsc/webcore_types.rs                           | 12 ++--
 src/runtime/webcore/blob/Store.rs                  |  9 ++-
 .../source-lints/bun-alloc-unsafe-free.test.ts     | 67 ++++++++++++++++++++++
 4 files changed, 92 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_alloc/lib.rs                                          5      8      6
src/jsc/webcore_types.rs                                      4      4      7
src/runtime/webcore/blob/Store.rs                             3      3      7
test/internal/source-lints/bun-alloc-unsafe-free.test.ts      0      0      3
```

</details>

**root cause** · written by the author bot

`StdAllocator::free` and `raw_free` were safe methods that took a shared `&[u8]`, cast it to `&mut [u8]`, and forwarded it to the allocator vtable's free callback, so fully safe Rust could ask the allocator to release stack, static, or otherwise non-owned memory it never allocated. The fix marks both methods `unsafe fn` with documented safety contracts and changes `free` to take a raw `(*mut u8, usize)` pair (null or zero length is a no-op), so callers must explicitly assert ownership and provenance at the call site. The two live callers in `Bytes::drop` and `to_internal_blob` were updated …

<!-- robobun:evidence:end -->