### PR TITLE
fs: clamp out-of-range libuv error results instead of truncating into errno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ version = "0.0.0"
 dependencies = [
  "bun_core",
  "bun_jsc",
+ "bun_libuv_sys",
  "bun_sys",
 ]
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -316,6 +316,18 @@ export const sysErrorNameFromLibuv: (errno: number) => string | undefined = $new
   1,
 );
 
+export const uvRawErrno: (rc: number) => number | undefined = $newZigFunction(
+  "sys/Error.zig",
+  "TestingAPIs.uvRawErrno",
+  1,
+);
+
+export const uvTranslatedErrno: (rc: number) => number | undefined = $newZigFunction(
+  "sys/Error.zig",
+  "TestingAPIs.uvTranslatedErrno",
+  1,
+);
+
 export const sigactionLayout: () =>
   | undefined
   | {

--- a/src/libuv_sys/lib.rs
+++ b/src/libuv_sys/lib.rs
@@ -32,6 +32,34 @@ pub const UV_DIRENT_BLOCK: core::ffi::c_int = 7;
 // subset so `bun_errno`'s per-OS `uv_e` modules can reference a single source
 // of truth instead of inlining the magic numbers.
 // ──────────────────────────────────────────────────────────────────────────
+/// `UV_UNKNOWN` (uv/errno.h `UV__UNKNOWN`): libuv's synthetic "unknown
+/// error" code. Lives at crate root (not the Windows-only `libuv` module)
+/// because [`uv_raw_errno`] below is compiled on every platform.
+pub const UV_UNKNOWN: core::ffi::c_int = -4094;
+
+/// Raw `|UV_E*|` magnitude of a negative libuv result, in the form stored in
+/// `bun_sys::Error.errno` alongside `from_libuv: true`. Returns `None` for
+/// non-negative (success) results.
+///
+/// On Windows, libuv's `uv_translate_sys_error` returns already-negative
+/// inputs unchanged (vendor/libuv/src/win/error.c), so `req->result` can
+/// carry system codes far outside the `UV_E*` range (NTSTATUS-shaped values
+/// have been observed in the wild). A magnitude that does not fit the u16
+/// errno field maps to `|UV_UNKNOWN|` instead of truncating, because a
+/// truncated magnitude aliases a real errno (e.g. `-0x10002` would read back
+/// as `ENOENT`).
+pub const fn uv_raw_errno(rc: i64) -> Option<u16> {
+    if rc >= 0 {
+        return None;
+    }
+    let magnitude = rc.unsigned_abs();
+    if magnitude <= u16::MAX as u64 {
+        Some(magnitude as u16)
+    } else {
+        Some(UV_UNKNOWN.unsigned_abs() as u16)
+    }
+}
+
 #[cfg(not(windows))]
 pub const UV_ECHARSET: core::ffi::c_int = -4080;
 #[cfg(not(windows))]

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -20,6 +20,12 @@ use core::ffi::{c_char, c_int, c_long, c_uint, c_ulong, c_ushort, c_void};
 use core::mem::MaybeUninit;
 use core::{fmt, mem, ptr};
 
+pub use crate::UV_UNKNOWN;
+
+/// `bun_errno::E::UNKNOWN` discriminant (layering forbids naming `E` here).
+/// Keep in sync with the `UV_UNKNOWN` row in [`uv_err_to_e_discriminant`].
+const E_UNKNOWN_DISCRIMINANT: u16 = 134;
+
 // ──────────────────────────────────────────────────────────────────────────
 // Debug log scope (`bun.Output.scoped(.uv, .hidden)`). This crate is leaf
 // (no `bun_output` dep), so the macro compiles to nothing in release and to
@@ -2203,7 +2209,7 @@ pub const fn uv_err_to_e_discriminant(code: c_int) -> Option<u16> {
         UV_ECANCELED => 125,      // E::CANCELED
         UV_ECHARSET => 135,       // E::CHARSET
         UV_EOF => 136,            // E::EOF
-        UV_UNKNOWN => 134,        // E::UNKNOWN
+        UV_UNKNOWN => E_UNKNOWN_DISCRIMINANT,
         // EAI_* codes — `bun_errno::E::UV_EAI_*` discriminants are defined as
         // `(-UV_EAI_*) as u16`, i.e. the raw magnitude is the discriminant.
         UV_EAI_ADDRFAMILY => (-UV_EAI_ADDRFAMILY) as u16,
@@ -2268,27 +2274,28 @@ impl ReturnCode {
         self.0
     }
     /// `Some(|UV_E*|)` when negative — the **raw** libuv error magnitude
-    /// (e.g. 4082 for `UV_EBUSY`). Use [`errno`] for the translated POSIX
-    /// `bun.sys.E` value (e.g. 16 for `BUSY`).
+    /// (e.g. 4082 for `UV_EBUSY`), clamped to `|UV_UNKNOWN|` when out of u16
+    /// range (see [`crate::uv_raw_errno`]). Use [`errno`] for the translated
+    /// POSIX `bun.sys.E` value (e.g. 16 for `BUSY`).
     #[inline]
     pub const fn raw_errno(self) -> Option<u16> {
-        if self.0 < 0 {
-            Some(self.0.unsigned_abs() as u16)
-        } else {
-            None
-        }
+        crate::uv_raw_errno(self.0 as i64)
     }
     /// When negative, map the
     /// `UV_E*` code to the small POSIX `bun.sys.E` discriminant (e.g.
-    /// `UV_ENOENT (-4058)` → `2`). Returns `None` for non-negative *or*
-    /// unmapped negative codes. Downstream callers
-    /// (`node_fs`, `sys::Fd`, `write_file`, …) store this directly into
-    /// `bun_sys::Error.errno`, so it MUST be the translated value, not the raw
-    /// `|UV_E*|` magnitude — see [`raw_errno`] for the latter.
+    /// `UV_ENOENT (-4058)` → `2`); unmapped negative codes resolve to the
+    /// `E::UNKNOWN` discriminant so a failed result is never mistaken for
+    /// success. Returns `None` only for non-negative codes. Downstream
+    /// callers (`node_fs`, `sys::Fd`, `write_file`, …) store this directly
+    /// into `bun_sys::Error.errno`, so it MUST be the translated value, not
+    /// the raw `|UV_E*|` magnitude — see [`raw_errno`] for the latter.
     #[inline]
     pub const fn errno(self) -> Option<u16> {
         if self.0 < 0 {
-            uv_err_to_e_discriminant(self.0)
+            match uv_err_to_e_discriminant(self.0) {
+                Some(d) => Some(d),
+                None => Some(E_UNKNOWN_DISCRIMINANT),
+            }
         } else {
             None
         }
@@ -2330,22 +2337,29 @@ impl ReturnCodeI64 {
     pub const fn int(self) -> i64 {
         self.0
     }
+    /// `Some(|UV_E*|)` when negative, clamped to `|UV_UNKNOWN|` when out of
+    /// u16 range (see [`crate::uv_raw_errno`]).
     #[inline]
     pub const fn errno(self) -> Option<u16> {
-        if self.0 < 0 {
-            Some(self.0.unsigned_abs() as u16)
-        } else {
-            None
-        }
+        crate::uv_raw_errno(self.0)
     }
     /// Translated `bun_sys::E`
     /// discriminant via [`uv_err_to_e_discriminant`] (matching
-    /// [`ReturnCode::err_enum`]). For the typed `bun_sys::E` use
+    /// [`ReturnCode::err_enum`]); unmapped negative codes resolve to the
+    /// `E::UNKNOWN` discriminant. For the typed `bun_sys::E` use
     /// `bun_sys::ReturnCodeExt::err_enum_e` (layering: `E` lives upstream).
     #[inline]
     pub const fn err_enum(self) -> Option<u16> {
         if self.0 < 0 {
-            uv_err_to_e_discriminant(self.0 as c_int)
+            // An i64 below c_int range cannot be a `UV_E*` code, and a
+            // wrapping `as c_int` cast could alias one.
+            if self.0 < c_int::MIN as i64 {
+                return Some(E_UNKNOWN_DISCRIMINANT);
+            }
+            match uv_err_to_e_discriminant(self.0 as c_int) {
+                Some(d) => Some(d),
+                None => Some(E_UNKNOWN_DISCRIMINANT),
+            }
         } else {
             None
         }
@@ -2582,7 +2596,6 @@ pub const UV_ESRCH: c_int = -4040;
 pub const UV_ETIMEDOUT: c_int = -4039;
 pub const UV_ETXTBSY: c_int = -4038;
 pub const UV_EXDEV: c_int = -4037;
-pub const UV_UNKNOWN: c_int = -4094;
 pub const UV_EOF: c_int = -4095;
 pub const UV_ENXIO: c_int = -4033;
 pub const UV_EMLINK: c_int = -4032;

--- a/src/runtime/dispatch_js2native.rs
+++ b/src/runtime/dispatch_js2native.rs
@@ -60,6 +60,8 @@ pub use bun_sys_jsc::error_jsc::TestingAPIs::sigaction_layout as sys_sys_testing
 pub use bun_sys_jsc::error_jsc::TestingAPIs::sys_error_name_from_libuv as sys_error_testing_ap_is_sys_error_name_from_libuv;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_nt_status_to_e as sys_sys_testing_ap_is_translate_nt_status_to_e;
 pub use bun_sys_jsc::error_jsc::TestingAPIs::translate_uv_error_to_e as sys_sys_testing_ap_is_translate_uv_error_to_e;
+pub use bun_sys_jsc::error_jsc::TestingAPIs::uv_raw_errno as sys_error_testing_ap_is_uv_raw_errno;
+pub use bun_sys_jsc::error_jsc::TestingAPIs::uv_translated_errno as sys_error_testing_ap_is_uv_translated_errno;
 
 pub use bun_http_jsc::headers_jsc::h2_live_counts as http_h2_client_testing_ap_is_live_counts;
 pub use bun_http_jsc::headers_jsc::h3_quic_live_counts as http_h3_client_testing_ap_is_quic_live_counts;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -19,6 +19,7 @@ use bun_jsc::EventLoopTaskPtr;
 use bun_jsc::debugger::AsyncTaskTracker;
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{EventLoopHandle, JSGlobalObject, JSValue, JsResult, Task, ThreadSafe, Unprotect};
+use bun_libuv_sys::uv_raw_errno;
 use bun_paths::{self as paths, OSPathBuffer, OSPathChar, OSPathSliceZ, PathBuffer};
 use bun_sys::FdExt as _;
 use bun_sys::{self as sys, E, Fd as FD, Maybe, Mode, SystemErrno};
@@ -4853,9 +4854,9 @@ impl NodeFS {
     }
 
     pub fn uv_close(&mut self, args: &args::Close, rc: i64) -> Maybe<ret::Close> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::close,
                 fd: args.fd,
                 #[cfg(windows)]
@@ -6103,9 +6104,9 @@ impl NodeFS {
     }
 
     pub fn uv_open(&mut self, args: &args::Open, rc: i64) -> Maybe<ret::Open> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::open,
                 path: args.path.slice().into(),
                 #[cfg(windows)]
@@ -6123,9 +6124,9 @@ impl NodeFS {
         req: &mut uv::fs_t,
         rc: i64,
     ) -> Maybe<ret::StatFS> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::open,
                 path: args.path.slice().into(),
                 #[cfg(windows)]
@@ -6202,9 +6203,9 @@ impl NodeFS {
     }
 
     pub fn uv_read(&mut self, args: &args::Read, rc: i64) -> Maybe<ret::Read> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::read,
                 fd: args.fd,
                 #[cfg(windows)]
@@ -6218,9 +6219,9 @@ impl NodeFS {
     }
 
     pub fn uv_readv(&mut self, args: &args::Readv, rc: i64) -> Maybe<ret::Readv> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::readv,
                 fd: args.fd,
                 #[cfg(windows)]
@@ -6264,9 +6265,9 @@ impl NodeFS {
     }
 
     pub fn uv_write(&mut self, args: &args::Write, rc: i64) -> Maybe<ret::Write> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::write,
                 fd: args.fd,
                 #[cfg(windows)]
@@ -6280,9 +6281,9 @@ impl NodeFS {
     }
 
     pub fn uv_writev(&mut self, args: &args::Writev, rc: i64) -> Maybe<ret::Writev> {
-        if rc < 0 {
+        if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
-                errno: (-rc) as _,
+                errno,
                 syscall: sys::Tag::writev,
                 fd: args.fd,
                 #[cfg(windows)]

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6127,7 +6127,7 @@ impl NodeFS {
         if let Some(errno) = uv_raw_errno(rc) {
             return Err(sys::Error {
                 errno,
-                syscall: sys::Tag::open,
+                syscall: sys::Tag::statfs,
                 path: args.path.slice().into(),
                 #[cfg(windows)]
                 from_libuv: true,

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -91,7 +91,10 @@ impl IntoErrnoInt for i32 {
         // a caller bug, so panic.
         #[cfg(windows)]
         {
-            self.unsigned_abs() as Int
+            // Windows system codes can exceed u16 (e.g. NTSTATUS-shaped
+            // values libuv passes through); map them to UNKNOWN instead of
+            // truncating into an aliased errno.
+            Int::try_from(self.unsigned_abs()).unwrap_or(E::UNKNOWN as Int)
         }
         #[cfg(not(windows))]
         {
@@ -151,15 +154,9 @@ impl Error {
 
     // c_int covers all call sites in practice.
     pub fn from_code_int(errno: c_int, syscall_tag: Tag) -> Error {
-        #[cfg(windows)]
-        let n = Int::try_from(errno.unsigned_abs()).unwrap();
-        #[cfg(not(windows))]
-        let n = u16::try_from(errno).expect("int cast");
-        Error {
-            errno: n,
-            syscall: syscall_tag,
-            ..Default::default()
-        }
+        // Same conversion as `IntoErrnoInt for i32`: absolute value clamped
+        // to UNKNOWN on Windows, non-negative asserted on POSIX.
+        Error::new(errno, syscall_tag)
     }
 
     #[inline]
@@ -575,9 +572,11 @@ impl ReturnCodeExt for crate::windows::libuv::ReturnCodeI64 {
     #[inline]
     fn err_enum_e(self) -> Option<crate::E> {
         if self.int() < 0 {
-            Some(crate::windows::translate_uv_error_to_e(
-                self.int() as core::ffi::c_int
-            ))
+            // Saturate: an i64 below c_int range is not a `UV_E*` code, and a
+            // wrapping `as` cast could alias one. `translate_uv_error_to_e`
+            // maps `c_int::MIN` to `E::UNKNOWN`.
+            let code = c_int::try_from(self.int()).unwrap_or(c_int::MIN);
+            Some(crate::windows::translate_uv_error_to_e(code))
         } else {
             None
         }

--- a/src/sys_jsc/Cargo.toml
+++ b/src/sys_jsc/Cargo.toml
@@ -12,4 +12,5 @@ workspace = true
 [dependencies]
 bun_core.workspace = true
 bun_jsc.workspace = true
+bun_libuv_sys.workspace = true
 bun_sys.workspace = true

--- a/src/sys_jsc/error_jsc.rs
+++ b/src/sys_jsc/error_jsc.rs
@@ -106,6 +106,54 @@ pub mod TestingAPIs {
         }
     }
 
+    /// Exposes `bun_libuv_sys::uv_raw_errno`, the libuv-result to raw
+    /// `Error.errno` magnitude conversion used by the Windows async node:fs
+    /// completion handlers, so tests can feed out-of-range negative results
+    /// (NTSTATUS-shaped codes libuv passes through untranslated) and verify
+    /// they clamp to `|UV_UNKNOWN|` instead of truncating into an aliased
+    /// errno. Pure integer logic, available on every platform.
+    #[bun_jsc::host_fn]
+    pub fn uv_raw_errno(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let arguments = frame.arguments();
+        if arguments.is_empty() || !arguments[0].is_number() {
+            return Err(global.throw(format_args!("uvRawErrno: expected 1 number argument")));
+        }
+        // f64 → i64 `as` casts saturate, which matches the helper's clamping
+        // contract for out-of-range magnitudes.
+        let rc = arguments[0].as_number() as i64;
+        match bun_libuv_sys::uv_raw_errno(rc) {
+            Some(errno) => Ok(JSValue::js_number(f64::from(errno))),
+            None => Ok(JSValue::UNDEFINED),
+        }
+    }
+
+    /// Exposes `ReturnCode::errno()`, the translated libuv-result to POSIX
+    /// `E` discriminant conversion used by the synchronous uv_fs_* call
+    /// sites, so tests can verify unmapped negative results resolve to
+    /// EUNKNOWN instead of `None` (which callers treat as success).
+    /// Windows-only.
+    #[bun_jsc::host_fn]
+    pub fn uv_translated_errno(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        let arguments = frame.arguments();
+        if arguments.is_empty() || !arguments[0].is_number() {
+            return Err(global.throw(format_args!(
+                "uvTranslatedErrno: expected 1 number argument"
+            )));
+        }
+        #[cfg(not(windows))]
+        {
+            return Ok(JSValue::UNDEFINED);
+        }
+        #[cfg(windows)]
+        {
+            let rc = bun_sys::windows::libuv::ReturnCode::from_raw(arguments[0].to_int32());
+            return match rc.errno() {
+                Some(errno) => Ok(JSValue::js_number(f64::from(errno))),
+                None => Ok(JSValue::UNDEFINED),
+            };
+        }
+    }
+
     /// Exposes libuv -> `bun.sys.E` translation so tests can feed out-of-range
     /// negative values and verify it does not panic. Windows-only.
     #[bun_jsc::host_fn]

--- a/test/js/node/fs/translate-uv-error-windows.test.ts
+++ b/test/js/node/fs/translate-uv-error-windows.test.ts
@@ -5,7 +5,7 @@
 // Windows release builds are ReleaseSafe, so this panicked in the wild via
 // fs.readFile -> sys_uv.preadv -> ReturnCodeI64.errEnum -> translateUVErrorToE.
 
-import { translateUVErrorToE } from "bun:internal-for-testing";
+import { translateUVErrorToE, uvRawErrno, uvTranslatedErrno } from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
 import { isWindows } from "harness";
 
@@ -25,4 +25,48 @@ test.skipIf(!isWindows)("translateUVErrorToE falls back to UNKNOWN for unmapped 
 
 test.skipIf(isWindows)("translateUVErrorToE is a no-op off Windows", () => {
   expect(translateUVErrorToE(-4058)).toBeUndefined();
+});
+
+// The async node:fs completion handlers (uv_open, uv_read, uv_write, ...)
+// store the negated libuv result into the u16 `Error.errno` field. libuv's
+// uv_translate_sys_error returns already-negative inputs unchanged, so
+// req->result can carry system codes (NTSTATUS-shaped values) whose magnitude
+// does not fit u16. The Zig implementation panicked on the narrowing cast
+// ("integer does not fit in destination type" in uv_callback); a truncating
+// cast instead aliases real errnos (-0x10002 would read back as ENOENT).
+// `uvRawErrno` is that conversion, now clamping to |UV_UNKNOWN| = 4094.
+test("uvRawErrno clamps out-of-range libuv results instead of truncating", () => {
+  // In-range magnitudes pass through untouched.
+  expect(uvRawErrno(-1)).toBe(1); // smallest magnitude
+  expect(uvRawErrno(-4058)).toBe(4058); // UV_ENOENT
+  expect(uvRawErrno(-65535)).toBe(65535); // largest magnitude that fits u16
+  // Out of u16 range: clamp to |UV_UNKNOWN|. A truncating cast would have
+  // produced 0, 2 (ENOENT), and 20 (ENOTDIR) respectively.
+  expect(uvRawErrno(-65536)).toBe(4094);
+  expect(uvRawErrno(-65538)).toBe(4094);
+  expect(uvRawErrno(-1073741804)).toBe(4094); // NTSTATUS 0xC0000014 as i32
+  expect(uvRawErrno(-(2 ** 53))).toBe(4094); // beyond c_int range
+  // Non-negative results are success, not errors.
+  expect(uvRawErrno(0)).toBeUndefined();
+  expect(uvRawErrno(7)).toBeUndefined();
+});
+
+// Sibling conversion for the synchronous uv_fs_* call sites (futime, mkdtemp,
+// realpath, ...): ReturnCode.errno() returned None for unmapped negative
+// results, which every `if let Some(errno) = rc.errno()` caller treats as
+// success - realpath then dereferences a req.ptr libuv never populated.
+test.skipIf(!isWindows)("uvTranslatedErrno never swallows a negative result", () => {
+  // Sanity: known mappings still translate.
+  expect(uvTranslatedErrno(-4058)).toBe(2); // UV_ENOENT -> ENOENT
+  expect(uvTranslatedErrno(-4094)).toBe(134); // UV_UNKNOWN -> EUNKNOWN
+  // Unmapped negative codes resolve to EUNKNOWN (134) instead of undefined.
+  expect(uvTranslatedErrno(-4021)).toBe(134); // one past UV_ENOEXEC (-4022)
+  expect(uvTranslatedErrno(-123456)).toBe(134); // negation outside u16 range
+  // Non-negative results stay success.
+  expect(uvTranslatedErrno(0)).toBeUndefined();
+  expect(uvTranslatedErrno(1)).toBeUndefined();
+});
+
+test.skipIf(isWindows)("uvTranslatedErrno is a no-op off Windows", () => {
+  expect(uvTranslatedErrno(-4058)).toBeUndefined();
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a Windows-only `Panic: integer does not fit in destination type` in the async node:fs completion path, along with two sibling defects at the same conversion boundary: truncated errnos that alias unrelated error codes, and failed libuv results silently treated as success.

### Stack (from shipped 1.3.14 Windows x64 builds)

```
Panic: integer does not fit in destination type
uv_callback      src/runtime/node/node_fs.zig:264
uv__work_done    libuv threadpool.c:340
uv__process_reqs libuv win/core.c:605
uv_run           libuv win/core.c:737
tickWithTimeout  src/uws_sys/Loop.zig:250
```

### Cause

On Windows, async `node:fs` operations complete through `uv_callback`, which hands `req.result` to the per-op handlers (`uv_open`, `uv_read`, `uv_write`, `uv_close`, `uv_readv`, `uv_writev`, `uv_statfs`). Each handler converted a negative result with a raw narrowing cast into the `u16` `Error.errno` field:

```rust
if rc < 0 {
    return Err(sys::Error { errno: (-rc) as _, from_libuv: true, .. });
}
```

Normal libuv error codes are small negatives (`-4095..-1`) and fit. But libuv's `uv_translate_sys_error` returns already-negative inputs unchanged (vendor/libuv/src/win/error.c), so `req->result` can carry raw system codes (NTSTATUS-shaped values) whose magnitude does not fit u16. The shipped Zig implementation used `@intCast`, which panics in release-safe builds: that is the crash above, seen steadily in the wild on 1.3.13/1.3.14 Windows. The Rust port's `as` cast truncates instead, which trades the crash for a lie: `-0x10002` reads back as errno 2 and the user sees `ENOENT` for an I/O failure that was nothing of the sort.

Auditing the same boundary turned up two more defects of the same class:

- `ReturnCode::errno()` returned `None` for a negative but unmapped code. Every `if let Some(errno) = rc.errno()` caller treats `None` as success: the sync `uv_fs_futime` / `uv_fs_mkdtemp` / `uv_fs_realpath` / `uv_fs_utime` / `uv_fs_lutime` sites in node_fs, `Fd::close`, and everything behind `ReturnCodeExt::to_error` / `to_result` (named pipes, fs watcher, blob copy). An unmapped failure was silently swallowed; `realpath` then reads the `req.ptr` libuv never populated.
- `ReturnCodeI64::err_enum()` and `err_enum_e()` cast i64 to c_int with `as`, so a result below i32 range could wrap and alias a valid `UV_E*` code. `Error::from_code_int` had the same narrowing with `.unwrap()` (a panic), and `IntoErrnoInt for i32` the same truncation.

### Fix

One total conversion, `bun_libuv_sys::uv_raw_errno(rc: i64) -> Option<u16>`: negative results keep their raw `|UV_E*|` magnitude when it fits u16 and clamp to `|UV_UNKNOWN|` (4094) when it does not, so they resolve to `EUNKNOWN` downstream instead of panicking, aliasing, or being dropped. The seven node_fs uv handlers, `ReturnCode::raw_errno()`, and `ReturnCodeI64::errno()` all route through it.

`ReturnCode::errno()` and `ReturnCodeI64::err_enum()` now resolve unmapped negative codes to the `E::UNKNOWN` discriminant instead of `None`, so a failed result can never be mistaken for success. `err_enum_e` saturates its i64-to-c_int conversion, and `from_code_int` / `IntoErrnoInt for i32` clamp to UNKNOWN instead of panicking or truncating.

The load-bearing hunks are `src/libuv_sys/lib.rs` (the new conversion) and the `errno()` / `err_enum()` fallbacks in `src/libuv_sys/libuv.rs`; the node_fs and Error.rs changes reroute existing call sites through them.

### Verification

There is no JS-reachable way to inject an out-of-range `req.result` (the triggering environments involve unusual Windows error sources such as network filesystems or filter drivers), so this follows the pattern from #29571 / #29651: the conversions are exposed through `bun:internal-for-testing` (`uvRawErrno`, `uvTranslatedErrno`) and pinned in `test/js/node/fs/translate-uv-error-windows.test.ts`:

- `uvRawErrno` runs on every platform: in-range magnitudes pass through unchanged; `-65536`, `-65538`, `-1073741804` (NTSTATUS `0xC0000014` as i32), and `-(2**53)` clamp to 4094, where the old cast produced 0, 2 (`ENOENT`), 20 (`ENOTDIR`), and 0.
- `uvTranslatedErrno` (Windows lanes): unmapped `-4021` and `-123456` resolve to 134 (`EUNKNOWN`) instead of disappearing as success; known mappings (`-4058` to `ENOENT`) are unchanged.
- The test file fails on the unfixed build (the `bun:internal-for-testing` exports do not exist there) and passes with this change.
- `cargo check --workspace` is clean on `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, and Linux.

Out of scope, noted for completeness: a few call sites store the raw `|UV_E*|` magnitude without setting `from_libuv` (`Error::from_uv_rc64`, the write_file completion), which makes in-range codes display with an UNKNOWN name. That is a pre-existing mislabeling with different user-visible behavior and is not touched here.
