### PR TITLE
Bun.serve: skip the WHATWG reparse of request.url for verified hosts

### DIFF
--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -898,6 +898,86 @@ impl Request {
         }
     }
 
+    /// `true` if WHATWG-parsing `http(s)://<host><target>` provably returns
+    /// the `<target>` part byte-for-byte: every byte is in the identity LUT
+    /// and the path contains no `.`/`..` segments (the only rewrites the
+    /// parser applies to an origin-form target made of identity-safe bytes;
+    /// the query is never path-normalized).
+    fn target_is_parse_identity(target: &[u8]) -> bool {
+        /// Bytes that serialize back unchanged through the WHATWG URL parser
+        /// in both the path and the query of a special-scheme URL. Derived by
+        /// running every ASCII byte through `new URL(...)` (see the
+        /// "request.url identity bytes" test): rejected bytes are controls,
+        /// space, DEL, non-ASCII, and `"` `'` `<` `>` `\` `^` `` ` `` `{` `}`.
+        /// Everything else — including `%` (even invalid escapes), `#`, `?`,
+        /// `|`, `[`, `]` — passes through verbatim.
+        static URL_IDENTITY_SAFE: [bool; 256] = {
+            let mut t = [false; 256];
+            let mut b = 0x21usize;
+            while b <= 0x7e {
+                t[b] = !matches!(
+                    b as u8,
+                    b'"' | b'\'' | b'<' | b'>' | b'\\' | b'^' | b'`' | b'{' | b'}'
+                );
+                b += 1;
+            }
+            t
+        };
+
+        for &b in target {
+            if !URL_IDENTITY_SAFE[b as usize] {
+                return false;
+            }
+        }
+        // Reject `.` / `..` path segments; scan stops at the query.
+        let path_end = strings::index_of_char(target, b'?')
+            .map_or(target.len(), |i| i as usize);
+        let path = &target[..path_end];
+        let mut seg_start = 1usize; // target[0] == b'/'
+        let mut i = 1usize;
+        while i <= path.len() {
+            if i == path.len() || path[i] == b'/' {
+                let seg = &path[seg_start..i];
+                if seg == b"." || seg == b".." {
+                    return false;
+                }
+                seg_start = i + 1;
+            }
+            i += 1;
+        }
+        true
+    }
+
+    /// 1-entry per-thread memo: does `http(s)://<host>` survive WHATWG
+    /// parsing unchanged (host already canonical, port non-default)? Keyed by
+    /// the exact header bytes, so it's a pure memo — correct across multiple
+    /// servers on the same thread, and workers get their own entry.
+    fn host_canonical_memo(https: bool, host: &[u8], verified: Option<bool>) -> Option<bool> {
+        std::thread_local! {
+            static LAST_HOST: core::cell::RefCell<(bool, Vec<u8>, bool)> =
+                const { core::cell::RefCell::new((false, Vec::new(), false)) };
+        }
+        LAST_HOST.with(|memo| {
+            let mut memo = memo.borrow_mut();
+            match verified {
+                Some(canonical) => {
+                    memo.0 = https;
+                    memo.1.clear();
+                    memo.1.extend_from_slice(host);
+                    memo.2 = canonical;
+                    None
+                }
+                None => {
+                    if memo.0 == https && memo.1 == host {
+                        Some(memo.2)
+                    } else {
+                        None
+                    }
+                }
+            }
+        })
+    }
+
     pub fn ensure_url(&self) -> Result<(), AllocError> {
         if !self.url.get().is_empty() {
             return Ok(());
@@ -935,8 +1015,36 @@ impl Request {
                         #[cfg(debug_assertions)]
                         debug_assert!(self.size_of_url() == url.len());
 
+                        // Fast path: when the target provably round-trips the
+                        // parser unchanged and this exact host already
+                        // verified as canonical, `url` IS the href — skip the
+                        // WHATWG parse entirely.
+                        let target_identity = Self::target_is_parse_identity(&req_url);
+                        if target_identity
+                            && Self::host_canonical_memo(self.flags.https, host, None)
+                                == Some(true)
+                        {
+                            // ASCII by construction (LUT + verified host bytes).
+                            self.url.set(BunString::clone_latin1(url));
+                            return Ok(());
+                        }
+
                         let href = bun_url::href_from_string(&BunString::from_bytes(url));
                         if !href.is_empty() {
+                            let unchanged = core::ptr::eq(
+                                href.byte_slice().as_ptr(),
+                                url.as_ptr(),
+                            ) || href.byte_slice() == url;
+                            if target_identity {
+                                // target is identity ⇒ href == url can only
+                                // hold when scheme+host serialize unchanged
+                                // too; remember that per host.
+                                Self::host_canonical_memo(
+                                    self.flags.https,
+                                    host,
+                                    Some(unchanged),
+                                );
+                            }
                             if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
                                 self.url.set(BunString::clone_latin1(&url[..href.length()]));
                                 href.deref();

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -930,8 +930,7 @@ impl Request {
             }
         }
         // Reject `.` / `..` path segments; scan stops at the query.
-        let path_end = strings::index_of_char(target, b'?')
-            .map_or(target.len(), |i| i as usize);
+        let path_end = strings::index_of_char(target, b'?').map_or(target.len(), |i| i as usize);
         let path = &target[..path_end];
         let mut seg_start = 1usize; // target[0] == b'/'
         let mut i = 1usize;
@@ -1021,8 +1020,7 @@ impl Request {
                         // WHATWG parse entirely.
                         let target_identity = Self::target_is_parse_identity(&req_url);
                         if target_identity
-                            && Self::host_canonical_memo(self.flags.https, host, None)
-                                == Some(true)
+                            && Self::host_canonical_memo(self.flags.https, host, None) == Some(true)
                         {
                             // ASCII by construction (LUT + verified host bytes).
                             self.url.set(BunString::clone_latin1(url));
@@ -1031,19 +1029,13 @@ impl Request {
 
                         let href = bun_url::href_from_string(&BunString::from_bytes(url));
                         if !href.is_empty() {
-                            let unchanged = core::ptr::eq(
-                                href.byte_slice().as_ptr(),
-                                url.as_ptr(),
-                            ) || href.byte_slice() == url;
+                            let unchanged = core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr())
+                                || href.byte_slice() == url;
                             if target_identity {
                                 // target is identity ⇒ href == url can only
                                 // hold when scheme+host serialize unchanged
                                 // too; remember that per host.
-                                Self::host_canonical_memo(
-                                    self.flags.https,
-                                    host,
-                                    Some(unchanged),
-                                );
+                                Self::host_canonical_memo(self.flags.https, host, Some(unchanged));
                             }
                             if core::ptr::eq(href.byte_slice().as_ptr(), url.as_ptr()) {
                                 self.url.set(BunString::clone_latin1(&url[..href.length()]));

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -546,6 +546,151 @@ it("request.url normalizes raw request targets like the WHATWG parser", async ()
   expect(await urlFor("/x", "a.example")).toBe("http://a.example/x");
 });
 
+it("request.url equals the WHATWG href for seeded-random raw targets", async () => {
+  // Deterministic fuzz over the byte classes the fast path classifies
+  // (identity-safe bytes, bytes the parser rewrites, dot segments) across
+  // hosts that exercise the per-thread host memo (mixed case, default and
+  // non-default ports, IPv6). Oracle: new URL(...) in this process — the
+  // parser itself is unchanged by the fast path.
+  let seed = 0x12345678;
+  const rand = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  const pool = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" + "-._~!$&()*+,;=:@/?%#[]|'\"<>\\^`{}";
+  function genTarget(): string {
+    let t = "/";
+    const len = 1 + Math.floor(rand() * 40);
+    for (let i = 0; i < len; i++) t += pool[Math.floor(rand() * pool.length)];
+    if (rand() < 0.25)
+      t = t.slice(0, 1 + Math.floor(rand() * t.length)) + "/../" + t.slice(1 + Math.floor(rand() * t.length));
+    if (rand() < 0.15) t += "/.";
+    if (rand() < 0.15) t = "/." + t;
+    return t;
+  }
+
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.url);
+    },
+  });
+
+  async function urlFor(target: string, host: string): Promise<string> {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const chunks: Buffer[] = [];
+    const socket = await Bun.connect({
+      hostname: server.hostname,
+      port: server.port,
+      socket: {
+        data(_s, c) {
+          chunks.push(Buffer.from(c));
+        },
+        close() {
+          resolve(Buffer.concat(chunks).toString("latin1"));
+        },
+        error(_s, e) {
+          reject(e);
+        },
+      },
+    });
+    socket.write(`GET ${target} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
+    const raw = await promise;
+    return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  }
+
+  const hosts = [
+    `127.0.0.1:${server.port}`,
+    "example.com",
+    "EXAMPLE.com",
+    "example.com:80",
+    "example.com:8080",
+    "127.0.0.1",
+    "[::1]:9999",
+    "a.example",
+  ];
+  for (let i = 0; i < 200; i++) {
+    const target = genTarget();
+    const host = hosts[Math.floor(rand() * hosts.length)];
+    const expected = new URL(`http://${host}${target}`).href;
+    const actual = await urlFor(target, host);
+    expect({ target, host, url: actual }).toEqual({ target, host, url: expected });
+  }
+});
+
+it("request.url fast path edge cases: keep-alive reuse, long URLs, missing Host", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.url);
+    },
+  });
+  const port = server.port;
+
+  async function raw(requests: string[]): Promise<string> {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const chunks: Buffer[] = [];
+    const socket = await Bun.connect({
+      hostname: "127.0.0.1",
+      port,
+      socket: {
+        data(_s, c) {
+          chunks.push(Buffer.from(c));
+        },
+        close() {
+          resolve(Buffer.concat(chunks).toString("latin1"));
+        },
+        error(_s, e) {
+          reject(e);
+        },
+      },
+    });
+    socket.write(requests.join(""));
+    return promise;
+  }
+
+  // keep-alive: alternating fast-path and parser-path targets on one socket
+  const long = "/" + "a".repeat(180) + "?q=" + "b".repeat(40);
+  const keepAlive = await raw([
+    `GET /first?x=1 HTTP/1.1\r\nHost: h.example\r\n\r\n`,
+    `GET /second/../x HTTP/1.1\r\nHost: h.example\r\n\r\n`,
+    `GET ${long} HTTP/1.1\r\nHost: h.example\r\nConnection: close\r\n\r\n`,
+  ]);
+  const bodies = keepAlive
+    .split("\r\n\r\n")
+    .slice(1)
+    .map(s => s.split("HTTP/1.1")[0]);
+  expect(bodies).toEqual(["http://h.example/first?x=1", "http://h.example/x", `http://h.example${long}`]);
+
+  // >=128-byte URL with dot segments takes the pre-existing slow path
+  const longDots = await raw([`GET /${"a".repeat(180)}/../z HTTP/1.1\r\nHost: h.example\r\nConnection: close\r\n\r\n`]);
+  expect(longDots.slice(longDots.indexOf("\r\n\r\n") + 4)).toBe("http://h.example/z");
+
+  // No Host header: url stays the bare target
+  const noHost = await raw([`GET /nohost?a=1 HTTP/1.0\r\n\r\n`]);
+  expect(noHost.slice(noHost.indexOf("\r\n\r\n") + 4)).toBe("/nohost?a=1");
+});
+
+it("request.url uses https scheme in the fast path for TLS servers", async () => {
+  using server = Bun.serve({
+    port: 0,
+    tls,
+    fetch(req) {
+      return new Response(req.url);
+    },
+  });
+  for (const [path, host, expected] of [
+    ["/a?b=c", "example.com", "https://example.com/a?b=c"],
+    ["/x/../y", "example.com", "https://example.com/y"],
+    // default https port is stripped by the parser — must not hit the fast path
+    ["/p'q", "example.com:443", "https://example.com/p'q"],
+    ["/p", "EXAMPLE.com", "https://example.com/p"],
+  ] as const) {
+    const res = await fetch(`https://127.0.0.1:${server.port}${path}`, {
+      headers: { Host: host },
+      tls: { rejectUnauthorized: false },
+    });
+    expect(await res.text()).toBe(expected);
+  }
+});
+
 it("request.url should be based on the Host header", async () => {
   const fixture = resolve(import.meta.dir, "./fetch.js.txt");
   const textToExpect = readFileSync(fixture, "utf-8");

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -459,6 +459,93 @@ it("request.url should log successfully", async () => {
   );
 });
 
+it("request.url identity bytes match the native fast-path table", () => {
+  // The fast path in Request::ensure_url (src/runtime/webcore/Request.rs,
+  // URL_IDENTITY_SAFE) assumes exactly these bytes round-trip the WHATWG
+  // parser unchanged in path and query position. If this fails, the parser
+  // changed — update the native table to match.
+  const pathBad: string[] = [];
+  const queryBad: string[] = [];
+  for (let b = 0x21; b <= 0x7e; b++) {
+    const c = String.fromCharCode(b);
+    const p = `http://h.example:3000/a${c}b?q`;
+    if (new URL(p).href !== p) pathBad.push(c);
+    const q = `http://h.example:3000/a?x${c}y`;
+    if (new URL(q).href !== q) queryBad.push(c);
+  }
+  expect(pathBad.join("")).toBe('"<>\\^`{}');
+  expect(queryBad.join("")).toBe(`"'<>`);
+});
+
+it("request.url normalizes raw request targets like the WHATWG parser", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.url);
+    },
+  });
+
+  async function urlFor(target: string, host: string): Promise<string> {
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const chunks: Buffer[] = [];
+    const socket = await Bun.connect({
+      hostname: server.hostname,
+      port: server.port,
+      socket: {
+        data(_s, chunk) {
+          chunks.push(Buffer.from(chunk));
+        },
+        close() {
+          resolve(Buffer.concat(chunks).toString("latin1"));
+        },
+        error(_s, err) {
+          reject(err);
+        },
+      },
+    });
+    socket.write(`GET ${target} HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
+    const raw = await promise;
+    return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  }
+
+  const H = `127.0.0.1:${server.port}`;
+  const cases: [string, string][] = [
+    ["/", `http://${H}/`],
+    ["/id/1?name=bun", `http://${H}/id/1?name=bun`],
+    // dot segments are collapsed (never served verbatim by the fast path)
+    ["/a/./b", `http://${H}/a/b`],
+    ["/a/../b", `http://${H}/b`],
+    ["/a/..", `http://${H}/`],
+    // not dot segments
+    ["/.well-known/x", `http://${H}/.well-known/x`],
+    ["/..x", `http://${H}/..x`],
+    ["//double", `http://${H}//double`],
+    // percent sequences pass through verbatim, even invalid ones
+    ["/%41%zz%", `http://${H}/%41%zz%`],
+    ["/a|b", `http://${H}/a|b`],
+    ["/a[1]?b=[2]", `http://${H}/a[1]?b=[2]`],
+    // ' survives in the path but is encoded in the query
+    ["/quote'path?q='v", `http://${H}/quote'path?q=%27v`],
+    ['/d"q', `http://${H}/d%22q`],
+    ["/back\\slash", `http://${H}/back/slash`],
+    ["/ca^ret", `http://${H}/ca%5Eret`],
+    ["/cu{rl}y", `http://${H}/cu%7Brl%7Dy`],
+    ["/frag#ment?x", `http://${H}/frag#ment?x`],
+  ];
+  for (const [target, expected] of cases) {
+    expect({ target, url: await urlFor(target, H) }).toEqual({ target, url: expected });
+  }
+
+  // The Host header becomes the URL authority verbatim; non-canonical forms
+  // must still go through the parser (no fast-path contamination).
+  expect(await urlFor("/x", "EXAMPLE.com")).toBe("http://example.com/x");
+  expect(await urlFor("/x", "example.com:80")).toBe("http://example.com/x");
+  // alternate hosts to exercise the per-thread host memo replacement
+  expect(await urlFor("/x", "a.example")).toBe("http://a.example/x");
+  expect(await urlFor("/x", "b.example")).toBe("http://b.example/x");
+  expect(await urlFor("/x", "a.example")).toBe("http://a.example/x");
+});
+
 it("request.url should be based on the Host header", async () => {
   const fixture = resolve(import.meta.dir, "./fetch.js.txt");
   const textToExpect = readFileSync(fixture, "utf-8");


### PR DESCRIPTION
### What does this PR do?

`request.url` runs the full WHATWG URL parser on `http(s)://<host><target>` for every request, even though for typical requests the parse returns its input unchanged. In HTTP benchmarks `WTF::URLParser::parse` + `parseHostAndPort` + `parseIPv4Host` account for ~1.5% of main-thread CPU (the benchmark host `127.0.0.1` goes through full IPv4 re-canonicalization on every request).

`Request::ensure_url` now skips the parse when two independently-checked conditions hold, and falls back to the existing full parse otherwise:

1. **The target provably round-trips the parser unchanged** (`target_is_parse_identity`): every byte is in a 256-entry table of bytes the parser serializes verbatim in both path and query position, and the path contains no `.`/`..` segments. The table was derived by running every ASCII byte through the parser in both positions — rejected bytes are controls, space, DEL, non-ASCII, and `"` `'` `<` `>` `\` `^` `` ` `` `{` `}`; notably `%` (even invalid escapes), `#`, `?`, `|`, `[`, `]` pass through verbatim. A test asserts this byte set against the engine, so a future parser change breaks loudly instead of silently invalidating the table.
2. **This exact host already round-tripped the parser unchanged once** (`host_canonical_memo`): a per-thread 1-entry memo keyed by the exact `(protocol, host header bytes)`. It is only populated from a full-parse result where the identity-target href compared byte-equal to the input, which is exactly the statement "scheme+host serialize unchanged" (non-canonical hosts — uppercase, default ports, punycode-needing, IPv4 shorthand — record `false` and keep taking the full parse). Workers get their own entry; the memo is pure content-keyed memoization, so multiple servers on a thread can't contaminate each other.

The slow paths (>=128-byte URLs, missing Host, absolute-form targets) are untouched.

### Observable-behavior verification

- 400-case seeded differential fuzz (random targets mixing identity-safe bytes, rewritten bytes, and dot segments, across 8 host variants including mixed case, `:80`, `:8080`, IPv6) run under the previous build and this build: outputs byte-identical.
- Same differential run for HTTPS (`:443` stripping), keep-alive socket reuse mixing fast/slow targets, >=128-byte URLs with dot segments, and HTTP/1.0 without Host: identical.

### Tests (`test/js/bun/http/serve.test.ts`)

- identity-byte invariant test pinning the table to the parser's actual behavior
- normalization matrix over raw sockets: dot segments collapse, `/.well-known` and `//` survive, invalid `%` sequences pass through, `'` survives in path but encodes in query, `\` becomes `/`, `^`/`{}`/`"` encode, non-canonical Host headers (uppercase, `:80`) still normalize, alternating hosts exercise memo replacement
- 200-case seeded fuzz asserting `req.url === new URL("http://" + host + target).href`
- keep-alive reuse, long-URL slow path, missing-Host edge cases
- TLS server cases (https scheme in the memo key, `:443` stripping)

The dot-segment and non-canonical-host cases fail if the fast path misclassifies them, and the fuzz fails if the byte table over-approximates, so the load-bearing conditions are covered. The pre-existing "normlizes incoming request URLs" test also passes.

### Performance

Measured together with #32009 on the saltyaom/bun-http-framework-benchmark hono suite (bombardier `-c 500`, 8 interleaved A/B rounds vs main, median, Apple Silicon): ping +3.5%, query +4.3%, body +3.1% combined. Profiles confirm `WTF::URLParser*` disappears from the per-request hot path (`ensure_url` drops to 0.20% self time — the concat + byte scan).