### PR TITLE
Pick data: URL module loaders from the MIME type at runtime

### DIFF
--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -458,13 +458,15 @@ pub(crate) fn normalize_specifier<'a>(
 
 /// Loader for a `data:` specifier, derived from its MIME type.
 ///
-/// The MIME essence is matched ASCII-case-insensitively (RFC 2045; Node loads
-/// `data:TEXT/JAVASCRIPT,...` as a JavaScript module). `Category::init`
-/// classifies both `text/javascript` and `application/javascript` as
-/// JavaScript (matching Node), unlike `decode_mime_type().category`, which
-/// files the latter under `Application`. Unknown and absent MIME types get
-/// the maximally permissive tsx default used for extensionless files;
-/// invalid data URLs do too, and the transpile path reports the parse error.
+/// The MIME essence is trimmed of ASCII whitespace and matched
+/// case-insensitively, per the WHATWG data: URL processor and RFC 2045 (Node
+/// loads `data: TEXT/JAVASCRIPT ,...` as a JavaScript module).
+/// `Category::init` classifies both `text/javascript` and
+/// `application/javascript` as JavaScript (matching Node), unlike
+/// `decode_mime_type().category`, which files the latter under `Application`.
+/// Unknown and absent MIME types get the maximally permissive tsx default
+/// used for extensionless files; invalid data URLs do too, and the transpile
+/// path reports the parse error.
 pub fn loader_from_data_url(path_text: &[u8]) -> Loader {
     use bun_http_types::MimeType::Category;
     let Ok(data_url) = bun_resolver::data_url::DataURL::parse_without_check(path_text) else {
@@ -474,6 +476,7 @@ pub fn loader_from_data_url(path_text: &[u8]) -> Loader {
         Some(i) => &data_url.mime_type[..i as usize],
         None => data_url.mime_type,
     };
+    let essence = essence.trim_ascii();
     let mut lowered = [0u8; 64];
     let Some(lowered) = lowered.get_mut(..essence.len()) else {
         // Longer than any MIME essence `Category::init` recognizes.

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -458,22 +458,34 @@ pub(crate) fn normalize_specifier<'a>(
 
 /// Loader for a `data:` specifier, derived from its MIME type.
 ///
-/// `Category::init` classifies both `text/javascript` and
-/// `application/javascript` as JavaScript (matching Node), unlike
-/// `decode_mime_type().category`, which files the latter under `Application`.
-/// Unknown and absent MIME types get the maximally permissive tsx default
-/// used for extensionless files; invalid data URLs do too, and the transpile
-/// path reports the parse error.
+/// The MIME essence is matched ASCII-case-insensitively (RFC 2045; Node loads
+/// `data:TEXT/JAVASCRIPT,...` as a JavaScript module). `Category::init`
+/// classifies both `text/javascript` and `application/javascript` as
+/// JavaScript (matching Node), unlike `decode_mime_type().category`, which
+/// files the latter under `Application`. Unknown and absent MIME types get
+/// the maximally permissive tsx default used for extensionless files;
+/// invalid data URLs do too, and the transpile path reports the parse error.
 pub fn loader_from_data_url(path_text: &[u8]) -> Loader {
     use bun_http_types::MimeType::Category;
-    match bun_resolver::data_url::DataURL::parse_without_check(path_text) {
-        Ok(data_url) => match Category::init(data_url.mime_type) {
-            Category::Javascript => Loader::Js,
-            Category::Json => Loader::Json,
-            Category::Css => Loader::Css,
-            _ => Loader::Tsx,
-        },
-        Err(_) => Loader::Tsx,
+    let Ok(data_url) = bun_resolver::data_url::DataURL::parse_without_check(path_text) else {
+        return Loader::Tsx;
+    };
+    let essence = match strings::index_of_char(data_url.mime_type, b';') {
+        Some(i) => &data_url.mime_type[..i as usize],
+        None => data_url.mime_type,
+    };
+    let mut lowered = [0u8; 64];
+    let Some(lowered) = lowered.get_mut(..essence.len()) else {
+        // Longer than any MIME essence `Category::init` recognizes.
+        return Loader::Tsx;
+    };
+    lowered.copy_from_slice(essence);
+    lowered.make_ascii_lowercase();
+    match Category::init(lowered) {
+        Category::Javascript => Loader::Js,
+        Category::Json => Loader::Json,
+        Category::Css => Loader::Css,
+        _ => Loader::Tsx,
     }
 }
 

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -488,6 +488,30 @@ pub fn get_loader_and_virtual_source<'a>(
     let mut loader: Option<Loader> = path.loader(unsafe { &*jsc_vm.loaders() });
     let mut virtual_source: Option<&'a bun_ast::Source> = None;
 
+    // A `data:` specifier is not a file path: the extension lookup above reads
+    // a fake extension out of the URL body (`Path::loader`'s `is_data_url`
+    // check only fires when the resolver tagged the path with the `dataurl`
+    // namespace, which the runtime loader never does). Pick the loader from
+    // the MIME type instead, matching the bundler pipeline
+    // (`enqueue_on_load_plugin_if_needed`). Unknown and absent MIME types keep
+    // the maximally permissive tsx default used for extensionless files;
+    // invalid data URLs fall through to the transpile path, which reports the
+    // parse error.
+    if strings::has_prefix_comptime(path.text, b"data:") {
+        use bun_http_types::MimeType::Category;
+        loader = Some(
+            match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
+                Ok(data_url) => match data_url.decode_mime_type().category {
+                    Category::Javascript => Loader::Js,
+                    Category::Json => Loader::Json,
+                    Category::Css => Loader::Css,
+                    _ => Loader::Tsx,
+                },
+                Err(_) => Loader::Tsx,
+            },
+        );
+    }
+
     if let Some(eval_source) = jsc_vm.eval_source() {
         // SAFETY: eval_source outlives jsc_vm
         let eval_source: &'a bun_ast::Source = unsafe { &*eval_source };

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -456,6 +456,27 @@ pub(crate) fn normalize_specifier<'a>(
     (slice, specifier, query)
 }
 
+/// Loader for a `data:` specifier, derived from its MIME type.
+///
+/// `Category::init` classifies both `text/javascript` and
+/// `application/javascript` as JavaScript (matching Node), unlike
+/// `decode_mime_type().category`, which files the latter under `Application`.
+/// Unknown and absent MIME types get the maximally permissive tsx default
+/// used for extensionless files; invalid data URLs do too, and the transpile
+/// path reports the parse error.
+pub fn loader_from_data_url(path_text: &[u8]) -> Loader {
+    use bun_http_types::MimeType::Category;
+    match bun_resolver::data_url::DataURL::parse_without_check(path_text) {
+        Ok(data_url) => match Category::init(data_url.mime_type) {
+            Category::Javascript => Loader::Js,
+            Category::Json => Loader::Json,
+            Category::Css => Loader::Css,
+            _ => Loader::Tsx,
+        },
+        Err(_) => Loader::Tsx,
+    }
+}
+
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr)]
 pub enum GetLoaderAndVirtualSourceErr {
     #[error("BlobNotFound")]
@@ -488,30 +509,10 @@ pub fn get_loader_and_virtual_source<'a>(
     let mut loader: Option<Loader> = path.loader(unsafe { &*jsc_vm.loaders() });
     let mut virtual_source: Option<&'a bun_ast::Source> = None;
 
-    // A `data:` specifier is not a file path: the extension lookup above reads
-    // a fake extension out of the URL body (`Path::loader`'s `is_data_url`
-    // check only fires when the resolver tagged the path with the `dataurl`
-    // namespace, which the runtime loader never does). Pick the loader from
-    // the MIME type instead, like the bundler does for `dataurl`-namespace
-    // paths. `Category::init` (rather than `decode_mime_type().category`)
-    // classifies `application/javascript` as JavaScript too, matching Node,
-    // which compiles both JS MIME spellings as JavaScript modules. Unknown
-    // and absent MIME types keep the maximally permissive tsx default used
-    // for extensionless files; invalid data URLs fall through to the
-    // transpile path, which reports the parse error.
+    // A `data:` specifier is not a file path; the extension lookup above
+    // would sniff a fake extension out of the URL body.
     if strings::has_prefix_comptime(path.text, b"data:") {
-        use bun_http_types::MimeType::Category;
-        loader = Some(
-            match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
-                Ok(data_url) => match Category::init(data_url.mime_type) {
-                    Category::Javascript => Loader::Js,
-                    Category::Json => Loader::Json,
-                    Category::Css => Loader::Css,
-                    _ => Loader::Tsx,
-                },
-                Err(_) => Loader::Tsx,
-            },
-        );
+        loader = Some(loader_from_data_url(path.text));
     }
 
     if let Some(eval_source) = jsc_vm.eval_source() {

--- a/src/bundler/options.rs
+++ b/src/bundler/options.rs
@@ -492,16 +492,18 @@ pub fn get_loader_and_virtual_source<'a>(
     // a fake extension out of the URL body (`Path::loader`'s `is_data_url`
     // check only fires when the resolver tagged the path with the `dataurl`
     // namespace, which the runtime loader never does). Pick the loader from
-    // the MIME type instead, matching the bundler pipeline
-    // (`enqueue_on_load_plugin_if_needed`). Unknown and absent MIME types keep
-    // the maximally permissive tsx default used for extensionless files;
-    // invalid data URLs fall through to the transpile path, which reports the
-    // parse error.
+    // the MIME type instead, like the bundler does for `dataurl`-namespace
+    // paths. `Category::init` (rather than `decode_mime_type().category`)
+    // classifies `application/javascript` as JavaScript too, matching Node,
+    // which compiles both JS MIME spellings as JavaScript modules. Unknown
+    // and absent MIME types keep the maximally permissive tsx default used
+    // for extensionless files; invalid data URLs fall through to the
+    // transpile path, which reports the parse error.
     if strings::has_prefix_comptime(path.text, b"data:") {
         use bun_http_types::MimeType::Category;
         loader = Some(
             match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
-                Ok(data_url) => match data_url.decode_mime_type().category {
+                Ok(data_url) => match Category::init(data_url.mime_type) {
                     Category::Javascript => Loader::Js,
                     Category::Json => Loader::Json,
                     Category::Css => Loader::Css,

--- a/src/http_types/MimeType.rs
+++ b/src/http_types/MimeType.rs
@@ -170,7 +170,7 @@ impl Category {
 }
 
 impl Category {
-    pub(crate) fn init(str: &[u8]) -> Category {
+    pub fn init(str: &[u8]) -> Category {
         if let Some(slash) = strings::index_of_char(str, b'/') {
             let category = &str[0..slash as usize];
             let mut after_slash: &[u8] = if str.len() > slash as usize + 1 {

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -92,10 +92,8 @@ fn dump_source_string_failiable(
     {
         return Ok(());
     }
-    // Not every specifier is a filesystem path: a `data:` URL carries the
-    // whole module source inline and can exceed MAX_PATH_BYTES, which
-    // `resolve_path::z` treats as a caller bug (debug panic). The dump is
-    // best-effort tooling, so skip anything whose dump path cannot fit.
+    // A `data:` URL specifier embeds the module source and can exceed
+    // MAX_PATH_BYTES; skip the best-effort dump when it cannot fit.
     if specifier.len() + b".map".len() >= bun_paths::MAX_PATH_BYTES {
         return Ok(());
     }

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -92,6 +92,13 @@ fn dump_source_string_failiable(
     {
         return Ok(());
     }
+    // Not every specifier is a filesystem path: a `data:` URL carries the
+    // whole module source inline and can exceed MAX_PATH_BYTES, which
+    // `resolve_path::z` treats as a caller bug (debug panic). The dump is
+    // best-effort tooling, so skip anything whose dump path cannot fit.
+    if specifier.len() + b".map".len() >= bun_paths::MAX_PATH_BYTES {
+        return Ok(());
+    }
 
     let mut holder = BUN_DEBUG_HOLDER.lock();
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4192,16 +4192,18 @@ unsafe fn get_loader_and_virtual_source<'a>(
     // a fake extension out of the URL body (`loader_for_path`'s `is_data_url`
     // check only fires when the resolver tagged the path with the `dataurl`
     // namespace, which the runtime loader never does). Pick the loader from
-    // the MIME type instead, matching the bundler pipeline
-    // (`enqueue_on_load_plugin_if_needed`). Unknown and absent MIME types keep
-    // the maximally permissive tsx default used for extensionless files;
-    // invalid data URLs fall through to the transpile path, which reports the
-    // parse error.
+    // the MIME type instead, like the bundler does for `dataurl`-namespace
+    // paths. `Category::init` (rather than `decode_mime_type().category`)
+    // classifies `application/javascript` as JavaScript too, matching Node,
+    // which compiles both JS MIME spellings as JavaScript modules. Unknown
+    // and absent MIME types keep the maximally permissive tsx default used
+    // for extensionless files; invalid data URLs fall through to the
+    // transpile path, which reports the parse error.
     if bun_core::strings::has_prefix_comptime(path.text, b"data:") {
         use bun_http_types::MimeType::Category;
         loader = Some(
             match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
-                Ok(data_url) => match data_url.decode_mime_type().category {
+                Ok(data_url) => match Category::init(data_url.mime_type) {
                     Category::Javascript => Loader::Js,
                     Category::Json => Loader::Json,
                     Category::Css => Loader::Css,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4188,6 +4188,30 @@ unsafe fn get_loader_and_virtual_source<'a>(
         loader_for_path(&path, unsafe { &(*jsc_vm).transpiler.options.loaders });
     let mut virtual_source: Option<&'a bun_ast::Source> = None;
 
+    // A `data:` specifier is not a file path: the extension lookup above reads
+    // a fake extension out of the URL body (`loader_for_path`'s `is_data_url`
+    // check only fires when the resolver tagged the path with the `dataurl`
+    // namespace, which the runtime loader never does). Pick the loader from
+    // the MIME type instead, matching the bundler pipeline
+    // (`enqueue_on_load_plugin_if_needed`). Unknown and absent MIME types keep
+    // the maximally permissive tsx default used for extensionless files;
+    // invalid data URLs fall through to the transpile path, which reports the
+    // parse error.
+    if bun_core::strings::has_prefix_comptime(path.text, b"data:") {
+        use bun_http_types::MimeType::Category;
+        loader = Some(
+            match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
+                Ok(data_url) => match data_url.decode_mime_type().category {
+                    Category::Javascript => Loader::Js,
+                    Category::Json => Loader::Json,
+                    Category::Css => Loader::Css,
+                    _ => Loader::Tsx,
+                },
+                Err(_) => Loader::Tsx,
+            },
+        );
+    }
+
     // Synthetic `[eval]`/`[stdin]` source.
     // SAFETY: per fn contract.
     if let Some(eval_source) = unsafe { &*jsc_vm }.module_loader.eval_source.as_deref() {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4188,30 +4188,10 @@ unsafe fn get_loader_and_virtual_source<'a>(
         loader_for_path(&path, unsafe { &(*jsc_vm).transpiler.options.loaders });
     let mut virtual_source: Option<&'a bun_ast::Source> = None;
 
-    // A `data:` specifier is not a file path: the extension lookup above reads
-    // a fake extension out of the URL body (`loader_for_path`'s `is_data_url`
-    // check only fires when the resolver tagged the path with the `dataurl`
-    // namespace, which the runtime loader never does). Pick the loader from
-    // the MIME type instead, like the bundler does for `dataurl`-namespace
-    // paths. `Category::init` (rather than `decode_mime_type().category`)
-    // classifies `application/javascript` as JavaScript too, matching Node,
-    // which compiles both JS MIME spellings as JavaScript modules. Unknown
-    // and absent MIME types keep the maximally permissive tsx default used
-    // for extensionless files; invalid data URLs fall through to the
-    // transpile path, which reports the parse error.
+    // A `data:` specifier is not a file path; the extension lookup above
+    // would sniff a fake extension out of the URL body.
     if bun_core::strings::has_prefix_comptime(path.text, b"data:") {
-        use bun_http_types::MimeType::Category;
-        loader = Some(
-            match bun_resolver::data_url::DataURL::parse_without_check(path.text) {
-                Ok(data_url) => match Category::init(data_url.mime_type) {
-                    Category::Javascript => Loader::Js,
-                    Category::Json => Loader::Json,
-                    Category::Css => Loader::Css,
-                    _ => Loader::Tsx,
-                },
-                Err(_) => Loader::Tsx,
-            },
-        );
+        loader = Some(options::loader_from_data_url(path.text));
     }
 
     // Synthetic `[eval]`/`[stdin]` source.

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -89,6 +89,12 @@ test.each(["application/json", "Application/JSON"])("%s data URL imports as JSON
   expect(mod.default).toEqual({ a: 1.5 });
 });
 
+test("text/css data URL imports like a .css file", async () => {
+  const mod = await import("data:text/css,body{color:red}");
+  expect(Object.keys(mod)).toEqual(["__esModule", "default"]);
+  expect(mod.default).toEqual({});
+});
+
 // https://github.com/oven-sh/bun/issues/29159
 test.each(["text/javascript", "application/javascript", "Text/JavaScript", " text/javascript"])(
   "TypeScript syntax in a %s data URL is a syntax error",

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -57,6 +57,12 @@ test("base64 module containing a '.' keeps its named exports", async () => {
   expect(mod.f.m).toBe(1);
 });
 
+test("raw unencoded module containing a '.' keeps its named exports", async () => {
+  const mod = await import("data:text/javascript,export const value = Math.max(1, 2);");
+  expect(Object.keys(mod)).toEqual(["value"]);
+  expect(mod.value).toBe(2);
+});
+
 test.each([
   "text/javascript",
   "text/javascript;charset=utf-8",

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -79,6 +79,16 @@ test("application/json data URL imports as JSON", async () => {
   expect(mod.default).toEqual({ a: 1.5 });
 });
 
+// https://github.com/oven-sh/bun/issues/29159
+test.each(["text/javascript", "application/javascript"])(
+  "TypeScript syntax in a %s data URL is a syntax error",
+  async mime => {
+    const code = `export const a = "a.b";\nexport enum A { A }\n`;
+    await expect(import(`data:${mime},` + encodeURIComponent(code))).rejects.toThrow("Unexpected enum");
+    await expect(import(`data:${mime};base64,` + btoa(code))).rejects.toThrow("Unexpected enum");
+  },
+);
+
 // https://github.com/oven-sh/bun/issues/28483
 test("errors from imports nested inside a data URL module propagate", async () => {
   const inner = "data:text/javascript," + encodeURIComponent(`throw new Error("boom.1");`);

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -57,7 +57,14 @@ test("base64 module containing a '.' keeps its named exports", async () => {
   expect(mod.f.m).toBe(1);
 });
 
-test.each(["text/javascript", "text/javascript;charset=utf-8", "application/javascript", "TEXT/JAVASCRIPT", ""])(
+test.each([
+  "text/javascript",
+  "text/javascript;charset=utf-8",
+  "application/javascript",
+  "TEXT/JAVASCRIPT",
+  " text/javascript ",
+  "",
+])(
   "percent-encoded module with a '.' executes for MIME %j",
   async mime => {
     const code = `export const x = Number.parseFloat("1.5");`;
@@ -80,7 +87,7 @@ test.each(["application/json", "Application/JSON"])("%s data URL imports as JSON
 });
 
 // https://github.com/oven-sh/bun/issues/29159
-test.each(["text/javascript", "application/javascript", "Text/JavaScript"])(
+test.each(["text/javascript", "application/javascript", "Text/JavaScript", " text/javascript"])(
   "TypeScript syntax in a %s data URL is a syntax error",
   async mime => {
     const code = `export const a = "a.b";\nexport enum A { A }\n`;

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 test("should import and execute ES module from string", async () => {
   const code = `export default function test(arg) { return arg + arg };`;
@@ -38,4 +39,70 @@ test("should import a base64 data: URL longer than the path-length limit", async
 test("should keep '?' as part of the data in a data: URL", async () => {
   const mod = await import(`data:text/javascript,export default "a?b=c";`);
   expect(mod.default).toBe("a?b=c");
+});
+
+// https://github.com/oven-sh/bun/issues/32057
+test("percent-encoded module containing a '.' keeps its named exports", async () => {
+  const code = "export function f(){}\nf.m = 1\nexport const x = 1\n";
+  const mod = await import("data:text/javascript," + encodeURIComponent(code));
+  expect(Object.keys(mod)).toEqual(["f", "x"]);
+  expect(mod.f.m).toBe(1);
+  expect(mod.x).toBe(1);
+});
+
+test("base64 module containing a '.' keeps its named exports", async () => {
+  const code = "export function f(){}\nf.m = 1\nexport const x = 1\n";
+  const mod = await import("data:text/javascript;base64," + btoa(code));
+  expect(Object.keys(mod)).toEqual(["f", "x"]);
+  expect(mod.f.m).toBe(1);
+});
+
+test.each(["text/javascript", "text/javascript;charset=utf-8", "application/javascript", ""])(
+  "percent-encoded module with a '.' executes for MIME %j",
+  async mime => {
+    const code = `export const x = Number.parseFloat("1.5");`;
+    const mod = await import(`data:${mime},` + encodeURIComponent(code));
+    expect(Object.keys(mod)).toEqual(["x"]);
+    expect(mod.x).toBe(1.5);
+  },
+);
+
+test("URL text ending in a known file extension is not sniffed as a loader", async () => {
+  // The fake ".json" extension previously routed this through the JSON loader.
+  const code = "export const x = 1 // tail.json";
+  const mod = await import("data:text/javascript," + encodeURIComponent(code));
+  expect(mod.x).toBe(1);
+});
+
+test("application/json data URL imports as JSON", async () => {
+  const mod = await import("data:application/json," + encodeURIComponent(`{"a": 1.5}`));
+  expect(mod.default).toEqual({ a: 1.5 });
+});
+
+// https://github.com/oven-sh/bun/issues/28483
+test("errors from imports nested inside a data URL module propagate", async () => {
+  const inner = "data:text/javascript," + encodeURIComponent(`throw new Error("boom.1");`);
+  const outer = "data:text/javascript," + encodeURIComponent(`import ${JSON.stringify(inner)};`);
+  await expect(import(outer)).rejects.toThrow("boom.1");
+});
+
+test.concurrent("static import and require of percent-encoded data URLs with dots", async () => {
+  const esmUrl = "data:text/javascript," + encodeURIComponent("export const obj = { a: 1.5 };\n");
+  const cjsUrl = "data:text/javascript," + encodeURIComponent("module.exports = { b: 2.5 };\n");
+  using dir = tempDir("data-url-import", {
+    "index.mjs": `
+      import { obj } from ${JSON.stringify(esmUrl)};
+      import { createRequire } from "node:module";
+      const cjs = createRequire(import.meta.url)(${JSON.stringify(cjsUrl)});
+      console.log(JSON.stringify({ ...obj, ...cjs }));
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "index.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, exitCode }).toEqual({ stdout: `{"a":1.5,"b":2.5}\n`, exitCode: 0 });
 });

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -57,7 +57,7 @@ test("base64 module containing a '.' keeps its named exports", async () => {
   expect(mod.f.m).toBe(1);
 });
 
-test.each(["text/javascript", "text/javascript;charset=utf-8", "application/javascript", ""])(
+test.each(["text/javascript", "text/javascript;charset=utf-8", "application/javascript", "TEXT/JAVASCRIPT", ""])(
   "percent-encoded module with a '.' executes for MIME %j",
   async mime => {
     const code = `export const x = Number.parseFloat("1.5");`;
@@ -74,13 +74,13 @@ test("URL text ending in a known file extension is not sniffed as a loader", asy
   expect(mod.x).toBe(1);
 });
 
-test("application/json data URL imports as JSON", async () => {
-  const mod = await import("data:application/json," + encodeURIComponent(`{"a": 1.5}`));
+test.each(["application/json", "Application/JSON"])("%s data URL imports as JSON", async mime => {
+  const mod = await import(`data:${mime},` + encodeURIComponent(`{"a": 1.5}`));
   expect(mod.default).toEqual({ a: 1.5 });
 });
 
 // https://github.com/oven-sh/bun/issues/29159
-test.each(["text/javascript", "application/javascript"])(
+test.each(["text/javascript", "application/javascript", "Text/JavaScript"])(
   "TypeScript syntax in a %s data URL is a syntax error",
   async mime => {
     const code = `export const a = "a.b";\nexport enum A { A }\n`;

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -64,15 +64,12 @@ test.each([
   "TEXT/JAVASCRIPT",
   " text/javascript ",
   "",
-])(
-  "percent-encoded module with a '.' executes for MIME %j",
-  async mime => {
-    const code = `export const x = Number.parseFloat("1.5");`;
-    const mod = await import(`data:${mime},` + encodeURIComponent(code));
-    expect(Object.keys(mod)).toEqual(["x"]);
-    expect(mod.x).toBe(1.5);
-  },
-);
+])("percent-encoded module with a '.' executes for MIME %j", async mime => {
+  const code = `export const x = Number.parseFloat("1.5");`;
+  const mod = await import(`data:${mime},` + encodeURIComponent(code));
+  expect(Object.keys(mod)).toEqual(["x"]);
+  expect(mod.x).toBe(1.5);
+});
 
 test("URL text ending in a known file extension is not sniffed as a loader", async () => {
   // The fake ".json" extension previously routed this through the JSON loader.

--- a/test/js/node/string-module.test.js
+++ b/test/js/node/string-module.test.js
@@ -114,5 +114,5 @@ test.concurrent("static import and require of percent-encoded data URLs with dot
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, exitCode }).toEqual({ stdout: `{"a":1.5,"b":2.5}\n`, exitCode: 0 });
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: `{"a":1.5,"b":2.5}\n`, stderr: "", exitCode: 0 });
 });


### PR DESCRIPTION
Fixes #32057
Fixes #28483
Fixes #29159

### Problem

`import()` of a percent-encoded `data:text/javascript` URL silently degrades to the file loader whenever the URL text contains a `.`:

```js
const code = 'export function f(){}\nf.m = 1\nexport const x = 1\n'
const mod = await import('data:text/javascript,' + encodeURIComponent(code))
console.log(Object.keys(mod)) // ["__esModule","default"], module never ran
```

The module's code never executes; the namespace is `export default "<the whole data URL>"`. Base64 payloads work only by accident (the base64 alphabet has no `.`). This also silently swallowed errors from nested imports (#28483), because the outer module was never evaluated in the first place. Separately, JS-MIME data URLs were fed to the TS-capable default loader, so TypeScript syntax like `export enum` was accepted where Node throws a SyntaxError (#29159).

### Root cause

The runtime loader selection (`get_loader_and_virtual_source` in `src/runtime/jsc_hooks.rs`) treats the specifier as a file path. For `data:` specifiers the path keeps the `file` namespace, so the `is_data_url()` check in `loader_for_path` (which tests for the resolver-assigned `dataurl` namespace, only set on the bundler path) never fires, and the loader is picked from the URL text's fake "file extension":

- no `.` anywhere (all base64 payloads): empty extension, falls back to tsx, works by accident
- any `.`: garbage extension, ESM falls back to the file loader, and the module becomes `export default "<url>"`
- URL text ending in `.json` or `.toml`: the payload is parsed as JSON/TOML

The transpile path already decodes `data:` URL bodies correctly; only the loader decision was wrong.

### Fix

When the specifier starts with `data:`, derive the loader from the data URL's MIME type via a new shared helper, `options::loader_from_data_url` (JavaScript to js, JSON to json, CSS to css), called from both the runtime's `get_loader_and_virtual_source` and its vtable-gated twin in `src/bundler/options.rs`. The helper lowercases the MIME essence before classification (MIME type and subtype are ASCII case-insensitive per RFC 2045; Node loads `data:TEXT/JAVASCRIPT` as a JavaScript module) and uses `Category::init`, which classifies both `text/javascript` and `application/javascript` as JavaScript (Node compiles both spellings as JavaScript modules and rejects TypeScript syntax in them). Unknown and absent MIME types keep the maximally permissive tsx default that extensionless specifiers already get, so currently-working cases (`data:,`, `text/ecmascript`, CJS bodies via `require`) behave exactly as before.

Two adjustments that routing data: URLs through the normal JS pipeline required:

- `Category::init` is `pub` again (a tidy pass had narrowed it to `pub(crate)` while it had no external callers).
- The debug-only source dump in `RuntimeTranspilerStore` now skips specifiers longer than `MAX_PATH_BYTES`. Data: URLs now reach the concurrent transpiler store, and a long data: URL specifier (the module source is embedded in it) tripped `resolve_path::z`'s debug "path too long" panic in the dump helper, visible in main's own long-data-URL test.

Out of scope: the bundler pipeline's own mapping in `enqueue_on_load_plugin_if_needed` uses `decode_mime_type().category`, which files `application/javascript` under `Category::Application` and routes it to the file loader at bundle time; that pre-existing bundler quirk is unchanged here.

Supersedes #28485, which fixed the same bug in the Zig implementation before the Rust port.

### Verification

New tests in `test/js/node/string-module.test.js` (the existing data: URL module test file) cover percent-encoded payloads containing dots (dynamic import, static import, and require), base64 payloads, MIME variants (`text/javascript`, `text/javascript;charset=utf-8`, `application/javascript`, no MIME), a URL ending in `.json`, `application/json` modules, TypeScript syntax rejection in both JS MIME spellings, and error propagation from nested data URL imports.

- `USE_SYSTEM_BUN=1 bun test test/js/node/string-module.test.js` (unfixed): 9 of the new tests fail
- `bun bd test test/js/node/string-module.test.js` (after rebase onto current main): 18 pass (15 from this PR, 3 pre-existing incl. main's long-data-URL tests)

Also verified against the original repros in #32057, #28483, and #29159 (all now match Node), and ran the worker suites that load dotted `data:` URLs (`message-port-context-destroy-leak`, `worker-terminate-lifetime`) plus `test/bundler/esbuild/loader.test.ts`.

<details>
<summary>Rebase note (conflict resolution)</summary>

Rebased onto current main after it gained its own data: URL work (#37157 ENAMETOOLONG fix, `?`-in-payload handling). The only textual conflict was in `test/js/node/string-module.test.js`, resolved by keeping both main's new tests and this PR's; no test was modified. The `Category::init` visibility change and the transpiler-store dump guard above are the two behavioral adaptations the rebase required.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 18 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string-module.test.js
bun test v1.4.0 (57588304a)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [18.43ms]
(pass) should import and execute ES module from string (base64) [8.68ms]
(pass) should throw when importing malformed string (base64) [4.77ms]
(pass) should import a data: URL longer than the path-length limit [168.42ms]
(pass) should import a base64 data: URL longer than the path-length limit [151.99ms]
(pass) should keep '?' as part of the data in a data: URL [12.05ms]
43 | 
44 | // https://github.com/oven-sh/bun/issues/32057
45 | test("percent-encoded module containing a '.' keeps its named exports", async () => {
46 |   const code = "export function f(){}\nf.m = 1\nexport const x = 1\n";
47 |   const mod = await import("data:text/javascript," + encodeURIComponent(code));
48 |   expect(Object.keys(mod)).toEqual(["f", "x"]);
                                ^
error: expect(received).toEqual(expected)

  [
-   "f",
-   "x",
+   "__esModule",
+   "default",
  ]

- Expected  
... (truncated)

release without fix: 18 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [0.32ms]
(pass) should import and execute ES module from string (base64) [0.15ms]
(pass) should throw when importing malformed string (base64) [0.09ms]
(pass) should import a data: URL longer than the path-length limit [6.32ms]
(pass) should import a base64 data: URL longer than the path-length limit [5.77ms]
(pass) should keep '?' as part of the data in a data: URL [0.25ms]
43 | 
44 | // https://github.com/oven-sh/bun/issues/32057
45 | test("percent-encoded module containing a '.' keeps its named exports", async () => {
46 |   const code = "export function f(){}\nf.m = 1\nexport const x = 1\n";
47 |   const mod = await import("data:text/javascript," + encodeURIComponent(code));
48 |   expect(Object.keys(mod)).toEqual(["f", "x"]);
                                ^
error: expect(received).toEqual(expected)

  [
-   "f",
-   "x",
+   "__esModule",
+   "default",
  ]

- Expected  - 2
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/string-module.test.js:48:28)
(fail) percent-encoded module containing a '.' keeps its named ex
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/string-module.test.js
bun test v1.4.0 (57588304a)

test/js/node/string-module.test.js:
(pass) should import and execute ES module from string [20.52ms]
(pass) should import and execute ES module from string (base64) [12.42ms]
(pass) should throw when importing malformed string (base64) [4.79ms]
(pass) should import a data: URL longer than the path-length limit [163.73ms]
(pass) should import a base64 data: URL longer than the path-length limit [145.64ms]
(pass) should keep '?' as part of the data in a data: URL [8.97ms]
(pass) percent-encoded module containing a '.' keeps its named exports [11.29ms]
(pass) base64 module containing a '.' keeps its named exports [8.02ms]
(pass) raw unencoded module containing a '.' keeps its named exports [8.53ms]
(pass) percent-encoded module with a '.' executes for MIME "text/javascript" [10.41ms]
(pass) percent-encoded module with a '.' executes for MIME "text/javascript;charset=utf-8" [4.98ms]
(pass) percent-encoded module with a '.' executes for MIME "application/javascript" [4.56ms]
(p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     bd39bd4daa
  features     baseline

22 deps, 120 codegen, 1174 objects in 762ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1220] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [3.00ms]
[2/1220] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [3.00ms]
[3/1220] esbuild runtime.out.js

  build/release/codegen/runtime.out.js  5.3kb

⚡ Done in 5ms
[4/1220] gen node-fallbacks/react-refresh.js
Bundled 1 module in 7ms

  react-refresh.js  4.81 KB  (entry point)

[5/1220] esbuild bun-error

  ../../build/release/codegen/bun-error/index.js       42.1kb
  ../../build/release/codegen/bun-error/bun-error.css  12.8kb

⚡ Done in 24ms
[6/1220] fetch zlib
[zlib] up to date
[7/1220] fetch tinycc
[tinycc] up to date
[8/1208] fetch picohttpparser
[picohttpparser] up to date
[9/1208] fetch libjpeg-turbo
[libjpeg-turbo] up to date

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/options.rs             | 42 +++++++++++++++++
 src/http_types/MimeType.rs         |  2 +-
 src/jsc/RuntimeTranspilerStore.rs  |  5 ++
 src/runtime/jsc_hooks.rs           |  6 +++
 test/js/node/string-module.test.js | 93 ++++++++++++++++++++++++++++++++++++++
 5 files changed, 147 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 3 passed · 1 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/bundler/options.rs                  7      7     15
src/http_types/MimeType.rs              2      2     15
src/jsc/RuntimeTranspilerStore.rs       1      2     15
src/runtime/jsc_hooks.rs                6      6     15
test/js/node/string-module.test.js      6     13     15
```

</details>

**root cause** · written by the author bot

The runtime and bundler chose the loader for data URL imports by parsing a file extension out of the specifier string, so a percent-encoded module whose source contained a dot (such as f.m = 1) yielded a bogus extension and fell back to a non-ESM loader, collapsing the module to CommonJS; base64 payloads avoided this because their encoded form never produced a misleading extension. The fix derives the loader from the data URL's MIME type category instead, mapping JavaScript, JSON, and CSS MIME types to their proper loaders with a TSX fallback, so the module source is parsed as ESM regardles…

<!-- robobun:evidence:end -->