### PR TITLE
fs: report node's syscall names for utimes-family errors

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8157,7 +8157,7 @@ impl NodeFS {
             return if let Some(errno) = rc.errno() {
                 Err(sys::Error {
                     errno,
-                    syscall: sys::Tag::utime,
+                    syscall: sys::Tag::lutime,
                     path: args.path.slice().into(),
                     ..Default::default()
                 })

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -2928,13 +2928,17 @@ mod posix_impl {
         let rc = unsafe { libc::faccessat(dir.native(), sub.as_ptr(), libc::F_OK, 0) };
         Ok(rc == 0)
     }
+    // The three time-setting wrappers tag `futime`/`utime`/`lutime` (libuv's
+    // op names, which node reports as `err.syscall`) rather than the
+    // underlying `futimens`/`utimensat` syscalls, matching the windows
+    // wrappers below.
     pub fn futimens(fd: Fd, atime: TimeLike, mtime: TimeLike) -> Maybe<()> {
         let ts = [atime.to_timespec(), mtime.to_timespec()];
         check!(
             // SAFETY: `fd` is a live descriptor; `ts` is a 2-element stack
             // array and `futimens` reads exactly two `timespec`s.
             unsafe { libc::futimens(fd.native(), ts.as_ptr()) },
-            Tag::futimens
+            Tag::futime
         );
         Ok(())
     }
@@ -2944,7 +2948,7 @@ mod posix_impl {
             // SAFETY: `path` is NUL-terminated (`ZStr`); `ts` is a 2-element
             // stack array and `utimensat` reads exactly two `timespec`s.
             unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), ts.as_ptr(), 0) },
-            Tag::utimensat,
+            Tag::utime,
             path
         );
         Ok(())
@@ -2962,7 +2966,7 @@ mod posix_impl {
                     libc::AT_SYMLINK_NOFOLLOW,
                 )
             },
-            Tag::utimensat,
+            Tag::lutime,
             path
         );
         Ok(())
@@ -4205,7 +4209,7 @@ mod windows_impl {
         // must run before any return (fd-based, so no path buffer is captured,
         // but keep the pattern uniform with utimens/lutimens below).
         req.deinit();
-        if let Some(err) = Error::from_uv_rc(rc, Tag::futimens) {
+        if let Some(err) = Error::from_uv_rc(rc, Tag::futime) {
             return Err(err.with_fd(fd));
         }
         Ok(())

--- a/test/js/node/fs/fs-utimes.test.ts
+++ b/test/js/node/fs/fs-utimes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import fs from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/32047
+describe("utimes-family errors report node's syscall names", () => {
+  const missing = join(tmpdir(), `utimes-syscall-${Math.random().toString(36).slice(2)}`, "f");
+  const badFd = 2147483640;
+
+  it("utimesSync reports 'utime'", () => {
+    expect(() => fs.utimesSync(missing, 0, 0)).toThrow(
+      expect.objectContaining({
+        code: "ENOENT",
+        syscall: "utime",
+        message: `ENOENT: no such file or directory, utime '${missing}'`,
+      }),
+    );
+  });
+
+  it("lutimesSync reports 'lutime'", () => {
+    expect(() => fs.lutimesSync(missing, 0, 0)).toThrow(
+      expect.objectContaining({
+        code: "ENOENT",
+        syscall: "lutime",
+        message: `ENOENT: no such file or directory, lutime '${missing}'`,
+      }),
+    );
+  });
+
+  it("futimesSync reports 'futime'", () => {
+    expect(() => fs.futimesSync(badFd, 0, 0)).toThrow(
+      expect.objectContaining({ code: "EBADF", syscall: "futime" }),
+    );
+  });
+
+  it("promises.utimes reports 'utime'", async () => {
+    await expect(fs.promises.utimes(missing, 0, 0)).rejects.toMatchObject({
+      code: "ENOENT",
+      syscall: "utime",
+    });
+  });
+
+  it("promises.lutimes reports 'lutime'", async () => {
+    await expect(fs.promises.lutimes(missing, 0, 0)).rejects.toMatchObject({
+      code: "ENOENT",
+      syscall: "lutime",
+    });
+  });
+
+  it("futimes callback reports 'futime'", async () => {
+    const { promise, resolve } = Promise.withResolvers<unknown>();
+    fs.futimes(badFd, 0, 0, resolve);
+    expect(await promise).toMatchObject({ code: "EBADF", syscall: "futime" });
+  });
+});

--- a/test/js/node/fs/fs-utimes.test.ts
+++ b/test/js/node/fs/fs-utimes.test.ts
@@ -29,7 +29,13 @@ describe("utimes-family errors report node's syscall names", () => {
   });
 
   it("futimesSync reports 'futime'", () => {
-    expect(() => fs.futimesSync(badFd, 0, 0)).toThrow(expect.objectContaining({ code: "EBADF", syscall: "futime" }));
+    expect(() => fs.futimesSync(badFd, 0, 0)).toThrow(
+      expect.objectContaining({
+        code: "EBADF",
+        syscall: "futime",
+        message: "EBADF: bad file descriptor, futime",
+      }),
+    );
   });
 
   it("promises.utimes reports 'utime'", async () => {
@@ -49,6 +55,10 @@ describe("utimes-family errors report node's syscall names", () => {
   it("futimes callback reports 'futime'", async () => {
     const { promise, resolve } = Promise.withResolvers<unknown>();
     fs.futimes(badFd, 0, 0, resolve);
-    expect(await promise).toMatchObject({ code: "EBADF", syscall: "futime" });
+    expect(await promise).toMatchObject({
+      code: "EBADF",
+      syscall: "futime",
+      message: "EBADF: bad file descriptor, futime",
+    });
   });
 });

--- a/test/js/node/fs/fs-utimes.test.ts
+++ b/test/js/node/fs/fs-utimes.test.ts
@@ -29,9 +29,7 @@ describe("utimes-family errors report node's syscall names", () => {
   });
 
   it("futimesSync reports 'futime'", () => {
-    expect(() => fs.futimesSync(badFd, 0, 0)).toThrow(
-      expect.objectContaining({ code: "EBADF", syscall: "futime" }),
-    );
+    expect(() => fs.futimesSync(badFd, 0, 0)).toThrow(expect.objectContaining({ code: "EBADF", syscall: "futime" }));
   });
 
   it("promises.utimes reports 'utime'", async () => {


### PR DESCRIPTION
Fixes #32047

### Problem

Node reports `err.syscall` as `"utime"`, `"futime"`, and `"lutime"` for `fs.utimes`, `fs.futimes`, and `fs.lutimes` failures. Bun reported the underlying syscall name instead, and did not distinguish the follow/nofollow variants:

```js
const fs = require("fs");
try { fs.utimesSync("/nonexistent-dir/f", 0, 0); } catch (e) { console.log(e.syscall); }
try { fs.lutimesSync("/nonexistent-dir/f", 0, 0); } catch (e) { console.log(e.syscall); }
try { fs.futimesSync(2147483640, 0, 0); } catch (e) { console.log(e.syscall); }
```

Bun 1.3.x prints `utimensat`, `utimensat`, `futimens`; Node v24 prints `utime`, `lutime`, `futime`. The syscall name embedded in `err.message` (e.g. `ENOENT: no such file or directory, utimensat '/nonexistent-dir/f'`) was wrong the same way. On Windows, `fs.lutimes` errors were additionally mislabeled as `utime`.

### Cause

The POSIX wrappers `bun_sys::utimens`/`lutimens`/`futimens` tagged errors with the raw syscall (`Tag::utimensat`, `Tag::futimens`) instead of the node-facing op names, which the tag table exists to carry (the Windows `utimens`/`lutimens` wrappers already tag `utime`/`lutime`, and `Tag::inotify` aliases `Tag::watch` for the same reason). The Windows `lutimes` branch in `node_fs.rs` separately used `Tag::utime` where it should use `Tag::lutime`.

### Fix

- `src/sys/lib.rs`: POSIX `utimens`/`lutimens`/`futimens` now tag `Tag::utime`/`Tag::lutime`/`Tag::futime`; the Windows `futimens` wrapper now tags `Tag::futime` to match.
- `src/runtime/node/node_fs.rs`: the Windows `lutimes` branch now tags `Tag::lutime`.

The `Tag::utimensat`/`Tag::futimens` constants stay (discriminants are frozen and FFI-observable). The only other caller of these wrappers is the shell's `touch` builtin, whose error output (`touch: <path>: No such file or directory`) does not include the syscall name, so it is unaffected.

### Verification

New tests in `test/js/node/fs/fs-utimes.test.ts` assert `err.syscall` (and the message for the path variants) for sync, callback, and `fs.promises` forms. All 6 fail on the unfixed build and pass with this change; expected values were confirmed against Node v24.3.0, which prints `utime`/`lutime`/`futime` for the same inputs. `test/js/node/test/parallel/test-fs-utimes.js` still passes, and `cargo check --target x86_64-pc-windows-msvc` is clean for the touched crates.