### PR TITLE
sql: consolidate per-driver StackReader into shared/

### DIFF
--- a/src/sql/lib.rs
+++ b/src/sql/lib.rs
@@ -11,6 +11,8 @@ pub mod shared {
     pub mod query_status;
     #[path = "SQLQueryResultMode.rs"]
     pub mod sql_query_result_mode;
+    #[path = "StackReader.rs"]
+    pub mod stack_reader;
     #[path = "StatementStatus.rs"]
     pub mod statement_status;
 
@@ -18,6 +20,7 @@ pub mod shared {
     pub use connection_flags::ConnectionFlags;
     pub use data::Data;
     pub use sql_query_result_mode::SQLQueryResultMode;
+    pub use stack_reader::StackReader;
 }
 
 pub mod mysql {
@@ -107,7 +110,7 @@ pub mod mysql {
         pub use handshake_response41::HandshakeResponse41;
         pub use handshake_v10::HandshakeV10;
         pub use local_infile_request::LocalInfileRequest;
-        pub use new_reader::{Decode, NewReader, NewReaderOf, ReadableInt, ReaderContext};
+        pub use new_reader::{Decode, NewReader, ReadableInt, ReaderContext};
         pub use new_writer::{NewWriter, NewWriterWrap, Packet, WriterContext, write_wrap};
         pub use ok_packet::OKPacket;
         pub use packet_header::PacketHeader;

--- a/src/sql/mysql/protocol/NewReader.rs
+++ b/src/sql/mysql/protocol/NewReader.rs
@@ -122,8 +122,6 @@ impl<C: ReaderContext> NewReader<C> {
 /// MySQL's u24/i24 are NOT routed through this trait — see `int_u24`/`int_i24`.
 pub use bun_core::NativeEndianInt as ReadableInt;
 
-pub type NewReaderOf<C> = NewReader<C>;
-
 impl<C: ReaderContext> From<C> for NewReader<C> {
     fn from(wrapped: C) -> Self {
         Self { wrapped }
@@ -137,13 +135,6 @@ pub trait Decode: Sized {
     ) -> Result<(), AnyMySQLError>;
 
     fn decode<C: ReaderContext>(
-        &mut self,
-        context: impl Into<NewReader<C>>,
-    ) -> Result<(), AnyMySQLError> {
-        self.decode_internal(context.into())
-    }
-
-    fn decode_allocator<C: ReaderContext>(
         &mut self,
         context: impl Into<NewReader<C>>,
     ) -> Result<(), AnyMySQLError> {

--- a/src/sql/mysql/protocol/StackReader.rs
+++ b/src/sql/mysql/protocol/StackReader.rs
@@ -1,116 +1,40 @@
-use core::cell::Cell;
-
-use bun_core::strings;
-
 use super::any_mysql_error::Error as AnyMySQLError;
 use super::new_reader::{NewReader, ReaderContext};
 use crate::shared::data::Data;
+use crate::shared::stack_reader::{ShortRead, WrapReader};
 
-#[derive(Clone, Copy)]
-pub struct StackReader<'a> {
-    pub buffer: &'a [u8],
-    pub offset: &'a Cell<usize>,
-    pub message_start: &'a Cell<usize>,
+pub use crate::shared::stack_reader::StackReader;
+
+impl ShortRead for AnyMySQLError {
+    const SHORT_READ: Self = AnyMySQLError::ShortRead;
 }
 
-impl<'a> StackReader<'a> {
-    pub fn mark_message_start(&self) {
-        self.message_start.set(self.offset.get());
-    }
-
-    pub fn set_offset_from_start(&self, offset: usize) {
-        self.offset.set(self.message_start.get() + offset);
-    }
-
-    pub fn ensure_capacity(&self, length: usize) -> bool {
-        self.offset
-            .get()
-            .checked_add(length)
-            .is_some_and(|end| self.buffer.len() >= end)
-    }
-
-    pub fn init(
-        buffer: &'a [u8],
-        offset: &'a Cell<usize>,
-        message_start: &'a Cell<usize>,
-    ) -> NewReader<StackReader<'a>> {
-        NewReader {
-            wrapped: StackReader {
-                buffer,
-                offset,
-                message_start,
-            },
-        }
-    }
-
-    pub fn peek(&self) -> &'a [u8] {
-        &self.buffer[self.offset.get()..]
-    }
-
-    pub fn skip(&self, count: isize) {
-        if count < 0 {
-            let abs_count = count.unsigned_abs();
-            if abs_count > self.offset.get() {
-                self.offset.set(0);
-                return;
-            }
-            self.offset.set(self.offset.get() - abs_count);
-            return;
-        }
-
-        let ucount: usize = usize::try_from(count).expect("int cast");
-        if self.offset.get() + ucount > self.buffer.len() {
-            self.offset.set(self.buffer.len());
-            return;
-        }
-
-        self.offset.set(self.offset.get() + ucount);
-    }
-
-    pub fn read(&self, count: usize) -> Result<Data, AnyMySQLError> {
-        let offset = self.offset.get();
-        if !self.ensure_capacity(count) {
-            return Err(AnyMySQLError::ShortRead);
-        }
-
-        self.skip(isize::try_from(count).expect("int cast"));
-        Ok(Data::Temporary(bun_ptr::RawSlice::new(
-            &self.buffer[offset..self.offset.get()],
-        )))
-    }
-
-    pub fn read_z(&self) -> Result<Data, AnyMySQLError> {
-        let remaining = self.peek();
-        if let Some(zero) = strings::index_of_char(remaining, 0) {
-            let zero = zero as usize;
-            self.skip(isize::try_from(zero + 1).expect("int cast"));
-            return Ok(Data::Temporary(bun_ptr::RawSlice::new(&remaining[0..zero])));
-        }
-
-        Err(AnyMySQLError::ShortRead)
+impl<'a> WrapReader<'a> for NewReader<StackReader<'a>> {
+    fn wrap(reader: StackReader<'a>) -> Self {
+        NewReader { wrapped: reader }
     }
 }
 
 impl<'a> ReaderContext for StackReader<'a> {
     fn mark_message_start(self) {
-        Self::mark_message_start(&self)
+        StackReader::mark_message_start(&self)
     }
     fn peek(&self) -> &[u8] {
-        Self::peek(self)
+        StackReader::peek(self)
     }
     fn skip(self, count: isize) {
-        Self::skip(&self, count)
+        StackReader::skip(&self, count)
     }
     fn ensure_capacity(self, count: usize) -> bool {
-        Self::ensure_capacity(&self, count)
+        StackReader::ensure_capacity(&self, count)
     }
     fn read(self, count: usize) -> Result<Data, AnyMySQLError> {
-        Self::read(&self, count)
+        StackReader::read(&self, count)
     }
     fn read_z(self) -> Result<Data, AnyMySQLError> {
-        Self::read_z(&self)
+        StackReader::read_z(&self)
     }
     fn set_offset_from_start(self, offset: usize) {
-        Self::set_offset_from_start(&self, offset)
+        StackReader::set_offset_from_start(&self, offset)
     }
 }

--- a/src/sql/postgres/protocol/NewReader.rs
+++ b/src/sql/postgres/protocol/NewReader.rs
@@ -36,8 +36,7 @@ macro_rules! impl_protocol_int {
 }
 impl_protocol_int!(u8, i8, u16, i16, u32, i32, u64, i64);
 
-// Blanket impl so `NewReaderWrap<&mut C>` works — the inner `Context` is
-// non-`Copy` (holds `&mut usize`), so callers reborrow instead.
+// Blanket impl so `NewReaderWrap<&mut C>` works for callers that reborrow.
 impl<C: ReaderContext + ?Sized> ReaderContext for &mut C {
     #[inline]
     fn mark_message_start(&mut self) {

--- a/src/sql/postgres/protocol/StackReader.rs
+++ b/src/sql/postgres/protocol/StackReader.rs
@@ -1,101 +1,39 @@
 use crate::postgres::any_postgres_error::AnyPostgresError;
 use crate::postgres::protocol::new_reader::{NewReader, ReaderContext};
 use crate::shared::data::Data;
-use bun_core::strings;
+use crate::shared::stack_reader::{ShortRead, WrapReader};
 
-pub struct StackReader<'a> {
-    pub buffer: &'a [u8],
-    pub offset: &'a mut usize,
-    pub message_start: &'a mut usize,
+pub use crate::shared::stack_reader::StackReader;
+
+impl ShortRead for AnyPostgresError {
+    const SHORT_READ: Self = AnyPostgresError::ShortRead;
 }
 
-impl<'a> StackReader<'a> {
-    pub fn mark_message_start(&mut self) {
-        *self.message_start = *self.offset;
-    }
-
-    pub fn ensure_length(&self, length: usize) -> bool {
-        self.buffer.len() >= (*self.offset + length)
-    }
-
-    pub fn init(
-        buffer: &'a [u8],
-        offset: &'a mut usize,
-        message_start: &'a mut usize,
-    ) -> NewReader<StackReader<'a>> {
-        NewReader {
-            wrapped: StackReader {
-                buffer,
-                offset,
-                message_start,
-            },
-        }
-    }
-
-    pub fn peek(&self) -> &[u8] {
-        &self.buffer[*self.offset..]
-    }
-
-    pub fn skip(&mut self, count: usize) {
-        if *self.offset + count > self.buffer.len() {
-            *self.offset = self.buffer.len();
-            return;
-        }
-
-        *self.offset += count;
-    }
-
-    pub fn ensure_capacity(&self, count: usize) -> bool {
-        self.buffer.len() >= (*self.offset + count)
-    }
-
-    pub fn read(&mut self, count: usize) -> Result<Data, AnyPostgresError> {
-        let offset = *self.offset;
-        if !self.ensure_capacity(count) {
-            return Err(AnyPostgresError::ShortRead);
-        }
-
-        self.skip(count);
-        // Copy the &'a [u8] out before slicing so the returned Data borrows 'a,
-        // not &mut self.
-        let buffer: &'a [u8] = self.buffer;
-        Ok(Data::Temporary(bun_ptr::RawSlice::new(
-            &buffer[offset..*self.offset],
-        )))
-    }
-
-    pub fn read_z(&mut self) -> Result<Data, AnyPostgresError> {
-        // Inline `peek()` so `remaining` borrows 'a (via the Copy &'a [u8])
-        // instead of &self, allowing `self.skip()` below.
-        let buffer: &'a [u8] = self.buffer;
-        let remaining = &buffer[*self.offset..];
-        if let Some(zero) = strings::index_of_char(remaining, 0) {
-            let zero = zero as usize;
-            self.skip(zero + 1);
-            return Ok(Data::Temporary(bun_ptr::RawSlice::new(&remaining[0..zero])));
-        }
-
-        Err(AnyPostgresError::ShortRead)
+impl<'a> WrapReader<'a> for NewReader<StackReader<'a>> {
+    fn wrap(reader: StackReader<'a>) -> Self {
+        NewReader { wrapped: reader }
     }
 }
 
 impl<'a> ReaderContext for StackReader<'a> {
     fn mark_message_start(&mut self) {
-        Self::mark_message_start(self)
+        StackReader::mark_message_start(self)
     }
     fn peek(&self) -> &[u8] {
-        Self::peek(self)
+        StackReader::peek(self)
     }
     fn skip(&mut self, count: usize) {
-        Self::skip(self, count)
+        // The shared reader's signed skip clamps to the buffer end, matching
+        // the old unsigned behavior even when `count` exceeds `isize::MAX`.
+        StackReader::skip(self, isize::try_from(count).unwrap_or(isize::MAX))
     }
     fn ensure_length(&mut self, count: usize) -> bool {
-        Self::ensure_length(self, count)
+        StackReader::ensure_capacity(self, count)
     }
     fn read(&mut self, count: usize) -> Result<Data, AnyPostgresError> {
-        Self::read(self, count)
+        StackReader::read(self, count)
     }
     fn read_z(&mut self) -> Result<Data, AnyPostgresError> {
-        Self::read_z(self)
+        StackReader::read_z(self)
     }
 }

--- a/src/sql/shared/StackReader.rs
+++ b/src/sql/shared/StackReader.rs
@@ -1,0 +1,116 @@
+use core::cell::Cell;
+
+use bun_core::strings;
+
+use super::data::Data;
+
+/// Supplies the protocol error enum's "buffer exhausted" variant for
+/// [`StackReader`]'s fallible reads.
+pub trait ShortRead {
+    const SHORT_READ: Self;
+}
+
+/// Wraps a [`StackReader`] in the protocol's reader type ([`StackReader::init`]).
+pub trait WrapReader<'a>: Sized {
+    fn wrap(reader: StackReader<'a>) -> Self;
+}
+
+/// Accepts either `&Cell<usize>` or `&mut usize` as a cursor slot in
+/// [`StackReader::init`].
+pub trait IntoCursor<'a> {
+    fn into_cursor(self) -> &'a Cell<usize>;
+}
+
+impl<'a> IntoCursor<'a> for &'a Cell<usize> {
+    fn into_cursor(self) -> &'a Cell<usize> {
+        self
+    }
+}
+
+impl<'a> IntoCursor<'a> for &'a mut usize {
+    fn into_cursor(self) -> &'a Cell<usize> {
+        Cell::from_mut(self)
+    }
+}
+
+/// Cursor over a borrowed wire buffer. `Cell`-based so copies share the
+/// offset and callers can read the cursor back after a short read.
+#[derive(Clone, Copy)]
+pub struct StackReader<'a> {
+    pub buffer: &'a [u8],
+    pub offset: &'a Cell<usize>,
+    pub message_start: &'a Cell<usize>,
+}
+
+impl<'a> StackReader<'a> {
+    pub fn init<R: WrapReader<'a>>(
+        buffer: &'a [u8],
+        offset: impl IntoCursor<'a>,
+        message_start: impl IntoCursor<'a>,
+    ) -> R {
+        R::wrap(StackReader {
+            buffer,
+            offset: offset.into_cursor(),
+            message_start: message_start.into_cursor(),
+        })
+    }
+
+    pub fn mark_message_start(&self) {
+        self.message_start.set(self.offset.get());
+    }
+
+    pub fn set_offset_from_start(&self, offset: usize) {
+        self.offset.set(self.message_start.get() + offset);
+    }
+
+    pub fn ensure_capacity(&self, length: usize) -> bool {
+        self.offset
+            .get()
+            .checked_add(length)
+            .is_some_and(|end| self.buffer.len() >= end)
+    }
+
+    pub fn peek(&self) -> &'a [u8] {
+        &self.buffer[self.offset.get()..]
+    }
+
+    /// Clamps to `[0, buffer.len()]` in both directions.
+    pub fn skip(&self, count: isize) {
+        let offset = self.offset.get();
+        if count < 0 {
+            self.offset.set(offset.saturating_sub(count.unsigned_abs()));
+            return;
+        }
+
+        let ucount = count.unsigned_abs();
+        if offset + ucount > self.buffer.len() {
+            self.offset.set(self.buffer.len());
+            return;
+        }
+
+        self.offset.set(offset + ucount);
+    }
+
+    pub fn read<E: ShortRead>(&self, count: usize) -> Result<Data, E> {
+        let offset = self.offset.get();
+        if !self.ensure_capacity(count) {
+            return Err(E::SHORT_READ);
+        }
+
+        self.offset.set(offset + count);
+        Ok(Data::Temporary(bun_ptr::RawSlice::new(
+            &self.buffer[offset..offset + count],
+        )))
+    }
+
+    pub fn read_z<E: ShortRead>(&self) -> Result<Data, E> {
+        let remaining = self.peek();
+        if let Some(zero) = strings::index_of_char(remaining, 0) {
+            let zero = zero as usize;
+            self.skip(isize::try_from(zero + 1).expect("int cast"));
+            return Ok(Data::Temporary(bun_ptr::RawSlice::new(&remaining[0..zero])));
+        }
+
+        Err(E::SHORT_READ)
+    }
+}


### PR DESCRIPTION
## What this does

Third (and last Rust) slice from #31994, on top of #32128 and #32135. Consolidates the per-driver `StackReader` cursor type into `src/sql/shared/StackReader.rs`. Net −29 lines across 6 files.

`StackReader` is the cursor-over-borrowed-buffer that both drivers' `NewReader` types wrap on the per-row decode path. The MySQL and Postgres copies were near-identical; the only per-driver bits were the error variant returned on a short read and the `NewReader<C>` wrapper type. Those become two small traits (`ShortRead`, `WrapReader`) that each driver implements in ~10 lines; the per-driver `StackReader.rs` files are now those impls plus a re-export.

Also drops two dead items from `mysql/protocol/NewReader.rs`: the `NewReaderOf<C>` type alias (= `NewReader<C>`, zero callers) and `Decode::decode_allocator` (body identical to `decode`, zero callers).

## Behavioral equivalence

- MySQL: byte-for-byte semantic match. Old already used `&Cell<usize>`; `skip` negative-count branch via `saturating_sub` is identical to the old explicit clamp.
- Postgres: cursor was `&mut usize`; new shared uses `&Cell<usize>` for both. `IntoCursor for &mut usize` is `Cell::from_mut` (a `repr(transparent)` pointer cast), so the existing `&mut consumed`/`&mut offset` call site at `PostgresSQLConnection.rs:982` is unchanged and reads back the same locals after the reader is consumed.
- `ShortRead::SHORT_READ` monomorphizes to the literal `AnyMySQLError::ShortRead` / `AnyPostgresError::ShortRead` — identical `Err` values to before.

Two strictly-safer deltas on the postgres side, both unreachable on real wire data but the correct direction:

- `ensure_length`/`ensure_capacity` use `checked_add` where the old `buffer.len() >= offset + length` could overflow-wrap in release on adversarial declared lengths.
- `skip(count > isize::MAX)` clamps to buffer end instead of overflow-wrapping.

## Performance

No new dynamic dispatch or boxing — `ShortRead`/`WrapReader`/`IntoCursor` are all generic-bound. `Cell::get/set` on `usize` compiles to plain load/store. The per-row hot path (`DataRow` → `NewReader::int` → `wrapped.read(N)`) is slightly leaner: shared `read` advances the cursor with `offset.set(offset + count)` instead of routing through `skip()` with its redundant bounds re-check. The one added `isize::try_from().unwrap_or()` in the postgres `skip` bridge is not on the row path (`skip` is called only from `FieldDescription` once per column definition and `Authentication` once per connection).

## Verification

- `cargo check -p bun_sql -p bun_sql_jsc` and `cargo clippy --no-deps`: clean.
- `cargo fmt`: no diffs.
- Zero callers of `NewReaderOf` / `decode_allocator` via grep.

## Left for a follow-up

The `src/js/internal/sql/shared.ts` JS adapter consolidation from #31994 (`BasePooledConnection`, +1308/−2273) — the higher-risk pool/lifecycle piece.
