### PR TITLE
Don't leak scope objects through host functions' raw this

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2292,6 +2292,14 @@ impl JSValue {
             Ok(p)
         }
     }
+    /// `JSValue.toThis` with strict-mode semantics: identity for every value
+    /// except scope objects (`JSLexicalEnvironment` etc., which JSC passes as
+    /// the raw `this` of bare calls resolved through a scope), which become
+    /// `undefined`. Use this before exposing a callframe's `this` to user JS.
+    /// Cannot throw.
+    pub fn to_this_strict(self, global: &JSGlobalObject) -> JSValue {
+        JSC__JSValue__toThisStrict(self, global)
+    }
     /// `JSValue.unwrapBoxedPrimitive` — unwraps Number,
     /// Boolean, String, and BigInt objects to their primitive forms.
     pub fn unwrap_boxed_primitive(self, global: &JSGlobalObject) -> JsResult<JSValue> {
@@ -2693,6 +2701,7 @@ unsafe extern "C" {
     ) -> bool;
     safe fn Bun__JSValue__toNumber(this: JSValue, global: &JSGlobalObject) -> f64;
     safe fn JSC__JSValue__toObject(this: JSValue, global: &JSGlobalObject) -> *mut JSObject;
+    safe fn JSC__JSValue__toThisStrict(this: JSValue, global: &JSGlobalObject) -> JSValue;
     safe fn JSC__JSValue__unwrapBoxedPrimitive(global: &JSGlobalObject, this: JSValue) -> JSValue;
     safe fn JSC__JSValue__getPrototype(this: JSValue, global: &JSGlobalObject) -> JSValue;
     safe fn JSC__JSValue__getName(

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -99,7 +99,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject*
     plugin.append(vm, filter->regExp(), func.getObject(), namespaceString);
     callback(ctx, globalObject);
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe)
@@ -167,7 +167,7 @@ static EncodedJSValue jsFunctionAppendVirtualModulePluginBody(JSC::JSGlobalObjec
         moduleLoader->removeEntry(idIdent);
     }
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target, BunPlugin::Base& plugin, void* ctx, OnAppendPluginCallback callback)
@@ -223,7 +223,7 @@ static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginBody(JSC::JSGlobalObje
     plugin.append(vm, filter->regExp(), uncheckedDowncast<JSObject>(func), namespaceString);
     callback(ctx, globalObject);
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnResolvePluginGlobal(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target)

--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -833,7 +833,9 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
     }
 
     JSC::ArgList args = JSC::ArgList(callframe);
-    JSValue thisValue = callframe->thisValue();
+    // Convert the raw `this` so a JSLexicalEnvironment passed by a scope-resolved
+    // bare call can never be stored in mock.contexts or returned by mockReturnThis.
+    JSValue thisValue = callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict());
     JSC::JSArray* argumentsArray = nullptr;
     {
         JSC::ObjectInitializationScope object(vm);
@@ -1457,7 +1459,7 @@ BUN_DEFINE_HOST_FUNCTION(JSMock__jsSetSystemTime, (JSC::JSGlobalObject * globalO
     // from this value instead of the activation-time clock.
     Bun__FakeTimers__setSystemTime(ms);
 
-    return JSValue::encode(callframe->thisValue());
+    return JSValue::encode(callframe->thisValue().toThis(globalObject, JSC::ECMAMode::strict()));
 }
 
 BUN_DEFINE_HOST_FUNCTION(JSMock__jsRestoreAllMocks, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))

--- a/src/jsc/bindings/JSStringDecoder.cpp
+++ b/src/jsc/bindings/JSStringDecoder.cpp
@@ -580,9 +580,8 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
             return Bun::ERR::UNKNOWN_ENCODING(throwScope, lexicalGlobalObject, view);
         }
     }
-    JSValue thisValue = callFrame->newTarget();
+    JSValue newTarget = callFrame->newTarget();
     auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-    JSObject* newTarget = asObject(thisValue);
     auto* constructor = globalObject->JSStringDecoder();
     Structure* structure = globalObject->JSStringDecoderStructure();
 
@@ -593,9 +592,10 @@ JSC::EncodedJSValue JSStringDecoderConstructor::construct(JSC::JSGlobalObject* l
     // This is a hack to make express' body-parser work
     // It does something weird with the prototype
     // Not exactly a subclass
-    if (constructor != newTarget && callFrame->thisValue().isObject()) {
+    JSValue thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
+    if (newTarget != constructor && thisValue.isObject()) {
         auto clientData = WebCore::clientData(vm);
-        JSObject* thisObject = asObject(callFrame->thisValue());
+        JSObject* thisObject = asObject(thisValue);
 
         thisObject->putDirect(vm, clientData->builtinNames().decodePrivateName(), jsObject, JSC::PropertyAttribute::DontEnum | 0);
         thisObject->putDirect(vm, clientData->builtinNames().encodingPublicName(), convertEnumerationToJS<BufferEncodingType>(*lexicalGlobalObject, encoding), JSC::PropertyAttribute::DontEnum | 0);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4500,6 +4500,11 @@ JSC::JSObject* JSC__JSValue__toObject(JSC::EncodedJSValue JSValue0, JSC::JSGloba
     return value.toObject(arg1);
 }
 
+[[ZIG_EXPORT(nothrow)]] JSC::EncodedJSValue JSC__JSValue__toThisStrict(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1)
+{
+    return JSC::JSValue::encode(JSC::JSValue::decode(JSValue0).toThis(arg1, JSC::ECMAMode::strict()));
+}
+
 [[ZIG_EXPORT(null_is_throw)]] JSC::JSString* JSC__JSValue__toStringOrNull(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1)
 {
     JSC::JSValue value = JSC::JSValue::decode(JSValue0);

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -391,7 +391,7 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     // This is used by testing-library/react to detect if jest.advanceTimersByTime should be called.
     set_fake_timer_marker(global, true);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -412,7 +412,7 @@ fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
     // Remove the setTimeout.clock marker when switching back to real timers.
     set_fake_timer_marker(global, false);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -421,7 +421,7 @@ fn advance_timers_to_next_timer(global: &JSGlobalObject, frame: &CallFrame) -> J
 
     let _ = FakeTimers::execute_next(global);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -456,7 +456,7 @@ fn advance_timers_by_time(global: &JSGlobalObject, frame: &CallFrame) -> JsResul
     FakeTimers::execute_until(global, target);
     CURRENT_TIME.set(global, &target, None);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -465,7 +465,7 @@ fn run_only_pending_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
 
     FakeTimers::execute_only_pending_timers(global);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -474,7 +474,7 @@ fn run_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValu
 
     FakeTimers::execute_all_timers(global);
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]
@@ -508,7 +508,7 @@ fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVa
         TimerObjectInternals::release_heap_pin(p, vm);
     }
 
-    Ok(frame.this())
+    Ok(frame.this().to_this_strict(global))
 }
 
 #[bun_jsc::host_fn]

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -722,3 +722,26 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+it("builder methods called as bare functions do not leak the scope object", () => {
+  // A bare call through a captured variable makes JSC pass the activation
+  // object as the raw `this`, which must not be returned for chaining.
+  let results: unknown[] = [];
+  plugin({
+    name: "bare call this",
+    setup(builder) {
+      const onLoad = builder.onLoad;
+      const onResolve = builder.onResolve;
+      const module_ = builder.module;
+      function capture() {
+        return [onLoad, onResolve, module_];
+      }
+      results = [
+        onLoad({ filter: /never-matches-bare-call-this/ }, () => undefined as any),
+        onResolve({ filter: /never-matches-bare-call-this/ }, () => undefined),
+        module_("never-imported-bare-call-this-module", () => ({ exports: {}, loader: "object" })),
+      ];
+    },
+  });
+  expect(results).toEqual([undefined, undefined, undefined]);
+});

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -486,6 +486,22 @@ describe("mock()", () => {
     expect(fn).toHaveBeenCalledWith(43);
     expect(fn).toHaveBeenCalledWith(44);
   });
+  test("bare call through a captured variable does not leak the scope object", () => {
+    // When the callee is resolved through a closure scope, JSC passes the
+    // activation object as the raw `this`; the mock must sanitize it.
+    const returnsThis = jest.fn();
+    returnsThis.mockReturnThis();
+    const impl = jest.fn(function () {
+      return this;
+    });
+    function capture() {
+      return [returnsThis, impl];
+    }
+    expect(returnsThis()).toBeUndefined();
+    expect(returnsThis.mock.contexts).toEqual([undefined]);
+    expect(impl()).toBeUndefined();
+    expect(impl.mock.contexts).toEqual([undefined]);
+  });
   test("this arg", () => {
     const fn = jest.fn(function (add) {
       return this.foo + add;

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -94,3 +94,26 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
 });
+
+test("timer methods sanitize `this` on bare calls", () => {
+  try {
+    // normal method calls keep returning the jest object for chaining
+    expect(jest.setSystemTime(0)).toBe(jest);
+    expect(jest.useFakeTimers()).toBe(jest);
+    expect(jest.useRealTimers()).toBe(jest);
+
+    // a bare call through a captured variable makes JSC pass the activation
+    // object as the raw `this`; it must not be returned to user code
+    const setSystemTime = jest.setSystemTime;
+    const useFakeTimers = jest.useFakeTimers;
+    const useRealTimers = jest.useRealTimers;
+    function capture() {
+      return [setSystemTime, useFakeTimers, useRealTimers];
+    }
+    expect(setSystemTime(0)).toBeUndefined();
+    expect(useFakeTimers()).toBeUndefined();
+    expect(useRealTimers()).toBeUndefined();
+  } finally {
+    jest.useRealTimers();
+  }
+});

--- a/test/js/node/string_decoder/string-decoder.test.js
+++ b/test/js/node/string_decoder/string-decoder.test.js
@@ -421,3 +421,19 @@ it(
   // Allocating a 2 GiB buffer under debug/ASAN is slow even when lazily committed.
   isDebug || isASAN ? 60_000 : undefined,
 );
+
+// Calling StringDecoder without new used to assert in debug builds (undefined
+// `this`), and with the callee resolved through a closure scope it wrote
+// `encoding` onto the activation object and returned it instead of a decoder.
+it("called without new returns a real decoder", () => {
+  expect(RealStringDecoder("utf8")).toBeInstanceOf(RealStringDecoder);
+
+  const SD = RealStringDecoder;
+  function capture() {
+    return SD;
+  }
+  let decoder;
+  decoder = SD("utf8");
+  expect(decoder).toBeInstanceOf(RealStringDecoder);
+  expect(decoder.write(Buffer.from("abc"))).toBe("abc");
+});


### PR DESCRIPTION
Fixes a fuzzer-found segfault (Fuzzilli fingerprint `07bc0d3cfacec7ff`, SIGSEGV in baseline JIT code).

### Root cause

When a bare call `f()` resolves its callee through a closure scope (i.e. `f` is a captured variable living in the activation), JSC passes the scope object (`JSLexicalEnvironment`) as the raw `this` value and relies on the callee to sanitize it. JS functions do that via `to_this` in their prologue; host functions see the raw value through `callFrame->thisValue()` and must call `JSValue::toThis` themselves.

Several Bun host functions returned or stored that raw value, leaking the activation object into user JavaScript:

```js
function outer() {
  const fn = jest.fn();
  fn.mockReturnThis();
  function capture() { return fn; }   // forces `fn` into the activation
  const leaked = fn();                // JSLexicalEnvironment, before this fix
}
```

The crash chain in the fuzzer input: `mockReturnThis` returned the activation, the script then read a property of it that corresponded to a not-yet-initialized `let` (a TDZ slot). `JSLexicalEnvironment::getOwnPropertySlot` returns the raw slot contents, so the read produced an empty `JSValue` inside user JS. A JIT-compiled `typeof` check on that value then dereferenced offset 5 of a null cell (empty passes the is-cell tag check) and segfaulted. In the ASAN build UBSAN reports `member call on null pointer of type 'JSC::JSCell'`.

### Fix

Apply `toThis` with strict semantics (identity for every value except scope objects, which become `undefined`, so behavior for all normal calls is unchanged) at every place a raw `this` escaped:

- `jsMockFunctionCall` (the crashing one, line 844 of JSMockFunction.cpp): covers `mock.contexts`, `mockReturnThis`, and the `this` forwarded to mock implementations
- `jest.setSystemTime` (C++) and the Rust fake timer methods (`useFakeTimers`, `useRealTimers`, `advanceTimersByTime`, etc. in `FakeTimers.rs`), via a new `JSC__JSValue__toThisStrict` binding exposed as `JSValue::to_this_strict`
- `Bun.plugin` builder `onLoad`/`onResolve`/`module` chaining returns
- `StringDecoder` called without `new`: it wrote `encoding` onto the activation object and returned it; this also fixes a debug-build assert (`asObject` on a non-cell) when `this` is `undefined`

The dead C++ `JSMock__jsUseRealTimers` that originally returned the raw `this` was removed on `main` independently while this PR was open; the live implementation is the Rust one in `FakeTimers.rs`, which is fixed here.

This same root cause also explains a second Fuzzilli crash, fingerprint `284a2ab00e963a39` (the `jsMockFunctionCall` hunk covers it), so no separate PR is needed for that one.

Rebased four times while open. First onto the WebKit upgrade (#33133): `JSMock__jsSetSystemTime` had been rewritten on `main` (the `overridenDateNow` "no override" sentinel changed from `-1` to `NaN`), resolved by taking `main`'s logic and applying `toThis` to its return; plus an EOF test-append in `test-timers.test.ts`, resolved by keeping both. Second onto `jest.resetAllMocks()` (#33374) and runtime `onResolve` (#33409): sources auto-merged, one EOF test-append conflict in `plugins.test.ts`, resolved by keeping all three tests. Third onto `advanceTimersByTime`/`setSystemTime` (#33623): `JSMock__jsSetSystemTime` reworked to a single exit routing through `Bun__FakeTimers__setSystemTime`, resolved by taking `main`'s body with `toThis` on that return; `FakeTimers.rs` auto-merged with all seven `to_this_strict` sites intact. Fourth onto the JSC C API removal (#33731), `string_decoder` `lastTotal` fix (#33703), and real-clock-under-fake-timers (#33896): sources auto-merged (the `JSValue.rs` reorg landed around `to_this_strict`, which survived; all seven `FakeTimers.rs` sites intact), one EOF test-append conflict in `test-timers.test.ts`, resolved by keeping both.

Audited the remaining `thisValue()` uses in `src/jsc/bindings` and host functions in `src/runtime`: the rest are type-checked downcasts (a scope object fails the cast and throws) or `host_fn(method)` shims that validate `this` before the body runs. The NAPI and V8 shim layers pass the raw `this` to native addons; that is a separate surface with its own compatibility questions and is not changed here.

### Tests

Regression tests in `mock-fn.test.js`, `test-timers.test.ts`, `plugins.test.ts`, and `string-decoder.test.js`. Each fails on bun without this change (`USE_SYSTEM_BUN=1`) and passes with it. The original fuzzer input now exits with an ordinary JS error instead of crashing.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock-fn.test.js test/js/bun/test/test-timers.test.ts test/js/node/string_decoder/string-decoder.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (58767ddf6)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.87ms]
(pass) mock() > mock [7.26ms]
(pass) mock() > checks the this value > mock [7.02ms]
(pass) mock() > checks the this value > _protoImpl [0.81ms]
(pass) mock() > checks the this value > getMockImplementation [1.47ms]
(pass) mock() > checks the this value > getMockName [0.88ms]
(pass) mock() > checks the this value > mockClear [0.73ms]
(pass) mock() > checks the this value > mockReset [0.71ms]
(pass) mock() > checks the this value > mockRestore [0.72ms]
(pass) mock() > checks the this value > mockImpleme
... (truncated)

release without fix: 21 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [0.03ms]
(pass) mock() > mock [0.16ms]
(pass) mock() > checks the this value > mock [0.12ms]
(pass) mock() > checks the this value > _protoImpl
(pass) mock() > checks the this value > getMockImplementation [0.04ms]
(pass) mock() > checks the this value > getMockName
(pass) mock() > checks the this value > mockClear
(pass) mock() > checks the this value > mockReset
(pass) mock() > checks the this value > mockRestore
(pass) mock() > checks the this value > mockImplementation
(pass) mock() > checks the this value > mockImplementationOnce [0.01ms]
(pass) mock() > checks the this value > withImplementation
(pass) mock() > checks the this value > mockName
(pass) mock() > checks the this value > mockReturnThis
(pass) mock() > checks the this value > mockReturnValue
(pass) mock() > checks the this value > mockReturnValueOnce
(pass) mock() > checks the this value > mockResolvedValue
(pass) mock() > checks the this value > mockResolvedValueOnce
(pass) mock() > checks the this value > mockRejectedValue
(pass) mock() > checks the this value > mockRe
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts test/js/bun/test/mock-fn.test.js test/js/bun/test/test-timers.test.ts test/js/node/string_decoder/string-decoder.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (58767ddf6)

test/js/bun/test/mock-fn.test.js:
(pass) mock() > exists as jest.fn, bunTest.mock, and vi.fn [1.78ms]
(pass) mock() > mock [6.85ms]
(pass) mock() > checks the this value > mock [6.87ms]
(pass) mock() > checks the this value > _protoImpl [0.80ms]
(pass) mock() > checks the this value > getMockImplementation [1.43ms]
(pass) mock() > checks the this value > getMockName [0.87ms]
(pass) mock() > checks the this value > mockClear [0.69ms]
(pass) mock() > checks the this value > mockReset [0.73ms]
(pass) mock() > checks the this value > mockRestore [0.70ms]
(pass) mock() > checks the this value > mockImpleme
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     58767ddf62
  features     (none)

22 deps, 105 codegen, 1168 objects in 838ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [12.00ms]
[2/1231] gen ErrorCode+*.h
[3/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [12.00ms]
[5/1231] gen bindgenv2
[6/1231] fetch tinycc
[tinycc] up to date
[7/1230] gen .bind.ts → GeneratedBindings.cpp
[8/1230] fetch zlib
[zli
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/JSValue.rs                                 |  9 +++++++++
 src/jsc/bindings/BunPlugin.cpp                     |  6 +++---
 src/jsc/bindings/JSMockFunction.cpp                |  6 ++++--
 src/jsc/bindings/JSStringDecoder.cpp               |  8 ++++----
 src/jsc/bindings/bindings.cpp                      |  5 +++++
 src/runtime/test_runner/timers/FakeTimers.rs       | 14 ++++++-------
 test/js/bun/plugin/plugins.test.ts                 | 23 ++++++++++++++++++++++
 test/js/bun/test/mock-fn.test.js                   | 16 +++++++++++++++
 test/js/bun/test/test-timers.test.ts               | 23 ++++++++++++++++++++++
 test/js/node/string_decoder/string-decoder.test.js | 16 +++++++++++++++
 10 files changed, 110 insertions(+), 16 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/jsc/JSValue.rs                                      1      2      9
src/jsc/bindings/BunPlugin.cpp                          0      0      9
src/jsc/bindings/JSMockFunction.cpp                     4      6      9
src/jsc/bindings/JSStringDecoder.cpp                    1      1      9
src/jsc/bindings/bindings.cpp                           1      2      9
src/runtime/test_runner/timers/FakeTimers.rs            0      0      9
test/js/bun/plugin/plugins.test.ts                      2      6      3
test/js/bun/test/mock-fn.test.js                        1      2      3
test/js/bun/test/test-timers.test.ts                    2      3      6
test/js/node/string_decoder/string-decoder.test.js      1      0      3
```

</details>

<!-- robobun:evidence:end -->