### PR TITLE
release: enable npm trusted publishing (OIDC) with token fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,12 @@ jobs:
     if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.use-npm == 'true' }}
     permissions:
       contents: read
+      # Lets npm mint an OIDC token for trusted publishing. For packages with
+      # a trusted publisher configured on npmjs.com, npm exchanges it for a
+      # short-lived publish token (and enables provenance); for the rest it
+      # silently falls back to NPM_TOKEN.
+      id-token: write
+    environment: release
     defaults:
       run:
         working-directory: packages/bun-release
@@ -101,6 +107,12 @@ jobs:
           persist-credentials: false
           # To workaround issue
           ref: main
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          # Trusted publishing requires npm >= 11.5.1; the runner's default
+          # node ships an older npm.
+          node-version: latest
       - name: Setup Bun
         uses: ./.github/actions/setup-bun
         with:
@@ -111,6 +123,10 @@ jobs:
         run: bun upload-npm -- "$BUN_VERSION" publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Fallback auth until every published package has a trusted
+          # publisher on npmjs.com. Remove together with the _authToken line
+          # in packages/bun-release/.npmrc (npm errors on .npmrc env
+          # references that are unset).
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   npm-types:
     name: Release types to NPM


### PR DESCRIPTION
### What

Part of #32048: wire the `npm` job in the release workflow (which publishes `bun` and the 16 `@oven/bun-*` platform packages) for npm trusted publishing (OIDC), keeping `NPM_TOKEN` as fallback auth so it can merge before the npm-side configuration exists without breaking the daily canary or tagged releases.

16-line addition to `.github/workflows/release.yml`:

- The `npm` job gets `id-token: write` and `environment: release`.
- It also gets a `setup-node` step (node latest) so `npm publish` runs with npm >= 11.5.1, the first version that supports trusted publishing; the runner's default node ships an older npm.
- Comments mark `NPM_TOKEN` as fallback auth and name what to remove once the migration completes.

`bun-types` is intentionally not touched here: #37341 reworks its publishing into a separate `release-types.yml` that already carries `id-token: write`, the `release` environment, and the token fallback.

### Why this is safe to merge now

npm's OIDC flow is explicitly opportunistic: the whole thing is wrapped in a try/catch that is documented "This function is intended to never throw ... OIDC is always an optional feature" ([npm/cli `lib/utils/oidc.js`](https://github.com/npm/cli/blob/latest/lib/utils/oidc.js)). Until a package has a trusted publisher configured on npmjs.com, the token exchange fails, npm logs it at verbose level, and the publish proceeds with the existing token auth. Once the trusted publisher is configured, the exchanged short-lived token is set at the user config layer, taking precedence over the `_authToken` entry in `packages/bun-release/.npmrc`, and provenance is enabled automatically for public packages.

`bun install` in this job is unaffected by `setup-node`: it reads only `$HOME`/`$XDG_CONFIG_HOME` and project `.npmrc` files.

### What owners need to do to complete the migration

1. On npmjs.com, add a trusted publisher (GitHub Actions: repository `oven-sh/bun`, workflow `release.yml`, environment `release`) for each package this job publishes:
   - `bun`
   - `@oven/bun-darwin-aarch64`, `@oven/bun-darwin-x64`, `@oven/bun-darwin-x64-baseline`, `@oven/bun-linux-aarch64`, `@oven/bun-linux-x64`, `@oven/bun-linux-x64-baseline`, `@oven/bun-linux-aarch64-musl`, `@oven/bun-linux-x64-musl`, `@oven/bun-linux-x64-musl-baseline`, `@oven/bun-linux-aarch64-android`, `@oven/bun-linux-x64-android`, `@oven/bun-freebsd-aarch64`, `@oven/bun-freebsd-x64`, `@oven/bun-windows-x64`, `@oven/bun-windows-x64-baseline`, `@oven/bun-windows-aarch64`
2. In repo settings, add deployment branch/tag policies to the `release` environment (it is auto-created on the first run after merge): allow `main` and tags matching `bun-v*`. Release events run on the tag ref and the canary schedule runs on `main`, so both must be allowed.
3. After the next canary run, confirm the packages show "published via GitHub Actions" with provenance on npmjs.com.
4. Follow-up PR: remove the `NPM_TOKEN` env line and the `_authToken` line in `packages/bun-release/.npmrc` (they must go together: npm errors on `.npmrc` env references that are unset), then revoke the token and restrict the packages to trusted publishing in their npm settings.

Note: trusted publishing only supports GitHub Actions and GitLab CI, so this is a consideration for the TODO at the top of `release.yml` about moving the release to Buildkite.

### Verification

- Workflow YAML parses (`Bun.YAML.parse`); the `npm` job carries `id-token: write`, `environment: release`, and a Setup Node.js step.
- npm CLI OIDC fallback semantics verified by reading `lib/utils/oidc.js` rather than assumed.

There is no automated test for this change: the OIDC exchange only happens inside a GitHub-hosted run of this workflow, which cannot be exercised from the test suite.

<details>
<summary>History: earlier scope of this PR</summary>

Earlier revisions also covered the `npm-types` job: OIDC permissions plus a replacement of `JS-DevTools/npm-publish@v1` with plain `npm publish` (split canary/latest steps and a skip-if-already-published guard that treated only an npm E404 as "not published", per review). Main independently replaced that action in #36778 with a combined Release step, and #37341 is moving bun-types publishing into its own workflow with OIDC, so the npm-types parts were dropped from this PR during rebases to avoid overlapping changes.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 8 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->