### PR TITLE
Substitute top-level this with undefined in ES modules

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6032,7 +6032,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // compile time using expression substitution here.
                 return Some(Expr {
                     loc,
-                    data: null_value_expr(),
+                    data: js_ast::ExprData::EUndefined(E::Undefined {}),
                 });
             } else {
                 // In a CommonJS module, "this" is supposed to be the same as "exports".
@@ -10274,10 +10274,6 @@ pub(crate) fn null_expr_data() -> js_ast::ExprData {
 #[inline]
 pub(crate) fn null_stmt_data() -> js_ast::StmtData {
     js_ast::StmtData::SEmpty(S::Empty {})
-}
-#[inline]
-pub(crate) fn null_value_expr() -> js_ast::ExprData {
-    js_ast::ExprData::ENull(E::Null {})
 }
 
 /// `require()` of an ES module returns a copy of the namespace with

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -265,9 +265,7 @@ impl<'a> Options<'a> {
             hasher.update(b"udfcf=0");
         }
 
-        // `exports_kind` for a file with no module syntax is decided by
-        // `module_type`, so byte-identical sources in an ESM package and a
-        // CommonJS package are different cache entries.
+        // `exports_kind` falls back to `module_type` when the content does not decide.
         hasher.update(&[self.module_type as u8]);
 
         self.features.hash_for_runtime_transpiler(hasher);

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -265,6 +265,11 @@ impl<'a> Options<'a> {
             hasher.update(b"udfcf=0");
         }
 
+        // `exports_kind` for a file with no module syntax is decided by
+        // `module_type`, so byte-identical sources in an ESM package and a
+        // CommonJS package are different cache entries.
+        hasher.update(&[self.module_type as u8]);
+
         self.features.hash_for_runtime_transpiler(hasher);
     }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,8 +57,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-/// Version 30: Top-level `this` in an ES module is `undefined`, not `null` (#32167),
-/// and `module_type` participates in the features hash.
+/// Version 30: ESM top-level `this` is `undefined`, not `null`; `module_type` is in the features hash.
 const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: Top-level `this` in an ES module is `undefined`, not `null` (#32167),
+/// and `module_type` participates in the features hash.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -5313,7 +5313,7 @@ describe.concurrent("bundler", () => {
       "/node_modules/pkg/file2.js": `export default [this, this]`,
     },
     run: {
-      stdout: "[ null, null ] [ null, null ]",
+      stdout: "[ undefined, undefined ] [ undefined, undefined ]",
     },
   });
   itBundled("default/QuotedProperty", {

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,48 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32167
+describe.concurrent("top-level this", () => {
+  const files = {
+    // the issue's repro: an import-only entry point, `this` captured by an arrow
+    "import-only.js": `import { EventEmitter } from "node:events";
+const emitter = new EventEmitter();
+emitter.on("event", () => {
+  console.log(typeof this, this === undefined);
+});
+emitter.emit("event");
+`,
+    "export-only.mjs": `export {};\nconsole.log(typeof this, this === undefined);\n`,
+    // an imported (not entry point) ES module goes through the async transpiler path
+    "imports-esm.js": `import { kind, isUndefined } from "./dep.mjs";\nconsole.log(kind, isUndefined);\n`,
+    "dep.mjs": `export const kind = typeof this;\nexport const isUndefined = this === undefined;\n`,
+    // CommonJS keeps `this === module.exports`, also when imported from an ES module
+    // in a "type": "module" package
+    "package.json": `{ "type": "module" }`,
+    "cjs.cjs": `console.log(typeof this, this === module.exports);\n`,
+    "imports-cjs.js": `import dep from "./dep.cjs";\nconsole.log(dep.kind, dep.isExports);\n`,
+    "dep.cjs": `var self = this;\nmodule.exports = { kind: typeof self, isExports: self === exports };\n`,
+  };
+
+  for (const [file, expected] of [
+    ["import-only.js", "undefined true\n"],
+    ["export-only.mjs", "undefined true\n"],
+    ["imports-esm.js", "undefined true\n"],
+    ["cjs.cjs", "object true\n"],
+    ["imports-cjs.js", "object true\n"],
+  ]) {
+    test(file, async () => {
+      using dir = tempDir("top-level-this", files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), file],
+        env: bunEnv,
+        cwd: String(dir),
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr }).toEqual({ stdout: expected, stderr: "" });
+      expect(exitCode).toBe(0);
+    });
+  }
+});

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -3722,6 +3722,22 @@ class Foo {
     );
   });
 
+  // https://github.com/oven-sh/bun/issues/32167
+  it("top-level this is undefined in an ES module and exports in CommonJS", () => {
+    expectPrinted_("export {}; console.log(this)", "export {};\nconsole.log(undefined)");
+    expectPrinted_('import "foo"; console.log(this)', 'import"foo";\nconsole.log(undefined)');
+    expectPrinted_(
+      "export {}; console.log(typeof this, this === undefined)",
+      'export {};\nconsole.log("undefined", true)',
+    );
+    expectPrinted_("export {}; const f = () => [this]", "export {};\nconst f = () => [undefined]");
+    // bare `delete undefined` is a SyntaxError in strict mode code
+    expectPrinted_("export {}; delete this", "export {};\ndelete (0, undefined)");
+    expectPrinted_("export {}; function f() { return this }", "export {};\nfunction f() {\n  return this;\n}");
+
+    expectPrinted_("console.log(this)", "console.log(exports)");
+  });
+
   it("declarations named eval or arguments, and reserved words, in strict mode", () => {
     expectParseError(
       '"use strict"; var arguments = 1',

--- a/test/cli/run/transpiler-cache.test.ts
+++ b/test/cli/run/transpiler-cache.test.ts
@@ -123,6 +123,27 @@ describe("transpiler cache", () => {
     expect(await bunRun(join(temp_dir, "main.js"), env)).toSpawn(expected);
     expect(!existsSync(cache_dir)).toBeTrue();
   });
+  test("byte-identical files with different package.json types do not share entries", async () => {
+    // A file with no import/export and no module/exports references is an ES
+    // module (strict) under "type": "module" and CommonJS (sloppy) under
+    // "type": "commonjs", so the package.json "type" must be part of the cache key.
+    const data = dummyFile(50 * 1024, "1", {
+      code: `(() => { try { undeclaredVariable = 1; return "sloppy"; } catch { return "strict"; } })()`,
+    });
+    mkdirSync(join(temp_dir, "esm"));
+    mkdirSync(join(temp_dir, "cjs"));
+    writeFileSync(join(temp_dir, "esm", "package.json"), '{ "type": "module" }');
+    writeFileSync(join(temp_dir, "cjs", "package.json"), '{ "type": "commonjs" }');
+    writeFileSync(join(temp_dir, "esm", "a.js"), data);
+    writeFileSync(join(temp_dir, "cjs", "a.js"), data);
+
+    expect(await bunRun(join(temp_dir, "esm", "a.js"), env)).toSpawn("strict");
+    expect(newCacheCount()).toBe(1);
+    // Same bytes in a CommonJS package must not be served the cached ES module entry.
+    expect(await bunRun(join(temp_dir, "cjs", "a.js"), env)).toSpawn("sloppy");
+    // And the reverse direction, now that the CommonJS entry was written last.
+    expect(await bunRun(join(temp_dir, "esm", "a.js"), env)).toSpawn("strict");
+  });
   test("it is indeed content addressable", async () => {
     writeFileSync(join(temp_dir, "a.js"), dummyFile(50 * 1024, "1", "b"));
     expect(await bunRun(join(temp_dir, "a.js"), env)).toSpawn("b");


### PR DESCRIPTION
Fixes #32167

### Problem
- In an ES module, a top-level `this` evaluates to `null` in bun: `typeof this` is `"object"` and `this === undefined` is `false`. Node and the spec give `undefined`. An arrow at module top level captures the same value, which is how the issue's `EventEmitter` repro shows it.
- The cause is `value_for_this` in `src/js_parser/p.rs:6029`. The parser substitutes a top-level `this` at compile time. For a file with ES module syntax it built `E::Null`. The comment above it says `undefined`, and so does the esbuild code it was ported from.

### Fix
- Substitute `E::Undefined`. The CommonJS branch (`this` is `exports`), the REPL path, and `this` nested in functions and class bodies are unchanged. The unused `null_value_expr` helper is removed.
- Bump `EXPECTED_VERSION` in `src/jsc/RuntimeTranspilerCache.rs` (29 to 30). The cache key does not include the bun version, so without the bump a cached module keeps the `null` output.
- Hash `module_type` into the transpiler cache features hash. `exports_kind` for a file with no module syntax is decided by `module_type`, so byte-identical files in a `"type": "module"` package and a `"type": "commonjs"` package shared one entry, and the first to run decided strict ESM or sloppy CommonJS for both.
- Verified: `test/bundler/transpiler/transpiler.test.js`, `runtime-transpiler.test.ts`, `test/cli/run/transpiler-cache.test.ts` (the new tests fail on 1.4.3), `esbuild/default.test.ts` (`ThisUndefinedWarningESM` now expects esbuild's output). Also ran `bundler_cjs`, `bundler_edgecase`, `esbuild/{dce,importstar,packagejson}`. Self-reviewed: 2 concerns raised, 2 addressed (see Notes).

### Background
- The visit pass rewrites every `E::This` outside a function. In an ES module it becomes a literal, so `typeof this` and `this === undefined` constant-fold from it. That is why the wrong literal also showed in folded output.
- The runtime transpiler cache stores transpiled output on disk for files of 4 KiB or more. An entry is keyed on the source hash plus a features hash of parser options. `src/js_parser/parser.rs` asks for a version bump on any parser change that affects output.
- `module_type` is `Esm`, `Cjs`, or `Unknown`, from the file extension or the package.json `"type"`. The parser reads it only to pick `exports_kind` when the file content does not decide.

<details><summary>Notes</summary>

- This PR supersedes #41515, which made the same `E::Null` to `E::Undefined` change without the cache version bump.
- An earlier revision of this branch also took the ESM branch when `module_type == Esm`, so that a `.mjs` or `"type": "module"` file with no import/export syntax gets `undefined` instead of `exports` (Node prints `undefined` there, bun prints `{}`). The self-review found that the runtime loader does not report `module_type` consistently yet: the async `import` path derives it from package.json only (`src/jsc/RuntimeTranspilerStore.rs:335`), so a `.cjs` file imported under `"type": "module"` reports `Esm`, and a nameless nested `{"type":"commonjs"}` package.json is only honored for files in its own directory (`read_dir_info_package_json` in `src/runtime/jsc_hooks.rs`). With the widening, `import dep from "./dep.cjs"` in a `"type": "module"` package gave `this === undefined` inside `dep.cjs` (verified), where Node and current bun give `module.exports`. That case is dropped from this PR. #33807 makes `module_type` authoritative at runtime and carries the same `value_for_this` change together with the loader fixes it needs. The new `imports-cjs.js` runtime test locks in the current `.cjs` behavior.
- The earlier revision also added `EUndefined` to the printer's delete-operand wrap (`delete this` would print `delete undefined`, a strict-mode SyntaxError). That has since landed on main in `is_identifier_or_numeric_constant_or_property_access`. The transpiler test still covers `delete (0, undefined)`.
- The earlier revision synced a `RUNTIME_TRANSPILER_CACHE_VERSION` mirror constant in `src/bundler/cache.rs`. That constant no longer exists on main.
- Cache poisoning repro on 1.4.3 with a 50 KiB file whose only code is `try { undeclaredVariable = 1; "sloppy" } catch { "strict" }`: run under `"type": "module"` then `"type": "commonjs"` prints `strict` twice. In the other order it prints `sloppy` twice. Node prints `strict` then `sloppy`. With `module_type` in the features hash bun matches Node in both orders.
- On 1.4.3, `export {}; console.log(typeof this, this === undefined, this === null)` prints `object false true`. Node prints `undefined true false`.

</details>
