### PR TITLE
Fix cwd-relative resolution of drive-letter specifiers on POSIX

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1740,8 +1740,15 @@ fn _join_abs_string_buf<'a, const IS_SENTINEL: bool, P: PlatformT>(
         let mut part_len: u16 = parts.len() as u16;
 
         while part_i < part_len {
-            if P::P.is_absolute(parts[part_i as usize]) {
-                cwd = parts[part_i as usize];
+            let part = parts[part_i as usize];
+            // An absolute part resets the join root. This branch produces a
+            // host-POSIX path, so under `Loose` a Windows drive-letter part
+            // (`C:/x`) must not become the root: the result would not be
+            // absolute on this host (e.g. a bare import specifier `C:/`
+            // joined under `node_modules`). Separator-rooted parts still
+            // reset; drive-letter parts join as ordinary components.
+            if P::P.is_absolute(part) && is_sep_any(part[0]) {
+                cwd = part;
                 parts = &parts[part_i as usize + 1..];
 
                 part_len = parts.len() as u16;

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 describe("ResolveMessage", () => {
   it("position object does not segfault", async () => {
@@ -180,5 +180,98 @@ describe.concurrent("long import path overflow", () => {
     using dir = makeDir();
     // Walk-up loop indexed into a fixed [256]DirEntryResolveQueueItem
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
+  });
+});
+
+// On POSIX, a specifier that merely looks like a Windows absolute path
+// ("C:/", "D:\foo") is a bare package specifier. The resolver's loose path
+// joins used to adopt it as a new join root, producing a non-absolute path
+// that tripped the dirInfoCached assert and crashed the process:
+//   panic: cannot resolve DirInfo for non-absolute path: C:/
+// https://github.com/oven-sh/bun/issues/32016
+describe.skipIf(isWindows)("drive letter specifiers on posix", () => {
+  it.concurrent("fail with a catchable error when searching node_modules", async () => {
+    using dir = tempDir("resolve-drive-letter", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      // The crash required a node_modules directory in cwd or an ancestor.
+      // "C:" is an ordinary directory name on posix; Node's CJS loader finds
+      // files under it, so ours must too (proves the join lands under
+      // node_modules instead of resetting to a fake root).
+      "node_modules/C:/real.js": `module.exports = "found";`,
+      "fixture.mjs": `
+        const results = [];
+        for (const specifier of ["C:/", "C:\\\\", "D:\\\\foo", "c:/x"]) {
+          const entries = {
+            "import.meta.resolve": () => import.meta.resolve(specifier),
+            "require.resolve": () => require.resolve(specifier),
+            "Bun.resolveSync": () => Bun.resolveSync(specifier, import.meta.dir),
+          };
+          for (const kind in entries) {
+            try {
+              entries[kind]();
+              results.push(kind + " " + specifier + " resolved");
+            } catch (e) {
+              results.push(kind + " " + specifier + " " + e.code);
+            }
+          }
+          try {
+            await import(specifier);
+            results.push("import() " + specifier + " resolved");
+          } catch (e) {
+            results.push("import() " + specifier + " " + e.code);
+          }
+        }
+        results.push("positive " + require.resolve("C:/real.js").endsWith("/node_modules/C:/real.js"));
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual([
+      ...["C:/", "C:\\", "D:\\foo", "c:/x"].flatMap(s => [
+        `import.meta.resolve ${s} ERR_MODULE_NOT_FOUND`,
+        `require.resolve ${s} MODULE_NOT_FOUND`,
+        `Bun.resolveSync ${s} ERR_MODULE_NOT_FOUND`,
+        `import() ${s} ERR_MODULE_NOT_FOUND`,
+      ]),
+      "positive true",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("fail with a catchable error through the tsconfig baseUrl join", async () => {
+    using dir = tempDir("resolve-drive-letter-tsconfig", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "node_modules/.keep": "",
+      "tsconfig.json": `{"compilerOptions": {"baseUrl": "."}}`,
+      "fixture.mjs": `
+        try {
+          await import("C:/nope");
+          console.log("resolved");
+        } catch (e) {
+          console.log("caught " + e.code);
+        }
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("caught ERR_MODULE_NOT_FOUND");
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- On POSIX, `C:/x` or `D:\foo` is a bare specifier. The resolver joins it under each `node_modules` with the loose join, which treats `C:/x` as absolute on every host. The part resets the join root, so the candidate is `C:/x`, not `<dir>/node_modules/C:/x` (`_join_abs_string_buf`, `src/paths/resolve_path.rs:1771`).
- `load_as_file` then opens the directory `C:` with a relative path, which the OS resolves against the process cwd. `require("C:/real.js")` loads `<cwd>/C:/real.js` when any ancestor has `node_modules`. Node's CJS loader resolves it to `node_modules/C:/real.js` from any cwd.
- The same candidate used to hit the `DirInfo` assert and crash (#32016). #35349 removed the crash but did not change the join.

### Fix
- In the POSIX branch of `_join_abs_string_buf`, a part resets the join root only when it starts with a separator. A drive-letter part joins as a normal component.
- Correct because this branch produces a host-POSIX path and a drive-letter root can never make one. The Windows host join runs in `_join_abs_string_buf_windows` before this loop and is unchanged.
- The tsconfig `baseUrl` and package.json `main`/`browser` joins share the primitive and get the same fix.
- Verified: `test/js/bun/resolve/resolve-error.test.ts`, "drive letter specifiers on posix". On main the node_modules test fails at the `node_modules/C:/real.js` assertion. Also `test/js/bun/resolve/`, `test/bundler/esbuild/tsconfig.test.ts`, `packagejson.test.ts`, `test/bundler/resolver/`.

### Background
- The resolver joins paths through `FileSystem::abs_buf` (`src/resolver/lib.rs:342`): `join_abs_string_buf::<platform::Loose>` with the process cwd as the base. An absolute part resets the join: it becomes the new base and drops the parts before it.
- `Loose` accepts POSIX and Windows separators and roots on every host, so its `is_absolute` is true for `C:/x` on Linux.

<details><summary>Notes</summary>

Status on main 731aa92dad (debug build, Linux):

```
$ mkdir -p node_modules/C: C: sub
$ echo 'module.exports = "from node_modules";' > node_modules/C:/real.js
$ echo 'module.exports = "from cwd";' > C:/real.js
$ echo 'console.log(require("C:/real.js"));' > sub/fixture.js

$ bun sub/fixture.js               # main
from cwd
$ (cd sub && bun fixture.js)       # main, same file, other cwd
error: Cannot find module 'C:/real.js' from '/tmp/drive/sub/fixture.js'

$ node sub/fixture.js
from node_modules
$ (cd sub && node fixture.js)
from node_modules
```

With this PR's hunk on top of main, both `bun` commands print `from node_modules`. `test/js/bun/resolve/` has two stress-test timeouts (`load-same-js-file-a-lot.test.ts`) that fail the same way on plain main in the debug build.

Node's ESM loader treats `C:/real.js` as a URL with the scheme `c:` and fails. Bun's ESM paths fail with `ERR_MODULE_NOT_FOUND`. Neither looks at the cwd.

Original description (June 2026), written when the join also crashed the process. Opened for #32016, which #35349 closed.

On Linux or macOS, with a `node_modules` directory in cwd or any ancestor (or a tsconfig.json with `baseUrl`):

```js
await import.meta.resolve("C:/", import.meta.url);
```

```
panic: cannot resolve DirInfo for non-absolute path: C:/
```

The same panic was reachable through `require.resolve("C:/")`, `Bun.resolveSync("C:/", dir)`, and dynamic `import("C:/")`, with any `X:/` or `X:\` shaped specifier. The loose join adopted `C:/` as a new join root and returned it verbatim. `dir_info_cached` then asserted host-native absoluteness and panicked. The assert was a plain `assert!`, so release builds crashed too. The tsconfig `baseUrl`/`paths` joins and the package.json `main`/`browser` field joins funnel through the same primitive and panicked the same way (`import("C:/nope")` with `"baseUrl": "."` reproduced it without any node_modules).

The two tests in `test/js/bun/resolve/resolve-error.test.ts` (POSIX-only; drive paths are absolute on Windows):

- node_modules search: `import.meta.resolve` / `require.resolve` / `Bun.resolveSync` / `import()` for `C:/`, `C:\`, `D:\foo`, `c:/x` all throw `ERR_MODULE_NOT_FOUND` / `MODULE_NOT_FOUND`, plus a positive case resolving `node_modules/C:/real.js`
- tsconfig baseUrl join: `import("C:/nope")` with `"baseUrl": "."` throws instead of panicking

Both tests panicked the child process on the build of that time and passed with the fix.

</details>
