### PR TITLE
Wait for end() when a direct stream's pull() returns synchronously in Bun.serve

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -700,41 +700,32 @@ JSObject* JS${controllerName}::createPrototype(VM& vm, JSDOMGlobalObject& global
 }
 
 void JS${controllerName}::detach() {
-    if (m_onDestroy) {
-        auto destroy = m_onDestroy;
-        m_onDestroy = 0;
-        Bun__onSinkDestroyed(destroy, m_sinkPtr);
-    }
+    // Prevent re-entrancy.
+    JSC::EnsureStillAliveScope readableStream(m_weakReadableStream.get());
+    JSC::EnsureStillAliveScope onClose(m_onClose.get());
 
-    if (m_sinkPtr) {
-        ${name}__controllerDetached(m_sinkPtr, JSC::JSValue::encode(this));
-    }
+    auto* sinkPtr = std::exchange(m_sinkPtr, nullptr);
+    auto destroy = std::exchange(m_onDestroy, 0);
 
-    m_sinkPtr = nullptr;
     m_onPull.clear();
-
-    auto readableStream = m_weakReadableStream.get();
-    JSC::JSValue onClose = m_onClose.get();
-    // Copy-and-null before invoking: the callback runs user JS (the direct
-    // stream's cancel()) which can re-enter detach(), so clear the one-shot
-    // state first to avoid firing onClose twice.
     m_onClose.clear();
     m_weakReadableStream.clear();
 
-    if (readableStream && onClose) {
+    if (destroy) {
+        Bun__onSinkDestroyed(destroy, sinkPtr);
+    }
+
+    if (sinkPtr) {
+        ${name}__controllerDetached(sinkPtr, JSC::JSValue::encode(this));
+    }
+
+    if (readableStream.value() && onClose.value()) {
         JSC::JSGlobalObject *globalObject = this->globalObject();
         auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
         JSC::MarkedArgumentBuffer arguments;
-        arguments.append(readableStream);
+        arguments.append(readableStream.value());
         arguments.append(jsUndefined());
-        // m_onClose may be an AsyncContextFrame (startDirectStream wraps the
-        // callback when the stream was created with an async context), which
-        // JSC::getCallData reports as not callable. AsyncContextFrame::call
-        // unwraps the frame and also handles plain callables.
-        AsyncContextFrame::call(globalObject, onClose, JSC::jsUndefined(), arguments);
-        // onClose runs user JS; let the exception propagate to the caller's
-        // scope (the ${controller}__end/__close host fns check it) instead of
-        // leaving it unchecked. Mirrors ${name}__onClose.
+        AsyncContextFrame::call(globalObject, onClose.value(), JSC::jsUndefined(), arguments);
         RELEASE_AND_RETURN(scope, void());
     }
 }

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -714,21 +714,29 @@ void JS${controllerName}::detach() {
     m_onPull.clear();
 
     auto readableStream = m_weakReadableStream.get();
-    auto onClose = m_onClose.get();
-    
-    if (readableStream && onClose) {
-        auto callData = JSC::getCallData(onClose);
-        if(callData.type != JSC::CallData::Type::None) {
-            JSC::JSGlobalObject *globalObject = this->globalObject();
-            JSC::MarkedArgumentBuffer arguments;
-            arguments.append(readableStream);
-            arguments.append(jsUndefined());
-            call(globalObject, onClose, callData, JSC::jsUndefined(), arguments);
-        }
-    }
-
+    JSC::JSValue onClose = m_onClose.get();
+    // Copy-and-null before invoking: the callback runs user JS (the direct
+    // stream's cancel()) which can re-enter detach(), so clear the one-shot
+    // state first to avoid firing onClose twice.
     m_onClose.clear();
     m_weakReadableStream.clear();
+
+    if (readableStream && onClose) {
+        JSC::JSGlobalObject *globalObject = this->globalObject();
+        auto scope = DECLARE_THROW_SCOPE(globalObject->vm());
+        JSC::MarkedArgumentBuffer arguments;
+        arguments.append(readableStream);
+        arguments.append(jsUndefined());
+        // m_onClose may be an AsyncContextFrame (startDirectStream wraps the
+        // callback when the stream was created with an async context), which
+        // JSC::getCallData reports as not callable. AsyncContextFrame::call
+        // unwraps the frame and also handles plain callables.
+        AsyncContextFrame::call(globalObject, onClose, JSC::jsUndefined(), arguments);
+        // onClose runs user JS; let the exception propagate to the caller's
+        // scope (the ${controller}__end/__close host fns check it) instead of
+        // leaving it unchecked. Mirrors ${name}__onClose.
+        RELEASE_AND_RETURN(scope, void());
+    }
 }
 `;
 

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -682,6 +682,7 @@ export function isReadableStreamDefaultController(controller) {
 export function readDirectStream(stream, sink, underlyingSource) {
   $putByIdDirectPrivate(stream, "underlyingSource", null); // doing this causes isReadableStreamDefaultController to return false
   $putByIdDirectPrivate(stream, "start", undefined);
+  var closePromiseCapability;
   function close(stream, reason) {
     const cancelFn = underlyingSource?.cancel;
     if (cancelFn) {
@@ -705,6 +706,12 @@ export function readDirectStream(stream, sink, underlyingSource) {
         $putByIdDirectPrivate(stream, "state", $streamClosed);
       }
       stream = undefined;
+    }
+
+    if (closePromiseCapability) {
+      const resolve = closePromiseCapability.resolve;
+      closePromiseCapability = undefined;
+      resolve.$call();
     }
   }
 
@@ -736,6 +743,17 @@ export function readDirectStream(stream, sink, underlyingSource) {
     }
 
     return maybePromise.then(() => {});
+  }
+
+  if ($getByIdDirectPrivate(stream, "state") === $streamReadable) {
+    // pull() returned synchronously without closing the sink: the producer
+    // kept the controller to write more data and call end() later
+    // (react-dom/server's renderToReadableStream does this while Suspense
+    // boundaries are still pending). Return a promise that settles when the
+    // sink closes so native consumers (Bun.serve, FileSink) wait for end()
+    // instead of finalizing the response early.
+    closePromiseCapability = $newPromiseCapability(Promise);
+    return closePromiseCapability.promise;
   }
 }
 

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2661,6 +2661,49 @@ where
     pub fn handle_resolve_stream(req: &mut Self) {
         stream_log!("handleResolveStream");
 
+        // endFromJS() can hit transport backpressure (common on QUIC right
+        // after the HEADERS frame) and park a pending_flush promise while
+        // onWritable drains the remaining bytes. Tearing the sink down now
+        // would discard those bytes and truncate the response, so wait for
+        // the flush to settle and re-enter. On abort, flushPromise() has
+        // already settled pending_flush, so this never waits on a dead
+        // socket.
+        if let Some(wrapper) = req.sink_mut() {
+            if !req.flags.aborted() && !wrapper.sink.aborted {
+                // Only defer when there is still a live response to drain the
+                // flush through: on_writable (which resolves the flush via
+                // flush_promise) is armed on `resp`. With no response the flush
+                // can never settle, so taking a ref and attaching here would
+                // leak the ref and hang the request; fall through to teardown.
+                if let (Some(flush), Some(resp)) = (wrapper.sink.pending_flush, req.resp) {
+                    stream_log!("handleResolveStream: waiting for pending flush");
+                    debug_assert!(req.server.is_some());
+                    // SAFETY: BACKREF
+                    let global_this = req.server().global_this();
+                    // The sink no longer registers its own drain callback;
+                    // RequestContext owns it (see on_writable_response_stream).
+                    // do_render_stream only arms it on the Pending branch, but
+                    // a fulfilled pull() reaches here directly, so arm it now
+                    // or the parked flush never drains. Re-arming with the same
+                    // handler is idempotent in uWS.
+                    resp.on_writable(
+                        |this, off, resp| Self::on_writable_response_stream(this, off, resp),
+                        std::ptr::from_mut::<Self>(req),
+                    );
+                    req.ref_();
+                    let cell = NativePromiseContext::create(global_this, req);
+                    // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+                    jsc::JSPromise::opaque_ref(flush).to_js().then_with_value(
+                        global_this,
+                        cell,
+                        Self::ON_RESOLVE_STREAM,
+                        Self::ON_REJECT_STREAM,
+                    );
+                    return;
+                }
+            }
+        }
+
         let mut wrote_anything = false;
         if let Some(wrapper) = req.sink_mut() {
             let wrapper_ptr = req.sink.take().expect("infallible: sink_mut returned Some");

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -661,13 +661,11 @@ impl<T: JsSinkAbi> JSSink<T> {
         // encoded JSValue bits (never a real Rust pointer); bitcast back.
         let value = JSValue::from_encoded(ptr.as_ptr() as usize);
         value.unprotect();
-        // `${abi}__detachPtr`
-        // calls the JS `onClose` callback via the bare `JSC::call(...)`
-        // overload (no NakedPtr/TopExceptionScope of its own), so
-        // `executeCallImpl`'s ThrowScope is the outermost scope and its dtor
-        // `simulateThrow()` leaves `m_needExceptionCheck` set. Wrap in a
-        // TopExceptionScope so the
-        // verifier is satisfied; discard the result.
+        // `${abi}__detachPtr` runs the JS `onClose` callback through the bare
+        // `AsyncContextFrame::call` overload (no TopExceptionScope of its own)
+        // and RELEASE_AND_RETURNs its ThrowScope, so `m_needExceptionCheck` is
+        // left set when it returns into this scope-less thunk. Wrap in a
+        // TopExceptionScope so the verifier is satisfied; discard the result.
         // TODO: properly propagate exception upwards.
         let _ = ::bun_jsc::call_check_slow(_global, || T::detach_ptr_extern(value));
     }

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1,6 +1,8 @@
 import { sleep } from "bun";
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { heapStats } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, tls } from "harness";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 test("HTTPResponseSink displays correct message", async () => {
   let leakedCtrl: any;
@@ -114,3 +116,221 @@ test.skipIf(!isASAN)(
   },
   30_000,
 );
+
+// https://github.com/oven-sh/bun/issues/32137
+// react-dom/server.bun's renderToReadableStream returns a direct ReadableStream
+// whose pull() writes the shell, captures the controller, and returns
+// synchronously (no promise). Resolved Suspense boundaries are written through
+// the captured controller later, followed by end(). Bun.serve must keep the
+// response open until end() instead of finalizing it when pull() returns.
+test("sync pull() that ends later streams the whole body", async () => {
+  const SHELL = "<div>SHELL</div>";
+  const RESOLVED = "<div>RESOLVED</div>";
+  let controller: any;
+  const pulled = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream(
+        {
+          type: "direct",
+          pull(c: any) {
+            c.write(SHELL);
+            c.flush();
+            controller = c;
+            pulled.resolve();
+            // returns undefined synchronously; more writes come later
+          },
+        } as any,
+        { highWaterMark: 2048 },
+      );
+      return new Response(stream, { headers: { "Content-Type": "text/html" } });
+    },
+  });
+
+  const response = await fetch(server.url);
+  await pulled.promise;
+
+  // the shell must arrive while the server is still waiting for end()
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let body = "";
+  while (body.length < SHELL.length) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    body += decoder.decode(value, { stream: true });
+  }
+  expect(body).toBe(SHELL);
+
+  controller.write(RESOLVED);
+  controller.flush();
+  controller.end();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    body += decoder.decode(value, { stream: true });
+  }
+  expect(body).toBe(SHELL + RESOLVED);
+  expect(response.status).toBe(200);
+});
+
+test("sync pull() that writes nothing and ends later still responds", async () => {
+  let controller: any;
+  const pulled = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(c: any) {
+            controller = c;
+            pulled.resolve();
+          },
+        } as any),
+      );
+    },
+  });
+
+  const responsePromise = fetch(server.url);
+  await pulled.promise;
+  controller.write("LATER");
+  controller.end();
+
+  const response = await responsePromise;
+  expect(await response.text()).toBe("LATER");
+  expect(response.status).toBe(200);
+});
+
+test("cancel() fires when the client disconnects while waiting for end()", async () => {
+  const pulled = Promise.withResolvers<void>();
+  const cancelled = Promise.withResolvers<void>();
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(
+        new ReadableStream({
+          type: "direct",
+          pull(c: any) {
+            c.write("partial");
+            c.flush();
+            pulled.resolve();
+          },
+          cancel() {
+            cancelled.resolve();
+          },
+        } as any),
+      );
+    },
+  });
+
+  const abort = new AbortController();
+  const response = await fetch(server.url, { signal: abort.signal });
+  await pulled.promise;
+  abort.abort();
+  // the server must tear down the stream (aborting e.g. React's render)
+  // instead of waiting for an end() that will never come
+  await cancelled.promise;
+  await response.text().catch(() => {});
+});
+
+// endFromJS() can hit transport backpressure right after the HEADERS frame on
+// QUIC and park a pending flush; the server must drain it instead of
+// finalizing the sink and truncating the response (HTTP3ContentLengthMismatch).
+describe("end() under transport backpressure over h3", () => {
+  function serveH3(body: () => ReadableStream) {
+    return Bun.serve({
+      port: 0,
+      tls,
+      // @ts-expect-error http3 is not in the public types yet
+      http3: true,
+      http1: false,
+      fetch: () => new Response(body()),
+    });
+  }
+  const h3fetch = (server: any) =>
+    fetch(`https://${server.hostname}:${server.port}/`, {
+      // @ts-expect-error protocol is bun-specific
+      protocol: "http3",
+      tls: { rejectUnauthorized: false },
+    });
+
+  test("async pull() that ends synchronously", async () => {
+    using server = serveH3(
+      () =>
+        new ReadableStream({
+          type: "direct",
+          async pull(c: any) {
+            c.write("hey");
+            c.end();
+          },
+        } as any),
+    );
+    const res = await h3fetch(server);
+    expect(await res.text()).toBe("hey");
+  });
+
+  test("sync pull() that ends from a microtask", async () => {
+    using server = serveH3(
+      () =>
+        new ReadableStream({
+          type: "direct",
+          pull(c: any) {
+            c.write("hey");
+            queueMicrotask(() => c.end());
+          },
+        } as any),
+    );
+    const res = await h3fetch(server);
+    expect(await res.text()).toBe("hey");
+  });
+});
+
+// The controller's detach() used to skip the close callback when it was
+// wrapped in an AsyncContextFrame (stream constructed inside
+// AsyncLocalStorage.run()), so the request context waiting for end() was
+// never released and every request leaked its ReadableStream.
+test("sync pull() under AsyncLocalStorage releases the request on end()", async () => {
+  const als = new AsyncLocalStorage();
+  let controller: any;
+  let pulled: any;
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return als.run(
+        {},
+        () =>
+          new Response(
+            new ReadableStream({
+              type: "direct",
+              pull(c: any) {
+                c.write("hey");
+                controller = c;
+                pulled.resolve();
+              },
+            } as any),
+          ),
+      );
+    },
+  });
+
+  async function once() {
+    pulled = Promise.withResolvers();
+    const responsePromise = fetch(server.url);
+    await pulled.promise;
+    controller.end();
+    const response = await responsePromise;
+    expect(await response.text()).toBe("hey");
+  }
+
+  // Baseline-delta so the assertion measures only this test's streams, not
+  // VM-global residue from earlier tests in the file.
+  const baseline = heapStats().objectTypeCounts.ReadableStream ?? 0;
+  for (let i = 0; i < 20; i++) await once();
+  Bun.gc(true);
+  await Bun.sleep(10);
+  Bun.gc(true);
+  const counts = heapStats().objectTypeCounts;
+  expect((counts.ReadableStream ?? 0) - baseline).toBeLessThan(10);
+});

--- a/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak-fixture.ts
@@ -1,22 +1,25 @@
-// Exercises the no-promise fallback path in doRenderStream().
-//
-// A direct ReadableStream whose pull() writes synchronously and returns a
-// non-promise value falls through to the "is in progress, but did not return
-// a Promise" branch. That branch must destroy the heap-allocated
-// HTTPServerWritable/JSSink it created a few lines earlier; otherwise each
-// request leaks the struct plus its buffer.
+// Exercises sink teardown for a direct ReadableStream whose pull() writes
+// synchronously and returns a non-promise without ending the sink. The server
+// keeps the response open until controller.end(); each request allocates a
+// heap HTTPServerWritable/JSSink plus the promise plumbing used to wait for
+// the close, and all of it must be released when end() completes the
+// response; otherwise each request leaks the struct plus its buffer.
 import { memoryUsage } from "bun:jsc";
+
+let controller: any;
+let pulled: { promise: Promise<void>; resolve: () => void };
 
 const server = Bun.serve({
   port: 0,
   fetch() {
     const stream = new ReadableStream({
       type: "direct",
-      pull(controller: any) {
+      pull(c: any) {
         // Less than highWaterMark so it buffers instead of sending. pull()
-        // returns undefined (not a promise), so assignToStream() also returns
-        // undefined and doRenderStream drops into its no-promise fallback.
-        controller.write("x");
+        // returns undefined (not a promise), so the request waits for end().
+        c.write("x");
+        controller = c;
+        pulled.resolve();
       },
     } as any);
     return new Response(stream);
@@ -26,7 +29,11 @@ const server = Bun.serve({
 const url = server.url.href;
 
 async function once() {
-  const res = await fetch(url);
+  pulled = Promise.withResolvers();
+  const resPromise = fetch(url);
+  await pulled.promise;
+  controller.end();
+  const res = await resPromise;
   await res.arrayBuffer();
 }
 

--- a/test/js/bun/http/serve-response-stream-sink-leak.test.ts
+++ b/test/js/bun/http/serve-response-stream-sink-leak.test.ts
@@ -3,13 +3,13 @@ import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
 // Regression: doRenderStream allocates a ResponseStream.JSSink on the heap
-// and stores it in RequestContext.sink. When assignToStream() returns
-// undefined (a direct stream drained synchronously with no pending promise)
-// the fallback branches detached the sink from JS but never called
-// sink.destroy(), and neither finalizeWithoutDeinit() nor deinit() touch
-// RequestContext.sink, so the allocation plus its pooled buffer leaked on
-// every such request.
-test("HTTPResponseSink is destroyed on doRenderStream no-promise fallback", async () => {
+// and stores it in RequestContext.sink. A direct stream whose pull() returns
+// synchronously without ending the sink keeps the request alive until
+// controller.end(); the resolve path must destroy the sink and release the
+// request context (neither finalizeWithoutDeinit() nor deinit() touch
+// RequestContext.sink), otherwise the allocation plus its pooled buffer
+// leaks on every such request.
+test("HTTPResponseSink is destroyed after a sync pull() that ends later", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), join(import.meta.dir, "serve-response-stream-sink-leak-fixture.ts")],
     env: bunEnv,

--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -56,16 +56,17 @@ describe.each([
 
     test("Should not crash when not returning a promise when stream is in progress", async () => {
       var called = false;
+      let controller;
+      const pulled = Promise.withResolvers();
       await runInServer(
         {
           async fetch() {
             var stream = new ReadableStream({
               type: "direct",
-              pull(controller) {
-                controller.write("hey");
-                setTimeout(() => {
-                  controller.end();
-                }, 100);
+              pull(c) {
+                c.write("hey");
+                controller = c;
+                pulled.resolve();
               },
             });
 
@@ -74,8 +75,11 @@ describe.each([
         },
         async url => {
           called = true;
-          // if we can flush it will be "hey" otherwise will be empty
-          expect(await fetch(url).then(res => res.text())).toBeOneOf(["hey", ""]);
+          const responsePromise = fetch(url);
+          await pulled.promise;
+          controller.end();
+          // the response stays open until controller.end() is called
+          expect(await responsePromise.then(res => res.text())).toBe("hey");
         },
       );
 


### PR DESCRIPTION
Fixes #32137

### Repro

```ts
Bun.serve({
  port: 3000,
  fetch() {
    const stream = new ReadableStream({
      type: "direct",
      pull(controller) {
        controller.write("SHELL");
        controller.flush();
        setTimeout(() => {       // like React resolving a Suspense boundary
          controller.write("RESOLVED");
          controller.end();
        }, 50);
        // returns undefined synchronously
      },
    });
    return new Response(stream);
  },
});
```

`curl` gets `SHELL` (5 bytes, clean 200) instead of `SHELLRESOLVED`. With react-dom 19's `renderToReadableStream` (its `server.bun.js` build uses exactly this shape), the response ends after the shell flush with the pending marker `<!--$?-->` and the fallback, missing `</body></html>`, and React logs `error: The render was aborted by the server without a reason.` because the server cancels the stream mid-render. Reproduces on 1.0.36 through current main.

### Cause

For a direct `ReadableStream`, `readDirectStream` calls `underlyingSource.pull(sink)` once and returns `undefined` when pull returns a non-promise. `Bun.serve`'s `do_render_stream` (src/runtime/server/RequestContext.rs) then has no way to know the stream isn't finished: it hits the `"is in progress, but did not return a Promise. Finalizing request context"` branch, which cancels the stream (aborting React's render) and finalizes the sink, truncating everything the producer would have written through the captured controller.

react-dom/server.bun.js depends on the captured-controller pattern: `pull` writes the shell and returns, then resolved Suspense boundaries are written later and `end()` is called when the render completes (facebook/react#25597, which Bun's SSR guide links).

### Fix

Three pieces, each with its own test:

1. **`readDirectStream`** (src/js/builtins/ReadableStreamInternals.ts): when `pull()` returns a non-promise and the stream is still readable, return a promise that settles when the sink closes (`end()`, or abort on client disconnect). Native consumers already handle a returned promise through the same pending path async `pull()` uses, so `Bun.serve` keeps the request context alive and lets the later `end()` complete the response. Client disconnects still tear the stream down through the sink's abort path, which invokes the source's `cancel()` (so React aborts its render on disconnect as before). The async-pull contract (socket terminates when the promise resolves) and the default-stream path are unchanged.

2. **`handle_resolve_stream`** (src/runtime/server/RequestContext.rs): `endFromJS()` can hit transport backpressure right after the HEADERS frame on QUIC and park a `pending_flush` promise while `onWritable` drains the remaining bytes. The resolve path destroyed the sink at that point, discarding the parked bytes and failing the request with `HTTP3ContentLengthMismatch`. This pre-exists the PR (an `async pull()` that calls `end()` synchronously fails the same way over h3 on main) and is the same bug class the undefined-result path already guards (the `effective_result`/`pending_flush` substitution). Now the resolve path waits for the parked flush to settle and re-enters.

3. **`detach()`** (src/codegen/generate-jssink.ts): the controller's detach used `JSC::getCallData` to invoke the stored close callback, which reports an `AsyncContextFrame` (stream constructed inside `AsyncLocalStorage.run()`, a common per-request SSR pattern) as not callable, silently skipping the callback. With the new wait this leaked the request context, sink, and `ReadableStream` on every request. Route through `AsyncContextFrame::call` like the generated `onClose` already does.

### Tests

In `test/js/bun/http/serve-direct-readable-stream.test.ts` (all fail on the unfixed build; the first two with `This HTTPResponseSink has already been closed. A "direct" ReadableStream terminates its underlying socket once 'async pull()' returns.`):

- sync `pull()` that ends later streams the whole body (also asserts the shell arrives before `end()`, i.e. streaming stays progressive)
- sync `pull()` that writes nothing and ends later still responds
- `cancel()` fires when the client disconnects while waiting for `end()`
- h3: async `pull()` that ends synchronously, and sync `pull()` that ends from a microtask (fail with `HTTP3ContentLengthMismatch` without fix 2)
- AsyncLocalStorage variant asserting `heapStats()` ReadableStream counts stay flat (leaks 20/20 without fix 3)

Also updated:

- `body-stream.test.ts` "Should not crash when not returning a promise when stream is in progress": `toBeOneOf(["hey", ""])` tightened to `toBe("hey")` and the timer replaced with condition-driven `end()`, per review
- `serve-response-stream-sink-leak-fixture.ts`: the fixture relied on the old truncating fallback (pull never called `end()`, which now means "keep the response open"); it ends each stream from the client side and still asserts flat memory over 10k requests (delta 0.0 bytes/request)

Verified the issue's React repro end to end with react@19.2.7: the response is the complete 1158-byte document containing `<span>RESOLVED</span>` and closing `</body></html>`, with no abort error. Existing suites (`serve.test.ts`, `bun-server.test.ts`, `body-stream.test.ts` incl. the h3 matrix, `streams.test.js`, `direct-readable-stream.test.tsx`, spawn stdin ReadableStream suites, the serve leak tests) show no new failures against the unfixed build.
