### PR TITLE
bun:ffi: stop allocating TinyCC JIT memory from the CRT heap on Windows

### DIFF
--- a/patches/tinycc/tccrun.c.patch
+++ b/patches/tinycc/tccrun.c.patch
@@ -1,0 +1,68 @@
+--- tccrun.c
++++ tccrun.c
+@@ -130,8 +130,15 @@
+     //printf("map %p %p %p\n", ptr, prw, (void*)ptr_diff);
+     size *= 2;
+ #else
++# ifdef _WIN32
++    /* Generated code is page-protected below; avoid changing CRT heap pages. */
++    ptr = VirtualAlloc(NULL, size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
++# else
+     ptr = tcc_malloc(size += PAGESIZE); /* one extra page to align malloc memory */
++# endif
+ #endif
++    if (!ptr)
++        return tcc_error_noabort("tccrun: could not allocate memory");
+     s1->run_ptr = ptr;
+     s1->run_size = size;
+     return ptr_diff;
+@@ -188,12 +195,20 @@
+ #ifdef CONFIG_SELINUX
+     munmap(ptr, size);
+ #else
++# ifdef _WIN32
++    (void)size;
++#  ifdef _WIN64
++    win64_del_function_table(s1->run_function_table);
++#  endif
++    VirtualFree(ptr, 0, MEM_RELEASE);
++# else
+     /* unprotect memory to make it usable for malloc again */
+     protect_pages((void*)PAGEALIGN(ptr), size - PAGESIZE, 2 /*rw*/);
+ # ifdef _WIN64
+     win64_del_function_table(s1->run_function_table);
+ # endif
+     tcc_free(ptr);
++# endif
+ #endif
+ }
+ 
+@@ -414,7 +429,11 @@
+             }
+             if (protect_pages((void*)addr, n, f) < 0)
+                 return tcc_error_noabort(
++#ifdef _WIN32
++                    "VirtualProtect failed");
++#else
+                     "mprotect failed (did you mean to configure --with-selinux?)");
++#endif
+         }
+     }
+ 
+@@ -487,11 +506,14 @@
+     void *p = NULL;
+     if (s1->uw_pdata) {
+         p = (void*)s1->uw_pdata->sh_addr;
+-        RtlAddFunctionTable(
++        if (!RtlAddFunctionTable(
+             (RUNTIME_FUNCTION*)p,
+             s1->uw_pdata->data_offset / sizeof (RUNTIME_FUNCTION),
+             s1->pe_imagebase
+-            );
++            )) {
++            tcc_error_noabort("RtlAddFunctionTable failed");
++            p = NULL;
++        }
+         s1->uw_pdata = NULL;
+     }
+     return p;

--- a/scripts/build/deps/tinycc.ts
+++ b/scripts/build/deps/tinycc.ts
@@ -28,7 +28,19 @@ export const tinycc: Dependency = {
     commit: TINYCC_COMMIT,
   }),
 
-  patches: ["patches/tinycc/tcc.h.patch"],
+  patches: [
+    "patches/tinycc/tcc.h.patch",
+    // Backport of upstream tinycc mob 6728a64f1b ("win32: use VirtualAlloc
+    // for run memory") and 601a088214 ("win32: improve tccrun protection
+    // diagnostics"). The pinned fork commit predates both. Without them,
+    // JIT run memory on Windows is malloc'd from the CRT heap, gets
+    // VirtualProtect'd RWX, and has SEH unwind tables registered inside it
+    // via RtlAddFunctionTable, whose failure was also silently ignored.
+    // Crashes in the field as an access violation inside ntdll during
+    // RtlAddFunctionTable on a later FFI compile. Drop when TINYCC_COMMIT
+    // advances past an oven-sh/tinycc merge of upstream mob >= 601a088214.
+    "patches/tinycc/tccrun.c.patch",
+  ],
 
   build: cfg => {
     const sources = ["libtcc.c", "tccpp.c", "tccgen.c", "tccdbg.c", "tccelf.c", "tccasm.c", "tccrun.c"];

--- a/scripts/build/deps/tinycc.ts
+++ b/scripts/build/deps/tinycc.ts
@@ -30,15 +30,9 @@ export const tinycc: Dependency = {
 
   patches: [
     "patches/tinycc/tcc.h.patch",
-    // Backport of upstream tinycc mob 6728a64f1b ("win32: use VirtualAlloc
-    // for run memory") and 601a088214 ("win32: improve tccrun protection
-    // diagnostics"). The pinned fork commit predates both. Without them,
-    // JIT run memory on Windows is malloc'd from the CRT heap, gets
-    // VirtualProtect'd RWX, and has SEH unwind tables registered inside it
-    // via RtlAddFunctionTable, whose failure was also silently ignored.
-    // Crashes in the field as an access violation inside ntdll during
-    // RtlAddFunctionTable on a later FFI compile. Drop when TINYCC_COMMIT
-    // advances past an oven-sh/tinycc merge of upstream mob >= 601a088214.
+    // Backport of upstream tinycc mob 6728a64f1b (win32: VirtualAlloc for run
+    // memory) and 601a088214 (win32 tccrun diagnostics); the pinned fork
+    // predates both. Drop once TINYCC_COMMIT advances past a merge of those.
     "patches/tinycc/tccrun.c.patch",
   ],
 


### PR DESCRIPTION
### Crash

Windows x64 processes using `bun:ffi` segfault inside ntdll while compiling symbols, always with this stack (symbolicated from bun 1.3.14):

```
FFI.open / Function.compile (ffi.zig, ffi_body.rs on main)
  -> tcc_relocate -> tcc_relocate_ex        vendor/tinycc/tccrun.c
  -> win64_add_function_table               (the RtlAddFunctionTable call)
  -> RtlAddFunctionTable -> <ntdll frames> -> access violation
```

Fault addresses vary per event and look heap-like (0x1CB99EF6BB8, 0x189937629B8, 0x2C426471E98, ...). Crash reporting has 12,000+ events across bun 1.3.8 through 1.3.14 (report ID BUN-2V2K), 100% Windows, spread over many distinct machines and apps. There is no known deterministic reproduction; the crash depends on accumulated heap state.

### Cause

The pinned oven-sh/tinycc commit allocates JIT "run memory" with `tcc_malloc`, i.e. from the CRT heap, which on Windows is the NT process heap. It then:

- lays generated code and data out inside that heap block,
- `VirtualProtect`s the code pages to `PAGE_EXECUTE_READWRITE`, and
- registers SEH unwind tables pointing into the block via `RtlAddFunctionTable`, ignoring the return value.

So executable JIT pages and registered unwind data live inside pages owned by the NT process heap. In bun that heap is used almost exclusively by TinyCC and by ntdll itself (bun's own allocations go through mimalloc, JSC's through bmalloc), which is why corrupted heap or unwind-table state surfaces precisely at the next `RtlAddFunctionTable` call: it allocates its dynamic-table node from the process heap and updates the process-wide table list.

Upstream TinyCC identified and fixed exactly this:

- [6728a64f1b](https://github.com/TinyCC/tinycc/commit/6728a64f1b) "win32: use VirtualAlloc for run memory", with the in-code comment "Generated code is page-protected below; avoid changing CRT heap pages."
- [601a088214](https://github.com/TinyCC/tinycc/commit/601a088214) "win32: improve tccrun protection diagnostics", which also treats `RtlAddFunctionTable` failure as an error instead of silently keeping a never-registered table pointer (previously that pointer was later handed to `RtlDeleteFunctionTable`).

The pinned fork commit predates both.

### Fix

Backport the two upstream commits verbatim as `patches/tinycc/tccrun.c.patch`, registered in `scripts/build/deps/tinycc.ts` (the existing vendor-patch mechanism) with a note to drop the patch once `TINYCC_COMMIT` advances past an upstream merge containing 601a088214:

- Windows run memory comes from a dedicated `VirtualAlloc(NULL, size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE)` region, released with `VirtualFree(MEM_RELEASE)` after `RtlDeleteFunctionTable` (same unregister-before-free order as before).
- `RtlAddFunctionTable` failure now fails the FFI compile with "RtlAddFunctionTable failed".
- `VirtualProtect` failure gets a Windows-specific diagnostic.

Non-Windows behavior is byte-identical: every new branch is `#ifdef _WIN32`.

Other explanations audited and ruled out on current code: registration/unregistration are strictly paired (`run_function_table` is set once in `tcc_relocate_ex` and deleted only in `tcc_run_free` before the memory is released, and bun frees TCC states only through `tcc_delete`), so there is no code path that frees a registered table's memory without unregistering it. Concurrent Worker compiles hitting TinyCC globals remain theoretically possible but cannot account for the event volume.

### Verification

- `bun bd` re-fetches the pinned tinycc commit, applies the patch cleanly (the patch-content hash invalidates the cached source), and builds.
- `bun bd test test/js/bun/ffi/` matches main (the two `ffi.test.js` errors about `/tmp/bun-ffi-test.dylib` are pre-existing; they reproduce with the released bun).
- A 20-iteration `JSCallback` + `CFunction` compile/call/close loop runs clean under the ASAN debug build.
- Windows CI lanes compile the patched `#ifdef _WIN32` branches and run the existing `bun:ffi` suite through the new allocation path.

### Why there is no new test

The changed code is Windows-only vendored C, dead on Linux, and the crash has no deterministic repro (heap-state dependent). No test can fail before and pass after this change on Linux, and a Windows stress test would not reliably fail on the unfixed build either. The existing Windows FFI tests exercise the new path on every CI run.


### Related issue

Should address #31941 (not auto-closing: the link is causal reasoning, not an observed before/after; please reopen if it recurs on a release containing this patch).

That report is the same memory class seen from the other side: a Windows x64 standalone executable doing sustained FFI polling crashes after ~2 hours while executing the compiled trampoline (`JSFFIFunction::trampoline` calling into an anonymous executable region), with the same heap-range fault addresses (0x1A5F8AF0108, 0x210D7F40108) as the compile-time crashes above. The workload churns the CRT heap heavily around the live JIT block (libuv allocates from it; the session had 1,484 spawns and 12k fetches). With this patch the JIT code no longer lives in heap pages at all. The issue's 2-hour repro has not been run against the patched build; if the crash recurs on a release containing this fix, the issue should be reopened.

