### PR TITLE
Fix multi-line paste in the bun feedback prompt

### DIFF
--- a/src/js/eval/feedback.ts
+++ b/src/js/eval/feedback.ts
@@ -321,6 +321,10 @@ async function promptForBody(
   }
 
   const header = `${symbols.question} ${bold}Share your feedback with Bun's team${reset} ${dim}(Enter to send, Shift+Enter for a newline)${reset}`;
+  // Bracketed paste mode wraps pasted input in \x1b[200~ ... \x1b[201~ so a
+  // multi-line paste is inserted as text instead of the first newline
+  // submitting the message. Terminals without support ignore the sequence.
+  output.write("\x1b[?2004h");
   output.write(`${header}\n`);
   if (attachments.length > 0) {
     output.write(`${dim}+ ${attachments.map(file => file.filename).join(", ")}${reset}\n`);
@@ -330,12 +334,15 @@ async function promptForBody(
   const lines: string[] = [""];
   let currentLine = 0;
   let resolved = false;
+  let pasting = false;
+  let pastePrevWasCR = false;
 
   return await new Promise<string | undefined>(resolve => {
     const cleanup = (value?: string) => {
       if (resolved) return;
       resolved = true;
       input.removeListener("keypress", onKeypress);
+      output.write("\x1b[?2004l");
       if (typeof input.setRawMode === "function") {
         if (typeof hadRawMode === "boolean") {
           input.setRawMode(hadRawMode);
@@ -350,11 +357,21 @@ async function promptForBody(
       resolve(value);
     };
 
+    const appendText = (text: string) => {
+      lines[currentLine] += text;
+      output.write(text);
+    };
+
+    const insertNewline = () => {
+      lines.push("");
+      currentLine += 1;
+      output.write(`\n${inputPrefix}`);
+    };
+
     const onKeypress = (str: string, key: readline.Key) => {
       if (!key) {
         if (str) {
-          lines[currentLine] += str;
-          output.write(str);
+          appendText(str);
         }
         return;
       }
@@ -365,15 +382,57 @@ async function promptForBody(
         return;
       }
 
+      if (key.name === "paste-start") {
+        pasting = true;
+        pastePrevWasCR = false;
+        return;
+      }
+
+      if (key.name === "paste-end") {
+        pasting = false;
+        return;
+      }
+
+      if (pasting) {
+        // Pasted newlines are literal text, never a submit. \r\n is one newline.
+        const prevWasCR = pastePrevWasCR;
+        pastePrevWasCR = key.name === "return";
+        if (key.name === "return") {
+          insertNewline();
+          return;
+        }
+        if (key.name === "enter") {
+          if (!prevWasCR) {
+            insertNewline();
+          }
+          return;
+        }
+        if (key.name === "tab") {
+          appendText("\t");
+          return;
+        }
+        if (key.name && key.name.length > 1 && key.name !== "space") {
+          return;
+        }
+        if (str) {
+          appendText(str);
+        }
+        return;
+      }
+
       if (key.name === "return") {
         if (key.shift) {
-          lines.push("");
-          currentLine += 1;
-          output.write(`\n${inputPrefix}`);
+          insertNewline();
           return;
         }
         const message = lines.join("\n");
         cleanup(message);
+        return;
+      }
+
+      // Ctrl+J, or a pasted \n on terminals without bracketed paste support.
+      if (key.name === "enter") {
+        insertNewline();
         return;
       }
 
@@ -398,8 +457,7 @@ async function promptForBody(
       }
 
       if (str) {
-        lines[currentLine] += str;
-        output.write(str);
+        appendText(str);
       }
     };
 

--- a/test/cli/feedback/feedback.test.ts
+++ b/test/cli/feedback/feedback.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/32108
+// Pasting multi-line text into the interactive `bun feedback` prompt must
+// insert the whole text instead of submitting at the first newline.
+//
+// Skipped on Windows: ConPTY rewrites VT input sequences, so the raw
+// bracketed-paste bytes this test writes are not delivered verbatim to the
+// child process.
+describe.concurrent.skipIf(isWindows)("bun feedback interactive prompt", () => {
+  const expected = "first line\nsecond line\nthird line";
+
+  async function runFeedbackWithTerminalInput(writes: string[]): Promise<{ message: string; exitCode: number }> {
+    const { promise: messagePromise, resolve: resolveMessage } = Promise.withResolvers<string>();
+
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const form = await req.formData();
+        resolveMessage(String(form.get("message")));
+        return new Response("ok");
+      },
+    });
+
+    using dir = tempDir("feedback-paste", {});
+
+    const received: string[] = [];
+    let notifyData: (() => void) | null = null;
+    const notify = () => {
+      notifyData?.();
+      notifyData = null;
+    };
+
+    await using terminal = new Bun.Terminal({
+      cols: 120,
+      rows: 40,
+      data(_terminal, data) {
+        received.push(Buffer.from(data).toString());
+        notify();
+      },
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "feedback", "--email", "test@example.com"],
+      terminal,
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        TERM: "xterm-256color",
+        BUN_FEEDBACK_URL: `http://localhost:${server.port}/`,
+        BUN_INSTALL: String(dir),
+      },
+    });
+
+    let exitCode: number | null = null;
+    const exited = proc.exited.then(code => {
+      exitCode = code;
+      notify();
+      return code;
+    });
+
+    const output = () => Bun.stripANSI(received.join(""));
+
+    // Wait for the interactive prompt before writing any input.
+    const deadline = Date.now() + 20_000;
+    while (!output().includes("Share your feedback")) {
+      if (exitCode !== null) {
+        throw new Error(`bun feedback exited early with code ${exitCode}. Output:\n${output()}`);
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`Timed out waiting for the feedback prompt. Output so far:\n${output()}`);
+      }
+      await new Promise<void>(resolve => {
+        notifyData = resolve;
+      });
+    }
+
+    for (const chunk of writes) {
+      terminal.write(chunk);
+    }
+
+    const result = await Promise.race([messagePromise.then(message => ({ message })), exited.then(code => ({ code }))]);
+    if (!("message" in result)) {
+      throw new Error(`bun feedback exited with code ${result.code} without submitting. Output:\n${output()}`);
+    }
+
+    return { message: result.message, exitCode: await exited };
+  }
+
+  test("bracketed paste with CR newlines is inserted, not submitted", async () => {
+    // Most terminals (iTerm2, Terminal.app, ...) send pasted newlines as \r.
+    const { message, exitCode } = await runFeedbackWithTerminalInput([
+      "\x1b[200~first line\rsecond line\rthird line\x1b[201~",
+      "\r",
+    ]);
+    expect(message).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bracketed paste with LF newlines is inserted, not dropped", async () => {
+    // xterm pastes the clipboard verbatim, so newlines arrive as \n.
+    const { message, exitCode } = await runFeedbackWithTerminalInput([
+      "\x1b[200~first line\nsecond line\nthird line\x1b[201~",
+      "\r",
+    ]);
+    expect(message).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test("bracketed paste with CRLF newlines counts each as one newline", async () => {
+    // Windows clipboard content uses \r\n line endings.
+    const { message, exitCode } = await runFeedbackWithTerminalInput([
+      "\x1b[200~first line\r\nsecond line\r\nthird line\x1b[201~",
+      "\r",
+    ]);
+    expect(message).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test("pasted LF newlines without bracketed paste insert newlines", async () => {
+    // Terminals without bracketed paste support deliver the pasted text as-is.
+    const { message, exitCode } = await runFeedbackWithTerminalInput(["first line\nsecond line\nthird line", "\r"]);
+    expect(message).toBe(expected);
+    expect(exitCode).toBe(0);
+  });
+
+  test("typing and pressing Enter still submits", async () => {
+    const { message, exitCode } = await runFeedbackWithTerminalInput(["hello world", "\r"]);
+    expect(message).toBe("hello world");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Fixes #32108

### Problem

Pasting multi-line text into the interactive `bun feedback` prompt submits only the first line. The prompt (`promptForBody` in `src/js/eval/feedback.ts`) submits on any unshifted `return` keypress, and it never enables bracketed paste mode, so a paste is indistinguishable from pressing Enter:

- Terminals that send pasted newlines as `\r` (iTerm2, Terminal.app, ...) submit at the first newline, losing everything after it.
- Terminals that send `\n` produce `key.name === "enter"`, which fell into the multi-character key-name ignore branch, so all lines were concatenated into one.

### Fix

- Enable bracketed paste mode (`\x1b[?2004h`) while the body prompt is active and disable it on cleanup, including the Ctrl+C path. Terminals that support it (effectively all current ones) wrap pastes in `\x1b[200~` ... `\x1b[201~`, which Bun's readline keypress parser already reports as `paste-start`/`paste-end`.
- Between those markers, treat `\r`, `\n`, and `\r\n` as literal newlines (CRLF counts once), keep tabs, and never submit.
- Outside a paste, treat a bare line feed (Ctrl+J, or a pasted `\n` on a terminal without bracketed paste) as a newline instead of dropping it.

Enter still submits and Shift+Enter still inserts a newline. A terminal that lacks bracketed paste and transmits pasted newlines as `\r` still submits at the first newline, since those bytes are byte-identical to the Enter key; that is the same limitation shells have there.

### Tests

`test/cli/feedback/feedback.test.ts` drives `bun feedback` in a PTY via `Bun.Terminal` with a local `BUN_FEEDBACK_URL` capture server and asserts the submitted message for bracketed pastes with CR, LF, and CRLF newlines, an unbracketed LF paste, and plain typing + Enter.

On the unfixed build the four paste tests fail (`"first line"` submitted early, or lines concatenated); all five pass with the fix.