### PR TITLE
Skip bunx.test.ts in CI until the Node.js version bump

### DIFF
--- a/test/expectations.txt
+++ b/test/expectations.txt
@@ -3,6 +3,7 @@
 
 # Tests that are broken
 test/cli/create/create-jsx.test.ts [ FAIL ] # false > react spa (no tailwind) > build
+test/cli/install/bunx.test.ts [ FAIL ] # should handle package that requires node 24: @angular/cli@latest needs a newer Node.js than Bun reports (24.3.0), unskip after the Node.js version bump
 [ WINDOWS-AARCH64 ] test/js/node/test/parallel/test-repl-close.js [ FAIL ] # EPIPE on stdin.write to closed child process
 test/bundler/native-plugin.test.ts [ FAIL ] # prints name when plugin crashes
 test/cli/run/run-crash-handler.test.ts [ FAIL ] # automatic crash reporter > segfault should report


### PR DESCRIPTION
## What

Adds `test/cli/install/bunx.test.ts` to `test/expectations.txt` so CI skips the file for now.

## Why

The test "should handle package that requires node 24" runs `bunx --bun @angular/cli@latest`, and the latest Angular CLI requires a newer Node.js version than Bun currently reports (`process.version` is v24.3.0). The file fails in CI until the reported Node.js version is bumped.

The expectations entry carries a comment pointing at the failing test so it can be unskipped after the version bump.
