### PR TITLE
Fix data loss and duplication after a partial writev in buffered socket writes

### DIFF
--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2468,6 +2468,8 @@ impl<const SSL: bool> NewSocket<SSL> {
                             )
                         };
                         let written: usize = usize::try_from(rc.max(0)).expect("int cast");
+                        self.bytes_written
+                            .set(self.bytes_written.get() + written as u64);
                         let leftover = total_to_write.saturating_sub(written);
                         if leftover == 0 {
                             self.buffered_data_for_node_net
@@ -2475,23 +2477,17 @@ impl<const SSL: bool> NewSocket<SSL> {
                             break 'brk rc;
                         }
 
-                        let buf_len = self.buffered_data_for_node_net.get().len() as usize;
-                        let remaining_in_buffered_len =
-                            self.buffered_data_for_node_net.get().slice()[written.min(buf_len)..]
-                                .len();
+                        let buf_len = self.buffered_data_for_node_net.get().len();
+                        // `write2` wrote the old buffered data first, then
+                        // `written - buf_len` bytes of the new input (zero when the
+                        // write stopped inside the old buffered data).
                         let remaining_in_input_data = &buffer.slice()
-                            [(buf_len.saturating_sub(written)).min(buffer.slice().len())..];
+                            [(written.saturating_sub(buf_len)).min(buffer.slice().len())..];
 
-                        if written > 0 {
-                            if remaining_in_buffered_len > 0 {
-                                self.buffered_data_for_node_net.with_mut(|b| {
-                                    // `remaining_in_buffered_len > 0` ⇒ `written < b.len()`,
-                                    // so `written..` is in-bounds; safe overlapping memmove.
-                                    b.copy_within(written.., 0);
-                                    b.truncate(remaining_in_buffered_len);
-                                });
-                            }
-                        }
+                        // Drop the prefix that hit the wire, keeping only the unsent
+                        // suffix (clears entirely when `written >= buf_len`).
+                        self.buffered_data_for_node_net
+                            .with_mut(|b| b.drain_front(written));
 
                         if !remaining_in_input_data.is_empty() {
                             // Result intentionally discarded

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1124,9 +1124,15 @@ describe.skipIf(isWindows)("socket write while data is buffered natively", () =>
   `;
 
   // Drives the native buffered-write path the same way net.ts's own stream
-  // machinery does: Socket.prototype._write -> handle.$write. The _write
-  // callback fires synchronously iff the kernel accepted the whole chunk, so
-  // a false return from writeDirect means bytes are now buffered natively.
+  // machinery does: Socket.prototype._write -> handle.$write, bypassing the
+  // Writable serialization so two writes reach the native layer while data is
+  // still buffered. writeDirect returns true iff the _write callback fired
+  // synchronously (kernel took the whole chunk); false means bytes are now
+  // buffered natively. The final write's callback is resolved only once the
+  // native buffer has fully drained (net.ts retries it on every drain event
+  // and fires it when the buffer empties), so we can end() without racing the
+  // flush: net.ts's _final half-closes via shutdown(), which discards any
+  // still-buffered bytes.
   const clientFixture = /* js */ `
     import net from "node:net";
     const phase = process.argv[2]; // "loss" | "dup"
@@ -1142,6 +1148,7 @@ describe.skipIf(isWindows)("socket write while data is buffered natively", () =>
       };
       const sent = { a: 0, i: 0, s: 0, other: 0 };
       let sawPartial = false;
+      let finalChunk;
       if (phase === "loss") {
         // Build a native remainder far larger than the kernel can accept in
         // one writev; the follow-up write's writev then always stops inside
@@ -1151,11 +1158,8 @@ describe.skipIf(isWindows)("socket write while data is buffered natively", () =>
           sawPartial = !writeDirect(A);
           sent.a += A.length;
         }
-        if (sawPartial) {
-          const S = Buffer.alloc(64 * 1024, 0x73);
-          writeDirect(S);
-          sent.s = S.length;
-        }
+        finalChunk = Buffer.alloc(64 * 1024, 0x73);
+        sent.s = finalChunk.length;
       } else {
         // Leave a small (< 1MB) native remainder...
         for (let attempt = 0; attempt < 64 && !sawPartial; attempt++) {
@@ -1163,25 +1167,30 @@ describe.skipIf(isWindows)("socket write while data is buffered natively", () =>
           sawPartial = !writeDirect(C);
           sent.a += C.length;
         }
-        if (sawPartial) {
-          // ...then block the event loop (so the native flush cannot run)
-          // while the peer drains the kernel buffers, and write a chunk the
-          // kernel will accept past the end of the buffered remainder
-          // (written > buffered.len).
-          Bun.sleepSync(1500);
-          const I = Buffer.alloc(32 * 1024 * 1024, 0x69);
-          writeDirect(I);
-          sent.i = I.length;
-        }
+        // ...then block the event loop (so the native flush cannot run) while
+        // the peer drains the kernel buffers, so the next writev accepts all
+        // of the buffered remainder plus a prefix of the new chunk
+        // (written > buffered.len).
+        if (sawPartial) Bun.sleepSync(1500);
+        finalChunk = Buffer.alloc(32 * 1024 * 1024, 0x69);
+        sent.i = finalChunk.length;
       }
       if (!sawPartial) {
         console.error("precondition failed: no direct write left data in the native buffer");
         sock.destroy();
         process.exit(3);
       }
+      // This write lands on the buffered path (the bug site). Its callback
+      // fires only once the whole native buffer has flushed to the peer.
+      const { promise: flushed, resolve } = Promise.withResolvers();
+      sock._write(finalChunk, "buffer", () => resolve());
+      // bytesWritten is flushed + still-buffered bytes, captured before the
+      // flush so it reflects everything handed to the native layer.
       sent.bw = sock.bytesWritten;
-      console.log(JSON.stringify(sent));
-      sock.end();
+      flushed.then(() => {
+        console.log(JSON.stringify(sent));
+        sock.end();
+      });
     });
     sock.on("error", err => {
       console.error("client socket error:", err);

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1064,7 +1064,11 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
 });
 
 // https://github.com/oven-sh/bun/issues/32087
-describe("socket write while data is buffered natively", () => {
+// The writev fast path under test is compiled only on POSIX (`#[cfg(unix)]` in
+// write_or_end_buffered); on Windows how much data a send accepts is machine
+// dependent, so the "data is buffered natively" precondition cannot be
+// constructed reliably there.
+describe.skipIf(isWindows)("socket write while data is buffered natively", () => {
   // Byte-counting sink. Counts received bytes per fill value by scanning runs
   // with indexOf so multi-MB streams stay cheap to verify in debug builds.
   // STALL_ON_ACCEPT=1 blocks the event loop on accept so nothing is read

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -1,7 +1,7 @@
 import { Socket as _BunSocket, TCPSocketListener } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tmpdirSync } from "harness";
+import { bunEnv, bunExe, expectMaxObjectTypeCount, isASAN, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import {
@@ -1061,4 +1061,199 @@ it.skipIf(isWindows)("connect({ localPort }) succeeds when the local port has TI
   } finally {
     target.close();
   }
+});
+
+// https://github.com/oven-sh/bun/issues/32087
+describe("socket write while data is buffered natively", () => {
+  // Byte-counting sink. Counts received bytes per fill value by scanning runs
+  // with indexOf so multi-MB streams stay cheap to verify in debug builds.
+  // STALL_ON_ACCEPT=1 blocks the event loop on accept so nothing is read
+  // while the client writes, keeping the kernel buffers full.
+  const serverFixture = /* js */ `
+    import net from "node:net";
+    const KNOWN = [0x61, 0x69, 0x73]; // 'a', 'i', 's'
+    const counts = { a: 0, i: 0, s: 0, other: 0 };
+    const runs = [];
+    let total = 0;
+    function scan(d) {
+      total += d.length;
+      let pos = 0;
+      while (pos < d.length) {
+        const byte = d[pos];
+        if (!KNOWN.includes(byte)) {
+          counts.other++;
+          pos++;
+          continue;
+        }
+        const ch = String.fromCharCode(byte);
+        let end = d.length;
+        for (const other of KNOWN) {
+          if (other === byte) continue;
+          const idx = d.indexOf(other, pos);
+          if (idx !== -1 && idx < end) end = idx;
+        }
+        counts[ch] += end - pos;
+        if (runs.length === 0 || runs[runs.length - 1] !== ch) runs.push(ch);
+        pos = end;
+      }
+    }
+    const server = net.createServer(c => {
+      c.on("data", scan);
+      let printed = false;
+      const done = () => {
+        if (printed) return;
+        printed = true;
+        console.log(JSON.stringify({ total, counts, runs }));
+        c.destroy();
+        server.close();
+      };
+      c.on("end", done);
+      c.on("close", done);
+      c.on("error", done);
+      if (process.env.STALL_ON_ACCEPT === "1") {
+        Bun.sleepSync(1500);
+      }
+    });
+    server.listen(0, "127.0.0.1", () => {
+      console.log(JSON.stringify({ port: server.address().port }));
+    });
+  `;
+
+  // Drives the native buffered-write path the same way net.ts's own stream
+  // machinery does: Socket.prototype._write -> handle.$write. The _write
+  // callback fires synchronously iff the kernel accepted the whole chunk, so
+  // a false return from writeDirect means bytes are now buffered natively.
+  const clientFixture = /* js */ `
+    import net from "node:net";
+    const phase = process.argv[2]; // "loss" | "dup"
+    const port = Number(process.argv[3]);
+    const sock = net.connect(port, "127.0.0.1", () => {
+      sock.setNoDelay(true);
+      const writeDirect = chunk => {
+        let fired = false;
+        sock._write(chunk, "buffer", () => {
+          fired = true;
+        });
+        return fired;
+      };
+      const sent = { a: 0, i: 0, s: 0, other: 0 };
+      let sawPartial = false;
+      if (phase === "loss") {
+        // Build a native remainder far larger than the kernel can accept in
+        // one writev; the follow-up write's writev then always stops inside
+        // the old buffered data (written < buffered.len).
+        for (let attempt = 0; attempt < 8 && !sawPartial; attempt++) {
+          const A = Buffer.alloc(16 * 1024 * 1024, 0x61);
+          sawPartial = !writeDirect(A);
+          sent.a += A.length;
+        }
+        if (sawPartial) {
+          const S = Buffer.alloc(64 * 1024, 0x73);
+          writeDirect(S);
+          sent.s = S.length;
+        }
+      } else {
+        // Leave a small (< 1MB) native remainder...
+        for (let attempt = 0; attempt < 64 && !sawPartial; attempt++) {
+          const C = Buffer.alloc(1024 * 1024, 0x61);
+          sawPartial = !writeDirect(C);
+          sent.a += C.length;
+        }
+        if (sawPartial) {
+          // ...then block the event loop (so the native flush cannot run)
+          // while the peer drains the kernel buffers, and write a chunk the
+          // kernel will accept past the end of the buffered remainder
+          // (written > buffered.len).
+          Bun.sleepSync(1500);
+          const I = Buffer.alloc(32 * 1024 * 1024, 0x69);
+          writeDirect(I);
+          sent.i = I.length;
+        }
+      }
+      if (!sawPartial) {
+        console.error("precondition failed: no direct write left data in the native buffer");
+        sock.destroy();
+        process.exit(3);
+      }
+      sent.bw = sock.bytesWritten;
+      console.log(JSON.stringify(sent));
+      sock.end();
+    });
+    sock.on("error", err => {
+      console.error("client socket error:", err);
+      process.exit(2);
+    });
+  `;
+
+  async function* lines(stream: ReadableStream<Uint8Array>) {
+    const decoder = new TextDecoder();
+    let buf = "";
+    for await (const chunk of stream) {
+      buf += decoder.decode(chunk, { stream: true });
+      let i;
+      while ((i = buf.indexOf("\n")) !== -1) {
+        yield buf.slice(0, i);
+        buf = buf.slice(i + 1);
+      }
+    }
+    if (buf.length) yield buf;
+  }
+
+  // "loss": after a partial writev that stops inside the previously buffered
+  // data, the unsent new chunk must be kept (not dropped).
+  // "dup": after a partial writev that consumes all previously buffered data
+  // plus a prefix of the new chunk, the bytes that hit the wire must not be
+  // buffered (and resent) again.
+  it.each(["loss", "dup"] as const)(
+    "a partial writev keeps exactly the unsent suffix (%s)",
+    async phase => {
+      using dir = tempDir("writev-remainder", {
+        "server-fixture.mjs": serverFixture,
+        "client-fixture.mjs": clientFixture,
+      });
+
+      await using server = Bun.spawn({
+        cmd: [bunExe(), "server-fixture.mjs"],
+        env: phase === "loss" ? { ...bunEnv, STALL_ON_ACCEPT: "1" } : bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const serverStderr = server.stderr.text();
+      const serverLines = lines(server.stdout);
+      const portLine = await serverLines.next();
+      if (portLine.done) throw new Error(`server exited before printing its port: ${await serverStderr}`);
+      const { port } = JSON.parse(portLine.value);
+
+      await using client = Bun.spawn({
+        cmd: [bunExe(), "client-fixture.mjs", phase, String(port)],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [clientOut, clientErr, clientExit] = await Promise.all([
+        client.stdout.text(),
+        client.stderr.text(),
+        client.exited,
+      ]);
+      if (clientExit !== 0) throw new Error(`client failed (exit ${clientExit}): ${clientErr}`);
+      const sent = JSON.parse(clientOut.trim().split("\n").pop()!);
+
+      const resultLine = await serverLines.next();
+      if (resultLine.done) throw new Error(`server exited before printing its result: ${await serverStderr}`);
+      const result = JSON.parse(resultLine.value);
+
+      const totalSent = sent.a + sent.i + sent.s;
+      expect(result).toEqual({
+        total: totalSent,
+        counts: { a: sent.a, i: sent.i, s: sent.s, other: 0 },
+        runs: phase === "loss" ? ["a", "s"] : ["a", "i"],
+      });
+      // handle.bytesWritten is flushed bytes + natively buffered bytes, so it
+      // must equal the submitted total as soon as the writes return.
+      expect(sent.bw).toBe(totalSent);
+    },
+    90_000,
+  );
 });


### PR DESCRIPTION
Fixes #32087. Likely also the root cause of at least some reports in #5627 (length-prefixed protocol desync over `node:net`).

### Bug

`write_or_end_buffered` (the native `$write`/`$end` path, `src/runtime/socket/socket_body.rs`) has a writev fast path used when new data arrives while `buffered_data_for_node_net` is non-empty. `write2(B, I)` is `writev(fd, [B, I])`: it writes the old buffered data `B` first, then the new chunk `I`, and returns the total bytes written. After a partial write, the number of bytes of `I` consumed is `written - B.len`, but the code computed the saturating subtraction in the reverse order:

```rust
let remaining_in_input_data = &buffer.slice()
    [(buf_len.saturating_sub(written)).min(buffer.slice().len())..];
```

With `b = B.len`, `n = I.len`, `w = written`:

| case | I consumed | code kept `I[min(b -| w, n)..]` | result |
|---|---|---|---|
| `w < b` | 0 | `I[min(b - w, n)..]` | unsent prefix of I silently lost (all of I when `b - w >= n`) |
| `w >= b` | `w - b` | `I[0..]` | already-written prefix of I re-buffered and sent twice |

A second defect in the same block: when `w >= b`, the truncation branch was skipped entirely (it only ran for `written < buf_len`), so the buffer still held all of `B` even though it was already on the wire, and the next flush resent it.

Both corruptions reproduce on main with plain `node:net` by calling `Socket.prototype._write` the way net.ts's own stream machinery does, with a backpressured peer: one run silently dropped 64 KiB (no error, FIN delivered), another put ~5.5 MB of duplicated bytes on the wire. For length-prefixed protocols (Postgres, MySQL, RESP, AMQP) this means desynced or stalled connections with no error attributable to the application. The bug shipped with the writev fast path in #14516 (v1.1.34); the `.zig` reference has the identical defect.

### Fix

Keep exactly the unsent suffix of `B ++ I`:

- slice the input remainder from `written.saturating_sub(buf_len)` (the reversed form is replaced),
- `drain_front(written)` on the buffer, which keeps the unsent suffix for a write that stopped inside `B` and clears the buffer when `B` was fully written,
- also add the bytes writev wrote to `bytes_written`; this was the only write site not doing so, and once the buffer is correctly truncated the omission becomes user-visible as `socket.bytesWritten` never reaching the submitted total.

### Verification

Two new tests in `test/js/node/net/node-net.test.ts` drive both partial-write shapes through a byte-counting peer and assert exact per-fill-byte counts, run ordering, and `bytesWritten`:

- loss (`w < b`): a multi-MB native remainder plus a 64 KiB follow-up write; unfixed, the server receives 0 of the 65536 `s` bytes.
- dup (`w > b`): a small remainder, kernel drained while the event loop is blocked, then a 32 MB write; unfixed, the server sees runs `a,i,a,i` and ~5.5 MB of duplicated bytes.

Both fail on the unfixed build (release and debug+ASAN, verified via `git stash push -- src/`) and pass with the fix. Node runs the identical client/server byte-perfect.


The tests are skipped on Windows: the writev fast path under test is compiled only on POSIX, and how much data a send accepts on Windows is machine dependent, so the buffered-data precondition cannot be constructed reliably there. (The first CI run also surfaced a pre-existing un-awaited `expectMaxObjectTypeCount` in the earlier Windows-only named-pipe test whose floating assertion fails whatever test runs after it; tracked in #32092.)


---

Rebased onto main (the net/tls rewrite in #31155 and the http2 rewrite in #31584 had moved the branch base). The src fix applied cleanly onto the new write path. The only conflict was additive in `node-net.test.ts` (main and this branch each appended a `describe` block), resolved by keeping both.

One follow-up the rebase surfaced: #31155 changed `net.ts`'s `_final` from `socket.$end()` to `socket.shutdown()`. `$end()` set `END_AFTER_FLUSH` and deferred the close until `buffered_data_for_node_net` drained, whereas `shutdown()` half-closes the write side immediately and discards whatever is still buffered. In normal `node:net` usage the Writable serialization keeps that buffer empty at `_final`, so it is masked, but the test fixtures drive `_write` directly and hit it. The fixtures now wait for the final write's drain callback (fired only once the native buffer empties) before calling `end()`, so they exercise the writev arithmetic rather than the shutdown discard.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/net/node-net.test.ts

<!-- robobun:evidence:end -->