### PR TITLE
Deduplicate webcore blob, sink, and S3 helpers

### DIFF
--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -216,9 +216,8 @@ impl crate::webcore::sink::JsSinkType for ArrayBufferSink {
     const HAS_FLUSH_FROM_JS: bool = true;
     const START_TAG: Option<streams::StartTag> = Some(streams::StartTag::ArrayBufferSink);
 
-    fn memory_cost(&self) -> usize {
-        Self::memory_cost(self)
-    }
+    crate::impl_js_sink_forwarders!();
+
     fn finalize(&mut self) {
         // The `JSSink::finalize` C export owns destroying the heap
         // allocation; the trait impl here is the *inner* finalize.
@@ -226,18 +225,6 @@ impl crate::webcore::sink::JsSinkType for ArrayBufferSink {
     }
     fn construct(this: &mut core::mem::MaybeUninit<Self>) {
         Self::construct(this);
-    }
-    fn write_bytes(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write(self, data)
-    }
-    fn write_utf16(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write_utf16(self, data)
-    }
-    fn write_latin1(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write_latin1(self, data)
-    }
-    fn end(&mut self, err: Option<syscall::Error>) -> bun_sys::Result<()> {
-        Self::end(self, err)
     }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         match Self::end_from_js(self, global) {
@@ -247,15 +234,6 @@ impl crate::webcore::sink::JsSinkType for ArrayBufferSink {
             }),
             bun_sys::Result::Err(e) => bun_sys::Result::Err(e),
         }
-    }
-    fn flush(&mut self) -> bun_sys::Result<()> {
-        Self::flush(self)
-    }
-    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> bun_sys::Result<JSValue> {
-        Self::flush_from_js(self, global, wait)
-    }
-    fn start(&mut self, config: streams::Start) -> bun_sys::Result<()> {
-        Self::start(self, &config)
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {
         Some(&mut self.source)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7126,12 +7126,9 @@ macro_rules! impl_file_closer {
             }
 
             fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
+                use ::bun_io::IntrusiveIoRequest as _;
                 // SAFETY: `request` is `&mut self.io_request` (intrusive); recover parent.
-                let this = unsafe {
-                    <$T as ::bun_io::IntrusiveIoRequest>::from_io_request(::core::ptr::from_mut(
-                        request,
-                    ))
-                };
+                let this = unsafe { $T::from_io_request(::core::ptr::from_mut(request)) };
                 fn on_done(ctx: *mut ()) {
                     // SAFETY: ctx is `self as *mut Self` set below.
                     let this = unsafe { ::bun_ptr::callback_ctx::<$T>(ctx.cast()) };
@@ -7156,11 +7153,11 @@ macro_rules! impl_file_closer {
             // in `on_io_request_closed` and is guaranteed live.
             #[allow(clippy::not_unsafe_ptr_arg_deref)]
             fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
+                use ::bun_threading::IntrusiveWorkTask as _;
                 // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
                 // `&mut self.task` (intrusive) registered in `on_io_request_closed`;
                 // recover parent.
-                let this =
-                    unsafe { <$T as ::bun_threading::IntrusiveWorkTask>::from_task_ptr(task) };
+                let this = unsafe { $T::from_task_ptr(task) };
                 // SAFETY: `this` is the live parent (see above); scoped access.
                 unsafe { (*this).close_after_io = false };
                 // SAFETY: as above; exclusive borrow scoped to the call.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1324,24 +1324,7 @@ impl BlobExt for Blob {
                 }
                 if let Some(content_type) = options_object.get_truthy(global_this, "type")? {
                     // override the content type
-                    if !content_type.is_string() {
-                        return Err(global_this.throw_invalid_argument_type(
-                            "write",
-                            "options.type",
-                            "string",
-                        ));
-                    }
-                    let content_type_str = content_type.to_slice(global_this)?;
-                    let slice = content_type_str.slice();
-                    if is_valid_blob_type(slice) {
-                        self.content_type_was_set.set(true);
-                        self.content_type.set(
-                            match global_this.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
-                    }
+                    set_content_type_from_js(global_this, self, content_type)?;
                 }
             } else if !options_object.is_empty_or_undefined_or_null() {
                 return Err(global_this.throw_invalid_argument_type("write", "options", "object"));
@@ -1721,24 +1704,7 @@ impl BlobExt for Blob {
                 let options = arg0;
                 if let Some(content_type) = options.get_truthy(global_this, "type")? {
                     // override the content type
-                    if !content_type.is_string() {
-                        return Err(global_this.throw_invalid_argument_type(
-                            "write",
-                            "options.type",
-                            "string",
-                        ));
-                    }
-                    let content_type_str = content_type.to_slice(global_this)?;
-                    let slice = content_type_str.slice();
-                    if is_valid_blob_type(slice) {
-                        self.content_type_was_set.set(true);
-                        self.content_type.set(
-                            match global_this.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => BlobContentType::from(mime),
-                                None => BlobContentType::from_lowercased(slice),
-                            },
-                        );
-                    }
+                    set_content_type_from_js(global_this, self, content_type)?;
                 }
 
                 let content_disposition_str: Option<ZigStringSlice> =
@@ -3281,20 +3247,7 @@ impl BlobExt for Blob {
                     }
                 }
 
-                jsc::JSType::ArrayBuffer
-                | jsc::JSType::Int8Array
-                | jsc::JSType::Uint8Array
-                | jsc::JSType::Uint8ClampedArray
-                | jsc::JSType::Int16Array
-                | jsc::JSType::Uint16Array
-                | jsc::JSType::Int32Array
-                | jsc::JSType::Uint32Array
-                | jsc::JSType::Float16Array
-                | jsc::JSType::Float32Array
-                | jsc::JSType::Float64Array
-                | jsc::JSType::BigInt64Array
-                | jsc::JSType::BigUint64Array
-                | jsc::JSType::DataView => {
+                t if t.is_array_buffer_like() => {
                     return Blob::try_create(
                         top_value.as_array_buffer(global).unwrap().byte_slice(),
                         global,
@@ -3419,21 +3372,8 @@ impl BlobExt for Blob {
                                 continue;
                             }
                             match item.js_type_loose() {
-                                jsc::JSType::String
-                                | jsc::JSType::ArrayBuffer
-                                | jsc::JSType::Int8Array
-                                | jsc::JSType::Uint8Array
-                                | jsc::JSType::Uint8ClampedArray
-                                | jsc::JSType::Int16Array
-                                | jsc::JSType::Uint16Array
-                                | jsc::JSType::Int32Array
-                                | jsc::JSType::Uint32Array
-                                | jsc::JSType::Float16Array
-                                | jsc::JSType::Float32Array
-                                | jsc::JSType::Float64Array
-                                | jsc::JSType::BigInt64Array
-                                | jsc::JSType::BigUint64Array
-                                | jsc::JSType::DataView => {}
+                                jsc::JSType::String => {}
+                                t if t.is_array_buffer_like() => {}
                                 jsc::JSType::DOMWrapper
                                     if item.as_class_ref::<Blob>().is_some() => {}
                                 _ => {
@@ -3462,20 +3402,7 @@ impl BlobExt for Blob {
                                     joiner.push_cloned(sliced.slice());
                                     continue;
                                 }
-                                jsc::JSType::ArrayBuffer
-                                | jsc::JSType::Int8Array
-                                | jsc::JSType::Uint8Array
-                                | jsc::JSType::Uint8ClampedArray
-                                | jsc::JSType::Int16Array
-                                | jsc::JSType::Uint16Array
-                                | jsc::JSType::Int32Array
-                                | jsc::JSType::Uint32Array
-                                | jsc::JSType::Float16Array
-                                | jsc::JSType::Float32Array
-                                | jsc::JSType::Float64Array
-                                | jsc::JSType::BigInt64Array
-                                | jsc::JSType::BigUint64Array
-                                | jsc::JSType::DataView => {
+                                t if t.is_array_buffer_like() => {
                                     could_have_non_ascii = true;
                                     let buf = item.as_array_buffer(global).unwrap();
                                     if parts_can_run_js {
@@ -3552,20 +3479,7 @@ impl BlobExt for Blob {
                     }
                 }
 
-                jsc::JSType::ArrayBuffer
-                | jsc::JSType::Int8Array
-                | jsc::JSType::Uint8Array
-                | jsc::JSType::Uint8ClampedArray
-                | jsc::JSType::Int16Array
-                | jsc::JSType::Uint16Array
-                | jsc::JSType::Int32Array
-                | jsc::JSType::Uint32Array
-                | jsc::JSType::Float16Array
-                | jsc::JSType::Float32Array
-                | jsc::JSType::Float64Array
-                | jsc::JSType::BigInt64Array
-                | jsc::JSType::BigUint64Array
-                | jsc::JSType::DataView => {
+                t if t.is_array_buffer_like() => {
                     let buf = current.as_array_buffer(global).unwrap();
                     // SAFETY: this arm is only reached when the typed array is the
                     // top-level value (the walk stack is empty), so no user JS runs
@@ -5314,6 +5228,29 @@ fn validate_writable_blob(global_this: &JSGlobalObject, blob: &Blob) -> JsResult
         return Err(global_this.throw_invalid_arguments(format_args!(
             "Cannot write to a Blob backed by bytes, which are always read-only"
         )));
+    }
+    Ok(())
+}
+
+/// Applies a write-path `options.type` override to `blob`. Throws if the
+/// value is not a string; an invalid blob type is silently ignored.
+fn set_content_type_from_js(
+    global_this: &JSGlobalObject,
+    blob: &Blob,
+    content_type: JSValue,
+) -> JsResult<()> {
+    if !content_type.is_string() {
+        return Err(global_this.throw_invalid_argument_type("write", "options.type", "string"));
+    }
+    let content_type_str = content_type.to_slice(global_this)?;
+    let slice = content_type_str.slice();
+    if is_valid_blob_type(slice) {
+        blob.content_type_was_set.set(true);
+        blob.content_type
+            .set(match global_this.bun_vm().as_mut().mime_type(slice) {
+                Some(mime) => BlobContentType::from(mime),
+                None => BlobContentType::from_lowercased(slice),
+            });
     }
     Ok(())
 }
@@ -7148,3 +7085,88 @@ pub trait FileCloser: Sized {
         false
     }
 }
+
+/// Implements [`FileCloser`] for a task struct with the standard field set
+/// (`opened_fd`, `close_after_io`, `state`, `io_request`, `io_poll`, `task`),
+/// an inherent `update()`, and a [`bun_io::Tag`] variant named after the type.
+/// The type must also carry `bun_threading::intrusive_work_task!` and
+/// `bun_io::intrusive_io_request!`, which provide the parent-pointer recovery
+/// used by the two trampolines.
+macro_rules! impl_file_closer {
+    ($T:ident) => {
+        impl crate::webcore::blob::FileCloser for $T {
+            const IO_TAG: ::bun_io::Tag = ::bun_io::Tag::$T;
+            fn opened_fd(&self) -> ::bun_sys::Fd {
+                self.opened_fd
+            }
+            fn set_opened_fd(&mut self, fd: ::bun_sys::Fd) {
+                self.opened_fd = fd;
+            }
+            fn close_after_io(&self) -> bool {
+                self.close_after_io
+            }
+            fn state(&self) -> &::core::sync::atomic::AtomicU8 {
+                &self.state
+            }
+            fn io_request(&mut self) -> Option<&mut ::bun_io::Request> {
+                Some(&mut self.io_request)
+            }
+            fn io_poll(&mut self) -> &mut ::bun_io::Poll {
+                &mut self.io_poll
+            }
+            fn task(&mut self) -> &mut ::bun_jsc::WorkPoolTask {
+                &mut self.task
+            }
+            fn update(&mut self) {
+                $T::update(self)
+            }
+            #[cfg(windows)]
+            fn loop_(&self) -> *mut ::bun_libuv_sys::uv_loop_t {
+                unreachable!()
+            }
+
+            fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
+                // SAFETY: `request` is `&mut self.io_request` (intrusive); recover parent.
+                let this = unsafe {
+                    <$T as ::bun_io::IntrusiveIoRequest>::from_io_request(::core::ptr::from_mut(
+                        request,
+                    ))
+                };
+                fn on_done(ctx: *mut ()) {
+                    // SAFETY: ctx is `self as *mut Self` set below.
+                    let this = unsafe { ::bun_ptr::callback_ctx::<$T>(ctx.cast()) };
+                    <$T as crate::webcore::blob::FileCloser>::on_io_request_closed(this);
+                }
+                // SAFETY: `request` is `&mut self.io_request` (intrusive), so `this` is the
+                // live parent; the `fd` copy and the `io_poll` field borrow are the only
+                // borrows formed.
+                let (fd, poll) = unsafe { ((*this).opened_fd, &mut (*this).io_poll) };
+                ::bun_io::Action::Close(::bun_io::CloseAction {
+                    fd,
+                    poll,
+                    ctx: this.cast::<()>(),
+                    tag: <Self as crate::webcore::blob::FileCloser>::IO_TAG,
+                    on_done,
+                })
+            }
+
+            // `FileCloser` fixes `on_close_io_request` to take `*mut WorkPoolTask`;
+            // the trait method cannot be marked `unsafe fn`, so the lint is
+            // unsatisfiable here. The pointer is the intrusive `&mut self.task` set
+            // in `on_io_request_closed` and is guaranteed live.
+            #[allow(clippy::not_unsafe_ptr_arg_deref)]
+            fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
+                // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
+                // `&mut self.task` (intrusive) registered in `on_io_request_closed`;
+                // recover parent.
+                let this =
+                    unsafe { <$T as ::bun_threading::IntrusiveWorkTask>::from_task_ptr(task) };
+                // SAFETY: `this` is the live parent (see above); scoped access.
+                unsafe { (*this).close_after_io = false };
+                // SAFETY: as above; exclusive borrow scoped to the call.
+                $T::update(unsafe { &mut *this });
+            }
+        }
+    };
+}
+pub(crate) use impl_file_closer;

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -1289,9 +1289,8 @@ impl crate::webcore::sink::JsSinkType for FileSink {
     const HAS_GET_FD: bool = true;
     const START_TAG: Option<streams::StartTag> = Some(streams::StartTag::FileSink);
 
-    fn memory_cost(&self) -> usize {
-        Self::memory_cost(self)
-    }
+    crate::impl_js_sink_forwarders!();
+
     fn finalize(&mut self) {
         Self::finalize(self)
     }
@@ -1300,29 +1299,8 @@ impl crate::webcore::sink::JsSinkType for FileSink {
         // the C++ `JSFileSink` wrapper `js_construct` is about to create.
         this.write(Self::construct());
     }
-    fn write_bytes(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write(self, data)
-    }
-    fn write_utf16(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write_utf16(self, data)
-    }
-    fn write_latin1(&mut self, data: &streams::Result) -> streams::result::Writable {
-        Self::write_latin1(self, data)
-    }
-    fn end(&mut self, err: Option<sys::Error>) -> sys::Result<()> {
-        Self::end(self, err)
-    }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> sys::Result<JSValue> {
         Self::end_from_js(self, global)
-    }
-    fn flush(&mut self) -> sys::Result<()> {
-        Self::flush(self)
-    }
-    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> sys::Result<JSValue> {
-        Self::flush_from_js(self, global, wait)
-    }
-    fn start(&mut self, config: streams::Start) -> sys::Result<()> {
-        Self::start(self, &config)
     }
     fn source(&mut self) -> Option<&mut streams::SourceHandle> {
         // SAFETY: JsCell — trait receiver is `&mut self`; sole borrow of `source`.

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -81,6 +81,16 @@ impl S3CredentialsExt for S3Credentials {
     }
 }
 
+/// How [`S3Client::blob_and_options`] reports a missing or unparseable path
+/// argument. `presign`/`exists`/`size`/`stat` distinguish "no argument"
+/// (`MISSING_ARGS`) from "argument is not a path" (invalid arguments), while
+/// `unlink` reports `MISSING_ARGS` for both.
+#[derive(Clone, Copy)]
+enum MissingPathError {
+    MissingOrInvalid,
+    AlwaysMissingArgs,
+}
+
 #[inline]
 fn opt_js(v: JSValue) -> Option<JSValue> {
     if v.is_empty_or_undefined_or_null() {
@@ -337,6 +347,58 @@ impl S3Client {
         Ok(())
     }
 
+    /// Constructs the S3 blob for `path` from this client's credentials and
+    /// per-client defaults merged with the per-call `options` object. The
+    /// returned blob releases its store ref on drop (the Zig `defer
+    /// blob.detach()`).
+    fn construct_blob(
+        &self,
+        global: &JSGlobalObject,
+        path: PathLike,
+        options: Option<JSValue>,
+    ) -> JsResult<crate::webcore::blob::Blob> {
+        S3File::construct_s3_file_with_s3_credentials_and_options(
+            global,
+            path,
+            options,
+            &self.credentials,
+            self.options,
+            self.acl,
+            self.storage_class,
+            self.request_payer,
+        )
+    }
+
+    /// Shared prologue of the `(path, options?)` instance methods: parses the
+    /// path, eats the options argument, and constructs the blob. `verb`
+    /// completes the "Expected a path to {verb}" error message.
+    fn blob_and_options(
+        &self,
+        global: &JSGlobalObject,
+        callframe: &CallFrame,
+        verb: &str,
+        missing_path: MissingPathError,
+    ) -> JsResult<(crate::webcore::blob::Blob, Option<JSValue>)> {
+        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
+        let vm = global.bun_vm();
+        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
+        let Some(path) = PathLike::from_js(global, &mut args)? else {
+            return Err(match missing_path {
+                MissingPathError::MissingOrInvalid if args.len() != 0 => {
+                    global.throw_invalid_arguments(format_args!("Expected a path to {verb}"))
+                }
+                _ => global
+                    .err(
+                        ErrorCode::MISSING_ARGS,
+                        format_args!("Expected a path to {verb}"),
+                    )
+                    .throw(),
+            });
+        };
+        let options = args.next_eat();
+        Ok((self.construct_blob(global, path, options)?, options))
+    }
+
     #[bun_jsc::host_fn(method)]
     pub(crate) fn file(
         ptr: &Self,
@@ -360,18 +422,7 @@ impl S3Client {
         let options = args.next_eat();
         // `Blob::new` heap-promotes and marks `ref_count = 1` so
         // the JSS3File wrapper's `finalize` knows to free the blob.
-        let blob = crate::webcore::blob::Blob::new(
-            S3File::construct_s3_file_with_s3_credentials_and_options(
-                global,
-                path,
-                options,
-                &ptr.credentials,
-                ptr.options,
-                ptr.acl,
-                ptr.storage_class,
-                ptr.request_payer,
-            )?,
-        );
+        let blob = crate::webcore::blob::Blob::new(ptr.construct_blob(global, path, options)?);
         // `to_js` runs `calculateEstimatedByteSize()`
         // before wrapping the heap Blob in a JSS3File so JSC sees the correct
         // GC pressure. Route through `BlobExt::to_js` (the `&mut self` method
@@ -387,38 +438,11 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
-        let vm = global.bun_vm();
-        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
-        let path: PathLike = match PathLike::from_js(global, &mut args)? {
-            Some(p) => p,
-            None => {
-                if args.len() == 0 {
-                    return Err(global
-                        .err(
-                            ErrorCode::MISSING_ARGS,
-                            format_args!("Expected a path to presign"),
-                        )
-                        .throw());
-                }
-                return Err(
-                    global.throw_invalid_arguments(format_args!("Expected a path to presign"))
-                );
-            }
-        };
-
-        let options = args.next_eat();
-        // `defer blob.detach()` — `Blob`'s `store: Option<StoreRef>` field
-        // drops at scope exit, which calls `Store::deref()` (same as detach).
-        let mut blob = S3File::construct_s3_file_with_s3_credentials_and_options(
+        let (mut blob, options) = ptr.blob_and_options(
             global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
+            callframe,
+            "presign",
+            MissingPathError::MissingOrInvalid,
         )?;
         S3File::get_presign_url_from(&mut blob, global, options)
     }
@@ -429,36 +453,11 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
-        let vm = global.bun_vm();
-        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
-        let path: PathLike = match PathLike::from_js(global, &mut args)? {
-            Some(p) => p,
-            None => {
-                if args.len() == 0 {
-                    return Err(global
-                        .err(
-                            ErrorCode::MISSING_ARGS,
-                            format_args!("Expected a path to check if it exists"),
-                        )
-                        .throw());
-                }
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Expected a path to check if it exists"
-                )));
-            }
-        };
-        let options = args.next_eat();
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
-        let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
+        let (blob, _) = ptr.blob_and_options(
             global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
+            callframe,
+            "check if it exists",
+            MissingPathError::MissingOrInvalid,
         )?;
         S3File::S3BlobStatTask::exists(global, &blob)
     }
@@ -469,36 +468,11 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
-        let vm = global.bun_vm();
-        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
-        let path: PathLike = match PathLike::from_js(global, &mut args)? {
-            Some(p) => p,
-            None => {
-                if args.len() == 0 {
-                    return Err(global
-                        .err(
-                            ErrorCode::MISSING_ARGS,
-                            format_args!("Expected a path to check the size of"),
-                        )
-                        .throw());
-                }
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Expected a path to check the size of"
-                )));
-            }
-        };
-        let options = args.next_eat();
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
-        let mut blob = S3File::construct_s3_file_with_s3_credentials_and_options(
+        let (mut blob, _) = ptr.blob_and_options(
             global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
+            callframe,
+            "check the size of",
+            MissingPathError::MissingOrInvalid,
         )?;
         S3File::S3BlobStatTask::size(global, &mut blob)
     }
@@ -509,36 +483,11 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
-        let vm = global.bun_vm();
-        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
-        let path: PathLike = match PathLike::from_js(global, &mut args)? {
-            Some(p) => p,
-            None => {
-                if args.len() == 0 {
-                    return Err(global
-                        .err(
-                            ErrorCode::MISSING_ARGS,
-                            format_args!("Expected a path to check the stat of"),
-                        )
-                        .throw());
-                }
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Expected a path to check the stat of"
-                )));
-            }
-        };
-        let options = args.next_eat();
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
-        let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
+        let (blob, _) = ptr.blob_and_options(
             global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
+            callframe,
+            "check the stat of",
+            MissingPathError::MissingOrInvalid,
         )?;
         S3File::S3BlobStatTask::stat(global, &blob)
     }
@@ -573,16 +522,7 @@ impl S3Client {
         };
 
         let options = args.next_eat();
-        let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
-            global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
-        )?;
+        let blob = ptr.construct_blob(global, path, options)?;
         // Move into `PathOrBlob` directly; cleanup of the moved-out value is
         // handled by `Drop`.
         let mut blob_internal = crate::webcore::node_types::PathOrBlob::Blob(Box::new(blob));
@@ -634,31 +574,11 @@ impl S3Client {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        // SAFETY: `bun_vm()` returns the live VM pointer for `global`.
-        let vm = global.bun_vm();
-        let mut args = bun_jsc::call_frame::ArgumentsSlice::init(vm, callframe.arguments());
-        let path: PathLike = match PathLike::from_js(global, &mut args)? {
-            Some(p) => p,
-            None => {
-                return Err(global
-                    .err(
-                        ErrorCode::MISSING_ARGS,
-                        format_args!("Expected a path to unlink"),
-                    )
-                    .throw());
-            }
-        };
-        let options = args.next_eat();
-        // `defer blob.detach()` — handled by Drop of `Option<StoreRef>` field.
-        let blob = S3File::construct_s3_file_with_s3_credentials_and_options(
+        let (blob, options) = ptr.blob_and_options(
             global,
-            path,
-            options,
-            &ptr.credentials,
-            ptr.options,
-            ptr.acl,
-            ptr.storage_class,
-            ptr.request_payer,
+            callframe,
+            "unlink",
+            MissingPathError::AlwaysMissingArgs,
         )?;
         let store = blob.store.get().as_ref().unwrap();
         store.data.as_s3().unlink(store, global, options)

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -105,16 +105,14 @@ where
     Ok(())
 }
 
-#[bun_jsc::host_fn]
-pub(crate) fn presign(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
-    // SAFETY: bun_vm() returns the live VM raw ptr.
-    let mut args =
-        bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
-
-    // accept a path or a blob
-    let path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-    // PathOrBlob impls Drop — path variant cleaned up automatically on `?`
-
+/// Shared prologue of the S3 static host fns: parse the first argument as a
+/// path or Blob and require Blob arguments to be S3-backed.
+fn parse_s3_path_or_blob(
+    global: &JSGlobalObject,
+    args: &mut bun_jsc::call_frame::ArgumentsSlice,
+    error_message: &str,
+) -> JsResult<PathOrBlob> {
+    let path_or_blob = PathOrBlob::from_js_no_copy(global, args)?;
     if let PathOrBlob::Blob(blob) = &path_or_blob {
         if blob.store.get().is_none()
             || !matches!(
@@ -122,24 +120,44 @@ pub(crate) fn presign(global: &JSGlobalObject, callframe: &CallFrame) -> JsResul
                 blob::store::Data::S3(_)
             )
         {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Expected a S3 or path to presign"))
-            );
+            return Err(global.throw_invalid_arguments(format_args!("{error_message}")));
         }
     }
+    Ok(path_or_blob)
+}
 
+/// Turns a parsed argument into an S3 blob: eats the options argument,
+/// rejects file-descriptor paths, and constructs the env-credentialed store
+/// for path arguments. Returns the blob together with the options it consumed.
+fn resolve_s3_blob(
+    global: &JSGlobalObject,
+    args: &mut bun_jsc::call_frame::ArgumentsSlice,
+    path_or_blob: PathOrBlob,
+    error_message: &str,
+) -> JsResult<(Box<Blob>, Option<JSValue>)> {
+    let options = args.next_eat();
     match path_or_blob {
         PathOrBlob::Path(path) => {
             if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(global
-                    .throw_invalid_arguments(format_args!("Expected a S3 or path to presign")));
+                return Err(global.throw_invalid_arguments(format_args!("{error_message}")));
             }
-            let options = args.next_eat();
-            let mut blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-            get_presign_url_from(&mut blob, global, options)
+            let blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
+            Ok((Box::new(blob), options))
         }
-        PathOrBlob::Blob(mut blob) => get_presign_url_from(&mut blob, global, args.next_eat()),
+        PathOrBlob::Blob(blob) => Ok((blob, options)),
     }
+}
+
+#[bun_jsc::host_fn]
+pub(crate) fn presign(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue> {
+    // SAFETY: bun_vm() returns the live VM raw ptr.
+    let mut args =
+        bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
+
+    let error_message = "Expected a S3 or path to presign";
+    let path_or_blob = parse_s3_path_or_blob(global, &mut args, error_message)?;
+    let (mut blob, options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
+    get_presign_url_from(&mut blob, global, options)
 }
 
 #[bun_jsc::host_fn]
@@ -148,39 +166,11 @@ pub(crate) fn unlink(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult
     let mut args =
         bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
 
-    // accept a path or a blob
-    let path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-
-    if let PathOrBlob::Blob(blob) = &path_or_blob {
-        if blob.store.get().is_none()
-            || !matches!(
-                blob.store.get().as_ref().unwrap().data,
-                blob::store::Data::S3(_)
-            )
-        {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Expected a S3 or path to delete"))
-            );
-        }
-    }
-
-    match path_or_blob {
-        PathOrBlob::Path(path) => {
-            if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("Expected a S3 or path to delete"))
-                );
-            }
-            let options = args.next_eat();
-            let blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-            let store = blob.store.get().as_ref().unwrap();
-            store.data.as_s3().unlink(store, global, options)
-        }
-        PathOrBlob::Blob(blob) => {
-            let store = blob.store.get().as_ref().unwrap();
-            store.data.as_s3().unlink(store, global, args.next_eat())
-        }
-    }
+    let error_message = "Expected a S3 or path to delete";
+    let path_or_blob = parse_s3_path_or_blob(global, &mut args, error_message)?;
+    let (blob, options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
+    let store = blob.store.get().as_ref().unwrap();
+    store.data.as_s3().unlink(store, global, options)
 }
 
 #[bun_jsc::host_fn]
@@ -189,21 +179,8 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
     let mut args =
         bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
 
-    // accept a path or a blob
-    let path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-
-    if let PathOrBlob::Blob(blob) = &path_or_blob {
-        if blob.store.get().is_none()
-            || !matches!(
-                blob.store.get().as_ref().unwrap().data,
-                blob::store::Data::S3(_)
-            )
-        {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Expected a S3 or path to upload"))
-            );
-        }
-    }
+    let error_message = "Expected a S3 or path to upload";
+    let path_or_blob = parse_s3_path_or_blob(global, &mut args, error_message)?;
 
     let Some(data) = args.next_eat() else {
         return Err(global
@@ -214,43 +191,19 @@ pub fn write(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<JSValue
             .throw());
     };
 
-    match path_or_blob {
-        PathOrBlob::Path(path) => {
-            let options = args.next_eat();
-            if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(
-                    global.throw_invalid_arguments(format_args!("Expected a S3 or path to upload"))
-                );
-            }
-            let blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-
-            let mut blob_internal = PathOrBlob::Blob(Box::new(blob));
-            blob::write_file_internal(
-                global,
-                &mut blob_internal,
-                data,
-                blob::WriteFileOptions {
-                    mkdirp_if_not_exists: Some(false),
-                    extra_options: options,
-                    ..Default::default()
-                },
-            )
-        }
-        PathOrBlob::Blob(blob) => {
-            // Reshaped for borrowck — match consumes path_or_blob; rebuild to pass &mut PathOrBlob
-            let mut pob = PathOrBlob::Blob(blob);
-            blob::write_file_internal(
-                global,
-                &mut pob,
-                data,
-                blob::WriteFileOptions {
-                    mkdirp_if_not_exists: Some(false),
-                    extra_options: args.next_eat(),
-                    ..Default::default()
-                },
-            )
-        }
-    }
+    let (blob, options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
+    // `write_file_internal` takes `&mut PathOrBlob`; rewrap the resolved blob.
+    let mut blob_internal = PathOrBlob::Blob(blob);
+    blob::write_file_internal(
+        global,
+        &mut blob_internal,
+        data,
+        blob::WriteFileOptions {
+            mkdirp_if_not_exists: Some(false),
+            extra_options: options,
+            ..Default::default()
+        },
+    )
 }
 
 #[bun_jsc::host_fn]
@@ -259,35 +212,12 @@ pub(crate) fn size(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<J
     let mut args =
         bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
 
-    // accept a path or a blob
-    let mut path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-
-    if let PathOrBlob::Blob(blob) = &path_or_blob {
-        if blob.store.get().is_none()
-            || !matches!(
-                blob.store.get().as_ref().unwrap().data,
-                blob::store::Data::S3(_)
-            )
-        {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Expected a S3 or path to get size"))
-            );
-        }
-    }
-
-    match &mut path_or_blob {
-        PathOrBlob::Path(path) => {
-            let options = args.next_eat();
-            if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(global
-                    .throw_invalid_arguments(format_args!("Expected a S3 or path to get size")));
-            }
-            let mut blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-
-            S3BlobStatTask::size(global, &mut blob)
-        }
-        PathOrBlob::Blob(blob) => Ok(blob.get_size(global)),
-    }
+    let error_message = "Expected a S3 or path to get size";
+    let mut blob = match parse_s3_path_or_blob(global, &mut args, error_message)? {
+        PathOrBlob::Blob(blob) => return Ok(blob.get_size(global)),
+        path => resolve_s3_blob(global, &mut args, path, error_message)?.0,
+    };
+    S3BlobStatTask::size(global, &mut blob)
 }
 
 #[bun_jsc::host_fn]
@@ -296,36 +226,12 @@ pub(crate) fn exists(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult
     let mut args =
         bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
 
-    // accept a path or a blob
-    let mut path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-
-    if let PathOrBlob::Blob(blob) = &path_or_blob {
-        if blob.store.get().is_none()
-            || !matches!(
-                blob.store.get().as_ref().unwrap().data,
-                blob::store::Data::S3(_)
-            )
-        {
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Expected a S3 or path to check if it exists"
-            )));
-        }
-    }
-
-    match &mut path_or_blob {
-        PathOrBlob::Path(path) => {
-            let options = args.next_eat();
-            if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(global.throw_invalid_arguments(format_args!(
-                    "Expected a S3 or path to check if it exists"
-                )));
-            }
-            let blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-
-            S3BlobStatTask::exists(global, &blob)
-        }
-        PathOrBlob::Blob(blob) => blob.get_exists(global, callframe),
-    }
+    let error_message = "Expected a S3 or path to check if it exists";
+    let blob = match parse_s3_path_or_blob(global, &mut args, error_message)? {
+        PathOrBlob::Blob(blob) => return blob.get_exists(global, callframe),
+        path => resolve_s3_blob(global, &mut args, path, error_message)?.0,
+    };
+    S3BlobStatTask::exists(global, &blob)
 }
 
 fn construct_s3_file_internal_store(
@@ -357,7 +263,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
     default_storage_class: Option<s3::StorageClass>,
     default_request_payer: bool,
 ) -> JsResult<Blob> {
-    let aws_options = <s3::S3Credentials>::get_credentials_with_options(
+    let mut aws_options = <s3::S3Credentials>::get_credentials_with_options(
         default_credentials,
         default_options,
         options,
@@ -367,47 +273,18 @@ pub(crate) fn construct_s3_file_with_s3_credentials_and_options(
         global,
     )?;
 
-    let mut store = 'brk: {
-        if aws_options.changed_credentials {
-            break 'brk blob::Store::init_s3(path, None, aws_options.credentials).expect("oom");
-        } else {
-            // The `Store::S3` field is `Rc<S3Credentials>` (separate rc
-            // layer), so we can't share the existing intrusive allocation —
-            // deep-clone the value instead and let `init_s3` `Rc::new` it.
-            // PERF: profile if hot once Store.rs migrates
-            // `Rc<S3Credentials>` → `IntrusiveRc`.
-            break 'brk blob::Store::init_s3(path, None, default_credentials.clone()).expect("oom");
-        }
+    let credentials = if aws_options.changed_credentials {
+        std::mem::take(&mut aws_options.credentials)
+    } else {
+        // The `Store::S3` field is `Rc<S3Credentials>` (separate rc
+        // layer), so we can't share the existing intrusive allocation —
+        // deep-clone the value instead and let `init_s3` `Rc::new` it.
+        // PERF: profile if hot once Store.rs migrates
+        // `Rc<S3Credentials>` → `IntrusiveRc`.
+        default_credentials.clone()
     };
-    // store cleanup on early return is handled by Drop
-    store.data.as_s3_mut().options = aws_options.options;
-    store.data.as_s3_mut().acl = aws_options.acl;
-    store.data.as_s3_mut().storage_class = aws_options.storage_class;
-    store.data.as_s3_mut().request_payer = aws_options.request_payer;
-
-    let blob = Blob::init_with_store(store, global);
-    if let Some(opts) = options {
-        if opts.is_object() {
-            if let Some(file_type) = opts.get_truthy(global, "type")? {
-                'inner: {
-                    if file_type.is_string() {
-                        let str = file_type.to_slice(global)?;
-                        let slice = str.slice();
-                        if !blob::is_valid_blob_type(slice) {
-                            break 'inner;
-                        }
-                        blob.content_type_was_set.set(true);
-                        blob.content_type
-                            .set(match global.bun_vm().as_mut().mime_type(slice) {
-                                Some(mime) => blob::BlobContentType::from(mime),
-                                None => blob::BlobContentType::from_lowercased(slice),
-                            });
-                    }
-                }
-            }
-        }
-    }
-    Ok(blob)
+    let store = blob::Store::init_s3(path, None, credentials).expect("oom");
+    finish_s3_blob(global, store, &aws_options, options)
 }
 
 pub(crate) fn construct_s3_file_with_s3_credentials(
@@ -416,7 +293,7 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
     options: Option<JSValue>,
     existing_credentials: &s3::S3Credentials,
 ) -> JsResult<Blob> {
-    let aws_options = <s3::S3Credentials>::get_credentials_with_options(
+    let mut aws_options = <s3::S3Credentials>::get_credentials_with_options(
         existing_credentials,
         Default::default(),
         options,
@@ -425,7 +302,20 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
         false,
         global,
     )?;
-    let mut store = blob::Store::init_s3(path, None, aws_options.credentials).expect("oom");
+    let credentials = std::mem::take(&mut aws_options.credentials);
+    let store = blob::Store::init_s3(path, None, credentials).expect("oom");
+    finish_s3_blob(global, store, &aws_options, options)
+}
+
+/// Shared constructor epilogue: copies the parsed per-request settings onto
+/// the store, wraps it in a `Blob`, and applies an `options.type` override.
+/// Unlike the write path, a non-string or invalid `type` is ignored here.
+fn finish_s3_blob(
+    global: &JSGlobalObject,
+    mut store: Box<blob::Store>,
+    aws_options: &s3::S3CredentialsWithOptions,
+    options: Option<JSValue>,
+) -> JsResult<Blob> {
     // store cleanup on early return is handled by Drop
     store.data.as_s3_mut().options = aws_options.options;
     store.data.as_s3_mut().acl = aws_options.acl;
@@ -436,13 +326,10 @@ pub(crate) fn construct_s3_file_with_s3_credentials(
     if let Some(opts) = options {
         if opts.is_object() {
             if let Some(file_type) = opts.get_truthy(global, "type")? {
-                'inner: {
-                    if file_type.is_string() {
-                        let str = file_type.to_slice(global)?;
-                        let slice = str.slice();
-                        if !blob::is_valid_blob_type(slice) {
-                            break 'inner;
-                        }
+                if file_type.is_string() {
+                    let str = file_type.to_slice(global)?;
+                    let slice = str.slice();
+                    if blob::is_valid_blob_type(slice) {
                         blob.content_type_was_set.set(true);
                         blob.content_type
                             .set(match global.bun_vm().as_mut().mime_type(slice) {
@@ -808,35 +695,10 @@ pub(crate) fn stat(global: &JSGlobalObject, callframe: &CallFrame) -> JsResult<J
     let mut args =
         bun_jsc::call_frame::ArgumentsSlice::init(global.bun_vm(), callframe.arguments());
 
-    // accept a path or a blob
-    let mut path_or_blob = PathOrBlob::from_js_no_copy(global, &mut args)?;
-
-    if let PathOrBlob::Blob(blob) = &path_or_blob {
-        if blob.store.get().is_none()
-            || !matches!(
-                blob.store.get().as_ref().unwrap().data,
-                blob::store::Data::S3(_)
-            )
-        {
-            return Err(
-                global.throw_invalid_arguments(format_args!("Expected a S3 or path to get size"))
-            );
-        }
-    }
-
-    match &mut path_or_blob {
-        PathOrBlob::Path(path) => {
-            let options = args.next_eat();
-            if matches!(path, crate::node::PathOrFileDescriptor::Fd(_)) {
-                return Err(global
-                    .throw_invalid_arguments(format_args!("Expected a S3 or path to get size")));
-            }
-            let blob = construct_s3_file_internal_store(global, path.path().clone(), options)?;
-
-            S3BlobStatTask::stat(global, &blob)
-        }
-        PathOrBlob::Blob(blob) => S3BlobStatTask::stat(global, blob),
-    }
+    let error_message = "Expected a S3 or path to get size";
+    let path_or_blob = parse_s3_path_or_blob(global, &mut args, error_message)?;
+    let (blob, _options) = resolve_s3_blob(global, &mut args, path_or_blob, error_message)?;
+    S3BlobStatTask::stat(global, &blob)
 }
 
 pub(crate) fn construct_internal_js(

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -113,6 +113,57 @@ macro_rules! impl_js_sink_abi {
     };
 }
 
+/// Emits the `JsSinkType` items that every sink forwards 1:1 to an inherent
+/// method of the same name (`memory_cost`, `write_bytes` -> `write`,
+/// `write_utf16`, `write_latin1`, `end`, `flush`, `flush_from_js`, `start`).
+/// Invoke inside the `impl JsSinkType for T` block; `Self::name` resolves to
+/// the inherent method ahead of the trait item being defined, so the forward
+/// does not recurse. Items whose bodies differ per sink (`finalize`,
+/// `construct`, `end_from_js`, `source`, `done`, the `HAS_*` consts) stay
+/// hand-written.
+#[macro_export]
+macro_rules! impl_js_sink_forwarders {
+    () => {
+        fn memory_cost(&self) -> usize {
+            Self::memory_cost(self)
+        }
+        fn write_bytes(
+            &mut self,
+            data: &$crate::webcore::streams::Result,
+        ) -> $crate::webcore::streams::result::Writable {
+            Self::write(self, data)
+        }
+        fn write_utf16(
+            &mut self,
+            data: &$crate::webcore::streams::Result,
+        ) -> $crate::webcore::streams::result::Writable {
+            Self::write_utf16(self, data)
+        }
+        fn write_latin1(
+            &mut self,
+            data: &$crate::webcore::streams::Result,
+        ) -> $crate::webcore::streams::result::Writable {
+            Self::write_latin1(self, data)
+        }
+        fn end(&mut self, err: ::core::option::Option<::bun_sys::Error>) -> ::bun_sys::Result<()> {
+            Self::end(self, err)
+        }
+        fn flush(&mut self) -> ::bun_sys::Result<()> {
+            Self::flush(self)
+        }
+        fn flush_from_js(
+            &mut self,
+            global: &::bun_jsc::JSGlobalObject,
+            wait: bool,
+        ) -> ::bun_sys::Result<::bun_jsc::JSValue> {
+            Self::flush_from_js(self, global, wait)
+        }
+        fn start(&mut self, config: $crate::webcore::streams::Start) -> ::bun_sys::Result<()> {
+            Self::start(self, &config)
+        }
+    };
+}
+
 /// Per-sink C ABI surface. `&str` const-generics can't drive `#[link_name]`,
 /// so each `SinkType` provides the resolved `${abi}__*` externs here (normally
 /// via `impl_js_sink_abi!`) for the generic `JSSink<T>` host-fn bodies to call.

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -313,6 +313,40 @@ impl CopyFile {
         Ok(())
     }
 
+    /// Copies the rest of the file with [`read_write_fallback`] when
+    /// `copy_file_range`/`sendfile`/`splice` is unavailable or unusable,
+    /// recording a failure in `system_error` the same way the syscall paths do.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn fallback_read_write(
+        &mut self,
+        remain: usize,
+        unknown_size: bool,
+        total_written: &mut u64,
+    ) -> Result<(), crate::Error> {
+        let bun_opened_dest = matches!(
+            self.destination_file_store.pathlike,
+            PathOrFileDescriptor::Path(_)
+        );
+        let cap = if unknown_size {
+            MAX_SIZE
+        } else {
+            remain as SizeType
+        };
+        match read_write_fallback(
+            self.source_fd,
+            self.destination_fd,
+            bun_opened_dest,
+            cap,
+            total_written,
+        ) {
+            bun_sys::Result::Err(err) => {
+                self.system_error = Some(err.to_system_error());
+                Err(bun_errno::from_errno(err.errno as i32).into())
+            }
+            bun_sys::Result::Ok(()) => Ok(()),
+        }
+    }
+
     #[cfg(any(target_os = "linux", target_os = "android"))]
     pub(crate) fn do_copy_file_range<const USE: TryWith, const CLEAR_APPEND_IF_INVALID: bool>(
         &mut self,
@@ -334,17 +368,6 @@ impl CopyFile {
         let mut total_written: u64 = 0;
         let src_fd = self.source_fd;
         let dest_fd = self.destination_fd;
-        let bun_opened_dest = matches!(
-            self.destination_file_store.pathlike,
-            PathOrFileDescriptor::Path(_)
-        );
-        let fallback_cap = |remain: usize| -> SizeType {
-            if unknown_size {
-                MAX_SIZE
-            } else {
-                remain as SizeType
-            }
-        };
 
         // defer { this.read_len = @truncate(total_written); }
         let read_len_slot: *mut SizeType = &raw mut self.read_len;
@@ -360,19 +383,7 @@ impl CopyFile {
         // If they can't use copy_file_range, they probably also can't
         // use sendfile() or splice()
         if !bun_sys::copy_file::can_use_copy_file_range_syscall() {
-            match read_write_fallback(
-                src_fd,
-                dest_fd,
-                bun_opened_dest,
-                fallback_cap(remain),
-                &mut total_written,
-            ) {
-                bun_sys::Result::Err(err) => {
-                    self.system_error = Some(err.to_system_error());
-                    return Err(bun_errno::from_errno(err.errno as i32).into());
-                }
-                bun_sys::Result::Ok(()) => return Ok(()),
-            }
+            return self.fallback_read_write(remain, unknown_size, &mut total_written);
         }
 
         loop {
@@ -425,19 +436,7 @@ impl CopyFile {
                 // OPNOTSUPP: filesystem doesn't support this operation
                 bun_sys::E::ENOSYS | bun_sys::E::EXDEV | bun_sys::E::ENOTSUP => {
                     // TODO: this should use non-blocking I/O.
-                    match read_write_fallback(
-                        src_fd,
-                        dest_fd,
-                        bun_opened_dest,
-                        fallback_cap(remain),
-                        &mut total_written,
-                    ) {
-                        bun_sys::Result::Err(err) => {
-                            self.system_error = Some(err.to_system_error());
-                            return Err(bun_errno::from_errno(err.errno as i32).into());
-                        }
-                        bun_sys::Result::Ok(()) => return Ok(()),
-                    }
+                    return self.fallback_read_write(remain, unknown_size, &mut total_written);
                 }
 
                 // EINVAL: eCryptfs and other filesystems may not support copy_file_range.
@@ -472,19 +471,7 @@ impl CopyFile {
                     // to a read/write loop
                     if total_written == 0 {
                         // TODO: this should use non-blocking I/O.
-                        match read_write_fallback(
-                            src_fd,
-                            dest_fd,
-                            bun_opened_dest,
-                            fallback_cap(remain),
-                            &mut total_written,
-                        ) {
-                            bun_sys::Result::Err(err) => {
-                                self.system_error = Some(err.to_system_error());
-                                return Err(bun_errno::from_errno(err.errno as i32).into());
-                            }
-                            bun_sys::Result::Ok(()) => return Ok(()),
-                        }
+                        return self.fallback_read_write(remain, unknown_size, &mut total_written);
                     }
 
                     self.system_error = Some(

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -290,6 +290,7 @@ pub struct ReadFile {
 }
 
 bun_threading::intrusive_work_task!(ReadFile, task);
+bun_io::intrusive_io_request!(ReadFile, io_request);
 
 // The default methods on the FileOpener/FileCloser traits provide the bodies.
 impl FileOpener for ReadFile {
@@ -326,78 +327,7 @@ impl FileOpener for ReadFile {
     }
 }
 
-impl FileCloser for ReadFile {
-    const IO_TAG: bun_io::Tag = bun_io::Tag::ReadFile;
-    fn opened_fd(&self) -> Fd {
-        self.opened_fd
-    }
-    fn set_opened_fd(&mut self, fd: Fd) {
-        self.opened_fd = fd;
-    }
-    fn close_after_io(&self) -> bool {
-        self.close_after_io
-    }
-    fn state(&self) -> &AtomicU8 {
-        &self.state
-    }
-    fn io_request(&mut self) -> Option<&mut bun_io::Request> {
-        Some(&mut self.io_request)
-    }
-    fn io_poll(&mut self) -> &mut bun_io::Poll {
-        &mut self.io_poll
-    }
-    fn task(&mut self) -> &mut bun_jsc::WorkPoolTask {
-        &mut self.task
-    }
-    fn update(&mut self) {
-        ReadFile::update(self)
-    }
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        unreachable!()
-    }
-
-    fn schedule_close(request: &mut bun_io::Request) -> bun_io::Action<'_> {
-        // SAFETY: request is &mut self.io_request (intrusive); recover parent.
-        let this: &mut ReadFile = unsafe {
-            &mut *(bun_core::from_field_ptr!(
-                ReadFile,
-                io_request,
-                std::ptr::from_mut::<io::Request>(request)
-            ))
-        };
-        fn on_done(ctx: *mut ()) {
-            // SAFETY: ctx is `self as *mut ReadFile` set below.
-            let this = unsafe { bun_ptr::callback_ctx::<ReadFile>(ctx.cast()) };
-            <ReadFile as FileCloser>::on_io_request_closed(this);
-        }
-        // reshaped for borrowck — compute the parent raw pointer
-        // before mutably borrowing `io_poll` so the two borrows do not overlap.
-        let ctx = std::ptr::from_mut::<ReadFile>(this).cast::<()>();
-        let fd = this.opened_fd;
-        io::Action::Close(io::CloseAction {
-            fd,
-            poll: &mut this.io_poll,
-            ctx,
-            tag: <Self as FileCloser>::IO_TAG,
-            on_done,
-        })
-    }
-
-    // `FileCloser` fixes `on_close_io_request` to take `*mut WorkPoolTask`;
-    // the trait method cannot be marked `unsafe fn`, so the lint is
-    // unsatisfiable here. The pointer is the intrusive `&mut self.task` set
-    // in `on_io_request_closed` and is guaranteed live.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn on_close_io_request(task: *mut bun_jsc::WorkPoolTask) {
-        // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
-        // `&mut self.task` (intrusive) registered in `on_io_request_closed`;
-        // recover parent.
-        let this = unsafe { &mut *ReadFile::from_task_ptr(task) };
-        this.close_after_io = false;
-        ReadFile::update(this);
-    }
-}
+crate::webcore::blob::impl_file_closer!(ReadFile);
 
 impl ReadFile {
     pub(crate) fn update(&mut self) {

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -6,18 +6,20 @@ use core::sync::atomic::Ordering;
 
 use crate::Error;
 use bun_core::ZigString;
-use bun_io::{self as io, IntrusiveIoRequest as _};
+use bun_io as io;
+#[cfg(not(windows))]
+use bun_io::IntrusiveIoRequest as _;
 use bun_jsc::ZigStringJsc as _;
 use bun_jsc::node_path::PathOrFileDescriptor;
 use bun_jsc::{self as jsc, JSGlobalObject, JSPromise, JSValue, JsTerminated, SystemError};
 use bun_sys::{self as sys, Fd};
 use bun_threading::{IntrusiveWorkTask as _, WorkPool, WorkPoolTask};
 
-#[cfg(not(windows))]
-use crate::webcore::blob::ClosingState;
 use crate::webcore::blob::{
-    self, Blob, FileCloser, FileOpener, MkdirpTarget, Retry, SizeType, mkdir_if_not_exists,
+    self, Blob, FileOpener, MkdirpTarget, Retry, SizeType, mkdir_if_not_exists,
 };
+#[cfg(not(windows))]
+use crate::webcore::blob::{ClosingState, FileCloser};
 use crate::webcore::body;
 
 bun_output::declare_scope!(WriteFile, hidden);
@@ -171,72 +173,7 @@ impl MkdirpTarget for WriteFile {
     }
 }
 
-impl FileCloser for WriteFile {
-    const IO_TAG: io::Tag = io::Tag::WriteFile;
-    fn opened_fd(&self) -> Fd {
-        self.opened_fd
-    }
-    fn set_opened_fd(&mut self, fd: Fd) {
-        self.opened_fd = fd;
-    }
-    fn close_after_io(&self) -> bool {
-        self.close_after_io
-    }
-    fn state(&self) -> &AtomicU8 {
-        &self.state
-    }
-    fn io_request(&mut self) -> Option<&mut io::Request> {
-        Some(&mut self.io_request)
-    }
-    fn io_poll(&mut self) -> &mut io::Poll {
-        &mut self.io_poll
-    }
-    fn task(&mut self) -> &mut bun_jsc::WorkPoolTask {
-        &mut self.task
-    }
-    fn update(&mut self) {
-        WriteFile::update(self)
-    }
-    #[cfg(windows)]
-    fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t {
-        unreachable!()
-    }
-
-    fn schedule_close(request: &mut io::Request) -> io::Action<'_> {
-        // SAFETY: `request` is `&mut self.io_request` (intrusive); recover parent.
-        let this = unsafe { WriteFile::from_io_request(std::ptr::from_mut(request)) };
-        fn on_done(ctx: *mut ()) {
-            // SAFETY: ctx is `self as *mut WriteFile` set below.
-            let this = unsafe { bun_ptr::callback_ctx::<WriteFile>(ctx.cast()) };
-            <WriteFile as FileCloser>::on_io_request_closed(this);
-        }
-        // SAFETY: `request` is `&mut self.io_request` (intrusive), so `this` is the live
-        // parent; `fd` copy and the `io_poll` field borrow are the only borrows formed.
-        let (fd, poll) = unsafe { ((*this).opened_fd, &mut (*this).io_poll) };
-        io::Action::Close(io::CloseAction {
-            fd,
-            poll,
-            ctx: this.cast::<()>(),
-            tag: <Self as FileCloser>::IO_TAG,
-            on_done,
-        })
-    }
-
-    // `FileCloser` fixes `on_close_io_request` to take `*mut WorkPoolTask`;
-    // the trait method cannot be marked `unsafe fn`, so the lint is
-    // unsatisfiable here. The pointer is the intrusive `&mut self.task` set
-    // in `on_io_request_closed` and is guaranteed live.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    fn on_close_io_request(task: *mut bun_jsc::WorkPoolTask) {
-        // SAFETY: only reached via `WorkPoolTask::callback` with `task` = `&mut self.task`
-        // (intrusive) registered in `on_io_request_closed`; recover parent.
-        let this = unsafe { WriteFile::from_task_ptr(task) };
-        // SAFETY: `this` is the live parent (see above); scoped access.
-        unsafe { (*this).close_after_io = false };
-        // SAFETY: as above; exclusive borrow scoped to the call.
-        WriteFile::update(unsafe { &mut *this });
-    }
-}
+crate::webcore::blob::impl_file_closer!(WriteFile);
 
 impl WriteFile {
     #[cfg(not(windows))]

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -277,35 +277,13 @@ impl crate::webcore::sink::JsSinkType for FetchRequestBodySink {
     const HAS_FLUSH_FROM_JS: bool = true;
     const START_TAG: Option<StartTag> = Some(StartTag::FetchRequestBodySink);
 
-    fn memory_cost(&self) -> usize {
-        Self::memory_cost(self)
-    }
+    crate::impl_js_sink_forwarders!();
+
     fn finalize(&mut self) {
         Self::finalize(self)
     }
-    fn write_bytes(&mut self, data: &StreamResult) -> Writable {
-        Self::write(self, data)
-    }
-    fn write_utf16(&mut self, data: &StreamResult) -> Writable {
-        Self::write_utf16(self, data)
-    }
-    fn write_latin1(&mut self, data: &StreamResult) -> Writable {
-        Self::write_latin1(self, data)
-    }
-    fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        Self::end(self, err)
-    }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)
-    }
-    fn flush(&mut self) -> bun_sys::Result<()> {
-        Self::flush(self)
-    }
-    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> bun_sys::Result<JSValue> {
-        Self::flush_from_js(self, global, wait)
-    }
-    fn start(&mut self, config: Start) -> bun_sys::Result<()> {
-        Self::start(self, &config)
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {
         Some(&mut self.source)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -2114,35 +2114,13 @@ impl<const SSL: bool, const HTTP3: bool> crate::webcore::sink::JsSinkType
         StartTag::HTTPResponseSink
     });
 
-    fn memory_cost(&self) -> usize {
-        Self::memory_cost(self)
-    }
+    crate::impl_js_sink_forwarders!();
+
     fn finalize(&mut self) {
         Self::finalize(self)
     }
-    fn write_bytes(&mut self, data: &StreamResult) -> Writable {
-        Self::write(self, data)
-    }
-    fn write_utf16(&mut self, data: &StreamResult) -> Writable {
-        Self::write_utf16(self, data)
-    }
-    fn write_latin1(&mut self, data: &StreamResult) -> Writable {
-        Self::write_latin1(self, data)
-    }
-    fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        Self::end(self, err)
-    }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)
-    }
-    fn flush(&mut self) -> bun_sys::Result<()> {
-        Self::flush(self)
-    }
-    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> bun_sys::Result<JSValue> {
-        Self::flush_from_js(self, global, wait)
-    }
-    fn start(&mut self, config: Start) -> bun_sys::Result<()> {
-        Self::start(self, &config)
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {
         Some(&mut self.source)
@@ -2560,35 +2538,13 @@ impl crate::webcore::sink::JsSinkType for NetworkSink {
     const HAS_FLUSH_FROM_JS: bool = true;
     const START_TAG: Option<StartTag> = Some(StartTag::NetworkSink);
 
-    fn memory_cost(&self) -> usize {
-        Self::memory_cost(self)
-    }
+    crate::impl_js_sink_forwarders!();
+
     fn finalize(&mut self) {
         Self::finalize(self)
     }
-    fn write_bytes(&mut self, data: &StreamResult) -> Writable {
-        Self::write(self, data)
-    }
-    fn write_utf16(&mut self, data: &StreamResult) -> Writable {
-        Self::write_utf16(self, data)
-    }
-    fn write_latin1(&mut self, data: &StreamResult) -> Writable {
-        Self::write_latin1(self, data)
-    }
-    fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        Self::end(self, err)
-    }
     fn end_from_js(&mut self, global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
         Self::end_from_js(self, global)
-    }
-    fn flush(&mut self) -> bun_sys::Result<()> {
-        Self::flush(self)
-    }
-    fn flush_from_js(&mut self, global: &JSGlobalObject, wait: bool) -> bun_sys::Result<JSValue> {
-        Self::flush_from_js(self, global, wait)
-    }
-    fn start(&mut self, config: Start) -> bun_sys::Result<()> {
-        Self::start(self, &config)
     }
     fn source(&mut self) -> Option<&mut SourceHandle> {
         Some(&mut self.source)

--- a/test/js/bun/s3/s3-argument-validation.test.ts
+++ b/test/js/bun/s3/s3-argument-validation.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+// Argument validation for the S3 static and instance methods. Every case here
+// is rejected synchronously, before any network request, so no server is
+// needed.
+
+// The static methods accept a path or an S3 blob; everything else is rejected
+// up front with a per-method message. Numbers parse as file descriptor paths,
+// which S3 also rejects.
+describe("S3Client static method argument validation", () => {
+  const staticCases = [
+    ["presign", "Expected a S3 or path to presign", []],
+    ["unlink", "Expected a S3 or path to delete", []],
+    ["write", "Expected a S3 or path to upload", ["data"]],
+    ["size", "Expected a S3 or path to get size", []],
+    ["exists", "Expected a S3 or path to check if it exists", []],
+    // stat reuses the size wording
+    ["stat", "Expected a S3 or path to get size", []],
+  ] as const;
+
+  test.each(staticCases)("S3Client.%s rejects non-S3 arguments", (method, message, extra) => {
+    const expected = expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message });
+    const fn = (Bun.S3Client as any)[method];
+    // a data-backed Blob is not S3-backed
+    expect(() => fn(new Blob(["x"]), ...extra)).toThrow(expected);
+    // a local file Blob is not S3-backed either
+    expect(() => fn(Bun.file(import.meta.path), ...extra)).toThrow(expected);
+    // a number is parsed as a file descriptor path
+    expect(() => fn(0, ...extra)).toThrow(expected);
+  });
+
+  test("S3Client.write requires data", () => {
+    expect(() => Bun.S3Client.write("some-key")).toThrow(
+      expect.objectContaining({ code: "ERR_MISSING_ARGS", message: "Expected a Blob-y thing to upload" }),
+    );
+  });
+});
+
+describe("S3Client instance method argument validation", () => {
+  const client = new Bun.S3Client({
+    accessKeyId: "test",
+    secretAccessKey: "test",
+    bucket: "bucket",
+    endpoint: "http://127.0.0.1:1",
+  });
+
+  const instanceCases = [
+    ["presign", "Expected a path to presign"],
+    ["exists", "Expected a path to check if it exists"],
+    ["size", "Expected a path to check the size of"],
+    ["stat", "Expected a path to check the stat of"],
+  ] as const;
+
+  test.each(instanceCases)("client.%s distinguishes a missing path from an invalid one", (method, message) => {
+    const fn = (client as any)[method].bind(client);
+    // no argument at all: MISSING_ARGS
+    expect(() => fn()).toThrow(expect.objectContaining({ code: "ERR_MISSING_ARGS", message }));
+    // an argument that is not a path: INVALID_ARG_TYPE, same message
+    expect(() => fn(123)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message }));
+    expect(() => fn({})).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE", message }));
+  });
+
+  test("client.unlink reports MISSING_ARGS for both missing and invalid paths", () => {
+    const expected = expect.objectContaining({ code: "ERR_MISSING_ARGS", message: "Expected a path to unlink" });
+    expect(() => (client as any).unlink()).toThrow(expected);
+    expect(() => (client as any).unlink(123)).toThrow(expected);
+    expect(() => (client as any).unlink({})).toThrow(expected);
+  });
+
+  test("S3 file writer() rejects a non-string type option before any request is made", () => {
+    const s3file = client.file("some-key.bin");
+    expect(() => s3file.writer({ type: 123 as any })).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: "Expected options.type to be a string for 'write'.",
+      }),
+    );
+  });
+});

--- a/test/js/web/fetch/blob-write.test.ts
+++ b/test/js/web/fetch/blob-write.test.ts
@@ -84,3 +84,43 @@ test("Bun.file(path).stat() returns stats", async () => {
   expect(stat).toBeDefined();
   expect(stat.size).toBe(13); // "Hello, world!" is 13 bytes
 });
+
+// Bun.file().write() accepts an options.type override: non-strings throw,
+// valid types are stored lowercased (through the mime table when known), and
+// invalid blob types are silently ignored.
+test("Bun.file(path).write() rejects a non-string options.type", async () => {
+  const dir = tempDirWithFiles("blob-write-type", { "a.txt": "hello" });
+  const file = Bun.file(path.join(dir, "a.txt"));
+  let err: any;
+  try {
+    await file.write("x", { type: 123 as any });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toMatchObject({
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "Expected options.type to be a string for 'write'.",
+  });
+});
+
+test("Bun.file(path).write() lowercases and applies a valid options.type", async () => {
+  const dir = tempDirWithFiles("blob-write-type", { "a.txt": "hello" });
+  const file = Bun.file(path.join(dir, "a.txt"));
+  await file.write("x", { type: "TEXT/PLAIN; CHARSET=UTF-8" });
+  expect(file.type).toBe("text/plain; charset=utf-8");
+});
+
+test("Bun.file(path).write() resolves a known options.type through the mime table", async () => {
+  const dir = tempDirWithFiles("blob-write-type", { "a.txt": "hello" });
+  const file = Bun.file(path.join(dir, "a.txt"));
+  await file.write("x", { type: "APPLICATION/JSON" });
+  expect(file.type).toBe("application/json");
+});
+
+test("Bun.file(path).write() silently ignores an invalid options.type", async () => {
+  const dir = tempDirWithFiles("blob-write-type", { "a.txt": "hello" });
+  const file = Bun.file(path.join(dir, "a.txt"));
+  await file.write("x", { type: "bad\r\ntype" });
+  // the .txt default is kept
+  expect(file.type).toBe("text/plain;charset=utf-8");
+});

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -689,3 +689,49 @@ describe("file-backed slice bounds are respected when streaming and serving", ()
     expect(s.size).toBe(5);
   });
 });
+
+// Blob conversion accepts every ArrayBuffer-like type, both as a direct body
+// value and as a part inside an array.
+describe("Blob from ArrayBuffer-like values", () => {
+  const bytes = Uint8Array.from({ length: 16 }, (_, i) => i + 1);
+  const views = [
+    ["ArrayBuffer", () => bytes.slice().buffer],
+    ["DataView", () => new DataView(bytes.slice().buffer)],
+    ["Int8Array", () => new Int8Array(bytes.slice().buffer)],
+    ["Uint8Array", () => bytes.slice()],
+    ["Uint8ClampedArray", () => new Uint8ClampedArray(bytes.slice().buffer)],
+    ["Int16Array", () => new Int16Array(bytes.slice().buffer)],
+    ["Uint16Array", () => new Uint16Array(bytes.slice().buffer)],
+    ["Int32Array", () => new Int32Array(bytes.slice().buffer)],
+    ["Uint32Array", () => new Uint32Array(bytes.slice().buffer)],
+    ["Float16Array", () => new Float16Array(bytes.slice().buffer)],
+    ["Float32Array", () => new Float32Array(bytes.slice().buffer)],
+    ["Float64Array", () => new Float64Array(bytes.slice().buffer)],
+    ["BigInt64Array", () => new BigInt64Array(bytes.slice().buffer)],
+    ["BigUint64Array", () => new BigUint64Array(bytes.slice().buffer)],
+  ] as const;
+
+  test.each(views)("new Blob([%s]) copies the bytes", async (_name, make) => {
+    const view = make();
+    const blob = new Blob([view as any]);
+    expect(blob.size).toBe(view.byteLength);
+    expect(await blob.bytes()).toEqual(bytes);
+  });
+
+  test.each(views)("new Response(%s).blob() copies the bytes", async (_name, make) => {
+    const view = make();
+    const blob = await new Response(view as any).blob();
+    expect(blob.size).toBe(view.byteLength);
+    expect(await blob.bytes()).toEqual(bytes);
+  });
+
+  test("string, view, and Blob parts concatenate in order", async () => {
+    const blob = new Blob([
+      "ab",
+      new Uint8Array([0x63, 0x64]),
+      new Blob(["ef"]),
+      new DataView(new Uint8Array([0x67, 0x68]).buffer),
+    ]);
+    expect(await blob.text()).toBe("abcdefgh");
+  });
+});


### PR DESCRIPTION
## What this does
Dedupes webcore lifecycle boilerplate with zero intended behavior change:

- `impl_file_closer!` (Blob.rs): shared `FileCloser` impl for blob `ReadFile`/`WriteFile`. The two hand-written impls were functionally identical; `ReadFile` gains `bun_io::intrusive_io_request!` so both recover the parent through `IntrusiveIoRequest` instead of an open-coded `from_field_ptr!`. `ReadFileUV` keeps its own impl (different shape).
- `impl_js_sink_forwarders!` (Sink.rs, next to `impl_js_sink_abi!`): the eight 1:1 `JsSinkType` forwarders shared by `ArrayBufferSink`, `FileSink`, `FetchRequestBodySink`, `HTTPServerWritable`, and `NetworkSink`. Per-sink items (`finalize`, `construct`, `end_from_js`, `source`, `done`, `HAS_*`) stay hand-written.
- `CopyFile::fallback_read_write`: the `read_write_fallback` call plus error recording appeared three times in `do_copy_file_range`.
- `Blob::set_content_type_from_js` and `S3File::finish_s3_blob`: the write-path `options.type` override (in `do_write` and `get_writer`) and the S3 constructor epilogue (in both `construct_s3_file_with_s3_credentials*` fns) were each duplicated verbatim.
- `S3File::parse_s3_path_or_blob`/`resolve_s3_blob` and `S3Client::construct_blob`/`blob_and_options`: shared argument parsing for the S3 static and instance methods. `MissingPathError` preserves the per-method split between `MISSING_ARGS` and invalid-argument errors (`unlink` always reports `MISSING_ARGS`; the others only when no argument was passed).
- The explicit 14-arm typed-array `JSType` lists in Blob construction use the existing `JSType::is_array_buffer_like()` (same 14-type set).

Net -401 lines of src.

## History
Originally the top of the foundations/install-cli/jsc-runtime stack split from #31912. Main moved far enough that every file conflicted, so this was re-derived against current main and retargeted at `main`; it has no code dependency on the other PRs in that stack.

## Tests
The consolidated paths had no coverage of their error contracts, so this adds characterization tests pinning them:

- `test/js/bun/s3/s3-argument-validation.test.ts`: per-method static rejection messages (including `stat` reusing the "get size" wording), the instance-method `ERR_MISSING_ARGS` vs `ERR_INVALID_ARG_TYPE` split, `unlink` always reporting `MISSING_ARGS`, and the S3 `writer()` non-string `type` rejection
- `test/js/web/fetch/blob-write.test.ts`: `Bun.file().write()` `options.type` contract (non-string throws, valid types lowercased, known types resolved through the mime table, invalid types ignored)
- `test/js/web/fetch/blob.test.ts`: Blob construction from all 14 ArrayBuffer-like types, as a direct body value and as an array part

Because this is a behavior-preserving refactor, these tests pass identically with and without the src changes by design; that is the equivalence check, not a gap.

## Verification
- Line-by-line audit against main for each consolidation: error messages, argument-eating order, drop order, and the unsafe parent-pointer recovery in `schedule_close`/`on_close_io_request` are unchanged (the macro's two trampolines are `WriteFile`'s current impl statement for statement, differing only in fully-qualified paths; `ReadFile` moves from its older `&mut *from_field_ptr!` form onto that same already-landed shape)
- `bun run rust:check-all`: all 10 CI target triples pass
- Debug (ASAN) build: the three test files above (102 pass), sink suites plus request-body and server-response stream suites (9161 pass), `Bun.write` including both `copyFileRange`-unavailable fallback tests, local S3 suites (38 pass), blob/FormData suites (165 pass). The large-file fallback test needs more than the 5s default on this ASAN box with or without the change.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/fetch/blob.test.ts

<!-- robobun:evidence:end -->