### PR TITLE
fix(sql): validate close({ timeout }) on the millisecond product, not seconds

### DIFF
--- a/src/js/bun/sql.ts
+++ b/src/js/bun/sql.ts
@@ -390,8 +390,12 @@ const SQL: typeof Bun.SQL = function SQL(
       let timeout = options?.timeout;
       if (timeout) {
         timeout = Number(timeout);
-        if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-          throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
+        if (timeout < 0 || timeout !== timeout || timeout * 1000 > 2 ** 31) {
+          throw $ERR_INVALID_ARG_VALUE(
+            "options.timeout",
+            timeout,
+            "must be a non-negative integer less than 2^31 / 1000",
+          );
         }
         if (timeout > 0 && (reserveQueries.size > 0 || reservedTransaction.size > 0)) {
           const { promise, resolve } = Promise.withResolvers();
@@ -656,8 +660,12 @@ const SQL: typeof Bun.SQL = function SQL(
       let timeout = options?.timeout;
       if (timeout) {
         timeout = Number(timeout);
-        if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-          throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
+        if (timeout < 0 || timeout !== timeout || timeout * 1000 > 2 ** 31) {
+          throw $ERR_INVALID_ARG_VALUE(
+            "options.timeout",
+            timeout,
+            "must be a non-negative integer less than 2^31 / 1000",
+          );
         }
 
         if (timeout > 0 && (transactionQueries.size > 0 || transactionSavepoints.size > 0)) {

--- a/src/js/internal/sql/mysql.ts
+++ b/src/js/internal/sql/mysql.ts
@@ -908,8 +908,12 @@ class MySQLAdapter
     let timeout = options?.timeout;
     if (timeout) {
       timeout = Number(timeout);
-      if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-        throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
+      if (timeout < 0 || timeout !== timeout || timeout * 1000 > 2 ** 31) {
+        throw $ERR_INVALID_ARG_VALUE(
+          "options.timeout",
+          timeout,
+          "must be a non-negative integer less than 2^31 / 1000",
+        );
       }
 
       this.closed = true;

--- a/src/js/internal/sql/postgres.ts
+++ b/src/js/internal/sql/postgres.ts
@@ -1151,8 +1151,12 @@ class PostgresAdapter
     let timeout = options?.timeout;
     if (timeout) {
       timeout = Number(timeout);
-      if (timeout > 2 ** 31 || timeout < 0 || timeout !== timeout) {
-        throw $ERR_INVALID_ARG_VALUE("options.timeout", timeout, "must be a non-negative integer less than 2^31");
+      if (timeout < 0 || timeout !== timeout || timeout * 1000 > 2 ** 31) {
+        throw $ERR_INVALID_ARG_VALUE(
+          "options.timeout",
+          timeout,
+          "must be a non-negative integer less than 2^31 / 1000",
+        );
       }
 
       this.closed = true;

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12879,3 +12879,37 @@ console.log("FIXTURE_DONE");
   expect(filteredStderr).toBe("");
   expect(exitCode).toBe(0);
 }, 30_000);
+
+// `sql.close({ timeout })` is documented in seconds and `setTimeout` is armed
+// with `timeout * 1000`. The validation upper bound was `timeout > 2 ** 31`,
+// which checked the seconds value against the millisecond limit — so any
+// `timeout` in (2147483.648, 2 ** 31] seconds passed validation, then the
+// millisecond product overflowed and `setTimeout` clamped to 1 ms, force-
+// closing the pool ~1 ms later and cancelling in-flight queries instead of
+// waiting the requested time. The bound now lives on the millisecond product.
+// See https://github.com/oven-sh/bun/issues/32096.
+describe("Bun.SQL close({ timeout }) — millisecond-product upper bound", () => {
+  // Smallest integer where the seconds value still fits in `2 ** 31` but the
+  // millisecond product (2_147_484_000) overflows the 32-bit signed range.
+  const TIMEOUT_THAT_OVERFLOWS_MS = 2_147_484;
+
+  test.each(["postgres", "mysql"])("rejects an overflowing timeout (%s)", async adapter => {
+    const sql = new SQL(`${adapter}://user:pass@127.0.0.1:1/db`);
+    await expect(sql.close({ timeout: TIMEOUT_THAT_OVERFLOWS_MS })).rejects.toThrow(
+      /must be a non-negative integer less than 2\^31 \/ 1000/,
+    );
+  });
+
+  test("accepts a timeout at the millisecond limit", async () => {
+    const sql = new SQL("postgres://user:pass@127.0.0.1:1/db");
+    // 2_147_483 * 1000 = 2_147_483_000 < 2 ** 31, so this fits.
+    await expect(sql.close({ timeout: 2_147_483 })).resolves.toBeUndefined();
+  });
+
+  test("still rejects negative timeouts", async () => {
+    const sql = new SQL("postgres://user:pass@127.0.0.1:1/db");
+    await expect(sql.close({ timeout: -1 })).rejects.toThrow(
+      /must be a non-negative integer less than 2\^31 \/ 1000/,
+    );
+  });
+});


### PR DESCRIPTION
Fixes #32096.

## Summary

`sql.close({ timeout })` is documented in seconds and `setTimeout` is armed with `timeout * 1000`. The upper-bound check was `timeout > 2 ** 31` — comparing the seconds value against the millisecond limit — so any timeout in `(2147483.648, 2 ** 31]` seconds passed validation. The millisecond product then overflowed the 32-bit signed range; Node's `setTimeout` issued a `TimeoutOverflowWarning` and clamped the delay to 1 ms, force-closing the pool ~1 ms later and cancelling in-flight queries instead of waiting the requested time.

```
$ bun -e "const t=Date.now(); setTimeout(() => console.log('fired after', Date.now()-t, 'ms'), 2**31 * 1000)"
TimeoutOverflowWarning: 2147483648000 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
fired after 3 ms
```

## Fix

Move the bound onto `timeout * 1000` so the validation matches the underlying `setTimeout` limit:

```ts
if (timeout < 0 || timeout !== timeout || timeout * 1000 > 2 ** 31) {
  throw $ERR_INVALID_ARG_VALUE(
    "options.timeout",
    timeout,
    "must be a non-negative integer less than 2^31 / 1000",
  );
}
```

Applied to all four sites that share the same pattern (per the issue):

- `src/js/internal/sql/postgres.ts` — `PostgresAdapter.close`
- `src/js/internal/sql/mysql.ts` — `MySQLAdapter.close`
- `src/js/bun/sql.ts` — `reserved_sql.close` and `transaction_sql.close`

Negative and zero handling is unchanged; the error message is updated to reflect the corrected bound.

## Testing

New tests at the end of `test/js/sql/sql.test.ts` (outside the Docker-gated block so they don't depend on a live database):

- `rejects an overflowing timeout (postgres)` — calls `close({ timeout: 2_147_484 })` (smallest integer whose millisecond product overflows `2 ** 31`) and asserts the new error message.
- `rejects an overflowing timeout (mysql)` — same against the MySQL adapter.
- `accepts a timeout at the millisecond limit` — `close({ timeout: 2_147_483 })` (`2_147_483_000 ms < 2 ** 31`) still resolves.
- `still rejects negative timeouts` — sanity check on the rest of the validation.

I verified the three regression tests fail under `USE_SYSTEM_BUN=1` (which runs the unfixed validation) — the overflowing-timeout cases resolve instead of rejecting, and the negative-timeout case rejects with the OLD error message string. I could not run `bun bd test` locally because this machine doesn't have a Rust toolchain set up; relying on CI to confirm the post-fix path. Happy to iterate if anything surfaces.

The `reserved_sql.close` / `transaction_sql.close` sibling paths in `sql.ts` receive the identical fix; testing them requires a connected pool (Docker-gated tests) — they're covered by inspection in the same patch.