### PR TITLE
fetch: settle buffered body promises when an aborted request still has a streaming request body

### DIFF
--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1175,6 +1175,23 @@ fn abort_tracker() -> &'static mut ArrayHashMap<u32, uws::AnySocket> {
     crate::abort_tracker()
 }
 
+/// Debug+ASAN invariant check: every socket pointer in the abort tracker must
+/// point at live (unfreed) memory. A stale entry here means some socket-close
+/// path forgot `unregister_abort_tracker`, which later manifests as a
+/// use-after-free in `drain_queued_shutdowns`/`drain_queued_writes` when the
+/// JS thread aborts that request id. Runs before and after each loop tick so
+/// the report fires at the tick that leaked, not at the eventual abort.
+#[inline]
+fn assert_abort_tracker_sockets_alive() {
+    if cfg!(debug_assertions) {
+        for socket in abort_tracker().values() {
+            if let Some(usocket) = socket.socket().get() {
+                bun_core::asan::assert_unpoisoned(usocket);
+            }
+        }
+    }
+}
+
 use core::cell::Cell;
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -1347,12 +1364,14 @@ mod _event_loop_draft {
                     }
                 }
                 self.drain_events();
+                assert_abort_tracker_sockets_alive();
                 Output::flush();
 
                 let uws_loop = self.uws_loop_mut();
                 uws_loop.inc();
                 uws_loop.tick();
                 uws_loop.dec();
+                assert_abort_tracker_sockets_alive();
 
                 if cfg!(debug_assertions) {
                     Output::flush();

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -670,13 +670,16 @@ impl FetchTasklet {
                     bytes.on_data(StreamResult::Err(StreamError::JSValue(js_err)))?;
                 }
             }
-            if let Some(sink) = self.sink_mut() {
-                if js_err.is_empty() {
-                    js_err = err.to_js(&global_this);
-                    js_err.ensure_still_alive();
-                }
-                sink.cancel(js_err);
-                return Ok(());
+            // A failure result is terminal (`to_result` forces `has_more =
+            // false` once `fail` is set), so everything pending must settle
+            // here: a still-streaming request-body sink does not exempt the
+            // response body. Returning right after `sink.cancel()` used to
+            // leave a buffered `arrayBuffer()`/`text()` promise pending
+            // forever when a fetch with an in-flight streaming request body
+            // was aborted mid-response.
+            if self.sink_mut().is_some() && js_err.is_empty() {
+                js_err = err.to_js(&global_this);
+                js_err.ensure_still_alive();
             }
             // if we are buffering resolve the promise
             if let Some(response) = self.current_response_mut() {
@@ -687,6 +690,14 @@ impl FetchTasklet {
                 // now; narrow back to the real `JsTerminated` here.
                 body.to_error_instance(err, &global_this)
                     .map_err(|_| bun_jsc::JsTerminated::JSTerminated)?;
+            }
+            // Cancel the request-body sink last: `ResumableSink::cancel`
+            // invokes the stream's JS cancel callback synchronously via
+            // `run_callback`, which can re-enter the tasklet.
+            if !js_err.is_empty() {
+                if let Some(sink) = self.sink_mut() {
+                    sink.cancel(js_err);
+                }
             }
             return Ok(());
         }

--- a/test/js/web/fetch/fetch-abort-buffered-body-fixture.ts
+++ b/test/js/web/fetch/fetch-abort-buffered-body-fixture.ts
@@ -1,0 +1,52 @@
+// Aborting a fetch whose request body stream is still uploading must also
+// settle the response side. The failure callback used to return right after
+// cancelling the request-body sink, so a buffered body promise
+// (arrayBuffer/text/json) never rejected and awaiting it hung forever.
+// Prints one line per consumer; a "timed out" line means the promise zombied.
+
+using server = Bun.serve({
+  port: 0,
+  fetch() {
+    return new Response(
+      new ReadableStream({
+        pull(c) {
+          c.enqueue(new Uint8Array(1024));
+          // keep the response body open until the client aborts
+          return new Promise(() => {});
+        },
+      }),
+    );
+  },
+});
+
+async function run(method: "arrayBuffer" | "text"): Promise<string> {
+  const controller = new AbortController();
+  const res = await fetch(server.url, {
+    method: "POST",
+    signal: controller.signal,
+    body: new ReadableStream({
+      pull(c) {
+        c.enqueue(new Uint8Array(64));
+        // keep the upload stream open so the sink is active at abort time
+        return new Promise(() => {});
+      },
+    }),
+  });
+  if (res.status !== 200) return method + " bad status " + res.status;
+
+  const pendingBody = res[method]();
+  controller.abort();
+  // Bounded sentinel only to convert the buggy "pending forever" state into a
+  // clean failure; the fixed path rejects immediately.
+  return Promise.race([
+    pendingBody.then(
+      () => method + " resolved",
+      (err: any) => method + " rejected " + err?.name,
+    ),
+    Bun.sleep(2500).then(() => method + " timed out"),
+  ]);
+}
+
+const results = await Promise.all([run("arrayBuffer"), run("text")]);
+for (const line of results.sort()) console.log(line);
+process.exit(results.every(r => r.includes("rejected AbortError")) ? 0 : 1);

--- a/test/js/web/fetch/fetch-abort-stream-body.test.ts
+++ b/test/js/web/fetch/fetch-abort-stream-body.test.ts
@@ -2,6 +2,30 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
+// Aborting a fetch whose request body stream is still uploading must also
+// settle the response side. The failure callback used to return right after
+// cancelling the request-body sink, so a buffered body promise
+// (arrayBuffer/text/json) never rejected and awaiting it hung forever.
+// Runs in a subprocess because the buggy build leaves zombie requests behind
+// that keep the process from exiting.
+test.concurrent(
+  "abort mid-response rejects buffered body promises while the request body stream is active",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "fetch-abort-buffered-body-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout).toBe("arrayBuffer rejected AbortError\ntext rejected AbortError\n");
+    expect(exitCode).toBe(0);
+  },
+);
+
 test("aborting fetch with a ReadableStream request body does not double-cancel the sink", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "fetch-abort-stream-body-fixture.ts")],


### PR DESCRIPTION
### Repro

```js
const server = Bun.serve({
  port: 0,
  fetch: () =>
    new Response(new ReadableStream({
      pull(c) { c.enqueue(new Uint8Array(1024)); return new Promise(() => {}); },
    })),
});

const controller = new AbortController();
const res = await fetch(server.url, {
  method: "POST",
  signal: controller.signal,
  body: new ReadableStream({
    pull(c) { c.enqueue(new Uint8Array(64)); return new Promise(() => {}); },
  }),
});

const p = res.arrayBuffer();
controller.abort();
await p; // hangs forever on 1.3.x and current main
```

`await p` never settles. The request is leaked permanently: under load (a client that uploads while downloading and aborts, e.g. proxies or streaming API clients), every such abort strands one request, and once enough accumulate all later fetches hang too.

### Cause

When the HTTP thread fails an in-flight request (abort, timeout, connection error), `FetchTasklet::on_body_received` handles the terminal failure result. If the request body was a JS `ReadableStream` whose sink was still active, the failure path did:

```rust
if let Some(sink) = self.sink_mut() {
    sink.cancel(js_err);
    return Ok(());   // <- skips erroring the response body
}
```

The early return skipped the `current_response_mut()` branch that rejects a buffered body promise (`arrayBuffer`/`text`/`json`), so that promise stayed pending forever. Failure results are terminal (`to_result` forces `has_more = false` once `fail` is set), so no later update can ever settle it. The bug only triggers when the response arrives while the upload stream is still open; consumers reading `res.body` directly were unaffected (the readable-stream branch above it errors the stream before the early return).

This was ported faithfully from the Zig implementation, which has the same early return, so 1.3.x releases are affected too.

### Fix

Remove the early return: materialize the error for the sink, reject the buffered response body, and cancel the sink last (`ResumableSink::cancel` invokes the stream's JS cancel callback synchronously via `run_callback`, so it runs after the tasklet state is settled).

Also restores the HTTP-thread debug+ASAN assertion (present in the Zig implementation, dropped in the port) that every socket pointer in the abort tracker points at live memory, checked around each loop tick. A stale entry there is the likely mechanism behind a family of release-build segfaults in `drainQueuedShutdowns -> us_internal_ssl_socket_close -> us_internal_set_loop_ssl_data` reported from 1.3.x builds; with the assertion back, any close path that forgets `unregister_abort_tracker` fails loudly in debug CI at the tick that leaked instead of segfaulting at a later abort.

### Verification

New test `test/js/web/fetch/fetch-abort-stream-body.test.ts` ("abort mid-response rejects buffered body promises while the request body stream is active") runs the repro in a subprocess fixture for both `arrayBuffer()` and `text()`.

- Unfixed (`USE_SYSTEM_BUN=1`, also reproduced on 1.3.14): fixture prints `arrayBuffer timed out` / `text timed out`, test fails in ~2.5s.
- Fixed: both reject with `AbortError`, test passes.

A stress run (60 concurrent workers doing this shape in a loop) wedged every worker within seconds on the unfixed build and completes cleanly on the fixed one. The wedge reproduces identically on bun 1.3.14, and ~200k aborted-fetch iterations across keepalive/redirect/proxy/TLS/h2 variants ran clean under ASAN with the restored tracker assertion enabled.
