### PR TITLE
Deduplicate package manager and CLI command helpers

### DIFF
--- a/src/install/PackageInstall.rs
+++ b/src/install/PackageInstall.rs
@@ -1285,224 +1285,106 @@ impl<'a> PackageInstall<'a> {
             Err(failure) => return InstallResult::Failure(failure),
         };
 
-        #[cfg(windows)]
-        type WinSlice<'b> = &'b mut [u16];
         #[cfg(not(windows))]
-        type WinSlice<'b> = ();
-        #[cfg(windows)]
-        type WinOffset = usize;
-        #[cfg(not(windows))]
-        type WinOffset = ();
-
-        // Two overlapping slices into the same buffer (`head` is the whole
-        // buffer, `to_copy_into` is its tail) would be two live aliasing
-        // `&mut [u16]`, which is UB — pass head buffer + tail offset and
-        // reslice inside.
         fn copy(
             destination_dir_: &Dir,
             walker: &mut Walker,
             mut progress_: Option<&mut Progress>,
-            to_copy_into1_offset: WinOffset,
-            head1: WinSlice<'_>,
-            to_copy_into2_offset: WinOffset,
-            head2: WinSlice<'_>,
         ) -> crate::Result<()> {
-            #[cfg(not(windows))]
             let mut copy_file_state = bun_sys::copy_file::CopyFileState::default();
-            #[cfg(not(windows))]
-            let _ = (to_copy_into1_offset, head1, to_copy_into2_offset, head2);
 
             while let Some(entry) = walker.next()? {
-                #[cfg(windows)]
-                {
-                    use bun_sys::windows;
-                    match entry.kind {
-                        EntryKind::Directory | EntryKind::File => {}
-                        _ => continue,
-                    }
+                if entry.kind != EntryKind::File {
+                    continue;
+                }
 
-                    if entry.path.len() > head1.len() - to_copy_into1_offset
-                        || entry.path.len() > head2.len() - to_copy_into2_offset
-                    {
-                        return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-                    }
+                let in_file = sys::openat(entry.dir, entry.basename, sys::O::RDONLY, 0)?;
+                let _close_in = sys::CloseOnDrop::new(in_file);
 
-                    let dest_len = to_copy_into1_offset + entry.path.len();
-                    head1[to_copy_into1_offset..dest_len].copy_from_slice(entry.path.as_slice());
-                    head1[dest_len] = 0;
-                    let dest = bun_core::WStr::from_buf(head1, dest_len);
-
-                    let src_len = to_copy_into2_offset + entry.path.len();
-                    head2[to_copy_into2_offset..src_len].copy_from_slice(entry.path.as_slice());
-                    head2[src_len] = 0;
-                    let src = bun_core::WStr::from_buf(head2, src_len);
-
-                    match entry.kind {
-                        EntryKind::Directory => {
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers built
-                            // into head1/head2 above.
-                            if unsafe {
-                                windows::CreateDirectoryExW(
-                                    src.as_ptr(),
-                                    dest.as_ptr(),
-                                    core::ptr::null_mut(),
-                                )
-                            } == 0
-                            {
-                                let _ = bun_sys::MakePath::make_path_u16(
-                                    destination_dir_,
-                                    entry.path.as_slice(),
-                                );
-                            }
+                bun_output::scoped_log!(
+                    install,
+                    "createFile {} {}\n",
+                    destination_dir_.fd(),
+                    bstr::BStr::new(entry.path.as_bytes())
+                );
+                // The file can be a hardlink of `in_file`, and O_TRUNC would empty both.
+                let create = |path: &ZStr| {
+                    let open = || {
+                        sys::openat(
+                            destination_dir_.fd(),
+                            path,
+                            sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
+                            0o666,
+                        )
+                    };
+                    match open() {
+                        Err(err) if err.get_errno() == sys::E::EEXIST => {
+                            let _ = sys::unlinkat(destination_dir_, path);
+                            open()
                         }
-                        EntryKind::File => {
-                            // `dest` can be a hardlink of `src`, which CopyFileW cannot overwrite.
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers.
-                            let copy_file =
-                                || unsafe { windows::CopyFileW(src.as_ptr(), dest.as_ptr(), 1) } != 0;
-                            if !copy_file() {
-                                let copied = match windows::Win32Error::get() {
-                                    windows::Win32Error::FILE_EXISTS
-                                    | windows::Win32Error::ALREADY_EXISTS => {
-                                        // SAFETY: FFI — dest is a valid NUL-terminated WStr buffer.
-                                        unsafe { windows::DeleteFileW(dest.as_ptr()) };
-                                        copy_file()
-                                    }
-                                    _ => {
-                                        match bun_paths::Dirname::dirname_u16(entry.path.as_slice())
-                                        {
-                                            Some(entry_dirname) => {
-                                                let _ = bun_sys::MakePath::make_path_u16(
-                                                    destination_dir_,
-                                                    entry_dirname,
-                                                );
-                                                copy_file()
-                                            }
-                                            None => false,
-                                        }
-                                    }
-                                };
-                                if copied {
-                                    continue;
-                                }
-
-                                let err = windows::last_system_errno();
-                                if let Some(progress) = progress_.as_deref_mut() {
+                        result => result,
+                    }
+                };
+                let outfile = match create(entry.path) {
+                    Ok(f) => f,
+                    Err(_) => 'brk: {
+                        let entry_dirname = bun_paths::resolve_path::dirname::<
+                            bun_paths::platform::Auto,
+                        >(entry.path.as_bytes());
+                        if !entry_dirname.is_empty() {
+                            let _ = bun_sys::MakePath::make_path::<OSPathChar>(
+                                destination_dir_,
+                                entry_dirname,
+                            );
+                        }
+                        match create(entry.path) {
+                            Ok(f) => break 'brk f,
+                            Err(err) => {
+                                if let Some(progress) = progress_ {
                                     progress.root.end();
                                     progress.refresh();
                                 }
 
                                 bun_core::pretty_errorln!(
                                     "<r><red>{}<r>: copying file {}",
-                                    err,
+                                    bstr::BStr::new(err.name()),
                                     bun_core::fmt::fmt_os_path(
-                                        entry.path.as_slice(),
+                                        entry.path.as_bytes(),
                                         Default::default()
                                     )
                                 );
-
                                 Global::crash();
                             }
                         }
-                        _ => unreachable!(), // handled above
                     }
-                }
-                #[cfg(not(windows))]
+                };
+                let _close_out = sys::CloseOnDrop::new(outfile);
+
+                #[cfg(unix)]
                 {
-                    if entry.kind != EntryKind::File {
+                    let Ok(stat) = sys::fstat(in_file) else {
                         continue;
+                    };
+                    // `sys::fchmod` is the safe by-value-fd wrapper (kernel
+                    // validates the fd; no memory-safety preconditions).
+                    // Result intentionally ignored.
+                    let _ = sys::fchmod(outfile, stat.st_mode as bun_sys::Mode);
+                }
+
+                if let Err(err) =
+                    bun_sys::copy_file::copy_file_with_state(in_file, outfile, &mut copy_file_state)
+                {
+                    if let Some(progress) = progress_.as_deref_mut() {
+                        progress.root.end();
+                        progress.refresh();
                     }
 
-                    let in_file = sys::openat(entry.dir, entry.basename, sys::O::RDONLY, 0)?;
-                    let _close_in = sys::CloseOnDrop::new(in_file);
-
-                    bun_output::scoped_log!(
-                        install,
-                        "createFile {} {}\n",
-                        destination_dir_.fd(),
-                        bstr::BStr::new(entry.path.as_bytes())
+                    bun_core::pretty_errorln!(
+                        "<r><red>{}<r>: copying file {}",
+                        bstr::BStr::new(err.name()),
+                        bun_core::fmt::fmt_os_path(entry.path.as_bytes(), Default::default())
                     );
-                    // The file can be a hardlink of `in_file`, and O_TRUNC would empty both.
-                    let create = |path: &ZStr| {
-                        let open = || {
-                            sys::openat(
-                                destination_dir_.fd(),
-                                path,
-                                sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
-                                0o666,
-                            )
-                        };
-                        match open() {
-                            Err(err) if err.get_errno() == sys::E::EEXIST => {
-                                let _ = sys::unlinkat(destination_dir_, path);
-                                open()
-                            }
-                            result => result,
-                        }
-                    };
-                    let outfile = match create(entry.path) {
-                        Ok(f) => f,
-                        Err(_) => 'brk: {
-                            let entry_dirname = bun_paths::resolve_path::dirname::<
-                                bun_paths::platform::Auto,
-                            >(entry.path.as_bytes());
-                            if !entry_dirname.is_empty() {
-                                let _ = bun_sys::MakePath::make_path::<OSPathChar>(
-                                    destination_dir_,
-                                    entry_dirname,
-                                );
-                            }
-                            match create(entry.path) {
-                                Ok(f) => break 'brk f,
-                                Err(err) => {
-                                    if let Some(progress) = progress_ {
-                                        progress.root.end();
-                                        progress.refresh();
-                                    }
-
-                                    bun_core::pretty_errorln!(
-                                        "<r><red>{}<r>: copying file {}",
-                                        bstr::BStr::new(err.name()),
-                                        bun_core::fmt::fmt_os_path(
-                                            entry.path.as_bytes(),
-                                            Default::default()
-                                        )
-                                    );
-                                    Global::crash();
-                                }
-                            }
-                        }
-                    };
-                    let _close_out = sys::CloseOnDrop::new(outfile);
-
-                    #[cfg(unix)]
-                    {
-                        let Ok(stat) = sys::fstat(in_file) else {
-                            continue;
-                        };
-                        // `sys::fchmod` is the safe by-value-fd wrapper (kernel
-                        // validates the fd; no memory-safety preconditions).
-                        // Result intentionally ignored.
-                        let _ = sys::fchmod(outfile, stat.st_mode as bun_sys::Mode);
-                    }
-
-                    if let Err(err) = bun_sys::copy_file::copy_file_with_state(
-                        in_file,
-                        outfile,
-                        &mut copy_file_state,
-                    ) {
-                        if let Some(progress) = progress_.as_deref_mut() {
-                            progress.root.end();
-                            progress.refresh();
-                        }
-
-                        bun_core::pretty_errorln!(
-                            "<r><red>{}<r>: copying file {}",
-                            bstr::BStr::new(err.name()),
-                            bun_core::fmt::fmt_os_path(entry.path.as_bytes(), Default::default())
-                        );
-                        Global::crash();
-                    }
+                    Global::crash();
                 }
             }
 
@@ -1510,24 +1392,68 @@ impl<'a> PackageInstall<'a> {
         }
 
         #[cfg(windows)]
-        let result = copy(
-            &state.subdir,
-            &mut state.walker,
-            self.progress.as_deref_mut(),
-            state.to_copy_buf_off,
-            &mut state.buf[..],
-            state.to_copy_buf2_off,
-            &mut state.buf2[..],
-        );
+        let result = {
+            use bun_sys::windows;
+            let destination_dir_ = &state.subdir;
+            let mut progress_ = self.progress.as_deref_mut();
+            walk_install_dir_windows(
+                destination_dir_,
+                &mut state.walker,
+                state.to_copy_buf_off,
+                &mut state.buf[..],
+                state.to_copy_buf2_off,
+                &mut state.buf2[..],
+                |dest, src, entry_path| {
+                    // `dest` can be a hardlink of `src`, which CopyFileW cannot overwrite.
+                    // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers.
+                    let copy_file =
+                        || unsafe { windows::CopyFileW(src.as_ptr(), dest.as_ptr(), 1) } != 0;
+                    if !copy_file() {
+                        let copied = match windows::Win32Error::get() {
+                            windows::Win32Error::FILE_EXISTS
+                            | windows::Win32Error::ALREADY_EXISTS => {
+                                // SAFETY: FFI — dest is a valid NUL-terminated WStr buffer.
+                                unsafe { windows::DeleteFileW(dest.as_ptr()) };
+                                copy_file()
+                            }
+                            _ => match bun_paths::Dirname::dirname_u16(entry_path) {
+                                Some(entry_dirname) => {
+                                    let _ = bun_sys::MakePath::make_path_u16(
+                                        destination_dir_,
+                                        entry_dirname,
+                                    );
+                                    copy_file()
+                                }
+                                None => false,
+                            },
+                        };
+                        if copied {
+                            return Ok(());
+                        }
+
+                        let err = windows::last_system_errno();
+                        if let Some(progress) = progress_.as_deref_mut() {
+                            progress.root.end();
+                            progress.refresh();
+                        }
+
+                        bun_core::pretty_errorln!(
+                            "<r><red>{}<r>: copying file {}",
+                            err,
+                            bun_core::fmt::fmt_os_path(entry_path, Default::default())
+                        );
+
+                        Global::crash();
+                    }
+                    Ok(())
+                },
+            )
+        };
         #[cfg(not(windows))]
         let result = copy(
             &state.subdir,
             &mut state.walker,
             self.progress.as_deref_mut(),
-            (),
-            (),
-            (),
-            (),
         );
 
         if let Err(err) = result {
@@ -1747,33 +1673,17 @@ impl<'a> PackageInstall<'a> {
             }
         }
 
-        #[cfg(windows)]
-        type WinSlice<'b> = &'b mut [u16];
-        #[cfg(not(windows))]
-        type WinSlice<'b> = ();
-        #[cfg(windows)]
-        type WinOffset = usize;
-        #[cfg(not(windows))]
-        type WinOffset = ();
-        #[cfg(windows)]
-        type Head2Char = u16;
-        #[cfg(not(windows))]
-        type Head2Char = u8;
-
         // Two overlapping slices into the same buffer (`head` is the whole
         // buffer, `to_copy_into` is its tail) would be two live aliasing
         // `&mut`, which is UB — pass head buffer + tail offset and reslice
         // inside.
+        #[cfg(not(windows))]
         fn copy(
             destination_dir: &Dir,
             walker: &mut Walker,
-            to_copy_into1_offset: WinOffset,
-            head1: WinSlice<'_>,
             to_copy_into2_offset: usize,
-            head2: &mut [Head2Char],
+            head2: &mut [u8],
         ) -> crate::Result<()> {
-            #[cfg(not(windows))]
-            let _ = (to_copy_into1_offset, head1);
             while let Some(entry) = walker.next()? {
                 #[cfg(unix)]
                 {
@@ -1806,99 +1716,51 @@ impl<'a> PackageInstall<'a> {
                         _ => {}
                     }
                 }
-                #[cfg(not(unix))]
-                {
-                    use bun_sys::windows;
-                    match entry.kind {
-                        EntryKind::Directory | EntryKind::File => {}
-                        _ => continue,
-                    }
-
-                    if entry.path.len() > head1.len() - to_copy_into1_offset
-                        || entry.path.len() > head2.len() - to_copy_into2_offset
-                    {
-                        return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
-                    }
-
-                    let dest_len = to_copy_into1_offset + entry.path.len();
-                    head1[to_copy_into1_offset..dest_len].copy_from_slice(entry.path.as_slice());
-                    head1[dest_len] = 0;
-                    let dest = bun_core::WStr::from_buf(head1, dest_len);
-
-                    let src_len = to_copy_into2_offset + entry.path.len();
-                    head2[to_copy_into2_offset..src_len].copy_from_slice(entry.path.as_slice());
-                    head2[src_len] = 0;
-                    let src = bun_core::WStr::from_buf(head2, src_len);
-
-                    match entry.kind {
-                        EntryKind::Directory => {
-                            // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers built
-                            // into head1/head2 above.
-                            if unsafe {
-                                windows::CreateDirectoryExW(
-                                    src.as_ptr(),
-                                    dest.as_ptr(),
-                                    core::ptr::null_mut(),
-                                )
-                            } == 0
-                            {
-                                let _ = bun_sys::MakePath::make_path_u16(
-                                    destination_dir,
-                                    entry.path.as_slice(),
-                                );
-                            }
-                        }
-                        EntryKind::File => match sys::symlink_w(dest, src, Default::default()) {
-                            Err(err) => {
-                                if let Some(entry_dirname) =
-                                    bun_paths::Dirname::dirname_u16(entry.path.as_slice())
-                                {
-                                    let _ = bun_sys::MakePath::make_path_u16(
-                                        destination_dir,
-                                        entry_dirname,
-                                    );
-                                    if sys::symlink_w(dest, src, Default::default()).is_ok() {
-                                        continue;
-                                    }
-                                }
-
-                                if PackageManager::verbose_install() {
-                                    bun_core::run_once! {{
-                                        bun_core::warn!(
-                                            "CreateHardLinkW failed, falling back to CopyFileW: {} -> {}\n",
-                                            bun_core::fmt::fmt_os_path(src.as_slice(), Default::default()),
-                                            bun_core::fmt::fmt_os_path(dest.as_slice(), Default::default()),
-                                        );
-                                    }}
-                                }
-
-                                return Err(err.into());
-                            }
-                            Ok(_) => {}
-                        },
-                        _ => unreachable!(), // handled above
-                    }
-                }
             }
 
             Ok(())
         }
 
         #[cfg(windows)]
-        let result = copy(
-            &state.subdir,
-            &mut state.walker,
-            state.to_copy_buf_off,
-            &mut state.buf[..],
-            state.to_copy_buf2_off,
-            &mut state.buf2[..],
-        );
+        let result = {
+            let destination_dir = &state.subdir;
+            walk_install_dir_windows(
+                destination_dir,
+                &mut state.walker,
+                state.to_copy_buf_off,
+                &mut state.buf[..],
+                state.to_copy_buf2_off,
+                &mut state.buf2[..],
+                |dest, src, entry_path| match sys::symlink_w(dest, src, Default::default()) {
+                    Err(err) => {
+                        if let Some(entry_dirname) = bun_paths::Dirname::dirname_u16(entry_path) {
+                            let _ =
+                                bun_sys::MakePath::make_path_u16(destination_dir, entry_dirname);
+                            if sys::symlink_w(dest, src, Default::default()).is_ok() {
+                                return Ok(());
+                            }
+                        }
+
+                        if PackageManager::verbose_install() {
+                            bun_core::run_once! {{
+                                bun_core::warn!(
+                                    "CreateHardLinkW failed, falling back to CopyFileW: {} -> {}\n",
+                                    bun_core::fmt::fmt_os_path(src.as_slice(), Default::default()),
+                                    bun_core::fmt::fmt_os_path(dest.as_slice(), Default::default()),
+                                );
+                            }}
+                        }
+
+                        Err(err.into())
+                    }
+                    Ok(_) => Ok(()),
+                },
+            )
+        };
         #[cfg(not(windows))]
         let result = copy(
             &state.subdir,
             &mut state.walker,
-            (),
-            (),
             to_copy_buf2_offset,
             &mut buf2[..],
         );
@@ -2419,3 +2281,65 @@ impl<'a> PackageInstall<'a> {
 }
 
 type Walker = walker_skippable::Walker;
+
+/// Shared Windows directory walk for the copyfile/symlink install backends:
+/// builds NUL-terminated wide dest/src paths for each entry, creates
+/// directories (`CreateDirectoryExW` with a `make_path` fallback), and calls
+/// `per_file(dest, src, entry_path)` for each file.
+///
+/// Two overlapping slices into the same buffer (`head` is the whole buffer,
+/// `to_copy_into` is its tail) would be two live aliasing `&mut [u16]`, which
+/// is UB — pass head buffer + tail offset and reslice inside.
+#[cfg(windows)]
+fn walk_install_dir_windows(
+    destination_dir: &Dir,
+    walker: &mut Walker,
+    to_copy_into1_offset: usize,
+    head1: &mut [u16],
+    to_copy_into2_offset: usize,
+    head2: &mut [u16],
+    mut per_file: impl FnMut(&bun_core::WStr, &bun_core::WStr, &[u16]) -> crate::Result<()>,
+) -> crate::Result<()> {
+    use bun_sys::windows;
+
+    while let Some(entry) = walker.next()? {
+        match entry.kind {
+            EntryKind::Directory | EntryKind::File => {}
+            _ => continue,
+        }
+
+        if entry.path.len() > head1.len() - to_copy_into1_offset
+            || entry.path.len() > head2.len() - to_copy_into2_offset
+        {
+            return Err(crate::Error::Sys(bun_errno::SystemErrno::ENAMETOOLONG));
+        }
+
+        let dest_len = to_copy_into1_offset + entry.path.len();
+        head1[to_copy_into1_offset..dest_len].copy_from_slice(entry.path.as_slice());
+        head1[dest_len] = 0;
+        let dest = bun_core::WStr::from_buf(head1, dest_len);
+
+        let src_len = to_copy_into2_offset + entry.path.len();
+        head2[to_copy_into2_offset..src_len].copy_from_slice(entry.path.as_slice());
+        head2[src_len] = 0;
+        let src = bun_core::WStr::from_buf(head2, src_len);
+
+        match entry.kind {
+            EntryKind::Directory => {
+                // SAFETY: FFI — src/dest are valid NUL-terminated WStr buffers built
+                // into head1/head2 above.
+                if unsafe {
+                    windows::CreateDirectoryExW(src.as_ptr(), dest.as_ptr(), core::ptr::null_mut())
+                } == 0
+                {
+                    let _ =
+                        bun_sys::MakePath::make_path_u16(destination_dir, entry.path.as_slice());
+                }
+            }
+            EntryKind::File => per_file(dest, src, entry.path.as_slice())?,
+            _ => unreachable!(), // handled above
+        }
+    }
+
+    Ok(())
+}

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -401,6 +401,17 @@ fn print_package_version<'a>(
     spill
 }
 
+/// Where to record a newly trusted dependency once its lifecycle scripts are
+/// enqueued. npm resolutions are recorded under the package name, everything
+/// else under the dependency alias.
+#[derive(Clone, Copy)]
+struct TrustedDepRecord {
+    /// Add the name to `trusted_deps_to_add_to_package_json`.
+    package_json: bool,
+    /// Add the name to the lockfile's `trusted_dependencies`.
+    lockfile: bool,
+}
+
 impl<'a> PackageInstaller<'a> {
     // ──────────────────────────────────────────────────────────────────────
     // BACKREF accessors
@@ -1955,79 +1966,20 @@ impl<'a> PackageInstaller<'a> {
                     if resolution.tag != resolution::Tag::Root
                         && (resolution.tag == resolution::Tag::Workspace || is_trusted)
                     {
-                        let mut folder_path =
-                            AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-                        // `defer folder_path.deinit()` — AbsPath impls Drop.
-                        folder_path
-                            .append(alias.slice(string_buf!()))
-                            .unwrap_or_oom();
-
-                        'enqueue_lifecycle_scripts: {
-                            if self
-                                .manager()
-                                .postinstall_optimizer
-                                .should_ignore_lifecycle_scripts(
-                                    &postinstall_optimizer::PkgInfo {
-                                        name_hash: pkg_name_hash,
-                                        version: if resolution.tag == resolution::Tag::Npm {
-                                            Some(resolution.npm().version)
-                                        } else {
-                                            None
-                                        },
-                                        version_buf: string_buf!(),
-                                    },
-                                    self.lockfile().packages.items_resolutions()
-                                        [package_id as usize]
-                                        .get(self.lockfile().buffers.resolutions.as_slice()),
-                                    self.lockfile().packages.items_meta(),
-                                    self.manager().options.cpu,
-                                    self.manager().options.os,
-                                )
-                            {
-                                if PackageManager::verbose_install() {
-                                    bun_core::pretty_errorln!(
-                                        "<d>[Lifecycle Scripts]<r> ignoring {} lifecycle scripts",
-                                        bstr::BStr::new(pkg_name.slice(string_buf!())),
-                                    );
-                                }
-                                break 'enqueue_lifecycle_scripts;
-                            }
-
-                            if self.enqueue_lifecycle_scripts(
-                                alias.slice(string_buf!()),
-                                log_level,
-                                &mut folder_path,
-                                package_id,
-                                dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
-                                resolution,
-                            ) {
-                                if is_trusted_through_update_request {
-                                    let (trusted_name, trusted_name_hash) =
-                                        if resolution.tag == resolution::Tag::Npm {
-                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                                        } else {
-                                            (alias, truncated_dep_name_hash)
-                                        };
-                                    self.manager_mut()
-                                        .trusted_deps_to_add_to_package_json
-                                        .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
-
-                                    if self.lockfile().trusted_dependencies.is_none() {
-                                        self.lockfile_mut().trusted_dependencies =
-                                            Some(Default::default());
-                                    }
-                                    self.lockfile_mut()
-                                        .trusted_dependencies
-                                        .as_mut()
-                                        .unwrap()
-                                        .put(
-                                            trusted_name_hash,
-                                            Box::<[u8]>::from(trusted_name.slice(string_buf!())),
-                                        )
-                                        .unwrap_or_oom();
-                                }
-                            }
-                        }
+                        self.enqueue_lifecycle_scripts_for_trusted(
+                            log_level,
+                            package_id,
+                            pkg_name,
+                            pkg_name_hash,
+                            alias,
+                            truncated_dep_name_hash,
+                            dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
+                            resolution,
+                            TrustedDepRecord {
+                                package_json: is_trusted_through_update_request,
+                                lockfile: is_trusted_through_update_request,
+                            },
+                        );
                     }
 
                     match resolution.tag {
@@ -2266,79 +2218,20 @@ impl<'a> PackageInstaller<'a> {
             };
 
             if resolution.tag != resolution::Tag::Root && is_trusted {
-                let mut folder_path =
-                    AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
-                folder_path
-                    .append(alias.slice(string_buf!()))
-                    .unwrap_or_oom();
-
-                'enqueue_lifecycle_scripts: {
-                    if self
-                        .manager()
-                        .postinstall_optimizer
-                        .should_ignore_lifecycle_scripts(
-                            &postinstall_optimizer::PkgInfo {
-                                name_hash: pkg_name_hash,
-                                version: if resolution.tag == resolution::Tag::Npm {
-                                    Some(resolution.npm().version)
-                                } else {
-                                    None
-                                },
-                                version_buf: string_buf!(),
-                            },
-                            self.lockfile().packages.items_resolutions()[package_id as usize]
-                                .get(self.lockfile().buffers.resolutions.as_slice()),
-                            self.lockfile().packages.items_meta(),
-                            self.manager().options.cpu,
-                            self.manager().options.os,
-                        )
-                    {
-                        if PackageManager::verbose_install() {
-                            bun_core::pretty_errorln!(
-                                "<d>[Lifecycle Scripts]<r> ignoring {} lifecycle scripts",
-                                bstr::BStr::new(pkg_name.slice(string_buf!())),
-                            );
-                        }
-                        break 'enqueue_lifecycle_scripts;
-                    }
-
-                    if self.enqueue_lifecycle_scripts(
-                        alias.slice(string_buf!()),
-                        log_level,
-                        &mut folder_path,
-                        package_id,
-                        dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
-                        resolution,
-                    ) {
-                        let (trusted_name, trusted_name_hash) =
-                            if resolution.tag == resolution::Tag::Npm {
-                                (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
-                            } else {
-                                (alias, truncated_dep_name_hash)
-                            };
-
-                        if is_trusted_through_update_request {
-                            self.manager_mut()
-                                .trusted_deps_to_add_to_package_json
-                                .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
-                        }
-
-                        if add_to_lockfile {
-                            if self.lockfile().trusted_dependencies.is_none() {
-                                self.lockfile_mut().trusted_dependencies = Some(Default::default());
-                            }
-                            self.lockfile_mut()
-                                .trusted_dependencies
-                                .as_mut()
-                                .unwrap()
-                                .put(
-                                    trusted_name_hash,
-                                    Box::<[u8]>::from(trusted_name.slice(string_buf!())),
-                                )
-                                .unwrap_or_oom();
-                        }
-                    }
-                }
+                self.enqueue_lifecycle_scripts_for_trusted(
+                    log_level,
+                    package_id,
+                    pkg_name,
+                    pkg_name_hash,
+                    alias,
+                    truncated_dep_name_hash,
+                    dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
+                    resolution,
+                    TrustedDepRecord {
+                        package_json: is_trusted_through_update_request,
+                        lockfile: add_to_lockfile,
+                    },
+                );
             }
 
             self.increment_tree_install_count(
@@ -2360,6 +2253,103 @@ impl<'a> PackageInstaller<'a> {
             self.current_tree_id,
             log_level,
         );
+    }
+
+    /// Enqueue lifecycle scripts for a trusted (or workspace) dependency, then
+    /// record it in `trusted_deps_to_add_to_package_json` and/or the lockfile's
+    /// `trusted_dependencies` as requested.
+    fn enqueue_lifecycle_scripts_for_trusted(
+        &mut self,
+        log_level: Options::LogLevel,
+        package_id: PackageID,
+        pkg_name: String,
+        pkg_name_hash: PackageNameHash,
+        alias: String,
+        truncated_dep_name_hash: TruncatedPackageNameHash,
+        optional: bool,
+        resolution: &Resolution,
+        record: TrustedDepRecord,
+    ) {
+        // SAFETY: `buffers.string_bytes` is append-only and never freed
+        // for the lifetime of this `PackageInstaller`.
+        let string_buf_ptr =
+            bun_ptr::RawSlice::new(self.lockfile().buffers.string_bytes.as_slice());
+        macro_rules! string_buf {
+            () => {
+                string_buf_ptr.slice()
+            };
+        }
+
+        let mut folder_path = AutoAbsPath::from(self.node_modules.path.as_slice()).unwrap_or_oom();
+        // `defer folder_path.deinit()` — AbsPath impls Drop.
+        folder_path
+            .append(alias.slice(string_buf!()))
+            .unwrap_or_oom();
+
+        if self
+            .manager()
+            .postinstall_optimizer
+            .should_ignore_lifecycle_scripts(
+                &postinstall_optimizer::PkgInfo {
+                    name_hash: pkg_name_hash,
+                    version: if resolution.tag == resolution::Tag::Npm {
+                        Some(resolution.npm().version)
+                    } else {
+                        None
+                    },
+                    version_buf: string_buf!(),
+                },
+                self.lockfile().packages.items_resolutions()[package_id as usize]
+                    .get(self.lockfile().buffers.resolutions.as_slice()),
+                self.lockfile().packages.items_meta(),
+                self.manager().options.cpu,
+                self.manager().options.os,
+            )
+        {
+            if PackageManager::verbose_install() {
+                bun_core::pretty_errorln!(
+                    "<d>[Lifecycle Scripts]<r> ignoring {} lifecycle scripts",
+                    bstr::BStr::new(pkg_name.slice(string_buf!())),
+                );
+            }
+            return;
+        }
+
+        if self.enqueue_lifecycle_scripts(
+            alias.slice(string_buf!()),
+            log_level,
+            &mut folder_path,
+            package_id,
+            optional,
+            resolution,
+        ) {
+            let (trusted_name, trusted_name_hash) = if resolution.tag == resolution::Tag::Npm {
+                (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
+            } else {
+                (alias, truncated_dep_name_hash)
+            };
+
+            if record.package_json {
+                self.manager_mut()
+                    .trusted_deps_to_add_to_package_json
+                    .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
+            }
+
+            if record.lockfile {
+                if self.lockfile().trusted_dependencies.is_none() {
+                    self.lockfile_mut().trusted_dependencies = Some(Default::default());
+                }
+                self.lockfile_mut()
+                    .trusted_dependencies
+                    .as_mut()
+                    .unwrap()
+                    .put(
+                        trusted_name_hash,
+                        Box::<[u8]>::from(trusted_name.slice(string_buf!())),
+                    )
+                    .unwrap_or_oom();
+            }
+        }
     }
 
     /// returns true if scripts are enqueued

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1472,6 +1472,133 @@ fn overlay_bunfig_install(install: &mut Api::BunInstall, bunfig: Api::BunInstall
     );
 }
 
+/// Placement-writes one field of the `PackageManager` singleton through the
+/// raw pointer `$p` — see the PERF NOTE in [`init`] for why the struct must
+/// not be built by value.
+macro_rules! wr {
+    ($p:ident, $field:ident, $val:expr) => {
+        core::ptr::addr_of_mut!((*$p).$field).write($val)
+    };
+}
+
+/// Writes the `PackageManager` fields that take identical default values in
+/// both init paths ([`init`] and [`init_with_runtime_once`]). Each caller
+/// writes the remaining (divergent) fields itself; together they must fully
+/// initialize the singleton.
+///
+/// Uses per-field placement writes — see the PERF NOTE in [`init`] for why
+/// the struct must not be built by value.
+///
+/// # Safety
+/// `p` must point to the allocated (possibly uninitialized) singleton from
+/// `allocate_package_manager()`, with no other references to it live.
+unsafe fn write_shared_default_fields(p: *mut PackageManager) {
+    // SAFETY: caller guarantees `p` is valid for per-field placement writes.
+    unsafe {
+        // The two large pools: in-place init that only zeros the 256 B
+        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched — no
+        // stack temporary, no memcpy.
+        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
+            (*p).preallocated_network_tasks
+        ));
+        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
+            (*p).preallocated_resolve_tasks
+        ));
+
+        wr!(p, cache_directory, None);
+        wr!(p, cache_directory_path, ZBox::from_bytes(b""));
+        wr!(
+            p,
+            active_lifecycle_scripts,
+            crate::lifecycle_script_runner::List {
+                root: core::ptr::null_mut(),
+                // `lifecycle_script_runner::List`'s heap comparator never
+                // dereferences its context arg, so it is modeled as a ZST
+                // (`StartedAtCtx`) instead of threading a back-pointer.
+                context: crate::lifecycle_script_runner::StartedAtCtx,
+            }
+        );
+        wr!(p, network_task_fifo, NetworkQueue::init());
+        wr!(p, patch_task_fifo, PatchTaskFifo::init());
+        wr!(p, ast_arena, bun_alloc::Arena::new());
+        wr!(p, resolve_tasks, ResolveTaskQueue::default());
+        // `Lockfile` contains `HashMap`/`Vec`/`NonNull` fields, so a
+        // zero-bit pattern is UB; allocate the real (empty) lockfile here directly.
+        // `Lockfile::default()` ≡ `Lockfile::init_empty()`.
+        wr!(p, lockfile, Box::new(Lockfile::default()));
+        wr!(p, timestamp_for_manifest_cache_control, 0);
+        wr!(p, extracted_count, 0);
+        wr!(p, summary, Default::default());
+        wr!(p, progress, Progress::default());
+        wr!(p, downloads_node, None);
+        wr!(p, scripts_node, None);
+        wr!(p, progress_name_buf, [0; 768]);
+        wr!(p, track_installed_bin, TrackInstalledBin::None);
+        wr!(p, root_progress_node, core::ptr::null_mut());
+        wr!(p, to_update, false);
+        wr!(p, update_requests, Box::default());
+        wr!(p, update_request_index, Default::default());
+        wr!(p, audit_fix_pins, Box::default());
+        wr!(p, root_package_id, RootPackageId::default());
+        wr!(p, task_batch, thread_pool::Batch::default());
+        wr!(p, task_queue, TaskDependencyQueue::default());
+        wr!(p, manifests, PackageManifestMap::default());
+        wr!(p, folders, Default::default());
+        wr!(p, git_repositories, RepositoryMap::default());
+        wr!(p, git_commits, GitCommitMap::default());
+        wr!(p, git_tasks, VecDeque::new());
+        wr!(p, running_git_tasks, AtomicU32::new(0));
+        wr!(p, appended_task_packages, AppendedTaskPackageMap::default());
+        wr!(p, network_dedupe_map, Default::default());
+        wr!(
+            p,
+            async_network_task_queue,
+            AsyncNetworkTaskQueue::default()
+        );
+        wr!(p, network_tarball_batch, thread_pool::Batch::default());
+        wr!(p, network_resolve_batch, thread_pool::Batch::default());
+        wr!(p, patch_apply_batch, thread_pool::Batch::default());
+        wr!(p, patch_calc_hash_batch, thread_pool::Batch::default());
+        wr!(p, patch_task_queue, PatchTaskQueue::default());
+        wr!(p, pending_pre_calc_hashes, AtomicU32::new(0));
+        wr!(p, pending_tasks, AtomicU32::new(0));
+        wr!(p, total_tasks, 0);
+        wr!(p, pending_lifecycle_script_tasks, AtomicU32::new(0));
+        wr!(p, finished_installing, AtomicBool::new(false));
+        wr!(p, total_scripts, 0);
+        wr!(p, root_lifecycle_scripts, None);
+        wr!(p, node_gyp_tempdir_name, Box::default());
+        wr!(p, preinstall_state, Vec::new());
+        wr!(p, postinstall_optimizer, Default::default());
+        wr!(p, global_link_dir, None);
+        wr!(p, global_dir, None);
+        wr!(p, global_link_dir_path, Box::default());
+        wr!(p, on_wake, WakeHandler::default());
+        wr!(
+            p,
+            peer_dependencies,
+            LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
+        );
+        wr!(p, known_npm_aliases, NpmAliasMap::default());
+        wr!(p, trusted_deps_to_add_to_package_json, Vec::new());
+        wr!(p, any_failed_to_install, false);
+        wr!(p, updating_packages, StringArrayHashMap::default());
+        wr!(p, updating_catalogs, Vec::new());
+        wr!(p, update_target_workspaces, None);
+        wr!(p, named_update_reachable, None);
+        wr!(p, kept_patched, Vec::new());
+        wr!(p, kept_patched_text, Vec::new());
+        wr!(p, dedupe_report, None);
+        wr!(p, filtered_link_targets, None);
+        wr!(p, pending_filtered_write, None);
+        wr!(p, edited_package_jsons, Vec::new());
+        wr!(p, catalog_add, add_catalog::State::default());
+        wr!(p, patched_dependencies_to_remove, ArrayHashMap::default());
+        wr!(p, last_reported_slow_lifecycle_script_at, 0);
+        wr!(p, cached_tick_for_slow_lifecycle_script_logging, 0);
+    }
+}
+
 /// Returns `&'static mut PackageManager` — the process-singleton (held in
 /// `holder::RAW_PTR`) is leaked for the process lifetime and `init()` is called
 /// exactly once on the single CLI dispatch thread. Every
@@ -2018,137 +2145,44 @@ pub fn init(
     // directly to the heap and keeps the frame under 16 KB.
     unsafe {
         let p = manager_ptr;
-        macro_rules! wr {
-            ($field:ident, $val:expr) => {
-                core::ptr::addr_of_mut!((*p).$field).write($val)
-            };
-        }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched — no
-        // stack temporary, no memcpy.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        write_shared_default_fields(p);
 
-        wr!(cache_directory, None);
-        wr!(cache_directory_path, ZBox::from_bytes(b""));
-        wr!(options, options);
-        wr!(
-            active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                // `lifecycle_script_runner::List`'s heap comparator never
-                // dereferences its context arg, so it is modeled as a ZST
-                // (`StartedAtCtx`) instead of threading a back-pointer.
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
-        );
-        wr!(network_task_fifo, NetworkQueue::init());
-        wr!(patch_task_fifo, PatchTaskFifo::init());
-        wr!(log, ctx.log);
-        wr!(root_dir, entries_option);
-        wr!(ast_arena, bun_alloc::Arena::new());
+        wr!(p, options, options);
+        wr!(p, log, ctx.log);
+        wr!(p, root_dir, entries_option);
         // reborrow `&mut *env` so the local stays usable for
         // the post-construction `BUN_MANIFEST_CACHE` / `options.load`
         // reads. `BackRef` stores a raw pointer —
         // ending the reborrow here does not alias the later uses.
-        wr!(env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
+        wr!(p, env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
         wr!(
+            p,
             thread_pool,
             ThreadPool::init(thread_pool::Config {
                 max_threads: cpu_count,
                 ..Default::default()
             })
         );
-        wr!(resolve_tasks, ResolveTaskQueue::default());
-        // `Lockfile` contains `HashMap`/`Vec`/`NonNull` fields, so a
-        // zero-bit pattern is UB; allocate the real (empty) lockfile here directly.
-        // `Lockfile::default()` ≡ `Lockfile::init_empty()`.
-        wr!(lockfile, Box::new(Lockfile::default()));
-        wr!(root_package_json_file, root_package_json_file);
+        wr!(p, root_package_json_file, root_package_json_file);
         // .progress
-        wr!(event_loop, AnyEventLoop::init());
+        wr!(p, event_loop, AnyEventLoop::init());
         wr!(
+            p,
             original_package_json_path,
             ZBox::from_vec_with_nul(original_package_json_path_buf)
         );
-        wr!(workspace_package_json_cache, workspace_package_json_cache);
-        wr!(workspace_name_hash, workspace_name_hash);
-        wr!(subcommand, subcommand);
         wr!(
+            p,
+            workspace_package_json_cache,
+            workspace_package_json_cache
+        );
+        wr!(p, workspace_name_hash, workspace_name_hash);
+        wr!(p, subcommand, subcommand);
+        wr!(
+            p,
             root_package_json_name_at_time_of_init,
             root_package_json_name_at_time_of_init
         );
-
-        // remaining defaults:
-        wr!(timestamp_for_manifest_cache_control, 0);
-        wr!(extracted_count, 0);
-        wr!(summary, Default::default());
-        wr!(progress, Progress::default());
-        wr!(downloads_node, None);
-        wr!(scripts_node, None);
-        wr!(progress_name_buf, [0; 768]);
-        wr!(track_installed_bin, TrackInstalledBin::None);
-        wr!(root_progress_node, core::ptr::null_mut());
-        wr!(to_update, false);
-        wr!(update_requests, Box::default());
-        wr!(update_request_index, Default::default());
-        wr!(audit_fix_pins, Box::default());
-        wr!(root_package_id, RootPackageId::default());
-        wr!(task_batch, thread_pool::Batch::default());
-        wr!(task_queue, TaskDependencyQueue::default());
-        wr!(manifests, PackageManifestMap::default());
-        wr!(folders, Default::default());
-        wr!(git_repositories, RepositoryMap::default());
-        wr!(git_commits, GitCommitMap::default());
-        wr!(git_tasks, VecDeque::new());
-        wr!(running_git_tasks, AtomicU32::new(0));
-        wr!(appended_task_packages, AppendedTaskPackageMap::default());
-        wr!(network_dedupe_map, Default::default());
-        wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
-        wr!(network_tarball_batch, thread_pool::Batch::default());
-        wr!(network_resolve_batch, thread_pool::Batch::default());
-        wr!(patch_apply_batch, thread_pool::Batch::default());
-        wr!(patch_calc_hash_batch, thread_pool::Batch::default());
-        wr!(patch_task_queue, PatchTaskQueue::default());
-        wr!(pending_pre_calc_hashes, AtomicU32::new(0));
-        wr!(pending_tasks, AtomicU32::new(0));
-        wr!(total_tasks, 0);
-        wr!(pending_lifecycle_script_tasks, AtomicU32::new(0));
-        wr!(finished_installing, AtomicBool::new(false));
-        wr!(total_scripts, 0);
-        wr!(root_lifecycle_scripts, None);
-        wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
-        wr!(postinstall_optimizer, Default::default());
-        wr!(global_link_dir, None);
-        wr!(global_dir, None);
-        wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
-        wr!(
-            peer_dependencies,
-            LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
-        );
-        wr!(known_npm_aliases, NpmAliasMap::default());
-        wr!(trusted_deps_to_add_to_package_json, Vec::new());
-        wr!(any_failed_to_install, false);
-        wr!(updating_packages, StringArrayHashMap::default());
-        wr!(updating_catalogs, Vec::new());
-        wr!(update_target_workspaces, None);
-        wr!(named_update_reachable, None);
-        wr!(kept_patched, Vec::new());
-        wr!(kept_patched_text, Vec::new());
-        wr!(dedupe_report, None);
-        wr!(filtered_link_targets, None);
-        wr!(pending_filtered_write, None);
-        wr!(edited_package_jsons, Vec::new());
-        wr!(catalog_add, add_catalog::State::default());
-        wr!(patched_dependencies_to_remove, ArrayHashMap::default());
-        wr!(last_reported_slow_lifecycle_script_at, 0);
-        wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
     }
     holder::INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
     // The per-field placement above fully initialized the singleton; the
@@ -2475,23 +2509,10 @@ fn init_with_runtime_once(
     // directly to the heap singleton.
     unsafe {
         let p = manager_ptr;
-        macro_rules! wr {
-            ($field:ident, $val:expr) => {
-                core::ptr::addr_of_mut!((*p).$field).write($val)
-            };
-        }
-        // The two large pools: in-place init that only zeros the 256 B
-        // occupancy bitset and leaves `[MaybeUninit<T>; N]` untouched.
-        PreallocatedNetworkTasks::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_network_tasks
-        ));
-        PreallocatedTaskStore::init_in_place(core::ptr::addr_of_mut!(
-            (*p).preallocated_resolve_tasks
-        ));
+        write_shared_default_fields(p);
 
-        wr!(cache_directory, None);
-        wr!(cache_directory_path, ZBox::from_bytes(b""));
         wr!(
+            p,
             options,
             Options {
                 max_concurrent_lifecycle_scripts: cli
@@ -2500,122 +2521,45 @@ fn init_with_runtime_once(
                 ..Default::default()
             }
         );
-        wr!(
-            active_lifecycle_scripts,
-            crate::lifecycle_script_runner::List {
-                root: core::ptr::null_mut(),
-                context: crate::lifecycle_script_runner::StartedAtCtx,
-            }
-        );
-        wr!(network_task_fifo, NetworkQueue::init());
-        wr!(log, std::ptr::from_mut(log));
-        wr!(root_dir, root_dir);
-        wr!(ast_arena, bun_alloc::Arena::new());
+        wr!(p, log, std::ptr::from_mut(log));
+        wr!(p, root_dir, root_dir);
         // reborrow `&mut *env` so the local stays usable for
         // the post-construction `BUN_MANIFEST_CACHE` / `options.load`
         // reads. `BackRef` stores a raw pointer —
         // ending the reborrow here does not alias the later uses.
-        wr!(env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
+        wr!(p, env, Some(bun_ptr::BackRef::new_mut(&mut *env)));
         wr!(
+            p,
             thread_pool,
             ThreadPool::init(thread_pool::Config {
                 max_threads: cpu_count,
                 ..Default::default()
             })
         );
-        // `Lockfile` holds `HashMap`/`Vec`/`NonNull` (zero-bit pattern is
-        // UB), so allocate the real empty lockfile here directly instead of a zeroed placeholder.
-        wr!(lockfile, Box::new(Lockfile::default()));
         // `.root_package_json_file` is never read in the runtime
         // path. Use the explicit invalid-fd sentinel rather than `mem::zeroed()` —
         // on posix `Fd(0)` is stdin, not the invalid marker.
         wr!(
+            p,
             root_package_json_file,
             bun_sys::File::from_fd(Fd::invalid())
         );
         // erased *mut () set by tier-6; `js_current()` resolves the per-thread JS
         // event loop via `bun_io::__bun_get_vm_ctx` (link-time, definer in bun_runtime).
-        wr!(event_loop, AnyEventLoop::js_current());
+        wr!(p, event_loop, AnyEventLoop::js_current());
         wr!(
+            p,
             original_package_json_path,
             ZBox::from_vec_with_nul(original_package_json_path)
         );
-        wr!(subcommand, Subcommand::Install);
-
-        // remaining defaults:
-        wr!(resolve_tasks, ResolveTaskQueue::default());
-        wr!(timestamp_for_manifest_cache_control, 0);
-        wr!(extracted_count, 0);
-        wr!(summary, Default::default());
-        wr!(progress, Progress::default());
-        wr!(downloads_node, None);
-        wr!(scripts_node, None);
-        wr!(progress_name_buf, [0; 768]);
-        wr!(track_installed_bin, TrackInstalledBin::None);
-        wr!(root_progress_node, core::ptr::null_mut());
-        wr!(to_update, false);
-        wr!(update_requests, Box::default());
-        wr!(update_request_index, Default::default());
-        wr!(audit_fix_pins, Box::default());
-        wr!(root_package_json_name_at_time_of_init, Box::default());
-        wr!(root_package_id, RootPackageId::default());
-        wr!(task_batch, thread_pool::Batch::default());
-        wr!(task_queue, TaskDependencyQueue::default());
-        wr!(manifests, PackageManifestMap::default());
-        wr!(folders, Default::default());
-        wr!(git_repositories, RepositoryMap::default());
-        wr!(git_commits, GitCommitMap::default());
-        wr!(git_tasks, VecDeque::new());
-        wr!(running_git_tasks, AtomicU32::new(0));
-        wr!(appended_task_packages, AppendedTaskPackageMap::default());
-        wr!(network_dedupe_map, Default::default());
-        wr!(async_network_task_queue, AsyncNetworkTaskQueue::default());
-        wr!(network_tarball_batch, thread_pool::Batch::default());
-        wr!(network_resolve_batch, thread_pool::Batch::default());
-        wr!(patch_apply_batch, thread_pool::Batch::default());
-        wr!(patch_calc_hash_batch, thread_pool::Batch::default());
-        wr!(patch_task_fifo, PatchTaskFifo::init());
-        wr!(patch_task_queue, PatchTaskQueue::default());
-        wr!(pending_pre_calc_hashes, AtomicU32::new(0));
-        wr!(pending_tasks, AtomicU32::new(0));
-        wr!(total_tasks, 0);
-        wr!(pending_lifecycle_script_tasks, AtomicU32::new(0));
-        wr!(finished_installing, AtomicBool::new(false));
-        wr!(total_scripts, 0);
-        wr!(root_lifecycle_scripts, None);
-        wr!(node_gyp_tempdir_name, Box::default());
-        wr!(preinstall_state, Vec::new());
-        wr!(postinstall_optimizer, Default::default());
-        wr!(global_link_dir, None);
-        wr!(global_dir, None);
-        wr!(global_link_dir_path, Box::default());
-        wr!(on_wake, WakeHandler::default());
+        wr!(p, subcommand, Subcommand::Install);
+        wr!(p, root_package_json_name_at_time_of_init, Box::default());
+        wr!(p, workspace_name_hash, None);
         wr!(
-            peer_dependencies,
-            LinearFifo::<DependencyID, DynamicBuffer<DependencyID>>::init()
-        );
-        wr!(known_npm_aliases, NpmAliasMap::default());
-        wr!(trusted_deps_to_add_to_package_json, Vec::new());
-        wr!(any_failed_to_install, false);
-        wr!(workspace_name_hash, None);
-        wr!(
+            p,
             workspace_package_json_cache,
             WorkspacePackageJSONCache::default()
         );
-        wr!(updating_packages, StringArrayHashMap::default());
-        wr!(updating_catalogs, Vec::new());
-        wr!(update_target_workspaces, None);
-        wr!(named_update_reachable, None);
-        wr!(kept_patched, Vec::new());
-        wr!(kept_patched_text, Vec::new());
-        wr!(dedupe_report, None);
-        wr!(filtered_link_targets, None);
-        wr!(pending_filtered_write, None);
-        wr!(edited_package_jsons, Vec::new());
-        wr!(catalog_add, add_catalog::State::default());
-        wr!(patched_dependencies_to_remove, ArrayHashMap::default());
-        wr!(last_reported_slow_lifecycle_script_at, 0);
-        wr!(cached_tick_for_slow_lifecycle_script_logging, 0);
     }
     holder::INITIALIZED.store(true, core::sync::atomic::Ordering::Release);
     // SAFETY: per-field placement above fully initialized the PackageManager;

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -758,6 +758,36 @@ fn resolve_from_appended_task(
     Some(pkg_id)
 }
 
+/// Returns the task-callback list for `task_id`, creating and initializing it
+/// if this is the first callback registered for the task.
+fn task_callback_list<'a>(
+    this: &'a mut PackageManager,
+    task_id: Task::Id,
+) -> crate::Result<&'a mut TaskCallbackList> {
+    let entry = this.task_queue.get_or_put_context(task_id, ())?;
+    if !entry.found_existing {
+        *entry.value_ptr = TaskCallbackList::default();
+    }
+    Ok(entry.value_ptr)
+}
+
+/// Registers dependency `id` as a callback for `task_id`, tagging it as a
+/// root or transitive dependency.
+fn push_dependency_task_callback(
+    this: &mut PackageManager,
+    task_id: Task::Id,
+    id: DependencyID,
+    is_root: bool,
+) -> crate::Result<()> {
+    let ctx = if is_root {
+        TaskCallbackContext::RootDependency(id)
+    } else {
+        TaskCallbackContext::Dependency(id)
+    };
+    task_callback_list(this, task_id)?.push(ctx);
+    Ok(())
+}
+
 /// Q: "What do we do with a dependency in a package.json?"
 /// A: "We enqueue it!"
 pub fn enqueue_dependency_with_main_and_success_fn(
@@ -1328,18 +1358,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                             return Ok(());
                         }
 
-                        let manifest_entry_parse =
-                            this.task_queue.get_or_put_context(task_id, ())?;
-                        if !manifest_entry_parse.found_existing {
-                            *manifest_entry_parse.value_ptr = TaskCallbackList::default();
-                        }
-
-                        let ctx = if is_root {
-                            TaskCallbackContext::RootDependency(id)
-                        } else {
-                            TaskCallbackContext::Dependency(id)
-                        };
-                        manifest_entry_parse.value_ptr.push(ctx);
+                        push_dependency_task_callback(this, task_id, id, is_root)?;
                     }
                     return Ok(());
                 }
@@ -1364,11 +1383,6 @@ pub fn enqueue_dependency_with_main_and_success_fn(
             let alias = this.lockfile.str_detached(&dependency.name);
             let url = this.lockfile.str_detached(&dep.repo);
             let clone_id = Task::Id::for_git_clone(url);
-            let ctx = if is_root {
-                TaskCallbackContext::RootDependency(id)
-            } else {
-                TaskCallbackContext::Dependency(id)
-            };
 
             if cfg!(debug_assertions) {
                 bun_output::scoped_log!(
@@ -1408,14 +1422,8 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         match this.git_commits.get(&commit_id) {
                             Some(resolved) => resolved.clone(),
                             None => {
-                                let entry = this
-                                    .task_queue
-                                    .get_or_put_context(commit_id, ())
+                                push_dependency_task_callback(this, commit_id, id, is_root)
                                     .expect("unreachable");
-                                if !entry.found_existing {
-                                    *entry.value_ptr = TaskCallbackList::default();
-                                }
-                                entry.value_ptr.push(ctx);
 
                                 if dependency.behavior.is_peer() && !install_peer {
                                     this.peer_dependencies.write_item(id)?;
@@ -1445,17 +1453,10 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                         success_fn(this, id, pkg_id);
                         return Ok(());
                     }
-                }
-
-                let entry = this
-                    .task_queue
-                    .get_or_put_context(checkout_id, ())
-                    .expect("unreachable");
-                if !entry.found_existing {
-                    *entry.value_ptr = TaskCallbackList::default();
-                }
-                if needs_ctx {
-                    entry.value_ptr.push(ctx);
+                    push_dependency_task_callback(this, checkout_id, id, is_root)
+                        .expect("unreachable");
+                } else {
+                    task_callback_list(this, checkout_id).expect("unreachable");
                 }
 
                 if dependency.behavior.is_peer() {
@@ -1481,14 +1482,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 );
                 this.enqueue_git_task(task);
             } else {
-                let entry = this
-                    .task_queue
-                    .get_or_put_context(clone_id, ())
-                    .expect("unreachable");
-                if !entry.found_existing {
-                    *entry.value_ptr = TaskCallbackList::default();
-                }
-                entry.value_ptr.push(ctx);
+                push_dependency_task_callback(this, clone_id, id, is_root).expect("unreachable");
 
                 if dependency.behavior.is_peer() {
                     if !install_peer {
@@ -1542,24 +1536,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
             }
 
-            let ctx = if is_root {
-                TaskCallbackContext::RootDependency(id)
-            } else {
-                TaskCallbackContext::Dependency(id)
-            };
-            // reshaped for borrowck — `entry` mutably borrows
-            // `this.task_queue`; scope it tightly so the calls below can
-            // reborrow `*this`.
-            {
-                let entry = this
-                    .task_queue
-                    .get_or_put_context(task_id, ())
-                    .expect("unreachable");
-                if !entry.found_existing {
-                    *entry.value_ptr = TaskCallbackList::default();
-                }
-                entry.value_ptr.push(ctx);
-            }
+            push_dependency_task_callback(this, task_id, id, is_root).expect("unreachable");
 
             if dependency.behavior.is_peer() {
                 if !install_peer {
@@ -1753,22 +1730,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                 }
             }
 
-            let ctx = if is_root {
-                TaskCallbackContext::RootDependency(id)
-            } else {
-                TaskCallbackContext::Dependency(id)
-            };
-            // reshaped for borrowck — scope `entry` tightly.
-            {
-                let entry = this
-                    .task_queue
-                    .get_or_put_context(task_id, ())
-                    .expect("unreachable");
-                if !entry.found_existing {
-                    *entry.value_ptr = TaskCallbackList::default();
-                }
-                entry.value_ptr.push(ctx);
-            }
+            push_dependency_task_callback(this, task_id, id, is_root).expect("unreachable");
 
             if dependency.behavior.is_peer() {
                 if !install_peer {

--- a/src/install/PackageManager/install_with_manager.rs
+++ b/src/install/PackageManager/install_with_manager.rs
@@ -163,32 +163,12 @@ pub fn install_with_manager(
                 let mut lockfile = Lockfile::default();
                 let mut maybe_root = lockfile::Package::default();
 
-                let source_copy = root_package_json_source(manager, root_package_json_path)?;
-
-                let mut resolver: () = ();
-                // `parse` needs `manager`, `manager.log` and a fresh
-                // stack `lockfile` simultaneously. Route through raw ptrs so
-                // borrowck doesn't see overlapping `&mut PackageManager` /
-                // `&mut Lockfile`.
-                {
-                    // `log_mut()` reads the BACKREF `self.log: *mut Log` and
-                    // returns the disjoint CLI `Log` allocation (lifetime
-                    // decoupled from `&self`), so call it safely through
-                    // `manager` *before* establishing the raw-ptr split — no
-                    // borrow on `*manager` survives into the `&mut *mgr` below.
-                    let log = manager.log_mut();
-                    let mgr: *mut PackageManager = manager;
-                    maybe_root.parse(
-                        &mut lockfile,
-                        // SAFETY: `mgr` is the sole provenance root for `*manager`; `log` is a
-                        // disjoint backref and `lockfile` is a stack local, so this `&mut` is unique.
-                        unsafe { &mut *mgr },
-                        log,
-                        &source_copy,
-                        &mut resolver,
-                        Features::main(),
-                    )?;
-                }
+                parse_root_package(
+                    manager,
+                    root_package_json_path,
+                    &mut lockfile,
+                    &mut maybe_root,
+                )?;
                 let mut mapping = vec![invalid_package_id; maybe_root.dependencies.len as usize]
                     .into_boxed_slice();
                 // @memset already done via vec! init
@@ -1890,6 +1870,39 @@ fn root_package_json_source(
     Global::exit(1);
 }
 
+/// Load the root package.json from the workspace cache (exiting on read/parse
+/// errors) and parse it as the root `Package` into `lockfile`. `lockfile` must
+/// be storage disjoint from `*manager` (a stack local, or the heap allocation
+/// behind `manager.lockfile`'s `Box`).
+fn parse_root_package(
+    manager: &mut PackageManager,
+    root_package_json_path: &ZStr,
+    lockfile: &mut Lockfile,
+    root: &mut lockfile::Package,
+) -> crate::Result<()> {
+    let source_copy = root_package_json_source(manager, root_package_json_path)?;
+
+    let mut resolver: () = ();
+    // `log_mut()` reads the BACKREF `self.log: *mut Log` and returns the
+    // disjoint CLI `Log` allocation (lifetime decoupled from `&self`), so call
+    // it safely through `manager` *before* establishing the raw-ptr split — no
+    // borrow on `*manager` survives into the `&mut *mgr` below.
+    let log = manager.log_mut();
+    let mgr: *mut PackageManager = manager;
+    root.parse(
+        lockfile,
+        // SAFETY: `mgr` is the sole provenance root for `*manager`; `log` is a
+        // disjoint backref and `lockfile` is caller-guaranteed disjoint
+        // storage, so this `&mut` is unique.
+        unsafe { &mut *mgr },
+        log,
+        &source_copy,
+        &mut resolver,
+        Features::main(),
+    )?;
+    Ok(())
+}
+
 #[cold]
 #[inline(never)]
 fn create_new_lockfile_and_enqueue(
@@ -1927,28 +1940,21 @@ fn create_new_lockfile_and_enqueue(
         Global::crash();
     }
 
-    let source_copy = root_package_json_source(manager, root_package_json_path)?;
-
-    let mut resolver: () = ();
     {
-        // `log_mut()` reads the BACKREF `self.log` and returns the disjoint
-        // CLI `Log` allocation (lifetime decoupled from `&self`); call it
-        // safely *before* the raw-ptr split.
-        let log = manager.log_mut();
         let mgr: *mut PackageManager = manager;
-        // SAFETY: `mgr` is the sole provenance root; `parse` reborrows the
-        // disjoint `lockfile` field through it. No other live `&mut` to
-        // `*mgr` exists across the call.
-        root.parse(
-            // SAFETY: disjoint field projection through the sole provenance root `mgr`.
-            unsafe { &mut (*mgr).lockfile },
-            // SAFETY: `parse` touches only `PackageManager` fields disjoint from
-            // `lockfile` through this borrow; `mgr` is the sole provenance root.
+        // SAFETY: `mgr` is the sole provenance root; `manager.lockfile` is an
+        // owned `Box`, so this projects its heap allocation, which is disjoint
+        // storage from the `PackageManager` struct itself.
+        let lockfile: *mut Lockfile = unsafe { &raw mut *(*mgr).lockfile };
+        parse_root_package(
+            // SAFETY: `parse_root_package` touches only `PackageManager` fields
+            // disjoint from `lockfile` through this borrow; `mgr` is the sole
+            // provenance root.
             unsafe { &mut *mgr },
-            log,
-            &source_copy,
-            &mut resolver,
-            Features::main(),
+            root_package_json_path,
+            // SAFETY: points to the Box-owned heap allocation, disjoint from `*mgr`.
+            unsafe { &mut *lockfile },
+            &mut root,
         )?;
     }
 

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -160,97 +160,9 @@ pub fn do_patch_commit(
 
     let mut iterator = tree::Iterator::<{ tree::IteratorPathStyle::NodeModules }>::init(&lockfile);
     let (changes_dir, pkg): (Vec<u8>, Package) = match arg_kind {
-        PatchArgKind::Path => 'result: {
-            let package_json_path =
-                resolve_path::join_z::<platform::Auto>(&[argument, b"package.json"]);
-            let package_json_source: bun_ast::Source =
-                match bun_ast::to_source(package_json_path, Default::default()) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        Output::err(
-                            e,
-                            "failed to read {f}",
-                            (bun_fmt::quote(package_json_path.as_bytes()),),
-                        );
-                        Global::crash();
-                    }
-                };
-
-            initialize_store();
-            let log = manager.log_mut();
-            let parsed = match JSON::ParsedJson::parse_package_json(&package_json_source, log) {
-                Ok(p) => p,
-                Err(err) => {
-                    let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-                    bun_core::pretty_errorln!(
-                        "<r><red>{}<r> parsing package.json in <b>\"{}\"<r>",
-                        err.name(),
-                        bstr::BStr::new(package_json_source.path.pretty_dir()),
-                    );
-                    Global::crash();
-                }
-            };
-            let json = parsed.root;
-
-            let version: &[u8] = 'version: {
-                if let Some(v) = json.get(b"version") {
-                    if let bun_ast::ExprData::EString(s) = &v.data {
-                        let s = s.data.slice();
-                        break 'version s;
-                    }
-                }
-                bun_core::pretty_error!(
-                    "<r><red>error<r>: invalid package.json, missing or invalid property \"version\": {}<r>\n",
-                    bstr::BStr::new(package_json_source.path.text()),
-                );
-                Global::crash();
-            };
-
-            let mut resolver: () = ();
-            let mut package = Package::default();
-            let log = manager.log_mut();
-            package.parse_with_json::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                json,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
-
-            let actual_package = match lockfile.package_index.get(&package.name_hash) {
-                None => {
-                    bun_core::pretty_error!(
-                        "<r><red>error<r>: failed to find package in lockfile package index, this is a bug in Bun. Please file a GitHub issue.<r>\n",
-                    );
-                    Global::crash();
-                }
-                Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
-                Some(PackageIndexEntry::Ids(ids)) => 'brk: {
-                    let mut resolution_label = Vec::new();
-                    for &id in ids.as_slice() {
-                        let pkg = *lockfile.packages.get(id as usize);
-                        if print_resolution_label(
-                            &mut resolution_label,
-                            &pkg.resolution,
-                            lockfile.buffers.string_bytes.as_slice(),
-                        ) == version
-                        {
-                            break 'brk pkg;
-                        }
-                    }
-                    bun_core::pretty_error!(
-                        "<r><red>error<r>: could not find package with name:<r> {}\n<r>",
-                        bstr::BStr::new(
-                            package.name.slice(lockfile.buffers.string_bytes.as_slice())
-                        ),
-                    );
-                    Global::crash();
-                }
-            };
-
-            break 'result (argument.to_vec(), actual_package);
+        PatchArgKind::Path => {
+            let (_, actual_package) = load_path_package(manager, &mut lockfile, argument)?;
+            (argument.to_vec(), actual_package)
         }
         PatchArgKind::NameAndVersion => 'brk: {
             let (name, version) = Dependency::split_name_and_maybe_version(argument);
@@ -735,105 +647,18 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
     let (cache_dir, cache_dir_subpath, module_folder, pkg_name): (Fd, &[u8], Vec<u8>, Vec<u8>) =
         match arg_kind {
             PatchArgKind::Path => 'brk: {
-                let package_json_path =
-                    resolve_path::join_z::<platform::Auto>(&[argument, b"package.json"]);
-                let package_json_source: bun_ast::Source =
-                    match bun_ast::to_source(package_json_path, Default::default()) {
-                        Ok(s) => s,
-                        Err(e) => {
-                            Output::err(
-                                e,
-                                "failed to read {f}",
-                                (bun_fmt::quote(package_json_path.as_bytes()),),
-                            );
-                            Global::crash();
-                        }
-                    };
-
-                initialize_store();
-                let log = manager.log_mut();
-                let parsed = match JSON::ParsedJson::parse_package_json(&package_json_source, log) {
-                    Ok(p) => p,
-                    Err(err) => {
-                        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-                        bun_core::pretty_errorln!(
-                            "<r><red>{}<r> parsing package.json in <b>\"{}\"<r>",
-                            err.name(),
-                            bstr::BStr::new(package_json_source.path.pretty_dir()),
-                        );
-                        Global::crash();
-                    }
-                };
-                let json = parsed.root;
-
-                let version: &[u8] = 'version: {
-                    if let Some(v) = json.get(b"version") {
-                        if let bun_ast::ExprData::EString(s) = &v.data {
-                            let s = s.data.slice();
-                            break 'version s;
-                        }
-                    }
-                    bun_core::pretty_error!(
-                        "<r><red>error<r>: invalid package.json, missing or invalid property \"version\": {}<r>\n",
-                        bstr::BStr::new(package_json_source.path.text()),
-                    );
-                    Global::crash();
-                };
-
-                let mut resolver: () = ();
-                let mut package = Package::default();
-                let log = manager.log_mut();
-                // borrowck — `parse_with_json` needs `&mut Lockfile` and
+                // borrowck — `load_path_package` needs `&mut Lockfile` and
                 // `&mut PackageManager` simultaneously, but the lockfile here is
                 // `manager.lockfile`. Temporarily move the Box out so the two
-                // borrows are disjoint; `parse_with_json` never reads `pm.lockfile`
-                // (it takes the lockfile as its own parameter). Restore before
-                // propagating any error so `manager` is never left half-torn.
+                // borrows are disjoint. Restore before propagating any error so
+                // `manager` is never left half-torn.
                 let mut lockfile: Box<Lockfile> = core::mem::take(&mut manager.lockfile);
-                let parse_result = package.parse_with_json::<()>(
-                    &mut lockfile,
-                    manager,
-                    log,
-                    &package_json_source,
-                    json,
-                    &mut resolver,
-                    Features::FOLDER,
-                );
+                let result = load_path_package(manager, &mut lockfile, argument);
                 manager.lockfile = lockfile;
-                parse_result?;
+                let (name, actual_package) = result?;
                 let lockfile: &Lockfile = &manager.lockfile;
                 let strbuf = lockfile.buffers.string_bytes.as_slice();
 
-                let actual_package = match lockfile.package_index.get(&package.name_hash) {
-                    None => {
-                        bun_core::pretty_error!(
-                            "<r><red>error<r>: failed to find package in lockfile package index, this is a bug in Bun. Please file a GitHub issue.<r>\n",
-                        );
-                        Global::crash();
-                    }
-                    Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
-                    Some(PackageIndexEntry::Ids(ids)) => 'id: {
-                        let mut resolution_label = Vec::new();
-                        for &id in ids.as_slice() {
-                            let pkg = *lockfile.packages.get(id as usize);
-                            if print_resolution_label(
-                                &mut resolution_label,
-                                &pkg.resolution,
-                                strbuf,
-                            ) == version
-                            {
-                                break 'id pkg;
-                            }
-                        }
-                        bun_core::pretty_error!(
-                            "<r><red>error<r>: could not find package with name:<r> {}\n<r>",
-                            bstr::BStr::new(package.name.slice(strbuf)),
-                        );
-                        Global::crash();
-                    }
-                };
-
-                let name = lockfile.str(&package.name).to_vec();
                 let existing_patchfile_hash: Option<u64> = 'existing_patchfile_hash: {
                     let mut name_and_version = Vec::new();
                     write!(
@@ -1247,6 +1072,104 @@ fn node_modules_folder_for_dependency_id(
         }
         return Some(node_modules.relative_path.as_bytes().to_vec());
     }
+}
+
+/// Shared `PatchArgKind::Path` handling for `bun patch` and `bun patch --commit`:
+/// parse `<argument>/package.json`, register it against the lockfile, and find
+/// the matching package in the lockfile's package index. Returns the package
+/// name and the lockfile's entry for the package.
+///
+/// `parse_with_json` never reads `manager.lockfile` (it takes the lockfile as
+/// its own parameter), so callers whose lockfile lives in `manager.lockfile`
+/// may temporarily move the Box out to make the two `&mut` borrows disjoint.
+fn load_path_package(
+    manager: &mut PackageManager,
+    lockfile: &mut Lockfile,
+    argument: &[u8],
+) -> crate::Result<(Vec<u8>, Package)> {
+    let package_json_path = resolve_path::join_z::<platform::Auto>(&[argument, b"package.json"]);
+    let package_json_source: bun_ast::Source =
+        match bun_ast::to_source(package_json_path, Default::default()) {
+            Ok(s) => s,
+            Err(e) => {
+                Output::err(
+                    e,
+                    "failed to read {f}",
+                    (bun_fmt::quote(package_json_path.as_bytes()),),
+                );
+                Global::crash();
+            }
+        };
+
+    initialize_store();
+    let log = manager.log_mut();
+    let parsed = match JSON::ParsedJson::parse_package_json(&package_json_source, log) {
+        Ok(p) => p,
+        Err(err) => {
+            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            bun_core::pretty_errorln!(
+                "<r><red>{}<r> parsing package.json in <b>\"{}\"<r>",
+                err.name(),
+                bstr::BStr::new(package_json_source.path.pretty_dir()),
+            );
+            Global::crash();
+        }
+    };
+    let json = parsed.root;
+
+    let version: &[u8] = 'version: {
+        if let Some(v) = json.get(b"version") {
+            if let bun_ast::ExprData::EString(s) = &v.data {
+                break 'version s.data.slice();
+            }
+        }
+        bun_core::pretty_error!(
+            "<r><red>error<r>: invalid package.json, missing or invalid property \"version\": {}<r>\n",
+            bstr::BStr::new(package_json_source.path.text()),
+        );
+        Global::crash();
+    };
+
+    let mut resolver: () = ();
+    let mut package = Package::default();
+    package.parse_with_json::<()>(
+        lockfile,
+        manager,
+        log,
+        &package_json_source,
+        json,
+        &mut resolver,
+        Features::FOLDER,
+    )?;
+
+    let strbuf = lockfile.buffers.string_bytes.as_slice();
+    let actual_package = match lockfile.package_index.get(&package.name_hash) {
+        None => {
+            bun_core::pretty_error!(
+                "<r><red>error<r>: failed to find package in lockfile package index, this is a bug in Bun. Please file a GitHub issue.<r>\n",
+            );
+            Global::crash();
+        }
+        Some(PackageIndexEntry::Id(id)) => *lockfile.packages.get(*id as usize),
+        Some(PackageIndexEntry::Ids(ids)) => 'brk: {
+            let mut resolution_label = Vec::new();
+            for &id in ids.as_slice() {
+                let pkg = *lockfile.packages.get(id as usize);
+                if print_resolution_label(&mut resolution_label, &pkg.resolution, strbuf) == version
+                {
+                    break 'brk pkg;
+                }
+            }
+            bun_core::pretty_error!(
+                "<r><red>error<r>: could not find package with name:<r> {}\n<r>",
+                bstr::BStr::new(package.name.slice(strbuf)),
+            );
+            Global::crash();
+        }
+    };
+
+    let name = lockfile.str(&package.name).to_vec();
+    Ok((name, actual_package))
 }
 
 type IdPair = (DependencyID, PackageID);

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -551,16 +551,7 @@ fn run_tasks_erased(
                             );
                         }
 
-                        if manager.subcommand != Subcommand::Remove {
-                            for request in manager.update_requests.iter_mut() {
-                                if strings::eql(request.name, name) {
-                                    request.failed = true;
-                                    manager.options.do_.remove(Do::SAVE_LOCKFILE);
-                                    manager.options.do_.remove(Do::SAVE_YARN_LOCK);
-                                    manager.options.do_.remove(Do::INSTALL_PACKAGES);
-                                }
-                            }
-                        }
+                        mark_update_request_failed(manager, name);
                     }
 
                     continue;
@@ -608,16 +599,7 @@ fn run_tasks_erased(
                             response.status_code,
                         );
                     }
-                    if manager.subcommand != Subcommand::Remove {
-                        for request in manager.update_requests.iter_mut() {
-                            if strings::eql(request.name, name) {
-                                request.failed = true;
-                                manager.options.do_.remove(Do::SAVE_LOCKFILE);
-                                manager.options.do_.remove(Do::SAVE_YARN_LOCK);
-                                manager.options.do_.remove(Do::INSTALL_PACKAGES);
-                            }
-                        }
-                    }
+                    mark_update_request_failed(manager, name);
 
                     continue;
                 }
@@ -810,41 +792,11 @@ fn run_tasks_erased(
                         .map(crate::Error::from)
                         .unwrap_or(crate::Error::TarballFailedToDownload);
 
-                    // The download will not be retried for this task_id. Mark
-                    // the dedupe entry as failed so a later
-                    // `enqueuePackageForDownload` for the same package observes
-                    // the failure and fails fast instead of either waiting
-                    // forever on a callback that never arrives (entry kept) or
-                    // re-running the entire download+retry cycle (entry removed).
-                    // Runs before the callback branch so `Store.Installer`
-                    // (which `continue`s from the callback) is covered too.
-                    let is_required = manager.is_network_task_required(task.task_id);
-                    manager.mark_network_task_failed(task.task_id);
-
-                    if cb.has_on_package_download_error {
-                        if cb.is_store_installer {
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
-                                task.task_id,
-                                extract.name.slice(),
-                                &extract.resolution,
-                                err,
-                                &task.url_buf,
-                            );
-                        } else {
-                            let package_id = manager.lockfile.buffers.resolutions
-                                [extract.dependency_id as usize];
-                            (cb.on_package_download_error_pkg)(
-                                extract_ctx,
-                                package_id,
-                                extract.name.slice(),
-                                &extract.resolution,
-                                err,
-                                &task.url_buf,
-                            );
-                        }
+                    let Some(is_required) =
+                        dispatch_tarball_error(cb, manager, extract_ctx, task, extract, err)
+                    else {
                         continue;
-                    }
+                    };
 
                     if is_required {
                         bun_ast::add_error_pretty!(
@@ -871,16 +823,7 @@ fn run_tasks_erased(
                                 .fmt(&manager.lockfile.buffers.string_bytes, PathSep::Auto,),
                         );
                     }
-                    if manager.subcommand != Subcommand::Remove {
-                        for request in manager.update_requests.iter_mut() {
-                            if strings::eql(request.name, extract.name.slice()) {
-                                request.failed = true;
-                                manager.options.do_.remove(Do::SAVE_LOCKFILE);
-                                manager.options.do_.remove(Do::SAVE_YARN_LOCK);
-                                manager.options.do_.remove(Do::INSTALL_PACKAGES);
-                            }
-                        }
-                    }
+                    mark_update_request_failed(manager, extract.name.slice());
 
                     if let Some(removed) = manager.task_queue.remove(&task.task_id) {
                         drop(removed);
@@ -892,48 +835,21 @@ fn run_tasks_erased(
                 let response = &metadata.response;
 
                 if response.status_code > 399 {
-                    // Non-retryable HTTP error: mark the dedupe entry as failed
-                    // so a later enqueue for this task_id fails fast instead of
-                    // waiting on this failed one or re-downloading it. Runs
-                    // before the callback branch so `Store.Installer` (which
-                    // `continue`s from the callback) is covered too.
-                    let is_required = manager.is_network_task_required(task.task_id);
-                    manager.mark_network_task_failed(task.task_id);
+                    let err = match response.status_code {
+                        400 => crate::Error::TarballHTTP400,
+                        401 => crate::Error::TarballHTTP401,
+                        402 => crate::Error::TarballHTTP402,
+                        403 => crate::Error::TarballHTTP403,
+                        404 => crate::Error::TarballHTTP404,
+                        405..=499 => crate::Error::TarballHTTP4xx,
+                        _ => crate::Error::TarballHTTP5xx,
+                    };
 
-                    if cb.has_on_package_download_error {
-                        let err = match response.status_code {
-                            400 => crate::Error::TarballHTTP400,
-                            401 => crate::Error::TarballHTTP401,
-                            402 => crate::Error::TarballHTTP402,
-                            403 => crate::Error::TarballHTTP403,
-                            404 => crate::Error::TarballHTTP404,
-                            405..=499 => crate::Error::TarballHTTP4xx,
-                            _ => crate::Error::TarballHTTP5xx,
-                        };
-
-                        if cb.is_store_installer {
-                            (cb.on_package_download_error_store)(
-                                extract_ctx,
-                                task.task_id,
-                                extract.name.slice(),
-                                &extract.resolution,
-                                err,
-                                &task.url_buf,
-                            );
-                        } else {
-                            let package_id = manager.lockfile.buffers.resolutions
-                                [extract.dependency_id as usize];
-                            (cb.on_package_download_error_pkg)(
-                                extract_ctx,
-                                package_id,
-                                extract.name.slice(),
-                                &extract.resolution,
-                                err,
-                                &task.url_buf,
-                            );
-                        }
+                    let Some(is_required) =
+                        dispatch_tarball_error(cb, manager, extract_ctx, task, extract, err)
+                    else {
                         continue;
-                    }
+                    };
 
                     if is_required {
                         bun_ast::add_error_pretty!(
@@ -954,16 +870,7 @@ fn run_tasks_erased(
                             response.status_code,
                         );
                     }
-                    if manager.subcommand != Subcommand::Remove {
-                        for request in manager.update_requests.iter_mut() {
-                            if strings::eql(request.name, extract.name.slice()) {
-                                request.failed = true;
-                                manager.options.do_.remove(Do::SAVE_LOCKFILE);
-                                manager.options.do_.remove(Do::SAVE_YARN_LOCK);
-                                manager.options.do_.remove(Do::INSTALL_PACKAGES);
-                            }
-                        }
-                    }
+                    mark_update_request_failed(manager, extract.name.slice());
 
                     if let Some(removed) = manager.task_queue.remove(&task.task_id) {
                         drop(removed);
@@ -1714,6 +1621,68 @@ fn run_tasks_erased(
     }
 
     Ok(())
+}
+
+/// Non-retryable tarball download failure. The download will not be retried
+/// for this task_id, so the dedupe entry is marked failed before the error is
+/// dispatched: a later `enqueue_package_for_download` for the same package
+/// then fails fast instead of waiting forever on a callback that never
+/// arrives (entry kept) or re-running the whole download (entry removed).
+/// The store installer's `on_package_download_error` drains `task_queue`
+/// itself but does not touch `network_dedupe_map`, so the mark runs on the
+/// callback path too. Returns `None` when the `on_package_download_error_*`
+/// callback consumed the error, otherwise `Some(is_required)` for the
+/// caller's log-and-mark fallback.
+fn dispatch_tarball_error(
+    cb: &ErasedCallbacks,
+    manager: &mut PackageManager,
+    extract_ctx: *mut (),
+    task: &NetworkTask,
+    extract: &ExtractTarball,
+    err: crate::Error,
+) -> Option<bool> {
+    let is_required = manager.is_network_task_required(task.task_id);
+    manager.mark_network_task_failed(task.task_id);
+
+    if cb.has_on_package_download_error {
+        if cb.is_store_installer {
+            (cb.on_package_download_error_store)(
+                extract_ctx,
+                task.task_id,
+                extract.name.slice(),
+                &extract.resolution,
+                err,
+                &task.url_buf,
+            );
+        } else {
+            let package_id = manager.lockfile.buffers.resolutions[extract.dependency_id as usize];
+            (cb.on_package_download_error_pkg)(
+                extract_ctx,
+                package_id,
+                extract.name.slice(),
+                &extract.resolution,
+                err,
+                &task.url_buf,
+            );
+        }
+        return None;
+    }
+
+    Some(is_required)
+}
+
+fn mark_update_request_failed(manager: &mut PackageManager, name: &[u8]) {
+    if manager.subcommand == Subcommand::Remove {
+        return;
+    }
+    for request in manager.update_requests.iter_mut() {
+        if strings::eql(request.name, name) {
+            request.failed = true;
+            manager.options.do_.remove(Do::SAVE_LOCKFILE);
+            manager.options.do_.remove(Do::SAVE_YARN_LOCK);
+            manager.options.do_.remove(Do::INSTALL_PACKAGES);
+        }
+    }
 }
 
 #[inline]

--- a/src/install/PackageManager/updatePackageJSONAndInstall.rs
+++ b/src/install/PackageManager/updatePackageJSONAndInstall.rs
@@ -1,9 +1,8 @@
 use crate::lockfile::package::PackageColumns as _;
+use bstr::BStr;
 use bun_collections::VecExt;
 use core::fmt;
 use std::borrow::Cow;
-
-use bstr::BStr;
 
 use crate::Error;
 use crate::ShellCompletions;
@@ -663,25 +662,22 @@ fn update_package_json_and_install_with_manager_with_updates(
         let (source, path): (&[u8], &ZStr) =
             if matches!(manager.options.patch_features, PatchFeatures::Commit { .. }) {
                 'source_and_path: {
-                    let root_package_json_entry = match manager
-                        .workspace_package_json_cache
-                        .get_with_path(
+                    let root_package_json_entry =
+                        match manager.workspace_package_json_cache.get_with_path(
                             manager.log_mut(),
                             root_package_json_path.as_bytes(),
                             GetJSONOptions::default(),
-                        )
-                        .unwrap()
-                    {
-                        Ok(e) => e,
-                        Err(err) => {
-                            Output::err(
-                                err,
-                                "failed to read/parse package.json at '{s}'",
-                                (BStr::new(root_package_json_path.as_bytes()),),
-                            );
-                            Global::exit(1);
-                        }
-                    };
+                        ) {
+                            GetResult::Entry(entry) => entry,
+                            GetResult::ReadErr(err) | GetResult::ParseErr(err) => {
+                                Output::err(
+                                    err,
+                                    "failed to read/parse package.json at '{s}'",
+                                    (BStr::new(root_package_json_path.as_bytes()),),
+                                );
+                                Global::exit(1);
+                            }
+                        };
 
                     break 'source_and_path (
                         &root_package_json_entry.source.contents,

--- a/src/install/hosted_git_info.rs
+++ b/src/install/hosted_git_info.rs
@@ -1007,6 +1007,104 @@ pub(crate) mod formatters {
 
         pub(crate) type Type = fn(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError>;
 
+        /// Percent-decode the parts into a single owned buffer and build the
+        /// `ExtractResult` over it.
+        fn build_result(
+            user: Option<&[u8]>,
+            project: &[u8],
+            committish: Option<&[u8]>,
+        ) -> Result<ExtractResult, HostedGitInfoError> {
+            let mut sb = StringBuilder::default();
+            if let Some(u) = user {
+                sb.count(u);
+            }
+            sb.count(project);
+            if let Some(c) = committish {
+                sb.count(c);
+            }
+
+            sb.allocate()?;
+
+            let user_slice = match user {
+                Some(u) => Some(HostedGitInfo::decode_and_append(&mut sb, u)?),
+                None => None,
+            };
+            let project_slice = HostedGitInfo::decode_and_append(&mut sb, project)?;
+            let committish_slice = match committish {
+                Some(c) => Some(HostedGitInfo::decode_and_append(&mut sb, c)?),
+                None => None,
+            };
+
+            Ok(ExtractResult {
+                user: user_slice,
+                project: project_slice,
+                committish: committish_slice,
+                _owned_buffer: Some(sb.move_to_slice()),
+            })
+        }
+
+        /// Shared tail for hosts whose URL shape is `/user/project[.git][/aux]`
+        /// with the committish in the fragment: reject `aux == reject_aux`,
+        /// trim `.git`, require a non-empty project (and user, unless
+        /// `user_optional`, in which case a lone segment is the project), then
+        /// build the result. With `error_as_none`, allocation or decode
+        /// failure maps to "not a hosted git URL" rather than an error.
+        fn user_project_committish(
+            url: &URL,
+            reject_aux: &[u8],
+            user_optional: bool,
+            error_as_none: bool,
+        ) -> Result<Option<ExtractResult>, HostedGitInfoError> {
+            let pathname_owned = url.pathname().to_owned_slice();
+            let pathname = strings::trim_prefix(&pathname_owned, b"/");
+
+            let mut iter = strings::split(pathname, b"/");
+            let Some(mut user_part) = iter.next() else {
+                return Ok(None);
+            };
+            let mut project_part = iter.next();
+
+            if iter.next() == Some(reject_aux) {
+                return Ok(None);
+            }
+
+            if user_optional && project_part.is_none_or(<[u8]>::is_empty) {
+                project_part = Some(user_part);
+                user_part = b"";
+            }
+            let Some(project_part) = project_part else {
+                return Ok(None);
+            };
+
+            let project = strings::trim_suffix(project_part, b".git");
+            if project.is_empty() {
+                return Ok(None);
+            }
+            let user: Option<&[u8]> = if user_part.is_empty() {
+                if !user_optional {
+                    return Ok(None);
+                }
+                None
+            } else {
+                Some(user_part)
+            };
+
+            let fragment_str = url.fragment_identifier();
+            let fragment_utf8 = fragment_str.to_utf8();
+            let fragment = fragment_utf8.slice();
+            let committish: Option<&[u8]> = if !fragment.is_empty() {
+                Some(fragment)
+            } else {
+                None
+            };
+
+            match build_result(user, project, committish) {
+                Ok(result) => Ok(Some(result)),
+                Err(_) if error_as_none => Ok(None),
+                Err(err) => Err(err),
+            }
+        }
+
         pub(crate) fn github(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError> {
             let pathname_owned = url.pathname().to_owned_slice();
             let pathname = strings::trim_prefix(&pathname_owned, b"/");
@@ -1050,86 +1148,13 @@ pub(crate) mod formatters {
                 committish_part
             };
 
-            let mut sb = StringBuilder::default();
-            sb.count(user_part);
-            sb.count(project);
-            if let Some(c) = committish {
-                sb.count(c);
-            }
-
-            sb.allocate()?;
-
-            let user_slice = HostedGitInfo::decode_and_append(&mut sb, user_part)?;
-            let project_slice = HostedGitInfo::decode_and_append(&mut sb, project)?;
-            let committish_slice = match committish {
-                Some(c) => Some(HostedGitInfo::decode_and_append(&mut sb, c)?),
-                None => None,
-            };
-
-            Ok(Some(ExtractResult {
-                user: Some(user_slice),
-                project: project_slice,
-                committish: committish_slice,
-                _owned_buffer: Some(sb.move_to_slice()),
-            }))
+            Ok(Some(build_result(Some(user_part), project, committish)?))
         }
 
         pub(crate) fn bitbucket(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError> {
-            let pathname_owned = url.pathname().to_owned_slice();
-            let pathname = strings::trim_prefix(&pathname_owned, b"/");
-
-            let mut iter = strings::split(pathname, b"/");
-            let Some(user_part) = iter.next() else {
-                return Ok(None);
-            };
-            let Some(project_part) = iter.next() else {
-                return Ok(None);
-            };
-            let aux = iter.next();
-
-            if let Some(a) = aux {
-                if a == b"get" {
-                    return Ok(None);
-                }
-            }
-
-            let project = strings::trim_suffix(project_part, b".git");
-
-            if user_part.is_empty() || project.is_empty() {
-                return Ok(None);
-            }
-
-            let fragment_str = url.fragment_identifier();
-            let fragment_utf8 = fragment_str.to_utf8();
-            let fragment = fragment_utf8.slice();
-            let committish: Option<&[u8]> = if !fragment.is_empty() {
-                Some(fragment)
-            } else {
-                None
-            };
-
-            let mut sb = StringBuilder::default();
-            sb.count(user_part);
-            sb.count(project);
-            if let Some(c) = committish {
-                sb.count(c);
-            }
-
-            sb.allocate()?;
-
-            let user_slice = HostedGitInfo::decode_and_append(&mut sb, user_part)?;
-            let project_slice = HostedGitInfo::decode_and_append(&mut sb, project)?;
-            let committish_slice = match committish {
-                Some(c) => Some(HostedGitInfo::decode_and_append(&mut sb, c)?),
-                None => None,
-            };
-
-            Ok(Some(ExtractResult {
-                user: Some(user_slice),
-                project: project_slice,
-                committish: committish_slice,
-                _owned_buffer: Some(sb.move_to_slice()),
-            }))
+            user_project_committish(
+                url, b"get", /* user_optional */ false, /* error_as_none */ false,
+            )
         }
 
         pub(crate) fn gitlab(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError> {
@@ -1187,176 +1212,15 @@ pub(crate) mod formatters {
         }
 
         pub(crate) fn gist(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError> {
-            let pathname_owned = url.pathname().to_owned_slice();
-            let pathname = strings::trim_prefix(&pathname_owned, b"/");
-
-            let mut iter = strings::split(pathname, b"/");
-            let Some(mut user_part) = iter.next() else {
-                return Ok(None);
-            };
-            let mut project_part = iter.next();
-            let aux = iter.next();
-
-            if let Some(a) = aux {
-                if a == b"raw" {
-                    return Ok(None);
-                }
-            }
-
-            if project_part.is_none() || project_part.unwrap().is_empty() {
-                project_part = Some(user_part);
-                user_part = b"";
-            }
-
-            let project = strings::trim_suffix(project_part.unwrap(), b".git");
-            let user: Option<&[u8]> = if !user_part.is_empty() {
-                Some(user_part)
-            } else {
-                None
-            };
-
-            if project.is_empty() {
-                return Ok(None);
-            }
-
-            let fragment_str = url.fragment_identifier();
-            let fragment_utf8 = fragment_str.to_utf8();
-            let fragment = fragment_utf8.slice();
-            let committish: Option<&[u8]> = if !fragment.is_empty() {
-                Some(fragment)
-            } else {
-                None
-            };
-
-            let mut sb = StringBuilder::default();
-            if let Some(u) = user {
-                sb.count(u);
-            }
-            sb.count(project);
-            if let Some(c) = committish {
-                sb.count(c);
-            }
-
-            let Ok(()) = sb.allocate() else {
-                return Ok(None);
-            };
-
-            let user_slice = match user {
-                Some(u) => {
-                    let Ok(r) = HostedGitInfo::decode_and_append(&mut sb, u) else {
-                        return Ok(None);
-                    };
-                    Some(r)
-                }
-                None => None,
-            };
-            let Ok(project_slice) = HostedGitInfo::decode_and_append(&mut sb, project) else {
-                return Ok(None);
-            };
-            let committish_slice = match committish {
-                Some(c) => {
-                    let Ok(r) = HostedGitInfo::decode_and_append(&mut sb, c) else {
-                        return Ok(None);
-                    };
-                    Some(r)
-                }
-                None => None,
-            };
-
-            Ok(Some(ExtractResult {
-                user: user_slice,
-                project: project_slice,
-                committish: committish_slice,
-                _owned_buffer: Some(sb.move_to_slice()),
-            }))
+            user_project_committish(
+                url, b"raw", /* user_optional */ true, /* error_as_none */ true,
+            )
         }
 
         pub(crate) fn sourcehut(url: &URL) -> Result<Option<ExtractResult>, HostedGitInfoError> {
-            let pathname_owned = url.pathname().to_owned_slice();
-            let pathname = strings::trim_prefix(&pathname_owned, b"/");
-
-            let mut iter = strings::split(pathname, b"/");
-            let Some(user_part) = iter.next() else {
-                return Ok(None);
-            };
-            let Some(project_part) = iter.next() else {
-                return Ok(None);
-            };
-            let aux = iter.next();
-
-            if let Some(a) = aux {
-                if a == b"archive" {
-                    return Ok(None);
-                }
-            }
-
-            let project = strings::trim_suffix(project_part, b".git");
-
-            if user_part.is_empty() || project.is_empty() {
-                return Ok(None);
-            }
-
-            let fragment_str = url.fragment_identifier();
-            let fragment_utf8 = fragment_str.to_utf8();
-            let fragment = fragment_utf8.slice();
-            let committish: Option<&[u8]> = if !fragment.is_empty() {
-                Some(fragment)
-            } else {
-                None
-            };
-
-            let mut sb = StringBuilder::default();
-            sb.count(user_part);
-            sb.count(project);
-            if let Some(c) = committish {
-                sb.count(c);
-            }
-
-            let Ok(()) = sb.allocate() else {
-                return Ok(None);
-            };
-
-            // Inline percent-decode rather than `decode_and_append`: this path
-            // returns None instead of erroring on decode failure.
-            let user_slice = 'blk: {
-                let start = sb.len;
-                let writable = sb.writable();
-                let Ok(decoded_len) = PercentEncoding::decode_into(writable, user_part) else {
-                    return Ok(None);
-                };
-                let decoded_len = decoded_len as usize;
-                sb.len += decoded_len;
-                break 'blk start..start + decoded_len;
-            };
-            let project_slice = 'blk: {
-                let start = sb.len;
-                let writable = sb.writable();
-                let Ok(decoded_len) = PercentEncoding::decode_into(writable, project) else {
-                    return Ok(None);
-                };
-                let decoded_len = decoded_len as usize;
-                sb.len += decoded_len;
-                break 'blk start..start + decoded_len;
-            };
-            let committish_slice = if let Some(c) = committish {
-                let start = sb.len;
-                let writable = sb.writable();
-                let Ok(decoded_len) = PercentEncoding::decode_into(writable, c) else {
-                    return Ok(None);
-                };
-                let decoded_len = decoded_len as usize;
-                sb.len += decoded_len;
-                Some(start..start + decoded_len)
-            } else {
-                None
-            };
-
-            Ok(Some(ExtractResult {
-                user: Some(user_slice),
-                project: project_slice,
-                committish: committish_slice,
-                _owned_buffer: Some(sb.move_to_slice()),
-            }))
+            user_project_committish(
+                url, b"archive", /* user_optional */ false, /* error_as_none */ true,
+            )
         }
     }
 }

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2410,6 +2410,29 @@ pub(crate) fn install_isolated_packages(
 
                     let dep = &lockfile_ro.buffers.dependencies[dep_id as usize];
 
+                    // Shared failure path for the enqueue-for-download arms
+                    // below; the caller `continue`s after invoking it.
+                    let fail_enqueue = |installer: &mut store::Installer, err, what| {
+                        Output::err(
+                            err,
+                            "failed to enqueue {} for download: {}@{}",
+                            (
+                                what,
+                                BStr::new(pkg_name.slice(string_buf)),
+                                pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
+                            ),
+                        );
+                        Output::flush();
+                        if installer.manager().options.enable.fail_early() {
+                            Global::exit(1);
+                        }
+                        // .monotonic is okay because an error means the task isn't
+                        // running on another thread.
+                        entry_steps[entry_id.get() as usize]
+                            .store(installer::Step::Done as u32, Ordering::Relaxed);
+                        installer.on_task_complete(entry_id, installer::CompleteState::Fail);
+                    };
+
                     match pkg_res_tag {
                         ResolutionTag::Npm => {
                             match installer.manager_mut().enqueue_package_for_download(
@@ -2439,24 +2462,7 @@ pub(crate) fn install_isolated_packages(
                                 }
                                 Err(err) => {
                                     // error.InvalidURL
-                                    Output::err(
-                                        err,
-                                        "failed to enqueue package for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
-                                    );
-                                    Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
-                                        Global::exit(1);
-                                    }
-                                    // .monotonic is okay because an error means the task isn't
-                                    // running on another thread.
-                                    entry_steps[entry_id.get() as usize]
-                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
-                                    installer
-                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    fail_enqueue(&mut installer, err, "package");
                                     continue;
                                 }
                             }
@@ -2508,24 +2514,7 @@ pub(crate) fn install_isolated_packages(
                                     continue;
                                 }
                                 Err(err) => {
-                                    Output::err(
-                                        err,
-                                        "failed to enqueue github package for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
-                                    );
-                                    Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
-                                        Global::exit(1);
-                                    }
-                                    // .monotonic is okay because an error means the task isn't
-                                    // running on another thread.
-                                    entry_steps[entry_id.get() as usize]
-                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
-                                    installer
-                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    fail_enqueue(&mut installer, err, "github package");
                                     continue;
                                 }
                             }
@@ -2564,24 +2553,7 @@ pub(crate) fn install_isolated_packages(
                                     continue;
                                 }
                                 Err(err) => {
-                                    Output::err(
-                                        err,
-                                        "failed to enqueue tarball for download: {}@{}",
-                                        (
-                                            BStr::new(pkg_name.slice(string_buf)),
-                                            pkg_res.fmt(string_buf, bun_fmt::PathSep::Auto),
-                                        ),
-                                    );
-                                    Output::flush();
-                                    if installer.manager().options.enable.fail_early() {
-                                        Global::exit(1);
-                                    }
-                                    // .monotonic is okay because an error means the task isn't
-                                    // running on another thread.
-                                    entry_steps[entry_id.get() as usize]
-                                        .store(installer::Step::Done as u32, Ordering::Relaxed);
-                                    installer
-                                        .on_task_complete(entry_id, installer::CompleteState::Fail);
+                                    fail_enqueue(&mut installer, err, "tarball");
                                     continue;
                                 }
                             }

--- a/src/install/yarn.rs
+++ b/src/install/yarn.rs
@@ -1686,7 +1686,18 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
         let deps_off = u32::try_from(this.buffers.dependencies.len()).expect("int cast");
         let resolutions_off = u32::try_from(this.buffers.resolutions.len()).expect("int cast");
 
-        if let Some(deps) = &entry.dependencies {
+        let dep_groups = [
+            (entry.dependencies.as_ref(), dependency::Behavior::PROD),
+            (
+                entry.optional_dependencies.as_ref(),
+                dependency::Behavior::OPTIONAL,
+            ),
+            (entry.peer_dependencies.as_ref(), dependency::Behavior::PEER),
+            (entry.dev_dependencies.as_ref(), dependency::Behavior::DEV),
+        ];
+
+        for (deps, behavior) in dep_groups {
+            let Some(deps) = deps else { continue };
             for (dep_name_key, dep_version_ref) in deps.iter() {
                 let dep_name: &[u8] = dep_name_key.as_ref();
                 let dep_version_literal: &[u8] = *dep_version_ref;
@@ -1715,163 +1726,7 @@ pub(crate) fn migrate_yarn_lockfile<'a>(
                     name: dep_name_string,
                     name_hash,
                     version: parsed_version,
-                    behavior: dependency::Behavior::PROD,
-                });
-
-                let mut dep_spec = Vec::new();
-                write!(
-                    &mut dep_spec,
-                    "{}@{}",
-                    bstr::BStr::new(dep_name),
-                    bstr::BStr::new(dep_version_literal)
-                )
-                .expect("unreachable");
-
-                if let Some(res_pkg_id) = spec_to_package_id.get(dep_spec.as_slice()).copied() {
-                    this.buffers.resolutions.push(res_pkg_id);
-                } else {
-                    this.buffers.resolutions.push(install::INVALID_PACKAGE_ID);
-                }
-
-                dep_count += 1;
-            }
-        }
-
-        if let Some(optional_deps) = &entry.optional_dependencies {
-            for (dep_name_key, dep_version_ref) in optional_deps.iter() {
-                let dep_name: &[u8] = dep_name_key.as_ref();
-                let dep_version_literal: &[u8] = *dep_version_ref;
-
-                let name_hash = string_hash(dep_name);
-                let dep_name_string = sbuf!().append_with_hash(dep_name, name_hash)?;
-
-                let dep_version_string = sbuf!().append(dep_version_literal)?;
-                let sliced_string = SlicedString::init(
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                );
-
-                let mut parsed_version = Dependency::parse(
-                    dep_name_string,
-                    Some(name_hash),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    &sliced_string,
-                    Some(&mut *log),
-                    Some(&mut *manager),
-                )
-                .unwrap_or_default();
-
-                parsed_version.literal = dep_version_string;
-
-                this.buffers.dependencies.push(Dependency {
-                    name: dep_name_string,
-                    name_hash,
-                    version: parsed_version,
-                    behavior: dependency::Behavior::OPTIONAL,
-                });
-
-                let mut dep_spec = Vec::new();
-                write!(
-                    &mut dep_spec,
-                    "{}@{}",
-                    bstr::BStr::new(dep_name),
-                    bstr::BStr::new(dep_version_literal)
-                )
-                .expect("unreachable");
-
-                if let Some(res_pkg_id) = spec_to_package_id.get(dep_spec.as_slice()).copied() {
-                    this.buffers.resolutions.push(res_pkg_id);
-                } else {
-                    this.buffers.resolutions.push(install::INVALID_PACKAGE_ID);
-                }
-
-                dep_count += 1;
-            }
-        }
-
-        if let Some(peer_deps) = &entry.peer_dependencies {
-            for (dep_name_key, dep_version_ref) in peer_deps.iter() {
-                let dep_name: &[u8] = dep_name_key.as_ref();
-                let dep_version_literal: &[u8] = *dep_version_ref;
-
-                let name_hash = string_hash(dep_name);
-                let dep_name_string = sbuf!().append_with_hash(dep_name, name_hash)?;
-
-                let dep_version_string = sbuf!().append(dep_version_literal)?;
-                let sliced_string = SlicedString::init(
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                );
-
-                let mut parsed_version = Dependency::parse(
-                    dep_name_string,
-                    Some(name_hash),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    &sliced_string,
-                    Some(&mut *log),
-                    Some(&mut *manager),
-                )
-                .unwrap_or_default();
-
-                parsed_version.literal = dep_version_string;
-
-                this.buffers.dependencies.push(Dependency {
-                    name: dep_name_string,
-                    name_hash,
-                    version: parsed_version,
-                    behavior: dependency::Behavior::PEER,
-                });
-
-                let mut dep_spec = Vec::new();
-                write!(
-                    &mut dep_spec,
-                    "{}@{}",
-                    bstr::BStr::new(dep_name),
-                    bstr::BStr::new(dep_version_literal)
-                )
-                .expect("unreachable");
-
-                if let Some(res_pkg_id) = spec_to_package_id.get(dep_spec.as_slice()).copied() {
-                    this.buffers.resolutions.push(res_pkg_id);
-                } else {
-                    this.buffers.resolutions.push(install::INVALID_PACKAGE_ID);
-                }
-
-                dep_count += 1;
-            }
-        }
-
-        if let Some(dev_deps) = &entry.dev_dependencies {
-            for (dep_name_key, dep_version_ref) in dev_deps.iter() {
-                let dep_name: &[u8] = dep_name_key.as_ref();
-                let dep_version_literal: &[u8] = *dep_version_ref;
-
-                let name_hash = string_hash(dep_name);
-                let dep_name_string = sbuf!().append_with_hash(dep_name, name_hash)?;
-
-                let dep_version_string = sbuf!().append(dep_version_literal)?;
-                let sliced_string = SlicedString::init(
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                );
-
-                let mut parsed_version = Dependency::parse(
-                    dep_name_string,
-                    Some(name_hash),
-                    dep_version_string.slice(this.buffers.string_bytes.as_slice()),
-                    &sliced_string,
-                    Some(&mut *log),
-                    Some(&mut *manager),
-                )
-                .unwrap_or_default();
-
-                parsed_version.literal = dep_version_string;
-
-                this.buffers.dependencies.push(Dependency {
-                    name: dep_name_string,
-                    name_hash,
-                    version: parsed_version,
-                    behavior: dependency::Behavior::DEV,
+                    behavior,
                 });
 
                 let mut dep_spec = Vec::new();

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -213,6 +213,19 @@ pub(crate) enum GetBinNameError {
     NeedToInstall,
 }
 
+/// Inputs shared by both post-install cached-bin probes; invariant across the
+/// initial-bin-name and package-json-bin-name attempts.
+struct CachedBinProbe<'a> {
+    bunx_cache_dir: &'a [u8],
+    ignore_cwd: &'a [u8],
+    top_level_dir: &'a [u8],
+    #[cfg(unix)]
+    uid: libc::uid_t,
+    #[cfg(not(unix))]
+    uid: u32,
+    dirname_store: &'static bun_resolver::fs::DirnameStore,
+}
+
 impl BunxCommand {
     /// Adds `create-` to the string, but also handles scoped packages correctly.
     /// Always clones the string in the process.
@@ -661,6 +674,77 @@ impl BunxCommand {
         _uid: u32,
     ) -> bool {
         true
+    }
+
+    /// Post-install cache probe: builds
+    /// `<bunx_cache_dir>/node_modules/.bin/<bin_name><EXE_SUFFIX>`, resolves it
+    /// via `bun_which::which`, and execs it via `Run::run_binary` (noreturn)
+    /// once it passes the `is_trusted_cached_binary` TOCTOU check. Returns
+    /// `Ok(())` only on a miss: the binary is absent or untrusted.
+    fn try_run_cached_bin(
+        ctx: &mut ContextData,
+        path_buf: &mut bun_paths::PathBuffer,
+        absolute_in_cache_dir_buf: &mut bun_paths::PathBuffer,
+        probe: &CachedBinProbe,
+        bin_name: &[u8],
+        env_loader: &mut bun_dotenv::Loader,
+        passthrough: &[Box<[u8]>],
+    ) -> crate::Result<()> {
+        let buf_total = absolute_in_cache_dir_buf.len();
+        let absolute_in_cache_dir: &[u8] = {
+            let mut cursor: &mut [u8] = &mut absolute_in_cache_dir_buf[..];
+            write!(
+                cursor,
+                "{cache}{sep}node_modules{sep}.bin{sep}{bin}{exe}",
+                cache = BStr::new(probe.bunx_cache_dir),
+                sep = bun_paths::SEP as char,
+                bin = BStr::new(bin_name),
+                exe = EXE_SUFFIX,
+            )
+            .expect("unreachable");
+            let written = buf_total - cursor.len();
+            // SAFETY: `written` bytes initialized above
+            unsafe { core::slice::from_raw_parts(absolute_in_cache_dir_buf.as_ptr(), written) }
+        };
+
+        // Similar to "npx": try the bin in the global cache. Do not try $PATH
+        // because we already checked it above if we should.
+        if let Some(destination) = bun_which::which(
+            path_buf,
+            probe.bunx_cache_dir,
+            if !probe.ignore_cwd.is_empty() {
+                b"".as_slice()
+            } else {
+                probe.top_level_dir
+            },
+            absolute_in_cache_dir,
+        ) {
+            let out: &[u8] = destination.as_bytes();
+            // The install we just ran should have created this symlink as the
+            // current user, but the cache lives in a world-writable temp dir; an
+            // attacker can race the install and plant a uid-mismatched entry.
+            // Bail out to the generic error rather than execute it.
+            if Self::is_trusted_cached_binary(destination, probe.uid) {
+                let stored = probe.dirname_store.append_slice(out)?;
+                Run::run_binary(
+                    ctx,
+                    stored,
+                    destination,
+                    probe.top_level_dir,
+                    env_loader,
+                    passthrough,
+                    None,
+                )?;
+                // run_binary is noreturn
+            } else {
+                bun_output::scoped_log!(
+                    bunx,
+                    "refusing untrusted cached binary: {}",
+                    BStr::new(out)
+                );
+            }
+        }
+        Ok(())
     }
 
     fn exit_with_usage() -> ! {
@@ -1457,61 +1541,23 @@ impl BunxCommand {
             _ => {}
         }
 
-        absolute_in_cache_dir = {
-            let mut cursor: &mut [u8] = &mut absolute_in_cache_dir_buf[..];
-            write!(
-                cursor,
-                "{cache}{sep}node_modules{sep}.bin{sep}{bin}{exe}",
-                cache = BStr::new(bunx_cache_dir),
-                sep = bun_paths::SEP as char,
-                bin = BStr::new(initial_bin_name),
-                exe = EXE_SUFFIX,
-            )
-            .expect("unreachable");
-            let written = buf_total - cursor.len();
-            // SAFETY: `written` bytes initialized above
-            unsafe { core::slice::from_raw_parts(absolute_in_cache_dir_buf.as_ptr(), written) }
+        let cached_bin_probe = CachedBinProbe {
+            bunx_cache_dir,
+            ignore_cwd: &ignore_cwd,
+            top_level_dir,
+            uid,
+            dirname_store: fs.dirname_store,
         };
 
-        // Similar to "npx":
-        //
-        //  1. Try the bin in the global cache
-        //     Do not try $PATH because we already checked it above if we should
-        if let Some(destination) = bun_which::which(
+        Self::try_run_cached_bin(
+            ctx,
             &mut path_buf,
-            bunx_cache_dir,
-            if !ignore_cwd.is_empty() {
-                b"".as_slice()
-            } else {
-                top_level_dir
-            },
-            absolute_in_cache_dir,
-        ) {
-            let out: &[u8] = destination.as_bytes();
-            // The install we just ran should have created this symlink as the
-            // current user, but the cache lives in a world-writable temp dir; an
-            // attacker can race the install and plant a uid-mismatched entry.
-            // Bail out to the generic error rather than execute it.
-            if Self::is_trusted_cached_binary(destination, uid) {
-                let stored = fs.dirname_store.append_slice(out)?;
-                Run::run_binary(
-                    ctx,
-                    stored,
-                    destination,
-                    top_level_dir,
-                    env_loader,
-                    passthrough,
-                    None,
-                )?;
-                // run_binary is noreturn
-            } else {
-                bun_output::scoped_log!(
-                    bunx,
-                    "refusing untrusted cached binary: {}",
-                    BStr::new(out)
-                );
-            }
-        }
+            &mut absolute_in_cache_dir_buf,
+            &cached_bin_probe,
+            initial_bin_name,
+            env_loader,
+            passthrough,
+        )?;
 
         // 2. The "bin" is possibly not the same as the package name, so we load the package.json to figure out what "bin" to use
         // BUT: Skip this if --package was used, as the user explicitly specified the binary name
@@ -1523,55 +1569,15 @@ impl BunxCommand {
                 false,
             ) {
                 if !strings::eql_long(&package_name_for_bin, initial_bin_name, true) {
-                    absolute_in_cache_dir = {
-                        let mut cursor: &mut [u8] = &mut absolute_in_cache_dir_buf[..];
-                        write!(
-                            cursor,
-                            "{}/node_modules/.bin/{}{}",
-                            BStr::new(bunx_cache_dir),
-                            BStr::new(&package_name_for_bin),
-                            EXE_SUFFIX,
-                        )
-                        .expect("unreachable");
-                        let written = buf_total - cursor.len();
-                        // SAFETY: `written` bytes initialized above
-                        unsafe {
-                            core::slice::from_raw_parts(absolute_in_cache_dir_buf.as_ptr(), written)
-                        }
-                    };
-
-                    if let Some(destination) = bun_which::which(
+                    Self::try_run_cached_bin(
+                        ctx,
                         &mut path_buf,
-                        bunx_cache_dir,
-                        if !ignore_cwd.is_empty() {
-                            b"".as_slice()
-                        } else {
-                            top_level_dir
-                        },
-                        absolute_in_cache_dir,
-                    ) {
-                        let out: &[u8] = destination.as_bytes();
-                        // Same TOCTOU hardening as the post-install probe above.
-                        if Self::is_trusted_cached_binary(destination, uid) {
-                            let stored = fs.dirname_store.append_slice(out)?;
-                            Run::run_binary(
-                                ctx,
-                                stored,
-                                destination,
-                                top_level_dir,
-                                env_loader,
-                                passthrough,
-                                None,
-                            )?;
-                            // run_binary is noreturn
-                        } else {
-                            bun_output::scoped_log!(
-                                bunx,
-                                "refusing untrusted cached binary: {}",
-                                BStr::new(out)
-                            );
-                        }
-                    }
+                        &mut absolute_in_cache_dir_buf,
+                        &cached_bin_probe,
+                        &package_name_for_bin,
+                        env_loader,
+                        passthrough,
+                    )?;
                 }
             }
         }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1337,61 +1337,37 @@ impl CreateCommand {
             }
 
             if !bun_paths::is_absolute(positional) {
-                'outer: {
-                    if let Some(home_dir) = env_loader.map.get(b"BUN_CREATE_DIR") {
-                        let parts = [home_dir, positional];
-                        let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
-                        let len = outdir_path.len();
-                        home_dir_buf[len] = 0;
-                        // SAFETY: home_dir_buf[len] == 0 written above
-                        let outdir_path_ = bun_core::ZStr::from_buf(&home_dir_buf[..], len);
-                        if bun_paths::resolve_path::has_any_illegal_chars(outdir_path_.as_bytes()) {
-                            break 'outer;
-                        }
-                        if bun_sys::directory_exists_at(bun_sys::Fd::cwd(), outdir_path_)
-                            .unwrap_or(false)
-                        {
-                            example_tag = ExampleTag::LocalFolder;
-                            break 'brk &home_dir_buf[..len];
-                        }
+                // Returns the path length if `parts` joins to an existing template directory.
+                let probe_template_dir = |buf: &mut PathBuffer, parts: &[&[u8]]| -> Option<usize> {
+                    let len = filesystem.abs_buf(parts, buf).len();
+                    buf[len] = 0;
+                    // SAFETY: buf[len] == 0 written above
+                    let outdir_path = bun_core::ZStr::from_buf(&buf[..], len);
+                    if bun_paths::resolve_path::has_any_illegal_chars(outdir_path.as_bytes()) {
+                        return None;
                     }
-                }
-
-                'outer: {
-                    let parts = [filesystem.top_level_dir, BUN_CREATE_DIR, positional];
-                    let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
-                    let len = outdir_path.len();
-                    home_dir_buf[len] = 0;
-                    // SAFETY: home_dir_buf[len] == 0 written above
-                    let outdir_path_ = bun_core::ZStr::from_buf(&home_dir_buf[..], len);
-                    if bun_paths::resolve_path::has_any_illegal_chars(outdir_path_.as_bytes()) {
-                        break 'outer;
-                    }
-                    if bun_sys::directory_exists_at(bun_sys::Fd::cwd(), outdir_path_)
+                    bun_sys::directory_exists_at(bun_sys::Fd::cwd(), outdir_path)
                         .unwrap_or(false)
-                    {
+                        .then_some(len)
+                };
+
+                // Empty parts are skipped by the path join, so the two-part
+                // BUN_CREATE_DIR candidate pads with `b""`.
+                let candidates: [Option<[&[u8]; 3]>; 3] = [
+                    env_loader
+                        .map
+                        .get(b"BUN_CREATE_DIR")
+                        .map(|home_dir| [home_dir, positional, b"".as_slice()]),
+                    Some([filesystem.top_level_dir, BUN_CREATE_DIR, positional]),
+                    env_loader
+                        .map
+                        .get(b"HOME")
+                        .map(|home_dir| [home_dir, BUN_CREATE_DIR, positional]),
+                ];
+                for parts in candidates.into_iter().flatten() {
+                    if let Some(len) = probe_template_dir(&mut *home_dir_buf, &parts) {
                         example_tag = ExampleTag::LocalFolder;
                         break 'brk &home_dir_buf[..len];
-                    }
-                }
-
-                'outer: {
-                    if let Some(home_dir) = env_loader.map.get(b"HOME") {
-                        let parts = [home_dir, BUN_CREATE_DIR, positional];
-                        let outdir_path = filesystem.abs_buf(&parts, home_dir_buf);
-                        let len = outdir_path.len();
-                        home_dir_buf[len] = 0;
-                        // SAFETY: home_dir_buf[len] == 0 written above
-                        let outdir_path_ = bun_core::ZStr::from_buf(&home_dir_buf[..], len);
-                        if bun_paths::resolve_path::has_any_illegal_chars(outdir_path_.as_bytes()) {
-                            break 'outer;
-                        }
-                        if bun_sys::directory_exists_at(bun_sys::Fd::cwd(), outdir_path_)
-                            .unwrap_or(false)
-                        {
-                            example_tag = ExampleTag::LocalFolder;
-                            break 'brk &home_dir_buf[..len];
-                        }
                     }
                 }
 

--- a/src/runtime/cli/filter_run.rs
+++ b/src/runtime/cli/filter_run.rs
@@ -1,14 +1,17 @@
 use core::ffi::{c_char, c_void};
 use std::io::Write as _;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
-use crate::api::bun::process::{self as spawn, Rusage, SpawnOptions, Status};
+use crate::api::bun::process::{self as spawn, SpawnOptions, Status};
 use crate::cli::Command;
 use crate::cli::filter_arg as FilterArg;
 use crate::cli::run_command::{ConfigureEnvOptions, RunCommand};
+use crate::cli::run_processes_shared::{
+    AbortHandler, SHOULD_ABORT, aggregate_exit_code, buffered_stdio, watch_or_reap,
+};
 use bun_collections::StringHashMap;
 use bun_core::{Global, Output};
 use bun_core::{ZStr, strings};
@@ -197,16 +200,7 @@ impl<'a> ProcessHandle<'a> {
             bun_spawn::ProcessExit::new(bun_spawn::ProcessExitKind::FilterRunHandle, handle_ptr)
         });
 
-        match process.watch_or_reap() {
-            Ok(_) => {}
-            Err(err) => {
-                if !process.has_exited() {
-                    // SAFETY: all-zero is a valid Rusage (POD C struct)
-                    let rusage = bun_core::ffi::zeroed::<Rusage>();
-                    process.on_exit(Status::Err(err), &rusage);
-                }
-            }
-        }
+        watch_or_reap(process);
         Ok(())
     }
 
@@ -681,91 +675,11 @@ impl<'a> State<'a> {
         if self.aborted {
             let _ = self.redraw(true);
         }
-        for handle in self.handles.iter() {
-            if let Some(proc) = &handle.process {
-                match &proc.status {
-                    Status::Exited(exited) => {
-                        if exited.code != 0 {
-                            return exited.code;
-                        }
-                    }
-                    Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1);
-                    }
-                    _ => return 1,
-                }
-            }
-        }
-        0
-    }
-}
-
-struct AbortHandler;
-
-static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
-// Atomic because it is set from a signal handler.
-
-impl AbortHandler {
-    #[cfg(unix)]
-    extern "C" fn posix_signal_handler(
-        sig: i32,
-        info: *const bun_sys::posix::siginfo_t,
-        _: *const c_void,
-    ) {
-        let _ = sig;
-        let _ = info;
-        SHOULD_ABORT.store(true, Ordering::SeqCst);
-    }
-
-    #[cfg(windows)]
-    extern "system" fn windows_ctrl_handler(
-        dw_ctrl_type: bun_sys::windows::DWORD,
-    ) -> bun_sys::windows::BOOL {
-        if dw_ctrl_type == bun_sys::windows::CTRL_C_EVENT {
-            SHOULD_ABORT.store(true, Ordering::SeqCst);
-            return bun_sys::windows::TRUE;
-        }
-        bun_sys::windows::FALSE
-    }
-
-    fn install() {
-        #[cfg(unix)]
-        {
-            // SAFETY: libc::sigaction is #[repr(C)] POD; all-zero is a valid value (fields overwritten below).
-            let mut act: libc::sigaction = bun_core::ffi::zeroed();
-            act.sa_sigaction = Self::posix_signal_handler as *const () as usize;
-            act.sa_flags = libc::SA_SIGINFO | libc::SA_RESTART | libc::SA_RESETHAND;
-            // SAFETY: sa_mask is a valid out-pointer; act is on the stack.
-            unsafe {
-                libc::sigemptyset(&raw mut act.sa_mask);
-                libc::sigaction(libc::SIGINT, &raw const act, core::ptr::null_mut());
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            let res = bun_sys::c::SetConsoleCtrlHandler(
-                Some(Self::windows_ctrl_handler),
-                bun_sys::windows::TRUE,
-            );
-            if res == 0 {
-                if bun_core::env::IS_DEBUG {
-                    bun_core::warn!("Failed to set abort handler\n");
-                }
-            }
-        }
-    }
-
-    fn uninstall() {
-        // only necessary on Windows, as on posix we pass the SA_RESETHAND flag
-        #[cfg(windows)]
-        {
-            // (None, FALSE) clears the ignore attribute; it does NOT unregister
-            // a handler routine — pass the address.
-            let _ = bun_sys::c::SetConsoleCtrlHandler(
-                Some(Self::windows_ctrl_handler),
-                bun_sys::windows::FALSE,
-            );
-        }
+        aggregate_exit_code(
+            self.handles
+                .iter()
+                .map(|h| h.process.as_ref().map(|p| &p.status)),
+        )
     }
 }
 
@@ -999,18 +913,8 @@ pub(crate) fn run_scripts_with_filter(
             process: None,
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,
-                #[cfg(unix)]
-                stdout: spawn::Stdio::Buffer,
-                #[cfg(not(unix))]
-                stdout: spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                    bun_core::ffi::zeroed::<bun_sys::windows::libuv::Pipe>(),
-                ))),
-                #[cfg(unix)]
-                stderr: spawn::Stdio::Buffer,
-                #[cfg(not(unix))]
-                stderr: spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                    bun_core::ffi::zeroed::<bun_sys::windows::libuv::Pipe>(),
-                ))),
+                stdout: buffered_stdio(),
+                stderr: buffered_stdio(),
                 cwd: bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(
                     &script.package_json_path,
                 )

--- a/src/runtime/cli/install_command.rs
+++ b/src/runtime/cli/install_command.rs
@@ -1,5 +1,4 @@
 use crate::Error;
-use bun_bundler::bundle_v2::{DependenciesScanner, DependenciesScannerResult};
 use bun_core::{Global, Output};
 use bun_install::package_manager_real::{
     CommandLineArguments, PackageManager, ROOT_PACKAGE_JSON_PATH, Subcommand, install_with_manager,
@@ -7,7 +6,7 @@ use bun_install::package_manager_real::{
 };
 
 use crate::Cli;
-use crate::build_command::BuildCommand;
+use crate::cli::pm_update_package_json::analyze_dependencies_and_install;
 use crate::command::ContextData;
 
 pub(crate) struct InstallCommand;
@@ -52,97 +51,8 @@ impl InstallCommand {
 fn install(ctx: &mut ContextData) -> Result<(), Error> {
     let mut cli = CommandLineArguments::parse(Subcommand::Install)?;
 
-    // The way this works:
-    // 1. Run the bundler on source files
-    // 2. Rewrite positional arguments to act identically to the developer
-    //    typing in the dependency names
-    // 3. Run the install command
     if cli.analyze {
-        // `ctx` is stored as a raw `*mut ContextData`; the `on_fetch` callback
-        // re-enters the install path while `BuildCommand::exec` still holds the
-        // global `Context`, so a `&mut` here would be aliased UB.
-        struct Analyzer {
-            ctx: *mut ContextData,
-            cli: *mut CommandLineArguments,
-        }
-        impl bun_bundler::bundle_v2::OnDependenciesAnalyze for Analyzer {
-            fn on_analyze(
-                &mut self,
-                result: &mut DependenciesScannerResult<'_, '_>,
-            ) -> Result<(), bun_bundler::Error> {
-                let this = self;
-                // TODO: add separate argument that makes it so positionals[1..] is not done     and instead the positionals are passed
-                //
-                // Process-lifetime storage for the rewritten positionals —
-                // `Global::exit(0)` follows immediately.
-                // `OnceLock` (not leaking) per PORTING.md §Forbidden.
-                static OWNED_KEYS: std::sync::OnceLock<Vec<Box<[u8]>>> = std::sync::OnceLock::new();
-                static POSITIONALS: std::sync::OnceLock<Vec<&'static [u8]>> =
-                    std::sync::OnceLock::new();
-
-                let owned = OWNED_KEYS.get_or_init(|| {
-                    result
-                        .dependencies
-                        .keys()
-                        .iter()
-                        .map(|k| Box::<[u8]>::from(&**k))
-                        .collect()
-                });
-                let positionals = POSITIONALS.get_or_init(|| {
-                    let mut v: Vec<&'static [u8]> = Vec::with_capacity(owned.len() + 1);
-                    v.push(b"install");
-                    for k in owned {
-                        v.push(&**k);
-                    }
-                    v
-                });
-
-                // SAFETY: `this.cli` / `this.ctx` were set from live stack
-                // locals in `install()` whose scope encloses the entire
-                // `BuildCommand::exec` call (and hence this callback). The
-                // bundler does not touch the global `ContextData` between
-                // dependency-scan completion and `on_fetch` invocation, so
-                // forming a fresh `&mut` here is exclusive for the duration of
-                // `install_with_cli`.
-                let cli = unsafe { &mut *this.cli };
-                cli.positionals = positionals.as_slice();
-                // SAFETY: see above — same invariant covers `this.ctx`.
-                let ctx = unsafe { &mut *this.ctx };
-
-                install_with_cli(ctx, cli.clone()).map_err(bun_bundler::Error::from)?;
-
-                Global::exit(0);
-            }
-        }
-
-        // `DependenciesScanner.entry_points` is `Box<[Box<[u8]>]>`. Clone the
-        // argv slices into an owned buffer (small one-shot list — no perf
-        // concern). Captured *before*
-        // raw-ptr aliasing of `cli` below so the access goes through the live
-        // `&mut cli` borrow.
-        let entry_points: Box<[Box<[u8]>]> = cli.positionals[1..]
-            .iter()
-            .map(|s| Box::<[u8]>::from(*s))
-            .collect();
-
-        // Derive raw pointers from the existing `&mut` borrows; all subsequent
-        // access to `ctx` / `cli` in this branch goes through these.
-        let ctx_ptr: *mut ContextData = ctx;
-        let mut analyzer = Analyzer {
-            ctx: ctx_ptr,
-            cli: &raw mut cli,
-        };
-
-        let fetcher = DependenciesScanner::new(&mut analyzer, entry_points);
-
-        // `Command.get()` resolves to the same `*ContextData` already held in
-        // `ctx`; reborrow through `ctx_ptr` rather than minting a fresh
-        // `&'static mut` from the global static (which would alias the
-        // still-live `ctx` parameter under stacked borrows).
-        // SAFETY: `ctx_ptr` was just derived from the live `ctx: &mut
-        // ContextData` parameter; `ctx` is not accessed again in this branch.
-        BuildCommand::exec(unsafe { &mut *ctx_ptr }, Some(&fetcher))?;
-        return Ok(());
+        return analyze_dependencies_and_install(ctx, &mut cli, b"install", &mut install_with_cli);
     }
 
     install_with_cli(ctx, cli)

--- a/src/runtime/cli/link_command.rs
+++ b/src/runtime/cli/link_command.rs
@@ -10,7 +10,7 @@ use bun_install::Features;
 use bun_install::bin_real as bin;
 use bun_install::lockfile_real::{Lockfile, package::Package};
 use bun_install::package_manager_real::{
-    self as pm, CommandLineArguments, Subcommand, attempt_to_create_package_json,
+    self as pm, CommandLineArguments, PackageManager, Subcommand, attempt_to_create_package_json,
     options::LogLevel, package_manager_options, setup_global_dir,
     update_package_json_and_install_with_manager,
 };
@@ -22,6 +22,108 @@ pub(crate) struct LinkCommand;
 impl LinkCommand {
     pub(crate) fn exec(ctx: command::Context) -> crate::Result<()> {
         link(ctx)
+    }
+}
+
+/// Shared by `bun link` / `bun unlink`: parse the nearest package.json into an
+/// empty lockfile and validate that it declares a valid npm package name.
+/// Crashes with a user-facing error otherwise. The package name is re-derived
+/// by callers via `lockfile.str(&package.name)`.
+pub(crate) fn load_package_for_link(
+    manager: &mut PackageManager,
+    verb: &str,
+) -> crate::Result<(Lockfile, Package)> {
+    let mut lockfile = Lockfile::default();
+    let mut package = Package::default();
+
+    let package_json_source = match bun_ast::to_source(
+        manager.original_package_json_path.as_zstr(),
+        Default::default(),
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            Output::err_generic(
+                "failed to read \"{}\" for {}: {}",
+                (
+                    BStr::new(manager.original_package_json_path.as_bytes()),
+                    verb,
+                    BStr::new(e.name()),
+                ),
+            );
+            Global::crash();
+        }
+    };
+    lockfile.init_empty();
+
+    let mut resolver: () = ();
+    // `log_mut()` returns a borrow decoupled from `&self`; disjoint
+    // storage from `&mut PackageManager` (owned by the CLI `Context`).
+    let log = manager.log_mut();
+    package.parse::<()>(
+        &mut lockfile,
+        manager,
+        log,
+        &package_json_source,
+        &mut resolver,
+        Features::FOLDER,
+    )?;
+    let name = lockfile.str(&package.name);
+    if name.is_empty() {
+        if manager.options.log_level != LogLevel::Silent {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> package.json missing \"name\" <d>in \"{}\"<r>",
+                BStr::new(package_json_source.path.text),
+            );
+        }
+        Global::crash();
+    } else if !strings::is_npm_package_name(name) {
+        if manager.options.log_level != LogLevel::Silent {
+            bun_core::pretty_errorln!(
+                "<r><red>error:<r> invalid package.json name \"{}\" <d>in \"{}\"<r>",
+                BStr::new(name),
+                BStr::new(package_json_source.path.text),
+            );
+        }
+        Global::crash();
+    }
+
+    Ok((lockfile, package))
+}
+
+/// Shared by `bun link` / `bun unlink`: open the global directory (storing it
+/// in `manager.global_dir`) and create+open its `node_modules` folder.
+/// Crashes with a user-facing error if `node_modules` cannot be created.
+pub(crate) fn open_global_node_modules(
+    manager: &mut PackageManager,
+    ctx: &mut command::ContextData,
+) -> crate::Result<Dir> {
+    bin::Linker::ensure_umask();
+    let explicit_global_dir: &[u8] = match &ctx.install {
+        Some(install_) => install_.global_dir.as_deref().unwrap_or(b""),
+        None => b"",
+    };
+    manager.global_dir = Some(Dir::from_fd(package_manager_options::open_global_dir(
+        explicit_global_dir,
+    )?));
+
+    setup_global_dir(manager, &ctx)?;
+
+    match manager
+        .global_dir
+        .as_ref()
+        .unwrap()
+        .make_open_path(b"node_modules", Default::default())
+    {
+        Ok(d) => Ok(d),
+        Err(e) => {
+            if manager.options.log_level != LogLevel::Silent {
+                bun_core::pretty_errorln!(
+                    "<r><red>error:<r> failed to create node_modules in global dir due to error {}",
+                    BStr::new(e.name()),
+                );
+            }
+            Global::crash();
+        }
     }
 }
 
@@ -51,98 +153,15 @@ fn link(ctx: command::Context) -> crate::Result<()> {
     if manager.options.positionals.len() == 1 {
         // bun link
 
-        let mut lockfile = Lockfile::default();
-        let mut package = Package::default();
-
         // Step 1. parse the nearest package.json file
-        {
-            let package_json_source = match bun_ast::to_source(
-                manager.original_package_json_path.as_zstr(),
-                Default::default(),
-            ) {
-                Ok(s) => s,
-                Err(e) => {
-                    Output::err_generic(
-                        "failed to read \"{s}\" for linking: {s}",
-                        (
-                            BStr::new(manager.original_package_json_path.as_bytes()),
-                            BStr::new(e.name()),
-                        ),
-                    );
-                    Global::crash();
-                }
-            };
-            lockfile.init_empty();
+        let (lockfile, package) = load_package_for_link(manager, "linking")?;
 
-            let mut resolver: () = ();
-            // `log_mut()` returns a borrow decoupled from `&self`; disjoint
-            // storage from `&mut PackageManager` (owned by the CLI `Context`).
-            let log = manager.log_mut();
-            package.parse::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
-            let name = lockfile.str(&package.name);
-            if name.is_empty() {
-                if manager.options.log_level != LogLevel::Silent {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error:<r> package.json missing \"name\" <d>in \"{}\"<r>",
-                        BStr::new(package_json_source.path.text),
-                    );
-                }
-                Global::crash();
-            } else if !strings::is_npm_package_name(name) {
-                if manager.options.log_level != LogLevel::Silent {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error:<r> invalid package.json name \"{}\" <d>in \"{}\"<r>",
-                        BStr::new(name),
-                        BStr::new(package_json_source.path.text),
-                    );
-                }
-                Global::crash();
-            }
-        }
-
-        // Reshaped for borrowck — re-derive `name` here so its
-        // lifetime is tied only to `lockfile.buffers.string_bytes`, decoupled
-        // from `package_json_source` (dropped above).
+        // `name` is a slice into `lockfile.buffers.string_bytes`, decoupled
+        // from the helper-local package.json source.
         let name = lockfile.str(&package.name);
 
         // Step 2. Setup the global directory
-        let node_modules: Dir = 'brk: {
-            bin::Linker::ensure_umask();
-            let explicit_global_dir: &[u8] = match &ctx.install {
-                Some(install_) => install_.global_dir.as_deref().unwrap_or(b""),
-                None => b"",
-            };
-            manager.global_dir = Some(Dir::from_fd(package_manager_options::open_global_dir(
-                explicit_global_dir,
-            )?));
-
-            setup_global_dir(manager, &&mut *ctx)?;
-
-            match manager
-                .global_dir
-                .as_ref()
-                .unwrap()
-                .make_open_path(b"node_modules", Default::default())
-            {
-                Ok(d) => break 'brk d,
-                Err(e) => {
-                    if manager.options.log_level != LogLevel::Silent {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error:<r> failed to create node_modules in global dir due to error {}",
-                            BStr::new(e.name()),
-                        );
-                    }
-                    Global::crash();
-                }
-            }
-        };
+        let node_modules: Dir = open_global_node_modules(manager, &mut *ctx)?;
 
         // Step 3a. symlink to the node_modules folder
         {

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -379,6 +379,7 @@ pub(crate) mod prune_command;
 pub mod publish_command;
 #[path = "remove_command.rs"]
 pub(crate) mod remove_command;
+pub(crate) mod run_processes_shared;
 #[path = "scan_command.rs"]
 pub mod scan_command;
 #[path = "unlink_command.rs"]
@@ -389,6 +390,7 @@ pub(crate) mod update_command;
 pub mod update_interactive_command;
 #[path = "why_command.rs"]
 pub mod why_command;
+pub(crate) mod workspace_helpers;
 
 // ─── crate-local helper for param-table concatenation ────────────────────────
 // `bun_clap::parse_param!` is a real proc-macro (const `Param<Help>` literal),

--- a/src/runtime/cli/multi_run.rs
+++ b/src/runtime/cli/multi_run.rs
@@ -1,6 +1,6 @@
 use core::ffi::{c_char, c_void};
 use core::ptr;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::Ordering;
 use std::time::Instant;
 
 use crate::Error;
@@ -14,6 +14,9 @@ use bun_io::BufferedReader;
 use bun_paths as path;
 
 use crate::Command;
+use crate::cli::run_processes_shared::{
+    AbortHandler, SHOULD_ABORT, aggregate_exit_code, buffered_stdio, watch_or_reap,
+};
 use crate::filter_arg as FilterArg;
 use crate::run_command::{ConfigureEnvOptions, RunCommand};
 
@@ -22,7 +25,7 @@ use crate::run_command::{ConfigureEnvOptions, RunCommand};
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
 use crate::api::bun::process::{
-    self as spawn, Rusage, SpawnOptions, SpawnProcessResult, Status, event_loop_handle_to_ctx,
+    self as spawn, SpawnOptions, SpawnProcessResult, Status, event_loop_handle_to_ctx,
 };
 use bun_collections::index_sort;
 use bun_dotenv::Loader as DotEnvLoader;
@@ -269,16 +272,7 @@ impl<'a> ProcessHandle<'a> {
             bun_spawn::ProcessExit::new(bun_spawn::ProcessExitKind::MultiRunHandle, self_ptr)
         });
 
-        match process.watch_or_reap() {
-            Ok(_) => {}
-            Err(err) => {
-                if !process.has_exited() {
-                    // SAFETY: all-zero is a valid Rusage (POD C struct)
-                    let rusage = bun_core::ffi::zeroed::<Rusage>();
-                    process.on_exit(Status::Err(err), &rusage);
-                }
-            }
-        }
+        watch_or_reap(process);
 
         Ok(())
     }
@@ -589,87 +583,11 @@ impl<'a> State<'a> {
     }
 
     fn finalize(&self) -> u8 {
-        for handle in self.handles.iter() {
-            if let Some(proc) = &handle.process {
-                match &proc.status {
-                    Status::Exited(exited) => {
-                        if exited.code != 0 {
-                            return exited.code;
-                        }
-                    }
-                    Status::Signaled(signal) => {
-                        return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1);
-                    }
-                    _ => return 1,
-                }
-            }
-        }
-        0
-    }
-}
-
-struct AbortHandler;
-
-static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
-
-impl AbortHandler {
-    #[cfg(unix)]
-    extern "C" fn posix_signal_handler(
-        _sig: i32,
-        _info: *const bun_sys::posix::siginfo_t,
-        _: *const c_void,
-    ) {
-        SHOULD_ABORT.store(true, Ordering::SeqCst);
-    }
-
-    #[cfg(windows)]
-    extern "system" fn windows_ctrl_handler(
-        dw_ctrl_type: bun_sys::windows::DWORD,
-    ) -> bun_sys::windows::BOOL {
-        if dw_ctrl_type == bun_sys::windows::CTRL_C_EVENT {
-            SHOULD_ABORT.store(true, Ordering::SeqCst);
-            return bun_sys::windows::TRUE;
-        }
-        bun_sys::windows::FALSE
-    }
-
-    fn install() {
-        #[cfg(unix)]
-        {
-            // bun_sys::posix::Sigaction is a re-export of libc::sigaction; construct
-            // via zeroed() (POD C struct) and populate sa_sigaction/sa_mask/sa_flags.
-            // SAFETY: all-zero is a valid `libc::sigaction`; sigemptyset/sigaction are
-            // FFI calls with no extra preconditions beyond valid pointers.
-            unsafe {
-                let mut action: bun_sys::posix::Sigaction = bun_core::ffi::zeroed();
-                action.sa_sigaction = Self::posix_signal_handler as *const () as usize;
-                libc::sigemptyset(&raw mut action.sa_mask);
-                action.sa_flags = (libc::SA_SIGINFO | libc::SA_RESTART | libc::SA_RESETHAND) as _;
-                bun_sys::posix::sigaction(libc::SIGINT, &raw const action, core::ptr::null_mut());
-            }
-        }
-        #[cfg(not(unix))]
-        {
-            let res = bun_sys::windows::SetConsoleCtrlHandler(
-                Some(Self::windows_ctrl_handler),
-                bun_sys::windows::TRUE,
-            );
-            if res == 0 {
-                if bun_core::env::IS_DEBUG {
-                    bun_core::warn!("Failed to set abort handler\n");
-                }
-            }
-        }
-    }
-
-    fn uninstall() {
-        #[cfg(windows)]
-        {
-            let _ = bun_sys::windows::SetConsoleCtrlHandler(
-                Some(Self::windows_ctrl_handler),
-                bun_sys::windows::FALSE,
-            );
-        }
+        aggregate_exit_code(
+            self.handles
+                .iter()
+                .map(|h| h.process.as_ref().map(|p| &p.status)),
+        )
     }
 }
 
@@ -1167,18 +1085,8 @@ pub(crate) fn run(ctx: &mut Command::ContextData) -> Result<core::convert::Infal
             next_dependents: Vec::new(),
             options: SpawnOptions {
                 stdin: spawn::Stdio::Ignore,
-                #[cfg(unix)]
-                stdout: spawn::Stdio::Buffer,
-                #[cfg(not(unix))]
-                stdout: spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                    bun_core::ffi::zeroed::<bun_sys::windows::libuv::Pipe>(),
-                ))),
-                #[cfg(unix)]
-                stderr: spawn::Stdio::Buffer,
-                #[cfg(not(unix))]
-                stderr: spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(
-                    bun_core::ffi::zeroed::<bun_sys::windows::libuv::Pipe>(),
-                ))),
+                stdout: buffered_stdio(),
+                stderr: buffered_stdio(),
                 cwd: config.cwd.clone(),
                 #[cfg(windows)]
                 windows: spawn::WindowsOptions {

--- a/src/runtime/cli/outdated_command.rs
+++ b/src/runtime/cli/outdated_command.rs
@@ -8,14 +8,12 @@ use bun_core::{Global, Output};
 use bun_glob as glob;
 use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::lockfile::{LoadResult, LoadStep};
-use bun_install::package_manager::{
-    LogLevel, Subcommand, WorkspaceFilter, populate_manifest_cache,
-};
+use bun_install::package_manager::{Subcommand, WorkspaceFilter, populate_manifest_cache};
 use bun_install::{CommandLineArguments, DependencyID, PackageID, PackageManager, resolution};
 use bun_wyhash::hash;
 
 use crate::Command;
+use crate::cli::workspace_helpers;
 
 pub(crate) struct OutdatedCommand;
 
@@ -87,71 +85,11 @@ impl OutdatedCommand {
         original_cwd: &[u8],
         manager: &mut PackageManager,
     ) -> crate::Result<()> {
-        // Reshaped for borrowck — `load_from_cwd` would otherwise alias
-        // `PackageManager` with its `lockfile` field. Project disjoint
-        // raw pointers from the singleton first; `load_from_cwd` only reads
-        // `manager.options` / migration helpers and never re-borrows
-        // `manager.lockfile` through the `pm` argument.
-        let pm_ptr: *mut PackageManager = manager;
-        let not_silent = manager.options.log_level != LogLevel::Silent;
-        let log_ptr: *mut bun_ast::Log = manager.log;
-
-        // SAFETY: `lockfile` is the owned `Box<Lockfile>` field on the singleton;
-        // no other live `&mut Lockfile` exists at this point.
-        let lockfile: &mut bun_install::lockfile::Lockfile = unsafe { &mut *(*pm_ptr).lockfile };
-        // SAFETY: `manager.log` is set non-null by `PackageManager::init`.
-        let log = unsafe { &mut *log_ptr };
-        match lockfile.load_from_cwd::<true>(
-            // SAFETY: see comment above — `load_from_cwd` accesses `manager`
-            // fields disjoint from `lockfile`.
-            Some(unsafe { &mut *pm_ptr }),
-            log,
-        ) {
-            LoadResult::NotFound => {
-                if not_silent {
-                    Output::err_generic("missing lockfile, nothing outdated", ());
-                    bun_core::note!("run 'bun install' first");
-                }
-                Global::crash();
-            }
-            LoadResult::Err(cause) => {
-                if not_silent
-                    && !bun_install::migration::reported_unsupported_lockfile_version(&cause)
-                {
-                    match cause.step {
-                        LoadStep::OpenFile => Output::err_generic(
-                            "failed to open lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ParseFile => Output::err_generic(
-                            "failed to parse lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ReadFile => Output::err_generic(
-                            "failed to read lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::Migrating => Output::err_generic(
-                            "failed to migrate lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                    }
-                    if ctx.log_ref().has_errors() {
-                        // SAFETY: `log_ptr` aliases `manager.log` which is the
-                        // `*logger.Log` borrowed from `Command::Context`; no
-                        // other `&mut Log` is live here.
-                        let _ =
-                            unsafe { (*log_ptr).print(std::ptr::from_mut(Output::error_writer())) };
-                    }
-                }
-                Global::crash();
-            }
-            LoadResult::Ok(_) => {
-                // `load_from_cwd(&mut self, ..)` populates the
-                // lockfile in place, so the `ok.lockfile: &mut Lockfile` reborrow
-                // is the same storage and no reassignment is needed.
-            }
-        }
+        workspace_helpers::load_lockfile_or_crash(
+            ctx,
+            manager,
+            "missing lockfile, nothing outdated",
+        );
 
         if Output::enable_ansi_colors_stdout() {
             Self::outdated_dispatch::<true>(original_cwd, manager)

--- a/src/runtime/cli/pack_command.rs
+++ b/src/runtime/cli/pack_command.rs
@@ -31,9 +31,7 @@ use bun_core::{ZStr, strings};
 use bun_paths::resolve_path;
 use bun_semver as Semver;
 use bun_sha_hmac::sha;
-use bun_sys::{
-    self, CloseOnDrop, Dir, Fd, FdDirExt as _, FdExt as _, File, dir_iterator as DirIterator,
-};
+use bun_sys::{self, Dir, Fd, FdDirExt as _, FdExt as _, File, dir_iterator as DirIterator};
 
 // ───────────────────────────────────────────────────────────────────────────
 // local shims for upstream-stub gaps
@@ -1830,7 +1828,7 @@ fn new_boxed_buffered_file_reader(file: bun_sys::File) -> Box<BufferedFileReader
 /// would create.
 ///
 /// `unbuffered_reader` is a *view* of a fd that the call site owns (e.g. via
-/// a `CloseOnDrop` or a `File` whose Drop fires after the read loop). The
+/// a `File` whose Drop fires after the read loop). The
 /// previous fd may already be closed; disarm its `File::Drop` before
 /// overwriting so we never close a stale (potentially-recycled) fd.
 #[inline]
@@ -1883,6 +1881,50 @@ fn opt_pack_gzip_level(m: &PackageManager) -> Option<&[u8]> {
 // ───────────────────────────────────────────────────────────────────────────
 // pack()
 // ───────────────────────────────────────────────────────────────────────────
+
+/// Reads `abs_package_json_path` through the workspace package.json cache;
+/// read/parse failures are fatal, using pack's own error wording and ordering
+/// (`Output::err` first, then the log printed unconditionally on parse
+/// errors), which bun-pack.test.ts asserts.
+///
+/// `'a` is unbounded: the entry lives in `workspace_package_json_cache`, so
+/// the reference is invalid once that map is mutated (`pack` removes the
+/// entry after lifecycle scripts run and immediately reloads it).
+fn load_package_json_or_exit<'a>(
+    manager_ptr: *mut PackageManager,
+    abs_package_json_path: &ZStr,
+) -> &'a mut WorkspacePackageJSONCache::MapEntry {
+    // Note: `workspace_package_json_cache` and `log` are disjoint fields on
+    // `PackageManager`; route through raw-pointer field projections so the
+    // two `&mut` borrows don't conflict.
+    match pm_workspace_cache(manager_ptr).get_with_path(
+        pm_log(manager_ptr),
+        abs_package_json_path.as_bytes(),
+        WorkspacePackageJSONCache::GetJSONOptions {
+            guess_indentation: true,
+            ..Default::default()
+        },
+    ) {
+        WorkspacePackageJSONCache::GetResult::ReadErr(err) => {
+            Output::err(
+                err,
+                "failed to read package.json: {}",
+                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
+            );
+            Global::crash();
+        }
+        WorkspacePackageJSONCache::GetResult::ParseErr(err) => {
+            Output::err(
+                err,
+                "failed to parse package.json: {}",
+                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
+            );
+            let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
+            Global::crash();
+        }
+        WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
+    }
+}
 
 // Const generics cannot vary the
 // return type directly, so both instantiations return an Option that is
@@ -2010,36 +2052,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
     let manager_ptr: *mut PackageManager = &raw mut *ctx.manager;
     let log_level = ctx.manager.options.log_level;
     let bump = pack_bump();
-    // Note: `workspace_package_json_cache` and `log` are disjoint fields on
-    // `PackageManager`; route through raw-pointer field projections so the
-    // two `&mut` borrows don't conflict.
-    let mut json = match pm_workspace_cache(manager_ptr).get_with_path(
-        pm_log(manager_ptr),
-        abs_package_json_path.as_bytes(),
-        WorkspacePackageJSONCache::GetJSONOptions {
-            guess_indentation: true,
-            ..Default::default()
-        },
-    ) {
-        WorkspacePackageJSONCache::GetResult::ReadErr(err) => {
-            Output::err(
-                err,
-                "failed to read package.json: {}",
-                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-            );
-            Global::crash();
-        }
-        WorkspacePackageJSONCache::GetResult::ParseErr(err) => {
-            Output::err(
-                err,
-                "failed to parse package.json: {}",
-                format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-            );
-            let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
-            Global::crash();
-        }
-        WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
-    };
+    let mut json = load_package_json_or_exit(manager_ptr, abs_package_json_path);
 
     if FOR_PUBLISH {
         if let Some(config) = json.root.get(b"publishConfig") {
@@ -2267,33 +2280,7 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
         let _ = pm_workspace_cache(manager_ptr).map.remove(cache_key);
 
         // Re-read package.json from disk
-        json = match pm_workspace_cache(manager_ptr).get_with_path(
-            pm_log(manager_ptr),
-            abs_package_json_path.as_bytes(),
-            WorkspacePackageJSONCache::GetJSONOptions {
-                guess_indentation: true,
-                ..Default::default()
-            },
-        ) {
-            WorkspacePackageJSONCache::GetResult::ReadErr(err) => {
-                Output::err(
-                    err,
-                    "failed to read package.json: {}",
-                    format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-                );
-                Global::crash();
-            }
-            WorkspacePackageJSONCache::GetResult::ParseErr(err) => {
-                Output::err(
-                    err,
-                    "failed to parse package.json: {}",
-                    format_args!("{}", bstr::BStr::new(abs_package_json_path.as_bytes())),
-                );
-                let _ = pm_log(manager_ptr).print(std::ptr::from_mut(Output::error_writer()));
-                Global::crash();
-            }
-            WorkspacePackageJSONCache::GetResult::Entry(entry) => entry,
-        };
+        json = load_package_json_or_exit(manager_ptr, abs_package_json_path);
 
         // Re-validate private flag after scripts may have modified it.
         if FOR_PUBLISH {
@@ -2597,11 +2584,9 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
             node = Some(progress.start(b"", pack_queue.count() + bundled_pack_queue.count() + 1));
             node.as_mut().expect("infallible: progress active").unit = Progress::Unit::Files;
         }
-        // Note: the loop bodies' only early exits are `continue`
-        // and `Global::crash()` (never returns, no
-        // unwinding). `scopeguard` captures of `&mut node` overlap the inline
-        // uses below, so call `complete_one()` explicitly at every loop-body
-        // exit and `end()` once after the loops.
+        // Note: `scopeguard` captures of `&mut node` would overlap the inline
+        // uses below, so call `complete_one()` explicitly after each archived
+        // entry and `end()` once after the queues drain.
 
         entry = archive_package_json(
             ctx,
@@ -2618,142 +2603,41 @@ pub(crate) fn pack<const FOR_PUBLISH: bool>(
                 .complete_one();
         }
 
-        while let Some(item) = pack_queue.remove_or_null() {
-            let file = match bun_sys::openat(
-                Fd::from_std_dir(&root_dir),
-                &item.path,
-                bun_sys::O::RDONLY,
-                0,
-            ) {
-                Ok(f) => f,
-                Err(err) => {
-                    if item.optional {
-                        ctx.stats.total_files -= 1;
-                        if log_level.show_progress() {
-                            node.as_mut()
-                                .expect("infallible: progress active")
-                                .complete_one();
-                        }
-                        continue;
-                    }
-                    Output::err(
-                        err,
-                        "failed to open file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
+        entry = archive_pack_queue(
+            ctx,
+            &mut pack_queue,
+            PackQueueOpenMode::UvOwnedFd,
+            &root_dir,
+            Some(&mut pack_list),
+            &mut read_buf,
+            &mut file_reader,
+            // SAFETY: `archive` is the non-null `*mut Archive` returned by
+            // `Archive::write_new()` above; only this thread accesses it.
+            unsafe { &mut *archive },
+            entry,
+            &mut print_buf,
+            &bins,
+            log_level,
+            &mut node,
+        )?;
 
-            let fd: Fd = match file
-                .make_lib_uv_owned_for_syscall(bun_sys::Tag::open, bun_sys::ErrorCase::CloseOnFail)
-            {
-                Ok(fd) => fd,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to open file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-
-            let _close_fd = CloseOnDrop::new(fd);
-
-            let stat = match bun_sys::sys_uv::fstat(fd) {
-                Ok(s) => s,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to stat file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-
-            pack_list.push(PackListEntry {
-                subpath: ZBox::from_bytes(item.path.as_bytes()),
-                size: usize::try_from(stat.st_size).expect("int cast"),
-            });
-
-            entry = add_archive_entry(
-                ctx,
-                fd,
-                &stat,
-                &item.path,
-                &mut read_buf,
-                &mut file_reader,
-                // SAFETY: `archive` is the non-null `*mut Archive` returned by
-                // `Archive::write_new()` above; only this thread accesses it.
-                unsafe { &mut *archive },
-                entry,
-                &mut print_buf,
-                &bins,
-            )?;
-
-            if log_level.show_progress() {
-                node.as_mut()
-                    .expect("infallible: progress active")
-                    .complete_one();
-            }
-        }
-
-        while let Some(item) = bundled_pack_queue.remove_or_null() {
-            let file = match root_dir.open_file(&item.path, bun_sys::O::RDONLY, 0) {
-                Ok(f) => f,
-                Err(err) => {
-                    if item.optional {
-                        ctx.stats.total_files -= 1;
-                        if log_level.show_progress() {
-                            node.as_mut()
-                                .expect("infallible: progress active")
-                                .complete_one();
-                        }
-                        continue;
-                    }
-                    Output::err(
-                        err,
-                        "failed to open file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-            let stat = match file.stat() {
-                Ok(s) => s,
-                Err(err) => {
-                    Output::err(
-                        err,
-                        "failed to stat file: \"{}\"",
-                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
-                    );
-                    Global::crash();
-                }
-            };
-
-            entry = add_archive_entry(
-                ctx,
-                file.handle,
-                &stat,
-                &item.path,
-                &mut read_buf,
-                &mut file_reader,
-                // SAFETY: `archive` is the non-null `*mut Archive` returned by
-                // `Archive::write_new()` above; only this thread accesses it.
-                unsafe { &mut *archive },
-                entry,
-                &mut print_buf,
-                &bins,
-            )?;
-
-            if log_level.show_progress() {
-                node.as_mut()
-                    .expect("infallible: progress active")
-                    .complete_one();
-            }
-        }
+        entry = archive_pack_queue(
+            ctx,
+            &mut bundled_pack_queue,
+            PackQueueOpenMode::PlainFile,
+            &root_dir,
+            None,
+            &mut read_buf,
+            &mut file_reader,
+            // SAFETY: `archive` is the non-null `*mut Archive` returned by
+            // `Archive::write_new()` above; only this thread accesses it.
+            unsafe { &mut *archive },
+            entry,
+            &mut print_buf,
+            &bins,
+            log_level,
+            &mut node,
+        )?;
 
         if log_level.show_progress() {
             if let Some(n) = node.as_mut() {
@@ -3193,6 +3077,138 @@ fn archive_package_json(
         usize::try_from(archive.write_data(edited_package_json)).expect("int cast");
 
     Ok(entry.clear())
+}
+
+/// How [`archive_pack_queue`] opens each queued file.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PackQueueOpenMode {
+    /// Open with `bun_sys::openat` and convert to a libuv-owned descriptor
+    /// stat'd through `sys_uv`.
+    UvOwnedFd,
+    /// Open relative to `root_dir` as a plain `File`.
+    PlainFile,
+}
+
+/// Drains `queue`, archiving each file via [`add_archive_entry`]; see
+/// [`PackQueueOpenMode`] for how each file is opened. Each entry is also
+/// appended to `pack_list` when provided.
+///
+/// The loop body's early exits are `continue`, `Global::crash()`, and `?` on
+/// `AllocError`; the last two never resume (the `AllocError` becomes
+/// `PackError::OutOfMemory` and the caller exits via `out_of_memory()`), so
+/// `node.complete_one()` is called explicitly before each `continue` instead
+/// of via a scope guard.
+fn archive_pack_queue(
+    ctx: &mut Context<'_>,
+    queue: &mut PackQueue,
+    open_mode: PackQueueOpenMode,
+    root_dir: &Dir,
+    mut pack_list: Option<&mut PackList>,
+    read_buf: &mut [u8],
+    file_reader: &mut BufferedFileReader,
+    archive: &mut Archive,
+    mut entry: *mut ArchiveEntry,
+    print_buf: &mut Vec<u8>,
+    bins: &[BinInfo],
+    log_level: LogLevel,
+    node: &mut Option<&mut Progress::Node>,
+) -> Result<*mut ArchiveEntry, AllocError> {
+    let uv_owned_fd = open_mode == PackQueueOpenMode::UvOwnedFd;
+    while let Some(item) = queue.remove_or_null() {
+        let opened = if uv_owned_fd {
+            bun_sys::openat(
+                Fd::from_std_dir(root_dir),
+                &item.path,
+                bun_sys::O::RDONLY,
+                0,
+            )
+            .map(File::from_fd)
+        } else {
+            root_dir.open_file(&item.path, bun_sys::O::RDONLY, 0)
+        };
+        let file = match opened {
+            Ok(f) => f,
+            Err(err) => {
+                if item.optional {
+                    ctx.stats.total_files -= 1;
+                    if log_level.show_progress() {
+                        node.as_mut()
+                            .expect("infallible: progress active")
+                            .complete_one();
+                    }
+                    continue;
+                }
+                Output::err(
+                    err,
+                    "failed to open file: \"{}\"",
+                    format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
+                );
+                Global::crash();
+            }
+        };
+
+        let file = if uv_owned_fd {
+            match file
+                .into_raw()
+                .make_lib_uv_owned_for_syscall(bun_sys::Tag::open, bun_sys::ErrorCase::CloseOnFail)
+            {
+                Ok(fd) => File::from_fd(fd),
+                Err(err) => {
+                    Output::err(
+                        err,
+                        "failed to open file: \"{}\"",
+                        format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
+                    );
+                    Global::crash();
+                }
+            }
+        } else {
+            file
+        };
+
+        let stat = match if uv_owned_fd {
+            bun_sys::sys_uv::fstat(file.handle)
+        } else {
+            file.stat()
+        } {
+            Ok(s) => s,
+            Err(err) => {
+                Output::err(
+                    err,
+                    "failed to stat file: \"{}\"",
+                    format_args!("{}", bstr::BStr::new(item.path.as_bytes())),
+                );
+                Global::crash();
+            }
+        };
+
+        if let Some(pack_list) = pack_list.as_deref_mut() {
+            pack_list.push(PackListEntry {
+                subpath: ZBox::from_bytes(item.path.as_bytes()),
+                size: usize::try_from(stat.st_size).expect("int cast"),
+            });
+        }
+
+        entry = add_archive_entry(
+            ctx,
+            file.handle,
+            &stat,
+            &item.path,
+            read_buf,
+            file_reader,
+            archive,
+            entry,
+            print_buf,
+            bins,
+        )?;
+
+        if log_level.show_progress() {
+            node.as_mut()
+                .expect("infallible: progress active")
+                .complete_one();
+        }
+    }
+    Ok(entry)
 }
 
 fn add_archive_entry(

--- a/src/runtime/cli/pm_update_package_json.rs
+++ b/src/runtime/cli/pm_update_package_json.rs
@@ -17,7 +17,7 @@ use bun_install::package_manager_real::{Subcommand, update_package_json_and_inst
 
 use crate::build_command::BuildCommand;
 use crate::cli::Cli;
-use crate::command::{self, Context, ContextData};
+use crate::command::{Context, ContextData};
 
 pub(crate) fn update_package_json_and_install_catch_error(
     ctx: Context,
@@ -48,96 +48,111 @@ pub(crate) fn update_package_json_and_install(
     // `parse` requires `<const CMD: Subcommand>`, expand to a `match`.
     let mut cli = CommandLineArguments::parse(subcommand)?;
 
-    // The way this works:
-    // 1. Run the bundler on source files
-    // 2. Rewrite positional arguments to act identically to the developer
-    //    typing in the dependency names
-    // 3. Run the install command
     if cli.analyze {
-        // `ctx`/`cli` are stored as raw `*mut` because
-        // `BuildCommand::exec` holds `command::get()` (the same `ContextData`) across
-        // the `on_fetch` callback, and `DependenciesScanner.entry_points` owns a copy
-        // of `cli.positionals[1..]` for the duration of the scan; storing `&mut` here
-        // would assert exclusivity we don't have.
-        struct Analyzer {
-            ctx: *mut ContextData,
-            cli: *mut CommandLineArguments,
-            subcommand: Subcommand,
-        }
-        impl bun_bundler::bundle_v2::OnDependenciesAnalyze for Analyzer {
-            fn on_analyze(
-                &mut self,
-                result: &mut DependenciesScannerResult<'_, '_>,
-            ) -> Result<(), bun_bundler::Error> {
-                let this = self;
-                // TODO: add separate argument that makes it so positionals[1..] is not done and instead the positionals are passed
-                //
-                // Process-lifetime storage for the rewritten positionals —
-                // `Global::exit(0)` follows immediately. `OnceLock` (not
-                // leaked).
-                static OWNED_KEYS: std::sync::OnceLock<Vec<Box<[u8]>>> = std::sync::OnceLock::new();
-                static POSITIONALS: std::sync::OnceLock<Vec<&'static [u8]>> =
-                    std::sync::OnceLock::new();
-
-                let owned = OWNED_KEYS.get_or_init(|| {
-                    result
-                        .dependencies
-                        .keys()
-                        .iter()
-                        .map(|k| Box::<[u8]>::from(&**k))
-                        .collect()
-                });
-                let positionals = POSITIONALS.get_or_init(|| {
-                    let mut v: Vec<&'static [u8]> = Vec::with_capacity(owned.len() + 1);
-                    v.push(b"add");
-                    for k in owned {
-                        v.push(&**k);
-                    }
-                    v
-                });
-
-                // SAFETY: `this.cli` / `this.ctx` were set from live stack locals in
-                // `update_package_json_and_install` whose scope encloses the entire
-                // `BuildCommand::exec` call (and hence this callback). The bundler has
-                // finished reading `entry_points` before invoking `on_fetch`, and this
-                // callback never returns (`Global::exit` below), so forming fresh `&mut`
-                // here is exclusive for the remainder of the process.
-                let cli = unsafe { &mut *this.cli };
-                cli.positionals = positionals.as_slice();
-                // SAFETY: `this.ctx` points to the `ctx` stack local in
-                // `update_package_json_and_install`, whose frame outlives this
-                // callback; `Global::exit` below makes this `&mut` exclusive for
-                // the remainder of the process.
-                let ctx = unsafe { &mut *this.ctx };
-
-                update_package_json_and_install_and_cli(ctx, this.subcommand, cli.clone())
-                    .map_err(crate::Error::from)?;
-
-                Global::exit(0);
-            }
-        }
-
-        // Note: `DependenciesScanner.entry_points` is `Box<[Box<[u8]>]>`.
-        // Clone the argv slices into an owned
-        // buffer (small one-shot list — no perf concern) so `cli` is not borrowed across
-        // the `&mut analyzer` setup.
-        let entry_points: Box<[Box<[u8]>]> = cli.positionals[1..]
-            .iter()
-            .map(|s| Box::<[u8]>::from(*s))
-            .collect();
-
-        let mut analyzer = Analyzer {
-            ctx: std::ptr::from_mut::<ContextData>(ctx),
-            cli: &raw mut cli,
-            subcommand,
-        };
-
-        let fetcher = DependenciesScanner::new(&mut analyzer, entry_points);
-
-        // This runs the bundler.
-        BuildCommand::exec(command::get(), Some(&fetcher))?;
-        return Ok(());
+        return analyze_dependencies_and_install(ctx, &mut cli, b"add", &mut |ctx, cli| {
+            update_package_json_and_install_and_cli(ctx, subcommand, cli).map_err(Into::into)
+        });
     }
 
     update_package_json_and_install_and_cli(ctx, subcommand, cli).map_err(Into::into)
+}
+
+/// Shared body of the `cli.analyze` branch of `bun install` / `bun add`:
+/// 1. Run the bundler's dependency scanner over the positional entry points
+/// 2. Rewrite the positionals to `[verb, ...discovered dependency names]`,
+///    acting identically to the developer typing in the dependency names
+/// 3. Re-enter the install path via `install` and exit the process
+pub(crate) fn analyze_dependencies_and_install(
+    ctx: &mut ContextData,
+    cli: &mut CommandLineArguments,
+    verb: &'static [u8],
+    install: &mut dyn FnMut(&mut ContextData, CommandLineArguments) -> Result<(), Error>,
+) -> Result<(), Error> {
+    // `ctx`/`cli` are stored as raw `*mut` because `BuildCommand::exec` holds
+    // the global `Context` (the same `ContextData`) across the `on_analyze`
+    // callback, and `DependenciesScanner.entry_points` owns a copy of
+    // `cli.positionals[1..]` for the duration of the scan; storing `&mut`
+    // here would assert exclusivity we don't have.
+    struct Analyzer<'a> {
+        ctx: *mut ContextData,
+        cli: *mut CommandLineArguments,
+        verb: &'static [u8],
+        install: &'a mut dyn FnMut(&mut ContextData, CommandLineArguments) -> Result<(), Error>,
+    }
+    impl bun_bundler::bundle_v2::OnDependenciesAnalyze for Analyzer<'_> {
+        fn on_analyze(
+            &mut self,
+            result: &mut DependenciesScannerResult<'_, '_>,
+        ) -> Result<(), bun_bundler::Error> {
+            let this = self;
+            // Process-lifetime storage for the rewritten positionals —
+            // `Global::exit(0)` follows immediately.
+            // `OnceLock` (not leaking) per PORTING.md §Forbidden.
+            static OWNED_KEYS: std::sync::OnceLock<Vec<Box<[u8]>>> = std::sync::OnceLock::new();
+            static POSITIONALS: std::sync::OnceLock<Vec<&'static [u8]>> =
+                std::sync::OnceLock::new();
+
+            let owned = OWNED_KEYS.get_or_init(|| {
+                result
+                    .dependencies
+                    .keys()
+                    .iter()
+                    .map(|k| Box::<[u8]>::from(&**k))
+                    .collect()
+            });
+            let positionals = POSITIONALS.get_or_init(|| {
+                let mut v: Vec<&'static [u8]> = Vec::with_capacity(owned.len() + 1);
+                v.push(this.verb);
+                for k in owned {
+                    v.push(&**k);
+                }
+                v
+            });
+
+            // SAFETY: `this.cli` / `this.ctx` were set from live locals in
+            // `analyze_dependencies_and_install`'s caller, whose scope
+            // encloses the entire `BuildCommand::exec` call (and hence this
+            // callback). The bundler does not touch the global `ContextData`
+            // between dependency-scan completion and `on_analyze` invocation,
+            // so forming a fresh `&mut` here is exclusive for the duration of
+            // the `install` continuation.
+            let cli = unsafe { &mut *this.cli };
+            cli.positionals = positionals.as_slice();
+            // SAFETY: see above — same invariant covers `this.ctx`.
+            let ctx = unsafe { &mut *this.ctx };
+
+            (this.install)(ctx, cli.clone()).map_err(bun_bundler::Error::from)?;
+
+            Global::exit(0);
+        }
+    }
+
+    // `DependenciesScanner.entry_points` is `Box<[Box<[u8]>]>`. Clone the
+    // argv slices into an owned buffer (small one-shot list — no perf
+    // concern). Captured *before* raw-ptr aliasing of `cli` below so the
+    // access goes through the live `&mut cli` borrow.
+    let entry_points: Box<[Box<[u8]>]> = cli.positionals[1..]
+        .iter()
+        .map(|s| Box::<[u8]>::from(*s))
+        .collect();
+
+    // Derive raw pointers from the existing `&mut` borrows; all subsequent
+    // access to `ctx` / `cli` in this function goes through these.
+    let ctx_ptr: *mut ContextData = ctx;
+    let mut analyzer = Analyzer {
+        ctx: ctx_ptr,
+        cli,
+        verb,
+        install,
+    };
+
+    let fetcher = DependenciesScanner::new(&mut analyzer, entry_points);
+
+    // `Command.get()` resolves to the same `*ContextData` already held in
+    // `ctx`; reborrow through `ctx_ptr` rather than minting a fresh
+    // `&'static mut` from the global static (which would alias the
+    // still-live `ctx` parameter under stacked borrows).
+    // SAFETY: `ctx_ptr` was just derived from the live `ctx: &mut
+    // ContextData` parameter; `ctx` is not accessed again in this function.
+    BuildCommand::exec(unsafe { &mut *ctx_ptr }, Some(&fetcher))
 }

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -587,6 +587,16 @@ enum ReplResult {
     SkipEval,
 }
 
+/// How `evaluate_to_value` reports promise rejections and interrupts.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ReportMode {
+    /// `evaluate_and_print`: a rejection also sets `_error` on globalThis, and
+    /// a promise still pending after the wait prints a newline.
+    Print,
+    /// `evaluate_and_copy`: neither of the above.
+    Copy,
+}
+
 fn cmd_help(repl: &mut Repl, _: &[u8]) -> ReplResult {
     repl.print(format_args!(
         "\n{}REPL Commands:{}\n",
@@ -1612,19 +1622,20 @@ impl<'a> Repl<'a> {
     // JavaScript Evaluation
     // ========================================================================
 
-    fn evaluate_and_print(&mut self, code: &[u8]) {
-        let Some(global) = self.global else {
-            return;
-        };
-        let Some(vm) = self.vm else {
-            return;
-        };
+    /// Run `code` through the interactive REPL pipeline: transform_for_repl,
+    /// evaluate, await any async IIFE promise (with Ctrl+C signal handling),
+    /// unwrap the `{ value: expr }` wrapper, then store the result and set `_`
+    /// on globalThis. Returns `None` when the outcome was already reported
+    /// (errors, interrupts, or raw-evaluation fallback).
+    fn evaluate_to_value(&mut self, code: &[u8], mode: ReportMode) -> Option<JSValue> {
+        let global = self.global?;
+        let vm = self.vm?;
 
         // Transform the code using REPL mode (hoists declarations, wraps result in { value: expr })
         let Some(transformed_code) = self.transform_for_repl(code) else {
             // Transform failed, try evaluating raw code (for syntax errors, etc.)
             self.evaluate_raw(code);
-            return;
+            return None;
         };
 
         // Evaluate the transformed code
@@ -1646,7 +1657,7 @@ impl<'a> Repl<'a> {
         if !exception.is_undefined() && !exception.is_null() {
             self.set_last_error(exception);
             self.print_js_error(exception);
-            return;
+            return None;
         }
 
         // Handle async IIFE results - wait for promise to resolve
@@ -1664,7 +1675,7 @@ impl<'a> Repl<'a> {
             if Self::wait_for_promise_or_sigint(vm, promise) {
                 self.print(format_args!("\n"));
                 self.disable_signals_during_wait();
-                return;
+                return None;
             }
 
             // SAFETY: `vm.jsc_vm` is the live JSC VM handle for this thread.
@@ -1677,18 +1688,22 @@ impl<'a> Repl<'a> {
                 PromiseStatus::Rejected => {
                     let rejection = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
                     self.set_last_error(rejection);
-                    // Set _error on the global object
-                    let global_this = global.to_js_value();
-                    global_this.put(global, b"_error", rejection);
+                    if mode == ReportMode::Print {
+                        // Set _error on the global object
+                        let global_this = global.to_js_value();
+                        global_this.put(global, b"_error", rejection);
+                    }
                     self.print_js_error(rejection);
                     self.disable_signals_during_wait();
-                    return;
+                    return None;
                 }
                 PromiseStatus::Pending => {
                     // Interrupted by signal or timed out
-                    self.print(format_args!("\n"));
+                    if mode == ReportMode::Print {
+                        self.print(format_args!("\n"));
+                    }
                     self.disable_signals_during_wait();
-                    return;
+                    return None;
                 }
             }
             self.disable_signals_during_wait();
@@ -1708,7 +1723,7 @@ impl<'a> Repl<'a> {
                         self.set_last_error(exc);
                         self.print_js_error(exc);
                         vm.as_mut().tick();
-                        return;
+                        return None;
                     }
                 };
             if let Some(value) = maybe_value {
@@ -1716,7 +1731,7 @@ impl<'a> Repl<'a> {
             }
         }
 
-        // Store and print result
+        // Store the result
         self.set_last_result(actual_result);
 
         // Set _ to the last result (only if not undefined)
@@ -1725,6 +1740,14 @@ impl<'a> Repl<'a> {
             let global_this = global.to_js_value();
             global_this.put(global, b"_", actual_result);
         }
+
+        Some(actual_result)
+    }
+
+    fn evaluate_and_print(&mut self, code: &[u8]) {
+        let Some(actual_result) = self.evaluate_to_value(code, ReportMode::Print) else {
+            return;
+        };
 
         if actual_result.is_undefined() {
             if self.use_colors {
@@ -1737,7 +1760,9 @@ impl<'a> Repl<'a> {
         }
 
         // Tick the event loop to handle any pending work
-        vm.as_mut().tick();
+        if let Some(vm) = self.vm {
+            vm.as_mut().tick();
+        }
     }
 
     /// Evaluate a script from `bun repl -e/--eval` or `-p/--print` non-interactively.
@@ -1919,100 +1944,20 @@ impl<'a> Repl<'a> {
 
     /// Evaluate code and copy the result to clipboard instead of printing it
     fn evaluate_and_copy(&mut self, code: &[u8]) {
-        let Some(global) = self.global else {
+        let Some(actual_result) = self.evaluate_to_value(code, ReportMode::Copy) else {
             return;
         };
-        let Some(vm) = self.vm else {
-            return;
-        };
-
-        let Some(transformed_code) = self.transform_for_repl(code) else {
-            self.evaluate_raw(code);
-            return;
-        };
-
-        let mut exception: JSValue = JSValue::UNDEFINED;
-        // SAFETY: `global` is a live opaque `JSGlobalObject` handle; slice ptr/len pairs
-        // are valid for the duration of the call; `exception` is a stack local.
-        let result = unsafe {
-            Bun__REPL__evaluate(
-                global,
-                transformed_code.as_ptr(),
-                transformed_code.len(),
-                b"[repl]".as_ptr(),
-                b"[repl]".len(),
-                &raw mut exception,
-            )
-        };
-
-        if !exception.is_undefined() && !exception.is_null() {
-            self.set_last_error(exception);
-            self.print_js_error(exception);
-            return;
-        }
-
-        let mut resolved_result = result;
-        if let Some(promise) = result.as_promise() {
-            // SAFETY: `promise` is a live JSC heap cell; `vm.jsc_vm` is the
-            // owning JSC VM handle for this thread.
-            jsc::JSPromise::opaque_mut(promise).set_handled();
-            self.enable_signals_during_wait();
-            // Wait for the promise to settle, or for a SIGINT.
-            if Self::wait_for_promise_or_sigint(vm, promise) {
-                self.print(format_args!("\n"));
-                self.disable_signals_during_wait();
-                return;
-            }
-            let jsc_vm_ref = vm.jsc_vm();
-            match jsc::JSPromise::opaque_mut(promise).status() {
-                PromiseStatus::Fulfilled => {
-                    resolved_result = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref)
-                }
-                PromiseStatus::Rejected => {
-                    let rejection = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
-                    self.set_last_error(rejection);
-                    self.print_js_error(rejection);
-                    self.disable_signals_during_wait();
-                    return;
-                }
-                PromiseStatus::Pending => {
-                    self.disable_signals_during_wait();
-                    return;
-                }
-            }
-            self.disable_signals_during_wait();
-        }
-
-        let mut actual_result = resolved_result;
-        if resolved_result.is_object() {
-            let maybe_value =
-                match resolved_result.get_own(global, &bun_core::String::static_("value")) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        let exc = global.take_exception(err);
-                        self.set_last_error(exc);
-                        self.print_js_error(exc);
-                        vm.as_mut().tick();
-                        return;
-                    }
-                };
-            if let Some(value) = maybe_value {
-                actual_result = value;
-            }
-        }
-
-        self.set_last_result(actual_result);
-        if !actual_result.is_undefined() {
-            let global_this = global.to_js_value();
-            global_this.put(global, b"_", actual_result);
-        }
 
         if let Err(err) = self.copy_value_to_clipboard(actual_result) {
-            let exc = global.take_exception(err);
-            self.set_last_error(exc);
-            self.print_js_error(exc);
+            if let Some(global) = self.global {
+                let exc = global.take_exception(err);
+                self.set_last_error(exc);
+                self.print_js_error(exc);
+            }
         }
-        vm.as_mut().tick();
+        if let Some(vm) = self.vm {
+            vm.as_mut().tick();
+        }
     }
 
     /// Format a JS value as a string suitable for clipboard.

--- a/src/runtime/cli/repl_command.rs
+++ b/src/runtime/cli/repl_command.rs
@@ -100,20 +100,7 @@ impl ReplCommand {
         // ReplRunner construction to avoid a move-after-borrow.
 
         // Configure bundler options
-        // `BundleOptions.install` is `Option<NonNull<_>>` so no
-        // lifetime-extension cast is needed.
-        let install_ptr = ctx.install.as_deref().map(core::ptr::NonNull::from);
-        b.options.install = install_ptr;
-        b.resolver.opts.install = install_ptr;
-        b.resolver.opts.global_cache = ctx.debug.global_cache;
-        let offline = ctx
-            .debug
-            .offline_mode_setting
-            .unwrap_or(OfflineMode::Online);
-        b.resolver.opts.install_preference = offline;
-        b.options.global_cache = b.resolver.opts.global_cache;
-        b.options.install_preference = offline;
-        b.resolver.env_loader = NonNull::new(b.env);
+        crate::cli::run_command::wire_install_options(b, ctx);
         b.options.env.behavior = EnvBehavior::LoadAllWithoutInlining;
         b.options.dead_code_elimination = false; // REPL needs all code
 
@@ -286,4 +273,3 @@ unsafe extern "C" {
 }
 
 use bun_bundler::options::EnvBehavior;
-use bun_options_types::offline_mode::OfflineMode;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -94,6 +94,33 @@ pub(crate) struct ConfigureEnvOptions {
     pub(crate) store_root_fd: bool,
 }
 
+/// Shared ctx→install/global-cache/offline-mode option projection for a
+/// transpiler and its resolver, used by the boot paths that run user code
+/// (`bun run`, the repl).
+pub(crate) fn wire_install_options(b: &mut Transpiler<'_>, ctx: &ContextData) {
+    use bun_options_types::offline_mode::OfflineMode;
+
+    // `BundleOptions::install` is a raw `NonNull` backref into
+    // the CLI's `Box<BunInstall>` (process-lifetime).
+    // `as_deref` yields `&BunInstall`, which
+    // `NonNull::from` converts without the lifetime tie.
+    let install_ptr = ctx.install.as_deref().map(::core::ptr::NonNull::from);
+    b.options.install = install_ptr;
+    b.resolver.opts.install = install_ptr;
+    b.resolver.opts.global_cache = ctx.debug.global_cache;
+    let offline = ctx
+        .debug
+        .offline_mode_setting
+        .unwrap_or(OfflineMode::Online);
+    b.resolver.opts.install_preference = offline;
+    b.options.global_cache = ctx.debug.global_cache;
+    b.options.install_preference = offline;
+    // Stored as `NonNull` (not `&Loader`): `configure_defines()` later
+    // reborrows the same allocation as `&mut Loader`, which would alias a
+    // live `&Loader`. The Loader outlives the resolver.
+    b.resolver.env_loader = ::core::ptr::NonNull::new(b.env);
+}
+
 pub(crate) struct RunCommand;
 
 impl RunCommand {
@@ -788,24 +815,8 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
     /// [`boot_standalone`].
     fn wire_transpiler_from_ctx(b: &mut Transpiler<'_>, ctx: &mut ContextData) {
         use bun_options_types::context::MacroOptions;
-        use bun_options_types::offline_mode::OfflineMode;
 
-        // `BundleOptions::install` is a raw `NonNull` backref into
-        // the CLI's `Box<BunInstall>` (process-lifetime).
-        // `as_deref` yields `&BunInstall`, which
-        // `NonNull::from` converts without the lifetime tie.
-        let install_ptr = ctx.install.as_deref().map(::core::ptr::NonNull::from);
-        b.options.install = install_ptr;
-        b.resolver.opts.install = install_ptr;
-        b.resolver.opts.global_cache = ctx.debug.global_cache;
-        let offline = ctx
-            .debug
-            .offline_mode_setting
-            .unwrap_or(OfflineMode::Online);
-        b.resolver.opts.install_preference = offline;
-        b.options.global_cache = ctx.debug.global_cache;
-        b.options.install_preference = offline;
-        b.resolver.env_loader = ::core::ptr::NonNull::new(b.env);
+        wire_install_options(b, ctx);
 
         b.options.minify_identifiers = ctx.bundler_options.minify_identifiers;
         b.options.minify_whitespace = ctx.bundler_options.minify_whitespace;

--- a/src/runtime/cli/run_processes_shared.rs
+++ b/src/runtime/cli/run_processes_shared.rs
@@ -1,0 +1,121 @@
+//! Helpers shared by the multi-process script runners: `filter_run`
+//! (`bun run --filter`) and `multi_run` (`bun run --parallel`/`--sequential`).
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use crate::api::bun::process::{self as spawn, Process, Rusage, Status};
+
+/// Set from a signal handler; polled by the run loops.
+pub(crate) static SHOULD_ABORT: AtomicBool = AtomicBool::new(false);
+
+pub(crate) struct AbortHandler;
+
+impl AbortHandler {
+    #[cfg(unix)]
+    extern "C" fn posix_signal_handler(
+        _sig: i32,
+        _info: *const bun_sys::posix::siginfo_t,
+        _: *const core::ffi::c_void,
+    ) {
+        SHOULD_ABORT.store(true, Ordering::SeqCst);
+    }
+
+    #[cfg(windows)]
+    extern "system" fn windows_ctrl_handler(
+        dw_ctrl_type: bun_sys::windows::DWORD,
+    ) -> bun_sys::windows::BOOL {
+        if dw_ctrl_type == bun_sys::windows::CTRL_C_EVENT {
+            SHOULD_ABORT.store(true, Ordering::SeqCst);
+            return bun_sys::windows::TRUE;
+        }
+        bun_sys::windows::FALSE
+    }
+
+    pub(crate) fn install() {
+        #[cfg(unix)]
+        {
+            // SAFETY: all-zero is a valid `libc::sigaction`; sigemptyset/sigaction are
+            // FFI calls with no extra preconditions beyond valid pointers.
+            unsafe {
+                let mut action: bun_sys::posix::Sigaction = bun_core::ffi::zeroed();
+                action.sa_sigaction = Self::posix_signal_handler as *const () as usize;
+                libc::sigemptyset(&raw mut action.sa_mask);
+                action.sa_flags = (libc::SA_SIGINFO | libc::SA_RESTART | libc::SA_RESETHAND) as _;
+                bun_sys::posix::sigaction(libc::SIGINT, &raw const action, core::ptr::null_mut());
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let res = bun_sys::windows::SetConsoleCtrlHandler(
+                Some(Self::windows_ctrl_handler),
+                bun_sys::windows::TRUE,
+            );
+            if res == 0 {
+                if bun_core::env::IS_DEBUG {
+                    bun_core::warn!("Failed to set abort handler\n");
+                }
+            }
+        }
+    }
+
+    pub(crate) fn uninstall() {
+        // only necessary on Windows, as on posix we pass the SA_RESETHAND flag
+        #[cfg(windows)]
+        {
+            // (None, FALSE) only clears the ignore attribute; unregistering the
+            // handler routine requires passing its address.
+            let _ = bun_sys::windows::SetConsoleCtrlHandler(
+                Some(Self::windows_ctrl_handler),
+                bun_sys::windows::FALSE,
+            );
+        }
+    }
+}
+
+/// `Process::watch_or_reap` with the shared error fallback: if registration
+/// fails and the process has not already exited, synthesize an error exit so
+/// the run loop still observes a terminal status.
+pub(crate) fn watch_or_reap(process: &mut Process) {
+    if let Err(err) = process.watch_or_reap() {
+        if !process.has_exited() {
+            // SAFETY: all-zero is a valid Rusage (POD C struct)
+            let rusage = bun_core::ffi::zeroed::<Rusage>();
+            process.on_exit(Status::Err(err), &rusage);
+        }
+    }
+}
+
+/// First non-zero exit code across all spawned handles; signaled/errored
+/// processes map to their signal exit code (or 1). 0 when every spawned
+/// process exited cleanly.
+pub(crate) fn aggregate_exit_code<'h>(statuses: impl Iterator<Item = Option<&'h Status>>) -> u8 {
+    for status in statuses.flatten() {
+        match status {
+            Status::Exited(exited) => {
+                if exited.code != 0 {
+                    return exited.code;
+                }
+            }
+            Status::Signaled(signal) => {
+                return bun_sys::SignalCode(*signal).to_exit_code().unwrap_or(1);
+            }
+            _ => return 1,
+        }
+    }
+    0
+}
+
+/// A `Stdio::Buffer` slot for `SpawnOptions`; on Windows this carries a freshly
+/// allocated libuv pipe whose ownership moves into the spawn result.
+pub(crate) fn buffered_stdio() -> spawn::Stdio {
+    #[cfg(unix)]
+    {
+        spawn::Stdio::Buffer
+    }
+    #[cfg(not(unix))]
+    {
+        spawn::Stdio::Buffer(bun_core::heap::into_raw(Box::new(bun_core::ffi::zeroed::<
+            bun_sys::windows::libuv::Pipe,
+        >())))
+    }
+}

--- a/src/runtime/cli/unlink_command.rs
+++ b/src/runtime/cli/unlink_command.rs
@@ -5,13 +5,11 @@ use bun_core::{Global, Output};
 use bun_paths::{AbsPath, platform, resolve_path};
 use bun_sys::{self as sys, Dir, Fd, FdDirExt};
 
-use bun_install::Features;
 use bun_install::bin as stub_bin;
 use bun_install::bin_real as bin;
-use bun_install::lockfile_real::{Lockfile, package::Package};
 use bun_install::package_manager_real::{
     self as pm, CommandLineArguments, Subcommand, attempt_to_create_package_json,
-    global_link_dir_path, options::LogLevel, package_manager_options, setup_global_dir,
+    global_link_dir_path, options::LogLevel,
 };
 
 use crate::command::ContextData;
@@ -50,66 +48,11 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
     if manager.options.positionals.len() == 1 {
         // bun unlink
 
-        let mut lockfile = Lockfile::default();
-        let mut package = Package::default();
-
         // Step 1. parse the nearest package.json file
-        {
-            let package_json_source = match bun_ast::to_source(
-                manager.original_package_json_path.as_zstr(),
-                Default::default(),
-            ) {
-                Ok(s) => s,
-                Err(e) => {
-                    Output::err_generic(
-                        "failed to read \"{}\" for unlinking: {}",
-                        (
-                            BStr::new(manager.original_package_json_path.as_bytes()),
-                            BStr::new(e.name()),
-                        ),
-                    );
-                    Global::crash();
-                }
-            };
-            lockfile.init_empty();
+        let (lockfile, package) = super::link_command::load_package_for_link(manager, "unlinking")?;
 
-            let mut resolver: () = ();
-            // `log_mut()` returns a borrow decoupled from `&self`; disjoint
-            // storage from `&mut PackageManager` (owned by the CLI `Context`).
-            let log = manager.log_mut();
-            package.parse::<()>(
-                &mut lockfile,
-                manager,
-                log,
-                &package_json_source,
-                &mut resolver,
-                Features::FOLDER,
-            )?;
-            let name = lockfile.str(&package.name);
-            if name.is_empty() {
-                if manager.options.log_level != LogLevel::Silent {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error:<r> package.json missing \"name\" <d>in \"{}\"<r>",
-                        BStr::new(package_json_source.path.text),
-                    );
-                }
-                Global::crash();
-            } else if !strings::is_npm_package_name(name) {
-                if manager.options.log_level != LogLevel::Silent {
-                    bun_core::pretty_errorln!(
-                        "<r><red>error:<r> invalid package.json name \"{}\" <d>in \"{}\"<r>",
-                        BStr::new(name),
-                        BStr::new(package_json_source.path.text),
-                    );
-                }
-                Global::crash();
-            }
-        }
-
-        // Reshaped for borrowck — `name` borrows `lockfile`; re-derive
-        // it after the parse block so its lifetime is decoupled from
-        // `package_json_source` (dropped above) while remaining a slice into
-        // `lockfile.buffers.string_bytes`.
+        // `name` is a slice into `lockfile.buffers.string_bytes`, decoupled
+        // from the helper-local package.json source.
         let name = lockfile.str(&package.name);
 
         match sys::lstat(resolve_path::join_abs_string_z::<platform::Auto>(
@@ -135,36 +78,7 @@ fn unlink(ctx: &mut ContextData) -> crate::Result<()> {
         }
 
         // Step 2. Setup the global directory
-        let node_modules: Dir = 'brk: {
-            bin::Linker::ensure_umask();
-            let explicit_global_dir: &[u8] = match &ctx.install {
-                Some(install_) => install_.global_dir.as_deref().unwrap_or(b""),
-                None => b"",
-            };
-            manager.global_dir = Some(Dir::from_fd(package_manager_options::open_global_dir(
-                explicit_global_dir,
-            )?));
-
-            setup_global_dir(manager, &&mut *ctx)?;
-
-            match manager
-                .global_dir
-                .as_ref()
-                .unwrap()
-                .make_open_path(b"node_modules", Default::default())
-            {
-                Ok(d) => break 'brk d,
-                Err(e) => {
-                    if manager.options.log_level != LogLevel::Silent {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error:<r> failed to create node_modules in global dir due to error {}",
-                            BStr::new(e.name()),
-                        );
-                    }
-                    Global::crash();
-                }
-            }
-        };
+        let node_modules: Dir = super::link_command::open_global_node_modules(manager, &mut *ctx)?;
 
         // Step 3b. Link any global bins
         if package.bin.tag != stub_bin::Tag::None {

--- a/src/runtime/cli/update_interactive_command.rs
+++ b/src/runtime/cli/update_interactive_command.rs
@@ -10,7 +10,6 @@ use bun_collections::{StringHashMap, index_sort};
 use bun_core::{Global, Output};
 use bun_install::dependency::{self, Behavior};
 use bun_install::lockfile::package::PackageColumns as _;
-use bun_install::lockfile::{LoadResult, LoadStep};
 use bun_install::package_manager::options::Do;
 use bun_install::package_manager::{
     LogLevel, Subcommand, WorkspaceFilter, populate_manifest_cache,
@@ -38,6 +37,7 @@ use bun_paths::{self as path, PathBuffer};
 use bun_semver::{self as semver, SlicedString};
 
 use crate::Command;
+use crate::cli::workspace_helpers;
 
 pub(crate) struct TerminalHyperlink<'a> {
     link: &'a [u8],
@@ -510,57 +510,12 @@ impl UpdateInteractiveCommand {
         manager: &mut PackageManager,
         groups: UpdateGroups,
     ) -> crate::Result<()> {
-        // Reshaped for borrowck — capture `log_level` / `ctx.log`
-        // before borrowing `&mut manager.lockfile`.
         let not_silent = manager.options.log_level != LogLevel::Silent;
-        let ctx_log_ptr: *mut bun_ast::Log = ctx.log;
-
-        match manager.load_lockfile_from_cwd::<true>() {
-            LoadResult::NotFound => {
-                if not_silent {
-                    Output::err_generic("missing lockfile, nothing to update", ());
-                    bun_core::note!("run 'bun install' first");
-                }
-                Global::crash();
-            }
-            LoadResult::Err(cause) => {
-                if not_silent
-                    && !bun_install::migration::reported_unsupported_lockfile_version(&cause)
-                {
-                    match cause.step {
-                        LoadStep::OpenFile => Output::err_generic(
-                            "failed to open lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ParseFile => Output::err_generic(
-                            "failed to parse lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::ReadFile => Output::err_generic(
-                            "failed to read lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                        LoadStep::Migrating => Output::err_generic(
-                            "failed to migrate lockfile: {s}",
-                            (cause.value.name(),),
-                        ),
-                    }
-                    // SAFETY: `ctx.log` is set by `Command::create_context_data`
-                    // for every subcommand and is non-null for the command's
-                    // lifetime.
-                    if unsafe { (*ctx_log_ptr).has_errors() } {
-                        manager
-                            .log_mut()
-                            .print(std::ptr::from_mut(Output::error_writer()))?;
-                    }
-                }
-                Global::crash();
-            }
-            LoadResult::Ok(_) => {
-                // `load_lockfile_from_cwd` populates `manager.lockfile` (Box)
-                // in place, so no reassignment is needed.
-            }
-        }
+        workspace_helpers::load_lockfile_or_crash(
+            ctx,
+            manager,
+            "missing lockfile, nothing to update",
+        );
 
         let workspace_pkg_ids: Vec<PackageID> =
             if !manager.options.filter_patterns.is_empty() || manager.options.do_.recursive() {

--- a/src/runtime/cli/workspace_helpers.rs
+++ b/src/runtime/cli/workspace_helpers.rs
@@ -1,0 +1,59 @@
+//! Lockfile helpers shared by `bun outdated` and `bun update --interactive`.
+
+use bun_core::{Global, Output};
+use bun_install::lockfile::{LoadResult, LoadStep};
+use bun_install::package_manager::LogLevel;
+use bun_install::{PackageManager, migration};
+
+use crate::Command;
+
+/// Load the lockfile from the current directory, reporting errors and exiting
+/// the process on failure. `missing_lockfile_message` is the error printed
+/// when there is no lockfile at all, e.g. `missing lockfile, nothing outdated`.
+pub(crate) fn load_lockfile_or_crash(
+    ctx: &Command::ContextData,
+    manager: &mut PackageManager,
+    missing_lockfile_message: &str,
+) {
+    let not_silent = manager.options.log_level != LogLevel::Silent;
+    match manager.load_lockfile_from_cwd::<true>() {
+        LoadResult::NotFound => {
+            if not_silent {
+                Output::err_generic(missing_lockfile_message, ());
+                bun_core::note!("run 'bun install' first");
+            }
+            Global::crash();
+        }
+        LoadResult::Err(cause) => {
+            if not_silent && !migration::reported_unsupported_lockfile_version(&cause) {
+                match cause.step {
+                    LoadStep::OpenFile => {
+                        Output::err_generic("failed to open lockfile: {s}", (cause.value.name(),));
+                    }
+                    LoadStep::ParseFile => {
+                        Output::err_generic("failed to parse lockfile: {s}", (cause.value.name(),));
+                    }
+                    LoadStep::ReadFile => {
+                        Output::err_generic("failed to read lockfile: {s}", (cause.value.name(),));
+                    }
+                    LoadStep::Migrating => {
+                        Output::err_generic(
+                            "failed to migrate lockfile: {s}",
+                            (cause.value.name(),),
+                        );
+                    }
+                }
+                if ctx.log_ref().has_errors() {
+                    let _ = manager
+                        .log_mut()
+                        .print(std::ptr::from_mut(Output::error_writer()));
+                }
+            }
+            Global::crash();
+        }
+        LoadResult::Ok(_) => {
+            // `load_lockfile_from_cwd` populates `manager.lockfile` in place,
+            // so no reassignment is needed.
+        }
+    }
+}

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8698,6 +8698,21 @@ describe("outdated", () => {
       expect(rest).toMatchSnapshot();
     });
   }
+  test("errors without a lockfile", async () => {
+    await write(packageJson, JSON.stringify({ name: "no-lockfile", version: "1.0.0" }));
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "outdated"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+
+    const [err, _out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+    expect(err).toContain("error: missing lockfile, nothing outdated");
+    expect(exitCode).toBe(1);
+  });
   test("in workspace", async () => {
     await Promise.all([
       write(

--- a/test/cli/install/bun-link.test.ts
+++ b/test/cli/install/bun-link.test.ts
@@ -471,3 +471,37 @@ it("should link dependency without crashing", async () => {
   // This should fail with a non-zero exit code.
   expect(await exited4).toBe(1);
 });
+
+for (const command of ["link", "unlink"]) {
+  it(`should error when ${command}ing a package without a name`, async () => {
+    await writeFile(join(link_dir, "package.json"), JSON.stringify({ version: "0.0.1" }));
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), command],
+      cwd: link_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [err, _out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+    expect(err).toContain('error: package.json missing "name"');
+    expect(exitCode).toBe(1);
+  });
+}
+
+it("should error when linking a package with an invalid name", async () => {
+  await writeFile(join(link_dir, "package.json"), JSON.stringify({ name: "NOT a valid name!", version: "0.0.1" }));
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "link"],
+    cwd: link_dir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [err, _out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+  expect(err).toContain('error: invalid package.json name "NOT a valid name!"');
+  expect(exitCode).toBe(1);
+});

--- a/test/cli/install/bun-pack.test.ts
+++ b/test/cli/install/bun-pack.test.ts
@@ -71,6 +71,16 @@ test.concurrent("basic", async () => {
   expect(tarballEntries(join(dir, "pack-basic-1.2.3.tgz"))).toEqual(["package/package.json", "package/index.js"]);
 });
 
+test.concurrent("fails when package.json cannot be parsed", async () => {
+  using dir = tempDir("pack-bad-json", {
+    "package.json": '{"name": "pack-bad-json",',
+  });
+
+  const { err, exitCode } = await runPack(dir);
+  expect(err).toContain("failed to parse package.json: <dir>/package.json");
+  expect(exitCode).toBe(1);
+});
+
 test.concurrent("package.json integers stay plain digits", async () => {
   // The packed package.json is re-printed. Integers must not come out as 1e4.
   using dir = tempDir("pack-integers", {

--- a/test/cli/install/catalogs.test.ts
+++ b/test/cli/install/catalogs.test.ts
@@ -475,6 +475,56 @@ describe("update", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("--latest keeps the npm: alias prefix and pin style of aliased catalog entries", async () => {
+    const { packageDir } = await registry.createTestDir();
+    await Promise.all([
+      write(
+        join(packageDir, "package.json"),
+        JSON.stringify({
+          name: "catalog-update-alias",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              "aliased": "npm:no-deps@^1.0.0",
+            },
+            catalogs: {
+              pinned: {
+                "aliased": "npm:no-deps@1.0.1",
+              },
+            },
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg1", "package.json"),
+        JSON.stringify({
+          name: "pkg1",
+          dependencies: {
+            "aliased": "catalog:",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "packages", "pkg2", "package.json"),
+        JSON.stringify({
+          name: "pkg2",
+          dependencies: {
+            "aliased": "catalog:pinned",
+          },
+        }),
+      ),
+    ]);
+    await runBunInstall(bunEnv, packageDir);
+
+    const { err, exitCode } = await runUpdate(packageDir, "--latest");
+    expect(err).not.toContain("error:");
+
+    const root = await file(join(packageDir, "package.json")).json();
+    expect(root.workspaces.catalog).toEqual({ "aliased": "npm:no-deps@^2.0.0" });
+    expect(root.workspaces.catalogs.pinned).toEqual({ "aliased": "npm:no-deps@2.0.0" });
+    expect(exitCode).toBe(0);
+  });
+
   for (const fromWorkspace of [false, true]) {
     test(`--latest --dry-run does not modify any package.json (from ${fromWorkspace ? "workspace" : "root"})`, async () => {
       const { packageDir } = await registry.createTestDir();

--- a/test/cli/install/hosted-git-info/from-url.test.ts
+++ b/test/cli/install/hosted-git-info/from-url.test.ts
@@ -18,6 +18,57 @@ describe("fromUrl", () => {
     });
   });
 
+  // bitbucket, gist, and sourcehut share the `/user/project[/aux]` extractor;
+  // these pin the per-host differences it is parameterized on.
+  describe("user/project extractors", () => {
+    it.each([
+      // tarball-ish aux segment rejected per host
+      "https://bitbucket.org/foo/bar/get/archive.tar.gz",
+      "https://gist.github.com/foo/feedbeef/raw/fix%2Fbug/",
+      "https://git.sr.ht/~foo/bar/archive/HEAD.tar.gz",
+      // missing project (gist: missing both user and project)
+      "https://bitbucket.org/foo",
+      "https://git.sr.ht/~foo",
+      "https://gist.github.com/",
+      // user is required everywhere except gist
+      "https://bitbucket.org//bar",
+      "https://git.sr.ht//bar",
+    ])("%s is not a hosted git url", url => {
+      expect(hostedGitInfo.fromUrl(url)).toBeNull();
+    });
+
+    // The rejected aux segment is per host: another host's segment parses.
+    it.each([
+      ["https://bitbucket.org/foo/bar/raw", { type: "bitbucket", user: "foo", project: "bar" }],
+      ["https://bitbucket.org/foo/bar/archive", { type: "bitbucket", user: "foo", project: "bar" }],
+      ["https://gist.github.com/foo/feedbeef/get", { type: "gist", user: "foo", project: "feedbeef" }],
+      ["https://gist.github.com/foo/feedbeef/archive", { type: "gist", user: "foo", project: "feedbeef" }],
+      ["https://git.sr.ht/~foo/bar/get", { type: "sourcehut", user: "~foo", project: "bar" }],
+      ["https://git.sr.ht/~foo/bar/raw", { type: "sourcehut", user: "~foo", project: "bar" }],
+    ])("%s parses despite the aux segment", (url, expected) => {
+      expect(hostedGitInfo.fromUrl(url)).toMatchObject(expected);
+    });
+
+    it.each([
+      ["https://gist.github.com/feedbeef", null],
+      ["https://gist.github.com//feedbeef", null],
+      ["https://gist.github.com/foo/feedbeef", "foo"],
+    ])("gist %s has user %p", (url, user) => {
+      expect(hostedGitInfo.fromUrl(url)).toMatchObject({ type: "gist", user, project: "feedbeef" });
+    });
+
+    it.each(["https://gist.github.com/foo/bar%0N", "https://git.sr.ht/~foo/bar%0N"])(
+      "%s with an undecodable project is not a hosted git url",
+      url => {
+        expect(hostedGitInfo.fromUrl(url)).toBeNull();
+      },
+    );
+
+    it("bitbucket rejects an undecodable project as an invalid url", () => {
+      expect(() => hostedGitInfo.fromUrl("https://bitbucket.org/foo/bar%0N")).toThrow("Invalid Git URL: InvalidURL");
+    });
+  });
+
   // TODO(markovejnovic): Unskip these tests.
   describe.skip("invalid urls", () => {
     describe.each(Object.entries(invalidGitUrls))("%s", (_, urls: (string | null | undefined)[]) => {

--- a/test/cli/update_interactive_install.test.ts
+++ b/test/cli/update_interactive_install.test.ts
@@ -240,3 +240,24 @@ describe.concurrent("bun update --interactive actually installs packages", () =>
     expect(pkg.dependencies["is-even"]).toBe("0.1.0");
   });
 });
+
+describe.concurrent("bun update --interactive error handling", () => {
+  test("errors without a lockfile", async () => {
+    using dir = tempDir("update-interactive-no-lockfile", {
+      "package.json": JSON.stringify({ name: "no-lockfile", version: "1.0.0" }),
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "update", "--interactive"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stderr, _stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+    expect(stderr).toContain("error: missing lockfile, nothing to update");
+    expect(exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## What this does

Consolidates duplicated blocks across the package manager and CLI commands (`bun install`/`add`/`update`/`link`/`unlink`/`outdated`/`update --interactive`/`pack`/`bunx`/`create`/`run --filter|--parallel|--sequential`/repl): the two `PackageManager` init paths, root package.json parsing, the trusted-dependency lifecycle enqueue, task-callback registration, tarball error dispatch, the patch path-package loader, the Windows copyfile/symlink walker, the hosted_git_info bitbucket/gist/sourcehut extractor tail, the yarn.lock dependency-group loop, the isolated-install enqueue failure path, and on the CLI side the lockfile load-or-crash, run-process plumbing (`run_processes_shared.rs`), `--analyze`, the bunx cached-bin probe, create's template-dir probe, link/unlink setup, pack's queue drain, run/repl install wiring, and the repl evaluate pipeline. 34 files, +1964/-2699.

Split from #31912. This PR only moves and removes code; zero intended behavior change. It originally sat on #32000 (since closed) and now targets `main` directly.

## Behavioral equivalence

Audited hunk by hunk against main: error messages, log-flush order, and exit semantics are byte-identical at every call site, with two reviewed edge-path exceptions:

1. bunx: the second cached-bin probe (the package.json bin-name retry) now builds its probe path with the platform separator, matching the first probe; it previously used literal `/`. On Windows the bytes differ but name the same file (`which_win` takes the absolute-path branch, and every consumer accepts both separators).
2. `load_lockfile_or_crash` ignores a failed `Log::print` to stderr where `bun update --interactive` propagated it with `?`. The path is unreachable: the writer behind `Output::error_writer()` discards fd write failures and always returns `Ok` (`adapter_write_all` in `src/sys/lib.rs`).

Where the original copies genuinely differ (trusted-deps lockfile gating in PackageInstaller, the per-backend Windows file actions, the per-path init fields, each command's missing-lockfile wording, gitlab's distinct URL extractor, pack's own package.json error wording), the helpers take the difference as a parameter instead of collapsing it.

`write_shared_default_fields` was re-derived against the current struct: 72 shared writes plus 12 per-path writes cover all 84 fields exactly once on both init paths, with values identical to main's inline writes; the 12 per-path fields are the ones whose values differ between the paths or capture locals.

## Rebase onto current main

Main has since deduplicated several of the same blocks itself, so those pieces of this PR were dropped in favor of main's versions rather than adding a second helper: version-literal replacement (`updated_version_literal`), bundleDependencies extraction (`collect_bundled_deps`), root workspace resolution in enqueue (`root_workspace_package_id`), workspace enumeration for outdated/update -i (`WorkspaceFilter::select_workspaces`), and the root package.json load (`root_package_json_source`, which `parse_root_package` now calls). `npm.rs`, `PackageJSONEditor.rs`, and `WorkspacePackageJSONCache.rs` are no longer touched.

Upstream changes that landed inside blocks this PR consolidates were ported into the helpers: the `run 'bun install' first` note and the unsupported-lockfile-version guard in `load_lockfile_or_crash` (which now takes each command's message, since main's wording differs between outdated and update -i); the install file-count removal and walker ownership change in `walk_install_dir_windows`; the npm-vs-alias trusted-name selection in `enqueue_lifecycle_scripts_for_trusted`; `print_resolution_label` in `load_path_package`; pack's stat error now naming the path in both modes; the 12 new and 1 removed `PackageManager` fields; and the appended-task checks at the enqueue call sites.

Later rebases were small: the repl SIGINT wait moved to `wait_for_promise_or_sigint` on both of the bodies merged into `evaluate_to_value` (carried once in the helper), and `bun pm diff` extracted `published_files` out of `pack()` at the same insertion point as `load_package_json_or_exit`, so both now sit side by side and `pack()` calls `published_files` as on main. The init field coverage was re-checked after each. Most recently, the binary-size pass turned `run_tasks` into a monomorphic `run_tasks_erased` driven by an `ErasedCallbacks` table, so `dispatch_tarball_error` now takes `&ErasedCallbacks` and the erased `*mut ()` context and dispatches through the table exactly as main's two inline copies do; `bun_core::String` owning its WTF ref (#40238) retyped the extractors from `&JscUrl` to `&URL` and dropped the `OwnedString::new` wrappers, which the shared `user_project_committish` follows; most recently, main's git-on-the-install-thread work (#40734) added three `PackageManager` fields, now in `write_shared_default_fields` (84 fields, 72 shared + 12 per path), plus a third git-arm task-callback site that now goes through `push_dependency_task_callback` like its two siblings, and main's hardlink-safe copy changes (#41228: `O_EXCL` + unlink-and-retry on posix, `CopyFileW` fail-if-exists + `DeleteFileW` retry and `last_system_errno` on Windows) were ported into the copyfile `copy` fn and the `walk_install_dir_windows` per-file closure; the same pass's dead-code removals in the other overlapping files were outside the consolidated blocks.

## Tests

- The shared error exits are pinned: package.json name validation for `bun link`/`bun unlink` (bun-link.test.ts), pack's package.json parse failure (bun-pack.test.ts), and the missing-lockfile error for `bun outdated` and `bun update --interactive` (bun-install-registry.test.ts, update_interactive_install.test.ts, using each command's current wording).
- `fromUrl` cases pin the per-host parameters of the shared extractor (rejected aux segment, foreign aux segments accepted, missing user/project, gist's optional user, undecodable segments), and catalogs.test.ts covers `bun update --latest` on aliased catalog entries. These describe pre-existing behavior and also pass on a release build of main.

## Verification

- `bun run rust:check-all` (all CI targets) is clean; the branch builds with `bun bd`.
- Debug-build runs pass for: hosted-git-info (3 files), catalogs, update_interactive_install, bun-link, bun-pack, the outdated group of bun-install-registry, bun-patch, bun-install-patch, yarn-lock-migration, repl, filter-workspace, multi-run, bun-run. bun-install-lifecycle-scripts matches the released binary except for three cases that fail only under the `bun bd test` wrapper's inherited npm environment and pass when the same binary runs the file directly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 25 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/cli/install/bun-pack.test.ts, test/cli/install/bun-link.test.ts, test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->



