### PR TITLE
Include JSX runtime and development mode in the runtime transpiler cache key

### DIFF
--- a/src/options_types/jsx.rs
+++ b/src/options_types/jsx.rs
@@ -218,6 +218,11 @@ impl Pragma {
         hasher.update(&self.import_source.production);
         hasher.update(&self.classic_import_source);
         hasher.update(&self.package_name);
+        // `runtime` selects classic (`React.createElement`) vs automatic
+        // (`jsx`) emission; `development` selects `jsx` vs `jsxDEV` and the
+        // dev vs prod import source. Both change transpiled output for
+        // identical source, so both must participate in the cache key.
+        hasher.update(&[self.runtime as u8, self.development as u8]);
     }
 
     pub fn import_source(&self) -> &[u8] {

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -223,6 +223,84 @@ describe("transpiler cache", () => {
     expect(b.stdout == "production 5");
     expect(newCacheCount()).toBe(0);
   });
+  test("NODE_ENV change invalidates cached JSX transpiles", () => {
+    // https://github.com/oven-sh/bun/issues/32151
+    // Development mode emits `jsxDEV` from react/jsx-dev-runtime, production
+    // emits `jsx` from react/jsx-runtime. The JSX development flag must be
+    // part of the features hash or a dev-cached artifact is reused verbatim
+    // in production, where `jsxDEV` does not exist.
+    const react_dir = join(temp_dir, "node_modules", "react");
+    mkdirSync(react_dir, { recursive: true });
+    writeFileSync(join(react_dir, "package.json"), `{ "name": "react", "version": "1.0.0" }`);
+    writeFileSync(
+      join(react_dir, "jsx-runtime.js"),
+      `exports.jsx = () => "prod";\nexports.jsxs = exports.jsx;\nexports.Fragment = Symbol.for("react.fragment");\n`,
+    );
+    writeFileSync(
+      join(react_dir, "jsx-dev-runtime.js"),
+      `exports.jsxDEV = () => "dev";\nexports.Fragment = Symbol.for("react.fragment");\n`,
+    );
+
+    const filler = "// " + Buffer.alloc(8 * 1024, "x").toString() + "\n";
+    writeFileSync(join(temp_dir, "big.tsx"), `export const probe: unknown = <div />;\n${filler}`);
+    writeFileSync(join(temp_dir, "main.ts"), `import { probe } from "./big.tsx";\nconsole.log(String(probe));`);
+
+    // development (NODE_ENV unset): transpiles with jsxDEV, writes a cache entry
+    expect(bunRun(join(temp_dir, "main.ts"), env).stdout).toBe("dev");
+    expect(newCacheCount()).toBe(1);
+
+    // same mode: cache hit
+    expect(bunRun(join(temp_dir, "main.ts"), env).stdout).toBe("dev");
+    expect(newCacheCount()).toBe(0);
+
+    // production: must not reuse the jsxDEV artifact (old entry deleted, new one written)
+    expect(bunRun(join(temp_dir, "main.ts"), { ...env, NODE_ENV: "production" }).stdout).toBe("prod");
+    expect(newCacheCount()).toBe(0);
+
+    // back to development: must not reuse the production artifact either
+    expect(bunRun(join(temp_dir, "main.ts"), env).stdout).toBe("dev");
+    expect(newCacheCount()).toBe(0);
+  });
+  test("tsconfig jsx runtime change invalidates cached JSX transpiles", () => {
+    // The cache is content addressed, so the same file contents under two
+    // directories whose tsconfigs select different JSX runtimes (automatic vs
+    // classic) share an input hash. The runtime must be part of the features
+    // hash or the classic-mode run reuses the automatic-mode artifact.
+    const big_tsx =
+      `import * as React from "react";\nexport const probe: unknown = <div />;\n// ` +
+      Buffer.alloc(8 * 1024, "x").toString() +
+      "\n";
+    const main_ts = `import { probe } from "./big.tsx";\nconsole.log(String(probe));`;
+
+    for (const mode of ["automatic", "classic"]) {
+      const react_dir = join(temp_dir, mode, "node_modules", "react");
+      mkdirSync(react_dir, { recursive: true });
+      writeFileSync(join(react_dir, "package.json"), `{ "name": "react", "version": "1.0.0" }`);
+      writeFileSync(
+        join(react_dir, "index.js"),
+        `exports.createElement = () => "classic";\nexports.Fragment = Symbol.for("react.fragment");\n`,
+      );
+      writeFileSync(
+        join(react_dir, "jsx-dev-runtime.js"),
+        `exports.jsxDEV = () => "dev";\nexports.Fragment = Symbol.for("react.fragment");\n`,
+      );
+      writeFileSync(
+        join(react_dir, "jsx-runtime.js"),
+        `exports.jsx = () => "prod";\nexports.jsxs = exports.jsx;\nexports.Fragment = Symbol.for("react.fragment");\n`,
+      );
+      writeFileSync(join(temp_dir, mode, "big.tsx"), big_tsx);
+      writeFileSync(join(temp_dir, mode, "main.ts"), main_ts);
+    }
+    writeFileSync(join(temp_dir, "classic", "tsconfig.json"), `{ "compilerOptions": { "jsx": "react" } }`);
+
+    // automatic runtime (no tsconfig): jsxDEV artifact cached
+    expect(bunRun(join(temp_dir, "automatic", "main.ts"), env).stdout).toBe("dev");
+    expect(newCacheCount()).toBe(1);
+
+    // classic runtime: must re-transpile to React.createElement
+    expect(bunRun(join(temp_dir, "classic", "main.ts"), env).stdout).toBe("classic");
+    expect(newCacheCount()).toBe(0);
+  });
   test("--feature flag invalidates cache", () => {
     // feature() can only appear in an if/ternary, so wrap it
     const code = `import { feature } from "bun:bundle";\nif (feature("SUPER_SECRET")) console.log("enabled"); else console.log("disabled");`;


### PR DESCRIPTION
Fixes #32151

### Problem

The runtime transpiler cache's features hash (`Pragma::hash_for_runtime_transpiler` in `src/options_types/jsx.rs`) hashed the JSX import-source strings for both modes but never the `development` bool that selects `jsx` vs `jsxDEV` emission. A `.tsx` module transpiled once under `NODE_ENV=development` was reused verbatim under `NODE_ENV=production`, where `react/jsx-dev-runtime` resolves to the production build whose `jsxDEV` export is `undefined`, crashing at first render:

```
TypeError: jsxDEV_7x81h0kn is not a function. (In 'jsxDEV_7x81h0kn("group", {}, void 0, !1, void 0, this)', 'jsxDEV_7x81h0kn' is undefined)
```

The reverse direction (production-cached `jsx` artifact reused in development) silently lost dev diagnostics.

Same bug class, sibling field: `Pragma.runtime` (classic vs automatic, selectable via tsconfig `compilerOptions.jsx`) was also missing from the hash. Since the cache is content addressed, identical file contents under two directories whose tsconfigs select different JSX runtimes shared one cache entry, so a classic-mode run could be handed an automatic-mode artifact (and vice versa).

### Fix

Hash `[runtime as u8, development as u8]` into the features hash. Since the hash participates in cache lookup, stale entries self-invalidate (mismatch is a miss, and the entry is rewritten); no cache format version bump is needed.

### Tests

Two new tests in `test/cli/run/transpiler-cache.test.ts`, using a stub `react` package whose `jsx-runtime` / `jsx-dev-runtime` / `createElement` each print a distinct marker:

- `NODE_ENV change invalidates cached JSX transpiles`: dev run caches a `jsxDEV` artifact, production run with the same cache must print the production marker, then switching back must print the dev marker again. Also asserts same-mode runs still hit the cache.
- `tsconfig jsx runtime change invalidates cached JSX transpiles`: identical file contents under an automatic-runtime dir and a classic-runtime (`"jsx": "react"`) dir sharing one cache; the classic run must emit `React.createElement` instead of replaying the automatic artifact.

Both fail on the unfixed build (stale marker replayed from the cache) and pass with the fix; the rest of the transpiler cache suite passes unchanged (13/13).