### PR TITLE
bake: fix "Runtime file not found" panic in production builds of custom frameworks

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2555,7 +2555,6 @@ pub mod parse_worker {
         opts.framework = topts.framework.map(|f| {
             // `Framework` is bump-allocated below, so `Drop` never runs — use arena-owned slices.
             let projected = js_parser::options::Framework {
-                is_built_in_react: f.is_built_in_react,
                 server_components: f.server_components.as_ref().map(|sc| {
                     js_parser::options::FrameworkServerComponents {
                         separate_ssr_graph: sc.separate_ssr_graph,

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -466,9 +466,6 @@ pub mod bv2_impl {
             /// (`js_parser/ast/Parser.rs:1997` resolves `framework.react_fast_refresh
             /// .import_source`) when `features.react_fast_refresh` is on.
             pub(crate) react_fast_refresh: Option<ReactFastRefresh>,
-            /// Mirrors `Framework.is_built_in_react` — read by
-            /// `linker_context::generateChunksInParallel` to gate `BakeExtra`.
-            pub(crate) is_built_in_react: bool,
         }
         impl Framework {
             /// Construct the bundler-side TYPE_ONLY view. Called from
@@ -479,13 +476,11 @@ pub mod bv2_impl {
                 built_in_modules: bun_collections::StringArrayHashMap<BuiltInModule>,
                 server_components: Option<ServerComponents>,
                 react_fast_refresh: Option<ReactFastRefresh>,
-                is_built_in_react: bool,
             ) -> Self {
                 Self {
                     built_in_modules,
                     server_components,
                     react_fast_refresh,
-                    is_built_in_react,
                 }
             }
         }

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -1260,10 +1260,10 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         crate::chunk::Content::Html => Box::default(),
                     },
                     bake_extra: 'brk: {
-                        if c.framework.is_none() || IS_DEV_SERVER {
+                        let Some(framework) = c.framework else {
                             break 'brk BakeExtra::default();
-                        }
-                        if !c.framework.unwrap().is_built_in_react {
+                        };
+                        if IS_DEV_SERVER {
                             break 'brk BakeExtra::default();
                         }
 
@@ -1276,12 +1276,15 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         if output_kind == options::OutputKind::EntryPoint
                             && side == options::Side::Server
                         {
-                            extra.route = if static_route_visitor
-                                .has_transitive_use_client(chunk.entry_point.source_index())
+                            // Without server components there are no "use client"
+                            // boundaries, so the visitor would call every route static.
+                            extra.route = if framework.server_components.is_some()
+                                && !static_route_visitor
+                                    .has_transitive_use_client(chunk.entry_point.source_index())
                             {
-                                BakeRouteKind::Route
-                            } else {
                                 BakeRouteKind::FullyStaticRoute
+                            } else {
+                                BakeRouteKind::Route
                             };
                         }
 

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -123,7 +123,6 @@ pub mod options {
     /// §Forbidden re: `&'static [T]` for arena-freed data.
     #[derive(Clone, Default)]
     pub struct Framework {
-        pub is_built_in_react: bool,
         pub server_components: Option<FrameworkServerComponents>,
         pub react_fast_refresh: Option<ReactFastRefresh>,
     }

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -1072,12 +1072,7 @@ impl Framework {
             .map(|rfr| bt::ReactFastRefresh {
                 import_source: rfr.import_source.into(),
             });
-        bt::Framework::new(
-            built_in_modules,
-            server_components,
-            react_fast_refresh,
-            self.is_built_in_react,
-        )
+        bt::Framework::new(built_in_modules, server_components, react_fast_refresh)
     }
 
     pub fn init_transpiler_with_options<'a>(

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -164,12 +164,7 @@ impl Framework {
             .map(|rfr| bt::ReactFastRefresh {
                 import_source: rfr.import_source.as_ref().into(),
             });
-        bt::Framework::new(
-            built_in_modules,
-            server_components,
-            react_fast_refresh,
-            self.is_built_in_react,
-        )
+        bt::Framework::new(built_in_modules, server_components, react_fast_refresh)
     }
 
     /// Sets up a per-graph

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -591,8 +591,8 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
     )?;
 
     // `bake_body::Framework` is the runtime-side superset; the bundler reads only
-    // `built_in_modules` / `server_components` / `react_fast_refresh` /
-    // `is_built_in_react` via its lower-tier `bake_types::Framework` view.
+    // `built_in_modules` / `server_components` / `react_fast_refresh`
+    // via its lower-tier `bake_types::Framework` view.
     // Project once here via the shared helper so the field-shape (e.g.
     // `BuiltInModule` `&'static [u8]` → `Box<[u8]>`) stays in one place.
     // (The two Framework types could only merge if `FileSystemRouterType` /

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -784,13 +784,9 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
             }
         }
     }
-    // Write the runtime file to disk if there are any client chunks
-    {
-        let Some(runtime_file_index) = maybe_runtime_file_index else {
-            Output::panic(format_args!(
-                "Runtime file not found. This is an unexpected bug in Bun. Please file a bug report on GitHub."
-            ));
-        };
+    // Write the runtime file to disk if there are any client chunks. The runtime
+    // is absent when no bundled module uses any of its helpers.
+    if let Some(runtime_file_index) = maybe_runtime_file_index {
         let any_client_chunks = bundled_outputs_list.iter().any(|file| {
             file.side == Some(bun_bundler::options::Side::Client)
                 && file.src_path.text != b"bun-framework-react/client.tsx"

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -694,10 +694,8 @@ export async function prerender(meta: any) {
       .env({ ...bunEnv, BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1" })
       .throws(false);
 
-    expect({ exitCode, stderr: stderr.toString() }).toMatchObject({ exitCode: 0 });
-
     const htmlPage = path.join(dir, "dist", "index.html");
-    expect(existsSync(htmlPage)).toBe(true);
+    expect(existsSync(htmlPage), stderr.toString()).toBe(true);
 
     const htmlContent = await Bun.file(htmlPage).text();
     expect(htmlContent).toContain("homepage");
@@ -711,5 +709,7 @@ export async function prerender(meta: any) {
     // The referenced client bundle was written to disk.
     const scriptSrc = scriptMatch![1].replace(/^\//, "");
     expect(existsSync(path.join(dir, "dist", scriptSrc))).toBe(true);
+
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/bake/dev/production.test.ts
+++ b/test/bake/dev/production.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { existsSync } from "fs";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 import path from "path";
 import { tempDirWithBakeDeps } from "../bake-harness";
 
@@ -658,5 +658,58 @@ export default function IndexPage() {
 
     // Verify NO JavaScript imports are included in the HTML
     expect(htmlContent).not.toContain('<script type="module"');
+  });
+
+  // https://github.com/oven-sh/bun/issues/32142
+  test("custom framework builds without the built-in react framework", async () => {
+    const dir = tempDirWithFiles("bake-production-custom-framework", {
+      "bun.app.ts": `export default {
+  app: {
+    framework: {
+      fileSystemRouterTypes: [
+        {
+          root: "pages",
+          style: "nextjs-pages",
+          serverEntryPoint: "./server-entry.ts",
+          clientEntryPoint: "./client-entry.ts",
+        },
+      ],
+    },
+  },
+};`,
+      "pages/index.tsx": `export default function Home() { return "homepage"; }`,
+      "server-entry.ts": `export function render(req: Request, meta: any) {
+  return new Response(String(meta.pageModule.default()));
+}
+export async function prerender(meta: any) {
+  const scripts = meta.modules.map(m => '<script type="module" src="' + m + '"></script>').join("");
+  const body = String(meta.pageModule.default());
+  return { files: { "index.html": "<!DOCTYPE html><html><body>" + body + scripts + "</body></html>" } };
+}`,
+      "client-entry.ts": `console.log("client loaded");`,
+    });
+
+    const { exitCode, stderr } = await Bun.$`${bunExe()} build --app ./bun.app.ts`
+      .cwd(dir)
+      .env({ ...bunEnv, BUN_FEATURE_FLAG_EXPERIMENTAL_BAKE: "1" })
+      .throws(false);
+
+    expect({ exitCode, stderr: stderr.toString() }).toMatchObject({ exitCode: 0 });
+
+    const htmlPage = path.join(dir, "dist", "index.html");
+    expect(existsSync(htmlPage)).toBe(true);
+
+    const htmlContent = await Bun.file(htmlPage).text();
+    expect(htmlContent).toContain("homepage");
+
+    // A framework without server components has no "use client" boundaries,
+    // so its routes must not be treated as fully static: the client entry
+    // point is still passed to prerender via `meta.modules`.
+    const scriptMatch = htmlContent.match(/<script type="module" src="([^"]*_bun[^"]*\.js)"><\/script>/);
+    expect(scriptMatch).toBeTruthy();
+
+    // The referenced client bundle was written to disk.
+    const scriptSrc = scriptMatch![1].replace(/^\//, "");
+    expect(existsSync(path.join(dir, "dist", scriptSrc))).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #32142

`bun build --app` with any custom `Bake.Framework` panicked after "Rendering routes":

```
panic: Runtime file not found. This is an unexpected bug in Bun. Please file a bug report on GitHub.
```

Repro (from the issue): a `bun.app.ts` with `fileSystemRouterTypes` pointing at custom `serverEntryPoint`/`clientEntryPoint` files. The client chunk was written, then bun crashed before running `prerender`, so `dist/index.html` was never produced.

### Cause

`generateChunksInParallel` only populated `OutputFile.bake_extra` when `framework.is_built_in_react` was true. For custom frameworks every chunk's `bake_extra.bake_is_runtime` stayed false, so `production.rs` never found a runtime file index and hit the panic.

Two problems hid behind that gate:

1. `bake_is_runtime` (and the route kind) must be set for any framework, not just built-in React.
2. `BakeRouteKind::FullyStaticRoute` feeds the `noClient` flag in `renderRoutesForProdStatic`, which drops the client entry URL from `RouteMetadata.modules`. The "use client" analysis it relies on only produces boundaries when server components are enabled; un-gating it blindly would have classified every route of a non-server-components framework as fully static and silently dropped its declared `clientEntryPoint` from prerendered pages.

There was also a second latent bug: when no bundled module needs the runtime's wrapper helpers (easy to hit with a small custom-framework app), the runtime is live in no chunk at all, so even with `bake_extra` populated there is legitimately no runtime file. That case now skips the disk write instead of panicking.

### Fix

- `src/bundler/linker_context/generateChunksInParallel.rs`: populate `bake_extra` for every framework; a server entry point is `FullyStaticRoute` only when `server_components` is configured and the visitor finds no client boundary, otherwise `Route` (built-in React always configures server components, so its classification is unchanged).
- `src/runtime/bake/production.rs`: a missing runtime chunk is not an error; only write it to disk when it exists.
- Removed the now-unread `is_built_in_react` mirrors from the bundler-side and parser-side framework views (the runtime-side field stays; it still gates the React install hint).

### Verification

New test in `test/bake/dev/production.test.ts` builds the issue's custom-framework app and asserts the build exits 0, `dist/index.html` contains the prerendered content, and the client entry script URL is passed to `prerender` via `meta.modules` and exists on disk. With the `src/` changes reverted it fails with the panic above (re-checked after the rebase below).

Existing production tests (including "don't include client code if fully static route", which covers the React fully-static path) and `test/bake/framework-router.test.ts` pass.

<details>
<summary>Rebase notes</summary>

Rebased onto main after `BakeExtra.is_route`/`fully_static` were replaced by the `BakeRouteKind` enum. Conflicts resolved:

- `generateChunksInParallel.rs`: the `server_components` gate is now expressed as the `FullyStaticRoute` vs `Route` choice shown above.
- `bundle_v2.rs`: kept main's `pub(crate)` fields and its removal of `client_css_in_js`; dropped `is_built_in_react` as before.

Everything else merged cleanly.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bake/dev/production.test.ts

<!-- robobun:evidence:end -->