### PR TITLE
Drop the body when a Response is constructed with a null body status

### DIFF
--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -1024,6 +1024,11 @@ impl Response {
             }
         }
 
+        // Null body statuses drop the body; see the constructor comment.
+        if Self::is_null_body_status(response.init.get().status_code) {
+            response.body.get().reset();
+        }
+
         let headers_ref = response.get_or_create_headers(global_this)?;
         let json_mime = bun_http_types::MimeType::JSON;
         headers_ref.put_default(
@@ -1037,6 +1042,11 @@ impl Response {
         let ptr = bun_core::heap::into_raw(Box::new(response));
         // SAFETY: `ptr` is freshly boxed and uniquely owned here.
         Ok(unsafe { (*ptr).to_js(global_this) })
+    }
+
+    /// https://fetch.spec.whatwg.org/#null-body-status
+    fn is_null_body_status(status_code: u16) -> bool {
+        matches!(status_code, 101 | 103 | 204 | 205 | 304)
     }
 
     fn validate_redirect_status_code(
@@ -1251,6 +1261,16 @@ impl Response {
 
         let body: Body = 'brk: {
             if arguments[0].is_undefined_or_null() {
+                break 'brk Body::new(BodyValue::Null);
+            }
+            // https://fetch.spec.whatwg.org/#initialize-a-response says a
+            // non-null body with a null body status throws a TypeError, but
+            // widely deployed code constructs these (Elysia's status(204) and
+            // its 304 file responses), so drop the body instead. The result
+            // has the spec's shape (null body) and matches what the HTTP
+            // layer writes for these statuses. Checked before extraction so
+            // a ReadableStream body is left untouched.
+            if Self::is_null_body_status(init.status_code) {
                 break 'brk Body::new(BodyValue::Null);
             }
             // `Body::extract` is a free fn re-exported as `body::extract`.

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+    "Response (11.89 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -150,11 +150,17 @@ test("new Response(123, { method: 456 }) does not throw", () => {
 });
 
 test("handle stack overflow", () => {
+  // Covers https://github.com/oven-sh/bun/pull/23961: a stack overflow during
+  // text()'s promise resolution must surface as a catchable JS error.
+  // The wide recursive call fattens each frame: debug builds spend ~0.2ms per
+  // frame in the Response constructor, and overflowing the stack with small
+  // frames takes ~26k frames, longer than the test timeout.
+  const pad = new Array(1024).fill(0);
   function f0(a1, a2) {
     const v4 = new Response();
     // @ts-ignore
     const v5 = v4.text(a2, a2, v4, f0, f0);
-    a1(a1); // Recursive call causes stack overflow
+    a1(a1, a2, ...pad); // Recursive call causes stack overflow
     return v5;
   }
   expect(() => {
@@ -213,5 +219,86 @@ describe("clone()", () => {
 
     expect(originalText).toBe("Hello, world!");
     expect(clonedText).toBe("Hello, world!");
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/32043
+describe("null body status", () => {
+  // https://fetch.spec.whatwg.org/#null-body-status
+  // The spec throws a TypeError for a non-null body with one of these
+  // statuses; Bun drops the body instead so existing code that builds such
+  // responses keeps working. 103 is excluded here: the constructor's status
+  // range check rejects it first.
+  const nullBodyStatuses = [101, 204, 205, 304];
+
+  describe.each(nullBodyStatuses)("status %i", status => {
+    test("constructor drops a string body", async () => {
+      const res = new Response("body", { status });
+      expect({ status: res.status, body: res.body }).toEqual({ status, body: null });
+      expect(await res.text()).toBe("");
+    });
+
+    test("constructor drops an empty string body", () => {
+      expect(new Response("", { status }).body).toBe(null);
+    });
+
+    test("constructor accepts null and undefined bodies", () => {
+      const fromNull = new Response(null, { status });
+      const fromUndefined = new Response(undefined, { status });
+      expect({ status: fromNull.status, body: fromNull.body }).toEqual({ status, body: null });
+      expect({ status: fromUndefined.status, body: fromUndefined.body }).toEqual({ status, body: null });
+    });
+
+    test("Response.json drops the body", async () => {
+      const res = Response.json({ a: 1 }, { status });
+      expect({ status: res.status, body: res.body }).toEqual({ status, body: null });
+      expect(await res.text()).toBe("");
+      // Bun also accepts a bare number as init
+      expect(Response.json({ a: 1 }, status).body).toBe(null);
+    });
+  });
+
+  test("constructor drops other body types", () => {
+    expect(new Response(new Blob(["body"]), { status: 204 }).body).toBe(null);
+    expect(new Response(new Uint8Array([1, 2, 3]), { status: 205 }).body).toBe(null);
+    expect(new Response(new URLSearchParams({ a: "1" }), { status: 304 }).body).toBe(null);
+  });
+
+  test("a ReadableStream body is left unlocked and usable", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1]));
+        controller.close();
+      },
+    });
+    const res = new Response(stream, { status: 204 });
+    expect(res.body).toBe(null);
+    expect(stream.locked).toBe(false);
+    expect((await stream.getReader().read()).value).toEqual(new Uint8Array([1]));
+  });
+
+  test("Response.json(null) still serializes to a body, so it is dropped too", () => {
+    expect(Response.json(null, { status: 204 }).body).toBe(null);
+  });
+
+  test("Response.json with bare number init 103 drops the body", () => {
+    // the bare-number init path skips the [200, 599] range check, so 103 is
+    // reachable here (unlike in the constructor)
+    expect(Response.json({ a: 1 }, 103).body).toBe(null);
+  });
+
+  test("Response.json with object init 103 is rejected by the range check first", () => {
+    expect(() => Response.json({ a: 1 }, { status: 103 })).toThrow(RangeError);
+  });
+
+  test("statuses outside the null body set still accept a body", () => {
+    for (const status of [200, 203, 206, 303, 305]) {
+      const res = new Response("body", { status });
+      expect({ status: res.status, hasBody: res.body !== null }).toEqual({ status, hasBody: true });
+    }
+  });
+
+  test("103 with a body is rejected by the range check first", () => {
+    expect(() => new Response("body", { status: 103 })).toThrow(RangeError);
   });
 });


### PR DESCRIPTION
Addresses #32043. The issue asks for the Fetch spec's TypeError; this PR deliberately implements body-dropping instead, for the reasons below.

### Repro

```js
new Response("body", { status: 204 }).body        // before: ReadableStream; after: null
Response.json({ a: 1 }, { status: 204 }).body     // same
```

The Fetch spec's [initialize a response](https://fetch.spec.whatwg.org/#initialize-a-response) algorithm forbids a non-null body combined with a [null body status](https://fetch.spec.whatwg.org/#null-body-status) (101, 103, 204, 205, 304) and throws a TypeError. Node/undici and browsers throw. Bun accepted the combination and kept the body.

### Why Bun drops the body instead of throwing

An earlier iteration of this PR implemented the spec's TypeError. CI's vendored Elysia suite showed it breaks real framework code at runtime, not just test expectations:

- Elysia's `status(204)` / `status(204, 'Hello')` routes map through `new Response(body, { status: 204 })` internally; with the throw they returned 500s. Elysia's own tests assert the opposite: body ignored, status preserved.
- Elysia's file handler (`src/adapter/utils.ts` handleFile) builds `new Response(file, { status: 304 })` for If-Modified-Since responses; with the throw, every such 304 became a 500.

Upstream Elysia main still constructs these, so throwing breaks current and future Elysia releases on Bun. Dropping the body keeps that code working while producing the spec's result shape: status preserved, `response.body === null`, nothing to serialize. That matches the wire reality (Bun.serve already never writes body bytes for 204/205/304) and this constructor's existing deliberate leniency (status 101 is accepted for the Cloudflare Workers upgrade pattern, a bare number init is accepted for Remix).

If throwing is preferred despite the Elysia breakage, the previous commits on this branch (up to e13b97875f) contain the complete TypeError implementation.

### Fix

A private `is_null_body_status` helper in `src/runtime/webcore/Response.rs`, used in both JS-facing construction paths:

- the constructor skips body extraction entirely for null body statuses, so a `ReadableStream` body is left unlocked and usable by the caller
- `Response.json` resets the serialized body; this also covers the bare-number init path (`Response.json(data, 204)`), which skips the [200, 599] status range check and is the only way 103 reaches the body logic

`new Response(null, ...)` / `new Response(undefined, ...)` behave as before. `Response.redirect`, `Response.error()`, `BakeResponse` (delegates to the same constructor), and responses received from `fetch()` are unaffected.

### Verification

New tests in `test/js/web/fetch/response.test.ts` cover the 101/204/205/304 matrix for the constructor and `Response.json` (object and bare-number init), string, empty-string, Blob, TypedArray, URLSearchParams, and ReadableStream bodies, null/undefined bodies staying valid, boundary statuses (200, 203, 206, 303, 305) keeping their bodies, and 103's RangeError precedence in both range-checked paths. They fail on the unfixed build (16 failures: the body is non-null there) and pass with the fix.

The three vendored Elysia suites that failed on the TypeError iteration (`test/core/status.test.ts`, `test/adapter/web-standard/map-response.test.ts`, `map-early-response.test.ts`) pass against this build at the pinned elysia 1.4.28: 75/75.

The "print size" inline snapshot in `response.test.ts` snapshots the test file's own size and was updated for the growth. The pre-existing "handle stack overflow" test in the same file overflowed the stack in ~26k small frames, and debug builds spend ~0.2ms per frame in the Response constructor, exceeding the 5s test timeout whenever the test starts with a mostly empty stack; the recursive call now passes a wide argument list so exhaustion happens in ~600 frames (~0.6s), still exercising the same overflow-during-`text()` path from #23961.
