### PR TITLE
Make the generated JS wrapper pointer-adoption surface unsafe

### DIFF
--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2499,10 +2499,12 @@ function generateRust(
 
   // `safe fn` (Rust 2024) inside `jsc_abi_extern! {}`: the C++ side
   // (ZigGeneratedClasses.cpp) tolerates every well-typed input — \`fromJS\`
-  // returns null on type mismatch, \`create\` allocates from a live global,
-  // \`SetCachedValue\` is a WriteBarrier store. Declaring them \`safe\` moves
-  // the audit obligation to this generator (one place) instead of an
-  // \`unsafe {}\` per call site (~800 in the emitted file).
+  // returns null on type mismatch, \`SetCachedValue\` is a WriteBarrier
+  // store. Declaring them \`safe\` moves the audit obligation to this
+  // generator (one place) instead of an \`unsafe {}\` per call site (~800 in
+  // the emitted file). \`create\` is the exception: it installs \`ptr\` into a
+  // GC cell whose finalizer later frees it (deferred deref → ownership
+  // precondition), so the import and the \`to_js\` wrapper are \`unsafe\`.
   //
   // Calling convention: every C++ definition uses `extern JSC_CALLCONV` =
   // `extern "C" SYSV_ABI` on Windows, so import them via `jsc_abi_extern!`
@@ -2517,7 +2519,7 @@ function generateRust(
         safe fn ${symbolName(typeName, "getConstructor")}(global: *mut JSGlobalObject) -> JSValue;`
             : ""
         }
-        safe fn ${symbolName(typeName, "create")}(global: *mut JSGlobalObject, ptr: *mut ${typeName}) -> JSValue;
+        fn ${symbolName(typeName, "create")}(global: *mut JSGlobalObject, ptr: *mut ${typeName}) -> JSValue;
         safe fn ${symbolName(typeName, "dangerouslySetPtr")}(value: JSValue, ptr: *mut ${typeName}) -> bool;
 ${cachedExterns}
     }
@@ -2537,8 +2539,16 @@ ${cachedExterns}
     ${
       !overridesToJS
         ? `/// Transfer ownership of \`this\` to a freshly-allocated JS wrapper.
-    #[inline] pub fn to_js(this: *mut ${typeName}, global: &JSGlobalObject) -> JSValue {
-        ${symbolName(typeName, "create")}(global.as_mut_ptr(), this)
+    ///
+    /// # Safety
+    /// \`this\` must be the unique, live pointer produced by this class's
+    /// construct-path heap allocation (the one \`${typeName}Class__finalize\`
+    /// frees, e.g. \`Box::into_raw\`/\`heap::into_raw\`). The GC finalizer
+    /// consumes it exactly once, so the caller must not free it, reuse it,
+    /// or install it in a second wrapper after this call.
+    #[inline] pub unsafe fn to_js(this: *mut ${typeName}, global: &JSGlobalObject) -> JSValue {
+        // SAFETY: ownership precondition forwarded to the caller.
+        unsafe { ${symbolName(typeName, "create")}(global.as_mut_ptr(), this) }
     }`
         : ""
     }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2538,7 +2538,13 @@ ${cachedExterns}
     }
     ${
       !overridesToJS
-        ? `/// Transfer ownership of \`this\` to a freshly-allocated JS wrapper.
+        ? `${
+            // The adoption precondition depends on the class's lifecycle:
+            // with a `finalize` hook the wrapper releases `m_ctx` at GC;
+            // without one the wrapper's destructor is empty and never
+            // releases it (see the C++ destructor emission above).
+            finalize
+              ? `/// Transfer ownership of \`this\` to a freshly-allocated JS wrapper.
     ///
     /// # Safety
     /// \`this\` must point to this class's live construct-path heap
@@ -2546,7 +2552,15 @@ ${cachedExterns}
     /// releases exactly once at GC: the unique \`Box::into_raw\`/
     /// \`heap::into_raw\` pointer for Box-backed classes, or a +1 ref for
     /// intrusively-refcounted ones. The caller must not release that
-    /// ownership itself or install it in a second wrapper after this call.
+    /// ownership itself or install it in a second wrapper after this call.`
+              : `/// Install \`this\` as the payload of a freshly-allocated JS wrapper.
+    ///
+    /// # Safety
+    /// This class declares no \`finalize\` hook, so the wrapper never
+    /// releases \`this\`: it must point to a live allocation that outlives
+    /// every JS wrapper created from it, and it must not be freed while any
+    /// wrapper can still reach it.`
+          }
     #[inline] pub unsafe fn to_js(this: *mut ${typeName}, global: &JSGlobalObject) -> JSValue {
         // SAFETY: ownership precondition forwarded to the caller.
         unsafe { ${symbolName(typeName, "create")}(global.as_mut_ptr(), this) }

--- a/src/codegen/generate-classes.ts
+++ b/src/codegen/generate-classes.ts
@@ -2541,11 +2541,12 @@ ${cachedExterns}
         ? `/// Transfer ownership of \`this\` to a freshly-allocated JS wrapper.
     ///
     /// # Safety
-    /// \`this\` must be the unique, live pointer produced by this class's
-    /// construct-path heap allocation (the one \`${typeName}Class__finalize\`
-    /// frees, e.g. \`Box::into_raw\`/\`heap::into_raw\`). The GC finalizer
-    /// consumes it exactly once, so the caller must not free it, reuse it,
-    /// or install it in a second wrapper after this call.
+    /// \`this\` must point to this class's live construct-path heap
+    /// allocation and carry the ownership that \`${typeName}Class__finalize\`
+    /// releases exactly once at GC: the unique \`Box::into_raw\`/
+    /// \`heap::into_raw\` pointer for Box-backed classes, or a +1 ref for
+    /// intrusively-refcounted ones. The caller must not release that
+    /// ownership itself or install it in a second wrapper after this call.
     #[inline] pub unsafe fn to_js(this: *mut ${typeName}, global: &JSGlobalObject) -> JSValue {
         // SAFETY: ownership precondition forwarded to the caller.
         unsafe { ${symbolName(typeName, "create")}(global.as_mut_ptr(), this) }

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -1080,11 +1080,13 @@ macro_rules! js_class_module {
             /// in `m_ctx`; ownership transfers to the GC (`finalize` frees it).
             ///
             /// # Safety
-            /// `ptr` must be the unique, live pointer produced by this class's
-            /// construct-path heap allocation (the one its finalizer frees,
-            /// e.g. `Box::into_raw`/`heap::into_raw`). The GC finalizer
-            /// consumes it exactly once, so the caller must not free it,
-            /// reuse it, or install it in a second wrapper after this call.
+            /// `ptr` must point to this class's live construct-path heap
+            /// allocation and carry the ownership that its finalizer releases
+            /// exactly once at GC: the unique `Box::into_raw`/`heap::into_raw`
+            /// pointer for Box-backed classes, or a +1 ref for
+            /// intrusively-refcounted ones. The caller must not release that
+            /// ownership itself or install it in a second wrapper after this
+            /// call.
             #[inline]
             pub unsafe fn to_js(ptr: *mut Payload, global: &JSGlobalObject) -> JSValue {
                 // SAFETY: ownership precondition forwarded to the caller.

--- a/src/jsc/generated.rs
+++ b/src/jsc/generated.rs
@@ -941,11 +941,15 @@ macro_rules! impl_js_class_via_generated {
             #[inline]
             fn to_js(self, g: &$crate::JSGlobalObject) -> $crate::JSValue {
                 use $gen as __g;
-                // Ownership of the boxed payload transfers to the C++ wrapper
-                // (freed via `${T}Class__finalize`). `.cast()` erases any
-                // payload-type / lifetime mismatch between `Self` and the
-                // accessor module's monomorphized pointee.
-                __g::to_js($crate::heap::into_raw(::std::boxed::Box::new(self)).cast(), g)
+                // `.cast()` erases any payload-type / lifetime mismatch
+                // between `Self` and the accessor module's monomorphized
+                // pointee.
+                // SAFETY: the payload is boxed right here, so the pointer is
+                // the unique construct-path allocation; ownership transfers to
+                // the C++ wrapper (freed exactly once via `${T}Class__finalize`).
+                unsafe {
+                    __g::to_js($crate::heap::into_raw(::std::boxed::Box::new(self)).cast(), g)
+                }
             }
             $(
                 #[inline]
@@ -1023,9 +1027,10 @@ macro_rules! js_class_module {
             // to a non-null `*mut`). `__from_js*` only type-check the encoded
             // value and return the stored `m_ctx` pointer (or null) — the C++
             // side never dereferences `Payload`, so there is no Rust-side
-            // precondition. `__dangerously_set_ptr` keeps `unsafe`
-            // because it installs `ptr` into a GC cell whose finalizer will
-            // later free it (deferred deref → ownership precondition).
+            // precondition. `__create` and `__dangerously_set_ptr` keep
+            // `unsafe` because they install `ptr` into a GC cell whose
+            // finalizer will later free it (deferred deref → ownership
+            // precondition).
             $crate::jsc_abi_extern! {
                 #[allow(improper_ctypes)]
                 {
@@ -1034,7 +1039,7 @@ macro_rules! js_class_module {
                     #[link_name = concat!($TypeName, "__fromJSDirect")]
                     safe fn __from_js_direct(value: JSValue) -> *mut Payload;
                     #[link_name = concat!($TypeName, "__create")]
-                    safe fn __create(global: *mut JSGlobalObject, ptr: *mut Payload) -> JSValue;
+                    fn __create(global: *mut JSGlobalObject, ptr: *mut Payload) -> JSValue;
                     #[link_name = concat!($TypeName, "__getConstructor")]
                     safe fn __get_constructor(global: &JSGlobalObject) -> JSValue;
                     #[link_name = concat!($TypeName, "__dangerouslySetPtr")]
@@ -1073,17 +1078,29 @@ macro_rules! js_class_module {
             /// Create a new JS wrapper instance owning `ptr`. The C++ side
             /// allocates the JSCell with the cached structure and stores `ptr`
             /// in `m_ctx`; ownership transfers to the GC (`finalize` frees it).
+            ///
+            /// # Safety
+            /// `ptr` must be the unique, live pointer produced by this class's
+            /// construct-path heap allocation (the one its finalizer frees,
+            /// e.g. `Box::into_raw`/`heap::into_raw`). The GC finalizer
+            /// consumes it exactly once, so the caller must not free it,
+            /// reuse it, or install it in a second wrapper after this call.
             #[inline]
-            pub fn to_js(ptr: *mut Payload, global: &JSGlobalObject) -> JSValue {
-                __create(global.as_ptr(), ptr)
+            pub unsafe fn to_js(ptr: *mut Payload, global: &JSGlobalObject) -> JSValue {
+                // SAFETY: ownership precondition forwarded to the caller.
+                unsafe { __create(global.as_ptr(), ptr) }
             }
 
             /// Alias for [`to_js`] with `(global, ptr)` argument
             /// order, so `Response::to_js` / `Request::to_js` call sites
             /// resolve without reordering.
+            ///
+            /// # Safety
+            /// Same ownership-transfer contract as [`to_js`].
             #[inline]
-            pub fn to_js_unchecked(global: &JSGlobalObject, ptr: *mut Payload) -> JSValue {
-                to_js(ptr, global)
+            pub unsafe fn to_js_unchecked(global: &JSGlobalObject, ptr: *mut Payload) -> JSValue {
+                // SAFETY: ownership precondition forwarded to the caller.
+                unsafe { to_js(ptr, global) }
             }
 
             /// Lazily fetch the constructor `JSFunction` from `globalObject`.

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -203,7 +203,9 @@ const _: () = {
             // JS wrapper) is layered on by `bun_runtime`'s `BlobExt::to_js` for
             // S3-backed blobs; lower-tier callers never construct S3 blobs.
             let ptr = Blob::new(self);
-            JSBlob::to_js(ptr, global)
+            // SAFETY: `ptr` is the unique heap allocation made by `Blob::new`
+            // on the line above; ownership transfers to the JS wrapper.
+            unsafe { JSBlob::to_js(ptr, global) }
         }
         fn get_constructor(global: &JSGlobalObject) -> JSValue {
             JSBlob::get_constructor(global)

--- a/src/jsc_macros/lib.rs
+++ b/src/jsc_macros/lib.rs
@@ -644,11 +644,13 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
 
     let trait_impl = quote! {
         const _: () = {
-            // `safe fn` (not bare `fn`) so these match the `safe fn`
-            // declarations `generate-classes.ts` emits in
-            // `generated_classes.rs` — otherwise `clashing_extern_declarations`
-            // fires for every codegen'd class (the only difference was the
-            // call-safety qualifier).
+            // Call-safety qualifiers must match the declarations
+            // `generate-classes.ts` emits in `generated_classes.rs` —
+            // otherwise `clashing_extern_declarations` fires for every
+            // codegen'd class. `__from_js*`/`__get_constructor` are `safe fn`
+            // (pure type-checked lookups); `__create` is unsafe because it
+            // installs `ptr` into a GC cell whose finalizer later frees it
+            // (deferred deref → ownership precondition).
             #[cfg(all(windows, target_arch = "x86_64"))]
             unsafe extern "sysv64" {
                 #[link_name = #from_js_lit]
@@ -656,7 +658,7 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
                 #[link_name = #from_js_direct_lit]
                 safe fn __from_js_direct(value: ::bun_jsc::JSValue) -> *mut #rust_ty;
                 #[link_name = #create_lit]
-                safe fn __create(
+                fn __create(
                     global: *mut ::bun_jsc::JSGlobalObject,
                     ptr: *mut #rust_ty,
                 ) -> ::bun_jsc::JSValue;
@@ -669,7 +671,7 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
                 #[link_name = #from_js_direct_lit]
                 safe fn __from_js_direct(value: ::bun_jsc::JSValue) -> *mut #rust_ty;
                 #[link_name = #create_lit]
-                safe fn __create(
+                fn __create(
                     global: *mut ::bun_jsc::JSGlobalObject,
                     ptr: *mut #rust_ty,
                 ) -> ::bun_jsc::JSValue;
@@ -693,9 +695,9 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
                     ptr: *mut Self,
                     global: &::bun_jsc::JSGlobalObject,
                 ) -> ::bun_jsc::JSValue {
-                    // Caller contract — `ptr` is a fresh heap payload;
+                    // SAFETY: caller contract — `ptr` is a fresh heap payload;
                     // ownership transfers to the C++ wrapper. See `to_js`.
-                    __create(global.as_mut_ptr(), ptr)
+                    unsafe { __create(global.as_mut_ptr(), ptr) }
                 }
 
                 /// Wrap an owned `Box<Self>` in a JS object. Typed sibling of
@@ -706,19 +708,22 @@ fn js_class_hooks(args: &JsClassArgs, rust_ty: &Ident) -> TokenStream2 {
                     this: ::std::boxed::Box<Self>,
                     global: &::bun_jsc::JSGlobalObject,
                 ) -> ::bun_jsc::JSValue {
-                    // Ownership transfers to the C++ wrapper; see `to_js`.
-                    __create(global.as_mut_ptr(), ::bun_jsc::heap::into_raw(this))
+                    // SAFETY: the owned `Box` is leaked right here, so the
+                    // pointer is a unique heap payload; ownership transfers to
+                    // the C++ wrapper. See `to_js`.
+                    unsafe { __create(global.as_mut_ptr(), ::bun_jsc::heap::into_raw(this)) }
                 }
             }
 
             impl ::bun_jsc::JsClass for #rust_ty {
                 fn to_js(self, global: &::bun_jsc::JSGlobalObject) -> ::bun_jsc::JSValue {
                     let ptr = ::bun_jsc::heap::alloc(self);
-                    // `ptr` ownership transfers to the C++ wrapper (freed via
+                    // SAFETY: `ptr` is the unique allocation made on the line
+                    // above; ownership transfers to the C++ wrapper (freed via
                     // `${T}Class__finalize`). `as_mut_ptr` derives `*mut` via
                     // `UnsafeCell` so C++ allocating on the GC heap through this
                     // pointer is sound (no read-only provenance from `&JSGlobalObject`).
-                    __create(global.as_mut_ptr(), ptr)
+                    unsafe { __create(global.as_mut_ptr(), ptr) }
                 }
                 fn from_js(value: ::bun_jsc::JSValue) -> ::core::option::Option<*mut Self> {
                     // Pure FFI downcast; returns null on type mismatch.

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1641,7 +1641,9 @@ pub(crate) fn serve(global_object: &JSGlobalObject, callframe: &CallFrame) -> Js
             if global_object.has_exception() {
                 return Ok(JSValue::ZERO);
             }
-            let obj = <$ServerType>::ptr_to_js(server, global_object);
+            // SAFETY: `server` is the unique heap allocation from `init`
+            // above, not yet wrapped; ownership transfers to the JS wrapper.
+            let obj = unsafe { <$ServerType>::ptr_to_js(server, global_object) };
             if route_list_object != JSValue::ZERO {
                 // NOTE: `ServerType.js.routeListSetCached` (codegen
                 // `.classes.ts`) — routed through the typed helper in
@@ -1963,7 +1965,9 @@ pub(crate) fn get_valkey_default_client(global_this: &JSGlobalObject, _: &JSObje
         }
     };
 
-    let as_js = JSValkeyClient::ptr_to_js(valkey, global_this);
+    // SAFETY: `valkey` is the fresh heap allocation from
+    // `create_no_js_no_pubsub`, not yet wrapped; the JS wrapper adopts it.
+    let as_js = unsafe { JSValkeyClient::ptr_to_js(valkey, global_this) };
 
     // SAFETY: `valkey` is a fresh heap allocation owned by the JS wrapper; we
     // hold the only reference for field init below.

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -539,8 +539,8 @@ impl Terminal {
         // SAFETY: `parent_ptr` is the terminal heap allocation created above;
         // the wrapper adopts the +1 taken by `RefCount::init()` (released in
         // `finalize`), and no other wrapper owns it yet on this path.
-        let this_value = existing_js_value
-            .unwrap_or_else(|| unsafe { js::to_js(parent_ptr, global_object) });
+        let this_value =
+            existing_js_value.unwrap_or_else(|| unsafe { js::to_js(parent_ptr, global_object) });
 
         // Store the this_value (JSValue wrapper) - start with strong ref since we're actively reading.
         // The JS-side ref is the one taken by RefCount.init() above; released in finalize().

--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -536,7 +536,11 @@ impl Terminal {
         terminal.reader.with_mut(|r| r.read());
 
         // Get or create the JS wrapper
-        let this_value = existing_js_value.unwrap_or_else(|| js::to_js(parent_ptr, global_object));
+        // SAFETY: `parent_ptr` is the terminal heap allocation created above;
+        // the wrapper adopts the +1 taken by `RefCount::init()` (released in
+        // `finalize`), and no other wrapper owns it yet on this path.
+        let this_value = existing_js_value
+            .unwrap_or_else(|| unsafe { js::to_js(parent_ptr, global_object) });
 
         // Store the this_value (JSValue wrapper) - start with strong ref since we're actively reading.
         // The JS-side ref is the one taken by RefCount.init() above; released in finalize().

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -74,16 +74,19 @@ fn sys_system_error_to_js(err: &bun_sys::SystemError, global: &JSGlobalObject) -
 /// field-assignment paths share one pointer type with `existing_terminal`.
 pub(crate) struct TerminalCreateResult {
     /// BACKREF — the `IntrusiveRc<Terminal>` pointer leaked via `into_raw()`
-    /// when this struct was populated; the +1 ref is held until
-    /// `Subprocess::finalize` (or the spawn-error scopeguard's
-    /// `abandon_from_spawn`) releases it, so the pointee outlives this struct.
+    /// when this struct was populated. That ref aliases the Terminal JS
+    /// wrapper's +1 (released via its finalize → `deref_`), so this is a
+    /// non-owning borrow: the pointee is kept live by `js_value` (and, once
+    /// spawn succeeds, by the Subprocess wrapper's cached `terminal` slot);
+    /// the spawn-error scopeguard's `abandon_from_spawn` covers the error
+    /// path.
     pub terminal: bun_ptr::BackRef<Terminal>,
     pub js_value: JSValue,
 }
 
 impl TerminalCreateResult {
-    /// Shared borrow of the held `Terminal` (BackRef invariant: +1-ref'd
-    /// IntrusiveRc, live while this struct is held).
+    /// Shared borrow of the held `Terminal` (BackRef invariant: the Terminal
+    /// JS wrapper's ref keeps the pointee live while this struct is held).
     #[inline]
     pub(crate) fn term(&self) -> &Terminal {
         self.terminal.get()

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1588,11 +1588,11 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
     }
 
     let out = if !IS_SYNC {
-        // `subprocess_ptr` came from `heap::alloc` above and has not yet been
-        // wrapped; ownership transfers to the C++ JS cell (released via
-        // `SubprocessClass__finalize`). Use the raw-ptr entrypoint instead of
-        // the by-value `JsClass::to_js` (which would re-box).
-        SubprocessT::to_js_from_ptr(subprocess_ptr, global_this)
+        // SAFETY: `subprocess_ptr` came from `heap::alloc` above and has not
+        // yet been wrapped; ownership transfers to the C++ JS cell (released
+        // via `SubprocessClass__finalize`). Use the raw-ptr entrypoint instead
+        // of the by-value `JsClass::to_js` (which would re-box).
+        unsafe { SubprocessT::to_js_from_ptr(subprocess_ptr, global_this) }
     } else {
         JSValue::ZERO
     };

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -805,10 +805,14 @@ pub(crate) fn spawn_maybe_sync<const IS_SYNC: bool>(
                         match Terminal::create_from_spawn(global_this, &mut term_options) {
                             Ok(created) => {
                                 **terminal_info = Some(TerminalCreateResult {
-                                    // Transfer the +1 ref to `Subprocess.terminal` (released
-                                    // in `Subprocess::finalize`); the scopeguard's
-                                    // `abandon_from_spawn` path covers the error case.
-                                    // `IntrusiveRc::into_raw` is never null (NonNull-backed).
+                                    // `into_raw` leaks the IntrusiveRc's ref, which aliases
+                                    // the JS wrapper's +1 (adopted from `RefCount::init()` in
+                                    // `init_terminal`) — `Subprocess.terminal` is a borrow
+                                    // kept live by the cached `terminal` slot on the
+                                    // Subprocess wrapper, not an independent ref. The
+                                    // scopeguard's `abandon_from_spawn` path covers the
+                                    // error case. `IntrusiveRc::into_raw` is never null
+                                    // (NonNull-backed).
                                     terminal: bun_ptr::BackRef::from(
                                         core::ptr::NonNull::new(created.terminal.into_raw())
                                             .expect("IntrusiveRc non-null"),

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -190,17 +190,17 @@ const _: () = {
         /// wired before `subprocess.toJS(globalThis)` runs; this is the raw-ptr
         /// entrypoint that avoids re-boxing.
         ///
+        /// # Safety
         /// `ptr` must come from `heap::alloc(Box::new(Subprocess { .. }))` and
         /// not yet be owned by any JS wrapper; ownership transfers to the C++
-        /// side (released via `SubprocessClass__finalize`). Thin forwarder to
-        /// the (already safe) generated `js_Subprocess::to_js`, which
-        /// encapsulates the FFI `__create` call internally.
+        /// side (released via `SubprocessClass__finalize`).
         #[inline]
-        pub fn to_js_from_ptr(ptr: *mut Self, global: &JSGlobalObject) -> JSValue {
+        pub unsafe fn to_js_from_ptr(ptr: *mut Self, global: &JSGlobalObject) -> JSValue {
             // The codegen wrapper is monomorphized at `'static`; the lifetime
             // parameter is purely a borrow-checker artifact (C++ stores the
             // pointer as opaque `m_ctx`), so erase it via `cast`.
-            js::to_js(ptr.cast(), global)
+            // SAFETY: ownership precondition forwarded to the caller.
+            unsafe { js::to_js(ptr.cast(), global) }
         }
     }
 
@@ -607,7 +607,13 @@ impl Subprocess<'_> {
     #[bun_jsc::host_fn(getter)]
     pub fn get_terminal(this: &Self, global_this: &JSGlobalObject) -> JSValue {
         if let Some(terminal) = this.terminal.get() {
-            return crate::api::bun_terminal_body::to_js(terminal.as_ptr(), global_this);
+            // SAFETY: `terminal` is the live allocation this subprocess holds
+            // a +1 ref on (released in `Subprocess::finalize`). The getter is
+            // `cache: true` and the spawn path pre-fills the cached slot with
+            // the wrapper created by `init_terminal`, so at most one wrapper
+            // adopts the terminal's JS-side ref (released via its finalize →
+            // `deref_`).
+            return unsafe { crate::api::bun_terminal_body::to_js(terminal.as_ptr(), global_this) };
         }
         JSValue::UNDEFINED
     }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -607,12 +607,13 @@ impl Subprocess<'_> {
     #[bun_jsc::host_fn(getter)]
     pub fn get_terminal(this: &Self, global_this: &JSGlobalObject) -> JSValue {
         if let Some(terminal) = this.terminal.get() {
-            // SAFETY: `terminal` is the live allocation this subprocess holds
-            // a +1 ref on (released in `Subprocess::finalize`). The getter is
-            // `cache: true` and the spawn path pre-fills the cached slot with
-            // the wrapper created by `init_terminal`, so at most one wrapper
-            // adopts the terminal's JS-side ref (released via its finalize →
-            // `deref_`).
+            // SAFETY: `terminal` is kept live by this Subprocess wrapper's
+            // cached `terminal` slot: the getter is `cache: true` and the
+            // spawn path pre-fills that slot (`terminal_set_cached`) with the
+            // Terminal JS wrapper, which owns the native +1 (released via its
+            // finalize → `deref_`). So at most one wrapper ever adopts the
+            // terminal's JS-side ref, and this fallback only runs while that
+            // wrapper is reachable.
             return unsafe { crate::api::bun_terminal_body::to_js(terminal.as_ptr(), global_this) };
         }
         JSValue::UNDEFINED

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3205,7 +3205,12 @@ fn transpile_source_code_inner(
             let html_bundle = crate::api::HTMLBundle::init(global, path.text);
             use bun_jsc::resolved_source::Tag as ResolvedSourceTag;
             Ok(OwnedResolvedSource::from(ResolvedSource {
-                jsvalue_for_export: crate::api::HTMLBundle::to_js(html_bundle.into_raw(), global),
+                // SAFETY: `into_raw` hands over the `IntrusiveRc`'s +1 ref on
+                // the fresh allocation from `init`; the JS wrapper adopts it
+                // (released via `finalize`).
+                jsvalue_for_export: unsafe {
+                    crate::api::HTMLBundle::to_js(html_bundle.into_raw(), global)
+                },
                 specifier: input_specifier.dupe_ref(),
                 source_url: create_if_different(input_specifier, path.text),
                 tag: ResolvedSourceTag::ExportDefaultObject,

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -59,8 +59,10 @@ const _: () = {
     // `*mut HTMLBundle` is opaque to C++ (linked by symbol name only); the
     // pointee's Rust layout is irrelevant to the FFI boundary, but HTMLBundle
     // lacks `#[repr(C)]` so rustc lints anyway.
-    // `safe fn` to match `generated_classes.rs` / the `#[bun_jsc::JsClass]`
-    // macro (avoids `clashing_extern_declarations`).
+    // Call-safety qualifiers match `generated_classes.rs` / the
+    // `#[bun_jsc::JsClass]` macro (avoids `clashing_extern_declarations`):
+    // `__from_js*` are `safe fn`; `__create` is unsafe because it installs
+    // `ptr` into a GC cell whose finalizer later releases it.
     bun_jsc::jsc_abi_extern! {
         #[allow(improper_ctypes)]
         {
@@ -69,7 +71,7 @@ const _: () = {
             #[link_name = "HTMLBundle__fromJSDirect"]
             safe fn __from_js_direct(value: JSValue) -> *mut HTMLBundle;
             #[link_name = "HTMLBundle__create"]
-            safe fn __create(global: *mut JSGlobalObject, ptr: *mut HTMLBundle) -> JSValue;
+            fn __create(global: *mut JSGlobalObject, ptr: *mut HTMLBundle) -> JSValue;
         }
     }
 
@@ -98,13 +100,16 @@ const _: () = {
 
     impl HTMLBundle {
         /// `jsc.Codegen.JSHTMLBundle.toJS` — wraps an existing intrusive-
-        /// refcounted allocation. The JS wrapper takes one ref (released in
-        /// `finalize`), so callers must have already accounted for that ref.
-        pub fn to_js(this: *mut HTMLBundle, global: &JSGlobalObject) -> JSValue {
-            // `this` is a live `IntrusiveRc::new`-boxed allocation; ownership
-            // of one ref transfers to the C++ wrapper (deref'd via
-            // `HTMLBundleClass__finalize` → `finalize()`).
-            __create(global.as_mut_ptr(), this)
+        /// refcounted allocation.
+        ///
+        /// # Safety
+        /// `this` must be a live `IntrusiveRc::new`-boxed allocation carrying
+        /// a +1 ref the caller has already accounted for; ownership of that
+        /// ref transfers to the C++ wrapper (deref'd via
+        /// `HTMLBundleClass__finalize` → `finalize()`).
+        pub unsafe fn to_js(this: *mut HTMLBundle, global: &JSGlobalObject) -> JSValue {
+            // SAFETY: ownership precondition forwarded to the caller.
+            unsafe { __create(global.as_mut_ptr(), this) }
         }
     }
 };

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -9,21 +9,28 @@ use core::sync::atomic::Ordering;
 /// `(SSL, DEBUG)` monomorphization. Routes through the
 /// `crate::generated_classes::js_*Server::to_js` wrappers (which own the
 /// canonical extern decl) instead of redeclaring the symbols here.
-pub(crate) fn server_js_create(
+///
+/// # Safety
+/// `ptr` must be the unique heap allocation of the `NewServer<SSL,DEBUG>`
+/// matching `(ssl, debug)`, not yet owned by any JS wrapper; ownership
+/// transfers to the C++ wrapper (freed via its `finalize`).
+pub(crate) unsafe fn server_js_create(
     ptr: *mut c_void,
     global: &jsc::JSGlobalObject,
     ssl: bool,
     debug: bool,
 ) -> jsc::JSValue {
     use crate::generated_classes as gc;
-    // `ptr` is a fresh `NewServer<SSL,DEBUG>` heap allocation; the C++
-    // wrapper takes ownership. Cast through the concrete monomorphization
-    // each codegen module is typed against.
-    match (ssl, debug) {
-        (false, false) => gc::js_HTTPServer::to_js(ptr.cast(), global),
-        (true, false) => gc::js_HTTPSServer::to_js(ptr.cast(), global),
-        (false, true) => gc::js_DebugHTTPServer::to_js(ptr.cast(), global),
-        (true, true) => gc::js_DebugHTTPSServer::to_js(ptr.cast(), global),
+    // Cast through the concrete monomorphization each codegen module is
+    // typed against.
+    // SAFETY: ownership precondition forwarded to the caller.
+    unsafe {
+        match (ssl, debug) {
+            (false, false) => gc::js_HTTPServer::to_js(ptr.cast(), global),
+            (true, false) => gc::js_HTTPSServer::to_js(ptr.cast(), global),
+            (false, true) => gc::js_DebugHTTPServer::to_js(ptr.cast(), global),
+            (true, true) => gc::js_DebugHTTPSServer::to_js(ptr.cast(), global),
+        }
     }
 }
 
@@ -1419,8 +1426,13 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
     /// Wrap an already-heap-allocated server pointer in its JS object.
     /// Ownership transfers to the C++ wrapper (freed via `finalize`).
-    pub fn ptr_to_js(this: *mut Self, global: &JSGlobalObject) -> JSValue {
-        server_js_create(this.cast(), global, SSL, DEBUG)
+    ///
+    /// # Safety
+    /// `this` must be the unique heap allocation produced by [`Self::init`],
+    /// not yet owned by any JS wrapper; the wrapper's finalizer releases it.
+    pub unsafe fn ptr_to_js(this: *mut Self, global: &JSGlobalObject) -> JSValue {
+        // SAFETY: ownership precondition forwarded to the caller.
+        unsafe { server_js_create(this.cast(), global, SSL, DEBUG) }
     }
 
     // `on_reload_from_zig` body lives in `server_body.rs` (`impl NewServer { … }`);

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -273,9 +273,9 @@ impl Listener {
                     }
                 }
 
-                // SAFETY: `global` is live; ownership of `this` (heap-allocated above)
-                // transfers to the C++ wrapper.
-                let this_value = js_Listener::to_js(this, global);
+                // SAFETY: `this` is the unique heap allocation from above, not
+                // yet wrapped; ownership transfers to the C++ wrapper.
+                let this_value = unsafe { js_Listener::to_js(this, global) };
                 // The listener holds the handlers cell in a visited slot; every
                 // accepted socket shares the same cell.
                 js_Listener::handlers_set_cached(this_value, global, this_ref.handlers.cell());
@@ -522,10 +522,10 @@ impl Listener {
         }
 
         let this = scopeguard::ScopeGuard::into_inner(cleanup); // ownership transfers to JS wrapper
-        // SAFETY: `global` is live; ownership of `this` (heap-allocated above)
-        // transfers to the C++ wrapper (freed via `ListenerClass__finalize` →
-        // `Listener::finalize` → `deinit`).
-        let this_value = js_Listener::to_js(this, global);
+        // SAFETY: `this` is the unique heap allocation from above, not yet
+        // wrapped; ownership transfers to the C++ wrapper (freed via
+        // `ListenerClass__finalize` → `Listener::finalize` → `deinit`).
+        let this_value = unsafe { js_Listener::to_js(this, global) };
         // The listener holds the handlers cell in a visited slot; every
         // accepted socket shares the same cell.
         js_Listener::handlers_set_cached(this_value, global, this_ref.handlers.cell());

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -454,16 +454,18 @@ impl<const SSL: bool> NewSocket<SSL> {
     // split and route through the codegen'd safe wrappers.
     pub fn to_js(&self, global: &JSGlobalObject) -> JSValue {
         jsc::mark_binding!();
-        // `self` is a heap-allocated `NewSocket` (every caller goes through
-        // `NewSocket::new` → `heap::alloc`); ownership is adopted by the C++
-        // JSCell wrapper, which calls `finalize` on GC. The codegen wrappers are
-        // monomorphic in `TCPSocket`/`TLSSocket`, so cast through the concrete
-        // alias each branch is typed against.
+        // The codegen wrappers are monomorphic in `TCPSocket`/`TLSSocket`, so
+        // cast through the concrete alias each branch is typed against.
         let ptr = self.as_ctx_ptr();
-        let value = if SSL {
-            js_TLSSocket::to_js(ptr.cast(), global)
-        } else {
-            js_TCPSocket::to_js(ptr.cast(), global)
+        // SAFETY: `self` is a heap-allocated `NewSocket` (every caller goes
+        // through `NewSocket::new` → `heap::alloc`); ownership is adopted by
+        // the C++ JSCell wrapper, which calls `finalize` on GC.
+        let value = unsafe {
+            if SSL {
+                js_TLSSocket::to_js(ptr.cast(), global)
+            } else {
+                js_TCPSocket::to_js(ptr.cast(), global)
+            }
         };
         debug_assert!(
             Some(ptr.cast::<c_void>())
@@ -3891,9 +3893,10 @@ macro_rules! impl_socket_js_class {
                 $gen::from_js_direct(value).map(|p| p.as_ptr())
             }
             fn to_js(self, global: &JSGlobalObject) -> JSValue {
-                // Ownership of the boxed `NewSocket` transfers to the C++
-                // wrapper (freed via `${typeName}Class__finalize`).
-                $gen::to_js(bun_core::heap::into_raw(Box::new(self)), global)
+                // SAFETY: the `NewSocket` is boxed right here, so the pointer
+                // is the unique construct-path allocation; ownership transfers
+                // to the C++ wrapper (freed via `${typeName}Class__finalize`).
+                unsafe { $gen::to_js(bun_core::heap::into_raw(Box::new(self)), global) }
             }
             // `noConstructor: true` — no `${name}__getConstructor` export; trait default applies.
         }

--- a/src/runtime/valkey_jsc/js_valkey_functions.rs
+++ b/src/runtime/valkey_jsc/js_valkey_functions.rs
@@ -1906,7 +1906,9 @@ impl JSValkeyClient {
         // JSValkeyClient (heap::alloc); valid for the rest of this scope.
         let new_client: &JSValkeyClient = unsafe { &*new_client_ptr };
 
-        let new_client_js = JSValkeyClient::ptr_to_js(new_client_ptr, global);
+        // SAFETY: `new_client_ptr` is that fresh allocation, not yet wrapped;
+        // ownership transfers to the JS wrapper.
+        let new_client_js = unsafe { JSValkeyClient::ptr_to_js(new_client_ptr, global) };
         new_client.this_value.set(JsRef::init_weak(new_client_js));
         new_client
             ._subscription_ctx

--- a/src/runtime/valkey_jsc/mod.rs
+++ b/src/runtime/valkey_jsc/mod.rs
@@ -77,11 +77,15 @@ use crate::generated_classes::js_RedisClient;
 impl JSValkeyClient {
     /// Wrap an already-heap-allocated client pointer in its JS object.
     /// Ownership transfers to the C++ wrapper (freed via `finalize`).
+    ///
+    /// # Safety
+    /// `ptr` must be the unique heap allocation produced by
+    /// `JSValkeyClient::new`, not yet owned by any JS wrapper; the wrapper's
+    /// finalizer frees it.
     #[inline]
-    pub fn ptr_to_js(ptr: *mut Self, global: &JSGlobalObject) -> JSValue {
-        // `ptr` was produced by `JSValkeyClient::new` (heap-allocated) and is
-        // hereby owned by the JS wrapper.
-        js_RedisClient::to_js(ptr, global)
+    pub unsafe fn ptr_to_js(ptr: *mut Self, global: &JSGlobalObject) -> JSValue {
+        // SAFETY: ownership precondition forwarded to the caller.
+        unsafe { js_RedisClient::to_js(ptr, global) }
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3711,10 +3711,13 @@ impl BlobExt for Blob {
         if self.is_s3() {
             // SAFETY: `self` is a heap-allocated *mut Blob (see `Blob::new`); the
             // C++ side wraps it in a JSS3File without taking a second ref.
-            return crate::webcore::s3_file::to_js_unchecked(global_object, this);
+            return unsafe { crate::webcore::s3_file::to_js_unchecked(global_object, this) };
         }
 
-        js::to_js_unchecked(global_object, this)
+        // SAFETY: same as the S3 branch — `self` is the heap allocation from
+        // `Blob::new` (caller contract); the wrapper adopts it, released via
+        // `finalize`.
+        unsafe { js::to_js_unchecked(global_object, this) }
     }
 
     /// `Bun.file(pathOrFd)` core: wrap a path-or-fd in a `Store::File` and

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -596,7 +596,12 @@ pub trait SourceContext: Sized {
     // Each context binds its per-type codegen module via `source_context_codegen!`.
     /// `js_${NAME}InternalReadableStreamSource::to_js` — `ptr` is the
     /// type-erased `*mut NewSource<Self>` (cast inside the macro impl).
-    fn js_create(ptr: *mut c_void, global: &JSGlobalObject) -> JSValue;
+    ///
+    /// # Safety
+    /// `ptr` must be the unique heap-allocated `NewSource<Self>`, not yet
+    /// owned by any JS wrapper; the wrapper's GC finalizer releases it
+    /// (`decrement_count` → `deinit`).
+    unsafe fn js_create(ptr: *mut c_void, global: &JSGlobalObject) -> JSValue;
     /// `js_${NAME}InternalReadableStreamSource::pending_promise_set_cached`
     fn js_pending_promise_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
     /// `js_${NAME}InternalReadableStreamSource::on_drain_callback_set_cached`
@@ -742,11 +747,13 @@ pub(crate) trait NewSourceCodegen {
 macro_rules! source_context_codegen {
     ($gen:ident) => {
         #[inline]
-        fn js_create(
+        unsafe fn js_create(
             ptr: *mut ::core::ffi::c_void,
             global: &$crate::webcore::jsc::JSGlobalObject,
         ) -> $crate::webcore::jsc::JSValue {
-            $crate::generated_classes::$gen::to_js(ptr.cast(), global)
+            // SAFETY: ownership precondition forwarded to the caller
+            // (`SourceContext::js_create` contract).
+            unsafe { $crate::generated_classes::$gen::to_js(ptr.cast(), global) }
         }
         #[inline]
         fn js_pending_promise_set_cached(
@@ -789,13 +796,16 @@ macro_rules! source_context_codegen {
 
 impl<C: SourceContext> NewSourceCodegen for NewSource<C> {
     fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue {
-        // `self` is a heap-allocated `NewSource<C>` produced by [`NewSource::new`]
-        // (`heap::alloc`); ownership transfers to the JS wrapper as `m_ctx`. C++ side
-        // stores it as `void*` and the GC finalizer drives `decrement_count` → `deinit`.
-        C::js_create(
-            std::ptr::from_mut::<Self>(self).cast::<c_void>(),
-            global_this,
-        )
+        // SAFETY: `self` is a heap-allocated `NewSource<C>` produced by
+        // [`NewSource::new`] (`heap::alloc`); ownership transfers to the JS
+        // wrapper as `m_ctx`. C++ side stores it as `void*` and the GC
+        // finalizer drives `decrement_count` → `deinit`.
+        unsafe {
+            C::js_create(
+                std::ptr::from_mut::<Self>(self).cast::<c_void>(),
+                global_this,
+            )
+        }
     }
     fn pending_promise_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue) {
         C::js_pending_promise_set_cached(this, global, value)

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -537,10 +537,15 @@ impl Request {
         // R-2: `to_js_unchecked` stores `self` as the C++ `m_ctx` payload (an
         // opaque `void*` never deref'd as `&mut Request` on the C++ side), so
         // forming `*mut` from `&self` here is provenance-safe.
-        let js_value = js_gen::to_js_unchecked(
-            global_object,
-            std::ptr::from_ref::<Request>(self).cast_mut().cast::<()>(),
-        );
+        // SAFETY: `self` is the heap allocation from `Request::new` (caller
+        // contract), not yet wrapped; the wrapper adopts it, released via
+        // `RequestClass__finalize`.
+        let js_value = unsafe {
+            js_gen::to_js_unchecked(
+                global_object,
+                std::ptr::from_ref::<Request>(self).cast_mut().cast::<()>(),
+            )
+        };
         self.js_ref.set(JsRef::init_weak(js_value));
 
         self.check_body_stream_ref(global_object);

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -435,10 +435,15 @@ impl Response {
         // R-2: cast through `*const` then `.cast_mut()` so the payload pointer
         // (which the C++ side stores into `m_ctx`) is derived from `&self`
         // without forging a `&mut`.
-        let js_value = js::to_js(
-            core::ptr::from_ref::<Self>(self).cast_mut().cast::<()>(),
-            global_object,
-        );
+        // SAFETY: `self` is the heap allocation from `Response::new` (caller
+        // contract), not yet wrapped; the wrapper adopts it, released via
+        // `ResponseClass__finalize`.
+        let js_value = unsafe {
+            js::to_js(
+                core::ptr::from_ref::<Self>(self).cast_mut().cast::<()>(),
+                global_object,
+            )
+        };
         self.js_ref.set(JsRef::init_weak(js_value));
 
         self.check_body_stream_ref(global_object);

--- a/src/runtime/webcore/ResumableSink.rs
+++ b/src/runtime/webcore/ResumableSink.rs
@@ -25,7 +25,11 @@ declare_scope!(ResumableSink, visible);
 /// Each monomorphization implements this trait by delegating to the matching
 /// `bun_jsc::generated::JS*` module — see [`impl_resumable_sink_js!`] below.
 pub trait ResumableSinkJs {
-    fn to_js(this: *mut (), global: &JSGlobalObject) -> JSValue;
+    /// # Safety
+    /// `this` must be the live heap-allocated sink carrying the ref the JS
+    /// wrapper adopts (released via the class finalizer); it must not already
+    /// be owned by another wrapper.
+    unsafe fn to_js(this: *mut (), global: &JSGlobalObject) -> JSValue;
     fn from_js(value: JSValue) -> Option<*mut ()>;
     fn from_js_direct(value: JSValue) -> Option<*mut ()>;
     fn oncancel_set_cached(this_value: JSValue, global: &JSGlobalObject, value: JSValue);
@@ -238,7 +242,10 @@ impl<Js: ResumableSinkJs, Context: ResumableSinkContext> ResumableSink<Js, Conte
             }
         }
         // lets go JS side route
-        let self_ = Js::to_js(this.cast(), global_this);
+        // SAFETY: `this` is the live sink allocated by `init_exact_refs`
+        // (`heap::into_raw`), not yet owned by a wrapper; the wrapper adopts
+        // the JS-side ref, released via `finalize` → `deref_`.
+        let self_ = unsafe { Js::to_js(this.cast(), global_this) };
         self_.ensure_still_alive();
         let js_stream = stream.to_js();
         js_stream.ensure_still_alive();
@@ -588,8 +595,10 @@ macro_rules! impl_resumable_sink_js {
         pub enum $name {}
         impl ResumableSinkJs for $name {
             #[inline]
-            fn to_js(this: *mut (), global: &JSGlobalObject) -> JSValue {
-                bun_jsc::generated::$name::to_js(this, global)
+            unsafe fn to_js(this: *mut (), global: &JSGlobalObject) -> JSValue {
+                // SAFETY: ownership precondition forwarded to the caller
+                // (`ResumableSinkJs::to_js` contract).
+                unsafe { bun_jsc::generated::$name::to_js(this, global) }
             }
             #[inline]
             fn from_js(value: JSValue) -> Option<*mut ()> {

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -862,9 +862,13 @@ pub(crate) fn construct_internal_js(
     Ok(BlobExt::to_js(unsafe { &mut *blob }, global))
 }
 
-pub fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {
+/// # Safety
+/// `this` must be the live heap-allocated `Blob` (see `Blob::new`), not yet
+/// owned by any JS wrapper; the JSS3File wrapper adopts it and its finalizer
+/// releases it exactly once.
+pub unsafe fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {
     // C++ adopts `this` opaquely (stored as `void* m_ctx` in the JS wrapper);
-    // ownership-transfer contract lives on `to_js_unchecked`'s callers.
+    // the ownership-transfer precondition is carried by this `unsafe fn`.
     BUN__createJSS3FileUnsafely(global, this.cast::<core::ffi::c_void>())
 }
 

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -598,7 +598,10 @@ impl JSMySQLConnection {
         this.connection_mut().status = my_sql_connection::Status::Connecting;
         this.reset_connection_timeout();
         this.poll_ref.with_mut(|p| p.r#ref(vm.vm_ctx()));
-        let js_value = js::to_js(ptr, global_object);
+        // SAFETY: `ptr` is the freshly-boxed allocation from above (the error
+        // paths that release it return early); the JS wrapper adopts it and
+        // its finalizer releases it exactly once.
+        let js_value = unsafe { js::to_js(ptr, global_object) };
         js_value.ensure_still_alive();
         this.js_value
             .with_mut(|r| r.set_strong(js_value, global_object));

--- a/src/sql_jsc/mysql/JSMySQLQuery.rs
+++ b/src/sql_jsc/mysql/JSMySQLQuery.rs
@@ -124,7 +124,9 @@ impl JSMySQLQuery {
         // so a shared `ParentRef` deref is sufficient even for the writes below.
         let this = ParentRef::from(NonNull::new(this_ptr).expect("heap::into_raw non-null"));
 
-        let this_value = js::to_js(this_ptr, global_this);
+        // SAFETY: `this_ptr` is the unique `heap::into_raw` allocation from
+        // above; the JS wrapper adopts it (freed via `finalize`).
+        let this_value = unsafe { js::to_js(this_ptr, global_this) };
         this_value.ensure_still_alive();
         this.this_value.with_mut(|v| v.set_weak(this_value));
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -62,8 +62,10 @@ pub use js::{from_js, from_js_direct, to_js};
 
 impl jsc::JsClass for PostgresSQLConnection {
     fn to_js(self, global: &JSGlobalObject) -> JSValue {
-        // Ownership transfers to the JSC wrapper's m_ctx; freed via `finalize`.
-        js::to_js(bun_core::heap::into_raw(Box::new(self)), global)
+        // SAFETY: the payload is boxed right here, so it is the unique
+        // construct-path allocation; ownership transfers to the JSC wrapper's
+        // m_ctx and is freed via `finalize`.
+        unsafe { js::to_js(bun_core::heap::into_raw(Box::new(self)), global) }
     }
     fn from_js(value: JSValue) -> Option<*mut Self> {
         js::from_js(value)
@@ -1292,7 +1294,10 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
     this.update_has_pending_activity();
     this.reset_connection_timeout();
     this.poll_ref.with_mut(|r| r.ref_(this.vm_ctx()));
-    let js_value = js::to_js(ptr, global_object);
+    // SAFETY: `ptr` is the unique `heap::into_raw` allocation from above (the
+    // error paths that free it return early); ownership transfers to the JS
+    // wrapper, released via `finalize`.
+    let js_value = unsafe { js::to_js(ptr, global_object) };
     js_value.ensure_still_alive();
     this.js_value.set(crate::jsc::JsRef::init_weak(js_value));
     js::onconnect_set_cached(js_value, global_object, on_connect);

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -372,8 +372,9 @@ impl PostgresSQLQuery {
 
         let ptr = bun_core::heap::into_raw(Box::new(PostgresSQLQuery::default()));
 
-        // SAFETY: ptr was just allocated and is the m_ctx payload; toJS wraps it in the JSCell.
-        let this_value = js::to_js(ptr, global_this);
+        // SAFETY: ptr was just allocated and is the m_ctx payload; toJS wraps
+        // it in the JSCell, which owns it from here (freed via `finalize`).
+        let this_value = unsafe { js::to_js(ptr, global_this) };
         this_value.ensure_still_alive();
 
         // SAFETY: ptr is exclusively owned here until returned to JS.

--- a/test/js/bun/net/socket-retention.test.ts
+++ b/test/js/bun/net/socket-retention.test.ts
@@ -243,7 +243,7 @@ test("Listener wrappers are adopted and finalized exactly once across GC", async
   const baseline = heapStats().objectTypeCounts.Listener || 0;
 
   for (let i = 0; i < 16; i++) {
-    const listener = Bun.listen({
+    using listener = Bun.listen({
       hostname: "127.0.0.1",
       port: 0,
       socket: { data() {} },
@@ -252,7 +252,6 @@ test("Listener wrappers are adopted and finalized exactly once across GC", async
     // dropping it, so the adoption is observed and not optimized away.
     expect(listener.port).toBeGreaterThan(0);
     expect(listener.hostname).toBe("127.0.0.1");
-    listener.stop(true);
   }
 
   // Conservative stack scanning can pin a stray wrapper; allow small slack.

--- a/test/js/bun/net/socket-retention.test.ts
+++ b/test/js/bun/net/socket-retention.test.ts
@@ -230,3 +230,32 @@ test("node:net reconnect after connectError does not accumulate wrappers", async
   expect(exitCode).toBe(0);
   void stderr;
 }, 30_000);
+
+// https://github.com/oven-sh/bun/issues/31975
+test("Listener wrappers are adopted and finalized exactly once across GC", async () => {
+  // `Bun.listen` wires the native Listener into its JS wrapper through the
+  // codegen `Listener__create` adoption path: the wrapper's finalizer frees
+  // the native allocation exactly once. Round-trip a batch of listeners
+  // through create → use → stop → GC and assert the wrapper count returns to
+  // baseline, locking both directions (adopted: the wrapper works; finalized
+  // exactly once: no accumulation, and a double-free would crash under ASAN).
+  Bun.gc(true);
+  const baseline = heapStats().objectTypeCounts.Listener || 0;
+
+  for (let i = 0; i < 16; i++) {
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data() {} },
+    });
+    // Exercise the wrapper → native backref (`Listener__fromJS`) before
+    // dropping it, so the adoption is observed and not optimized away.
+    expect(listener.port).toBeGreaterThan(0);
+    expect(listener.hostname).toBe("127.0.0.1");
+    listener.stop(true);
+  }
+
+  // Conservative stack scanning can pin a stray wrapper; allow small slack.
+  const count = await gcUntilCountAtMost("Listener", baseline + 2);
+  expect(count).toBeLessThanOrEqual(baseline + 2);
+});


### PR DESCRIPTION
Fixes #31975

### Problem

A safe `pub fn` accepting `*mut Payload` transfers ownership to the JS wrapper, whose GC finalizer later frees the pointer (`host_fn_finalize` → `Box::from_raw`, or an intrusive-refcount deref). Safe code can therefore trigger UB with zero `unsafe` tokens:

```rust
let ptr = NonNull::<Archive>::dangling().as_ptr();
let _ = js_Archive::to_js(ptr, global); // Box::from_raw(dangling) at GC time
```

The same shape existed in four parallel surfaces:

- the per-class modules emitted by `src/codegen/generate-classes.ts` (`js_Archive::to_js`, the `${T}__create` externs)
- the `js_class_module!` macro in `src/jsc/generated.rs` (`to_js` / `to_js_unchecked` / `__create`)
- the `#[bun_jsc::JsClass]` proc macro's `__create` externs in `src/jsc_macros/lib.rs`
- HTMLBundle's hand-expanded copy in `src/runtime/server/HTMLBundle.rs`

This was inconsistent with the same files' own treatment of the identical contract: `dangerously_set_ptr` and `host_fn_finalize` were already `unsafe` with the ownership precondition documented ("unique GC-owned `m_ctx` pointer originally produced by `Box::into_raw` in the construct path, consumed exactly once").

### Fix

Mark the raw-pointer adoption surface `unsafe fn` with the precondition in a `# Safety` section, in all four generators:

- `generate-classes.ts`: `${T}__create` extern loses `safe`, the generated `to_js` becomes `pub unsafe fn` with `# Safety`; the `safe fn` rationale comment now names `create` as the exception.
- `js_class_module!`: same for `__create`, `to_js`, `to_js_unchecked`.
- `#[bun_jsc::JsClass]`: `__create` extern loses `safe` (the macro's `to_js_ptr` was already `unsafe fn`, and `to_js_boxed`/`JsClass::to_js` stay safe because they take ownership or allocate internally).
- `HTMLBundle.rs`: same for its hand-written extern and `HTMLBundle::to_js(*mut Self, ..)`.

Call sites (~30, found by the compiler) are swept:

- Sites that allocate locally (`Box::new` / `heap::into_raw` on the preceding line) discharge the obligation with an `unsafe {}` block and a SAFETY comment.
- Thin forwarders whose entire contract *is* the adoption precondition become `unsafe fn` themselves instead of hiding it behind a safe signature again: `NewServer::ptr_to_js` / `server_js_create`, `JSValkeyClient::ptr_to_js`, `Subprocess::to_js_from_ptr`, `s3_file::to_js_unchecked`, `SourceContext::js_create`, `ResumableSinkJs::to_js`.
- `&self`-receiver methods with a documented heap-allocation caller contract (`Blob`/`Request`/`Response`/`NewSocket`/`NewSource` `to_js`) keep their signatures; the internal `unsafe` block cites that contract.

No behavior change: the emitted code is identical, only call-safety qualifiers and comments moved. `clashing_extern_declarations` (deny) cross-checks that all four extern surfaces agree on the new signatures, which is how the proc-macro and HTMLBundle copies were found.

### Verification

The change is type-level, so the verification is the compiler: the unsound calls no longer compile outside `unsafe`, and every swept call site's SAFETY justification is reviewable at the allocation it names. Checked with:

- `cargo check -p bun_bin` on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc` (covers the `sysv64` extern branch and the `cfg(windows)` Listener call site)
- `cargo clippy` on the four touched crates, full `bun bd` debug build
- `bun bd test test/js/bun/net/socket-retention.test.ts` (5 pass)

The new test ("Listener wrappers are adopted and finalized exactly once across GC") is a regression lock on the adopt → finalize round trip for one of the swept paths, not proof of the fix: like the fix itself, it passes on unfixed builds, since the unsoundness is only reachable from new Rust code, not from JS.

One of the `[Unsoundness]` batch (#31967-#31976); this PR covers only the `to_js`/`__create` adoption surface.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket-retention.test.ts

<!-- robobun:evidence:end -->