### PR TITLE
Fix missing exception check when coercing Bun.plugin target to a string

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -306,12 +306,13 @@ static inline JSC::EncodedJSValue setupBunPlugin(JSC::JSGlobalObject* globalObje
     auto targetValue = obj->getIfPropertyExists(globalObject, Identifier::fromString(vm, "target"_s));
     RETURN_IF_EXCEPTION(throwScope, {});
     if (targetValue) {
-        if (auto* targetJSString = targetValue.toStringOrNull(globalObject)) {
-            String targetString = targetJSString->value(globalObject);
-            if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
-                JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
-                return {};
-            }
+        auto* targetJSString = targetValue.toStringOrNull(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        String targetString = targetJSString->value(globalObject);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!(targetString == "node"_s || targetString == "bun"_s || targetString == "browser"_s)) {
+            JSC::throwTypeError(globalObject, throwScope, "plugin target must be one of 'node', 'bun' or 'browser'"_s);
+            return {};
         }
     }
 

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -383,6 +383,25 @@ describe("errors", () => {
     expect(called).toBe(false);
   });
 
+  it("handles a 'target' whose toString throws", () => {
+    let called = false;
+    const opts = {
+      setup: () => {
+        called = true;
+      },
+      target: {
+        toString() {
+          throw new Error("target toString error");
+        },
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("target toString error");
+    expect(called).toBe(false);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -366,6 +366,23 @@ describe("errors", () => {
     }).toThrow("plugin target must be one of 'node', 'bun' or 'browser'");
   });
 
+  it("handles 'target' that throws while being coerced to a string", () => {
+    let called = false;
+    const opts = {
+      setup: () => {
+        called = true;
+      },
+      target: {
+        [Symbol.toPrimitive]: () => ({}),
+      },
+    };
+
+    expect(() => {
+      plugin(opts as any);
+    }).toThrow("Symbol.toPrimitive returned an object");
+    expect(called).toBe(false);
+  });
+
   it("invalid loaders throw", () => {
     const invalidLoaders = ["blah", "blah2", "blah3", "blah4"];
     const inputs = ["body { background: red; }", "<h1>hi</h1>", '{"hi": "there"}', "hi"];


### PR DESCRIPTION
### What does this PR do?

Fixes a debug assertion failure (`ASSERTION FAILED: Unexpected exception observed` / `assertNoException()`) found by fuzzing, fingerprint `99e6ccd6698f2a64`.

Repro:

```js
Bun.plugin({
  setup() {},
  target: { [Symbol.toPrimitive]: () => ({}) },
});
```

On a debug build this aborts with SIGABRT instead of throwing.

Root cause: in `setupBunPlugin` (src/jsc/bindings/BunPlugin.cpp), the `target` property is coerced with `JSValue::toStringOrNull`, which can run user JS (`Symbol.toPrimitive`, `toString`). Per the JSC header, `toStringOrNull` returns null exactly when an exception was thrown, so the old `if (auto* targetJSString = ...)` silently skipped validation and continued into builder-object construction and the `setup()` call with the exception still pending on the VM. Debug builds trip `assertNoException()` at the next VM entry.

The fix adds `RETURN_IF_EXCEPTION` after the coercion and after `JSString::value` (rope resolution can also throw), matching the pattern the rest of the file already uses. The thrown error now propagates to the `Bun.plugin()` caller and `setup()` is not invoked.

### How did you verify your code works?

- Added a test in `test/js/bun/plugin/plugins.test.ts` next to the existing invalid-target test. It asserts the coercion error propagates and that `setup` is not called. On an unfixed debug build the test aborts with the assertion (exit 134); with the fix it passes. Release builds do not compile the assertion, so the crash is only observable on debug/ASAN builds.
- Ran the fuzzer repro against the fixed debug build: clean `TypeError: Symbol.toPrimitive returned an object` (exit 1), also clean under `BUN_JSC_validateExceptionChecks=1`.
- Full `plugins.test.ts` suite passes with the fix (30 pass, 1 todo, 0 fail), including the existing valid and invalid `target` cases.
