### PR TITLE
sql: throw validation errors for degenerate helper inputs instead of raw TypeErrors and engine errors

### DIFF
--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -547,7 +547,10 @@ declare module "bun" {
      * const result = await sql`SELECT * FROM users WHERE id IN ${sql([1, 2, 3])}`;
      * ```
      */
-    <T>(value: T): SQL.Helper<T>;
+    // `T & {}` rejects a bare `null`/`undefined` value, which the runtime
+    // throws on. An array such as `[null]` stays allowed: it is a valid
+    // `WHERE IN` binding and is an object, so it still satisfies `{}`.
+    <T>(value: T & {}): SQL.Helper<T>;
   }
 
   /**

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -198,6 +198,14 @@ function buildDefinedColumnsAndQuery<T>(
   let columnsSql = "(";
   const columnCount = columns.length;
 
+  if ($isArray(items)) {
+    for (let j = 0; j < items.length; j++) {
+      if (items[j] == null) {
+        throw new SyntaxError("Cannot use null or undefined as an item in INSERT helper");
+      }
+    }
+  }
+
   for (let k = 0; k < columnCount; k++) {
     const column = columns[k];
 
@@ -489,6 +497,8 @@ function normalizeQuery(
                 const value = items[j];
                 if (typeof value === "undefined") {
                   binding_values.push(null);
+                } else if (value === null) {
+                  throw new SyntaxError("Cannot use null as an item in WHERE IN helper with a column");
                 } else {
                   const value_from_key = value[columns[0]];
 
@@ -518,6 +528,9 @@ function normalizeQuery(
               item = items[0];
             } else {
               item = items;
+            }
+            if (item == null) {
+              throw new SyntaxError("Cannot use null or undefined as an item in UPDATE helper");
             }
             // no need to include SET if is updateSet or upsert
             if (command === SQLCommand.update && !adapter.isUpsertUpdate(query)) {

--- a/src/js/internal/sql/sqlite.ts
+++ b/src/js/internal/sql/sqlite.ts
@@ -408,8 +408,8 @@ class SQLiteAdapter implements DatabaseAdapter<BunSQLiteModule.Database, BunSQLi
     return false;
   }
 
-  throwIfUpdateEmpty(query: string, _hasValues: boolean): void {
-    if (query.endsWith("SET ")) {
+  throwIfUpdateEmpty(_query: string, hasValues: boolean): void {
+    if (!hasValues) {
       throw new SyntaxError("Update needs to have at least one column");
     }
   }

--- a/test/integration/bun-types/fixture/sql.ts
+++ b/test/integration/bun-types/fixture/sql.ts
@@ -263,6 +263,28 @@ sql(users, "notAKey");
 // @ts-expect-error - array of numbers, extra key argument
 sql([1, 2, 3], "notAKey");
 
+// Degenerate helper inputs that throw at runtime are rejected at the type
+// level too. See https://github.com/oven-sh/bun/issues/32155.
+
+// @ts-expect-error - bare null is not a valid helper value
+sql(null);
+
+// @ts-expect-error - bare undefined is not a valid helper value
+sql(undefined);
+
+// @ts-expect-error - null item in a keyed WHERE IN helper
+sql([null], "id");
+
+// @ts-expect-error - null single object in an UPDATE helper with a column
+sql(null, "name");
+
+// @ts-expect-error - undefined item in an UPDATE/keyed helper
+sql([undefined], "name");
+
+// Still allowed: a null/primitive array binds NULL for WHERE IN.
+sql([null]);
+sql([1, null, 2]);
+
 // check the deprecated stuff still exists
 expectType<Bun.SQLQuery<"hey">>();
 expectType<Bun.SQLTransactionContextCallback<"hey">>();

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -59,6 +59,22 @@ describe.each(adapters)("%s helper validation", (_adapter, makeSql) => {
       expect(err.message).toBe("Update needs to have at least one column");
     }
   });
+
+  test("empty update helper throws even alongside a literal assignment", async () => {
+    // sqlite previously allowed the helper-last form of this (it stripped the
+    // trailing comma and executed the literal assignment) while throwing for
+    // the helper-first form; postgres and mysql throw for both. All three now
+    // throw for both orders.
+    await using sql = makeSql();
+    for (const query of [
+      () => sql`UPDATE t SET updated_at = CURRENT_TIMESTAMP, ${sql({ name: undefined })} WHERE id = 1`,
+      () => sql`UPDATE t SET ${sql({ name: undefined })}, updated_at = CURRENT_TIMESTAMP WHERE id = 1`,
+    ]) {
+      const err = await query().catch(e => e);
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).toBe("Update needs to have at least one column");
+    }
+  });
 });
 
 // Behaviors that must keep working; these execute real queries, so they run
@@ -71,6 +87,15 @@ describe("sqlite helper behavior preserved", () => {
 
     await sql`update t set ${sql({ name: "Mary", age: undefined })} where id = 1`;
     expect(await sql`SELECT * FROM t`).toEqual([{ id: 1, name: "Mary", age: 30 }]);
+  });
+
+  test("update helper alongside a literal assignment still works with defined values", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, flag INT)`;
+    await sql`INSERT INTO t (id, name, flag) VALUES (1, 'John', 0)`;
+
+    await sql`UPDATE t SET flag = 1, ${sql({ name: "Mary", age: undefined })} WHERE id = 1`;
+    expect(await sql`SELECT * FROM t`).toEqual([{ id: 1, name: "Mary", flag: 1 }]);
   });
 
   test("undefined items and null column values in WHERE IN helper still bind NULL", async () => {

--- a/test/js/sql/sql-helpers-validation.test.ts
+++ b/test/js/sql/sql-helpers-validation.test.ts
@@ -1,0 +1,85 @@
+// Degenerate inputs to the sql() helpers (null/undefined items where objects
+// are expected, update objects with no defined values) must surface clear
+// validation errors from query normalization rather than raw TypeErrors or
+// engine syntax errors. The validation contract is identical across the three
+// adapters, so it is tested as one matrix. Normalization runs when a query is
+// first awaited, before any connection is attempted, so the postgres and
+// mysql rows need no live server: their URLs point at a closed port that is
+// never actually dialed. The sqlite row uses an in-memory database.
+// https://github.com/oven-sh/bun/issues/32155
+import { SQL } from "bun";
+import { describe, expect, test } from "bun:test";
+
+const adapters: [string, () => SQL][] = [
+  ["sqlite", () => new SQL("sqlite://:memory:")],
+  ["postgres", () => new SQL("postgres://bun_sql_test@127.0.0.1:1/bun_sql_test", { max: 1 })],
+  ["mysql", () => new SQL("mysql://bun_sql_test@127.0.0.1:1/bun_sql_test", { max: 1 })],
+];
+
+describe.each(adapters)("%s helper validation", (_adapter, makeSql) => {
+  test("null items in WHERE IN helper with a column are rejected", async () => {
+    await using sql = makeSql();
+    for (const items of [[null], [{ id: 1 }, null]]) {
+      const err = await sql`SELECT * FROM t WHERE id IN ${sql(items as any, "id")}`.catch(e => e);
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).toBe("Cannot use null as an item in WHERE IN helper with a column");
+    }
+  });
+
+  test("null and undefined items in INSERT helper are rejected", async () => {
+    await using sql = makeSql();
+    for (const item of [null, undefined]) {
+      const err = await sql`INSERT INTO t ${sql([{ id: 1 }, item as any])}`.catch(e => e);
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).toBe("Cannot use null or undefined as an item in INSERT helper");
+    }
+  });
+
+  test("null and undefined items in UPDATE helper are rejected", async () => {
+    await using sql = makeSql();
+    const err1 = await sql`UPDATE t SET ${sql(null as any, "name")} WHERE id = 1`.catch(e => e);
+    expect(err1).toBeInstanceOf(SyntaxError);
+    expect(err1.message).toBe("Cannot use null or undefined as an item in UPDATE helper");
+
+    const err2 = await sql`UPDATE t SET ${sql([undefined as any], "name")} WHERE id = 1`.catch(e => e);
+    expect(err2).toBeInstanceOf(SyntaxError);
+    expect(err2.message).toBe("Cannot use null or undefined as an item in UPDATE helper");
+  });
+
+  test("empty update helper throws regardless of SET casing", async () => {
+    await using sql = makeSql();
+    for (const query of [
+      () => sql`update t set ${sql({ name: undefined })} where id = 1`,
+      () => sql`UPDATE t SET ${sql({ name: undefined })} WHERE id = 1`,
+      // the helper emits SET itself when the query does not end with one
+      () => sql`update t ${sql({ name: undefined })} where id = 1`,
+    ]) {
+      const err = await query().catch(e => e);
+      expect(err).toBeInstanceOf(SyntaxError);
+      expect(err.message).toBe("Update needs to have at least one column");
+    }
+  });
+});
+
+// Behaviors that must keep working; these execute real queries, so they run
+// against sqlite only.
+describe("sqlite helper behavior preserved", () => {
+  test("update helper with lowercase set and defined values still works", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    await sql`CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, age INT)`;
+    await sql`INSERT INTO t ${sql({ id: 1, name: "John", age: 30 })}`;
+
+    await sql`update t set ${sql({ name: "Mary", age: undefined })} where id = 1`;
+    expect(await sql`SELECT * FROM t`).toEqual([{ id: 1, name: "Mary", age: 30 }]);
+  });
+
+  test("undefined items and null column values in WHERE IN helper still bind NULL", async () => {
+    await using sql = new SQL("sqlite://:memory:");
+    // an undefined item binds NULL
+    expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([undefined as any, { id: 1 }], "id")}`).toEqual([{ num: 1 }]);
+    // a null value under the column key binds NULL
+    expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([{ id: null }, { id: 1 }], "id")}`).toEqual([{ num: 1 }]);
+    // a null item without a column binds NULL
+    expect(await sql`SELECT 1 as num WHERE 1 IN ${sql([null, 1])}`).toEqual([{ num: 1 }]);
+  });
+});


### PR DESCRIPTION
Fixes #32155

### Repro

```ts
const sql = new SQL("sqlite://:memory:");
await sql`SELECT * FROM t WHERE id IN ${sql([null], "id")}`;
// TypeError: null is not an object (evaluating 'strings')

await sql`update t set ${sql({ name: undefined })} where id = 1`;
// SQLiteError: near "where": syntax error
await sql`update t SET ${sql({ name: undefined })} where id = 1`;
// SyntaxError: Update needs to have at least one column
```

Both reproduce on 1.4.0 and main, on all three adapters for the first case.

### Cause

1. The keyed WHERE IN branch of the shared `normalizeQuery` (`src/js/internal/sql/shared.ts`) only guards items against `undefined` before reading `value[columns[0]]`, so a `null` item throws a raw TypeError. The same property-access-on-null pattern exists in the INSERT item scan (`buildDefinedColumnsAndQuery`) and in the keyed UPDATE branch, so `sql([{...}, null])` for INSERT and `sql(null, "col")` / `sql([undefined], "col")` for UPDATE hit the same TypeError.

2. The sqlite adapter's `throwIfUpdateEmpty` hook detects an empty update helper with `query.endsWith("SET ")`, a case-sensitive check against the user's original spelling. Command detection is case-insensitive, so lowercase `set` takes the helper path but misses the check and the malformed SQL reaches the engine. postgres and mysql use the `BaseSQLAdapter` default, which gates on the `hasValues` flag instead.

### Fix

All in `src/js/internal/sql/shared.ts` plus the sqlite hook (after #32145 consolidated `normalizeQuery`, these are single sites covering all three adapters):

- Keyed WHERE IN: a `null` item now throws `SyntaxError: Cannot use null as an item in WHERE IN helper with a column`. `undefined` items keep binding NULL (existing behavior), as do `null` items in the non-keyed form `sql([null])` and `null` values under the key (`sql([{ id: null }], "id")`).
- INSERT (`buildDefinedColumnsAndQuery`): `null`/`undefined` items throw `SyntaxError: Cannot use null or undefined as an item in INSERT helper`. Previously both were raw TypeErrors.
- Keyed UPDATE: a `null`/`undefined` item throws `SyntaxError: Cannot use null or undefined as an item in UPDATE helper`.
- sqlite empty update: `SQLiteAdapter.throwIfUpdateEmpty` now checks the `hasValues` flag like the `BaseSQLAdapter` default (sqlite implements the adapter interface standalone, so the override stays but with the correct body), making the empty-helper error spelling-independent.

One deliberate sqlite behavior change beyond the lowercase fix, raised in review: a literal assignment followed by an all-undefined helper, `UPDATE t SET updated_at = CURRENT_TIMESTAMP, ${sql({ name: undefined })}`, previously executed on sqlite (the trailing comma was stripped and the suffix check missed). The old behavior was order-dependent (the helper-first form already threw), and postgres/mysql throw for both orders, so sqlite now throws for both as well. A helper with defined values mixed with literal assignments keeps working; both are pinned by tests.

The mysql `ON DUPLICATE KEY UPDATE` suffix check (`isUpsertUpdate`) has a similar case-sensitivity problem, tracked separately in #32035 (fix in #32040), so it is not touched here.

### Tests

`test/js/sql/sql-helpers-validation.test.ts` (new): the validation contract is identical across the three adapters, so it is tested as one `describe.each` matrix (null item in keyed WHERE IN, null/undefined items in INSERT and keyed UPDATE, empty update helper for lowercase `set`, uppercase `SET`, the helper-emitted SET form, and the empty helper alongside a literal assignment in both orders), plus sqlite-only tests for the behaviors that must keep working (lowercase `set` with defined values updates, a helper with defined values alongside a literal assignment updates, undefined items / null column values / non-keyed null still bind NULL). Normalization runs when a query is first awaited, before any connection is attempted, so the postgres and mysql rows run without a server; sqlite uses `:memory:`.

On the unfixed build, 11 of the 18 tests fail (raw `TypeError: null is not an object` instead of the validation errors, and the empty-helper updates reaching the engine); the other 7 are behavior-preservation and cross-adapter parity guards. All 18 pass with the fix.

### Rebase note

Originally the guards were duplicated across `sqlite.ts`/`postgres.ts`/`mysql.ts`; after #32145 landed (consolidating `normalizeQuery` into `shared.ts`), the branch was rebased and the same fix re-applied at the now-shared sites, shrinking the diff to `shared.ts` + the sqlite `throwIfUpdateEmpty` hook.
