### PR TITLE
Add Rust async/await support on the event loop and convert Bun.password

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -15,6 +15,8 @@ on:
       - "src/collections/**"
       - "src/dispatch/**"
       - "src/errno/**"
+      - "src/event_loop/**"
+      - "src/threading/**"
       - "src/hash/**"
       - "src/http_types/**"
       - "src/md/**"

--- a/bench/snippets/password.mjs
+++ b/bench/snippets/password.mjs
@@ -1,0 +1,32 @@
+// so it can run in environments without node module resolution
+import { bench, run } from "../runner.mjs";
+
+const pw = "correct horse battery staple";
+const argonHash = await Bun.password.hash(pw); // argon2id defaults
+const bcryptHash = await Bun.password.hash(pw, { algorithm: "bcrypt", cost: 4 });
+
+bench("password.hashSync argon2id (pure compute)", () => Bun.password.hashSync(pw));
+bench("password.hash argon2id", async () => await Bun.password.hash(pw));
+bench("password.verify argon2id", async () => await Bun.password.verify(pw, argonHash));
+bench("password.hash bcrypt cost=4", async () => await Bun.password.hash(pw, { algorithm: "bcrypt", cost: 4 }));
+bench("password.verify bcrypt cost=4", async () => await Bun.password.verify(pw, bcryptHash));
+bench("password.hash argon2id x8 concurrent", async () => {
+  await Promise.all(Array.from({ length: 8 }, () => Bun.password.hash(pw)));
+});
+
+bench("password.hash argon2id x32 concurrent", async () => {
+  await Promise.all(Array.from({ length: 32 }, () => Bun.password.hash(pw)));
+});
+
+// Promise stacking: N pending password promises in flight at once, settled
+// together. bcrypt cost=4 keeps per-op compute small (~0.67 ms) so queue,
+// wake, and completion machinery dominate as N grows.
+for (const n of [8, 32, 128, 512]) {
+  bench(`bcrypt x${n} Promise.all`, async () => {
+    await Promise.all(
+      Array.from({ length: n }, () => Bun.password.hash(pw, { algorithm: "bcrypt", cost: 4 })),
+    );
+  });
+}
+
+await run();

--- a/bench/snippets/password.mjs
+++ b/bench/snippets/password.mjs
@@ -19,8 +19,10 @@ bench("password.hash argon2id x32 concurrent", async () => {
 });
 
 // Promise stacking: N pending password promises in flight at once, settled
-// together. bcrypt cost=4 keeps per-op compute small (~0.67 ms) so queue,
-// wake, and completion machinery dominate as N grows.
+// together. bcrypt cost=4 keeps per-op compute small (~0.67 ms) so the
+// completion path is a visible slice of each op; totals scale with
+// N / pool-threads (compute saturates the pool), so the series measures
+// completion-path throughput at increasing in-flight counts.
 for (const n of [8, 32, 128, 512]) {
   bench(`bcrypt x${n} Promise.all`, async () => {
     await Promise.all(

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -37,6 +37,7 @@ const MIRI_CRATES = [
   "bun_collections",
   "bun_dispatch",
   "bun_errno",
+  "bun_event_loop",
   "bun_hash",
   "bun_http_types",
   "bun_md",

--- a/scripts/rust-miri.ts
+++ b/scripts/rust-miri.ts
@@ -45,6 +45,7 @@ const MIRI_CRATES = [
   "bun_ptr",
   "bun_resolve_builtins",
   "bun_shell_parser",
+  "bun_threading",
   "bun_wyhash",
 ];
 

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1693,13 +1693,6 @@ pub fn free_sensitive<T: Copy>(mut slice: Box<[T]>) {
 /// through logging.
 pub struct SensitiveBytes(Box<[u8]>);
 
-impl SensitiveBytes {
-    #[inline]
-    pub fn new(bytes: Box<[u8]>) -> Self {
-        Self(bytes)
-    }
-}
-
 impl From<Box<[u8]>> for SensitiveBytes {
     #[inline]
     fn from(bytes: Box<[u8]>) -> Self {
@@ -1708,9 +1701,19 @@ impl From<Box<[u8]>> for SensitiveBytes {
 }
 
 impl From<Vec<u8>> for SensitiveBytes {
-    #[inline]
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes.into_boxed_slice())
+    fn from(mut bytes: Vec<u8>) -> Self {
+        if bytes.capacity() == bytes.len() {
+            return Self(bytes.into_boxed_slice());
+        }
+        // `into_boxed_slice` on a Vec with spare capacity reallocates and
+        // frees the original buffer WITHOUT zeroing — exactly the leak this
+        // type exists to prevent. Copy to an exact-size allocation, then
+        // volatile-zero the source's initialized bytes before they are freed.
+        let boxed: Box<[u8]> = bytes.as_slice().into();
+        // SAFETY: `bytes` is exclusively owned and `len` bytes are initialized.
+        unsafe { secure_zero(bytes.as_mut_ptr(), bytes.len()) };
+        drop(bytes);
+        Self(boxed)
     }
 }
 

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -1683,6 +1683,57 @@ pub fn free_sensitive<T: Copy>(mut slice: Box<[T]>) {
     drop(slice);
 }
 
+/// Owned byte buffer that is volatile-zeroed before its memory is freed
+/// ([`free_sensitive`]).
+///
+/// Use for plaintext secrets (passwords, keys, passphrases). Wrap at the
+/// parse/creation boundary — the guarantee then travels with the data through
+/// every later owner (closures, spawned futures, error paths) with no
+/// per-site calls. `Debug` redacts the contents so secrets cannot leak
+/// through logging.
+pub struct SensitiveBytes(Box<[u8]>);
+
+impl SensitiveBytes {
+    #[inline]
+    pub fn new(bytes: Box<[u8]>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Box<[u8]>> for SensitiveBytes {
+    #[inline]
+    fn from(bytes: Box<[u8]>) -> Self {
+        Self(bytes)
+    }
+}
+
+impl From<Vec<u8>> for SensitiveBytes {
+    #[inline]
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes.into_boxed_slice())
+    }
+}
+
+impl core::ops::Deref for SensitiveBytes {
+    type Target = [u8];
+    #[inline]
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl core::fmt::Debug for SensitiveBytes {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "SensitiveBytes({} bytes redacted)", self.0.len())
+    }
+}
+
+impl Drop for SensitiveBytes {
+    fn drop(&mut self) {
+        free_sensitive(core::mem::take(&mut self.0));
+    }
+}
+
 /// [`free_sensitive`] for the C-string
 /// case used by http SSLConfig. Zeros the allocation before freeing
 /// (defence-in-depth for keys/passphrases).

--- a/src/event_loop/AsyncTask.rs
+++ b/src/event_loop/AsyncTask.rs
@@ -302,14 +302,7 @@ fn raw_waker_vtable<S: Schedule>() -> &'static RawWakerVTable {
         // SAFETY: releases this waker's reference.
         unsafe { ref_dec(data.cast_mut().cast::<AsyncTask>()) };
     }
-    const {
-        &RawWakerVTable::new(
-            clone_waker::<S>,
-            wake::<S>,
-            wake_by_ref::<S>,
-            drop_waker,
-        )
-    }
+    const { &RawWakerVTable::new(clone_waker::<S>, wake::<S>, wake_by_ref::<S>, drop_waker) }
 }
 
 // ─── poll (dispatch entry) ───────────────────────────────────────────────────
@@ -329,7 +322,12 @@ unsafe fn poll_with<S: Schedule>(this: *mut AsyncTask) {
     let waker = ManuallyDrop::new(
         // SAFETY: vtable contract upheld by the fns in `raw_waker_vtable`;
         // `this` is live for the duration (queue ref).
-        unsafe { Waker::from_raw(RawWaker::new(this.cast_const().cast::<()>(), raw_waker_vtable::<S>())) },
+        unsafe {
+            Waker::from_raw(RawWaker::new(
+                this.cast_const().cast::<()>(),
+                raw_waker_vtable::<S>(),
+            ))
+        },
     );
     let mut cx = Context::from_waker(&waker);
 
@@ -701,7 +699,10 @@ mod tests {
         });
         let enqueued = drain_enqueued();
         assert_eq!(enqueued.len(), 1, "wake is idempotent while SCHEDULED");
-        assert!(!enqueued[0].1, "foreign-thread wake takes the concurrent path");
+        assert!(
+            !enqueued[0].1,
+            "foreign-thread wake takes the concurrent path"
+        );
         // SAFETY: test owns the task ref.
         assert_eq!(unsafe { state_of(this) }, SCHEDULED);
 

--- a/src/event_loop/AsyncTask.rs
+++ b/src/event_loop/AsyncTask.rs
@@ -950,4 +950,44 @@ mod tests {
         // SAFETY: queued (SCHEDULED) task on the consumer thread.
         unsafe { release_with::<TestSchedule>(this) };
     }
+
+    #[test]
+    fn consuming_wake_from_foreign_thread_transfers_its_reference() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(Park {
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        let waker = waker_out.take().expect("stored");
+        // SAFETY: test owns the task ref.
+        let before = unsafe { refs_of(this) };
+
+        // Consuming wake from a FOREIGN thread: must take the concurrent
+        // path and transfer the waker's reference into the queue slot.
+        std::thread::scope(|scope| {
+            scope.spawn(move || waker.wake());
+        });
+        let enqueued = drain_enqueued();
+        assert_eq!(enqueued.len(), 1);
+        assert!(
+            !enqueued[0].1,
+            "foreign-thread wake takes the concurrent path"
+        );
+        // SAFETY: test owns the task ref.
+        assert_eq!(
+            unsafe { refs_of(this) },
+            before,
+            "waker ref transferred to the queue slot - no net refcount change"
+        );
+
+        // SAFETY: queued (SCHEDULED) task on the consumer thread.
+        unsafe { release_with::<TestSchedule>(this) };
+    }
 }

--- a/src/event_loop/AsyncTask.rs
+++ b/src/event_loop/AsyncTask.rs
@@ -40,7 +40,8 @@
 //!
 //! `refs` counts: +1 held by the task itself from spawn until a terminal
 //! state (COMPLETE/CLOSED) is processed, +1 while the task sits in a queue,
-//! +1 per live `Waker` clone. The future is dropped in place at the terminal
+//! +1 per live `Waker` clone. A consuming `wake` that wins the enqueue
+//! transfers its reference into the queue slot instead of an inc/dec pair. The future is dropped in place at the terminal
 //! transition (always on the JS thread); after that the allocation is plain
 //! bytes, so the last reference may safely be dropped — and the memory freed
 //! — from any thread.
@@ -56,6 +57,16 @@ use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use crate::ConcurrentTask::{AutoDeinit, ConcurrentTask};
 use crate::{JsEventLoop, Task};
 use bun_io::KeepAlive;
+
+// The poll path has no unwind guards: a panicking poll would leave the task
+// in `RUNNING` forever and leak the pinned future. Every workspace profile
+// builds with `panic = "abort"` (root Cargo.toml); this trips if that ever
+// changes. Test/Miri builds compile with unwind by design (cargo ignores the
+// profile's panic setting for the test profile), hence the carve-outs.
+#[cfg(all(panic = "unwind", not(test), not(miri)))]
+compile_error!(
+    "bun_event_loop::AsyncTask requires panic=abort: its poll path has no unwind guards"
+);
 
 // ─── state machine ───────────────────────────────────────────────────────────
 
@@ -169,6 +180,13 @@ trait Schedule {
     unsafe fn enqueue_concurrent(this: *mut AsyncTask);
     /// Release the event-loop keepalive at a terminal transition. JS thread only.
     unsafe fn release_keep_alive(this: *mut AsyncTask);
+    /// The waker vtable for this schedule. Implementations return a true
+    /// `static` (not a const-promoted temporary): promotion can be
+    /// duplicated per codegen unit in non-LTO builds, giving wakers for the
+    /// same task different vtable addresses — `Waker::will_wake` then
+    /// reports false for equivalent wakers and defeats leaf futures'
+    /// stored-waker dedup.
+    fn vtable() -> &'static RawWakerVTable;
 }
 
 /// Production effects: the real event loop.
@@ -207,6 +225,16 @@ impl Schedule for LoopSchedule {
         let keep_alive = unsafe { &mut (*this).keep_alive };
         keep_alive.unref(bun_io::js_vm_ctx());
     }
+
+    fn vtable() -> &'static RawWakerVTable {
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(
+            waker_clone::<LoopSchedule>,
+            waker_wake::<LoopSchedule>,
+            waker_wake_by_ref::<LoopSchedule>,
+            waker_drop,
+        );
+        &VTABLE
+    }
 }
 
 // ─── refcounting ─────────────────────────────────────────────────────────────
@@ -215,7 +243,11 @@ unsafe fn ref_inc(this: *mut AsyncTask) {
     // SAFETY: shared projection of the atomic field only.
     let refs = unsafe { &(*this).refs };
     let prev = refs.fetch_add(1, ORD);
-    debug_assert!(prev < u32::MAX / 2, "AsyncTask refcount overflow");
+    if prev > u32::MAX / 2 {
+        // A leaked-clone loop must trap before the count wraps into a
+        // use-after-free; the guard stays in release builds.
+        std::process::abort();
+    }
 }
 
 unsafe fn ref_dec(this: *mut AsyncTask) {
@@ -239,7 +271,7 @@ unsafe fn on_js_thread(this: *mut AsyncTask) -> bool {
     std::thread::current().id() == js_thread
 }
 
-unsafe fn wake_with<S: Schedule>(this: *mut AsyncTask) {
+unsafe fn wake_with<S: Schedule, const CONSUME: bool>(this: *mut AsyncTask) {
     // SAFETY: shared projection of the atomic field only.
     let state = unsafe { &(*this).state };
     let mut current = state.load(ORD);
@@ -247,12 +279,16 @@ unsafe fn wake_with<S: Schedule>(this: *mut AsyncTask) {
         match current {
             IDLE => match state.compare_exchange(IDLE, SCHEDULED, ORD, ORD) {
                 Ok(_) => {
-                    // Take the queue reference BEFORE enqueueing: once the
-                    // task is visible to the consumer it may run, complete,
-                    // and release while we are still here.
-                    // SAFETY: caller holds a reference (waker or task ref),
-                    // so `this` is live.
-                    unsafe { ref_inc(this) };
+                    if !CONSUME {
+                        // Take the queue reference BEFORE enqueueing: once
+                        // the task is visible to the consumer it may run,
+                        // complete, and release while we are still here.
+                        // SAFETY: caller holds a reference (waker), so
+                        // `this` is live.
+                        unsafe { ref_inc(this) };
+                    }
+                    // A consuming wake transfers its own reference into the
+                    // queue slot instead — no refcount traffic.
                     // SAFETY: we won the CAS — sole enqueuer for this cycle.
                     if unsafe { on_js_thread(this) } {
                         // SAFETY: on the JS thread (just checked).
@@ -268,41 +304,60 @@ unsafe fn wake_with<S: Schedule>(this: *mut AsyncTask) {
             RUNNING => match state.compare_exchange(RUNNING, NOTIFIED, ORD, ORD) {
                 // The poll exit observes NOTIFIED and re-enqueues; no queue
                 // traffic from this thread.
-                Ok(_) => return,
+                Ok(_) => break,
                 Err(actual) => current = actual,
             },
-            SCHEDULED | NOTIFIED | COMPLETE | CLOSED => return,
+            SCHEDULED | NOTIFIED => {
+                // Same-value CAS, not a plain load: a wake that loses the
+                // enqueue race must still publish a release edge pairing
+                // with the dispatcher's Acquire side of SCHEDULED→RUNNING,
+                // so writes made before this wake are visible to the poll
+                // that consumes the existing enqueue. (A leaf future with
+                // its own release/acquire pair doesn't need this; futures
+                // relying on the wake→poll edge do.)
+                match state.compare_exchange(current, current, ORD, ORD) {
+                    Ok(_) => break,
+                    Err(actual) => current = actual,
+                }
+            }
+            // Terminal states are final: nothing will poll again, no edge
+            // to publish, nothing to do.
+            COMPLETE | CLOSED => break,
             _ => unreachable!("AsyncTask.state corrupted: {current}"),
         }
+    }
+    if CONSUME {
+        // No enqueue happened on this path (the enqueue path returns above
+        // after transferring the reference) — release the waker's reference.
+        // SAFETY: this waker held a reference until here.
+        unsafe { ref_dec(this) };
     }
 }
 
 // ─── waker vtable ────────────────────────────────────────────────────────────
 
-fn raw_waker_vtable<S: Schedule>() -> &'static RawWakerVTable {
-    // Nested fns can't capture the enclosing `S`; each takes it explicitly.
-    unsafe fn clone_waker<S: Schedule>(data: *const ()) -> RawWaker {
-        let this = data.cast_mut().cast::<AsyncTask>();
-        // SAFETY: the cloned-from waker holds a reference, so `this` is live.
-        unsafe { ref_inc(this) };
-        RawWaker::new(data, raw_waker_vtable::<S>())
-    }
-    unsafe fn wake<S: Schedule>(data: *const ()) {
-        let this = data.cast_mut().cast::<AsyncTask>();
-        // SAFETY: this waker holds a reference (consumed below).
-        unsafe { wake_with::<S>(this) };
-        // SAFETY: consumes this waker's reference.
-        unsafe { ref_dec(this) };
-    }
-    unsafe fn wake_by_ref<S: Schedule>(data: *const ()) {
-        // SAFETY: this waker holds a reference for the duration of the call.
-        unsafe { wake_with::<S>(data.cast_mut().cast::<AsyncTask>()) };
-    }
-    unsafe fn drop_waker(data: *const ()) {
-        // SAFETY: releases this waker's reference.
-        unsafe { ref_dec(data.cast_mut().cast::<AsyncTask>()) };
-    }
-    const { &RawWakerVTable::new(clone_waker::<S>, wake::<S>, wake_by_ref::<S>, drop_waker) }
+unsafe fn waker_clone<S: Schedule>(data: *const ()) -> RawWaker {
+    let this = data.cast_mut().cast::<AsyncTask>();
+    // SAFETY: the cloned-from waker holds a reference, so `this` is live.
+    unsafe { ref_inc(this) };
+    RawWaker::new(data, S::vtable())
+}
+
+unsafe fn waker_wake<S: Schedule>(data: *const ()) {
+    // Consuming wake: the enqueue path transfers this waker's reference into
+    // the queue slot; every other path releases it inside `wake_with`.
+    // SAFETY: this waker holds a reference until `wake_with` disposes of it.
+    unsafe { wake_with::<S, true>(data.cast_mut().cast::<AsyncTask>()) };
+}
+
+unsafe fn waker_wake_by_ref<S: Schedule>(data: *const ()) {
+    // SAFETY: this waker holds a reference for the duration of the call.
+    unsafe { wake_with::<S, false>(data.cast_mut().cast::<AsyncTask>()) };
+}
+
+unsafe fn waker_drop(data: *const ()) {
+    // SAFETY: releases this waker's reference.
+    unsafe { ref_dec(data.cast_mut().cast::<AsyncTask>()) };
 }
 
 // ─── poll (dispatch entry) ───────────────────────────────────────────────────
@@ -320,14 +375,9 @@ unsafe fn poll_with<S: Schedule>(this: *mut AsyncTask) {
     // through `clone_waker` and count normally. `ManuallyDrop` skips the
     // vtable drop that would release a reference we never took.
     let waker = ManuallyDrop::new(
-        // SAFETY: vtable contract upheld by the fns in `raw_waker_vtable`;
-        // `this` is live for the duration (queue ref).
-        unsafe {
-            Waker::from_raw(RawWaker::new(
-                this.cast_const().cast::<()>(),
-                raw_waker_vtable::<S>(),
-            ))
-        },
+        // SAFETY: vtable contract upheld by the `waker_*` fns; `this` is
+        // live for the duration (queue ref).
+        unsafe { Waker::from_raw(RawWaker::new(this.cast_const().cast::<()>(), S::vtable())) },
     );
     let mut cx = Context::from_waker(&waker);
 
@@ -569,6 +619,15 @@ mod tests {
             record(this, false);
         }
         unsafe fn release_keep_alive(_this: *mut AsyncTask) {}
+        fn vtable() -> &'static RawWakerVTable {
+            static VTABLE: RawWakerVTable = RawWakerVTable::new(
+                waker_clone::<TestSchedule>,
+                waker_wake::<TestSchedule>,
+                waker_wake_by_ref::<TestSchedule>,
+                waker_drop,
+            );
+            &VTABLE
+        }
     }
 
     /// Fabricated handle: `TestSchedule` never dispatches through it.

--- a/src/event_loop/AsyncTask.rs
+++ b/src/event_loop/AsyncTask.rs
@@ -1,0 +1,924 @@
+//! Rust `async fn` support on the JS event loop.
+//!
+//! [`spawn`] pins a future into a single heap allocation and drives it with
+//! the event loop's own task queue: every `Waker::wake` enqueues the task
+//! (tag `task_tag::AsyncTask`) and `bun_runtime::dispatch::run_task` polls it
+//! on the JS thread. There is no separate executor, reactor, or worker —
+//! the event loop is the runtime.
+//!
+//! Futures are deliberately **not** `Send`: they may capture JS-thread-affine
+//! state (`Strong`, `JsRef`, raw `JSValue` roots). The executor's matching
+//! guarantee is that the future is polled *and dropped* only on the JS
+//! thread, including the shutdown path — so `!Send` captures are sound by
+//! construction. Wakers, by contrast, are `Send + Sync` and may fire from any
+//! thread; a cross-thread wake performs the same MPSC push + loop wakeup as
+//! every existing work-pool completion.
+//!
+//! ## Wake protocol
+//!
+//! The loop's queues do not deduplicate: enqueueing the same pointer twice
+//! would poll freed or aliased state. `state` is a small CAS machine that
+//! makes wakes idempotent — at most one enqueue (and therefore one embedded
+//! [`ConcurrentTask`] node arming) is in flight at any time:
+//!
+//! ```text
+//!  IDLE ──wake──▶ SCHEDULED ──dispatch──▶ RUNNING ──Ready──▶ COMPLETE
+//!   ▲                 ▲                   │     │
+//!   │                 │ (re-enqueue)      │     └─wake─▶ NOTIFIED ─┐
+//!   └────Pending──────┴───────────────────┘            (after poll)┘
+//! ```
+//!
+//! A queued-but-never-dispatched task at VM teardown is released by
+//! [`AsyncTask::release_at_shutdown`] (wired into
+//! `bun_runtime::dispatch::__bun_release_task_at_shutdown`), which drops the
+//! future on the JS thread while JSC handles are still valid. A task parked
+//! on an external event (state `IDLE`) at forced teardown follows the same
+//! rules as every in-flight completion today: its keepalive prevents natural
+//! exit, and abrupt termination leaks the box rather than touching a dead VM.
+//!
+//! ## Reference counts
+//!
+//! `refs` counts: +1 held by the task itself from spawn until a terminal
+//! state (COMPLETE/CLOSED) is processed, +1 while the task sits in a queue,
+//! +1 per live `Waker` clone. The future is dropped in place at the terminal
+//! transition (always on the JS thread); after that the allocation is plain
+//! bytes, so the last reference may safely be dropped — and the memory freed
+//! — from any thread.
+
+use core::future::Future;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
+use core::pin::Pin;
+use core::ptr::NonNull;
+use core::sync::atomic::{AtomicU32, Ordering};
+use core::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
+
+use crate::ConcurrentTask::{AutoDeinit, ConcurrentTask};
+use crate::{JsEventLoop, Task};
+use bun_io::KeepAlive;
+
+// ─── state machine ───────────────────────────────────────────────────────────
+
+/// Not queued, not running. A wake may transition to `SCHEDULED` and enqueue.
+const IDLE: u32 = 0;
+/// In a queue (local FIFO or concurrent MPSC). Wakes are no-ops.
+const SCHEDULED: u32 = 1;
+/// Being polled on the JS thread. A wake transitions to `NOTIFIED`.
+const RUNNING: u32 = 2;
+/// Woken while `RUNNING`; the poll exit re-enqueues instead of parking.
+const NOTIFIED: u32 = 3;
+/// The future returned `Ready` and was dropped. Wakes are no-ops.
+const COMPLETE: u32 = 4;
+/// Dropped without completing (shutdown release). Wakes are no-ops.
+const CLOSED: u32 = 5;
+
+// All atomics use `SeqCst`: wakes are orders of magnitude rarer than the
+// loads/stores a poll performs, and the enqueue they guard already pays an
+// MPSC push (and possibly a wakeup syscall). Weaken only with a benchmark.
+const ORD: Ordering = Ordering::SeqCst;
+
+// ─── task header ─────────────────────────────────────────────────────────────
+
+/// Type-erased header of a spawned future. The concrete allocation is
+/// `Storage<F>` (`#[repr(C)]`, header first), so a `*mut AsyncTask` is the
+/// allocation pointer; `vtable` recovers the `F`-typed operations.
+///
+/// Cross-thread paths (wakers) touch only the atomic fields and the embedded
+/// `concurrent` node, via per-field raw projections — never `&AsyncTask` /
+/// `&mut AsyncTask` — so JS-thread mutation of the non-atomic fields
+/// (`keep_alive`, the future payload) never aliases a live reference.
+pub struct AsyncTask {
+    state: AtomicU32,
+    refs: AtomicU32,
+    /// The owning loop, captured at spawn. Deliberately the specific
+    /// `jsc::EventLoop` (not re-derived per wake): if spawnSync has swapped
+    /// `vm.event_loop`, a wake must still target the regular loop — the task
+    /// then runs after the swap-back, never inside the isolated loop.
+    event_loop: JsEventLoop,
+    js_thread: std::thread::ThreadId,
+    /// Embedded envelope for cross-thread wakes. At most one enqueue is in
+    /// flight (state machine), and the consumer copies a popped batch into
+    /// the local FIFO before dispatching any task, so re-arming on a later
+    /// wake can never race the MPSC iterator's read of `next`.
+    concurrent: ConcurrentTask,
+    keep_alive: KeepAlive,
+    vtable: &'static VTable,
+}
+
+impl crate::Taskable for AsyncTask {
+    const TAG: crate::TaskTag = crate::task_tag::AsyncTask;
+}
+
+/// `F`-typed operations, monomorphized once per [`spawn`] instantiation.
+struct VTable {
+    poll: for<'a, 'b> unsafe fn(*mut AsyncTask, &'a mut Context<'b>) -> Poll<()>,
+    drop_future: unsafe fn(*mut AsyncTask),
+    dealloc: unsafe fn(*mut AsyncTask),
+}
+
+#[repr(C)]
+struct Storage<F: Future<Output = ()>> {
+    header: AsyncTask,
+    /// `Some` until the terminal transition drops the future in place.
+    future: Option<F>,
+}
+
+unsafe fn poll_thunk<F: Future<Output = ()>>(
+    this: *mut AsyncTask,
+    cx: &mut Context<'_>,
+) -> Poll<()> {
+    let storage = this.cast::<Storage<F>>();
+    // SAFETY: `RUNNING` is exclusive (single consumer dispatches, wakes only
+    // flip atomics), so no other access to the future slot exists. Projecting
+    // the field leaves the header's atomic fields untouched for racing wakers.
+    let slot = unsafe { &mut (*storage).future };
+    debug_assert!(slot.is_some(), "polled after terminal transition");
+    // SAFETY: `slot` is `Some` until the terminal transition, which cannot
+    // happen while we are `RUNNING`.
+    let future = unsafe { slot.as_mut().unwrap_unchecked() };
+    // SAFETY: pinned by construction — the storage allocation never moves
+    // (heap-allocated at spawn, freed only by `dealloc_thunk`) and the future
+    // is dropped in place by `drop_future_thunk`.
+    unsafe { Pin::new_unchecked(future) }.poll(cx)
+}
+
+unsafe fn drop_future_thunk<F: Future<Output = ()>>(this: *mut AsyncTask) {
+    // SAFETY: called exactly once, on the JS thread, at the terminal
+    // transition; same exclusivity argument as `poll_thunk`. The raw place
+    // assignment drops the previous `Some(F)` in place.
+    unsafe { (*this.cast::<Storage<F>>()).future = None };
+}
+
+unsafe fn dealloc_thunk<F: Future<Output = ()>>(this: *mut AsyncTask) {
+    // SAFETY: `this` was produced by `heap::into_raw(Box<Storage<F>>)` in
+    // `spawn_raw`, and `refs` reached zero exactly once. The future slot is
+    // already `None`, so the remaining drop is plain header bytes — safe from
+    // any thread.
+    unsafe { bun_core::heap::destroy(this.cast::<Storage<F>>()) };
+}
+
+// ─── effect layer (factored for headless tests) ──────────────────────────────
+
+/// The executor's effects, separated from the wake/poll state machine so the
+/// protocol is unit-testable without a live VM. Production uses
+/// [`LoopSchedule`]; tests inject a recorder.
+trait Schedule {
+    /// Push onto the owning loop's JS-thread FIFO. JS thread only.
+    unsafe fn enqueue_local(this: *mut AsyncTask);
+    /// Push onto the concurrent MPSC queue + wake the loop. Any thread.
+    unsafe fn enqueue_concurrent(this: *mut AsyncTask);
+    /// Release the event-loop keepalive at a terminal transition. JS thread only.
+    unsafe fn release_keep_alive(this: *mut AsyncTask);
+}
+
+/// Production effects: the real event loop.
+struct LoopSchedule;
+
+impl Schedule for LoopSchedule {
+    unsafe fn enqueue_local(this: *mut AsyncTask) {
+        // SAFETY: field read of the `Copy` handle; `event_loop` is immutable
+        // after spawn.
+        let event_loop = unsafe { (*this).event_loop };
+        // Forms a transient `&mut jsc::EventLoop` inside the link impl — the
+        // same re-entrant discipline as every task body that enqueues during
+        // a tick (cf. `dispatch::run_task` arms running JS while the drain
+        // loop's borrows exist).
+        event_loop.enqueue_task(Task::init(this));
+    }
+
+    unsafe fn enqueue_concurrent(this: *mut AsyncTask) {
+        // SAFETY: exclusive access to the embedded node — only the wake that
+        // won the IDLE→SCHEDULED CAS reaches an enqueue, and any prior
+        // enqueue's node was fully consumed before the task could return to
+        // IDLE (see the field's doc comment).
+        let node = unsafe { &mut (*this).concurrent };
+        node.from(this, AutoDeinit::ManualDeinit);
+        // SAFETY: same immutable-field read as `enqueue_local`.
+        let event_loop = unsafe { (*this).event_loop };
+        // `enqueue_task_concurrent` is the `&self` thread-safe surface:
+        // lock-free MPSC push, then `us_wakeup_loop` (lost-wakeup-proof via
+        // the loop's `pending_wakeups` handshake).
+        event_loop.enqueue_task_concurrent(NonNull::from(node));
+    }
+
+    unsafe fn release_keep_alive(this: *mut AsyncTask) {
+        // SAFETY: terminal transitions run on the JS thread only; no waker
+        // touches `keep_alive`, so the field projection is exclusive.
+        let keep_alive = unsafe { &mut (*this).keep_alive };
+        keep_alive.unref(bun_io::js_vm_ctx());
+    }
+}
+
+// ─── refcounting ─────────────────────────────────────────────────────────────
+
+unsafe fn ref_inc(this: *mut AsyncTask) {
+    // SAFETY: shared projection of the atomic field only.
+    let refs = unsafe { &(*this).refs };
+    let prev = refs.fetch_add(1, ORD);
+    debug_assert!(prev < u32::MAX / 2, "AsyncTask refcount overflow");
+}
+
+unsafe fn ref_dec(this: *mut AsyncTask) {
+    // SAFETY: shared projection of the atomic field only.
+    let refs = unsafe { &(*this).refs };
+    if refs.fetch_sub(1, ORD) == 1 {
+        // SAFETY: immutable field, valid until dealloc — which is exactly
+        // what this last-reference path performs, once.
+        let vtable = unsafe { (*this).vtable };
+        // SAFETY: `refs` hit zero: no queue slot, no waker, no task ref
+        // remain; the future was dropped at the terminal transition.
+        unsafe { (vtable.dealloc)(this) };
+    }
+}
+
+// ─── wake ────────────────────────────────────────────────────────────────────
+
+unsafe fn on_js_thread(this: *mut AsyncTask) -> bool {
+    // SAFETY: `js_thread` is immutable after spawn.
+    let js_thread = unsafe { (*this).js_thread };
+    std::thread::current().id() == js_thread
+}
+
+unsafe fn wake_with<S: Schedule>(this: *mut AsyncTask) {
+    // SAFETY: shared projection of the atomic field only.
+    let state = unsafe { &(*this).state };
+    let mut current = state.load(ORD);
+    loop {
+        match current {
+            IDLE => match state.compare_exchange(IDLE, SCHEDULED, ORD, ORD) {
+                Ok(_) => {
+                    // Take the queue reference BEFORE enqueueing: once the
+                    // task is visible to the consumer it may run, complete,
+                    // and release while we are still here.
+                    // SAFETY: caller holds a reference (waker or task ref),
+                    // so `this` is live.
+                    unsafe { ref_inc(this) };
+                    // SAFETY: we won the CAS — sole enqueuer for this cycle.
+                    if unsafe { on_js_thread(this) } {
+                        // SAFETY: on the JS thread (just checked).
+                        unsafe { S::enqueue_local(this) };
+                    } else {
+                        // SAFETY: any-thread surface.
+                        unsafe { S::enqueue_concurrent(this) };
+                    }
+                    return;
+                }
+                Err(actual) => current = actual,
+            },
+            RUNNING => match state.compare_exchange(RUNNING, NOTIFIED, ORD, ORD) {
+                // The poll exit observes NOTIFIED and re-enqueues; no queue
+                // traffic from this thread.
+                Ok(_) => return,
+                Err(actual) => current = actual,
+            },
+            SCHEDULED | NOTIFIED | COMPLETE | CLOSED => return,
+            _ => unreachable!("AsyncTask.state corrupted: {current}"),
+        }
+    }
+}
+
+// ─── waker vtable ────────────────────────────────────────────────────────────
+
+fn raw_waker_vtable<S: Schedule>() -> &'static RawWakerVTable {
+    // Nested fns can't capture the enclosing `S`; each takes it explicitly.
+    unsafe fn clone_waker<S: Schedule>(data: *const ()) -> RawWaker {
+        let this = data.cast_mut().cast::<AsyncTask>();
+        // SAFETY: the cloned-from waker holds a reference, so `this` is live.
+        unsafe { ref_inc(this) };
+        RawWaker::new(data, raw_waker_vtable::<S>())
+    }
+    unsafe fn wake<S: Schedule>(data: *const ()) {
+        let this = data.cast_mut().cast::<AsyncTask>();
+        // SAFETY: this waker holds a reference (consumed below).
+        unsafe { wake_with::<S>(this) };
+        // SAFETY: consumes this waker's reference.
+        unsafe { ref_dec(this) };
+    }
+    unsafe fn wake_by_ref<S: Schedule>(data: *const ()) {
+        // SAFETY: this waker holds a reference for the duration of the call.
+        unsafe { wake_with::<S>(data.cast_mut().cast::<AsyncTask>()) };
+    }
+    unsafe fn drop_waker(data: *const ()) {
+        // SAFETY: releases this waker's reference.
+        unsafe { ref_dec(data.cast_mut().cast::<AsyncTask>()) };
+    }
+    const {
+        &RawWakerVTable::new(
+            clone_waker::<S>,
+            wake::<S>,
+            wake_by_ref::<S>,
+            drop_waker,
+        )
+    }
+}
+
+// ─── poll (dispatch entry) ───────────────────────────────────────────────────
+
+unsafe fn poll_with<S: Schedule>(this: *mut AsyncTask) {
+    // SAFETY: shared projection of the atomic field only.
+    let state = unsafe { &(*this).state };
+    // A queued task is dispatched exactly once (single consumer), and only
+    // the dispatcher moves a task out of SCHEDULED — a plain swap suffices.
+    let prev = state.swap(RUNNING, ORD);
+    debug_assert_eq!(prev, SCHEDULED, "dispatched while not scheduled");
+
+    // Borrowed waker: the queue reference we hold outlives this poll, so the
+    // waker needs no refcount of its own; clones taken by the future go
+    // through `clone_waker` and count normally. `ManuallyDrop` skips the
+    // vtable drop that would release a reference we never took.
+    let waker = ManuallyDrop::new(
+        // SAFETY: vtable contract upheld by the fns in `raw_waker_vtable`;
+        // `this` is live for the duration (queue ref).
+        unsafe { Waker::from_raw(RawWaker::new(this.cast_const().cast::<()>(), raw_waker_vtable::<S>())) },
+    );
+    let mut cx = Context::from_waker(&waker);
+
+    // SAFETY: immutable field.
+    let vtable = unsafe { (*this).vtable };
+    // SAFETY: state is RUNNING — exclusive future access (see `poll_thunk`).
+    // The poll body may call into JS and re-enter the event loop through
+    // TLS; we hold no `&`/`&mut` to any of it (raw projections only).
+    match unsafe { (vtable.poll)(this, &mut cx) } {
+        Poll::Ready(()) => {
+            // SAFETY: terminal transition, JS thread, exclusive (RUNNING).
+            unsafe { (vtable.drop_future)(this) };
+            // SAFETY: JS thread; terminal transition runs once.
+            unsafe { S::release_keep_alive(this) };
+            // Wakes racing this store saw RUNNING (→ NOTIFIED, no enqueue) or
+            // see COMPLETE (no-op); either way no queue traffic after this.
+            state.store(COMPLETE, ORD);
+            // SAFETY: releases the queue reference, then the task reference.
+            unsafe { ref_dec(this) };
+            // SAFETY: ditto — header stays valid until the final ref_dec.
+            unsafe { ref_dec(this) };
+        }
+        Poll::Pending => {
+            match state.compare_exchange(RUNNING, IDLE, ORD, ORD) {
+                // Parked: a leaf future stored the waker. Release the queue
+                // reference; outstanding wakers keep the task alive.
+                // SAFETY: releases the queue reference.
+                Ok(_) => unsafe { ref_dec(this) },
+                Err(actual) => {
+                    // Woken mid-poll. Keep the queue reference and go around
+                    // again. Note: lands in the live FIFO, so a future that
+                    // self-wakes every poll re-runs within the current tick
+                    // (nextTick-like). Use [`yield_now`] judiciously.
+                    debug_assert_eq!(actual, NOTIFIED);
+                    state.store(SCHEDULED, ORD);
+                    // SAFETY: poll runs on the JS thread.
+                    unsafe { S::enqueue_local(this) };
+                }
+            }
+        }
+    }
+}
+
+unsafe fn release_with<S: Schedule>(this: *mut AsyncTask) {
+    // SAFETY: shared projection of the atomic field only.
+    let state = unsafe { &(*this).state };
+    let prev = state.swap(CLOSED, ORD);
+    debug_assert_eq!(prev, SCHEDULED, "shutdown release of a non-queued task");
+    // SAFETY: immutable field.
+    let vtable = unsafe { (*this).vtable };
+    // SAFETY: JS thread (shutdown drain), exclusive — the task was queued, so
+    // no poll is running and wakes are atomic-only.
+    unsafe { (vtable.drop_future)(this) };
+    // SAFETY: JS thread; terminal transition runs once.
+    unsafe { S::release_keep_alive(this) };
+    // SAFETY: releases the queue reference held since the enqueue, then the
+    // task reference. Waker clones parked elsewhere release theirs later;
+    // the header is plain bytes by then.
+    unsafe { ref_dec(this) };
+    // SAFETY: ditto.
+    unsafe { ref_dec(this) };
+}
+
+impl AsyncTask {
+    /// Poll the spawned future once. Called by `bun_runtime::dispatch::run_task`
+    /// for `task_tag::AsyncTask`. ([`spawn`] performs the eager first poll
+    /// through the same entry path, minus the queue hop.)
+    ///
+    /// # Safety
+    /// `this` must be the live header of a `SCHEDULED` task popped from the
+    /// event loop's FIFO, on the JS thread.
+    pub unsafe fn run_from_js(this: *mut AsyncTask) {
+        // SAFETY: per fn contract.
+        unsafe { poll_with::<LoopSchedule>(this) };
+    }
+
+    /// Drop a queued-but-never-dispatched task at VM shutdown. Called by
+    /// `bun_runtime::dispatch::__bun_release_task_at_shutdown`.
+    ///
+    /// # Safety
+    /// `this` must be the live header of a queued (`SCHEDULED`) task drained
+    /// from the event loop's queues during shutdown, on the JS thread, before
+    /// JSC handle teardown (the future may hold `Strong`s).
+    pub unsafe fn release_at_shutdown(this: *mut AsyncTask) {
+        // SAFETY: per fn contract.
+        unsafe { release_with::<LoopSchedule>(this) };
+    }
+}
+
+// ─── spawn ───────────────────────────────────────────────────────────────────
+
+/// Allocate the pinned task storage. Caller enqueues (state starts
+/// `SCHEDULED` with refs = task + queue).
+fn spawn_raw<F: Future<Output = ()> + 'static>(
+    event_loop: JsEventLoop,
+    keep_alive: KeepAlive,
+    future: F,
+) -> *mut AsyncTask {
+    struct VTableOf<F>(PhantomData<F>);
+    impl<F: Future<Output = ()> + 'static> VTableOf<F> {
+        const VTABLE: VTable = VTable {
+            poll: poll_thunk::<F>,
+            drop_future: drop_future_thunk::<F>,
+            dealloc: dealloc_thunk::<F>,
+        };
+    }
+    let storage = bun_core::heap::into_raw(Box::new(Storage::<F> {
+        header: AsyncTask {
+            state: AtomicU32::new(SCHEDULED),
+            refs: AtomicU32::new(2),
+            event_loop,
+            js_thread: std::thread::current().id(),
+            concurrent: ConcurrentTask::default(),
+            keep_alive,
+            vtable: &VTableOf::<F>::VTABLE,
+        },
+        future: Some(future),
+    }));
+    storage.cast::<AsyncTask>()
+}
+
+/// Spawn a future onto the current thread's JS event loop.
+///
+/// **Eager, like a JS promise executor**: the first poll runs synchronously,
+/// before `spawn` returns — code ahead of the first `.await` (scheduling pool
+/// work, issuing I/O) executes immediately, exactly when a hand-rolled task
+/// would have started it. When work begins is observable API surface; a
+/// lazy first poll would silently defer it by a queue turn. Subsequent polls
+/// are driven by wakes through the task queue.
+///
+/// JS thread only (panics otherwise, via [`JsEventLoop::current`]). The
+/// future is polled and dropped on the JS thread; it may capture `!Send`
+/// JS-thread state, which **must** be GC-rooted across `.await` points
+/// (`Strong`/`JsRef` — never a bare `JSValue`). The pending task holds an
+/// event-loop keepalive, so the process stays alive until it completes.
+pub fn spawn<F>(future: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    let event_loop = JsEventLoop::current();
+    let mut keep_alive = KeepAlive::init();
+    keep_alive.ref_(bun_io::js_vm_ctx());
+    let this = spawn_raw(event_loop, keep_alive, future);
+    // SAFETY: freshly allocated SCHEDULED task on the JS thread — the eager
+    // first poll consumes the SCHEDULED state exactly as a queue dispatch
+    // would; the state machine does not distinguish the two entry paths.
+    unsafe { poll_with::<LoopSchedule>(this) };
+}
+
+// ─── yield_now ───────────────────────────────────────────────────────────────
+
+/// Cooperatively yield: wake immediately and return `Pending` once.
+///
+/// The re-poll happens within the **current** tick (the re-enqueue lands in
+/// the live FIFO), so this yields to other queued tasks and microtasks — it
+/// does not reach the I/O poll. A "yield past I/O" awaits a 0-deadline timer
+/// instead (ships with the timer leaf future).
+pub fn yield_now() -> YieldNow {
+    YieldNow { yielded: false }
+}
+
+pub struct YieldNow {
+    yielded: bool,
+}
+
+impl Future for YieldNow {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.yielded {
+            Poll::Ready(())
+        } else {
+            self.yielded = true;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicBool, AtomicUsize};
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    // Pure-atomic test plumbing: `std::sync` locks are disallowed
+    // workspace-wide, and `bun_threading`'s futex paths are FFI Miri can't
+    // interpret — so both the test serializer and the enqueue recorder are
+    // lock-free.
+
+    /// Serializes tests (the recorder below is a process-global).
+    struct SerialGuard;
+    static SERIAL: AtomicBool = AtomicBool::new(false);
+    impl SerialGuard {
+        fn acquire() -> SerialGuard {
+            while SERIAL.swap(true, Ordering::Acquire) {
+                std::thread::yield_now();
+            }
+            SerialGuard
+        }
+    }
+    impl Drop for SerialGuard {
+        fn drop(&mut self) {
+            SERIAL.store(false, Ordering::Release);
+        }
+    }
+
+    /// Lock-free enqueue recorder: each slot is `addr | (local as usize)` —
+    /// `AsyncTask` is pointer-aligned, so bit 0 is free for the path flag.
+    const RECORD_CAP: usize = 64;
+    static RECORDS: [AtomicUsize; RECORD_CAP] = [const { AtomicUsize::new(0) }; RECORD_CAP];
+    static RECORD_LEN: AtomicUsize = AtomicUsize::new(0);
+
+    fn record(this: *mut AsyncTask, local: bool) {
+        let i = RECORD_LEN.fetch_add(1, Ordering::AcqRel);
+        assert!(i < RECORD_CAP, "test recorder overflow");
+        RECORDS[i].store(this.addr() | usize::from(local), Ordering::Release);
+    }
+
+    fn drain_enqueued() -> Vec<(usize, bool)> {
+        let n = RECORD_LEN.swap(0, Ordering::AcqRel);
+        (0..n)
+            .map(|i| {
+                let v = RECORDS[i].swap(0, Ordering::AcqRel);
+                (v & !1, v & 1 == 1)
+            })
+            .collect()
+    }
+
+    struct TestSchedule;
+    impl Schedule for TestSchedule {
+        unsafe fn enqueue_local(this: *mut AsyncTask) {
+            record(this, true);
+        }
+        unsafe fn enqueue_concurrent(this: *mut AsyncTask) {
+            record(this, false);
+        }
+        unsafe fn release_keep_alive(_this: *mut AsyncTask) {}
+    }
+
+    /// Fabricated handle: `TestSchedule` never dispatches through it.
+    fn dead_event_loop() -> JsEventLoop {
+        // SAFETY: never dereferenced — every effect goes through TestSchedule.
+        unsafe { JsEventLoop::new(crate::JsEventLoopKind::Jsc, core::ptr::null_mut::<()>()) }
+    }
+
+    fn test_spawn<F: Future<Output = ()> + 'static>(future: F) -> *mut AsyncTask {
+        spawn_raw(dead_event_loop(), KeepAlive::init(), future)
+    }
+
+    unsafe fn state_of(this: *mut AsyncTask) -> u32 {
+        // SAFETY: test holds the task ref.
+        unsafe { &(*this).state }.load(ORD)
+    }
+    unsafe fn refs_of(this: *mut AsyncTask) -> u32 {
+        // SAFETY: test holds the task ref.
+        unsafe { &(*this).refs }.load(ORD)
+    }
+
+    /// `Pending` `n` times (waking itself each time), then `Ready`. Sets
+    /// `dropped` from `Drop` so tests can observe the in-place future drop.
+    struct Yields {
+        left: u32,
+        dropped: Rc<Cell<bool>>,
+    }
+    impl Future for Yields {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.left == 0 {
+                Poll::Ready(())
+            } else {
+                self.left -= 1;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    impl Drop for Yields {
+        fn drop(&mut self) {
+            self.dropped.set(true);
+        }
+    }
+
+    /// Pending forever; clones and stashes its waker like a leaf future.
+    struct Park {
+        waker_out: Rc<Cell<Option<Waker>>>,
+    }
+    impl Future for Park {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            self.waker_out.set(Some(cx.waker().clone()));
+            Poll::Pending
+        }
+    }
+
+    #[test]
+    fn full_lifecycle_drives_to_completion_and_drops() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let dropped = Rc::new(Cell::new(false));
+        let this = test_spawn(Yields {
+            left: 2,
+            dropped: Rc::clone(&dropped),
+        });
+        // Pump exactly like the dispatch arm would: poll whenever queued.
+        // Yields wakes DURING the poll, exercising RUNNING→NOTIFIED→re-enqueue.
+        let mut polls = 0u32;
+        // The initial enqueue is the caller's job (spawn() does it in prod).
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        loop {
+            let batch = drain_enqueued();
+            if batch.is_empty() {
+                break;
+            }
+            // The state machine permits at most one outstanding enqueue.
+            assert_eq!(batch.len(), 1);
+            let (addr, local) = batch[0];
+            assert_eq!(addr, this.addr());
+            assert!(local, "all wakes here happen on the test (JS) thread");
+            polls += 1;
+            // SAFETY: queued task, single consumer (this loop).
+            unsafe { poll_with::<TestSchedule>(this) };
+        }
+        assert_eq!(polls, 3, "initial poll + two yield re-polls");
+        assert!(dropped.get(), "future dropped in place on Ready");
+        // refs hit zero inside the last poll (queue + task refs released);
+        // the allocation is gone — nothing further to assert through `this`.
+    }
+
+    #[test]
+    fn parked_task_wakes_once_from_many_threads() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(Park {
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        // SAFETY: test owns the task ref.
+        assert_eq!(unsafe { state_of(this) }, IDLE);
+        let waker = waker_out.take().expect("Park stored its waker");
+        // task ref + stored waker clone.
+        // SAFETY: test owns the task ref.
+        assert_eq!(unsafe { refs_of(this) }, 2);
+
+        // Hammer wake from 8 foreign threads; exactly one enqueue may land.
+        let barrier = std::sync::Barrier::new(8);
+        std::thread::scope(|scope| {
+            for _ in 0..8 {
+                let waker = waker.clone();
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..1000 {
+                        waker.wake_by_ref();
+                    }
+                });
+            }
+        });
+        let enqueued = drain_enqueued();
+        assert_eq!(enqueued.len(), 1, "wake is idempotent while SCHEDULED");
+        assert!(!enqueued[0].1, "foreign-thread wake takes the concurrent path");
+        // SAFETY: test owns the task ref.
+        assert_eq!(unsafe { state_of(this) }, SCHEDULED);
+
+        // Complete it: poll Park again (it parks again), then drop wakers and
+        // finish via a fresh wake → poll cycle is unnecessary — instead close
+        // the cycle by polling (re-parks, releasing the queue ref) and
+        // letting the waker drops free the task after a terminal transition.
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        // Parked again with a fresh waker stored; release everything via the
+        // shutdown path after a synthetic wake puts it back in the queue.
+        let waker2 = waker_out.take().expect("Park stored a second waker");
+        waker2.wake();
+        let enqueued = drain_enqueued();
+        assert_eq!(enqueued.len(), 1);
+        // SAFETY: queued (SCHEDULED) task on the consumer thread.
+        unsafe { release_with::<TestSchedule>(this) };
+        // Remaining refs: the original `waker` clone (waker2 was consumed by
+        // `wake()`). Dropping it frees the allocation (not observable here;
+        // ASAN/LSan in CI assert it).
+        drop(waker);
+    }
+
+    #[test]
+    fn eager_first_poll_runs_without_queue_hop() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        // `spawn` polls the fresh SCHEDULED task directly — no enqueue before
+        // the first poll. Work ahead of the first await (here: Yields' wake)
+        // must happen during that synchronous poll.
+        let dropped = Rc::new(Cell::new(false));
+        let this = test_spawn(Yields {
+            left: 1,
+            dropped: Rc::clone(&dropped),
+        });
+        // SAFETY: freshly spawned SCHEDULED task on the consumer thread —
+        // the eager-poll entry path `spawn` uses.
+        unsafe { poll_with::<TestSchedule>(this) };
+        // The mid-poll self-wake re-enqueued it (the only enqueue so far).
+        let enqueued = drain_enqueued();
+        assert_eq!(enqueued.len(), 1, "eager poll itself never enqueues");
+        assert!(!dropped.get());
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        assert!(dropped.get(), "completed on the wake-driven second poll");
+        assert!(drain_enqueued().is_empty());
+    }
+
+    #[test]
+    fn wake_after_complete_is_noop() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(Park {
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        let waker = waker_out.take().expect("stored");
+
+        // Drive to CLOSED via wake → shutdown release.
+        waker.wake_by_ref();
+        drain_enqueued();
+        // SAFETY: queued (SCHEDULED) task on the consumer thread.
+        unsafe { release_with::<TestSchedule>(this) };
+
+        // The header is still alive (we hold `waker`); wakes must be no-ops.
+        waker.wake_by_ref();
+        waker.wake_by_ref();
+        assert!(drain_enqueued().is_empty(), "wake after CLOSED is a no-op");
+        drop(waker);
+    }
+
+    /// `Pending` (storing the waker) until `ready` is set, then `Ready`.
+    struct ReadyWhen {
+        ready: Rc<Cell<bool>>,
+        dropped: Rc<Cell<bool>>,
+        waker_out: Rc<Cell<Option<Waker>>>,
+    }
+    impl Future for ReadyWhen {
+        type Output = ();
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.ready.get() {
+                Poll::Ready(())
+            } else {
+                self.waker_out.set(Some(cx.waker().clone()));
+                Poll::Pending
+            }
+        }
+    }
+    impl Drop for ReadyWhen {
+        fn drop(&mut self) {
+            self.dropped.set(true);
+        }
+    }
+
+    #[test]
+    fn wakes_racing_completion_never_enqueue_twice() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let ready = Rc::new(Cell::new(false));
+        let dropped = Rc::new(Cell::new(false));
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(ReadyWhen {
+            ready: Rc::clone(&ready),
+            dropped: Rc::clone(&dropped),
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        let waker = waker_out.take().expect("stored");
+        ready.set(true);
+
+        // Foreign threads hammer wakes while the consumer thread performs the
+        // Ready transition. The state machine must allow exactly ONE enqueue
+        // (the one that moves IDLE→SCHEDULED); wakes during RUNNING coalesce
+        // into NOTIFIED and wakes after COMPLETE are no-ops — so the future
+        // is polled exactly once more, and never after it was dropped.
+        let barrier = std::sync::Barrier::new(5);
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                let waker = waker.clone();
+                let barrier = &barrier;
+                scope.spawn(move || {
+                    barrier.wait();
+                    for _ in 0..500 {
+                        waker.wake_by_ref();
+                    }
+                });
+            }
+            barrier.wait();
+            // Spin until the single enqueue lands, then dispatch it.
+            while RECORD_LEN.load(Ordering::Acquire) == 0 {
+                std::thread::yield_now();
+            }
+            drain_enqueued();
+            // SAFETY: queued task, single consumer.
+            unsafe { poll_with::<TestSchedule>(this) };
+        });
+        assert!(dropped.get(), "future dropped at the Ready transition");
+        assert!(
+            drain_enqueued().is_empty(),
+            "no wake after COMPLETE may enqueue"
+        );
+        drop(waker);
+    }
+
+    #[test]
+    fn last_waker_ref_dropped_off_thread_deallocs() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(Park {
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        let waker = waker_out.take().expect("stored");
+        let keepalive_clone = waker.clone();
+
+        // Re-queue (consumes `waker`), then close on the consumer thread.
+        waker.wake();
+        drain_enqueued();
+        // SAFETY: queued (SCHEDULED) task on the consumer thread.
+        unsafe { release_with::<TestSchedule>(this) };
+
+        // The future is gone (dropped on the "JS" thread above); the header
+        // is plain bytes. The LAST reference is dropped on a foreign thread,
+        // which must be a valid place to free the allocation. Miri verifies
+        // the cross-thread dealloc.
+        std::thread::scope(|scope| {
+            scope.spawn(move || drop(keepalive_clone));
+        });
+    }
+
+    #[test]
+    fn waker_clone_refcounts_balance() {
+        let _guard = SerialGuard::acquire();
+        drain_enqueued();
+
+        let waker_out = Rc::new(Cell::new(None));
+        let this = test_spawn(Park {
+            waker_out: Rc::clone(&waker_out),
+        });
+        // SAFETY: freshly spawned SCHEDULED task.
+        unsafe { TestSchedule::enqueue_local(this) };
+        drain_enqueued();
+        // SAFETY: queued task, single consumer.
+        unsafe { poll_with::<TestSchedule>(this) };
+        let waker = waker_out.take().expect("stored");
+        // SAFETY: test owns the task ref.
+        let baseline = unsafe { refs_of(this) };
+
+        let clones: Vec<Waker> = (0..16).map(|_| waker.clone()).collect();
+        // SAFETY: test owns the task ref.
+        assert_eq!(unsafe { refs_of(this) }, baseline + 16);
+        drop(clones);
+        // SAFETY: test owns the task ref.
+        assert_eq!(unsafe { refs_of(this) }, baseline);
+
+        // Tear down: queue it, then release.
+        waker.wake();
+        drain_enqueued();
+        // SAFETY: queued (SCHEDULED) task on the consumer thread.
+        unsafe { release_with::<TestSchedule>(this) };
+    }
+}

--- a/src/event_loop/AsyncTask.rs
+++ b/src/event_loop/AsyncTask.rs
@@ -34,7 +34,9 @@
 //! future on the JS thread while JSC handles are still valid. A task parked
 //! on an external event (state `IDLE`) at forced teardown follows the same
 //! rules as every in-flight completion today: its keepalive prevents natural
-//! exit, and abrupt termination leaks the box rather than touching a dead VM.
+//! exit, and abrupt termination leaks the box. (Worker teardown shares the
+//! pre-existing hazard of every in-flight pool completion: a late
+//! cross-thread wake targets the worker's freed loop.)
 //!
 //! ## Reference counts
 //!
@@ -60,13 +62,10 @@ use bun_io::KeepAlive;
 
 // The poll path has no unwind guards: a panicking poll would leave the task
 // in `RUNNING` forever and leak the pinned future. Every workspace profile
-// builds with `panic = "abort"` (root Cargo.toml); this trips if that ever
-// changes. Test/Miri builds compile with unwind by design (cargo ignores the
-// profile's panic setting for the test profile), hence the carve-outs.
-#[cfg(all(panic = "unwind", not(test), not(miri)))]
-compile_error!(
-    "bun_event_loop::AsyncTask requires panic=abort: its poll path has no unwind guards"
-);
+// builds with `panic = "abort"` (root Cargo.toml). A `cfg(panic = "unwind")`
+// compile_error is not viable as a guard: cargo builds the dependency graph
+// of every test target with unwind and without `cfg(test)`, which would
+// break `cargo test` for this crate and all dependents.
 
 // ─── state machine ───────────────────────────────────────────────────────────
 
@@ -101,10 +100,9 @@ const ORD: Ordering = Ordering::SeqCst;
 pub struct AsyncTask {
     state: AtomicU32,
     refs: AtomicU32,
-    /// The owning loop, captured at spawn. Deliberately the specific
-    /// `jsc::EventLoop` (not re-derived per wake): if spawnSync has swapped
-    /// `vm.event_loop`, a wake must still target the regular loop — the task
-    /// then runs after the swap-back, never inside the isolated loop.
+    /// The owning loop, captured at spawn. Wakes may fire from any thread,
+    /// where no TLS lookup exists — the handle pins the loop this task
+    /// belongs to for its whole life.
     event_loop: JsEventLoop,
     js_thread: std::thread::ThreadId,
     /// Embedded envelope for cross-thread wakes. At most one enqueue is in
@@ -214,8 +212,9 @@ impl Schedule for LoopSchedule {
         // SAFETY: same immutable-field read as `enqueue_local`.
         let event_loop = unsafe { (*this).event_loop };
         // `enqueue_task_concurrent` is the `&self` thread-safe surface:
-        // lock-free MPSC push, then `us_wakeup_loop` (lost-wakeup-proof via
-        // the loop's `pending_wakeups` handshake).
+        // lock-free MPSC push, then a loop wakeup that is lose-proof on
+        // every backend (`pending_wakeups` handshake on POSIX, `uv_async`
+        // on Windows).
         event_loop.enqueue_task_concurrent(NonNull::from(node));
     }
 
@@ -410,7 +409,7 @@ unsafe fn poll_with<S: Schedule>(this: *mut AsyncTask) {
                     // Woken mid-poll. Keep the queue reference and go around
                     // again. Note: lands in the live FIFO, so a future that
                     // self-wakes every poll re-runs within the current tick
-                    // (nextTick-like). Use [`yield_now`] judiciously.
+                    // (nextTick-like), never reaching the I/O poll.
                     debug_assert_eq!(actual, NOTIFIED);
                     state.store(SCHEDULED, ORD);
                     // SAFETY: poll runs on the JS thread.
@@ -525,36 +524,6 @@ where
     // first poll consumes the SCHEDULED state exactly as a queue dispatch
     // would; the state machine does not distinguish the two entry paths.
     unsafe { poll_with::<LoopSchedule>(this) };
-}
-
-// ─── yield_now ───────────────────────────────────────────────────────────────
-
-/// Cooperatively yield: wake immediately and return `Pending` once.
-///
-/// The re-poll happens within the **current** tick (the re-enqueue lands in
-/// the live FIFO), so this yields to other queued tasks and microtasks — it
-/// does not reach the I/O poll. A "yield past I/O" awaits a 0-deadline timer
-/// instead (ships with the timer leaf future).
-pub fn yield_now() -> YieldNow {
-    YieldNow { yielded: false }
-}
-
-pub struct YieldNow {
-    yielded: bool,
-}
-
-impl Future for YieldNow {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        if self.yielded {
-            Poll::Ready(())
-        } else {
-            self.yielded = true;
-            cx.waker().wake_by_ref();
-            Poll::Pending
-        }
-    }
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -781,7 +750,7 @@ mod tests {
         unsafe { release_with::<TestSchedule>(this) };
         // Remaining refs: the original `waker` clone (waker2 was consumed by
         // `wake()`). Dropping it frees the allocation (not observable here;
-        // ASAN/LSan in CI assert it).
+        // Miri verifies the free in last_waker_ref_dropped_off_thread_deallocs).
         drop(waker);
     }
 

--- a/src/event_loop/ConcurrentTask.rs
+++ b/src/event_loop/ConcurrentTask.rs
@@ -76,6 +76,7 @@ pub mod task_tag {
         ArchiveFilesTask,
         AsyncGlobWalkTask,
         AsyncImageTask,
+        AsyncTask,
         AsyncTransformTask,
         BakeHotReloadEvent,       // bun.bake.DevServer.HotReloadEvent
         BundleV2DeferredBatchTask, // bun.bundle_v2.DeferredBatchTask

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -2,6 +2,7 @@
 #![warn(unused_must_use)]
 pub mod AnyTask;
 pub mod AnyTaskWithExtraContext;
+pub mod AsyncTask;
 pub mod AutoFlusher;
 pub mod ConcurrentTask;
 pub mod DeferredTaskQueue;

--- a/src/jsc/async_promise.rs
+++ b/src/jsc/async_promise.rs
@@ -54,7 +54,14 @@ where
                 promise.reject_with_async_stack(global, Ok(global.create_out_of_memory_error()))
             }
             Err(_) => match global.try_take_exception() {
-                Some(exception) => promise.reject_with_async_stack(global, Ok(exception)),
+                Some(exception) => {
+                    // Match `JSPromise::reject`'s normalization: unwrap a
+                    // `JSC::Exception` cell to the thrown error so the
+                    // rejection reason and async-stack attachment behave
+                    // exactly like a plain `throw`.
+                    let exception = exception.to_error().unwrap_or(exception);
+                    promise.reject_with_async_stack(global, Ok(exception))
+                }
                 // Same contract violation `JSPromise::reject` panics on: an
                 // `Err` future output requires the exception to be pending.
                 None => panic!(

--- a/src/jsc/async_promise.rs
+++ b/src/jsc/async_promise.rs
@@ -1,0 +1,67 @@
+//! `async fn` → `JSPromise` bridge.
+//!
+//! [`js_promise`] is the blessed way to implement a promise-returning native
+//! API as a Rust future: it creates a pending promise, spawns the future onto
+//! the JS event loop (`bun_event_loop::AsyncTask::spawn`), and settles the
+//! promise when the future completes. Settlement happens inside the task
+//! drain loop, so microtasks run at exactly the same point they do for every
+//! hand-rolled completion task, with no extra ceremony.
+//!
+//! The future may capture `!Send` JS-thread state; anything held across an
+//! `.await` must be GC-rooted (`Strong`/`JsRef` — never a bare `JSValue`).
+//! Rejection follows the same contract as host functions: return
+//! `Err(JsError)` with the exception pending (e.g. via
+//! `global.throw_value(...)`); the bridge takes the exception, attaches async
+//! stack frames from the promise's await chain, and rejects — mirroring
+//! `JSPromise::reject` + `reject_with_async_stack`.
+
+use core::future::Future;
+
+use crate::{JSGlobalObject, JSPromiseStrong, JSValue, JsError, JsResult};
+
+/// Create a JS promise driven by `fut`.
+///
+/// **Eager, like `new Promise(executor)`**: `fut` runs synchronously up to
+/// its first `.await` before this returns — pool work and I/O it issues
+/// start at exactly the point a hand-rolled task would have started them.
+/// When work begins is observable API surface; conversions must not defer it.
+/// A future that is ready immediately settles the promise synchronously
+/// (JS-legal: reactions still run on the microtask queue).
+///
+/// `Ok(v)` resolves with `v`; `Err` rejects with the pending VM exception
+/// (async stack attached); termination leaves the promise pending, like
+/// every existing task that observes a dying VM.
+pub fn js_promise<Fut>(global: &JSGlobalObject, fut: Fut) -> JSValue
+where
+    Fut: Future<Output = JsResult<JSValue>> + 'static,
+{
+    let mut promise = JSPromiseStrong::init(global);
+    let value = promise.value();
+    let global_ptr = core::ptr::from_ref(global);
+    bun_event_loop::AsyncTask::spawn(async move {
+        let result = fut.await;
+        // SAFETY: spawned futures are polled — and, via the shutdown release
+        // hook, dropped — on the JS thread while the VM is alive; the global
+        // outlives every spawned task (same contract as the raw
+        // `*const JSGlobalObject` every completion task stores today).
+        let global = unsafe { &*global_ptr };
+        let _ = match result {
+            Ok(v) => promise.resolve(global, v),
+            // The VM is going away; leave the promise pending (matches every
+            // existing completion path that observes termination).
+            Err(JsError::Terminated) => Ok(()),
+            Err(JsError::OutOfMemory) => {
+                promise.reject_with_async_stack(global, Ok(global.create_out_of_memory_error()))
+            }
+            Err(_) => match global.try_take_exception() {
+                Some(exception) => promise.reject_with_async_stack(global, Ok(exception)),
+                // Same contract violation `JSPromise::reject` panics on: an
+                // `Err` future output requires the exception to be pending.
+                None => panic!(
+                    "js_promise: future returned Err but the exception was cleared before it could be read."
+                ),
+            },
+        };
+    });
+    value
+}

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1334,7 +1334,8 @@ fn el_ref<'a>(owner: *mut ()) -> &'a mut EventLoop {
 
 // `this: *mut EventLoop` — owner was erased from a live `*mut EventLoop` in
 // `__bun_js_event_loop_current` / `EventLoopHandle::js`. All calls run on the
-// JS thread.
+// JS thread, except `enqueue_task_concurrent` (the `&self` thread-safe
+// surface; async-task wakers dispatch it from any thread).
 bun_event_loop::link_impl_JsEventLoop! {
     Jsc for EventLoop => |this| {
         // Reads the EventLoop's own `uws_loop` field; on

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -57,6 +57,7 @@ pub const CONV: &str = "C";
 // Submodules. Each `#[path]` points at the actual PascalCase / snake_case
 // .rs file.
 // ──────────────────────────────────────────────────────────────────────────
+pub mod async_promise;
 #[path = "CommonAbortReason.rs"]
 pub mod common_abort_reason;
 #[path = "CustomGetterSetter.rs"]

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -3,22 +3,14 @@ use core::fmt::Write as _;
 use std::io::Write as _;
 
 use bun_core::ZigString;
-use bun_io::KeepAlive;
-use bun_jsc::{
-    self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsError, JsResult, WorkPoolTask,
-};
-// `bun_jsc::{AnyTask, ConcurrentTask, EventLoop}` are *modules* (re-exported from
-// `bun_event_loop`); pull the concrete types out by name.
-use bun_jsc::event_loop::EventLoop;
+use bun_jsc::{self as jsc, CallFrame, JSFunction, JSGlobalObject, JSValue, JsError, JsResult};
 // JSC-side ZigString carries `to_js` (the `bun_core::ZigString` repr-twin
 // lives in `bun_jsc::zig_string`); used for ASCII→JS conversions only.
-use bun_jsc::AnyTask::{AnyTask, JsResult as AnyTaskJsResult};
-use bun_jsc::ConcurrentTask::ConcurrentTask;
+use bun_jsc::JSPromise;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::zig_string::ZigString as JscZigString;
-use bun_jsc::{JSPromise, JSPromiseStrong};
-use bun_threading::work_pool::WorkPool;
 
+use bun_alloc::SensitiveBytes;
 use crate::node::StringOrBuffer;
 
 // The argon2/bcrypt API-surface shim lives at `crypto::pwhash` (this dir);
@@ -501,13 +493,14 @@ pub(crate) extern "C" fn JSPasswordObject__create(global_object: &JSGlobalObject
 // both into one `PasswordJob<Op>` / `PasswordResult<Op>` parameterised on a
 // `PasswordOp` carrying exactly those three axes.
 
-trait PasswordOp: 'static {
+trait PasswordOp: Send + 'static {
     /// Success payload (`Box<[u8]>` for hash, `bool` for verify).
-    type Value;
+    /// `Send`: produced on the work pool, converted on the JS thread.
+    type Value: Send;
     /// "hashing" | "verification" — slotted into the JS Error message.
     const ERR_VERB: &'static str;
     /// Off-thread compute. `self` borrows the op so its inputs stay owned by
-    /// the job and are `free_sensitive`d in the job's / op's `Drop`.
+    /// the pool closure; sensitive inputs are `SensitiveBytes`, zeroed on drop.
     fn compute(&self, password: &[u8]) -> Result<Self::Value, HashError>;
     /// Convert the success payload to a `JSValue` on the JS thread.
     fn to_js(value: Self::Value, g: &JSGlobalObject) -> JSValue;
@@ -529,15 +522,8 @@ impl PasswordOp for HashOp {
 }
 
 struct VerifyOp {
-    prev_hash: Box<[u8]>,
+    prev_hash: SensitiveBytes,
     algorithm: Option<Algorithm>,
-}
-impl Drop for VerifyOp {
-    fn drop(&mut self) {
-        // bun.freeSensitive — volatile-zero then free; the job's Drop handles
-        // `password`, this handles the op-specific `prev_hash`.
-        bun_alloc::free_sensitive(core::mem::take(&mut self.prev_hash));
-    }
 }
 impl PasswordOp for VerifyOp {
     type Value = bool;
@@ -570,110 +556,15 @@ fn password_error_instance(err: HashError, verb: &str, g: &JSGlobalObject) -> JS
     instance
 }
 
-struct PasswordJob<Op: PasswordOp> {
-    op: Op,
-    password: Box<[u8]>,
-    promise: JSPromiseStrong,
-    event_loop: *mut EventLoop,
-    global: *const JSGlobalObject,
-    r#ref: KeepAlive,
-    task: WorkPoolTask,
-}
-
-impl<Op: PasswordOp> Drop for PasswordJob<Op> {
-    fn drop(&mut self) {
-        // promise: Drop on JSPromiseStrong handles deinit.
-        // bun.freeSensitive — volatile-zero the buffer then free; take the Box so
-        // the field's own Drop sees an empty slice afterwards. Any op-owned
-        // sensitive buffers (`prev_hash`) are freed by the op's own `Drop`.
-        bun_alloc::free_sensitive(core::mem::take(&mut self.password));
-    }
-}
-
-bun_threading::owned_task!([Op: PasswordOp] PasswordJob<Op>, task);
-
-impl<Op: PasswordOp> PasswordJob<Op> {
-    // `owned_task!` requires `fn run_owned(self: Box<Self>)`; clippy::boxed_local
-    // is a false positive on this macro contract.
-    #[allow(clippy::boxed_local)]
-    fn run_owned(mut self: Box<Self>) {
-        let value = self.op.compute(&self.password);
-        let result = bun_core::heap::into_raw(Box::new(PasswordResult::<Op> {
-            value,
-            task: AnyTask::default(), // overwritten below
-            promise: core::mem::take(&mut self.promise),
-            global: self.global,
-            r#ref: core::mem::take(&mut self.r#ref),
-        }));
-        // SAFETY: `result` was just heap-allocated and is not yet shared
-        // (enqueue happens after this write).
-        unsafe {
-            (*result).task = AnyTask::from_typed(result, PasswordResult::<Op>::run_from_js_erased);
-        }
-        // SAFETY: `event_loop` was stored from the JS-thread VM and outlives the
-        // job; ownership of `result` transfers to the event loop here. `task` is
-        // an intrusive field at a stable address.
-        unsafe {
-            (*self.event_loop).enqueue_task_concurrent(ConcurrentTask::create_from(
-                core::ptr::addr_of_mut!((*result).task),
-            ));
-        }
-        // `self: Box<Self>` drops here; Drop runs secure_zero on password (+op).
-    }
-}
-
-struct PasswordResult<Op: PasswordOp> {
-    value: Result<Op::Value, HashError>,
-    r#ref: KeepAlive,
-    task: AnyTask,
-    promise: JSPromiseStrong,
-    global: *const JSGlobalObject,
-}
-
-impl<Op: PasswordOp> PasswordResult<Op> {
-    fn run_from_js_erased(p: *mut Self) -> AnyTaskJsResult<()> {
-        Self::run_from_js(p)
-            .map_err(|_: jsc::JsTerminated| bun_event_loop::ErasedJsError::Terminated)
-    }
-
-    fn run_from_js(this: *mut Self) -> Result<(), jsc::JsTerminated> {
-        // SAFETY: `this` was produced by heap::into_raw in `run_owned` and the
-        // event loop hands sole ownership to this callback. Reclaim the Box once
-        // up-front so all fields drop on scope exit (no `mem::replace` dance).
-        let this = *unsafe { bun_core::heap::take(this) };
-        let PasswordResult {
-            value,
-            mut r#ref,
-            mut promise,
-            global,
-            task: _,
-        } = this;
-        // SAFETY: `global` stored from a live `&JSGlobalObject`; VM outlives the task.
-        let global = unsafe { &*global };
-        r#ref.unref(bun_io::js_vm_ctx());
-        match value {
-            Err(err) => {
-                let error_instance = password_error_instance(err, Op::ERR_VERB, global);
-                promise.reject_with_async_stack(global, Ok(error_instance))?;
-            }
-            Ok(v) => {
-                let js = Op::to_js(v, global);
-                promise.resolve(global, js)?;
-            }
-        }
-        Ok(())
-    }
-}
-
 // ─── hash / verify entry points ───────────────────────────────────────────
 
 impl JSPasswordObject {
     /// Shared body of `hash`/`verify`: sync path computes inline and either
-    /// throws or returns the converted value; async path boxes a
-    /// `PasswordJob<Op>`, refs the loop, and schedules it.
+    /// throws or returns the converted value; async path runs the compute on
+    /// the work pool and settles a promise (`js_promise` + `work_pool::run`).
     fn run<Op: PasswordOp, const SYNC: bool>(
         global_object: &JSGlobalObject,
-        password: Box<[u8]>,
+        password: SensitiveBytes,
         op: Op,
     ) -> JsResult<JSValue> {
         debug_assert!(!password.is_empty()); // caller must check
@@ -688,28 +579,28 @@ impl JSPasswordObject {
             };
         }
 
-        let promise = JSPromiseStrong::init(global_object);
-        let promise_value = promise.value();
-
-        let mut job = Box::new(PasswordJob::<Op> {
-            op,
-            password,
-            promise,
-            // SAFETY: bun_vm() is non-null for a Bun-owned global; VM outlives the job.
-            event_loop: global_object.bun_vm().event_loop(),
-            global: std::ptr::from_ref(global_object),
-            r#ref: KeepAlive::default(),
-            task: WorkPoolTask::default(),
-        });
-        job.r#ref.ref_(bun_io::js_vm_ctx());
-        WorkPool::schedule_owned(job);
-
-        Ok(promise_value)
+        let global = core::ptr::from_ref(global_object);
+        Ok(jsc::async_promise::js_promise(global_object, async move {
+            // The closure's captures drop on the pool thread right after
+            // compute; `SensitiveBytes` volatile-zeroes `password` (and the
+            // op's `prev_hash`) wherever they die.
+            let value = bun_threading::work_pool::run(move || op.compute(&password)).await;
+            // SAFETY: spawned futures run (and are dropped) on the JS thread
+            // while the VM is alive; the global outlives every spawned task.
+            let global_object = unsafe { &*global };
+            match value {
+                Ok(v) => Ok(Op::to_js(v, global_object)),
+                Err(err) => {
+                    let error_instance = password_error_instance(err, Op::ERR_VERB, global_object);
+                    Err(global_object.throw_value(error_instance))
+                }
+            }
+        }))
     }
 
     pub fn hash<const SYNC: bool>(
         global_object: &JSGlobalObject,
-        password: Box<[u8]>,
+        password: SensitiveBytes,
         algorithm: AlgorithmValue,
     ) -> JsResult<JSValue> {
         Self::run::<HashOp, SYNC>(global_object, password, HashOp { algorithm })
@@ -717,8 +608,8 @@ impl JSPasswordObject {
 
     pub fn verify<const SYNC: bool>(
         global_object: &JSGlobalObject,
-        password: Box<[u8]>,
-        prev_hash: Box<[u8]>,
+        password: SensitiveBytes,
+        prev_hash: SensitiveBytes,
         algorithm: Option<Algorithm>,
     ) -> JsResult<JSValue> {
         Self::run::<VerifyOp, SYNC>(
@@ -769,7 +660,7 @@ pub(crate) fn js_password_object_hash(
 
     JSPasswordObject::hash::<false>(
         global_object,
-        password_to_hash.into_boxed_slice(),
+        password_to_hash.into_boxed_slice().into(),
         algorithm,
     )
 }
@@ -808,11 +699,11 @@ pub(crate) fn js_password_object_hash_sync(
         );
     }
 
-    // The sync path only needs `&[u8]`; copy into a Box to share the async
-    // signature.
+    // The sync path only needs `&[u8]`; copy into a `SensitiveBytes` to
+    // share the async signature.
     JSPasswordObject::hash::<true>(
         global_object,
-        Box::<[u8]>::from(string_or_buffer.slice()),
+        Box::<[u8]>::from(string_or_buffer.slice()).into(),
         algorithm,
     )
 }
@@ -894,8 +785,8 @@ pub(crate) fn js_password_object_verify(
 
     JSPasswordObject::verify::<false>(
         global_object,
-        owned_password.into_boxed_slice(),
-        owned_hash.into_boxed_slice(),
+        owned_password.into_boxed_slice().into(),
+        owned_hash.into_boxed_slice().into(),
         algorithm,
     )
 }
@@ -964,12 +855,12 @@ pub(crate) fn js_password_object_verify_sync(
         return Ok(JSValue::FALSE);
     }
 
-    // The sync path only needs `&[u8]`; copy into Boxes to share the async
-    // signature.
+    // The sync path only needs `&[u8]`; copy into `SensitiveBytes` to share
+    // the async signature.
     JSPasswordObject::verify::<true>(
         global_object,
-        Box::<[u8]>::from(password.slice()),
-        Box::<[u8]>::from(hash_.slice()),
+        Box::<[u8]>::from(password.slice()).into(),
+        Box::<[u8]>::from(hash_.slice()).into(),
         algorithm,
     )
 }

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -488,10 +488,10 @@ pub(crate) extern "C" fn JSPasswordObject__create(global_object: &JSGlobalObject
 
 // ─── PasswordOp: generic hash/verify off-thread job ───────────────────────
 //
-// Hash and verify jobs differ only in (a) extra input fields, (b) success
-// payload type + JS conversion, (c) the verb in the error message. Collapse
-// both into one `PasswordJob<Op>` / `PasswordResult<Op>` parameterised on a
-// `PasswordOp` carrying exactly those three axes.
+// Hash and verify differ only in (a) extra input fields, (b) success payload
+// type + JS conversion, (c) the verb in the error message. Both collapse into
+// one async `run` parameterised on a `PasswordOp` carrying exactly those
+// three axes.
 
 trait PasswordOp: Send + 'static {
     /// Success payload (`Box<[u8]>` for hash, `bool` for verify).
@@ -583,7 +583,8 @@ impl JSPasswordObject {
         Ok(jsc::async_promise::js_promise(global_object, async move {
             // The closure's captures drop on the pool thread right after
             // compute; `SensitiveBytes` volatile-zeroes `password` (and the
-            // op's `prev_hash`) wherever they die.
+            // op's `prev_hash`) wherever they die. Parse-time intermediates
+            // (`StringOrBuffer` copies) are out of scope, as before.
             let value = bun_threading::work_pool::run(move || op.compute(&password)).await;
             // SAFETY: spawned futures run (and are dropped) on the JS thread
             // while the VM is alive; the global outlives every spawned task.
@@ -658,11 +659,7 @@ pub(crate) fn js_password_object_hash(
         );
     }
 
-    JSPasswordObject::hash::<false>(
-        global_object,
-        password_to_hash.into_boxed_slice().into(),
-        algorithm,
-    )
+    JSPasswordObject::hash::<false>(global_object, password_to_hash.into(), algorithm)
 }
 
 // Once we have bindings generator, this should be replaced with a generated function
@@ -785,8 +782,8 @@ pub(crate) fn js_password_object_verify(
 
     JSPasswordObject::verify::<false>(
         global_object,
-        owned_password.into_boxed_slice().into(),
-        owned_hash.into_boxed_slice().into(),
+        owned_password.into(),
+        owned_hash.into(),
         algorithm,
     )
 }

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -10,8 +10,8 @@ use bun_jsc::JSPromise;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::zig_string::ZigString as JscZigString;
 
-use bun_alloc::SensitiveBytes;
 use crate::node::StringOrBuffer;
+use bun_alloc::SensitiveBytes;
 
 // The argon2/bcrypt API-surface shim lives at `crypto::pwhash` (this dir);
 // the implementation is wired there, not here.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -25,6 +25,7 @@
 pub mod js2native;
 
 use bun_event_loop::AnyTask::AnyTask;
+use bun_event_loop::AsyncTask::AsyncTask;
 use bun_event_loop::ManagedTask::ManagedTask;
 use bun_event_loop::{Task, task_tag};
 
@@ -269,6 +270,15 @@ pub fn run_task(
             if let Err(err) = cast!(CppTask).run(global) {
                 report_error_or_terminate(global, err)?;
             }
+        }
+        task_tag::AsyncTask => {
+            // SAFETY: §Dispatch — tag identifies pointee; the pointer is the
+            // pinned executor allocation, kept alive by the queue reference
+            // taken at wake. The poll body may re-enter JS/the event loop
+            // through TLS; `run_from_js` holds no `&`/`&mut` across the poll
+            // (raw per-field projections only). JS errors are handled inside
+            // the future (a poll has no JS-error channel by construction).
+            unsafe { AsyncTask::run_from_js(cast_ptr!(AsyncTask)) };
         }
 
         // ── archive ──────────────────────────────────────────────────────
@@ -579,7 +589,7 @@ fn run_task_cold(task: Task) {
 /// Compile-time guard that the arm count above tracks
 /// `bun_event_loop::task_tag::COUNT`. Bump when adding a variant.
 const _: () = assert!(
-    task_tag::COUNT == 96,
+    task_tag::COUNT == 97,
     "dispatch::run_task arm count out of sync with bun_event_loop::task_tag",
 );
 
@@ -1186,6 +1196,17 @@ pub(crate) fn __bun_release_task_at_shutdown(task: bun_event_loop::Task) -> bool
                 }};
             }
             for_each_fs_async_op!(__fs_destroy);
+            true
+        }
+        // A queued-but-never-polled spawned future: drop the future on the
+        // JS thread (it may hold `Strong`s — still valid here, before
+        // `destructOnExit`), release the keepalive and the queue + task
+        // references. Waker clones parked elsewhere release theirs whenever
+        // they drop; by then the header is plain bytes.
+        task_tag::AsyncTask => {
+            // SAFETY: `task.ptr` is the live pinned executor allocation,
+            // drained from the queue in SCHEDULED state on the JS thread.
+            unsafe { AsyncTask::release_at_shutdown(task.ptr.cast::<AsyncTask>()) };
             true
         }
         // Re-queued by the caller; the box stays reachable from the

--- a/src/threading/RwLock.rs
+++ b/src/threading/RwLock.rs
@@ -297,6 +297,7 @@ impl<'a, T> Drop for RwLockWriteGuard<'a, T> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(miri, ignore = "futex FFI is not interpretable under Miri")]
     #[test]
     fn smoke() {
         let rwl = RwLock::new(0u32);
@@ -333,6 +334,7 @@ mod tests {
         let _w = rwl.write();
     }
 
+    #[cfg_attr(miri, ignore = "futex FFI is not interpretable under Miri")]
     #[test]
     fn raw_internal_state() {
         // Regression test: the WRITER flag must be cleared (not subtracted) by lock().

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -225,7 +225,8 @@ impl WorkPool {
 /// `futures_core::task::AtomicWaker` uses: the side that fails to take the
 /// cell lock never spins — it leaves its bit set and the lock holder
 /// resolves the collision on exit. A registrant that observes `WAKING` at
-/// unlock reclaims the waker it just stored; a completer that observes
+/// unlock reclaims the cell's waker (the one it stored, or the surviving
+/// equivalent when the `will_wake` dedup skipped the store); a completer that observes
 /// `REGISTERING` simply returns, knowing the registrant will see `WAKING`.
 const WAITING: u8 = 0;
 const REGISTERING: u8 = 0b01;

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -252,6 +252,33 @@ struct Oneshot<T> {
 // `T: Send` is required by [`run`]'s bounds.
 unsafe impl<T: Send> Sync for Oneshot<T> {}
 
+impl<T: Send> Oneshot<T> {
+    /// Deliver the value and wake the registered waker, if any. Sole
+    /// completion entry point; called exactly once, from the pool thread.
+    fn complete(&self, value: T) {
+        // SAFETY: the completing thread is the only writer of `value`; the
+        // poller reads it only after acquiring `done`.
+        unsafe { *self.value.get() = Some(value) };
+        // Publish the value BEFORE the wake hand-off (state change precedes
+        // wake): a poller that misses the hand-off still observes `done`
+        // after registering.
+        self.done.store(true, Ordering::Release);
+        // Take the cell lock to wake. If the poller is mid-register, leave
+        // `WAKING` set and return — its unlock CAS fails, it reclaims its
+        // waker and reads `done`. Nobody spins.
+        if self.waker_state.fetch_or(WAKING, Ordering::AcqRel) == WAITING {
+            // SAFETY: we hold the cell lock (`WAKING`, was WAITING); a
+            // registrant cannot enter until the store below.
+            let waker = unsafe { (*self.waker.get()).take() };
+            let prev = self.waker_state.swap(WAITING, Ordering::Release);
+            debug_assert_eq!(prev, WAKING);
+            if let Some(waker) = waker {
+                waker.wake();
+            }
+        }
+    }
+}
+
 /// Run `f` on the global [`WorkPool`] and await its result.
 ///
 /// Lazy: nothing is scheduled until the first poll (a future that is never
@@ -304,27 +331,7 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
                 F: FnOnce() -> T + Send + 'static,
                 T: Send + 'static,
             {
-                let value = job();
-                // SAFETY: the pool thread is the only writer of `value`; the
-                // poller reads it only after acquiring `done`.
-                unsafe { *shared.value.get() = Some(value) };
-                // Publish the value BEFORE the wake hand-off (state change
-                // precedes wake): a poller that misses the hand-off still
-                // observes `done` after registering.
-                shared.done.store(true, Ordering::Release);
-                // Take the cell lock to wake. If the poller is mid-register,
-                // leave `WAKING` set and return — its unlock CAS fails, it
-                // reclaims its waker and reads `done`. Nobody spins.
-                if shared.waker_state.fetch_or(WAKING, Ordering::AcqRel) == WAITING {
-                    // SAFETY: we hold the cell lock (`WAKING`, was WAITING);
-                    // a registrant cannot enter until the store below.
-                    let waker = unsafe { (*shared.waker.get()).take() };
-                    let prev = shared.waker_state.swap(WAITING, Ordering::Release);
-                    debug_assert_eq!(prev, WAKING);
-                    if let Some(waker) = waker {
-                        waker.wake();
-                    }
-                }
+                shared.complete(job());
             }
 
             let shared = Arc::clone(&this.shared);
@@ -380,5 +387,139 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
             return Poll::Ready(value.expect("RunOnWorkPool polled after completion"));
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod oneshot_tests {
+    use super::*;
+    use core::sync::atomic::AtomicUsize;
+    use core::task::{Context, RawWaker, RawWakerVTable};
+
+    /// Per-test counting waker: `data` points at a leaked `WakeCounter`, so
+    /// tests are isolated without serialization.
+    struct WakeCounter {
+        wakes: AtomicUsize,
+        clones: AtomicUsize,
+    }
+
+    unsafe fn cw_clone(d: *const ()) -> RawWaker {
+        // SAFETY: `d` is the leaked WakeCounter installed below.
+        unsafe { &*d.cast::<WakeCounter>() }
+            .clones
+            .fetch_add(1, Ordering::Relaxed);
+        RawWaker::new(d, &CW_VT)
+    }
+    unsafe fn cw_wake(d: *const ()) {
+        // SAFETY: as above.
+        unsafe { &*d.cast::<WakeCounter>() }
+            .wakes
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    unsafe fn cw_wake_by_ref(d: *const ()) {
+        // SAFETY: as above.
+        unsafe { &*d.cast::<WakeCounter>() }
+            .wakes
+            .fetch_add(1, Ordering::Relaxed);
+    }
+    unsafe fn cw_drop(_d: *const ()) {}
+    static CW_VT: RawWakerVTable = RawWakerVTable::new(cw_clone, cw_wake, cw_wake_by_ref, cw_drop);
+
+    /// The returned `Box` must outlive every clone of the waker that can
+    /// still be WOKEN (drops are no-ops and never dereference).
+    fn counting_waker() -> (Box<WakeCounter>, Waker) {
+        let c = Box::new(WakeCounter {
+            wakes: AtomicUsize::new(0),
+            clones: AtomicUsize::new(0),
+        });
+        let waker =
+            // SAFETY: vtable fns only touch the counter, which the caller
+            // keeps alive for the duration of the test.
+            unsafe { Waker::from_raw(RawWaker::new(core::ptr::from_ref(&*c).cast::<()>(), &CW_VT)) };
+        (c, waker)
+    }
+
+    fn fresh() -> Arc<Oneshot<i32>> {
+        Arc::new(Oneshot {
+            waker_state: AtomicU8::new(WAITING),
+            done: AtomicBool::new(false),
+            value: UnsafeCell::new(None),
+            waker: UnsafeCell::new(None),
+        })
+    }
+
+    /// A future past its first poll (job already handed off).
+    fn pending(shared: Arc<Oneshot<i32>>) -> RunOnWorkPool<i32, fn() -> i32> {
+        RunOnWorkPool { shared, job: None }
+    }
+
+    #[test]
+    fn complete_before_register_is_ready_without_a_wake() {
+        let shared = fresh();
+        shared.complete(7);
+        let (c, waker) = counting_waker();
+        let mut fut = pending(Arc::clone(&shared));
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Ready(7));
+        assert_eq!(c.wakes.load(Ordering::Relaxed), 0, "nobody to wake");
+    }
+
+    #[test]
+    fn register_then_complete_wakes_exactly_once() {
+        let shared = fresh();
+        let (c, waker) = counting_waker();
+        let mut fut = pending(Arc::clone(&shared));
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending);
+        assert_eq!(c.clones.load(Ordering::Relaxed), 1, "waker stored");
+        shared.complete(9);
+        assert_eq!(c.wakes.load(Ordering::Relaxed), 1, "stored waker woken");
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Ready(9));
+    }
+
+    #[test]
+    fn repoll_with_equivalent_waker_skips_the_clone() {
+        let shared = fresh();
+        let (c, waker) = counting_waker();
+        let mut fut = pending(Arc::clone(&shared));
+        let mut cx = Context::from_waker(&waker);
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending);
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Pending);
+        assert_eq!(
+            c.clones.load(Ordering::Relaxed),
+            1,
+            "will_wake dedup keeps the stored waker"
+        );
+        shared.complete(3);
+        assert_eq!(Pin::new(&mut fut).poll(&mut cx), Poll::Ready(3));
+    }
+
+    #[test]
+    fn stress_register_racing_complete_never_strands_the_poller() {
+        let rounds: i32 = if cfg!(miri) { 25 } else { 1000 };
+        for i in 0..rounds {
+            let shared = fresh();
+            let (_c, waker) = counting_waker();
+            let completer = Arc::clone(&shared);
+            std::thread::scope(|scope| {
+                scope.spawn(move || completer.complete(i));
+                let mut fut = pending(Arc::clone(&shared));
+                let mut cx = Context::from_waker(&waker);
+                let mut spins = 0u64;
+                loop {
+                    match Pin::new(&mut fut).poll(&mut cx) {
+                        Poll::Ready(v) => {
+                            assert_eq!(v, i);
+                            break;
+                        }
+                        Poll::Pending => {
+                            spins += 1;
+                            assert!(spins < 50_000_000, "poller stranded: lost wakeup");
+                            std::thread::yield_now();
+                        }
+                    }
+                }
+            });
+        }
     }
 }

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -1,7 +1,7 @@
 use core::cell::UnsafeCell;
 use core::future::Future;
 use core::pin::Pin;
-use core::sync::atomic::{AtomicU8, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use core::task::{Context, Poll, Waker};
 use std::sync::Arc;
 use std::sync::OnceLock;
@@ -221,28 +221,34 @@ impl WorkPool {
 
 // ─── awaitable offload ───────────────────────────────────────────────────────
 
-/// Oneshot completion state. `RUNNING`: the job may still produce a value.
-/// `WAKER_BUSY`: the poller is swapping the waker; completion spins briefly.
-/// `DONE`: the value is written and release-published.
-const RUNNING: u8 = 0;
-const WAKER_BUSY: u8 = 1;
-const DONE: u8 = 2;
+/// Waker-cell lock states. The hand-off protocol is the one
+/// `futures_core::task::AtomicWaker` uses: the side that fails to take the
+/// cell lock never spins — it leaves its bit set and the lock holder
+/// resolves the collision on exit. A registrant that observes `WAKING` at
+/// unlock reclaims the waker it just stored; a completer that observes
+/// `REGISTERING` simply returns, knowing the registrant will see `WAKING`.
+const WAITING: u8 = 0;
+const REGISTERING: u8 = 0b01;
+const WAKING: u8 = 0b10;
 
 /// Result cell shared between the pool thread and the awaiting task.
 ///
-/// `value` is written only by the pool thread before `DONE` and read only by
-/// the poller after observing `DONE`. `waker` is touched by the poller before
-/// the job is scheduled or inside the `WAKER_BUSY` window, and by the pool
-/// thread only after winning the `RUNNING→DONE` transition — never
-/// concurrently.
+/// `done` publishes the value: stored `Release` by the pool thread after the
+/// `value` write, loaded `Acquire` by the poller. The `waker` cell is guarded
+/// by `waker_state` (protocol above). The poller registers its waker and
+/// *then* re-checks `done` — the canonical register-before-checking order
+/// that makes a completion racing the registration impossible to lose: if
+/// the completion's take ran first, `done` was already set before it.
 struct Oneshot<T> {
-    state: AtomicU8,
+    waker_state: AtomicU8,
+    done: AtomicBool,
     value: UnsafeCell<Option<T>>,
     waker: UnsafeCell<Option<Waker>>,
 }
 
-// SAFETY: cross-thread access to the `UnsafeCell`s is mediated by the `state`
-// protocol documented above; `T: Send` is required by [`run`]'s bounds.
+// SAFETY: cross-thread access to the `UnsafeCell`s is mediated by the
+// `waker_state` lock (waker cell) and the `done` publish (value cell);
+// `T: Send` is required by [`run`]'s bounds.
 unsafe impl<T: Send> Sync for Oneshot<T> {}
 
 /// Run `f` on the global [`WorkPool`] and await its result.
@@ -259,7 +265,8 @@ where
 {
     RunOnWorkPool {
         shared: Arc::new(Oneshot {
-            state: AtomicU8::new(RUNNING),
+            waker_state: AtomicU8::new(WAITING),
+            done: AtomicBool::new(false),
             value: UnsafeCell::new(None),
             waker: UnsafeCell::new(None),
         }),
@@ -285,10 +292,10 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
         let this = self.get_mut();
 
         if let Some(job) = this.job.take() {
-            // First poll: register the waker BEFORE scheduling so the
+            // First poll: store the waker BEFORE scheduling so the
             // completion can never miss it, then hand the job to the pool.
             // SAFETY: the job is not yet scheduled — no other thread exists
-            // that could touch `waker`.
+            // that could touch `waker` (the schedule hand-off publishes it).
             unsafe { *this.shared.waker.get() = Some(cx.waker().clone()) };
 
             fn finish<T, F>((shared, job): (Arc<Oneshot<T>>, F))
@@ -297,22 +304,25 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
                 T: Send + 'static,
             {
                 let value = job();
-                // SAFETY: the pool thread is the only writer of `value`, and
-                // the poller reads it only after observing `DONE`.
+                // SAFETY: the pool thread is the only writer of `value`; the
+                // poller reads it only after acquiring `done`.
                 unsafe { *shared.value.get() = Some(value) };
-                // Win the baton; a poller mid-waker-swap holds `WAKER_BUSY`
-                // for a few instructions at most.
-                while shared
-                    .state
-                    .compare_exchange(RUNNING, DONE, Ordering::AcqRel, Ordering::Acquire)
-                    .is_err()
-                {
-                    std::thread::yield_now();
-                }
-                // SAFETY: once `DONE` is published the poller never touches
-                // `waker` again (it goes straight to the value).
-                if let Some(waker) = unsafe { (*shared.waker.get()).take() } {
-                    waker.wake();
+                // Publish the value BEFORE the wake hand-off (state change
+                // precedes wake): a poller that misses the hand-off still
+                // observes `done` after registering.
+                shared.done.store(true, Ordering::Release);
+                // Take the cell lock to wake. If the poller is mid-register,
+                // leave `WAKING` set and return — its unlock CAS fails, it
+                // reclaims its waker and reads `done`. Nobody spins.
+                if shared.waker_state.fetch_or(WAKING, Ordering::AcqRel) == WAITING {
+                    // SAFETY: we hold the cell lock (`WAKING`, was WAITING);
+                    // a registrant cannot enter until the store below.
+                    let waker = unsafe { (*shared.waker.get()).take() };
+                    let prev = shared.waker_state.swap(WAITING, Ordering::Release);
+                    debug_assert_eq!(prev, WAKING);
+                    if let Some(waker) = waker {
+                        waker.wake();
+                    }
                 }
             }
 
@@ -321,34 +331,53 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
             return Poll::Pending;
         }
 
-        if this.shared.state.load(Ordering::Acquire) == DONE {
-            // SAFETY: `DONE` was release-published after the value write;
+        // Re-poll: register first, then check `done` — never the reverse.
+        match this.shared.waker_state.compare_exchange(
+            WAITING,
+            REGISTERING,
+            Ordering::Acquire,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {
+                // Lock held: refresh the cell, skipping the clone when the
+                // stored waker already wakes this task.
+                // SAFETY: `REGISTERING` excludes the completion's take.
+                unsafe {
+                    match &*this.shared.waker.get() {
+                        Some(old) if old.will_wake(cx.waker()) => {}
+                        _ => *this.shared.waker.get() = Some(cx.waker().clone()),
+                    }
+                }
+                // Unlock. Failure means the completion set `WAKING` while we
+                // held the lock and backed off without the waker: reclaim it
+                // (the `done` check below settles the poll — the completion
+                // published `done` before `WAKING`, and our failed CAS
+                // acquired that edge).
+                if this
+                    .shared
+                    .waker_state
+                    .compare_exchange(REGISTERING, WAITING, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+                {
+                    // SAFETY: the completion never touches the cell after
+                    // observing `REGISTERING`; it is ours until the swap.
+                    let _stale = unsafe { (*this.shared.waker.get()).take() };
+                    let prev = this.shared.waker_state.swap(WAITING, Ordering::AcqRel);
+                    debug_assert_eq!(prev, REGISTERING | WAKING);
+                }
+            }
+            // The completion holds the cell lock (mid-take of the previous
+            // waker). `done` was published before `WAKING`, and this failed
+            // CAS acquired it — fall through to the check.
+            Err(actual) => debug_assert_eq!(actual & WAKING, WAKING, "single poller"),
+        }
+
+        if this.shared.done.load(Ordering::Acquire) {
+            // SAFETY: `done` was release-published after the value write;
             // the single poller takes the value exactly once.
             let value = unsafe { (*this.shared.value.get()).take() };
             return Poll::Ready(value.expect("RunOnWorkPool polled after completion"));
         }
-
-        // Re-polled before completion (e.g. a spurious wake of the parent
-        // task): refresh the waker under the `WAKER_BUSY` baton so the
-        // completion can't read it concurrently.
-        match this.shared.state.compare_exchange(
-            RUNNING,
-            WAKER_BUSY,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => {
-                // SAFETY: `WAKER_BUSY` excludes the completion's waker read.
-                unsafe { *this.shared.waker.get() = Some(cx.waker().clone()) };
-                this.shared.state.store(RUNNING, Ordering::Release);
-                Poll::Pending
-            }
-            Err(_) => {
-                // Completion won the race; the value is ready now.
-                // SAFETY: as in the `DONE` fast path above.
-                let value = unsafe { (*this.shared.value.get()).take() };
-                Poll::Ready(value.expect("RunOnWorkPool polled after completion"))
-            }
-        }
+        Poll::Pending
     }
 }

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -1,3 +1,9 @@
+use core::cell::UnsafeCell;
+use core::future::Future;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU8, Ordering};
+use core::task::{Context, Poll, Waker};
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use crate::ThreadPool;
@@ -210,5 +216,138 @@ impl WorkPool {
         // SAFETY: task_ is a valid Box-allocated TaskType<C>; .task is its first field.
         Self::schedule(unsafe { &raw mut (*task_).task });
         Ok(())
+    }
+}
+
+// ─── awaitable offload ───────────────────────────────────────────────────────
+
+/// Oneshot completion state. `RUNNING`: the job may still produce a value.
+/// `WAKER_BUSY`: the poller is swapping the waker; completion spins briefly.
+/// `DONE`: the value is written and release-published.
+const RUNNING: u8 = 0;
+const WAKER_BUSY: u8 = 1;
+const DONE: u8 = 2;
+
+/// Result cell shared between the pool thread and the awaiting task.
+///
+/// `value` is written only by the pool thread before `DONE` and read only by
+/// the poller after observing `DONE`. `waker` is touched by the poller before
+/// the job is scheduled or inside the `WAKER_BUSY` window, and by the pool
+/// thread only after winning the `RUNNING→DONE` transition — never
+/// concurrently.
+struct Oneshot<T> {
+    state: AtomicU8,
+    value: UnsafeCell<Option<T>>,
+    waker: UnsafeCell<Option<Waker>>,
+}
+
+// SAFETY: cross-thread access to the `UnsafeCell`s is mediated by the `state`
+// protocol documented above; `T: Send` is required by [`run`]'s bounds.
+unsafe impl<T: Send> Sync for Oneshot<T> {}
+
+/// Run `f` on the global [`WorkPool`] and await its result.
+///
+/// Lazy: nothing is scheduled until the first poll (a future that is never
+/// polled never runs the closure). Once scheduled, the closure runs exactly
+/// once even if the future is dropped early — there is no cancellation, same
+/// as every existing pool task; the result is then discarded with the shared
+/// cell.
+pub fn run<T, F>(f: F) -> RunOnWorkPool<T, F>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    RunOnWorkPool {
+        shared: Arc::new(Oneshot {
+            state: AtomicU8::new(RUNNING),
+            value: UnsafeCell::new(None),
+            waker: UnsafeCell::new(None),
+        }),
+        job: Some(f),
+    }
+}
+
+/// Future returned by [`run`].
+pub struct RunOnWorkPool<T: Send + 'static, F: FnOnce() -> T + Send + 'static> {
+    shared: Arc<Oneshot<T>>,
+    job: Option<F>,
+}
+
+// No field is structurally pinned: `job` is moved out (never polled through)
+// and `shared` is an `Arc`. The future itself holds no self-references.
+impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Unpin for RunOnWorkPool<T, F> {}
+
+impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkPool<T, F> {
+    type Output = T;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        // `RunOnWorkPool` is `Unpin` (`Arc` + `Option<F>`), so no projection.
+        let this = self.get_mut();
+
+        if let Some(job) = this.job.take() {
+            // First poll: register the waker BEFORE scheduling so the
+            // completion can never miss it, then hand the job to the pool.
+            // SAFETY: the job is not yet scheduled — no other thread exists
+            // that could touch `waker`.
+            unsafe { *this.shared.waker.get() = Some(cx.waker().clone()) };
+
+            fn finish<T, F>((shared, job): (Arc<Oneshot<T>>, F))
+            where
+                F: FnOnce() -> T + Send + 'static,
+                T: Send + 'static,
+            {
+                let value = job();
+                // SAFETY: the pool thread is the only writer of `value`, and
+                // the poller reads it only after observing `DONE`.
+                unsafe { *shared.value.get() = Some(value) };
+                // Win the baton; a poller mid-waker-swap holds `WAKER_BUSY`
+                // for a few instructions at most.
+                while shared
+                    .state
+                    .compare_exchange(RUNNING, DONE, Ordering::AcqRel, Ordering::Acquire)
+                    .is_err()
+                {
+                    std::thread::yield_now();
+                }
+                // SAFETY: once `DONE` is published the poller never touches
+                // `waker` again (it goes straight to the value).
+                if let Some(waker) = unsafe { (*shared.waker.get()).take() } {
+                    waker.wake();
+                }
+            }
+
+            let shared = Arc::clone(&this.shared);
+            bun_core::handle_oom(WorkPool::go((shared, job), finish::<T, F>));
+            return Poll::Pending;
+        }
+
+        if this.shared.state.load(Ordering::Acquire) == DONE {
+            // SAFETY: `DONE` was release-published after the value write;
+            // the single poller takes the value exactly once.
+            let value = unsafe { (*this.shared.value.get()).take() };
+            return Poll::Ready(value.expect("RunOnWorkPool polled after completion"));
+        }
+
+        // Re-polled before completion (e.g. a spurious wake of the parent
+        // task): refresh the waker under the `WAKER_BUSY` baton so the
+        // completion can't read it concurrently.
+        match this
+            .shared
+            .state
+            .compare_exchange(RUNNING, WAKER_BUSY, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => {
+                // SAFETY: `WAKER_BUSY` excludes the completion's waker read.
+                unsafe { *this.shared.waker.get() = Some(cx.waker().clone()) };
+                this.shared.state.store(RUNNING, Ordering::Release);
+                Poll::Pending
+            }
+            Err(_) => {
+                // Completion won the race; the value is ready now.
+                // SAFETY: as in the `DONE` fast path above.
+                let value = unsafe { (*this.shared.value.get()).take() };
+                Poll::Ready(value.expect("RunOnWorkPool polled after completion"))
+            }
+        }
     }
 }

--- a/src/threading/work_pool.rs
+++ b/src/threading/work_pool.rs
@@ -331,11 +331,12 @@ impl<T: Send + 'static, F: FnOnce() -> T + Send + 'static> Future for RunOnWorkP
         // Re-polled before completion (e.g. a spurious wake of the parent
         // task): refresh the waker under the `WAKER_BUSY` baton so the
         // completion can't read it concurrently.
-        match this
-            .shared
-            .state
-            .compare_exchange(RUNNING, WAKER_BUSY, Ordering::AcqRel, Ordering::Acquire)
-        {
+        match this.shared.state.compare_exchange(
+            RUNNING,
+            WAKER_BUSY,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
             Ok(_) => {
                 // SAFETY: `WAKER_BUSY` excludes the completion's waker read.
                 unsafe { *this.shared.waker.get() = Some(cx.waker().clone()) };

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -421,3 +421,20 @@ test("verify rejects encoded argon2 hashes with cost parameters above the suppor
   expect(() => password.verifySync("correct horse", hugeParallelism)).toThrow("WeakParameters");
   await expect(password.verify("correct horse", hugeParallelism)).rejects.toThrow("WeakParameters");
 });
+
+// The event loop must stay alive while a native password promise is pending,
+// even when the main script never awaits it.
+test("pending password.hash keeps the process alive until it settles", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `Bun.password.hash("k", { algorithm: "bcrypt", cost: 4 }).then(h => { if (typeof h \!== "string" || h.length < 10) process.exit(2); console.log("SETTLED"); });`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("SETTLED");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
Draft to run full CI.

## What this does

Implements the std `Future`/`Waker` contract directly on the existing event loop so native promise-returning APIs can be written as Rust `async` blocks. No external async runtime: futures are polled as ordinary event loop tasks through one new task tag, wakes reuse the existing concurrent task queue + `us_wakeup_loop`, and pending futures hold the normal event-loop keepalive.

New pieces:

- `bun_event_loop::AsyncTask` — `spawn()` + the waker. A CAS state machine makes wakes idempotent (the loop's queues do not deduplicate; enqueueing one pointer twice would double-poll). Same-thread wakes push to the local FIFO; cross-thread wakes do the same MPSC push + wakeup as every work-pool completion today. The first poll runs synchronously (JS promise-executor semantics) so work starts exactly where the hand-rolled task code started it — start timing is observable API surface (see verification).
- `bun_threading::work_pool::run` — await a closure's result computed on the work pool.
- `bun_jsc::async_promise::js_promise` — implement a promise-returning API as an async block; settles inside the task drain loop (normal microtask timing) and attaches async stacks on rejection.
- `bun_alloc::SensitiveBytes` — shared zero-on-drop secret buffer with a redacting `Debug`.

First conversion: `Bun.password.hash`/`verify`. The hand-rolled `PasswordJob`/`PasswordResult` machinery is deleted. `hashSync`/`verifySync` now zero the password buffer too (previously only the async path zeroed).

Everything is additive except `src/runtime/crypto/PasswordObject.rs` (the conversion) and the one-line tag insertion in `ConcurrentTask.rs`. The insertion renumbers later tag constants, which is compile-time symbolic only: all tag references in the tree are the named constants (no raw `TaskTag(n)` constructions exist outside the macro) and `dispatch.rs` asserts `COUNT == 97`.

## How it's verified

- Wake protocol under Miri (Tree Borrows), tests in `src/event_loop/AsyncTask.rs`: 8-thread×1000 wake storms (single-enqueue idempotence), wakes racing the Ready transition, woken-mid-poll re-enqueue, off-thread last-reference dealloc, waker refcount balance, and the eager first-poll path. `bun_event_loop` added to `scripts/rust-miri.ts`.
- `bun bd test test/js/bun/util/password.test.ts`: 68 pass / 0 fail.
- Start-timing parity: with a lazy first poll, `Bun.password.hash` lost all overlap with subsequent synchronous JS (total = spin + hash). With the eager first poll the total equals the spin, matching the previous behavior exactly.
- `bench/snippets/password.mjs` (new, mitata): against the released 1.4.0 binary there is no measurable difference on any row — single-op argon2id and bcrypt, `hashSync`, 8×/32× concurrent argon2id, and `Promise.all` stacking of bcrypt cost=4 at 8/32/128/512 promises in flight (interleaved runs; deltas within run-to-run spread, about 0.6 µs on the machinery-sensitive rows).

## Notes for review

- Futures are deliberately `\!Send`; the executor guarantees poll and drop happen on the JS thread, including the shutdown path, so `Strong`/`JsRef` captures are sound by construction.
- Tasks still queued at VM shutdown drop their future on the JS thread via `__bun_release_task_at_shutdown`, before `destructOnExit`.
