### PR TITLE
node:fs: implement lchown on Windows

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5666,18 +5666,12 @@ impl NodeFS {
     }
 
     pub fn lchown(&mut self, args: &args::LChown, _: Flavor) -> Maybe<ret::Lchown> {
-        #[cfg(windows)]
-        {
-            let _ = args;
-            return Maybe::<ret::Lchown>::todo();
-        }
-        #[cfg(not(windows))]
-        {
-            let path = args.path.slice_z(&mut self.sync_error_buf);
-            match Syscall::lchown(path, args.uid, args.gid) {
-                Err(err) => Err(err.with_path(args.path.slice())),
-                Ok(_) => Ok(()),
-            }
+        // On Windows `Syscall::lchown` routes through uv_fs_lchown, which is
+        // a no-op success, matching Node.
+        let path = args.path.slice_z(&mut self.sync_error_buf);
+        match Syscall::lchown(path, args.uid, args.gid) {
+            Err(err) => Err(err.with_path(args.path.slice())),
+            Ok(_) => Ok(()),
         }
     }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -4126,9 +4126,9 @@ mod windows_impl {
         // Windows has no lchmod; libuv chmod follows symlinks. Match Node: fall through.
         chmod(path, mode)
     }
-    pub fn lchown(_path: &ZStr, _uid: u32, _gid: u32) -> Maybe<()> {
+    pub fn lchown(path: &ZStr, uid: u32, gid: u32) -> Maybe<()> {
         // Windows has no ownership model; libuv uv_fs_lchown is a no-op success.
-        Ok(())
+        sys_uv::lchown(path, uid as _, gid as _)
     }
     pub fn fchownat(_dir: impl AsFd, _path: &ZStr, _uid: u32, _gid: u32, _flags: i32) -> Maybe<()> {
         let _dir = _dir.as_fd();

--- a/src/sys/sys_uv.rs
+++ b/src/sys/sys_uv.rs
@@ -263,6 +263,34 @@ pub fn chown(file_path: &ZStr, uid: uv::uv_uid_t, gid: uv::uv_uid_t) -> Result<(
     }
 }
 
+pub fn lchown(file_path: &ZStr, uid: uv::uv_uid_t, gid: uv::uv_uid_t) -> Result<()> {
+    let mut req = FsReq::new();
+    // SAFETY: synchronous libuv fs call; req lives on the stack for the duration.
+    let rc = unsafe {
+        uv::uv_fs_lchown(
+            uv::Loop::get(),
+            &mut *req,
+            file_path.as_ptr(),
+            uid,
+            gid,
+            None,
+        )
+    };
+
+    log!(
+        "uv lchown({}, {}, {}) = {}",
+        BStr::new(file_path.as_bytes()),
+        uid,
+        gid,
+        rc.int()
+    );
+    if let Some(errno) = rc.err_enum_e() {
+        Result::Err(Error::new(errno, Tag::lchown).with_path(file_path.as_bytes()))
+    } else {
+        Result::Ok(())
+    }
+}
+
 pub fn fchown(fd: Fd, uid: uv::uv_uid_t, gid: uv::uv_uid_t) -> Result<()> {
     let uv_fd = fd.uv();
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3703,6 +3703,26 @@ it("chown should verify its arguments", () => {
   expect(() => fs.chown("doesnt-matter.txt", 0, "a")).toThrowWithCode(TypeError, "ERR_INVALID_ARG_TYPE");
 });
 
+// https://github.com/oven-sh/bun/issues/32050
+it("lchown succeeds on every platform", async () => {
+  const dir = tmpdirSync();
+  const file = join(dir, "lchown.txt");
+  writeFileSync(file, "x");
+  // A dangling symlink distinguishes lchown from chown: it operates on the
+  // link itself, so the missing target must not matter.
+  const link = join(dir, "lchown-link");
+  symlinkSync(join(dir, "does-not-exist"), link);
+
+  for (const target of [file, link]) {
+    // uid/gid of -1 means "leave unchanged", so this succeeds unprivileged.
+    expect(fs.lchownSync(target, -1, -1)).toBeUndefined();
+    await expect(fs.promises.lchown(target, -1, -1)).resolves.toBeUndefined();
+    await new Promise<void>((resolve, reject) => {
+      fs.lchown(target, -1, -1, err => (err ? reject(err) : resolve()));
+    });
+  }
+});
+
 it("open flags verification", async () => {
   const invalid = 4_294_967_296;
   expect(() => fs.open(__filename, invalid, () => {})).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");


### PR DESCRIPTION
Fixes #32050

### Repro (Windows)

```js
const fs = require("fs");
fs.writeFileSync("f.txt", "x");
fs.lchownSync("f.txt", -1, -1); // bun: throws "Unknown Error, TODO"; node: succeeds
```

### Cause

The Windows arm of `NodeFS::lchown` in `src/runtime/node/node_fs.rs` was a `Maybe::todo()` stub, so every `fs.lchown`/`fs.lchownSync`/`fs.promises.lchown` call that passed argument validation threw `Unknown Error, TODO` on Windows (and `Error::todo()` panics outright in debug builds). Node succeeds: libuv implements the whole chown family on Windows (`fs__chown`, `fs__fchown`, `fs__lchown` in libuv's `src/win/fs.c`) as no-ops that report success, and Bun's `fs.chown`/`fs.fchown` already route through `uv_fs_chown`/`uv_fs_fchown` via `sys_uv`. Only `lchown` was missing: on Windows `Syscall` aliases `bun_sys::sys_uv`, which had no `lchown`.

### Fix

- `src/sys/sys_uv.rs`: add `lchown` wrapping `uv_fs_lchown`, mirroring the existing `chown` (the FFI declaration in `src/libuv_sys/libuv.rs` already existed).
- `src/sys/lib.rs`: route the `windows_impl` facade's `lchown` through `sys_uv::lchown` like its `chown` sibling, instead of a hardcoded `Ok(())`.
- `src/runtime/node/node_fs.rs`: drop the `cfg(windows)` stub so every platform uses `Syscall::lchown`. This is a deliberate deviation from the `.zig` reference, which stubbed Windows.

`lchmod` directly above has the same stub shape but is intentionally left alone: Node only implements `fs.lchmod` on macOS, so erroring there matches Node.

### Verification

New test in `test/js/node/fs/fs.test.ts` exercises `lchownSync`, callback `lchown`, and `promises.lchown` on a regular file and on a dangling symlink (which distinguishes lchown from chown: it must not follow the link). The bug is Windows-only, so the test passes on POSIX with or without the fix; on Windows it fails before this change (the stub throws on every call) and passes after. Cross-compilation checked for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`; `bun bd test test/js/node/fs/fs.test.ts` passes on Linux.