### PR TITLE
sql: report connect failures distinctly from closed connections

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1043,7 +1043,8 @@ try {
 
 | Connection Errors                 | Description                                          |
 | --------------------------------- | ---------------------------------------------------- |
-| `ERR_POSTGRES_CONNECTION_CLOSED`  | Connection was terminated or never established       |
+| `ERR_POSTGRES_CONNECTION_CLOSED`  | An established connection was terminated             |
+| `ERR_POSTGRES_CONNECTION_FAILED`  | Connection could not be established (refused, or closed before the handshake completed — e.g. the server is still starting up) |
 | `ERR_POSTGRES_CONNECTION_TIMEOUT` | Failed to establish connection within timeout period |
 | `ERR_POSTGRES_IDLE_TIMEOUT`       | Connection closed due to inactivity                  |
 | `ERR_POSTGRES_LIFETIME_TIMEOUT`   | Connection exceeded maximum lifetime                 |

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1041,15 +1041,15 @@ try {
 
 ### PostgreSQL Connection Errors
 
-| Connection Errors                 | Description                                                                                                                    |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `ERR_POSTGRES_CONNECTION_CLOSED`  | An established connection was terminated                                                                                       |
-| `ERR_POSTGRES_CONNECTION_FAILED`  | Connection could not be established (refused, or closed before the handshake completed — e.g. the server is still starting up) |
-| `ERR_POSTGRES_CONNECTION_TIMEOUT` | Failed to establish connection within timeout period                                                                           |
-| `ERR_POSTGRES_IDLE_TIMEOUT`       | Connection closed due to inactivity                                                                                            |
-| `ERR_POSTGRES_LIFETIME_TIMEOUT`   | Connection exceeded maximum lifetime                                                                                           |
-| `ERR_POSTGRES_TLS_NOT_AVAILABLE`  | SSL/TLS connection not available                                                                                               |
-| `ERR_POSTGRES_TLS_UPGRADE_FAILED` | Failed to upgrade connection to SSL/TLS                                                                                        |
+| Connection Errors                 | Description                                                                                                                                                                                                                             |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ERR_POSTGRES_CONNECTION_CLOSED`  | An established connection was terminated                                                                                                                                                                                                |
+| `ERR_POSTGRES_CONNECTION_FAILED`  | Connection could not be established (refused, or socket closed before the handshake completed, e.g. an intermediary accepted then closed); errors the server sends during startup, like `57P03`, surface as `ERR_POSTGRES_SERVER_ERROR` |
+| `ERR_POSTGRES_CONNECTION_TIMEOUT` | Failed to establish connection within timeout period                                                                                                                                                                                    |
+| `ERR_POSTGRES_IDLE_TIMEOUT`       | Connection closed due to inactivity                                                                                                                                                                                                     |
+| `ERR_POSTGRES_LIFETIME_TIMEOUT`   | Connection exceeded maximum lifetime                                                                                                                                                                                                    |
+| `ERR_POSTGRES_TLS_NOT_AVAILABLE`  | SSL/TLS connection not available                                                                                                                                                                                                        |
+| `ERR_POSTGRES_TLS_UPGRADE_FAILED` | Failed to upgrade connection to SSL/TLS                                                                                                                                                                                                 |
 
 ### Authentication Errors
 

--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -1041,15 +1041,15 @@ try {
 
 ### PostgreSQL Connection Errors
 
-| Connection Errors                 | Description                                          |
-| --------------------------------- | ---------------------------------------------------- |
-| `ERR_POSTGRES_CONNECTION_CLOSED`  | An established connection was terminated             |
+| Connection Errors                 | Description                                                                                                                    |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `ERR_POSTGRES_CONNECTION_CLOSED`  | An established connection was terminated                                                                                       |
 | `ERR_POSTGRES_CONNECTION_FAILED`  | Connection could not be established (refused, or closed before the handshake completed — e.g. the server is still starting up) |
-| `ERR_POSTGRES_CONNECTION_TIMEOUT` | Failed to establish connection within timeout period |
-| `ERR_POSTGRES_IDLE_TIMEOUT`       | Connection closed due to inactivity                  |
-| `ERR_POSTGRES_LIFETIME_TIMEOUT`   | Connection exceeded maximum lifetime                 |
-| `ERR_POSTGRES_TLS_NOT_AVAILABLE`  | SSL/TLS connection not available                     |
-| `ERR_POSTGRES_TLS_UPGRADE_FAILED` | Failed to upgrade connection to SSL/TLS              |
+| `ERR_POSTGRES_CONNECTION_TIMEOUT` | Failed to establish connection within timeout period                                                                           |
+| `ERR_POSTGRES_IDLE_TIMEOUT`       | Connection closed due to inactivity                                                                                            |
+| `ERR_POSTGRES_LIFETIME_TIMEOUT`   | Connection exceeded maximum lifetime                                                                                           |
+| `ERR_POSTGRES_TLS_NOT_AVAILABLE`  | SSL/TLS connection not available                                                                                               |
+| `ERR_POSTGRES_TLS_UPGRADE_FAILED` | Failed to upgrade connection to SSL/TLS                                                                                        |
 
 ### Authentication Errors
 

--- a/src/jsc/ErrorCode.rs
+++ b/src/jsc/ErrorCode.rs
@@ -681,9 +681,13 @@ impl ErrorCode {
     pub const SECRETS_AUTH_FAILED: ErrorCode = ErrorCode(310);
     /// `ERR_SECRETS_INTERACTION_REQUIRED` (instanceof Error)
     pub const SECRETS_INTERACTION_REQUIRED: ErrorCode = ErrorCode(311);
+    /// `ERR_POSTGRES_CONNECTION_FAILED` (instanceof Error)
+    pub const POSTGRES_CONNECTION_FAILED: ErrorCode = ErrorCode(312);
+    /// `ERR_MYSQL_CONNECTION_FAILED` (instanceof Error)
+    pub const MYSQL_CONNECTION_FAILED: ErrorCode = ErrorCode(313);
 
     /// == C++ `NODE_ERROR_COUNT`.
-    pub const COUNT: u16 = 312;
+    pub const COUNT: u16 = 314;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -870,6 +874,7 @@ impl ErrorCode {
     pub const ERR_POSTGRES_AUTHENTICATION_FAILED_PBKDF2: ErrorCode =
         ErrorCode::POSTGRES_AUTHENTICATION_FAILED_PBKDF2;
     pub const ERR_POSTGRES_CONNECTION_CLOSED: ErrorCode = ErrorCode::POSTGRES_CONNECTION_CLOSED;
+    pub const ERR_POSTGRES_CONNECTION_FAILED: ErrorCode = ErrorCode::POSTGRES_CONNECTION_FAILED;
     pub const ERR_POSTGRES_CONNECTION_TIMEOUT: ErrorCode = ErrorCode::POSTGRES_CONNECTION_TIMEOUT;
     pub const ERR_POSTGRES_EXPECTED_REQUEST: ErrorCode = ErrorCode::POSTGRES_EXPECTED_REQUEST;
     pub const ERR_POSTGRES_EXPECTED_STATEMENT: ErrorCode = ErrorCode::POSTGRES_EXPECTED_STATEMENT;
@@ -925,6 +930,7 @@ impl ErrorCode {
         ErrorCode::POSTGRES_UNSUPPORTED_NUMERIC_FORMAT;
     pub const ERR_PROXY_INVALID_CONFIG: ErrorCode = ErrorCode::PROXY_INVALID_CONFIG;
     pub const ERR_MYSQL_CONNECTION_CLOSED: ErrorCode = ErrorCode::MYSQL_CONNECTION_CLOSED;
+    pub const ERR_MYSQL_CONNECTION_FAILED: ErrorCode = ErrorCode::MYSQL_CONNECTION_FAILED;
     pub const ERR_MYSQL_CONNECTION_TIMEOUT: ErrorCode = ErrorCode::MYSQL_CONNECTION_TIMEOUT;
     pub const ERR_MYSQL_IDLE_TIMEOUT: ErrorCode = ErrorCode::MYSQL_IDLE_TIMEOUT;
     pub const ERR_MYSQL_LIFETIME_TIMEOUT: ErrorCode = ErrorCode::MYSQL_LIFETIME_TIMEOUT;
@@ -1368,6 +1374,8 @@ static CODE_STR: [&str; ErrorCode::COUNT as usize] = [
     "ERR_SECRETS_INTERACTION_NOT_ALLOWED",
     "ERR_SECRETS_AUTH_FAILED",
     "ERR_SECRETS_INTERACTION_REQUIRED",
+    "ERR_POSTGRES_CONNECTION_FAILED",
+    "ERR_MYSQL_CONNECTION_FAILED",
 ];
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -322,5 +322,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_SECRETS_INTERACTION_NOT_ALLOWED", Error],
   ["ERR_SECRETS_AUTH_FAILED", Error],
   ["ERR_SECRETS_INTERACTION_REQUIRED", Error],
+  ["ERR_POSTGRES_CONNECTION_FAILED", Error, "PostgresError"],
+  ["ERR_MYSQL_CONNECTION_FAILED", Error, "MySQLError"],
 ];
 export default errors;

--- a/src/sql/mysql/protocol/AnyMySQLError.rs
+++ b/src/sql/mysql/protocol/AnyMySQLError.rs
@@ -4,6 +4,7 @@
 #[derive(strum::IntoStaticStr, strum::EnumString, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     ConnectionClosed,
+    ConnectionFailed,
     ConnectionTimedOut,
     LifetimeTimeout,
     IdleTimeout,

--- a/src/sql/postgres/AnyPostgresError.rs
+++ b/src/sql/postgres/AnyPostgresError.rs
@@ -9,6 +9,7 @@
 #[derive(Debug, Copy, Clone, Eq, PartialEq, strum::IntoStaticStr, strum::EnumString)]
 pub enum AnyPostgresError {
     ConnectionClosed,
+    ConnectionFailed,
     ExpectedRequest,
     ExpectedStatement,
     InvalidBackendKeyData,

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -1072,7 +1072,21 @@ impl<const SSL: bool> SocketHandler<SSL> {
         // RAII guard adopts that existing ref (no `ref_()` here); raw-pointer
         // shaped so no reference outlives the potential free.
         let _ref = DerefOnDrop(this.as_ctx_ptr());
-        this.fail(b"Connection closed", AnyMySQLErrorT::ConnectionClosed);
+        // A close before the handshake finished means the server (or an
+        // intermediary like a container port proxy) accepted the TCP
+        // connection but went away before completing startup — e.g. the
+        // database is still initializing. Report it as a connect failure
+        // (the connection was never established) rather than a closed
+        // connection so the error is actionable.
+        use my_sql_connection::Status as S;
+        let (message, err): (&'static [u8], AnyMySQLErrorT) = match this.connection.get().status {
+            S::Connecting | S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => (
+                b"Connection closed before the connection was established",
+                AnyMySQLErrorT::ConnectionFailed,
+            ),
+            _ => (b"Connection closed", AnyMySQLErrorT::ConnectionClosed),
+        };
+        this.fail(message, err);
     }
 
     pub fn on_end(_: &JSMySQLConnection, socket: NewSocketHandler<SSL>) {
@@ -1081,8 +1095,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_connect_error(this: &JSMySQLConnection, _: NewSocketHandler<SSL>, _: i32) {
-        // TODO: proper propagation of the error
-        this.fail(b"Connection closed", AnyMySQLErrorT::ConnectionClosed);
+        this.fail(b"Failed to connect", AnyMySQLErrorT::ConnectionFailed);
     }
 
     pub fn on_timeout(this: &JSMySQLConnection, _: NewSocketHandler<SSL>) {

--- a/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
+++ b/src/sql_jsc/mysql/protocol/any_mysql_error_jsc.rs
@@ -87,6 +87,7 @@ pub(crate) fn mysql_error_to_js(
 
     let code: &'static [u8] = match name {
         "ConnectionClosed" => b"ERR_MYSQL_CONNECTION_CLOSED",
+        "ConnectionFailed" => b"ERR_MYSQL_CONNECTION_FAILED",
         "Overflow" => b"ERR_MYSQL_OVERFLOW",
         "AuthenticationFailed" => b"ERR_MYSQL_AUTHENTICATION_FAILED",
         "UnsupportedAuthPlugin" => b"ERR_MYSQL_UNSUPPORTED_AUTH_PLUGIN",

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -761,6 +761,31 @@ impl PostgresSQLConnection {
     }
 
     pub fn on_close(&self) {
+        // A close before the handshake finished means the server (or an
+        // intermediary like a container port proxy) accepted the TCP
+        // connection but went away before completing startup — e.g. the
+        // database is still initializing. Report it as a connect failure
+        // (the connection was never established) rather than a closed
+        // connection so the error is actionable.
+        self.handle_socket_failure(|this| match this.status.get() {
+            Status::Connecting | Status::SentStartupMessage => this.fail_fmt(
+                b"ERR_POSTGRES_CONNECTION_FAILED",
+                format_args!("Connection closed before the connection was established"),
+            ),
+            _ => this.fail(b"Connection closed", AnyPostgresError::ConnectionClosed),
+        });
+    }
+
+    pub fn on_connect_error(&self) {
+        self.handle_socket_failure(|this| {
+            this.fail_fmt(
+                b"ERR_POSTGRES_CONNECTION_FAILED",
+                format_args!("Failed to connect"),
+            );
+        });
+    }
+
+    fn handle_socket_failure(&self, fail: impl FnOnce(&Self)) {
         self.unregister_auto_flusher();
 
         if self.vm().is_shutting_down() {
@@ -778,7 +803,7 @@ impl PostgresSQLConnection {
             event_loop.enter();
             self.poll_ref.with_mut(|r| r.unref(self.vm_ctx()));
 
-            self.fail(b"Connection closed", AnyPostgresError::ConnectionClosed);
+            fail(self);
             event_loop.exit();
         }
     }
@@ -1421,7 +1446,7 @@ impl<const SSL: bool> SocketHandler<SSL> {
     }
 
     pub fn on_connect_error(this: &PostgresSQLConnection, _socket: SocketType<SSL>, _: i32) {
-        Self::guarded(this, |t| t.on_close());
+        Self::guarded(this, |t| t.on_connect_error());
     }
 
     pub fn on_timeout(this: &PostgresSQLConnection, _socket: SocketType<SSL>) {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -768,9 +768,9 @@ impl PostgresSQLConnection {
         // (the connection was never established) rather than a closed
         // connection so the error is actionable.
         self.handle_socket_failure(|this| match this.status.get() {
-            Status::Connecting | Status::SentStartupMessage => this.fail_fmt(
-                b"ERR_POSTGRES_CONNECTION_FAILED",
-                format_args!("Connection closed before the connection was established"),
+            Status::Connecting | Status::SentStartupMessage => this.fail(
+                b"Connection closed before the connection was established",
+                AnyPostgresError::ConnectionFailed,
             ),
             _ => this.fail(b"Connection closed", AnyPostgresError::ConnectionClosed),
         });
@@ -778,10 +778,7 @@ impl PostgresSQLConnection {
 
     pub fn on_connect_error(&self) {
         self.handle_socket_failure(|this| {
-            this.fail_fmt(
-                b"ERR_POSTGRES_CONNECTION_FAILED",
-                format_args!("Failed to connect"),
-            );
+            this.fail(b"Failed to connect", AnyPostgresError::ConnectionFailed);
         });
     }
 

--- a/src/sql_jsc/postgres/error_jsc.rs
+++ b/src/sql_jsc/postgres/error_jsc.rs
@@ -58,6 +58,7 @@ pub(crate) fn postgres_error_to_js(
     use AnyPostgresError::*;
     let code: &'static [u8] = match err {
         ConnectionClosed => b"ERR_POSTGRES_CONNECTION_CLOSED",
+        ConnectionFailed => b"ERR_POSTGRES_CONNECTION_FAILED",
         ExpectedRequest => b"ERR_POSTGRES_EXPECTED_REQUEST",
         ExpectedStatement => b"ERR_POSTGRES_EXPECTED_STATEMENT",
         InvalidBackendKeyData => b"ERR_POSTGRES_INVALID_BACKEND_KEY_DATA",

--- a/test/js/sql/sql-connect-error-reporting.test.ts
+++ b/test/js/sql/sql-connect-error-reporting.test.ts
@@ -1,0 +1,160 @@
+// During database-server startup (e.g. a postgres/mysql docker container that
+// is still initializing), clients hit two socket-level failures that are not
+// protocol errors: the connection is refused outright, or an intermediary
+// (like the container port proxy) accepts the TCP connection and closes it
+// with no data. Bun previously reported both as a generic
+// ERR_POSTGRES_CONNECTION_CLOSED "Connection closed", which is misleading —
+// the connection was never established. Both are now reported as
+// ERR_*_CONNECTION_FAILED with a message saying what actually happened, while
+// real server errors (e.g. 57P03 "the database system is starting up") and
+// closes of established connections keep their existing reporting.
+// See https://github.com/oven-sh/bun/issues/16691.
+//
+// Uses plain TCP servers / closed ports so the tests run without Docker.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import net from "node:net";
+
+async function listeningServer(onSocket: (socket: net.Socket) => void): Promise<{ port: number; server: net.Server }> {
+  const server = net.createServer(onSocket);
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  return { port: (server.address() as net.AddressInfo).port, server };
+}
+
+async function closedPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  await new Promise<void>(resolve => server.close(() => resolve()));
+  return port;
+}
+
+async function connectError(url: string): Promise<any> {
+  const db = new SQL({ url, max: 1 });
+  try {
+    await db.connect();
+    throw new Error("expected connect() to reject");
+  } catch (err) {
+    return err;
+  } finally {
+    await db.close({ timeout: 0 });
+  }
+}
+
+function postgresAuthOkAndReady(socket: net.Socket) {
+  const authOk = Buffer.alloc(9);
+  authOk.write("R", 0);
+  authOk.writeInt32BE(8, 1);
+  authOk.writeInt32BE(0, 5);
+  const ready = Buffer.alloc(6);
+  ready.write("Z", 0);
+  ready.writeInt32BE(5, 1);
+  ready.write("I", 5);
+  socket.write(Buffer.concat([authOk, ready]));
+}
+
+test("postgres: connection refused is reported as a connect failure, not a closed connection", async () => {
+  const port = await closedPort();
+  const err = await connectError(`postgres://postgres@127.0.0.1:${port}/postgres`);
+  expect(err.message).toBe("Failed to connect");
+  expect(err.code).toBe("ERR_POSTGRES_CONNECTION_FAILED");
+});
+
+test("postgres: connection closed before handshake completes is a connect failure", async () => {
+  // What a docker port proxy does while the database inside is still
+  // initializing: accept, then close with no data.
+  const { port, server } = await listeningServer(socket => socket.destroy());
+  try {
+    const err = await connectError(`postgres://postgres@127.0.0.1:${port}/postgres`);
+    expect(err.message).toBe("Connection closed before the connection was established");
+    expect(err.code).toBe("ERR_POSTGRES_CONNECTION_FAILED");
+  } finally {
+    server.close();
+  }
+});
+
+test("postgres: server ErrorResponse during startup is still surfaced (57P03)", async () => {
+  // A real postgres that is up but still starting replies to the startup
+  // message with FATAL 57P03 and closes. That error must win over the
+  // socket close that follows it.
+  const { port, server } = await listeningServer(socket => {
+    socket.on("data", () => {
+      const fields: [string, string][] = [
+        ["S", "FATAL"],
+        ["V", "FATAL"],
+        ["C", "57P03"],
+        ["M", "the database system is starting up"],
+      ];
+      let len = 4;
+      for (const [, v] of fields) len += 1 + v.length + 1;
+      len += 1;
+      const buf = Buffer.alloc(1 + len);
+      let o = 0;
+      buf.write("E", o++);
+      buf.writeInt32BE(len, o);
+      o += 4;
+      for (const [k, v] of fields) {
+        buf.write(k, o++);
+        buf.write(v + "\0", o);
+        o += v.length + 1;
+      }
+      buf[o] = 0;
+      socket.end(buf);
+    });
+  });
+  try {
+    const err = await connectError(`postgres://postgres@127.0.0.1:${port}/postgres`);
+    expect(err.message).toBe("the database system is starting up");
+    expect(err.code).toBe("ERR_POSTGRES_SERVER_ERROR");
+    expect(err.errno).toBe("57P03");
+  } finally {
+    server.close();
+  }
+});
+
+test("postgres: established connection that closes keeps the plain message", async () => {
+  // Minimal handshake: AuthenticationOk + ReadyForQuery, then close on the
+  // first query so the failure happens on an established connection.
+  const { port, server } = await listeningServer(socket => {
+    let handshakeDone = false;
+    socket.on("data", () => {
+      if (handshakeDone) {
+        socket.destroy();
+        return;
+      }
+      handshakeDone = true;
+      postgresAuthOkAndReady(socket);
+    });
+  });
+  const db = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1 });
+  try {
+    await db.connect();
+    await db`SELECT 1`;
+    throw new Error("expected the query to reject");
+  } catch (err: any) {
+    expect(err.message).toBe("Connection closed");
+    expect(err.code).toBe("ERR_POSTGRES_CONNECTION_CLOSED");
+  } finally {
+    await db.close({ timeout: 0 });
+    server.close();
+  }
+});
+
+test("mysql: connection refused is reported as a connect failure, not a closed connection", async () => {
+  const port = await closedPort();
+  const err = await connectError(`mysql://root@127.0.0.1:${port}/mysql`);
+  expect(err.message).toBe("Failed to connect");
+  expect(err.code).toBe("ERR_MYSQL_CONNECTION_FAILED");
+});
+
+test("mysql: connection closed before handshake completes is a connect failure", async () => {
+  const { port, server } = await listeningServer(socket => socket.destroy());
+  try {
+    const err = await connectError(`mysql://root@127.0.0.1:${port}/mysql`);
+    expect(err.message).toBe("Connection closed before the connection was established");
+    expect(err.code).toBe("ERR_MYSQL_CONNECTION_FAILED");
+  } finally {
+    server.close();
+  }
+});

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1092,7 +1092,7 @@ if (isDockerEnabled()) {
           } catch (err) {
             error = err;
           }
-          expect(error.code).toBe("ERR_MYSQL_CONNECTION_CLOSED");
+          expect(error.code).toBe("ERR_MYSQL_CONNECTION_FAILED");
         });
 
         test("dynamic table name", async () => {

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -2298,7 +2298,7 @@ if (isDockerEnabled()) {
       }
       expect(error).toBeInstanceOf(SQL.SQLError);
       expect(error).toBeInstanceOf(SQL.PostgresError);
-      expect(error.code).toBe("ERR_POSTGRES_CONNECTION_CLOSED");
+      expect(error.code).toBe("ERR_POSTGRES_CONNECTION_FAILED");
     });
 
     test("dynamic table name", async () => {


### PR DESCRIPTION
### What does this PR do?

When a postgres or mysql server is starting up (the common case: a docker container that is still running initdb), `Bun.SQL` connection attempts fail at the socket level in one of two ways:

- the connection is refused (`ECONNREFUSED`), or
- an intermediary — docker's port proxy is the canonical one — accepts the TCP connection and closes it with no data before the handshake completes.

Both were reported as the generic `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED` `"Connection closed"`. That is indistinguishable from an established connection dropping, claims a connection existed when none did (for refused), and gives no hint that the server was simply not ready. This is what the long tail of reports in #16691 is about: at the same instant during a container start, postgres.js reports `57P03: the database system is starting up` while Bun reports `Connection closed`.

This PR introduces `ERR_POSTGRES_CONNECTION_FAILED` / `ERR_MYSQL_CONNECTION_FAILED` for connections that were **never established**:

- connect error (refused/unreachable) → `Failed to connect` (matches the message Bun's `node:net` uses)
- closed while connecting/authenticating → `Connection closed before the connection was established`

`ERR_*_CONNECTION_CLOSED` now only means an established connection was closed (queries after `sql.end()`, idle drops, etc. are unchanged). Server errors sent during the startup window (e.g. `57P03`) were already surfaced correctly — verified against a real postgres pinned in the "starting up" state (standby with `hot_standby = off`) on every release back to 1.2.0 — and are unchanged.

Measured timeline of `docker run postgres` (first boot, macOS) that motivated the classification, raw TCP probe vs `Bun.SQL` every ~15ms:

| window | wire truth | bun before | bun after |
|---|---|---|---|
| +141ms | ECONNREFUSED | `Connection closed` | `Failed to connect` (`CONNECTION_FAILED`) |
| +158..2478ms | accepted, EOF, 0 bytes (~140 attempts) | `Connection closed` | `Connection closed before the connection was established` (`CONNECTION_FAILED`) |
| +2500ms | `ErrorResponse 57P03` | `57P03` ✓ | `57P03` ✓ (unchanged) |
| +2519ms | auth OK | success | success |

### What changed

- `src/sql_jsc/postgres/PostgresSQLConnection.rs`: `on_connect_error` no longer funnels into `on_close`; pre-handshake closes (status `Connecting`/`SentStartupMessage`) report `CONNECTION_FAILED`.
- `src/sql_jsc/mysql/JSMySQLConnection.rs`: same, for `Connecting`/`Handshaking`/`Authenticating`/`AuthenticationAwaitingPk` (also removes the `// TODO: proper propagation of the error` in `on_connect_error`).
- `AnyMySQLError`: new `ConnectionFailed` variant + code mapping.
- `ErrorCode.ts`/`ErrorCode.rs`: registered the two new codes (appended at the end so existing discriminants are unchanged).
- Docs: error-code table updated.
- Two existing tests that connect to a dead port (`port: 1`) updated to expect the new code.

### How was this tested?

New `test/js/sql/sql-connect-error-reporting.test.ts` (plain TCP mock servers, no docker): refused, accepted-then-closed, real `57P03` ErrorResponse still surfaced, and established-connection close keeps the old code/message — for both postgres and mysql. All 6 fail (4 new-behavior) on the current release and pass with this change. `sql.test.ts`, `sql-mysql.test.ts`, and `sqlite-sql.test.ts` show the same pass/fail set as `main` run side-by-side locally (the remaining failures are pre-existing docker-infra flakes, identical on a clean checkout).

### Follow-up

A second PR (stacked on this one) makes the pool retry `CONNECTION_FAILED` errors with backoff until `connectionTimeout` while queries are waiting, so a server that becomes ready mid-startup is invisible to the application — that is the behavioral half of #16691 and is kept separate so it can be reviewed on its own.