### PR TITLE
Fix duplicate clientNavigated inspector events on successful SetUrl

### DIFF
--- a/src/runtime/bake/DevServer/HmrSocket.rs
+++ b/src/runtime/bake/DevServer/HmrSocket.rs
@@ -206,7 +206,6 @@ impl HmrSocket {
                 response[1..].copy_from_slice(&rbi.get().to_ne_bytes());
 
                 let _ = ws.send(&response, Opcode::Binary, false, true);
-                self.notify_inspector_client_navigation(pattern, Some(rbi));
             }
             x if x == IncomingMessageId::TestingBatchEvents as u8 => {
                 // SAFETY: JS-thread only; sole `&mut DevServer` for this scope.
@@ -384,26 +383,5 @@ impl HmrSocket {
         // SAFETY: `s` was heap-allocated in `new()`'s caller; this is the sole
         // owner reclaiming it. Matches `s.dev.arena().destroy(s)`.
         drop(unsafe { bun_core::heap::take(s) });
-    }
-
-    fn notify_inspector_client_navigation(
-        &self,
-        pattern: &[u8],
-        rbi: super::route_bundle::IndexOptional,
-    ) {
-        if self.inspector_connection_id > -1 {
-            // SAFETY: JS-thread only; sole `&mut DevServer` for this scope.
-            let dev = unsafe { self.dev() };
-            if let Some(agent) = dev.inspector() {
-                let mut pattern_str = bun_core::String::init(pattern);
-                // `defer pattern_str.deref()` → Drop on bun_core::String
-                agent.notify_client_navigated(
-                    dev.inspector_server_id,
-                    self.inspector_connection_id,
-                    &mut pattern_str,
-                    rbi.map(|i| i.get() as i32).unwrap_or(-1),
-                );
-            }
-        }
     }
 }

--- a/test/cli/inspect/BunFrontendDevServer.test.ts
+++ b/test/cli/inspect/BunFrontendDevServer.test.ts
@@ -513,6 +513,41 @@ describe.if(isPosix)("BunFrontendDevServer inspector protocol", () => {
     ws.close();
   });
 
+  test("sends exactly one clientNavigated event per SetUrl message", async () => {
+    // https://github.com/oven-sh/bun/issues/32080
+    await fetch(serverUrl.href).then(r => r.blob());
+
+    const connectedEventPromise = session.waitForEvent("BunFrontendDevServer.clientConnected");
+    const ws = await createHMRClient();
+    const { connectionId } = await connectedEventPromise;
+
+    const navigated: any[] = [];
+    const { promise: sawSentinelNavigation, resolve, reject } = Promise.withResolvers<void>();
+    session.addEventListener("BunFrontendDevServer.clientNavigated", (params: any) => {
+      if (params.connectionId !== connectionId) return;
+      navigated.push(params);
+      if (params.url === "/does-not-exist") resolve();
+    });
+    ws.addEventListener("close", e => reject(new Error(`HMR socket closed unexpectedly: ${e.code}`)));
+    ws.addEventListener("error", () => reject(new Error("HMR socket error")));
+
+    // Navigate to a matched route, then to an unknown one. The server handles
+    // the messages in order and emits inspector events synchronously, so once
+    // the event for the unknown route arrives, every event for "/second" has
+    // been delivered.
+    ws.send("n" + "/second");
+    ws.send("n" + "/does-not-exist");
+    await sawSentinelNavigation;
+
+    expect(navigated).toEqual([
+      { serverId: expect.any(Number), connectionId, url: "/second", routeBundleId: 1 },
+      // Failed lookups report a single event with no routeBundleId.
+      { serverId: expect.any(Number), connectionId, url: "/does-not-exist" },
+    ]);
+
+    ws.close();
+  });
+
   test("should notify on consoleLog events", async () => {
     await fetch(serverUrl.href).then(r => r.blob());
 

--- a/test/cli/inspect/BunFrontendDevServer.test.ts
+++ b/test/cli/inspect/BunFrontendDevServer.test.ts
@@ -515,37 +515,41 @@ describe.if(isPosix)("BunFrontendDevServer inspector protocol", () => {
 
   test("sends exactly one clientNavigated event per SetUrl message", async () => {
     // https://github.com/oven-sh/bun/issues/32080
+    // Request "/" first so its route bundle takes index 0 and "/second" below
+    // deterministically gets index 1, even when this test runs in isolation.
     await fetch(serverUrl.href).then(r => r.blob());
 
     const connectedEventPromise = session.waitForEvent("BunFrontendDevServer.clientConnected");
     const ws = await createHMRClient();
-    const { connectionId } = await connectedEventPromise;
+    try {
+      const { connectionId } = await connectedEventPromise;
 
-    const navigated: any[] = [];
-    const { promise: sawSentinelNavigation, resolve, reject } = Promise.withResolvers<void>();
-    session.addEventListener("BunFrontendDevServer.clientNavigated", (params: any) => {
-      if (params.connectionId !== connectionId) return;
-      navigated.push(params);
-      if (params.url === "/does-not-exist") resolve();
-    });
-    ws.addEventListener("close", e => reject(new Error(`HMR socket closed unexpectedly: ${e.code}`)));
-    ws.addEventListener("error", () => reject(new Error("HMR socket error")));
+      const navigated: any[] = [];
+      const { promise: sawSentinelNavigation, resolve, reject } = Promise.withResolvers<void>();
+      session.addEventListener("BunFrontendDevServer.clientNavigated", (params: any) => {
+        if (params.connectionId !== connectionId) return;
+        navigated.push(params);
+        if (params.url === "/does-not-exist") resolve();
+      });
+      ws.addEventListener("close", e => reject(new Error(`HMR socket closed unexpectedly: ${e.code}`)));
+      ws.addEventListener("error", () => reject(new Error("HMR socket error")));
 
-    // Navigate to a matched route, then to an unknown one. The server handles
-    // the messages in order and emits inspector events synchronously, so once
-    // the event for the unknown route arrives, every event for "/second" has
-    // been delivered.
-    ws.send("n" + "/second");
-    ws.send("n" + "/does-not-exist");
-    await sawSentinelNavigation;
+      // Navigate to a matched route, then to an unknown one. The server handles
+      // the messages in order and emits inspector events synchronously, so once
+      // the event for the unknown route arrives, every event for "/second" has
+      // been delivered.
+      ws.send("n" + "/second");
+      ws.send("n" + "/does-not-exist");
+      await sawSentinelNavigation;
 
-    expect(navigated).toEqual([
-      { serverId: expect.any(Number), connectionId, url: "/second", routeBundleId: 1 },
-      // Failed lookups report a single event with no routeBundleId.
-      { serverId: expect.any(Number), connectionId, url: "/does-not-exist" },
-    ]);
-
-    ws.close();
+      expect(navigated).toEqual([
+        { serverId: expect.any(Number), connectionId, url: "/second", routeBundleId: 1 },
+        // Failed lookups report a single event with no routeBundleId.
+        { serverId: expect.any(Number), connectionId, url: "/does-not-exist" },
+      ]);
+    } finally {
+      ws.close();
+    }
   });
 
   test("should notify on consoleLog events", async () => {


### PR DESCRIPTION
Fixes #32080

### Problem

The HMR socket's `SetUrl` handler notified the inspector's `BunFrontendDevServer.clientNavigated` twice for a successful navigation to a new route bundle: once inline right after `route_to_bundle_index_slow`, and again via `notify_inspector_client_navigation` after `SetUrlResponse` was sent. Both events carried identical payloads. One `SetUrl` message over `/_bun/hmr` produced:

```
{"serverId":0,"connectionId":0,"url":"/second","routeBundleId":1}
{"serverId":0,"connectionId":0,"url":"/second","routeBundleId":1}
```

The failed-lookup and same-route paths correctly sent a single event. Both calls date back to the original inspector support in 570e6b7e6a (#19340); the Rust port reproduced the behavior faithfully.

### Fix

Remove the trailing `notify_inspector_client_navigation` call in the `SetUrl` arm of `HmrSocket::on_message`. The inline notify already fires exactly once for every `SetUrl`, with the correct `routeBundleId` on all three paths (new route, same route, failed lookup with `routeBundleId` absent). The helper had no remaining callers, so it is deleted.

Note: this issue surfaced during review of #32076, which has since merged; this branch is rebased on top of it.

### Verification

New test in `test/cli/inspect/BunFrontendDevServer.test.ts` sends one `SetUrl` for a matched route followed by one for an unknown route (an ordering sentinel, since inspector events are emitted synchronously and delivered in order), then asserts exactly one `clientNavigated` per message, including that the failed lookup still reports a single event with no `routeBundleId`.

On the unfixed build the test fails with two identical `/second` events; with the fix the whole file passes (6 pass, 2 todo).
