### PR TITLE
Reject unterminated \u{ escapes in string literals

### DIFF
--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -817,7 +817,8 @@ lexer_impl_header! {
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
                                     if !iterator.next(&mut iter) {
-                                        break 'variable_length;
+                                        // The string ended before the closing `}`.
+                                        return self.syntax_error();
                                     }
                                     c3 = iter.c;
 

--- a/src/parsers/toml/lexer.rs
+++ b/src/parsers/toml/lexer.rs
@@ -1051,7 +1051,8 @@ impl<'a> Lexer<'a> {
                                 let mut is_out_of_range = false;
                                 'variable_length: loop {
                                     if !iterator.next(&mut iter) {
-                                        break 'variable_length;
+                                        // The string ended before the closing `}`.
+                                        return self.syntax_error();
                                     }
                                     c3 = iter.c;
 

--- a/test/js/bun/resolve/toml/toml-parse.test.ts
+++ b/test/js/bun/resolve/toml/toml-parse.test.ts
@@ -68,6 +68,20 @@ test("Bun.TOML.parse normalizes literal CRLF to LF in multiline basic strings", 
   expect(Bun.TOML.parse(input).k).toBe("a\nb\tc");
 });
 
+// https://github.com/oven-sh/bun/issues/32025
+// An unterminated `\u{` escape (the string body ends before the closing `}`)
+// fell out of the decoder's variable-length digit loop at end of input and
+// silently decoded the accumulated value instead of raising a syntax error.
+test("Bun.TOML.parse rejects an unterminated \\u{ escape (#32025)", () => {
+  expect(() => Bun.TOML.parse('key = "\\u{41"')).toThrow("Syntax Error");
+  expect(() => Bun.TOML.parse('key = "\\u{"')).toThrow("Syntax Error");
+  expect(() => Bun.TOML.parse('key = """\\u{41"""')).toThrow("Syntax Error");
+
+  // Terminated \u{...} escapes (a Bun extension) still decode.
+  expect(Bun.TOML.parse('key = "\\u{41}"')).toEqual({ key: "A" });
+  expect(Bun.TOML.parse('key = """\\u{41}"""')).toEqual({ key: "A" });
+});
+
 // https://github.com/oven-sh/bun/issues/31252
 // `Lexer::expect` in the TOML lexer logs a mismatch via `add_range_error` and
 // then falls through to `next()` for error recovery, so the parser returned

--- a/test/regression/issue/invalid-escape-sequences.test.ts
+++ b/test/regression/issue/invalid-escape-sequences.test.ts
@@ -242,6 +242,68 @@ test("Valid unicode escapes in identifiers should work", async () => {
   }
 });
 
+// https://github.com/oven-sh/bun/issues/32025
+// An unterminated `\u{` escape (the string body ends before the closing `}`)
+// fell out of the decoder's variable-length digit loop at end of input and
+// silently decoded the accumulated value instead of raising a syntax error.
+describe("unterminated \\u{ escape is a syntax error (#32025)", () => {
+  const cases = [
+    { name: "double-quoted string", source: 'var a = "\\u{41";' },
+    { name: "single-quoted string", source: "var a = '\\u{41';" },
+    { name: "zero digits before the closing quote", source: 'var a = "\\u{";' },
+    { name: "untagged template literal", source: "var a = `\\u{48`;" },
+    { name: "untagged template literal tail", source: "var a = `${1}\\u{48`;" },
+  ];
+
+  test.each(cases)("$name", ({ source }) => {
+    using dir = tempDir("unterminated-u-brace", { "test.js": source });
+    const { stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), join(dir, "test.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      cwd: String(dir),
+    });
+
+    expect(stderr.toString()).toContain("Syntax Error");
+    expect(exitCode).toBe(1);
+  });
+
+  // Tagged templates legally contain invalid escape sequences (ES2018): the
+  // cooked value becomes undefined and the raw text is preserved.
+  test("tagged template literal still allows an unterminated \\u{ escape", () => {
+    using dir = tempDir("unterminated-u-brace-tagged", {
+      "test.js": "function tag(s) { return [s[0], s.raw[0]]; } console.log(JSON.stringify(tag`\\u{48`));",
+    });
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), join(dir, "test.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      cwd: String(dir),
+    });
+
+    expect(stdout.toString()).toBe('[null,"\\\\u{48"]\n');
+    expect(exitCode).toBe(0);
+  });
+
+  test("terminated \\u{} escapes still decode", () => {
+    using dir = tempDir("terminated-u-brace", {
+      "test.js": 'console.log("\\u{41}", `\\u{42}`);',
+    });
+    const { stdout, stderr, exitCode } = Bun.spawnSync({
+      cmd: [bunExe(), join(dir, "test.js")],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+      cwd: String(dir),
+    });
+
+    expect(stdout.toString()).toBe("A B\n");
+    expect(exitCode).toBe(0);
+  });
+});
+
 // https://github.com/oven-sh/bun/issues/31134
 // Invalid escape-sequence diagnostics in `decode_escape_sequences` reported
 // caret locations at text-relative offsets instead of absolute source


### PR DESCRIPTION
Fixes #32025

## Reproduction

```console
$ bun -e 'console.log("\u{41")'
A
$ node -e 'console.log("\u{41")'
SyntaxError: Invalid Unicode escape sequence
```

Also reachable through untagged template literals (`` `\u{48` `` cooks to `"H"`), with zero digits (`"\u{"` decodes to NUL), and through `Bun.TOML.parse('a = "\u{41"')`, where `\u{...}` is a Bun extension.

## Cause

The variable-length branch of `decode_escape_sequences` breaks out of its digit loop when the input ends before the closing `}` and falls through to emitting the accumulated value:

```rust
'variable_length: loop {
    if !iterator.next(&mut iter) {
        break 'variable_length;   // falls through to iter.c = value
    }
```

The fixed-length `\uXXXX` and `\xXX` branches already return a syntax error when input ends mid-escape. This can only trigger when the string body itself ends inside the braces (the closing quote immediately follows the partial escape), since an unterminated string errors earlier.

## Fix

Return `self.syntax_error()` at end of input in the variable-length loop, in both copies of the decoder (`src/js_parser/lexer.rs` and `src/parsers/toml/lexer.rs`). The JSON lexer (`src/parsers/json_lexer.rs`) has no `\u{` branch and is unaffected.

Tagged templates are unaffected: they legally contain invalid escapes (cooked value `undefined`, raw preserved) and go through `raw_template_contents()`, never the decoder. Identifier escapes validate `\u{...}` in a separate first pass that already rejects EOF.

## Verification

New tests in `test/regression/issue/invalid-escape-sequences.test.ts` (double/single-quoted strings, zero digits, untagged template head and tail, plus tagged-template and terminated-escape behavior preserved) and `test/js/bun/resolve/toml/toml-parse.test.ts` (basic and multiline strings). The syntax-error cases fail on the unfixed build and pass with the fix; `test/bundler/transpiler/transpiler.test.js` and the TOML suites still pass.
