### PR TITLE
Drain VM cleanup hooks in global_exit so bun test runs napi at-exit cleanup

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -209,7 +209,8 @@ pub struct VirtualMachine {
 
     pub is_printing_plugin: bool,
     pub is_shutting_down: bool,
-    /// Set once `on_exit()` has finished draining `RareData::cleanup_hooks`.
+    /// Set once `run_cleanup_hooks()` (called from `on_exit()` and
+    /// `global_exit()`) has finished draining `RareData::cleanup_hooks`.
     /// After this point the cleanup-hook list is never iterated again, so
     /// pushing to it (e.g. from a deferred N-API finalizer scheduled during
     /// the final `collectNow()` in `Zig__GlobalObject__destructOnExit`) would

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -373,6 +373,9 @@ unsafe extern "C" {
     safe fn Bun__closeAllSQLiteDatabasesForTermination();
     safe fn Bun__WebView__closeAllForTermination();
     safe fn Zig__GlobalObject__destructOnExit(global: &JSGlobalObject);
+    /// Makes `NapiEnv::cleanup()` run only the explicit env cleanup hooks,
+    /// skipping pending `napi_wrap` finalizers (src/jsc/bindings/napi.cpp).
+    fn napi_internal_set_cleanup_hooks_only();
 }
 
 pub const HOT_RELOAD_HOT: u8 = 1;
@@ -1536,12 +1539,22 @@ impl VirtualMachine {
         debug_assert!(self.is_shutting_down());
         // Exit paths that never go through `on_exit()` (the test runner and
         // its --parallel workers jump straight here) must still drain the
-        // cleanup hooks. Skipping the drain means napi env cleanup hooks and
-        // at-exit `napi_wrap` finalizers never run, and it leaves
-        // `has_run_cleanup_hooks` false, so `NapiFinalizerTask::schedule()`
-        // parks every finalizer deferred by `destructOnExit`'s final
-        // collection on a list that is never walked again (an LSAN-visible
-        // leak of the task boxes). No-op when `on_exit()` already ran.
+        // cleanup hooks. Skipping the drain means napi env cleanup hooks
+        // never run, and it leaves `has_run_cleanup_hooks` false, so
+        // `NapiFinalizerTask::schedule()` parks every finalizer deferred by
+        // `destructOnExit`'s final collection on a list that is never walked
+        // again (an LSAN-visible leak of the task boxes). No-op when
+        // `on_exit()` already ran.
+        //
+        // Unlike `on_exit()`, these paths reach here without draining the
+        // event loop, so addons may still have queued async work; running
+        // their pending `napi_wrap` finalizers now could tear down wraps
+        // that the abandoned work still references (see `NapiEnv::cleanup`).
+        // Restrict the napi env cleanup to the explicit cleanup hooks.
+        if !self.has_run_cleanup_hooks() {
+            // SAFETY: sets a process-global flag in napi.cpp; no preconditions.
+            unsafe { napi_internal_set_cleanup_hooks_only() };
+        }
         self.run_cleanup_hooks();
         // FIXME: we should be doing this, but we're not, but unfortunately
         // doing it causes like 50+ tests to break

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1500,7 +1500,16 @@ impl VirtualMachine {
 
         ExitHandler::dispatch_on_exit(self);
         self.is_shutting_down = true;
+        self.run_cleanup_hooks();
+    }
 
+    /// Drain `RareData::cleanup_hooks` and set `has_run_cleanup_hooks`.
+    /// Every `NapiEnv` registers its at-exit cleanup on this list (env
+    /// cleanup hooks + pending `napi_wrap` finalizers), so it must run while
+    /// JSC and the global are still fully alive. Idempotent: the drained
+    /// list stays empty and the flag makes later `NapiFinalizerTask`s drop
+    /// instead of re-registering.
+    fn run_cleanup_hooks(&mut self) {
         // Make sure we run new cleanup hooks introduced by running cleanup
         // hooks.
         // Note: each iteration re-fetches `rare_data` so the FFI hook
@@ -1524,6 +1533,15 @@ impl VirtualMachine {
 
     pub fn global_exit(&mut self) -> ! {
         debug_assert!(self.is_shutting_down());
+        // Exit paths that never go through `on_exit()` (the test runner and
+        // its --parallel workers jump straight here) must still drain the
+        // cleanup hooks. Skipping the drain means napi env cleanup hooks and
+        // at-exit `napi_wrap` finalizers never run, and it leaves
+        // `has_run_cleanup_hooks` false, so `NapiFinalizerTask::schedule()`
+        // parks every finalizer deferred by `destructOnExit`'s final
+        // collection on a list that is never walked again (an LSAN-visible
+        // leak of the task boxes). No-op when `on_exit()` already ran.
+        self.run_cleanup_hooks();
         // FIXME: we should be doing this, but we're not, but unfortunately
         // doing it causes like 50+ tests to break
         // self.event_loop().tick();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -375,7 +375,8 @@ unsafe extern "C" {
     safe fn Zig__GlobalObject__destructOnExit(global: &JSGlobalObject);
     /// Makes `NapiEnv::cleanup()` run only the explicit env cleanup hooks,
     /// skipping pending `napi_wrap` finalizers (src/jsc/bindings/napi.cpp).
-    fn napi_internal_set_cleanup_hooks_only();
+    /// Sets a process-global flag; no preconditions.
+    safe fn napi_internal_set_cleanup_hooks_only();
 }
 
 pub const HOT_RELOAD_HOT: u8 = 1;
@@ -1552,8 +1553,7 @@ impl VirtualMachine {
         // that the abandoned work still references (see `NapiEnv::cleanup`).
         // Restrict the napi env cleanup to the explicit cleanup hooks.
         if !self.has_run_cleanup_hooks() {
-            // SAFETY: sets a process-global flag in napi.cpp; no preconditions.
-            unsafe { napi_internal_set_cleanup_hooks_only() };
+            napi_internal_set_cleanup_hooks_only();
         }
         self.run_cleanup_hooks();
         // FIXME: we should be doing this, but we're not, but unfortunately

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4042,16 +4042,6 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // mirror WebWorker__teardownJSCVM — leave any pending exception in place
     }
-    // Nothing enters JS after this point. Request termination so
-    // NapiEnv::mustDeferFinalizers() turns false: finalizers for napi wraps
-    // swept by the collection below run immediately (a raw callback, same as
-    // during lastChanceToFinalize in ~VM) instead of being deferred to an
-    // event loop that will never tick again. Without this, every swept wrap
-    // leaks its NapiFinalizerTask box plus whatever the finalizer would have
-    // freed, and LeakSanitizer reports both on exit paths that skipped
-    // on_exit()'s full napi cleanup.
-    vm.ensureTerminationException();
-    vm.setHasTerminationRequest();
     gcUnprotect(globalObject);
     globalObject = nullptr;
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -4042,6 +4042,16 @@ extern "C" void Zig__GlobalObject__destructOnExit(Zig::GlobalObject* globalObjec
         globalObject->requireMap()->clear(globalObject);
         scope.exception(); // mirror WebWorker__teardownJSCVM — leave any pending exception in place
     }
+    // Nothing enters JS after this point. Request termination so
+    // NapiEnv::mustDeferFinalizers() turns false: finalizers for napi wraps
+    // swept by the collection below run immediately (a raw callback, same as
+    // during lastChanceToFinalize in ~VM) instead of being deferred to an
+    // event loop that will never tick again. Without this, every swept wrap
+    // leaks its NapiFinalizerTask box plus whatever the finalizer would have
+    // freed, and LeakSanitizer reports both on exit paths that skipped
+    // on_exit()'s full napi cleanup.
+    vm.ensureTerminationException();
+    vm.setHasTerminationRequest();
     gcUnprotect(globalObject);
     globalObject = nullptr;
     vm.heap.collectNow(JSC::Sync, JSC::CollectionScope::Full);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -3034,6 +3034,23 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
     NAPI_RETURN_SUCCESS(env);
 }
 
+// Whether NapiEnv::cleanup() should run only the explicit env cleanup hooks
+// and skip pending napi_wrap finalizers. Set (never cleared; the process is
+// exiting) by VirtualMachine::global_exit() on exit paths that never drained
+// the event loop. Process-global rather than per-VM: only the main thread's
+// final exit takes this path, and worker teardown goes through on_exit().
+static bool s_napiCleanupHooksOnly = false;
+
+extern "C" void napi_internal_set_cleanup_hooks_only()
+{
+    s_napiCleanupHooksOnly = true;
+}
+
+extern "C" bool napi_internal_cleanup_is_hooks_only()
+{
+    return s_napiCleanupHooksOnly;
+}
+
 extern "C" void napi_internal_cleanup_env_cpp(napi_env env)
 {
     env->cleanup();

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1,5 +1,7 @@
 #include "BunProcess.h"
 #include "headers.h"
+
+#include <atomic>
 #include "node_api.h"
 #include "root.h"
 #include "JavaScriptCore/ConstructData.h"
@@ -3039,16 +3041,19 @@ extern "C" JS_EXPORT napi_status napi_remove_async_cleanup_hook(napi_async_clean
 // exiting) by VirtualMachine::global_exit() on exit paths that never drained
 // the event loop. Process-global rather than per-VM: only the main thread's
 // final exit takes this path, and worker teardown goes through on_exit().
-static bool s_napiCleanupHooksOnly = false;
+// Atomic because worker threads can be mid-teardown (their own on_exit() ->
+// NapiEnv::cleanup()) while the main thread stores the flag; relaxed is
+// enough since either value read is safe at exit.
+static std::atomic<bool> s_napiCleanupHooksOnly { false };
 
 extern "C" void napi_internal_set_cleanup_hooks_only()
 {
-    s_napiCleanupHooksOnly = true;
+    s_napiCleanupHooksOnly.store(true, std::memory_order_relaxed);
 }
 
 extern "C" bool napi_internal_cleanup_is_hooks_only()
 {
-    return s_napiCleanupHooksOnly;
+    return s_napiCleanupHooksOnly.load(std::memory_order_relaxed);
 }
 
 extern "C" void napi_internal_cleanup_env_cpp(napi_env env)

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -249,9 +249,13 @@ public:
             // The napi_set_instance_data() finalizer is part of env teardown
             // in Node and is still safe here: nothing on this path has been
             // freed, so it cannot observe the dangling state the skipped
-            // wrap-finalizer pass avoids.
+            // wrap-finalizer pass avoids. Null the pointer so finalizers that
+            // run later (the exit collection under BUN_DESTRUCT_VM_ON_EXIT
+            // runs swept wraps' finalizers immediately) see null from
+            // napi_get_instance_data instead of freed memory.
             instanceDataFinalizer.call(this, instanceData, true);
             instanceDataFinalizer.clear();
+            instanceData = nullptr;
             return;
         }
 
@@ -283,6 +287,7 @@ public:
 
         instanceDataFinalizer.call(this, instanceData, true);
         instanceDataFinalizer.clear();
+        instanceData = nullptr;
         clearExceptionsBetweenFinalizers();
     }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -523,8 +523,9 @@ public:
         // shutdown case: once is_shutting_down() it either pushes a cleanup hook
         // (if those haven't run yet) or drops the task (if they have). Running a
         // non-EXPERIMENTAL finalizer immediately during the final collectNow() is
-        // never safe — by then on_exit() has already run cleanup hooks (including
-        // the napi_set_instance_data finalizer that frees per-addon state the
+        // never safe — by then run_cleanup_hooks() (via on_exit() or
+        // global_exit()) has already run cleanup hooks (including the
+        // napi_set_instance_data finalizer that frees per-addon state the
         // object finalizer reads), the heap is sweeping (no allocation, no handle
         // scope), and napi_call_function returns the termination exception.
         return m_napiModule.nm_version != NAPI_VERSION_EXPERIMENTAL;

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -258,6 +258,7 @@ public:
             instanceDataFinalizer.call(this, instanceData, true);
             instanceDataFinalizer.clear();
             instanceData = nullptr;
+            clearExceptionsBetweenFinalizers();
             return;
         }
 

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -29,6 +29,11 @@ extern "C" void napi_internal_register_cleanup_zig(napi_env env);
 extern "C" void napi_internal_threadsafe_function_env_teardown(void* tsfn);
 extern "C" void napi_internal_suppress_crash_on_abort_if_desired();
 extern "C" void Bun__crashHandler(const char* message, size_t message_len);
+// Set by VirtualMachine::global_exit() on exit paths that never drained the
+// event loop (the test runner and its --parallel workers); read by
+// NapiEnv::cleanup().
+extern "C" void napi_internal_set_cleanup_hooks_only();
+extern "C" bool napi_internal_cleanup_is_hooks_only();
 
 static bool equal(napi_async_cleanup_hook_handle, napi_async_cleanup_hook_handle);
 
@@ -229,6 +234,19 @@ public:
             drain();
         }
         clearExceptionsBetweenFinalizers();
+
+        // When the process exits without draining the event loop (the test
+        // runner jumps straight to global_exit()), pending napi_wrap
+        // finalizers are not safe to run: an addon may have queued async
+        // work whose teardown touches other wraps this loop would already
+        // have deleted (e.g. duckdb's Task destructor Unref()s the
+        // Connection it captured). Run only the explicit env cleanup hooks
+        // above, matching Node, which does not guarantee wrap finalizers run
+        // at process exit. Under BUN_DESTRUCT_VM_ON_EXIT the final exit
+        // collection runs the remaining finalizers immediately instead (see
+        // Zig__GlobalObject__destructOnExit).
+        if (napi_internal_cleanup_is_hooks_only())
+            return;
 
         // Defer GC during entire finalizer cleanup to prevent iterator invalidation.
         // This prevents any GC-triggered finalizer execution while m_finalizers is being iterated.

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -245,8 +245,15 @@ public:
         // at process exit. Under BUN_DESTRUCT_VM_ON_EXIT the final exit
         // collection runs the remaining finalizers immediately instead (see
         // Zig__GlobalObject__destructOnExit).
-        if (napi_internal_cleanup_is_hooks_only())
+        if (napi_internal_cleanup_is_hooks_only()) {
+            // The napi_set_instance_data() finalizer is part of env teardown
+            // in Node and is still safe here: nothing on this path has been
+            // freed, so it cannot observe the dangling state the skipped
+            // wrap-finalizer pass avoids.
+            instanceDataFinalizer.call(this, instanceData, true);
+            instanceDataFinalizer.clear();
             return;
+        }
 
         // Defer GC during entire finalizer cleanup to prevent iterator invalidation.
         // This prevents any GC-triggered finalizer execution while m_finalizers is being iterated.

--- a/src/jsc/bindings/napi.h
+++ b/src/jsc/bindings/napi.h
@@ -242,17 +242,19 @@ public:
         // have deleted (e.g. duckdb's Task destructor Unref()s the
         // Connection it captured). Run only the explicit env cleanup hooks
         // above, matching Node, which does not guarantee wrap finalizers run
-        // at process exit. Under BUN_DESTRUCT_VM_ON_EXIT the final exit
-        // collection runs the remaining finalizers immediately instead (see
-        // Zig__GlobalObject__destructOnExit).
+        // at process exit. Wraps swept by a later collection (the exit GC
+        // under BUN_DESTRUCT_VM_ON_EXIT) still defer their finalizers, and
+        // NapiFinalizerTask::schedule() drops those tasks because the VM
+        // cleanup hooks already ran, so only the addon's own allocations are
+        // left for the OS to reclaim.
         if (napi_internal_cleanup_is_hooks_only()) {
             // The napi_set_instance_data() finalizer is part of env teardown
             // in Node and is still safe here: nothing on this path has been
             // freed, so it cannot observe the dangling state the skipped
-            // wrap-finalizer pass avoids. Null the pointer so finalizers that
-            // run later (the exit collection under BUN_DESTRUCT_VM_ON_EXIT
-            // runs swept wraps' finalizers immediately) see null from
-            // napi_get_instance_data instead of freed memory.
+            // wrap-finalizer pass avoids. Null the pointer so any finalizer
+            // that still runs later (lastChanceToFinalize calls them
+            // immediately) sees null from napi_get_instance_data instead of
+            // freed memory.
             instanceDataFinalizer.call(this, instanceData, true);
             instanceDataFinalizer.clear();
             instanceData = nullptr;

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -4535,9 +4535,9 @@ impl NapiFinalizerTask {
 
         if vm.is_shutting_down() {
             if vm.has_run_cleanup_hooks() {
-                // `on_exit()` already drained cleanup hooks; we are inside the
-                // final `collectNow()` (Heap::sweepArrayBuffers) and the JSC
-                // VM is being torn down. The cleanup-hook list will never be
+                // `run_cleanup_hooks()` already drained cleanup hooks; we are
+                // inside the final `collectNow()` (Heap::sweepArrayBuffers)
+                // and the JSC VM is being torn down. The cleanup-hook list will never be
                 // walked again, and running the user finalizer here (mid-GC,
                 // with the global about to be freed) is unsafe. Drop the task
                 // so the `Box<NapiFinalizerTask>` and its `NapiEnvRef` are

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -37,10 +37,22 @@ const wrapAddon = join(napiAppDir, "build", "Debug", "test_wrap_cleanup_order.no
 // test/no-validate-exceptions.txt), so the child aborts while loading the
 // addon, before the fixture runs. Strip the validator from the child env
 // only, same as test/regression/issue/30205.test.ts.
+//
+// BUN_DESTRUCT_VM_ON_EXIT is stripped too: these tests pin the normal exit
+// path, where pending wrap finalizers are skipped. Under destruct-vm the
+// final exit collection deliberately runs them (in sweep order, not LIFO),
+// which would print "finalize order:" and break the negative assertion
+// below. This file is also in test/no-validate-leaksan.txt so the asan
+// runner does not set destruct-vm or detect_leaks for it in the first place.
 const childEnv = {
   ...bunEnv,
   BUN_JSC_validateExceptionChecks: undefined,
   BUN_JSC_dumpSimulatedThrows: undefined,
+  BUN_DESTRUCT_VM_ON_EXIT: undefined,
+  // detect_leaks aborts debug builds on known-benign exit allocations and is
+  // not what these tests measure; drop back to bun's baked ASAN defaults.
+  ASAN_OPTIONS: undefined,
+  LSAN_OPTIONS: undefined,
 };
 
 describe.concurrent("napi cleanup at bun test exit", () => {

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -3,21 +3,23 @@
 // Every `bun test` exit site (and the --parallel worker exit in
 // test/parallel/runner.rs) jumped straight to VirtualMachine::global_exit()
 // without draining RareData::cleanup_hooks, the list on which each NapiEnv
-// registers its at-exit cleanup (NapiEnv::cleanup: env cleanup hooks +
-// pending napi_wrap finalizers). Consequences:
+// registers its at-exit cleanup. Consequences:
 //   - napi_add_env_cleanup_hook hooks silently never ran under `bun test`
 //     (Node runs them whenever the environment tears down);
-//   - napi_wrap at-exit finalizers never ran, so with
-//     BUN_DESTRUCT_VM_ON_EXIT=1 the final GC deferred them as
-//     NapiFinalizerTasks parked on that same never-walked list, which
-//     LeakSanitizer reports at exit (the intermittent exit-134 failures of
-//     test/regression/issue/30205.test.ts on the asan CI lane).
+//   - with BUN_DESTRUCT_VM_ON_EXIT=1 the final GC deferred the swept wraps'
+//     finalizers as NapiFinalizerTasks parked on that same never-walked
+//     list, which LeakSanitizer reports at exit (the intermittent exit-134
+//     failures of test/regression/issue/30205.test.ts on the asan CI lane).
 //
-// These two tests are the deterministic, build-independent half: they fail
-// on an unfixed build on every platform because the hook/finalizer output
-// never appears. They live in their own file (rather than napi.test.ts)
-// only because that 100-test concurrent suite is too heavy to run as a
-// whole alongside these.
+// The fix drains the cleanup hooks in global_exit(). Pending napi_wrap
+// finalizers are deliberately NOT run on this path: unlike `bun run`, the
+// test runner exits without draining the event loop, so addons may still
+// have queued async work whose teardown references wraps the finalizer pass
+// would have deleted (duckdb's Task destructor Unref()s its Connection).
+// Node does not guarantee wrap finalizers run at process exit either.
+//
+// This file lives apart from napi.test.ts only because that 100-test
+// concurrent suite is too heavy to run as a whole alongside these.
 
 import { spawn, spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
@@ -82,7 +84,14 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("napi_wrap finalizers run during env teardown when exiting from bun test", async () => {
+  test("pending napi_wrap finalizers are skipped at bun test exit", async () => {
+    // Negative contract for the hooks-only drain: wraps still rooted when
+    // `bun test` exits must NOT have their finalizers run (the event loop
+    // was never drained, so running them can touch wraps that abandoned
+    // async work still references), and the process must exit cleanly. The
+    // equivalent `bun run` exit does run them; that behavior is covered by
+    // "napi_wrap finalizers run in LIFO order during env teardown" in
+    // napi.test.ts.
     using dir = tempDir("napi-wrap-teardown-bun-test", {
       "wrap.test.js": `
         import { test, expect } from "bun:test";
@@ -99,17 +108,8 @@ describe.concurrent("napi cleanup at bun test exit", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // The addon prints the accumulated LIFO order once the parent (id 0) is
-    // finalized; stdout also carries the test runner's version banner, so
-    // assert the exact line rather than the whole stream. No trailing
-    // newline in the needle: the addon's printf("\n") arrives as CRLF on
-    // Windows (text-mode CRT stdout).
-    expect(stdout).toContain(
-      "finalize order: " +
-        Array.from({ length: 32 }, (_, i) => 32 - i)
-          .concat(0)
-          .join(" "),
-    );
+    // The addon prints "finalize order: ..." if any wrap finalizer runs.
+    expect(stdout).not.toContain("finalize order:");
     expect(stderr).toContain("1 pass");
     expect(exitCode).toBe(0);
   });

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -89,13 +89,14 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     // The addon prints the accumulated LIFO order once the parent (id 0) is
     // finalized; stdout also carries the test runner's version banner, so
-    // assert the exact line rather than the whole stream.
+    // assert the exact line rather than the whole stream. No trailing
+    // newline in the needle: the addon's printf("\n") arrives as CRLF on
+    // Windows (text-mode CRT stdout).
     expect(stdout).toContain(
       "finalize order: " +
         Array.from({ length: 32 }, (_, i) => 32 - i)
           .concat(0)
-          .join(" ") +
-        "\n",
+          .join(" "),
     );
     expect(stderr).toContain("1 pass");
     expect(exitCode).toBe(0);

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -29,6 +29,18 @@ const napiAppDir = join(import.meta.dir, "napi-app");
 const hookAddon = join(napiAppDir, "build", "Debug", "test_cleanup_hook_order.node");
 const wrapAddon = join(napiAppDir, "build", "Debug", "test_wrap_cleanup_order.node");
 
+// CI's ASAN lane sets BUN_JSC_validateExceptionChecks=1, which leaks into the
+// spawned bun processes via bunEnv. The napi addon init path has a known
+// unchecked ThrowScope (see the "3rd party napi" section in
+// test/no-validate-exceptions.txt), so the child aborts while loading the
+// addon, before the fixture runs. Strip the validator from the child env
+// only, same as test/regression/issue/30205.test.ts.
+const childEnv = {
+  ...bunEnv,
+  BUN_JSC_validateExceptionChecks: undefined,
+  BUN_JSC_dumpSimulatedThrows: undefined,
+};
+
 describe.concurrent("napi cleanup at bun test exit", () => {
   beforeAll(() => {
     if (existsSync(hookAddon) && existsSync(wrapAddon)) return;
@@ -55,7 +67,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     });
     await using proc = spawn({
       cmd: [bunExe(), "test", "hooks.test.js"],
-      env: bunEnv,
+      env: childEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
@@ -81,7 +93,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     });
     await using proc = spawn({
       cmd: [bunExe(), "test", "wrap.test.js"],
-      env: bunEnv,
+      env: childEnv,
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -1,0 +1,103 @@
+// https://github.com/oven-sh/bun/issues/32144
+//
+// Every `bun test` exit site (and the --parallel worker exit in
+// test/parallel/runner.rs) jumped straight to VirtualMachine::global_exit()
+// without draining RareData::cleanup_hooks, the list on which each NapiEnv
+// registers its at-exit cleanup (NapiEnv::cleanup: env cleanup hooks +
+// pending napi_wrap finalizers). Consequences:
+//   - napi_add_env_cleanup_hook hooks silently never ran under `bun test`
+//     (Node runs them whenever the environment tears down);
+//   - napi_wrap at-exit finalizers never ran, so with
+//     BUN_DESTRUCT_VM_ON_EXIT=1 the final GC deferred them as
+//     NapiFinalizerTasks parked on that same never-walked list, which
+//     LeakSanitizer reports at exit (the intermittent exit-134 failures of
+//     test/regression/issue/30205.test.ts on the asan CI lane).
+//
+// These two tests are the deterministic, build-independent half: they fail
+// on an unfixed build on every platform because the hook/finalizer output
+// never appears. They live in their own file (rather than napi.test.ts)
+// only because that 100-test concurrent suite is too heavy to run as a
+// whole alongside these.
+
+import { spawn, spawnSync } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const napiAppDir = join(import.meta.dir, "napi-app");
+const hookAddon = join(napiAppDir, "build", "Debug", "test_cleanup_hook_order.node");
+const wrapAddon = join(napiAppDir, "build", "Debug", "test_wrap_cleanup_order.node");
+
+describe.concurrent("napi cleanup at bun test exit", () => {
+  beforeAll(() => {
+    if (existsSync(hookAddon) && existsSync(wrapAddon)) return;
+    // Same one-shot build pattern as test/regression/issue/30205.test.ts.
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: napiAppDir,
+      env: bunEnv,
+      stderr: "inherit",
+      stdout: "inherit",
+      stdin: "inherit",
+    });
+    if (!install.success) throw new Error("node-gyp build failed");
+  }, 120_000);
+
+  test("napi env cleanup hooks run when the process exits from bun test", async () => {
+    const dir = tempDirWithFiles("napi-cleanup-hooks-bun-test", {
+      "hooks.test.js": `
+        import { test, expect } from "bun:test";
+        const addon = require(${JSON.stringify(hookAddon)});
+        addon.test();
+        test("registers env cleanup hooks", () => expect(1).toBe(1));
+      `,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "hooks.test.js"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The addon registers hooks 1, 2, 3; they must fire at exit in reverse
+    // order, same as when the process exits from `bun run`.
+    expect(stdout).toContain("hook3 executed at position 0");
+    expect(stdout).toContain("hook2 executed at position 1");
+    expect(stdout).toContain("hook1 executed at position 2");
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test("napi_wrap finalizers run during env teardown when exiting from bun test", async () => {
+    const dir = tempDirWithFiles("napi-wrap-teardown-bun-test", {
+      "wrap.test.js": `
+        import { test, expect } from "bun:test";
+        const addon = require(${JSON.stringify(wrapAddon)});
+        globalThis.keep = addon.createParentAndChildren(32);
+        test("wraps stay rooted until exit", () => expect(globalThis.keep.length).toBe(33));
+      `,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "test", "wrap.test.js"],
+      env: bunEnv,
+      cwd: dir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The addon prints the accumulated LIFO order once the parent (id 0) is
+    // finalized; stdout also carries the test runner's version banner, so
+    // assert the exact line rather than the whole stream.
+    expect(stdout).toContain(
+      "finalize order: " +
+        Array.from({ length: 32 }, (_, i) => 32 - i)
+          .concat(0)
+          .join(" ") +
+        "\n",
+    );
+    expect(stderr).toContain("1 pass");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -40,10 +40,12 @@ const wrapAddon = join(napiAppDir, "build", "Debug", "test_wrap_cleanup_order.no
 //
 // BUN_DESTRUCT_VM_ON_EXIT is stripped too: these tests pin the normal exit
 // path, where pending wrap finalizers are skipped. Under destruct-vm the
-// final exit collection deliberately runs them (in sweep order, not LIFO),
-// which would print "finalize order:" and break the negative assertion
-// below. This file is also in test/no-validate-leaksan.txt so the asan
-// runner does not set destruct-vm or detect_leaks for it in the first place.
+// exit collection defers swept wraps' finalizers (and schedule() drops the
+// tasks), but wraps that survive the collection can still be finalized
+// immediately by ~VM's lastChanceToFinalize, which would print
+// "finalize order:" and break the negative assertion below. This file is
+// also in test/no-validate-leaksan.txt so the asan runner does not set
+// destruct-vm or detect_leaks for it in the first place.
 const childEnv = {
   ...bunEnv,
   BUN_JSC_validateExceptionChecks: undefined,

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -21,7 +21,7 @@
 
 import { spawn, spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -45,7 +45,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
   }, 120_000);
 
   test("napi env cleanup hooks run when the process exits from bun test", async () => {
-    const dir = tempDirWithFiles("napi-cleanup-hooks-bun-test", {
+    using dir = tempDir("napi-cleanup-hooks-bun-test", {
       "hooks.test.js": `
         import { test, expect } from "bun:test";
         const addon = require(${JSON.stringify(hookAddon)});
@@ -56,7 +56,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     await using proc = spawn({
       cmd: [bunExe(), "test", "hooks.test.js"],
       env: bunEnv,
-      cwd: dir,
+      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -71,7 +71,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
   });
 
   test("napi_wrap finalizers run during env teardown when exiting from bun test", async () => {
-    const dir = tempDirWithFiles("napi-wrap-teardown-bun-test", {
+    using dir = tempDir("napi-wrap-teardown-bun-test", {
       "wrap.test.js": `
         import { test, expect } from "bun:test";
         const addon = require(${JSON.stringify(wrapAddon)});
@@ -82,7 +82,7 @@ describe.concurrent("napi cleanup at bun test exit", () => {
     await using proc = spawn({
       cmd: [bunExe(), "test", "wrap.test.js"],
       env: bunEnv,
-      cwd: dir,
+      cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/napi/napi-exit-cleanup.test.ts
+++ b/test/napi/napi-exit-cleanup.test.ts
@@ -23,7 +23,7 @@
 
 import { spawn, spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, canBuildNodeAddons, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -57,7 +57,7 @@ const childEnv = {
   LSAN_OPTIONS: undefined,
 };
 
-describe.concurrent("napi cleanup at bun test exit", () => {
+describe.concurrent.skipIf(!canBuildNodeAddons())("napi cleanup at bun test exit", () => {
   beforeAll(() => {
     if (existsSync(hookAddon) && existsSync(wrapAddon)) return;
     // Same one-shot build pattern as test/regression/issue/30205.test.ts.

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -73,6 +73,7 @@ test/js/third_party/prisma/prisma.test.ts
 test/js/third_party/remix/remix.test.ts
 test/js/third_party/resvg/bbox.test.js
 test/js/third_party/rollup-v4/rollup-v4.test.ts
+test/napi/napi-exit-cleanup.test.ts
 test/napi/napi-finalizer-delete-ref.test.ts
 test/napi/uv.test.ts
 test/napi/uv_stub.test.ts

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -408,6 +408,11 @@ test/napi/node-napi-tests/test/js-native-api/6_object_wrap/do.test.ts
 # LSAN per-spawn adds no coverage and slows the file significantly.
 test/napi/uv_stub.test.ts
 
+# Spawns bun test children that pin the non-destruct exit path; destruct-vm
+# and detect_leaks would leak into them via bunEnv and change the behavior
+# under test (see the childEnv comment in the file).
+test/napi/napi-exit-cleanup.test.ts
+
 test/bake/dev/production.test.ts
 test/js/third_party/pg-gateway/pglite.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -413,6 +413,14 @@ test/napi/uv_stub.test.ts
 # under test (see the childEnv comment in the file).
 test/napi/napi-exit-cleanup.test.ts
 
+# The inner `bun test --isolate/--parallel` processes inherit destruct-vm and
+# detect_leaks via bunEnv. Their last file's napi wraps are deliberately not
+# finalized at exit (NapiEnv::cleanup runs hooks only on the test-runner exit
+# path), so the addon's own 4-byte wrap payloads are reclaimed by the OS, not
+# freed, and LSAN reports them. The NapiFinalizerTask boxes from issue 32144
+# no longer leak: schedule() drops them once the cleanup hooks have run.
+test/regression/issue/30205.test.ts
+
 test/bake/dev/production.test.ts
 test/js/third_party/pg-gateway/pglite.test.ts
 test/js/bun/test/parallel/test-integration-rspack.ts


### PR DESCRIPTION
Fixes #32144

### Problem

On the debian x64-asan CI lane, `test/regression/issue/30205.test.ts` intermittently fails with exit 134: the inner `bun test --isolate` process trips LeakSanitizer at exit:

```
==5438==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 31904 byte(s) in 997 object(s) allocated from:
    #8 new<bun_runtime::napi::napi_body::NapiFinalizerTask>
    ...
    #24 Zig__GlobalObject__destructOnExit src/jsc/bindings/ZigGlobalObject.cpp:3966
    #25 VirtualMachine::global_exit       src/jsc/VirtualMachine.rs:1581
```

### Cause

Every `bun test` exit site (4 in `test_command.rs`, plus the `--parallel` worker exit in `test/parallel/runner.rs`) sets `vm.is_shutting_down = true` by hand and jumps straight to `global_exit()`. None of them calls `on_exit()`, which was the only place that drained `RareData::cleanup_hooks` and set `has_run_cleanup_hooks`. Each `NapiEnv` registers its at-exit cleanup on that list. So under `bun test`:

- `napi_add_env_cleanup_hook` hooks silently never ran (Node runs them whenever the environment tears down, regardless of entry point)
- with `BUN_DESTRUCT_VM_ON_EXIT=1` + `detect_leaks=1` (the asan lane), the final `collectNow()` in `destructOnExit` deferred each swept wrap's finalizer as a `NapiFinalizerTask`, and `NapiFinalizerTask::schedule()` parked all of them back on the same cleanup-hook list, which is never walked again. 997 task boxes (32 bytes each, matching the report) plus their `NapiEnvRef`s were live when LSAN scanned.

### Fix

1. `global_exit()` now drains the cleanup hooks (the loop extracted from `on_exit()` into `run_cleanup_hooks()`), so napi env cleanup hooks fire on the test-runner exit paths and `has_run_cleanup_hooks` is set before `destructOnExit`. Exit paths that go through `on_exit()` (`bun run`, `process.exit()`, repl, workers) are unchanged; their second drain sees an empty list.

2. On these undrained-loop exit paths, `NapiEnv::cleanup()` runs only the explicit env cleanup hooks and skips the pending `napi_wrap` finalizer pass (`napi_internal_set_cleanup_hooks_only`, set by `global_exit()` before its drain). Running that pass proved unsafe when the event loop never drained: an addon can still have queued async work whose teardown references other wraps. Concretely, duckdb keeps a `ConnectTask` queued on its `Database`; the task's destructor `Unref()`s the Connection ObjectWrap that the finalizer pass had already deleted, and `test/js/third_party/duckdb/duckdb-basic-usage.test.ts` crashed at exit with `SEGV ... in NapiEnv::vm()` reading the freed wrap's env pointer (reproduced 6/8 runs locally, 0/10 after this change). Node does not guarantee wrap finalizers run at process exit either. `bun run` exits keep the full cleanup: pending async work holds the loop alive there, so the queue is empty by the time `on_exit()` runs.

3. With `has_run_cleanup_hooks` set by the drain, `NapiFinalizerTask`s deferred by `destructOnExit`'s final collection under `BUN_DESTRUCT_VM_ON_EXIT` take the existing drop branch in `schedule()` instead of being parked on the dead list: the task boxes and their `NapiEnvRef`s (the leak in the report) are freed. The addon's own wrap payloads are deliberately not freed (their finalizers are skipped, matching the hooks-only rule above), so `test/regression/issue/30205.test.ts` is added to `test/no-validate-leaksan.txt` next to the other tests whose intentional at-exit non-cleanup LSAN would report. An earlier revision instead requested termination before the exit collection so the finalizers ran immediately mid-sweep; that trips JSC's `validateIsNotSweeping` assertion for addons whose finalizers call JS-heap-touching napi functions (`test_cannot_run_js` on the asan lane), which is exactly what deferral exists for, so it was reverted.

The load-bearing lines are the `run_cleanup_hooks()` call plus the hooks-only flag in `global_exit()`, and the `napi_internal_cleanup_is_hooks_only()` early return in `NapiEnv::cleanup()`.

### Verification

New `test/napi/napi-exit-cleanup.test.ts` (deterministic on every build; the hooks test fails on unfixed bun including the current release):

- napi env cleanup hooks run when the process exits from `bun test` (existing `test_cleanup_hook_order` addon; on unfixed builds the hook lines never appear)
- pending `napi_wrap` finalizers are skipped at `bun test` exit (negative contract for the hooks-only drain; the `bun run` finalizer behavior is covered by the existing LIFO test in napi.test.ts)

Verified locally on a debug-asan build:

- the exact CI scenario from the issue (8 isolate files x 1000 `addon.wrap(...)`, `BUN_JSC_collectContinuously=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1:abort_on_error=1`) exits 0 with no leak report and zero `NapiFinalizerTask` frames on a debug-asan build
- `test/js/third_party/duckdb/duckdb-basic-usage.test.ts` (duckdb built from source) passes 10/10; before the hooks-only restriction it crashed at exit most runs
- `test/regression/issue/30205.test.ts` (4 pass), `test/napi/napi.test.ts -t "LIFO order during env teardown"` (bun run wrap finalizers unchanged), `test/cli/test/bun-test.test.ts` (73 pass)

The leaking branch itself only fires on release-asan CI timing (conservative stack scanning keeps the wraps alive through the final collection on local debug builds), so the asan lane on this PR is the direct check for the original report.

The test file is added to `test/no-validate-exceptions.txt` and `test/no-validate-leaksan.txt`, and strips `BUN_JSC_validateExceptionChecks`, `BUN_DESTRUCT_VM_ON_EXIT`, and the sanitizer options from its child env: all of these leak into spawned bun processes via `bunEnv` on the asan lane, and they either abort the child while loading the addon (exception validator) or deliberately change the exit behavior under test (destruct-vm runs the skipped finalizers in the exit collection).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/napi/napi-exit-cleanup.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f90e199ae)

test/napi/napi-exit-cleanup.test.ts:
89 |       stderr: "pipe",
90 |     });
91 |     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
92 |     // The addon registers hooks 1, 2, 3; they must fire at exit in reverse
93 |     // order, same as when the process exits from `bun run`.
94 |     expect(stdout).toContain("hook3 executed at position 0");
                        ^
error: expect(received).toContain(expected)

Expected to contain: "hook3 executed at position 0"
Received: "bun test v1.4.0 (f90e199ae)\nAdded hooks in order: 1, 2, 3\nThey should execute in reverse order: 3, 2, 1\n"

      at <anonymous> (/workspace/bun/test/napi/napi-exit-cleanup.test.ts:94
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (cd9028faa)

test/napi/napi-exit-cleanup.test.ts:
(pass) napi cleanup at bun test exit > napi env cleanup hooks run when the process exits from bun test [14.76ms]
(pass) napi cleanup at bun test exit > pending napi_wrap finalizers are skipped at bun test exit [13.43ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [187.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/napi/napi-exit-cleanup.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f90e199ae)

test/napi/napi-exit-cleanup.test.ts:
(pass) napi cleanup at bun test exit > napi env cleanup hooks run when the process exits from bun test [598.61ms]
(pass) napi cleanup at bun test exit > pending napi_wrap finalizers are skipped at bun test exit [766.72ms]

 2 pass
 0 fail
 8 expect() calls
Ran 2 tests across 1 file. [2.90s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 802ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/26] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/26] gen cpp.rs (cppbind)
[3/26] gen JS modules (bundle-modules)
Preprocess modules (6924ms)
Bundle modules (42ms)
Postprocesss modules (144ms)
Bundle Functions (814ms)
Generate Code (108ms)

[8.05s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[3/16] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component ru
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs           |  34 +++++++++-
 src/jsc/bindings/napi.cpp           |  22 ++++++
 src/jsc/bindings/napi.h             |  38 ++++++++++-
 src/runtime/napi/napi_body.rs       |   6 +-
 test/napi/napi-exit-cleanup.test.ts | 130 ++++++++++++++++++++++++++++++++++++
 test/no-validate-exceptions.txt     |   1 +
 test/no-validate-leaksan.txt        |  13 ++++
 7 files changed, 238 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/VirtualMachine.rs                4      4     29
src/jsc/bindings/napi.cpp                1      1     32
src/jsc/bindings/napi.h                  5     10     34
src/runtime/napi/napi_body.rs            1      2     29
test/napi/napi-exit-cleanup.test.ts      5     13     28
test/no-validate-exceptions.txt          1      2     33
test/no-validate-leaksan.txt             2      2     35
```

</details>

**root cause** · written by the author bot

Deferred napi finalizers swept during the final garbage collection at process exit were enqueued as NapiFinalizerTask boxes into a queue or cleanup hook list that is never drained again at that point in teardown, since cleanup hooks had already run and the event loop would never tick, leaking the tasks and their environment references. The fix extracts cleanup hook draining into a shared run_cleanup_hooks helper invoked idempotently from every exit path, sets a hooks-only flag so NapiEnv::cleanup skips pending wrap finalizers on non-loop exits, and requests VM termination before the final c…

<!-- robobun:evidence:end -->