### PR TITLE
Fix panic on relative or non-string require.resolve options.paths entries

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -372,6 +372,12 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 WTF::Vector<BunString> paths;
                 for (size_t i = 0; i < userPathListArray->length(); ++i) {
                     JSValue path = userPathListArray->getIndex(globalObject, i);
+                    if (scope.exception()) [[unlikely]]
+                        goto cleanup;
+                    if (!path.isString()) {
+                        Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, makeString("paths["_s, i, "]"_s), "string"_s, path);
+                        goto cleanup;
+                    }
                     WTF::String pathStr = path.toWTFString(globalObject);
                     if (scope.exception()) [[unlikely]]
                         goto cleanup;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -379,6 +379,11 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
                 if (scope.exception())
                     return;
 
+                if (!item.isString()) {
+                    Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, makeString("paths["_s, paths.size(), "]"_s), "string"_s, item);
+                    return;
+                }
+
                 WTF::String pathStr = item.toWTFString(lexicalGlobalObject);
                 if (scope.exception())
                     return;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -380,6 +380,7 @@ pub struct Bufs {
     pub dir_info_uncached_path: PathBuffer,
     pub tsconfig_base_url: PathBuffer,
     pub relative_abs_path: PathBuffer,
+    pub custom_dir_path: PathBuffer,
     pub load_as_file_or_directory_via_tsconfig_base_path: PathBuffer,
     pub node_modules_check: PathBuffer,
     pub field_abs_path: PathBuffer,
@@ -2091,12 +2092,17 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    // `custom_dir_paths` entries are user input (`options.paths`)
+                    // and may be relative; Node.js resolves them against the
+                    // working directory (`path.resolve`), and
+                    // `check_package_path` requires an absolute `source_dir`.
+                    let Some(custom_abs) = self
+                        .fs_ref()
+                        .abs_buf_checked(&[custom_utf8.slice()], bufs!(custom_dir_path))
+                    else {
+                        continue;
+                    };
+                    match self.check_package_path(custom_abs, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -2,7 +2,7 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs";
 import Module from "module";
 import { tmpdir } from "os";
-import { dirname, join, resolve } from "path";
+import { dirname, join, relative, resolve } from "path";
 
 // Detect runtime and import appropriate test framework
 const isBun = typeof Bun !== "undefined";
@@ -180,6 +180,80 @@ test("require.resolve with relative path and options.paths (Next.js use case)", 
     expect(resolved).toBe(resolve(dir, "node_modules/babel-plugin-react-compiler/dist/index.js"));
   } finally {
     cleanup();
+  }
+});
+
+test("require.resolve throws ERR_INVALID_ARG_TYPE for non-string options.paths entries", () => {
+  let err;
+  try {
+    require.resolve("nonexistent-pkg-for-paths-test", { paths: [ArrayBuffer] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message).toBe('The "paths[0]" argument must be of type string. Received function ArrayBuffer');
+
+  err = undefined;
+  try {
+    require.resolve("nonexistent-pkg-for-paths-test", { paths: [{}] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message).toBe('The "paths[0]" argument must be of type string. Received an instance of Object');
+});
+
+test("require with non-string options.paths entries does not crash", () => {
+  let err;
+  try {
+    require("nonexistent-pkg-for-paths-test", { paths: [ArrayBuffer, ArrayBuffer, Set] });
+  } catch (e) {
+    err = e;
+  }
+  // Node ignores the second argument to require(); Bun forwards options.paths
+  // to the resolver, so the non-string entry is rejected.
+  expect(err.code).toBe(isBun ? "ERR_INVALID_ARG_TYPE" : "MODULE_NOT_FOUND");
+});
+
+test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE for non-string options.paths entries", () => {
+  const fakeParent = new Module("/some/other/directory/file.js");
+  fakeParent.filename = "/some/other/directory/file.js";
+  fakeParent.paths = Module._nodeModulePaths("/some/other/directory");
+
+  let err;
+  try {
+    Module._resolveFilename("nonexistent-pkg-for-paths-test", fakeParent, false, { paths: [5] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message).toBe('The "paths[0]" argument must be of type string. Received type number (5)');
+});
+
+test("require.resolve resolves relative options.paths entries against the working directory", () => {
+  const { path: dir, cleanup } = createTempDir("relative-paths-entry", {
+    "node_modules/relative-paths-pkg/package.json": JSON.stringify({ name: "relative-paths-pkg", main: "index.js" }),
+    "node_modules/relative-paths-pkg/index.js": "module.exports = 'relative-paths-pkg';",
+  });
+
+  try {
+    const relDir = relative(process.cwd(), dir);
+    const resolved = require.resolve("relative-paths-pkg", { paths: [relDir] });
+    expect(resolved).toBe(resolve(dir, "node_modules/relative-paths-pkg/index.js"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("require.resolve does not crash on relative or empty options.paths entries", () => {
+  for (const entry of ["some-relative-dir", "", "."]) {
+    let err;
+    try {
+      require.resolve("nonexistent-pkg-for-paths-test", { paths: [entry] });
+    } catch (e) {
+      err = e;
+    }
+    expect(err.code).toBe("MODULE_NOT_FOUND");
   }
 });
 


### PR DESCRIPTION
Fixes a fuzzer-found panic (release builds included) reachable from `require()`, `require.resolve()`, and `Module._resolveFilename()` when `options.paths` contains a relative string, an empty string, or a non-string value:

```js
require.resolve("total", { paths: ["foo"] });       // panic: cannot resolve DirInfo for non-absolute path: foo
require.resolve("total", { paths: [ArrayBuffer] }); // panic: ... function ArrayBuffer() { [native code] }
require("total", { paths: [new Set()] });           // panic: ... [object Set]
```

Root cause: entries of `options.paths` were stringified in the C++ bindings and handed straight to the resolver as `custom_dir_paths`, whose package-path loop passes each entry to `check_package_path` as a `source_dir`. `dir_info_cached` asserts its input is absolute, so any non-absolute entry tripped `assert!(bun_paths::is_absolute(...))` in `resolver.rs`, which is live in release builds too.

Node's behavior for these inputs:

- Relative (and empty) entries are resolved against the working directory (`Module._nodeModulePaths` calls `path.resolve(from)`), so `require.resolve("pkg", { paths: ["reldir"] })` finds `$CWD/reldir/node_modules/pkg`.
- Non-string entries throw `TypeError [ERR_INVALID_ARG_TYPE]: The "paths[0]" argument must be of type string. Received function ArrayBuffer`.

This PR matches that:

- `src/resolver/resolver.rs`: the fixing change. The `custom_dir_paths` package-path loop now joins each entry against the working directory (`abs_buf_checked`) before calling `check_package_path`, using a new dedicated scratch buffer in `Bufs`. The relative-import loop already joins via `check_relative_path`, so it was not affected.
- `src/jsc/bindings/ImportMetaObject.cpp` and `src/jsc/modules/NodeModuleModule.cpp`: non-string `paths` entries now throw `ERR_INVALID_ARG_TYPE` with Node's message instead of being stringified. Also adds a missing exception check after `getIndex` in the ImportMetaObject loop.

One deliberate message divergence: for a mixed array like `["ok", 5]`, Node always reports `paths[0]` (the name comes from `path.resolve`'s own argument position), while Bun reports the actual index. Same code and message shape; the index is just accurate. Node also uses a different message (`The "paths" argument must be array of strings`) when the request itself is relative; Bun uses the `paths[i]` form for both.

Tests are added to `test/js/node/module/module-resolve-filename-paths.test.js`, which runs under both Bun and Node. All 11 tests pass under `bun bd test` and under Node v24.3.0 (`node --test`), and the new ones panic on the unfixed build (`USE_SYSTEM_BUN=1`). The positive case (relative `paths` entry resolving a package) is verified against Node output. Upstream `test/js/node/test/parallel/test-require-resolve.js` still passes.
