### PR TITLE
bun:ffi: keep ptr(typedArray) valid across DFG tier-up

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -959,6 +959,17 @@ impl JSValue {
         }
         self.as_array_buffer(global)
     }
+    /// If `self` is a `FastTypedArray` (small view whose vector lives in the
+    /// GC heap), force it into wasteful mode so the engine can never relocate
+    /// its data. JSC moves such vectors on its own, e.g. DFG tier-up
+    /// registers an ArrayBufferView watchpoint whose installation calls
+    /// `possiblySharedBuffer()` and repoints the vector. Must be called
+    /// before capturing the data pointer for use beyond the current native
+    /// call. No-op for every other storage mode (their data never moves).
+    /// Returns `false` on allocation failure.
+    pub fn ensure_stable_typed_array_vector(self) -> bool {
+        JSC__JSValue__ensureStableTypedArrayVector(self)
+    }
     /// Generic downcast. Dispatches via [`JsClass::from_js`].
     #[inline]
     pub fn as_<T: JsClass>(self) -> Option<*mut T> {
@@ -2075,6 +2086,7 @@ unsafe extern "C" {
         out: &mut ArrayBuffer,
     ) -> bool;
     safe fn JSC__JSValue__pinArrayBuffer(this: JSValue) -> bool;
+    safe fn JSC__JSValue__ensureStableTypedArrayVector(this: JSValue) -> bool;
     safe fn JSC__JSValue__asPromise(this: JSValue) -> *mut JSPromise;
     safe fn JSC__JSValue__asInternalPromise(this: JSValue) -> *mut JSInternalPromise;
     safe fn Bun__attachAsyncStackFromPromise(

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -3381,6 +3381,27 @@ CPP_DECL void JSC__JSValue__unpinArrayBuffer(JSC::EncodedJSValue v)
     }
 }
 
+// Make a view's data pointer permanently stable before handing the raw
+// address out for use beyond the current call (FFI.ptr). A FastTypedArray's
+// vector lives in the GC heap and is RELOCATED when the view transitions to
+// wasteful mode (slowDownAndWasteMemory copies into a fresh ArrayBuffer and
+// repoints m_vector), and the engine triggers that transition on its own:
+// DFG tier-up folds the view into compiled code and registers an
+// ArrayBufferView watchpoint, whose installation calls
+// possiblySharedBuffer() (ArrayBufferViewWatchpointAdaptor::add in
+// DFGDesiredWatchpoints.cpp). Forcing the transition up front means the
+// address we are about to capture can never be invalidated. Every other mode
+// already has stable storage: Oversize is fastMalloc'd and adopted in place,
+// Wasteful/DataView already have an ArrayBuffer, and JSArrayBuffer data never
+// moves. Returns false only if the transition failed (allocation failure).
+CPP_DECL bool JSC__JSValue__ensureStableTypedArrayVector(JSC::EncodedJSValue v)
+{
+    auto* view = dynamicDowncast<JSC::JSArrayBufferView>(JSC::JSValue::decode(v));
+    if (!view || view->mode() != JSC::FastTypedArray)
+        return true;
+    return !!view->possiblySharedBuffer();
+}
+
 // Borrow `v`'s byte storage for off-thread reading. Splits out only the
 // `FastTypedArray` case from `pinArrayBuffer`, because that's the one mode
 // where `possiblySharedBuffer()` actually COPIES data

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -428,6 +428,15 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
         return JSValue::NULL;
     }
 
+    // The returned address outlives this call, so the view's storage must be
+    // made permanently immovable first: a FastTypedArray's vector is
+    // relocated by the engine itself (e.g. at DFG tier-up), which would leave
+    // the captured pointer dangling.
+    // https://github.com/oven-sh/bun/issues/32054
+    if !value.ensure_stable_typed_array_vector() {
+        return global_this.throw_out_of_memory_value();
+    }
+
     let Some(array_buffer) = value.as_array_buffer(global_this) else {
         return global_this.to_invalid_arguments(format_args!(
             "Expected ArrayBufferView but received {:?}",

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -647,6 +647,50 @@ it("read", () => {
   delete globalThis.buffer;
 });
 
+// https://github.com/oven-sh/bun/issues/32054
+it("ptr(typedArray) stays valid after DFG tier-up", async () => {
+  const code = `
+    import { ptr, read } from "bun:ffi";
+    const out = new Float64Array(1);
+    out[0] = 1.5;
+    const outPtr = ptr(out);
+    function main() {
+      let sum = 0;
+      for (let i = 0; i < 10_000; i++) {
+        sum += out[0];
+      }
+      return sum;
+    }
+    main();
+    if (ptr(out) !== outPtr) {
+      console.log("MOVED: the view's storage was relocated after ptr() was taken");
+      process.exit(1);
+    }
+    out[0] = 42.5;
+    if (read.f64(outPtr) !== 42.5) {
+      console.log("STALE: write through the view is not visible at the captured address");
+      process.exit(1);
+    }
+    console.log("STABLE");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: {
+      ...bunEnv,
+      // Force deterministic, early tier-up so the loop above reliably
+      // DFG-compiles (which registers an ArrayBufferView watchpoint on the
+      // folded view; registration relocates a FastTypedArray's vector).
+      BUN_JSC_useConcurrentJIT: "false",
+      BUN_JSC_thresholdForOptimizeAfterWarmUp: "100",
+      BUN_JSC_thresholdForOptimizeSoon: "100",
+    },
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout.trim()).toBe("STABLE");
+  expect(exitCode).toBe(0);
+});
+
 if (ok) {
   describe("run ffi", () => {
     ffiRunner(false);


### PR DESCRIPTION
Fixes #32054

`bun:ffi`'s `ptr(typedArray)` goes stale once the calling function is DFG-compiled: native code keeps writing through the captured address while JS reads of the typed array return frozen values. Reported with out-param C APIs on macOS arm64; reproduced on Linux x64 with the issue's exact repro:

```
iter=17571: C wrote 571.5; memory actually contains 571.5; JS reads out[0] = 570.5
FAIL: 82347/100000 stale typed-array reads (first at iter 17571)
```

## Cause

Not DFG load elimination (the issue's suspicion): the typed array's backing store is physically relocated at tier-up, and the pointer captured by `ptr()` dangles.

A small typed array (`new Float64Array(1)`) is a JSC `FastTypedArray` whose vector lives in the GC heap. `ptr()` returned that raw vector address without forcing the view out of fast mode. When DFG compiles the hot caller, it folds the view into the compiled code and registers an ArrayBufferView watchpoint; registration calls `possiblySharedBuffer()` -> `slowDownAndWasteMemory()`, which copies the storage into a fresh `ArrayBuffer` and repoints `m_vector`. From that moment the captured address points at the abandoned allocation: native writes land there (a heap-corruption hazard once the GC reuses it), while JS indexing reads the new vector, frozen at tier-up-time contents. This explains every observation in the issue, including `read.f64(ptr)` "working" (it reads the abandoned block where the native writes land) and the onset tracking tier-up thresholds. Confirmed by printing `ptr(out)` again at first mismatch: the address changes exactly at tier-up.

## Fix

`ptr()` now forces the one-time fast-to-wasteful transition (`possiblySharedBuffer()`) before reading the address, so the pointer it hands out can never be invalidated by the engine. The fixing line is the `ensure_stable_typed_array_vector()` call in `ptr_` (`src/runtime/ffi/FFIObject.rs`); the rest is the C++ helper and its Rust binding. Cost: a one-time copy of at most `fastSizeLimit` (1000) elements on the first `ptr()` call per array. Every other storage mode already has immovable data and is untouched (Oversize is adopted in place, Wasteful/DataView already have an ArrayBuffer). Per-call argument marshaling reads the vector fresh at call time and was never affected.

This is the same hazard `src/runtime/image/Image.rs` and `JSC__JSValue__borrowBytesForOffThread` already document and handle for their own pointer captures.

## Verification

New test `ptr(typedArray) stays valid after DFG tier-up` in `test/js/bun/ffi/ffi.test.js` spawns a subprocess with deterministic early tier-up (`useConcurrentJIT=false`, low optimize thresholds), hot-loops over the view, then asserts `ptr(out)` is unchanged and that a JS write is visible through the captured address. It fails on the unfixed build (`MOVED: the view's storage was relocated after ptr() was taken`, also reproducible on bun 1.3.x/1.4 releases) and passes with the fix. The issue's original C repro (100k native out-param writes) passes on the fixed build: `OK: no stale reads`, at default thresholds and with forced early tier-up.

Noted while testing, not part of this change: the `run ffi` suite in `ffi.test.js` dlopens a hardcoded `/tmp/bun-ffi-test.dylib` (line ~381), so it can't run on Linux even when the helper lib is compiled; CI never compiles the lib, so the suite is skip-only there. Running it locally also surfaces a pre-existing ASAN bad-free in the `toBuffer(ptr, 0, 4)` no-deallocator path freeing static library memory at GC (the footgun already documented in `FFIObject.rs` re: PR #31753), reproducible without this change.
