### PR TITLE
sql: fix pool stall when sql.begin() runs concurrently with pooled queries

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1039,7 +1039,9 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
 
     while (true) {
       const nonReservedConnections = Array.from(this.readyConnections).filter(
-        c => !(c.flags & PooledConnectionFlags.preReserved) && c.queryCount < maxDistribution,
+        c =>
+          !(c.flags & (PooledConnectionFlags.preReserved | PooledConnectionFlags.reserved)) &&
+          c.queryCount < maxDistribution,
       );
       if (nonReservedConnections.length === 0) {
         return;
@@ -1112,6 +1114,9 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
         connection.flags |= PooledConnectionFlags.reserved;
         connection.queryCount++;
         this.totalQueries++;
+        // the connection now belongs to the reserved waiter; it must not stay
+        // visible to flushConcurrentQueries (same as the reserved path in connect())
+        this.readyConnections.delete(connection);
         // we have a connection waiting for a reserved connection lets prioritize it
         pendingReserved(connection.storedError, connection);
         return;

--- a/test/js/sql/postgres-pool-pipeline-flag-fixture.ts
+++ b/test/js/sql/postgres-pool-pipeline-flag-fixture.ts
@@ -1,0 +1,56 @@
+// Fixture for postgres-pool-transaction-stall.test.ts ("pipelining feature
+// flag keeps one query in flight per connection"). Runs with
+// BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING=1: a second prepared query
+// fired while another is in flight must not be written to the wire until the
+// first one's response arrives.
+import { SQL } from "bun";
+
+const url = process.env.DATABASE_URL!;
+const sql = new SQL({ url, max: 1 });
+const ctl = new SQL({ url, max: 1 });
+
+// Hang guard: turn "hangs forever" into a loud nonzero exit.
+const watchdog = setTimeout(() => {
+  console.error("WATCHDOG: queries never completed");
+  process.exit(1);
+}, 15_000);
+
+function step(name: string) {
+  console.log(`STEP ${name}`);
+}
+
+// Warm the statement so later executions take the already-prepared path.
+await sql`select ${1}::int as hold_me`;
+step("prepared");
+
+// From here on, the mock server holds the response to hold_me executions
+// until the release control query arrives.
+await ctl.unsafe("/* ctl:arm_hold */ select 1");
+step("armed");
+
+// q1 is held by the mock. q2 is fired while q1 is in flight; with pipelining
+// disabled it must stay queued client-side until q1 completes.
+const q1 = sql`select ${2}::int as hold_me`;
+q1.execute();
+const q2 = sql`select ${3}::int as hold_me`;
+q2.execute();
+
+// Let the connection's deferred flush run so anything the client (wrongly)
+// decided to write for q2 is on the socket before the control query below.
+await new Promise(resolve => setImmediate(resolve));
+
+// Release the held response. The mock snapshots how many hold_me Binds have
+// arrived when it handles this query; the parent test asserts q2's was not
+// among them.
+await ctl.unsafe("/* ctl:release_slow */ select 1");
+step("released");
+
+await q1;
+step("q1 done");
+await q2;
+step("q2 done");
+
+clearTimeout(watchdog);
+await sql.close();
+await ctl.close();
+console.log("DONE");

--- a/test/js/sql/postgres-pool-transaction-stall-fixture.ts
+++ b/test/js/sql/postgres-pool-transaction-stall-fixture.ts
@@ -1,0 +1,89 @@
+// Fixture for postgres-pool-transaction-stall.test.ts. Drives the connection
+// pool into the state from https://github.com/oven-sh/bun/issues/32004:
+// a transaction acquires its connection through the release() -> reservedQueue
+// handoff while concurrent pooled prepared-statement queries are running.
+import { SQL } from "bun";
+
+const url = process.env.DATABASE_URL!;
+const sql = new SQL({ url, max: 1 });
+const ctl = new SQL({ url, max: 1 });
+
+// Hang guard: the bug wedges the pool forever. Turn "hangs forever" into a
+// loud nonzero exit so the parent test fails fast with a useful message.
+const watchdog = setTimeout(() => {
+  console.error("WATCHDOG: pool wedged, queries never completed");
+  process.exit(1);
+}, 20_000);
+
+function step(name: string) {
+  console.log(`STEP ${name}`);
+}
+
+// Prepare all three statements up-front so later executions of the same query
+// text take the already-prepared pipelining path in the native queue.
+await sql`select ${1}::int as hold_me`;
+await sql`select ${1}::int as fast_q`;
+await sql`select ${1}::int as warmup_q`;
+step("prepared");
+
+// From here on, the mock server holds the response to hold_me executions
+// until the release control query arrives.
+await ctl.unsafe("/* ctl:arm_hold */ select 1");
+step("armed");
+
+// A pooled query that is still in flight when sql.begin() is called, so the
+// transaction cannot take the direct reserved path in connect() and instead
+// waits in reservedQueue for the release() handoff.
+const p0 = sql`select ${2}::int as warmup_q`;
+p0.execute();
+
+const bodyGate = Promise.withResolvers<void>();
+let slowQ: Promise<unknown>;
+let victimQ: Promise<unknown>;
+
+const txP = sql.begin(async tx => {
+  // Pooled query (NOT tx): with the pool bug it is distributed onto this
+  // transaction's connection and written to the wire immediately. The mock
+  // server holds its response until the control query arrives.
+  slowQ = sql`select ${3}::int as hold_me`;
+  (slowQ as any).execute();
+  // Simple-protocol query on the transaction connection: it is queued
+  // UNWRITTEN behind slowQ until the pipeline drains.
+  victimQ = tx.unsafe("select 641 as victim_q");
+  (victimQ as any).execute();
+  bodyGate.resolve();
+  await victimQ;
+  step("victim resolved");
+});
+
+await p0;
+step("p0 done");
+await bodyGate.promise;
+step("body gate");
+
+// Another pooled prepared query while victim_q is queued unwritten. The bug:
+// run()'s pipelining fast path writes its Bind+Execute to the wire ahead of
+// the queued victim_q, so the server's response to fast_q is attributed to
+// victim_q (FIFO queue order) and the connection desyncs permanently.
+const fastQ = sql`select ${4}::int as fast_q`;
+fastQ.execute();
+
+// Release the held response for slowQ.
+await ctl.unsafe("/* ctl:release_slow */ select 1");
+step("released");
+
+await fastQ;
+step("fast resolved");
+await slowQ!;
+step("slow resolved");
+await txP;
+step("tx resolved");
+
+// The pool must still be usable afterwards.
+await sql`select ${5}::int as warmup_q`;
+step("pool alive");
+
+clearTimeout(watchdog);
+await sql.close();
+await ctl.close();
+console.log("DONE");

--- a/test/js/sql/postgres-pool-transaction-stall.test.ts
+++ b/test/js/sql/postgres-pool-transaction-stall.test.ts
@@ -1,0 +1,386 @@
+// https://github.com/oven-sh/bun/issues/32004
+//
+// Under concurrency, a Bun.SQL postgres pool could permanently stall when
+// sql.begin() transactions ran alongside pooled prepared-statement queries:
+//
+// 1. release() handed an idle connection to a waiting sql.begin() but did not
+//    remove it from readyConnections, and flushConcurrentQueries() did not
+//    filter reserved connections, so pooled queries kept getting distributed
+//    onto the transaction's connection.
+// 2. The native queue's pipelining fast path could then write a prepared
+//    query's Bind+Execute to the wire while an earlier queued simple-protocol
+//    request (e.g. the transaction's COMMIT) was still unwritten. Responses
+//    are matched to requests in FIFO queue order, so the unwritten request
+//    stole the pipelined query's result and the connection wedged forever.
+//    (That half is fixed separately: the fast path is gated on
+//    pending_requests == 0, covered by postgres-prepared-pipeline-reorder.)
+//
+// The tests run a scripted mock postgres server so both sides of the race are
+// deterministic: the mock holds one query's response until a control query on
+// a second connection arrives, which forces the exact interleaving. Without
+// the pool fix the first test fails its wire-order assertion: pooled queries
+// are written to the transaction's connection between BEGIN and COMMIT.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import net from "node:net";
+import path from "node:path";
+
+function pkt(type: string, body: Buffer = Buffer.alloc(0)): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0);
+  header.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([header, body]);
+}
+
+function int16(n: number): Buffer {
+  const b = Buffer.alloc(2);
+  b.writeInt16BE(n, 0);
+  return b;
+}
+
+function int32(n: number): Buffer {
+  const b = Buffer.alloc(4);
+  b.writeInt32BE(n, 0);
+  return b;
+}
+
+function cstr(s: string): Buffer {
+  return Buffer.concat([Buffer.from(s), Buffer.from([0])]);
+}
+
+const authenticationOk = pkt("R", int32(0));
+const readyForQuery = pkt("Z", Buffer.from("I"));
+const parseComplete = pkt("1");
+const bindComplete = pkt("2");
+// zero result columns for every statement: no DataRow needed
+const rowDescription = pkt("T", int16(0));
+const commandComplete = (tag: string) => pkt("C", cstr(tag));
+const parameterDescription = (oids: number[]) => pkt("t", Buffer.concat([int16(oids.length), ...oids.map(int32)]));
+
+interface Frame {
+  type: string;
+  body: Buffer;
+}
+
+interface Conn {
+  socket: net.Socket;
+  buf: Buffer;
+  sawStartup: boolean;
+  frames: Frame[];
+  busy: boolean;
+  // prepared statement name -> { query text, declared param oids }
+  statements: Map<string, { query: string; oids: number[] }>;
+  // arrival-order log of P/B/E/Q frames for assertions, recorded when the
+  // frame is parsed off the socket (holds only delay responses, not logging)
+  log: string[];
+}
+
+function readCStr(buf: Buffer, offset: number): [string, number] {
+  const end = buf.indexOf(0, offset);
+  return [buf.toString("utf8", offset, end), end + 1];
+}
+
+// Scripted mini postgres server. Responds to everything immediately, except
+// that once a "/* ctl:arm_hold */" control query has been seen, a Bind to a
+// statement whose text contains "hold_me" blocks that connection's responses
+// (like a slow query) until a "/* ctl:release_slow */" control query arrives
+// on any connection.
+function startMockServer() {
+  const conns: Conn[] = [];
+  const release = Promise.withResolvers<void>();
+  let armed = false;
+  let released = false;
+  // frame handler failures; asserted empty by the tests so protocol bugs in
+  // the mock surface as failures instead of fixture hangs
+  const errors: unknown[] = [];
+  // count of hold_me Binds that had arrived (across connections) when the
+  // release control query was handled
+  let holdMeBindsAtRelease = -1;
+
+  const countHoldMeBinds = () =>
+    conns.reduce((n, c) => n + c.log.filter(entry => entry.startsWith("B:") && entry.includes("hold_me")).length, 0);
+
+  function logFrame(conn: Conn, frame: Frame) {
+    const { type, body } = frame;
+    switch (type) {
+      case "P": {
+        // Parse: name, query, nParams, oids
+        const [name, afterName] = readCStr(body, 0);
+        const [query, afterQuery] = readCStr(body, afterName);
+        const nParams = body.readInt16BE(afterQuery);
+        const oids: number[] = [];
+        for (let i = 0; i < nParams; i++) {
+          oids.push(body.readInt32BE(afterQuery + 2 + i * 4));
+        }
+        conn.statements.set(name, { query, oids });
+        conn.log.push(`P:${query}`);
+        break;
+      }
+      case "B": {
+        // Bind: portal, statement name
+        const [, afterPortal] = readCStr(body, 0);
+        const [name] = readCStr(body, afterPortal);
+        const stmt = conn.statements.get(name);
+        conn.log.push(`B:${stmt ? stmt.query : ""}`);
+        break;
+      }
+      case "E": {
+        conn.log.push("E");
+        break;
+      }
+      case "Q": {
+        const [query] = readCStr(body, 0);
+        conn.log.push(`Q:${query}`);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  async function handleFrame(conn: Conn, frame: Frame) {
+    const { type, body } = frame;
+    switch (type) {
+      case "P": {
+        conn.socket.write(parseComplete);
+        break;
+      }
+      case "D": {
+        // Describe statement: echo the Parse-declared param oids, zero columns
+        const [name] = readCStr(body, 1);
+        const stmt = conn.statements.get(name);
+        conn.socket.write(Buffer.concat([parameterDescription(stmt ? stmt.oids : []), rowDescription]));
+        break;
+      }
+      case "B": {
+        const [, afterPortal] = readCStr(body, 0);
+        const [name] = readCStr(body, afterPortal);
+        const stmt = conn.statements.get(name);
+        const query = stmt ? stmt.query : "";
+        if (query.includes("hold_me") && armed && !released) {
+          // act like a slow query: block this connection's responses (and
+          // everything queued after it) until the control query arrives
+          await release.promise;
+        }
+        conn.socket.write(bindComplete);
+        break;
+      }
+      case "E": {
+        conn.socket.write(commandComplete("SELECT 0"));
+        break;
+      }
+      case "S": {
+        conn.socket.write(readyForQuery);
+        break;
+      }
+      case "Q": {
+        const [query] = readCStr(body, 0);
+        if (query.includes("ctl:arm_hold")) {
+          armed = true;
+        }
+        if (query.includes("ctl:release_slow")) {
+          released = true;
+          holdMeBindsAtRelease = countHoldMeBinds();
+          release.resolve();
+        }
+        let tag = "SELECT 1";
+        const first = query.trimStart().slice(0, 8).toUpperCase();
+        if (first.startsWith("BEGIN")) tag = "BEGIN";
+        else if (first.startsWith("COMMIT")) tag = "COMMIT";
+        else if (first.startsWith("ROLLBACK")) tag = "ROLLBACK";
+        conn.socket.write(Buffer.concat([commandComplete(tag), readyForQuery]));
+        break;
+      }
+      case "H": // Flush: no response
+      case "X": // Terminate
+        break;
+      default:
+        break;
+    }
+  }
+
+  async function pump(conn: Conn) {
+    if (conn.busy) return;
+    conn.busy = true;
+    try {
+      while (conn.frames.length > 0) {
+        await handleFrame(conn, conn.frames.shift()!);
+      }
+    } finally {
+      conn.busy = false;
+    }
+  }
+
+  const server = net.createServer(socket => {
+    const conn: Conn = {
+      socket,
+      buf: Buffer.alloc(0),
+      sawStartup: false,
+      frames: [],
+      busy: false,
+      statements: new Map(),
+      log: [],
+    };
+    conns.push(conn);
+    socket.on("error", () => {});
+    socket.on("data", data => {
+      conn.buf = Buffer.concat([conn.buf, data]);
+      while (true) {
+        if (!conn.sawStartup) {
+          if (conn.buf.length < 4) break;
+          const len = conn.buf.readInt32BE(0);
+          if (conn.buf.length < len) break;
+          conn.buf = conn.buf.subarray(len);
+          conn.sawStartup = true;
+          socket.write(Buffer.concat([authenticationOk, readyForQuery]));
+          continue;
+        }
+        if (conn.buf.length < 5) break;
+        const len = conn.buf.readInt32BE(1);
+        if (conn.buf.length < len + 1) break;
+        const frame: Frame = {
+          type: conn.buf.toString("utf8", 0, 1),
+          body: conn.buf.subarray(5, len + 1),
+        };
+        conn.buf = conn.buf.subarray(len + 1);
+        logFrame(conn, frame);
+        conn.frames.push(frame);
+      }
+      pump(conn).catch(err => {
+        errors.push(err);
+        // kill the connection so the fixture fails fast instead of hanging
+        socket.destroy(err instanceof Error ? err : new Error(String(err)));
+      });
+    });
+  });
+
+  return {
+    server,
+    conns,
+    errors,
+    forceRelease: () => release.resolve(),
+    holdMeBindsAtRelease: () => holdMeBindsAtRelease,
+    listen: () =>
+      new Promise<number>(resolve =>
+        server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port)),
+      ),
+  };
+}
+
+async function runFixture(fixture: string, port: number, extraEnv: Record<string, string> = {}) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, fixture)],
+    env: {
+      ...bunEnv,
+      ...extraEnv,
+      DATABASE_URL: `postgres://bun:bun@127.0.0.1:${port}/bun?sslmode=disable`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test("pool does not stall when sql.begin() runs concurrently with pooled prepared queries", async () => {
+  const mock = startMockServer();
+  const port = await mock.listen();
+
+  try {
+    const { stdout, stderr, exitCode } = await runFixture("postgres-pool-transaction-stall-fixture.ts", port);
+
+    // every stage of the fixture must have completed, in order; only the
+    // relative order of "released" and "victim resolved" legitimately depends
+    // on scheduling, so normalize that adjacent pair before the exact
+    // sequence comparison
+    const steps = stdout.split(/\r?\n/).filter(line => line.startsWith("STEP ") || line === "DONE");
+    const released = steps.indexOf("STEP released");
+    const victim = steps.indexOf("STEP victim resolved");
+    if (released !== -1 && victim === released - 1) {
+      steps[victim] = "STEP released";
+      steps[released] = "STEP victim resolved";
+    }
+    expect({
+      steps: steps.join("\n"),
+      stderr: stderr.includes("WATCHDOG") ? "WATCHDOG" : "",
+      exitCode,
+      mockErrors: mock.errors,
+    }).toEqual({
+      steps: [
+        "STEP prepared",
+        "STEP armed",
+        "STEP p0 done",
+        "STEP body gate",
+        "STEP released",
+        "STEP victim resolved",
+        "STEP fast resolved",
+        "STEP slow resolved",
+        "STEP tx resolved",
+        "STEP pool alive",
+        "DONE",
+      ].join("\n"),
+      stderr: "",
+      exitCode: 0,
+      mockErrors: [],
+    });
+
+    // wire-order assertions on the transaction's connection: while the
+    // transaction owns the connection, no pooled query may be written to it,
+    // and COMMIT must actually reach the server
+    const txConn = mock.conns.find(c => c.log.some(entry => entry === "Q:BEGIN"));
+    expect(txConn).toBeDefined();
+    const log = txConn!.log;
+    const beginIndex = log.indexOf("Q:BEGIN");
+    const commitIndex = log.indexOf("Q:COMMIT");
+    expect(commitIndex).toBeGreaterThan(beginIndex);
+    expect(log.slice(beginIndex + 1, commitIndex)).toEqual(["Q:select 641 as victim_q"]);
+  } finally {
+    mock.forceRelease();
+    mock.server.close();
+  }
+});
+
+// BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING must keep at most one query in
+// flight per connection: a second prepared query fired while another is in
+// flight may not be written to the wire until the first one's response
+// arrives.
+test("pipelining feature flag keeps one query in flight per connection", async () => {
+  const mock = startMockServer();
+  const port = await mock.listen();
+
+  try {
+    const { stdout, stderr, exitCode } = await runFixture("postgres-pool-pipeline-flag-fixture.ts", port, {
+      BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING: "1",
+    });
+
+    expect({
+      steps: stdout
+        .split(/\r?\n/)
+        .filter(line => line.startsWith("STEP ") || line === "DONE")
+        .join("\n"),
+      stderr: stderr.includes("WATCHDOG") ? "WATCHDOG" : "",
+      exitCode,
+      mockErrors: mock.errors,
+    }).toEqual({
+      steps: ["STEP prepared", "STEP armed", "STEP released", "STEP q1 done", "STEP q2 done", "DONE"].join("\n"),
+      stderr: "",
+      exitCode: 0,
+      mockErrors: [],
+    });
+
+    // By the time the release control query was handled, only the held
+    // query's Bind may have reached the server. The warmup execution happens
+    // before arm_hold, so the expected count is exactly 2 (warmup + held q1);
+    // q2's Bind must arrive only after the release.
+    expect(mock.holdMeBindsAtRelease()).toBe(2);
+    const total = mock.conns.reduce(
+      (n, c) => n + c.log.filter(entry => entry.startsWith("B:") && entry.includes("hold_me")).length,
+      0,
+    );
+    expect(total).toBe(3);
+  } finally {
+    mock.forceRelease();
+    mock.server.close();
+  }
+});


### PR DESCRIPTION
Fixes #32004

### Repro

From the issue: a pool (`max: 4`) running `sql.begin()` transactions concurrently with plain parameterized `sql.unsafe()` queries intermittently stalls forever. `pg_stat_activity` shows every connection idle at `ClientRead` (one left `idle in transaction`, its COMMIT never sent), no lock waits, while several `sql.unsafe()` calls wait for a connection that never comes back. Reproduced on the released build: 4 hangs in 15 runs of the issue's script; 0 in 30 runs with the fix.

### Cause

Two cooperating bugs. The second has since been fixed on main by #33627, so this PR now carries only the first:

1. **Pool handoff leaves the connection visible to the distributor** (this PR). `connect(reserved=true)`'s direct path removes the connection from `readyConnections`, but the `release()` path that hands a drained connection to a waiting `sql.begin()` does not, and `flushConcurrentQueries()` only filtered `preReserved` (not `reserved`) connections. Pooled queries therefore kept getting distributed onto a connection a transaction owned, and executed inside that transaction.

2. **Native queue could write out of order** (fixed by #33627). The enqueue-time pipelining fast path wrote a prepared query's Bind+Execute while an earlier queued request was still unwritten; responses are matched FIFO, so the unwritten request (the transaction's COMMIT) stole the pipelined query's result, the transaction "committed" without COMMIT reaching the server (the `idle in transaction` connection), `nonpipelinable_requests` underflowed, and the connection wedged. Main now gates that fast path on `pending_requests == 0`; earlier revisions of this PR fixed it by removing the fast path, and that half was dropped in the rebase in favor of main's version.

### Fix

`src/js/internal/sql/shared.ts` (the pool shared by the postgres and mysql adapters): `release()` removes the connection from `readyConnections` when handing it to a reserved waiter (mirroring `connect()`), and `flushConcurrentQueries()` skips `reserved` connections.

### Verification

`test/js/sql/postgres-pool-transaction-stall.test.ts` has two tests against a scripted mock postgres server (no Docker/services). The first forces the issue's interleaving deterministically: a transaction acquires its connection through the `release()` handoff while pooled prepared queries are in flight. Without this fix it fails its wire-order assertion (pooled queries are written to the transaction's connection between BEGIN and COMMIT; before #33627 landed, the same fixture wedged the pool outright). With the fix, no pooled query touches the transaction's connection and everything completes. The second test asserts `BUN_FEATURE_FLAG_DISABLE_SQL_AUTO_PIPELINING` keeps at most one query in flight per connection, coverage main's #33627 tests do not include.

Also ran the issue's original repro in a loop against real Postgres 17: 30/30 clean with the fix (debug build), 4/15 hangs without it (released build at the time of the original investigation).

MySQL's native queue has a narrower variant of the ordering window; tracked in #32005. The pool fix here applies to the MySQL adapter too and removes the transaction-driven trigger there.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-pool-transaction-stall.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0809bdd14)

test/js/sql/postgres-pool-transaction-stall.test.ts:
332 |     expect(txConn).toBeDefined();
333 |     const log = txConn!.log;
334 |     const beginIndex = log.indexOf("Q:BEGIN");
335 |     const commitIndex = log.indexOf("Q:COMMIT");
336 |     expect(commitIndex).toBeGreaterThan(beginIndex);
337 |     expect(log.slice(beginIndex + 1, commitIndex)).toEqual(["Q:select 641 as victim_q"]);
                                                         ^
error: expect(received).toEqual(expected)

  [
+   "B:select $1 ::int as hold_me",
+   "E",
    "Q:select 641 as victim_q",
+   "B:select $1 ::int as fast_q",
+   "E",
  ]

- Expected  - 0
+ Received  + 4

      at <anonymous> (/workspace/bun/test/js/sql/postgre
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/sql/postgres-pool-transaction-stall.test.ts:
killed 1 dangling process
(fail) pool does not stall when sql.begin() runs concurrently with pooled prepared queries [5000.43ms]
  ^ this test timed out after 5000ms.

# Unhandled error between tests
-------------------------------
304 |     expect({
305 |       steps: steps.join("\n"),
306 |       stderr: stderr.includes("WATCHDOG") ? "WATCHDOG" : "",
307 |       exitCode,
308 |       mockErrors: mock.errors,
309 |     }).toEqual({
             ^
error: expect(received).toEqual(expected)

  {
-   "exitCode": 0,
+   "exitCode": 143,
    "mockErrors": [],
    "stderr": "",
    "steps": 
  "STEP prepared
  STEP armed
  STEP p0 done
  STEP body gate
  STEP released
- STEP victim resolved
- STEP fast resolved
- STEP slow resolved
- STEP tx resolved
- STEP pool alive
- DONE"
+ STEP victim resolved"
  ,
  }

- Expected  - 7
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/sql/postgres-pool-transaction-stall.test.ts:309:8)
-------------------------------

(pass) pipelining feature flag keeps one query in flight per connection [33.84ms]

 1 pass
 1 fail
 1 error
 4 expect
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/sql/postgres-pool-transaction-stall.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (0809bdd14)

test/js/sql/postgres-pool-transaction-stall.test.ts:
(pass) pool does not stall when sql.begin() runs concurrently with pooled prepared queries [1911.97ms]
(pass) pipelining feature flag keeps one query in flight per connection [1480.52ms]

 2 pass
 0 fail
 7 expect() calls
Ran 2 tests across 1 file. [5.55s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     0809bdd14a
  features     (none)

22 deps, 105 codegen, 1168 objects in 848ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [10.00ms]
[2/1231] gen ErrorCode+*.h
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [6.00ms]
[4/1231] gen bindgenv2
[5/1231] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[7/1231] fetch tinycc
[tinycc] up to date
[8/1230] fetch z
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/sql/shared.ts                      |   7 +-
 test/js/sql/postgres-pool-pipeline-flag-fixture.ts |  56 +++
 .../sql/postgres-pool-transaction-stall-fixture.ts |  89 +++++
 .../js/sql/postgres-pool-transaction-stall.test.ts | 386 +++++++++++++++++++++
 4 files changed, 537 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/internal/sql/shared.ts                               1      2     28
test/js/sql/postgres-pool-pipeline-flag-fixture.ts          0      1     26
test/js/sql/postgres-pool-transaction-stall-fixture.ts      1      2     27
test/js/sql/postgres-pool-transaction-stall.test.ts         5     11     26
```

</details>

<!-- robobun:evidence:end -->