### PR TITLE
node: fix prototype property descriptor on builtin constructors

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -765,14 +765,19 @@ declare function $ERR_HTTP2_PING_CANCEL(): Error;
  *
  * This does:
  * - Sets the name of the function to the given name
- * - Sets .prototype to Object.create(base?.prototype, { constructor: { value: fn } })
+ * - Defines .prototype with the spec's descriptor for a function-style class
+ *   ({ writable: true, enumerable: false, configurable: false }), using the
+ *   passed `prototype` object, or creating one inheriting base?.prototype.
+ *   A pre-existing own .prototype (e.g. a lazy accessor) is kept as-is.
+ * - Sets prototype.constructor to fn unless the object already has its own
  * - Calls Object.setPrototypeOf(fn, base ?? Function.prototype)
  *
  * @param fn - The function to convert to a class
  * @param name - The name of the class
  * @param base - The base class to inherit from
+ * @param prototype - Use this object as the prototype instead of creating one
  */
-declare function $toClass(fn: Function, name: string, base?: Function | undefined | null);
+declare function $toClass(fn: Function, name: string, base?: Function | undefined | null, prototype?: object);
 
 declare function $min(a: number, b: number): number;
 

--- a/src/js/builtins/ConsoleObject.ts
+++ b/src/js/builtins/ConsoleObject.ts
@@ -340,7 +340,8 @@ export function createConsoleConstructor(console: typeof globalThis.console) {
   const kColorInspectOptions = { colors: true };
   const kNoColorInspectOptions = {};
 
-  Object.defineProperties((Console.prototype = {}), {
+  $toClass(Console, "Console");
+  Object.defineProperties(Console.prototype, {
     [kBindStreamsEager]: {
       ...consolePropAttributes,
       // Eager version for the Console constructor

--- a/src/js/builtins/shell.ts
+++ b/src/js/builtins/shell.ts
@@ -340,8 +340,7 @@ export function createBunShellTemplateFunction(createShellInterpreter_, createPa
     return Shell;
   }
 
-  Shell.prototype = ShellPrototype.prototype;
-  Object.setPrototypeOf(Shell, ShellPrototype);
+  $toClass(Shell, "Shell", ShellPrototype, ShellPrototype.prototype);
   Object.setPrototypeOf(BunShell, ShellPrototype.prototype);
 
   BunShell[cwdSymbol] = defaultCwd;

--- a/src/js/internal/streams/readable.ts
+++ b/src/js/internal/streams/readable.ts
@@ -128,7 +128,7 @@ function ReadableState(options, stream, isDuplex) {
     this.encoding = options.encoding;
   }
 }
-ReadableState.prototype = {};
+$toClass(ReadableState, "ReadableState");
 ObjectDefineProperties(ReadableState.prototype, {
   objectMode: makeBitMapDescriptor(kObjectMode),
   ended: makeBitMapDescriptor(kEnded),

--- a/src/js/internal/streams/writable.ts
+++ b/src/js/internal/streams/writable.ts
@@ -91,7 +91,7 @@ function makeBitMapDescriptor(bit) {
     },
   };
 }
-WritableState.prototype = {};
+$toClass(WritableState, "WritableState");
 ObjectDefineProperties(WritableState.prototype, {
   // Object stream flag to indicate whether or not this stream
   // contains buffers or objects.

--- a/src/js/node/crypto.ts
+++ b/src/js/node/crypto.ts
@@ -92,7 +92,7 @@ function Certificate(): void {
   this.exportPublicKey = exportPublicKey;
   this.exportChallenge = exportChallenge;
 }
-Certificate.prototype = {};
+$toClass(Certificate, "Certificate");
 Certificate.verifySpkac = verifySpkac;
 Certificate.exportPublicKey = exportPublicKey;
 Certificate.exportChallenge = exportChallenge;

--- a/src/js/node/events.ts
+++ b/src/js/node/events.ts
@@ -76,8 +76,8 @@ function EventEmitter(opts) {
     }
   }
 }
-Object.defineProperty(EventEmitter, "name", { value: "EventEmitter", configurable: true });
-const EventEmitterPrototype = (EventEmitter.prototype = {});
+$toClass(EventEmitter, "EventEmitter");
+const EventEmitterPrototype = EventEmitter.prototype;
 
 EventEmitterPrototype.setMaxListeners = function setMaxListeners(n) {
   validateNumber(n, "setMaxListeners", 0);
@@ -85,8 +85,6 @@ EventEmitterPrototype.setMaxListeners = function setMaxListeners(n) {
   return this;
 };
 Object.defineProperty(EventEmitterPrototype.setMaxListeners, "name", { value: "setMaxListeners" });
-
-EventEmitterPrototype.constructor = EventEmitter;
 
 EventEmitterPrototype.getMaxListeners = function getMaxListeners() {
   return _getMaxListeners(this);

--- a/src/js/node/tty.ts
+++ b/src/js/node/tty.ts
@@ -21,11 +21,16 @@ function ReadStream(fd): void {
   // Only set isTTY to true if the fd is actually a TTY
   this.isTTY = isatty(fd);
 }
-$toClass(ReadStream, "ReadStream", fs.ReadStream);
-
+// Defined before $toClass so $toClass keeps this lazy accessor as the "prototype".
 Object.defineProperty(ReadStream, "prototype", {
   get() {
     const Prototype = Object.create(fs.ReadStream.prototype);
+    Object.defineProperty(Prototype, "constructor", {
+      value: ReadStream,
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
 
     // Add ref/unref methods to make tty.ReadStream behave like Node.js
     // where TTY streams have socket-like behavior
@@ -95,13 +100,20 @@ Object.defineProperty(ReadStream, "prototype", {
       return this;
     };
 
-    Object.defineProperty(ReadStream, "prototype", { value: Prototype });
+    // Once materialized, match the descriptor of a regular function's "prototype".
+    Object.defineProperty(ReadStream, "prototype", {
+      value: Prototype,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
 
     return Prototype;
   },
-  enumerable: true,
+  enumerable: false,
   configurable: true,
 });
+$toClass(ReadStream, "ReadStream", fs.ReadStream);
 
 function WriteStream(fd): void {
   if (!(this instanceof WriteStream)) return new WriteStream(fd);
@@ -125,7 +137,13 @@ function WriteStream(fd): void {
 Object.defineProperty(WriteStream, "prototype", {
   get() {
     const Real = fs.WriteStream.prototype;
-    Object.defineProperty(WriteStream, "prototype", { value: Real });
+    // Once materialized, match the descriptor of a regular function's "prototype".
+    Object.defineProperty(WriteStream, "prototype", {
+      value: Real,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
 
     WriteStream.prototype._refreshSize = function () {
       const oldCols = this.columns;
@@ -190,7 +208,7 @@ Object.defineProperty(WriteStream, "prototype", {
 
     return Real;
   },
-  enumerable: true,
+  enumerable: false,
   configurable: true,
 });
 

--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -44,7 +44,7 @@ function Url() {
   this.path = null;
   this.href = null;
 }
-Url.prototype = {};
+$toClass(Url, "Url");
 
 // Reference: RFC 3986, RFC 1808, RFC 2396
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2756,6 +2756,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionToClass, (JSC::JSGlobalObject * globalObject,
     auto target = callFrame->argument(0).toObject(globalObject);
     auto name = callFrame->argument(1);
     JSObject* base = callFrame->argument(2).getObject();
+    JSValue prototypeValue = callFrame->argument(3);
     JSObject* prototypeBase = nullptr;
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
@@ -2774,14 +2775,48 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionToClass, (JSC::JSGlobalObject * globalObject,
         }
     }
 
-    JSObject* prototype = prototypeBase ? JSC::constructEmptyObject(globalObject, prototypeBase) : JSC::constructEmptyObject(globalObject);
+    // Builtin function declarations have no own "prototype" property, so one is
+    // created below. A `class` declaration already owns its prototype (holding the
+    // class body), and node:tty installs a lazy "prototype" accessor before calling
+    // $toClass; both of those are kept rather than overwritten.
+    JSC::PropertySlot prototypeSlot(target, JSC::PropertySlot::InternalMethodType::GetOwnProperty, nullptr);
+    bool hasOwnPrototype = target->methodTable()->getOwnPropertySlot(target, globalObject, vm.propertyNames->prototype, prototypeSlot);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-    prototype->structure()->setMayBePrototype(true);
-    prototype->putDirect(vm, vm.propertyNames->constructor, target, PropertyAttribute::DontEnum | 0);
+    if (!hasOwnPrototype) {
+        JSObject* prototype = prototypeValue.getObject();
+        if (!prototype) {
+            // No prototype object was passed: create one inheriting from the base's.
+            prototype = prototypeBase ? JSC::constructEmptyObject(globalObject, prototypeBase) : JSC::constructEmptyObject(globalObject);
+            RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        }
+
+        // Transitions the structure rather than flagging it in place: the object may
+        // share its structure (object literals, the empty-object structure cache).
+        prototype->didBecomePrototype(vm);
+
+        // Keep a "constructor" the caller already defined (e.g. a shared class prototype).
+        bool hasOwnConstructor = prototype->hasOwnProperty(globalObject, vm.propertyNames->constructor);
+        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        if (!hasOwnConstructor) {
+            prototype->putDirect(vm, vm.propertyNames->constructor, target, PropertyAttribute::DontEnum | 0);
+        }
+
+        // A function's own "prototype" property is non-enumerable and non-configurable
+        // (writable for function-style constructors): https://tc39.es/ecma262/#sec-function-instances-prototype
+        target->putDirect(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | 0);
+    } else if (!prototypeSlot.isAccessor() && prototypeBase) {
+        // A `class` declaration keeps its own prototype (with the class body on it),
+        // but a bare `class X {}` given a base would not inherit from it. Wire the
+        // class prototype's [[Prototype]] to the base so instances inherit, mirroring
+        // `class X extends base {}`. An accessor prototype (node:tty) is left alone.
+        JSValue existingPrototype = target->getDirect(vm, vm.propertyNames->prototype);
+        if (JSObject* prototypeObject = existingPrototype.getObject()) {
+            prototypeObject->setPrototypeDirect(vm, prototypeBase);
+        }
+    }
 
     target->setPrototypeDirect(vm, base);
-    target->putDirect(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | 0);
     target->putDirect(vm, vm.propertyNames->name, name, PropertyAttribute::DontEnum | 0);
 
     return JSValue::encode(jsUndefined());

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -912,3 +912,79 @@ test("getEventListeners", () => {
 test("EventEmitter.name", () => {
   expect(EventEmitter.name).toBe("EventEmitter");
 });
+
+// https://github.com/oven-sh/bun/issues/32160
+describe("constructor 'prototype' property descriptor", () => {
+  test("EventEmitter.prototype is non-enumerable and non-configurable", () => {
+    expect(Object.getOwnPropertyDescriptor(EventEmitter, "prototype")).toEqual({
+      value: EventEmitter.prototype,
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
+  });
+
+  test("copying EventEmitter's descriptors onto another function does not throw", () => {
+    const target = function () {};
+    Object.defineProperties(target, Object.getOwnPropertyDescriptors(EventEmitter));
+    expect(target.prototype).toBe(EventEmitter.prototype);
+  });
+
+  // The same bug applied to every builtin constructor whose prototype is
+  // assigned (or set up via $toClass) in builtin JS rather than created by
+  // a function declaration.
+  const constructors: [name: string, get: () => Function][] = [
+    ["events.EventEmitter", () => require("node:events").EventEmitter],
+    ["events.init", () => require("node:events").init],
+    ["url.Url", () => require("node:url").Url],
+    ["crypto.Certificate", () => require("node:crypto").Certificate],
+    ["console.Console", () => require("node:console").Console],
+    ["http.OutgoingMessage", () => require("node:http").OutgoingMessage],
+    ["http.IncomingMessage", () => require("node:http").IncomingMessage],
+    ["http.ClientRequest", () => require("node:http").ClientRequest],
+    ["stream.Readable", () => require("node:stream").Readable],
+    ["stream.Writable", () => require("node:stream").Writable],
+    ["stream.Duplex", () => require("node:stream").Duplex],
+    ["net.Socket", () => require("node:net").Socket],
+    ["tty.ReadStream", () => require("node:tty").ReadStream],
+    ["tty.WriteStream", () => require("node:tty").WriteStream],
+    ["Bun.$.Shell", () => require("bun").$.Shell],
+  ];
+
+  test.each(constructors)("%s matches a regular function's descriptor", (_name, get) => {
+    const ctor = get();
+    // Read .prototype first: tty's streams materialize theirs lazily.
+    const prototype = ctor.prototype;
+    const { value, ...attributes } = Object.getOwnPropertyDescriptor(ctor, "prototype")!;
+    expect(value).toBe(prototype);
+    expect(attributes).toEqual({
+      writable: true,
+      enumerable: false,
+      configurable: false,
+    });
+
+    // "name" has the spec's descriptor too (non-writable, unlike "prototype").
+    const { value: _value, ...nameAttributes } = Object.getOwnPropertyDescriptor(ctor, "name")!;
+    expect(nameAttributes).toEqual({
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  // $toClass also fills in prototype.constructor the way a class declaration
+  // would. tty.WriteStream and Bun.$.Shell deliberately reuse prototype objects
+  // owned by other constructors, so they are excluded here.
+  const withOwnConstructor = constructors.filter(([name]) => name !== "tty.WriteStream" && name !== "Bun.$.Shell");
+
+  test.each(withOwnConstructor)("%s prototype.constructor matches Node's descriptor", (_name, get) => {
+    const ctor = get();
+    const { value, ...attributes } = Object.getOwnPropertyDescriptor(ctor.prototype, "constructor")!;
+    expect(value).toBe(ctor);
+    expect(attributes).toEqual({
+      writable: true,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+});

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -9,6 +9,19 @@ test("stubs", () => {
   expect(perf.performance.eventLoopUtilization()).toBeObject();
 });
 
+// $toClass is used to wire PerformanceNodeTiming/PerformanceResourceTiming
+// (class declarations) to PerformanceEntry as their base. The instance
+// prototype chain must reach PerformanceEntry.prototype, and the class body's
+// own getters must remain in place. https://github.com/oven-sh/bun/issues/32160
+test("nodeTiming inherits from PerformanceEntry and keeps its class getters", () => {
+  const nodeTiming = perf.performance.nodeTiming;
+  expect(nodeTiming instanceof perf.PerformanceEntry).toBe(true);
+  expect(Object.getPrototypeOf(perf.PerformanceNodeTiming.prototype)).toBe(perf.PerformanceEntry.prototype);
+  expect(nodeTiming.name).toBe("node");
+  expect(nodeTiming.entryType).toBe("node");
+  expect(Object.getPrototypeOf(perf.PerformanceResourceTiming.prototype)).toBe(perf.PerformanceEntry.prototype);
+});
+
 test("doesn't throw", () => {
   expect(() => performance.mark("test")).not.toThrow();
   expect(() => performance.measure("test", "test")).not.toThrow();


### PR DESCRIPTION
Fixes #32160

### Problem

```js
const { EventEmitter } = require('events');
Object.getOwnPropertyDescriptor(EventEmitter, 'prototype');
// Bun:  { value: ..., writable: true, enumerable: true, configurable: true }
// Node: { value: ..., writable: true, enumerable: false, configurable: false }

const target = function () {};
Object.defineProperties(target, Object.getOwnPropertyDescriptors(EventEmitter));
// Bun: TypeError: Attempting to change configurable attribute of unconfigurable property.
// Node: ok
```

Per spec (https://tc39.es/ecma262/#sec-function-instances-prototype) a function's own `prototype` property is `{ [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }`. Because Bun reported it as configurable, the common "copy a function's shape onto a wrapper" idiom threw: the copied descriptor conflicts with the target function's correctly non-configurable `prototype`.

### Cause

Functions declared in builtin JS don't get an automatic own `prototype` property, so `Fn.prototype = {}` at module setup *creates* one via `[[Set]]` with default attributes (all true). The same class of bug existed in `$toClass` (the internal helper that mimics `class` setup for function-style constructors), which put `prototype` with only `DontEnum`, leaving it configurable.

### Fix

`$toClass` is now the one place that knows the correct descriptor, and every hand-assigned `Fn.prototype = ...` site becomes a `$toClass` call:

- `jsFunctionToClass` (ZigGlobalObject.cpp) defines `prototype` with `DontEnum | DontDelete`, matching the spec for all 44 existing `$toClass` users (`stream.Readable`/`Writable`/`Duplex`, `net.Socket`, zlib classes, ...) plus the converted sites.
- It accepts an optional 4th argument: a caller-built prototype object (the `http` message classes and `Bun.$.Shell` pass their existing prototype objects instead of getting a fresh one).
- It keeps a pre-existing own `prototype` (node:tty installs a lazy accessor first; `$toClass` now leaves it in place and still wires up static inheritance and the name). tty's accessors materialize into the spec-correct descriptor on first use; previously the materialized descriptor was `{ writable: false, enumerable: true, configurable: true }`, wrong on all three attributes.
- It keeps a pre-existing own `constructor` on the passed prototype (`Bun.$.Shell` shares a class prototype whose `constructor` must stay). Where it was absent or hand-assigned, `prototype.constructor` is now the non-enumerable data property Node has: `events.EventEmitter`'s was enumerable (visible to `for...in`), and `url.Url`, `crypto.Certificate`, `console.Console`, and the `http` classes either lacked it or defined it enumerable in their prototype literals.
- Marking the prototype object uses `didBecomePrototype()` instead of `structure()->setMayBePrototype(true)`: passed objects (and `constructEmptyObject(globalObject)` without a base) can share structures with the literal/empty-object structure caches, and flagging those in place trips `ASSERTION FAILED: !newStructure->mayBePrototype()` in JSON parsing on debug builds.

tty.ReadStream's lazily created prototype also gets its own `constructor` now (previously inherited fs.ReadStream's); tty.WriteStream keeps sharing `fs.WriteStream.prototype` by design, so its `constructor` is unchanged.

Converted sites: `events.EventEmitter` (also exported as `events.init`), `url.Url`, `crypto.Certificate`, `console.Console`, `http.OutgoingMessage`/`IncomingMessage`/`ClientRequest`, internal stream `ReadableState`/`WritableState`, `Bun.$.Shell`, and `tty.ReadStream`.

- `$toClass` now also handles `class` declarations correctly. A class carries its own `prototype` (from ClassDefinitionEvaluation), so `$toClass` keeps it rather than overwriting, and when a base is supplied it wires that prototype's `[[Prototype]]` to the base so instances still inherit (`perf_hooks` `PerformanceNodeTiming`/`PerformanceResourceTiming` extend `PerformanceEntry`). This is checked via a PropertySlot so node:tty's lazy accessor prototype is still left untouched. Previously the overwrite silently dropped the class body's own getters; `nodeTiming.name`/`entryType` now return `"node"` and `instanceof PerformanceEntry` is `true`, matching Node v24. Regression test added in `test/js/node/perf_hooks/perf_hooks.test.ts`.

Out of scope: before first access, `tty.ReadStream`/`WriteStream.prototype` is still reported as an accessor (the deliberate lazy-initialization mechanism), and native classes like `Buffer` (whose `prototype` is non-writable, a different mechanism) are unchanged.

### Verification

Tests in `test/js/node/events/event-emitter.test.ts` assert the exact `prototype` descriptor for every fixed constructor, the `defineProperties` copy idiom from the issue, and the `prototype.constructor` descriptor; 25 of 96 fail on the unfixed build, all pass with this change. Both descriptor shapes verified against Node v24 for every entry.

Also ran the events, url, crypto, console, http, stream, net, tty, and shell suites plus Node's ported `test-event-emitter-*` files with the debug build; no new failures (the http proxy test fails identically without this change: network sandboxing in the test environment).


