### PR TITLE
http: prevent double final-result delivery after client failure

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1606,6 +1606,19 @@ impl<'a> HTTPClient<'a> {
         // `result.body` and `state.reset()` are disjoint.
         let result = unsafe { self.to_result().detach_lifetime() };
         self.state.reset();
+        // `state.reset()` returns every stage field to Pending, which makes
+        // this finished client indistinguishable from a fresh one. Every
+        // caller reaches here with `stage == Fail` (a terminal state), and the
+        // final result dispatched below frees the HTTP-thread AsyncHTTP clone
+        // that embeds this client. Restore the terminal stage so a late event
+        // on a still-reachable reference (socket tag, timer, tracker entry)
+        // hits the `stage != Done && stage != Fail` guards and becomes a
+        // no-op instead of delivering a second final result into freed
+        // memory. The success path (`send_progress_update_without_stage_check`)
+        // already restores `Stage::Done` the same way after its reset.
+        self.state.request_stage = RequestStage::Fail;
+        self.state.response_stage = ResponseStage::Fail;
+        self.state.stage = Stage::Fail;
         if clear_proxy_tunneling {
             self.flags.proxy_tunneling = false;
         }
@@ -2101,7 +2114,12 @@ impl<'a> HTTPClient<'a> {
             }
         }
 
-        if self.allow_retry
+        // `in_progress` also keeps a client whose final result was already
+        // delivered (stage Done/Fail) from restarting; the AsyncHTTP clone
+        // that embeds it is freed once that result is dispatched, so a late
+        // close event must not re-enter `start()`.
+        if in_progress
+            && self.allow_retry
             && self.method.is_idempotent()
             // Only a Bytes body can be rebuilt from `original_request_body`.
             // Stream/Sendfile bodies are consumed as they are written, so a
@@ -2136,8 +2154,14 @@ impl<'a> HTTPClient<'a> {
             return;
         }
         bun_core::scoped_log!(fetch, "Timeout  {}\n", BStr::new(self.url.href));
-        self.fail(crate::Error::Timeout);
+        // Terminate (mark dead + close) BEFORE failing, matching
+        // `close_and_fail`: `fail()` dispatches the final result, which frees
+        // the HTTP-thread AsyncHTTP clone that embeds `self`, so nothing may
+        // run after it, and the socket must already be de-tagged so the
+        // synchronous close callbacks (TLS close fires on_handshake for a
+        // mid-handshake socket) cannot re-enter this client.
         GenHttpContext::<IS_SSL>::terminate_socket(socket);
+        self.fail(crate::Error::Timeout);
     }
 
     /// `dns_error` is the raw `getaddrinfo(3)` return code when the name

--- a/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
+++ b/test/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts
@@ -1,0 +1,204 @@
+// Fixture for "rejects a trusted cert with a mismatched hostname cleanly under churn".
+//
+// Reproduces the traffic shape behind a family of HTTP-thread use-after-free
+// crashes (sentry BUN-2WC6 and siblings): TLS connections whose certificate
+// chain is trusted but whose hostname does not match, with the server
+// speaking first so SSL_read completes the handshake from the data path
+// (on_handshake fires from us_internal_ssl_on_data), racing AbortSignal
+// timeouts and keepalive pool churn. Run with BUN_CONFIG_HTTP_IDLE_TIMEOUT=1
+// so the idle-timeout failure path (HTTPClient::on_timeout) is reachable.
+//
+// Exits non-zero if any fetch produces an unexpected outcome or if the
+// process crashes.
+import tls from "node:tls";
+import net from "node:net";
+// Harness localhost cert (test/harness.ts `tls`): valid for localhost/127.0.0.1,
+// self-signed so it doubles as its own CA.
+const validTls = {
+  cert: "-----BEGIN CERTIFICATE-----\nMIID4jCCAsqgAwIBAgIUcaRq6J/YF++Bo01Zc+HeQvCbnWMwDQYJKoZIhvcNAQEL\nBQAwaTELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJh\nbmNpc2NvMQ0wCwYDVQQKDARPdmVuMREwDwYDVQQLDAhUZWFtIEJ1bjETMBEGA1UE\nAwwKc2VydmVyLWJ1bjAeFw0yNTA5MDYwMzAwNDlaFw0zNTA5MDQwMzAwNDlaMGkx\nCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEWMBQGA1UEBwwNU2FuIEZyYW5jaXNj\nbzENMAsGA1UECgwET3ZlbjERMA8GA1UECwwIVGVhbSBCdW4xEzARBgNVBAMMCnNl\ncnZlci1idW4wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDlYzosgRgX\nHL6vMh1V0ERFhsvlZrtRojSw6tafr3SQBphU793/rGiYZlL/lJ9HIlLkx9JMbuTj\nNm5U2eRwHiTQIeWD4aCIESwPlkdaVYtC+IOj55bJN8xNa7h5GyJwF7PnPetAsKyE\n8DMBn1gKMhaIis7HHOUtk4/K3Y4peU44d04z0yPt6JtY5Sbvi1E7pGX6T/2c9sHs\ndIDeDctWnewpXXs8zkAla0KNWQfpDnpS53wxAfStTA4lSrA9daxC7hZopQlLxFIb\nJk+0BLbEsXtrJ54T5iguHk+2MDVAy4MOqP9XbKV7eGHk73l6+CSwmHyHBxh4ChxR\nQeT5BP0MUTn1AgMBAAGjgYEwfzAdBgNVHQ4EFgQUw7nEnh4uOdZVZUapQzdAUaVa\nAn0wHwYDVR0jBBgwFoAUw7nEnh4uOdZVZUapQzdAUaVaAn0wDwYDVR0TAQH/BAUw\nAwEB/zAsBgNVHREEJTAjgglsb2NhbGhvc3SHBH8AAAGHEAAAAAAAAAAAAAAAAAAA\nAAEwDQYJKoZIhvcNAQELBQADggEBAEA8r1fvDLMSCb8bkAURpFk8chn8pl5MChzT\nYUDaLdCCBjPXJkSXNdyuwS+T/ljAGyZbW5xuDccCNKltawO4CbyEXUEZbYr3w9eq\nj8uqymJPhFf0O1rKOI2han5GBCgHwG13QwKI+4uu7390nD+TlzLOhxFfvOG7OadH\nQNMNLNyldgF4Nb8vWdz0FtQiGUIrO7iq4LFhhd1lCxe0q+FAYSEYcc74WtF/Yo8V\nJQauXuXyoP5FqLzNt/yeNQhceyIXJGKCsjr5/bASBmVlCwgRfsD3jpG37L8YCJs1\nL4WEikcY4Lzb2NF9e94IyZdQsRqd9DFBF5zP013MSUiuhiow32k=\n-----END CERTIFICATE-----\n",
+  key: "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDlYzosgRgXHL6v\nMh1V0ERFhsvlZrtRojSw6tafr3SQBphU793/rGiYZlL/lJ9HIlLkx9JMbuTjNm5U\n2eRwHiTQIeWD4aCIESwPlkdaVYtC+IOj55bJN8xNa7h5GyJwF7PnPetAsKyE8DMB\nn1gKMhaIis7HHOUtk4/K3Y4peU44d04z0yPt6JtY5Sbvi1E7pGX6T/2c9sHsdIDe\nDctWnewpXXs8zkAla0KNWQfpDnpS53wxAfStTA4lSrA9daxC7hZopQlLxFIbJk+0\nBLbEsXtrJ54T5iguHk+2MDVAy4MOqP9XbKV7eGHk73l6+CSwmHyHBxh4ChxRQeT5\nBP0MUTn1AgMBAAECggEABtPvC5uVGr0DjQX2GxONsK8cOxoVec7U+C4pUMwBcXcM\nyjxwlHdujpi/IDXtjsm+A2rSPu2vGPdKDfMFanPvPxW/Ne99noc6U0VzHsR8lnP8\nwSB328nyJhzOeyZcXk9KTtgIPF7156gZsJLsZTNL+ej90i3xQWvKxCxXmrLuad5O\nz/TrgZkC6wC3fgj1d3e8bMljQ7tLxbshJMYVI5o6RFTxy84DLI+rlvPkf7XbiMPf\n2lsm4jcJKvfx+164HZJ9QVlx8ncqOHAnGvxb2xHHfqv4JAbz615t7yRvtaw4Paj5\n6kQSf0VWnsVzgxNJWvnUZym/i/Qf5nQafjChCyKOEQKBgQD9f4SkvJrp/mFKWLHd\nkDvRpSIIltfJsa5KShn1IHsQXFwc0YgyP4SKQb3Ckv+/9UFHK9EzM+WlPxZi7ZOS\nhsWhIfkI4c4ORpxUQ+hPi0K2k+HIY7eYyONqDAzw5PGkKBo3mSGMHDXYywSqexhB\nCCMHuHdMhwyHdz4PWYOK3C2VMQKBgQDnpsrHK7lM9aVb8wNhTokbK5IlTSzH/5oJ\nlAVu6G6H3tM5YQeoDXztbZClvrvKU8DU5UzwaC+8AEWQwaram29QIDpAI3nVQQ0k\ndmHHp/pCeADdRG2whaGcl418UJMMv8AUpWTRm+kVLTLqfTHBC0ji4NlCQMHCUCfd\nU8TeUi5QBQKBgQDvJNd7mboDOUmLG7VgMetc0Y4T0EnuKsMjrlhimau/OYJkZX84\n+BcPXwmnf4nqC3Lzs3B9/12L0MJLvZjUSHQ0mJoZOPxtF0vvasjEEbp0B3qe0wOn\nDQ0NRCUJNNKJbJOfE8VEKnDZ/lx+f/XXk9eINwvElDrLqUBQtr+TxjbyYQKBgAxQ\nlZ8Y9/TbajsFJDzcC/XhzxckjyjisbGoqNFIkfevJNN8EQgiD24f0Py+swUChtHK\njtiI8WCxMwGLCiYs9THxRKd8O1HW73fswy32BBvcfU9F//7OW9UTSXY+YlLfLrrq\nP/3UqAN0L6y/kxGMJAfLpEEdaC+IS1Y8yc531/ZxAoGASYiasDpePtmzXklDxk3h\njEw64QAdXK2p/xTMjSeTtcqJ7fvaEbg+Mfpxq0mdTjfbTdR9U/nzAkwS7OoZZ4Du\nueMVls0IVqcNnBtikG8wgdxN27b5JPXS+GzQ0zDSpWFfRPZiIh37BAXr0D1voluJ\nrEHkcals6p7hL98BoxjFIvA=\n-----END PRIVATE KEY-----\n",
+};
+
+// Self-signed cert (its own CA) whose SAN is only DNS:wrong.example, so
+// passing it as `ca` makes the chain trusted while hostname verification
+// against "localhost" must fail with ERR_TLS_CERT_ALTNAME_INVALID.
+const mismatchedTls = {
+  cert: "-----BEGIN CERTIFICATE-----\nMIID0zCCArugAwIBAgIUeeJvzODsvS5vWYogT7IJhM5u3wMwDQYJKoZIhvcNAQEL\nBQAwbDELMAkGA1UEBhMCVVMxCzAJBgNVBAgMAkNBMRYwFAYDVQQHDA1TYW4gRnJh\nbmNpc2NvMQ0wCwYDVQQKDARPdmVuMREwDwYDVQQLDAhUZWFtIEJ1bjEWMBQGA1UE\nAwwNd3JvbmcuZXhhbXBsZTAeFw0yNjA2MDkxNjE4NDFaFw0zNjA2MDYxNjE4NDFa\nMGwxCzAJBgNVBAYTAlVTMQswCQYDVQQIDAJDQTEWMBQGA1UEBwwNU2FuIEZyYW5j\naXNjbzENMAsGA1UECgwET3ZlbjERMA8GA1UECwwIVGVhbSBCdW4xFjAUBgNVBAMM\nDXdyb25nLmV4YW1wbGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCt\nOMsk7M5X9jX7Jp5DjC/CgPxaDmDmv5Thy/9jwiVsKBQySwVxHot3/O7Y7yerFPHb\n7hqK6rADyTVPH3OIFrmd81craTr02Zby4iDJXZfmG/Iv7aeX0w79Ma56bapiHBXN\n1Uujt2Beuy6mCFfsWpfeMmbhLVu/VfJYWXAEdQDyu4v8vZtJhBiwpike+Pwso+Sn\nD42UESH2Cn/AJcGxiUyKs8R2x3od+eN+gE3wFbEbzNru3dbiqtjNNv5ixOoZaFJn\nj20EyPotp9jGcPzUZBZ5YnKeCD3RzR0neWNBIi6zn2JmMX/VOns3GduBB1iWaRgY\nA3fbqI4kLeqZujf7f0RjAgMBAAGjbTBrMB0GA1UdDgQWBBQ9dpQdhgH/W4kwAYXX\nH4osejnfpTAfBgNVHSMEGDAWgBQ9dpQdhgH/W4kwAYXXH4osejnfpTAPBgNVHRMB\nAf8EBTADAQH/MBgGA1UdEQQRMA+CDXdyb25nLmV4YW1wbGUwDQYJKoZIhvcNAQEL\nBQADggEBAJeGJIq28/pqkDZxKXEaGyXj7vNGv2qYowXmgISSfB9KMsD/k2Elsfpl\nClRey1GBwQaAnmziIs9iEO4rdvtsHwrwvTy3lQlIs1KtUIIMvZMDKKT1vigYCPiT\nQhyOGblTuzkPQ+7m0vJhsLzyY3PDB9I24LT04IREU7mT9oMXq6we0JQfzNUGeA3a\nTOPQH3CpNuzkk8SQBk7bLU8+B3ie2yO2FFIinngyIECgWkAe7O3C3o62f6N38gE2\nfgOrPu6g1SkcpPC2Zn37Lafg1BVcE1rHeBwgYmvmgHVZmqj38gSgJkmNd6iKeD+X\nIO0Q1sOjMdaQGbjrPa62Afhyb83FpPQ=\n-----END CERTIFICATE-----\n",
+  key: "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCtOMsk7M5X9jX7\nJp5DjC/CgPxaDmDmv5Thy/9jwiVsKBQySwVxHot3/O7Y7yerFPHb7hqK6rADyTVP\nH3OIFrmd81craTr02Zby4iDJXZfmG/Iv7aeX0w79Ma56bapiHBXN1Uujt2Beuy6m\nCFfsWpfeMmbhLVu/VfJYWXAEdQDyu4v8vZtJhBiwpike+Pwso+SnD42UESH2Cn/A\nJcGxiUyKs8R2x3od+eN+gE3wFbEbzNru3dbiqtjNNv5ixOoZaFJnj20EyPotp9jG\ncPzUZBZ5YnKeCD3RzR0neWNBIi6zn2JmMX/VOns3GduBB1iWaRgYA3fbqI4kLeqZ\nujf7f0RjAgMBAAECggEAI4q+q+Hm6Md9Bf5DhOqTth4PKU8/9LikjLv1t/tTAGEs\n27Dm+fHhfgoo29weUI0onw645X4IBY7YYFa8ttSq20zduuuJjEnFHirlvUt16mIb\njFgABjfpIGx8N2SfDChlFOnJ7lqm7GkNxkV5/OYNuSqwT02mQJka86PORyvWuPcJ\nX6NmhhEJDCnVTL1D7FaEHrRUCC0n4hDMe0LLRNo7JrGljPIqPvpuQXEP52wdbzMC\nYfXJb7NbsiGOKLfrs9RXnR9ztr04gJ7jD5pMoeubbsM/tivRDm2VOY/U3NK2LN2q\ngFJ4hokBbUtIxU46RCTWSyQRRpNzFIBrL5y3a30DOQKBgQDsd/jvDPg55TzCNxFq\n6gLuoemIu4JIkSG4hSn6dtSpE5myQl9HuKvGlIS/kgB44zly8X8havxDuAinpzJc\n+oCnFWOFqi2IOt+OhiqjgeK2p0nsAxFVgWepdnPpv0LZXTj2SR09ZZ74YTh+ZQV8\nBiSuuEKZ064wwAg6esXVEMpkHwKBgQC7h360xoo/+m/ncANtDuA7zuHtE8fdsUaM\nLJ+zqlBsivsmM7ohqKqreIMKdw9b1aW/WrVmJavj9zX8ht/kt8vAYwmjk3lc7wso\nEa7EKF7Qa/IPhDkxQwnn/XTpzFsitItn1JCnnwoQUWcGtH/Su6b2I6T8+WZ8ia4Z\nXFpjyeV3PQKBgFVm2uPTBk86iGAILWU0kMyIc2RrfBkjOU9/4HJRumo55vdnWyv2\n+Srl9q+NVlhSkCwAJg72qZb3f0C1dM35tr8hTWk31evuf1DlCb81qKCY+GyhiwAb\nlUmxuxk/dzAzp9/i9gl3ixtfWVzktT9epJ7pczxFJBL9N7uPHaXew4m3AoGAUwwT\nKb2O9fxTWFv7uG1REktxNAuBhIUAaA1PAELZcOgvhuB7enJ2eo9ZAOZvD81SpKZo\nFP9z2vXcm6OjPWfDvMRfPWiO44AdIbaK/eWe75AOV57HsTAuD+Xnw64zYfAwmF/D\nW+gLjeRuysJepRVjQDfS1hEguOBEEIkconqDu0UCgYAQpb1SRymW/40bD3cTnF41\nDPH6Veqgdzu/6MOlD3oWTugPisH1aPq4UIsK03h+NJlVemQ92fTW47ZUjBuRZojZ\nrxah/Jl1Ta1Ww1q98fpZ2julkm+zEmErTw6plfveSVMC+jmgRjWXGbXYPxfxcUsb\nQlPkp7bJgio6h32XI0nWzA==\n-----END PRIVATE KEY-----\n",
+};
+
+function listen(server: net.Server): Promise<number> {
+  return new Promise(resolve => {
+    server.listen(0, "127.0.0.1", () => resolve((server.address() as net.AddressInfo).port));
+  });
+}
+
+// Trusted chain, wrong hostname. Speaks first: the HTTP response bytes ride
+// right behind the server's handshake flight, so the client's SSL_read both
+// completes the handshake and surfaces app data in one read event.
+const mismatchServer = tls.createServer({ key: mismatchedTls.key, cert: mismatchedTls.cert }, socket => {
+  socket.on("error", () => {});
+  socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok");
+});
+
+// Valid cert, keepalive churn: normal responses, redirects, and mid-response
+// hangups so pooled sockets get reused, retried, and torn down.
+let goodHits = 0;
+const goodServer = tls.createServer({ key: validTls.key, cert: validTls.cert }, socket => {
+  socket.on("error", () => {});
+  socket.on("data", () => {
+    const n = goodHits++;
+    switch (n % 5) {
+      case 0:
+        socket.write("HTTP/1.1 302 Found\r\nLocation: /next\r\nContent-Length: 0\r\n\r\n");
+        break;
+      case 1:
+        socket.destroy();
+        break;
+      case 2:
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial");
+        setTimeout(() => socket.destroy(), 5);
+        break;
+      default:
+        socket.write("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok");
+    }
+  });
+});
+
+// Accepts TCP, never answers the ClientHello: exercises the idle-timeout
+// (HTTPClient::on_timeout) failure path mid-handshake.
+const stallServer = net.createServer(socket => {
+  socket.on("error", () => {});
+  socket.on("data", () => {});
+});
+
+const mismatchPort = await listen(mismatchServer);
+const goodPort = await listen(goodServer);
+const stallPort = await listen(stallServer);
+
+const counts = new Map<string, number>();
+const bump = (k: string) => counts.set(k, (counts.get(k) ?? 0) + 1);
+
+const failures: string[] = [];
+
+// Launched up front so the ~1s idle-timeout waits overlap the batch loop.
+const stallJobs: Promise<void>[] = [];
+for (let i = 0; i < 3; i++) {
+  stallJobs.push(
+    fetch(`https://localhost:${stallPort}/`, {
+      tls: { ca: validTls.cert },
+      signal: AbortSignal.timeout(1200),
+    }).then(
+      res => {
+        failures.push(`stalled handshake fetch resolved with status ${res.status}`);
+      },
+      err => {
+        const code = typeof err?.code === "string" ? err.code : err?.name;
+        if (code === "Timeout" || code === "TimeoutError" || code === "ETIMEDOUT" || code === "ECONNRESET") {
+          bump("stalled");
+        } else {
+          failures.push(`stalled handshake fetch rejected with ${code ?? err}`);
+        }
+      },
+    ),
+  );
+}
+
+for (let batch = 0; batch < 8; batch++) {
+  const jobs: Promise<void>[] = [];
+
+  // Plain mismatched-cert fetches: must reject with the altname error.
+  for (let i = 0; i < 4; i++) {
+    jobs.push(
+      fetch(`https://localhost:${mismatchPort}/`, { tls: { ca: mismatchedTls.cert }, keepalive: false }).then(
+        res => {
+          failures.push(`mismatched cert fetch resolved with status ${res.status}`);
+        },
+        err => {
+          if (err?.code !== "ERR_TLS_CERT_ALTNAME_INVALID") {
+            failures.push(`mismatched cert fetch rejected with ${err?.code ?? err}`);
+          } else {
+            bump("altname");
+          }
+        },
+      ),
+    );
+  }
+
+  // Mismatched-cert fetches with aborts racing connect/handshake/failure delivery.
+  for (let i = 0; i < 4; i++) {
+    jobs.push(
+      fetch(`https://localhost:${mismatchPort}/`, {
+        tls: { ca: mismatchedTls.cert },
+        keepalive: false,
+        signal: AbortSignal.timeout(i * 2),
+      }).then(
+        res => {
+          failures.push(`aborted mismatched cert fetch resolved with status ${res.status}`);
+        },
+        err => {
+          const code = typeof err?.code === "string" ? err.code : err?.name;
+          if (code === "ERR_TLS_CERT_ALTNAME_INVALID" || code === "TimeoutError" || err?.name === "TimeoutError") {
+            bump(code === "ERR_TLS_CERT_ALTNAME_INVALID" ? "altname" : "aborted");
+          } else {
+            failures.push(`aborted mismatched cert fetch rejected with ${code ?? err}`);
+          }
+        },
+      ),
+    );
+  }
+
+  // Keepalive churn against the valid-cert server, some aborted.
+  for (let i = 0; i < 4; i++) {
+    jobs.push(
+      fetch(`https://localhost:${goodPort}/`, {
+        tls: { ca: validTls.cert },
+        signal: i % 2 === 0 ? AbortSignal.timeout(5 + i) : undefined,
+      })
+        .then(res => res.text())
+        .then(
+          () => bump("good"),
+          err => {
+            const code = typeof err?.code === "string" ? err.code : err?.name;
+            // redirect-target 302s loop back to the same handler; hangups and
+            // truncation surface as ECONNRESET-flavored errors.
+            if (
+              code === "TimeoutError" ||
+              code === "ECONNRESET" ||
+              code === "ConnectionClosed" ||
+              err?.name === "TimeoutError"
+            ) {
+              bump("churn");
+            } else {
+              failures.push(`good cert fetch rejected with ${code ?? err}`);
+            }
+          },
+        ),
+    );
+  }
+
+  await Promise.all(jobs);
+}
+
+// Stalled handshakes run concurrently with the batches above (launched before
+// the loop, awaited here); BUN_CONFIG_HTTP_IDLE_TIMEOUT=1 fails each through
+// on_timeout mid-handshake, the AbortSignal keeps the fixture bounded either
+// way.
+await Promise.all(stallJobs);
+
+mismatchServer.close();
+goodServer.close();
+stallServer.close();
+
+if (failures.length > 0) {
+  console.log("unexpected outcomes:", failures.slice(0, 10));
+  process.exit(1);
+}
+if ((counts.get("altname") ?? 0) === 0) {
+  console.log("expected at least one ERR_TLS_CERT_ALTNAME_INVALID rejection");
+  process.exit(1);
+}
+console.log("OK", JSON.stringify(Object.fromEntries(counts)));
+// Keepalive server-side sockets survive server.close() and would keep the
+// process alive; everything is settled at this point.
+process.exit(0);

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -195,6 +195,27 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
+  // Covers a family of HTTP-thread crashes (sentry BUN-2WC6 and siblings) where
+  // a certificate identity failure during a handshake completed from the
+  // SSL_read path, racing aborts, idle timeouts, and keepalive churn, caused a
+  // finished HTTPClient to deliver its final result twice: the second delivery
+  // read the freed AsyncHTTP clone and called through a null callback pointer.
+  // The fixture drives that exact traffic shape and exits non-zero on any
+  // unexpected outcome; every failure must surface as a catchable error.
+  it("rejects a trusted cert with a mismatched hostname cleanly under abort/timeout/keepalive churn", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fetch.tls.cert-mismatch-churn.fixture.ts")],
+      env: { ...bunEnv, BUN_CONFIG_HTTP_IDLE_TIMEOUT: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Fixture reports unexpected outcomes on stdout; stderr carries only
+    // crash/sanitizer output (and benign debug-build noise).
+    expect(stdout).toStartWith("OK ");
+    expect(exitCode).toBe(0);
+  });
+
   // When checkServerIdentity is provided, the HTTP thread sends an intermediate
   // progress update carrying the server certificate before response headers
   // arrive. If the connection then fails (e.g. an mTLS server rejects a

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -210,8 +210,12 @@ describe.concurrent("fetch-tls", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Fixture reports unexpected outcomes on stdout; stderr carries only
-    // crash/sanitizer output (and benign debug-build noise).
+    // Check stderr for sanitizer reports first (and unconditionally): a
+    // recovered ASAN report can leave exit code 0, and on an abort this
+    // surfaces the actual report instead of a bare exit-code mismatch.
+    // Don't assert emptiness: debug builds emit benign startup noise.
+    expect(stderr).not.toMatch(/AddressSanitizer|ERROR: (Leak|Thread)Sanitizer/);
+    // Fixture reports unexpected outcomes on stdout.
     expect(stdout).toStartWith("OK ");
     expect(exitCode).toBe(0);
   });

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -545,7 +545,10 @@ describe.concurrent("fetch-tls", () => {
   it("fetch timeout works on tls", async () => {
     using server = Bun.serve({
       tls: validTls,
-      hostname: "localhost",
+      // Explicit 127.0.0.1 (in the cert's SAN): "localhost" binds ::1 on
+      // v6-first resolvers while the fetch client pins localhost to
+      // 127.0.0.1, turning the timeout under test into ConnectionRefused.
+      hostname: "127.0.0.1",
       port: 0,
       rejectUnauthorized: false,
       async fetch() {


### PR DESCRIPTION
### Crash

Sentry aggregates a family of HTTP-thread crashes on bun 1.3.12-1.3.14 (~1,700 events across the siblings), all dying inside `AsyncHTTP.onAsyncHTTPCallback` when it forwards the final `HTTPClientResult` to the consumer callback:

- [BUN-2WC6](https://bun-p9.sentry.io/issues/7406052566/) (209 events, Windows): Zig panic `attempt to use null value` casting a null `callback.ctx`, entered from `us_internal_ssl_on_data` -> `ssl_trigger_handshake` (openssl.c:1057, handshake completed by `SSL_read`) -> `onHandshake` -> `checkServerIdentity` -> `closeAndFail(ERR_TLS_CERT_ALTNAME_INVALID)` -> `fail`
- [BUN-36KH](https://bun-p9.sentry.io/issues/7467238384/) (1,257 events, macOS): `Segmentation fault at address 0x00000000` (call through a null `callback.function`), entered from the idle timer: `us_internal_timer_sweep` -> `onTimeout` -> `fail`
- [BUN-36PT](https://bun-p9.sentry.io/issues/7467715451/) (219 events): same null call, entered from `onData` -> `sendProgressUpdateWithoutStageCheck`
- [BUN-36VV](https://bun-p9.sentry.io/issues/7468982580/), [BUN-364M](https://bun-p9.sentry.io/issues/7463692753/) (Linux, plain `bun run`), [BUN-2WTH](https://bun-p9.sentry.io/issues/7407385937/) (1.3.13, proxy tunnel flavor): same shape from `onConnectError`/`onData`

Nearly every event has `abort_signal = true`, and the population is dominated by TLS traffic through intercepting proxies (hostname-mismatch certificates) under AbortSignal churn. The 1.3.14 spike in BUN-2WC6 tracks #29797, which made `on_handshake` (and therefore `checkServerIdentity` -> `closeAndFail` -> result delivery) fire from the `SSL_read` completion path, the entry point visible in that issue's stack.

### Cause

When a request fails, `fail()` -> `dispatch_result_and_reset()` builds the final result, calls `state.reset()`, and dispatches the callback. Dispatching a final (`has_more == false`) result frees the HTTP-thread `ThreadlocalAsyncHTTP` clone, which embeds the `HTTPClient` itself.

`state.reset()` returns every stage field to `Pending`, so the finished client is left indistinguishable from a fresh one. Any late event that still reaches it (a socket whose ext tag still points at the client, a timer, a tracker entry) sails through the `stage != Done && stage != Fail` guards in `fail()`/`on_close`/`on_data` and delivers a **second** final result by reading `result_callback` out of the freed clone: a null/garbage `ctx` produces the 1.3.14 panic, a null `function` the SIGSEGV at 0x0. The success path does not have this hole: `send_progress_update_without_stage_check` explicitly restores `stage = Done` after its reset. The failure path forgot the equivalent.

Two adjacent re-entry doors in the same file compound it:

- the idempotent-retry branch in `on_close` is not gated on `in_progress`, so a late close event on a finished client restarts the whole request from freed memory
- `on_timeout` called `fail()` **before** `terminate_socket()`; `fail()` frees the clone that embeds `self`, so nothing may run after it, and the socket was still tagged with the client while the final result was dispatched (every other failure site terminates first, e.g. `close_and_fail`)

### Fix

All in `src/http/lib.rs` (the Zig files are the non-compiled porting reference; the 1.3.x code has the same structure):

1. `dispatch_result_and_reset`: restore `request_stage`/`response_stage`/`stage` to `Fail` after `state.reset()` (every caller reaches it with `stage == Fail`). Late re-entry now hits the existing stage guards and no-ops; `on_data` already has a no-op `ResponseStage::Fail` arm.
2. `on_close`: gate the retry branch on `in_progress`. For live clients this is behavior-preserving (a retryable close always happens mid-flight, where `in_progress` is true).
3. `on_timeout`: terminate the socket first, then `fail()` last, matching `close_and_fail` ordering.

### Verification

- New test in `test/js/web/fetch/fetch.tls.test.ts` spawns `fetch.tls.cert-mismatch-churn.fixture.ts`, which drives the exact traffic shape from the crash reports: a trusted-chain certificate whose hostname does not match, served by a server that speaks first (so `SSL_read` completes the handshake and `on_handshake` fires from the data path, as in BUN-2WC6), racing `AbortSignal.timeout` aborts, keepalive pool churn with redirects and mid-response hangups, and stalled handshakes failed by `BUN_CONFIG_HTTP_IDLE_TIMEOUT=1` through `on_timeout`. The fixture asserts every outcome is a clean catchable error (`ERR_TLS_CERT_ALTNAME_INVALID` for every non-aborted mismatch fetch) and exits non-zero otherwise.
- Honest caveat on fail-before: the double delivery needs a socket event to land on a client after its final result, a window that on Linux closes synchronously on every path I could drive from JS. An ASAN debug build of unfixed main survived ~8,600 requests of this workload (plus ~2,400 on the fixed build), so the test locks the error contract and the crash scenario but does not segfault on the unfixed build; the field evidence for the second delivery is the Sentry family above, whose 0x0-call/null-ctx artifacts are exactly a read of the freed, recycled clone. The fleet hitting this is Windows/macOS, where event delivery (libuv poll batches, kqueue) gives the window the Linux epoll path does not.
- `bun bd test test/js/web/fetch/fetch.tls.test.ts` passes except `fetch timeout works on tls`, which fails identically on unfixed main in this container (localhost/IPv6 resolution quirk, fails with `ConnectionRefused` before the timeout); `fetch-preconnect.test.ts` failures also reproduce on unfixed main here. `tls-keepalive.test.ts`, `fetch-abort-queued.test.ts`, and `test/js/node/tls/fetch-tls-cert.test.ts` pass.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c7b576c47)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1144.38ms]
(pass) fetch-tls > fetch with valid tls should not throw [1785.46ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1844.83ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [272.39ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2057.86ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2085.22ms]
(pass) fetch-tls > fetch with self-sign tls should throw [144.98ms]
(pa
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls should not throw [1534.52ms]
(pass) fetch-tls > fetch with checkServerIdentity rejects when connection closes before response headers (with AbortSignal) [37.45ms]
(pass) fetch-tls > checkServerIdentity approval still transmits the request and round-trips the response [37.10ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [1554.06ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [1558.32ms]
478 | 
479 |       expect(await fetch(url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
480 |       expect(await fetch(url, { tls: { ca: validTls.cert } }).then(res => res.text())).toBe("ok");
481 |       expect(await fetch(url, { tls: tlsWithCallback }).then(res => res.text())).toBe("ok");
482 | 
483 |       expect(verified).toEqual(["127.0.0.1", "127.0.0.1"]);
                             ^
error: expect(received).toEqual(expected)

  [
    "127.0.0.1",
-   "127.0.0.1",
  ]

- Expected  - 1
+ Received  + 0

      at <anonymous
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch.tls.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (c7b576c47)

test/js/web/fetch/fetch.tls.test.ts:
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity that throws should reject [1143.79ms]
(pass) fetch-tls > fetch with valid tls should not throw [1780.30ms]
(pass) fetch-tls > can handle multiple requests with non native checkServerIdentity [1840.03ms]
(pass) fetch-tls > fetch with rejectUnauthorized: false should not call checkServerIdentity [279.58ms]
(pass) fetch-tls > re-derives the Host header and TLS verification hostname from the redirect target on a cross-origin redirect [2059.13ms]
(pass) fetch-tls > fetch with valid tls and non-native checkServerIdentity should work [2087.44ms]
(pass) fetch-tls > fetch with self-sign tls should throw [144.56ms]
(pa
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c7b576c475
  features     (none)

22 deps, 106 codegen, 1168 objects in 848ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] gen ErrorCode+*.h
[5/1231] fetch tinycc
[tinycc] up to date
[6/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [26.00ms]
[7/1230] gen .bind.ts → GeneratedBindings.cpp
[8/1230] fetch libjpeg-t
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/lib.rs                                    |  28 ++-
 .../fetch/fetch.tls.cert-mismatch-churn.fixture.ts | 204 +++++++++++++++++++++
 test/js/web/fetch/fetch.tls.test.ts                |  30 ++-
 3 files changed, 259 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http/lib.rs                                               2      4     21
…t/js/web/fetch/fetch.tls.cert-mismatch-churn.fixture.ts      4      6     32
test/js/web/fetch/fetch.tls.test.ts                           3      6     21
```

</details>

**root cause** · written by the author bot

The crash was a use-after-free and stale callback invocation caused by the TLS handshake completing from the SSL read path, where a failed server identity check in `check_server_identity` triggered `close_and_fail` and synchronous result delivery while the client was in a request stage the consumer no longer expected, leaving `onAsyncHTTPCallback` to unwrap a null callback field, with a related re-entry where a late `on_close` after terminal result delivery dispatched the result callback a second time. The fix makes the failure path terminate the client state before delivering the failure r…

<!-- robobun:evidence:end -->