### PR TITLE
Fix panic when require options.paths contains non-string or relative entries

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -53,6 +53,24 @@
 #include "isBuiltinModule.h"
 #include "WebCoreJSBuiltins.h"
 
+namespace Bun {
+
+bool appendResolvePathsEntry(JSC::JSGlobalObject* globalObject, JSC::ThrowScope& scope, JSC::JSValue entry, WTF::Vector<BunString>& paths)
+{
+    if (!entry.isString()) {
+        ERR::INVALID_ARG_TYPE(scope, globalObject, "paths[0]"_s, "string"_s, entry);
+        return false;
+    }
+
+    WTF::String pathStr = entry.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    paths.append(toStringRef(pathResolveWTFString(globalObject, pathStr)));
+    return true;
+}
+
+}
+
 namespace Zig {
 using namespace JSC;
 using namespace WebCore;
@@ -372,10 +390,10 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
                 WTF::Vector<BunString> paths;
                 for (size_t i = 0; i < userPathListArray->length(); ++i) {
                     JSValue path = userPathListArray->getIndex(globalObject, i);
-                    WTF::String pathStr = path.toWTFString(globalObject);
                     if (scope.exception()) [[unlikely]]
                         goto cleanup;
-                    paths.append(Bun::toStringRef(pathStr));
+                    if (!Bun::appendResolvePathsEntry(globalObject, scope, path, paths))
+                        goto cleanup;
                 }
 
                 result = Bun__resolveSyncWithPaths(lexicalGlobalObject, JSC::JSValue::encode(moduleName), JSValue::encode(from), isESM, isRequireDotResolve, paths.begin(), paths.size());

--- a/src/jsc/bindings/ImportMetaObject.h
+++ b/src/jsc/bindings/ImportMetaObject.h
@@ -16,6 +16,19 @@ extern "C" JSC::EncodedJSValue Bun__resolveSyncWithPaths(JSC::JSGlobalObject* gl
 extern "C" JSC::EncodedJSValue Bun__resolveSyncWithSource(JSC::JSGlobalObject* global, JSC::EncodedJSValue specifier, BunString* from, bool is_esm, bool isUserRequireResolve);
 extern "C" JSC::EncodedJSValue Bun__resolveSyncWithStrings(JSC::JSGlobalObject* global, BunString* specifier, BunString* from, bool is_esm);
 
+namespace Bun {
+
+// Appends one entry of a `require.resolve` / `Module._resolveFilename`
+// `options.paths` array for Bun__resolveSyncWithPaths, resolved against the
+// current working directory (the module resolver requires absolute
+// directories). Node passes each entry through path.resolve() in
+// Module._nodeModulePaths(), which reports "paths[0]" for a non-string entry
+// regardless of its index. Returns false with an exception thrown when the
+// entry is not a string.
+bool appendResolvePathsEntry(JSC::JSGlobalObject*, JSC::ThrowScope&, JSC::JSValue entry, WTF::Vector<BunString>& paths);
+
+}
+
 namespace Zig {
 
 using namespace JSC;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -16,6 +16,7 @@
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JSCommonJSExtensions.h"
 
+#include "ImportMetaObject.h"
 #include "PathInlines.h"
 #include "ZigGlobalObject.h"
 #include "headers.h"
@@ -379,11 +380,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionResolveFileName,
                 if (scope.exception())
                     return;
 
-                WTF::String pathStr = item.toWTFString(lexicalGlobalObject);
-                if (scope.exception())
-                    return;
-
-                paths.append(Bun::toStringRef(pathStr));
+                Bun::appendResolvePathsEntry(lexicalGlobalObject, scope, item, paths);
             });
 
             if (scope.exception()) {

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -243,6 +243,36 @@ test("require.resolve throws MODULE_NOT_FOUND for relative options.paths entries
   expect(error.code).toBe("MODULE_NOT_FOUND");
 });
 
+test("Module._resolveFilename resolves relative options.paths entries against the current working directory", () => {
+  const { path: dir, cleanup } = createTempDir("resolve-filename-relative-entry", {
+    "node_modules/relative-paths-entry-pkg/package.json": JSON.stringify({
+      name: "relative-paths-entry-pkg",
+      main: "index.js",
+    }),
+    "node_modules/relative-paths-entry-pkg/index.js": "module.exports = 'ok';",
+  });
+
+  try {
+    const relativeDir = relative(process.cwd(), dir);
+    const resolved = Module._resolveFilename("relative-paths-entry-pkg", null, false, { paths: [relativeDir] });
+    expect(resolved).toBe(resolve(dir, "node_modules/relative-paths-entry-pkg/index.js"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("Module._resolveFilename throws MODULE_NOT_FOUND for relative options.paths entries that do not resolve", () => {
+  let error;
+  try {
+    Module._resolveFilename("package-that-does-not-exist-paths-entry", null, false, {
+      paths: ["directory-that-does-not-exist"],
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect(error.code).toBe("MODULE_NOT_FOUND");
+});
+
 test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array", () => {
   // Test with string (which is iterable but not an array)
   expect(() => {

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -2,7 +2,7 @@
 import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "fs";
 import Module from "module";
 import { tmpdir } from "os";
-import { dirname, join, resolve } from "path";
+import { dirname, join, relative, resolve } from "path";
 
 // Detect runtime and import appropriate test framework
 const isBun = typeof Bun !== "undefined";
@@ -181,6 +181,66 @@ test("require.resolve with relative path and options.paths (Next.js use case)", 
   } finally {
     cleanup();
   }
+});
+
+// Non-string entries and relative entries in options.paths used to crash Bun
+// (panic: cannot resolve DirInfo for non-absolute path).
+test("require.resolve throws ERR_INVALID_ARG_TYPE for non-string entries in options.paths", () => {
+  for (const badEntry of [{}, null, 42]) {
+    let error;
+    try {
+      require.resolve("package-that-does-not-exist-paths-entry", { paths: [badEntry] });
+    } catch (e) {
+      error = e;
+    }
+    expect(error.code).toBe("ERR_INVALID_ARG_TYPE");
+  }
+
+  let error;
+  try {
+    require.resolve("package-that-does-not-exist-paths-entry", { paths: [{}] });
+  } catch (e) {
+    error = e;
+  }
+  expect(error.message).toBe('The "paths[0]" argument must be of type string. Received an instance of Object');
+});
+
+test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE for non-string entries in options.paths", () => {
+  let error;
+  try {
+    Module._resolveFilename("package-that-does-not-exist-paths-entry", null, false, { paths: [{}] });
+  } catch (e) {
+    error = e;
+  }
+  expect(error.code).toBe("ERR_INVALID_ARG_TYPE");
+});
+
+test("require.resolve resolves relative options.paths entries against the current working directory", () => {
+  const { path: dir, cleanup } = createTempDir("resolve-paths-relative-entry", {
+    "node_modules/relative-paths-entry-pkg/package.json": JSON.stringify({
+      name: "relative-paths-entry-pkg",
+      main: "index.js",
+    }),
+    "node_modules/relative-paths-entry-pkg/index.js": "module.exports = 'ok';",
+  });
+
+  try {
+    const relativeDir = relative(process.cwd(), dir);
+    const resolved = require.resolve("relative-paths-entry-pkg", { paths: [relativeDir] });
+    expect(resolved).toBe(resolve(dir, "node_modules/relative-paths-entry-pkg/index.js"));
+  } finally {
+    cleanup();
+  }
+});
+
+test("require.resolve throws MODULE_NOT_FOUND for relative options.paths entries that do not resolve", () => {
+  let error;
+  try {
+    require.resolve("package-that-does-not-exist-paths-entry", { paths: ["directory-that-does-not-exist"] });
+  } catch (e) {
+    error = e;
+  }
+  expect(error.code).toBe("MODULE_NOT_FOUND");
 });
 
 test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is not an array", () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -121,6 +121,24 @@ describe.concurrent("node-module-module", () => {
     expect(await proc.exited).toBe(0);
   });
 
+  // require with a non-string entry in options.paths used to crash the process
+  // (panic: cannot resolve DirInfo for non-absolute path)
+  test("require with non-string entries in options.paths throws instead of crashing", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `try { require("package-that-does-not-exist-paths-entry", { paths: [{}] }) } catch (e) { console.log(e.code) }`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "ERR_INVALID_ARG_TYPE", exitCode: 0 });
+  });
+
   test.each([
     "/file/name/goes/here.js",
     "file/here.js",


### PR DESCRIPTION
### What

Fixes a panic (`panic: cannot resolve DirInfo for non-absolute path`) reachable from JS through the `paths` option of `require()`, `require.resolve()`, and `Module._resolveFilename()`:

```js
require.resolve("total", { paths: [{}] });        // panic: ... non-absolute path: [object Object]
require.resolve("total", { paths: ["relative"] }); // panic: ... non-absolute path: relative
require("module").Module._resolveFilename("total", null, false, { paths: [{}] }); // same panic
```

Found by fuzzing.

### Root cause

Both C++ extraction loops (`functionImportMeta__resolveSyncPrivate` in `ImportMetaObject.cpp` and `jsFunctionResolveFileName` in `NodeModuleModule.cpp`) stringified every `paths` entry with `toWTFString()` and passed the result straight to `Bun__resolveSyncWithPaths`. The resolver uses each entry as a source directory and asserts it is absolute in `dir_info_cached`, so any entry that stringifies to a non-absolute path (an object becomes `[object Object]`, or just a plain relative string) tripped the release assert and aborted the process.

Node handles both cases: each entry goes through `path.resolve()` inside `Module._nodeModulePaths()`, which throws `ERR_INVALID_ARG_TYPE` (named `"paths[0]"` regardless of index, since it is called with one argument per entry) for non-strings, and resolves relative strings against the current working directory.

### Fix

New shared helper `Bun::appendResolvePathsEntry` (declared in `ImportMetaObject.h`, used by both call sites):

- non-string entry: throws `ERR_INVALID_ARG_TYPE` with Node's exact message, e.g. `The "paths[0]" argument must be of type string. Received an instance of Object`
- string entry: resolved against cwd via the existing `pathResolveWTFString` helper before it reaches the resolver, so relative entries now work like in Node instead of crashing

The loop in `ImportMetaObject.cpp` also gains the missing exception check after `getIndex()` (an index getter can run arbitrary JS), which previously fed an unchecked value to `toWTFString()`.

Verified against Node v24: error code, message text, and resolution behavior for relative entries all match (including `require.resolve("pkg", { paths: ["dir-relative-to-cwd"] })` resolving successfully).

### Tests

- `test/js/node/module/module-resolve-filename-paths.test.js`: four new cases (non-string entries for `require.resolve` and `Module._resolveFilename`, relative entry resolving against cwd, relative entry that does not resolve). The file runs under both Bun and Node; all 10 tests pass under Node v24.3.0 unchanged.
- `test/js/node/module/node-module-module.test.js`: spawned subprocess running the original crashing shape `require(id, { paths: [{}] })`, asserting the child exits 0 with `ERR_INVALID_ARG_TYPE` instead of dying.

Without the fix, the in-process tests crash the test runner and the subprocess test fails with a non-zero exit code (verified with `USE_SYSTEM_BUN=1`, which aborts with SIGILL on these inputs).
