### PR TITLE
Fix panic when require paths option contains non-absolute entries

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2091,12 +2091,22 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    let mut custom_dir_buf = bun_paths::path_buffer_pool::get();
+                    // Node resolves relative `paths` entries against the cwd
+                    // (Module._nodeModulePaths); `check_package_path` requires
+                    // an absolute source dir.
+                    let custom_dir = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        let Some(joined) = self
+                            .fs_ref()
+                            .abs_buf_checked(&[custom_utf8.slice()], &mut *custom_dir_buf)
+                        else {
+                            continue;
+                        };
+                        joined
+                    };
+                    match self.check_package_path(custom_dir, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -183,6 +183,42 @@ test("require.resolve with relative path and options.paths (Next.js use case)", 
   }
 });
 
+test("options.paths entries that are relative throw MODULE_NOT_FOUND instead of crashing", () => {
+  let err;
+  try {
+    require.resolve("package-that-does-not-exist-for-this-test", { paths: ["relative-dir"] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+
+  const fakeParent = new Module("/some/other/directory/file.js");
+  fakeParent.filename = "/some/other/directory/file.js";
+  fakeParent.paths = Module._nodeModulePaths("/some/other/directory");
+
+  err = undefined;
+  try {
+    Module._resolveFilename("package-that-does-not-exist-for-this-test", fakeParent, false, {
+      paths: ["relative-dir"],
+    });
+  } catch (e) {
+    err = e;
+  }
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+});
+
+test("options.paths entries that are numbers throw instead of crashing", () => {
+  let err;
+  try {
+    require.resolve("package-that-does-not-exist-for-this-test", { paths: [-2147483648, -2147483648] });
+  } catch (e) {
+    err = e;
+  }
+  // Node.js rejects non-string entries; Bun coerces them to strings and
+  // treats them as relative directories.
+  expect(err.code).toBe(isBun ? "MODULE_NOT_FOUND" : "ERR_INVALID_ARG_TYPE");
+});
+
 test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array", () => {
   // Test with string (which is iterable but not an array)
   expect(() => {
@@ -199,3 +235,81 @@ test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is no
     Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
+
+if (isBun) {
+  // The unfixed resolver aborted the whole process on non-absolute
+  // options.paths entries, so run the crashing inputs in a subprocess.
+  const { bunExe, bunEnv } = await import("harness");
+
+  test("non-absolute options.paths entries do not abort the process", async () => {
+    const { path: dir, cleanup } = createTempDir("resolve-paths-nonabs", {
+      "package.json": JSON.stringify({ name: "fixture", version: "1.0.0" }),
+      // An existing node_modules directory disables auto-install in the
+      // spawned process, so no network is involved.
+      "node_modules/.bun-keep": "",
+      "index.js": `
+        for (const paths of [[-2147483648, -2147483648], ["relative-dir"], [""]]) {
+          try {
+            require("package-that-does-not-exist-for-this-test", { paths });
+            console.log("resolved");
+          } catch (e) {
+            console.log(e.code);
+          }
+        }
+      `,
+    });
+
+    try {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        cwd: dir,
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout: stdout.split(/\r?\n/).filter(Boolean), exitCode }).toEqual({
+        stdout: ["MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "MODULE_NOT_FOUND"],
+        exitCode: 0,
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("relative options.paths entries resolve against the current working directory", async () => {
+    const { path: dir, cleanup } = createTempDir("resolve-paths-relcwd", {
+      "package.json": JSON.stringify({ name: "fixture", version: "1.0.0" }),
+      "node_modules/.bun-keep": "",
+      "subdir/node_modules/paths-rel-pkg/package.json": JSON.stringify({
+        name: "paths-rel-pkg",
+        main: "index.js",
+      }),
+      "subdir/node_modules/paths-rel-pkg/index.js": "module.exports = 'found-relative';",
+      "index.js": `
+        const resolved = require.resolve("paths-rel-pkg", { paths: ["subdir"] });
+        console.log(require(resolved));
+      `,
+    });
+
+    try {
+      const proc = Bun.spawn({
+        cmd: [bunExe(), "index.js"],
+        cwd: dir,
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "found-relative", exitCode: 0 });
+    } finally {
+      cleanup();
+    }
+  });
+}

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -266,11 +266,7 @@ if (isBun) {
         env: bunEnv,
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.split(/\r?\n/).filter(Boolean), exitCode }).toEqual({
         stdout: ["MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "MODULE_NOT_FOUND"],
         exitCode: 0,
@@ -302,11 +298,7 @@ if (isBun) {
         env: bunEnv,
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "found-relative", exitCode: 0 });
     } finally {
       cleanup();


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found crash: any non-absolute entry in the `paths` option of `require()`, `require.resolve()`, or `Module._resolveFilename()` aborted the whole process.

```
panic: cannot resolve DirInfo for non-absolute path: -2147483648
```

Repro on current main:

```js
require.resolve("total", { paths: ["relative-dir"] });
```

Entries from `options.paths` are stored in `Resolver.custom_dir_paths` and were passed straight to `check_package_path`, whose `dir_info_cached` asserts `bun_paths::is_absolute` on the source directory. Any relative string reached that assert, and non-string entries get coerced by the option parsing, so `paths: [-2147483648]` crashed too.

The fix is in the `custom_dir_paths` loop in `resolve_without_symlinks`: entries that are not absolute are joined against the current working directory (into a pooled path buffer) before the node_modules lookup. This matches Node, where `Module._nodeModulePaths` calls `path.resolve` on each entry. Absolute entries pass through unchanged. The `check_relative_path` loop above needs no change because it already joins the entry against the cwd.

Behavior after the fix, verified against Node v24:

- a relative entry pointing at a real directory resolves `node_modules` from there, same result as Node
- a relative entry that does not contain the package throws `MODULE_NOT_FOUND`, same as Node

One pre-existing divergence is left as is: Node validates that `paths` entries are strings and throws `ERR_INVALID_ARG_TYPE` for numbers, while Bun coerces them to strings in the C++ option parsing. After this change a numeric entry produces `MODULE_NOT_FOUND` instead of a crash.

### How did you verify your code works?

New tests in `test/js/node/module/module-resolve-filename-paths.test.js`:

- in-process: relative and numeric `paths` entries throw `MODULE_NOT_FOUND` for both `require.resolve` and `Module._resolveFilename` (the file also runs under Node, where the same tests pass apart from the documented `ERR_INVALID_ARG_TYPE` branch)
- spawned fixtures: the crashing inputs (numeric, relative, and empty-string entries) exit cleanly with `MODULE_NOT_FOUND`, and a relative entry resolves a package against the subprocess cwd

Without the fix, the in-process tests abort the test runner with the panic above (reproduced on Bun 1.4.0 canary and a debug build). With the fix, all 10 tests in the file pass, as do `test/js/node/module/node-module-module.test.js` and `test/js/bun/resolve/resolve.test.ts`.
