### PR TITLE
node:http: report real connection endpoints on client req.socket

### DIFF
--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -3,7 +3,9 @@ use core::ptr::NonNull;
 use bun_core::MutableString;
 use bun_core::{Error, Output};
 
-use crate::{CertificateInfo, Decompressor, Encoding, HTTPRequestBody, HTTPResponseMetadata};
+use crate::{
+    CertificateInfo, ConnectionInfo, Decompressor, Encoding, HTTPRequestBody, HTTPResponseMetadata,
+};
 
 bun_core::define_scoped_log!(log, HTTPInternalState, hidden);
 
@@ -46,6 +48,10 @@ pub struct InternalState<'a> {
     pub request_stage: HTTPStage,
     pub response_stage: HTTPStage,
     pub certificate_info: Option<CertificateInfo>,
+    /// Endpoints of the current connection; captured in `HTTPClient::on_open`
+    /// for node:http client requests (`None` otherwise). Cleared by `reset()`
+    /// so each redirect hop reports its own connection.
+    pub connection_info: Option<ConnectionInfo>,
 }
 
 // Struct-of-bools so the
@@ -123,6 +129,7 @@ impl Default for InternalState<'_> {
             request_stage: HTTPStage::Pending,
             response_stage: HTTPStage::Pending,
             certificate_info: None,
+            connection_info: None,
         }
     }
 }

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -409,6 +409,40 @@ pub enum BodySize {
     Unknown,
 }
 
+/// Local/peer endpoints of the TCP connection a response arrived on.
+/// Captured on the HTTP thread in [`HTTPClient::on_open`] for node:http
+/// client requests only, so `req.socket` can report real address data.
+/// `None` for unix sockets and whenever the endpoints are unavailable.
+#[derive(Copy, Clone, Debug)]
+pub struct ConnectionInfo {
+    pub local: std::net::SocketAddr,
+    pub remote: std::net::SocketAddr,
+}
+
+impl ConnectionInfo {
+    fn from_socket<const IS_SSL: bool>(socket: &HttpSocket<IS_SSL>) -> Option<Self> {
+        fn to_ip(bytes: &[u8]) -> Option<std::net::IpAddr> {
+            // `us_socket_{local,remote}_address` yield 4 (IPv4) or 16 (IPv6)
+            // binary bytes; anything else (0 on failure / AF_UNIX) means no
+            // endpoint info.
+            match bytes.len() {
+                4 => Some(std::net::Ipv4Addr::from(<[u8; 4]>::try_from(bytes).unwrap()).into()),
+                16 => Some(std::net::Ipv6Addr::from(<[u8; 16]>::try_from(bytes).unwrap()).into()),
+                _ => None,
+            }
+        }
+        let mut buf = [0u8; 64];
+        let local_ip = to_ip(socket.local_address(&mut buf)?)?;
+        let local_port = u16::try_from(socket.local_port()).ok()?;
+        let remote_ip = to_ip(socket.remote_address(&mut buf)?)?;
+        let remote_port = u16::try_from(socket.remote_port()).ok()?;
+        Some(Self {
+            local: std::net::SocketAddr::new(local_ip, local_port),
+            remote: std::net::SocketAddr::new(remote_ip, remote_port),
+        })
+    }
+}
+
 #[derive(Default)]
 pub struct HTTPClientResult<'a> {
     pub body: Option<&'a mut MutableString>,
@@ -430,6 +464,7 @@ pub struct HTTPClientResult<'a> {
     /// If is not chunked encoded and Content-Length is not provided this will be unknown
     pub body_size: BodySize,
     pub certificate_info: Option<CertificateInfo>,
+    pub connection_info: Option<ConnectionInfo>,
 }
 
 impl<'a> HTTPClientResult<'a> {
@@ -480,6 +515,7 @@ impl<'a> HTTPClientResult<'a> {
             metadata: self.metadata,
             body_size: self.body_size,
             certificate_info: self.certificate_info,
+            connection_info: self.connection_info,
         }
     }
 }
@@ -1588,6 +1624,14 @@ impl<'a> HTTPClient<'a> {
         if self.signals.get(signals::Field::Aborted) {
             self.close_and_abort::<IS_SSL>(socket);
             return Err(err!(ClientAborted));
+        }
+
+        // Only node:http exposes the connection endpoints (via `req.socket`),
+        // so skip the getsockname/getpeername syscalls for plain fetch().
+        // Runs for fresh connects and adopted pooled sockets alike; a redirect
+        // resets the state and re-enters here with the follow-up socket.
+        if self.flags.is_node_http_client {
+            self.state.connection_info = ConnectionInfo::from_socket(&socket);
         }
 
         if self.state.request_stage == RequestStage::Pending {
@@ -3654,6 +3698,7 @@ impl<'a> HTTPClient<'a> {
             metadata,
             body_size,
             certificate_info,
+            connection_info,
         ) = {
             let r = self.to_result();
             (
@@ -3665,6 +3710,7 @@ impl<'a> HTTPClient<'a> {
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
+                r.connection_info,
             )
         }; // r (and its &mut borrow of self) dropped here
         let is_done = !has_more;
@@ -3789,6 +3835,7 @@ impl<'a> HTTPClient<'a> {
             metadata,
             body_size,
             certificate_info,
+            connection_info,
         };
         callback.run(async_http, result);
 
@@ -3828,6 +3875,7 @@ impl<'a> HTTPClient<'a> {
             metadata,
             body_size,
             certificate_info,
+            connection_info,
         ) = {
             let r = self.to_result();
             (
@@ -3839,6 +3887,7 @@ impl<'a> HTTPClient<'a> {
                 r.metadata,
                 r.body_size,
                 r.certificate_info,
+                r.connection_info,
             )
         }; // r (and its &mut borrow of self) dropped here
         let is_done = !has_more;
@@ -3866,6 +3915,7 @@ impl<'a> HTTPClient<'a> {
             metadata,
             body_size,
             certificate_info,
+            connection_info,
         };
         callback.run(async_http, result);
     }
@@ -4032,6 +4082,7 @@ impl<'a> HTTPClient<'a> {
                     || (self.state.fail.is_none() && !self.state.is_done()),
                 body_size,
                 certificate_info: None,
+                connection_info: self.state.connection_info,
                 can_stream: (self.state.request_stage == RequestStage::Body
                     || self.state.request_stage == RequestStage::ProxyBody)
                     && self.flags.is_streaming_request_body,
@@ -4048,6 +4099,7 @@ impl<'a> HTTPClient<'a> {
                 || (self.state.fail.is_none() && !self.state.is_done()),
             body_size,
             certificate_info,
+            connection_info: self.state.connection_info,
             // we can stream the request_body at this stage
             can_stream: (self.state.request_stage == RequestStage::Body
                 || self.state.request_stage == RequestStage::ProxyBody)

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -57,6 +57,9 @@ const kSignal = Symbol("signal");
 const kMaxHeaderSize = Symbol("maxHeaderSize");
 const abortedSymbol = Symbol("aborted");
 const kClearTimeout = Symbol("kClearTimeout");
+// Real local/peer endpoints of the connection a ClientRequest's response
+// arrived on; set in _http_client.ts, read by FakeSocket's address getters.
+const kConnectionInfo = Symbol("connectionInfo");
 
 const headerStateSymbol = Symbol("headerState");
 // used for pretending to emit events in the right order
@@ -514,6 +517,7 @@ export {
   kBodyChunks,
   kClearTimeout,
   kCloseCallback,
+  kConnectionInfo,
   kDeferredTimeouts,
   kDeprecatedReplySymbol,
   kEmitState,

--- a/src/js/internal/http/FakeSocket.ts
+++ b/src/js/internal/http/FakeSocket.ts
@@ -1,6 +1,17 @@
-const { kInternalSocketData, serverSymbol } = require("internal/http");
+const { kInternalSocketData, kConnectionInfo, serverSymbol } = require("internal/http");
 const { kAutoDestroyed } = require("internal/shared");
 const { Duplex } = require("internal/stream");
+
+// node:http client over fetch: the real endpoints of the connection the
+// response arrived on, captured in _http_client.ts once the fetch resolves.
+// Reached through either the ClientRequest (req.socket) or the client
+// IncomingMessage (res.socket, via res.req). undefined on the server side and
+// before the response arrives. A plain function (not a #private method)
+// because these getters can run with a non-FakeSocket receiver.
+function clientConnectionInfo(socket) {
+  const message = socket._httpMessage;
+  return message?.[kConnectionInfo] ?? message?.req?.[kConnectionInfo];
+}
 
 type FakeSocket = InstanceType<typeof FakeSocket>;
 var FakeSocket = class Socket extends Duplex {
@@ -44,15 +55,17 @@ var FakeSocket = class Socket extends Duplex {
   _final(_callback) {}
 
   get localAddress() {
+    const info = clientConnectionInfo(this);
+    if (info) return info.localAddress;
     return this.address() ? "127.0.0.1" : undefined;
   }
 
   get localFamily() {
-    return "IPv4";
+    return clientConnectionInfo(this)?.localFamily ?? "IPv4";
   }
 
   get localPort() {
-    return 80;
+    return clientConnectionInfo(this)?.localPort ?? 80;
   }
 
   get pending() {
@@ -75,7 +88,7 @@ var FakeSocket = class Socket extends Duplex {
   }
 
   get remoteAddress() {
-    return this.address()?.address;
+    return this.address()?.address ?? clientConnectionInfo(this)?.remoteAddress;
   }
 
   set remoteAddress(val) {
@@ -84,7 +97,7 @@ var FakeSocket = class Socket extends Duplex {
   }
 
   get remotePort() {
-    return this.address()?.port;
+    return this.address()?.port ?? clientConnectionInfo(this)?.remotePort;
   }
 
   set remotePort(val) {
@@ -93,7 +106,7 @@ var FakeSocket = class Socket extends Duplex {
   }
 
   get remoteFamily() {
-    return this.address()?.family;
+    return this.address()?.family ?? clientConnectionInfo(this)?.remoteFamily;
   }
 
   set remoteFamily(val) {

--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -11,6 +11,9 @@ const {
 
 // Internal fetch that allows body on GET/HEAD/OPTIONS for Node.js compatibility
 const nodeHttpClient = $newZigFunction("fetch.zig", "nodeHttpClient", 2);
+// Real local/peer endpoints of the connection a response arrived on, so
+// req.socket can report them like Node does.
+const getFetchResponseConnectionInfo = $newZigFunction("fetch.zig", "getFetchResponseConnectionInfo", 1);
 const { urlToHttpOptions } = require("internal/url");
 const { throwOnInvalidTLSArray } = require("internal/tls");
 const { validateHeaderName } = require("node:_http_common");
@@ -44,6 +47,7 @@ const {
   kEmitState,
   ClientRequestEmitState,
   kSignal,
+  kConnectionInfo,
   kEmptyObject,
   getIsNextIncomingMessageHTTPS,
   setIsNextIncomingMessageHTTPS,
@@ -419,6 +423,8 @@ function ClientRequest(input, options, cb) {
           maybeEmitClose();
           return;
         }
+
+        this[kConnectionInfo] = getFetchResponseConnectionInfo(response);
 
         handleResponse = () => {
           this[kFetchRequest] = null;

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -196,6 +196,12 @@ pub struct Response {
 
     // We must report a consistent value for this
     reported_estimated_size: Cell<usize>,
+
+    /// Endpoints of the connection this response arrived on. Only set for
+    /// fetches issued by the node:http client (FetchTasklet::to_response);
+    /// read back through `getFetchResponseConnectionInfo` in fetch.rs.
+    /// Boxed so every other Response pays one null pointer, not ~72 bytes.
+    pub(crate) connection_info: Option<Box<bun_http::ConnectionInfo>>,
 }
 
 impl Default for Response {
@@ -209,6 +215,7 @@ impl Default for Response {
             weak_ptr_data: WeakPtrData::EMPTY,
             js_ref: JsCell::new(JsRef::empty()),
             reported_estimated_size: Cell::new(0),
+            connection_info: None,
         }
     }
 }
@@ -836,6 +843,7 @@ impl Response {
             init: JsCell::new(init),
             url: JsCell::new(self.url.get().clone()),
             redirected: Cell::new(self.redirected.get()),
+            connection_info: self.connection_info.clone(),
             ..Default::default()
         })
     }
@@ -865,6 +873,9 @@ impl Response {
             (*this).body.get_mut().reset();
             (*this).url.set(OwnedString::new(BunString::empty()));
             (*this).js_ref.set(JsRef::empty());
+            // `connection_info: Option<Box<_>>` — assignment drops the Box
+            // (the raw dealloc below runs no drop glue).
+            (*this).connection_info = None;
 
             // Contents are gone; the allocation itself stays until any outstanding
             // WeakRef derefs (RequestContext.response_weakref). WeakRef.get() returns

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -361,6 +361,66 @@ pub(crate) fn node_http_client(ctx: &JSGlobalObject, callframe: &CallFrame) -> J
     fetch_impl::<true>(ctx, callframe)
 }
 
+/// Internal binding for the Node.js HTTP client: local/peer endpoints of the
+/// connection a fetch `Response` arrived on, so `req.socket` can report real
+/// address data. Returns `undefined` when unknown (non-fetch Response, unix
+/// socket, connection info unavailable).
+pub(crate) fn get_fetch_response_connection_info(
+    ctx: &JSGlobalObject,
+    callframe: &CallFrame,
+) -> JsResult<JSValue> {
+    let arguments = callframe.arguments_old::<1>();
+    let response_value = arguments.ptr[0];
+    if response_value.is_empty_or_undefined_or_null() {
+        return Ok(JSValue::UNDEFINED);
+    }
+    let Some(response) = response_value.as_class_ref::<Response>() else {
+        return Ok(JSValue::UNDEFINED);
+    };
+    let Some(info) = response.connection_info.as_deref().copied() else {
+        return Ok(JSValue::UNDEFINED);
+    };
+
+    let object = JSValue::create_empty_object(ctx, 6);
+    let mut text_buf = [0u8; 64];
+    for (address_key, port_key, family_key, addr) in [
+        (
+            &b"localAddress"[..],
+            &b"localPort"[..],
+            &b"localFamily"[..],
+            info.local,
+        ),
+        (
+            &b"remoteAddress"[..],
+            &b"remotePort"[..],
+            &b"remoteFamily"[..],
+            info.remote,
+        ),
+    ] {
+        // `format_ip` strips the `:port` suffix and IPv6 brackets from the
+        // `SocketAddr` Display form, matching Node's address strings. 64 bytes
+        // always fit the Display form, so NoSpaceLeft is unreachable.
+        let text = bun_core::fmt::format_ip(&addr, &mut text_buf).expect("unreachable");
+        let address_js = bun_jsc::bun_string_jsc::create_utf8_for_js(ctx, text)?;
+        object.put(ctx, address_key, address_js);
+        object.put(
+            ctx,
+            port_key,
+            JSValue::js_number_from_int32(i32::from(addr.port())),
+        );
+        object.put(
+            ctx,
+            family_key,
+            if addr.is_ipv6() {
+                ctx.common_strings().ipv6()
+            } else {
+                ctx.common_strings().ipv4()
+            },
+        );
+    }
+    Ok(object)
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // URLType
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -1638,7 +1638,7 @@ impl FetchTasklet {
         };
         let url = BunString::clone_utf8(metadata.url.slice());
         let redirected = self.result.redirected;
-        Response::init(
+        let mut response = Response::init(
             crate::webcore::response::Init {
                 // SAFETY: create_from_pico_headers returns a fresh refcount=1 FetchHeaders*.
                 headers: Some(unsafe { HeadersRef::adopt(headers) }),
@@ -1649,7 +1649,11 @@ impl FetchTasklet {
             Body::new(self.to_body_value()),
             url,
             redirected,
-        )
+        );
+        // node:http reads these via getFetchResponseConnectionInfo so
+        // `req.socket` can report the real endpoints.
+        response.connection_info = self.result.connection_info.map(Box::new);
+        response
     }
 
     fn ignore_remaining_response_body(&mut self) {
@@ -2215,6 +2219,7 @@ impl FetchTasklet {
         let prev_metadata = task_ref.result.metadata.take();
         let prev_cert_info = task_ref.result.certificate_info.take();
         let prev_can_stream = task_ref.result.can_stream;
+        let prev_connection_info = task_ref.result.connection_info;
         // SAFETY: lifetime erasure — `HTTPClientResult<'a>` borrows the
         // `*mut MutableString` we passed into `AsyncHTTP::init` (which lives
         // in `self.response_buffer` for the FetchTasklet's lifetime); widen
@@ -2229,6 +2234,11 @@ impl FetchTasklet {
             if let Some(cert_info) = prev_cert_info {
                 task_ref.result.certificate_info = Some(cert_info);
             }
+        }
+
+        // Keep previously reported connection endpoints if this update lacks them.
+        if task_ref.result.connection_info.is_none() {
+            task_ref.result.connection_info = prev_connection_info;
         }
 
         // metadata should be provided only once

--- a/test/js/node/http/node-http-client-socket-endpoints.test.ts
+++ b/test/js/node/http/node-http-client-socket-endpoints.test.ts
@@ -48,13 +48,19 @@ it("client req.socket reports the connection's real endpoints", async () => {
 
     // res.socket reports the same connection.
     expect({
+      localAddress: res.socket.localAddress,
       localPort: res.socket.localPort,
-      remotePort: res.socket.remotePort,
+      localFamily: res.socket.localFamily,
       remoteAddress: res.socket.remoteAddress,
+      remotePort: res.socket.remotePort,
+      remoteFamily: res.socket.remoteFamily,
     }).toEqual({
+      localAddress: peer.remoteAddress,
       localPort: peer.remotePort,
-      remotePort: port,
+      localFamily: "IPv4",
       remoteAddress: "127.0.0.1",
+      remotePort: port,
+      remoteFamily: "IPv4",
     });
 
     res.resume();

--- a/test/js/node/http/node-http-client-socket-endpoints.test.ts
+++ b/test/js/node/http/node-http-client-socket-endpoints.test.ts
@@ -1,0 +1,65 @@
+// https://github.com/oven-sh/bun/issues/32169
+// The node:http client's req.socket must report the connection's real
+// local/peer endpoints like Node.js does, not placeholder values.
+// This test also passes when run under Node.js.
+import { expect, it } from "bun:test";
+import { once } from "node:events";
+import http, { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+it("client req.socket reports the connection's real endpoints", async () => {
+  const peerSeenByServer = Promise.withResolvers<{ remoteAddress: string; remotePort: number }>();
+  const server = createServer((req, res) => {
+    peerSeenByServer.resolve({
+      remoteAddress: req.socket.remoteAddress!,
+      remotePort: req.socket.remotePort!,
+    });
+    res.end("hello");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    let req!: import("node:http").ClientRequest;
+    const res = await new Promise<import("node:http").IncomingMessage>((resolve, reject) => {
+      req = http.get({ host: "127.0.0.1", port }, resolve);
+      req.on("error", reject);
+    });
+    const peer = await peerSeenByServer.promise;
+
+    // What the client reports about itself must match what the server
+    // observed about it, and vice versa.
+    expect({
+      localAddress: req.socket.localAddress,
+      localPort: req.socket.localPort,
+      localFamily: req.socket.localFamily,
+      remoteAddress: req.socket.remoteAddress,
+      remotePort: req.socket.remotePort,
+      remoteFamily: req.socket.remoteFamily,
+    }).toEqual({
+      localAddress: peer.remoteAddress,
+      localPort: peer.remotePort,
+      localFamily: "IPv4",
+      remoteAddress: "127.0.0.1",
+      remotePort: port,
+      remoteFamily: "IPv4",
+    });
+
+    // res.socket reports the same connection.
+    expect({
+      localPort: res.socket.localPort,
+      remotePort: res.socket.remotePort,
+      remoteAddress: res.socket.remoteAddress,
+    }).toEqual({
+      localPort: peer.remotePort,
+      remotePort: port,
+      remoteAddress: "127.0.0.1",
+    });
+
+    res.resume();
+    await once(res, "end");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Fixes #32169

### Problem

`req.socket` on the node:http client reported fake endpoint data. With a request like:

```js
const req = http.get(options);
req.once("response", (res) => {
  console.log(req.socket.localAddress, req.socket.localPort);
});
```

Node prints the machine's real address and the ephemeral source port; Bun always printed `127.0.0.1` and `80`, and `remoteAddress`/`remotePort`/`remoteFamily` were `undefined`. The client is implemented over fetch, and `req.socket` is a `FakeSocket` whose getters were hardcoded constants with no plumbing from the native connection.

### Fix

Capture the socket's local/peer endpoints on the HTTP thread and plumb them through to the `FakeSocket` getters:

- `HTTPClient::on_open` (src/http/lib.rs) captures `getsockname`/`getpeername` data into a new `ConnectionInfo { local, remote }` on the request state. Gated on `is_node_http_client` so plain `fetch()` pays no extra syscalls. `on_open` runs for fresh connects and adopted pooled sockets, and again after a redirect resets the state, so each response reports the connection it actually arrived on.
- `HTTPClientResult` carries the info to the JS thread; `FetchTasklet` stores it on the `Response` (boxed: `Option<Box<ConnectionInfo>>`, so every other Response pays 8 bytes; freed explicitly in `Response::destroy`, which deallocates without drop glue).
- A new internal binding `getFetchResponseConnectionInfo` (src/runtime/webcore/fetch.rs) returns `{localAddress, localPort, localFamily, remoteAddress, remotePort, remoteFamily}`; `_http_client.ts` stashes it on the `ClientRequest` when the fetch resolves.
- `FakeSocket`'s six address getters prefer the real endpoints (reachable from both `req.socket` and `res.socket`) and keep the previous fallbacks when none are known (server side, before the response arrives, unix sockets), so no existing behavior changes there.

HTTP/2 streams coalesced onto an existing session don't pass through `on_open` and keep reporting the fallbacks (that path is behind `--experimental-http2-fetch`).

### Out of scope

The issue also notes that Node keeps the process alive while an unconsumed response's socket is open, whereas Bun exits. That's an event-loop liveness divergence in the fetch-backed client, independent of the endpoint data, and making unconsumed client responses pin the event loop would change exit behavior for existing programs, so it needs a separate discussion.

### Verification

New test `test/js/node/http/node-http-client-socket-endpoints.test.ts` cross-checks the client's view against the server's: `req.socket.localAddress/localPort` must equal the `remoteAddress`/`remotePort` the server observed for the connection, and `req.socket.remotePort` must equal the server's port; same for `res.socket`. On the unfixed build it fails with `localPort: 80` and `remoteAddress/remotePort/remoteFamily: undefined`; it passes with this change and the identical logic passes under Node v24. (Standalone file rather than an addition to node-http.test.ts because that file's proxy test is sensitive to the sandbox's localhost/proxy environment; the new test must be green on its own.)

Also verified manually (in addition to the test): HTTPS, IPv6 (`::1`, family `IPv6`), keep-alive agent socket reuse, and that requests through an HTTP proxy report the proxy connection's endpoints (the socket's actual peer).
