### PR TITLE
fix(plugin): handle exception from Bun.plugin target string coercion

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,8 +306,11 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (targetJSString) {
             String targetString = targetJSString->value(globalObject);
+            RETURN_IF_EXCEPTION(throwScope, {});
             if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
                 JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
                 return {};

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="./plugins" />
 import { plugin } from "bun";
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, jest } from "bun:test";
 import { resolve } from "path";
 
 declare global {
@@ -364,6 +364,19 @@ describe("errors", () => {
     expect(() => {
       plugin(opts as any);
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
+  });
+
+  it("handles 'target' whose string coercion throws", () => {
+    const setup = jest.fn();
+    const opts = {
+      setup,
+      target: { toString: () => ({}) },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("No default value");
+    expect(setup).not.toHaveBeenCalled();
   });
 
   it("invalid loaders throw", () => {


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion failure (`ASSERTION FAILED: Unexpected exception observed`, `ExceptionScope.h(61) assertNoException`) found by fuzzing, fingerprint `890c68dc4cf1789a`.

In `setupBunPlugin` (`src/jsc/bindings/BunPlugin.cpp`), the `target` option is coerced with `targetValue.toStringOrNull(globalObject)`. That coercion can run user JS (`toString`/`valueOf`). When it throws, for example when `toString` returns a non-primitive so OrdinaryToPrimitive raises "No default value", `toStringOrNull` returns null and the old code simply skipped the validation block and kept going with the exception still pending. The subsequent `call()` into the plugin's `setup` function then trips `assertNoException` and aborts debug builds.

The fix adds `RETURN_IF_EXCEPTION` after `toStringOrNull` and after `targetJSString->value()` (rope resolution can also throw), so the coercion error propagates to the caller as a normal catchable TypeError.

Repro that aborted before this change:

```js
Bun.plugin({
  setup: () => {},
  target: { toString: () => ({}) },
});
```

### How did you verify your code works?

- The repro now throws `TypeError: No default value` cleanly on a debug build (also under `BUN_JSC_validateExceptionChecks=1`) instead of asserting.
- Added a regression test in `test/js/bun/plugin/plugins.test.ts` ("handles 'target' whose string coercion throws"). It aborts the unfixed debug build with the exact assertion from the fuzzer (SIGABRT, exit 134) and passes with the fix. Release builds already surfaced the error correctly because JSC bails out at VM entry with a pending exception, so the bug was only observable on debug/ASAN builds.
- Full `test/js/bun/plugin/plugins.test.ts` suite passes with the debug build (30 pass, 1 pre-existing todo).
