### PR TITLE
feat: add @shopify/react-native-skia to trusted deps

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -86,6 +86,7 @@
 @serialport/bindings-cpp
 @shopify/ngrok
 @shopify/plugin-cloudflare
+@shopify/react-native-skia
 @sitespeed.io/chromedriver
 @sitespeed.io/edgedriver
 @softvisio/core


### PR DESCRIPTION
### What does this PR do?

Add a dependency that is required for building mobile apps that use https://github.com/shopify/react-native-skia .
Since shopify already has a few trusted deps, I think this one is also trustworthy. WDYT?

### How did you verify your code works?

I used the `bun pm trust` command. This list works in a similar way.

I started a build without trusting the package -> didn't work
I did one after trusting the package -> did work

I did not compile bun to try this.
