### PR TITLE
Fix crash when RedisClient onclose/onconnect is set to a non-callable

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1275,7 +1275,9 @@ impl JSValkeyClient {
             };
             Js::hello_set_cached(this_value, &global_object, hello_value);
             // Call onConnect callback if defined by the user
-            if let Some(on_connect) = Js::onconnect_get_cached(this_value) {
+            if let Some(on_connect) =
+                Js::onconnect_get_cached(this_value).filter(|cb| cb.is_callable())
+            {
                 let js_value = this_value;
                 js_value.ensure_still_alive();
                 global_object.queue_microtask(on_connect, &[js_value, hello_value]);
@@ -1430,7 +1432,7 @@ impl JSValkeyClient {
         }
 
         // Call onClose callback if it exists
-        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue) {
+        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue).filter(|cb| cb.is_callable()) {
             on_close.call(&global_object, this_jsvalue, &[error_value])?;
         }
         Ok(())

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, RedisClient, spawn } from "bun";
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { bunExe, bunRun } from "harness";
+import { bunEnv, bunExe, bunRun } from "harness";
 import { join } from "node:path";
 import {
   ctx as _ctx,
@@ -7577,5 +7577,105 @@ describe("RedisClient command methods", () => {
     "xsetid",
   ] as const)("RedisClient.prototype.%s is a function", name => {
     expect(typeof RedisClient.prototype[name]).toBe("function");
+  });
+});
+
+// These tests don't need a real Redis server: they use in-process TCP
+// listeners to drive the client's connect/close paths.
+describe.concurrent("RedisClient onclose/onconnect handler values", () => {
+  // Accepts the connection, then immediately closes it, so the client runs
+  // its close path (which invokes onclose) without a Redis server.
+  const closingServer = `
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { open(s) { s.end(); }, data() {} },
+    });
+  `;
+
+  // Replies to HELLO with an empty RESP3 map, enough for the client to
+  // consider the connection established (which invokes onconnect).
+  const helloServer = `
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { open() {}, data(s) { s.write("%0\\r\\n"); } },
+    });
+  `;
+
+  async function expectChildOk(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, stderr: stderr.includes("ASSERTION FAILED") ? stderr : "" }).toEqual({
+      stdout: "ok",
+      exitCode: 0,
+      stderr: "",
+    });
+  }
+
+  test.each(["{}", "42", "null", "undefined", '"not a function"'])(
+    "assigning %s to onclose does not crash when the connection closes",
+    async value => {
+      await expectChildOk(`
+        ${closingServer}
+        const client = new Bun.RedisClient("redis://127.0.0.1:" + server.port, { maxRetries: 0 });
+        client.onclose = ${value};
+        try { await client.connect(); } catch {}
+        console.log("ok");
+      `);
+    },
+  );
+
+  test("assigning a non-callable to onconnect does not crash on successful connect", async () => {
+    await expectChildOk(`
+      ${helloServer}
+      const client = new Bun.RedisClient("redis://127.0.0.1:" + server.port);
+      client.onconnect = {};
+      await client.connect();
+      client.close();
+      console.log("ok");
+    `);
+  });
+
+  test("callable onclose still receives the connection error", async () => {
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(s) {
+          s.end();
+        },
+        data() {},
+      },
+    });
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { maxRetries: 0 });
+    const { promise, resolve } = Promise.withResolvers<Error>();
+    client.onclose = resolve;
+    client.connect().catch(() => {});
+    expect(await promise).toBeInstanceOf(Error);
+  });
+
+  test("callable onconnect still fires after connecting", async () => {
+    using server = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open() {},
+        data(s) {
+          s.write("%0\r\n");
+        },
+      },
+    });
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`);
+    const { promise, resolve } = Promise.withResolvers<void>();
+    client.onconnect = () => resolve();
+    await client.connect();
+    await promise;
+    client.close();
   });
 });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -7611,7 +7611,10 @@ describe.concurrent("RedisClient onclose/onconnect handler values", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode, stderr: stderr.includes("ASSERTION FAILED") ? stderr : "" }).toEqual({
+    // stderr is only compared when the child failed, so the failure diff
+    // carries the crash output without requiring exactly-empty stderr on
+    // debug/ASAN builds (which may emit benign warnings).
+    expect({ stdout: stdout.trim(), exitCode, stderr: exitCode === 0 ? "" : stderr }).toEqual({
       stdout: "ok",
       exitCode: 0,
       stderr: "",
@@ -7666,10 +7669,14 @@ describe.concurrent("RedisClient onclose/onconnect handler values", () => {
       },
     });
     const client = new RedisClient(`redis://127.0.0.1:${server.port}`, { maxRetries: 0 });
-    const { promise, resolve } = Promise.withResolvers<Error>();
-    client.onclose = resolve;
-    client.connect().catch(() => {});
-    expect(await promise).toBeInstanceOf(Error);
+    try {
+      const { promise, resolve } = Promise.withResolvers<Error>();
+      client.onclose = resolve;
+      client.connect().catch(() => {});
+      expect(await promise).toBeInstanceOf(Error);
+    } finally {
+      client.close();
+    }
   });
 
   test("callable onconnect still fires after connecting", async () => {
@@ -7684,10 +7691,13 @@ describe.concurrent("RedisClient onclose/onconnect handler values", () => {
       },
     });
     const client = new RedisClient(`redis://127.0.0.1:${server.port}`);
-    const { promise, resolve } = Promise.withResolvers<void>();
-    client.onconnect = () => resolve();
-    await client.connect();
-    await promise;
-    client.close();
+    try {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      client.onconnect = () => resolve();
+      await client.connect();
+      await promise;
+    } finally {
+      client.close();
+    }
   });
 });

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -7642,6 +7642,18 @@ describe.concurrent("RedisClient onclose/onconnect handler values", () => {
     `);
   });
 
+  // https://github.com/oven-sh/bun/issues/29145
+  test("assigning null to onclose does not crash on a manual close() after connecting", async () => {
+    await expectChildOk(`
+      ${helloServer}
+      const client = new Bun.RedisClient("redis://127.0.0.1:" + server.port);
+      await client.connect();
+      client.onclose = null;
+      client.close();
+      console.log("ok");
+    `);
+  });
+
   test("callable onclose still receives the connection error", async () => {
     using server = Bun.listen({
       hostname: "127.0.0.1",


### PR DESCRIPTION
### What does this PR do?

Fixes #29145

Fixes a crash found by fuzzing (fingerprint `2aea0593fbc3536c`). The same defect was independently reported in #29145 (`client.onclose = null` panics on the next `close()` with "A JavaScript exception was thrown, but it was cleared before it could be read").

`RedisClient.prototype.onclose` and `.onconnect` store whatever value is assigned (the generated cached-property setter does no validation), but the native close and connect paths invoked the stored value unconditionally:

- `on_valkey_close` called `onclose` via `JSValue::call`, which hits `ASSERTION FAILED: Function passed to .call must be callable.` in `Bun__JSValue__call` (bindings.cpp:2985) on debug builds, and crashes release builds in the error-reporting path that follows the empty return.
- `on_valkey_connect` passed `onconnect` to `queue_microtask`, which hits `ASSERTION FAILED: queueMicrotask must be called with an async context frame or a callable.` (bindings.cpp:5708) on debug builds.

Any non-callable triggers it, including `null`, which the published types (`packages/bun-types/redis.d.ts`) explicitly allow for clearing the handler:

```js
const client = new Bun.RedisClient("redis://127.0.0.1:6399", { maxRetries: 0 });
client.onclose = null; // or {}, 42, undefined, "str"
client.connect().catch(() => {});
// aborts when the connection closes
```

The crash fires whenever the connection closes or connects, which can be seconds after the assignment (for example the 10s connection timeout), so in the fuzzer's REPRL harness it often landed while an unrelated later script was executing. That is why the minimized reproducer looked unrelated and the crash was flagged flaky.

The fix guards the invocation sites in `src/runtime/valkey_jsc/js_valkey.rs` so only callable values are invoked, matching how event-handler properties behave elsewhere. Setter behavior is unchanged (values still round-trip through the getter).

Rebase note: this PR originally guarded three sites. #39513 removed the third one (`JSValkeyClient::fail_with_js_value`, which also invoked `onclose` from the reconnect error path) and routes that path through `on_valkey_close` instead, so after the rebase onto current main the diff is the two remaining sites, `on_valkey_connect` and `on_valkey_close`, which are the only reads of these slots left in the crate.

The same cached onclose/onconnect pattern exists in the Postgres and MySQL connection classes, but those slots are only written by internal JS (`src/js/internal/sql/*.ts`) which always passes its own bound methods, and the native connection objects are not reachable from user code, so they are left unchanged.

### How did you verify your code works?

- `test/js/valkey/valkey.test.ts` gains a `RedisClient onclose/onconnect handler values` block that needs no Redis server (in-process TCP listeners drive the close and connect paths). The non-callable cases spawn subprocesses since the bug is a process abort.
- Fails on the unfixed build: the five onclose cases crash both the release build (`USE_SYSTEM_BUN=1 bun test`: 5 fail, children die with exit 132) and debug builds; the onconnect case aborts unfixed debug builds with the queueMicrotask assertion (verified by stashing the fix and rebuilding).
- Passes with `bun bd test test/js/valkey/valkey.test.ts -t "handler values"` (8 pass).
- The original fuzzer script runs to completion on the fixed debug build.
- Positive tests confirm callable onclose still receives the connection error and callable onconnect still fires.
- The repro from #29145 (assign `null`, then a manual `close()` on a connected client) is covered by a dedicated test; it crashes the unfixed release build with exit 132 and passes with this fix.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 992 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release without fix: 52 failed, 992 skipped
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME
(skip) Valkey Redis Client (tls) > Basic Operations > should rename a key with RENAME overwr
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 992 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/valkey/valkey.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/valkey/valkey.test.ts:
failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
Redis is not enabled, skipping tests
(skip) Valkey Redis Client (tls) > (unnamed)
(skip) Valkey Redis Client (tls) > Basic Operations > should keep process alive when connecting
(skip) Valkey Redis Client (tls) > Basic Operations > should set and get strings
(skip) Valkey Redis Client (tls) > Basic Operations > should test key existence
(skip) Valkey Redis Client (tls) > Basic Operations > should increment and decrement counters
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by specified amount with INCRBY
(skip) Valkey Redis Client (tls) > Basic Operations > should increment by float amount with INCRBYFLOAT
(skip) Valkey Redis Client (tls) > Basic Operations > should decrement by specified amount with DECRBY
(skip) Valkey Redis Clie
... (truncated)

release with fix: 992 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     892f065edb
  features     baseline

22 deps, 120 codegen, 1144 objects in 733ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1206] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [12.00ms]
[2/1206] gen ErrorCode+*.h
[3/1206] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1206] gen bindgenv2
[5/1206] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [18.00ms]
[6/1206] fetch tinycc
[tinycc] up to date
[7/1205] fetch zlib
[zlib] up to date
[8/1205] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[9/1205] gen .bind.ts → GeneratedBindings.cpp
[10/1205] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/valkey_jsc/js_valkey.rs |   6 +-
 test/js/valkey/valkey.test.ts       | 124 +++++++++++++++++++++++++++++++++++-
 2 files changed, 127 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/runtime/valkey_jsc/js_valkey.rs      4      6     14
test/js/valkey/valkey.test.ts            4      8     14
```

</details>

<!-- robobun:evidence:end -->
