### PR TITLE
Skip the delete-on-reboot MoveFileExW call in dlopen when the process is not elevated

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -386,6 +386,26 @@ extern "C" void Bun__unlink(const char*, size_t);
 extern "C" void CrashHandler__setDlOpenAction(const char* action);
 extern "C" bool Bun__VM__allowAddons(void* vm);
 
+#if OS(WINDOWS)
+// MOVEFILE_DELAY_UNTIL_REBOOT appends to
+// HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations,
+// which only elevated processes can write.
+static bool processIsElevated()
+{
+    static const bool elevated = [] {
+        HANDLE token = nullptr;
+        if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &token))
+            return false;
+        TOKEN_ELEVATION elevation {};
+        DWORD returnLength = 0;
+        const bool result = GetTokenInformation(token, TokenElevation, &elevation, sizeof(elevation), &returnLength) && elevation.TokenIsElevated;
+        CloseHandle(token);
+        return result;
+    }();
+    return elevated;
+}
+#endif
+
 JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalObject_, JSC::CallFrame* callFrame))
 {
     Zig::GlobalObject* globalObject = static_cast<Zig::GlobalObject*>(globalObject_);
@@ -486,12 +506,21 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionDlopen, (JSC::JSGlobalObject * globalOb
                 memcpy(dupeZ, span.data(), span.size_bytes());
                 dupeZ[span.size()] = L'\0';
 
-                // We can't immediately delete the file on Windows.
-                // Instead, we mark it for deletion on reboot.
-                MoveFileExW(
-                    dupeZ,
-                    NULL, // NULL destination means delete
-                    MOVEFILE_DELAY_UNTIL_REBOOT);
+                // This only succeeds when LoadLibrary failed: while the module
+                // is loaded, deleting its file fails with a sharing violation.
+                if (!DeleteFileW(dupeZ)) {
+                    // Fall back to marking the file for deletion on reboot.
+                    // Skip the call when the process is not elevated: it could
+                    // only fail with ERROR_ACCESS_DENIED, and third-party
+                    // MoveFileExW hooks (AV/EDR) have been observed to crash on
+                    // the NULL-destination (delete) form of this call.
+                    if (processIsElevated()) {
+                        MoveFileExW(
+                            dupeZ,
+                            NULL, // NULL destination means delete
+                            MOVEFILE_DELAY_UNTIL_REBOOT);
+                    }
+                }
                 delete[] dupeZ;
             }
         }

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -109,8 +109,11 @@ describe.concurrent("napi", () => {
             if (process.platform !== "win32") {
               expect(readdirSync(tmpdir), "bun should clean up .node files").toBeEmpty();
             } else {
-              // On Windows, we have to mark it for deletion on reboot.
-              // Not clear how to test for that.
+              // On Windows the extracted file can't be deleted while the
+              // module is loaded, so it stays behind (elevated processes mark
+              // it for deletion on reboot). This at least proves the
+              // extraction went to BUN_TMPDIR.
+              expect(readdirSync(tmpdir), "extraction should use BUN_TMPDIR").not.toBeEmpty();
             }
           },
           10 * 1000,
@@ -149,6 +152,43 @@ describe.concurrent("napi", () => {
         }
       });
     });
+  });
+
+  it("cleans up the extracted .node file when dlopen fails in a compiled executable", async () => {
+    const dir = tempDirWithFiles("dlopen-fail-compile", {
+      "package.json": JSON.stringify({ name: "dlopen-fail", version: "1.0.0" }),
+      "main.js": `try {
+        require("./invalid.node");
+        console.log("unexpected: dlopen succeeded");
+      } catch (err) {
+        console.log("code: " + err.code);
+      }`,
+      "invalid.node": "this is not a native addon",
+    });
+
+    const build = spawnSync({
+      cmd: [bunExe(), "build", "--compile", join(dir, "main.js")],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    expect(build.success).toBeTrue();
+
+    const exe = join(dir, "main" + (process.platform === "win32" ? ".exe" : ""));
+    const tmpdir = tempDirWithFiles("dlopen-fail-tmpdir", {});
+    const result = spawnSync({
+      cmd: [exe],
+      env: { ...bunEnv, BUN_TMPDIR: tmpdir },
+      stdin: "inherit",
+      stderr: "inherit",
+      stdout: "pipe",
+    });
+    expect(result.stdout.toString().trim()).toBe("code: ERR_DLOPEN_FAILED");
+    expect(result.success).toBeTrue();
+    // Nothing keeps the extracted copy open after dlopen fails, so it must be
+    // deleted immediately, on Windows too (no reliance on delete-on-reboot).
+    expect(readdirSync(tmpdir), "bun should clean up the extracted .node file").toBeEmpty();
   });
 
   describe("issue_7685", () => {


### PR DESCRIPTION
### Problem

Crash telemetry for Windows x86_64 standalone executables (`bun build --compile`) shows a steady stream of segmentation faults at address `0x00000000` while loading an embedded `.node` addon, ~60 events/day across bun 1.3.10-1.3.14. The faulting stack is always:

```
Bun::Process_functionDlopen                 BunProcess.cpp (success-path tryToDeleteIfNecessary())
Bun::Process_functionDlopen::<lambda_0>     BunProcess.cpp (MoveFileExW call)
<unsymbolized system frames>                -> SIGSEGV at 0x0
```

For compiled executables, embedded `.node` files are extracted to a temp file, loaded with `LoadLibrary`, and then immediately scheduled for deletion (#19550):

```cpp
MoveFileExW(dupeZ, NULL /* delete */, MOVEFILE_DELAY_UNTIL_REBOOT);
```

Two problems with that call:

- `MOVEFILE_DELAY_UNTIL_REBOOT` writes `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations`, which requires administrator rights. For a normal non-elevated process it always fails with `ERROR_ACCESS_DENIED`, so today it is a no-op for most users.
- The crash is inside the call itself, in unsymbolized system-side frames, with the fault address exactly `0x0`. Plain kernelbase handles the NULL-destination delete form fine; the evidence points at user-mode `MoveFileExW` hooks (AV/EDR shims, near-universal on Windows fleets) dereferencing the NULL `lpNewFileName`. The events come from many distinct machines (top single source is 24 of 1,200 recent events), so it is not one broken install.

Bun can't fix the hooks, but it is choosing to make the one call form they mishandle, on every addon load, when the call cannot succeed anyway.

### Fix

In `tryToDeleteIfNecessary` (Windows branch):

1. Try `DeleteFileW` first. It succeeds whenever `LoadLibrary` failed, because the file is not mapped; while the module is loaded it fails with a sharing violation. This makes the failure path actually clean up the temp file for everyone (previously it leaked for non-admins and lingered until reboot for admins).
2. Only fall back to `MoveFileExW(path, NULL, MOVEFILE_DELAY_UNTIL_REBOOT)` when the process token is elevated (`GetTokenInformation(TokenElevation)`, cached). For non-elevated processes this removes the crashing call entirely with no behavior change: the call was failing with `ERROR_ACCESS_DENIED` for them anyway, so temp file cleanup for successfully loaded addons is exactly as (un)reliable as before.

Elevated processes keep the existing delete-on-reboot behavior.

The POSIX branch (`Bun__unlink` after `dlopen`) is untouched.

Related: #30036 statically merges addons into the PE at build time, but keeps this extract-to-tempfile path as its fallback, so this call site remains reachable either way.

### Tests

There is no repro for the crash itself (it needs a third-party hook that mishandles the call), so the fix is justified by the mechanism above. The behavior that is testable:

- New test in `test/napi/napi.test.ts`: a compiled executable embedding an invalid `.node` file throws `ERR_DLOPEN_FAILED` and leaves `BUN_TMPDIR` empty. On Windows this fails before this change (the extracted temp file was left behind) and passes after; on POSIX it pins the existing unlink-on-failure behavior.
- The existing `should work with --compile` tests (esm/cjs) verify a real node-gyp addon still loads and works in a compiled executable on all platforms. Extended the Windows branch to assert extraction actually targets `BUN_TMPDIR` (previously unasserted).

Verified on Linux: both tests pass with this change, and the new test also passes unchanged on the released build (the POSIX path is intentionally unchanged; the fail-before is Windows-only).
