### PR TITLE
Replace c-ares status transmute with a checked from_repr conversion

### DIFF
--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1621,7 +1621,7 @@ const ARES_ESERVICE: c_int = 25;
 pub(crate) const ARES_ENOSERVER: c_int = 26;
 
 #[repr(i32)]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, strum::IntoStaticStr)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, strum::IntoStaticStr, strum::FromRepr)]
 pub enum Error {
     ENODATA = ARES_ENODATA,
     EFORMERR = ARES_EFORMERR,
@@ -1845,10 +1845,10 @@ impl Error {
             (1..=ARES_ENOSERVER as u32).contains(&n),
             "c-ares status {rc} out of range",
         );
-        // SAFETY: `n` is in `1..=ARES_ENOSERVER`; `Error` is `#[repr(i32)]` with
-        // contiguous discriminants `1..=ARES_ENOSERVER + 1`, so every value in
-        // the asserted range is a valid discriminant.
-        Some(unsafe { core::mem::transmute::<i32, Error>(n as i32) })
+        // Every value in the asserted range is a declared discriminant, so the
+        // checked `from_repr` (strum::FromRepr) always returns `Some` here and
+        // never yields `EAI_AGAIN`, which lies outside the range.
+        Error::from_repr(n as i32)
     }
 }
 

--- a/src/cares_sys/c_ares.rs
+++ b/src/cares_sys/c_ares.rs
@@ -1845,9 +1845,6 @@ impl Error {
             (1..=ARES_ENOSERVER as u32).contains(&n),
             "c-ares status {rc} out of range",
         );
-        // Every value in the asserted range is a declared discriminant, so the
-        // checked `from_repr` (strum::FromRepr) always returns `Some` here and
-        // never yields `EAI_AGAIN`, which lies outside the range.
         Error::from_repr(n as i32)
     }
 }

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -1081,3 +1081,56 @@ describe("getaddrinfo status mapping", () => {
     });
   });
 });
+
+describe("resolver errors from a local DNS server", () => {
+  // The server answers every query by echoing the question section back with
+  // an RCODE chosen by the queried name, so the c-ares status -> error code
+  // mapping is exercised without any external network traffic. Node maps
+  // NXDOMAIN (RCODE 3) to ENOTFOUND and SERVFAIL (RCODE 2) to ESERVFAIL.
+  it("resolve4 surfaces ENOTFOUND for NXDOMAIN and ESERVFAIL for SERVFAIL", async () => {
+    const server = dgram.createSocket("udp4");
+    try {
+      server.on("message", (msg, rinfo) => {
+        // Walk labels from offset 12 until the zero-length root label, then
+        // QTYPE(2) + QCLASS(2).
+        const labels = [];
+        let off = 12;
+        while (off < msg.length && msg[off] !== 0) {
+          labels.push(msg.subarray(off + 1, off + 1 + msg[off]).toString("latin1"));
+          off += msg[off] + 1;
+        }
+        off += 1 + 2 + 2;
+        const question = msg.subarray(12, off);
+
+        const rcode = labels[0] === "servfail" ? 2 : 3;
+        const header = Buffer.alloc(12);
+        header[0] = msg[0]; // ID
+        header[1] = msg[1];
+        header[2] = 0x81; // QR=1 Opcode=0 AA=0 TC=0 RD=1
+        header[3] = 0x80 | rcode; // RA=1 Z=0 RCODE
+        header[5] = 1; // QDCOUNT
+        server.send(Buffer.concat([header, question]), rinfo.port, rinfo.address);
+      });
+      server.bind(0, "127.0.0.1");
+      await once(server, "listening");
+
+      const resolver = new dns_promises.Resolver({ timeout: 5000, tries: 1 });
+      resolver.setServers([`127.0.0.1:${server.address().port}`]);
+
+      const results = await Promise.all(
+        ["nxdomain.example", "servfail.example"].map(hostname =>
+          resolver.resolve4(hostname).then(
+            addresses => ({ addresses }),
+            err => ({ code: err.code, syscall: err.syscall, hostname: err.hostname }),
+          ),
+        ),
+      );
+      expect(results).toEqual([
+        { code: "ENOTFOUND", syscall: "queryA", hostname: "nxdomain.example" },
+        { code: "ESERVFAIL", syscall: "queryA", hostname: "servfail.example" },
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem
- `Error::get` in `src/cares_sys/c_ares.rs` converts a c-ares status code to the `Error` enum with a range `assert!` followed by `unsafe { mem::transmute::<i32, Error>(n as i32) }`. The transmute is sound only because a SAFETY comment says the discriminants are contiguous. Nothing the compiler checks keeps that true.

### Fix
- Derive `strum::FromRepr` on `Error` and return `Error::from_repr(n as i32)`. This is the checked `match` over every declared discriminant that `src/errno` already uses for int-to-enum conversion. The `unsafe` block and its SAFETY comment go away.
- Behavior-preserving: the range assert stays as it is, with the same panic message. Every value it admits (`1..=ARES_ENOSERVER`, 1 to 26) is a declared discriminant, so `from_repr` returns `Some` for exactly the inputs the transmute accepted. `EAI_AGAIN` (27) stays outside the asserted range, so `get` still never produces it.
- Verified: `test/js/node/dns/node-dns.test.js` gains a hermetic test (local UDP DNS server, NXDOMAIN and SERVFAIL answers, asserts `ENOTFOUND` and `ESERVFAIL` with `syscall: "queryA"` and the hostname, same values as Node). It passes before and after by design. The file gives 141 pass / 29 fail on this branch and with main's `src/`, and the 29 are tests that need external DNS, which my environment blocks. The `EAI_AGAIN` mapping tests and `test-dns-channel-{cancel,cancel-promise,timeout}.js` pass.

### Background
- c-ares reports a query result as a positive `ARES_*` status integer. `Error::get` maps it to the `Error` enum that the `node:dns` layer turns into Node-style error codes (`ENOTFOUND`, `ESERVFAIL`, ...).
- `strum::FromRepr` generates `const fn from_repr(i32) -> Option<Self>` as an exhaustive `match` on the declared discriminants. An unlisted value yields `None` instead of an invalid enum bit pattern.

<details><summary>Notes</summary>

- Rebase onto current main: both files conflicted. In `c_ares.rs`, main had narrowed the `ARES_*` constants to `pub(crate)` and added the `EAI_AGAIN = ARES_ENOSERVER + 1` variant. I kept main's range assert unchanged (it excludes 27) and replaced only the transmute line. In the test file, main already imports `node:dgram` and `once` and added new `describe` blocks at the end of the file, so the resolution keeps all of main's content and appends only the new `describe` block.
- The explanatory comment that an earlier revision added above the `from_repr` call is deleted. The assert message and the doc comment on the `EAI_AGAIN` variant already state the invariant.
- `cargo clippy -p bun_cares_sys` is clean. `bun bd` builds.
- Earlier CI rounds on this PR failed only on tests unrelated to the diff (the `bunx.test.ts` Node-version breakage from #31797, the `30205.test.ts` napi isolate flake on the asan lane, and the repo-wide `streams-leak.test.ts` flake). Details are in the PR comments.

</details>

[daily-code-quality]

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->