### PR TITLE
test(sql): fix malformed force_tls.cnf in mysql-tls image

### DIFF
--- a/test/js/sql/mysql-tls/Dockerfile
+++ b/test/js/sql/mysql-tls/Dockerfile
@@ -16,7 +16,7 @@ COPY conf.d /etc/mysql/conf.d
 RUN chown -R mysql:mysql /etc/mysql/ssl /etc/mysql/conf.d \
  && chmod 600 /etc/mysql/ssl/server-key.pem \
  && find /etc/mysql/ssl -type f -name "*.pem" -exec chmod 640 {} \; \
- && echo "require_secure_transport=ON" >> /etc/mysql/conf.d/force_tls.cnf
+ && printf "[mysqld]\nrequire_secure_transport=ON\n" > /etc/mysql/conf.d/force_tls.cnf
 
 # Expose MySQL
 EXPOSE 3306


### PR DESCRIPTION
## What
One-line fix: `test/js/sql/mysql-tls/Dockerfile` appended `require_secure_transport=ON` to a fresh cnf file with no `[mysqld]` group header.

## Why
MySQL config files require options to live under a group. The mysql client reads `conf.d` during the entrypoint's temporary-server phase and errors with `Found option without preceding group in config file /etc/mysql/conf.d/force_tls.cnf at line 1`; the container healthcheck reads the same config and can fail the same way, so `docker compose up --wait` times out and every test depending on `mysql_tls` fails at `ensure()`.

## How verified
With the group header, the image builds and the container reaches healthy; `sql-mysql.test.ts`'s mysql_tls-dependent tests get a working server (verified on macOS arm64 against a remote Docker daemon).