### PR TITLE
Enforce coverageThreshold regardless of coverage reporter

### DIFF
--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -57,18 +57,27 @@ mod coverage {
         pub(crate) fn write_format(
             report: &CodeCoverageReport,
             max_filename_length: usize,
-            fraction: &mut Fraction,
+            vals: Fraction,
+            threshold: Fraction,
             base_path: &[u8],
             writer: &mut impl bun_io::Write,
             enable_ansi_colors: bool,
         ) -> bun_io::Result<()> {
             if enable_ansi_colors {
-                text::write_format::<true>(report, max_filename_length, fraction, base_path, writer)
+                text::write_format::<true>(
+                    report,
+                    max_filename_length,
+                    vals,
+                    threshold,
+                    base_path,
+                    writer,
+                )
             } else {
                 text::write_format::<false>(
                     report,
                     max_filename_length,
-                    fraction,
+                    vals,
+                    threshold,
                     base_path,
                     writer,
                 )
@@ -1778,12 +1787,19 @@ impl CommandLineReporter {
                 continue;
             };
 
+            // The threshold check decides the exit code, so it runs for every
+            // reporter combination, not only when the text table is printed.
+            let fraction = report.coverage_fraction(base_fraction);
+            if fraction.failing {
+                failing = true;
+            }
+
             if REPORTERS_TEXT {
-                let mut fraction = base_fraction;
                 if coverage::Text::write_format(
                     &report,
                     max_filepath_length,
-                    &mut fraction,
+                    fraction,
+                    base_fraction,
                     relative_dir,
                     console_writer,
                     ENABLE_ANSI_COLORS,
@@ -1796,9 +1812,6 @@ impl CommandLineReporter {
                 avg.lines += fraction.lines;
                 avg.stmts += fraction.stmts;
                 avg_count += 1.0;
-                if fraction.failing {
-                    failing = true;
-                }
 
                 console_writer.extend_from_slice(b"\n");
             }
@@ -1813,6 +1826,8 @@ impl CommandLineReporter {
 
             drop(report);
         }
+
+        opts.fractions.failing = failing;
 
         if REPORTERS_TEXT {
             {
@@ -1872,7 +1887,6 @@ impl CommandLineReporter {
                 return Ok(());
             }
 
-            opts.fractions.failing = failing;
             Output::flush();
         }
 

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -1435,7 +1435,10 @@ impl CommandLineReporter {
         vm: &mut VirtualMachine,
         opts: &mut CodeCoverageOptions,
     ) -> crate::Result<()> {
-        if !REPORTERS_TEXT && !REPORTERS_LCOV {
+        // With no reporters (`coverageReporter = []` in bunfig) there is still
+        // work to do when a coverageThreshold is configured: the per-file
+        // fractions decide the exit code.
+        if !REPORTERS_TEXT && !REPORTERS_LCOV && !opts.fail_on_low_coverage {
             return Ok(());
         }
 
@@ -1561,13 +1564,9 @@ impl CommandLineReporter {
         } else if REPORTERS_LCOV {
             bun::perf::trace("TestCommand.printCodeCoverageLCov")
         } else {
-            // Unreachable by construction.
-            unreachable!("No reporters enabled")
+            // No reporters enabled: only the coverageThreshold evaluation runs.
+            bun::perf::trace("TestCommand.printCodeCoverageThresholdOnly")
         };
-
-        if !REPORTERS_TEXT && !REPORTERS_LCOV {
-            unreachable!("No reporters enabled");
-        }
 
         let relative_dir = bun_resolver::fs::FileSystem::get().top_level_dir;
 

--- a/src/sourcemap_jsc/CodeCoverage.rs
+++ b/src/sourcemap_jsc/CodeCoverage.rs
@@ -76,6 +76,19 @@ impl Report {
         (self.functions_which_have_executed.count() as f64) / total_count
     }
 
+    /// Per-file coverage fractions, with `failing` set relative to `threshold`.
+    /// `stmts` is not checked against the threshold (the metric is less accurate).
+    pub fn coverage_fraction(&self, threshold: Fraction) -> Fraction {
+        let functions = self.function_coverage_fraction();
+        let lines = self.lines_coverage_fraction();
+        Fraction {
+            functions,
+            lines,
+            stmts: self.stmts_coverage_fraction(),
+            failing: functions < threshold.functions || lines < threshold.lines,
+        }
+    }
+
     pub fn generate(
         global_this: &JSGlobalObject,
         byte_range_mapping: &mut ByteRangeMapping,
@@ -185,24 +198,16 @@ pub mod text {
         Ok(())
     }
 
+    /// Writes one table row for `report`. `vals` is the precomputed result of
+    /// `report.coverage_fraction(threshold)`.
     pub fn write_format<const ENABLE_COLORS: bool>(
         report: &Report,
         max_filename_length: usize,
-        fraction: &mut Fraction,
+        vals: Fraction,
+        threshold: Fraction,
         base_path: &[u8],
         writer: &mut impl bun_io::Write,
     ) -> bun_io::Result<()> {
-        let failing = *fraction;
-        let fns = report.function_coverage_fraction();
-        let lines = report.lines_coverage_fraction();
-        let stmts = report.stmts_coverage_fraction();
-        fraction.functions = fns;
-        fraction.lines = lines;
-        fraction.stmts = stmts;
-
-        let failed = fns < failing.functions || lines < failing.lines; // || stmts < failing.stmts;
-        fraction.failing = failed;
-
         let mut filename = report.source_url.slice();
         if !base_path.is_empty() {
             filename = bun_paths::resolve_path::relative(base_path, filename);
@@ -211,9 +216,9 @@ pub mod text {
         write_format_with_values::<ENABLE_COLORS>(
             filename,
             max_filename_length,
-            *fraction,
-            failing,
-            failed,
+            vals,
+            threshold,
+            vals.failing,
             writer,
             true,
         )?;
@@ -914,7 +919,8 @@ pub(crate) extern "C" fn ByteRangeMapping__findExecutedLines(
         Err(_) => return global_this.throw_out_of_memory_value(),
     };
 
-    let mut coverage_fraction = Fraction::default();
+    let threshold = Fraction::default();
+    let coverage_fraction = report.coverage_fraction(threshold);
 
     // std.Io.Writer.Allocating → Vec<u8> byte buffer (bun_io::Write target).
     let mut buf: Vec<u8> = Vec::new();
@@ -922,7 +928,8 @@ pub(crate) extern "C" fn ByteRangeMapping__findExecutedLines(
     if text::write_format::<false>(
         &report,
         source_url.utf8_byte_length(),
-        &mut coverage_fraction,
+        coverage_fraction,
+        threshold,
         b"",
         &mut buf,
     )

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -619,6 +619,25 @@ test.concurrent("coverageThreshold is enforced for every reporter combination", 
   }
 });
 
+test.concurrent("coverageThreshold is enforced when coverageReporter is an empty array", async () => {
+  using dir = tempDir("coverage-threshold-no-reporter", {
+    "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\ncoverageReporter = []\n`,
+    "lib.js": `export function used() { return 1; }\nexport function unused() { return 2; }\nexport function alsoUnused() { return 3; }\n`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib.js"; test("a",()=>expect(used()).toBe(1));`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("1 pass");
+  expect(exitCode).toBe(1);
+});
+
 test.concurrent("lcov-only reporter exits 0 when coverageThreshold is met", async () => {
   using dir = tempDir("coverage-threshold-met", {
     "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import { readFileSync } from "node:fs";
 import path from "path";
 
@@ -588,4 +588,53 @@ All files  |    0.00 |    0.00 |
 Ran 1 test across 1 file."
 `);
   expect(result.exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/32118
+test.concurrent("coverageThreshold is enforced for every reporter combination", async () => {
+  using dir = tempDir("coverage-threshold-reporters", {
+    "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
+    "lib.js": `export function used() { return 1; }\nexport function unused() { return 2; }\nexport function alsoUnused() { return 3; }\n`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {used} from "./lib.js"; test("a",()=>expect(used()).toBe(1));`,
+  });
+
+  // lib.js has 1/3 functions covered, below the 0.9 threshold: the run must
+  // exit 1 no matter which reporters are enabled.
+  for (const reporterArgs of [
+    ["--coverage-reporter=lcov"],
+    ["--coverage-reporter=text"],
+    ["--coverage-reporter=text", "--coverage-reporter=lcov"],
+    [],
+  ]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "--coverage", ...reporterArgs],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain("1 pass");
+    expect({ reporterArgs, exitCode }).toEqual({ reporterArgs, exitCode: 1 });
+  }
+});
+
+test.concurrent("lcov-only reporter exits 0 when coverageThreshold is met", async () => {
+  using dir = tempDir("coverage-threshold-met", {
+    "bunfig.toml": `[test]\ncoverageThreshold = 0.9\ncoverageSkipTestFiles = true\n`,
+    "lib.js": `export function used() { return 1; }\nexport function alsoUsed() { return 2; }\n`,
+    "a.test.js": `import {test,expect} from "bun:test"; import {used,alsoUsed} from "./lib.js"; test("a",()=>expect(used()+alsoUsed()).toBe(3));`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--coverage", "--coverage-reporter=lcov"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("1 pass");
+  expect(readFileSync(path.join(String(dir), "coverage", "lcov.info"), "utf-8")).toContain("end_of_record");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### What does this PR do?

Fixes #32118

`bun test --coverage --coverage-reporter=lcov` exited 0 even when coverage was below the configured `coverageThreshold`. The threshold was only enforced when the text reporter was active.

#### Repro

```toml
# bunfig.toml
[test]
coverageThreshold = { lines = 1.0, functions = 1.0, statements = 1.0 }
```

```console
$ bun test --coverage                          # exits 1 (correct)
$ bun test --coverage --coverage-reporter=lcov # exits 0 (bug: threshold skipped)
```

#### Cause

In `print_code_coverage` (src/runtime/cli/test_command.rs), the per-file threshold evaluation happened as a side effect of `text::write_format`, inside the `if REPORTERS_TEXT` block, and `opts.fractions.failing` was also only assigned inside that block. With `--coverage-reporter=lcov` alone, `fractions.failing` stayed `false`, so the exit-code check passed. The parallel path (`test/parallel/aggregate.rs`) already computes the fractions unconditionally and did not have this bug.

The same class of bug existed one level up: with `coverageReporter = []` in bunfig (both reporters disabled), `generate_code_coverage` returned early and skipped the threshold entirely.

#### Fix

- Add `Report::coverage_fraction(threshold)` in src/sourcemap_jsc/CodeCoverage.rs, which computes the per-file fractions and the `failing` bit in one place.
- In `print_code_coverage`, compute the fraction for every report before any reporter runs, accumulate `failing` unconditionally, and move `opts.fractions.failing = failing` out of the `REPORTERS_TEXT` block (mirroring the parallel path).
- `text::write_format` now takes the precomputed fractions instead of recomputing them; the other caller (`ByteRangeMapping__findExecutedLines`) computes them the same way it effectively did before (default threshold).
- `generate_code_coverage` only returns early with no reporters when no `coverageThreshold` is configured, so the no-reporter case still evaluates the threshold (found in review).

No user-visible change when no `coverageThreshold` is configured: `fail_on_low_coverage` is only set from bunfig, and the exit-code check requires it. The no-reporter no-threshold case keeps its zero-cost early return.

### How did you verify your code works?

New tests in test/cli/test/coverage.test.ts:

- `coverageThreshold is enforced for every reporter combination`: below-threshold project must exit 1 with `lcov`, `text`, `text`+`lcov`, and no explicit reporter. Fails on the unfixed build (lcov-only case exits 0), passes with this change.
- `coverageThreshold is enforced when coverageReporter is an empty array`: below-threshold project with `coverageReporter = []` in bunfig must exit 1. Also fails on the unfixed build.
- `lcov-only reporter exits 0 when coverageThreshold is met`: guards against false positives and checks lcov.info is still written.

Full `test/cli/test/coverage.test.ts` and the coverage tests in `test/cli/test/parallel.test.ts` pass with the debug build.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dd809ba21)

test/cli/test/coverage.test.ts:
bun test v1.4.0 (dd809ba21)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [368.00ms]
(pass) coverage crash [433.39ms]
bun test v1.4.0 (dd809ba21)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [452.00ms]
(pass) lcov coverage reporter [513.84ms]
(pass) coverage excludes node_modules directory [428.78ms]
(pass) coveragePathIgnorePatterns - single pattern string [445.69ms]
(pass) coverage
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/cli/test/coverage.test.ts:
bun test v1.4.0-canary.1 (1498d7b77)

demo.test.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [11.00ms]
(pass) coverage crash [14.43ms]
bun test v1.4.0-canary.1 (1498d7b77)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [10.00ms]
(pass) lcov coverage reporter [13.19ms]
(pass) coverage excludes node_modules directory [12.42ms]
(pass) coveragePathIgnorePatterns - single pattern string [12.76ms]
(pass) coveragePathIgnorePatterns - partial coverage without nan [11.96ms]
(pass) coveragePathIgnorePatterns - array of patterns [12.72ms]
(pass) coveragePathIgnorePatterns - glob patterns [12.53ms]
(pass) coveragePathIgnorePatterns - lcov reporter [12.02ms]
(pass) coveragePathIgnorePatterns - invalid config type [1.59ms]
(pass) coveragePathIgnorePatterns - invalid array item [1.63ms]
(pass) coveragePathIgnorePatterns - empty array [11.86ms]
(pass) coveragePathIgnorePatterns - ignore all files [11.77ms]
613 |       stdout: "pipe",
614 |       stderr: "pipe",
615 |     });
616 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
617 |     
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/test/coverage.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (dd809ba21)

test/cli/test/coverage.test.ts:
bun test v1.4.0 (dd809ba21)

demo.test.ts:
--------------|---------|---------|-------------------
File          | % Funcs | % Lines | Uncovered Line #s
--------------|---------|---------|-------------------
All files     |    0.00 |   66.67 |
 demo.test.ts |    0.00 |   66.67 | 
--------------|---------|---------|-------------------

 0 pass
 0 fail
Ran 0 tests across 1 file. [373.00ms]
(pass) coverage crash [423.67ms]
bun test v1.4.0 (dd809ba21)

demo2.ts:

 0 pass
 0 fail
Ran 0 tests across 1 file. [456.00ms]
(pass) lcov coverage reporter [516.56ms]
(pass) coverage excludes node_modules directory [427.76ms]
(pass) coveragePathIgnorePatterns - single pattern string [524.02ms]
(pass) coverage
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     dd809ba219
  features     (none)

22 deps, 106 codegen, 1168 objects in 813ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [20.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [11.00ms]
[5/1231] fetch picohttpparser
[picohttpparser] up to date
[6/1231] gen ErrorCode+*.h
[7/1231] fetch tinycc
[tinycc] up to date
[8/1230] fetch
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/test_command.rs   | 45 ++++++++++++++++---------
 src/sourcemap_jsc/CodeCoverage.rs | 41 +++++++++++++----------
 test/cli/test/coverage.test.ts    | 70 ++++++++++++++++++++++++++++++++++++++-
 3 files changed, 122 insertions(+), 34 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/cli/test_command.rs        7      8     12
src/sourcemap_jsc/CodeCoverage.rs      2      3     12
test/cli/test/coverage.test.ts         3      4     12
```

</details>

**root cause** · written by the author bot

The root cause was that the coverage threshold evaluation was coupled to the text reporter path, so when a non-default reporter such as lcov was selected, or when reporters were disabled entirely, the code either skipped the per-file failure computation or early-returned before the threshold check ran. The fix computes the coverage fractions and per-file failing state for every report up front via a shared coverage_fraction helper, sets the aggregate failing flag unconditionally after that loop, and removes the early return so fail_on_low_coverage is honored regardless of reporter configura…

<!-- robobun:evidence:end -->