### PR TITLE
dns: fail over from a nameserver that refuses instead of spinning until the query times out

### DIFF
--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4749,11 +4749,23 @@ impl Resolver {
         // SAFETY: `self` is the heap allocation from `init`; ref_scope keeps count > 0 across re-entrant callbacks.
         let _deref = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
+        // A pending socket error (ICMP port unreachable on the UDP socket of a
+        // nameserver nothing listens on) is reported by epoll as EPOLLERR
+        // without EPOLLIN/EPOLLOUT, which `from_epoll_event` maps to Eof/Hup.
+        // Hand the fd to c-ares as readable and writable anyway so it recv()s
+        // the error and fails over to the next server; otherwise the
+        // level-triggered EPOLLERR re-fires every tick until the query times
+        // out. Same as `on_dns_poll_uv` and Node's cares_wrap.
+        let errored =
+            poll.flags.contains(Async::PollFlag::Eof) || poll.flags.contains(Async::PollFlag::Hup);
+        let readable = poll.is_readable() || errored;
+        let writable = poll.is_writable() || errored;
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
         // to `*self` is held across this re-entrant call (all fields are
         // UnsafeCell-backed).
         unsafe {
-            (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
+            (*channel).process(poll.fd.native(), readable, writable);
         }
 
         // c-ares detaches a query only *after* its callback returns, so

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4749,13 +4749,9 @@ impl Resolver {
         // SAFETY: `self` is the heap allocation from `init`; ref_scope keeps count > 0 across re-entrant callbacks.
         let _deref = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
-        // A pending socket error (ICMP port unreachable on the UDP socket of a
-        // nameserver nothing listens on) is reported by epoll as EPOLLERR
-        // without EPOLLIN/EPOLLOUT, which `from_epoll_event` maps to Eof/Hup.
-        // Hand the fd to c-ares as readable and writable anyway so it recv()s
-        // the error and fails over to the next server; otherwise the
-        // level-triggered EPOLLERR re-fires every tick until the query times
-        // out. Same as `on_dns_poll_uv` and Node's cares_wrap.
+        // Eof/Hup (EPOLLERR/EPOLLHUP) means a pending socket error: treat the fd
+        // as readable+writable so c-ares recv()s it. Same as `on_dns_poll_uv` and
+        // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
         let errored =
             poll.flags.contains(Async::PollFlag::Eof) || poll.flags.contains(Async::PollFlag::Hup);
         let readable = poll.is_readable() || errored;

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -992,3 +992,77 @@ describe("pending cache", () => {
     expect(results).toEqual(Array(8).fill({ address: "127.0.0.1", family: 4 }));
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32164
+describe("Resolver with a nameserver that nothing is listening on", () => {
+  // A query sent to a loopback UDP port with no listener comes back as an ICMP
+  // port unreachable, which the kernel reports on the next recv() of the query
+  // socket. c-ares has to see that error to give up on the server; until it
+  // does, the query sits there for the full `timeout`.
+  async function closedUdpPort() {
+    const socket = dgram.createSocket("udp4");
+    socket.bind(0, "127.0.0.1");
+    await once(socket, "listening");
+    const { port } = socket.address();
+    await new Promise(resolve => socket.close(resolve));
+    return `127.0.0.1:${port}`;
+  }
+
+  // Answers every query with a single A record, 10.20.0.1.
+  async function liveServer() {
+    const socket = dgram.createSocket("udp4");
+    socket.on("message", (query, rinfo) => {
+      let off = 12;
+      while (off < query.length && query[off] !== 0) off += query[off] + 1;
+      off += 1 + 2 + 2;
+      const question = query.subarray(12, off);
+      const header = Buffer.from([query[0], query[1], 0x81, 0x80, 0, 1, 0, 1, 0, 0, 0, 0]);
+      const answer = Buffer.from([0xc0, 0x0c, 0, 1, 0, 1, 0, 0, 0, 60, 0, 4, 10, 20, 0, 1]);
+      socket.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
+    });
+    socket.bind(0, "127.0.0.1");
+    await once(socket, "listening");
+    return {
+      address: `127.0.0.1:${socket.address().port}`,
+      [Symbol.dispose]: () => socket.close(),
+    };
+  }
+
+  it("dns.promises.Resolver rejects with ECONNREFUSED instead of ETIMEOUT", async () => {
+    const resolver = new dns_promises.Resolver({ timeout: 1000, tries: 1 });
+    resolver.setServers([await closedUdpPort()]);
+    const err = await resolver.resolve4("refused.example.test").then(
+      () => {
+        throw new Error("expected resolve4 to reject");
+      },
+      e => e,
+    );
+    expect({ code: err.code, syscall: err.syscall, message: err.message }).toEqual({
+      code: "ECONNREFUSED",
+      syscall: "queryA",
+      message: "queryA ECONNREFUSED refused.example.test",
+    });
+  });
+
+  it("dns.Resolver (callback API) errors with ECONNREFUSED instead of ETIMEOUT", async () => {
+    const resolver = new dns.Resolver({ timeout: 1000, tries: 1 });
+    resolver.setServers([await closedUdpPort()]);
+    const { promise, resolve } = Promise.withResolvers();
+    resolver.resolve4("refused.example.test", (err, addresses) => resolve({ code: err?.code, addresses }));
+    expect(await promise).toEqual({ code: "ECONNREFUSED", addresses: undefined });
+  });
+
+  it("falls over to the next server without waiting out the timeout", async () => {
+    using live = await liveServer();
+    const timeout = 3000;
+    const resolver = new dns_promises.Resolver({ timeout, tries: 1 });
+    resolver.setServers([await closedUdpPort(), await closedUdpPort(), live.address]);
+    const start = performance.now();
+    const addresses = await resolver.resolve4("failover.example.test");
+    const elapsed = performance.now() - start;
+    expect(addresses).toEqual(["10.20.0.1"]);
+    // Without the fix each dead server is only abandoned once its `timeout`
+    // expires, so this takes at least 2 * timeout.
+    expect(elapsed).toBeLessThan(timeout);
+  });
+});


### PR DESCRIPTION
Fixes #32164

### Problem
- A `node:dns` `Resolver` whose first nameserver has nothing listening on it (stopped systemd-resolved, docker's 127.0.0.11 before it is up, a LAN resolver rebooting) makes every query wait out the full c-ares `timeout` (2s by default) per dead server before moving on. A dead-only server list fails with `ETIMEOUT`; Node fails it with `ECONNREFUSED` in about 1ms and fails over to the next server in about 1ms.
- While waiting, the event loop spins: the repro below burns about 2.8s of CPU per 2s query. An strace in the original report shows `epoll_wait` returning `EPOLLERR` for the query socket tens of thousands of times per second and never a `recvfrom` on it.
- Cause: the ICMP port unreachable is reported on the connected UDP socket as a level-triggered `EPOLLERR` with no `EPOLLIN`/`EPOLLOUT`. `Flags::from_epoll_event` (src/io/posix_event_loop.rs) maps that to `Eof`/`Hup`, so `Resolver::on_dns_poll` (src/runtime/dns_jsc/dns.rs) called `ares_process_fd(channel, ARES_SOCKET_BAD, ARES_SOCKET_BAD)`, a no-op. c-ares never `recv()`s the error, nothing clears the condition, and epoll reports it again on the next tick.
- Reproduced on Linux only. The Windows path (`on_dns_poll_uv`) already passes the fd as readable and writable when libuv reports an error. Not tried on macOS: reading xnu's `filt_soread`, a pending socket error fires `EVFILT_READ`, which already takes the readable path; the new tests run on the darwin lanes either way.

### Fix
- `on_dns_poll` treats a wakeup carrying `Eof` or `Hup` as readable and writable, so c-ares gets the fd either way. This is what `on_dns_poll_uv` and Node's `cares_wrap` do on a poll error, and what c-ares's own epoll backend does (`EPOLLERR`/`EPOLLHUP` map to its read event).
- c-ares then `recv()`s `ECONNREFUSED`, closes that server's connection and requeues the query on the next server (`read_conn_packets` -> `handle_conn_error` in `ares_process.c`). With no server left the query ends with `ECONNREFUSED`, matching Node's error code. The extra write flag is harmless: `process_write` finds nothing buffered on a UDP connection, and if it ever did, the `send()` would surface the same error.
- Closing the c-ares socket inside `ares_process_fd` frees the `FilePoll` we were dispatched with; that is already the normal path for every answered query, and `Store::put` defers the actual free to the end of the tick, so a new socket opened for the next server cannot reuse the slot mid-dispatch.
- Tests (`test/js/node/dns/node-dns.test.js`, "Resolver with a nameserver that nothing is listening on"): the dead port is a loopback UDP port bound and closed again, so no network is involved. Two tests check that a dead-only list fails with `ECONNREFUSED` (promise and callback API); the third points the resolver at two dead ports followed by a local stub server and checks the answer arrives before a single `timeout` could have expired.
- Without the fix (bun 1.4.0): the first two fail with `ETIMEOUT`, the third needs 2 x `timeout` = 6s. With the fix all three pass, the failover one in about 70ms on a debug+ASAN build.
- Also run on the fixed build: the rest of `node-dns.test.js` (only the tests that need internet fail here, identically to the unfixed binary), `dns-tcp-bidirectional-poll.test.ts`, `dns-resolver-concurrent-timeout.test.ts`, `dns-lookup-keepalive.test.ts`, and the upstream `test-dns-channel-*`, `test-dns-multi-channel`, `test-dns-setserver-when-querying`, `test-dns-resolvesrv*`, `test-dns-cancel-reverse-lookup`, `test-worker-dns-terminate-during-query` tests, all passing.

### Background
- c-ares does not own an event loop. It opens sockets and tells the embedder, through a socket state callback, which ones to watch for reading and/or writing (`on_dns_socket_state` here, which registers a `FilePoll` per socket). When the embedder's poll fires, it calls `ares_process_fd(channel, read_fd, write_fd)`, passing `ARES_SOCKET_BAD` for whichever direction is not ready; c-ares then does the `recv()`/`send()` itself. Passing `ARES_SOCKET_BAD` for both does nothing at all, which is what happened here.
- A UDP socket that has been `connect()`ed receives ICMP errors for datagrams it sent. The kernel stores the error on the socket and reports it as `EPOLLERR` until the next `recv()`/`send()` returns it (`ECONNREFUSED`). Because epoll is level-triggered by default, an unconsumed error wakes up every `epoll_wait`, which is the CPU spin.
- `FilePoll` is Bun's per-fd poll registration on POSIX. `Flags::from_epoll_event` translates the kernel's event bits into `Readable`/`Writable`/`Eof`/`Hup` flags before dispatching to the owner (`__bun_run_file_poll` -> `on_dns_poll` for the resolver). Only `Readable` and `Writable` were previously forwarded to c-ares.

<details>
<summary>Repro output (loopback only: a stub server answering A queries plus 127.0.0.1:1 as the dead server)</summary>

bun 1.4.0:

```
dead-only  2001ms wall 2789ms cpu ETIMEOUT
dead-first 2002ms wall 2808ms cpu [ "10.20.0.1" ]
3 dead + live, timeout 1000 3001ms wall 4137ms cpu [ "10.20.0.1" ]
dead-first, default opts 2001ms wall 2770ms cpu [ "10.20.0.1" ]
```

node v26.3.0:

```
dead-only  1ms wall 2ms cpu ECONNREFUSED
dead-first 1ms wall 1ms cpu [ '10.20.0.1' ]
3 dead + live, timeout 1000 0ms wall 0ms cpu [ '10.20.0.1' ]
dead-first, default opts 0ms wall 0ms cpu [ '10.20.0.1' ]
```

this branch (debug build):

```
dead-only  20ms wall 20ms cpu ECONNREFUSED
dead-first 79ms wall 82ms cpu [ "10.20.0.1" ]
3 dead + live, timeout 1000 6ms wall 7ms cpu [ "10.20.0.1" ]
dead-first, default opts 3ms wall 3ms cpu [ "10.20.0.1" ]
```

</details>

<details>
<summary>History</summary>

The first version of this PR (June) made the same change through `FilePoll::is_eof()`/`is_hup()`, which have since been removed, and only had the dead-only tests. It was rebased onto current main, switched to checking `poll.flags` directly (as `memory_pressure.rs` does for the same EPOLLERR situation), and the failover test was added.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/dns/node-dns.test.js

<!-- robobun:evidence:end -->