### PR TITLE
Fix crash when a client aborts a streaming response under backpressure

### DIFF
--- a/packages/bun-uws/src/Http3ResponseData.h
+++ b/packages/bun-uws/src/Http3ResponseData.h
@@ -34,11 +34,11 @@ struct Http3ResponseData {
     void *userData = nullptr;
     /* onWritable is owned by the body writer (HTTPServerWritable sink),
      * which is a different object than the RequestContext that owns
-     * onAborted/onTimeout/onData. uWS HttpResponseData<SSL> shares one
-     * userData and gets away with it because tryEnd() over a corked TCP
-     * socket never reports backpressure for in-memory bodies; QUIC does
-     * (lsquic needs a process_conns() between HEADERS and DATA), so the
-     * sink and the request context are armed concurrently. */
+     * onAborted/onTimeout/onData, and the two are armed concurrently:
+     * QUIC always reports backpressure between HEADERS and DATA (lsquic
+     * needs a process_conns() in between), and TCP tryEnd() does when the
+     * peer stalls or aborts mid-stream. Keep the onWritable context
+     * pointer in its own slot, same as HttpResponseData<SSL>. */
     void *writableUserData = nullptr;
     void *socketData = nullptr;
     OnWritableCallback onWritable = nullptr;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -695,7 +695,7 @@ public:
     HttpResponse *onWritable(void* userData, HttpResponseData<SSL>::OnWritableCallback handler) {
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
-        httpResponseData->userData = userData;
+        httpResponseData->writableUserData = userData;
         httpResponseData->onWritable = handler;
         return this;
     }
@@ -705,6 +705,7 @@ public:
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
+        httpResponseData->writableUserData = nullptr;
         return this;
     }
 
@@ -729,6 +730,7 @@ public:
         HttpResponseData<SSL> *httpResponseData = getHttpResponseData();
 
         httpResponseData->onWritable = nullptr;
+        httpResponseData->writableUserData = nullptr;
         httpResponseData->onAborted = nullptr;
         httpResponseData->onTimeout = nullptr;
 

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -46,6 +46,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         onAborted = nullptr;
         /* Also remove onWritable so that we do not emit when draining behind the scenes. */
         onWritable = nullptr;
+        writableUserData = nullptr;
         /* Ignore data after this point */
         inStream = nullptr;
 
@@ -68,7 +69,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         onWritable = [](uWS::HttpResponse<SSL>*, uint64_t, void*) {return true;};
 
         /* Run borrowed onWritable */
-        bool ret = borrowedOnWritable(response, offset, userData);
+        bool ret = borrowedOnWritable(response, offset, writableUserData);
 
         /* If we still have onWritable (the placeholder) then move back the real one */
         if (onWritable) {
@@ -90,8 +91,15 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
         HTTP_WROTE_TRANSFER_ENCODING_HEADER = 128, // used
     };
 
-    /* Shared context pointer */
+    /* Shared context pointer for onAborted/onTimeout/onData */
     void* userData = nullptr;
+    /* onWritable can be owned by a different object (the streaming body
+     * writer, e.g. Bun's HTTPServerWritable sink) than the one owning
+     * onAborted/onTimeout/onData (the RequestContext), and it can be armed
+     * mid-response when tryEnd() reports backpressure. Keep its context
+     * pointer in its own slot so arming it does not redirect the other
+     * callbacks to the wrong object. Mirrors Http3ResponseData. */
+    void* writableUserData = nullptr;
     void* socketData = nullptr;
 
     /* Per socket event handlers */

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -296,6 +296,7 @@ namespace WebCore {
 using namespace JSC;
 
 ${classes.map(name => `extern "C" size_t ${name}__memoryCost(void* sinkPtr);`).join("\n")}
+${classes.map(name => `extern "C" void ${name}__controllerDetached(void* sinkPtr, JSC::EncodedJSValue controllerValue);`).join("\n")}
 
 JSC_DEFINE_HOST_FUNCTION(functionStartDirectStream, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame *callFrame))
 {
@@ -644,6 +645,7 @@ ${controller}::~${controller}()
     }
 
     if (m_sinkPtr) {
+        ${name}__controllerDetached(m_sinkPtr, JSC::JSValue::encode(this));
         ${name}__finalize(m_sinkPtr);
     }
 }
@@ -663,6 +665,10 @@ void JS${controllerName}::detach() {
         auto destroy = m_onDestroy;
         m_onDestroy = 0;
         Bun__onSinkDestroyed(destroy, m_sinkPtr);
+    }
+
+    if (m_sinkPtr) {
+        ${name}__controllerDetached(m_sinkPtr, JSC::JSValue::encode(this));
     }
 
     m_sinkPtr = nullptr;
@@ -1129,6 +1135,17 @@ pub extern "C" fn ${name}__memoryCost(this: &${name}) -> usize {
     templ += `#[unsafe(no_mangle)]
 pub extern "C" fn ${name}__finalize(this: &mut ${name}) {
     ${JSSinkT}::js_finalize(this)
+}
+
+`;
+
+    // extern "C" void ${name}__controllerDetached(void* sinkPtr, JSC::EncodedJSValue)
+    // — called from JSReadable${name}Controller::detach() and its destructor.
+    // C++ caller null-checks `m_sinkPtr` before calling.
+    symbols.push(`${name}__controllerDetached`);
+    templ += `#[unsafe(no_mangle)]
+pub extern "C" fn ${name}__controllerDetached(this: &mut ${name}, controller: JSValue) {
+    ${JSSinkT}::js_controller_detached(this, controller)
 }
 
 `;

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1819,9 +1819,9 @@ where
         }
 
         // FileResponseStream registers its own onAborted/onWritable with itself
-        // as userData. uWS keeps a single shared userData slot per response, so
-        // any later setAbortHandler()/onWritable() from this RequestContext would
-        // stomp it and hand FileResponseStream's callbacks a *RequestContext.
+        // as userData; any later setAbortHandler()/onWritable() from this
+        // RequestContext would replace them and FileResponseStream would never
+        // hear about the abort/drain it is driving.
         self.flags.set_has_sendfile_ctx(true);
         self.flags.set_has_abort_handler(true);
         self.flags.set_has_marked_pending(true);
@@ -1984,8 +1984,12 @@ where
 
         assignment_result.ensure_still_alive();
 
-        // assert that it was updated
-        debug_assert!(!response_stream.sink.signal.is_dead());
+        // assignToStream stored the controller's encoded JSValue in
+        // signal.ptr. If the stream already finished synchronously inside the
+        // call, controller.end()/.close() detached the controller and cleared
+        // the signal again (`__controllerDetached`), so the signal may be
+        // legitimately dead here; the has_responded()/promise-status branches
+        // below handle that state.
 
         #[cfg(debug_assertions)]
         if resp.has_responded() {

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -1041,6 +1041,28 @@ impl<T: JsSinkType + JsSinkAbi> JSSink<T> {
         this.finalize();
     }
 
+    /// `${abi_name}__controllerDetached` body — called from
+    /// `JSReadable*Controller::detach()` (controller `.end()`/`.close()` host
+    /// fns) and from the controller's destructor, i.e. whenever the
+    /// controller stops being attached to this sink.
+    ///
+    /// `signal.ptr` stores the controller's encoded JSValue bits (written by
+    /// `__assignToStream`) without rooting the cell, so the controller can be
+    /// collected while the native sink still has a flush in flight (e.g. a
+    /// response stream parked on tryEnd() backpressure). Once the controller
+    /// detaches or dies the signal must never fire again: `onClose`/`onReady`
+    /// would decode a dead cell. Clear it, but only when it still holds this
+    /// controller's bits — `connect()`-style signals store a live native
+    /// pointer instead, and a sink re-assigned to a new stream holds the
+    /// newer controller's bits.
+    pub fn js_controller_detached(this: &mut T, controller: crate::webcore::jsc::JSValue) {
+        if let Some(signal) = this.signal() {
+            if signal.ptr.map(|p| p.as_ptr() as usize) == Some(controller.encoded()) {
+                signal.clear();
+            }
+        }
+    }
+
     /// `${abi_name}__close` body — called from
     /// `${controller}__close` and `${name}__doClose` in JSSink.cpp with a raw
     /// `m_sinkPtr` (not a host-fn callframe), so exceptions become `.zero`.

--- a/test/js/bun/http/serve-async-stream-client-abort-fixture.ts
+++ b/test/js/bun/http/serve-async-stream-client-abort-fixture.ts
@@ -1,0 +1,58 @@
+// Repro for https://github.com/oven-sh/bun/issues/32111
+//
+// The fetch handler returns a ReadableStream whose async pull() yields to the
+// event loop. When the client aborts mid-pull, the stream sink's tryEnd()
+// fails on the dying socket and arms uWS onWritable with the sink as user
+// data. uWS kept a single shared userData slot for all per-socket callbacks,
+// so the socket-close abort callback then fired with the *sink* pointer
+// instead of the RequestContext it was registered with — a type-confused
+// read that segfaulted (ASAN: heap-buffer-overflow in onAbort).
+
+const server = Bun.serve({
+  port: 0,
+  fetch() {
+    return new Response(
+      new ReadableStream({
+        async pull(controller) {
+          // The await is load-bearing: it parks the stream so the abort can
+          // interleave between stream completion and teardown.
+          await Bun.sleep(0);
+          controller.enqueue(new Uint8Array(8));
+          controller.close();
+        },
+      }),
+    );
+  },
+});
+
+let completed = 0;
+let aborted = 0;
+
+async function worker(iterations: number) {
+  for (let i = 0; i < iterations; i++) {
+    const controller = new AbortController();
+    // Random abort point so the aborts straddle every phase of the request:
+    // pre-connect, mid-headers, mid-pull, and post-completion.
+    const timer = setTimeout(() => controller.abort(), Math.random() * 10);
+    try {
+      await (await fetch(`http://127.0.0.1:${server.port}/`, { signal: controller.signal })).text();
+      completed++;
+    } catch {
+      aborted++;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+const WORKERS = 20;
+const ITERATIONS = 30;
+await Promise.all(Array.from({ length: WORKERS }, () => worker(ITERATIONS)));
+
+server.stop(true);
+
+if (aborted === 0 || completed + aborted !== WORKERS * ITERATIONS) {
+  console.error(`expected some aborted requests, got completed=${completed} aborted=${aborted}`);
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, completed, aborted }));

--- a/test/js/bun/http/serve-async-stream-client-abort.test.ts
+++ b/test/js/bun/http/serve-async-stream-client-abort.test.ts
@@ -3,24 +3,20 @@ import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
 // https://github.com/oven-sh/bun/issues/32111
-test(
-  "client aborting an async-pull ReadableStream response does not crash the server",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(import.meta.dir, "serve-async-stream-client-abort-fixture.ts")],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
+test("client aborting an async-pull ReadableStream response does not crash the server", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "serve-async-stream-client-abort-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
 
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
-      stderr: "",
-      stdout: expect.stringContaining('"ok":true'),
-      exitCode: 0,
-      signalCode: null,
-    });
-  },
-  60_000,
-);
+  expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stderr: "",
+    stdout: expect.stringContaining('"ok":true'),
+    exitCode: 0,
+    signalCode: null,
+  });
+}, 60_000);

--- a/test/js/bun/http/serve-async-stream-client-abort.test.ts
+++ b/test/js/bun/http/serve-async-stream-client-abort.test.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// https://github.com/oven-sh/bun/issues/32111
+test(
+  "client aborting an async-pull ReadableStream response does not crash the server",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "serve-async-stream-client-abort-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stderr, stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+      stderr: "",
+      stdout: expect.stringContaining('"ok":true'),
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  60_000,
+);


### PR DESCRIPTION
Fixes #32111

## Repro

```ts
Bun.serve({ port: 8090, fetch() {
  return new Response(new ReadableStream({
    async pull(c) { await Bun.sleep(0); c.enqueue(new Uint8Array(8)); c.close(); },
  }));
}});

async function w() {
  for (;;) {
    const a = new AbortController();
    setTimeout(() => a.abort(), Math.random() * 10);
    try { await (await fetch("http://127.0.0.1:8090/", { signal: a.signal })).text(); } catch {}
  }
}
await Promise.all(Array.from({ length: 20 }, () => w()));
```

Crashes in under a second on 1.3.14 and current main:

```
panic(main thread): Segmentation fault at address 0x20
RequestContext.NewRequestContext.onAbort          RequestContext.zig:651
uws_sys.Response.NewResponse.onAborted.Wrapper    Response.zig:196
uWS::HttpContext<false>::onClose                  HttpContext.h:232
```

Under ASAN on main: heap-buffer-overflow, READ in `RequestContext::on_abort` 0 bytes past a 176-byte `Box<JSSink<HTTPServerWritable>>` allocation.

## Cause

Two bugs stack up on this path.

**1. uWS shared userData slot (the reported crash).** `HttpResponseData<SSL>` keeps one `userData` pointer for all four per-socket callbacks (onWritable/onAborted/onTimeout/onData). The RequestContext arms `onAborted` with itself as user data. When the stream sink's `tryEnd()` fails, which is exactly what happens when the client aborted mid-stream, the sink arms `onWritable` with *itself* as user data, overwriting the shared slot. The socket close then invokes the abort callback with the sink pointer cast to a `*RequestContext`: type confusion, reads past the 176-byte sink box. The ASAN report ("0 bytes after a live JSSink region") matches exactly. HTTP/3's `Http3ResponseData` already fixed this with a dedicated `writableUserData` slot (its comment claimed TCP "gets away with it" because tryEnd never reports backpressure for in-memory bodies; an aborted socket disproves that). This PR gives `HttpResponseData<SSL>` the same dedicated slot. An audit of every registrant (RequestContext, NodeHTTPResponse, FileResponseStream, StaticRoute, HTMLBundle, DevServer, BodyReaderMixin, the sink) found none that rely on the old stomping behavior; each either uses one object for all callbacks or owns onWritable exclusively.

**2. Sink signal outliving the GC'd controller (exposed once the abort reaches the right object).** The sink stores the JSSink controller's encoded JSValue in `signal.ptr` without rooting it. `readStreamIntoSink` drops the controller right after `controller.end()` parks the pending flush (and `controller.end()` already nulled `m_sinkPtr` via `detach()`), so GC can collect the controller while the native sink still waits for the drain. The abort path's `signal.close()` then decodes a dead cell: UBSan null member access in `HTTPResponseSink__onClose`, garbage reads in release. Fixed by a new `__controllerDetached` notification called from `JSReadable*Controller::detach()` and its destructor, which clears the sink's signal when it still holds that controller's bits (identity-compared, since `connect()`-style signals store a native pointer and re-assigned sinks hold a newer controller). This bug predates the Rust port; it was masked by bug 1 handing the abort to the wrong object.

The `do_render_stream` debug assert that the signal is always live after `assignToStream` is removed: a stream completing synchronously inside `assignToStream` now legitimately clears the signal through the detach hook (this tripped on `serve.test.ts` with only bug 2's fix in place).

The fixing lines are `httpResponseData->writableUserData = userData;` in `HttpResponse::onWritable` (plus the `callOnWritable` read) and `JSSink::js_controller_detached` in `Sink.rs`; the rest is plumbing and comments.

## Verification

`test/js/bun/http/serve-async-stream-client-abort.test.ts` spawns the issue's repro as a fixture (20 concurrent clients, 600 requests, aborts at random points straddling the async pull) and asserts the server exits cleanly with a mix of completed and aborted requests.

- Unfixed: fails in under 5s, both release (SIGSEGV/SIGILL) and `bun bd` ASAN (heap-buffer-overflow in `on_abort`). With only fix 1, still fails (UBSan null member access in `HTTPResponseSink__onClose`).
- Fixed: 11 consecutive passes; the issue's original unbounded repro survives a 60s ASAN soak (previously crashed in <1s).
- Regression sweep on the debug build: serve.test.ts, bun-serve-ssl, serve-direct-readable-stream, serve sink/abort/leak suites, streams suites, filesink, bun-write, node:http backpressure tests. The only failures also reproduce on an unfixed debug build in the same container (IPv6-less environment, root user, debug timeouts); details verified by building main and re-running each.