### PR TITLE
bunx: use globally installed packages before downloading

### DIFF
--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -283,97 +283,104 @@ pub struct Update {
     pub peer: bool,
 }
 
-// mkdir -p + open the dir. Callers store the raw `Fd` (`options.global_bin_dir: Fd`).
-pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd> {
+/// Resolve the path to the global install directory (where `bun add -g`
+/// installs packages) without creating or opening it. `buf` backs the joined
+/// path for the `$BUN_INSTALL` / `$HOME` fallbacks.
+pub fn global_dir_path<'a>(
+    explicit_global_dir: &'a [u8],
+    buf: &'a mut PathBuffer,
+) -> crate::Result<&'a [u8]> {
     use bun_paths::{platform, resolve_path::join_abs_string_buf};
-    use bun_sys::{Dir, OpenDirOptions};
 
     if let Some(home_dir) = env_var::BUN_INSTALL_GLOBAL_DIR.get() {
-        return Dir::cwd()
-            .make_open_path(home_dir, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(home_dir);
     }
 
     if !explicit_global_dir.is_empty() {
-        return Dir::cwd()
-            .make_open_path(explicit_global_dir, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(explicit_global_dir);
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [b"install", b"global"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(join_abs_string_buf::<platform::Auto>(
+            home_dir, &mut buf.0, &parts,
+        ));
     }
 
     if let Some(home_dir) = env_var::XDG_CACHE_HOME
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(join_abs_string_buf::<platform::Auto>(
+            home_dir, &mut buf.0, &parts,
+        ));
     }
 
     Err(crate::Error::NoGlobalDirectoryFound)
 }
 
-pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Result<bun_sys::Fd> {
-    use bun_paths::{platform, resolve_path::join_abs_string_buf};
+// mkdir -p + open the dir. Callers store the raw `Fd` (`options.global_bin_dir: Fd`).
+pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd> {
     use bun_sys::{Dir, OpenDirOptions};
 
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let path = global_dir_path(explicit_global_dir, &mut buf)?;
+    Dir::cwd()
+        .make_open_path(path, OpenDirOptions::default())
+        .map(|d| d.into_raw())
+        .map_err(Into::into)
+}
+
+/// Resolve the path to the global bin directory (where `bun add -g` links bin
+/// shims) without creating or opening it. `buf` backs the joined path for the
+/// `$BUN_INSTALL` / `$HOME` fallbacks.
+pub fn global_bin_dir_path<'a>(
+    explicit_global_bin_dir: &'a [u8],
+    buf: &'a mut PathBuffer,
+) -> crate::Result<&'a [u8]> {
+    use bun_paths::{platform, resolve_path::join_abs_string_buf};
+
     if let Some(home_dir) = env_var::BUN_INSTALL_BIN.get() {
-        return Dir::cwd()
-            .make_open_path(home_dir, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(home_dir);
     }
 
-    if let Some(opts) = opts_ {
-        if let Some(home_dir) = &opts.global_bin_dir {
-            if !home_dir.is_empty() {
-                return Dir::cwd()
-                    .make_open_path(home_dir, OpenDirOptions::default())
-                    .map(|d| d.into_raw())
-                    .map_err(Into::into);
-            }
-        }
+    if !explicit_global_bin_dir.is_empty() {
+        return Ok(explicit_global_bin_dir);
     }
 
     if let Some(home_dir) = env_var::BUN_INSTALL.get() {
-        let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 1] = [b"bin"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(join_abs_string_buf::<platform::Auto>(
+            home_dir, &mut buf.0, &parts,
+        ));
     }
 
     if let Some(home_dir) = env_var::XDG_CACHE_HOME
         .get()
         .or_else(|| env_var::HOME.get())
     {
-        let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [b".bun", b"bin"];
-        let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
-        return Dir::cwd()
-            .make_open_path(path, OpenDirOptions::default())
-            .map(|d| d.into_raw())
-            .map_err(Into::into);
+        return Ok(join_abs_string_buf::<platform::Auto>(
+            home_dir, &mut buf.0, &parts,
+        ));
     }
 
     Err(crate::Error::MissingGlobalBinDirectoryTrySettingBUNINSTALL)
+}
+
+pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Result<bun_sys::Fd> {
+    use bun_sys::{Dir, OpenDirOptions};
+
+    let explicit_global_bin_dir: &[u8] = opts_
+        .and_then(|opts| opts.global_bin_dir.as_deref())
+        .unwrap_or(b"");
+    let mut buf = bun_paths::path_buffer_pool::get();
+    let path = global_bin_dir_path(explicit_global_bin_dir, &mut buf)?;
+    Dir::cwd()
+        .make_open_path(path, OpenDirOptions::default())
+        .map(|d| d.into_raw())
+        .map_err(Into::into)
 }
 
 // `BunInstall` owns `Box<[u8]>`; Options stores `&'static [u8]`

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -16,6 +16,7 @@ use bun_collections::BoundedArray;
 use bun_core::{self, Global, Output};
 use bun_core::{ZStr, strings};
 use bun_install::dependency::VersionTag;
+use bun_install::package_manager_real::package_manager_options;
 use bun_install::update_request::{self, UpdateRequest};
 use bun_parsers::json;
 use bun_paths::{self, DELIMITER, PathBuffer};
@@ -525,6 +526,90 @@ impl BunxCommand {
         }
     }
 
+    /// Probe the `bun add -g` global install tree for `package_name`, like
+    /// `npx` does with npm's global prefix. On a hit, read the package's real
+    /// bin name from its own package.json and resolve that name in bun's
+    /// global bin directory (where global installs link their bin shims).
+    ///
+    /// Both lookups are keyed on the full (possibly scoped) package name
+    /// inside bun-controlled directories, so unlike searching the system
+    /// $PATH with a bin name guessed from a scoped package name, this cannot
+    /// match an unrelated system binary.
+    ///
+    /// A copy installed in the project's node_modules always wins over a
+    /// global install: when the package exists under `project_dir_fd`, this
+    /// abstains so the caller's package.json-based lookup (which searches
+    /// local .bin dirs) resolves it instead.
+    fn which_global_install_bin<'a>(
+        transpiler: &mut Transpiler,
+        path_buf: &'a mut PathBuffer,
+        project_dir_fd: Fd,
+        explicit_global_dir: &[u8],
+        explicit_global_bin_dir: &[u8],
+        package_name: &[u8],
+        cwd: &[u8],
+    ) -> Option<&'a ZStr> {
+        if package_name.is_empty() {
+            return None;
+        }
+
+        match Self::get_bin_name_from_project_directory(transpiler, project_dir_fd, package_name) {
+            // Locally installed: leave resolution to the caller.
+            Ok(_) => return None,
+            Err(err) => {
+                // Locally installed without a usable bin: abstain too, so the
+                // caller keeps reporting "could not determine executable"
+                // instead of silently running a global copy.
+                if matches!(err, crate::Error::NoBinFound) {
+                    return None;
+                }
+                // Any other error means the package.json could not be read
+                // (typically: not installed locally); probe the global tree.
+            }
+        }
+
+        let mut global_dir_buf = bun_paths::path_buffer_pool::get();
+        let global_dir =
+            package_manager_options::global_dir_path(explicit_global_dir, &mut global_dir_buf)
+                .ok()?;
+
+        // <global dir>/node_modules/<package_name>/package.json
+        let mut subpath = bun_paths::path_buffer_pool::get();
+        let len = {
+            let total = subpath.len();
+            let mut cursor: &mut [u8] = &mut subpath[..];
+            write!(
+                cursor,
+                "{global}{sep}node_modules{sep}{pkg}{sep}package.json",
+                global = BStr::new(global_dir),
+                sep = bun_paths::SEP as char,
+                pkg = BStr::new(package_name),
+            )
+            .ok()?;
+            total - cursor.len()
+        };
+        if len >= subpath.len() {
+            return None;
+        }
+        subpath[len] = 0;
+        // SAFETY: subpath[len] == 0 written above
+        let subpath_z = ZStr::from_buf(&subpath[..], len);
+        let bin_name = Self::get_bin_name_from_subpath(transpiler, Fd::cwd(), subpath_z).ok()?;
+
+        let mut bin_dir_buf = bun_paths::path_buffer_pool::get();
+        let global_bin_dir =
+            package_manager_options::global_bin_dir_path(explicit_global_bin_dir, &mut bin_dir_buf)
+                .ok()?;
+
+        let destination = bun_which::which(path_buf, global_bin_dir, cwd, &bin_name)?;
+        bun_output::scoped_log!(
+            bunx,
+            "found global install bin: {}",
+            BStr::new(destination.as_bytes())
+        );
+        Some(destination)
+    }
+
     /// Refuse to execute a binary resolved from inside the bunx cache unless
     /// it is owned by the current user.
     ///
@@ -969,6 +1054,38 @@ impl BunxCommand {
                             initial_bin_name,
                         ) {
                             break 'find Some(d);
+                        }
+
+                        // Like npx, prefer a package installed with `bun add -g`
+                        // over (re)installing a copy into the bunx cache. For
+                        // scoped packages this is the only route to a global
+                        // install: their guessed bin name must not be searched
+                        // in the system $PATH (above), while this lookup is
+                        // keyed on the full package name instead.
+                        if opts.binary_name.is_none() {
+                            let (explicit_global_dir, explicit_global_bin_dir): (&[u8], &[u8]) =
+                                match &ctx.install {
+                                    Some(install_) => (
+                                        install_.global_dir.as_deref().unwrap_or(b""),
+                                        install_.global_bin_dir.as_deref().unwrap_or(b""),
+                                    ),
+                                    None => (b"", b""),
+                                };
+                            if let Some(d) = Self::which_global_install_bin(
+                                this_transpiler,
+                                &mut path_buf,
+                                root_dir_info.get_file_descriptor(),
+                                explicit_global_dir,
+                                explicit_global_bin_dir,
+                                result_package_name,
+                                if !ignore_cwd.is_empty() {
+                                    b"".as_slice()
+                                } else {
+                                    top_level_dir
+                                },
+                            ) {
+                                break 'find Some(d);
+                            }
                         }
                     }
                     bun_which::which(

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
 import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
-import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
+import { chmodSync, copyFileSync, readdirSync, statSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
 import { dummyAfterAll, dummyBeforeAll, dummyBeforeEach, dummyRegistry, getPort, setHandler } from "./dummy.registry";
@@ -26,6 +26,10 @@ function setup() {
       BUN_TMPDIR: current_tmpdir,
       TMPDIR: current_tmpdir,
       BUN_INSTALL_CACHE_DIR: install_cache_dir,
+      // bunx consults the `bun add -g` global install tree under $BUN_INSTALL;
+      // point it at an empty dir so globally installed packages on the machine
+      // running the tests can't leak into resolution.
+      BUN_INSTALL: tmpdirSync(),
     } as Record<string, string>,
   };
 }
@@ -1123,6 +1127,205 @@ describe("scoped packages should not match unrelated system binaries", () => {
       expect(out).toContain("CORRECT: ran the cached package's bin");
       expect(exited).toBe(0);
     }
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/32147: `bunx @scope/pkg` ignored
+// packages installed with `bun add -g` and downloaded a fresh copy into the
+// bunx cache. Like npx, bunx must check the global install tree — keyed on
+// the full package name inside $BUN_INSTALL — before installing, because the
+// scoped guess for the bin name is (deliberately) never searched in the
+// system $PATH.
+describe("bunx uses globally installed packages", () => {
+  let port: number;
+
+  beforeAll(() => {
+    dummyBeforeAll();
+    port = getPort()!;
+  });
+
+  afterAll(() => {
+    dummyAfterAll();
+  });
+
+  beforeEach(async () => {
+    await dummyBeforeEach();
+  });
+
+  // Builds a tarball fixture, serves it from the dummy registry, installs it
+  // globally into an isolated $BUN_INSTALL, then rewrites the globally
+  // installed bin script so output identifies whether the global copy or a
+  // freshly downloaded copy ran.
+  async function installGlobally(pkgName: string, binName: string): Promise<{ bunInstall: string; urls: string[] }> {
+    const unscoped = pkgName.split("/").pop()!;
+    const pkgRoot = tmpdirSync();
+    const packageDir = join(pkgRoot, "package");
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name: pkgName, version: "1.0.0", bin: { [binName]: "cli.js" } }),
+    );
+    await writeFile(join(packageDir, "cli.js"), `#!/usr/bin/env node\nconsole.log("FROM_REGISTRY");\n`);
+    const tgzDir = tmpdirSync();
+    // The dummy registry serves tarballs by the basename of the request URL,
+    // which for `@scope/name` + version 1.0.0 is `name-1.0.0.tgz`.
+    await Bun.$`tar -czf ${join(tgzDir, `${unscoped}-1.0.0.tgz`)} -C ${pkgRoot} package`;
+
+    const urls: string[] = [];
+    setHandler(dummyRegistry(urls, { "1.0.0": { bin: { [binName]: "cli.js" }, as: "1.0.0" } }, 0, tgzDir));
+
+    const bunInstall = tmpdirSync();
+    const addProc = spawn({
+      cmd: [bunExe(), "add", "-g", `${pkgName}@1.0.0`],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL: bunInstall,
+        npm_config_registry: `http://localhost:${port}/`,
+      },
+    });
+    const [addErr, addOut, addExited] = await Promise.all([
+      addProc.stderr.text(),
+      addProc.stdout.text(),
+      addProc.exited,
+    ]);
+    expect(addErr).not.toContain("error:");
+    expect(addOut).toContain("installed");
+    expect(addExited).toBe(0);
+
+    // The global bin shim must exist (it resolves through the global tree).
+    expect(await Bun.file(join(bunInstall, "bin", isWindows ? `${binName}.exe` : binName)).exists()).toBeTrue();
+
+    // Rewrite the globally installed script; a run of the global copy now
+    // prints FROM_GLOBAL_INSTALL while a freshly downloaded copy prints
+    // FROM_REGISTRY. Unlink first: the installer hardlinks files from the
+    // install cache, and writing through the hardlink would poison the cache
+    // entry that a fresh download is served from.
+    const globalCli = join(bunInstall, "install", "global", "node_modules", pkgName, "cli.js");
+    const mode = statSync(globalCli).mode;
+    await rm(globalCli);
+    await writeFile(globalCli, `#!/usr/bin/env node\nconsole.log("FROM_GLOBAL_INSTALL");\n`, { mode });
+
+    return { bunInstall, urls };
+  }
+
+  function runBunx(spec: string, bunInstall: string) {
+    const subprocess = spawn({
+      // The global bin dir is intentionally NOT added to $PATH: the global
+      // install must be found through the global node_modules tree.
+      cmd: [bunExe(), "x", spec],
+      cwd: x_dir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL: bunInstall,
+        npm_config_registry: `http://localhost:${port}/`,
+      },
+    });
+    return Promise.all([subprocess.stderr.text(), subprocess.stdout.text(), subprocess.exited] as const);
+  }
+
+  it("`bunx @scope/pkg` runs the `bun add -g` installed copy without downloading", async () => {
+    const { bunInstall, urls } = await installGlobally("@globally-installed/gtool", "gtool");
+    const requestsAfterInstall = urls.length;
+
+    const [err, out, exited] = await runBunx("@globally-installed/gtool", bunInstall);
+
+    expect(out).toContain("FROM_GLOBAL_INSTALL");
+    expect(out).not.toContain("FROM_REGISTRY");
+    expect(err).not.toContain("error:");
+    // No registry traffic: the globally installed copy was reused.
+    expect(urls.length).toBe(requestsAfterInstall);
+    expect(exited).toBe(0);
+  });
+
+  it("`bunx @scope/pkg` whose bin name differs from the unscoped name finds the global install", async () => {
+    const { bunInstall, urls } = await installGlobally("@globally-installed/cli", "totally-different-bin");
+    const requestsAfterInstall = urls.length;
+
+    const [err, out, exited] = await runBunx("@globally-installed/cli", bunInstall);
+
+    expect(out).toContain("FROM_GLOBAL_INSTALL");
+    expect(out).not.toContain("FROM_REGISTRY");
+    expect(err).not.toContain("error:");
+    expect(urls.length).toBe(requestsAfterInstall);
+    expect(exited).toBe(0);
+  });
+
+  it("`bunx pkg` (unscoped) runs the global install even when the global bin dir is not on $PATH", async () => {
+    const { bunInstall, urls } = await installGlobally("plain-global-pkg", "plain-global-pkg");
+    const requestsAfterInstall = urls.length;
+
+    const [err, out, exited] = await runBunx("plain-global-pkg", bunInstall);
+
+    expect(out).toContain("FROM_GLOBAL_INSTALL");
+    expect(out).not.toContain("FROM_REGISTRY");
+    expect(err).not.toContain("error:");
+    expect(urls.length).toBe(requestsAfterInstall);
+    expect(exited).toBe(0);
+  });
+
+  it("a locally installed package wins over a global install", async () => {
+    const { bunInstall, urls } = await installGlobally("@globally-installed/local-wins", "local-wins-bin");
+    const requestsAfterInstall = urls.length;
+
+    // Install the same package locally with a bin name that differs from the
+    // unscoped basename, so only the package.json-based lookup can resolve it.
+    await mkdir(join(x_dir, "node_modules", "@globally-installed", "local-wins"), { recursive: true });
+    await mkdir(join(x_dir, "node_modules", ".bin"), { recursive: true });
+    await writeFile(
+      join(x_dir, "node_modules", "@globally-installed", "local-wins", "package.json"),
+      JSON.stringify({
+        name: "@globally-installed/local-wins",
+        version: "1.0.0",
+        bin: { "local-wins-bin": "./cli.js" },
+      }),
+    );
+    await writeFile(
+      join(x_dir, "node_modules", "@globally-installed", "local-wins", "cli.js"),
+      `#!/usr/bin/env node\nconsole.log("FROM_LOCAL_INSTALL");\n`,
+    );
+    if (isWindows) {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "local-wins-bin.cmd"),
+        `@echo off\r\nnode "%~dp0..\\@globally-installed\\local-wins\\cli.js" %*\r\n`,
+      );
+    } else {
+      await writeFile(
+        join(x_dir, "node_modules", ".bin", "local-wins-bin"),
+        `#!/usr/bin/env node\nrequire("../@globally-installed/local-wins/cli.js");\n`,
+      );
+      chmodSync(join(x_dir, "node_modules", "@globally-installed", "local-wins", "cli.js"), 0o755);
+      chmodSync(join(x_dir, "node_modules", ".bin", "local-wins-bin"), 0o755);
+    }
+
+    const [err, out, exited] = await runBunx("@globally-installed/local-wins", bunInstall);
+
+    expect(out).toContain("FROM_LOCAL_INSTALL");
+    expect(out).not.toContain("FROM_GLOBAL_INSTALL");
+    expect(out).not.toContain("FROM_REGISTRY");
+    expect(err).not.toContain("error:");
+    expect(urls.length).toBe(requestsAfterInstall);
+    expect(exited).toBe(0);
+  });
+
+  it("`bunx @scope/pkg@latest` still re-resolves from the registry", async () => {
+    const { bunInstall, urls } = await installGlobally("@globally-installed/retag", "retag");
+    const requestsAfterInstall = urls.length;
+
+    const [err, out, exited] = await runBunx("@globally-installed/retag@latest", bunInstall);
+
+    // An explicit dist-tag must bypass the global install and re-resolve.
+    expect(out).toContain("FROM_REGISTRY");
+    expect(out).not.toContain("FROM_GLOBAL_INSTALL");
+    expect(err).not.toContain("error:");
+    expect(urls.length).toBeGreaterThan(requestsAfterInstall);
+    expect(exited).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes #32147

### Problem

`bunx @scope/pkg` ignored packages installed with `bun add -g` and downloaded a fresh copy into the bunx cache:

```console
$ bun add -g @antfu/ni
$ NPM_CONFIG_REGISTRY=http://127.0.0.1:9/ bunx @antfu/ni --version
Resolving dependencies
Resolved, downloaded and extracted [6]
error: ConnectionRefused downloading package manifest @antfu/ni
```

The unscoped form (`bunx ni`) worked because it reaches the global bin shim through `$PATH`. For scoped packages the bin name is only a guess (the unscoped basename), and since #29511 that guess is deliberately never searched in the system `$PATH` (it used to match unrelated system binaries, e.g. `bunx @uidotsh/install` ran `/usr/bin/install`). There was no other route to the global install, so scoped names always fell through to a fresh install.

### Fix

When no version is specified and no local bin is found, probe the global install tree before installing: check `$BUN_INSTALL/install/global/node_modules/<full-package-name>/package.json`, read the package's real bin name from it, and resolve that name in bun's global bin directory. This is what npx does with npm's global prefix. Both lookups are keyed on the full (possibly scoped) package name inside bun-controlled directories, so the #29511 hazard does not apply; the system `$PATH` is still never searched with guessed names.

Resolution order is now: local node_modules / `$PATH` (unchanged, guess-hardened), then the global install tree, then the bunx cache, then install. An explicit version or dist-tag (`@latest`) keeps bypassing the global install and re-resolving, matching the behavior described when #32019 was closed.

`global_dir_path` / `global_bin_dir_path` are extracted from `open_global_dir` / `open_global_bin_dir` (same precedence: env vars, bunfig `globalDir`/`globalBinDir`, `$BUN_INSTALL`, `$HOME` fallbacks) so the probe can resolve the directories without creating them. The load-bearing change is the `which_global_install_bin` probe in `bunx_command.rs` and its call in the existing-bin lookup chain.

### Tests

New tests in `test/cli/install/bunx.test.ts` (`bun add -g` into an isolated `$BUN_INSTALL` from the dummy registry, then `bunx` with the global bin dir kept off `$PATH`):

- `bunx @scope/pkg` runs the globally installed copy with no registry traffic
- same with a bin name that differs from the unscoped basename (requires the package.json read; never worked via `$PATH`)
- unscoped `bunx pkg` finds the global install even when the global bin dir is not on `$PATH`
- `bunx @scope/pkg@latest` still re-resolves from the registry

The first three fail on the unfixed build with `FROM_REGISTRY` instead of `FROM_GLOBAL_INSTALL`. The fixture unlinks before rewriting the globally installed script because the installer hardlinks from the shared install cache; writing in place would poison the cache entry a fresh download is served from. `setup()` now also points `BUN_INSTALL` at an empty temp dir so machine-global packages can't leak into any bunx test.

All existing bunx tests pass, including the #29511 suite ("scoped packages should not match unrelated system binaries").

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->