### PR TITLE
Consolidate node fs/path/types helpers

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2737,32 +2737,8 @@ pub mod args {
             // `Drop for PathLike` covers every
             // error return below (including `validate_integer`).
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
-            let uid: UidT = 'brk: {
-                let Some(uid_value) = arguments.next() else {
-                    return Err(ctx.throw_invalid_arguments(format_args!("uid is required")));
-                };
-                arguments.eat();
-                break 'brk wrap_to::<UidT>(validators::validate_integer(
-                    ctx,
-                    uid_value,
-                    "uid",
-                    Some(-1),
-                    Some(u32::MAX as i64),
-                )?);
-            };
-            let gid: GidT = 'brk: {
-                let Some(gid_value) = arguments.next() else {
-                    return Err(ctx.throw_invalid_arguments(format_args!("gid is required")));
-                };
-                arguments.eat();
-                break 'brk wrap_to::<GidT>(validators::validate_integer(
-                    ctx,
-                    gid_value,
-                    "gid",
-                    Some(-1),
-                    Some(u32::MAX as i64),
-                )?);
-            };
+            let uid = id_from_js(ctx, arguments, "uid")?;
+            let gid = id_from_js(ctx, arguments, "gid")?;
             Ok(Chown { path, uid, gid })
         }
     }
@@ -2775,32 +2751,8 @@ pub mod args {
     impl Fchown {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Fchown> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let uid: UidT = 'brk: {
-                let Some(uid_value) = arguments.next() else {
-                    return Err(ctx.throw_invalid_arguments(format_args!("uid is required")));
-                };
-                arguments.eat();
-                break 'brk wrap_to::<UidT>(validators::validate_integer(
-                    ctx,
-                    uid_value,
-                    "uid",
-                    Some(-1),
-                    Some(u32::MAX as i64),
-                )?);
-            };
-            let gid: GidT = 'brk: {
-                let Some(gid_value) = arguments.next() else {
-                    return Err(ctx.throw_invalid_arguments(format_args!("gid is required")));
-                };
-                arguments.eat();
-                break 'brk wrap_to::<GidT>(validators::validate_integer(
-                    ctx,
-                    gid_value,
-                    "gid",
-                    Some(-1),
-                    Some(u32::MAX as i64),
-                )?);
-            };
+            let uid = id_from_js(ctx, arguments, "uid")?;
+            let gid = id_from_js(ctx, arguments, "gid")?;
             Ok(Fchown { fd, uid, gid })
         }
     }
@@ -2819,7 +2771,57 @@ pub mod args {
         T::from(in_ as u8)
     }
 
+    /// Reads a required `uid`/`gid` argument, validated to `[-1, u32::MAX]`.
+    /// `uid_t` and `gid_t` are the same primitive on every supported platform
+    /// (`u32` on POSIX, libuv's `unsigned char` on Windows), so one reader
+    /// serves both.
+    fn id_from_js(
+        ctx: &JSGlobalObject,
+        arguments: &mut ArgumentsSlice,
+        name: &str,
+    ) -> JsResult<UidT> {
+        let Some(value) = arguments.next() else {
+            return Err(ctx.throw_invalid_arguments(format_args!("{name} is required")));
+        };
+        arguments.eat();
+        Ok(wrap_to(validators::validate_integer(
+            ctx,
+            value,
+            name,
+            Some(-1),
+            Some(u32::MAX as i64),
+        )?))
+    }
+
     pub(crate) type LChown<'a> = Chown<'a>;
+
+    fn time_arg_from_js(
+        ctx: &JSGlobalObject,
+        arguments: &mut ArgumentsSlice,
+        name: &str,
+    ) -> JsResult<TimeLike> {
+        let time = node::time_like_from_js(
+            ctx,
+            arguments
+                .next()
+                .ok_or_else(|| ctx.throw_invalid_arguments(format_args!("{name} is required")))?,
+        )?
+        .ok_or_else(|| {
+            ctx.throw_invalid_arguments(format_args!("{name} must be a number or a Date"))
+        })?;
+        arguments.eat();
+        Ok(time)
+    }
+
+    /// Parse the `atime, mtime` argument pair shared by `utimes`/`lutimes`/`futimes`.
+    fn times_from_js(
+        ctx: &JSGlobalObject,
+        arguments: &mut ArgumentsSlice,
+    ) -> JsResult<(TimeLike, TimeLike)> {
+        let atime = time_arg_from_js(ctx, arguments, "atime")?;
+        let mtime = time_arg_from_js(ctx, arguments, "mtime")?;
+        Ok((atime, mtime))
+    }
 
     pub struct Lutimes<'a> {
         pub path: PathLike<'a>,
@@ -2829,28 +2831,9 @@ pub mod args {
     impl Lutimes<'static> {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Self> {
             // `Drop for PathLike` covers the
-            // `time_like_from_js` throws below.
+            // `times_from_js` throws below.
             let path = PathLike::from_js_required(ctx, arguments, "path")?;
-            let atime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("atime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("atime must be a number or a Date"))
-            })?;
-            arguments.eat();
-            let mtime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("mtime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("mtime must be a number or a Date"))
-            })?;
-            arguments.eat();
+            let (atime, mtime) = times_from_js(ctx, arguments)?;
             Ok(Lutimes { path, atime, mtime })
         }
     }
@@ -3470,26 +3453,7 @@ pub mod args {
     impl Futimes {
         pub fn from_js(ctx: &JSGlobalObject, arguments: &mut ArgumentsSlice) -> JsResult<Futimes> {
             let fd = FD::from_js_required(ctx, arguments)?;
-            let atime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("atime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("atime must be a number or a Date"))
-            })?;
-            arguments.eat();
-            let mtime = node::time_like_from_js(
-                ctx,
-                arguments.next().ok_or_else(|| {
-                    ctx.throw_invalid_arguments(format_args!("mtime is required"))
-                })?,
-            )?
-            .ok_or_else(|| {
-                ctx.throw_invalid_arguments(format_args!("mtime must be a number or a Date"))
-            })?;
-            arguments.eat();
+            let (atime, mtime) = times_from_js(ctx, arguments)?;
             Ok(Futimes { fd, atime, mtime })
         }
     }
@@ -4433,6 +4397,18 @@ fn encode_path_result(bytes: &[u8], encoding: Encoding) -> StringOrBuffer<'stati
     }
 }
 
+/// How `copy_file_range_with_fallbacks` handles EINTR from copy_file_range(2),
+/// preserving the historical split between its two callers: `fs.copyFile`
+/// retries while `fs.cp` surfaces it (matching the original implementations).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EintrPolicy {
+    /// Retry the syscall (`fs.copyFile`).
+    Retry,
+    /// Surface EINTR to the caller as an error (`fs.cp`).
+    Surface,
+}
+
 impl NodeFS {
     pub(crate) fn access(&mut self, args: &args::Access, _: Flavor) -> Maybe<ret::Access> {
         if let Some(graph) = standalone_module_graph() {
@@ -4673,6 +4649,105 @@ impl NodeFS {
                 break;
             }
         }
+        Ok(())
+    }
+
+    /// Shared Linux copy loop for `fs.copyFile` and `fs.cp` once both fds are
+    /// open and the ioctl_ficlone fast path has been ruled out: drains
+    /// `src_fd` into `dest_fd` via copy_file_range(2) (Linux 5.3+; not
+    /// supported in gVisor), falling back to sendfile/read-write when the
+    /// syscall is unavailable or the filesystem rejects it. Takes ownership of
+    /// `dest_fd`: on every exit path it is ftruncated to the bytes written,
+    /// fchmod'd to `st_mode`, and closed.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn copy_file_range_with_fallbacks(
+        src: &ZStr,
+        dest: &ZStr,
+        src_fd: FD,
+        dest_fd: FD,
+        st_mode: Mode,
+        mut size: usize,
+        eintr_policy: EintrPolicy,
+    ) -> Maybe<ret::CopyFile> {
+        // `wrote` is read by the deferred-close scopeguard *after* the copy
+        // loop below mutates it. `Cell<u64>` lets the guard borrow by
+        // reference while the loop `get`s/`set`s, so the value observed at
+        // scope-exit time is the final one.
+        let wrote: core::cell::Cell<u64> = core::cell::Cell::new(0);
+        let _close_dest = scopeguard::guard((dest_fd, st_mode, &wrote), |(fd, m, wrote)| {
+            // ftruncate/fchmod take only ints — no memory-safety preconditions;
+            // route through the existing `bun_sys` safe wrappers.
+            let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
+            let _ = Syscall::fchmod(fd, m);
+            fd.close();
+        });
+
+        let mut off_in_copy: i64 = 0;
+        let mut off_out_copy: i64 = 0;
+
+        if !sys::copy_file::can_use_copy_file_range_syscall() {
+            let mut w = wrote.get();
+            let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
+                src, dest, src_fd, dest_fd, size, &mut w,
+            );
+            wrote.set(w);
+            return r;
+        }
+
+        // size == 0 means the source stat'd as empty (e.g. procfs): copy
+        // page-sized chunks until EOF instead of trusting the stat size.
+        let until_eof = size == 0;
+        loop {
+            let chunk = if until_eof { sys::page_size() } else { size };
+            // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
+            let written = unsafe {
+                sys::linux::copy_file_range(
+                    src_fd.native(),
+                    &raw mut off_in_copy,
+                    dest_fd.native(),
+                    &raw mut off_out_copy,
+                    chunk,
+                    0,
+                )
+            };
+            if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
+                written,
+                sys::Tag::copy_file_range,
+                dest.as_bytes(),
+            ) {
+                match err.get_errno() {
+                    E::EINTR if eintr_policy == EintrPolicy::Retry => continue,
+                    // EINVAL: eCryptfs and other filesystems may not support copy_file_range
+                    // XDEV: cross-device copy not supported
+                    // NOSYS: syscall not available
+                    // OPNOTSUPP: filesystem doesn't support this operation
+                    E::EXDEV | E::ENOSYS | E::EINVAL | E::EOPNOTSUPP => {
+                        if matches!(err.get_errno(), E::ENOSYS | E::EOPNOTSUPP) {
+                            sys::copy_file::disable_copy_file_range_syscall();
+                        }
+                        let mut w = wrote.get();
+                        let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
+                            src, dest, src_fd, dest_fd, size, &mut w,
+                        );
+                        wrote.set(w);
+                        return r;
+                    }
+                    _ => return err,
+                }
+            }
+            // wrote zero bytes means EOF
+            if written == 0 {
+                break;
+            }
+            wrote.set(wrote.get().saturating_add(written as u64));
+            if !until_eof {
+                size = size.saturating_sub(written as usize);
+                if size == 0 {
+                    break;
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -4928,20 +5003,13 @@ impl NodeFS {
             }
 
             let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
-            // VERIFY-FIX(round1): `wrote` is read by the deferred-close scopeguard
-            // *after* the copy loops below mutate it. As a `usize` captured by-copy
-            // the guard always saw 0, and the `&mut (wrote as u64)` call sites
-            // wrote into discarded temporaries. `Cell<u64>` lets the guard borrow
-            // by reference while the loops `get`/`set`, so the value observed at
-            // scope-exit time is the final one.
-            let wrote: core::cell::Cell<u64> = core::cell::Cell::new(0);
             if args.mode.shouldnt_overwrite() {
                 flags |= sys::O::EXCL;
             }
 
             let dest_fd = Syscall::open(dest, flags, stat_.st_mode as Mode)?;
 
-            let mut size: usize = stat_.st_size.max(0) as usize;
+            let size: usize = stat_.st_size.max(0) as usize;
 
             // https://manpages.debian.org/testing/manpages-dev/ioctl_ficlone.2.en.html
             if args.mode.is_force_clone() {
@@ -4973,109 +5041,15 @@ impl NodeFS {
                 sys::copy_file::disable_ioctl_ficlone();
             }
 
-            let _close_dest =
-                scopeguard::guard((dest_fd, stat_.st_mode, &wrote), |(fd, m, wrote)| {
-                    // ftruncate/fchmod take only ints — no memory-safety preconditions; route
-                    // through the existing `bun_sys` safe wrappers (same as lines above).
-                    let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
-                    let _ = Syscall::fchmod(fd, m as u32);
-                    fd.close();
-                });
-
-            let mut off_in_copy: i64 = 0;
-            let mut off_out_copy: i64 = 0;
-
-            if !sys::copy_file::can_use_copy_file_range_syscall() {
-                let mut w = wrote.get();
-                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
-                    src, dest, src_fd, dest_fd, size, &mut w,
-                );
-                wrote.set(w);
-                return r;
-            }
-
-            if size == 0 {
-                // copy until EOF
-                loop {
-                    // Linux Kernel 5.3 or later
-                    // Not supported in gVisor
-                    // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
-                    let written = unsafe {
-                        sys::linux::copy_file_range(
-                            src_fd.native(),
-                            &raw mut off_in_copy,
-                            dest_fd.native(),
-                            &raw mut off_out_copy,
-                            sys::page_size(),
-                            0,
-                        )
-                    };
-                    if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
-                        written,
-                        sys::Tag::copy_file_range,
-                        dest,
-                    ) {
-                        match err.get_errno() {
-                            E::EINTR => continue,
-                            E::EXDEV | E::ENOSYS | E::EINVAL | E::EOPNOTSUPP => {
-                                if matches!(err.get_errno(), E::ENOSYS | E::EOPNOTSUPP) {
-                                    sys::copy_file::disable_copy_file_range_syscall();
-                                }
-                                let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
-                                wrote.set(w);
-                                return r;
-                            }
-                            _ => return err,
-                        }
-                    }
-                    // wrote zero bytes means EOF
-                    if written == 0 {
-                        break;
-                    }
-                    wrote.set(wrote.get().saturating_add(written as u64));
-                }
-            } else {
-                while size > 0 {
-                    // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
-                    let written = unsafe {
-                        sys::linux::copy_file_range(
-                            src_fd.native(),
-                            &raw mut off_in_copy,
-                            dest_fd.native(),
-                            &raw mut off_out_copy,
-                            size,
-                            0,
-                        )
-                    };
-                    if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
-                        written,
-                        sys::Tag::copy_file_range,
-                        dest,
-                    ) {
-                        match err.get_errno() {
-                            E::EINTR => continue,
-                            E::EXDEV | E::ENOSYS | E::EINVAL | E::EOPNOTSUPP => {
-                                if matches!(err.get_errno(), E::ENOSYS | E::EOPNOTSUPP) {
-                                    sys::copy_file::disable_copy_file_range_syscall();
-                                }
-                                let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
-                                wrote.set(w);
-                                return r;
-                            }
-                            _ => return err,
-                        }
-                    }
-                    if written == 0 {
-                        break;
-                    }
-                    wrote.set(wrote.get().saturating_add(written as u64));
-                    size = size.saturating_sub(written as usize);
-                }
-            }
-
-            return Ok(());
+            return Self::copy_file_range_with_fallbacks(
+                src,
+                dest,
+                src_fd,
+                dest_fd,
+                stat_.st_mode as Mode,
+                size,
+                EintrPolicy::Retry,
+            );
         }
 
         #[cfg(windows)]
@@ -7804,12 +7778,28 @@ impl NodeFS {
         }
     }
 
-    pub(crate) fn utimes(&mut self, args: &args::Utimes, _: Flavor) -> Maybe<ret::Utimes> {
+    /// Shared body of [`Self::utimes`] / [`Self::lutimes`]; they differ only
+    /// in which syscall applies the timestamps and in the node operation name
+    /// (`utime` / `lutime`) reported on errors.
+    fn utimes_with(
+        &mut self,
+        args: &args::Utimes,
+        syscall: sys::Tag,
+        #[cfg(windows)] uv_utime: unsafe extern "C" fn(
+            *mut uv::Loop,
+            *mut uv::fs_t,
+            *const core::ffi::c_char,
+            f64,
+            f64,
+            uv::uv_fs_cb,
+        ) -> uv::ReturnCode,
+        #[cfg(not(windows))] utimens: fn(&ZStr, sys::TimeLike, sys::TimeLike) -> Maybe<()>,
+    ) -> Maybe<ret::Utimes> {
         #[cfg(windows)]
         {
             let mut req = UvFsReq::new();
             let rc = unsafe {
-                uv::uv_fs_utime(
+                uv_utime(
                     bun_io::Loop::get(),
                     &mut *req,
                     args.path.slice_z(&mut self.sync_error_buf).as_ptr(),
@@ -7818,52 +7808,35 @@ impl NodeFS {
                     None,
                 )
             };
-            if let Some(err) = rc.to_error(sys::Tag::utime) {
+            if let Some(err) = rc.to_error(syscall) {
                 return Err(err.with_path(args.path.slice()));
             }
             return Ok(());
         }
         #[cfg(not(windows))]
-        match Syscall::utimens(
+        match utimens(
             args.path.slice_z(&mut self.sync_error_buf),
             to_sys_time_like(args.atime),
             to_sys_time_like(args.mtime),
         ) {
             // `err.syscall` must be node's operation name, not `utimensat(2)`.
-            Err(err) => Err(err.with_path_and_syscall(args.path.slice(), sys::Tag::utime)),
+            Err(err) => Err(err.with_path_and_syscall(args.path.slice(), syscall)),
             Ok(_) => Ok(()),
         }
     }
 
+    pub(crate) fn utimes(&mut self, args: &args::Utimes, _: Flavor) -> Maybe<ret::Utimes> {
+        #[cfg(windows)]
+        return self.utimes_with(args, sys::Tag::utime, uv::uv_fs_utime);
+        #[cfg(not(windows))]
+        self.utimes_with(args, sys::Tag::utime, Syscall::utimens)
+    }
+
     pub(crate) fn lutimes(&mut self, args: &args::Lutimes, _: Flavor) -> Maybe<ret::Lutimes> {
         #[cfg(windows)]
-        {
-            let mut req = UvFsReq::new();
-            let rc = unsafe {
-                uv::uv_fs_lutime(
-                    bun_io::Loop::get(),
-                    &mut *req,
-                    args.path.slice_z(&mut self.sync_error_buf).as_ptr(),
-                    args.atime,
-                    args.mtime,
-                    None,
-                )
-            };
-            if let Some(err) = rc.to_error(sys::Tag::lutime) {
-                return Err(err.with_path(args.path.slice()));
-            }
-            return Ok(());
-        }
+        return self.utimes_with(args, sys::Tag::lutime, uv::uv_fs_lutime);
         #[cfg(not(windows))]
-        match Syscall::lutimens(
-            args.path.slice_z(&mut self.sync_error_buf),
-            to_sys_time_like(args.atime),
-            to_sys_time_like(args.mtime),
-        ) {
-            // `err.syscall` must be node's operation name, not `utimensat(2)`.
-            Err(err) => Err(err.with_path_and_syscall(args.path.slice(), sys::Tag::lutime)),
-            Ok(_) => Ok(()),
-        }
+        self.utimes_with(args, sys::Tag::lutime, Syscall::lutimens)
     }
 
     pub(crate) fn watch(&mut self, args: &args::Watch<'_>, _: Flavor) -> Maybe<ret::Watch> {
@@ -8403,14 +8376,13 @@ impl NodeFS {
             }
 
             let mut flags: i32 = sys::O::CREAT | sys::O::WRONLY;
-            let wrote: core::cell::Cell<u64> = core::cell::Cell::new(0);
             if mode.shouldnt_overwrite() {
                 flags |= sys::O::EXCL;
             }
 
             let dest_fd = Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
 
-            let mut size: usize = stat_.st_size.max(0) as usize;
+            let size: usize = stat_.st_size.max(0) as usize;
 
             if sys::S::ISREG(stat_.st_mode as u32) && sys::copy_file::can_use_ioctl_ficlone() {
                 let rc = sys::linux::ioctl_ficlone(dest_fd, src_fd);
@@ -8422,118 +8394,15 @@ impl NodeFS {
                 sys::copy_file::disable_ioctl_ficlone();
             }
 
-            let _close_dest = scopeguard::guard(
-                (dest_fd, stat_.st_mode as Mode, &wrote),
-                |(fd, m, wrote)| {
-                    let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
-                    let _ = Syscall::fchmod(fd, m);
-                    fd.close();
-                },
+            return Self::copy_file_range_with_fallbacks(
+                src,
+                dest,
+                src_fd,
+                dest_fd,
+                stat_.st_mode as Mode,
+                size,
+                EintrPolicy::Surface,
             );
-
-            let mut off_in_copy: i64 = 0;
-            let mut off_out_copy: i64 = 0;
-
-            if !sys::copy_file::can_use_copy_file_range_syscall() {
-                let mut w = wrote.get();
-                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(
-                    src, dest, src_fd, dest_fd, size, &mut w,
-                );
-                wrote.set(w);
-                return r;
-            }
-
-            if size == 0 {
-                // copy until EOF
-                loop {
-                    // Linux Kernel 5.3 or later
-                    // Not supported in gVisor
-                    // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
-                    let written = unsafe {
-                        sys::linux::copy_file_range(
-                            src_fd.native(),
-                            &raw mut off_in_copy,
-                            dest_fd.native(),
-                            &raw mut off_out_copy,
-                            sys::page_size(),
-                            0,
-                        )
-                    };
-                    if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
-                        written,
-                        sys::Tag::copy_file_range,
-                        dest.as_bytes(),
-                    ) {
-                        match err.get_errno() {
-                            // EINVAL: eCryptfs and other filesystems may not support copy_file_range
-                            // XDEV: cross-device copy not supported
-                            // NOSYS: syscall not available
-                            // OPNOTSUPP: filesystem doesn't support this operation
-                            E::EXDEV | E::ENOSYS | E::EINVAL | E::EOPNOTSUPP => {
-                                if matches!(err.get_errno(), E::ENOSYS | E::EOPNOTSUPP) {
-                                    sys::copy_file::disable_copy_file_range_syscall();
-                                }
-                                let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
-                                wrote.set(w);
-                                return r;
-                            }
-                            _ => return err,
-                        }
-                    }
-                    // wrote zero bytes means EOF
-                    if written == 0 {
-                        break;
-                    }
-                    wrote.set(wrote.get().saturating_add(written as u64));
-                }
-            } else {
-                while size > 0 {
-                    // Linux Kernel 5.3 or later
-                    // Not supported in gVisor
-                    // SAFETY: src_fd/dest_fd are valid open fds; copy_file_range is the libc FFI
-                    let written = unsafe {
-                        sys::linux::copy_file_range(
-                            src_fd.native(),
-                            &raw mut off_in_copy,
-                            dest_fd.native(),
-                            &raw mut off_out_copy,
-                            size,
-                            0,
-                        )
-                    };
-                    if let Some(err) = Maybe::<ret::CopyFile>::errno_sys_p(
-                        written,
-                        sys::Tag::copy_file_range,
-                        dest.as_bytes(),
-                    ) {
-                        match err.get_errno() {
-                            // EINVAL: eCryptfs and other filesystems may not support copy_file_range
-                            // XDEV: cross-device copy not supported
-                            // NOSYS: syscall not available
-                            // OPNOTSUPP: filesystem doesn't support this operation
-                            E::EXDEV | E::ENOSYS | E::EINVAL | E::EOPNOTSUPP => {
-                                if matches!(err.get_errno(), E::ENOSYS | E::EOPNOTSUPP) {
-                                    sys::copy_file::disable_copy_file_range_syscall();
-                                }
-                                let mut w = wrote.get();
-                                let r = Self::copy_file_using_sendfile_on_linux_with_read_write_fallback(src, dest, src_fd, dest_fd, size, &mut w);
-                                wrote.set(w);
-                                return r;
-                            }
-                            _ => return err,
-                        }
-                    }
-                    // wrote zero bytes means EOF
-                    if written == 0 {
-                        break;
-                    }
-                    wrote.set(wrote.get().saturating_add(written as u64));
-                    size = size.saturating_sub(written as usize);
-                }
-            }
-
-            return Ok(());
         }
 
         #[cfg(target_os = "freebsd")]

--- a/src/runtime/node/path.rs
+++ b/src/runtime/node/path.rs
@@ -304,110 +304,23 @@ fn get_cwd_t<T: PathCharCwd>(buf: &mut [T]) -> MaybeBuf<'_, T> {
     T::get_cwd(buf)
 }
 
-/// Based on Node v21.6.1 path.posix.basename:
-/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1309
-pub(crate) fn basename_posix_t<'a, T: PathCharCwd>(path: &'a [T], suffix: Option<&[T]>) -> &'a [T] {
-    // validateString of `path` is performed in pub fn basename.
-    let len = path.len();
-    // Exit early for easier number type use.
-    if len == 0 {
-        return &[];
-    }
-    let mut start: usize = 0;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut end: Option<usize> = None;
-    let mut matched_slash: bool = true;
-
-    let _suffix: &[T] = suffix.unwrap_or(&[]);
-    let _suffix_len = _suffix.len();
-    if suffix.is_some() && _suffix_len > 0 && _suffix_len <= len {
-        if _suffix == path {
-            return &[];
-        }
-        // We use an optional value instead of -1, as in Node code, for easier number type use.
-        let mut ext_idx: Option<usize> = Some(_suffix_len - 1);
-        // We use an optional value instead of -1, as in Node code, for easier number type use.
-        let mut first_non_slash_end: Option<usize> = None;
-        let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-        while i_i64 >= i64::try_from(start).expect("int cast") {
-            let i = usize::try_from(i_i64).expect("int cast");
-            let byte = path[i];
-            if byte == T::from_u8(CHAR_FORWARD_SLASH) {
-                // If we reached a path separator that was not part of a set of path
-                // separators at the end of the string, stop now
-                if !matched_slash {
-                    start = i + 1;
-                    break;
-                }
-            } else {
-                if first_non_slash_end.is_none() {
-                    // We saw the first non-path separator, remember this index in case
-                    // we need it if the extension ends up not matching
-                    matched_slash = false;
-                    first_non_slash_end = Some(i + 1);
-                }
-                if let Some(_ext_ix) = ext_idx {
-                    // Try to match the explicit extension
-                    if byte == _suffix[_ext_ix] {
-                        if _ext_ix == 0 {
-                            // We matched the extension, so mark this as the end of our path
-                            // component
-                            end = Some(i);
-                            ext_idx = None;
-                        } else {
-                            ext_idx = Some(_ext_ix - 1);
-                        }
-                    } else {
-                        // Extension does not match, so our result is the entire path
-                        // component
-                        ext_idx = None;
-                        end = first_non_slash_end;
-                    }
-                }
-            }
-            i_i64 -= 1;
-        }
-
-        if let Some(_end) = end {
-            if start == _end {
-                return &path[start..first_non_slash_end.unwrap()];
-            } else {
-                return &path[start.._end];
-            }
-        }
-        return &path[start..len];
-    }
-
-    let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-    while i_i64 > -1 {
-        let i = usize::try_from(i_i64).expect("int cast");
-        let byte = path[i];
-        if byte == T::from_u8(CHAR_FORWARD_SLASH) {
-            // If we reached a path separator that was not part of a set of path
-            // separators at the end of the string, stop now
-            if !matched_slash {
-                start = i + 1;
-                break;
-            }
-        } else if end.is_none() {
-            // We saw the first non-path separator, mark this as the end of our
-            // path component
-            matched_slash = false;
-            end = Some(i + 1);
-        }
-        i_i64 -= 1;
-    }
-
-    if let Some(_end) = end {
-        &path[start.._end]
+/// `path.win32` treats both `/` and `\` as separators; `path.posix` only `/`.
+/// `IS_WINDOWS` is const so the check monomorphizes to the exact comparison
+/// the split posix/win32 functions used.
+#[inline(always)]
+fn is_sep_t<T: PathCharCwd, const IS_WINDOWS: bool>(byte: T) -> bool {
+    if IS_WINDOWS {
+        is_sep_windows_t(byte)
     } else {
-        &[]
+        byte == T::from_u8(CHAR_FORWARD_SLASH)
     }
 }
 
-/// Based on Node v21.6.1 path.win32.basename:
+/// Based on Node v21.6.1 path.posix.basename / path.win32.basename, which
+/// differ only in the separator set and the win32 drive-letter prologue:
+/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1309
 /// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L753
-pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
+fn basename_t<'a, T: PathCharCwd, const IS_WINDOWS: bool>(
     path: &'a [T],
     suffix: Option<&[T]>,
 ) -> &'a [T] {
@@ -417,9 +330,6 @@ pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
     if len == 0 {
         return &[];
     }
-
-    let is_sep_t = is_sep_windows_t::<T>;
-
     let mut start: usize = 0;
     // We use an optional value instead of -1, as in Node code, for easier number type use.
     let mut end: Option<usize> = None;
@@ -428,7 +338,11 @@ pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
     // Check for a drive letter prefix so as not to mistake the following
     // path separator as an extra separator at the end of the path that can be
     // disregarded
-    if len >= 2 && is_windows_device_root_t(path[0]) && path[1] == T::from_u8(CHAR_COLON) {
+    if IS_WINDOWS
+        && len >= 2
+        && is_windows_device_root_t(path[0])
+        && path[1] == T::from_u8(CHAR_COLON)
+    {
         start = 2;
     }
 
@@ -446,7 +360,7 @@ pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
         while i_i64 >= i64::try_from(start).expect("int cast") {
             let i = usize::try_from(i_i64).expect("int cast");
             let byte = path[i];
-            if is_sep_t(byte) {
+            if is_sep_t::<T, IS_WINDOWS>(byte) {
                 // If we reached a path separator that was not part of a set of path
                 // separators at the end of the string, stop now
                 if !matched_slash {
@@ -496,12 +410,16 @@ pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
     while i_i64 >= i64::try_from(start).expect("int cast") {
         let i = usize::try_from(i_i64).expect("int cast");
         let byte = path[i];
-        if is_sep_t(byte) {
+        if is_sep_t::<T, IS_WINDOWS>(byte) {
+            // If we reached a path separator that was not part of a set of path
+            // separators at the end of the string, stop now
             if !matched_slash {
                 start = i + 1;
                 break;
             }
         } else if end.is_none() {
+            // We saw the first non-path separator, mark this as the end of our
+            // path component
             matched_slash = false;
             end = Some(i + 1);
         }
@@ -513,6 +431,17 @@ pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
     } else {
         &[]
     }
+}
+
+pub(crate) fn basename_posix_t<'a, T: PathCharCwd>(path: &'a [T], suffix: Option<&[T]>) -> &'a [T] {
+    basename_t::<T, false>(path, suffix)
+}
+
+pub(crate) fn basename_windows_t<'a, T: PathCharCwd>(
+    path: &'a [T],
+    suffix: Option<&[T]>,
+) -> &'a [T] {
+    basename_t::<T, true>(path, suffix)
 }
 
 pub(crate) fn basename_posix_js_t<T: PathCharCwd>(
@@ -792,116 +721,39 @@ fn dirname(
     dirname_js_t::<u8>(global_object, is_windows, path_slice.slice())
 }
 
-/// Based on Node v21.6.1 path.posix.extname:
-/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1388
-fn extname_posix_t<T: PathCharCwd>(path: &[T]) -> &[T] {
-    // validateString of `path` is performed in pub fn extname.
-    let len = path.len();
-    // Exit early for easier number type use.
-    if len == 0 {
-        return &[];
-    }
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut start_dot: Option<usize> = None;
-    let mut start_part: usize = 0;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut end: Option<usize> = None;
-    let mut matched_slash: bool = true;
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut pre_dot_state: Option<usize> = Some(0);
-
-    let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-    while i_i64 > -1 {
-        let i = usize::try_from(i_i64).expect("int cast");
-        let byte = path[i];
-        if byte == T::from_u8(CHAR_FORWARD_SLASH) {
-            // If we reached a path separator that was not part of a set of path
-            // separators at the end of the string, stop now
-            if !matched_slash {
-                start_part = i + 1;
-                break;
-            }
-            i_i64 -= 1;
-            continue;
-        }
-
-        if end.is_none() {
-            // We saw the first non-path separator, mark this as the end of our
-            // extension
-            matched_slash = false;
-            end = Some(i + 1);
-        }
-
-        if byte == T::from_u8(CHAR_DOT) {
-            // If this is our first dot, mark it as the start of our extension
-            if start_dot.is_none() {
-                start_dot = Some(i);
-            } else if pre_dot_state.is_some() && pre_dot_state.unwrap() != 1 {
-                pre_dot_state = Some(1);
-            }
-        } else if start_dot.is_some() {
-            // We saw a non-dot and non-path separator before our dot, so we should
-            // have a good chance at having a non-empty extension
-            pre_dot_state = None;
-        }
-        i_i64 -= 1;
-    }
-
-    let _end = end.unwrap_or(0);
-    let _pre_dot_state = pre_dot_state.unwrap_or(0);
-    let _start_dot = start_dot.unwrap_or(0);
-    if start_dot.is_none()
-        || end.is_none()
-        // We saw a non-dot character immediately before the dot
-        || (pre_dot_state.is_some() && _pre_dot_state == 0)
-        // The (right-most) trimmed path component is exactly '..'
-        || (_pre_dot_state == 1 && _start_dot == _end - 1 && _start_dot == start_part + 1)
-    {
-        return &[];
-    }
-
-    &path[_start_dot.._end]
+/// Result of [`scan_last_component_t`].
+struct LastComponentScan {
+    // We use optional values instead of -1, as in Node code, for easier number type use.
+    start_dot: Option<usize>,
+    start_part: usize,
+    end: Option<usize>,
+    pre_dot_state: Option<usize>,
 }
 
-/// Based on Node v21.6.1 path.win32.extname:
-/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L840
-fn extname_windows_t<T: PathCharCwd>(path: &[T]) -> &[T] {
-    // validateString of `path` is performed in pub fn extname.
-    let len = path.len();
-    // Exit early for easier number type use.
-    if len == 0 {
-        return &[];
-    }
-    let mut start: usize = 0;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
+/// Reverse scan over the last path component, tracking dot positions. Node
+/// repeats this loop verbatim in both the posix and win32 variants of
+/// `extname` and `parse`; all four call sites share this copy.
+///
+/// `path` must be non-empty; indices below `lower_bound` are not scanned.
+fn scan_last_component_t<T: PathCharCwd, const IS_WINDOWS: bool>(
+    path: &[T],
+    lower_bound: usize,
+    initial_start_part: usize,
+) -> LastComponentScan {
     let mut start_dot: Option<usize> = None;
-    let mut start_part: usize = 0;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
+    let mut start_part = initial_start_part;
     let mut end: Option<usize> = None;
-    let mut matched_slash: bool = true;
+    let mut matched_slash = true;
+
     // Track the state of characters (if any) we see before our first dot and
     // after any path separator we find
-
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
     let mut pre_dot_state: Option<usize> = Some(0);
 
-    // Check for a drive letter prefix so as not to mistake the following
-    // path separator as an extra separator at the end of the path that can be
-    // disregarded
-
-    if len >= 2 && path[1] == T::from_u8(CHAR_COLON) && is_windows_device_root_t(path[0]) {
-        start = 2;
-        start_part = start;
-    }
-
-    let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-    while i_i64 >= i64::try_from(start).expect("int cast") {
+    let mut i_i64 = i64::try_from(path.len() - 1).expect("int cast");
+    while i_i64 >= i64::try_from(lower_bound).expect("int cast") {
         let i = usize::try_from(i_i64).expect("int cast");
         let byte = path[i];
-        if is_sep_windows_t(byte) {
+        if is_sep_t::<T, IS_WINDOWS>(byte) {
             // If we reached a path separator that was not part of a set of path
             // separators at the end of the string, stop now
             if !matched_slash {
@@ -934,6 +786,45 @@ fn extname_windows_t<T: PathCharCwd>(path: &[T]) -> &[T] {
         i_i64 -= 1;
     }
 
+    LastComponentScan {
+        start_dot,
+        start_part,
+        end,
+        pre_dot_state,
+    }
+}
+
+/// Based on Node v21.6.1 path.posix.extname / path.win32.extname, which differ
+/// only in the separator set and the win32 drive-letter prologue:
+/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L1388
+/// https://github.com/nodejs/node/blob/6ae20aa63de78294b18d5015481485b7cd8fbb60/lib/path.js#L840
+fn extname_t<T: PathCharCwd, const IS_WINDOWS: bool>(path: &[T]) -> &[T] {
+    // validateString of `path` is performed in pub fn extname.
+    let len = path.len();
+    // Exit early for easier number type use.
+    if len == 0 {
+        return &[];
+    }
+    let mut start: usize = 0;
+
+    // Check for a drive letter prefix so as not to mistake the following
+    // path separator as an extra separator at the end of the path that can be
+    // disregarded
+    if IS_WINDOWS
+        && len >= 2
+        && path[1] == T::from_u8(CHAR_COLON)
+        && is_windows_device_root_t(path[0])
+    {
+        start = 2;
+    }
+
+    let LastComponentScan {
+        start_dot,
+        start_part,
+        end,
+        pre_dot_state,
+    } = scan_last_component_t::<T, IS_WINDOWS>(path, start, start);
+
     let _end = end.unwrap_or(0);
     let _pre_dot_state = pre_dot_state.unwrap_or(0);
     let _start_dot = start_dot.unwrap_or(0);
@@ -948,6 +839,14 @@ fn extname_windows_t<T: PathCharCwd>(path: &[T]) -> &[T] {
     }
 
     &path[_start_dot.._end]
+}
+
+fn extname_posix_t<T: PathCharCwd>(path: &[T]) -> &[T] {
+    extname_t::<T, false>(path)
+}
+
+fn extname_windows_t<T: PathCharCwd>(path: &[T]) -> &[T] {
+    extname_t::<T, true>(path)
 }
 
 pub use bun_paths::resolve_path::is_sep_posix_t;
@@ -2011,56 +1910,13 @@ pub(crate) fn parse_posix_t<T: PathCharCwd>(path: &[T]) -> PathParsed<'_, T> {
         start = 1;
     }
 
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut start_dot: Option<usize> = None;
-    let mut start_part: usize = 0;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut end: Option<usize> = None;
-    let mut matched_slash = true;
-    let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut pre_dot_state: Option<usize> = Some(0);
-
     // Get non-dir info
-    while i_i64 >= i64::try_from(start).expect("int cast") {
-        let i = usize::try_from(i_i64).expect("int cast");
-        let byte = path[i];
-        if byte == T::from_u8(CHAR_FORWARD_SLASH) {
-            // If we reached a path separator that was not part of a set of path
-            // separators at the end of the string, stop now
-            if !matched_slash {
-                start_part = i + 1;
-                break;
-            }
-            i_i64 -= 1;
-            continue;
-        }
-        if end.is_none() {
-            // We saw the first non-path separator, mark this as the end of our
-            // extension
-            matched_slash = false;
-            end = Some(i + 1);
-        }
-        if byte == T::from_u8(CHAR_DOT) {
-            // If this is our first dot, mark it as the start of our extension
-            if start_dot.is_none() {
-                start_dot = Some(i);
-            } else if let Some(_pre_dot_state) = pre_dot_state {
-                if _pre_dot_state != 1 {
-                    pre_dot_state = Some(1);
-                }
-            }
-        } else if start_dot.is_some() {
-            // We saw a non-dot and non-path separator before our dot, so we should
-            // have a good chance at having a non-empty extension
-            pre_dot_state = None;
-        }
-        i_i64 -= 1;
-    }
+    let LastComponentScan {
+        start_dot,
+        start_part,
+        end,
+        pre_dot_state,
+    } = scan_last_component_t::<T, false>(path, start, 0);
 
     if let Some(_end) = end {
         let _pre_dot_state = pre_dot_state.unwrap_or(0);
@@ -2125,7 +1981,7 @@ pub(crate) fn parse_windows_t<T: PathCharCwd>(path: &[T]) -> PathParsed<'_, T> {
     let is_sep_t = is_sep_windows_t::<T>;
 
     let mut root_end: usize = 0;
-    let mut byte = path[0];
+    let byte = path[0];
 
     if len == 1 {
         if is_sep_t(byte) {
@@ -2220,56 +2076,13 @@ pub(crate) fn parse_windows_t<T: PathCharCwd>(path: &[T]) -> PathParsed<'_, T> {
         root = &path[0..root_end];
     }
 
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut start_dot: Option<usize> = None;
-    let mut start_part = root_end;
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut end: Option<usize> = None;
-    let mut matched_slash = true;
-    let mut i_i64 = i64::try_from(len - 1).expect("int cast");
-
-    // Track the state of characters (if any) we see before our first dot and
-    // after any path separator we find
-
-    // We use an optional value instead of -1, as in Node code, for easier number type use.
-    let mut pre_dot_state: Option<usize> = Some(0);
-
     // Get non-dir info
-    while i_i64 >= i64::try_from(root_end).expect("int cast") {
-        let i = usize::try_from(i_i64).expect("int cast");
-        byte = path[i];
-        if is_sep_t(byte) {
-            // If we reached a path separator that was not part of a set of path
-            // separators at the end of the string, stop now
-            if !matched_slash {
-                start_part = i + 1;
-                break;
-            }
-            i_i64 -= 1;
-            continue;
-        }
-        if end.is_none() {
-            // We saw the first non-path separator, mark this as the end of our
-            // extension
-            matched_slash = false;
-            end = Some(i + 1);
-        }
-        if byte == T::from_u8(CHAR_DOT) {
-            // If this is our first dot, mark it as the start of our extension
-            if start_dot.is_none() {
-                start_dot = Some(i);
-            } else if let Some(_pre_dot_state) = pre_dot_state {
-                if _pre_dot_state != 1 {
-                    pre_dot_state = Some(1);
-                }
-            }
-        } else if start_dot.is_some() {
-            // We saw a non-dot and non-path separator before our dot, so we should
-            // have a good chance at having a non-empty extension
-            pre_dot_state = None;
-        }
-        i_i64 -= 1;
-    }
+    let LastComponentScan {
+        start_dot,
+        start_part,
+        end,
+        pre_dot_state,
+    } = scan_last_component_t::<T, true>(path, root_end, root_end);
 
     if let Some(_end) = end {
         let _pre_dot_state = pre_dot_state.unwrap_or(0);

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -413,20 +413,7 @@ impl StringOrBuffer<'static> {
                 Ok(true)
             }
 
-            JSType::ArrayBuffer
-            | JSType::Int8Array
-            | JSType::Uint8Array
-            | JSType::Uint8ClampedArray
-            | JSType::Int16Array
-            | JSType::Uint16Array
-            | JSType::Int32Array
-            | JSType::Uint32Array
-            | JSType::Float32Array
-            | JSType::Float16Array
-            | JSType::Float64Array
-            | JSType::BigInt64Array
-            | JSType::BigUint64Array
-            | JSType::DataView => {
+            t if t.is_array_buffer_like() => {
                 *out = Self::buffer_from_js(global, value, flavor)?;
                 Ok(true)
             }

--- a/test/js/node/fs/fs-chown-utimes.test.ts
+++ b/test/js/node/fs/fs-chown-utimes.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+import { tempDir } from "harness";
+import fs from "node:fs";
+import { join } from "node:path";
+
+// chown/fchown/lchown share one uid/gid reader and utimes/futimes/lutimes
+// share one atime/mtime reader in src/runtime/node/node_fs.rs, so every
+// sibling must validate identically and name the failing argument itself.
+
+describe.concurrent("chown/fchown/lchown argument validation", () => {
+  it("validates uid and gid to [-1, 2**32 - 1] with the argument's own name", () => {
+    using dir = tempDir("fs-chown-args", { "chown-args.txt": "x" });
+    const tmp = join(String(dir), "chown-args.txt");
+    const fd = fs.openSync(tmp, "r+");
+    try {
+      const variants: ((uid: any, gid: any) => void)[] = [
+        (uid, gid) => fs.chownSync(tmp, uid, gid),
+        (uid, gid) => fs.fchownSync(fd, uid, gid),
+        (uid, gid) => fs.lchownSync(tmp, uid, gid),
+      ];
+      for (const call of variants) {
+        // -1 ("leave unchanged") and the u32 maximum are both in range.
+        expect(() => call(-1, -1)).not.toThrow();
+        expect(() => call(2 ** 32 - 1, 2 ** 32 - 1)).not.toThrow();
+        expect(() => call(-2, 0)).toThrow(
+          RangeError('The value of "uid" is out of range. It must be >= -1 && <= 4294967295. Received -2'),
+        );
+        expect(() => call(0, 2 ** 32)).toThrow(
+          RangeError('The value of "gid" is out of range. It must be >= -1 && <= 4294967295. Received 4294967296'),
+        );
+        expect(() => call(1.5, 0)).toThrow(
+          RangeError('The value of "uid" is out of range. It must be an integer. Received 1.5'),
+        );
+        expect(() => call(0, "a")).toThrow(
+          TypeError("The \"gid\" argument must be of type number. Received type string ('a')"),
+        );
+        expect(() => call(0, "a")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+});
+
+describe.concurrent("utimes/futimes/lutimes argument validation", () => {
+  it("rejects non-finite and non-number atime/mtime with the argument's own name", () => {
+    using dir = tempDir("fs-utimes-args", { "utimes-args.txt": "x" });
+    const tmp = join(String(dir), "utimes-args.txt");
+    const fd = fs.openSync(tmp, "r+");
+    try {
+      const variants: ((atime: any, mtime: any) => void)[] = [
+        (atime, mtime) => fs.utimesSync(tmp, atime, mtime),
+        (atime, mtime) => fs.futimesSync(fd, atime, mtime),
+        (atime, mtime) => fs.lutimesSync(tmp, atime, mtime),
+      ];
+      for (const call of variants) {
+        expect(() => call(0, 0)).not.toThrow();
+        expect(() => call(new Date(), new Date())).not.toThrow();
+        for (const bad of [{}, NaN, Infinity, -Infinity]) {
+          expect(() => call(bad, 0)).toThrow(TypeError("atime must be a number or a Date"));
+          expect(() => call(0, bad)).toThrow(TypeError("mtime must be a number or a Date"));
+        }
+        expect(() => call({}, 0)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  it("utimesSync follows symlinks and lutimesSync does not", () => {
+    using dir = tempDir("fs-utimes-symlink", { "target.txt": "x" });
+    const target = join(String(dir), "target.txt");
+    const link = join(String(dir), "link");
+    fs.symlinkSync(target, link);
+
+    const linkTime = new Date("2000-01-02T03:04:05.000Z");
+    fs.lutimesSync(link, linkTime, linkTime);
+    const targetTime = new Date("2010-06-07T08:09:10.000Z");
+    fs.utimesSync(link, targetTime, targetTime);
+
+    expect({
+      link: fs.lstatSync(link).mtime.toISOString(),
+      target: fs.statSync(target).mtime.toISOString(),
+    }).toEqual({
+      link: linkTime.toISOString(),
+      target: targetTime.toISOString(),
+    });
+  });
+});

--- a/test/js/node/fs/fs-chown-utimes.test.ts
+++ b/test/js/node/fs/fs-chown-utimes.test.ts
@@ -22,18 +22,18 @@ describe.concurrent("chown/fchown/lchown argument validation", () => {
         // -1 ("leave unchanged") and the u32 maximum are both in range.
         expect(() => call(-1, -1)).not.toThrow();
         expect(() => call(2 ** 32 - 1, 2 ** 32 - 1)).not.toThrow();
-        expect(() => call(-2, 0)).toThrow(
-          RangeError('The value of "uid" is out of range. It must be >= -1 && <= 4294967295. Received -2'),
-        );
-        expect(() => call(0, 2 ** 32)).toThrow(
-          RangeError('The value of "gid" is out of range. It must be >= -1 && <= 4294967295. Received 4294967296'),
-        );
-        expect(() => call(1.5, 0)).toThrow(
-          RangeError('The value of "uid" is out of range. It must be an integer. Received 1.5'),
-        );
-        expect(() => call(0, "a")).toThrow(
-          TypeError("The \"gid\" argument must be of type number. Received type string ('a')"),
-        );
+        // .toThrow(err) compares only the message, so class and code are
+        // asserted separately with toThrowWithCode.
+        const rangeCases: [uid: number, gid: number, message: string][] = [
+          [-2, 0, 'The value of "uid" is out of range. It must be >= -1 && <= 4294967295. Received -2'],
+          [0, 2 ** 32, 'The value of "gid" is out of range. It must be >= -1 && <= 4294967295. Received 4294967296'],
+          [1.5, 0, 'The value of "uid" is out of range. It must be an integer. Received 1.5'],
+        ];
+        for (const [uid, gid, message] of rangeCases) {
+          expect(() => call(uid, gid)).toThrow(message);
+          expect(() => call(uid, gid)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
+        }
+        expect(() => call(0, "a")).toThrow("The \"gid\" argument must be of type number. Received type string ('a')");
         expect(() => call(0, "a")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
       }
     } finally {
@@ -57,10 +57,11 @@ describe.concurrent("utimes/futimes/lutimes argument validation", () => {
         expect(() => call(0, 0)).not.toThrow();
         expect(() => call(new Date(), new Date())).not.toThrow();
         for (const bad of [{}, NaN, Infinity, -Infinity]) {
-          expect(() => call(bad, 0)).toThrow(TypeError("atime must be a number or a Date"));
-          expect(() => call(0, bad)).toThrow(TypeError("mtime must be a number or a Date"));
+          expect(() => call(bad, 0)).toThrow("atime must be a number or a Date");
+          expect(() => call(bad, 0)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
+          expect(() => call(0, bad)).toThrow("mtime must be a number or a Date");
+          expect(() => call(0, bad)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
         }
-        expect(() => call({}, 0)).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
       }
     } finally {
       fs.closeSync(fd);


### PR DESCRIPTION
## What this does
Dedupes repeated argument-conversion and error-path blocks in `node_fs.rs` and removes dead helpers in node `path`/`types`. Net -330 lines in src (323 added, 653 removed) after the rebases below.

Split from #31912 (whole-repo simplification pass; closing that PR in favor of module-scoped splits). This PR only moves and removes code — zero intended behavior change. Verified there by a per-file behavioral-equivalence audit and full CI; verified here by a standalone full-workspace compile check.

## Tests
`test/js/node/fs/fs-chown-utimes.test.ts` pins the consolidated surface: chown/fchown/lchown must validate uid and gid identically and name the failing argument itself, utimes/futimes/lutimes likewise for atime/mtime, and utimesSync must follow symlinks while lutimesSync must not (the dispatch the merged `utimes_with` preserves). Because this PR intends zero behavior change, these tests pass before and after the refactor by design; they guard the shared readers against future drift. A test that fails on main cannot exist for this PR: any such failure would mean the consolidation changed observable behavior, which is the one outcome it must not have. The correctness argument is the behavioral-equivalence audit plus the full existing suite passing on both sides, not a fail-before proof.

The `error.syscall` suite added on main by #32964 runs through the consolidated `utimes_with` and passes, so the utime/lutime naming is covered by an existing test that would fail if the consolidation got it wrong. The upstream node path-* and fs utimes/chown/copyfile/cp suites (102 files, including the ones #34505 added) also pass on this branch.

## Rebase notes
Rebased eight times as main moved; the consolidation itself is unchanged except where noted.

- #32964 made `utimes` and `lutimes` report node's operation names (`utime` / `lutime`) in `err.syscall`. The shared `utimes_with` takes that `sys::Tag` as a parameter and each caller passes its own; keeping the old helper shape would have silently made `lutimes` report `utime` again.
- #32052 implemented `fs.lchown` on Windows, so the interim test gating for it was dropped.
- Main later deleted `NodeFSFunctionEnum::heap_label` as dead code, so the hunk that derived the enum and `heap_label` from one macro no longer has a purpose and was dropped; the enum and its impl are byte-identical to main.
- Main narrowed visibility across these files (`pub` to `pub(crate)` or private); the consolidated wrappers adopt main's current visibility for each function they replace.
- Main changed ERR_OUT_OF_RANGE wording to node's `&&` form; the test tracks that.
- #39164 rewrote the body of the `StringOrBuffer` buffer arm (bool flags to enums); this PR's change to that arm is only its pattern, so the resolution keeps main's body under the `is_array_buffer_like()` guard.
- #39448 deleted `unwatch_file`, the function adjacent to the new `utimes_with`; it stays deleted.
- #40374 added borrowed lifetimes to the fs argument structs on the lines where the shared readers are inserted; main's annotations are kept and the readers, which return integers and `TimeLike`, need none.
- #40511 rewrote the `StringOrBuffer` buffer arm body again (now `Self::buffer_from_js`); as with #39164, main's body is kept under the `is_array_buffer_like()` guard.
- #40860 replaced libuv `ReturnCode::errno()` plus a hand-built `sys::Error` with `rc.to_error(tag)` in the Windows arms of `utimes`/`lutimes`; the shared `utimes_with` uses that same form (`rc.to_error(syscall)` then `with_path`), so its Windows error path matches main's two functions. Checked with `cargo check --target x86_64-pc-windows-msvc`, since that arm is cfg(windows).
- The test also asserts constructor and `err.code` (`toThrowWithCode`) for every validation case, since `.toThrow(err)` compares only the message.

Every function main has modified in these files that this PR does not consolidate is byte-identical to main on this branch, and the only main-added lines this branch removes are the signature lines of the functions it rewrites. The Linux copy helper was re-verified against current main: everything before the removed loop block is identical at both call sites, the removed block at the `fs.copyFile` site contains the EINTR retry (`EintrPolicy::Retry`) and the one at the `fs.cp` site does not (`EintrPolicy::Surface`), and the new FreeBSD copy paths main added are separate cfg blocks the helper does not touch. `cargo check` passes for the windows-msvc, apple-darwin, and freebsd targets in addition to the full Linux debug build and clippy.





