### PR TITLE
ci: raise darwin test-step timeout to 40 minutes

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -824,7 +824,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
     parallelism: os === "darwin" ? 2 : os === "windows" ? 8 : 20,
-    timeout_in_minutes: profile === "asan" || os === "windows" ? 45 : 30,
+    timeout_in_minutes: profile === "asan" || os === "windows" ? 45 : os === "darwin" ? 40 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       // Platform smoke check: runner.node.mjs asserts the agent matches what


### PR DESCRIPTION
## What
One value: darwin test steps get `timeout_in_minutes: 40` (was 30). Linux stays 30, asan/windows stay 45.

## Why
darwin test shards (parallelism 2) regularly run 26–31 minutes wall including checkout. Under the 30-minute cap there's effectively zero margin: a shard that lands on a busy agent or hits a slow patch gets killed at ~100% completion and burns a retry for no signal. Recent examples hit 30.7 minutes with a normal pass-residue exit.

## Impact
- No effect on healthy fast runs (timeout is a ceiling, not a target)
- Genuinely-hung jobs still die — 10 minutes later at worst
- Removes a class of spurious darwin timeouts/retries