### PR TITLE
Bun.serve: create request AbortSignals lazily instead of per-request

### DIFF
--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -219,6 +219,15 @@ impl AnyRequestContext {
         dispatch!(self, (), |_T, ctx| ctx.set_signal_aborted(reason))
     }
 
+    /// Lazily create + wire the context's `AbortSignal` on first
+    /// `request.signal` access. Returns `None` when there is no live context.
+    pub(crate) fn ensure_ctx_signal(
+        self,
+        global: &crate::server::jsc::JSGlobalObject,
+    ) -> Option<core::ptr::NonNull<crate::webcore::AbortSignal>> {
+        dispatch!(self, None, |_T, ctx| ctx.ensure_ctx_signal(global))
+    }
+
     pub(crate) fn dev_server(self) -> Option<&'static crate::bake::DevServer::DevServer> {
         dispatch!(self, None, |_T, ctx| ctx.dev_server().map(|r| {
             // SAFETY: the server backref outlives any AnyRequestContext (held only

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -580,13 +580,35 @@ where
     }
 
     pub(crate) fn set_signal_aborted(&mut self, reason: jsc::CommonAbortReason) {
-        if let Some(signal) = &self.signal {
+        if let Some(signal) = self.signal {
             if let Some(server) = self.server {
                 // server is a BACKREF — valid while this RequestContext is alive
                 let global = server.global_this();
-                shim::signal_fire(*signal, global, reason);
+                shim::signal_fire(signal, global, reason);
             }
+        } else if let Some(request) = self.request_weakref.get() {
+            // Signal not yet materialized (lazy); record the abort on the
+            // Request so a later `request.signal` read observes it.
+            request.server_abort.set(Some(reason));
         }
+    }
+
+    /// Lazily create this context's `AbortSignal`. Signals used to be created
+    /// eagerly for every request; now they materialize on the first
+    /// `request.signal` access or on WebSocket upgrade. Idempotent.
+    pub(crate) fn ensure_ctx_signal(
+        &mut self,
+        global: &JSGlobalObject,
+    ) -> Option<NonNull<AbortSignal>> {
+        if let Some(signal) = self.signal {
+            return Some(signal);
+        }
+        let signal = NonNull::new(AbortSignal::new(global))?;
+        // GC-visibility count; released together with the intrusive `+1` from
+        // `new()` via `shim::signal_release` (see the `signal` field docs).
+        bun_ptr::BackRef::from(signal).pending_activity_ref();
+        self.signal = Some(signal);
+        Some(signal)
     }
 
     fn drain_microtasks(&self) {
@@ -1392,7 +1414,13 @@ where
             }
         }
 
+        let had_signal = this.signal.is_some();
         if let Some(request) = this.request_weakref.get() {
+            if !had_signal {
+                request
+                    .server_abort
+                    .set(Some(jsc::CommonAbortReason::ConnectionClosed));
+            }
             request.request_context = AnyRequestContext::NULL;
             if shim::iec_trigger(
                 &request.internal_event_callback,
@@ -1489,7 +1517,13 @@ where
         // Releases the ref taken in `set_cookies` (via `CookieMapRef::drop`).
         drop(self.cookies.take());
 
+        let record_abort = self.signal.is_none() && self.flags.aborted();
         if let Some(request) = self.request_weakref.get() {
+            if record_abort {
+                request
+                    .server_abort
+                    .set(Some(jsc::CommonAbortReason::ConnectionClosed));
+            }
             request.request_context = AnyRequestContext::NULL;
             // we can already clean this strong refs
             shim::iec_deinit(&request.internal_event_callback);

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -768,14 +768,8 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         ctx_mut.request_body = Some(body_hive.clone());
 
         let global = server.global_this();
-        let signal = jsc::AbortSignal::new(global);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        ctx_mut.signal = core::ptr::NonNull::new(signal);
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        // SAFETY: `signal.ref_()` bumps the intrusive count and returns +1.
-        let signal_ref =
-            unsafe { jsc::AbortSignalRef::adopt(bun_opaque::opaque_deref_mut(signal).ref_()) };
+        // The AbortSignal is created lazily on first `request.signal` access
+        // (`Request::materialize_server_signal`) or on WebSocket upgrade.
         // ownership: `Request::new` is `bun.TrivialNew` — the heap
         // allocation is handed to the JS GC via `to_js`/`to_js_for_bake` (C++
         // wrapper finalizer frees it), or, for `CreateJsRequest::No`, retained
@@ -787,7 +781,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 ctx_mut.method,
                 AnyRequestContext::init(ctx),
                 SSL,
-                Some(signal_ref),
                 body_hive,
             )));
         // SAFETY: freshly leaked from `heap::into_raw`, so `request_object`

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -13,9 +13,7 @@ use crate::webcore::BlobExt;
 use crate::webcore::body::Value as BodyValue;
 use crate::webcore::fetch as Fetch;
 use crate::webcore::response::HeadersRef;
-use crate::webcore::{
-    self as WebCore, AbortSignal, AnyBlob, Blob, FetchHeaders, Request, Response,
-};
+use crate::webcore::{self as WebCore, AnyBlob, Blob, FetchHeaders, Request, Response};
 use ::bstr::BStr;
 use bun_collections::HashMap;
 use bun_core::{Output, fmt as bun_fmt};
@@ -119,7 +117,6 @@ trait RequestCtxOps: RequestCtx {
     fn defer_deinit_ptr(&mut self) -> &mut Option<DeferDeinitFlag>;
     fn set_request_body(&mut self, body: Option<crate::webcore::body::BodyHiveHandle>);
     fn request_body_mut(&mut self) -> Option<&mut BodyValue>;
-    fn set_signal(&mut self, sig: *mut AbortSignal);
     fn set_request_weakref(&mut self, req: *mut Request);
     fn clear_req(&mut self);
     fn set_is_web_browser_navigation(&mut self, v: bool);
@@ -206,14 +203,6 @@ where
         self.request_body
             .as_ref()
             .map(|h| unsafe { &mut (*h.as_ptr()).value })
-    }
-    #[inline]
-    fn set_signal(&mut self, sig: *mut AbortSignal) {
-        // `AbortSignal::new` returns a raw +1 ref to a C++-refcounted opaque;
-        // `RequestContext.signal` stores it as `Option<NonNull<AbortSignal>>`
-        // and pairs the unref in RequestContext cleanup (`shim::signal_release`,
-        // which drops both the pending-activity count and the intrusive ref).
-        self.signal = NonNull::new(sig);
     }
     #[inline]
     fn set_request_weakref(&mut self, req: *mut Request) {
@@ -2186,6 +2175,18 @@ where
         // --- After this point, do not throw an exception
         // See https://github.com/oven-sh/bun/issues/1339
         upgrader.upgrade_context = Some(usize::MAX as *mut WebSocketUpgradeContext);
+        // Signals are lazy; the WebSocket needs one (it fires ConnectionClosed
+        // on ws close), so materialize it now and mirror a `+1` into the
+        // Request so post-upgrade `request.signal` observes the same abort.
+        if let Some(sig) = upgrader.ensure_ctx_signal(global) {
+            if request.signal.get().is_none() {
+                // SAFETY: ctx holds a live `+1`; `ref_()` bumps once more for
+                // the Request's RAII handle (paired with `AbortSignalRef::Drop`).
+                request.signal.set(Some(unsafe {
+                    jsc::AbortSignalRef::adopt((*sig.as_ptr()).ref_())
+                }));
+            }
+        }
         let signal = upgrader.signal.take();
         upgrader.resp = None;
 
@@ -3181,20 +3182,12 @@ where
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.set_request_body(Some(body_hive.clone()));
 
-        let signal = AbortSignal::new(&self.global());
-        ctx.set_signal(signal);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-
-        // Bump once for the Request's owned
-        // copy and adopt into RAII so it pairs with `Request::Drop`'s unref.
-        // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
-        let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
+        // The AbortSignal is created lazily on first `request.signal` access
+        // (`Request::materialize_server_signal`) or on WebSocket upgrade.
         let request_object_box = Request::new(Request::init(
             ctx.ctx_method(),
             AnyRequestContext::init(std::ptr::from_ref::<Ctx>(ctx)),
             SSL,
-            Some(signal_for_req),
             body_hive,
         ));
         // Leak so the ctx (which outlives this stack frame) can hold the
@@ -3442,22 +3435,12 @@ where
         // same slot. Paired drop in `RequestContext::deinit` / `Request::finalize`.
         ctx.request_body = Some(body_hive.clone());
 
-        let signal = AbortSignal::new(&this.global());
-        // The
-        // RequestContext owns one ref so aborts during the WS-upgrade fallback
-        // fetch path propagate.
-        ctx.signal = NonNull::new(signal);
-        // S008: `AbortSignal` is an `opaque_ffi!` ZST — safe deref.
-        bun_opaque::opaque_deref_mut(signal).pending_activity_ref();
-        // Bump once for the Request's copy and
-        // adopt into RAII so it pairs with `Request::Drop`'s unref.
-        // SAFETY: `signal` is live; `ref_()` returns the same non-null ptr +1.
-        let signal_for_req = unsafe { jsc::AbortSignalRef::adopt((*signal).ref_()) };
+        // The AbortSignal is created lazily on first `request.signal` access
+        // (`Request::materialize_server_signal`) or on WebSocket upgrade.
         let request_object_box = Request::new(Request::init(
             ctx.method,
             AnyRequestContext::init(std::ptr::from_ref(ctx)),
             SSL,
-            Some(signal_for_req),
             body_hive,
         ));
         ctx.upgrade_context = Some(upgrade_ctx);

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -100,6 +100,9 @@ pub struct Request {
     js_ref: JsCell<JsRef>,
     pub method: Method,
     pub(crate) flags: Flags,
+    /// Set when the server aborts before `request.signal` is materialized; a
+    /// later `get_signal` creates an already-aborted signal with this reason.
+    pub(crate) server_abort: Cell<Option<jsc::CommonAbortReason>>,
     pub(crate) request_context: AnyRequestContext,
     pub(crate) weak_ptr_data: WeakPtrData,
     // We must report a consistent value for this
@@ -469,6 +472,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method,
             flags: Flags::default(),
+            server_abort: Cell::new(None),
             request_context: AnyRequestContext::NULL,
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
@@ -721,7 +725,36 @@ impl Request {
         ZigString::EMPTY.to_js(global_this)
     }
 
+    /// Server requests create their `AbortSignal` lazily. Materialize the
+    /// context-wired signal (abort fires on client disconnect) and mirror a
+    /// `+1` into this Request. If the context is gone and the server recorded
+    /// an abort, create an already-aborted signal instead. No-op otherwise.
+    fn materialize_server_signal(&self, global_this: &JSGlobalObject) {
+        if self.signal.get().is_some() {
+            return;
+        }
+        if let Some(signal) = self.request_context.ensure_ctx_signal(global_this) {
+            // SAFETY: the ctx holds a live `+1`; `ref_()` bumps once more for
+            // the Request's RAII handle (paired with `AbortSignalRef::Drop`).
+            let owned = unsafe { AbortSignalRef::adopt((*signal.as_ptr()).ref_()) };
+            self.signal.set(Some(owned));
+            return;
+        }
+        if let Some(reason) = self.server_abort.get() {
+            let Some(signal) = NonNull::new(AbortSignal::new(global_this)) else {
+                return;
+            };
+            // SAFETY: `new()` returned a live `+1`; fire then adopt into the
+            // Request's RAII handle. No pending-activity count: it can never
+            // fire again, so the JS wrapper needs no native keep-alive.
+            unsafe { (*signal.as_ptr()).signal(global_this, reason) };
+            self.signal
+                .set(Some(unsafe { AbortSignalRef::adopt(signal.as_ptr()) }));
+        }
+    }
+
     pub(crate) fn get_signal(&self, global_this: &JSGlobalObject) -> JSValue {
+        self.materialize_server_signal(global_this);
         // Already have a C++ instance
         if let Some(signal) = self.signal.get() {
             return signal.to_js(global_this);
@@ -1035,6 +1068,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::init_weak(this_value)),
             method: Method::GET,
             flags: Flags::default(),
+            server_abort: Cell::new(None),
             request_context: AnyRequestContext::NULL,
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
@@ -1594,6 +1628,7 @@ impl Request {
                     js_ref: JsCell::new(JsRef::empty()),
                     method: self.method,
                     flags: self.flags,
+                    server_abort: Cell::new(None),
                     request_context: AnyRequestContext::NULL,
                     weak_ptr_data: WeakPtrData::EMPTY,
                     reported_estimated_size: Cell::new(0),
@@ -1602,6 +1637,10 @@ impl Request {
             );
         }
 
+        // Materialize the server-wired signal first so the clone shares it
+        // (aborts propagate to clones of in-flight server requests, matching
+        // the old eager-creation behavior).
+        self.materialize_server_signal(global_this);
         if let Some(signal) = self.signal.get() {
             // `AbortSignalRef::clone` → C++ `ref()`.
             req.signal.set(Some(signal.clone()));
@@ -1627,6 +1666,7 @@ impl Request {
             js_ref: JsCell::new(JsRef::empty()),
             method: Method::GET,
             flags: Flags::default(),
+            server_abort: Cell::new(None),
             request_context: AnyRequestContext::NULL,
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),
@@ -1685,13 +1725,12 @@ impl Request {
         method: Method,
         request_context: AnyRequestContext,
         https: bool,
-        signal: Option<AbortSignalRef>,
         body: BodyHiveHandle,
     ) -> Request {
         Request {
             url: OwnedStringCell::new(BunString::empty()),
             headers: JsCell::new(None),
-            signal: JsCell::new(signal),
+            signal: JsCell::new(None),
             body: ManuallyDrop::new(body),
             js_ref: JsCell::new(JsRef::empty()),
             method,
@@ -1699,6 +1738,7 @@ impl Request {
                 https,
                 ..Flags::default()
             },
+            server_abort: Cell::new(None),
             request_context,
             weak_ptr_data: WeakPtrData::EMPTY,
             reported_estimated_size: Cell::new(0),

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -266,6 +266,206 @@ describe.concurrent("Server", () => {
     }
   });
 
+  describe("lazy request.signal", () => {
+    // Helper: issue a GET over a raw socket, wait for the handler to observe
+    // it, then close the socket and wait for the disconnect to register.
+    async function connectAndDisconnect<T>(server: Server, gotReq: Promise<T>): Promise<T> {
+      const { promise: closed, resolve: onClose } = Promise.withResolvers<void>();
+      const socket = await Bun.connect({
+        hostname: server.hostname,
+        port: server.port,
+        socket: {
+          data() {},
+          close: () => onClose(),
+          error: () => onClose(),
+        },
+      });
+      socket.write(`GET / HTTP/1.1\r\nHost: ${server.hostname}\r\n\r\n`);
+      const req = await gotReq;
+      socket.end();
+      await closed;
+      return req;
+    }
+
+    const connectionClosedReason = { name: "AbortError", code: 20, message: "The connection was closed." };
+
+    test("first access after client disconnect observes aborted", async () => {
+      // Signals are created lazily; an abort that happens before the first
+      // `request.signal` access must still be observable afterwards.
+      const { promise: gotReq, resolve: resolveReq } = Promise.withResolvers<Request>();
+      let unpark!: (value: Response) => void;
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          resolveReq(req);
+          // Park the handler; deliberately do NOT touch req.signal here.
+          return new Promise<Response>(resolve => {
+            unpark = resolve;
+          });
+        },
+      });
+      const req = await connectAndDisconnect(server, gotReq);
+
+      // The server notices the disconnect asynchronously; await the condition.
+      while (!req.signal.aborted) await Bun.sleep(5);
+      // identical observable surface to a signal that existed before the abort
+      expect(req.signal).toBe(req.signal);
+      const reason = req.signal.reason;
+      expect(reason).toBeInstanceOf(DOMException);
+      expect({ name: reason.name, code: reason.code, message: reason.message }).toEqual(connectionClosedReason);
+      expect(() => req.signal.throwIfAborted()).toThrow(reason);
+      // listeners added to an already-aborted signal never fire
+      let lateFired = false;
+      req.signal.addEventListener("abort", () => {
+        lateFired = true;
+      });
+      await Bun.sleep(10);
+      expect(lateFired).toBe(false);
+      unpark(new Response("late"));
+    });
+
+    test("first access after a normal response completes stays non-aborted", async () => {
+      const { promise: gotReq, resolve: resolveReq } = Promise.withResolvers<Request>();
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          resolveReq(req);
+          return new Response("ok");
+        },
+      });
+      expect(await fetch(server.url).then(r => r.text())).toBe("ok");
+      const req = await gotReq;
+      expect(req.signal.aborted).toBe(false);
+      expect(req.signal.reason).toBeUndefined();
+      expect(req.signal).toBe(req.signal);
+    });
+
+    test("req.clone() taken before any signal access observes server abort", async () => {
+      const { promise: gotPair, resolve: resolvePair } = Promise.withResolvers<{ req: Request; clone: Request }>();
+      let unpark!: (value: Response) => void;
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          // Clone before anyone touches req.signal.
+          resolvePair({ req, clone: req.clone() });
+          return new Promise<Response>(resolve => {
+            unpark = resolve;
+          });
+        },
+      });
+      const { req, clone } = await connectAndDisconnect(server, gotPair);
+      while (!req.signal.aborted) await Bun.sleep(5);
+      expect(clone.signal.aborted).toBe(true);
+      expect(clone.signal).toBe(req.signal);
+      unpark(new Response("late"));
+    });
+
+    test("req.clone() taken after signal access shares server aborts", async () => {
+      const { promise: gotPair, resolve: resolvePair } = Promise.withResolvers<{ req: Request; clone: Request }>();
+      let unpark!: (value: Response) => void;
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          const signal = req.signal; // materialize first
+          expect(signal.aborted).toBe(false);
+          resolvePair({ req, clone: req.clone() });
+          return new Promise<Response>(resolve => {
+            unpark = resolve;
+          });
+        },
+      });
+      const { req, clone } = await connectAndDisconnect(server, gotPair);
+      while (!req.signal.aborted) await Bun.sleep(5);
+      expect(clone.signal.aborted).toBe(true);
+      unpark(new Response("late"));
+    });
+
+    test("fetch(req) inside a handler inherits the server abort", async () => {
+      const { promise: gotSignal, resolve: resolveSignal } = Promise.withResolvers<AbortSignal>();
+      let unpark!: (value: Response) => void;
+      using upstream = Bun.serve({
+        port: 0,
+        fetch(req) {
+          resolveSignal(req.signal);
+          return new Promise<Response>(resolve => {
+            unpark = resolve;
+          });
+        },
+      });
+      const upstreamUrl = upstream.url;
+      let fetchErr: unknown;
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          // fetch builds its Request from the incoming one, inheriting req.signal.
+          return fetch(upstreamUrl, req).catch(e => {
+            fetchErr = e;
+            return new Response("aborted", { status: 499 });
+          });
+        },
+      });
+      await connectAndDisconnect(server, gotSignal);
+      const upstreamSignal = await gotSignal;
+      while (!upstreamSignal.aborted) await Bun.sleep(5);
+      expect(upstreamSignal.aborted).toBe(true);
+      while (fetchErr === undefined) await Bun.sleep(5);
+      expect((fetchErr as Error).name).toBe("AbortError");
+      unpark(new Response("late"));
+    });
+
+    test("upgraded request's signal aborts when the WebSocket closes", async () => {
+      const { promise: gotReq, resolve: resolveReq } = Promise.withResolvers<Request>();
+      using server = Bun.serve({
+        port: 0,
+        fetch(req, server) {
+          resolveReq(req);
+          if (server.upgrade(req)) return;
+          return new Response("expected upgrade", { status: 400 });
+        },
+        websocket: { message() {} },
+      });
+
+      const ws = new WebSocket(`ws://${server.hostname}:${server.port}`);
+      const { promise: wsClosed, resolve: onWsClose } = Promise.withResolvers<void>();
+      const { promise: wsOpened, resolve: onWsOpen, reject: rejectOpen } = Promise.withResolvers<void>();
+      ws.onopen = () => onWsOpen();
+      ws.onerror = e => rejectOpen(e);
+      ws.onclose = () => onWsClose();
+      await wsOpened;
+      const req = await gotReq;
+      ws.close();
+      await wsClosed;
+
+      while (!req.signal.aborted) await Bun.sleep(5);
+      expect(req.signal.aborted).toBe(true);
+      const reason = req.signal.reason;
+      expect(reason).toBeInstanceOf(DOMException);
+      expect({ name: reason.name, code: reason.code, message: reason.message }).toEqual(connectionClosedReason);
+    });
+
+    test("survives GC pressure", async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req) {
+          // exercise both shapes: with and without signal materialization
+          const url = new URL(req.url);
+          if (url.pathname === "/touch") {
+            req.signal.addEventListener("abort", () => {});
+            return new Response(String(req.signal.aborted));
+          }
+          return new Response("untouched");
+        },
+      });
+      for (let i = 0; i < 200; i++) {
+        const path = i % 2 ? "/touch" : "/plain";
+        const res = await fetch(`${server.url.origin}${path}`);
+        expect(await res.text()).toBe(i % 2 ? "false" : "untouched");
+        if (i % 50 === 0) Bun.gc(true);
+      }
+      Bun.gc(true);
+    });
+  });
+
   test("abort signal on server with direct stream", async () => {
     {
       let signalOnServer = false;


### PR DESCRIPTION
### What does this PR do?

Every incoming request in `Bun.serve` eagerly allocated a C++ `AbortSignal` (plus a pending-activity ref, an intrusive ref for the `Request`, and a `ContextDestructionObserver` registration) even though most handlers never read `request.signal`.

This PR creates the signal lazily:

- `Request::get_signal` materializes the context-wired signal on first access via `RequestContext::ensure_ctx_signal`, dispatched through `AnyRequestContext`. After materialization the ref topology is identical to the old eager creation (ctx: intrusive +1 and pending-activity; Request: intrusive +1 via `AbortSignalRef::Drop`).
- If the client disconnects before anyone touches `request.signal`, the abort paths (`on_abort`, `finalize_without_deinit` of an aborted context, `set_signal_aborted`) record a `CommonAbortReason` on the `Request` instead of allocating. A later `request.signal` access creates an already-aborted signal with that reason, matching Deno's `signal === false` branch in `ext/fetch/23_request.js`. No allocation happens at teardown when nobody is listening.
- WebSocket upgrade materializes the signal (the `ServerWebSocket` fires `ConnectionClosed` on close) and mirrors a ref into the Request so post-upgrade `request.signal` observes the same abort.
- `request.clone()` and `new Request(serverReq)` materialize the source signal first so aborts keep propagating to clones, as before.

All three eager-creation sites (`mod.rs` route-callback path, `server_body.rs` generic `on_request`, `server_body.rs` `on_web_socket_upgrade`) now pass no signal, the `signal` parameter is removed from `Request::init`, and the dead `set_signal` trait method is gone.

### Savings per request that never touches `request.signal`

One `fastMalloc`/free of a ~150B `WebCore::AbortSignal`, a HashSet add+remove on `ScriptExecutionContext::m_destructionObservers`, a WeakPtr, and ~4 refcount ops. The JS wrapper was already lazy via `get_signal`'s `toJS`, so this does not save a JS object allocation.

### Tests

7 new tests under `describe("lazy request.signal")` in `test/js/bun/http/bun-server.test.ts`:

- first `request.signal` read after client disconnect observes `aborted === true` with the exact `DOMException` reason
- signal stays non-aborted after a normal response completes
- `req.clone()` taken before and after signal access both observe server aborts (and share the same signal)
- `fetch(url, req)` inside a handler inherits the server abort (upstream fetch is cancelled on disconnect)
- `request.signal` of an upgraded request aborts with `ConnectionClosed` when the WebSocket closes
- mixed materialized/unmaterialized signals survive GC pressure

Verified no leak: `test/js/web/fetch/abortsignal-leak-fixture.ts` run to completion ends at `AbortSignal: 1` in `heapStats` (pending-activity balanced).

Existing suites pass locally: `bun-server.test.ts` abort tests, `serve.test.ts` abort/signal tests, `serve-pending-promise-abort-leak.test.ts`, `test/js/web/request/request.test.ts`, `test/js/web/abort/`.
