### PR TITLE
sql: make forced close() resolve while a pool connection is mid-handshake

### DIFF
--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -421,12 +421,23 @@ class PooledMySQLConnection {
     this.#startConnection();
   }
 
-  #startConnection() {
+  async #startConnection() {
     if (this.connectStartedAt === 0) {
       this.connectStartedAt = Date.now();
       this.connectAttempts = 0;
     }
-    PooledMySQLConnection.createConnection(this.connectionInfo, this.#onConnected.bind(this), this.#onClose.bind(this));
+    // store the handle right away (not only in #onConnected) so a forced
+    // pool close can tear down a connection whose handshake is in flight
+    this.connection = await PooledMySQLConnection.createConnection(
+      this.connectionInfo,
+      this.#onConnected.bind(this),
+      this.#onClose.bind(this),
+    );
+    if (this.onFinish !== null) {
+      // the pool was force-closed while the native handle was being created;
+      // close it now so onClose fires and onFinish settles
+      this.connection?.close();
+    }
   }
 
   /// Connect failures (ERR_MYSQL_CONNECTION_FAILED) mean the server

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -660,6 +660,11 @@ class PooledPostgresConnection {
       this.#onConnected.bind(this),
       this.#onClose.bind(this),
     );
+    if (this.onFinish !== null) {
+      // the pool was force-closed while the native handle was being created;
+      // close it now so onClose fires and onFinish settles
+      this.connection?.close();
+    }
   }
 
   /// Connect failures (ERR_POSTGRES_CONNECTION_FAILED) mean the server

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -698,8 +698,22 @@ impl JSMySQLConnection {
         scopeguard::defer! {
             this.update_reference_type();
         }
-        let queries = this.get_queries_array();
-        this.connection_mut().clean_queue_and_close(None, queries);
+        use my_sql_connection::Status as S;
+        match this.connection.get().status {
+            // A close while the connect/handshake is still in flight gets no
+            // socket event (uws skips the on_close dispatch for sockets whose
+            // connect never completed), so the socket-close -> on_close ->
+            // fail chain never runs: fail directly so the JS onclose callback
+            // fires and the status goes terminal instead of staying
+            // Connecting forever.
+            S::Connecting | S::Handshaking | S::Authenticating | S::AuthenticationAwaitingPk => {
+                this.fail(b"Connection closed", AnyMySQLErrorT::ConnectionClosed);
+            }
+            S::Connected | S::Disconnected | S::Failed => {
+                let queries = this.get_queries_array();
+                this.connection_mut().clean_queue_and_close(None, queries);
+            }
+        }
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -1440,7 +1440,27 @@ impl PostgresSQLConnection {
     }
 
     fn close(&self) {
-        self.disconnect();
+        // A close while the connect/handshake is still in flight gets no
+        // socket event: uws skips the on_close dispatch for sockets whose
+        // connect never completed, and `disconnect()` only tears down
+        // connected sockets. Fail the connection directly so the JS onclose
+        // callback fires, pending queries are rejected, and the in-flight
+        // socket is torn down instead of completing the handshake after
+        // close.
+        if !self.vm().is_shutting_down()
+            && matches!(
+                self.status.get(),
+                Status::Connecting | Status::SentStartupMessage
+            )
+        {
+            self.fail(b"Connection closed", AnyPostgresError::ConnectionClosed);
+            // closing an in-flight connect dispatches no socket event, so the
+            // poll ref taken at creation is released here rather than in a
+            // socket callback
+            self.poll_ref.with_mut(|r| r.unref(self.vm_ctx()));
+        } else {
+            self.disconnect();
+        }
         self.unregister_auto_flusher();
         self.write_buffer.with_mut(|b| b.clear_and_free());
     }

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -1,0 +1,69 @@
+// https://github.com/oven-sh/bun/issues/32095
+//
+// A forced pool close (`close({ timeout: "0" })`) must resolve even when a
+// pool connection has been accepted at the TCP level but the database
+// handshake has not completed yet (a database that is still starting up).
+// Previously the pending queries were rejected but the promise returned by
+// close() stayed pending forever: the native close path emitted no socket
+// event for in-flight connects, so the JS onclose callback never fired.
+//
+// connectionTimeout: 0 disables the connect timer, so close() is the only
+// thing that can tear the connection down — without the fix these tests hang.
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import net from "node:net";
+
+const drivers = [
+  ["postgres", "postgres://postgres@", "ERR_POSTGRES_CONNECTION_CLOSED"],
+  ["mysql", "mysql://root@", "ERR_MYSQL_CONNECTION_CLOSED"],
+] as const;
+
+async function neverAnsweringServer(): Promise<{
+  port: number;
+  server: net.Server;
+  sockets: net.Socket[];
+  accepted: Promise<void>;
+}> {
+  const first = Promise.withResolvers<void>();
+  const sockets: net.Socket[] = [];
+  const server = net.createServer(socket => {
+    sockets.push(socket);
+    first.resolve();
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  return { port: (server.address() as net.AddressInfo).port, server, sockets, accepted: first.promise };
+}
+
+for (const [name, scheme, closedCode] of drivers) {
+  test(`${name}: forced close() resolves while a connection is mid-handshake`, async () => {
+    const { port, server, sockets, accepted } = await neverAnsweringServer();
+    try {
+      const sql = new SQL({ url: `${scheme}127.0.0.1:${port}/db`, max: 1, connectionTimeout: 0 });
+      const queryError = sql`SELECT 1`.catch(e => e);
+      // the server holds the connection open without ever completing the
+      // handshake, so the pool connection stays mid-handshake from here on
+      await accepted;
+      await sql.close({ timeout: "0" });
+      expect((await queryError).code).toBe(closedCode);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    }
+  });
+
+  test(`${name}: forced close() resolves when called before the native handle is stored`, async () => {
+    const { port, server, sockets } = await neverAnsweringServer();
+    try {
+      const sql = new SQL({ url: `${scheme}127.0.0.1:${port}/db`, max: 1, connectionTimeout: 0 });
+      const connectError = sql.connect().catch(e => e);
+      // close in the same tick: the pool slot exists but its native handle
+      // has not been assigned yet
+      await sql.close({ timeout: "0" });
+      expect((await connectError).code).toBe(closedCode);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      server.close();
+    }
+  });
+}


### PR DESCRIPTION
### What does this PR do?

Fixes #32095. A forced pool close (`sql.close({ timeout: "0" })`) never resolved when a pool connection had been accepted at the TCP level but the database handshake had not completed yet (a database that is still starting up). The pending queries were rejected with `ERR_POSTGRES_CONNECTION_CLOSED` / `ERR_MYSQL_CONNECTION_CLOSED`, but the promise returned by `close()` stayed pending forever. With a nonzero `connectionTimeout` the close blocked until the connect timer fired (up to 30s by default); with `connectionTimeout: 0` it hung forever.

```ts
import { SQL } from "bun";
import net from "node:net";

// server that accepts and never answers
const first = Promise.withResolvers<void>();
const server = net.createServer(() => first.resolve());
await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
const port = (server.address() as net.AddressInfo).port;

const sql = new SQL({ url: `postgres://postgres@127.0.0.1:${port}/postgres`, max: 1, connectionTimeout: 0 });
const query = sql`SELECT 1`.catch(e => console.log("query rejected:", e.code));
await first.promise;

await sql.close({ timeout: "0" }); // never resolves
console.log("closed"); // never reached
```

### Root cause

The pool's `#close()` resolves its per-connection promise from the `onFinish` hook, which only fires from the JS `onClose`/`onConnected` callbacks. For a mid-handshake connection those callbacks never came:

- uws does not dispatch `on_close` when an application closes a socket whose TCP connect has not resolved yet (`POLL_TYPE_SEMI_SOCKET`, see `us_internal_socket_close_raw` in `packages/bun-usockets/src/socket.c`), so closing an in-flight connect produces no event at all.
- postgres: `disconnect()` gated on `Status::Connected`, so a close during `Connecting`/`SentStartupMessage` did not touch the socket. The connect kept going and even sent the startup message after `close()` returned.
- mysql: `do_close` closed the socket unconditionally but got no event back for in-flight connects and never changed the status, so `is_active()` stayed true and kept the event loop referenced forever.
- mysql (js): the pool only stored the native handle in `#onConnected`, so `connection.connection?.close()` was a no-op for every pending connection.

### The fix

- `src/sql_jsc/postgres/PostgresSQLConnection.rs`: `close()` now fails the connection directly when the status is `Connecting`/`SentStartupMessage` (outside VM shutdown). `fail()` consumes and fires the JS onclose callback, rejects pending queries, and closes whatever socket is live; since no socket event will do it, the poll ref is released explicitly. Shutdown paths and connected/terminal states keep going through `disconnect()` unchanged.
- `src/sql_jsc/mysql/JSMySQLConnection.rs`: `do_close` does the same for `Connecting`/`Handshaking`/`Authenticating`/`AuthenticationAwaitingPk`; connected/terminal states keep the existing `clean_queue_and_close` path.
- `src/js/internal/sql/mysql.ts`: `#startConnection` stores the native handle at creation (like the postgres adapter already did) so a forced close can reach it.
- `src/js/internal/sql/postgres.ts` + `mysql.ts`: if the pool is force-closed in the microtask window before the native handle is assigned, close the handle as soon as it materializes so `onFinish` settles.

`fail()` is idempotent (early-returns once the status is `Failed`), so the established-socket case, where closing does dispatch `on_close` synchronously, does not double-fire. The valkey client already works around the same uws behavior (`src/runtime/valkey_jsc/valkey.rs` `close()`), so this brings the SQL drivers in line; no other NsHandler consumer is affected.

### How did you verify your code works?

`test/js/sql/sql-close-pending-connection.test.ts` (no docker needed): for each driver, a TCP server accepts and never answers, and the test asserts `close({ timeout: "0" })` resolves, both while a connection is mid-handshake and when close is called before the native handle is stored. All four tests hang (5s timeout) on the unfixed build and pass with the fix.

Also verified:

- the issue's repro prints `closed` and the process exits on its own (no lingering poll ref), for both drivers
- with `connectionTimeout: 2`, forced close resolves in ~40ms instead of ~2s
- normal lifecycle against real postgres and mariadb servers (query, reserve, transaction, graceful close, forced close while connected, forced close with a query in flight, onconnect/onclose counts) is unchanged
- process exit while a connection is mid-handshake stays clean under the ASAN debug build
- `test/js/sql/sql-connect-error-reporting.test.ts` and `test/js/sql/sql-onconnect-onclose-throw.test.ts` still pass
