### PR TITLE
Fix use-after-free in Error.appendStackTrace when source is destination

### DIFF
--- a/src/jsc/bindings/FormatStackTraceForJS.cpp
+++ b/src/jsc/bindings/FormatStackTraceForJS.cpp
@@ -645,6 +645,12 @@ JSC_DEFINE_HOST_FUNCTION(errorConstructorFuncAppendStackTrace, (JSC::JSGlobalObj
         return {};
     }
 
+    // Appending an error's stack trace to itself would make Vector::appendVector
+    // read from its own (possibly reallocated and freed) buffer.
+    if (source == destination) {
+        return JSC::JSValue::encode(jsUndefined());
+    }
+
     if (!destination->stackTrace()) {
         destination->captureStackTrace(vm, globalObject, 1);
     }

--- a/test/js/bun/util/error-append-stack-trace.test.ts
+++ b/test/js/bun/util/error-append-stack-trace.test.ts
@@ -1,10 +1,8 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 
 // Appending an error's stack trace to itself made Vector::appendVector read
 // from its own freed buffer once the append grew past the vector's capacity.
-// Malloc=1 routes WTF allocations through the system allocator so ASan builds
-// can see the use-after-free; symbolize=0 keeps the failing child fast.
 test("Error.appendStackTrace with the same error as source and destination", async () => {
   const code = `
     function f(n) {
@@ -21,13 +19,18 @@ test("Error.appendStackTrace with the same error as source and destination", asy
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", code],
-    env: {
-      ...bunEnv,
-      Malloc: "1",
-      // detect_leaks=0: with Malloc=1 LeakSanitizer sees JSC's exit-time
-      // allocations and would fail the child for unrelated reports.
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
-    },
+    // Malloc=1 routes WTF allocations through the system allocator so ASan can
+    // see the use-after-free. symbolize=0 keeps a failing child fast, and
+    // detect_leaks=0 keeps LeakSanitizer from flagging JSC's exit-time
+    // allocations. Only ASan builds can observe the bug, and Malloc=1 is not
+    // safe to force on every platform's release build.
+    env: isASAN
+      ? {
+          ...bunEnv,
+          Malloc: "1",
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
+        }
+      : bunEnv,
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/test/js/bun/util/error-append-stack-trace.test.ts
+++ b/test/js/bun/util/error-append-stack-trace.test.ts
@@ -24,7 +24,9 @@ test("Error.appendStackTrace with the same error as source and destination", asy
     env: {
       ...bunEnv,
       Malloc: "1",
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+      // detect_leaks=0: with Malloc=1 LeakSanitizer sees JSC's exit-time
+      // allocations and would fail the child for unrelated reports.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
     },
     stdout: "pipe",
     stderr: "pipe",

--- a/test/js/bun/util/error-append-stack-trace.test.ts
+++ b/test/js/bun/util/error-append-stack-trace.test.ts
@@ -29,7 +29,8 @@ test("Error.appendStackTrace with the same error as source and destination", asy
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toMatch(/(ERROR|SUMMARY): AddressSanitizer/);
   expect(stdout).toBe("ok\n");
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/util/error-append-stack-trace.test.ts
+++ b/test/js/bun/util/error-append-stack-trace.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Appending an error's stack trace to itself made Vector::appendVector read
+// from its own freed buffer once the append grew past the vector's capacity.
+// Malloc=1 routes WTF allocations through the system allocator so ASan builds
+// can see the use-after-free; symbolize=0 keeps the failing child fast.
+test("Error.appendStackTrace with the same error as source and destination", async () => {
+  const code = `
+    function f(n) {
+      if (n > 0) return f(n - 1) + 1;
+      try {
+        null();
+      } catch (e) {
+        Error.appendStackTrace(e, e);
+      }
+      return 0;
+    }
+    f(64);
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: {
+      ...bunEnv,
+      Malloc: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});
+
+test("Error.appendStackTrace moves the source stack trace into the destination", () => {
+  function inner() {
+    try {
+      null();
+    } catch (e) {
+      return e;
+    }
+  }
+  const src = inner();
+  const dst = new Error("dst");
+  (Error as any).appendStackTrace(src, dst);
+  expect(dst.stack).toContain("inner");
+});

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import { join } from "path";
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
@@ -27,6 +27,49 @@ test("error gc test", () => {
     fn();
     Bun.gc(true);
   }
+});
+
+// Appending an error's stack trace to itself made Vector::appendVector read
+// from its own freed buffer once the append grew past the vector's capacity.
+// Malloc=1 routes WTF allocations through the system allocator so ASan builds
+// can see the use-after-free.
+test("Error.appendStackTrace with the same error as source and destination", async () => {
+  const code = `
+    function f(n) {
+      if (n > 0) return f(n - 1) + 1;
+      try {
+        null();
+      } catch (e) {
+        Error.appendStackTrace(e, e);
+      }
+      return 0;
+    }
+    f(64);
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: { ...bunEnv, Malloc: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("ok\n");
+  expect(exitCode).toBe(0);
+});
+
+test("Error.appendStackTrace moves the source stack trace into the destination", () => {
+  function inner() {
+    try {
+      null();
+    } catch (e) {
+      return e;
+    }
+  }
+  const src = inner();
+  const dst = new Error("dst");
+  Error.appendStackTrace(src, dst);
+  expect(dst.stack).toContain("inner");
 });
 
 test("error gc test #2", () => {

--- a/test/js/bun/util/error-gc-test.test.js
+++ b/test/js/bun/util/error-gc-test.test.js
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { readFileSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { tmpdirSync } from "harness";
 import { join } from "path";
 // This test checks that printing stack traces increments and decrements
 // reference-counted strings
@@ -27,49 +27,6 @@ test("error gc test", () => {
     fn();
     Bun.gc(true);
   }
-});
-
-// Appending an error's stack trace to itself made Vector::appendVector read
-// from its own freed buffer once the append grew past the vector's capacity.
-// Malloc=1 routes WTF allocations through the system allocator so ASan builds
-// can see the use-after-free.
-test("Error.appendStackTrace with the same error as source and destination", async () => {
-  const code = `
-    function f(n) {
-      if (n > 0) return f(n - 1) + 1;
-      try {
-        null();
-      } catch (e) {
-        Error.appendStackTrace(e, e);
-      }
-      return 0;
-    }
-    f(64);
-    console.log("ok");
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", code],
-    env: { ...bunEnv, Malloc: "1" },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("ok\n");
-  expect(exitCode).toBe(0);
-});
-
-test("Error.appendStackTrace moves the source stack trace into the destination", () => {
-  function inner() {
-    try {
-      null();
-    } catch (e) {
-      return e;
-    }
-  }
-  const src = inner();
-  const dst = new Error("dst");
-  Error.appendStackTrace(src, dst);
-  expect(dst.stack).toContain("inner");
 });
 
 test("error gc test #2", () => {


### PR DESCRIPTION
Fixes a use-after-free found by fuzzing (fingerprint `35392e9d08621196`).

### Root cause

`Error.appendStackTrace(source, destination)` merges stack traces with:

```cpp
destination->stackTrace()->appendVector(*source->stackTrace());
source->stackTrace()->clear();
```

When `source === destination`, `appendVector` appends the vector to itself. `Vector::appendVector` goes through the span-based `append`, and when the append grows the vector past its capacity, `reserveCapacity` allocates a new buffer and frees the old one. The span path passes a `const T*` source pointer, which binds to the generic `expandCapacity(size_t, U*)` overload that returns the pointer unadjusted (only the non-const `T*` overload relocates interior pointers). The subsequent copy then reads the StackFrames from the freed buffer.

Reallocation only happens once the trace has 9 or more frames (initial capacity is 16), and WTF allocations normally come from bmalloc where ASan cannot see the freed memory, which is why the fuzzer only hit this intermittently: the stale data is usually copied back intact before the block is reused. When the block does get reused or decommitted in that window, the copy constructs `StackFrame`s (a `Variant` holding a `RefPtr` in its wasm alternative) from garbage, corrupting memory.

With `Malloc=1` (forces bmalloc through the system allocator) the unfixed ASan build reports it deterministically:

```
==ERROR: AddressSanitizer: heap-use-after-free ...
READ of size 1 at 0x74c8df8e1618 thread T0
    #0 mpark::detail::base<JSC::JSFrameData, JSC::WasmFrameData>::valueless_by_exception() wtf/Variant.h:1465
    #4 JSC::StackFrame::StackFrame(JSC::StackFrame const&)
    #5 WTF::VectorCopier<JSC::StackFrame>::uninitializedCopy(...)
    #6 WTF::Vector<JSC::StackFrame, ...>::append(std::span<JSC::StackFrame const, ...>) wtf/Vector.h:1516
    ...
    #9 errorConstructorFuncAppendStackTrace
```

### Fix

The fixing change is the `source == destination` early return in `errorConstructorFuncAppendStackTrace`: appending an error's trace to itself and then clearing it has no useful effect, so it is now a no-op that leaves the trace unchanged.

### Tests

Added `test/js/bun/util/error-append-stack-trace.test.ts`:

- a spawned repro of the self-append with a deep enough stack to force the reallocation, run with `Malloc=1` so ASan builds catch the use-after-free (`symbolize=0` keeps the failing child fast); it fails on the unfixed ASan build and passes with the fix
- a behavior test that the normal two-error `Error.appendStackTrace` still merges the source frames into the destination

Repro script:

```js
function f(n) {
  if (n > 0) return f(n - 1) + 1;
  try { null(); } catch (e) {
    Error.appendStackTrace(e, e);
  }
  return 0;
}
f(64);
```
