### PR TITLE
Make reference-receiver to_js adoption methods unsafe, fix DevServer stack Response

### DIFF
--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -141,7 +141,7 @@ pub fn to_fetch_headers(
         // and mojibake any UTF-8 header value bytes ≥0x80.
         &ZigString::from_bytes(this.buf.as_slice()),
         this.entries.len() as u32,
-    )
+    )?
     .ok_or(JsError::Thrown)
 }
 

--- a/src/jsc/FetchHeaders.rs
+++ b/src/jsc/FetchHeaders.rs
@@ -162,18 +162,27 @@ impl FetchHeaders {
         self.put(name_, value, global)
     }
 
+    /// Returns `Err` when header validation (`FetchHeaders::fill`) throws;
+    /// `None` does not happen without a pending exception, so a successful
+    /// call always yields `Ok(Some(..))`.
     pub fn create(
         global: &JSGlobalObject,
         names: *mut StringPointer,
         values: *mut StringPointer,
         buf: &ZigString,
         count_: u32,
-    ) -> Option<NonNull<FetchHeaders>> {
-        // SAFETY: forwarding caller-provided buffers to C++; `global` is an opaque ZST handle
-        // passed by address only.
-        let p =
-            unsafe { WebCore__FetchHeaders__createValueNotJS(global, names, values, buf, count_) };
-        NonNull::new(p)
+    ) -> JsResult<Option<NonNull<FetchHeaders>>> {
+        // `createValueNotJS` can throw (header validation); route through the
+        // exception-checking wrapper so the pending-exception state is
+        // observed (BUN_JSC_validateExceptionChecks).
+        host_fn::from_js_host_call_generic(global, || {
+            // SAFETY: forwarding caller-provided buffers to C++; `global` is an opaque ZST handle
+            // passed by address only.
+            let p = unsafe {
+                WebCore__FetchHeaders__createValueNotJS(global, names, values, buf, count_)
+            };
+            NonNull::new(p)
+        })
     }
 
     pub fn from(

--- a/src/runtime/api/Archive.rs
+++ b/src/runtime/api/Archive.rs
@@ -1271,7 +1271,9 @@ impl TaskContext for FilesContext {
                     blob.last_modified.set((entry.mtime * 1000) as f64);
 
                     let name_js = blob.name.get().to_js(global)?;
-                    let blob_js = blob.to_js(global);
+                    // SAFETY: `blob` is the fresh `Blob::new` heap allocation
+                    // from above; no wrapper exists yet.
+                    let blob_js = unsafe { blob.to_js(global) };
                     // SAFETY: map_ptr came from JSMap::from_js on a live value.
                     unsafe { map_ptr.as_mut() }.set(global, name_js, blob_js)?;
                 }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5536,7 +5536,11 @@ impl DevServer {
                 // ownership is transferred to `HeadersRef`.
                 let headers_ref =
                     unsafe { crate::webcore::response::HeadersRef::adopt(fetch_headers) };
-                let response: Response = Response::init(
+                // Ownership of the allocation transfers to the JS wrapper
+                // (freed in `ResponseClass__finalize`); a stack `Response`
+                // here would leave the wrapper's `m_ctx` pointing at a dead
+                // stack slot.
+                let response = bun_core::heap::into_raw(Box::new(Response::init(
                     crate::webcore::response::Init {
                         status_code: 500,
                         headers: Some(headers_ref),
@@ -5547,10 +5551,13 @@ impl DevServer {
                     )),
                     BunString::empty(),
                     false,
-                );
+                )));
                 let vm = self.vm();
                 let _exit = vm.enter_event_loop_scope();
-                r.promise.reject(global, Ok(response.to_js(global)))?;
+                // SAFETY: `response` is the fresh heap allocation from above;
+                // the JS wrapper adopts it.
+                let response_js = unsafe { (*response).to_js(global) };
+                r.promise.reject(global, Ok(response_js))?;
             }
         }
         Ok(())

--- a/src/runtime/node/node_net_binding.rs
+++ b/src/runtime/node/node_net_binding.rs
@@ -155,7 +155,9 @@ pub(crate) fn new_detached_socket(global: &JSGlobalObject, frame: &CallFrame) ->
             native_callback: JsCell::new(NativeCallbacks::None),
             twin: JsCell::new(None),
         });
-        socket.get_this_value(global)
+        // SAFETY: `socket` is the fresh heap allocation from `NewSocket::new`
+        // above; no wrapper exists yet.
+        unsafe { socket.get_this_value(global) }
     }
 
     Ok(if !is_ssl {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3162,12 +3162,18 @@ where
 
         Some(PreparedRequestFor {
             js_request: match create_js_request {
-                CreateJsRequest::Yes => request_object.to_js(&self.global()),
-                CreateJsRequest::Bake => match request_object.to_js_for_bake(&self.global()) {
-                    Ok(v) => v,
-                    Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
-                    Err(_) => return None,
-                },
+                // SAFETY: `request_object` is the fresh heap allocation leaked
+                // from `Request::new` above (no wrapper yet); the ctx only
+                // keeps a WeakPtr alias.
+                CreateJsRequest::Yes => unsafe { request_object.to_js(&self.global()) },
+                CreateJsRequest::Bake => {
+                    // SAFETY: same provenance as the `Yes` arm above.
+                    match unsafe { request_object.to_js_for_bake(&self.global()) } {
+                        Ok(v) => v,
+                        Err(JsError::OutOfMemory) => bun_core::out_of_memory(),
+                        Err(_) => return None,
+                    }
+                }
                 CreateJsRequest::No => JSValue::ZERO,
             },
             request_object,
@@ -3332,8 +3338,10 @@ where
 
         // We keep the Request object alive for the duration of the request so that we can remove the pointer to the UWS request object.
         let global = this.global();
-        // SAFETY: `request_object_ptr` is live; no other borrow is outstanding.
         let args = [
+            // SAFETY: `request_object_ptr` is the fresh heap allocation leaked
+            // from `Request::new` above (live, no other borrow outstanding, no
+            // wrapper yet); the ctx only keeps a WeakPtr alias.
             unsafe { (*request_object_ptr).to_js(&global) },
             this.js_value_assert_alive(),
         ];

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -556,7 +556,13 @@ impl Listener {
         s.ref_();
         if let Some(default_data) = listener.strong_data.get().get() {
             let global = listener.handlers.global_object;
-            NewSocket::<SSL>::data_set_cached(s.get_this_value(&global), &global, default_data);
+            // SAFETY: `s` wraps `this_socket`, the fresh heap allocation from
+            // `NewSocket::new` above; no wrapper exists yet.
+            NewSocket::<SSL>::data_set_cached(
+                unsafe { s.get_this_value(&global) },
+                &global,
+                default_data,
+            );
         }
         s
     }
@@ -599,7 +605,13 @@ impl Listener {
         let default_data = listener.strong_data.get().get();
         if let Some(default_data) = default_data {
             let global = listener.handlers.global_object;
-            NewSocket::<SSL>::data_set_cached(s.get_this_value(&global), &global, default_data);
+            // SAFETY: `s` wraps `this_socket`, the fresh heap allocation from
+            // `NewSocket::new` above; no wrapper exists yet.
+            NewSocket::<SSL>::data_set_cached(
+                unsafe { s.get_this_value(&global) },
+                &global,
+                default_data,
+            );
         }
         if let Some(ctx) = socket.ext::<*mut c_void>() {
             // SAFETY: ext storage is at least pointer-sized; we stash *mut NewSocket<SSL>
@@ -1117,7 +1129,9 @@ impl Listener {
                     };
                     let tls_ref = tls;
                     TLSSocket::data_set_cached(
-                        tls_ref.get_this_value(global),
+                        // SAFETY: see above; the memo in `get_this_value`
+                        // covers the reused-wrapper case.
+                        unsafe { tls_ref.get_this_value(global) },
                         global,
                         default_data,
                     );
@@ -1198,7 +1212,9 @@ impl Listener {
                     let tcp_ref = tcp;
                     tcp_ref.ref_();
                     TCPSocket::data_set_cached(
-                        tcp_ref.get_this_value(global),
+                        // SAFETY: see above; the memo in `get_this_value`
+                        // covers the reused-wrapper case.
+                        unsafe { tcp_ref.get_this_value(global) },
                         global,
                         default_data,
                     );
@@ -1435,7 +1451,13 @@ fn connect_finish<const IS_SSL: bool>(
     // Either the caller's JS-owned socket (reconnect) or the fresh one above.
     let socket_ref = socket;
     socket_ref.ref_();
-    NewSocket::<IS_SSL>::data_set_cached(socket_ref.get_this_value(global), global, default_data);
+    NewSocket::<IS_SSL>::data_set_cached(
+        // SAFETY: see above; the memo in `get_this_value` covers the
+        // reused-wrapper case.
+        unsafe { socket_ref.get_this_value(global) },
+        global,
+        default_data,
+    );
     // On the reuse-prev path, `prev.this_value` was downgraded to Weak by the
     // previous close's `mark_inactive()`. `get_this_value()` returns the
     // existing wrapper (the Weak `try_get()` succeeds while the JS side still
@@ -1819,7 +1841,9 @@ pub(crate) extern "C" fn us_dispatch_server_name(
         let s_ref = uws_sys::us_socket_t::opaque_mut(socket.cast());
         if s_ref.kind() == uws_sys::SocketKind::BunSocketTls {
             match *s_ref.ext::<Option<bun_ptr::ThisPtr<TLSSocket>>>() {
-                Some(tls) => tls.get_this_value(&global),
+                // SAFETY: ext slot holds the live construct-path TLSSocket
+                // allocation; single-threaded dispatch.
+                Some(tls) => unsafe { tls.get_this_value(&global) },
                 None => JSValue::UNDEFINED,
             }
         } else {

--- a/src/runtime/socket/WindowsNamedPipeContext.rs
+++ b/src/runtime/socket/WindowsNamedPipeContext.rs
@@ -247,7 +247,9 @@ impl WindowsNamedPipeContext {
                 // SAFETY: `this` is live; `global_this` is disjoint from the caller's
                 // `&mut named_pipe` and the borrow ends before `handle_error` runs JS.
                 let js_err = err.to_js(unsafe { &(*this).global_this });
-                s.handle_error(js_err);
+                // SAFETY: `s` is the context's stored construct-path socket
+                // allocation (set when the pipe was created/connected).
+                unsafe { s.handle_error(js_err) };
             });
         } else {
             match_socket!(socket, |s: NewSocket<SSL>| _ =

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -112,7 +112,9 @@ extern "C" fn select_alpn_callback(
         if !callback.is_empty() && !handlers.vm.is_shutting_down() && !in_.is_null() && inlen > 0 {
             let scope = handlers.enter();
             let global = handlers.global_object;
-            let this_value = this.get_this_value(&global);
+            // SAFETY: `this` reborrows the ex_data `*mut TLSSocket` set in
+            // `on_open`, which is the construct-path heap allocation.
+            let this_value = unsafe { this.get_this_value(&global) };
             let wire_len = inlen as usize;
             let buffer = match JSValue::create_buffer_from_length(&global, wire_len) {
                 Ok(b) => b,
@@ -448,11 +450,15 @@ impl<const SSL: bool> NewSocket<SSL> {
     // `#[bun_jsc::JsClass]` can't express the per-monomorphisation symbol
     // dispatch, so these hand-roll the `if (ssl) js_TLSSocket else js_TCPSocket`
     // split and route through the codegen'd safe wrappers.
-    pub fn to_js(&self, global: &JSGlobalObject) -> JSValue {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`NewSocket::new`])
+    /// and must not already have a JS wrapper: the C++ JSCell wrapper adopts
+    /// the pointer (holding the allocation's initial ref) and `finalize` on GC
+    /// ends in [`Self::deref`] → `deinit_and_destroy` → `heap::take`.
+    pub unsafe fn to_js(&self, global: &JSGlobalObject) -> JSValue {
         jsc::mark_binding!();
-        // `self` is a heap-allocated `NewSocket` (every caller goes through
-        // `NewSocket::new` → `heap::alloc`); ownership is adopted by the C++
-        // JSCell wrapper, which calls `finalize` on GC. The codegen wrappers are
+        // The codegen wrappers are
         // monomorphic in `TCPSocket`/`TLSSocket`, so cast through the concrete
         // alias each branch is typed against.
         let ptr = self.as_ctx_ptr();
@@ -850,7 +856,12 @@ impl<const SSL: bool> NewSocket<SSL> {
         Ok(JSValue::UNDEFINED)
     }
 
-    pub fn handle_error(&self, err_value: JSValue) {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`NewSocket::new`]):
+    /// dispatching the error handler may create the JS wrapper via
+    /// [`Self::get_this_value`].
+    pub unsafe fn handle_error(&self, err_value: JSValue) {
         log!("handleError");
         let handlers = self.get_handlers();
         let vm = handlers.vm;
@@ -861,7 +872,8 @@ impl<const SSL: bool> NewSocket<SSL> {
         // that way if we need to call the error handler, we can
         let scope = handlers.enter();
         let global = handlers.global_object;
-        let this_value = self.get_this_value(&global);
+        // SAFETY: forwarded caller contract (see `# Safety` above).
+        let this_value = unsafe { self.get_this_value(&global) };
         let _ = handlers.call_error_handler(this_value, &[this_value, err_value]);
         self.exit_scope(scope);
     }
@@ -924,7 +936,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let scope = handlers.enter();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
@@ -966,7 +980,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let scope = handlers.enter();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
@@ -1177,7 +1193,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             return Ok(());
         }
 
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         this_value.ensure_still_alive();
         // Connection failed before open; allow the wrapper to be GC'd once this
         // callback returns. The on-stack `this_value` keeps it alive for the call.
@@ -1444,7 +1462,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let handshake_callback = handlers.on_handshake();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
 
         this.mark_active();
         // TODO: properly propagate exception upwards
@@ -1514,7 +1534,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         this.exit_scope(scope);
     }
 
-    pub fn get_this_value(&self, global: &JSGlobalObject) -> JSValue {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`NewSocket::new`]):
+    /// when no wrapper exists yet, this hands the pointer to [`Self::to_js`],
+    /// whose wrapper adopts it (see that method's `# Safety`). Receivers
+    /// reborrowed from the uSockets ext slot or the wrapper's `m_ctx` satisfy
+    /// this — both store the allocation-root pointer.
+    pub unsafe fn get_this_value(&self, global: &JSGlobalObject) -> JSValue {
         if let Some(value) = self.this_value.get().try_get() {
             return value;
         }
@@ -1523,7 +1550,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             // here would result in a second `finalize` (and double-deref) later.
             return JSValue::UNDEFINED;
         }
-        let value = self.to_js(global);
+        // SAFETY: forwarded caller contract (see `# Safety` above); the
+        // `this_value` memo above guarantees no wrapper exists yet.
+        let value = unsafe { self.to_js(global) };
         value.ensure_still_alive();
         // The wrapper holds the shared handlers cell in a visited slot, so the
         // callbacks stay reachable from every socket that can still fire them.
@@ -1589,7 +1618,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let scope = handlers.enter();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         if let Err(err) = callback.call(&global, this_value, &[this_value]) {
             let _ = handlers.call_error_handler(this_value, &[this_value, global.take_error(err)]);
         }
@@ -1679,7 +1710,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let scope = handlers.enter();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
 
         let result: JSValue;
         // open callback only have 1 parameters and its the socket
@@ -1757,7 +1790,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
         let scope = handlers.enter();
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         let buffer = match JSValue::create_buffer_from_length(&global, session.len()) {
             Ok(b) => b,
             Err(e) => {
@@ -1804,7 +1839,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
         let scope = handlers.enter();
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         let buffer = match JSValue::create_buffer_from_length(&global, line.len()) {
             Ok(b) => b,
             Err(e) => {
@@ -1902,7 +1939,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         let scope = handlers.enter();
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         let mut js_error: JSValue = JSValue::UNDEFINED;
         // `err` is overloaded: when WE closed the socket it's a libus
         // CloseCode enum (0=clean, 1=failure/RST, 2=fast-shutdown); when the
@@ -1965,11 +2004,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         let global = handlers.global_object;
-        let this_value = this.get_this_value(&global);
+        // SAFETY: `this` reborrows the fn's `*mut Self` parameter, which is
+        // the construct-path heap allocation (fn contract).
+        let this_value = unsafe { this.get_this_value(&global) };
         let output_value = match handlers.binary_type.get().to_js(data, &global) {
             Ok(v) => v,
             Err(err) => {
-                this.handle_error(global.take_exception(err));
+                // SAFETY: same `this` provenance as `get_this_value` above.
+                unsafe { this.handle_error(global.take_exception(err)) };
                 return;
             }
         };
@@ -1994,7 +2036,9 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(setter)]
     pub fn set_data(this: &Self, global: &JSGlobalObject, value: JSValue) -> JsResult<bool> {
         log!("setData()");
-        Self::data_set_cached(this.get_this_value(global), global, value);
+        // SAFETY: host_fn receiver — `this` is the wrapper's `m_ctx`, the
+        // construct-path heap allocation.
+        Self::data_set_cached(unsafe { this.get_this_value(global) }, global, value);
         Ok(true)
     }
 
@@ -3395,7 +3439,10 @@ impl<const SSL: bool> NewSocket<SSL> {
         // Capture before downgrade so the cached `data` (net.ts stores
         // `{self: net.Socket}` there) survives onto the raw twin.
         let original_data: JSValue =
-            Self::data_get_cached(this.get_this_value(global)).unwrap_or(JSValue::UNDEFINED);
+            // SAFETY: host_fn receiver — `this` is the wrapper's `m_ctx`, the
+            // construct-path heap allocation.
+            Self::data_get_cached(unsafe { this.get_this_value(global) })
+                .unwrap_or(JSValue::UNDEFINED);
         original_data.ensure_still_alive();
         if this.flags.get().contains(Flags::IS_ACTIVE) {
             this.poll_ref.with_mut(|p| p.disable());
@@ -3451,8 +3498,12 @@ impl<const SSL: bool> NewSocket<SSL> {
         // S008: `us_socket_t` is an `opaque_ffi!` ZST — safe deref.
         bun_opaque::opaque_deref_mut(new_raw.as_ptr()).set_ssl_raw_tap(true);
 
-        let tls_js_value = tls.get_this_value(global);
-        let raw_js_value = raw_ref.get_this_value(global);
+        // SAFETY: `tls` and `raw_ref` are the freshly heap-allocated
+        // `TLSSocket::new` twins (no wrappers yet); no dispatch can fire
+        // until `on_open`/`start_tls_handshake` below.
+        let tls_js_value = unsafe { tls.get_this_value(global) };
+        // SAFETY: see above.
+        let raw_js_value = unsafe { raw_ref.get_this_value(global) };
         TLSSocket::data_set_cached(tls_js_value, global, default_data);
         // `raw` keeps the pre-upgrade `data` so its callbacks emit on the
         // original net.Socket, not the TLS one.
@@ -3963,8 +4014,9 @@ impl DuplexUpgradeContext {
     fn on_error(&mut self, err_value: JSValue) {
         if self.is_open {
             if let Some(tls) = &self.tls {
-                // `RefPtr: Deref<Target = TLSSocket>`; `handle_error(&self)`.
-                tls.handle_error(err_value);
+                // SAFETY: `RefPtr: Deref<Target = TLSSocket>` over the
+                // intrusively-refcounted heap allocation from `TLSSocket::new`.
+                unsafe { tls.handle_error(err_value) };
             }
         } else {
             if let Some(tls) = self.tls.take() {
@@ -4276,7 +4328,9 @@ pub fn js_upgrade_duplex_to_tls(
         twin: JsCell::new(None),
     });
     let tls_ref = tls;
-    let tls_js_value = tls_ref.get_this_value(global);
+    // SAFETY: `tls` was just allocated via `TLSSocket::new`; no wrapper
+    // exists yet.
+    let tls_js_value = unsafe { tls_ref.get_this_value(global) };
     TLSSocket::data_set_cached(tls_js_value, global, default_data);
 
     // The +1 `SSL_CTX` ref transfers into `DuplexUpgradeContext.owned_ctx` below.

--- a/src/runtime/webcore/BakeResponse.rs
+++ b/src/runtime/webcore/BakeResponse.rs
@@ -142,7 +142,7 @@ pub(crate) fn construct_redirect(
     let ptr = bun_core::heap::into_raw(response);
     // SAFETY: `ptr` is a fresh heap allocation; `Response::to_js` hands it to
     // the C++ wrapper which owns it thereafter.
-    Ok(unsafe { &mut *ptr }.to_js(global_this))
+    Ok(unsafe { (*ptr).to_js(global_this) })
 }
 
 // C++ side declares `extern "C" SYSV_ABI ... JSC_HOST_CALL_ATTRIBUTES`.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2037,8 +2037,8 @@ impl BlobExt for Blob {
             .set(self.content_type_was_set.get() || content_type_was_allocated);
 
         let ptr = Blob::new(blob);
-        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Explicit
-        // `&mut *` forces the inherent `Blob::to_js(&mut self)` (which calls
+        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new` (no
+        // wrapper yet). UFCS picks `BlobExt::to_js(&self)` (which calls
         // `calculate_estimated_byte_size` and routes S3 blobs to
         // `S3File.toJSUnchecked`) over the by-value `JsClass::to_js`.
         unsafe { BlobExt::to_js(&*ptr, global_this) }
@@ -2052,8 +2052,8 @@ impl BlobExt for Blob {
 
         if self.size.get() == 0 {
             let ptr = Blob::new(Blob::init_empty(global_this));
-            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; force
-            // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js`.
+            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new` (no
+            // wrapper yet); `BlobExt::to_js(&self)` over `JsClass::to_js`.
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
@@ -4341,8 +4341,9 @@ fn _on_structured_clone_deserialize<B: AsRef<[u8]>>(
     }
 
     let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
-    // SAFETY: blob_ptr is valid; toJS is infallible. Explicit `&mut *` forces
-    // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
+    // SAFETY: `blob_ptr` is the fresh `Blob::new` heap allocation (guard
+    // disarmed above, no wrapper yet); `BlobExt::to_js(&self)` over
+    // `JsClass::to_js(self)`.
     Ok(unsafe { BlobExt::to_js(&*blob_ptr, global_this) })
 }
 
@@ -4862,9 +4863,9 @@ pub fn write_file_with_source_destination(
         // this is an edgecase
         // it will happen if someone did Bun.write(new Blob([123]), new Blob([456]))
         let cloned = Blob::new(source_blob.dupe());
-        // SAFETY: ptr was just produced by heap::alloc in Blob::new; the
-        // inherent `to_js(&mut self)` (not the by-value `JsClass` one) hands
-        // ownership to the C++ wrapper.
+        // SAFETY: `cloned` was just produced by `heap::alloc` in `Blob::new`
+        // (no wrapper yet); `BlobExt::to_js(&self)` (not the by-value
+        // `JsClass` one) hands ownership to the C++ wrapper.
         return Ok(JSPromise::resolved_promise_value(ctx, unsafe {
             BlobExt::to_js(&*cloned, ctx)
         }));
@@ -5792,8 +5793,8 @@ pub fn construct_bun_file(
     }
 
     let ptr = Blob::new(blob);
-    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Explicit
-    // `&mut *` forces inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
+    // SAFETY: `ptr` was just produced by `heap::alloc` in `Blob::new` (no
+    // wrapper yet); `BlobExt::to_js(&self)` over `JsClass::to_js(self)`.
     Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
 }
 
@@ -6552,8 +6553,8 @@ impl Any {
             streams::BufferActionTag::Blob => {
                 let result = Blob::new(self.to_blob(global_this));
                 // SAFETY: `Blob::new` returns a fresh heap allocation we own;
-                // `BlobExt::to_js` (the `&mut self` overload) consumes the
-                // pointer into a JS wrapper which takes ownership.
+                // `BlobExt::to_js(&self)` consumes the pointer into a JS
+                // wrapper which takes ownership.
                 unsafe { (*result).global_this.set(global_this) };
                 // SAFETY: same fresh `result` allocation; ownership transfers to the JS wrapper.
                 Ok(unsafe { BlobExt::to_js(&*result, global_this) })

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -390,7 +390,15 @@ pub trait BlobExt {
         Self: Sized;
     fn calculate_estimated_byte_size(&self);
     fn estimated_size(&self) -> usize;
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue;
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`Blob::new`], which
+    /// sets the initial ref owed to the wrapper) and must not already have a
+    /// JS wrapper: the wrapper returned here adopts the pointer as its `m_ctx`
+    /// and releases that ref at GC finalize ([`Blob::finalize`] →
+    /// `Blob__deref`). Stack blobs (`is_heap_allocated() == false`) must never
+    /// reach this.
+    unsafe fn to_js(&self, global_object: &JSGlobalObject) -> JSValue;
     fn find_or_create_file_from_path(
         path_or_fd: &mut PathOrFileDescriptor,
         global_this: &JSGlobalObject,
@@ -3700,8 +3708,8 @@ impl BlobExt for Blob {
         self.reported_estimated_size.get()
     }
 
-    fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
-        // if cfg!(debug_assertions) { debug_assert!(self.is_heap_allocated()); }
+    unsafe fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
+        debug_assert!(self.is_heap_allocated());
         self.calculate_estimated_byte_size();
 
         // R-2: `&self` receiver, but the FFI shims take `*mut Blob` (the
@@ -6548,7 +6556,7 @@ impl Any {
                 // pointer into a JS wrapper which takes ownership.
                 unsafe { (*result).global_this.set(global_this) };
                 // SAFETY: same fresh `result` allocation; ownership transfers to the JS wrapper.
-                Ok(BlobExt::to_js(unsafe { &*result }, global_this))
+                Ok(unsafe { BlobExt::to_js(&*result, global_this) })
             }
             streams::BufferActionTag::ArrayBuffer => {
                 if matches!(self, Any::Blob(_)) {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -897,7 +897,9 @@ impl Value {
                 locked.readable = webcore::readable_stream::Strong::init(
                     ReadableStream {
                         ptr: webcore::readable_stream::Source::Bytes(context_ptr),
-                        value: reader.to_readable_stream(global_this)?,
+                        // SAFETY: `reader` is the fresh heap allocation from
+                        // `NewSource::new_mut` above; no wrapper exists yet.
+                        value: unsafe { reader.to_readable_stream(global_this) }?,
                     },
                     global_this,
                 );
@@ -1167,7 +1169,9 @@ impl Value {
                         if !blob.content_type_was_set.get() && blob.store.get().is_some() {
                             set_blob_content_type(blob, bun_http_types::MimeType::TEXT);
                         }
-                        promise.resolve(global, blob.to_js(global))?;
+                        // SAFETY: `blob` is the fresh `Blob::new` heap
+                        // allocation from above; no wrapper exists yet.
+                        promise.resolve(global, unsafe { blob.to_js(global) })?;
                     }
                 }
                 promise_.unprotect();
@@ -1560,7 +1564,9 @@ impl Value {
         locked.readable = webcore::readable_stream::Strong::init(
             ReadableStream {
                 ptr: webcore::readable_stream::Source::Bytes(context_ptr),
-                value: reader.to_readable_stream(global_this)?,
+                // SAFETY: `reader` is the fresh heap allocation from
+                // `NewSource::new_mut` above; no wrapper exists yet.
+                value: unsafe { reader.to_readable_stream(global_this) }?,
             },
             global_this,
         );
@@ -2196,7 +2202,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         }
         Ok(JSPromise::resolved_promise_value(
             global_object,
-            blob.to_js(global_object),
+            // SAFETY: `blob` is the fresh `Blob::new` heap allocation from
+            // above; no wrapper exists yet.
+            unsafe { blob.to_js(global_object) },
         ))
     }
 

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -339,7 +339,9 @@ impl ReadableStream {
                     ..Default::default()
                 });
                 reader.context.setup(blob, recommended_chunk_size);
-                reader.to_readable_stream(global_this)
+                // SAFETY: `reader` is the fresh heap allocation from
+                // `NewSource::new_mut` above; no wrapper exists yet.
+                unsafe { reader.to_readable_stream(global_this) }
             }
             webcore::blob::store::Data::File(_) => {
                 let reader = NewSource::<FileReader>::new_mut(NewSource {
@@ -359,7 +361,9 @@ impl ReadableStream {
                     },
                     ..Default::default()
                 });
-                reader.to_readable_stream(global_this)
+                // SAFETY: `reader` is the fresh heap allocation from
+                // `NewSource::new_mut` above; no wrapper exists yet.
+                unsafe { reader.to_readable_stream(global_this) }
             }
             webcore::blob::store::Data::S3(s3) => {
                 let credentials = s3.get_credentials();
@@ -413,7 +417,9 @@ impl ReadableStream {
                     },
                     ..Default::default()
                 });
-                reader.to_readable_stream(global_this)
+                // SAFETY: `reader` is the fresh heap allocation from
+                // `NewSource::new_mut` above; no wrapper exists yet.
+                unsafe { reader.to_readable_stream(global_this) }
             }
             _ => Err(global_this.throw(format_args!("Expected FileBlob"))),
         }
@@ -440,7 +446,9 @@ impl ReadableStream {
             .reader()
             .from(buffered_reader, ctx_ptr.cast::<c_void>());
 
-        let stream = source.to_readable_stream(global_this)?;
+        // SAFETY: `source` is the fresh heap allocation from
+        // `NewSource::new_mut` above; no wrapper exists yet.
+        let stream = unsafe { source.to_readable_stream(global_this) }?;
 
         // The transferred poll's owner now points into this box; root the
         // wrapper before JS can GC it. `on_start` skips a second ref via the
@@ -724,7 +732,13 @@ impl<C: SourceContext + Default> Default for NewSource<C> {
 // The `.classes.ts` → `.rs` generator (when re-run with Rust output) is expected
 // to emit those `const JS_*` bindings directly.
 pub(crate) trait NewSourceCodegen {
-    fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue;
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`NewSource::new`] /
+    /// [`NewSource::new_mut`]) and must not already have a JS wrapper: the
+    /// wrapper returned here adopts the pointer as its `m_ctx` and the GC
+    /// finalizer drives [`NewSource::decrement_count`] → `heap::take`.
+    unsafe fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue;
     fn pending_promise_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
     fn on_drain_callback_set_cached(this: JSValue, global: &JSGlobalObject, value: JSValue);
     fn on_drain_callback_get_cached(this: JSValue) -> Option<JSValue>;
@@ -788,10 +802,10 @@ macro_rules! source_context_codegen {
 }
 
 impl<C: SourceContext> NewSourceCodegen for NewSource<C> {
-    fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue {
-        // `self` is a heap-allocated `NewSource<C>` produced by [`NewSource::new`]
-        // (`heap::alloc`); ownership transfers to the JS wrapper as `m_ctx`. C++ side
-        // stores it as `void*` and the GC finalizer drives `decrement_count` → `deinit`.
+    unsafe fn to_js(&mut self, global_this: &JSGlobalObject) -> JSValue {
+        // Ownership transfers to the JS wrapper as `m_ctx` (caller contract —
+        // see the trait's `# Safety`). C++ side stores it as `void*` and the
+        // GC finalizer drives `decrement_count` → `deinit`.
         C::js_create(
             std::ptr::from_mut::<Self>(self).cast::<c_void>(),
             global_this,
@@ -1010,11 +1024,19 @@ impl<C: SourceContext> NewSource<C> {
         self.context.drain_internal_buffer()
     }
 
-    pub fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation ([`Self::new`] /
+    /// [`Self::new_mut`]): when no wrapper exists yet, this hands the pointer
+    /// to [`NewSourceCodegen::to_js`], whose wrapper adopts it (see that
+    /// method's `# Safety`).
+    pub unsafe fn to_readable_stream(&mut self, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         let out_value = if let Some(v) = self.this_jsvalue.try_get() {
             v
         } else {
-            <Self as NewSourceCodegen>::to_js(self, global_this)
+            // SAFETY: forwarded caller contract (see `# Safety` above); an
+            // empty `this_jsvalue` means no wrapper has adopted `self` yet.
+            unsafe { <Self as NewSourceCodegen>::to_js(self, global_this) }
         };
         out_value.ensure_still_alive();
         if self.this_jsvalue.is_empty() {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -532,7 +532,14 @@ impl Request {
         <Self as BodyMixin>::detach_readable_stream(self, global_object)
     }
 
-    pub fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation
+    /// (`heap::into_raw(Box::new(..))`) and must not already have a JS
+    /// wrapper: the wrapper returned here adopts the pointer as its `m_ctx`
+    /// and the GC finalizer reclaims it (`RequestClass__finalize` →
+    /// `Box::from_raw`).
+    pub unsafe fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
         self.calculate_estimated_byte_size();
         // R-2: `to_js_unchecked` stores `self` as the C++ `m_ctx` payload (an
         // opaque `void*` never deref'd as `&mut Request` on the C++ side), so
@@ -553,24 +560,32 @@ impl Request {
 bun_jsc::jsc_abi_extern! {
     #[allow(improper_ctypes)]
     #[link_name = "Bun__JSRequest__createForBake"]
-    // `&JSGlobalObject` discharges the only deref'd-param precondition;
-    // `request_ptr` is stored opaquely as `void* m_ctx` (module-private —
-    // sole caller forwards `from_ref(self)`). Matches the `*__createObject`
-    // precedent.
-    safe fn Bun__JSRequest__createForBake(
+    // `request_ptr` is stored opaquely as `void* m_ctx` and the wrapper's GC
+    // finalizer reclaims it (`JSBunRequest` subclasses the codegen
+    // `JSRequest`), so this is adoption surface: callers must own the heap
+    // allocation (module-private — sole caller is `to_js_for_bake`).
+    fn Bun__JSRequest__createForBake(
         global_object: &JSGlobalObject,
         request_ptr: *mut Request,
     ) -> JSValue;
 }
 
 impl Request {
-    pub fn to_js_for_bake(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
+    /// # Safety
+    ///
+    /// Same contract as [`Request::to_js`]: `self` must be the construct-path
+    /// heap allocation with no existing JS wrapper; the `JSBunRequest` wrapper
+    /// adopts the pointer and the GC finalizer reclaims it.
+    pub unsafe fn to_js_for_bake(&self, global_object: &JSGlobalObject) -> JsResult<JSValue> {
         bun_jsc::from_js_host_call(global_object, || {
             // C++ stores `self` as opaque `void* m_ctx`; see `to_js` note.
-            Bun__JSRequest__createForBake(
-                global_object,
-                std::ptr::from_ref::<Request>(self).cast_mut(),
-            )
+            // SAFETY: forwarded caller contract (see `# Safety` above).
+            unsafe {
+                Bun__JSRequest__createForBake(
+                    global_object,
+                    std::ptr::from_ref::<Request>(self).cast_mut(),
+                )
+            }
         })
     }
 }

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -428,7 +428,14 @@ impl Response {
         <Self as BodyMixin>::check_body_stream_ref(self, global_object)
     }
 
-    pub fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
+    /// # Safety
+    ///
+    /// `self` must be the construct-path heap allocation
+    /// (`heap::into_raw(Box::new(..))`) and must not already have a JS
+    /// wrapper: the wrapper returned here adopts the pointer as its `m_ctx`
+    /// and releases the allocation's initial ref at GC finalize
+    /// ([`Self::finalize`] → [`Self::unref`]).
+    pub unsafe fn to_js(&self, global_object: &JSGlobalObject) -> JSValue {
         self.calculate_estimated_byte_size();
         // `bun_jsc::generated::JSResponse::to_js` ⇒ `Response__create` (C++
         // shim). Payload type is erased (`*mut ()`) at the bun_jsc tier.
@@ -810,19 +817,18 @@ impl Response {
         let this_value = callframe.this();
         let cloned = this.clone(global_this)?;
 
-        // SAFETY: `cloned` is a freshly-boxed Response from `clone()`.
-        let js_wrapper = Response::make_maybe_pooled(global_this, cloned);
+        // SAFETY: `cloned` is a freshly-boxed Response from `clone()`, not yet
+        // adopted by any wrapper.
+        let js_wrapper = unsafe { Response::make_maybe_pooled(global_this, cloned) };
         this.sync_cloned_body_stream_caches(this_value, js_wrapper, global_this);
         Ok(js_wrapper)
     }
 
     /// # Safety
-    /// `ptr` must point to a live `Response` allocation (e.g. freshly boxed via
-    /// [`Response::clone`]); ownership of the +1 ref transfers to the returned
-    /// JS wrapper.
-    // Safety contract is documented above; callers pass freshly-boxed pointers.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub fn make_maybe_pooled(global_object: &JSGlobalObject, ptr: *mut Response) -> JSValue {
+    /// `ptr` must be the construct-path heap allocation (e.g. freshly boxed
+    /// via [`Response::clone`]) with no existing JS wrapper; ownership of the
+    /// +1 ref transfers to the returned JS wrapper.
+    pub unsafe fn make_maybe_pooled(global_object: &JSGlobalObject, ptr: *mut Response) -> JSValue {
         // SAFETY: caller contract — `ptr` is live and uniquely owned.
         unsafe { (*ptr).to_js(global_object) }
     }

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -376,11 +376,11 @@ impl S3Client {
         );
         // `to_js` runs `calculateEstimatedByteSize()`
         // before wrapping the heap Blob in a JSS3File so JSC sees the correct
-        // GC pressure. Route through `BlobExt::to_js` (the `&mut self` method
-        // that owns the heap pointer), same as `S3File::construct_internal_js`.
-        // SAFETY: `blob` is a freshly leaked `*mut Blob` from `Blob::new`;
-        // `to_js` hands ownership of that pointer to the C++ wrapper.
-        Ok(unsafe { &mut *blob }.to_js(global))
+        // GC pressure. Route through `BlobExt::to_js` (the `&self` method
+        // that takes the heap pointer), same as `S3File::construct_internal_js`.
+        // SAFETY: `blob` is a freshly leaked `*mut Blob` from `Blob::new`
+        // with no wrapper yet; `to_js` hands ownership to the C++ wrapper.
+        Ok(unsafe { (*blob).to_js(global) })
     }
 
     #[bun_jsc::host_fn(method)]

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -855,11 +855,11 @@ pub(crate) fn construct_internal_js(
     options: Option<JSValue>,
 ) -> JsResult<JSValue> {
     let blob = construct_s3_file_internal(global, path, options)?;
-    // SAFETY: `blob` is a freshly heap-allocated `*mut Blob` from `Blob::new`.
-    // Call the `BlobExt::to_js` `&mut self` method (not the by-value
-    // `JsClass::to_js`), which hands the existing heap pointer to the C++
-    // wrapper.
-    Ok(BlobExt::to_js(unsafe { &mut *blob }, global))
+    // SAFETY: `blob` is a freshly heap-allocated `*mut Blob` from `Blob::new`
+    // with no wrapper yet. Call the `BlobExt::to_js` `&self` method (not the
+    // by-value `JsClass::to_js`), which hands the existing heap pointer to
+    // the C++ wrapper.
+    Ok(unsafe { BlobExt::to_js(&*blob, global) })
 }
 
 pub fn to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -222,7 +222,7 @@ fn data_url_response(data_url_: DataURL, global_this: &JSGlobalObject) -> JSValu
         global_this,
         // SAFETY: `response` is a freshly allocated heap `Response`; ownership
         // transfers to JSC.
-        Response::make_maybe_pooled(global_this, response),
+        unsafe { Response::make_maybe_pooled(global_this, response) },
     )
 }
 
@@ -1594,7 +1594,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
             global_this,
             // SAFETY: `response` is a freshly allocated heap `Response`; ownership
             // transfers to JSC.
-            Response::make_maybe_pooled(global_this, response),
+            unsafe { Response::make_maybe_pooled(global_this, response) },
         ));
     }
 
@@ -2140,8 +2140,9 @@ impl<'a> S3StreamWrapper<'a> {
                 ));
                 // SAFETY: `into_raw` yields a freshly allocated heap `Response`;
                 // ownership transfers to JSC.
-                let response_js =
-                    Response::make_maybe_pooled(global, bun_core::heap::into_raw(response));
+                let response_js = unsafe {
+                    Response::make_maybe_pooled(global, bun_core::heap::into_raw(response))
+                };
                 response_js.ensure_still_alive();
                 self_.promise.resolve(global, response_js)?;
             }
@@ -2163,8 +2164,9 @@ impl<'a> S3StreamWrapper<'a> {
 
                 // SAFETY: `into_raw` yields a freshly allocated heap `Response`;
                 // ownership transfers to JSC.
-                let response_js =
-                    Response::make_maybe_pooled(global, bun_core::heap::into_raw(response));
+                let response_js = unsafe {
+                    Response::make_maybe_pooled(global, bun_core::heap::into_raw(response))
+                };
                 response_js.ensure_still_alive();
                 self_.promise.resolve(global, response_js)?;
             }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1818,10 +1818,9 @@ impl FetchTasklet {
         if self.is_waiting_body {
             self.poll_ref.unref(bun_io::js_vm_ctx());
         }
-        // SAFETY: response is a freshly allocated Response; makeMaybePooled takes ownership semantics on the JS side
         let global_this = self.global_this;
         // SAFETY: `response` is freshly allocated above; ownership transfers to JSC.
-        let response_js = Response::make_maybe_pooled(&global_this, response);
+        let response_js = unsafe { Response::make_maybe_pooled(&global_this, response) };
         response_js.ensure_still_alive();
         self.response = jsc::Weak::<FetchTasklet>::create(
             response_js,

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1251,7 +1251,9 @@ pub fn readable_stream(
     let reader_mut = unsafe { &mut *reader };
 
     reader_mut.context.setup();
-    let readable_value = reader_mut.to_readable_stream(global_this)?;
+    // SAFETY: `reader_mut` is the fresh heap allocation from `Source::new`
+    // above; no wrapper exists yet.
+    let readable_value = unsafe { reader_mut.to_readable_stream(global_this) }?;
 
     let wrapper = S3DownloadStreamWrapper::new(S3DownloadStreamWrapper {
         readable_stream_ref: ReadableStreamStrong::init(

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,3 +865,46 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+
+devTest("bundle failure surfaced through the Response.render rewrite promise", {
+  // https://github.com/oven-sh/bun/issues/31985
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      export default function (req, meta) {
+        throw Response.render("/broken");
+      }
+    `,
+    "routes/broken.ts": `
+      import { x } from "./does-not-exist";
+      export default function () {
+        return new Response(x);
+      }
+    `,
+    "routes/gc.ts": `
+      export default function () {
+        Bun.gc(true);
+        return new Response("gc-ok");
+      }
+    `,
+  },
+  async test(dev) {
+    // The rewrite target fails to bundle; the dev server rejects the internal
+    // bundleNewRoute promise with an error-page Response and the request
+    // resolves as a 500.
+    expect((await dev.fetch("/")).status).toBe(500);
+    // Force a GC so the error-page Response wrapper from the rejected promise
+    // is finalized; the server must survive and keep serving.
+    {
+      const response = await dev.fetch("/gc");
+      expect(await response.text()).toBe("gc-ok");
+      expect(response.status).toBe(200);
+    }
+    expect((await dev.fetch("/")).status).toBe(500);
+    {
+      const response = await dev.fetch("/gc");
+      expect(await response.text()).toBe("gc-ok");
+      expect(response.status).toBe(200);
+    }
+  },
+});


### PR DESCRIPTION
Fixes #31985

### Problem

Five safe methods take `&self`/`&mut self` and hand the receiver pointer to a JS wrapper that adopts it as `m_ctx`; the GC finalizer later frees the allocation (`Box::from_raw` or an intrusive-refcount deref). The heap-allocation requirement was a prose comment, so safe code could construct one of these types by value and wrap a stack address:

- `Request::to_js` (src/runtime/webcore/Request.rs)
- `Response::to_js` (src/runtime/webcore/Response.rs)
- `BlobExt::to_js` (src/runtime/webcore/Blob.rs)
- `NewSourceCodegen::to_js` for `NewSource<C>` (src/runtime/webcore/ReadableStream.rs)
- `NewSocket::to_js` (src/runtime/socket/socket_body.rs)

This was not hypothetical. `DevServer::send_serialized_failures` (the `DevResponse::Promise` arm) called the inherent `Response::to_js(&self)` on a stack-local `Response` (`bun_jsc::JsClass` is not imported in DevServer.rs, so method resolution picks the `&self` inherent method over the by-value trait method). The wrapper's `m_ctx` pointed into a dead stack frame, and the first read, the unhandled-rejection printer formatting the rejected Response, crashes the dev server:

```
==ERROR: AddressSanitizer: SEGV on unknown address ... The signal is caused by a READ memory access.
    #0 WTF::RefCountedBase::hasOneRef() const
SUMMARY: AddressSanitizer: SEGV ... in WTF::RefCountedBase::hasOneRef() const
```

(r12/r13 hold the ASAN stack-redzone fill pattern `0xf2f2f2f8..`: the "Response" field values were read out of the dead stack slot.)

Reachable from JS: a bake framework route throws `Response.render("/x")` and the rewrite target fails to bundle; the dev server rejects the internal `bundleNewRoute` promise with an error-page Response that was built on the stack.

### Fix

Follow-up to #31984, one layer up, using the `unsafe fn` direction from the issue:

- The five methods become `unsafe fn` with the precondition in `# Safety`: the receiver must be the construct-path heap allocation with no existing JS wrapper.
- Thin forwarders whose entire contract is that same precondition become `unsafe fn` instead of re-hiding it behind a safe signature: `Response::make_maybe_pooled` (its `#[allow(clippy::not_unsafe_ptr_arg_deref)]` is gone), `Request::to_js_for_bake` plus the `Bun__JSRequest__createForBake` extern (loses `safe`; `JSBunRequest` subclasses the codegen `JSRequest`, so the pointer is finalizer-owned), `NewSource::to_readable_stream`, `NewSocket::get_this_value`, `NewSocket::handle_error`.
- Call sites (~45, enumerated by the compiler; `unsafe_op_in_unsafe_fn` is denied, so sites inside existing `unsafe fn`s were swept too) discharge the obligation with a SAFETY comment naming the allocation or root-pointer provenance. Host-fn receivers (`set_data`, `upgrade_tls`) cite the wrapper's `m_ctx`.
- DevServer.rs heap-allocates the error-page Response before wrapping (the fixing line).
- `Blob::to_js` re-enables the previously commented-out `debug_assert!(self.is_heap_allocated())`.

No behavior change outside DevServer.rs and FetchHeaders.rs; everything else moves call-safety qualifiers and comments.

Follow-up found by the new test on the ASAN lane (the `BUN_JSC_validateExceptionChecks` mode): `WebCore__FetchHeaders__createValueNotJS` can throw during header validation, and `FetchHeaders::create` (sole caller: `headers_jsc::to_fetch_headers`, used by the DevServer error-page path) never observed the exception state:

```
ERROR: Unchecked JS exception:
    This scope can throw a JS exception: WebCore__FetchHeaders__createValueNotJS @ src/jsc/bindings/bindings.cpp:2044
ASSERTION FAILED: exception check validation failed
```

Fixed by routing it through `from_js_host_call_generic`, matching the sibling `create_from_js`. Reproduced and verified locally by running test/bake/dev/bundle.test.ts with exception-check validation enabled.

### Verification

New test, `test/bake/dev/bundle.test.ts` "bundle failure surfaced through the Response.render rewrite promise": on the unfixed build the dev server dies with the ASAN SEGV above on the first fetch and the test fails; with the fix it passes (including a `Bun.gc(true)` route so the error-page wrapper is finalized, and repeat requests).

- `cargo check -p bun_bin` on `x86_64-unknown-linux-gnu` and `x86_64-pc-windows-msvc` (covers the `cfg(windows)` named-pipe call sites in Listener.rs), `cargo clippy -p bun_runtime`, `cargo fmt`.
- Suites on the fixed debug build: test/bake/dev/bundle.test.ts (21 pass), test/js/web/fetch/{blob,body,body-clone}.test.ts (397 pass), test/js/bun/net/socket-retention.test.ts (4 pass), test/js/web/streams/streams.test.js, test/js/bun/http/serve.test.ts, test/js/node/net/node-net.test.ts: every remaining failure reproduces identically with the baked release bun or the unfixed debug build (container has no IPv6, runs as root, ASAN timing), zero delta from this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 15 · 21 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (225a743c6)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-q4bX6r
[0;30mdev|[0m Started development server: http://localhost:43821
[0;30mdev|[0m [32mBundled page in 155ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 57ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To preven
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (225a743c6)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-vEkWZ6
[0;30mdev|[0m Started development server: http://localhost:38155
[0;30mdev|[0m [32mBundled page in 3ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [1203.48ms]
[0;30mdev|[0m Started development server: http://localho
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (225a743c6)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-hhqEwb
[0;30mdev|[0m Started development server: http://localhost:45623
[0;30mdev|[0m [32mBundled page in 173ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 57ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To preven
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 662ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
[1m[9
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http_jsc/headers_jsc.rs                   |   2 +-
 src/jsc/FetchHeaders.rs                       |  21 +++--
 src/runtime/api/Archive.rs                    |   4 +-
 src/runtime/bake/DevServer.rs                 |  13 +++-
 src/runtime/node/node_net_binding.rs          |   4 +-
 src/runtime/server/server_body.rs             |  22 ++++--
 src/runtime/socket/Listener.rs                |  36 +++++++--
 src/runtime/socket/WindowsNamedPipeContext.rs |   4 +-
 src/runtime/socket/socket_body.rs             | 108 +++++++++++++++++++-------
 src/runtime/webcore/BakeResponse.rs           |   2 +-
 src/runtime/webcore/Blob.rs                   |  43 ++++++----
 src/runtime/webcore/Body.rs                   |  16 +++-
 src/runtime/webcore/ReadableStream.rs         |  44 ++++++++---
 src/runtime/webcore/Request.rs                |  37 ++++++---
 src/runtime/webcore/Response.rs               |  24 +++---
 src/runtime/webcore/S3Client.rs               |  10 +--
 src/runtime/webcore/S3File.rs                 |  10 +--
 src/runtime/webcore/fetch.rs                  |  14 ++--
 src/runtime/webcore/fetch/FetchTasklet.rs     |   3 +-
 src/runtime/webcore/s3/client.rs              |   4 +-
 test/bake/dev/bundle.test.ts                  |  43 ++++++++++
 21 files changed, 339 insertions(+), 125 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 15

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
src/http_jsc/headers_jsc.rs                        1      2     24
src/jsc/FetchHeaders.rs                            1      1     24
src/runtime/api/Archive.rs                         1      2     24
src/runtime/bake/DevServer.rs                      1      1     24
src/runtime/node/node_net_binding.rs               1      2     24
src/runtime/server/server_body.rs                  2      2     24
src/runtime/socket/Listener.rs                     4     10     24
src/runtime/socket/WindowsNamedPipeContext.rs      1      2     24
src/runtime/socket/socket_body.rs                  5     13     24
src/runtime/webcore/BakeResponse.rs                1      1     24
src/runtime/webcore/Blob.rs                        2      3     24
src/runtime/webcore/Body.rs                        1      3     24
src/runtime/webcore/ReadableStream.rs              3      6     24
src/runtime/webcore/Request.rs                     1      2     24
src/runtime/webcore/Response.rs                    1      1     24
src/runtime/webcore/S3Client.rs                    1      3     24
(+ 5 more files)
```

</details>

**root cause** · written by the author bot

Several safe methods that adopt a Rust object into a GC-finalized JS wrapper, including Request, Response, Blob, NewSource, and NewSocket to_js variants, took plain reference receivers while relying on an undocumented contract that the receiver came from the class's heap construct path, so safe code could call them on a stack or by-value instance and the GC finalizer would later free non-heap memory, causing undefined behavior. The fix makes these methods and their thin forwarders unsafe fn with explicit # Safety contracts stating the heap-allocation and ownership-transfer preconditions, up…

<!-- robobun:evidence:end -->