### PR TITLE
test: await expectMaxObjectTypeCount in the named-pipe leak check

### DIFF
--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -838,7 +838,7 @@ it.if(isWindows)(
     }
 
     const batch = [];
-    const before = heapStats().objectTypeCounts.TLSSocket || 0;
+    const before = heapStats().objectTypeCounts.TCPSocket || 0;
     for (let i = 0; i < 100; i++) {
       batch.push(test(`\\\\.\\pipe\\test\\${randomUUID()}`));
       batch.push(test(`\\\\?\\pipe\\test\\${randomUUID()}`));
@@ -853,7 +853,11 @@ it.if(isWindows)(
       }
     }
     await Promise.all(batch);
-    expectMaxObjectTypeCount(expect, "TCPSocket", before);
+    // Allow a few stragglers: server.close() can resolve before the last
+    // accepted pipe socket's finalizer runs (same margin as
+    // node-tls-namedpipes.test.ts). A leak on this path would leave hundreds
+    // of sockets behind.
+    await expectMaxObjectTypeCount(expect, "TCPSocket", before + 10, 5000);
   },
   20_000,
 );


### PR DESCRIPTION
Fixes #32092

### Problem

`test/js/node/net/node-net.test.ts`, inside the Windows-only test `should work with named pipes`:

```ts
const before = heapStats().objectTypeCounts.TLSSocket || 0;
// ... ~700 named-pipe connections ...
expectMaxObjectTypeCount(expect, "TCPSocket", before);
```

`expectMaxObjectTypeCount` is async (it polls `heapStats()` with `Bun.sleep` between GC passes) but the call is not awaited, the only un-awaited call site in the repo. Two consequences:

1. The leak assertion is vacuous for the named-pipe test itself: the test completes before the poll finishes.
2. The floating promise keeps polling across test boundaries, and its eventual failure gets attributed to whichever test is running at that moment. Observed on the Windows lanes of build 61865: later tests failed with `expectMaxObjectTypeCount ... Expected: <= 0, Received: 5` despite never calling the helper.

The baseline is also read from the wrong object type: `TLSSocket` (always 0 in this file) instead of `TCPSocket`, so the effective bound was "TCPSocket count settles to <= 0".

### Fix

- Read the baseline from `objectTypeCounts.TCPSocket`.
- `await` the call so the assertion actually runs inside this test and cannot poison later ones.
- Allow `before + 10` with a 5s poll window. In build 61865 the count was still 5 over baseline after more than a second of polling; the sibling `node-tls-namedpipes.test.ts` documents the same behavior (`server.close()` can resolve before the last accepted pipe socket's finalizer runs) and allows a small absolute margin for it. A genuine leak on this path would leave hundreds of sockets behind (the test opens ~1400), which the now-live assertion will catch.

### Verification

The edited test is `it.if(isWindows)`, so Windows CI is the real signal. On Linux, `bun bd test test/js/node/net/node-net.test.ts` produces identical results with and without this change (the named-pipe test is skipped; the 10 failures in my sandbox are pre-existing container-networking failures that reproduce on main).