### PR TITLE
Surface posix_spawn file action errors on macOS instead of spawning with closed stdio

### DIFF
--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -47,7 +47,7 @@ mod darwin_spawn_np {
 #[cfg(unix)]
 use self::posix_compat::{Errno, errno};
 #[cfg(target_os = "macos")]
-use self::posix_compat::{errno_from_posix_spawn, mode_t, unexpected_errno};
+use self::posix_compat::{errno_from_posix_spawn, mode_t};
 use self::posix_compat::{fd_t, pid_t, to_posix_path};
 
 #[allow(non_camel_case_types)]
@@ -82,13 +82,7 @@ mod posix_compat {
     impl Errno {
         pub(super) const SUCCESS: Errno = Errno(0);
         #[cfg(target_os = "macos")]
-        pub(super) const NOMEM: Errno = Errno(libc::ENOMEM);
-        #[cfg(target_os = "macos")]
         pub(super) const INVAL: Errno = Errno(libc::EINVAL);
-        #[cfg(target_os = "macos")]
-        pub(super) const BADF: Errno = Errno(libc::EBADF);
-        #[cfg(target_os = "macos")]
-        pub(super) const NAMETOOLONG: Errno = Errno(libc::ENAMETOOLONG);
         pub(super) const INTR: Errno = Errno(libc::EINTR);
     }
     /// Decode a syscall return: with libc, `rc == -1 ⇒ read __errno`,
@@ -115,12 +109,6 @@ mod posix_compat {
     /// Copy a path into a NUL-terminated buffer.
     pub(super) fn to_posix_path(path: &[u8]) -> Result<CString, Error> {
         CString::new(path).map_err(|_| err!("Unexpected"))
-    }
-
-    /// Returns an "Unexpected" error for an errno we don't handle.
-    #[cfg(target_os = "macos")]
-    pub(super) fn unexpected_errno(_e: Errno) -> Error {
-        err!("Unexpected")
     }
 }
 
@@ -300,23 +288,19 @@ pub mod posix_spawn {
         pub status: u32,
     }
 
-    /// Map a `posix_spawn*` errno to `Result<(), Error>`. Shared across all
-    /// `posix_spawnattr_*` / `posix_spawn_file_actions_*` wrappers — they only
-    /// differ in which errnos are *documented* impossible for a given call.
-    /// Those were previously per-site `unreachable!()`; here they become error
-    /// returns, which widens the contract without changing observable behaviour
-    /// for any errno the libc calls actually produce. `INVAL` stays a panic: it
+    /// Map a `posix_spawn*` errno to `sys::Result<()>`, preserving the errno
+    /// so callers can surface it (Darwin's file-action registration returns
+    /// EBADF for any fd >= OPEN_MAX, which must fail the spawn the way node
+    /// does). Shared across all `posix_spawnattr_*` /
+    /// `posix_spawn_file_actions_*` wrappers. `INVAL` stays a panic: it
     /// indicates a corrupted attr/actions object, i.e. a Bun bug.
     #[cfg(target_os = "macos")]
     #[inline]
-    fn spawn_errno(e: Errno) -> Result<(), Error> {
+    fn spawn_errno(e: Errno) -> sys::Result<()> {
         match e {
             Errno::SUCCESS => Ok(()),
-            Errno::NOMEM => Err(err!("SystemResources")),
-            Errno::BADF => Err(err!("InvalidFileDescriptor")),
-            Errno::NAMETOOLONG => Err(err!("NameTooLong")),
             Errno::INVAL => unreachable!(), // attr/actions object is invalid
-            e => Err(unexpected_errno(e)),
+            e => Err(sys::Error::from_code_int(e.0, SYSCALL_POSIX_SPAWN)),
         }
     }
 
@@ -336,7 +320,7 @@ pub mod posix_spawn {
 
     #[cfg(target_os = "macos")]
     impl PosixSpawnAttr {
-        pub fn init() -> Result<PosixSpawnAttr, Error> {
+        pub fn init() -> sys::Result<PosixSpawnAttr> {
             let mut attr = core::mem::MaybeUninit::<system::posix_spawnattr_t>::uninit();
             // SAFETY: posix_spawnattr_init writes into attr on SUCCESS
             spawn_errno(errno_from_posix_spawn(unsafe {
@@ -350,7 +334,7 @@ pub mod posix_spawn {
             })
         }
 
-        pub fn set(&mut self, flags: u16) -> Result<(), Error> {
+        pub fn set(&mut self, flags: u16) -> sys::Result<()> {
             // `as` between same-width signed/unsigned is a bitcast.
             let flags_s: c_short = flags as c_short;
             // SAFETY: self.attr is a live posix_spawnattr_t
@@ -359,10 +343,12 @@ pub mod posix_spawn {
             }))
         }
 
-        pub fn reset_signals(&mut self) -> Result<(), Error> {
+        pub fn reset_signals(&mut self) -> sys::Result<()> {
             // SAFETY: self.attr is a live posix_spawnattr_t
             if unsafe { posix_spawnattr_reset_signals(&raw mut self.attr) } != 0 {
-                return Err(err!("SystemResources"));
+                // posix_spawnattr_setsigdefault/setsigmask only fail on an
+                // invalid attr; the C shim collapses the errno to 0/1.
+                return Err(sys::Error::from_code(sys::E::EINVAL, SYSCALL_POSIX_SPAWN));
             }
             Ok(())
         }
@@ -389,7 +375,7 @@ pub mod posix_spawn {
 
     #[cfg(target_os = "macos")]
     impl PosixSpawnActions {
-        pub(crate) fn init() -> Result<PosixSpawnActions, Error> {
+        pub(crate) fn init() -> sys::Result<PosixSpawnActions> {
             let mut actions =
                 core::mem::MaybeUninit::<system::posix_spawn_file_actions_t>::uninit();
             // SAFETY: posix_spawn_file_actions_init writes into actions on SUCCESS
@@ -408,7 +394,7 @@ pub mod posix_spawn {
             path: &CStr,
             flags: u32,
             mode: mode_t,
-        ) -> Result<(), Error> {
+        ) -> sys::Result<()> {
             let flags_c: c_int = flags as c_int;
             // SAFETY: self.actions is live; path is NUL-terminated
             spawn_errno(errno_from_posix_spawn(unsafe {
@@ -422,14 +408,14 @@ pub mod posix_spawn {
             }))
         }
 
-        pub(crate) fn close(&mut self, fd: Fd) -> Result<(), Error> {
+        pub(crate) fn close(&mut self, fd: Fd) -> sys::Result<()> {
             // SAFETY: self.actions is live
             spawn_errno(errno_from_posix_spawn(unsafe {
                 system::posix_spawn_file_actions_addclose(&raw mut self.actions, fd.native())
             }))
         }
 
-        pub(crate) fn dup2(&mut self, fd: Fd, newfd: Fd) -> Result<(), Error> {
+        pub(crate) fn dup2(&mut self, fd: Fd, newfd: Fd) -> sys::Result<()> {
             if fd == newfd {
                 return self.inherit(fd);
             }
@@ -444,7 +430,7 @@ pub mod posix_spawn {
             }))
         }
 
-        pub(crate) fn inherit(&mut self, fd: Fd) -> Result<(), Error> {
+        pub(crate) fn inherit(&mut self, fd: Fd) -> sys::Result<()> {
             // SAFETY: self.actions is live
             spawn_errno(errno_from_posix_spawn(unsafe {
                 super::darwin_spawn_np::posix_spawn_file_actions_addinherit_np(
@@ -454,13 +440,8 @@ pub mod posix_spawn {
             }))
         }
 
-        pub(crate) fn chdir(&mut self, path: &[u8]) -> Result<(), Error> {
-            let posix_path = to_posix_path(path)?;
-            self.chdir_z(&posix_path)
-        }
-
         // deliberately not pub
-        fn chdir_z(&mut self, path: &CStr) -> Result<(), Error> {
+        fn chdir_z(&mut self, path: &CStr) -> sys::Result<()> {
             // SAFETY: self.actions is live; path is NUL-terminated
             spawn_errno(errno_from_posix_spawn(unsafe {
                 super::darwin_spawn_np::posix_spawn_file_actions_addchdir_np(
@@ -550,6 +531,70 @@ pub mod posix_spawn {
         })
     }
 
+    /// Convert portable `bun_spawn` actions/attrs into libc `posix_spawn`
+    /// objects for the system posix_spawn path. Registration failures must
+    /// fail the spawn: Darwin rejects file actions on fds >= OPEN_MAX (10240)
+    /// with EBADF, and with POSIX_SPAWN_CLOEXEC_DEFAULT set, a silently
+    /// dropped dup2 leaves the child's stdio closed, so the child looks like
+    /// a successful run that produced no output.
+    #[cfg(target_os = "macos")]
+    fn convert_spawn_objects(
+        actions: Option<&Actions>,
+        attr: Option<&Attr>,
+    ) -> sys::Result<(PosixSpawnActions, PosixSpawnAttr)> {
+        let mut posix_actions = PosixSpawnActions::init()?;
+        let mut posix_attr = PosixSpawnAttr::init()?;
+
+        // Pass through all flags from the BunSpawn.Attr
+        if let Some(a) = attr {
+            let mut flags = a.flags;
+            if a.new_process_group {
+                flags |= system::POSIX_SPAWN_SETPGROUP as u16;
+                // pgroup defaults to 0 in a freshly-init'd attr, i.e. child's own pid.
+            }
+            if flags != 0 {
+                posix_attr.set(flags)?;
+            }
+            if a.reset_signals {
+                posix_attr.reset_signals()?;
+            }
+        }
+
+        if let Some(act) = actions {
+            for action in &act.actions {
+                match action.kind {
+                    bun_spawn::FileActionType::Close => {
+                        posix_actions.close(Fd::from_native(action.fds[0]))?;
+                    }
+                    bun_spawn::FileActionType::Dup2 => {
+                        posix_actions.dup2(
+                            Fd::from_native(action.fds[0]),
+                            Fd::from_native(action.fds[1]),
+                        )?;
+                    }
+                    bun_spawn::FileActionType::Open => {
+                        // SAFETY: `.Open` actions always have a non-null path
+                        // backed by a CString in `act.paths` (see `open_z`).
+                        let p = unsafe { bun_core::ffi::cstr(action.path) };
+                        posix_actions.open_z(
+                            Fd::from_native(action.fds[0]),
+                            p,
+                            u32::try_from(action.flags).expect("int cast"),
+                            mode_t::try_from(action.mode).unwrap(),
+                        )?;
+                    }
+                    bun_spawn::FileActionType::None => {}
+                }
+            }
+
+            if let Some(chdir_path) = act.chdir_buf.as_deref() {
+                posix_actions.chdir_z(chdir_path)?;
+            }
+        }
+
+        Ok((posix_actions, posix_attr))
+    }
+
     #[cfg(unix)]
     pub(crate) fn spawn_z(
         path: &CStr,
@@ -600,117 +645,13 @@ pub mod posix_spawn {
         }
 
         // macOS without PTY: use system posix_spawn
-        // Need to convert BunSpawn.Actions to PosixSpawnActions for system posix_spawn
         #[cfg(target_os = "macos")]
         {
-            let mut posix_actions = match PosixSpawnActions::init() {
-                Ok(a) => a,
-                Err(_) => {
-                    return sys::Result::Err(sys::Error {
-                        errno: Errno::NOMEM.0 as sys::ErrorInt,
-                        syscall: SYSCALL_POSIX_SPAWN,
-                        ..Default::default()
-                    });
-                }
+            let (posix_actions, posix_attr) = match convert_spawn_objects(actions, attr) {
+                Ok(converted) => converted,
+                Err(e) => return sys::Result::Err(e.with_path(path.to_bytes())),
             };
-            // Drop handles posix_actions.deinit()
-
-            let mut posix_attr = match PosixSpawnAttr::init() {
-                Ok(a) => a,
-                Err(_) => {
-                    return sys::Result::Err(sys::Error {
-                        errno: Errno::NOMEM.0 as sys::ErrorInt,
-                        syscall: SYSCALL_POSIX_SPAWN,
-                        ..Default::default()
-                    });
-                }
-            };
-            // Drop handles posix_attr.deinit()
-
-            // Pass through all flags from the BunSpawn.Attr
-            if let Some(a) = attr {
-                let mut flags = a.flags;
-                if a.new_process_group {
-                    flags |= system::POSIX_SPAWN_SETPGROUP as u16;
-                    // pgroup defaults to 0 in a freshly-init'd attr, i.e. child's own pid.
-                }
-                if flags != 0 {
-                    let _ = posix_attr.set(flags);
-                }
-                if a.reset_signals {
-                    let _ = posix_attr.reset_signals();
-                }
-            }
-
-            // Convert actions
-            if let Some(act) = actions {
-                for action in &act.actions {
-                    match action.kind {
-                        bun_spawn::FileActionType::Close => {
-                            if let Err(e) = posix_actions.close(Fd::from_native(action.fds[0])) {
-                                if cfg!(debug_assertions) {
-                                    sys::syslog!(
-                                        "posix_spawn_file_actions_addclose({}) failed: {}",
-                                        action.fds[0],
-                                        e.name()
-                                    );
-                                }
-                            }
-                        }
-                        bun_spawn::FileActionType::Dup2 => {
-                            if let Err(e) = posix_actions.dup2(
-                                Fd::from_native(action.fds[0]),
-                                Fd::from_native(action.fds[1]),
-                            ) {
-                                if cfg!(debug_assertions) {
-                                    sys::syslog!(
-                                        "posix_spawn_file_actions_adddup2({}, {}) failed: {}",
-                                        action.fds[0],
-                                        action.fds[1],
-                                        e.name()
-                                    );
-                                }
-                            }
-                        }
-                        bun_spawn::FileActionType::Open => {
-                            // SAFETY: `.Open` actions always have a non-null path
-                            // backed by a CString in `act.paths` (see `open_z`).
-                            let p = unsafe { bun_core::ffi::cstr(action.path) };
-                            if let Err(e) = posix_actions.open_z(
-                                Fd::from_native(action.fds[0]),
-                                p,
-                                u32::try_from(action.flags).expect("int cast"),
-                                mode_t::try_from(action.mode).unwrap(),
-                            ) {
-                                if cfg!(debug_assertions) {
-                                    sys::syslog!(
-                                        "posix_spawn_file_actions_addopen({}, {}, {}, {}) failed: {}",
-                                        action.fds[0],
-                                        bstr::BStr::new(p.to_bytes()),
-                                        action.flags,
-                                        action.mode,
-                                        e.name()
-                                    );
-                                }
-                            }
-                        }
-                        bun_spawn::FileActionType::None => {}
-                    }
-                }
-
-                // Handle chdir
-                if let Some(chdir_path) = act.chdir_buf.as_deref() {
-                    if let Err(e) = posix_actions.chdir(chdir_path.to_bytes()) {
-                        if cfg!(debug_assertions) {
-                            sys::syslog!(
-                                "posix_spawn_file_actions_addchdir({}) failed: {}",
-                                bstr::BStr::new(chdir_path.to_bytes()),
-                                e.name()
-                            );
-                        }
-                    }
-                }
-            }
+            // Drop handles posix_actions.deinit() / posix_attr.deinit()
 
             let mut pid: pid_t = 0;
             // SAFETY: all pointers valid; argv/envp NULL-terminated. Darwin's

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -470,3 +470,81 @@ it("spawnSync(does-not-exist)", () => {
   expect(x.stdout).toEqual(null);
   expect(x.stderr).toEqual(null);
 });
+
+// https://github.com/oven-sh/bun/issues/32067
+it.if(!isWindows)(
+  "spawn with pipe fds above Darwin OPEN_MAX reports EBADF instead of losing output",
+  async () => {
+    const script = /* js */ `
+      const fs = require("fs");
+      const { spawn, spawnSync } = require("child_process");
+
+      // Occupy fd numbers up to ~11000 so the stdio pipes created by spawn
+      // get fd numbers above Darwin's OPEN_MAX (10240).
+      let opened = 0;
+      let setup = "ok";
+      try {
+        for (; opened < 11000; opened++) fs.openSync("/dev/null", "r");
+      } catch (err) {
+        setup = err.code + " after " + opened + " fds";
+      }
+
+      const r = spawnSync("echo", ["hi"], { stdio: ["ignore", "pipe", "pipe"] });
+      const sync = {
+        status: r.status ?? null,
+        stdout: r.stdout?.toString() ?? null,
+        error: r.error?.code ?? null,
+      };
+
+      let asyncResult;
+      try {
+        const child = spawn("echo", ["hi"], { stdio: ["ignore", "pipe", "pipe"] });
+        asyncResult = await new Promise(resolve => {
+          child.on("error", err => resolve({ outcome: "error-event", code: err.code }));
+          child.on("exit", code => resolve({ outcome: "exit", code }));
+        });
+      } catch (err) {
+        asyncResult = { outcome: "throw", code: err.code };
+      }
+
+      console.log(JSON.stringify({ setup, sync, async: asyncResult }));
+    `;
+
+    await using proc = Bun.spawn({
+      // The repro needs more open fds than some environments allow by
+      // default; raise the soft limit before exec'ing bun (which raises it
+      // further on startup).
+      cmd: ["/bin/sh", "-c", `ulimit -Sn 12000 2>/dev/null; exec "$1" -e "$2"`, "sh", bunExe(), script],
+      env: bunEnv,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    let result: any;
+    try {
+      result = JSON.parse(stdout);
+    } catch {
+      throw new Error(`child did not produce a result; stdout: ${JSON.stringify(stdout)} stderr: ${stderr}`);
+    }
+
+    if (process.platform === "darwin") {
+      // Darwin's posix_spawn file actions reject fds >= OPEN_MAX (10240)
+      // with EBADF. The spawn must fail the way node's does, not run a child
+      // with closed stdio that looks like a successful run with empty output.
+      expect(result).toEqual({
+        setup: "ok",
+        sync: { status: null, stdout: null, error: "EBADF" },
+        async: { outcome: "throw", code: "EBADF" },
+      });
+    } else {
+      expect(result).toEqual({
+        setup: "ok",
+        sync: { status: 0, stdout: "hi\n", error: null },
+        async: { outcome: "exit", code: 0 },
+      });
+    }
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -472,10 +472,8 @@ it("spawnSync(does-not-exist)", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/32067
-it.if(!isWindows)(
-  "spawn with pipe fds above Darwin OPEN_MAX reports EBADF instead of losing output",
-  async () => {
-    const script = /* js */ `
+it.if(!isWindows)("spawn with pipe fds above Darwin OPEN_MAX reports EBADF instead of losing output", async () => {
+  const script = /* js */ `
       const fs = require("fs");
       const { spawn, spawnSync } = require("child_process");
 
@@ -510,41 +508,40 @@ it.if(!isWindows)(
       console.log(JSON.stringify({ setup, sync, async: asyncResult }));
     `;
 
-    await using proc = Bun.spawn({
-      // The repro needs more open fds than some environments allow by
-      // default; raise the soft limit before exec'ing bun (which raises it
-      // further on startup).
-      cmd: ["/bin/sh", "-c", `ulimit -Sn 12000 2>/dev/null; exec "$1" -e "$2"`, "sh", bunExe(), script],
-      env: bunEnv,
-      stdin: "ignore",
-      stdout: "pipe",
-      stderr: "pipe",
+  await using proc = Bun.spawn({
+    // The repro needs more open fds than some environments allow by
+    // default; raise the soft limit before exec'ing bun (which raises it
+    // further on startup).
+    cmd: ["/bin/sh", "-c", `ulimit -Sn 12000 2>/dev/null; exec "$1" -e "$2"`, "sh", bunExe(), script],
+    env: bunEnv,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  let result: any;
+  try {
+    result = JSON.parse(stdout);
+  } catch {
+    throw new Error(`child did not produce a result; stdout: ${JSON.stringify(stdout)} stderr: ${stderr}`);
+  }
+
+  if (process.platform === "darwin") {
+    // Darwin's posix_spawn file actions reject fds >= OPEN_MAX (10240)
+    // with EBADF. The spawn must fail the way node's does, not run a child
+    // with closed stdio that looks like a successful run with empty output.
+    expect(result).toEqual({
+      setup: "ok",
+      sync: { status: null, stdout: null, error: "EBADF" },
+      async: { outcome: "throw", code: "EBADF" },
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    let result: any;
-    try {
-      result = JSON.parse(stdout);
-    } catch {
-      throw new Error(`child did not produce a result; stdout: ${JSON.stringify(stdout)} stderr: ${stderr}`);
-    }
-
-    if (process.platform === "darwin") {
-      // Darwin's posix_spawn file actions reject fds >= OPEN_MAX (10240)
-      // with EBADF. The spawn must fail the way node's does, not run a child
-      // with closed stdio that looks like a successful run with empty output.
-      expect(result).toEqual({
-        setup: "ok",
-        sync: { status: null, stdout: null, error: "EBADF" },
-        async: { outcome: "throw", code: "EBADF" },
-      });
-    } else {
-      expect(result).toEqual({
-        setup: "ok",
-        sync: { status: 0, stdout: "hi\n", error: null },
-        async: { outcome: "exit", code: 0 },
-      });
-    }
-    expect(exitCode).toBe(0);
-  },
-);
+  } else {
+    expect(result).toEqual({
+      setup: "ok",
+      sync: { status: 0, stdout: "hi\n", error: null },
+      async: { outcome: "exit", code: 0 },
+    });
+  }
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, spawn, spawnSync } from "node:child_process";
 import { promisify } from "node:util";
 import path from "path";
@@ -472,13 +472,48 @@ it("spawnSync(does-not-exist)", () => {
 });
 
 // https://github.com/oven-sh/bun/issues/32067
-it.if(!isWindows)("spawn with pipe fds above Darwin OPEN_MAX reports EBADF instead of losing output", async () => {
+// Darwin's posix_spawn file actions reject any fd number >= OPEN_MAX (10240)
+// with EBADF at registration time, before checking whether the fd is open.
+// Bun used to swallow that error and spawn anyway with the action silently
+// dropped, so the child ran with closed stdio and looked like a successful
+// run that produced no output. The spawn must fail with EBADF, matching
+// node. On other POSIX platforms the child-side dup2 of an fd that is not
+// open fails with EBADF, so the observable behavior is the same.
+it.if(!isWindows)("spawn with an fd number at Darwin OPEN_MAX in stdio reports EBADF", () => {
+  // Precondition: fd 10240 is not open in this process, so the fd is
+  // invalid on every platform (on Darwin it is invalid by number alone).
+  expect(() => fs.fstatSync(10240)).toThrow();
+
+  const r = spawnSync("echo", ["hi"], { stdio: ["ignore", "pipe", "pipe", 10240] });
+  expect({
+    status: r.status ?? null,
+    stdout: r.stdout?.toString() ?? null,
+    error: r.error?.code ?? null,
+  }).toEqual({ status: null, stdout: null, error: "EBADF" });
+
+  // Async spawn throws synchronously: EBADF is not in node's delayed-error
+  // list (EACCES/EAGAIN/EMFILE/ENFILE/ENOENT), so node throws here too.
+  let asyncCode: string | undefined;
+  try {
+    spawn("echo", ["hi"], { stdio: ["ignore", "pipe", "pipe", 10240] });
+  } catch (err: any) {
+    asyncCode = err.code;
+  }
+  expect(asyncCode).toBe("EBADF");
+});
+
+// https://github.com/oven-sh/bun/issues/32067
+// The fd-pressure variant of the case above: with more than 10240 fds open,
+// freshly created stdio pipes get numbers past OPEN_MAX. Linux has no such
+// cap, so spawning must keep working. The test is Linux-only because default
+// macOS installs cap RLIMIT_NOFILE at kern.maxfilesperproc = 10240, which
+// makes it impossible to open this many fds there (the Darwin EBADF surface
+// is covered by the test above, which needs no fd pressure).
+it.if(isLinux)("spawn still works with more than 10240 fds open", async () => {
   const script = /* js */ `
       const fs = require("fs");
       const { spawn, spawnSync } = require("child_process");
 
-      // Occupy fd numbers up to ~11000 so the stdio pipes created by spawn
-      // get fd numbers above Darwin's OPEN_MAX (10240).
       let opened = 0;
       let setup = "ok";
       try {
@@ -509,10 +544,7 @@ it.if(!isWindows)("spawn with pipe fds above Darwin OPEN_MAX reports EBADF inste
     `;
 
   await using proc = Bun.spawn({
-    // The repro needs more open fds than some environments allow by
-    // default; raise the soft limit before exec'ing bun (which raises it
-    // further on startup).
-    cmd: ["/bin/sh", "-c", `ulimit -Sn 12000 2>/dev/null; exec "$1" -e "$2"`, "sh", bunExe(), script],
+    cmd: [bunExe(), "-e", script],
     env: bunEnv,
     stdin: "ignore",
     stdout: "pipe",
@@ -527,21 +559,10 @@ it.if(!isWindows)("spawn with pipe fds above Darwin OPEN_MAX reports EBADF inste
     throw new Error(`child did not produce a result; stdout: ${JSON.stringify(stdout)} stderr: ${stderr}`);
   }
 
-  if (process.platform === "darwin") {
-    // Darwin's posix_spawn file actions reject fds >= OPEN_MAX (10240)
-    // with EBADF. The spawn must fail the way node's does, not run a child
-    // with closed stdio that looks like a successful run with empty output.
-    expect(result).toEqual({
-      setup: "ok",
-      sync: { status: null, stdout: null, error: "EBADF" },
-      async: { outcome: "throw", code: "EBADF" },
-    });
-  } else {
-    expect(result).toEqual({
-      setup: "ok",
-      sync: { status: 0, stdout: "hi\n", error: null },
-      async: { outcome: "exit", code: 0 },
-    });
-  }
+  expect(result).toEqual({
+    setup: "ok",
+    sync: { status: 0, stdout: "hi\n", error: null },
+    async: { outcome: "exit", code: 0 },
+  });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #32067.

### Repro

On macOS, with more than OPEN_MAX (10240) fds open:

```js
const fs = require("fs");
const { spawnSync } = require("child_process");
for (let i = 0; i < 11000; i++) fs.openSync("/dev/null", "r");
const r = spawnSync("echo", ["hi"], { stdio: ["ignore", "pipe", "pipe"] });
```

- bun 1.3.14: `{ status: 1, stdout: "", error: null }` (silent output loss; some binaries even exit 0 with empty stdout)
- node: `{ status: null, stdout: null, error: 'EBADF' }`

### Cause

Non-PTY spawns on macOS go through the system `posix_spawn`. Darwin's `posix_spawn_file_actions_adddup2` (and the other file-action registration calls) return EBADF for any fd >= OPEN_MAX (10240, hardcoded in `sys/syslimits.h`), independent of RLIMIT_NOFILE. In `spawn_z` (`src/spawn_sys/posix_spawn.rs`) every registration error was debug-logged and dropped, then `posix_spawn` ran anyway. Because Bun sets `POSIX_SPAWN_CLOEXEC_DEFAULT`, the silently missing dup2 meant the child executed with its stdio fds closed: the pipe's parent end hit immediate EOF, so the child looked like a successful run that produced no output. libuv checks these return values, which is why node reports EBADF.

### Fix

The `PosixSpawnActions` / `PosixSpawnAttr` wrappers now return `sys::Result` carrying the real errno, and `spawn_z` propagates any registration failure as a spawn error (same channel as an ENOENT from `posix_spawn` itself). The load-bearing change is the new `convert_spawn_objects` helper replacing the swallow-and-continue loop; the rest is the signature change from `bun_core::Error` to `bun_sys::Error` so the errno survives. The now-unused errno constants, `unexpected_errno`, and the byte-slice `chdir` wrapper are deleted.

After the fix, `spawnSync` returns `error.code === "EBADF"` and async `spawn` throws EBADF synchronously, both matching node (EBADF is not in node's delayed-error list, so node also throws rather than emitting `error`).

The issue also mentions that `bun test` filter mode holds repo-scan directory fds during test execution, which is what pushed pipe fds above 10240 in the first place. That retention is the resolver's deliberate fd cache (`FileSystem::need_to_close_files`), and this PR does not change it; with this fix the condition now surfaces as a clear EBADF instead of silent empty output.

### Verification

Two tests in `test/js/node/child_process/child_process.test.ts`:

1. All POSIX platforms: `spawnSync`/`spawn` with a numeric stdio fd of 10240. Darwin's `posix_spawn_file_actions_adddup2` rejects any fd number >= OPEN_MAX at registration time, before checking whether the fd is open, so this hits the exact swallow site deterministically with no fd exhaustion. Expectation is uniform (`error.code === "EBADF"` for sync, synchronous EBADF throw for async, matching node on both platforms; on Linux the child-side dup2 of a not-open fd produces the same EBADF). On an unfixed macOS build this "succeeds" silently, so it fails before the fix there.
2. Linux only: the issue's original fd-pressure scenario (open ~11000 fds, then spawn with piped stdio) asserting spawns keep working. It is Linux-only because default macOS installs cap RLIMIT_NOFILE at `kern.maxfilesperproc` = 10240, which makes it impossible to exceed OPEN_MAX open fds there at all (the first CI run confirmed this: the child hit EMFILE after 10236 fds on the darwin lane). On machines with a raised sysctl, like the reporter's, the condition arises organically and is covered by the mechanism test above.

Note for the fail-before check: the buggy code is inside `#[cfg(target_os = "macos")]` and the Darwin OPEN_MAX registration behavior does not exist on Linux, so the failing branch of test 1 cannot execute on a Linux machine. macOS CI exercises it.

- `cargo check --workspace` clean on x86_64/aarch64-apple-darwin and the Linux host target
- Full `child_process.test.ts` run: only pre-existing failures also present on main (`$SHELL`-dependent tests)


### Related

#24690 reports the same mechanism (empty subprocess output inside `bun test` on macOS; its thread confirms fd counts above 10240 during test discovery). This PR intentionally does not auto-close it: after this change that scenario fails loudly with EBADF instead of silently returning empty output, but the spawn still does not succeed until the test runner's fd retention is addressed, and one report in that thread is on Linux, which this bug cannot explain.

