### PR TITLE
Fix AES-GCM output when OPENSSL_ia32cap masks AES-NI but not VAES

### DIFF
--- a/patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch
+++ b/patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch
@@ -1,0 +1,36 @@
+CRYPTO_gcm128_init_aes_key selects the stitched VAES AES-GCM implementations
+(gcm_x86_vaes_avx2/avx512) based only on the VPCLMULQDQ/AVX ghash choice and
+CRYPTO_is_VAES_capable(), without checking that the AES key schedule was
+actually produced by aes_hw_set_encrypt_key. When OPENSSL_ia32cap masks
+AES-NI (bit 57, e.g. `~0x200000000000000`) but leaves VAES set,
+aes_ctr_set_key falls back to vpaes, whose key schedule is stored in a
+transformed basis. The VAES bulk assembly then runs against that vpaes-format
+schedule and silently produces wrong ciphertext (and decrypts garbage whose
+tag still verifies, since GHASH and EK0 come from the consistent vpaes block
+function). The aarch64 branches directly below already gate on |is_hwaes|;
+this adds the same gate to the two x86-64 VAES branches.
+
+Upstream BoringSSL main has the same bug as of 2026-02.
+See https://github.com/oven-sh/bun/issues/32126
+
+--- a/crypto/fipsmodule/aes/gcm.cc.inc
++++ b/crypto/fipsmodule/aes/gcm.cc.inc
+@@ -276,11 +276,16 @@ void bssl::CRYPTO_gcm128_init_aes_key(GCM128_KEY *gcm_key, const uint8_t *key,
+ 
+ #if !defined(OPENSSL_NO_ASM)
+ #if defined(OPENSSL_X86_64)
++  // The stitched AES-GCM implementations consume |gcm_key->aes| directly and
++  // expect the standard round-key layout produced by |aes_hw_set_encrypt_key|.
++  // Without |is_hwaes|, masking AES-NI but not VAES via OPENSSL_ia32cap made
++  // |aes_ctr_set_key| fall back to vpaes's transformed key schedule while the
++  // VAES bulk code still ran, silently producing wrong ciphertext.
+   if (gcm_key->ghash == gcm_ghash_vpclmulqdq_avx512 &&
+-      CRYPTO_is_VAES_capable()) {
++      CRYPTO_is_VAES_capable() && is_hwaes) {
+     gcm_key->impl = gcm_x86_vaes_avx512;
+   } else if (gcm_key->ghash == gcm_ghash_vpclmulqdq_avx2 &&
+-             CRYPTO_is_VAES_capable()) {
++             CRYPTO_is_VAES_capable() && is_hwaes) {
+     gcm_key->impl = gcm_x86_vaes_avx2;
+   } else if (gcm_key->ghash == gcm_ghash_avx && is_hwaes) {
+     gcm_key->impl = gcm_x86_aesni;

--- a/patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch
+++ b/patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch
@@ -10,7 +10,12 @@ tag still verifies, since GHASH and EK0 come from the consistent vpaes block
 function). The aarch64 branches directly below already gate on |is_hwaes|;
 this adds the same gate to the two x86-64 VAES branches.
 
-Upstream BoringSSL main has the same bug as of 2026-02.
+Upstream BoringSSL fixed this the same way in
+997bafbf73886ec19ac3eb70b31db64fe42832c3 ("Gate VAES codepaths on is_hwaes
+to fix a theoretical concern",
+https://boringssl-review.googlesource.com/c/boringssl/+/101787). Delete
+this patch when the pinned BoringSSL commit includes that change. The
+patch application fails loudly at dep-fetch time when that happens.
 See https://github.com/oven-sh/bun/issues/32126
 
 --- a/crypto/fipsmodule/aes/gcm.cc.inc

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -36,6 +36,15 @@ export const boringssl: Dependency = {
     commit: BORINGSSL_COMMIT,
   }),
 
+  // AES-GCM picked the stitched VAES implementation based on CPU bits alone,
+  // without checking that the key schedule came from aes_hw_set_encrypt_key.
+  // With OPENSSL_ia32cap masking AES-NI but not VAES, the VAES bulk assembly
+  // ran against a vpaes-format key schedule and silently produced wrong
+  // output. Upstream BoringSSL main has the same bug (its aarch64 branches
+  // gate on is_hwaes; the x86-64 VAES branches don't).
+  // https://github.com/oven-sh/bun/issues/32126
+  patches: ["patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch"],
+
   build: cfg => {
     // win-x64 uses NASM-syntax .asm; everything else (including win-aarch64)
     // uses gas .S that clang assembles.

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -40,8 +40,9 @@ export const boringssl: Dependency = {
   // without checking that the key schedule came from aes_hw_set_encrypt_key.
   // With OPENSSL_ia32cap masking AES-NI but not VAES, the VAES bulk assembly
   // ran against a vpaes-format key schedule and silently produced wrong
-  // output. Upstream BoringSSL main has the same bug (its aarch64 branches
-  // gate on is_hwaes; the x86-64 VAES branches don't).
+  // output. Upstream fixed this the same way in google/boringssl
+  // 997bafbf73886ec19ac3eb70b31db64fe42832c3. Delete the patch when the
+  // pinned commit includes that change (patch application fails loudly then).
   // https://github.com/oven-sh/bun/issues/32126
   patches: ["patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch"],
 

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -1316,3 +1316,76 @@ describe("Certificate spkac argument validation", () => {
     expect(new crypto.Certificate().verifySpkac("not a spkac", "utf8")).toBe(false);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32126
+it("AES-GCM stays correct when OPENSSL_ia32cap masks AES-NI but not VAES", async () => {
+  const script = `
+    const crypto = require("node:crypto");
+    const assert = require("node:assert");
+    function run(alg, keyLen, pt) {
+      const key = Buffer.alloc(keyLen);
+      const iv = Buffer.alloc(12);
+      const c = crypto.createCipheriv(alg, key, iv);
+      const ct = Buffer.concat([c.update(pt), c.final()]);
+      const tag = c.getAuthTag();
+      const d = crypto.createDecipheriv(alg, key, iv);
+      d.setAuthTag(tag);
+      const rt = Buffer.concat([d.update(ct), d.final()]);
+      assert(rt.equals(pt), "round-trip failed for " + alg);
+      return { ct: ct.toString("hex"), tag: tag.toString("hex") };
+    }
+    // Decrypt the authentic NIST test-case-2 ciphertext separately: the broken
+    // dispatch emitted garbage plaintext while the tag still verified.
+    const d = crypto.createDecipheriv("aes-128-gcm", Buffer.alloc(16), Buffer.alloc(12));
+    d.setAuthTag(Buffer.from("ab6e47d42cec13bdf53a67b21257bddf", "hex"));
+    const decNist = Buffer.concat([
+      d.update(Buffer.from("0388dace60b6a392f328c2b971b2fe78", "hex")),
+      d.final(),
+    ]).toString("hex");
+    console.log(JSON.stringify({
+      gcm128: run("aes-128-gcm", 16, Buffer.alloc(16)),
+      gcm192: run("aes-192-gcm", 24, Buffer.alloc(16)),
+      gcm256: run("aes-256-gcm", 32, Buffer.alloc(16)),
+      big: run("aes-128-gcm", 16, Buffer.alloc(1024, 7)),
+      decNist,
+    }));
+  `;
+
+  async function runWithCaps(caps) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, OPENSSL_ia32cap: caps },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) {
+      throw new Error(`child (OPENSSL_ia32cap=${caps}) exited with ${exitCode}: ${stderr}`);
+    }
+    return JSON.parse(stdout);
+  }
+
+  // "~0x200000000000000" clears AES-NI (CPUID.1:ECX bit 25) from the first
+  // OPENSSL_ia32cap word; ":~0x60000000000" additionally clears
+  // VAES/VPCLMULQDQ (CPUID.7:ECX bits 9-10) from the second. On non-x86-64
+  // platforms or CPUs without VAES, the masked runs dispatch the same as the
+  // unmasked one and pass trivially.
+  const [unmasked, aesniMasked, bothMasked] = await Promise.all(
+    [undefined, "~0x200000000000000", "~0x200000000000000:~0x60000000000"].map(runWithCaps),
+  );
+
+  // GCM spec (McGrew & Viega) test cases 2, 8 and 14: all-zero key, IV and
+  // 16-byte plaintext.
+  const expected = {
+    gcm128: { ct: "0388dace60b6a392f328c2b971b2fe78", tag: "ab6e47d42cec13bdf53a67b21257bddf" },
+    gcm192: { ct: "98e7247c07f0fe411c267e4384b0f600", tag: "2ff58d80033927ab8ef4d4587514f0fb" },
+    gcm256: { ct: "cea7403d4d606b6e074ec5d3baf39d18", tag: "d0d1c8a799996bf0265b98b5d48ab919" },
+    decNist: "00000000000000000000000000000000",
+    // Multi-block output has no published vector; it must be identical no
+    // matter which implementation the capability mask selects.
+    big: unmasked.big,
+  };
+  expect(unmasked).toEqual(expected);
+  expect(aesniMasked).toEqual(expected);
+  expect(bothMasked).toEqual(expected);
+});


### PR DESCRIPTION
Fixes #32126

### Repro

On any x86-64 CPU with VAES (the reporter's i5-13420H, or any recent Intel/AMD), with the issue's NIST-test-vector script:

```
OPENSSL_ia32cap='~0x200000000000000' bun repro.js
```

produces wrong AES-GCM output on every released build (reproduced with bun-linux-x64 1.3.14 and current main, same bytes as the Windows report):

```
encrypted: e2f9ddf26034baa3fe6dd790aa5fa47f   (expected 0388dace60b6a392f328c2b971b2fe78)
tag:       c22d854b1be1643fbf3294953f75a6b4   (expected ab6e47d42cec13bdf53a67b21257bddf)
```

`decipher.final()` does not throw: decrypting the authentic NIST ciphertext yields garbage whose tag still verifies.

### Cause

`~0x200000000000000` clears AES-NI (CPUID.1:ECX bit 25) from the first OPENSSL_ia32cap word but leaves VAES/VPCLMULQDQ (CPUID.7:ECX bits 9-10) set. In vendored BoringSSL, `crypto/fipsmodule/aes/gcm.cc.inc` `CRYPTO_gcm128_init_aes_key`:

1. `aes_ctr_set_key` sees `hwaes_capable()` false and builds the key schedule with `vpaes_set_encrypt_key`, which stores round keys in a transformed basis (`is_hwaes = 0`).
2. The impl selection then picks `gcm_x86_vaes_avx2/avx512` based only on the ghash choice and `CRYPTO_is_VAES_capable()`, without checking `is_hwaes`.
3. The stitched VAES bulk assembly expects the standard `aes_hw_set_encrypt_key` round-key layout, so it encrypts with a misinterpreted key schedule: deterministic garbage ciphertext. H and EK0 still come from the consistent vpaes block function, so tags verify over the garbage.

The aarch64 branches directly below gate on `is_hwaes`; the two x86-64 VAES branches are missing the same gate. Upstream BoringSSL has since fixed this the same way in [997bafbf](https://boringssl-review.googlesource.com/c/boringssl/+/101787), after the reporter filed it upstream. The commit Bun pins (upstream 606d3a344, via #32521) predates that fix, so the patch is still required. It only fires when capability bits are split artificially via OPENSSL_ia32cap, but that is exactly what users do to work around CPU errata (e.g. the VAES masking suggested in #32124), and silently wrong crypto is the worst possible failure mode. Both `node:crypto` cipheriv and WebCrypto AES-GCM funnel through this init.

Node is unaffected because OpenSSL keys its stitched paths off AES-NI.

### Fix

`patches/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch`, applied at dep fetch time via the existing `patches` mechanism: add `is_hwaes` to the two x86-64 VAES impl branches, mirroring the aarch64 branches and the upstream fix. Behavior on consistent capability sets is unchanged (real VAES hardware always has AES-NI). When a future BoringSSL bump includes the upstream fix, the patch stops applying and dep fetch fails loudly. That is the signal to delete the patch file.

### Verification

New test in `test/js/node/crypto/node-crypto.test.js` spawns subprocesses with the masks set (the env var is read once at startup) and checks GCM spec test vectors for AES-128/192/256-GCM, the decrypt-of-authentic-ciphertext case, and that multi-block output is identical across masked/unmasked runs. On CPUs without VAES the masked runs dispatch identically and pass trivially, so it is safe on all CI lanes.

- `USE_SYSTEM_BUN=1 bun test ... -t "AES-GCM stays correct"`: fails with the exact bytes from the issue (all three key sizes corrupted)
- `bun bd test test/js/node/crypto/node-crypto.test.js`: all pass (213 after the rebase onto the BoringSSL 606d3a344 bump, which still lacks the upstream fix; the patch applies cleanly to the new pin)
- `test/js/web/crypto/web-crypto.test.ts` under the mask: 10 pass
- The issue's repro script under `bun bd` with the mask now matches the NIST vector

Note for reviewers: the production change lives in `patches/` + `scripts/build/deps/boringssl.ts` (vendored dep patch), not `src/`, so fail-before verification means running the test against a build without the patch (or any released bun).

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 6 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/crypto/node-crypto.test.js'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/crypto/node-crypto.test.js
bun test v1.4.1 (65362b53b)

test/js/node/crypto/node-crypto.test.js:
(pass) crypto.randomBytes should return a Buffer [4.38ms]
(pass) crypto.randomInt should return a number [2.10ms]
(pass) crypto.randomInt with no arguments [3.61ms]
(pass) crypto.randomInt with one argument [3.12ms]
(pass) crypto.randomInt with a callback [36.89ms]
(pass) createHash > rsa-md5 - "Hello World" [8.91ms]
(pass) createHash > rsa-md5 - "Hello World" -> binary [4.39ms]
(pass) createHash > rsa-ripemd160 - "Hello World" [0.84ms]
(pass) createHash > rsa-ripemd160 - "Hello World" -> binary [0.82ms]
(pass) createHash > rsa-sha1 - "Hello World" [7.93ms]
(pass) createHash > rsa-sha1 - "Hello World" -> binary [1.29ms]
(pass) createHash > rsa-sha1-2 - "Hello World" [0.60ms]
(pass) createHash > rsa-sha1-2 - "Hello World" -> binary [0.65ms]
(pass) createHash > rsa-sha224 - "Hello World" [2.27ms]
(pass) createHash > rsa-sha224 - "Hello World" -> binary [0.83ms]
(pass) createHash > rsa-sha256 - "Hello World" [1.52ms]
(pass) createHash > rsa-sha256 - "Hello World" -> binary [0.59ms]
(pass) createHash > rsa-sha3-224 - "Hello World" [0.59ms]
(pass) createHash > rsa-sha3-224 - "Hello World" -> binary [0.54ms]
(pass) createHash > rsa-sha3-256 - "Hello World" [0.55ms]
(pass) createHash > rsa-sha3-256 - "Hello World" -> binary [1.29ms]
(pass) createHash > rsa-sha3-384 - "Hello World" [0.61ms]
(pass) createHash > rsa-sha3-384 - "Hello World" -> binary [0.78ms]
(pass) createHash > rsa-sha3-512 - "Hello World" [0.55ms]
(pass) createHash > rsa-sha3-512 - "Hello World" -> binary [0.58ms]
(pass) createHash > rsa-sha384 - "Hello World" [1.61ms]
(pass) createHash > rsa-sha384 - "Hello World" -> binary [0.82ms]
(pass) createHash > rsa-sha512 - "Hello World" [3.05ms]
(pass) createHash > rsa-sha512 - "Hello World" -> binary [0.94ms]
(pass) createHash > rsa-sha512/224 - "Hello World" [0.58m
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../gcm-vaes-requires-hwaes-key-schedule.patch     | 41 ++++++++++++
 scripts/build/deps/boringssl.ts                    | 10 +++
 test/js/node/crypto/node-crypto.test.js            | 73 ++++++++++++++++++++++
 3 files changed, 124 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
…es/boringssl/gcm-vaes-requires-hwaes-key-schedule.patch      1      2     10
scripts/build/deps/boringssl.ts                               2      2     10
test/js/node/crypto/node-crypto.test.js                       1      1     10
```

</details>

**root cause** · written by the author bot

The bug was in the vendored BoringSSL's AES-GCM dispatch, where `CRYPTO_gcm128_init_aes_key` selected the VAES bulk implementation based solely on `CRYPTO_is_VAES_capable()`, without confirming that hardware AES was also available. When `OPENSSL_ia32cap=~0x200000000000000` masked the AES-NI bit on a VAES-capable CPU, the key schedule was generated by the vpaes fallback, whose layout is incompatible with the VAES assembly, so encryption silently produced incorrect ciphertext and tags. The fix patches the dispatch to additionally require `is_hwaes` before taking the VAES path, ensuring the VA…

<!-- robobun:evidence:end -->
