### PR TITLE
Error.captureStackTrace: keep frames when the callee frame was elided by a tail call

### DIFF
--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -173,11 +173,8 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     WTF::String callerName = Zig::functionName(vm, globalObject, callerObject);
     RETURN_IF_EXCEPTION(scope, );
 
-    // Match V8: remove all frames up to and including the caller. We match by
-    // cell identity first, then by name — name matching is needed because a
-    // resumed async function's frame callee is the generator's `next` function
-    // (a different cell) but Zig::functionName still reports the original
-    // async function's name.
+    // Match V8: remove all frames up to and including the caller. Name matching
+    // covers resumed async functions, whose frame callee is the generator's `next`.
     std::optional<size_t> removeCount;
     for (size_t i = 0; i < stackTrace.size(); i++) {
         const auto& frame = stackTrace.at(i);

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -173,8 +173,6 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     WTF::String callerName = Zig::functionName(vm, globalObject, callerObject);
     RETURN_IF_EXCEPTION(scope, );
 
-    // Match V8: remove all frames up to and including the caller. Name matching
-    // covers resumed async functions, whose frame callee is the generator's `next`.
     std::optional<size_t> removeCount;
     for (size_t i = 0; i < stackTrace.size(); i++) {
         const auto& frame = stackTrace.at(i);

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -113,18 +113,8 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
     return JSCStackTrace(newFrames);
 }
 
-// Whether callerObject's call frame could have been elided by a proper tail
-// call, making it unfindable on the machine stack even while the function is
-// logically still executing. Mirrors the conditions under which the bytecode
-// generator emits tail calls (BytecodeGenerator's m_allowTailCallOptimization):
-// only strict-mode non-constructor JS code makes tail calls, and a function
-// that never generated code for a regular call never had a call frame to
-// elide (construct invocations are never tail calls).
 static bool callerCouldBeTailCallElided(JSC::JSObject* callerObject)
 {
-    // A bound function's frame is a native thunk the JITs can bypass while the
-    // bound target runs. V8 never matches bound functions against stack frames
-    // either: Node keeps the full trace for them instead of clearing it.
     if (dynamicDowncast<JSC::JSBoundFunction>(callerObject))
         return true;
     if (auto* function = dynamicDowncast<JSC::JSFunction>(callerObject)) {
@@ -135,12 +125,8 @@ static bool callerCouldBeTailCallElided(JSC::JSObject* callerObject)
             return false;
         return executable->isGeneratedForCall();
     }
-    // Native constructors (Function, Array, ...) execute no JS code, so their
-    // frames are never tail-elided.
     if (dynamicDowncast<JSC::InternalFunction>(callerObject))
         return false;
-    // Remaining callables (e.g. callable proxies) can forward tail calls, so
-    // their absence from the stack proves nothing.
     return true;
 }
 
@@ -188,7 +174,7 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     RETURN_IF_EXCEPTION(scope, );
 
     // Match V8: remove all frames up to and including the caller. We match by
-    // cell identity first, then by name: name matching is needed because a
+    // cell identity first, then by name — name matching is needed because a
     // resumed async function's frame callee is the generator's `next` function
     // (a different cell) but Zig::functionName still reports the original
     // async function's name.
@@ -211,16 +197,6 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
         }
     }
 
-    // V8 removes every frame when the caller is not found: without tail calls,
-    // "not on the stack" can only mean the function was never called, so every
-    // collected frame is machinery above it. JSC implements ES2015 proper tail
-    // calls, so a strict-mode function whose body ends in a tail call has its
-    // frame replaced by its callee's and is unfindable here even though it is
-    // logically on the stack. zod v4's .parse() passes exactly such a function
-    // (`inst.parse = (data, params) => parse.parse(inst, data, params, ...)`),
-    // and wiping gave every ZodError an empty stack (issue #13904). Only wipe
-    // when the caller's frame provably could not have been tail-elided; keep
-    // the whole trace otherwise, since extra frames beat an empty stack.
     if (!removeCount && !callerCouldBeTailCallElided(callerObject))
         removeCount = stackTrace.size();
 

--- a/src/jsc/bindings/ErrorStackTrace.cpp
+++ b/src/jsc/bindings/ErrorStackTrace.cpp
@@ -113,6 +113,37 @@ JSCStackTrace JSCStackTrace::fromExisting(JSC::VM& vm, const WTF::Vector<JSC::St
     return JSCStackTrace(newFrames);
 }
 
+// Whether callerObject's call frame could have been elided by a proper tail
+// call, making it unfindable on the machine stack even while the function is
+// logically still executing. Mirrors the conditions under which the bytecode
+// generator emits tail calls (BytecodeGenerator's m_allowTailCallOptimization):
+// only strict-mode non-constructor JS code makes tail calls, and a function
+// that never generated code for a regular call never had a call frame to
+// elide (construct invocations are never tail calls).
+static bool callerCouldBeTailCallElided(JSC::JSObject* callerObject)
+{
+    // A bound function's frame is a native thunk the JITs can bypass while the
+    // bound target runs. V8 never matches bound functions against stack frames
+    // either: Node keeps the full trace for them instead of clearing it.
+    if (dynamicDowncast<JSC::JSBoundFunction>(callerObject))
+        return true;
+    if (auto* function = dynamicDowncast<JSC::JSFunction>(callerObject)) {
+        if (function->isHostFunction())
+            return false;
+        JSC::FunctionExecutable* executable = function->jsExecutable();
+        if (!executable->isInStrictContext())
+            return false;
+        return executable->isGeneratedForCall();
+    }
+    // Native constructors (Function, Array, ...) execute no JS code, so their
+    // frames are never tail-elided.
+    if (dynamicDowncast<JSC::InternalFunction>(callerObject))
+        return false;
+    // Remaining callables (e.g. callable proxies) can forward tail calls, so
+    // their absence from the stack proves nothing.
+    return true;
+}
+
 void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, JSC::JSCell* owner, JSC::JSValue caller, WTF::Vector<JSC::StackFrame>& stackTrace, size_t stackTraceLimit)
 {
     UNUSED_PARAM(callFrame);
@@ -156,13 +187,12 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
     WTF::String callerName = Zig::functionName(vm, globalObject, callerObject);
     RETURN_IF_EXCEPTION(scope, );
 
-    // Match V8: remove all frames up to and including the caller. If the caller
-    // is not found anywhere in the sync portion of the stack, remove everything.
-    // We match by cell identity first, then by name — name matching is needed
-    // because a resumed async function's frame callee is the generator's `next`
-    // function (a different cell) but Zig::functionName still reports the
-    // original async function's name.
-    size_t removeCount = stackTrace.size();
+    // Match V8: remove all frames up to and including the caller. We match by
+    // cell identity first, then by name: name matching is needed because a
+    // resumed async function's frame callee is the generator's `next` function
+    // (a different cell) but Zig::functionName still reports the original
+    // async function's name.
+    std::optional<size_t> removeCount;
     for (size_t i = 0; i < stackTrace.size(); i++) {
         const auto& frame = stackTrace.at(i);
         if (frame.isAsyncFrame())
@@ -181,8 +211,21 @@ void JSCStackTrace::getFramesForCaller(JSC::VM& vm, JSC::CallFrame* callFrame, J
         }
     }
 
-    if (removeCount > 0)
-        stackTrace.removeAt(0, removeCount);
+    // V8 removes every frame when the caller is not found: without tail calls,
+    // "not on the stack" can only mean the function was never called, so every
+    // collected frame is machinery above it. JSC implements ES2015 proper tail
+    // calls, so a strict-mode function whose body ends in a tail call has its
+    // frame replaced by its callee's and is unfindable here even though it is
+    // logically on the stack. zod v4's .parse() passes exactly such a function
+    // (`inst.parse = (data, params) => parse.parse(inst, data, params, ...)`),
+    // and wiping gave every ZodError an empty stack (issue #13904). Only wipe
+    // when the caller's frame provably could not have been tail-elided; keep
+    // the whole trace otherwise, since extra frames beat an empty stack.
+    if (!removeCount && !callerCouldBeTailCallElided(callerObject))
+        removeCount = stackTrace.size();
+
+    if (removeCount)
+        stackTrace.removeAt(0, *removeCount);
 
     if (stackTrace.size() > stackTraceLimit)
         stackTrace.shrink(stackTraceLimit);

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1282,3 +1282,21 @@ test("captureStackTrace keeps frames for a bound function not in the stack", () 
   expect(e.stack).toContain("at makeErr");
   expect(e.stack).toContain("at invoker");
 });
+
+test("captureStackTrace keeps frames when the second argument is a non-callable object", () => {
+  function makeErr(arg) {
+    const e = new Error("test");
+    Error.captureStackTrace(e, arg);
+    return [e];
+  }
+  noInline(makeErr);
+  function outer() {
+    const r = makeErr({});
+    return [r];
+  }
+  noInline(outer);
+
+  const [[e]] = outer();
+  expect(e.stack).toContain("at makeErr");
+  expect(e.stack).toContain("at outer");
+});

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1225,11 +1225,6 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
 );
 
 // https://github.com/oven-sh/bun/issues/13904
-// JSC implements ES2015 proper tail calls: `inst.parse = data => inner(data)` is
-// an implicit-return tail call in strict mode, so the `inst.parse` frame is
-// replaced by inner's frame and the function passed to captureStackTrace is not
-// findable on the stack. zod v4's .parse() passes exactly such a function. The
-// frames that do exist must survive instead of the whole trace being cleared.
 test("captureStackTrace keeps frames when the caller frame was elided by a tail call", () => {
   const inst = {};
   function innerParse(data, callee) {
@@ -1242,7 +1237,6 @@ test("captureStackTrace keeps frames when the caller frame was elided by a tail 
 
   function initPlugin() {
     const result = inst.parse({});
-    // Not a tail call, so initPlugin's frame stays on the stack.
     return [result];
   }
   noInline(initPlugin);
@@ -1252,10 +1246,6 @@ test("captureStackTrace keeps frames when the caller frame was elided by a tail 
   expect(err.stack).toContain("at initPlugin");
 });
 
-// The tail-call exception must not weaken V8 parity where the caller's frame
-// provably could not have been elided: host functions and sloppy-mode
-// functions never make tail calls, so "not on the stack" means "not called"
-// and the trace is cleared like in Node.js.
 test("captureStackTrace still clears frames for a host function not in the stack", () => {
   Math.max(1, 2);
   const e = new Error("test");
@@ -1264,7 +1254,6 @@ test("captureStackTrace still clears frames for a host function not in the stack
 });
 
 test("captureStackTrace still clears frames for a sloppy-mode function not in the stack", () => {
-  // Indirect eval runs in the global scope in sloppy mode.
   const sloppyFn = (0, eval)("(function sloppyNotOnStack() { return 1; })");
   sloppyFn();
   const e = new Error("test");
@@ -1273,9 +1262,6 @@ test("captureStackTrace still clears frames for a sloppy-mode function not in th
 });
 
 test("captureStackTrace keeps frames for a bound function not in the stack", () => {
-  // Node keeps the full trace when the second argument is a bound function
-  // that is not on the stack: V8 never matches bound functions against stack
-  // frames, so no filtering happens.
   function target() {
     return 1;
   }

--- a/test/js/node/v8/capture-stack-trace.test.js
+++ b/test/js/node/v8/capture-stack-trace.test.js
@@ -1223,3 +1223,76 @@ test.concurrent.each([[{}], [{ BUN_JSC_useSourceProviderCache: "0" }]])(
     expect(exitCode).toBe(0);
   },
 );
+
+// https://github.com/oven-sh/bun/issues/13904
+// JSC implements ES2015 proper tail calls: `inst.parse = data => inner(data)` is
+// an implicit-return tail call in strict mode, so the `inst.parse` frame is
+// replaced by inner's frame and the function passed to captureStackTrace is not
+// findable on the stack. zod v4's .parse() passes exactly such a function. The
+// frames that do exist must survive instead of the whole trace being cleared.
+test("captureStackTrace keeps frames when the caller frame was elided by a tail call", () => {
+  const inst = {};
+  function innerParse(data, callee) {
+    const err = new Error("invalid input");
+    Error.captureStackTrace(err, callee);
+    return err;
+  }
+  noInline(innerParse);
+  inst.parse = data => innerParse(data, inst.parse);
+
+  function initPlugin() {
+    const result = inst.parse({});
+    // Not a tail call, so initPlugin's frame stays on the stack.
+    return [result];
+  }
+  noInline(initPlugin);
+
+  const [err] = initPlugin();
+  expect(err.stack).toContain("at innerParse");
+  expect(err.stack).toContain("at initPlugin");
+});
+
+// The tail-call exception must not weaken V8 parity where the caller's frame
+// provably could not have been elided: host functions and sloppy-mode
+// functions never make tail calls, so "not on the stack" means "not called"
+// and the trace is cleared like in Node.js.
+test("captureStackTrace still clears frames for a host function not in the stack", () => {
+  Math.max(1, 2);
+  const e = new Error("test");
+  Error.captureStackTrace(e, Math.max);
+  expect(e.stack).toBe("Error: test");
+});
+
+test("captureStackTrace still clears frames for a sloppy-mode function not in the stack", () => {
+  // Indirect eval runs in the global scope in sloppy mode.
+  const sloppyFn = (0, eval)("(function sloppyNotOnStack() { return 1; })");
+  sloppyFn();
+  const e = new Error("test");
+  Error.captureStackTrace(e, sloppyFn);
+  expect(e.stack).toBe("Error: test");
+});
+
+test("captureStackTrace keeps frames for a bound function not in the stack", () => {
+  // Node keeps the full trace when the second argument is a bound function
+  // that is not on the stack: V8 never matches bound functions against stack
+  // frames, so no filtering happens.
+  function target() {
+    return 1;
+  }
+  const bound = target.bind(null);
+  function makeErr() {
+    const e = new Error("test");
+    Error.captureStackTrace(e, bound);
+    return [e];
+  }
+  noInline(makeErr);
+  function invoker() {
+    const r = makeErr();
+    return [r];
+  }
+  noInline(invoker);
+
+  const [[e]] = invoker();
+  expect(e.stack).toContain("at makeErr");
+  expect(e.stack).toContain("at invoker");
+});


### PR DESCRIPTION
### What does this PR do?

Fixes #13904.

`Error.captureStackTrace(err, fn)` cleared the entire stack trace whenever `fn` could not be found on the stack. That matches V8's skip-until-seen semantics, but JSC implements ES2015 proper tail calls: a strict-mode function whose body ends in a tail call has its frame replaced by its callee's, so a function that is logically mid-execution can be unfindable. "Not on the stack" no longer implies "never called", and the V8 behavior degrades into destroying the whole trace.

zod v4 hits this on every failed `.parse()`: the callee it passes is `inst.parse = (data, params) => parse.parse(inst, data, params, { callee: inst.parse })`, an implicit-return tail call, so every ZodError arrived with an empty stack:

```js
import { z } from 'zod'
const schema = z.object({ schema: z.object({}) })
function initPlugin() {
  return schema.parse({})
}
try { initPlugin() } catch (e) { console.log(e.stack) }
```

Before: the ZodError has zero `at` lines. After, the trace keeps the frames that exist, including the user's call site:

```
    at <anonymous> (node_modules/zod/v4/core/parse.js:12:14)
    at /tmp/zodrepro/zr.mjs:7:3
```

### The fix

`JSCStackTrace::getFramesForCaller` now only clears the trace when the callee's frame provably could not have been tail-elided, mirroring the conditions under which the bytecode generator emits tail calls (`m_allowTailCallOptimization`):

- host functions, native constructors (`InternalFunction`), and sloppy-mode functions never make tail calls, and a function that never generated code for a regular call was never on the stack (construct invocations are never tail calls): these still clear the trace, matching Node.
- anything else (including bound functions, which V8 never matches against stack frames; Node keeps the full trace for them) keeps the collected frames, since extra frames beat an empty stack.

Frames that JSC's tail calls elide stay elided; per #26001 tail calls stay enabled for performance, so exact Node frame-for-frame parity in those traces is out of scope. This PR removes the failure mode where a trimming heuristic deletes every frame that does exist.

### How did you verify your code works?

New tests in `test/js/node/v8/capture-stack-trace.test.js`:

- `captureStackTrace keeps frames when the caller frame was elided by a tail call` (the zod shape) and `captureStackTrace keeps frames for a bound function not in the stack` both fail on the unfixed build (stack is bare `Error: ...`) and pass with the fix.
- `captureStackTrace still clears frames for a host function not in the stack` and `... for a sloppy-mode function not in the stack` pin the preserved V8/Node wipe behavior (output verified against Node 24).

All 42 tests in the file pass, including the existing caller-not-in-stack tests from #27017 and #28651, which keep asserting the Node-matching cleared trace. Also ran the jsc-stress suite (83 pass), assert suites, and the sourcemap suites.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.1 (731aa92da)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [13.86ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [22.31ms]
(pass) capture stack trace [8.57ms]
(pass) capture stack trace with message [6.93ms]
(pass) capture stack trace with constructor [5.13ms]
(pass) capture stack trace limit [21.51ms]
(pass) prepare stack trace [11.12ms]
(pass) capture stack trace second argument [17.50ms]
(pass) capture stack trace edge cases [10.40ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [19.48ms]
(pass) prepare stack trace call sites [11.60ms]
(pass) sanity check [11.76ms]
(pass) CallFrame isEval works as expected [8.41ms]
(pass) CallFrame isTopLevel returns false for Function constructor [7.16ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.19ms]
(pass) CallFrame.p.isConstructor [3.37ms]
(pass) CallFrame.p.isNative [2.82ms]
(pass) return non-strings from Error.prepareStackTrace [3.09ms]
(pass) Call
... (truncated)

release without fix: 4 FAILED
bun test v1.4.1-canary.1 (731aa92da)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [0.13ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [0.12ms]
(pass) capture stack trace [0.05ms]
(pass) capture stack trace with message [0.06ms]
(pass) capture stack trace with constructor [0.06ms]
(pass) capture stack trace limit [0.20ms]
(pass) prepare stack trace [0.11ms]
(pass) capture stack trace second argument [0.16ms]
(pass) capture stack trace edge cases [0.09ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [0.24ms]
(pass) prepare stack trace call sites [0.13ms]
(pass) sanity check [0.11ms]
(pass) CallFrame isEval works as expected [0.09ms]
(pass) CallFrame isTopLevel returns false for Function constructor [0.10ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [0.09ms]
(pass) CallFrame.p.isConstructor [0.04ms]
(pass) CallFrame.p.isNative [0.03ms]
(pass) return non-strings from Error.prepareStackTrace [0.03ms]
(pass) CallFrame.p.toString [0.03ms]
(pass) err.stack should invoke prepareStackTrace [0.19ms]
(pass) Error.prepareStackTrace inside a node:vm works [1.28ms]
(pass) Error.captureStackTrace i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/v8/capture-stack-trace.test.js"
bun test v1.4.1 (731aa92da)

test/js/node/v8/capture-stack-trace.test.js:
(pass) Regular .stack [15.04ms]
(pass) throw inside Error.prepareStackTrace doesnt crash [6.60ms]
(pass) capture stack trace [22.49ms]
(pass) capture stack trace with message [8.94ms]
(pass) capture stack trace with constructor [5.19ms]
(pass) capture stack trace limit [21.31ms]
(pass) prepare stack trace [10.44ms]
(pass) capture stack trace second argument [17.86ms]
(pass) capture stack trace edge cases [11.85ms]
(pass) Error.captureStackTrace installs .stack as non-enumerable [18.49ms]
(pass) prepare stack trace call sites [11.55ms]
(pass) sanity check [11.43ms]
(pass) CallFrame isEval works as expected [7.43ms]
(pass) CallFrame isTopLevel returns false for Function constructor [8.62ms]
(pass) CallFrame.p.getThisgetFunction: strict/sloppy mode interaction [8.50ms]
(pass) CallFrame.p.isConstructor [3.31ms]
(pass) CallFrame.p.isNative [2.82ms]
(pass) return non-strings from Error.prepareStackTrace [3.15ms]
(pass) Call
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 743ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/142] gen cpp.rs (cppbind)
[2/142] gen JS modules (bundle-modules)
Preprocess modules (10495ms)
Bundle modules (1424ms)
Postprocesss modules (2111ms)
Bundle Functions (2006ms)
Generate Code (295ms)

[16.34s] Bundled "src/js" for production
  2595 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[2/142] cargo bun_runtime → libbun_runtime.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_output_tags v0.0.0 (/workspace/bun/src/bun_output_tags)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_parsers v0.0.0 (/workspace/bun/src/parsers)
[1m[92m   Compiling[0m bun_install v0.0.0 (/workspace/bun/src/install)
[1m[92m   Compiling[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
[1m[92m   Compiling[0m bun_dispatch v0.0.0 (/workspace/bun/src/dispatch)
[1m[92m   Compiling[0m bun_jsc_macros v0.0.0 (/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/ErrorStackTrace.cpp        | 32 ++++++++----
 test/js/node/v8/capture-stack-trace.test.js | 77 +++++++++++++++++++++++++++++
 2 files changed, 100 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                         reads  edits  tests
src/jsc/bindings/ErrorStackTrace.cpp             5     11     23
test/js/node/v8/capture-stack-trace.test.js     11     17     23
```

</details>

**root cause** · written by the author bot

In JavaScriptCore, strict-mode functions that invoke another function in tail position can have their frames elided by proper tail calls, so the function passed to Error.captureStackTrace may legitimately be absent from the stack even though it is on the call path, as happens with zod's parse wrapper. Bun's implementation treated a missing caller as grounds to clear the entire trace, producing errors with no frames at all. The fix introduces a callerCouldBeTailCallElided check in getFramesForCaller so that when the caller is not found, the trace is only cleared for functions that cannot hav…

<!-- robobun:evidence:end -->