### PR TITLE
Emit sourcemaps for standalone HTML builds (--compile --target=browser)

### DIFF
--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -612,9 +612,14 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     // `Chunk::allocator_for_size` ever becomes size-dependent, matched-arena
     // dealloc must be restored here.
     let mut standalone_chunk_contents: Option<Vec<Option<Box<[u8]>>>> = None;
+    // Finalized sourcemap JSON for standalone-mode chunks whose sourcemap
+    // option writes a separate .map file (linked/external). Indexed by chunk;
+    // consumed by the output-file loops below.
+    let mut standalone_sourcemaps: Vec<Option<Box<[u8]>>> = Vec::new();
 
     if is_standalone {
         let mut scc: Vec<Option<Box<[u8]>>> = vec![None; chunks.len()];
+        standalone_sourcemaps = vec![None; chunks.len()];
 
         // `IntermediateOutput.code_standalone` reads `&Chunk` /
         // `&[Chunk]` (chunk is `&chunks[ci]`). Take `intermediate_output` out
@@ -623,6 +628,7 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             if matches!(chunks[ci].content, crate::chunk::Content::Html) {
                 continue;
             }
+            let sourcemap_option = chunks[ci].content.sourcemap(c.options.source_maps);
             let mut ds: usize = 0;
             // Pass `scc` so that `.asset` pieces (e.g. `import logo from "./logo.svg"` with
             // the file loader) are resolved to data: URIs from `url_for_css` instead of
@@ -631,21 +637,117 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             // back to file paths when their entry in `scc` is null, matching the previous
             // behavior for inter-chunk imports.
             let mut intermediate_output = core::mem::take(&mut chunks[ci].intermediate_output);
-            let buffer = intermediate_output
-                .code_standalone(
-                    None,
-                    c.parse_graph(),
-                    &c.graph,
-                    c.options.public_path,
-                    &chunks[ci],
-                    chunks,
-                    &mut ds,
-                    false,
-                    false,
-                    &scc,
-                )?
-                .buffer;
+            let code_result = intermediate_output.code_standalone(
+                None,
+                c.parse_graph(),
+                &c.graph,
+                c.options.public_path,
+                &chunks[ci],
+                chunks,
+                &mut ds,
+                false,
+                sourcemap_option != SourceMapOption::None,
+                &scc,
+            )?;
             chunks[ci].intermediate_output = intermediate_output;
+            let mut buffer = code_result.buffer;
+
+            match sourcemap_option {
+                tag @ (SourceMapOption::External | SourceMapOption::Linked) => {
+                    let output_source_map = chunks[ci]
+                        .output_source_map
+                        .finalize(&code_result.shifts)
+                        .expect("Failed to allocate memory for external source map");
+
+                    if tag == SourceMapOption::Linked {
+                        let mut source_map_final_rel_path: Vec<u8> =
+                            Vec::with_capacity(chunks[ci].final_rel_path.len() + b".map".len());
+                        source_map_final_rel_path.extend_from_slice(&chunks[ci].final_rel_path);
+                        source_map_final_rel_path.extend_from_slice(b".map");
+
+                        // The chunk content is inlined into the HTML document,
+                        // so the sourceMappingURL resolves relative to the HTML
+                        // file rather than a JS file next to the .map. Point at
+                        // the .map path relative to the HTML chunk's directory.
+                        let mut relative_platform_buf = path::path_buffer_pool::get();
+                        let [a, b]: [&[u8]; 2] = if !c.options.public_path.is_empty() {
+                            cheap_prefix_normalizer(
+                                c.options.public_path,
+                                &source_map_final_rel_path,
+                            )
+                        } else {
+                            let entry_point_id = chunks[ci].entry_point.entry_point_id();
+                            let mut html_dir: &[u8] = chunks
+                                .iter()
+                                .find(|ch| {
+                                    matches!(ch.content, crate::chunk::Content::Html)
+                                        && ch.entry_point.entry_point_id() == entry_point_id
+                                })
+                                .map(|ch| {
+                                    path::resolve_path::dirname::<path::platform::Posix>(
+                                        &ch.final_rel_path,
+                                    )
+                                })
+                                .unwrap_or(b"");
+                            if html_dir == b"." {
+                                html_dir = b"";
+                            }
+                            cheap_prefix_normalizer(
+                                b"",
+                                if html_dir.is_empty() {
+                                    &source_map_final_rel_path
+                                } else {
+                                    path::resolve_path::relative_platform_buf::<
+                                        path::platform::Posix,
+                                        false,
+                                    >(
+                                        &mut relative_platform_buf[..],
+                                        html_dir,
+                                        &source_map_final_rel_path,
+                                    )
+                                },
+                            )
+                        };
+
+                        let source_map_start = b"//# sourceMappingURL=";
+                        let total_len =
+                            buffer.len() + source_map_start.len() + a.len() + b.len() + b"\n".len();
+                        let mut buf: Vec<u8> = Vec::with_capacity(total_len);
+                        buf.extend_from_slice(&buffer);
+                        buf.extend_from_slice(source_map_start);
+                        buf.extend_from_slice(a);
+                        buf.extend_from_slice(b);
+                        buf.push(b'\n');
+                        buffer = buf.into_boxed_slice();
+                    }
+
+                    standalone_sourcemaps[ci] = Some(output_source_map);
+                }
+                SourceMapOption::Inline => {
+                    let output_source_map = chunks[ci]
+                        .output_source_map
+                        .finalize(&code_result.shifts)
+                        .expect("Failed to allocate memory for inline source map");
+                    let encode_len = bun_base64::encode_len(&output_source_map);
+
+                    let source_map_start = b"//# sourceMappingURL=data:application/json;base64,";
+                    let total_len = buffer.len() + source_map_start.len() + encode_len + 1;
+                    let mut buf: Vec<u8> = Vec::with_capacity(total_len);
+
+                    buf.extend_from_slice(&buffer);
+                    buf.extend_from_slice(source_map_start);
+
+                    let old_len = buf.len();
+                    // Capacity reserved above; resize zero-fills then base64 overwrites.
+                    buf.resize(old_len + encode_len, 0);
+                    let _ = bun_base64::encode(&mut buf[old_len..], &output_source_map);
+
+                    buf.push(b'\n');
+                    buffer = buf.into_boxed_slice();
+                }
+                SourceMapOption::None => {}
+            }
+
             scc[ci] = Some(buffer);
         }
 
@@ -661,6 +763,7 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             chunks,
             &mut output_files,
             standalone_chunk_contents.as_deref(),
+            &mut standalone_sourcemaps,
         )?;
     } else {
         // In-memory build (also used for standalone mode)
@@ -677,6 +780,46 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                     crate::chunk::Content::Html
                 )
             {
+                // Emit the chunk's .map file (linked/external) even though the
+                // chunk itself is inlined into the HTML document.
+                let source_map_index: Option<u32> = if let Some(output_source_map) =
+                    standalone_sourcemaps[chunk_index_in_chunks_list].take()
+                {
+                    let chunk = &chunks[chunk_index_in_chunks_list];
+                    let mut source_map_final_rel_path: Vec<u8> =
+                        Vec::with_capacity(chunk.final_rel_path.len() + b".map".len());
+                    source_map_final_rel_path.extend_from_slice(&chunk.final_rel_path);
+                    source_map_final_rel_path.extend_from_slice(b".map");
+                    let input_path: &[u8] = if chunk.entry_point.is_entry_point() {
+                        c.parse_graph().input_files.items_source()
+                            [chunk.entry_point.source_index() as usize]
+                            .path
+                            .text
+                    } else {
+                        chunk.final_rel_path.as_ref()
+                    };
+
+                    Some(output_files.insert_for_sourcemap_or_bytecode(
+                        options::OutputFile::init(options::OutputFileInit {
+                            data: options::OutputFileData::Buffer {
+                                data: output_source_map,
+                            },
+                            hash: None,
+                            loader: Loader::Json,
+                            input_loader: Loader::File,
+                            output_path: source_map_final_rel_path.into_boxed_slice(),
+                            output_kind: options::OutputKind::Sourcemap,
+                            input_path: strings::concat(&[input_path, b".map"]),
+                            side: None,
+                            entry_point_index: None,
+                            is_executable: false,
+                            ..Default::default()
+                        }),
+                    )?)
+                } else {
+                    None
+                };
+
                 let _ = output_files.insert_for_chunk(options::OutputFile::init(
                     options::OutputFileInit {
                         data: options::OutputFileData::Buffer {
@@ -690,7 +833,7 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         input_loader: Loader::Js,
                         output_path: Box::default(),
                         is_executable: false,
-                        source_map_index: None,
+                        source_map_index,
                         bytecode_index: None,
                         module_info_index: None,
                         side: Some(options::Side::Client),
@@ -1144,13 +1287,16 @@ pub fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     }
 
     if is_standalone {
-        // For standalone mode, filter to only HTML output files.
+        // For standalone mode, filter to HTML output files plus the .map files
+        // of the inlined chunks (linked/external sourcemaps).
         // Deinit dropped items to free their heap allocations (paths, buffers).
         let mut result = output_files.take();
         let mut write_idx: usize = 0;
         let len = result.len();
         for i in 0..len {
-            if result[i].loader == Loader::Html {
+            if result[i].loader == Loader::Html
+                || result[i].output_kind == options::OutputKind::Sourcemap
+            {
                 result.swap(write_idx, i);
                 write_idx += 1;
             }

--- a/src/bundler/linker_context/writeOutputFilesToDisk.rs
+++ b/src/bundler/linker_context/writeOutputFilesToDisk.rs
@@ -34,6 +34,7 @@ pub fn write_output_files_to_disk(
     chunks: &mut [Chunk],
     output_files: &mut OutputFileList,
     standalone_chunk_contents: Option<&[Option<Box<[u8]>>]>,
+    standalone_sourcemaps: &mut [Option<Box<[u8]>>],
 ) -> Result<(), Error> {
     let _trace = bun_core::perf::trace("Bundler.writeOutputFilesToDisk");
 
@@ -90,6 +91,86 @@ pub fn write_output_files_to_disk(
         // In standalone mode, only write HTML chunks to disk.
         // Insert placeholder output files for non-HTML chunks to keep indices aligned.
         if standalone_chunk_contents.is_some() && !matches!(chunk.content, Content::Html) {
+            // The chunk itself is inlined into the HTML document, but its .map
+            // file (linked/external sourcemaps) is still written to disk.
+            let source_map_index: Option<u32> = if let Some(output_source_map) =
+                standalone_sourcemaps
+                    .get_mut(chunk_index_in_chunks_list)
+                    .and_then(Option::take)
+            {
+                let source_map_final_rel_path = strings::concat(&[&chunk.final_rel_path, b".map"]);
+
+                let rel_parent = paths::resolve_path::dirname::<paths::platform::Posix>(
+                    &source_map_final_rel_path,
+                );
+                if !rel_parent.is_empty() {
+                    if let Err(e) = root_dir.make_path(rel_parent) {
+                        c.log_mut().add_error_fmt(
+                            None,
+                            Loc::EMPTY,
+                            format_args!(
+                                "{} creating outdir {} while saving sourcemap {}",
+                                e.name(),
+                                quote(rel_parent),
+                                quote(&*source_map_final_rel_path),
+                            ),
+                        );
+                        return Err(e);
+                    }
+                }
+
+                if let Err(e) = bun_sys::File::write_file(
+                    bun_sys::Fd::from_std_dir(&root_dir),
+                    paths::resolve_path::z(&source_map_final_rel_path, &mut pathbuf),
+                    &output_source_map,
+                ) {
+                    c.log_mut().add_sys_error(
+                        &e,
+                        format_args!(
+                            "writing sourcemap for chunk {}",
+                            quote(&chunk.final_rel_path)
+                        ),
+                    );
+                    return Err(err!("WriteFailed"));
+                }
+
+                let input_path: &[u8] = if chunk.entry_point.is_entry_point() {
+                    c.parse_graph().input_files.items_source()
+                        [chunk.entry_point.source_index() as usize]
+                        .path
+                        .text
+                } else {
+                    &chunk.final_rel_path
+                };
+
+                Some(
+                    output_files.insert_for_sourcemap_or_bytecode(OutputFile::init(
+                        OutputFileInit {
+                            output_path: source_map_final_rel_path,
+                            input_path: strings::concat(&[input_path, b".map"]),
+                            loader: Loader::Json,
+                            input_loader: Loader::File,
+                            output_kind: options::OutputKind::Sourcemap,
+                            size: Some(output_source_map.len()),
+                            data: OutputFileData::Saved(0),
+                            side: Some(options::Side::Client),
+                            entry_point_index: None,
+                            is_executable: false,
+                            hash: None,
+                            source_map_index: None,
+                            bytecode_index: None,
+                            module_info_index: None,
+                            display_size: 0,
+                            referenced_css_chunks: Box::default(),
+                            source_index: IndexOptional::NONE,
+                            bake_extra: BakeExtra::default(),
+                        },
+                    ))?,
+                )
+            } else {
+                None
+            };
+
             let _ = output_files.insert_for_chunk(OutputFile::init(OutputFileInit {
                 data: OutputFileData::Saved(0),
                 hash: None,
@@ -100,7 +181,7 @@ pub fn write_output_files_to_disk(
                 input_loader: Loader::Js,
                 output_path: Box::default(),
                 is_executable: false,
-                source_map_index: None,
+                source_map_index,
                 bytecode_index: None,
                 module_info_index: None,
                 side: Some(options::Side::Client),

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2384,11 +2384,10 @@ fn parse_build_command_options(
             Global::crash();
         }
 
-        // when using --compile, only `external` works, as we do not
-        // look at the source map comment. so after we validate the
-        // user's choice was in the list, we secretly override it
-        if ctx.bundler_options.compile {
-            opts.source_map = Some(api::SourceMap::External);
-        }
+        // When using --compile, only `external` sourcemaps work, as the
+        // runtime does not look at the source map comment. That override
+        // happens in build_command.rs once it's known whether --compile
+        // produces an executable or a standalone HTML file (browsers do read
+        // the comment, so standalone HTML keeps the user's choice).
     }
 }

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -289,6 +289,15 @@ impl BuildCommand {
                     Global::exit(1);
                 }
 
+                // When compiling to an executable, only `external` sourcemaps
+                // work, as the runtime does not look at the source map
+                // comment. After validating the user's choice, secretly
+                // override it. (Standalone HTML builds keep the user's choice
+                // because browsers do read the comment.)
+                if this_transpiler.options.source_map != options::SourceMapOption::None {
+                    this_transpiler.options.source_map = options::SourceMapOption::External;
+                }
+
                 let base_public_path =
                     bun_standalone_module_graph::StandaloneModuleGraph::target_base_public_path(
                         compile_target.os,

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -516,4 +516,145 @@ console.log(message);`,
     expect(html).toContain('<script type="module">');
     expect(html).toContain("</script>");
   });
+
+  // https://github.com/oven-sh/bun/issues/32114
+  describe.concurrent("sourcemaps", () => {
+    const fixture = {
+      "index.html": `<!DOCTYPE html>
+<html>
+<head><title>Test</title><link rel="stylesheet" href="./style.css"></head>
+<body><script src="./index.ts"></script></body>
+</html>`,
+      "index.ts": `function greet(name: string): string {
+  return \`Hello, \${name}!\`;
+}
+console.log(greet("world"));`,
+      "style.css": `body { color: red; }`,
+    };
+
+    async function buildWithSourcemap(dir: string, outdir: string, sourcemap: string) {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--compile",
+          "--target=browser",
+          `--sourcemap=${sourcemap}`,
+          `${dir}/index.html`,
+          "--outdir",
+          outdir,
+        ],
+        env: bunEnv,
+        cwd: dir,
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      return stdout;
+    }
+
+    test("CLI --sourcemap=linked writes a .map file and links it from the inline script", async () => {
+      using dir = tempDir("compile-browser-sourcemap-linked", fixture);
+      const outdir = `${dir}/dist`;
+      await buildWithSourcemap(String(dir), outdir, "linked");
+
+      const files = Array.from(new Bun.Glob("**/*").scanSync({ cwd: outdir })).sort();
+      expect(files).toHaveLength(2);
+      expect(files).toContain("index.html");
+      const mapFile = files.find(f => f.endsWith(".js.map"))!;
+      expect(mapFile).toMatch(/^index-[0-9a-z]+\.js\.map$/);
+
+      // The inline <script> must reference the .map file relative to the HTML document.
+      const html = await Bun.file(`${outdir}/index.html`).text();
+      expect(html).toContain(`//# sourceMappingURL=./${mapFile}\n</script>`);
+
+      const map = await Bun.file(`${outdir}/${mapFile}`).json();
+      expect(map.version).toBe(3);
+      expect(map.sources.some((s: string) => s.endsWith("index.ts"))).toBe(true);
+      expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
+      expect(typeof map.mappings).toBe("string");
+      expect(map.mappings.length).toBeGreaterThan(0);
+    });
+
+    test("CLI --sourcemap=inline embeds a data: URL sourcemap in the inline script", async () => {
+      using dir = tempDir("compile-browser-sourcemap-inline", fixture);
+      const outdir = `${dir}/dist`;
+      await buildWithSourcemap(String(dir), outdir, "inline");
+
+      // Still a single self-contained file.
+      const files = Array.from(new Bun.Glob("**/*").scanSync({ cwd: outdir }));
+      expect(files).toEqual(["index.html"]);
+
+      const html = await Bun.file(`${outdir}/index.html`).text();
+      const match = html.match(/\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/);
+      expect(match).not.toBeNull();
+      const map = JSON.parse(Buffer.from(match![1], "base64").toString("utf8"));
+      expect(map.version).toBe(3);
+      expect(map.sources.some((s: string) => s.endsWith("index.ts"))).toBe(true);
+      expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
+      expect(map.mappings.length).toBeGreaterThan(0);
+    });
+
+    test("CLI --sourcemap=external writes a .map file without a sourceMappingURL comment", async () => {
+      using dir = tempDir("compile-browser-sourcemap-external", fixture);
+      const outdir = `${dir}/dist`;
+      await buildWithSourcemap(String(dir), outdir, "external");
+
+      const files = Array.from(new Bun.Glob("**/*").scanSync({ cwd: outdir })).sort();
+      expect(files).toHaveLength(2);
+      expect(files).toContain("index.html");
+      const mapFile = files.find(f => f.endsWith(".js.map"))!;
+      expect(mapFile).toMatch(/^index-[0-9a-z]+\.js\.map$/);
+
+      const html = await Bun.file(`${outdir}/index.html`).text();
+      expect(html).not.toContain("sourceMappingURL");
+
+      const map = await Bun.file(`${outdir}/${mapFile}`).json();
+      expect(map.version).toBe(3);
+      expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
+    });
+
+    test("Bun.build() with sourcemap: 'linked' returns the sourcemap artifact", async () => {
+      using dir = tempDir("compile-browser-sourcemap-api", fixture);
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+        sourcemap: "linked",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.outputs.length).toBe(2);
+      expect(result.outputs[0].loader).toBe("html");
+      expect(result.outputs[1].kind).toBe("sourcemap");
+
+      const html = await result.outputs[0].text();
+      expect(html).toContain("//# sourceMappingURL=");
+
+      const map = JSON.parse(await result.outputs[1].text());
+      expect(map.version).toBe(3);
+      expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
+    });
+
+    test("Bun.build() with sourcemap: 'inline' keeps a single HTML output", async () => {
+      using dir = tempDir("compile-browser-sourcemap-api-inline", fixture);
+
+      const result = await Bun.build({
+        entrypoints: [`${dir}/index.html`],
+        compile: true,
+        target: "browser",
+        sourcemap: "inline",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.outputs.length).toBe(1);
+      expect(result.outputs[0].loader).toBe("html");
+
+      const html = await result.outputs[0].text();
+      expect(html).toContain("//# sourceMappingURL=data:application/json;base64,");
+    });
+  });
 });

--- a/test/bundler/standalone.test.ts
+++ b/test/bundler/standalone.test.ts
@@ -628,13 +628,15 @@ console.log(greet("world"));`,
 
       expect(result.success).toBe(true);
       expect(result.outputs.length).toBe(2);
-      expect(result.outputs[0].loader).toBe("html");
-      expect(result.outputs[1].kind).toBe("sourcemap");
+      const htmlOutput = result.outputs.find(o => o.loader === "html");
+      const mapOutput = result.outputs.find(o => o.kind === "sourcemap");
+      expect(htmlOutput).toBeDefined();
+      expect(mapOutput).toBeDefined();
 
-      const html = await result.outputs[0].text();
+      const html = await htmlOutput!.text();
       expect(html).toContain("//# sourceMappingURL=");
 
-      const map = JSON.parse(await result.outputs[1].text());
+      const map = JSON.parse(await mapOutput!.text());
       expect(map.version).toBe(3);
       expect(map.sourcesContent.join("\n")).toContain("function greet(name: string): string {");
     });


### PR DESCRIPTION
Fixes #32114

### Problem

`bun build --compile --target=browser --sourcemap=linked ./index.html --outdir=dist` produced no sourcemap and no warning. Debug builds of main panic instead:

```
panic: total_insertions (2) != output_files.items.len (3)
  <OutputFileList>::take  src/bundler/linker_context/OutputFileListBuilder.rs:76
```

Two causes:

1. `Arguments.rs` silently overrides every `--sourcemap` value to `external` whenever `--compile` is set. That override exists because the executable runtime only reads `.map` files, not `sourceMappingURL` comments, but it ran at arg-parse time, before `build_command.rs` decides that `--compile --target=browser` with HTML entrypoints means standalone HTML (where the output is read by a browser, which does read the comment). The JS API already scopes the same override to non-standalone builds in `JSBundler.rs`.
2. The standalone HTML output loops insert placeholder output files for inlined chunks and skip sourcemap emission entirely, while `OutputFileList::calculate_output_file_list_capacity` still reserves a slot per linked/external chunk. Release builds truncate the empty slot away (silent drop); debug builds trip the `debug_assert` in `OutputFileList::take`.

### Fix

- The standalone HTML first pass in `generateChunksInParallel.rs` now generates each inlined chunk's sourcemap (with piece shifts enabled, since asset references become `data:` URIs):
  - `inline`: appends a `//# sourceMappingURL=data:application/json;base64,...` comment to the inlined script, keeping the output a single self-contained file.
  - `linked`: writes the `.map` file next to the output and appends a `sourceMappingURL` comment whose path is resolved relative to the HTML document (the script is inline, so the browser resolves the URL against the page, not a JS file).
  - `external`: writes the `.map` file with no comment.
- Both output paths (`write_output_files_to_disk` and the in-memory loop) fill the reserved sourcemap slot, fixing the accounting, and the standalone output filter keeps sourcemap files alongside HTML.
- The compile sourcemap override moved from `Arguments.rs` to the executable branch of `build_command.rs`, so it no longer applies to standalone HTML builds. Executable `--compile` behavior is unchanged.

```console
$ bun build --compile --target=browser --sourcemap=linked ./index.html --outdir=dist
  index.html             296 bytes  (entry point)
  index-mqftyfbv.js.map  352 bytes  (source map)
```

The inlined script now ends with `//# sourceMappingURL=./index-mqftyfbv.js.map`.

### Tests

Added 5 tests to `test/bundler/standalone.test.ts` covering linked/inline/external through the CLI and `sourcemap: "linked"`/`"inline"` through `Bun.build()`, asserting the `.map` file contents (`sources`, `sourcesContent`, `mappings`) and the comment placement. All 5 fail on the unfixed build (release: missing map/comment; debug: the assertion panic) and pass with the fix. Existing compile sourcemap suites (`bun-build-compile-sourcemap.test.ts`, `compile-sourcemap-internal.test.ts`, the `compile/10344+sourcemap` matrix, `bundler_html.test.ts`) still pass.