### PR TITLE
sql: reject close() timeouts that overflow setTimeout's millisecond range

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -7,7 +7,7 @@ const { Query, SQLQueryFlags } = require("internal/sql/query");
 const { PostgresAdapter } = require("internal/sql/postgres");
 const { MySQLAdapter } = require("internal/sql/mysql");
 const { SQLiteAdapter } = require("internal/sql/sqlite");
-const { SQLHelper, parseOptions, validateCloseTimeout } = require("internal/sql/shared");
+const { SQLHelper, parseOptions, validateTimeoutSeconds } = require("internal/sql/shared");
 
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 const { validateAbortSignal } = require("internal/validators");
@@ -472,7 +472,7 @@ const SQL: typeof Bun.SQL = function SQL(
       }
       let timeout = options?.timeout;
       if (timeout) {
-        timeout = validateCloseTimeout(timeout);
+        timeout = validateTimeoutSeconds("options.timeout", timeout);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
       if (timeout) {
@@ -754,7 +754,7 @@ const SQL: typeof Bun.SQL = function SQL(
       }
       let timeout = options?.timeout;
       if (timeout) {
-        timeout = validateCloseTimeout(timeout);
+        timeout = validateTimeoutSeconds("options.timeout", timeout);
       }
       state.connectionState &= ~ReservedConnectionState.acceptQueries;
       const transactionQueries = state.queries;

--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -7,7 +7,7 @@ const { Query, SQLQueryFlags } = require("internal/sql/query");
 const { PostgresAdapter } = require("internal/sql/postgres");
 const { MySQLAdapter } = require("internal/sql/mysql");
 const { SQLiteAdapter } = require("internal/sql/sqlite");
-const { SQLHelper, parseOptions } = require("internal/sql/shared");
+const { SQLHelper, parseOptions, validateCloseTimeout } = require("internal/sql/shared");
 
 const { SQLError, PostgresError, SQLiteError, MySQLError } = require("internal/sql/errors");
 const { validateAbortSignal } = require("internal/validators");
@@ -470,13 +470,12 @@ const SQL: typeof Bun.SQL = function SQL(
       ) {
         return Promise.$resolve(undefined);
       }
-      state.connectionState &= ~ReservedConnectionState.acceptQueries;
       let timeout = options?.timeout;
       if (timeout) {
-        timeout = Number(timeout);
-        if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-          throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
-        }
+        timeout = validateCloseTimeout(timeout);
+      }
+      state.connectionState &= ~ReservedConnectionState.acceptQueries;
+      if (timeout) {
         if (timeout > 0 && (reserveQueries.size > 0 || reservedTransaction.size > 0)) {
           const { promise, resolve } = Promise.withResolvers();
           // race all queries vs timeout
@@ -753,15 +752,13 @@ const SQL: typeof Bun.SQL = function SQL(
       ) {
         return Promise.$resolve(undefined);
       }
-      state.connectionState &= ~ReservedConnectionState.acceptQueries;
-      const transactionQueries = state.queries;
       let timeout = options?.timeout;
       if (timeout) {
-        timeout = Number(timeout);
-        if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-          throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
-        }
-
+        timeout = validateCloseTimeout(timeout);
+      }
+      state.connectionState &= ~ReservedConnectionState.acceptQueries;
+      const transactionQueries = state.queries;
+      if (timeout) {
         if (timeout > 0 && (transactionQueries.size > 0 || transactionSavepoints.size > 0)) {
           const { promise, resolve } = Promise.withResolvers();
           // race all queries vs timeout

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -157,18 +157,18 @@ function normalizeSSLMode(value: string): SSLMode {
   );
 }
 
-// close({ timeout }) takes seconds but arms its deadline timer in
-// milliseconds, and setTimeout clamps delays above 2 ** 31 - 1 ms to 1 ms, so
-// the upper bound must hold for the millisecond product.
-const MAX_CLOSE_TIMEOUT = (2 ** 31 - 1) / 1000;
+// setTimeout clamps a delay above this to 1 ms, and the native timers saturate at it.
+const MAX_TIMER_MS = 2 ** 31 - 1;
+const MAX_TIMEOUT_SECONDS = MAX_TIMER_MS / 1000;
 
-function validateCloseTimeout(timeout: number): number {
+// For options given in seconds that arm a millisecond timer.
+function validateTimeoutSeconds(name: string, timeout: number): number {
   timeout = Number(timeout);
-  if (timeout > MAX_CLOSE_TIMEOUT || timeout < 0 || timeout !== timeout) {
+  if (timeout > MAX_TIMEOUT_SECONDS || timeout < 0 || timeout !== timeout) {
     throw $ERR_INVALID_ARG_VALUE(
-      "options.timeout",
+      name,
       timeout,
-      `must be a non-negative number no greater than ${MAX_CLOSE_TIMEOUT} seconds`,
+      `must be a non-negative number no greater than ${MAX_TIMEOUT_SECONDS} seconds`,
     );
   }
   return timeout;
@@ -1323,7 +1323,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
     let timeout = options?.timeout;
     const hasTimeout = !!timeout;
     if (hasTimeout) {
-      timeout = validateCloseTimeout(timeout);
+      timeout = validateTimeoutSeconds("options.timeout", timeout);
     }
 
     this.closed = true;
@@ -2085,39 +2085,15 @@ function parseOptions(
   }
 
   if (idleTimeout != null) {
-    idleTimeout = Number(idleTimeout);
-    if (idleTimeout > 2 ** 31 || idleTimeout < 0 || idleTimeout !== idleTimeout) {
-      throw $ERR_INVALID_ARG_VALUE(
-        "options.idle_timeout",
-        idleTimeout,
-        "must be a non-negative integer less than 2^31",
-      );
-    }
-    idleTimeout *= 1000;
+    idleTimeout = validateTimeoutSeconds("options.idle_timeout", idleTimeout) * 1000;
   }
 
   if (connectionTimeout != null) {
-    connectionTimeout = Number(connectionTimeout);
-    if (connectionTimeout > 2 ** 31 || connectionTimeout < 0 || connectionTimeout !== connectionTimeout) {
-      throw $ERR_INVALID_ARG_VALUE(
-        "options.connection_timeout",
-        connectionTimeout,
-        "must be a non-negative integer less than 2^31",
-      );
-    }
-    connectionTimeout *= 1000;
+    connectionTimeout = validateTimeoutSeconds("options.connection_timeout", connectionTimeout) * 1000;
   }
 
   if (maxLifetime != null) {
-    maxLifetime = Number(maxLifetime);
-    if (maxLifetime > 2 ** 31 || maxLifetime < 0 || maxLifetime !== maxLifetime) {
-      throw $ERR_INVALID_ARG_VALUE(
-        "options.max_lifetime",
-        maxLifetime,
-        "must be a non-negative integer less than 2^31",
-      );
-    }
-    maxLifetime *= 1000;
+    maxLifetime = validateTimeoutSeconds("options.max_lifetime", maxLifetime) * 1000;
   }
 
   if (max != null) {
@@ -2250,7 +2226,7 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
 export default {
   parseOptions,
   SQLHelper,
-  validateCloseTimeout,
+  validateTimeoutSeconds,
   SQLResultArray,
   SQLArrayParameter,
   getHelperCommandFromDetect,

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -157,6 +157,23 @@ function normalizeSSLMode(value: string): SSLMode {
   );
 }
 
+// close({ timeout }) takes seconds but arms its deadline timer in
+// milliseconds, and setTimeout clamps delays above 2 ** 31 - 1 ms to 1 ms, so
+// the upper bound must hold for the millisecond product.
+const MAX_CLOSE_TIMEOUT = (2 ** 31 - 1) / 1000;
+
+function validateCloseTimeout(timeout: number): number {
+  timeout = Number(timeout);
+  if (timeout > MAX_CLOSE_TIMEOUT || timeout < 0 || timeout !== timeout) {
+    throw $ERR_INVALID_ARG_VALUE(
+      "options.timeout",
+      timeout,
+      `must be a non-negative number no greater than ${MAX_CLOSE_TIMEOUT} seconds`,
+    );
+  }
+  return timeout;
+}
+
 export type { SQLHelper };
 class SQLHelper<T> {
   public readonly value: T;
@@ -1306,10 +1323,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
     let timeout = options?.timeout;
     const hasTimeout = !!timeout;
     if (hasTimeout) {
-      timeout = Number(timeout);
-      if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-        throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
-      }
+      timeout = validateCloseTimeout(timeout);
     }
 
     this.closed = true;
@@ -2236,6 +2250,7 @@ export interface DatabaseAdapter<Connection, ConnectionHandle, QueryHandle> {
 export default {
   parseOptions,
   SQLHelper,
+  validateCloseTimeout,
   SQLResultArray,
   SQLArrayParameter,
   getHelperCommandFromDetect,

--- a/test/js/sql/sql-close-timeout-overflow.test.ts
+++ b/test/js/sql/sql-close-timeout-overflow.test.ts
@@ -1,0 +1,115 @@
+// close({ timeout }) takes seconds but arms its deadline timer in
+// milliseconds. The upper bound used to be checked against the seconds value
+// (2 ** 31), so timeouts in (2147483.647, 2 ** 31] seconds passed validation,
+// overflowed setTimeout's 32-bit millisecond range (which clamps to 1 ms) and
+// force-closed after ~1 ms, cancelling in-flight queries. On reserved
+// connections and transactions, validation also ran after acceptQueries was
+// already cleared, so a rejected close left the handle refusing all further
+// queries.
+// https://github.com/oven-sh/bun/issues/32096
+
+import { SQL } from "bun";
+import { expect, test } from "bun:test";
+import { describeWithContainer, isDockerEnabled } from "harness";
+
+// setTimeout's maximum delay is 2 ** 31 - 1 milliseconds.
+const MAX_TIMEOUT_SECONDS = (2 ** 31 - 1) / 1000; // 2147483.647
+
+// Pool connections are created lazily and close() validates its options
+// before touching any connection, so no database server is needed here.
+const adapters = [
+  ["postgres", "postgres://bun_sql_test@localhost:5432/bun_sql_test"],
+  ["mysql", "mysql://bun_sql_test@localhost:3306/bun_sql_test"],
+] as const;
+
+for (const [adapter, url] of adapters) {
+  test.each([2 ** 31, 2147483.648, Infinity])(
+    `${adapter}: close() rejects timeout %p, whose millisecond value overflows setTimeout`,
+    async timeout => {
+      await using sql = new SQL(url, { max: 1 });
+      const err = await sql.close({ timeout }).then(
+        () => null,
+        e => e,
+      );
+      expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+    },
+  );
+
+  test.each([MAX_TIMEOUT_SECONDS, 60, 0.5])(`${adapter}: close() accepts timeout %p`, async timeout => {
+    await using sql = new SQL(url, { max: 1 });
+    await sql.close({ timeout });
+  });
+
+  // Values the old bound already rejected must stay rejected.
+  test.each([-1, "not a number"])(`${adapter}: close() still rejects timeout %p`, async timeout => {
+    await using sql = new SQL(url, { max: 1 });
+    const err = await sql.close({ timeout: timeout as number }).then(
+      () => null,
+      e => e,
+    );
+    expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+  });
+}
+
+test("close() rejection names the real bound", async () => {
+  await using sql = new SQL("postgres://bun_sql_test@localhost:5432/bun_sql_test", { max: 1 });
+  const err = await sql.close({ timeout: 2 ** 31 }).then(
+    () => null,
+    e => e,
+  );
+  expect(err?.message).toBe(
+    "The property 'options.timeout' must be a non-negative number no greater than 2147483.647 seconds. Received 2147483648",
+  );
+});
+
+// transaction_sql.close() shares the same validation. SQLite transactions run
+// in-process, so this exercises it without a server. Before the fix the
+// overflowing timeout was accepted: the transaction was rolled back, queries
+// after the close rejected with ERR_SQLITE_CONNECTION_CLOSED, and the commit
+// rejected the begin() promise.
+test("sqlite: transaction close() rejects an overflowing timeout and leaves the transaction usable", async () => {
+  await using sql = new SQL("sqlite://:memory:");
+  let closeError: any = null;
+  let rowsAfterRejectedClose: any = null;
+  const result = await sql
+    .begin(async tx => {
+      closeError = await tx.close({ timeout: 2 ** 31 }).then(
+        () => null,
+        e => e,
+      );
+      rowsAfterRejectedClose = await tx`select 1 as x`.then(
+        rows => rows[0],
+        e => `query failed: ${e.code}`,
+      );
+      return "callback completed";
+    })
+    .then(
+      value => value,
+      e => `begin rejected: ${e.code}`,
+    );
+  expect(closeError?.code).toBe("ERR_INVALID_ARG_VALUE");
+  expect(rowsAfterRejectedClose).toEqual({ x: 1 });
+  expect(result).toBe("callback completed");
+});
+
+// reserved_sql.close() is the remaining variant; it needs a real connection,
+// so it runs against the docker postgres service when available.
+if (isDockerEnabled()) {
+  describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+    test("reserved connection close() rejects an overflowing timeout and stays usable", async () => {
+      await container.ready;
+      const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+      await using sql = new SQL(url, { max: 2 });
+      const reserved = await sql.reserve();
+      const err = await reserved.close({ timeout: 2 ** 31 }).then(
+        () => null,
+        e => e,
+      );
+      expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+      // the rejected close must leave the reserved connection untouched
+      const rows = await reserved`select 1 as x`;
+      expect(rows[0]).toEqual({ x: 1 });
+      reserved.release();
+    });
+  });
+}

--- a/test/js/sql/sql-close-timeout-overflow.test.ts
+++ b/test/js/sql/sql-close-timeout-overflow.test.ts
@@ -100,7 +100,8 @@ if (isDockerEnabled()) {
       await container.ready;
       const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
       await using sql = new SQL(url, { max: 2 });
-      const reserved = await sql.reserve();
+      // disposal calls release(); it runs before the pool's own disposal
+      await using reserved = await sql.reserve();
       const err = await reserved.close({ timeout: 2 ** 31 }).then(
         () => null,
         e => e,
@@ -109,7 +110,6 @@ if (isDockerEnabled()) {
       // the rejected close must leave the reserved connection untouched
       const rows = await reserved`select 1 as x`;
       expect(rows[0]).toEqual({ x: 1 });
-      reserved.release();
     });
   });
 }

--- a/test/js/sql/sql-close-timeout-overflow.test.ts
+++ b/test/js/sql/sql-close-timeout-overflow.test.ts
@@ -5,7 +5,8 @@
 // force-closed after ~1 ms, cancelling in-flight queries. On reserved
 // connections and transactions, validation also ran after acceptQueries was
 // already cleared, so a rejected close left the handle refusing all further
-// queries.
+// queries. The idle_timeout, connection_timeout and max_lifetime options had
+// the same seconds-bounded check before their own * 1000.
 // https://github.com/oven-sh/bun/issues/32096
 
 import { SQL } from "bun";
@@ -48,6 +49,24 @@ for (const [adapter, url] of adapters) {
       e => e,
     );
     expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+  });
+}
+
+// The constructor options are validated synchronously in parseOptions, before
+// any connection exists.
+for (const option of ["idle_timeout", "connection_timeout", "max_lifetime"] as const) {
+  test.each([2 ** 31, 2147483.648, Infinity])(
+    `${option}: constructor rejects %p, whose millisecond value overflows`,
+    timeout => {
+      expect(() => new SQL("postgres://bun_sql_test@localhost:5432/bun_sql_test", { [option]: timeout })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+    },
+  );
+
+  test.each([MAX_TIMEOUT_SECONDS, 60, 0])(`${option}: constructor accepts %p`, async timeout => {
+    await using sql = new SQL("postgres://bun_sql_test@localhost:5432/bun_sql_test", { [option]: timeout });
+    expect(sql).toBeDefined();
   });
 }
 

--- a/test/js/sql/sql-close-timeout-overflow.test.ts
+++ b/test/js/sql/sql-close-timeout-overflow.test.ts
@@ -11,7 +11,7 @@
 
 import { SQL } from "bun";
 import { expect, test } from "bun:test";
-import { describeWithContainer, isDockerEnabled } from "harness";
+import { describeWithContainer } from "harness";
 
 // setTimeout's maximum delay is 2 ** 31 - 1 milliseconds.
 const MAX_TIMEOUT_SECONDS = (2 ** 31 - 1) / 1000; // 2147483.647
@@ -111,24 +111,23 @@ test("sqlite: transaction close() rejects an overflowing timeout and leaves the 
   expect(result).toBe("callback completed");
 });
 
-// reserved_sql.close() is the remaining variant; it needs a real connection,
-// so it runs against the docker postgres service when available.
-if (isDockerEnabled()) {
-  describeWithContainer("postgres", { image: "postgres_plain" }, container => {
-    test("reserved connection close() rejects an overflowing timeout and stays usable", async () => {
-      await container.ready;
-      const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
-      await using sql = new SQL(url, { max: 2 });
-      // disposal calls release(); it runs before the pool's own disposal
-      await using reserved = await sql.reserve();
-      const err = await reserved.close({ timeout: 2 ** 31 }).then(
-        () => null,
-        e => e,
-      );
-      expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
-      // the rejected close must leave the reserved connection untouched
-      const rows = await reserved`select 1 as x`;
-      expect(rows[0]).toEqual({ x: 1 });
-    });
+// reserved_sql.close() is the remaining variant; it needs a real connection.
+// describeWithContainer marks the block todo when no postgres service is
+// reachable.
+describeWithContainer("postgres", { image: "postgres_plain" }, container => {
+  test("reserved connection close() rejects an overflowing timeout and stays usable", async () => {
+    await container.ready;
+    const url = `postgres://bun_sql_test@${container.host}:${container.port}/bun_sql_test`;
+    await using sql = new SQL(url, { max: 2 });
+    // disposal calls release(); it runs before the pool's own disposal
+    await using reserved = await sql.reserve();
+    const err = await reserved.close({ timeout: 2 ** 31 }).then(
+      () => null,
+      e => e,
+    );
+    expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
+    // the rejected close must leave the reserved connection untouched
+    const rows = await reserved`select 1 as x`;
+    expect(rows[0]).toEqual({ x: 1 });
   });
-}
+});


### PR DESCRIPTION
Fixes #32096

### Repro

```ts
const sql = new Bun.SQL(url, { max: 1 });
const query = sql`select pg_sleep(2)`.catch(e => e.code);
await Bun.sleep(100);
await sql.close({ timeout: 2 ** 31 }); // resolves after ~1 ms
console.log(await query);              // ERR_POSTGRES_CONNECTION_CLOSED
```

```
TimeoutOverflowWarning: 2147483648000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
```

### Cause

`close({ timeout })` takes seconds, but every close site (the pool close shared by the postgres and mysql adapters, `reserved_sql.close`, `transaction_sql.close`) validated the upper bound against the seconds value and then armed the timer in milliseconds:

```ts
if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) { throw ... }
...
setTimeout(..., timeout * 1000);
```

`setTimeout` clamps delays above `2 ** 31 - 1` ms to 1 ms, so any timeout in `(2147483.647, 2 ** 31]` seconds passed validation and force-closed after about 1 ms, cancelling in-flight queries instead of waiting.

### Fix

- One shared `validateTimeoutSeconds(name, value)` in `internal/sql/shared.ts`, bounded at `(2 ** 31 - 1) / 1000` seconds, replaces the inline checks. It also covers the `idle_timeout`, `connection_timeout` and `max_lifetime` constructor options, which had the same seconds-bounded check before their own `* 1000`; their native consumer saturates at `2 ** 31 - 1` ms, so out of range values silently became 24.8 days. The error message now states the real bound: `must be a non-negative number no greater than 2147483.647 seconds`. After the rebase onto #32145 (which consolidated the postgres and mysql adapters' pool plumbing into shared.ts), that means the consolidated pool `close()` in `shared.ts` plus `reserved_sql.close` and `transaction_sql.close` in `sql.ts`.
- In `reserved_sql.close` and `transaction_sql.close`, validation ran after `acceptQueries` was already cleared, so a rejected close left the handle refusing all further queries. Validation now runs before the state mutation. Main has since given the pool `close()` the same shape (a `hasTimeout` flag checked before `closed = true`), and this PR drops the validator into that block.

While verifying the reserved path I hit an unrelated pre-existing hang (`reserved.close()` then `sql.close()` never resolves, with no timeout option at all); filed as #32099, not touched here.

### Verification

`test/js/sql/sql-close-timeout-overflow.test.ts`:

- `idle_timeout`, `connection_timeout` and `max_lifetime` reject `2 ** 31`, `2147483.648`, and `Infinity` in the constructor and accept the exact max, `60`, and `0`.
- postgres and mysql pool `close()` reject `2 ** 31`, `2147483.648`, and `Infinity` with `ERR_INVALID_ARG_VALUE`, accept `2147483.647` (the exact max), `60`, and `0.5`, and still reject `-1` and non-numeric input. Pool connections are lazy, so these run without a server.
- sqlite transaction: `tx.close({ timeout: 2 ** 31 })` rejects and the transaction still runs queries and commits.
- reserved connection (docker-gated, postgres): the rejected close leaves the connection usable and releasable.

The server-free tests fail on the unfixed build (13 fail: the close resolves instead of rejecting, and the sqlite transaction gets rolled back with `ERR_SQLITE_CONNECTION_CLOSED`) and pass with the fix (37 pass). Re-verified after each rebase (onto #32145, and again onto current main at ae3c3ad753).

The new test file is separate from `sql.test.ts` because that file is wrapped in `isDockerEnabled()` and skips entirely without docker; these tests need no server.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 5 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/sql-close-timeout-overflow.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/sql-close-timeout-overflow.test.ts:
30 |       await using sql = new SQL(url, { max: 1 });
31 |       const err = await sql.close({ timeout }).then(
32 |         () => null,
33 |         e => e,
34 |       );
35 |       expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
                             ^
error: expect(received).toBe(expected)

Expected: "ERR_INVALID_ARG_VALUE"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-timeout-overflow.test.ts:35:25)
(fail) postgres: close() rejects timeout 2147483648, whose millisecond value overflows setTimeout [183.99ms]
30 |       await using sql = new SQL(url, { max: 1 });
31 |       const err = await sql.close({ timeout }).then(
32 |         () => null,
33 |         e => e,
34 |       );
35 |       expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
                             ^
error: expect(received).toBe(expected)

Expected: "ERR_INVALID_ARG_VALUE"
Received: undefined

      at <
... (truncated)

release without fix: 13 FAILED
bun test v1.4.3-canary.1 (f42e98025)

test/js/sql/sql-close-timeout-overflow.test.ts:
30 |       await using sql = new SQL(url, { max: 1 });
31 |       const err = await sql.close({ timeout }).then(
32 |         () => null,
33 |         e => e,
34 |       );
35 |       expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
                             ^
error: expect(received).toBe(expected)

Expected: "ERR_INVALID_ARG_VALUE"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-timeout-overflow.test.ts:35:25)
(fail) postgres: close() rejects timeout 2147483648, whose millisecond value overflows setTimeout [2.66ms]
30 |       await using sql = new SQL(url, { max: 1 });
31 |       const err = await sql.close({ timeout }).then(
32 |         () => null,
33 |         e => e,
34 |       );
35 |       expect(err?.code).toBe("ERR_INVALID_ARG_VALUE");
                             ^
error: expect(received).toBe(expected)

Expected: "ERR_INVALID_ARG_VALUE"
Received: undefined

      at <anonymous> (/workspace/bun/test/js/sql/sql-close-timeout-overflow.test.ts:35:25)
(fail) postgres: close() rejects timeout 2147483.648, whose millisecond value overflows set
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/sql/sql-close-timeout-overflow.test.ts
bun test v1.4.3 (f42e98025)

test/js/sql/sql-close-timeout-overflow.test.ts:
(pass) postgres: close() rejects timeout 2147483648, whose millisecond value overflows setTimeout [127.87ms]
(pass) postgres: close() rejects timeout 2147483.648, whose millisecond value overflows setTimeout [6.42ms]
(pass) postgres: close() rejects timeout Infinity, whose millisecond value overflows setTimeout [4.71ms]
(pass) postgres: close() accepts timeout 2147483.647 [11.36ms]
(pass) postgres: close() accepts timeout 60 [3.73ms]
(pass) postgres: close() accepts timeout 0.5 [3.79ms]
(pass) postgres: close() still rejects timeout -1 [15.14ms]
(pass) postgres: close() still rejects timeout "not a number" [4.78ms]
(pass) mysql: close() rejects timeout 2147483648, whose millisecond value overflows setTimeout [8.23ms]
(pass) mysql: close() rejects timeout 2147483.648, whose millisecond value overflows setTimeout [4.34ms]
(pass) mysql: close() rejects timeout Infinity, whose millisecond value overflows setTimeout [4.
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 890ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (9006ms)
Bundle modules (80ms)
Postprocesss modules (37ms)
Bundle Functions (633ms)
Generate Code (44ms)

[9.81s] Bundled "src/js" for production
  2594 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
[1m[92m   Compiling[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
[1m[92m   Compiling[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
[1m[92m   Compiling[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
[1m[92m   Compiling[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
[1m[92m   Compiling[0m bun_bundler_jsc v0.0.0 (/work
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/bun/sql.ts                              |  21 ++--
 src/js/internal/sql/shared.ts                  |  53 ++++------
 test/js/sql/sql-close-timeout-overflow.test.ts | 133 +++++++++++++++++++++++++
 3 files changed, 164 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                            reads  edits  tests
src/js/bun/sql.ts                                   3      5     32
src/js/internal/sql/shared.ts                       7     10     28
test/js/sql/sql-close-timeout-overflow.test.ts      3      9     28
```

</details>

**root cause** · written by the author bot

The timeout validation in the SQL close paths and constructor options compared the raw seconds value against 2 ** 31, but the timer was armed with timeout * 1000 milliseconds, so any value between roughly 2147483.648 and 2 ** 31 seconds passed validation and then overflowed setTimeout's 32-bit delay, which clamped it to 1 ms and force-closed the pool almost immediately. The fix introduces a shared validateTimeoutSeconds helper that bounds the seconds value against (2 ** 31 - 1) / 1000 so the millisecond product can never overflow, and routes all six inline checks through it. It also moves v…

<!-- robobun:evidence:end -->