### PR TITLE
dev server: fix stale JSON and CommonJS exports after hot reload

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -301,6 +301,10 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
         require: mod.require.bind(this),
       };
       mod.exports = null;
+    } else {
+      // Reloading a stale CommonJS module. Drop the memoized ESM namespace
+      // (`getEsmExports`) so importers observe the re-evaluated exports.
+      mod.exports = null;
     }
     if (importer) {
       mod.importers.add(importer);
@@ -400,6 +404,10 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         exports: {},
         require: mod.require.bind(this),
       };
+      mod.exports = null;
+    } else {
+      // Reloading a stale CommonJS module. Drop the memoized ESM namespace
+      // (`getEsmExports`) so importers observe the re-evaluated exports.
       mod.exports = null;
     }
     if (importer) {
@@ -748,14 +756,22 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Reload all modules
+  // Reload all modules. Mark everything stale and detach the accept handlers
+  // before reloading anything: `toReload` is in discovery order, which may
+  // visit an importer before one of its dependencies. A reloading importer
+  // then re-evaluates any still-stale dependency on demand, instead of
+  // reusing the previous module instance and its exports.
   const promises: Promise<HMRModule>[] = [];
+  const selfAccepts: (HotAcceptFunction | null)[] = [];
   for (const mod of toReload) {
     mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
+    selfAccepts.push(mod.selfAccept);
     mod.selfAccept = null;
     mod.depAccepts = null;
-
+  }
+  let reloadIndex = 0;
+  for (const mod of toReload) {
+    const selfAccept = selfAccepts[reloadIndex++];
     const modOrPromise = loadModuleAsync(mod.id, false, null);
     if (modOrPromise === mod) {
       if (selfAccept) {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -527,3 +527,43 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
     }
   },
 });
+devTest("hot reload of an imported json file updates the value", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import data from "./data.json";
+      console.log("value=" + data.value);
+      import.meta.hot.accept();
+    `,
+    "data.json": `{ "value": 1 }`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("value=1");
+    await dev.write("data.json", `{ "value": 2 }`);
+    await c.expectMessage("value=2");
+    await dev.write("data.json", `{ "value": 3 }`);
+    await c.expectMessage("value=3");
+  },
+});
+devTest("hot reload of a CommonJS module updates exports seen by importers", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import data from "./data.cjs";
+      console.log("value=" + data.value);
+      import.meta.hot.accept();
+    `,
+    "data.cjs": `module.exports = { value: 1 };`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("value=1");
+    await dev.write("data.cjs", `module.exports = { value: 2 };`);
+    await c.expectMessage("value=2");
+  },
+});

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -528,6 +528,7 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
   },
 });
 devTest("hot reload of an imported json file updates the value", {
+  // https://github.com/oven-sh/bun/issues/24067
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
@@ -549,6 +550,7 @@ devTest("hot reload of an imported json file updates the value", {
   },
 });
 devTest("hot reload of a CommonJS module updates exports seen by importers", {
+  // https://github.com/oven-sh/bun/issues/24067
   files: {
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],


### PR DESCRIPTION
### Problem

In the full-stack dev server (`Bun.serve` with an HTML route and `development: { hmr: true }`), editing an imported `.json` file fires a hot update and re-runs the importing module, but the importer keeps seeing the JSON value parsed at the first bundle, frozen forever (not even one edit behind). Only a full page reload picks up the change:

```tsx
// data.json: { "value": 1 }
import data from './data.json';
console.log(data.value); // stays 1 after every edit to data.json
```

The same staleness applies to any CommonJS-format module (`module.exports = ...`) under HMR. From a user field report on Discord (observed on 1.3.14, reproduces on current main).

### Cause

Two client-runtime bugs in `src/runtime/bake/hmr-module.ts` stack up:

1. JSON compiles to a CommonJS-style module in dev (`hmr.cjs.exports = {...}`). `getEsmExports` memoizes the ESM namespace for CJS modules (`m.exports ??= toESM(m.cjs.exports)`), and the CJS reload path never drops the memo. Importers are therefore patched with the namespace built from the first-ever `cjs.exports` object. The ESM reload path does not have this problem because an ESM module's load function assigns a fresh exports object on every run.

2. `replaceModules` marked each module stale one at a time inside the reload loop. `toReload` is in discovery order, and for asset-content files (JSON) the hot chunk lists the rebuilt importer before the changed file, so the importer re-ran while `data.json` was still `State.Loaded` and reused the previous module instance. (Plain JS edits dodge this because only the edited file is rebuilt, so it lands first in the chunk.)

### Fix

- `loadModuleSync` / `loadModuleAsync`: when reloading a stale module that stays CommonJS, reset the memoized ESM namespace so `getEsmExports` rebuilds it from the re-evaluated exports.
- `replaceModules`: mark every module in `toReload` stale (and capture + clear accept handlers) before starting any reload. A reloading importer then re-evaluates still-stale dependencies on demand, which yields dependency-before-importer order naturally regardless of chunk key order.

### Verification

Two new tests in `test/bake/dev/hot.test.ts`, both fail on the unfixed build (importer logs `value=1` after the file was edited to `{ "value": 2 }`):

- `hot reload of an imported json file updates the value`: requires both hunks (chunk lists the importer first, so it needs the upfront stale marking, and the rebuilt JSON needs the namespace reset).
- `hot reload of a CommonJS module updates exports seen by importers`: isolates the namespace memo reset.

`test/bake/dev` hot, esm, react-spa, css, bundle, and html suites all pass with the fix.


Fixes #24067
