### PR TITLE
ci: automatically retry jobs killed by timeout or agent loss (once)

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -306,7 +306,17 @@ function getRetry() {
     manual: {
       permit_on_passed: true,
     },
-    automatic: false,
+    // Self-heal infra deaths once instead of leaving the build failed until a
+    // human notices and clicks retry:
+    //   -1  = agent lost / process killed (box died, agent restarted)
+    //   255 = step timeout kill (timeout_in_minutes SIGTERM cascade)
+    // User-canceled jobs are state=canceled, which never triggers automatic
+    // retry, so this cannot resurrect deliberately canceled builds. limit: 1
+    // caps the cost when a suite genuinely crashes with these statuses.
+    automatic: [
+      { exit_status: -1, limit: 1 },
+      { exit_status: 255, limit: 1 },
+    ],
   };
 }
 


### PR DESCRIPTION
## What
`getRetry()` had `automatic: false` — no automatic retries anywhere in the pipeline. This adds a single automatic retry for the two infra failure modes:
- `exit_status: -1` — agent lost / process killed (box death, agent restart)
- `exit_status: 255` — `timeout_in_minutes` kill (SIGTERM cascade)

## Why
A shard killed by step timeout or agent loss currently leaves the build **failed until a human notices and manually retries** — on a busy day that's hours of lost signal for an infra blip that a fresh agent would have absorbed. Several recent builds (61534, 61779) died exactly this way: shards timed out during an agent-pool crunch and sat dead.

## Safety
- User-canceled jobs are `state=canceled`, which never triggers automatic retry — deliberately canceled builds stay canceled
- `limit: 1` bounds the cost if a suite genuinely dies with these statuses
- `manual.permit_on_passed` behavior unchanged