### PR TITLE
bun:test: add test.extend() fixtures

### DIFF
--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -389,6 +389,93 @@ test.each(["apple", "banana"])("fruit #%# is %s", fruit => {
 });
 ```
 
+## Fixtures
+
+### test.extend
+
+Use `test.extend()` to create a test function with reusable setup and teardown, modeled on [Playwright](https://playwright.dev/docs/test-fixtures) and [Vitest](https://vitest.dev/guide/test-context.html#test-extend) fixtures. Each fixture is either a plain value or a setup function; tests access fixtures by destructuring the context object, which is passed as the test callback's last parameter.
+
+```ts title="db.test.ts" icon="/icons/typescript.svg"
+import { test as base, expect } from "bun:test";
+
+const test = base.extend<{ db: Database }>({
+  db: async ({}, use) => {
+    const db = await connect(); // runs before the test
+    await use(db); // the test runs while use() is pending
+    await db.close(); // runs after the test
+  },
+});
+
+test("select user", async ({ db }) => {
+  const rows = await db.query("SELECT 1");
+  expect(rows).toHaveLength(1);
+});
+```
+
+A fixture setup function receives the context as its first parameter and a `use` function as its second. Call `await use(value)` exactly once to provide the fixture value; code after `await use(value)` is the fixture's teardown and runs after the test finishes, even if the test fails. Teardown runs in reverse setup order.
+
+A fixture function can also return its value instead of calling `use()`. If the returned value is disposable (it implements `Symbol.asyncDispose` or `Symbol.dispose`), disposing it after the test is the fixture's teardown. This makes resources designed for `await using` one-liners:
+
+```ts
+// Database implements AsyncDisposable, so it is disposed after the test
+const test = base.extend<{ db: Database }>({
+  db: () => connect(),
+});
+```
+
+`await using` also composes with `use()`-style fixtures: the fixture function resumes after the test, so its `await using` declarations are disposed as teardown:
+
+```ts
+const test = base.extend<{ db: Database }>({
+  db: async ({}, use) => {
+    await using db = await connect();
+    await use(db);
+    // db is disposed here, after the test
+  },
+});
+```
+
+Fixtures are **lazy**: a fixture is only set up when a test (or another fixture) destructures it. To run a fixture for every test regardless, pass `{ auto: true }`:
+
+```ts
+const test = base.extend<{ logs: string[] }>({
+  logs: [
+    async ({}, use) => {
+      const logs: string[] = [];
+      await use(logs);
+      console.log(logs.join("\n"));
+    },
+    { auto: true },
+  ],
+});
+```
+
+Fixtures can depend on other fixtures by destructuring them, and `.extend()` calls chain, with later fixtures overriding earlier ones of the same name:
+
+```ts
+const test = base.extend<{ port: number }>({ port: 3000 }).extend<{ url: string }>({
+  url: async ({ port }, use) => {
+    await use(`http://localhost:${port}`);
+  },
+});
+
+test("fixtures compose", ({ url }) => {
+  expect(url).toBe("http://localhost:3000");
+});
+```
+
+The extended test function keeps all modifiers (`.skip`, `.only`, `.todo`, `.each`, `.if`, and so on). With `test.each`, the table arguments come first and the fixture context last:
+
+```ts
+const withN = base.extend<{ n: number }>({ n: 10 });
+
+withN.each([[1], [2]])("n + %i", (i, { n }) => {
+  expect(n + i).toBeGreaterThan(10);
+});
+```
+
+Because the runner detects used fixtures from the destructuring pattern, the context parameter of a test (or fixture) must use object destructuring; rest elements (`...rest`) are not supported. Tests registered through an extended test function do not take a `done` callback; return a promise instead. Fixture teardown does not run for tests that time out.
+
 ## Assertion Counting
 
 Bun supports verifying that a specific number of assertions were called during a test:

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -393,16 +393,16 @@ test.each(["apple", "banana"])("fruit #%# is %s", fruit => {
 
 ### test.extend
 
-Use `test.extend()` to create a test function with reusable setup and teardown, modeled on [Playwright](https://playwright.dev/docs/test-fixtures) and [Vitest](https://vitest.dev/guide/test-context.html#test-extend) fixtures. Each fixture is either a plain value or a setup function; tests access fixtures by destructuring the context object, which is passed as the test callback's last parameter.
+Use `test.extend()` to create a test function with reusable setup and teardown, modeled on [Playwright](https://playwright.dev/docs/test-fixtures) and [Vitest](https://vitest.dev/guide/test-context.html#test-extend) fixtures. Each fixture is either a plain value or a setup function; tests receive the fixtures as a context object, passed as the test callback's last parameter, and pick the ones they need by destructuring it.
 
 ```ts title="db.test.ts" icon="/icons/typescript.svg"
 import { test as base, expect } from "bun:test";
 
 const test = base.extend<{ db: Database }>({
   db: async ({}, use) => {
-    const db = await connect(); // runs before the test
+    const db = await connect(); // setup: runs before the test
     await use(db); // the test runs while use() is pending
-    await db.close(); // runs after the test
+    await db.close(); // teardown: runs after the test
   },
 });
 
@@ -412,18 +412,7 @@ test("select user", async ({ db }) => {
 });
 ```
 
-A fixture setup function receives the context as its first parameter and a `use` function as its second. Call `await use(value)` exactly once to provide the fixture value; code after `await use(value)` is the fixture's teardown and runs after the test finishes, even if the test fails. Teardown runs in reverse setup order.
-
-A fixture function can also return its value instead of calling `use()`. If the returned value is disposable (it implements `Symbol.asyncDispose` or `Symbol.dispose`), disposing it after the test is the fixture's teardown. This makes resources designed for `await using` one-liners:
-
-```ts
-// Database implements AsyncDisposable, so it is disposed after the test
-const test = base.extend<{ db: Database }>({
-  db: () => connect(),
-});
-```
-
-`await using` also composes with `use()`-style fixtures: the fixture function resumes after the test, so its `await using` declarations are disposed as teardown:
+A setup function receives the context as its first parameter and a `use` function as its second, and must call `await use(value)` exactly once. Resources declared with `await using` before `use()` are disposed as part of the teardown:
 
 ```ts
 const test = base.extend<{ db: Database }>({
@@ -435,7 +424,11 @@ const test = base.extend<{ db: Database }>({
 });
 ```
 
-Fixtures are **lazy**: a fixture is only set up when a test (or another fixture) destructures it. To run a fixture for every test regardless, pass `{ auto: true }`:
+#### Lifecycle
+
+For each test, fixtures are set up after the `beforeEach` hooks and torn down after the `afterEach` hooks, in reverse setup order. Teardown always runs, including when the test fails, times out, or a hook throws, and an error thrown during teardown fails the test.
+
+The fixtures a test uses are detected from the destructuring pattern of its context parameter, so the parameter must be written as an object destructuring pattern (`({ db }) => ...`, or `({}, use) => ...` for a fixture that depends on nothing); rest elements (`...rest`) are not supported. Fixtures are **lazy**: a fixture is only set up when the test, or another fixture it uses, destructures it. To set a fixture up for every test regardless, pass `{ auto: true }`:
 
 ```ts
 const test = base.extend<{ logs: string[] }>({
@@ -450,7 +443,9 @@ const test = base.extend<{ logs: string[] }>({
 });
 ```
 
-Fixtures can depend on other fixtures by destructuring them, and `.extend()` calls chain, with later fixtures overriding earlier ones of the same name:
+#### Composing fixtures
+
+Fixtures depend on other fixtures by destructuring them, and `.extend()` calls chain:
 
 ```ts
 const test = base.extend<{ port: number }>({ port: 3000 }).extend<{ url: string }>({
@@ -464,6 +459,16 @@ test("fixtures compose", ({ url }) => {
 });
 ```
 
+A fixture with the same name as an existing one replaces it for tests registered through the new test function. The replacement can destructure its own name to receive the value of the definition it replaces, which is how to wrap or configure a fixture defined elsewhere:
+
+```ts
+const loggedTest = test.extend<{ db: Database }>({
+  db: async ({ db }, use) => {
+    await use(withQueryLogging(db));
+  },
+});
+```
+
 The extended test function keeps all modifiers (`.skip`, `.only`, `.todo`, `.each`, `.if`, and so on). With `test.each`, the table arguments come first and the fixture context last:
 
 ```ts
@@ -474,7 +479,7 @@ withN.each([[1], [2]])("n + %i", (i, { n }) => {
 });
 ```
 
-Because the runner detects used fixtures from the destructuring pattern, the context parameter of a test (or fixture) must use object destructuring; rest elements (`...rest`) are not supported. Tests registered through an extended test function do not take a `done` callback; return a promise instead. Fixture teardown does not run for tests that time out.
+Tests registered through an extended test function do not take a `done` callback; return a promise instead. Fixtures are scoped to a single test: a fixture is set up and torn down again for every test (and every retry) that uses it, so share expensive resources across tests with `beforeAll`.
 
 ## Assertion Counting
 

--- a/docs/test/writing-tests.mdx
+++ b/docs/test/writing-tests.mdx
@@ -426,7 +426,7 @@ const test = base.extend<{ db: Database }>({
 
 #### Lifecycle
 
-For each test, fixtures are set up after the `beforeEach` hooks and torn down after the `afterEach` hooks, in reverse setup order. Teardown always runs, including when the test fails, times out, or a hook throws, and an error thrown during teardown fails the test.
+For each test, fixtures are set up after the `beforeEach` hooks and torn down after the `afterEach` hooks, in reverse setup order; `onTestFinished` callbacks run last, after the fixtures are torn down. Teardown always runs, including when the test fails, times out, or a hook throws, and an error thrown during teardown fails the test.
 
 The fixtures a test uses are detected from the destructuring pattern of its context parameter, so the parameter must be written as an object destructuring pattern (`({ db }) => ...`, or `({}, use) => ...` for a fixture that depends on nothing); rest elements (`...rest`) are not supported. Fixtures are **lazy**: a fixture is only set up when the test, or another fixture it uses, destructures it. To set a fixture up for every test regardless, pass `{ auto: true }`:
 

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -445,7 +445,60 @@ declare module "bun:test" {
      * Accepts `[1, 2, 3] | ["a", "b", "c"]` and returns `[1 | "a", 2 | "b", 3 | "c"]`
      */
     type Flatten<T, Copy extends T = T> = { [Key in keyof T]: Copy[Key] };
+
+    /**
+     * `Test<T>` uses `never` as the "not extended" marker; after `.extend()` the
+     * context is a real object type. This maps the marker to `{}` so fixture
+     * contexts can be intersected.
+     */
+    type ContextOrEmpty<Ctx> = [Ctx] extends [never] ? {} : Ctx;
+
+    /** A fixture value of a function type must be declared with the setup-function form. */
+    type FixtureValue<V, Ctx> = ((...args: any) => any) extends V ? FixtureFn<V, Ctx> : V | FixtureFn<V, Ctx>;
   }
+
+  /**
+   * The `use` function passed to a fixture function. Call `await use(value)` to
+   * provide the fixture value; the test runs while `use()` is pending, and code
+   * after `await use(value)` runs as teardown once the test finishes.
+   */
+  export type Use<V> = (value: V) => Promise<void>;
+
+  /**
+   * A fixture setup function. Receives the context (other fixtures it depends
+   * on, referenced by destructuring) and a {@link Use} function.
+   *
+   * Either call `await use(value)` exactly once (code after it is the
+   * fixture's teardown), or return the fixture value directly without calling
+   * `use()`; a returned value that is disposable (it implements
+   * `Symbol.asyncDispose` or `Symbol.dispose`) is disposed after the test as
+   * the fixture's teardown.
+   */
+  export type FixtureFn<V, Ctx> = (
+    context: Ctx,
+    use: Use<V>,
+  ) => Exclude<V, undefined> | Promise<Exclude<V, undefined>> | void | Promise<void>;
+
+  export interface FixtureOptions {
+    /**
+     * Set up this fixture for every test registered through the extended test
+     * function, even tests that do not destructure it.
+     *
+     * @default false
+     */
+    auto?: boolean;
+  }
+
+  /**
+   * The object passed to `test.extend()`. Each property is either a plain
+   * fixture value or a fixture setup function, optionally wrapped in a
+   * `[valueOrFn, options]` tuple.
+   */
+  export type Fixtures<FixturesCtx extends Record<string, unknown>, Ctx = {}> = {
+    [K in keyof FixturesCtx]:
+      | __internal.FixtureValue<FixturesCtx[K], Ctx & Omit<FixturesCtx, K>>
+      | [__internal.FixtureValue<FixturesCtx[K], Ctx & Omit<FixturesCtx, K>>, FixtureOptions];
+  };
 
   /**
    * Runs a test.
@@ -472,13 +525,16 @@ declare module "bun:test" {
    *
    * @category Testing
    */
-  export interface Test<T extends ReadonlyArray<unknown>> {
+  export interface Test<T extends ReadonlyArray<unknown>, Ctx extends Record<string, unknown> = never> {
     (
       label: string,
 
       fn: (
         ...args: __internal.IsTuple<T> extends true
-          ? [...table: __internal.Flatten<T>, done: (err?: unknown) => void]
+          ? [
+              ...table: __internal.Flatten<T>,
+              ...rest: [Ctx] extends [never] ? [done: (err?: unknown) => void] : [context: Ctx],
+            ]
           : T
       ) => void | Promise<unknown>,
 
@@ -494,11 +550,11 @@ declare module "bun:test" {
     /**
      * Skips all other tests, except this test.
      */
-    only: Test<T>;
+    only: Test<T, Ctx>;
     /**
      * Skips this test.
      */
-    skip: Test<T>;
+    skip: Test<T, Ctx>;
     /**
      * Marks this test as to be written or to be fixed.
      *
@@ -506,7 +562,7 @@ declare module "bun:test" {
      * a `.todo` test that passes is marked as `fail` in the results: remove
      * the `.todo` or check that the test is implemented correctly.
      */
-    todo: Test<T>;
+    todo: Test<T, Ctx>;
     /**
      * Marks this test as failing.
      *
@@ -516,16 +572,16 @@ declare module "bun:test" {
      * `test.failing` is similar to {@link test.todo} except that it always
      * runs, regardless of the `--todo` flag.
      */
-    failing: Test<T>;
+    failing: Test<T, Ctx>;
     /**
      * Runs the test concurrently with other concurrent tests.
      */
-    concurrent: Test<T>;
+    concurrent: Test<T, Ctx>;
     /**
      * Forces the test to run serially (not in parallel),
      * even when the --concurrent flag is used.
      */
-    serial: Test<T>;
+    serial: Test<T, Ctx>;
     /**
      * Runs this test, if `condition` is true.
      *
@@ -533,46 +589,82 @@ declare module "bun:test" {
      *
      * @param condition if the test should run
      */
-    if(condition: boolean): Test<T>;
+    if(condition: boolean): Test<T, Ctx>;
     /**
      * Skips this test, if `condition` is true.
      *
      * @param condition if the test should be skipped
      */
-    skipIf(condition: boolean): Test<T>;
+    skipIf(condition: boolean): Test<T, Ctx>;
     /**
      * Marks this test as to be written or to be fixed, if `condition` is true.
      *
      * @param condition if the test should be marked TODO
      */
-    todoIf(condition: boolean): Test<T>;
+    todoIf(condition: boolean): Test<T, Ctx>;
     /**
      * Marks this test as failing, if `condition` is true.
      *
      * @param condition if the test should be marked as failing
      */
-    failingIf(condition: boolean): Test<T>;
+    failingIf(condition: boolean): Test<T, Ctx>;
     /**
      * Runs the test concurrently with other concurrent tests, if `condition` is true.
      *
      * @param condition if the test should run concurrently
      */
-    concurrentIf(condition: boolean): Test<T>;
+    concurrentIf(condition: boolean): Test<T, Ctx>;
     /**
      * Forces the test to run serially (not in parallel), if `condition` is true.
      * This applies even when the --concurrent flag is used.
      *
      * @param condition if the test should run serially
      */
-    serialIf(condition: boolean): Test<T>;
+    serialIf(condition: boolean): Test<T, Ctx>;
     /**
      * Returns a function that runs for each item in `table`.
      *
      * @param table Array of Arrays with the arguments that are passed into the test fn for each row.
      */
-    each<T extends Readonly<[unknown, ...unknown[]]>>(table: readonly T[]): Test<T>;
-    each<T extends unknown[]>(table: readonly T[]): Test<T>;
-    each<const T>(table: T[]): Test<[T]>;
+    each<T extends Readonly<[unknown, ...unknown[]]>>(table: readonly T[]): Test<T, Ctx>;
+    each<T extends unknown[]>(table: readonly T[]): Test<T, Ctx>;
+    each<const T>(table: T[]): Test<[T], Ctx>;
+    /**
+     * Returns a new test function with the given fixtures available to every
+     * test registered through it. The test callback receives the fixture
+     * context as its last parameter; access fixtures by destructuring it.
+     *
+     * A fixture is either a plain value or a setup function. A setup function
+     * either calls `await use(value)` (setup code before `use()` runs before
+     * the test, teardown code after it runs after the test, in reverse setup
+     * order) or returns the fixture value directly, in which case a disposable
+     * value (`Symbol.asyncDispose` or `Symbol.dispose`) is disposed after the
+     * test. Fixture setup functions can depend on other fixtures by
+     * destructuring their first parameter. Fixtures are lazy: a fixture is only
+     * set up when the test (or another fixture it uses) destructures it, unless
+     * it is declared with `{ auto: true }`.
+     *
+     * Tests registered through an extended test function do not take a `done`
+     * callback; return a promise instead.
+     *
+     * @example
+     * const dbTest = test.extend<{ db: Database }>({
+     *   db: async ({}, use) => {
+     *     const db = await connect();
+     *     await use(db);
+     *     await db.close();
+     *   },
+     * });
+     *
+     * dbTest("select", async ({ db }) => {
+     *   expect(await db.query("SELECT 1")).toHaveLength(1);
+     * });
+     *
+     * @param fixtures an object defining the fixtures
+     */
+    extend<FixturesCtx extends Record<string, unknown>>(
+      fixtures: Fixtures<FixturesCtx, __internal.ContextOrEmpty<Ctx>>,
+    ): Test<T, Omit<__internal.ContextOrEmpty<Ctx>, keyof FixturesCtx> & FixturesCtx>;
   }
   /**
    * Runs a test.

--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -453,36 +453,45 @@ declare module "bun:test" {
      */
     type ContextOrEmpty<Ctx> = [Ctx] extends [never] ? {} : Ctx;
 
-    /** A fixture value of a function type must be declared with the setup-function form. */
-    type FixtureValue<V, Ctx> = ((...args: any) => any) extends V ? FixtureFn<V, Ctx> : V | FixtureFn<V, Ctx>;
+    /**
+     * A fixture whose value type is itself a function can only be declared with
+     * the setup-function form, since a plain function value would be ambiguous.
+     */
+    type FixtureValue<V, Ctx> = 0 extends 1 & V
+      ? V | FixtureFn<V, Ctx>
+      : ((...args: any) => any) extends V
+        ? FixtureFn<V, Ctx>
+        : V | FixtureFn<V, Ctx>;
   }
 
   /**
    * The `use` function passed to a fixture function. Call `await use(value)` to
    * provide the fixture value; the test runs while `use()` is pending, and code
-   * after `await use(value)` runs as teardown once the test finishes.
+   * after `await use(value)` runs as teardown once the test (and its `afterEach`
+   * hooks) have finished.
    */
   export type Use<V> = (value: V) => Promise<void>;
 
   /**
-   * A fixture setup function. Receives the context (other fixtures it depends
-   * on, referenced by destructuring) and a {@link Use} function.
+   * A fixture setup function. It must call `await use(value)` exactly once;
+   * code before it is setup, code after it is teardown. Its return value is
+   * ignored.
    *
-   * Either call `await use(value)` exactly once (code after it is the
-   * fixture's teardown), or return the fixture value directly without calling
-   * `use()`; a returned value that is disposable (it implements
-   * `Symbol.asyncDispose` or `Symbol.dispose`) is disposed after the test as
-   * the fixture's teardown.
+   * The first parameter is the context holding the other fixtures. Dependencies
+   * are detected from the parameter's object destructuring pattern, so it must
+   * be written as a destructuring pattern (`({ db }, use) => ...`, or `({}, use)`
+   * when the fixture depends on nothing). A fixture passed to `.extend()` under
+   * a name that already exists may destructure that name to receive the value of
+   * the definition it overrides.
    */
-  export type FixtureFn<V, Ctx> = (
-    context: Ctx,
-    use: Use<V>,
-  ) => Exclude<V, undefined> | Promise<Exclude<V, undefined>> | void | Promise<void>;
+  export type FixtureFn<V, Ctx> = (context: Ctx, use: Use<V>) => unknown | Promise<unknown>;
 
   export interface FixtureOptions {
     /**
      * Set up this fixture for every test registered through the extended test
-     * function, even tests that do not destructure it.
+     * function, even tests that do not destructure it. A fixture that overrides
+     * an existing one inherits this from the definition it overrides unless it
+     * specifies its own options.
      *
      * @default false
      */
@@ -491,10 +500,10 @@ declare module "bun:test" {
 
   /**
    * The object passed to `test.extend()`. Each property is either a plain
-   * fixture value or a fixture setup function, optionally wrapped in a
+   * fixture value or a {@link FixtureFn}, optionally wrapped in a
    * `[valueOrFn, options]` tuple.
    */
-  export type Fixtures<FixturesCtx extends Record<string, unknown>, Ctx = {}> = {
+  export type Fixtures<FixturesCtx extends Record<string, any>, Ctx = {}> = {
     [K in keyof FixturesCtx]:
       | __internal.FixtureValue<FixturesCtx[K], Ctx & Omit<FixturesCtx, K>>
       | [__internal.FixtureValue<FixturesCtx[K], Ctx & Omit<FixturesCtx, K>>, FixtureOptions];
@@ -525,7 +534,7 @@ declare module "bun:test" {
    *
    * @category Testing
    */
-  export interface Test<T extends ReadonlyArray<unknown>, Ctx extends Record<string, unknown> = never> {
+  export interface Test<T extends ReadonlyArray<unknown>, Ctx extends Record<string, any> = never> {
     (
       label: string,
 
@@ -632,17 +641,19 @@ declare module "bun:test" {
     /**
      * Returns a new test function with the given fixtures available to every
      * test registered through it. The test callback receives the fixture
-     * context as its last parameter; access fixtures by destructuring it.
+     * context as its last parameter (after any `test.each` arguments).
      *
-     * A fixture is either a plain value or a setup function. A setup function
-     * either calls `await use(value)` (setup code before `use()` runs before
-     * the test, teardown code after it runs after the test, in reverse setup
-     * order) or returns the fixture value directly, in which case a disposable
-     * value (`Symbol.asyncDispose` or `Symbol.dispose`) is disposed after the
-     * test. Fixture setup functions can depend on other fixtures by
-     * destructuring their first parameter. Fixtures are lazy: a fixture is only
-     * set up when the test (or another fixture it uses) destructures it, unless
-     * it is declared with `{ auto: true }`.
+     * The fixtures a test uses are detected from the context parameter's object
+     * destructuring pattern, so the parameter must be written as one
+     * (`({ db }) => ...`); a fixture is only set up when the test, or another
+     * fixture it uses, destructures it, unless it is declared with
+     * `{ auto: true }`. Setup runs after the `beforeEach` hooks, in dependency
+     * order; teardown (the code after `await use()`) runs after the `afterEach`
+     * hooks, in reverse order, including when the test fails or times out.
+     *
+     * `.extend()` calls chain. A fixture with the same name as an existing one
+     * replaces it, and may destructure that name to build on the definition it
+     * replaces.
      *
      * Tests registered through an extended test function do not take a `done`
      * callback; return a promise instead.
@@ -662,7 +673,7 @@ declare module "bun:test" {
      *
      * @param fixtures an object defining the fixtures
      */
-    extend<FixturesCtx extends Record<string, unknown>>(
+    extend<FixturesCtx extends Record<string, any>>(
       fixtures: Fixtures<FixturesCtx, __internal.ContextOrEmpty<Ctx>>,
     ): Test<T, Omit<__internal.ContextOrEmpty<Ctx>, keyof FixturesCtx> & FixturesCtx>;
   }

--- a/src/js/builtins/BunTestFixtures.ts
+++ b/src/js/builtins/BunTestFixtures.ts
@@ -1,0 +1,340 @@
+// Fixture support for bun:test's `test.extend()` (modeled on vitest/playwright fixtures).
+//
+// A fixture registry is an array of records `{ name, value, isFn, auto }` built by
+// `mergeTestFixtures` when `.extend()` is called, and consumed by
+// `wrapTestFixtureCallback` each time a test registered through an extended test
+// function runs. Both functions are invoked from native code
+// (src/runtime/test_runner/ScopeFunctions.rs via Bun__TestFixtures__* in
+// src/jsc/bindings/BunTestFixtures.cpp).
+
+interface FixtureRecord {
+  name: string;
+  value: unknown;
+  isFn: boolean;
+  auto: boolean;
+}
+
+/**
+ * Validate the object passed to `test.extend()` and merge it over the parent
+ * registry (later `.extend()` calls override earlier fixtures with the same name).
+ */
+export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, newFixtures: unknown) {
+  if (!$isObject(newFixtures) || $isJSArray(newFixtures) || $isCallable(newFixtures)) {
+    throw new TypeError("test.extend() expects an object where each property is a fixture");
+  }
+
+  const merged: FixtureRecord[] = [];
+  if (parentFixtures !== undefined) {
+    for (let i = 0; i < parentFixtures.length; i++) {
+      $arrayPush(merged, parentFixtures[i]);
+    }
+  }
+
+  const names = Object.keys(newFixtures as object);
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i];
+    let value = (newFixtures as Record<string, unknown>)[name];
+    let auto = false;
+
+    // `[value, options]` tuple form. Mirrors vitest: only treated as a tuple when the
+    // second element is an object carrying at least one known fixture option key;
+    // otherwise the array itself is the fixture value.
+    if ($isJSArray(value) && (value as unknown[]).length >= 2) {
+      const maybeOptions = (value as unknown[])[1];
+      if ($isObject(maybeOptions) && !$isJSArray(maybeOptions)) {
+        const optionKeys = Object.keys(maybeOptions as object);
+        let isOptions = false;
+        for (let k = 0; k < optionKeys.length; k++) {
+          const key = optionKeys[k];
+          if (key === "auto" || key === "injected" || key === "scope") {
+            isOptions = true;
+            break;
+          }
+        }
+        if (isOptions) {
+          const options = maybeOptions as { auto?: unknown; injected?: unknown; scope?: unknown };
+          const scope = options.scope;
+          if (scope !== undefined && scope !== "test") {
+            throw new TypeError(
+              `test.extend() fixture "${name}": scope "${String(scope)}" is not supported. Only "test" scoped fixtures are supported.`,
+            );
+          }
+          if (options.injected) {
+            throw new TypeError(`test.extend() fixture "${name}": the "injected" option is not supported`);
+          }
+          auto = !!options.auto;
+          value = (value as unknown[])[0];
+        }
+      }
+    }
+
+    const record: FixtureRecord = { name, value, isFn: $isCallable(value), auto };
+    let replaced = false;
+    for (let m = 0; m < merged.length; m++) {
+      if (merged[m].name === name) {
+        merged[m] = record;
+        replaced = true;
+        break;
+      }
+    }
+    if (!replaced) {
+      $arrayPush(merged, record);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Wrap a test callback so that, when the test runs, the fixtures it uses are set
+ * up first (in dependency order), the callback receives the fixture context as
+ * its last argument (after any `test.each` case arguments), and teardown runs in
+ * reverse setup order once the callback settles. Fixture functions either call
+ * `await use(value)` (code after it is the teardown) or return the value
+ * directly (a disposable return value is disposed as the teardown).
+ */
+export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback: Function) {
+  function arrayIncludes(array: string[], value: string): boolean {
+    for (let i = 0; i < array.length; i++) {
+      if (array[i] === value) return true;
+    }
+    return false;
+  }
+
+  // Split a parameter list (or destructuring pattern body) at top-level commas,
+  // skipping over nested `{}`/`[]`/`()` groups.
+  function splitByComma(s: string): string[] {
+    const result: string[] = [];
+    const stack: string[] = [];
+    let start = 0;
+    for (let i = 0; i < s.length; i++) {
+      const c = s[i];
+      if (c === "{" || c === "[" || c === "(") {
+        $arrayPush(stack, c === "{" ? "}" : c === "[" ? "]" : ")");
+      } else if (stack.length !== 0 && c === stack[stack.length - 1]) {
+        stack.length -= 1;
+      } else if (stack.length === 0 && c === ",") {
+        const token = s.substring(start, i).trim();
+        if (token) $arrayPush(result, token);
+        start = i + 1;
+      }
+    }
+    const token = s.substring(start).trim();
+    if (token) $arrayPush(result, token);
+    return result;
+  }
+
+  // Determine which fixture names a function destructures from its context
+  // parameter (the parameter at `paramIndex`). Like vitest, this reads the
+  // function's source text, so the context parameter must use an object
+  // destructuring pattern for fixtures to be detected. Returns null when the
+  // source is unavailable (bound functions, AsyncLocalStorage-wrapped
+  // callbacks), in which case the caller decides a fallback.
+  function getUsedProps(fn: Function, paramIndex: number): string[] | null {
+    let source: string;
+    try {
+      source = fn.toString();
+    } catch {
+      return null;
+    }
+    if (source.indexOf("[native code]") !== -1) {
+      return null;
+    }
+    const parenIndex = source.indexOf("(");
+    if (parenIndex === -1) {
+      // single-parameter arrow function with no parentheses; it cannot
+      // destructure, so it uses no fixtures.
+      return [];
+    }
+    let depth = 1;
+    let end = parenIndex + 1;
+    while (end < source.length && depth > 0) {
+      const c = source[end];
+      if (c === "(") depth++;
+      else if (c === ")") depth--;
+      end++;
+    }
+    const params = splitByComma(source.substring(parenIndex + 1, end - 1));
+    const target = params[paramIndex];
+    if (target === undefined) return [];
+    if (!(target.startsWith("{") && target.endsWith("}"))) {
+      throw new TypeError(
+        `In tests using test.extend(), the fixture context parameter must use object destructuring, e.g. ({ myFixture }) => { ... }. Received "${target}".`,
+      );
+    }
+    const props = splitByComma(target.substring(1, target.length - 1));
+    const used: string[] = [];
+    for (let i = 0; i < props.length; i++) {
+      const prop = props[i];
+      if (prop.startsWith("...")) {
+        throw new TypeError(`Rest parameters are not supported when destructuring fixtures. Received "${prop}".`);
+      }
+      // strip renames (`a: b`) and default values (`a = 1`)
+      let name = prop;
+      for (let c = 0; c < prop.length; c++) {
+        if (prop[c] === ":" || prop[c] === "=") {
+          name = prop.substring(0, c);
+          break;
+        }
+      }
+      name = name.trim();
+      if (
+        name.length >= 2 &&
+        ((name.startsWith("'") && name.endsWith("'")) || (name.startsWith('"') && name.endsWith('"')))
+      ) {
+        name = name.substring(1, name.length - 1);
+      }
+      if (name) $arrayPush(used, name);
+    }
+    return used;
+  }
+
+  function findFixture(name: string): FixtureRecord | undefined {
+    for (let i = 0; i < fixtures.length; i++) {
+      if (fixtures[i].name === name) return fixtures[i];
+    }
+    return undefined;
+  }
+
+  return async function (...caseArgs: unknown[]) {
+    const context: Record<string, unknown> = {};
+    if (fixtures.length === 0) {
+      return testCallback(...caseArgs, context);
+    }
+
+    const teardowns: (() => Promise<unknown>)[] = [];
+    const resolvedNames: string[] = [];
+
+    // Run one fixture function. The value passed to `use()` (or, when `use()` is
+    // never called, the function's resolved return value) becomes the fixture
+    // value. A `use()`-style fixture stays suspended inside `use()` until
+    // teardown, when the remainder of the fixture function runs. A return-style
+    // fixture whose value is disposable (`Symbol.asyncDispose`/`Symbol.dispose`)
+    // is disposed at teardown instead.
+    function runFixtureSetup(name: string, setupFn: Function): Promise<unknown> {
+      const valueCapability = $newPromiseCapability(Promise);
+      let useCalled = false;
+      // assigned before any teardown can run; teardown closures only execute
+      // after the test body, long after this synchronous assignment
+      let fixtureReturn: Promise<unknown>;
+      fixtureReturn = (async () => {
+        return await setupFn(context, async (useValue: unknown) => {
+          if (useCalled) {
+            throw new Error(`Fixture "${name}" called use() more than once. Call \`await use(value)\` exactly once.`);
+          }
+          useCalled = true;
+          valueCapability.resolve.$call(undefined, useValue);
+          const releaseCapability = $newPromiseCapability(Promise);
+          $arrayPush(teardowns, () => {
+            releaseCapability.resolve.$call(undefined);
+            return fixtureReturn;
+          });
+          await releaseCapability.promise;
+        });
+      })().$then(
+        (returnValue: unknown) => {
+          if (useCalled) return;
+          try {
+            if (returnValue === undefined) {
+              throw new Error(
+                `Fixture "${name}" completed without calling use() or returning a value. Call \`await use(value)\` or return the fixture value.`,
+              );
+            }
+            // return-style fixture: the resolved return value is the fixture
+            // value. If it is disposable, disposing it is the teardown.
+            if (returnValue !== null && (typeof returnValue === "object" || typeof returnValue === "function")) {
+              const asyncDispose = (returnValue as Record<symbol, unknown>)[Symbol.asyncDispose];
+              const dispose = $isCallable(asyncDispose)
+                ? asyncDispose
+                : (returnValue as Record<symbol, unknown>)[Symbol.dispose];
+              if ($isCallable(dispose)) {
+                $arrayPush(teardowns, async () => {
+                  await (dispose as Function).$call(returnValue);
+                });
+              }
+            }
+            valueCapability.resolve.$call(undefined, returnValue);
+          } catch (error) {
+            valueCapability.reject.$call(undefined, error);
+          }
+        },
+        (error: unknown) => {
+          if (!useCalled) {
+            // setup failed; surface the error where the fixture value is awaited
+            valueCapability.reject.$call(undefined, error);
+            return;
+          }
+          // teardown failed; surface the error when teardown awaits fixtureReturn
+          throw error;
+        },
+      );
+      return valueCapability.promise;
+    }
+
+    async function setupFixture(record: FixtureRecord, chain: string[]): Promise<void> {
+      const name = record.name;
+      if (arrayIncludes(resolvedNames, name)) return;
+      if (arrayIncludes(chain, name)) {
+        let path = "";
+        for (let i = 0; i < chain.length; i++) {
+          path += chain[i] + " -> ";
+        }
+        throw new Error(`Circular fixture dependency: ${path}${name}`);
+      }
+      if (!record.isFn) {
+        context[name] = record.value;
+        $arrayPush(resolvedNames, name);
+        return;
+      }
+      // a fixture function whose source is unavailable has no detectable
+      // dependencies; treat it as depending on nothing
+      const deps = getUsedProps(record.value as Function, 0) ?? [];
+      for (let i = 0; i < deps.length; i++) {
+        const dep = deps[i];
+        if (dep === name) continue;
+        const depRecord = findFixture(dep);
+        if (depRecord === undefined) continue;
+        const nextChain: string[] = [];
+        for (let c = 0; c < chain.length; c++) $arrayPush(nextChain, chain[c]);
+        $arrayPush(nextChain, name);
+        await setupFixture(depRecord, nextChain);
+      }
+      context[name] = await runFixtureSetup(name, record.value as Function);
+      $arrayPush(resolvedNames, name);
+    }
+
+    let bodyError: unknown;
+    let hasBodyError = false;
+    try {
+      // `test.each` case arguments are bound before the context parameter, so the
+      // destructuring pattern to analyze is the parameter after them. When the
+      // callback's source is unavailable, set up every fixture.
+      const used = getUsedProps(testCallback, caseArgs.length);
+      for (let i = 0; i < fixtures.length; i++) {
+        const record = fixtures[i];
+        if (record.auto || used === null || arrayIncludes(used, record.name)) {
+          await setupFixture(record, []);
+        }
+      }
+      await testCallback(...caseArgs, context);
+    } catch (error) {
+      hasBodyError = true;
+      bodyError = error;
+    }
+
+    // Teardown in reverse setup order. Always run every teardown, even when the
+    // test body or an earlier teardown failed.
+    const teardownErrors: unknown[] = [];
+    for (let i = teardowns.length - 1; i >= 0; i--) {
+      try {
+        await teardowns[i]();
+      } catch (error) {
+        $arrayPush(teardownErrors, error);
+      }
+    }
+
+    if (hasBodyError) throw bodyError;
+    if (teardownErrors.length === 1) throw teardownErrors[0];
+    if (teardownErrors.length > 1) throw new AggregateError(teardownErrors, "fixture teardown failed");
+  };
+}

--- a/src/js/builtins/BunTestFixtures.ts
+++ b/src/js/builtins/BunTestFixtures.ts
@@ -1,5 +1,4 @@
-// bun:test `test.extend()` fixtures. Called from src/runtime/test_runner/ScopeFunctions.rs
-// through src/jsc/bindings/BunTestFixtures.cpp.
+// bun:test `test.extend()` fixtures; ScopeFunctions.rs calls in through src/jsc/bindings/BunTestFixtures.cpp.
 
 interface FixtureRecord {
   name: string;
@@ -88,10 +87,7 @@ export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, n
   return merged;
 }
 
-/**
- * Returns `[run, teardown]` for one scheduled test. `run` is the test body (fixture setup, then the
- * callback with the context appended); the runner schedules `teardown` after the afterEach hooks.
- */
+/** Returns `[run, teardown]` for one scheduled test; the runner schedules `teardown` after the afterEach hooks. */
 export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback: Function) {
   function includes<T>(array: T[], value: T): boolean {
     for (let i = 0; i < array.length; i++) {

--- a/src/js/builtins/BunTestFixtures.ts
+++ b/src/js/builtins/BunTestFixtures.ts
@@ -118,7 +118,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     return result;
   }
 
-  /** Names destructured by `fn`'s parameter at `paramIndex` (read from its source, as in vitest); null if the source is unavailable. */
+  /** Names destructured by `fn`'s parameter at `paramIndex` (read from its source, as in vitest); null for bound and native functions. */
   function getUsedProps(fn: Function, paramIndex: number): string[] | null {
     let source: string;
     try {
@@ -126,7 +126,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     } catch {
       return null;
     }
-    if (source.indexOf("[native code]") !== -1) {
+    if (/^function\b[^(]*\([^)]*\)\s*\{\s*\[native code\]\s*\}$/.test(source)) {
       return null;
     }
     const parenIndex = source.indexOf("(");
@@ -254,7 +254,12 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     for (let i = 0; i < chain.length; i++) $arrayPush(nextChain, chain[i]);
     $arrayPush(nextChain, record);
 
-    const deps = getUsedProps(record.value as Function, 0) ?? [];
+    const deps = getUsedProps(record.value as Function, 0);
+    if (deps === null) {
+      throw new TypeError(
+        `Fixture "${name}" is a bound or native function, so the fixtures it depends on cannot be read from its source. Define it as a function that destructures the fixtures it uses, e.g. ({ db }, use) => { ... }.`,
+      );
+    }
     for (let i = 0; i < deps.length; i++) {
       const dep = deps[i];
       if (dep === name) {
@@ -285,7 +290,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
 
     const { length } = fixtures;
     if (length !== 0) {
-      // the `.each` row values precede the context parameter
+      // the `.each` row values precede the context parameter; a bound callback (null) gets every fixture
       const used = getUsedProps(testCallback, caseArgs.length);
       for (let i = 0; i < length; i++) {
         const record = fixtures[i];

--- a/src/js/builtins/BunTestFixtures.ts
+++ b/src/js/builtins/BunTestFixtures.ts
@@ -1,23 +1,23 @@
-// Fixture support for bun:test's `test.extend()` (modeled on vitest/playwright fixtures).
-//
-// A fixture registry is an array of records `{ name, value, isFn, auto }` built by
-// `mergeTestFixtures` when `.extend()` is called, and consumed by
-// `wrapTestFixtureCallback` each time a test registered through an extended test
-// function runs. Both functions are invoked from native code
-// (src/runtime/test_runner/ScopeFunctions.rs via Bun__TestFixtures__* in
-// src/jsc/bindings/BunTestFixtures.cpp).
+// bun:test `test.extend()` fixtures. Called from src/runtime/test_runner/ScopeFunctions.rs
+// through src/jsc/bindings/BunTestFixtures.cpp.
 
 interface FixtureRecord {
   name: string;
   value: unknown;
   isFn: boolean;
   auto: boolean;
+  /** The definition this one replaced; received by a fixture that destructures its own name. */
+  parent: FixtureRecord | undefined;
 }
 
-/**
- * Validate the object passed to `test.extend()` and merge it over the parent
- * registry (later `.extend()` calls override earlier fixtures with the same name).
- */
+interface RunState {
+  context: Record<string, unknown>;
+  /** Pushed during setup, run in reverse by `teardown`. */
+  teardowns: (() => Promise<void>)[];
+  resolved: FixtureRecord[];
+}
+
+/** Merges the object passed to `.extend()` over the parent registry; same-named fixtures replace their parent. */
 export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, newFixtures: unknown) {
   if (!$isObject(newFixtures) || $isJSArray(newFixtures) || $isCallable(newFixtures)) {
     throw new TypeError("test.extend() expects an object where each property is a fixture");
@@ -34,25 +34,21 @@ export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, n
   for (let i = 0; i < names.length; i++) {
     const name = names[i];
     let value = (newFixtures as Record<string, unknown>)[name];
-    let auto = false;
+    let options: { auto?: unknown; injected?: unknown; scope?: unknown } | undefined;
 
-    // `[value, options]` tuple form. Mirrors vitest: only treated as a tuple when the
-    // second element is an object carrying at least one known fixture option key;
-    // otherwise the array itself is the fixture value.
+    // `[value, options]` is only a tuple when the second element carries a known option key (as in vitest).
     if ($isJSArray(value) && (value as unknown[]).length >= 2) {
       const maybeOptions = (value as unknown[])[1];
       if ($isObject(maybeOptions) && !$isJSArray(maybeOptions)) {
         const optionKeys = Object.keys(maybeOptions as object);
-        let isOptions = false;
         for (let k = 0; k < optionKeys.length; k++) {
           const key = optionKeys[k];
           if (key === "auto" || key === "injected" || key === "scope") {
-            isOptions = true;
+            options = maybeOptions as typeof options;
             break;
           }
         }
-        if (isOptions) {
-          const options = maybeOptions as { auto?: unknown; injected?: unknown; scope?: unknown };
+        if (options !== undefined) {
           const scope = options.scope;
           if (scope !== undefined && scope !== "test") {
             throw new TypeError(
@@ -62,23 +58,30 @@ export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, n
           if (options.injected) {
             throw new TypeError(`test.extend() fixture "${name}": the "injected" option is not supported`);
           }
-          auto = !!options.auto;
           value = (value as unknown[])[0];
         }
       }
     }
 
-    const record: FixtureRecord = { name, value, isFn: $isCallable(value), auto };
-    let replaced = false;
+    let existingIndex = -1;
     for (let m = 0; m < merged.length; m++) {
       if (merged[m].name === name) {
-        merged[m] = record;
-        replaced = true;
+        existingIndex = m;
         break;
       }
     }
-    if (!replaced) {
+    const parent = existingIndex === -1 ? undefined : merged[existingIndex];
+    const record: FixtureRecord = {
+      name,
+      value,
+      isFn: $isCallable(value),
+      auto: options !== undefined ? !!options.auto : parent !== undefined && parent.auto,
+      parent,
+    };
+    if (existingIndex === -1) {
       $arrayPush(merged, record);
+    } else {
+      merged[existingIndex] = record;
     }
   }
 
@@ -86,23 +89,18 @@ export function mergeTestFixtures(parentFixtures: FixtureRecord[] | undefined, n
 }
 
 /**
- * Wrap a test callback so that, when the test runs, the fixtures it uses are set
- * up first (in dependency order), the callback receives the fixture context as
- * its last argument (after any `test.each` case arguments), and teardown runs in
- * reverse setup order once the callback settles. Fixture functions either call
- * `await use(value)` (code after it is the teardown) or return the value
- * directly (a disposable return value is disposed as the teardown).
+ * Returns `[run, teardown]` for one scheduled test. `run` is the test body (fixture setup, then the
+ * callback with the context appended); the runner schedules `teardown` after the afterEach hooks.
  */
 export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback: Function) {
-  function arrayIncludes(array: string[], value: string): boolean {
+  function includes<T>(array: T[], value: T): boolean {
     for (let i = 0; i < array.length; i++) {
       if (array[i] === value) return true;
     }
     return false;
   }
 
-  // Split a parameter list (or destructuring pattern body) at top-level commas,
-  // skipping over nested `{}`/`[]`/`()` groups.
+  /** Splits at top-level commas, skipping nested `{}`/`[]`/`()` groups. */
   function splitByComma(s: string): string[] {
     const result: string[] = [];
     const stack: string[] = [];
@@ -124,12 +122,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     return result;
   }
 
-  // Determine which fixture names a function destructures from its context
-  // parameter (the parameter at `paramIndex`). Like vitest, this reads the
-  // function's source text, so the context parameter must use an object
-  // destructuring pattern for fixtures to be detected. Returns null when the
-  // source is unavailable (bound functions, AsyncLocalStorage-wrapped
-  // callbacks), in which case the caller decides a fallback.
+  /** Names destructured by `fn`'s parameter at `paramIndex` (read from its source, as in vitest); null if the source is unavailable. */
   function getUsedProps(fn: Function, paramIndex: number): string[] | null {
     let source: string;
     try {
@@ -142,8 +135,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     }
     const parenIndex = source.indexOf("(");
     if (parenIndex === -1) {
-      // single-parameter arrow function with no parentheses; it cannot
-      // destructure, so it uses no fixtures.
+      // `x => ...` cannot destructure
       return [];
     }
     let depth = 1;
@@ -169,7 +161,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
       if (prop.startsWith("...")) {
         throw new TypeError(`Rest parameters are not supported when destructuring fixtures. Received "${prop}".`);
       }
-      // strip renames (`a: b`) and default values (`a = 1`)
+      // strip renames (`a: b`) and defaults (`a = 1`)
       let name = prop;
       for (let c = 0; c < prop.length; c++) {
         if (prop[c] === ":" || prop[c] === "=") {
@@ -178,11 +170,12 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
         }
       }
       name = name.trim();
+      const { length } = name;
       if (
-        name.length >= 2 &&
+        length >= 2 &&
         ((name.startsWith("'") && name.endsWith("'")) || (name.startsWith('"') && name.endsWith('"')))
       ) {
-        name = name.substring(1, name.length - 1);
+        name = name.substring(1, length - 1);
       }
       if (name) $arrayPush(used, name);
     }
@@ -196,145 +189,136 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
     return undefined;
   }
 
-  return async function (...caseArgs: unknown[]) {
-    const context: Record<string, unknown> = {};
-    if (fixtures.length === 0) {
-      return testCallback(...caseArgs, context);
+  /** Resolves to the value passed to `use()`; the fixture function stays parked in `use()` until teardown releases it. */
+  function runFixtureSetup(state: RunState, name: string, setupFn: Function): Promise<unknown> {
+    const valueCapability = $newPromiseCapability(Promise);
+    let useCalled = false;
+    let failedAfterUse = false;
+    let errorAfterUse: unknown;
+
+    async function use(value: unknown): Promise<void> {
+      if (useCalled) {
+        throw new Error(`Fixture "${name}" called use() more than once. Call \`await use(value)\` exactly once.`);
+      }
+      useCalled = true;
+      const release = $newPromiseCapability(Promise);
+      $arrayPush(state.teardowns, async () => {
+        release.resolve.$call(undefined);
+        await finished;
+        if (failedAfterUse) throw errorAfterUse;
+      });
+      valueCapability.resolve.$call(undefined, value);
+      await release.promise;
     }
 
-    const teardowns: (() => Promise<unknown>)[] = [];
-    const resolvedNames: string[] = [];
-
-    // Run one fixture function. The value passed to `use()` (or, when `use()` is
-    // never called, the function's resolved return value) becomes the fixture
-    // value. A `use()`-style fixture stays suspended inside `use()` until
-    // teardown, when the remainder of the fixture function runs. A return-style
-    // fixture whose value is disposable (`Symbol.asyncDispose`/`Symbol.dispose`)
-    // is disposed at teardown instead.
-    function runFixtureSetup(name: string, setupFn: Function): Promise<unknown> {
-      const valueCapability = $newPromiseCapability(Promise);
-      let useCalled = false;
-      // assigned before any teardown can run; teardown closures only execute
-      // after the test body, long after this synchronous assignment
-      let fixtureReturn: Promise<unknown>;
-      fixtureReturn = (async () => {
-        return await setupFn(context, async (useValue: unknown) => {
-          if (useCalled) {
-            throw new Error(`Fixture "${name}" called use() more than once. Call \`await use(value)\` exactly once.`);
-          }
-          useCalled = true;
-          valueCapability.resolve.$call(undefined, useValue);
-          const releaseCapability = $newPromiseCapability(Promise);
-          $arrayPush(teardowns, () => {
-            releaseCapability.resolve.$call(undefined);
-            return fixtureReturn;
-          });
-          await releaseCapability.promise;
-        });
-      })().$then(
-        (returnValue: unknown) => {
-          if (useCalled) return;
-          try {
-            if (returnValue === undefined) {
-              throw new Error(
-                `Fixture "${name}" completed without calling use() or returning a value. Call \`await use(value)\` or return the fixture value.`,
-              );
-            }
-            // return-style fixture: the resolved return value is the fixture
-            // value. If it is disposable, disposing it is the teardown.
-            if (returnValue !== null && (typeof returnValue === "object" || typeof returnValue === "function")) {
-              const asyncDispose = (returnValue as Record<symbol, unknown>)[Symbol.asyncDispose];
-              const dispose = $isCallable(asyncDispose)
-                ? asyncDispose
-                : (returnValue as Record<symbol, unknown>)[Symbol.dispose];
-              if ($isCallable(dispose)) {
-                $arrayPush(teardowns, async () => {
-                  await (dispose as Function).$call(returnValue);
-                });
-              }
-            }
-            valueCapability.resolve.$call(undefined, returnValue);
-          } catch (error) {
-            valueCapability.reject.$call(undefined, error);
-          }
-        },
-        (error: unknown) => {
-          if (!useCalled) {
-            // setup failed; surface the error where the fixture value is awaited
-            valueCapability.reject.$call(undefined, error);
-            return;
-          }
-          // teardown failed; surface the error when teardown awaits fixtureReturn
-          throw error;
-        },
-      );
-      return valueCapability.promise;
-    }
-
-    async function setupFixture(record: FixtureRecord, chain: string[]): Promise<void> {
-      const name = record.name;
-      if (arrayIncludes(resolvedNames, name)) return;
-      if (arrayIncludes(chain, name)) {
-        let path = "";
-        for (let i = 0; i < chain.length; i++) {
-          path += chain[i] + " -> ";
+    // Never rejects: a failure after use() is reported by the teardown, one before it by the value promise.
+    const finished: Promise<void> = (async () => {
+      await setupFn(state.context, use);
+    })().$then(
+      () => {
+        if (!useCalled) {
+          valueCapability.reject.$call(
+            undefined,
+            new Error(
+              `Fixture "${name}" completed without calling use(). Call \`await use(value)\` in the fixture function.`,
+            ),
+          );
         }
-        throw new Error(`Circular fixture dependency: ${path}${name}`);
+      },
+      (error: unknown) => {
+        if (useCalled) {
+          failedAfterUse = true;
+          errorAfterUse = error;
+        } else {
+          valueCapability.reject.$call(undefined, error);
+        }
+      },
+    );
+
+    return valueCapability.promise;
+  }
+
+  async function setupFixture(state: RunState, record: FixtureRecord, chain: FixtureRecord[]): Promise<void> {
+    if (includes(state.resolved, record)) return;
+    const name = record.name;
+    if (includes(chain, record)) {
+      let path = "";
+      for (let i = 0; i < chain.length; i++) {
+        path += chain[i].name + " -> ";
       }
-      if (!record.isFn) {
-        context[name] = record.value;
-        $arrayPush(resolvedNames, name);
-        return;
-      }
-      // a fixture function whose source is unavailable has no detectable
-      // dependencies; treat it as depending on nothing
-      const deps = getUsedProps(record.value as Function, 0) ?? [];
-      for (let i = 0; i < deps.length; i++) {
-        const dep = deps[i];
-        if (dep === name) continue;
-        const depRecord = findFixture(dep);
-        if (depRecord === undefined) continue;
-        const nextChain: string[] = [];
-        for (let c = 0; c < chain.length; c++) $arrayPush(nextChain, chain[c]);
-        $arrayPush(nextChain, name);
-        await setupFixture(depRecord, nextChain);
-      }
-      context[name] = await runFixtureSetup(name, record.value as Function);
-      $arrayPush(resolvedNames, name);
+      throw new Error(`Circular fixture dependency: ${path}${name}`);
+    }
+    if (!record.isFn) {
+      state.context[name] = record.value;
+      $arrayPush(state.resolved, record);
+      return;
     }
 
-    let bodyError: unknown;
-    let hasBodyError = false;
-    try {
-      // `test.each` case arguments are bound before the context parameter, so the
-      // destructuring pattern to analyze is the parameter after them. When the
-      // callback's source is unavailable, set up every fixture.
+    const nextChain: FixtureRecord[] = [];
+    for (let i = 0; i < chain.length; i++) $arrayPush(nextChain, chain[i]);
+    $arrayPush(nextChain, record);
+
+    const deps = getUsedProps(record.value as Function, 0) ?? [];
+    for (let i = 0; i < deps.length; i++) {
+      const dep = deps[i];
+      if (dep === name) {
+        if (record.parent === undefined) {
+          throw new Error(
+            `Fixture "${name}" depends on itself, but there is no earlier definition of "${name}" for it to extend.`,
+          );
+        }
+        await setupFixture(state, record.parent, nextChain);
+        continue;
+      }
+      const depRecord = findFixture(dep);
+      if (depRecord !== undefined) {
+        await setupFixture(state, depRecord, nextChain);
+      }
+    }
+
+    state.context[name] = await runFixtureSetup(state, name, record.value as Function);
+    $arrayPush(state.resolved, record);
+  }
+
+  /** Set by `run`, consumed by the `teardown` entry that follows it (also after a timed out body). */
+  let active: RunState | null = null;
+
+  async function run(...caseArgs: unknown[]) {
+    const state: RunState = { context: {}, teardowns: [], resolved: [] };
+    active = state;
+
+    const { length } = fixtures;
+    if (length !== 0) {
+      // the `.each` row values precede the context parameter
       const used = getUsedProps(testCallback, caseArgs.length);
-      for (let i = 0; i < fixtures.length; i++) {
+      for (let i = 0; i < length; i++) {
         const record = fixtures[i];
-        if (record.auto || used === null || arrayIncludes(used, record.name)) {
-          await setupFixture(record, []);
+        if (record.auto || used === null || includes(used, record.name)) {
+          await setupFixture(state, record, []);
         }
       }
-      await testCallback(...caseArgs, context);
-    } catch (error) {
-      hasBodyError = true;
-      bodyError = error;
     }
 
-    // Teardown in reverse setup order. Always run every teardown, even when the
-    // test body or an earlier teardown failed.
-    const teardownErrors: unknown[] = [];
-    for (let i = teardowns.length - 1; i >= 0; i--) {
+    await testCallback(...caseArgs, state.context);
+  }
+
+  async function teardown() {
+    const state = active;
+    active = null;
+    if (state === null) return;
+
+    const errors: unknown[] = [];
+    for (let i = state.teardowns.length - 1; i >= 0; i--) {
       try {
-        await teardowns[i]();
+        await state.teardowns[i]();
       } catch (error) {
-        $arrayPush(teardownErrors, error);
+        $arrayPush(errors, error);
       }
     }
+    const failures = errors.length;
+    if (failures === 1) throw errors[0];
+    if (failures > 1) throw new AggregateError(errors, `${failures} fixture teardowns failed`);
+  }
 
-    if (hasBodyError) throw bodyError;
-    if (teardownErrors.length === 1) throw teardownErrors[0];
-    if (teardownErrors.length > 1) throw new AggregateError(teardownErrors, "fixture teardown failed");
-  };
+  return [run, teardown];
 }

--- a/src/js/builtins/BunTestFixtures.ts
+++ b/src/js/builtins/BunTestFixtures.ts
@@ -285,7 +285,7 @@ export function wrapTestFixtureCallback(fixtures: FixtureRecord[], testCallback:
   let active: RunState | null = null;
 
   async function run(...caseArgs: unknown[]) {
-    const state: RunState = { context: {}, teardowns: [], resolved: [] };
+    const state: RunState = { context: { __proto__: null }, teardowns: [], resolved: [] };
     active = state;
 
     const { length } = fixtures;

--- a/src/jsc/bindings/BunTestFixtures.cpp
+++ b/src/jsc/bindings/BunTestFixtures.cpp
@@ -1,0 +1,41 @@
+#include "root.h"
+#include "headers-handwritten.h"
+#include "WebCoreJSBuiltins.h"
+#include "ZigGlobalObject.h"
+
+// Bridges for bun:test's `test.extend()` fixtures. The implementation lives in
+// src/js/builtins/BunTestFixtures.ts; the Rust test runner
+// (src/runtime/test_runner/ScopeFunctions.rs) calls these to merge fixture
+// registries and to wrap test callbacks with fixture setup/teardown.
+
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__TestFixtures__merge(Zig::GlobalObject* global, JSC::EncodedJSValue parentFixtures, JSC::EncodedJSValue newFixtures)
+{
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSFunction* mergeFunction = global->m_bunTestMergeFixturesFunction.getInitializedOnMainThread(global);
+    JSC::CallData callData = JSC::getCallData(mergeFunction);
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(JSC::JSValue::decode(parentFixtures));
+    args.append(JSC::JSValue::decode(newFixtures));
+
+    auto result = JSC::call(global, mergeFunction, callData, JSC::jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(result);
+}
+
+extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__TestFixtures__wrapCallback(Zig::GlobalObject* global, JSC::EncodedJSValue fixtures, JSC::EncodedJSValue testCallback)
+{
+    auto& vm = JSC::getVM(global);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSC::JSFunction* wrapFunction = global->m_bunTestWrapFixtureCallbackFunction.getInitializedOnMainThread(global);
+    JSC::CallData callData = JSC::getCallData(wrapFunction);
+
+    JSC::MarkedArgumentBuffer args;
+    args.append(JSC::JSValue::decode(fixtures));
+    args.append(JSC::JSValue::decode(testCallback));
+
+    auto result = JSC::call(global, wrapFunction, callData, JSC::jsUndefined(), args);
+    RETURN_IF_EXCEPTION(scope, {});
+    return JSC::JSValue::encode(result);
+}

--- a/src/jsc/bindings/BunTestFixtures.cpp
+++ b/src/jsc/bindings/BunTestFixtures.cpp
@@ -3,10 +3,7 @@
 #include "WebCoreJSBuiltins.h"
 #include "ZigGlobalObject.h"
 
-// Bridges for bun:test's `test.extend()` fixtures. The implementation lives in
-// src/js/builtins/BunTestFixtures.ts; the Rust test runner
-// (src/runtime/test_runner/ScopeFunctions.rs) calls these to merge fixture
-// registries and to wrap test callbacks with fixture setup/teardown.
+// Entry points into src/js/builtins/BunTestFixtures.ts for the test runner (ScopeFunctions.rs).
 
 extern "C" [[ZIG_EXPORT(zero_is_throw)]] JSC::EncodedJSValue Bun__TestFixtures__merge(Zig::GlobalObject* global, JSC::EncodedJSValue parentFixtures, JSC::EncodedJSValue newFixtures)
 {

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2566,6 +2566,12 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_ipcRestoreAdvancedBuffersFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
              init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::ipcRestoreAdvancedBuffersCodeGenerator(init.vm), init.owner));
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_bunTestMergeFixturesFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
+             init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::bunTestFixturesMergeTestFixturesCodeGenerator(init.vm), init.owner));
+         } },
+        { OBJECT_OFFSETOF(GlobalObject, m_bunTestWrapFixtureCallbackFunction), [](const LazyProperty<JSGlobalObject, JSFunction>::Initializer& init) {
+             init.set(JSC::JSFunction::create(init.vm, init.owner, WebCore::bunTestFixturesWrapTestFixtureCallbackCodeGenerator(init.vm), init.owner));
+         } },
     };
 
     Bun::addNodeModuleConstructorProperties(vm, this);

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -676,7 +676,9 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcSerializeFunction)                                \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcParseHandleFunction)                              \
     V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcTagAdvancedBuffersFunction)                       \
-    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcRestoreAdvancedBuffersFunction)
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_ipcRestoreAdvancedBuffersFunction)                   \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_bunTestMergeFixturesFunction)                        \
+    V(public, LazyPropertyOfGlobalObject<JSFunction>, m_bunTestWrapFixtureCallbackFunction)
 
 #define DECLARE_GLOBALOBJECT_GC_MEMBER(visibility, T, name) \
     visibility:                                             \

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1158,7 +1158,7 @@ impl CommandLineReporter {
                     let _ = bun_core::write_pretty!(
                         writer,
                         colors,
-                        "  <d>^<r> <red>a beforeEach/afterEach hook timed out for this test.<r>\n"
+                        "  <d>^<r> <red>a beforeEach/afterEach hook or fixture teardown timed out for this test.<r>\n"
                     );
                 }
                 R::FailBecauseTimeoutWithDoneCallback => {

--- a/src/runtime/test_runner/Execution.rs
+++ b/src/runtime/test_runner/Execution.rs
@@ -199,6 +199,22 @@ impl ExecutionSequence {
         }
         ScopeMode::Normal
     }
+
+    /// The test's fixture teardown entry, if it is still linked after `after`.
+    fn fixture_teardown_after(&self, after: NonNull<ExecutionEntry>) -> Option<NonNull<ExecutionEntry>> {
+        // SAFETY: arena-owned entries, alive for the lifetime of BunTest which owns Execution
+        let teardown: *const ExecutionEntry = unsafe { self.test_entry?.as_ref() }.fixture_teardown.as_deref()?;
+        // SAFETY: see above
+        let mut cursor = unsafe { after.as_ref() }.next;
+        while let Some(entry) = cursor {
+            if core::ptr::eq(entry, teardown) {
+                return NonNull::new(entry);
+            }
+            // SAFETY: intrusive list nodes are valid while the sequence is live
+            cursor = unsafe { (*entry).next };
+        }
+        None
+    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr)]
@@ -524,6 +540,10 @@ impl Execution {
                     Some(failure_skip_past) => nn(unsafe { (*failure_skip_past).next }),
                     None => None,
                 };
+                if sequence.active_entry.is_none() {
+                    // a failing afterEach must not skip the fixture teardown
+                    sequence.active_entry = sequence.fixture_teardown_after(entry_ptr);
+                }
             } else {
                 sequence.active_entry = nn(entry.next);
             }

--- a/src/runtime/test_runner/Order.rs
+++ b/src/runtime/test_runner/Order.rs
@@ -183,6 +183,12 @@ impl Order {
             }
         }
 
+        // fixture teardown runs after the afterEach hooks (the vitest/playwright order)
+        // SAFETY: caller-guaranteed live entry; the teardown Box it owns outlives the order.
+        if let Some(teardown) = unsafe { (*current.as_ptr()).fixture_teardown.as_deref_mut() } {
+            list.append(core::ptr::from_mut(teardown));
+        }
+
         // set skip_to values
         let mut index = list.first;
         let mut failure_skip_past: Option<*mut ExecutionEntry> = Some(current.as_ptr());

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -47,7 +47,7 @@ pub enum Mode {
     Test,
 }
 
-// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`. All three
+// R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`. All four
 // fields are written exactly once in `create_unbound` and never mutated again,
 // so no `Cell`/`JsCell` wrapping is needed — the type is read-only after
 // construction. `generic_if`/`generic_extend`/`fn_each`/`call_as_function` all
@@ -62,6 +62,11 @@ pub struct ScopeFunctions {
     /// WriteBarrier on the JS wrapper (see `values: ["each"]` in jest.classes.ts). This
     /// field is kept in sync with that slot via `js::each_set_cached` in `create_unbound`.
     pub(crate) each: JSValue,
+    /// Fixture registry created by `.extend()` (an array of records built by the
+    /// `mergeTestFixtures` builtin), or `.zero` when the function has no fixtures.
+    /// GC-visited the same way as `each`: mirrored into the C++ `m_fixtures`
+    /// WriteBarrier via `js::fixtures_set_cached` in `create_unbound`.
+    pub(crate) fixtures: JSValue,
 }
 
 impl ScopeFunctions {
@@ -126,7 +131,20 @@ impl ScopeFunctions {
         if !this.each.is_empty() {
             return Err(global.throw(format_args!("Cannot {} on {}", "each", this)));
         }
-        create_bound(global, this.mode, array, this.cfg, "each")
+        create_bound(global, this.mode, array, this.fixtures, this.cfg, "each")
+    }
+    #[bun_jsc::host_fn(method)]
+    pub fn fn_extend(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let _g = group_log::begin();
+
+        if this.mode == Mode::Describe {
+            return Err(global.throw(format_args!("Cannot {} on {}", "call .extend()", this)));
+        }
+        let [new_fixtures] = frame.arguments_as_array::<1>();
+        let parent = if this.fixtures.is_empty() { JSValue::UNDEFINED } else { this.fixtures };
+        // validates the fixtures object and merges it over the parent registry
+        let merged = bun_jsc::cpp::Bun__TestFixtures__merge(global, parent, new_fixtures)?;
+        create_bound(global, this.mode, this.each, merged, this.cfg, "extend")
     }
 }
 
@@ -153,18 +171,30 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         _ => CallbackMode::Require,
     };
 
-    let args = parse_arguments(
+    let mut args = parse_arguments(
         global,
         frame,
         Signature::ScopeFunctions(this),
         ParseArgumentsCfg { callback: callback_mode, kind: FunctionKind::TestOrDescribe },
     )?;
 
-    let callback_length: usize = if let Some(callback) = args.callback {
+    let mut callback_length: usize = if let Some(callback) = args.callback {
         callback.get_length(global)? as usize
     } else {
         0
     };
+
+    // Tests registered through an extended test function (`test.extend()`) receive
+    // the fixture context as their last parameter instead of a done callback. Wrap
+    // the callback so fixtures are set up before it runs and torn down after, and
+    // zero the length so the done-callback heuristic below never fires.
+    if this.mode == Mode::Test && !this.fixtures.is_empty() {
+        if let Some(cb) = args.callback {
+            let wrapped = bun_jsc::cpp::Bun__TestFixtures__wrapCallback(global, this.fixtures, cb)?;
+            args.callback = Some(wrapped.with_async_context_if_needed(global));
+            callback_length = 0;
+        }
+    }
 
     if !this.each.is_empty() {
         if this.each.is_undefined_or_null() || !this.each.is_array() {
@@ -454,7 +484,7 @@ impl ScopeFunctions {
         if cond != invert {
             self.generic_extend(global, conditional_cfg, name, fn_name)
         } else {
-            create_bound(global, self.mode, self.each, self.cfg, fn_name)
+            create_bound(global, self.mode, self.each, self.fixtures, self.cfg, fn_name)
         }
     }
 
@@ -476,7 +506,7 @@ impl ScopeFunctions {
         let Some(extended) = self.cfg.extend(cfg) else {
             return Err(global.throw(format_args!("Cannot {} on {}", bstr::BStr::new(name), self)));
         };
-        create_bound(global, self.mode, self.each, extended, fn_name)
+        create_bound(global, self.mode, self.each, self.fixtures, extended, fn_name)
     }
 }
 
@@ -716,12 +746,13 @@ pub(crate) fn parse_arguments(
 // (see jest.classes.ts `values: ["each"]`).
 //
 // Hand-expansion of the cached-value accessors `src/codegen/generate-classes.ts` emits:
-// `eachSetCached` / `eachGetCached` thin-wrap the C++-side
-// `ScopeFunctionsPrototype__each{Set,Get}CachedValue` shims, which write/read the
-// `JSC::WriteBarrier<Unknown> m_each` slot on the JSCell wrapper so the GC visits
-// the `.each(arr)` argument between construction and the trailing `("name", cb)` call.
+// `eachSetCached` / `eachGetCached` (and the `fixtures` pair) thin-wrap the C++-side
+// `ScopeFunctionsPrototype__{each,fixtures}{Set,Get}CachedValue` shims, which write/read
+// the `JSC::WriteBarrier<Unknown>` slots on the JSCell wrapper so the GC visits the
+// `.each(arr)` / `.extend(fixtures)` arguments between construction and the trailing
+// `("name", cb)` call.
 pub mod js {
-    bun_jsc::codegen_cached_accessors!("ScopeFunctions"; each);
+    bun_jsc::codegen_cached_accessors!("ScopeFunctions"; each, fixtures);
 }
 
 impl fmt::Display for ScopeFunctions {
@@ -741,6 +772,9 @@ impl fmt::Display for ScopeFunctions {
         if !self.each.is_empty() {
             write!(f, ".each()")?;
         }
+        if !self.fixtures.is_empty() {
+            write!(f, ".extend()")?;
+        }
         Ok(())
     }
 }
@@ -753,18 +787,21 @@ impl ScopeFunctions {
     }
 }
 
-fn create_unbound(global: &JSGlobalObject, mode: Mode, each: JSValue, cfg: BaseScopeCfg) -> JSValue {
+fn create_unbound(global: &JSGlobalObject, mode: Mode, each: JSValue, fixtures: JSValue, cfg: BaseScopeCfg) -> JSValue {
     let _g = group_log::begin();
 
     // `JsClass::to_js` boxes `self` and hands the raw pointer to the C++
     // wrapper (m_ctx); freed in `finalize`.
-    let value = ScopeFunctions { mode, cfg, each }.to_js(global);
+    let value = ScopeFunctions { mode, cfg, each, fixtures }.to_js(global);
     value.ensure_still_alive();
-    // Write into the C++ m_each WriteBarrier so GC visits it. The Rust `each` field
-    // lives in unmanaged memory that JSC never scans; without this the array can be
-    // collected between `.each(arr)` and the trailing `("name", cb)` call.
+    // Write into the C++ m_each/m_fixtures WriteBarriers so GC visits them. The Rust
+    // fields live in unmanaged memory that JSC never scans; without this the values
+    // can be collected between construction and the trailing `("name", cb)` call.
     if !each.is_empty() {
         js::each_set_cached(value, global, each);
+    }
+    if !fixtures.is_empty() {
+        js::fixtures_set_cached(value, global, fixtures);
     }
     value
 }
@@ -793,12 +830,13 @@ pub(crate) fn create_bound(
     global: &JSGlobalObject,
     mode: Mode,
     each: JSValue,
+    fixtures: JSValue,
     cfg: BaseScopeCfg,
     name: &'static str,
 ) -> JsResult<JSValue> {
     let _g = group_log::begin();
 
-    let value = create_unbound(global, mode, each, cfg);
+    let value = create_unbound(global, mode, each, fixtures, cfg);
     bind(value, global, name)
 }
 

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -152,10 +152,8 @@ impl ScopeFunctions {
     ) -> JsResult<TestCallbacks> {
         let pair = bun_jsc::cpp::Bun__TestFixtures__wrapCallback(global, self.fixtures, callback)?;
         rooted.append(pair);
-        let run = pair.get_index(global, 0)?.with_async_context_if_needed(global);
-        rooted.append(run);
-        let teardown = pair.get_index(global, 1)?.with_async_context_if_needed(global);
-        rooted.append(teardown);
+        let run = pair.get_index(global, 0)?;
+        let teardown = pair.get_index(global, 1)?;
         Ok(TestCallbacks { callback: Some(run), fixture_teardown: Some(teardown) })
     }
 }
@@ -349,7 +347,8 @@ impl ScopeFunctions {
         line_no: u32,
     ) -> JsResult<()> {
         let _g = group_log::begin();
-        let TestCallbacks { callback, fixture_teardown } = callbacks;
+        let callback = callbacks.callback.map(|cb| cb.with_async_context_if_needed(global));
+        let fixture_teardown = callbacks.fixture_teardown.map(|cb| cb.with_async_context_if_needed(global));
 
         // only allow in collection phase
         match bun_test.phase {
@@ -680,7 +679,8 @@ pub(crate) fn parse_arguments(
     let result_callback: Option<JSValue> = if cfg.callback != CallbackMode::Require && callback.is_undefined_or_null() {
         None
     } else if callback.is_function() {
-        Some(callback.with_async_context_if_needed(global))
+        // An AsyncContextFrame is not callable, so callers measure, bind and wrap the callback before attaching the context.
+        Some(callback)
     } else {
         let ordinal = if cfg.kind == FunctionKind::Hook { "first" } else { "second" };
         return Err(global.throw(format_args!("{} expects a function as the {} argument", signature, ordinal)));

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -143,8 +143,7 @@ impl ScopeFunctions {
         create_bound(global, this.mode, this.each, merged, this.cfg, "extend")
     }
 
-    /// Splits a `test.extend()` callback into its `[run, teardown]` pair. The pair holds one
-    /// run's fixture state, so this is called once per scheduled test (once per `.each` row).
+    /// The `[run, teardown]` pair holds one run's fixture state, so this is called once per scheduled test.
     fn wrap_with_fixtures(
         &self,
         global: &JSGlobalObject,
@@ -198,8 +197,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         ParseArgumentsCfg { callback: callback_mode, kind: FunctionKind::TestOrDescribe },
     )?;
 
-    // `test.extend()` callbacks take the fixture context where a done callback would go,
-    // so their length must not feed the done-callback heuristic.
+    // An extended callback's extra parameter is the fixture context, not a done callback.
     let uses_fixtures = this.mode == Mode::Test && !this.fixtures.is_empty() && args.callback.is_some();
     let callback_length: usize = match args.callback {
         Some(callback) if !uses_fixtures => callback.get_length(global)? as usize,

--- a/src/runtime/test_runner/ScopeFunctions.rs
+++ b/src/runtime/test_runner/ScopeFunctions.rs
@@ -62,10 +62,7 @@ pub struct ScopeFunctions {
     /// WriteBarrier on the JS wrapper (see `values: ["each"]` in jest.classes.ts). This
     /// field is kept in sync with that slot via `js::each_set_cached` in `create_unbound`.
     pub(crate) each: JSValue,
-    /// Fixture registry created by `.extend()` (an array of records built by the
-    /// `mergeTestFixtures` builtin), or `.zero` when the function has no fixtures.
-    /// GC-visited the same way as `each`: mirrored into the C++ `m_fixtures`
-    /// WriteBarrier via `js::fixtures_set_cached` in `create_unbound`.
+    /// `.extend()` registry (see BunTestFixtures.ts) or `.zero`; GC-rooted like `each`.
     pub(crate) fixtures: JSValue,
 }
 
@@ -134,7 +131,7 @@ impl ScopeFunctions {
         create_bound(global, this.mode, array, this.fixtures, this.cfg, "each")
     }
     #[bun_jsc::host_fn(method)]
-    pub fn fn_extend(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+    pub(crate) fn fn_extend(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         let _g = group_log::begin();
 
         if this.mode == Mode::Describe {
@@ -142,10 +139,33 @@ impl ScopeFunctions {
         }
         let [new_fixtures] = frame.arguments_as_array::<1>();
         let parent = if this.fixtures.is_empty() { JSValue::UNDEFINED } else { this.fixtures };
-        // validates the fixtures object and merges it over the parent registry
         let merged = bun_jsc::cpp::Bun__TestFixtures__merge(global, parent, new_fixtures)?;
         create_bound(global, this.mode, this.each, merged, this.cfg, "extend")
     }
+
+    /// Splits a `test.extend()` callback into its `[run, teardown]` pair. The pair holds one
+    /// run's fixture state, so this is called once per scheduled test (once per `.each` row).
+    fn wrap_with_fixtures(
+        &self,
+        global: &JSGlobalObject,
+        callback: JSValue,
+        rooted: &mut bun_jsc::MarkedArgumentBuffer,
+    ) -> JsResult<TestCallbacks> {
+        let pair = bun_jsc::cpp::Bun__TestFixtures__wrapCallback(global, self.fixtures, callback)?;
+        rooted.append(pair);
+        let run = pair.get_index(global, 0)?.with_async_context_if_needed(global);
+        rooted.append(run);
+        let teardown = pair.get_index(global, 1)?.with_async_context_if_needed(global);
+        rooted.append(teardown);
+        Ok(TestCallbacks { callback: Some(run), fixture_teardown: Some(teardown) })
+    }
+}
+
+/// The callback to schedule and, for `test.extend()` tests, the teardown entry that follows it.
+#[derive(Clone, Copy)]
+struct TestCallbacks {
+    callback: Option<JSValue>,
+    fixture_teardown: Option<JSValue>,
 }
 
 #[bun_jsc::host_fn]
@@ -171,30 +191,20 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         _ => CallbackMode::Require,
     };
 
-    let mut args = parse_arguments(
+    let args = parse_arguments(
         global,
         frame,
         Signature::ScopeFunctions(this),
         ParseArgumentsCfg { callback: callback_mode, kind: FunctionKind::TestOrDescribe },
     )?;
 
-    let mut callback_length: usize = if let Some(callback) = args.callback {
-        callback.get_length(global)? as usize
-    } else {
-        0
+    // `test.extend()` callbacks take the fixture context where a done callback would go,
+    // so their length must not feed the done-callback heuristic.
+    let uses_fixtures = this.mode == Mode::Test && !this.fixtures.is_empty() && args.callback.is_some();
+    let callback_length: usize = match args.callback {
+        Some(callback) if !uses_fixtures => callback.get_length(global)? as usize,
+        _ => 0,
     };
-
-    // Tests registered through an extended test function (`test.extend()`) receive
-    // the fixture context as their last parameter instead of a done callback. Wrap
-    // the callback so fixtures are set up before it runs and torn down after, and
-    // zero the length so the done-callback heuristic below never fires.
-    if this.mode == Mode::Test && !this.fixtures.is_empty() {
-        if let Some(cb) = args.callback {
-            let wrapped = bun_jsc::cpp::Bun__TestFixtures__wrapCallback(global, this.fixtures, cb)?;
-            args.callback = Some(wrapped.with_async_context_if_needed(global));
-            callback_length = 0;
-        }
-    }
 
     if !this.each.is_empty() {
         if this.each.is_undefined_or_null() || !this.each.is_array() {
@@ -234,7 +244,11 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     None
                 };
 
-                let bound = if let Some(cb) = args.callback {
+                let callbacks = match args.callback {
+                    Some(cb) if uses_fixtures => this.wrap_with_fixtures(global, cb, rooted)?,
+                    other => TestCallbacks { callback: other, fixture_teardown: None },
+                };
+                let bound = if let Some(cb) = callbacks.callback {
                     Some(JSValueTestExt::bind(cb, global, item, &BunString::static_("cb"), 0.0, args_list.as_slice())?)
                 } else {
                     None
@@ -245,7 +259,7 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
                     &mut *bun_test_ptr,
                     global,
                     frame,
-                    bound,
+                    TestCallbacks { callback: bound, fixture_teardown: callbacks.fixture_teardown },
                     formatted_label.as_deref(),
                     &args.options,
                     callback_length.saturating_sub(args_list.len()),
@@ -256,16 +270,22 @@ fn call_as_function(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
             test_idx += 1;
         }
     } else {
-        this.enqueue_describe_or_test_callback(
-            bun_test_ptr,
-            global,
-            frame,
-            args.callback,
-            args.description.as_deref(),
-            &args.options,
-            callback_length,
-            line_no,
-        )?;
+        bun_jsc::MarkedArgumentBuffer::new(|rooted| -> JsResult<()> {
+            let callbacks = match args.callback {
+                Some(cb) if uses_fixtures => this.wrap_with_fixtures(global, cb, rooted)?,
+                other => TestCallbacks { callback: other, fixture_teardown: None },
+            };
+            this.enqueue_describe_or_test_callback(
+                &mut *bun_test_ptr,
+                global,
+                frame,
+                callbacks,
+                args.description.as_deref(),
+                &args.options,
+                callback_length,
+                line_no,
+            )
+        })?;
     }
 
     Ok(JSValue::UNDEFINED)
@@ -324,13 +344,14 @@ impl ScopeFunctions {
         bun_test: &mut BunTest,
         global: &JSGlobalObject,
         frame: &CallFrame,
-        callback: Option<JSValue>,
+        callbacks: TestCallbacks,
         description: Option<&[u8]>,
         options: &ParseArgumentsOptions,
         callback_length: usize,
         line_no: u32,
     ) -> JsResult<()> {
         let _g = group_log::begin();
+        let TestCallbacks { callback, fixture_teardown } = callbacks;
 
         // only allow in collection phase
         match bun_test.phase {
@@ -451,6 +472,7 @@ impl ScopeFunctions {
                 let _ = bun_test.collection.active_scope_mut().append_test(
                     description,
                     if matches_filter { callback } else { None },
+                    if matches_filter { fixture_teardown } else { None },
                     bun_test::ExecutionEntryCfg {
                         has_done_parameter,
                         timeout: options.timeout,
@@ -746,11 +768,10 @@ pub(crate) fn parse_arguments(
 // (see jest.classes.ts `values: ["each"]`).
 //
 // Hand-expansion of the cached-value accessors `src/codegen/generate-classes.ts` emits:
-// `eachSetCached` / `eachGetCached` (and the `fixtures` pair) thin-wrap the C++-side
-// `ScopeFunctionsPrototype__{each,fixtures}{Set,Get}CachedValue` shims, which write/read
-// the `JSC::WriteBarrier<Unknown>` slots on the JSCell wrapper so the GC visits the
-// `.each(arr)` / `.extend(fixtures)` arguments between construction and the trailing
-// `("name", cb)` call.
+// `eachSetCached` / `eachGetCached` thin-wrap the C++-side
+// `ScopeFunctionsPrototype__each{Set,Get}CachedValue` shims, which write/read the
+// `JSC::WriteBarrier<Unknown> m_each` slot on the JSCell wrapper so the GC visits
+// the `.each(arr)` argument between construction and the trailing `("name", cb)` call.
 pub mod js {
     bun_jsc::codegen_cached_accessors!("ScopeFunctions"; each, fixtures);
 }
@@ -794,9 +815,7 @@ fn create_unbound(global: &JSGlobalObject, mode: Mode, each: JSValue, fixtures: 
     // wrapper (m_ctx); freed in `finalize`.
     let value = ScopeFunctions { mode, cfg, each, fixtures }.to_js(global);
     value.ensure_still_alive();
-    // Write into the C++ m_each/m_fixtures WriteBarriers so GC visits them. The Rust
-    // fields live in unmanaged memory that JSC never scans; without this the values
-    // can be collected between construction and the trailing `("name", cb)` call.
+    // The Rust fields are invisible to the GC; the C++ WriteBarriers keep the values alive.
     if !each.is_empty() {
         js::each_set_cached(value, global, each);
     }

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1079,9 +1079,15 @@ impl BunTest {
                 );
                 for seq in &order.sequences[describe_seq_start..describe_seq_end] {
                     let Some(test_entry) = seq.test_entry else { continue };
+                    // SAFETY: live `DescribeScope`-owned entry; read-only access.
+                    let fixture_teardown: Option<*const ExecutionEntry> = unsafe { test_entry.as_ref() }
+                        .fixture_teardown
+                        .as_deref()
+                        .map(core::ptr::from_ref);
                     let mut cur = seq.first_entry;
                     while let Some(p) = cur {
-                        if p != test_entry {
+                        // the fixture teardown entry is owned by the test entry, not a clone
+                        if p != test_entry && fixture_teardown != Some(p.as_ptr().cast_const()) {
                             self.cloned_hook_entries.push(p.as_ptr());
                         }
                         // SAFETY: live linked-list nodes built by `generate_order_test`.
@@ -1818,16 +1824,34 @@ impl DescribeScope {
         }
     }
 
+    /// `fixture_teardown` (the teardown half of a `test.extend()` callback pair) is
+    /// scheduled as its own entry after the test's afterEach hooks, see `Order`.
     pub(crate) fn append_test(
         &mut self,
         name_not_owned: Option<&[u8]>,
         callback: Option<JSValue>,
+        fixture_teardown: Option<JSValue>,
         cfg: ExecutionEntryCfg,
         base: BaseScopeCfg,
         phase: AddedInPhase,
     ) -> JsResult<&mut ExecutionEntry> {
         let mut entry = ExecutionEntry::create(name_not_owned, callback, cfg, Some(std::ptr::from_mut(self)), base, phase);
         let has_cb = entry.callback.is_some();
+        if has_cb {
+            if let Some(teardown) = fixture_teardown {
+                let teardown_entry = ExecutionEntry::create(
+                    None,
+                    Some(teardown),
+                    ExecutionEntryCfg { timeout: cfg.timeout, ..Default::default() },
+                    Some(std::ptr::from_mut(self)),
+                    BaseScopeCfg::default(),
+                    phase,
+                );
+                if teardown_entry.callback.is_some() {
+                    entry.fixture_teardown = Some(teardown_entry);
+                }
+            }
+        }
         entry.base.propagate(has_cb);
         self.entries.push(TestScheduleEntry::TestCallback(entry));
         match self.entries.last_mut().unwrap() {
@@ -1906,6 +1930,9 @@ pub struct ExecutionEntry {
     pub(crate) next: Option<*mut ExecutionEntry>,
     /// if this entry fails, go to the entry 'failure_skip_past.next'
     pub(crate) failure_skip_past: Option<*mut ExecutionEntry>,
+    /// Test entries registered through `test.extend()` own the entry that tears their
+    /// fixtures down; `Order` links it into the sequence after the afterEach hooks.
+    pub(crate) fixture_teardown: Option<Box<ExecutionEntry>>,
 }
 
 impl ExecutionEntry {
@@ -1928,6 +1955,7 @@ impl ExecutionEntry {
             timespec: Timespec::EPOCH,
             next: None,
             failure_skip_past: None,
+            fixture_teardown: None,
         });
 
         if let Some(c) = cb {

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -180,6 +180,7 @@ pub mod js_fns {
             } else {
                 false
             };
+            let callback = args.callback.map(|cb| cb.with_async_context_if_needed(global_this));
 
             let bun_test_root = get_test_root(global_this, Signature::Str(sig_bytes))?;
 
@@ -200,7 +201,7 @@ pub mod js_fns {
 
                 let _ = bun_test_root.hook_scope.append_hook(
                     tag.as_hook_tag().unwrap(),
-                    args.callback,
+                    callback,
                     cfg,
                     BaseScopeCfg::default(),
                     AddedInPhase::Preload,
@@ -218,7 +219,7 @@ pub mod js_fns {
                     }
                     let _ = bun_test.collection.active_scope_mut().append_hook(
                         tag.as_hook_tag().unwrap(),
-                        args.callback,
+                        callback,
                         cfg,
                         BaseScopeCfg::default(),
                         AddedInPhase::Collection,
@@ -291,7 +292,7 @@ pub mod js_fns {
 
                     let new_item = ExecutionEntry::create(
                         None,
-                        args.callback,
+                        callback,
                         cfg,
                         None,
                         BaseScopeCfg::default(),

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1824,8 +1824,6 @@ impl DescribeScope {
         }
     }
 
-    /// `fixture_teardown` (the teardown half of a `test.extend()` callback pair) is
-    /// scheduled as its own entry after the test's afterEach hooks, see `Order`.
     pub(crate) fn append_test(
         &mut self,
         name_not_owned: Option<&[u8]>,
@@ -1930,8 +1928,7 @@ pub struct ExecutionEntry {
     pub(crate) next: Option<*mut ExecutionEntry>,
     /// if this entry fails, go to the entry 'failure_skip_past.next'
     pub(crate) failure_skip_past: Option<*mut ExecutionEntry>,
-    /// Test entries registered through `test.extend()` own the entry that tears their
-    /// fixtures down; `Order` links it into the sequence after the afterEach hooks.
+    /// Set on `test.extend()` tests; `Order` schedules it after the test's afterEach hooks.
     pub(crate) fixture_teardown: Option<Box<ExecutionEntry>>,
 }
 

--- a/src/runtime/test_runner/jest.classes.ts
+++ b/src/runtime/test_runner/jest.classes.ts
@@ -810,7 +810,7 @@ export default [
     forBind: true,
     finalize: true,
     JSType: "0b11101110",
-    values: ["each"],
+    values: ["each", "fixtures"],
     configurable: false,
     klass: {},
     proto: {
@@ -864,6 +864,10 @@ export default [
       },
       each: {
         fn: "fnEach",
+        length: 1,
+      },
+      extend: {
+        fn: "fnExtend",
         length: 1,
       },
     },

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -337,6 +337,7 @@ pub mod Jest {
             global_object,
             ScopeKind::Test,
             JSValue::ZERO,
+            JSValue::ZERO,
             BaseScopeCfg::default(),
             "test",
         )?;
@@ -346,6 +347,7 @@ pub mod Jest {
         let xtest_scope_functions = create_bound(
             global_object,
             ScopeKind::Test,
+            JSValue::ZERO,
             JSValue::ZERO,
             BaseScopeCfg { self_mode: ScopeMode::Skip, ..Default::default() },
             "xtest",
@@ -357,6 +359,7 @@ pub mod Jest {
             global_object,
             ScopeKind::Describe,
             JSValue::ZERO,
+            JSValue::ZERO,
             BaseScopeCfg::default(),
             "describe",
         )?;
@@ -365,6 +368,7 @@ pub mod Jest {
         let xdescribe_scope_functions = create_bound(
             global_object,
             ScopeKind::Describe,
+            JSValue::ZERO,
             JSValue::ZERO,
             BaseScopeCfg { self_mode: ScopeMode::Skip, ..Default::default() },
             "xdescribe",

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -421,3 +421,108 @@ unknownMatchers.toContainEqual([""]);
 unknownMatchers.toEqual(["a", "b"]);
 unknownMatchers.toBeCloseTo(2);
 unknownMatchers.toBe("a");
+
+// test.extend() fixtures (#8257)
+{
+  // plain test callbacks still accept a done callback
+  test("done still works", done => {
+    expectType<(err?: unknown) => void>(done);
+    done();
+  });
+
+  const withValue = test.extend({ port: 3000 });
+  withValue("value fixture", ({ port }) => {
+    expectType<number>(port);
+  });
+  withValue("context param", context => {
+    expectType<number>(context.port);
+  });
+  // extended tests receive the context, not a done callback
+  withValue("no done", arg => {
+    // @ts-expect-error the first parameter is the fixture context, not a done callback
+    arg();
+  });
+
+  interface DB {
+    query(sql: string): Promise<unknown[]>;
+  }
+  const withDb = withValue.extend<{ db: DB; user: string }>({
+    db: async ({ port }, use) => {
+      expectType<number>(port);
+      expectType<(value: DB) => Promise<void>>(use);
+      await use({ query: async () => [] });
+    },
+    user: async ({ db }, use) => {
+      expectType<DB>(db);
+      await use("alice");
+    },
+  });
+  withDb("chained fixtures merge contexts", ({ port, db, user }) => {
+    expectType<number>(port);
+    expectType<DB>(db);
+    expectType<string>(user);
+  });
+
+  // modifiers preserve the context type
+  withDb.skip("skip", ({ db }) => {
+    expectType<DB>(db);
+  });
+  withDb.todoIf(false)("todoIf", ({ user }) => {
+    expectType<string>(user);
+  });
+  withDb.each([1, 2])("each %d", (n, { db }) => {
+    expectType<number>(n);
+    expectType<DB>(db);
+  });
+
+  // [value, options] tuple form
+  test.extend<{ log: string[] }>({
+    log: [
+      async ({}, use) => {
+        await use([]);
+      },
+      { auto: true },
+    ],
+  });
+
+  // function-typed fixtures are declared with the setup-function form
+  test.extend<{ fn: () => void }>({
+    fn: async ({}, use) => {
+      await use(() => {});
+    },
+  });
+
+  // invalid fixture value types are rejected
+  const typed = test.extend<{ port: number }>({ port: 3000 });
+  // @ts-expect-error string is not assignable to number
+  typed.extend<{ port: number }>({ port: "nope" });
+
+  // re-extending the same fixture name with a different type: the later type wins
+  const retyped = test.extend<{ v: number }>({ v: 1 }).extend<{ v: string }>({ v: "s" });
+  retyped("override replaces the fixture type", ({ v }) => {
+    expectType<string>(v);
+  });
+
+  // return-style fixtures: the setup function may return the value instead of
+  // calling use(); disposable values are disposed after the test
+  const withDisposable = test.extend<{ res: { tag: string } & AsyncDisposable; plain: number }>({
+    res: () => ({
+      tag: "r",
+      async [Symbol.asyncDispose]() {},
+    }),
+    plain: ctx => {
+      expectType<string>(ctx.res.tag);
+      return 42;
+    },
+  });
+  withDisposable("return-style fixtures are typed", ({ res, plain }) => {
+    expectType<string>(res.tag);
+    expectType<number>(plain);
+  });
+
+  // return-style fixtures must return the declared fixture type
+  test.extend<{ port: number }>({
+    // @ts-expect-error string is not assignable to the declared fixture type
+    port: () => "nope",
+  });
+}

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -434,14 +434,12 @@ unknownMatchers.toBe("a");
   withValue("value fixture", ({ port }) => {
     expectType<number>(port);
   });
-  withValue("context param", context => {
-    expectType<number>(context.port);
+  withValue("renamed in the pattern", ({ port: p }) => {
+    expectType<number>(p);
   });
-  // extended tests receive the context, not a done callback
-  withValue("no done", arg => {
-    // @ts-expect-error the first parameter is the fixture context, not a done callback
-    arg();
-  });
+  // extended tests receive the context where plain tests receive `done`
+  type WithValueCallbackArgs = Parameters<Parameters<typeof withValue>[1]>;
+  expectType<[context: { port: number }]>(null! as WithValueCallbackArgs);
 
   interface DB {
     query(sql: string): Promise<unknown[]>;
@@ -463,6 +461,43 @@ unknownMatchers.toBe("a");
     expectType<string>(user);
   });
 
+  // an interface works as the fixture map (no index signature required)
+  interface MyFixtures {
+    db: DB;
+    retries: number;
+  }
+  const withInterface = test.extend<MyFixtures>({
+    db: async ({}, use) => {
+      await use({ query: async () => [] });
+    },
+    retries: 3,
+  });
+  withInterface("interface fixture map", ({ db, retries }) => {
+    expectType<DB>(db);
+    expectType<number>(retries);
+  });
+
+  // an override may destructure its own name to receive the definition it replaces
+  const withLoggedDb = withDb.extend<{ db: DB }>({
+    db: async ({ db, port }, use) => {
+      expectType<DB>(db);
+      expectType<number>(port);
+      await use(db);
+    },
+  });
+  withLoggedDb("override keeps the context type", ({ db, user }) => {
+    expectType<DB>(db);
+    expectType<string>(user);
+  });
+
+  // a fixture defined for the first time has no earlier definition to destructure
+  test.extend<{ fresh: number }>({
+    // @ts-expect-error `fresh` does not exist on the context of its own definition
+    fresh: async ({ fresh }, use) => {
+      await use(fresh);
+    },
+  });
+
   // modifiers preserve the context type
   withDb.skip("skip", ({ db }) => {
     expectType<DB>(db);
@@ -471,6 +506,14 @@ unknownMatchers.toBe("a");
     expectType<string>(user);
   });
   withDb.each([1, 2])("each %d", (n, { db }) => {
+    expectType<number>(n);
+    expectType<DB>(db);
+  });
+  test.each([1, 2]).extend<{ db: DB }>({
+    db: async ({}, use) => {
+      await use({ query: async () => [] });
+    },
+  })("each().extend() %d", (n, { db }) => {
     expectType<number>(n);
     expectType<DB>(db);
   });
@@ -492,6 +535,9 @@ unknownMatchers.toBe("a");
     },
   });
 
+  // `any`-typed fixtures accept plain values
+  test.extend<{ anything: any }>({ anything: 1 });
+
   // invalid fixture value types are rejected
   const typed = test.extend<{ port: number }>({ port: 3000 });
   // @ts-expect-error string is not assignable to number
@@ -501,28 +547,5 @@ unknownMatchers.toBe("a");
   const retyped = test.extend<{ v: number }>({ v: 1 }).extend<{ v: string }>({ v: "s" });
   retyped("override replaces the fixture type", ({ v }) => {
     expectType<string>(v);
-  });
-
-  // return-style fixtures: the setup function may return the value instead of
-  // calling use(); disposable values are disposed after the test
-  const withDisposable = test.extend<{ res: { tag: string } & AsyncDisposable; plain: number }>({
-    res: () => ({
-      tag: "r",
-      async [Symbol.asyncDispose]() {},
-    }),
-    plain: ctx => {
-      expectType<string>(ctx.res.tag);
-      return 42;
-    },
-  });
-  withDisposable("return-style fixtures are typed", ({ res, plain }) => {
-    expectType<string>(res.tag);
-    expectType<number>(plain);
-  });
-
-  // return-style fixtures must return the declared fixture type
-  test.extend<{ port: number }>({
-    // @ts-expect-error string is not assignable to the declared fixture type
-    port: () => "nope",
   });
 }

--- a/test/js/bun/test/bun_test.test.ts
+++ b/test/js/bun/test/bun_test.test.ts
@@ -308,6 +308,58 @@ test.concurrent("hooks may be registered during preload, test/describe may not",
   expect(exitCode).toBe(0);
 });
 
+test.concurrent("tests and hooks registered inside an AsyncLocalStorage context run in it", async () => {
+  using dir = tempDir("bun-test-als-registration", {
+    "a.test.ts": `
+      import { test, describe, beforeEach, afterEach, onTestFinished } from "bun:test";
+      import { AsyncLocalStorage } from "node:async_hooks";
+      const als = new AsyncLocalStorage<string>();
+      const log = (what: string) => console.log(what + ": " + als.getStore());
+      als.run("store", () => {
+        describe("registered in als.run", () => {
+          beforeEach(() => log("beforeEach"), 1000);
+          afterEach(() => log("afterEach"), 1000);
+          test("without parameters", () => {
+            onTestFinished(() => log("onTestFinished"));
+            log("test");
+          }, 1000);
+          test("with a done callback", done => {
+            log("done test");
+            done();
+          }, 1000);
+          test.each([1, 2])("each %d", n => log("each " + n), 1000);
+        });
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./a.test.ts"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`
+    "bun test <version> (<revision>)
+    beforeEach: store
+    test: store
+    afterEach: store
+    onTestFinished: store
+    beforeEach: store
+    done test: store
+    afterEach: store
+    beforeEach: store
+    each 1: store
+    afterEach: store
+    beforeEach: store
+    each 2: store
+    afterEach: store"
+  `);
+  expect(stderr).toContain("4 pass");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("test/describe and hooks throw outside of the test runner", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/bun/test/jest-each-gc-root.test.ts
+++ b/test/js/bun/test/jest-each-gc-root.test.ts
@@ -1,10 +1,12 @@
-// test.each(arr) / describe.each(arr) create a ScopeFunctions whose Zig struct
-// stores `arr` as a raw jsc.JSValue. The codegen for `values: ["each"]` in
-// jest.classes.ts emits a C++ `m_each` WriteBarrier that visitChildren walks,
-// but the Zig side never called `eachSetCached` to populate it — so the only
-// reference to `arr` lived in unmanaged memory the GC never scans. If GC ran
-// between `.each(arr)` and the trailing `("name", cb)` call, the array could
-// be collected and `callAsFunction` would iterate a freed cell.
+// test.each(arr) / describe.each(arr) create a ScopeFunctions whose native struct
+// stores `arr` as a raw JSValue, and test.extend(fixtures) stores the merged
+// fixture registry the same way. The codegen for `values: ["each", "fixtures"]`
+// in jest.classes.ts emits C++ `m_each` / `m_fixtures` WriteBarriers that
+// visitChildren walks, but they only protect the values if the native side
+// actually populates them (`eachSetCached` / `fixturesSetCached`); otherwise the
+// only reference lives in unmanaged memory the GC never scans, and a GC between
+// `.each(arr)` / `.extend(fixtures)` and the trailing `("name", cb)` call frees
+// the value that `callAsFunction` is about to read.
 //
 // useZombieMode scribbles 0xbadbeef0 over swept cells so the dangling access
 // manifests as a hard crash / wrong-type error instead of a heisenbug.
@@ -45,6 +47,18 @@ const chainedEach = (() => (() =>
   test.each([["zeta", 10], ["eta", 20]]).skipIf(false)
 )())();
 
+// test.extend() keeps the merged fixture registry in m_fixtures; it is only
+// reachable from the ScopeFunctions until the trailing ("name", cb) call.
+const extended = (() => (() =>
+  test.extend({ theta: "theta", iota: 30 })
+)())();
+
+// .extend() -> .skipIf(false) -> .each() propagates the registry through
+// genericIf/createBound and fnEach; each row is wrapped separately.
+const chainedExtend = (() => (() =>
+  test.extend({ suffix: "!" }).skipIf(false).each([["kappa"], ["lambda"]])
+)())();
+
 gcHard();
 
 testEach("test.each %s", (name, num) => {
@@ -70,7 +84,22 @@ chainedEach("chained.each %s", (name, num) => {
   seen.push([name, num]);
 });
 
-test("all .each() table rows survived GC", () => {
+gcHard();
+
+extended("test.extend fixtures", ({ theta, iota }) => {
+  expect(theta).toBe("theta");
+  expect(iota).toBe(30);
+  seen.push([theta, iota]);
+});
+
+gcHard();
+
+chainedExtend("chained.extend %s", (name, { suffix }) => {
+  expect(typeof name).toBe("string");
+  seen.push([name + suffix]);
+});
+
+test("all .each() table rows and .extend() fixtures survived GC", () => {
   expect(seen).toEqual([
     ["alpha", 1],
     ["beta", 2],
@@ -79,11 +108,14 @@ test("all .each() table rows survived GC", () => {
     ["epsilon"],
     ["zeta", 10],
     ["eta", 20],
+    ["theta", 30],
+    ["kappa!"],
+    ["lambda!"],
   ]);
 });
 `;
 
-test("test.each/describe.each table array is a GC root", async () => {
+test("test.each/describe.each tables and test.extend fixtures are GC roots", async () => {
   using dir = tempDir("jest-each-gc-root", {
     "each-gc.test.ts": fixture,
   });
@@ -108,7 +140,7 @@ test("test.each/describe.each table array is a GC root", async () => {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toContain("8 pass");
+  expect(stderr).toContain("11 pass");
   expect(stderr).toContain("0 fail");
   expect(stdout + stderr).not.toContain("Expected array");
   expect(exitCode).toBe(0);

--- a/test/js/bun/test/test-extend.test.ts
+++ b/test/js/bun/test/test-extend.test.ts
@@ -1,0 +1,515 @@
+// test.extend() fixtures: https://github.com/oven-sh/bun/issues/8257
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+describe("test.extend", () => {
+  // ── happy paths run inline in this file through the real runner ──────────
+
+  const withValues = test.extend<{ port: number; names: string[] }>({
+    port: 3000,
+    names: ["alice", "bob"],
+  });
+
+  withValues("provides plain value fixtures", ({ port, names }) => {
+    expect(port).toBe(3000);
+    expect(names).toEqual(["alice", "bob"]);
+  });
+
+  // setup/teardown ordering across dependent fixtures
+  const order: string[] = [];
+  const withDeps = test.extend<{ base: string; derived: string }>({
+    base: async ({}, use) => {
+      order.push("setup base");
+      await use("base-value");
+      order.push("teardown base");
+    },
+    derived: async ({ base }, use) => {
+      order.push("setup derived");
+      await use(`derived-of-${base}`);
+      order.push("teardown derived");
+    },
+  });
+
+  withDeps("initializes dependencies before dependents", ({ derived, base }) => {
+    expect(base).toBe("base-value");
+    expect(derived).toBe("derived-of-base-value");
+    expect(order).toEqual(["setup base", "setup derived"]);
+    order.push("test body");
+  });
+
+  test("teardown ran in reverse setup order after the previous test", () => {
+    expect(order).toEqual(["setup base", "setup derived", "test body", "teardown derived", "teardown base"]);
+  });
+
+  // laziness
+  const initialized: string[] = [];
+  const lazy = test.extend<{ used: number; unused: number; auto: number }>({
+    used: async ({}, use) => {
+      initialized.push("used");
+      await use(1);
+    },
+    unused: async ({}, use) => {
+      initialized.push("unused");
+      await use(2);
+    },
+    auto: [
+      async ({}, use) => {
+        initialized.push("auto");
+        await use(3);
+      },
+      { auto: true },
+    ],
+  });
+
+  lazy("only sets up destructured and auto fixtures", ({ used }) => {
+    expect(used).toBe(1);
+    expect(initialized).toEqual(["used", "auto"]);
+  });
+
+  // chaining + overriding
+  const baseTest = test.extend<{ a: number; b: number }>({ a: 1, b: 2 });
+  const chained = baseTest.extend<{ b: number; c: number }>({ b: 20, c: 3 });
+
+  baseTest("base fixtures are unchanged by later extends", ({ a, b }) => {
+    expect(a).toBe(1);
+    expect(b).toBe(2);
+  });
+
+  chained("chained extend merges and overrides fixtures", ({ a, b, c }) => {
+    expect(a).toBe(1);
+    expect(b).toBe(20);
+    expect(c).toBe(3);
+  });
+
+  // fixture functions can depend on overridden fixtures
+  const overridden = test
+    .extend<{ value: number; doubled: number }>({
+      value: 1,
+      doubled: async ({ value }, use) => {
+        await use(value * 2);
+      },
+    })
+    .extend<{ value: number }>({ value: 21 });
+
+  overridden("dependencies resolve against the overriding fixture", ({ doubled }) => {
+    expect(doubled).toBe(42);
+  });
+
+  // diamond dependencies: d -> (b, c) -> a. The shared dependency is set up
+  // exactly once and torn down exactly once, in reverse setup order.
+  const diamondOrder: string[] = [];
+  const diamond = test.extend<{ a: number; b: number; c: number; d: number }>({
+    a: async ({}, use) => {
+      diamondOrder.push("+a");
+      await use(1);
+      diamondOrder.push("-a");
+    },
+    b: async ({ a }, use) => {
+      diamondOrder.push("+b");
+      await use(a + 1);
+      diamondOrder.push("-b");
+    },
+    c: async ({ a }, use) => {
+      diamondOrder.push("+c");
+      await use(a + 2);
+      diamondOrder.push("-c");
+    },
+    d: async ({ b, c }, use) => {
+      diamondOrder.push("+d");
+      await use(b + c);
+      diamondOrder.push("-d");
+    },
+  });
+
+  diamond("diamond dependencies set up the shared fixture once", ({ d }) => {
+    expect(d).toBe(5); // b = 2, c = 3
+    expect(diamondOrder).toEqual(["+a", "+b", "+c", "+d"]);
+  });
+
+  test("diamond teardown ran once per fixture, in reverse order", () => {
+    expect(diamondOrder).toEqual(["+a", "+b", "+c", "+d", "-d", "-c", "-b", "-a"]);
+  });
+
+  // fixture functions may return the value instead of calling use(); a
+  // disposable return value (Symbol.asyncDispose / Symbol.dispose) is disposed
+  // after the test as the fixture's teardown
+  const disposeLog: string[] = [];
+  const returned = test.extend<{
+    res: { tag: string; [Symbol.asyncDispose](): Promise<void>; [Symbol.dispose](): void };
+    syncRes: { [Symbol.dispose](): void };
+    plain: number;
+    nothing: null;
+  }>({
+    res: () => ({
+      tag: "res",
+      async [Symbol.asyncDispose]() {
+        disposeLog.push("asyncDispose res");
+      },
+      [Symbol.dispose]() {
+        disposeLog.push("dispose res");
+      },
+    }),
+    syncRes: async () => ({
+      [Symbol.dispose]() {
+        disposeLog.push("dispose syncRes");
+      },
+    }),
+    plain: ({ res }) => (disposeLog.push("create plain"), res.tag.length),
+    nothing: () => null,
+  });
+
+  returned("return-style fixtures provide the returned value", ({ res, syncRes, plain, nothing }) => {
+    expect(res.tag).toBe("res");
+    expect(typeof syncRes[Symbol.dispose]).toBe("function");
+    expect(plain).toBe(3);
+    expect(nothing).toBeNull();
+    expect(disposeLog).toEqual(["create plain"]);
+  });
+
+  test("returned disposables were disposed in reverse order, preferring asyncDispose", () => {
+    // `plain` has no teardown; `syncRes` only has Symbol.dispose; `res` has
+    // both and asyncDispose wins. Setup order was res, syncRes, plain.
+    expect(disposeLog).toEqual(["create plain", "dispose syncRes", "asyncDispose res"]);
+  });
+
+  // `await using` inside a use()-style fixture disposes when the fixture
+  // function resumes after the test
+  const usingLog: string[] = [];
+  const usingFixture = test.extend<{ conn: { name: string } }>({
+    conn: async ({}, use) => {
+      await using guard = {
+        async [Symbol.asyncDispose]() {
+          usingLog.push("disposed");
+        },
+      };
+      expect(guard).toBeDefined();
+      await use({ name: "conn" });
+      usingLog.push("after use");
+    },
+  });
+
+  usingFixture("await using composes with use()-style fixtures", ({ conn }) => {
+    expect(conn.name).toBe("conn");
+    expect(usingLog).toEqual([]);
+  });
+
+  test("await using declarations in fixtures were disposed after the test", () => {
+    expect(usingLog).toEqual(["after use", "disposed"]);
+  });
+
+  // a [value, options] tuple whose second element carries no fixture option keys
+  // is a plain array fixture value, not a tuple
+  const plainTuple = test.extend<{ pair: unknown }>({ pair: [1, { other: true }] as any });
+  plainTuple("an array without fixture options is a plain value", ({ pair }) => {
+    expect(pair).toEqual([1, { other: true }]);
+  });
+
+  // destructuring forms
+  const forms = test.extend<{ "quoted-name": number; renamed: number; defaulted: number }>({
+    "quoted-name": 7,
+    renamed: 8,
+    defaulted: 9,
+  });
+
+  forms(
+    "supports quoted keys, renames and defaults in the pattern",
+    ({ "quoted-name": q, renamed: r, defaulted = 0 }) => {
+      expect(q).toBe(7);
+      expect(r).toBe(8);
+      expect(defaulted).toBe(9);
+    },
+  );
+
+  // modifiers are preserved on extended test functions
+  const modTest = test.extend<{ n: number }>({ n: 5 });
+  modTest.skip("skip on an extended test is still skip", () => {
+    throw new Error("should not run");
+  });
+  modTest.todo("todo on an extended test is still todo");
+  modTest.skipIf(true)("skipIf(true) on an extended test skips", () => {
+    throw new Error("should not run");
+  });
+  modTest.if(true)("if(true) on an extended test runs with fixtures", ({ n }) => {
+    expect(n).toBe(5);
+  });
+
+  // .each combined with fixtures: case args come first, context last
+  modTest.each([
+    [1, 2],
+    [3, 4],
+  ])("each %d %d passes case args before the context", (x, y, { n }) => {
+    expect(typeof x).toBe("number");
+    expect(typeof y).toBe("number");
+    expect(n).toBe(5);
+  });
+
+  // async value through use()
+  const asyncFixture = test.extend<{ later: string }>({
+    later: async ({}, use) => {
+      const value = await Promise.resolve("resolved");
+      await use(value);
+    },
+  });
+
+  asyncFixture("awaits asynchronous fixture setup", ({ later }) => {
+    expect(later).toBe("resolved");
+  });
+
+  // concurrent tests each get their own context. A shared barrier guarantees
+  // all three test bodies overlap before any of them re-checks its context.
+  const concurrent = test.extend<{ bag: { id?: number } }>({
+    bag: async ({}, use) => {
+      await use({});
+    },
+  });
+
+  let startedCount = 0;
+  const allStarted = Promise.withResolvers<void>();
+  concurrent.concurrent.each([[1], [2], [3]])("concurrent test %d has an isolated context", async (id, { bag }) => {
+    expect(bag.id).toBeUndefined();
+    bag.id = id;
+    if (++startedCount === 3) allStarted.resolve();
+    await allStarted.promise;
+    expect(bag.id).toBe(id);
+  });
+
+  // validation errors thrown at .extend() call time
+  test("extend() rejects non-object arguments", () => {
+    expect(() => (test as any).extend()).toThrow("test.extend() expects an object");
+    expect(() => (test as any).extend(null)).toThrow("test.extend() expects an object");
+    expect(() => (test as any).extend([1, 2])).toThrow("test.extend() expects an object");
+    expect(() => (test as any).extend("nope")).toThrow("test.extend() expects an object");
+  });
+
+  test("extend() rejects unsupported fixture options", () => {
+    expect(() => (test as any).extend({ db: [1, { scope: "worker" }] })).toThrow('scope "worker" is not supported');
+    expect(() => (test as any).extend({ db: [1, { injected: true }] })).toThrow('"injected" option is not supported');
+  });
+
+  test("extend() is not available on describe", () => {
+    expect(() => (describe as any).extend({})).toThrow("Cannot call .extend() on describe");
+  });
+});
+
+// ── failure modes run in a child process so they don't fail this file ──────
+
+async function runFixtureFile(contents: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  using dir = tempDir("test-extend", { "fixture.test.ts": contents });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "fixture.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent("test.extend failure modes", () => {
+  test("fixture setup error fails the test and tears down earlier fixtures", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      const t = test.extend<{ ok: string; bad: string }>({
+        ok: async ({}, use) => {
+          console.error("setup ok");
+          await use("ok");
+          console.error("teardown ok");
+        },
+        bad: async ({ ok }, use) => {
+          throw new Error("setup exploded");
+        },
+      });
+      t("uses bad fixture", ({ bad }) => {});
+      t("later test still runs", ({ ok }) => {
+        expect(ok).toBe("ok");
+      });
+    `);
+    expect(stderr).toContain("setup exploded");
+    // the already-initialized fixture was torn down even though setup failed
+    expect(stderr).toContain("teardown ok");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fixture teardown error fails the test", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ leaky: number }>({
+        leaky: async ({}, use) => {
+          await use(1);
+          throw new Error("teardown exploded");
+        },
+      });
+      t("body passes but teardown fails", ({ leaky }) => {});
+    `);
+    expect(stderr).toContain("teardown exploded");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("test body error takes precedence and teardown still runs", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ res: number }>({
+        res: async ({}, use) => {
+          await use(1);
+          console.error("teardown ran");
+        },
+      });
+      t("fails", ({ res }) => {
+        throw new Error("body exploded");
+      });
+    `);
+    expect(stderr).toContain("body exploded");
+    expect(stderr).toContain("teardown ran");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a fixture that neither calls use() nor returns a value fails the test", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ nope: number }>({
+        nope: async ({}, use) => {},
+      });
+      t("uses nope", ({ nope }) => {});
+    `);
+    expect(stderr).toContain('Fixture "nope" completed without calling use() or returning a value');
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("calling use() twice fails the test instead of deadlocking", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ x: number }>({
+        x: async ({}, use) => {
+          await use(1);
+          await use(2);
+        },
+      });
+      t("double use", ({ x }) => {});
+    `);
+    expect(stderr).toContain('Fixture "x" called use() more than once');
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a throwing Symbol.asyncDispose on a returned fixture value fails the test", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ bad: object }>({
+        bad: () => ({
+          async [Symbol.asyncDispose]() {
+            throw new Error("dispose exploded");
+          },
+        }),
+      });
+      t("uses bad", ({ bad }) => {});
+    `);
+    expect(stderr).toContain("dispose exploded");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("circular fixture dependencies fail the test", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ a: number; b: number }>({
+        a: async ({ b }, use) => {
+          await use(1);
+        },
+        b: async ({ a }, use) => {
+          await use(2);
+        },
+      });
+      t("circular", ({ a }) => {});
+    `);
+    expect(stderr).toContain("Circular fixture dependency: a -> b -> a");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a non-destructured context parameter with fixtures fails with a helpful error", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ db: number }>({ db: 1 });
+      t("bad signature", (context) => {});
+    `);
+    expect(stderr).toContain("must use object destructuring");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("rest parameters in the destructuring pattern fail with a helpful error", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ db: number }>({ db: 1 });
+      t("rest", ({ ...rest }) => {});
+    `);
+    expect(stderr).toContain("Rest parameters are not supported");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fixtures are re-created for each retry", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      let setups = 0;
+      let attempts = 0;
+      const t = test.extend<{ n: number }>({
+        n: async ({}, use) => {
+          setups++;
+          await use(setups);
+        },
+      });
+      t("retry gets a fresh fixture", ({ n }) => {
+        attempts++;
+        expect(n).toBe(attempts);
+        if (attempts < 3) throw new Error("flaky");
+      }, { retry: 5 });
+    `);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("extended test callbacks never receive a done callback", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      // a plain test with a parameter receives a done callback and would hang
+      // until timeout if it is never called; an extended test's parameter is
+      // the fixture context object instead.
+      const t = test.extend({});
+      t("context instead of done", (context) => {
+        expect(typeof context).toBe("object");
+      });
+    `);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("beforeEach/afterEach hooks run around fixture setup and teardown", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, beforeEach, afterEach } from "bun:test";
+      beforeEach(() => console.error("hook: beforeEach"));
+      afterEach(() => console.error("hook: afterEach"));
+      const t = test.extend<{ f: number }>({
+        f: async ({}, use) => {
+          console.error("fixture: setup");
+          await use(1);
+          console.error("fixture: teardown");
+        },
+      });
+      t("ordering", ({ f }) => {
+        console.error("test body");
+      });
+    `);
+    const lines = stderr
+      .split(/\r?\n/)
+      .filter(line => line.startsWith("hook:") || line.startsWith("fixture:") || line.startsWith("test body"));
+    expect(lines).toEqual(["hook: beforeEach", "fixture: setup", "test body", "fixture: teardown", "hook: afterEach"]);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/test/test-extend.test.ts
+++ b/test/js/bun/test/test-extend.test.ts
@@ -268,6 +268,37 @@ describe("test.extend", () => {
     },
   );
 
+  // a test callback whose source is unavailable gets every fixture
+  const unreadable: string[] = [];
+  const unreadableTest = test.extend<{ a: number; b: number }>({
+    a: async ({}, use) => {
+      unreadable.push("a");
+      await use(1);
+    },
+    b: async ({}, use) => {
+      unreadable.push("b");
+      await use(2);
+    },
+  });
+  unreadableTest(
+    "a bound test callback receives every fixture",
+    function ({ a, b }: { a: number; b: number }) {
+      expect([a, b]).toEqual([1, 2]);
+      expect(unreadable).toEqual(["a", "b"]);
+    }.bind(null),
+  );
+
+  // only the function's shape marks it unreadable, not the words "[native code]" appearing in its body
+  const nativeText = test.extend<{ base: number; derived: string }>({
+    base: 2,
+    derived: async ({ base }, use) => {
+      await use(`${base} [native code]`);
+    },
+  });
+  nativeText("a fixture body may mention [native code]", ({ derived }) => {
+    expect(derived).toBe("2 [native code]");
+  });
+
   // modifiers are preserved on extended test functions
   const modTest = test.extend<{ n: number }>({ n: 5 });
   modTest.skip("skip on an extended test is still skip", () => {
@@ -705,6 +736,22 @@ describe.concurrent("test.extend lifecycle", () => {
       t("rest", ({ ...rest }) => {});
     `);
     expect(stderr).toContain("Rest parameters are not supported");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a bound fixture function fails the test instead of running without its dependencies", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      function makeDb(config: string, { port }: { port: number }, use: (db: string) => Promise<void>) {
+        return use(config + ":" + port);
+      }
+      const t = test.extend<{ port: number; db: string }>({ port: 5432, db: makeDb.bind(null, "pg") });
+      t("bound fixture", ({ db }) => {});
+    `);
+    expect(stderr).toContain(
+      'TypeError: Fixture "db" is a bound or native function, so the fixtures it depends on cannot be read from its source.',
+    );
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });

--- a/test/js/bun/test/test-extend.test.ts
+++ b/test/js/bun/test/test-extend.test.ts
@@ -15,6 +15,13 @@ describe("test.extend", () => {
     expect(names).toEqual(["alice", "bob"]);
   });
 
+  // with no fixtures registered there is nothing to detect, so any parameter
+  // shape works and receives the (empty) context
+  const empty = test.extend({});
+  empty("an empty fixture map still passes a context object", (...args) => {
+    expect(args).toEqual([{}]);
+  });
+
   // setup/teardown ordering across dependent fixtures
   const order: string[] = [];
   const withDeps = test.extend<{ base: string; derived: string }>({
@@ -81,7 +88,7 @@ describe("test.extend", () => {
     expect(c).toBe(3);
   });
 
-  // fixture functions can depend on overridden fixtures
+  // fixture functions depend on the overriding definition of other fixtures
   const overridden = test
     .extend<{ value: number; doubled: number }>({
       value: 1,
@@ -93,6 +100,89 @@ describe("test.extend", () => {
 
   overridden("dependencies resolve against the overriding fixture", ({ doubled }) => {
     expect(doubled).toBe(42);
+  });
+
+  // an override that destructures its own name builds on the definition it replaces
+  const overrideOrder: string[] = [];
+  const wrapped = test
+    .extend<{ db: string[] }>({
+      db: async ({}, use) => {
+        overrideOrder.push("setup original");
+        await use(["original"]);
+        overrideOrder.push("teardown original");
+      },
+    })
+    .extend<{ db: string[] }>({
+      db: async ({ db }, use) => {
+        overrideOrder.push("setup override");
+        await use([...db, "override"]);
+        overrideOrder.push("teardown override");
+      },
+    })
+    .extend<{ db: string[] }>({
+      db: async ({ db }, use) => {
+        overrideOrder.push("setup second override");
+        await use([...db, "second override"]);
+        overrideOrder.push("teardown second override");
+      },
+    });
+
+  wrapped("an override receives the value of the definition it replaces", ({ db }) => {
+    expect(db).toEqual(["original", "override", "second override"]);
+    expect(overrideOrder).toEqual(["setup original", "setup override", "setup second override"]);
+  });
+
+  test("override chains tear down innermost first", () => {
+    expect(overrideOrder).toEqual([
+      "setup original",
+      "setup override",
+      "setup second override",
+      "teardown second override",
+      "teardown override",
+      "teardown original",
+    ]);
+  });
+
+  const wrappedValue = test.extend<{ n: number }>({ n: 20 }).extend<{ n: number }>({
+    n: async ({ n }, use) => {
+      await use(n + 22);
+    },
+  });
+  wrappedValue("an override can build on a plain value fixture", ({ n }) => {
+    expect(n).toBe(42);
+  });
+
+  // an override inherits `auto` unless it specifies its own options
+  const autoLog: string[] = [];
+  const autoBase = test.extend<{ tracker: string }>({
+    tracker: [
+      async ({}, use) => {
+        autoLog.push("base");
+        await use("base");
+      },
+      { auto: true },
+    ],
+  });
+  const autoInherited = autoBase.extend<{ tracker: string }>({
+    tracker: async ({}, use) => {
+      autoLog.push("inherited");
+      await use("inherited");
+    },
+  });
+  const autoDisabled = autoBase.extend<{ tracker: string }>({
+    tracker: [
+      async ({}, use) => {
+        autoLog.push("disabled");
+        await use("disabled");
+      },
+      { auto: false },
+    ],
+  });
+  autoInherited("an override inherits auto from the definition it replaces", () => {
+    expect(autoLog).toEqual(["inherited"]);
+  });
+  autoDisabled("an override with its own options replaces auto", () => {
+    expect(autoLog).toEqual(["inherited"]);
   });
 
   // diamond dependencies: d -> (b, c) -> a. The shared dependency is set up
@@ -130,50 +220,8 @@ describe("test.extend", () => {
     expect(diamondOrder).toEqual(["+a", "+b", "+c", "+d", "-d", "-c", "-b", "-a"]);
   });
 
-  // fixture functions may return the value instead of calling use(); a
-  // disposable return value (Symbol.asyncDispose / Symbol.dispose) is disposed
-  // after the test as the fixture's teardown
-  const disposeLog: string[] = [];
-  const returned = test.extend<{
-    res: { tag: string; [Symbol.asyncDispose](): Promise<void>; [Symbol.dispose](): void };
-    syncRes: { [Symbol.dispose](): void };
-    plain: number;
-    nothing: null;
-  }>({
-    res: () => ({
-      tag: "res",
-      async [Symbol.asyncDispose]() {
-        disposeLog.push("asyncDispose res");
-      },
-      [Symbol.dispose]() {
-        disposeLog.push("dispose res");
-      },
-    }),
-    syncRes: async () => ({
-      [Symbol.dispose]() {
-        disposeLog.push("dispose syncRes");
-      },
-    }),
-    plain: ({ res }) => (disposeLog.push("create plain"), res.tag.length),
-    nothing: () => null,
-  });
-
-  returned("return-style fixtures provide the returned value", ({ res, syncRes, plain, nothing }) => {
-    expect(res.tag).toBe("res");
-    expect(typeof syncRes[Symbol.dispose]).toBe("function");
-    expect(plain).toBe(3);
-    expect(nothing).toBeNull();
-    expect(disposeLog).toEqual(["create plain"]);
-  });
-
-  test("returned disposables were disposed in reverse order, preferring asyncDispose", () => {
-    // `plain` has no teardown; `syncRes` only has Symbol.dispose; `res` has
-    // both and asyncDispose wins. Setup order was res, syncRes, plain.
-    expect(disposeLog).toEqual(["create plain", "dispose syncRes", "asyncDispose res"]);
-  });
-
-  // `await using` inside a use()-style fixture disposes when the fixture
-  // function resumes after the test
+  // `await using` inside a fixture disposes when the fixture function resumes
+  // after the test
   const usingLog: string[] = [];
   const usingFixture = test.extend<{ conn: { name: string } }>({
     conn: async ({}, use) => {
@@ -188,7 +236,7 @@ describe("test.extend", () => {
     },
   });
 
-  usingFixture("await using composes with use()-style fixtures", ({ conn }) => {
+  usingFixture("await using inside a fixture is still alive during the test", ({ conn }) => {
     expect(conn.name).toBe("conn");
     expect(usingLog).toEqual([]);
   });
@@ -233,14 +281,27 @@ describe("test.extend", () => {
     expect(n).toBe(5);
   });
 
-  // .each combined with fixtures: case args come first, context last
+  // .each combined with fixtures, in either order: case args come first, context last
   modTest.each([
     [1, 2],
     [3, 4],
-  ])("each %d %d passes case args before the context", (x, y, { n }) => {
+  ])("extend().each() %d %d passes case args before the context", (x, y, { n }) => {
     expect(typeof x).toBe("number");
     expect(typeof y).toBe("number");
     expect(n).toBe(5);
+  });
+
+  const eachSeen: number[] = [];
+  test.each([[10], [20]]).extend<{ n: number }>({ n: 5 })(
+    "each().extend() %d passes case args before the context",
+    (x, { n }) => {
+      expect(n).toBe(5);
+      eachSeen.push(x);
+    },
+  );
+
+  test("each().extend() ran once per row", () => {
+    expect(eachSeen).toEqual([10, 20]);
   });
 
   // async value through use()
@@ -291,9 +352,9 @@ describe("test.extend", () => {
   });
 });
 
-// ── failure modes run in a child process so they don't fail this file ──────
+// ── lifecycle and failure modes run in a child process ──────────────────────
 
-async function runFixtureFile(contents: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+async function runFixtureFile(contents: string) {
   using dir = tempDir("test-extend", { "fixture.test.ts": contents });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "test", "fixture.test.ts"],
@@ -306,34 +367,155 @@ async function runFixtureFile(contents: string): Promise<{ stdout: string; stder
   return { stdout, stderr, exitCode };
 }
 
-describe.concurrent("test.extend failure modes", () => {
-  test("fixture setup error fails the test and tears down earlier fixtures", async () => {
+/** The `error: ...` lines the runner printed, in order. */
+function errorLines(stderr: string): string[] {
+  return stderr.split(/\r?\n/).filter(line => line.startsWith("error: "));
+}
+
+/** The `event: ...` lines a fixture file logged, in order. */
+function events(stderr: string): string[] {
+  return stderr
+    .split(/\r?\n/)
+    .filter(line => line.startsWith("event:"))
+    .map(line => line.slice("event:".length).trim());
+}
+
+describe.concurrent("test.extend lifecycle", () => {
+  test("fixtures are set up after beforeEach and torn down after afterEach", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
-      import { test, expect } from "bun:test";
-      const t = test.extend<{ ok: string; bad: string }>({
-        ok: async ({}, use) => {
-          console.error("setup ok");
-          await use("ok");
-          console.error("teardown ok");
-        },
-        bad: async ({ ok }, use) => {
-          throw new Error("setup exploded");
+      import { test, beforeEach, afterEach } from "bun:test";
+      beforeEach(() => console.error("event: beforeEach"));
+      afterEach(() => console.error("event: afterEach"));
+      const t = test.extend<{ f: number }>({
+        f: async ({}, use) => {
+          console.error("event: setup");
+          await use(1);
+          console.error("event: teardown");
         },
       });
-      t("uses bad fixture", ({ bad }) => {});
-      t("later test still runs", ({ ok }) => {
-        expect(ok).toBe("ok");
+      t("ordering", ({ f }) => {
+        afterEach(() => console.error("event: afterEach registered inside the test"));
+        console.error("event: body");
       });
     `);
-    expect(stderr).toContain("setup exploded");
-    // the already-initialized fixture was torn down even though setup failed
-    expect(stderr).toContain("teardown ok");
+    expect(events(stderr)).toEqual([
+      "beforeEach",
+      "setup",
+      "body",
+      "afterEach registered inside the test",
+      "afterEach",
+      "teardown",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("a test that times out is still torn down, after its afterEach hooks", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, afterEach, expect } from "bun:test";
+      afterEach(() => console.error("event: afterEach"));
+      const t = test.extend<{ server: string }>({
+        server: async ({}, use) => {
+          console.error("event: setup");
+          await use("listening");
+          console.error("event: teardown");
+        },
+      });
+      t("hangs", async ({ server }) => {
+        console.error("event: body");
+        await new Promise(() => {});
+      }, { timeout: 50 });
+      t("the next test gets a fresh fixture", ({ server }) => {
+        expect(server).toBe("listening");
+        console.error("event: next body");
+      });
+    `);
+    expect(events(stderr)).toEqual([
+      "setup",
+      "body",
+      "afterEach",
+      "teardown",
+      "setup",
+      "next body",
+      "afterEach",
+      "teardown",
+    ]);
+    expect(stderr).toContain("timed out after 50ms");
     expect(stderr).toContain("1 pass");
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
 
-  test("fixture teardown error fails the test", async () => {
+  test("a throwing afterEach hook does not skip fixture teardown", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, afterEach } from "bun:test";
+      afterEach(() => {
+        throw new Error("afterEach exploded");
+      });
+      const t = test.extend<{ f: number }>({
+        f: async ({}, use) => {
+          await use(1);
+          console.error("event: teardown");
+        },
+      });
+      t("body passes", ({ f }) => {});
+    `);
+    expect(events(stderr)).toEqual(["teardown"]);
+    expect(stderr).toContain("afterEach exploded");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a failing beforeEach hook skips setup, and there is nothing to tear down", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, beforeEach } from "bun:test";
+      beforeEach(() => {
+        throw new Error("beforeEach exploded");
+      });
+      const t = test.extend<{ f: number }>({
+        f: async ({}, use) => {
+          console.error("event: setup");
+          await use(1);
+          console.error("event: teardown");
+        },
+      });
+      t("never runs", ({ f }) => {
+        console.error("event: body");
+      });
+    `);
+    expect(events(stderr)).toEqual([]);
+    expect(stderr).toContain("beforeEach exploded");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fixture setup error fails the test and tears down earlier fixtures", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      const t = test.extend<{ ok: string; bad: string }>({
+        ok: async ({}, use) => {
+          console.error("event: setup ok");
+          await use("ok");
+          console.error("event: teardown ok");
+        },
+        bad: async ({ ok }, use) => {
+          throw new Error("setup exploded");
+        },
+      });
+      t("uses bad fixture", ({ bad }) => {
+        console.error("event: body");
+      });
+      t("later test still runs", ({ ok }) => {
+        expect(ok).toBe("ok");
+      });
+    `);
+    expect(events(stderr)).toEqual(["setup ok", "teardown ok", "setup ok", "teardown ok"]);
+    expect(stderr).toContain("setup exploded");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("fixture teardown error fails a test whose body passed", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";
       const t = test.extend<{ leaky: number }>({
@@ -345,30 +527,68 @@ describe.concurrent("test.extend failure modes", () => {
       t("body passes but teardown fails", ({ leaky }) => {});
     `);
     expect(stderr).toContain("teardown exploded");
+    expect(stderr).not.toContain("Unhandled error");
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
 
-  test("test body error takes precedence and teardown still runs", async () => {
+  test("body and teardown errors are all reported", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";
-      const t = test.extend<{ res: number }>({
-        res: async ({}, use) => {
+      const t = test.extend<{ first: number; second: number }>({
+        first: async ({}, use) => {
           await use(1);
-          console.error("teardown ran");
+          console.error("event: teardown first");
+          throw new Error("first teardown exploded");
+        },
+        second: async ({}, use) => {
+          await use(2);
+          console.error("event: teardown second");
+          throw new Error("second teardown exploded");
         },
       });
-      t("fails", ({ res }) => {
+      t("everything fails", ({ first, second }) => {
         throw new Error("body exploded");
       });
     `);
-    expect(stderr).toContain("body exploded");
-    expect(stderr).toContain("teardown ran");
+    expect(events(stderr)).toEqual(["teardown second", "teardown first"]);
+    // the body error and each teardown error (unpacked from the AggregateError)
+    // are reported exactly once, under the one failing test
+    expect(errorLines(stderr)).toEqual([
+      "error: body exploded",
+      "error: second teardown exploded",
+      "error: first teardown exploded",
+    ]);
+    expect(stderr).not.toContain("Unhandled error");
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
 
-  test("a fixture that neither calls use() nor returns a value fails the test", async () => {
+  test("a fixture that fails after use() is reported once, by the teardown", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend<{ server: number }>({
+        server: async ({}, use) => {
+          await Promise.race([use(1), Promise.reject(new Error("server closed unexpectedly"))]);
+        },
+      });
+      t("body runs to completion", async ({ server }) => {
+        await Promise.resolve();
+        console.error("event: body finished");
+      });
+      t("next test still runs", () => {
+        console.error("event: next test");
+      });
+    `);
+    expect(events(stderr)).toEqual(["body finished", "next test"]);
+    expect(errorLines(stderr)).toEqual(["error: server closed unexpectedly"]);
+    expect(stderr).not.toContain("Unhandled error");
+    expect(stderr).toContain("1 pass");
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a fixture that never calls use() fails the test", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";
       const t = test.extend<{ nope: number }>({
@@ -376,7 +596,7 @@ describe.concurrent("test.extend failure modes", () => {
       });
       t("uses nope", ({ nope }) => {});
     `);
-    expect(stderr).toContain('Fixture "nope" completed without calling use() or returning a value');
+    expect(stderr).toContain('Fixture "nope" completed without calling use()');
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
@@ -393,23 +613,6 @@ describe.concurrent("test.extend failure modes", () => {
       t("double use", ({ x }) => {});
     `);
     expect(stderr).toContain('Fixture "x" called use() more than once');
-    expect(stderr).toContain("1 fail");
-    expect(exitCode).toBe(1);
-  });
-
-  test("a throwing Symbol.asyncDispose on a returned fixture value fails the test", async () => {
-    const { stderr, exitCode } = await runFixtureFile(`
-      import { test } from "bun:test";
-      const t = test.extend<{ bad: object }>({
-        bad: () => ({
-          async [Symbol.asyncDispose]() {
-            throw new Error("dispose exploded");
-          },
-        }),
-      });
-      t("uses bad", ({ bad }) => {});
-    `);
-    expect(stderr).toContain("dispose exploded");
     expect(stderr).toContain("1 fail");
     expect(exitCode).toBe(1);
   });
@@ -432,7 +635,22 @@ describe.concurrent("test.extend failure modes", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("a non-destructured context parameter with fixtures fails with a helpful error", async () => {
+  test("a first definition that destructures its own name fails the test", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test } from "bun:test";
+      const t = test.extend({
+        db: async ({ db }, use) => {
+          await use(db);
+        },
+      });
+      t("self reference", ({ db }) => {});
+    `);
+    expect(stderr).toContain('Fixture "db" depends on itself, but there is no earlier definition of "db"');
+    expect(stderr).toContain("1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a non-destructured context parameter fails with a helpful error", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";
       const t = test.extend<{ db: number }>({ db: 1 });
@@ -443,7 +661,7 @@ describe.concurrent("test.extend failure modes", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("rest parameters in the destructuring pattern fail with a helpful error", async () => {
+  test("rest elements in the destructuring pattern fail with a helpful error", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";
       const t = test.extend<{ db: number }>({ db: 1 });
@@ -454,7 +672,7 @@ describe.concurrent("test.extend failure modes", () => {
     expect(exitCode).toBe(1);
   });
 
-  test("fixtures are re-created for each retry", async () => {
+  test("fixtures are set up and torn down again for every retry and repeat", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test, expect } from "bun:test";
       let setups = 0;
@@ -463,6 +681,7 @@ describe.concurrent("test.extend failure modes", () => {
         n: async ({}, use) => {
           setups++;
           await use(setups);
+          console.error("event: teardown " + setups);
         },
       });
       t("retry gets a fresh fixture", ({ n }) => {
@@ -470,46 +689,35 @@ describe.concurrent("test.extend failure modes", () => {
         expect(n).toBe(attempts);
         if (attempts < 3) throw new Error("flaky");
       }, { retry: 5 });
+      t("repeats get fresh fixtures", ({ n }) => {
+        expect(n).toBe(setups);
+      }, { repeats: 2 });
     `);
-    expect(stderr).toContain("1 pass");
+    // three attempts of the first test, then three runs of the second
+    expect(events(stderr)).toEqual([
+      "teardown 1",
+      "teardown 2",
+      "teardown 3",
+      "teardown 4",
+      "teardown 5",
+      "teardown 6",
+    ]);
+    expect(stderr).toContain("0 fail");
     expect(exitCode).toBe(0);
   });
 
   test("extended test callbacks never receive a done callback", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test, expect } from "bun:test";
-      // a plain test with a parameter receives a done callback and would hang
-      // until timeout if it is never called; an extended test's parameter is
-      // the fixture context object instead.
+      // A plain test with a parameter receives a done callback and would hang
+      // until its timeout if it never called it; an extended test's parameter
+      // is the fixture context instead.
       const t = test.extend({});
-      t("context instead of done", (context) => {
-        expect(typeof context).toBe("object");
+      t("context instead of done", context => {
+        expect(context).toEqual({});
       });
     `);
     expect(stderr).toContain("1 pass");
-    expect(exitCode).toBe(0);
-  });
-
-  test("beforeEach/afterEach hooks run around fixture setup and teardown", async () => {
-    const { stderr, exitCode } = await runFixtureFile(`
-      import { test, beforeEach, afterEach } from "bun:test";
-      beforeEach(() => console.error("hook: beforeEach"));
-      afterEach(() => console.error("hook: afterEach"));
-      const t = test.extend<{ f: number }>({
-        f: async ({}, use) => {
-          console.error("fixture: setup");
-          await use(1);
-          console.error("fixture: teardown");
-        },
-      });
-      t("ordering", ({ f }) => {
-        console.error("test body");
-      });
-    `);
-    const lines = stderr
-      .split(/\r?\n/)
-      .filter(line => line.startsWith("hook:") || line.startsWith("fixture:") || line.startsWith("test body"));
-    expect(lines).toEqual(["hook: beforeEach", "fixture: setup", "test body", "fixture: teardown", "hook: afterEach"]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/test/test-extend.test.ts
+++ b/test/js/bun/test/test-extend.test.ts
@@ -381,9 +381,9 @@ function events(stderr: string): string[] {
 }
 
 describe.concurrent("test.extend lifecycle", () => {
-  test("fixtures are set up after beforeEach and torn down after afterEach", async () => {
+  test("fixtures are set up after beforeEach and torn down after afterEach, before onTestFinished", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
-      import { test, beforeEach, afterEach } from "bun:test";
+      import { test, beforeEach, afterEach, onTestFinished } from "bun:test";
       beforeEach(() => console.error("event: beforeEach"));
       afterEach(() => console.error("event: afterEach"));
       const t = test.extend<{ f: number }>({
@@ -395,6 +395,7 @@ describe.concurrent("test.extend lifecycle", () => {
       });
       t("ordering", ({ f }) => {
         afterEach(() => console.error("event: afterEach registered inside the test"));
+        onTestFinished(() => console.error("event: onTestFinished"));
         console.error("event: body");
       });
     `);
@@ -405,7 +406,43 @@ describe.concurrent("test.extend lifecycle", () => {
       "afterEach registered inside the test",
       "afterEach",
       "teardown",
+      "onTestFinished",
     ]);
+    expect(exitCode).toBe(0);
+  });
+
+  test("fixtures registered inside an AsyncLocalStorage context see its store", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      import { AsyncLocalStorage } from "node:async_hooks";
+      const als = new AsyncLocalStorage<string>();
+      const t = test.extend<{ f: string }>({
+        f: async ({}, use) => {
+          console.error("event: setup sees " + als.getStore());
+          await use("f");
+          console.error("event: teardown sees " + als.getStore());
+        },
+      });
+      als.run("store", () => {
+        t("plain", ({ f }) => {
+          expect(f).toBe("f");
+          console.error("event: body sees " + als.getStore());
+        });
+        t.each([1])("each %d", (n, { f }) => {
+          expect(f).toBe("f");
+          console.error("event: each " + n + " sees " + als.getStore());
+        });
+      });
+    `);
+    expect(events(stderr)).toEqual([
+      "setup sees store",
+      "body sees store",
+      "teardown sees store",
+      "setup sees store",
+      "each 1 sees store",
+      "teardown sees store",
+    ]);
+    expect(stderr).toContain("2 pass");
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/test/test-extend.test.ts
+++ b/test/js/bun/test/test-extend.test.ts
@@ -740,6 +740,20 @@ describe.concurrent("test.extend lifecycle", () => {
     expect(exitCode).toBe(1);
   });
 
+  test("a destructured name that is not a fixture is undefined, even if Object.prototype has it", async () => {
+    const { stderr, exitCode } = await runFixtureFile(`
+      import { test, expect } from "bun:test";
+      Object.defineProperty(Object.prototype, "ghost", { value: "from the prototype", configurable: true });
+      const t = test.extend<{ real: number }>({ real: 1 });
+      t("context has no prototype", ({ real, ghost }: { real: number; ghost?: unknown }) => {
+        expect(real).toBe(1);
+        expect(ghost).toBeUndefined();
+      });
+    `);
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
   test("a bound fixture function fails the test instead of running without its dependencies", async () => {
     const { stderr, exitCode } = await runFixtureFile(`
       import { test } from "bun:test";


### PR DESCRIPTION
### Problem
- `bun:test` has no per-test fixtures (#8257). Resources a test needs (a database, a server, a temp dir) have to be wired up with `beforeEach`/`afterEach` plus module-level variables, and nothing types the values a test receives.
- vitest and playwright solve this with `test.extend()`, and the issue asks for the same shape.

### Fix
- Adds `test.extend(fixtures)` to `bun:test`. It returns a new test function whose callbacks receive a context object, with the fixtures set up before the body and torn down after it:

  ```ts
  import { test as base, expect } from "bun:test";

  const test = base.extend<{ db: Database }>({
    db: async ({}, use) => {
      const db = await connect(); // setup
      await use(db);              // the test runs while use() is pending
      await db.close();           // teardown
    },
  });

  test("select", async ({ db }) => {
    expect(await db.query("select 1")).toHaveLength(1);
  });
  ```

- Lifecycle (the part that cannot change after it ships):
  - Setup runs inside the test entry, after the `beforeEach` hooks. Only fixtures the callback destructures (or marks `{ auto: true }`) are set up, in dependency order; a fixture's own dependencies come from the names it destructures. A test callback whose source cannot be read (a bound function) gets every fixture; a fixture function whose source cannot be read fails the test, since guessing its dependencies is not possible. Setup failure fails the test and tears down the fixtures that were already set up.
  - Teardown is its own execution entry, scheduled after the test's `afterEach` entries (the vitest/playwright order). It therefore still runs when the body times out or an `afterEach` hook throws, it has the test's timeout rather than sharing the body's, and a teardown failure fails the test. When the body and one or more teardowns both throw, every error is reported under the one failure; several failing teardowns are reported as an `AggregateError`.
  - A fixture function must call `await use(value)` exactly once. A fixture that returns without calling `use()`, or calls it twice, fails the test. An error thrown after `use()` resolved is held and reported by the teardown, so it is never an unhandled rejection during the body. There is no return-value shorthand and nothing is implicitly disposed; `await using` inside the fixture function is the disposal story.
  - `.extend()` chains. A later definition replaces an earlier one of the same name and is what dependent fixtures see. An override that destructures its own name is given the value of the definition it replaces (which is set up first and torn down last), and it inherits that definition's `auto` unless it passes options of its own. A first definition that destructures its own name is an error.
  - `onTestFinished` callbacks run after the fixture teardown, which is also vitest's order (it runs fixture cleanup before the `onTestFinished` hooks); an `afterEach` registered inside the body runs before it, while the fixtures are still alive. This falls out of the existing runner code (`onTestFinished` appends to the end of the sequence) and is pinned by a test and the docs.
  - Extended callbacks get the context where the `done` callback would go, so they never receive `done`; with `.each`, the row values come first and the context last. All modifiers (`.skip`, `.only`, `.todo`, `.failing`, `.if`, `.each`, `.concurrent`, ...) keep working, and `describe.extend()` throws.
  - Out of scope, and rejected with a specific error: vitest's `scope: "file" | "worker"` and `injected` options. Fixtures are not visible to hooks.
- Where the pieces live:
  - `src/js/builtins/BunTestFixtures.ts`: `mergeTestFixtures` builds the registry at `.extend()` time (each record keeps the record it replaced); `wrapTestFixtureCallback` returns a `[run, teardown]` pair per scheduled test. `run` sets up and calls the user callback; `teardown` releases the `use()` promises in reverse order and rethrows what failed. Reached through `src/jsc/bindings/BunTestFixtures.cpp` and two lazy properties on the global object.
  - `src/runtime/test_runner/ScopeFunctions.rs`: `fixtures` travels alongside `each` through every bound variant, is GC-visited through a cached value slot declared in `jest.classes.ts`, and `call_as_function` wraps the callback once per test (once per `.each` row) and turns off the `done` arity heuristic for extended tests.
  - `src/runtime/test_runner/bun_test.rs`, `Order.rs`, `Execution.rs`: a test entry created with a teardown owns a second `ExecutionEntry` for it; `generate_order_test` appends that entry after the `afterEach` clones, and `advance_sequence` jumps to it when a failing `afterEach` would otherwise end the sequence. The entry is skipped by the cloned-hook bookkeeping, since the test entry owns it. A timed out teardown is reported with the existing hook timeout message.
  - `ScopeFunctions::parse_arguments` no longer wraps the callback in an `AsyncContextFrame`; the wrap moves to `enqueue_describe_or_test_callback` and the hook registration path, after the callback has been measured, bound or handed to the fixture builtin. The fixture builtin needs a callable function, and this also fixes a pre-existing bug: with an `AsyncLocalStorage` context active at registration time (for example `als.enterWith()` in a preload), `test.each` threw `bind() called on non-callable` and every zero-parameter test and hook was treated as taking a `done` callback and timed out.
  - `packages/bun-types/test.d.ts`: `Test<T, Ctx>` gains a defaulted context parameter, so existing `Test<[]>` usage is unchanged; `extend()` returns `Test<T, Omit<Ctx, keyof New> & New>` so an override can retype a fixture; the constraints are `Record<string, any>` so an interface works as the fixture map; `FixtureFn`/`Use`/`FixtureOptions`/`Fixtures` are exported and the JSDoc carries the `use()` and destructuring rules.
  - `docs/test/writing-tests.mdx`: new Fixtures section (every snippet was run).
- Verification:
  - `test/js/bun/test/test-extend.test.ts` (new, 56 tests): values, laziness and `auto`, dependency and diamond ordering, override chains, `each().extend()`, concurrent isolation, bound callbacks, and, in child processes, the lifecycle above: hook and `onTestFinished` ordering, timeout, throwing `afterEach`, failing `beforeEach`, setup/teardown failures, body plus teardown failures, failure after `use()`, missing and double `use()`, cycles, self-reference, bad parameter shapes, retries and repeats, registration inside an `AsyncLocalStorage` context, and the absence of `done`. Fails on main with `test.extend is not a function`.
  - `test/js/bun/test/bun_test.test.ts`: tests, `test.each`, hooks and `onTestFinished` registered inside `als.run()` all run and see the store (on main the child throws at the `test.each` call).
  - `test/js/bun/test/jest-each-gc-root.test.ts`: an extended and a chained extended test function survive a GC between `.extend()` and the registration call.
  - `test/integration/bun-types/fixture/test.ts`: context inference, interface fixture maps, override typing, `.each` ordering, no `done` parameter, and the negative cases; `bun test test/integration/bun-types/bun-types.test.ts` passes.
  - Existing runner suites still pass: `bun_test`, `jest-hooks`, `jest-each`, `done-async`, `describe`, `concurrent`, `concurrent_immediate`, `test-on-test-finished`, `test-retry-repeats-basic`, `test/cli/test/bun-test`, `test-timeout-behavior`, `test-filter-lifecycle-snapshot`, `retry-flag`, `rerun-each`.

### Background
- The runner turns each test into an execution sequence: cloned `beforeEach` entries, the test's own `ExecutionEntry`, then cloned `afterEach` entries (`Order.rs`). `Execution.rs` walks the sequence one entry at a time; an entry that fails or times out sends the walk to `failure_skip_past.next`, which is how a failing body still reaches its `afterEach` hooks, and each entry has its own timeout. Making teardown an entry in that sequence is what gives it the same guarantees hooks already have.
- `use()` is the vitest/playwright fixture protocol: the fixture function runs up to `await use(value)`, the value is handed to the test, and the function only resumes (and runs its teardown code) when the runner releases that promise after the test. The implementation parks each fixture on a promise and resolves it from the teardown entry.
- Which fixtures a callback needs is read from the destructuring pattern in its source text (`fn.toString()`), the same approach vitest uses; that is why the context parameter has to be destructured and why a non-destructured parameter is rejected up front.
- The `ScopeFunctions` object behind `test`/`test.each`/`test.extend` lives in Rust memory the GC does not scan, so any JS value it holds (the `.each` table, and now the fixture registry) is mirrored into a cached slot on the JS wrapper so the GC keeps it alive; `jest-each-gc-root.test.ts` exercises that.
- An `AsyncContextFrame` is how Bun makes a callback run later inside the `AsyncLocalStorage` context that was active when it was registered: it is a small non-callable object holding the function and the context, which the runner's call path unwraps when it invokes the entry. Anything that wants to inspect, bind or wrap the user's function has to do so before that object is created, which is why the wrap now happens at the end of registration.

<details>
<summary>Review history and rebase notes</summary>

The first version of this PR ran teardown inside the test's own promise (before `afterEach`, skipped on timeout, teardown errors dropped when the body failed), let an override that destructured its own name see `undefined`, and allowed a fixture to return its value with implicit disposal of disposable return values. All of that was replaced in the lifecycle rework after review; the current behavior is what the Fix section describes.

The branch was rebuilt on top of current main. Conflicts were in `src/jsc/bindings/ZigGlobalObject.{h,cpp}` (main added the IPC advanced-buffer lazy properties next to the two added here; both sets are kept) and `src/runtime/test_runner/ScopeFunctions.rs` (main changed the fields' visibility and the `create_unbound` signature; the `fixtures` field and argument were re-applied on top of the new shape). No behavior from main was changed while resolving them.

Second rebase (onto 77afa71e9d): the only conflict was in `src/jsc/bindings/ZigGlobalObject.cpp`. Main (#39770) replaced the per-member `initLater` calls in `finishCreation` with the `lazyFunctionInits` table, so the two `initLater` calls this PR added became two entries in that table; `ZigGlobalObject.h` and the runner files merged cleanly. The rebased branch was rebuilt and the test files listed above were re-run.

Third rebase (onto 865130f652): the conflicts were in `src/runtime/test_runner/ScopeFunctions.rs` only. Main (#40238) removed the `strings` module of `BunString` constants and made the bound-function names `&'static str`, so `fn_extend` now passes `"extend"` and `create_bound` takes `&'static str` like the other callers; the `.each` bind site kept main's `BunString::static_("cb")`. Rebuilt and re-ran the same test files.
</details>

Fixes #8257

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 6 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/test/jest-each-gc-root.test.ts

<!-- robobun:evidence:end -->


