### PR TITLE
windows: retry renames without extended flags

### DIFF
--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -901,7 +901,6 @@ pub mod fs {
             #[cfg(windows)]
             {
                 use bun_sys::windows as w;
-                use w::Win32ErrorUnwrap as _;
                 let _ = from_name;
                 let mut existing_buf = bun_paths::WPathBuffer::uninit();
                 let mut new_buf = bun_paths::WPathBuffer::uninit();
@@ -921,20 +920,17 @@ pub mod fs {
                         name.as_bytes(),
                     )
                 };
-                // SAFETY: `existing`/`new` are NUL-terminated WTF-16 backed by
-                // stack `WPathBuffer`s alive for this frame.
-                if unsafe {
-                    w::kernel32::MoveFileExW(
+                // SAFETY: `existing`/`new` are NUL-terminated WTF-16 paths
+                // backed by stack `WPathBuffer`s alive for this call.
+                unsafe {
+                    w::move_file_ex_w(
                         existing.as_ptr(),
                         new.as_ptr(),
                         w::MOVEFILE_COPY_ALLOWED
                             | w::MOVEFILE_REPLACE_EXISTING
                             | w::MOVEFILE_WRITE_THROUGH,
                     )
-                } == w::FALSE
-                {
-                    w::Win32Error::get().unwrap()?;
-                }
+                }?;
                 Ok(())
             }
         }

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1838,18 +1838,16 @@ pub fn to_executable(
         // Close the file handle before moving (Windows requires this)
         fd.close();
 
-        use bun_sys::windows;
+        use bun_sys::windows as w;
         // SAFETY: NUL-terminated wide strings constructed above. Pass the
         // full-buffer pointer (not a `[..len]` sub-slice) so the pointer's
         // provenance covers the trailing NUL at index `len` that the W-suffix
         // API will read.
         if let Err(err) = unsafe {
-            windows::move_file_ex_w(
+            w::move_file_ex_w(
                 temp_buf_u16.as_ptr(),
                 dest_buf_u16.as_ptr(),
-                windows::MOVEFILE_COPY_ALLOWED
-                    | windows::MOVEFILE_REPLACE_EXISTING
-                    | windows::MOVEFILE_WRITE_THROUGH,
+                w::MOVEFILE_COPY_ALLOWED | w::MOVEFILE_REPLACE_EXISTING | w::MOVEFILE_WRITE_THROUGH,
             )
         } {
             if err.get_errno() == bun_sys::E::EISDIR {
@@ -1877,7 +1875,7 @@ pub fn to_executable(
             // The file has been moved to dest_path
             // SAFETY: full-buffer pointer so provenance includes the NUL at
             // `dest_buf_u16[dest_w_len]` (FFI reads it as a C wide string).
-            if let Err(e) = windows::rescle::set_windows_metadata(
+            if let Err(e) = w::rescle::set_windows_metadata(
                 dest_buf_u16.as_ptr(),
                 windows_options.icon.as_deref(),
                 windows_options.title.as_deref(),

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1838,40 +1838,30 @@ pub fn to_executable(
         // Close the file handle before moving (Windows requires this)
         fd.close();
 
-        use bun_sys::windows::{self, Win32ErrorExt as _};
-        // Move the file using MoveFileExW
+        use bun_sys::windows;
         // SAFETY: NUL-terminated wide strings constructed above. Pass the
         // full-buffer pointer (not a `[..len]` sub-slice) so the pointer's
         // provenance covers the trailing NUL at index `len` that the W-suffix
         // API will read.
-        if unsafe {
-            windows::kernel32::MoveFileExW(
+        if let Err(err) = unsafe {
+            windows::move_file_ex_w(
                 temp_buf_u16.as_ptr(),
                 dest_buf_u16.as_ptr(),
                 windows::MOVEFILE_COPY_ALLOWED
                     | windows::MOVEFILE_REPLACE_EXISTING
                     | windows::MOVEFILE_WRITE_THROUGH,
             )
-        } == windows::FALSE
-        {
-            let werr = windows::Win32Error::get();
-            if let Some(sys_err) = werr.to_system_errno() {
-                if sys_err == bun_sys::SystemErrno::EISDIR {
-                    return Ok(CompileResult::fail_fmt(format_args!(
-                        "{} is a directory. Please choose a different --outfile or delete the directory",
-                        bstr::BStr::new(outfile)
-                    )));
-                } else {
-                    return Ok(CompileResult::fail_fmt(format_args!(
-                        "failed to move executable to {}: {}",
-                        bstr::BStr::new(dest_path),
-                        <&'static str>::from(sys_err)
-                    )));
-                }
+        } {
+            if err.get_errno() == bun_sys::E::EISDIR {
+                return Ok(CompileResult::fail_fmt(format_args!(
+                    "{} is a directory. Please choose a different --outfile or delete the directory",
+                    bstr::BStr::new(outfile)
+                )));
             } else {
                 return Ok(CompileResult::fail_fmt(format_args!(
-                    "failed to move executable to {}",
-                    bstr::BStr::new(dest_path)
+                    "failed to move executable to {}: {}",
+                    bstr::BStr::new(dest_path),
+                    bstr::BStr::new(err.name())
                 )));
             }
         }

--- a/src/sys/sys_uv.rs
+++ b/src/sys/sys_uv.rs
@@ -9,7 +9,7 @@ use bstr::BStr;
 use bun_core::ZStr;
 
 use crate::Tag;
-use crate::windows::libuv as uv;
+use crate::windows::{self, Win32Error, libuv as uv};
 use crate::{E, Fd, FdExt, Mode, PlatformIOVec, PlatformIOVecConst, Stat, StatFS};
 // `ReturnCodeExt::err_enum_e` overlays the libuv→POSIX errno translation;
 // without it the raw `UV_E*` magnitude (e.g. 4058 for UV_ENOENT) would land
@@ -380,6 +380,14 @@ pub fn rename(from: &ZStr, to: &ZStr) -> Result<()> {
         rc.int()
     );
     if let Some(errno) = rc.err_enum_e() {
+        if req.sys_errno_ == Win32Error::INVALID_PARAMETER.int() as u32 {
+            let mut from_buf = bun_paths::WPathBuffer::default();
+            let mut to_buf = bun_paths::WPathBuffer::default();
+            let from_w = bun_paths::string_paths::to_nt_path(&mut from_buf, from.as_bytes());
+            let to_w = bun_paths::string_paths::to_nt_path(&mut to_buf, to.as_bytes());
+            return windows::rename_at_w(Fd::cwd(), from_w, Fd::cwd(), to_w, true);
+        }
+
         // which one goes in the .path field?
         Result::Err(Error::new(errno, Tag::rename))
     } else {

--- a/src/sys/sys_uv.rs
+++ b/src/sys/sys_uv.rs
@@ -381,10 +381,10 @@ pub fn rename(from: &ZStr, to: &ZStr) -> Result<()> {
     );
     if let Some(errno) = rc.err_enum_e() {
         if req.sys_errno_ == Win32Error::INVALID_PARAMETER.int() as u32 {
-            let mut from_buf = bun_paths::WPathBuffer::default();
-            let mut to_buf = bun_paths::WPathBuffer::default();
-            let from_w = bun_paths::string_paths::to_nt_path(&mut from_buf, from.as_bytes());
-            let to_w = bun_paths::string_paths::to_nt_path(&mut to_buf, to.as_bytes());
+            let mut from_buf = bun_paths::w_path_buffer_pool::get();
+            let mut to_buf = bun_paths::w_path_buffer_pool::get();
+            let from_w = bun_paths::string_paths::to_nt_path(&mut from_buf[..], from.as_bytes());
+            let to_w = bun_paths::string_paths::to_nt_path(&mut to_buf[..], to.as_bytes());
             return windows::rename_at_w(Fd::cwd(), from_w, Fd::cwd(), to_w, true);
         }
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -4925,6 +4925,17 @@ pub unsafe fn move_file_ex_w(
         return bun_sys::Result::errno(err.to_e(), bun_sys::Tag::rename);
     }
 
+    const RENAME_FALLBACK_FLAGS: DWORD =
+        MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH;
+    if flags & !RENAME_FALLBACK_FLAGS != 0 {
+        return bun_sys::Result::errno(err.to_e(), bun_sys::Tag::rename);
+    }
+
+    // COPY_ALLOWED/WRITE_THROUGH only affect MoveFileExW copy/delete moves.
+    // The fallback below is deliberately rename-only: same-volume renames
+    // preserve the requested operation, while cross-volume moves fail loudly
+    // instead of copying into the final destination.
+
     let existing_len = unsafe { nul_terminated_wide_len(existing_file_name) };
     let new_len = unsafe { nul_terminated_wide_len(new_file_name) };
     // SAFETY: both pointers were checked non-null above and are

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -7,7 +7,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
 use core::ffi::{c_char, c_int, c_void};
-use core::mem::{MaybeUninit, size_of};
+use core::mem::{MaybeUninit, offset_of, size_of};
 use core::ptr;
 
 use bun_windows_sys as win32;
@@ -4630,18 +4630,26 @@ pub fn move_opened_file_at(
     // (PATH_MAX_WIDE*3+1, ≈98 KB) would just waste ~32 KB of stack on a
     // function called from already-deep install/bundler call chains. Any
     // `new_file_name.len() <= PATH_MAX_WIDE` still fits.
-    const STRUCT_BUF_LEN: usize =
-        size_of::<win32::FILE_RENAME_INFORMATION_EX>() + (bun_paths::PATH_MAX_WIDE * 2 - 1);
+    const FILE_NAME_TAIL_SIZE: usize = size_of::<u16>();
+    const STRUCT_BUF_LEN: usize = offset_of!(win32::FILE_RENAME_INFORMATION_EX, FileName)
+        + bun_paths::PATH_MAX_WIDE * FILE_NAME_TAIL_SIZE;
     #[repr(align(8))] // align_of FILE_RENAME_INFORMATION_EX
     struct AlignedBuf {
         _buf: [u8; STRUCT_BUF_LEN],
     }
     let mut rename_info_buf = MaybeUninit::<AlignedBuf>::uninit();
 
-    let struct_len = size_of::<win32::FILE_RENAME_INFORMATION_EX>() - 1 + new_file_name.len() * 2;
+    let file_name_len = new_file_name.len() * FILE_NAME_TAIL_SIZE;
+    let struct_len = offset_of!(win32::FILE_RENAME_INFORMATION_EX, FileName) + file_name_len;
     if struct_len > STRUCT_BUF_LEN {
         return bun_sys::Result::errno(E::NAMETOOLONG, bun_sys::Tag::NtSetInformationFile);
     }
+    let file_name_len = u32::try_from(file_name_len).expect("int cast"); // already checked error.NameTooLong
+    let root_directory = if bun_paths::is_absolute_windows_wtf16(new_file_name) {
+        ptr::null_mut()
+    } else {
+        new_dir_fd.native()
+    };
 
     // SAFETY: AlignedBuf is #[repr(align(8))] which matches FILE_RENAME_INFORMATION_EX alignment.
     // Kept as a raw pointer (not &mut) so provenance covers the full STRUCT_BUF_LEN bytes; the
@@ -4656,22 +4664,14 @@ pub fn move_opened_file_at(
     if replace_if_exists {
         flags |= win32::FILE_RENAME_REPLACE_IF_EXISTS;
     }
-    // SAFETY: rename_info is aligned, non-null, and points into uninitialized storage we own;
-    // ptr::write initializes the header without dropping prior (uninit) contents.
+    // SAFETY: rename_info is aligned, non-null, and points into storage we own.
+    // Zero the exact byte range sent to NtSetInformationFile so C padding stays
+    // initialized, then write fields individually so padding remains zero.
     unsafe {
-        ptr::write(
-            rename_info,
-            win32::FILE_RENAME_INFORMATION_EX {
-                Flags: flags,
-                RootDirectory: if bun_paths::is_absolute_windows_wtf16(new_file_name) {
-                    ptr::null_mut()
-                } else {
-                    new_dir_fd.native()
-                },
-                FileNameLength: u32::try_from(new_file_name.len() * 2).expect("int cast"), // already checked error.NameTooLong
-                FileName: [0; 1], // overwritten below
-            },
-        );
+        ptr::write_bytes(rename_info.cast::<u8>(), 0, struct_len);
+        ptr::addr_of_mut!((*rename_info).Flags).write(flags);
+        ptr::addr_of_mut!((*rename_info).RootDirectory).write(root_directory);
+        ptr::addr_of_mut!((*rename_info).FileNameLength).write(file_name_len);
     }
     // SAFETY: rename_info_buf has STRUCT_BUF_LEN bytes (>= struct_len, checked above) reserved for
     // the variable-length FileName tail. addr_of_mut! on the raw pointer preserves full-buffer
@@ -4683,7 +4683,7 @@ pub fn move_opened_file_at(
             new_file_name.len(),
         );
     }
-    // SAFETY: src_fd valid; rename_info has struct_len initialized bytes
+    // SAFETY: src_fd valid; rename_info has struct_len initialized bytes.
     let rc = unsafe {
         ntdll::NtSetInformationFile(
             src_fd.native(),
@@ -4713,10 +4713,69 @@ pub fn move_opened_file_at(
         );
     }
 
-    if rc == win32::ntstatus::SUCCESS {
-        bun_sys::Result::success()
-    } else {
-        bun_sys::Result::errno(rc, bun_sys::Tag::NtSetInformationFile)
+    match rc {
+        x if x == win32::ntstatus::SUCCESS => bun_sys::Result::success(),
+        x if x == win32::ntstatus::INVALID_PARAMETER => {
+            // Some corporate antivirus and filesystem filter drivers reject the
+            // `FileRenameInformationEx` flags even on NTFS. Retry with the older
+            // rename information class instead of copying bytes: copying would
+            // expose partial destination contents and would not preserve the
+            // source-handle semantics of this helper.
+            let rename_info: *mut win32::FILE_RENAME_INFORMATION =
+                rename_info_buf.as_mut_ptr().cast();
+
+            let fallback_struct_len = offset_of!(win32::FILE_RENAME_INFORMATION, FileName)
+                + usize::try_from(file_name_len).expect("int cast");
+
+            // SAFETY: same stack buffer, alignment, and FileName-tail reasoning
+            // as the Ex call above. Zero the exact byte range sent to
+            // NtSetInformationFile, then write fields individually so C padding
+            // stays initialized.
+            unsafe {
+                ptr::write_bytes(rename_info.cast::<u8>(), 0, fallback_struct_len);
+                ptr::addr_of_mut!((*rename_info).ReplaceIfExists).write(if replace_if_exists {
+                    TRUE as BOOLEAN
+                } else {
+                    FALSE as BOOLEAN
+                });
+                ptr::addr_of_mut!((*rename_info).RootDirectory).write(root_directory);
+                ptr::addr_of_mut!((*rename_info).FileNameLength).write(file_name_len);
+                ptr::copy_nonoverlapping(
+                    new_file_name.as_ptr(),
+                    ptr::addr_of_mut!((*rename_info).FileName).cast::<u16>(),
+                    new_file_name.len(),
+                );
+            }
+
+            let fallback_rc = unsafe {
+                ntdll::NtSetInformationFile(
+                    src_fd.native(),
+                    &mut io_status_block,
+                    rename_info.cast::<c_void>(),
+                    u32::try_from(fallback_struct_len).expect("int cast"),
+                    win32::FileInformationClass::FileRenameInformation,
+                )
+            };
+            bun_sys::syslog!(
+                "moveOpenedFileAt({} ->> {} '{}', {}, legacy) = {}",
+                src_fd,
+                new_dir_fd,
+                bun_core::fmt::utf16(new_file_name),
+                if replace_if_exists {
+                    "replace_if_exists"
+                } else {
+                    "no flag"
+                },
+                format_args!("{:?}", fallback_rc)
+            );
+
+            if fallback_rc == win32::ntstatus::SUCCESS {
+                bun_sys::Result::success()
+            } else {
+                bun_sys::Result::errno(fallback_rc, bun_sys::Tag::NtSetInformationFile)
+            }
+        }
+        _ => bun_sys::Result::errno(rc, bun_sys::Tag::NtSetInformationFile),
     }
 }
 
@@ -4822,7 +4881,64 @@ pub fn rename_at_w(
     };
     let _close = bun_sys::CloseOnDrop::new(src_fd);
 
-    move_opened_file_at(src_fd, new_dir_fd, new_path_w, replace_if_exists)
+    move_opened_file_at_loose(src_fd, new_dir_fd, new_path_w, replace_if_exists)
+}
+
+unsafe fn nul_terminated_wide_len(ptr: LPCWSTR) -> usize {
+    let mut len = 0;
+    loop {
+        if unsafe { *ptr.add(len) } == 0 {
+            return len;
+        }
+        len += 1;
+    }
+}
+
+/// `MoveFileExW`, with a rename-only fallback for filter drivers that reject
+/// `FILE_RENAME_INFORMATION_EX` flags through the Win32 path.
+///
+/// This intentionally does not emulate `MOVEFILE_COPY_ALLOWED` after the
+/// Win32 call fails: copying into the final destination can expose truncated
+/// files, and copying is not equivalent to a rename for open source handles.
+///
+/// # Safety
+///
+/// `existing_file_name` must be a valid NUL-terminated UTF-16 string. When
+/// `new_file_name` is non-null, it must also be a valid NUL-terminated UTF-16
+/// string. This matches `MoveFileExW`'s raw pointer contract.
+pub unsafe fn move_file_ex_w(
+    existing_file_name: LPCWSTR,
+    new_file_name: LPCWSTR,
+    flags: DWORD,
+) -> bun_sys::Result<()> {
+    // SAFETY: Win32 validates the two NUL-terminated input strings. A bad
+    // pointer is caller UB for MoveFileExW itself, matching the raw API.
+    if unsafe { kernel32::MoveFileExW(existing_file_name, new_file_name, flags) } != FALSE {
+        return bun_sys::Result::success();
+    }
+
+    let err = Win32Error::get();
+    if err != Win32Error::INVALID_PARAMETER
+        || existing_file_name.is_null()
+        || new_file_name.is_null()
+    {
+        return bun_sys::Result::errno(err.to_e(), bun_sys::Tag::rename);
+    }
+
+    let existing_len = unsafe { nul_terminated_wide_len(existing_file_name) };
+    let new_len = unsafe { nul_terminated_wide_len(new_file_name) };
+    // SAFETY: both pointers were checked non-null above and are
+    // NUL-terminated, so the computed lengths are in-bounds.
+    let existing = unsafe { core::slice::from_raw_parts(existing_file_name, existing_len) };
+    let new = unsafe { core::slice::from_raw_parts(new_file_name, new_len) };
+
+    rename_at_w(
+        Fd::cwd(),
+        existing,
+        Fd::cwd(),
+        new,
+        (flags & MOVEFILE_REPLACE_EXISTING) != 0,
+    )
 }
 
 mod kernel32_2 {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -415,6 +415,16 @@ pub struct FILE_DISPOSITION_INFORMATION_EX {
     pub Flags: ULONG,
 }
 
+/// `FILE_RENAME_INFORMATION` (`ntifs.h`). `FileName` is a variable-length
+/// tail; declared `[u16; 1]` to match the C flex-array idiom.
+#[repr(C)]
+pub struct FILE_RENAME_INFORMATION {
+    pub ReplaceIfExists: BOOLEAN,
+    pub RootDirectory: HANDLE,
+    pub FileNameLength: ULONG,
+    pub FileName: [u16; 1],
+}
+
 /// `FILE_RENAME_INFORMATION` ex variant (`ntifs.h`). `FileName` is a
 /// variable-length tail; declared `[u16; 1]` to match the C flex-array idiom.
 #[repr(C)]
@@ -1756,4 +1766,30 @@ unsafe extern "system" {
 
 unsafe extern "C" {
     pub fn windows_enable_stdio_inheritance();
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use core::mem::{offset_of, size_of};
+
+    #[test]
+    fn file_rename_information_layout_matches_ex_variant() {
+        assert_eq!(
+            offset_of!(FILE_RENAME_INFORMATION, RootDirectory),
+            offset_of!(FILE_RENAME_INFORMATION_EX, RootDirectory)
+        );
+        assert_eq!(
+            offset_of!(FILE_RENAME_INFORMATION, FileNameLength),
+            offset_of!(FILE_RENAME_INFORMATION_EX, FileNameLength)
+        );
+        assert_eq!(
+            offset_of!(FILE_RENAME_INFORMATION, FileName),
+            offset_of!(FILE_RENAME_INFORMATION_EX, FileName)
+        );
+        assert_eq!(
+            size_of::<FILE_RENAME_INFORMATION>(),
+            size_of::<FILE_RENAME_INFORMATION_EX>()
+        );
+    }
 }

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -50,10 +50,13 @@ describe.concurrent(
         const baseDir = `${tmpdir}/bun-build-outfile-${Date.now()}`;
         const outfile = path.join(baseDir, "index.exe");
         mkdirSync(baseDir, { recursive: true });
-        writeFileSync(outfile, "stale executable");
-        await testCompile(outfile);
-        await testExec(outfile);
-        fs.rmSync(baseDir, { recursive: true, force: true });
+        try {
+          writeFileSync(outfile, "stale executable");
+          await testCompile(outfile);
+          await testExec(outfile);
+        } finally {
+          fs.rmSync(baseDir, { recursive: true, force: true });
+        }
       }
       {
         const baseDir = `${tmpdir}/bun-build-outfile2-${Date.now()}`;

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -49,6 +49,8 @@ describe.concurrent(
       {
         const baseDir = `${tmpdir}/bun-build-outfile-${Date.now()}`;
         const outfile = path.join(baseDir, "index.exe");
+        mkdirSync(baseDir, { recursive: true });
+        writeFileSync(outfile, "stale executable");
         await testCompile(outfile);
         await testExec(outfile);
         fs.rmSync(baseDir, { recursive: true, force: true });

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3567,6 +3567,47 @@ it("test syscall errno, issue#4198", () => {
   rmdirSync(path);
 });
 
+it.if(isWindows)("rename and renameSync replace existing files on Windows", async () => {
+  const dir = tempDir("windows-rename-replace", {
+    "from-sync.txt": "from sync",
+    "to-sync.txt": "to sync",
+    "from-async.txt": "from async",
+    "to-async.txt": "to async",
+  });
+
+  const fromSync = join(dir, "from-sync.txt");
+  const toSync = join(dir, "to-sync.txt");
+  renameSync(fromSync, toSync);
+  expect(readFileSync(toSync, "utf8")).toBe("from sync");
+  expect(existsSync(fromSync)).toBe(false);
+
+  const fromAsync = join(dir, "from-async.txt");
+  const toAsync = join(dir, "to-async.txt");
+  await new Promise<void>((resolve, reject) => {
+    fs.rename(fromAsync, toAsync, err => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+  expect(readFileSync(toAsync, "utf8")).toBe("from async");
+  expect(existsSync(fromAsync)).toBe(false);
+
+  const relativeDir = tempDir("windows-rename-relative", {
+    "nested/from.txt": "relative",
+    "to.txt": "old",
+  });
+  const relativePath = String(relativeDir);
+  const cwd = process.cwd();
+  try {
+    process.chdir(relativePath);
+    renameSync(join("nested", "from.txt"), "to.txt");
+  } finally {
+    process.chdir(cwd);
+  }
+  expect(readFileSync(join(relativePath, "to.txt"), "utf8")).toBe("relative");
+  expect(existsSync(join(relativePath, "nested", "to.txt"))).toBe(false);
+});
+
 it.if(isWindows)("writing to windows hidden file is possible", () => {
   const temp = tmpdir();
   writeFileSync(join(temp, "file.txt"), "FAIL");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3568,7 +3568,7 @@ it("test syscall errno, issue#4198", () => {
 });
 
 it.if(isWindows)("rename and renameSync replace existing files on Windows", async () => {
-  const dir = tempDir("windows-rename-replace", {
+  using dir = tempDir("windows-rename-replace", {
     "from-sync.txt": "from sync",
     "to-sync.txt": "to sync",
     "from-async.txt": "from async",
@@ -3592,7 +3592,7 @@ it.if(isWindows)("rename and renameSync replace existing files on Windows", asyn
   expect(readFileSync(toAsync, "utf8")).toBe("from async");
   expect(existsSync(fromAsync)).toBe(false);
 
-  const relativeDir = tempDir("windows-rename-relative", {
+  using relativeDir = tempDir("windows-rename-relative", {
     "nested/from.txt": "relative",
     "to.txt": "old",
   });
@@ -3605,7 +3605,7 @@ it.if(isWindows)("rename and renameSync replace existing files on Windows", asyn
     process.chdir(cwd);
   }
   expect(readFileSync(join(relativePath, "to.txt"), "utf8")).toBe("relative");
-  expect(existsSync(join(relativePath, "nested", "to.txt"))).toBe(false);
+  expect(existsSync(join(relativePath, "nested", "from.txt"))).toBe(false);
 });
 
 it.if(isWindows)("writing to windows hidden file is possible", () => {

--- a/test/regression/issue/3192.test.ts
+++ b/test/regression/issue/3192.test.ts
@@ -1,3 +1,6 @@
+// https://github.com/oven-sh/bun/issues/3192
+// yarn lockfile must quote workspace:* versions
+
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 

--- a/test/regression/issue/3192.test.ts
+++ b/test/regression/issue/3192.test.ts
@@ -34,7 +34,6 @@ describe("issue #3192", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toContain("Saved yarn.lock");
-    expect(exitCode).toBe(0);
 
     // Read the generated yarn.lock
     const yarnLock = await Bun.file(`${dir}/yarn.lock`).text();
@@ -44,5 +43,6 @@ describe("issue #3192", () => {
     // Good output: "package-b@packages/package-b", "package-b@workspace:*":
     expect(yarnLock).toContain('"package-b@workspace:*"');
     expect(yarnLock).not.toMatch(/package-b@workspace:\*[^"]/);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/regression/issue/3192.test.ts
+++ b/test/regression/issue/3192.test.ts
@@ -20,6 +20,7 @@ describe("issue #3192", () => {
         name: "package-b",
         version: "1.0.0",
       }),
+      "yarn.lock": "stale lockfile contents",
     });
 
     await using proc = Bun.spawn({

--- a/test/regression/issue/3192.test.ts
+++ b/test/regression/issue/3192.test.ts
@@ -33,6 +33,7 @@ describe("issue #3192", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+    expect(stderr).toContain("Saved yarn.lock");
     expect(exitCode).toBe(0);
 
     // Read the generated yarn.lock


### PR DESCRIPTION
### What does this PR do?

Fixes #10169.

Corporate endpoint-security and filesystem filter drivers can reject Windows `FileRenameInformationEx` / POSIX rename flags with `STATUS_INVALID_PARAMETER`, even for ordinary same-volume lockfile replacements. When that happens today, Bun can fail to write lockfiles in managed Windows environments.

This keeps Bun's existing fast rename path, then retries only `STATUS_INVALID_PARAMETER` / `ERROR_INVALID_PARAMETER` through the legacy `FileRenameInformation` shape. The fallback is rename-only: it does not copy file bytes into the final destination, because a generic rename helper cannot safely copy without risking truncated destination files or changing source-handle semantics.

Coverage in this PR:

- `bun.lock` / `bun.lockb`: `move_opened_file_at` retries `FileRenameInformationEx` failures with legacy `FileRenameInformation`.
- `node:fs.rename` / `fs.renameSync`: the libuv rename path retries `ERROR_INVALID_PARAMETER` through Bun's NT rename helper.
- `yarn.lock`: `RealFsTmpfile::promote_to_cwd` uses the shared `MoveFileExW` wrapper instead of calling `MoveFileExW` directly.
- Standalone `bun build --compile --outfile`: publish/overwrite uses the same wrapper.
- `bun upgrade`: the existing `sys::rename` calls are covered through the `sys_uv::rename` fallback.

This is related to #31185, but avoids the broad copy fallback there and routes the other Windows rename entrypoints through the same fallback.

### How did you verify your code works?

- `cargo fmt --all --check`
- `cargo check -p bun_windows_sys -p bun_sys -p bun_resolver -p bun_standalone_graph --message-format=short`
- `rustc --edition=2024 --test src/windows_sys/lib.rs -o windows_sys_test.exe && cmd /C windows_sys_test.exe --nocapture && cmd /C del windows_sys_test.exe`
- `bunx prettier --check test/bundler/cli.test.ts test/js/node/fs/fs.test.ts test/regression/issue/3192.test.ts`
- `bun test test/js/node/fs/fs.test.ts --test-name-pattern "rename and renameSync replace existing files on Windows"`
- `bun test test/regression/issue/3192.test.ts`
- `bun test test/bundler/cli.test.ts --test-name-pattern "generating a standalone binary in nested path"`

Local setup note: `cargo check` needed `vendor/lolhtml/c-api` restored from the pinned `cloudflare/lol-html` commit used by `scripts/build/deps/lolhtml.ts`. Full `bun run build --configure-only` still rejects this machine's LLVM 22.1.3 because the current repo expects LLVM 21.1.x.
