### PR TITLE
Apply implicit strict mode to files forced to ESM by .mjs or package.json type module

### DIFF
--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1207,10 +1207,9 @@ pub enum StrictModeKind {
 }
 
 impl StrictModeKind {
-    /// Strictness that is final. `ImplicitStrictModeModuleType` is provisional
-    /// until `exports_kind` is classified, so decisions that shape the output
-    /// before then (hoisting, mapped `arguments`, duplicate parameters) treat
-    /// it as sloppy; diagnostics go through the deferral queue instead.
+    /// Final strictness. `ImplicitStrictModeModuleType` is provisional until
+    /// `exports_kind` is classified, so structural decisions made before then
+    /// (Annex B hoisting, mapped `arguments`) treat it as sloppy.
     pub fn is_settled_strict(self) -> bool {
         !matches!(self, Self::SloppyMode | Self::ImplicitStrictModeModuleType)
     }

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1199,6 +1199,11 @@ pub enum StrictModeKind {
     ImplicitStrictModeExport,
     ImplicitStrictModeTopLevelAwait,
     ImplicitStrictModeClass,
+    /// Strict only because ".mjs"/".mts" or package.json "type": "module"
+    /// forces ESM. Errors under this kind are deferred until `exports_kind`
+    /// is known and emitted only for `ExportsKind::Esm`; every other
+    /// classification executes as sloppy CommonJS and discards them.
+    ImplicitStrictModeModuleType,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]

--- a/src/ast/nodes.rs
+++ b/src/ast/nodes.rs
@@ -1206,6 +1206,16 @@ pub enum StrictModeKind {
     ImplicitStrictModeModuleType,
 }
 
+impl StrictModeKind {
+    /// Strictness that is final. `ImplicitStrictModeModuleType` is provisional
+    /// until `exports_kind` is classified, so decisions that shape the output
+    /// before then (hoisting, mapped `arguments`, duplicate parameters) treat
+    /// it as sloppy; diagnostics go through the deferral queue instead.
+    pub fn is_settled_strict(self) -> bool {
+        !matches!(self, Self::SloppyMode | Self::ImplicitStrictModeModuleType)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, strum::IntoStaticStr)]
 pub enum ToJSError {
     #[strum(serialize = "Cannot convert argument type to JS")]

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -532,7 +532,12 @@ impl Scope {
     }
 
     pub fn recursive_set_strict_mode(&mut self, kind: StrictModeKind) {
-        if self.strict_mode == StrictModeKind::SloppyMode {
+        // Class bodies are unconditionally strict, so the class kind overrides
+        // `ImplicitStrictModeModuleType`, whose deferred errors may be discarded.
+        if self.strict_mode == StrictModeKind::SloppyMode
+            || (kind == StrictModeKind::ImplicitStrictModeClass
+                && self.strict_mode == StrictModeKind::ImplicitStrictModeModuleType)
+        {
             self.strict_mode = kind;
             for child in self.children.slice_mut() {
                 child.recursive_set_strict_mode(kind);

--- a/src/js_parser/lexer.rs
+++ b/src/js_parser/lexer.rs
@@ -3185,6 +3185,10 @@ impl<'a> Lexer<'a> {
             let is_invalid_legacy_octal_literal =
                 first == 0x30 && (self.code_point == 0x38 || self.code_point == 0x39);
 
+            // "08"/"09" are decimal but count as legacy octal literals for
+            // strict-mode errors; the parser consumes the flag after the scan.
+            self.is_legacy_octal_literal = is_invalid_legacy_octal_literal;
+
             // Initial digits;
             loop {
                 if self.code_point < 0x30 || self.code_point > 0x39 {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3607,13 +3607,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let original_member_ref = value.ref_;
 
                     if self.symbols[symbol_idx].kind == js_ast::symbol::Kind::HoistedFunction {
-                        // Block-level function declarations behave like "let" in strict
-                        // mode. Hoisting runs before `exports_kind` classification, so
-                        // `ImplicitStrictModeModuleType` keeps the sloppy Annex B behavior.
-                        if scope_strict_mode != js_ast::StrictModeKind::SloppyMode
-                            && scope_strict_mode
-                                != js_ast::StrictModeKind::ImplicitStrictModeModuleType
-                        {
+                        // Block-level function declarations behave like "let" in strict mode
+                        if scope_strict_mode.is_settled_strict() {
                             continue;
                         }
 
@@ -5105,6 +5100,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     #[inline]
     pub(crate) fn is_strict_mode(&self) -> bool {
         self.current_scope().strict_mode != js_ast::StrictModeKind::SloppyMode
+    }
+
+    /// See `StrictModeKind::is_settled_strict`.
+    #[inline]
+    pub(crate) fn is_settled_strict_mode(&self) -> bool {
+        self.current_scope().strict_mode.is_settled_strict()
     }
 
     #[inline]

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -309,6 +309,17 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
 
     pub(crate) is_file_considered_to_have_esm_exports: bool,
 
+    /// Source ranges of legacy octal number literals (e.g. `010`, `08`), keyed
+    /// by the literal's location. Recorded during the parse pass; the visit
+    /// pass reports them as errors when the enclosing scope is in strict mode.
+    pub(crate) legacy_octal_literals: HashMap<bun_ast::Loc, bun_ast::Range>,
+
+    /// Strict-mode errors from scopes that are strict only via
+    /// `ImplicitStrictModeModuleType`; emitted or discarded by
+    /// `flush_deferred_forced_esm_strict_features` once `exports_kind` is known.
+    pub(crate) deferred_forced_esm_strict_features:
+        List<'a, (StrictModeFeature, bun_ast::Range, &'a [u8])>,
+
     pub(crate) has_called_runtime: bool,
 
     /// The current part's symbol uses, built from `part_uses` when the part
@@ -3391,6 +3402,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         } else if self.top_level_await_keyword.len > 0 {
             self.module_scope_mut()
                 .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait);
+        } else if self.options.module_type == options::ModuleType::Esm
+            && !self.has_with_scope
+            && !self.has_top_level_return
+        {
+            // No ESM syntax, only the extension/package.json forces ESM; the
+            // file may still classify as CommonJS, so errors under this kind
+            // are deferred. `with`/top-level return already prove CommonJS.
+            self.module_scope_mut()
+                .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeModuleType);
         }
 
         self.hoist_symbols(self.module_scope_ref());
@@ -3587,8 +3607,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     let original_member_ref = value.ref_;
 
                     if self.symbols[symbol_idx].kind == js_ast::symbol::Kind::HoistedFunction {
-                        // Block-level function declarations behave like "let" in strict mode
-                        if scope_strict_mode != js_ast::StrictModeKind::SloppyMode {
+                        // Block-level function declarations behave like "let" in strict
+                        // mode. Hoisting runs before `exports_kind` classification, so
+                        // `ImplicitStrictModeModuleType` keeps the sloppy Annex B behavior.
+                        if scope_strict_mode != js_ast::StrictModeKind::SloppyMode
+                            && scope_strict_mode
+                                != js_ast::StrictModeKind::ImplicitStrictModeModuleType
+                        {
                             continue;
                         }
 
@@ -4901,9 +4926,35 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         &mut self,
         feature: StrictModeFeature,
         r: bun_ast::Range,
-        detail: &[u8],
+        detail: &'a [u8],
     ) -> Result<(), crate::Error> {
-        let text: &'a [u8] = match feature {
+        if self.is_strict_mode() {
+            let strict_mode = self.current_scope().strict_mode;
+            if strict_mode == js_ast::StrictModeKind::ImplicitStrictModeModuleType {
+                // Strictness from this kind is provisional: the file may still
+                // classify as sloppy CommonJS. Queue the error; `parse_entry.rs`
+                // flushes or discards it once `exports_kind` is known.
+                self.deferred_forced_esm_strict_features
+                    .push((feature, r, detail));
+            } else {
+                self.strict_mode_feature_error(feature, r, detail, strict_mode);
+            }
+        } else if self.is_strict_mode_output_format() {
+            let text = self.strict_mode_feature_text(feature, detail);
+            self.log().add_range_error_fmt(
+                Some(self.source),
+                r,
+                format_args!(
+                    "{} cannot be used with the ESM output format due to strict mode",
+                    bstr::BStr::new(text)
+                ),
+            );
+        }
+        Ok(())
+    }
+
+    fn strict_mode_feature_text(&self, feature: StrictModeFeature, detail: &[u8]) -> &'a [u8] {
+        match feature {
             StrictModeFeature::EvalOrArguments => bun_alloc::arena_format!(
                 in self.arena,
                 "Declarations with the name \"{}\"",
@@ -4918,57 +4969,137 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             )
             .into_bump_str()
             .as_bytes(),
-        };
+            StrictModeFeature::LegacyOctalLiteral => b"Legacy octal literals",
+        }
+    }
 
-        let scope = self.current_scope();
-        if self.is_strict_mode() {
-            let mut why: &'a [u8] = b"";
-            let mut where_: bun_ast::Range = bun_ast::Range::NONE;
-            match scope.strict_mode {
-                js_ast::StrictModeKind::ImplicitStrictModeImport => {
-                    where_ = self.esm_import_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeExport => {
-                    where_ = self.esm_export_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait => {
-                    where_ = self.top_level_await_keyword
-                }
-                js_ast::StrictModeKind::ImplicitStrictModeClass => {
-                    why = b"All code inside a class is implicitly in strict mode";
-                    where_ = self.enclosing_class_keyword;
-                }
-                _ => {}
+    fn strict_mode_feature_error(
+        &mut self,
+        feature: StrictModeFeature,
+        r: bun_ast::Range,
+        detail: &[u8],
+        strict_mode: js_ast::StrictModeKind,
+    ) {
+        let text = self.strict_mode_feature_text(feature, detail);
+        let mut why: &'a [u8] = b"";
+        let mut where_: bun_ast::Range = bun_ast::Range::NONE;
+        match strict_mode {
+            js_ast::StrictModeKind::ImplicitStrictModeImport => where_ = self.esm_import_keyword,
+            js_ast::StrictModeKind::ImplicitStrictModeExport => where_ = self.esm_export_keyword,
+            js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait => {
+                where_ = self.top_level_await_keyword
             }
-            if why.is_empty() {
-                why = bun_alloc::arena_format!(
-                    in self.arena,
-                    "This file is implicitly in strict mode because of the \"{}\" keyword here",
-                    bstr::BStr::new(self.source.text_for_range(where_))
-                )
-                .into_bump_str()
-                .as_bytes();
+            js_ast::StrictModeKind::ImplicitStrictModeClass => {
+                why = b"All code inside a class is implicitly in strict mode";
+                where_ = self.enclosing_class_keyword;
             }
-            // bun_ast::Data is !Copy (Cow) — build the notes Box directly.
-            let notes: Box<[bun_ast::Data]> =
-                Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())]);
-            self.log().add_range_error_fmt_with_notes(
-                Some(self.source),
+            js_ast::StrictModeKind::ImplicitStrictModeModuleType => {
+                // No source keyword to point at; the note carries no location.
+                let ext = self.source.path.name().ext;
+                why = if ext == b".mjs" {
+                    b"This file is implicitly in strict mode because the \".mjs\" extension makes it an ECMAScript module"
+                } else if ext == b".mts" {
+                    b"This file is implicitly in strict mode because the \".mts\" extension makes it an ECMAScript module"
+                } else {
+                    b"This file is implicitly in strict mode because the enclosing package.json sets \"type\" to \"module\", making it an ECMAScript module"
+                };
+            }
+            js_ast::StrictModeKind::ExplicitStrictMode => {
+                if self.module_scope_directive_loc.start >= 0 {
+                    why =
+                        b"This file is in strict mode because of the \"use strict\" directive here";
+                    where_ = self.source.range_of_string(self.module_scope_directive_loc);
+                } else {
+                    // Directive in an untracked nested scope; no location.
+                    why = b"This code is in strict mode because of a \"use strict\" directive";
+                }
+            }
+            _ => {}
+        }
+        if why.is_empty() {
+            why = bun_alloc::arena_format!(
+                in self.arena,
+                "This file is implicitly in strict mode because of the \"{}\" keyword here",
+                bstr::BStr::new(self.source.text_for_range(where_))
+            )
+            .into_bump_str()
+            .as_bytes();
+        }
+        // bun_ast::Data is !Copy (Cow) — build the notes Box directly.
+        let notes: Box<[bun_ast::Data]> = if where_ == bun_ast::Range::NONE {
+            Box::new([bun_ast::Data {
+                text: why.to_vec().into(),
+                ..Default::default()
+            }])
+        } else {
+            Box::new([bun_ast::range_data(Some(self.source), where_, why.to_vec())])
+        };
+        self.log().add_range_error_fmt_with_notes(
+            Some(self.source),
+            r,
+            notes,
+            format_args!("{} cannot be used in strict mode", bstr::BStr::new(text)),
+        );
+    }
+
+    /// Emit or discard the `ImplicitStrictModeModuleType` error queue once
+    /// `exports_kind` is final: only a file that executes as an ES module is
+    /// really strict; CommonJS-classified files run sloppy via the interop.
+    pub(crate) fn flush_deferred_forced_esm_strict_features(&mut self, is_esm: bool) {
+        if self.deferred_forced_esm_strict_features.is_empty() {
+            return;
+        }
+        let deferred = core::mem::replace(
+            &mut self.deferred_forced_esm_strict_features,
+            BumpVec::new_in(self.arena),
+        );
+        if !is_esm {
+            // Not strict-mode errors (the file runs sloppy), but bundling to
+            // an ESM output format puts the CommonJS wrapper inside a strict
+            // module, so re-apply the sloppy-scope output-format check.
+            if self.is_strict_mode_output_format() {
+                for (feature, r, detail) in deferred {
+                    // These never survive into the printed output: the printer
+                    // emits `E::Number` from its f64 (`010` is already `8`) and
+                    // the renamer remaps bound reserved words; unbound
+                    // reserved-word references behave as before this queue (#32193).
+                    if matches!(
+                        feature,
+                        StrictModeFeature::LegacyOctalLiteral | StrictModeFeature::ReservedWord
+                    ) {
+                        continue;
+                    }
+                    let text = self.strict_mode_feature_text(feature, detail);
+                    self.log().add_range_error_fmt(
+                        Some(self.source),
+                        r,
+                        format_args!(
+                            "{} cannot be used with the ESM output format due to strict mode",
+                            bstr::BStr::new(text)
+                        ),
+                    );
+                }
+            }
+            return;
+        }
+        for (feature, r, detail) in deferred {
+            self.strict_mode_feature_error(
+                feature,
                 r,
-                notes,
-                format_args!("{} cannot be used in strict mode", bstr::BStr::new(text)),
-            );
-        } else if self.is_strict_mode_output_format() {
-            self.log().add_range_error_fmt(
-                Some(self.source),
-                r,
-                format_args!(
-                    "{} cannot be used with the ESM output format due to strict mode",
-                    bstr::BStr::new(text)
-                ),
+                detail,
+                js_ast::StrictModeKind::ImplicitStrictModeModuleType,
             );
         }
-        Ok(())
+    }
+
+    /// Record the numeric literal at `loc` when the lexer scanned it as a
+    /// legacy octal literal (e.g. `010` or `08`) so the visit pass can report
+    /// it if the enclosing scope turns out to be in strict mode. Must be
+    /// called while the literal is still the lexer's current token.
+    pub fn check_for_legacy_octal_literal(&mut self, loc: bun_ast::Loc) {
+        if self.lexer.is_legacy_octal_literal {
+            self.legacy_octal_literals.insert(loc, self.lexer.range());
+        }
     }
 
     #[inline]
@@ -9664,6 +9795,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         };
 
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
+        fn_or_arrow_data_parse.is_outside_fn_or_arrow = true;
         if opts.features.top_level_await || SCAN_ONLY {
             fn_or_arrow_data_parse.allow_await = crate::AwaitOrYield::AllowExpr;
             fn_or_arrow_data_parse.is_top_level = true;
@@ -9750,6 +9882,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_with_scope: false,
             has_top_level_function_merged_with_var: false,
             is_file_considered_to_have_esm_exports: false,
+            legacy_octal_literals: Default::default(),
+            deferred_forced_esm_strict_features: BumpVec::new_in(arena),
             has_called_runtime: false,
             symbol_uses,
             part_uses: Vec::new(),

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1182,7 +1182,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
             T::TNumericLiteral => {
                 key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                // check for legacy octal literal
+                p.check_for_legacy_octal_literal(key.loc);
                 p.lexer.next()?;
             }
             T::TStringLiteral => {

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1953,6 +1953,10 @@ impl<'a> Parser<'a> {
             exports_kind = js_ast::ExportsKind::EsmWithDynamicFallbackFromCjs;
         }
 
+        // `exports_kind` is final here; only `ExportsKind::Esm` executes as a
+        // real (strict) ES module, every other classification runs sloppy.
+        p.flush_deferred_forced_esm_strict_features(exports_kind == js_ast::ExportsKind::Esm);
+
         // Auto inject jest globals into the test file
         'outer: {
             if !p.options.features.inject_jest_globals {

--- a/src/js_parser/parse/parse_prefix.rs
+++ b/src/js_parser/parse/parse_prefix.rs
@@ -308,7 +308,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     fn pfx_t_numeric_literal(p: &mut Self) -> PResult<Expr> {
         let loc = p.lexer.loc();
         let value = p.new_expr(E::Number::new(p.lexer.number), loc);
-        // p.checkForLegacyOctalLiteral()
+        p.check_for_legacy_octal_literal(loc);
         p.lexer.next()?;
         Ok(value)
     }

--- a/src/js_parser/parse/parse_property.rs
+++ b/src/js_parser/parse/parse_property.rs
@@ -261,7 +261,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match p.lexer.token {
                 T::TNumericLiteral => {
                     key = p.new_expr(E::Number::new(p.lexer.number), p.lexer.loc());
-                    // p.checkForLegacyOctalLiteral()
+                    p.check_for_legacy_octal_literal(key.loc);
                     p.lexer.next()?;
                 }
                 T::TStringLiteral => {

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -752,6 +752,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 b"A return statement cannot be used here",
             );
         }
+        if p.fn_or_arrow_data_parse.is_outside_fn_or_arrow
+            && !p.options.features.remove_cjs_module_wrapper
+            && !p.options.repl_mode
+        {
+            // A top-level return classifies the file as CommonJS. `[eval]` and
+            // `[stdin]` run as a bare program with no wrapper for the return
+            // (`node -e "return"` is a SyntaxError too), and the REPL wraps
+            // input in an IIFE, so both are excluded.
+            p.has_top_level_return = true;
+        }
         p.lexer.next()?;
         let mut value: Option<Expr> = None;
         if p.lexer.token != T::TSemicolon
@@ -1879,7 +1889,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     p.lexer.expect(T::TOpenBrace)?;
                     let scope_index = p.scopes_in_order.len();
+                    // The body is ambient and dropped, so a `return` inside it
+                    // must not count as a module-level return.
+                    let old_is_outside_fn_or_arrow =
+                        p.fn_or_arrow_data_parse.is_outside_fn_or_arrow;
+                    p.fn_or_arrow_data_parse.is_outside_fn_or_arrow = false;
                     let _ = p.parse_stmts_up_to(T::TCloseBrace, opts)?;
+                    p.fn_or_arrow_data_parse.is_outside_fn_or_arrow = old_is_outside_fn_or_arrow;
                     p.lexer.next()?;
                     // The statements inside are dropped, so discard any scopes they
                     // recorded or the visit pass will hit a scope order mismatch.

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -1082,6 +1082,7 @@ pub struct ParsedPath<'a> {
 pub enum StrictModeFeature {
     EvalOrArguments,
     ReservedWord,
+    LegacyOctalLiteral,
 }
 
 #[derive(Clone, Copy)]
@@ -1226,6 +1227,10 @@ pub struct FnOrArrowDataParse {
     pub(crate) allow_super_call: bool,
     pub(crate) allow_super_property: bool,
     pub(crate) is_top_level: bool,
+    /// True while parsing statements lexically outside every function/arrow
+    /// body (mirrors the visit struct). Unlike `is_top_level`, an
+    /// await-permission flag, this does not vary with `top_level_await`.
+    pub(crate) is_outside_fn_or_arrow: bool,
     pub(crate) is_constructor: bool,
     pub(crate) is_typescript_declare: bool,
 
@@ -1254,6 +1259,7 @@ impl Default for FnOrArrowDataParse {
             allow_super_call: false,
             allow_super_property: false,
             is_top_level: false,
+            is_outside_fn_or_arrow: false,
             is_constructor: false,
             is_typescript_declare: false,
             has_argument_decorators: false,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -186,7 +186,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         // A sloppy-mode function with a simple parameter list has a mapped
         // `arguments` object: `arguments[0] = v` rebinds the first parameter.
-        if !self.is_strict_mode()
+        if !self.is_settled_strict_mode()
             && func.arguments_ref.is_valid()
             && self.symbols[func.arguments_ref.inner_index() as usize].use_count_estimate > 0
             && Self::is_simple_parameter_list(

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -97,8 +97,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // if e.LegacyOctalLoc.Start > 0 {
     }
 
-    fn e_number(_: &mut Self, _e: &mut Expr, _: ExprIn) {
-        // idc about legacy octal loc
+    fn e_number(p: &mut Self, e: &mut Expr, _: ExprIn) {
+        if !p.legacy_octal_literals.is_empty() && p.is_strict_mode() {
+            if let Some(r) = p.legacy_octal_literals.get(&e.loc).copied() {
+                p.mark_strict_mode_feature(StrictModeFeature::LegacyOctalLiteral, r, b"")
+                    .expect("unreachable");
+            }
+        }
     }
 
     fn e_this(p: &mut Self, e: &mut Expr, _: ExprIn) {

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -57,7 +57,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
 /// Version 28: the define table and `--drop` entries participate in the features hash.
 /// Version 29: `new Array(x, ...spread)` is no longer folded into an array literal.
-const EXPECTED_VERSION: u32 = 29;
+/// Version 30: Files forced to ESM by ".mjs"/".mts" or package.json
+/// "type": "module" are parsed in strict mode (#32175); a cache hit from an
+/// older version would hide the new strict-mode errors.
+const EXPECTED_VERSION: u32 = 30;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -252,3 +252,387 @@ describe("unterminated string literals in large files", () => {
     expect(exitCode).toBe(1);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32175
+describe.concurrent("implicit strict mode for files forced to ESM", () => {
+  async function run(dir: unknown, file: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), file],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("legacy octal literal in a bare .mjs file is an error", async () => {
+    using dir = tempDir("forced-esm-strict-octal", {
+      "octal.mjs": "var v = 010;\nconsole.log(v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "octal.mjs");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain('".mjs" extension makes it an ECMAScript module');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal in a bare .mts file is an error", async () => {
+    using dir = tempDir("forced-esm-strict-octal-mts", {
+      "octal.mts": "var v = 010;\nconsole.log(v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "octal.mts");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain('".mts" extension makes it an ECMAScript module');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test('legacy octal literal in a "type": "module" package is an error', async () => {
+    using dir = tempDir("forced-esm-strict-type-module", {
+      "package.json": '{ "type": "module" }',
+      "octal.js": "var v = 010;\nconsole.log(v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "octal.js");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain('package.json sets "type" to "module"');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("leading-zero decimal like 08 in a bare .mjs file is an error", async () => {
+    using dir = tempDir("forced-esm-strict-08", {
+      "zero.mjs": "console.log(08);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "zero.mjs");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal as an object property key in a .mjs file is an error", async () => {
+    using dir = tempDir("forced-esm-strict-octal-key", {
+      "key.mjs": "console.log({ 010: 1 });\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "key.mjs");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal as a destructuring binding key in a .mjs file is an error", async () => {
+    using dir = tempDir("forced-esm-strict-octal-binding", {
+      "binding.mjs": "var { 010: x } = { 8: 1 };\nconsole.log(x);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "binding.mjs");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("eval and arguments declarations in CommonJS-classified .mjs files still fail ESM-format bundles", async () => {
+    // The file executes as CommonJS via the interop, but `bun build
+    // --format=esm` puts its wrapper inside a strict ES module, so the
+    // sloppy-only declaration must keep failing the build.
+    using dir = tempDir("forced-esm-bundle-esm-format", {
+      "utils.mjs": "exports.x = 1;\nvar arguments = 5;\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "utils.mjs", "--format=esm"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(
+      'Declarations with the name "arguments" cannot be used with the ESM output format due to strict mode',
+    );
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal in a CommonJS-classified .mjs file still bundles to ESM format", async () => {
+    // Unlike sloppy-only declarations, legacy octal literals never survive
+    // into the printed bundle (the printer emits the numeric value), so the
+    // ESM output format check must not reject them.
+    using dir = tempDir("forced-esm-bundle-octal", {
+      "utils.mjs": "exports.x = 010;\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "utils.mjs", "--format=esm"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("Legacy octal literals");
+    expect(stdout).toContain("8");
+    expect(exitCode).toBe(0);
+  });
+
+  test("reserved word declarations in CommonJS-classified .mjs files still bundle to ESM format", async () => {
+    // The renamer remaps bound reserved-word symbols (package -> _package),
+    // so the bundle is strict-valid and the build must not error.
+    using dir = tempDir("forced-esm-bundle-reserved", {
+      "utils.mjs": "exports.x = 1;\nvar package = 1;\nconsole.log(package);\n",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "utils.mjs", "--format=esm"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("reserved word");
+    expect(stdout).toContain("_package");
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level return inside a TypeScript namespace body does not opt out of strict mode", async () => {
+    // Namespace bodies parse with a fresh FnOrArrowDataParse, so a return
+    // there is rejected outright (like tsc) and must not classify the file
+    // as CommonJS: the sloppy path would print 8.
+    using dir = tempDir("forced-esm-ns-return", {
+      "ns.mts": "namespace N {\n  if (globalThis.never) return;\n}\nvar v = 010;\nconsole.log(v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "ns.mts");
+    expect(stderr).toContain("A return statement cannot be used here");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("return inside declare global does not opt out of strict mode", async () => {
+    // The ambient body is parsed then dropped, so a return there is not a
+    // module-level return.
+    using dir = tempDir("forced-esm-declare-global-return", {
+      "dg.mts": "declare global {\n  return;\n}\nvar v = 010;\nconsole.log(v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "dg.mts");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("top-level return keeps the interop carve-out under non-ESM bundle formats", async () => {
+    // Top-level return detection must not depend on the output format: the
+    // same .mjs file classifies as CommonJS (sloppy) whether bundling to
+    // esm, cjs, or iife.
+    using dir = tempDir("forced-esm-bundle-return-formats", {
+      "r.mjs": "var v = 010;\nconsole.log(v);\nreturn;\n",
+    });
+    for (const [format, outfile, expected] of [
+      ["esm", "out.mjs", "8\n"],
+      ["cjs", "out.cjs", "8\n"],
+      // A CommonJS-classified entry point is wrapped but not invoked under
+      // the iife format (pre-existing for any CJS entry, e.g. a .cjs file).
+      ["iife", "out.iife.js", ""],
+    ]) {
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "r.mjs", `--format=${format}`, `--outfile=${outfile}`],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [buildStdout, buildStderr, buildExit] = await Promise.all([
+        build.stdout.text(),
+        build.stderr.text(),
+        build.exited,
+      ]);
+      expect({ format, buildStdout, buildStderr }).toMatchObject({ format, buildStderr: "" });
+      expect(buildExit).toBe(0);
+      const { stdout, stderr, exitCode } = await run(dir, outfile);
+      expect({ format, stdout, stderr }).toEqual({ format, stdout: expected, stderr: "" });
+      expect(exitCode).toBe(0);
+    }
+  });
+
+  test("block-level functions in CommonJS-style .mjs files keep sloppy hoisting when bundled", async () => {
+    // Symbol hoisting runs before exports_kind classification, so the
+    // forced-ESM marking must not disable the sloppy-mode Annex B handling
+    // for files that execute as CommonJS via the interop.
+    using dir = tempDir("forced-esm-bundle-annex-b", {
+      "f.mjs": "exports.x = 1;\n{ function g() { return 1; } }\nconsole.log(g());\n",
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "f.mjs", "--format=esm", "--outfile=out.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildStdout, buildStderr, buildExit] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect({ buildStdout, buildStderr }).toMatchObject({ buildStderr: "" });
+    expect(buildExit).toBe(0);
+    const { stdout, stderr, exitCode } = await run(dir, "out.mjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "1\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("strict mode reserved word in a bare .mjs file is a transpiler error", async () => {
+    using dir = tempDir("forced-esm-strict-reserved", {
+      "reserved.mjs": "var package = { name: 1 };\nconsole.log(package.name);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "reserved.mjs");
+    // The transpiler reports this; previously it was left for the JS engine,
+    // which printed a different message at runtime.
+    expect(stderr).toContain('"package" is a reserved word and cannot be used in strict mode');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal with explicit ESM syntax is an error", async () => {
+    using dir = tempDir("esm-syntax-strict-octal", {
+      "octal.js": "export {};\nconsole.log(010);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "octal.js");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain('because of the "export" keyword');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal inside a class body is an error even in CommonJS", async () => {
+    using dir = tempDir("class-strict-octal", {
+      "class.js": "class C { m() { return 010; } }\nconsole.log(new C().m());\nmodule.exports = C;\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "class.js");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain("All code inside a class is implicitly in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("legacy octal literal inside a class body is an error even in a CommonJS-classified .mjs file", async () => {
+    // Class bodies are unconditionally strict; the CommonJS interop
+    // classification (the file uses `exports`) must not swallow this.
+    using dir = tempDir("forced-esm-class-octal", {
+      "class.mjs": "exports.C = class { m() { return 010; } };\nconsole.log(new exports.C().m());\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "class.mjs");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain("All code inside a class is implicitly in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("reserved word inside a class body is an error even in a CommonJS-classified .mjs file", async () => {
+    using dir = tempDir("forced-esm-class-reserved", {
+      "class.mjs":
+        "exports.C = class { m() { var package = 1; return package; } };\nconsole.log(new exports.C().m());\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "class.mjs");
+    expect(stderr).toContain('"package" is a reserved word and cannot be used in strict mode');
+    expect(stderr).toContain("All code inside a class is implicitly in strict mode");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test('legacy octal literal under "use strict" is an error', async () => {
+    using dir = tempDir("use-strict-octal", {
+      "strict.js": '"use strict";\nconsole.log(010);\n',
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "strict.js");
+    expect(stderr).toContain("Legacy octal literals cannot be used in strict mode");
+    expect(stderr).toContain('because of the "use strict" directive');
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  // Bun deliberately executes forced-ESM files that use CommonJS-only
+  // features as CommonJS (sloppy mode), so none of the above applies to them.
+  test("file using exports still runs as sloppy CommonJS despite .mjs", async () => {
+    using dir = tempDir("forced-esm-cjs-interop-exports", {
+      "interop.mjs": "exports.v = 010;\nconsole.log(exports.v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "interop.mjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "8\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test('file using exports still runs as sloppy CommonJS under "type": "module"', async () => {
+    using dir = tempDir("type-module-cjs-interop-exports", {
+      "package.json": '{ "type": "module" }',
+      "interop.js": "exports.v = 010;\nconsole.log(exports.v);\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "interop.js");
+    expect({ stdout, stderr }).toEqual({ stdout: "8\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("file using a with statement still runs as sloppy CommonJS despite .mjs", async () => {
+    using dir = tempDir("forced-esm-cjs-interop-with", {
+      "with.mjs": "with ({ x: 1 }) { console.log(x); }\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "with.mjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "1\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("file using a top-level return still runs as sloppy CommonJS despite .mjs", async () => {
+    using dir = tempDir("forced-esm-cjs-interop-return", {
+      "return.mjs": "console.log(010);\nreturn;\n",
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "return.mjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "8\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level return makes a plain .js file CommonJS like Node", async () => {
+    using dir = tempDir("top-level-return-cjs", {
+      "return.js": 'console.log("before");\nreturn;\nconsole.log("after");\n',
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "return.js");
+    expect({ stdout, stderr }).toEqual({ stdout: "before\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test("top-level return stays a SyntaxError for bun -e, like node -e", async () => {
+    // The [eval] entry point executes as a bare program with no CommonJS
+    // function wrapper, so a top-level return cannot make it CommonJS.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", 'console.log("a"); return;'],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("SyntaxError");
+    expect(exitCode).toBe(1);
+  });
+
+  test("top-level return stays a SyntaxError for piped stdin too", async () => {
+    // Same carve-out as [eval]: the [stdin] entry point has no CommonJS
+    // function wrapper either.
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "-"],
+      env: bunEnv,
+      stdin: new Blob(['console.log("a"); return;']),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("SyntaxError");
+    expect(exitCode).toBe(1);
+  });
+
+  test("strict-clean CommonJS code in a .mjs file keeps working", async () => {
+    using dir = tempDir("forced-esm-cjs-interop-clean", {
+      "clean.mjs":
+        'exports.foo = 42;\nconsole.log("ran as", typeof module === "undefined" ? "esm" : "cjs", exports.foo);\n',
+    });
+    const { stdout, stderr, exitCode } = await run(dir, "clean.mjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "ran as cjs 42\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/bundler/transpiler/runtime-transpiler.test.ts
+++ b/test/bundler/transpiler/runtime-transpiler.test.ts
@@ -635,4 +635,40 @@ describe.concurrent("implicit strict mode for files forced to ESM", () => {
     expect({ stdout, stderr }).toEqual({ stdout: "ran as cjs 42\n", stderr: "" });
     expect(exitCode).toBe(0);
   });
+
+  test("mapped arguments in a CommonJS-classified .mjs file still pin parameters when bundled", async () => {
+    // In a sloppy function with simple parameters, `arguments[0] = v` rebinds
+    // the first parameter. The visit pass records that as an assignment so the
+    // printer does not merge `a = t.foo, b = t.bar` into one read of `t`; the
+    // provisional strict kind must not skip that record, or the cjs bundle
+    // reads the stale object.
+    using dir = tempDir("forced-esm-cjs-mapped-arguments", {
+      "args.mjs": [
+        "exports.f = function (t) {",
+        '  globalThis.hook = () => { arguments[0] = { foo: 0, bar: "changed" }; };',
+        "  const a = t.foo, b = t.bar;",
+        "  return b;",
+        "};",
+        'console.log(exports.f({ get foo() { globalThis.hook(); return 0; }, bar: "original" }));',
+        "",
+      ].join("\n"),
+    });
+    await using build = Bun.spawn({
+      cmd: [bunExe(), "build", "args.mjs", "--format=cjs", "--outfile=out.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [buildStdout, buildStderr, buildExit] = await Promise.all([
+      build.stdout.text(),
+      build.stderr.text(),
+      build.exited,
+    ]);
+    expect({ buildStdout, buildStderr }).toMatchObject({ buildStderr: "" });
+    expect(buildExit).toBe(0);
+    const { stdout, stderr, exitCode } = await run(dir, "out.cjs");
+    expect({ stdout, stderr }).toEqual({ stdout: "changed\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -349,6 +349,16 @@ describe.concurrent("Bun REPL", () => {
       expect(stderr).toBe("");
       expect(exitCode).toBe(0);
     });
+
+    test("evaluates a top-level return via the REPL wrapper", async () => {
+      // REPL input is wrapped in an IIFE, so a top-level return yields the
+      // returned value; it must not be treated as a CommonJS top-level return
+      // (which would skip the wrap and leave an invalid bare return).
+      const { outputs, stderr, exitCode } = await runRepl(["return 42069", ".exit"]);
+      expect(outputs).toEqual(["42069"]);
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
   });
 
   describe("special variables", () => {


### PR DESCRIPTION
Fixes #32175

### Problem

Files that are ES modules only because of their extension (`.mjs`/`.mts`) or package.json `"type": "module"` were parsed in sloppy mode. Per ECMA-262, module code is always strict, so Node rejects sloppy-only syntax in them:

```console
$ cat octal.mjs
var v = 010; console.log(v);
$ node octal.mjs
SyntaxError: Octal literals are not allowed in strict mode.
$ bun octal.mjs
8
```

The strict-mode marking in `prepare_for_visit_pass` only had three triggers (import keyword, export keyword, top-level await); `module_type == Esm` was missing.

### The interop constraint

Bun deliberately executes forced-ESM files that use CommonJS features (`exports.foo = ...`, `module`, `with`, top-level return) as CommonJS via interop, and whether a file uses `exports`/`module` is only known after the visit pass, while strict mode must be set before it (it affects hoisting). Marking unconditionally would either break the interop or be order-dependent.

The fix resolves this by deferring: forced-ESM files are marked with a new `StrictModeKind::ImplicitStrictModeModuleType`, and strict-mode feature errors raised under that kind are queued instead of emitted. Once `exports_kind` is final in `parse_entry.rs`, the queue is emitted if the file is classified `Esm` and discarded otherwise (including `EsmWithDynamicFallbackFromCjs`, which executes with CommonJS sloppy semantics). `with` statements and top-level return are known at parse time, so files containing them skip the marking entirely, exactly mirroring the classification. Files that execute as CommonJS via the interop behave byte-for-byte as before (verified by diffing transpiled output).

### Also in this change (same mechanism, required to make it observable)

- **Wire the legacy octal literal check.** `checkForLegacyOctalLiteral` from the esbuild/Zig reference was a stub comment in the Rust port, so octal literals were silently accepted in every strict context: `export {}; console.log(010)` printed 8, as did octal inside class bodies and under `"use strict"` (the lexer converts the literal before the engine can reject it, so this is unfixable at runtime). Recorded at parse time in a side map, reported at `ENumber` visit when the scope is strict, matching esbuild. The lexer now also flags `08`/`09` leading-zero decimals in the float branch, as the integer branch already did for `010`.
- **Set `has_top_level_return`.** The flag existed and the `exports_kind` classification reads it (the "This file is CommonJS because top-level return was used" note exists for it), but nothing ever set it, in the Zig reference either. As a result `console.log("x"); return;` in a plain `.js` file failed with "SyntaxError: Return statements are only valid inside functions" where Node runs it as CommonJS. It is now set in `t_return` for top-level returns, excluding the `[eval]`/`[stdin]` entry points, which execute as a bare program with no CommonJS wrapper for the return to live in (`node -e "return"` is a SyntaxError too; classifying those CommonJS made them silently evaluate to nothing).
- **Bump the runtime transpiler cache version** (now 29 to 30 after rebasing; main took 23 through 29 in the meantime), since a cache hit from an older version would replay sloppy output and hide the new errors.

### Behavior summary

| file | before | after |
|---|---|---|
| `var v = 010` in `.mjs`/`.mts`/type-module | prints 8 | error, like Node |
| `export {}; console.log(010)` | prints 8 | error, like Node |
| octal in class body or under `"use strict"` | prints 8 | error, like Node |
| `var package = 1; console.log(package)` in `.mjs` | JSC runtime SyntaxError | transpiler error with a note naming the `.mjs` extension |
| `exports.v = 010` in `.mjs` (CJS interop) | prints 8 | prints 8 (unchanged) |
| `with (...) {}` in `.mjs` (CJS interop) | runs | runs (unchanged) |
| top-level return in `.js`/`.mjs` | SyntaxError | runs as CommonJS, like Node |
| `bun -e 'return'` | SyntaxError | SyntaxError (unchanged) |

Deliberate non-goals, kept per the issue's interop constraint: `with`-only and `exports`-using forced-ESM files still run as CommonJS (Node rejects them); Annex B block-function hoisting is unrelated and unchanged (the sloppy-mode machinery only activates under the bundler renamer).

### Tests

`test/bundler/transpiler/runtime-transpiler.test.ts`, new `describe("implicit strict mode for files forced to ESM")`: octal in `.mjs`, `.mts`, and type-module packages, `08`, octal property keys, reserved words, explicit-ESM/class/`"use strict"` octal, plus interop controls asserting `exports`/`with`/top-level-return files still run sloppy, top-level return in plain `.js` runs like Node, and `bun -e 'return'` still errors. 11 of the 16 tests fail on the unfixed build; the controls pass on both.

Review fixes after the initial push: the `"use strict"` directive is now named in strict-mode notes, class bodies stay strict inside CommonJS-classified forced-ESM files (`recursive_set_strict_mode` lets the class kind override the module-type kind), destructuring binding keys record legacy octals like the two sibling sites, dropping deferred errors for CommonJS-classified files re-applies the ESM-output-format check (`bun build --format=esm` errors again like before), and the REPL keeps wrapping top-level `return` in its IIFE (`return 5` prints 5 again). Symbol hoisting also keeps the sloppy-mode Annex B handling for forced-ESM files (it runs before `exports_kind` classification, and the strict skip broke bundled CommonJS-interop files using block-level functions). The same applies to the mapped-`arguments` handling in `visit_fn`: a sloppy function with simple parameters must still record `arguments[i] = v` as an assignment to parameter `i`, or the printer merges `a = t.foo, b = t.bar` into one read of `t` and a `--format=cjs` bundle of a CommonJS-classified `.mjs` reads the stale object. A `StrictModeKind::is_settled_strict` helper now names the provisional-counts-as-sloppy rule for both structural sites. The re-applied output-format check skips legacy octal literals, which never survive into the printed bundle (the printer emits the numeric value). And top-level return detection now uses a new `FnOrArrowDataParse::is_outside_fn_or_arrow` flag mirroring the visit struct, instead of the `top_level_await`-gated `is_top_level`, so the interop carve-out no longer varies with the bundler output format. That skip list also covers reserved words, since the renamer remaps bound reserved-word symbols (`package` to `_package`); unbound references keep their pre-existing behavior, tracked in #32193. And TypeScript namespace bodies and `declare global` blocks clear the new flag around their body parse, since a `return` inside them is not a module-level return (namespace bodies compile to closures, ambient bodies are dropped). Each has a test: runtime-transpiler.test.ts, transpiler-cache.test.ts (cache-hit main), and repl.test.ts.

Rebase notes (current main): the branch is now one squashed commit. Main's dead-code sweep (#39732) deleted the unused `StrictModeFeature` variants, so this PR re-adds only `LegacyOctalLiteral` (the one it constructs) and drops its references to the removed `ForInVarInit` (the `can_be_transformed` carve-out and the flush skip list now cover just `LegacyOctalLiteral | ReservedWord`). Earlier rounds: the cache-hit `has_loaded` fix this PR originally carried was landed independently by #33371 (along with its test), so both were dropped here; the cache version entry moved to 26; the dead `RUNTIME_TRANSPILER_CACHE_VERSION` mirror in `src/bundler/cache.rs` was dropped because main deleted it; main now parses TypeScript namespace bodies with a fresh `FnOrArrowDataParse` that rejects `return` outright, which supersedes this PR's namespace carve-out (the explicit flag clearing remains only for `declare global`, which still parses with the parent struct); and the cache-hit test was adapted to the new async `bunRun`/`toSpawn` harness contract.

Also ran: transpiler.test.js, preserve-use-strict-cjs, syntax.test.ts (590), transpiler-cache, repl.test.ts (117), repl-transform, esbuild default/packagejson/tsconfig/dce/ts/importstar/loader/lower, bundler_cjs, bundler_edgecase, node-module-module, esModule-annotation: no failures.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->






