### PR TITLE
bun test: free test-runner finalizer-owned allocations before exit so LSan lanes don't abort green runs

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1503,6 +1503,30 @@ impl VirtualMachine {
         self.has_run_cleanup_hooks = true;
     }
 
+    /// Final collection for `bun test`'s exit paths, which never run
+    /// `on_exit()`. ASAN lanes leak-check at exit (LSAN_OPTIONS
+    /// `detect_leaks=1` + `abort_on_error=1`), and without a collection
+    /// between the last test and `exit()`, the final file's GC-finalizer-owned
+    /// Rust boxes (bun:test `Expect` wrappers and the `RefData` pinning that
+    /// file's `BunTestCell`) are still malloc-live when LSan scans, aborting a
+    /// green run. No-op in non-ASAN builds, which skip all teardown for exit
+    /// speed. https://github.com/oven-sh/bun/issues/32176
+    pub fn collect_for_leak_check_at_exit(&mut self) {
+        debug_assert!(self.is_shutting_down());
+        if !bun_core::env::ENABLE_ASAN {
+            return;
+        }
+        // Deferred napi finalizers enqueued by the sweep below (non-
+        // experimental addons route GC finalizers through
+        // `NapiFinalizerTask::schedule`) would be parked on
+        // `RareData::cleanup_hooks`, which this exit path never drains.
+        // Marking the list as done routes them to schedule()'s
+        // drop-immediately branch instead, same as finalizers deferred
+        // during `destructOnExit()`'s collection after `on_exit()` ran.
+        self.has_run_cleanup_hooks = true;
+        let _ = self.garbage_collect(true);
+    }
+
     pub fn global_exit(&mut self) -> ! {
         debug_assert!(self.is_shutting_down());
         // FIXME: we should be doing this, but we're not, but unfortunately

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1504,7 +1504,7 @@ impl VirtualMachine {
     }
 
     /// Final collection for `bun test`'s exit paths, which never run
-    /// `on_exit()`. ASAN lanes leak-check at exit (LSAN_OPTIONS
+    /// `on_exit()`. ASAN lanes leak-check at exit (ASAN_OPTIONS
     /// `detect_leaks=1` + `abort_on_error=1`), and without a collection
     /// between the last test and `exit()`, the final file's GC-finalizer-owned
     /// Rust boxes (bun:test `Expect` wrappers and the `RefData` pinning that

--- a/src/runtime/cli/test/parallel/runner.rs
+++ b/src/runtime/cli/test/parallel/runner.rs
@@ -710,6 +710,7 @@ pub fn run_as_worker(
     // (lastChanceToFinalize) runs; bypassing it leaks JSC-owned native state.
     vm_ref.exit_handler.exit_code = 0;
     vm_ref.is_shutting_down = true;
+    vm_ref.collect_for_leak_check_at_exit();
     vm_ref.run_with_api_lock(|| {
         // SAFETY: caller guarantees `vm` is a valid live VM pointer for the worker's lifetime.
         unsafe { (*vm).global_exit() }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2952,6 +2952,7 @@ impl TestCommand {
             jest::Jest::RUNNER.write(None);
         }
         drop(reporter);
+        vm.collect_for_leak_check_at_exit();
         {
             let vm_ptr: *mut VirtualMachine = vm;
             // SAFETY: `vm_ptr` reborrows the live `&mut VirtualMachine`;

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -886,40 +886,39 @@ describe.concurrent("exit is leak-clean under LeakSanitizer", () => {
     `;
   }
 
-  const cases: [label: string, args: string[]][] = [
+  // LeakSanitizer only exists in ASAN builds, and `detect_leaks=1` is a
+  // startup error on platforms without LSan (macOS arm64); the CI lane
+  // that leak-checks is linux x64-asan.
+  const leakCheckEnv = {
+    ...bunEnv,
+    // The CI runner sets this for outer test processes; the exit path
+    // must be leak-clean without the full destruct-on-exit teardown too.
+    BUN_DESTRUCT_VM_ON_EXIT: undefined,
+    BUN_TEST_PARALLEL_SCALE_MS: "0",
+    ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+    LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "..", "..", "leaksan.supp")}`,
+  };
+
+  test.skipIf(!isASAN || !isLinux).each([
     ["serial", []],
     ["--isolate", ["--isolate"]],
     ["--parallel=2", ["--parallel=2"]],
-  ];
-  for (const [label, args] of cases) {
-    // LeakSanitizer only exists in ASAN builds, and `detect_leaks=1` is a
-    // startup error on platforms without LSan (macOS arm64); the CI lane
-    // that leak-checks is linux x64-asan.
-    test.skipIf(!isASAN || !isLinux)(label, async () => {
-      using dir = tempDir(`test-exit-lsan-${args.length ? args[0].replace(/[^a-z0-9]/g, "") : "serial"}`, files);
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "test", ...args, "."],
-        env: {
-          ...bunEnv,
-          // The CI runner sets this for outer test processes; the exit path
-          // must be leak-clean without the full destruct-on-exit teardown too.
-          BUN_DESTRUCT_VM_ON_EXIT: undefined,
-          BUN_TEST_PARALLEL_SCALE_MS: "0",
-          ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
-          LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "..", "..", "leaksan.supp")}`,
-        },
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      // A --parallel worker's at-exit abort does not change the coordinator's
-      // exit code (its results were already collected by then), but the
-      // report still prints to inherited stderr, so assert on the report
-      // text too. On failure, not.toContain prints the whole report.
-      expect(stderr).not.toContain("LeakSanitizer");
-      expect(stderr).toContain(`${FILE_COUNT} pass`);
-      expect(exitCode).toBe(0);
+  ] as [label: string, args: string[]][])("%s", async (label, args) => {
+    using dir = tempDir(`test-exit-lsan-${label.replace(/[^a-z0-9]/g, "")}`, files);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args, "."],
+      env: leakCheckEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
     });
-  }
+    const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // A --parallel worker's at-exit abort does not change the coordinator's
+    // exit code (its results were already collected by then), but the
+    // report still prints to inherited stderr, so assert on the report
+    // text too. On failure, not.toContain prints the whole report.
+    expect(stderr).not.toContain("LeakSanitizer");
+    expect(stderr).toContain(`${FILE_COUNT} pass`);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isASAN, isLinux, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
 import { join } from "node:path";
@@ -892,8 +892,10 @@ describe.concurrent("exit is leak-clean under LeakSanitizer", () => {
     ["--parallel=2", ["--parallel=2"]],
   ];
   for (const [label, args] of cases) {
-    // LeakSanitizer only exists in ASAN builds.
-    test.skipIf(!isASAN)(label, async () => {
+    // LeakSanitizer only exists in ASAN builds, and `detect_leaks=1` is a
+    // startup error on platforms without LSan (macOS arm64); the CI lane
+    // that leak-checks is linux x64-asan.
+    test.skipIf(!isASAN || !isLinux)(label, async () => {
       using dir = tempDir(`test-exit-lsan-${args.length ? args[0].replace(/[^a-z0-9]/g, "") : "serial"}`, files);
       await using proc = Bun.spawn({
         cmd: [bunExe(), "test", ...args, "."],

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, normalizeBunSnapshot, tempDir } from "harness";
 import fs from "node:fs";
 import net from "node:net";
+import { join } from "node:path";
 
 // Every case spawns at least one full `bun test --isolate` child; the heavy
 // ones (8-file leak fixtures, 500-2000-export module_info modules) exceed the
@@ -866,5 +867,57 @@ test.concurrent("--isolate: require(esm) caches a BunTranspiledModule SourceProv
     expect(stderr, `run ${run}`).toContain("1 pass");
     expect(stderr, `run ${run}`).toContain("0 fail");
     expect(exitCode, `run ${run}`).toBe(0);
+  }
+});
+
+// At exit, the final file's `expect()` wrapper boxes (and the `RefData` /
+// `BunTestCell` they pin) are freed only by GC finalizers, and no collection
+// used to run between the last test and `exit()`. With LeakSanitizer active
+// (the ASAN CI lane runs subprocesses with `detect_leaks=1:abort_on_error=1`),
+// the exit scan reported those boxes and SIGABRT'd (exit 134) an otherwise
+// green run. https://github.com/oven-sh/bun/issues/32176
+describe.concurrent("exit is leak-clean under LeakSanitizer", () => {
+  const FILE_COUNT = 4;
+  const files: Record<string, string> = {};
+  for (let i = 0; i < FILE_COUNT; i++) {
+    files[`f${i}.test.js`] = `
+      import { test, expect } from "bun:test";
+      test("f${i}", () => { expect(1 + 1).toBe(2); });
+    `;
+  }
+
+  const cases: [label: string, args: string[]][] = [
+    ["serial", []],
+    ["--isolate", ["--isolate"]],
+    ["--parallel=2", ["--parallel=2"]],
+  ];
+  for (const [label, args] of cases) {
+    // LeakSanitizer only exists in ASAN builds.
+    test.skipIf(!isASAN)(label, async () => {
+      using dir = tempDir(`test-exit-lsan-${args.length ? args[0].replace(/[^a-z0-9]/g, "") : "serial"}`, files);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", ...args, "."],
+        env: {
+          ...bunEnv,
+          // The CI runner sets this for outer test processes; the exit path
+          // must be leak-clean without the full destruct-on-exit teardown too.
+          BUN_DESTRUCT_VM_ON_EXIT: undefined,
+          BUN_TEST_PARALLEL_SCALE_MS: "0",
+          ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1",
+          LSAN_OPTIONS: `malloc_context_size=30:print_suppressions=0:suppressions=${join(import.meta.dir, "..", "..", "leaksan.supp")}`,
+        },
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      // A --parallel worker's at-exit abort does not change the coordinator's
+      // exit code (its results were already collected by then), but the
+      // report still prints to inherited stderr, so assert on the report
+      // text too. On failure, not.toContain prints the whole report.
+      expect(stderr).not.toContain("LeakSanitizer");
+      expect(stderr).toContain(`${FILE_COUNT} pass`);
+      expect(exitCode).toBe(0);
+    });
   }
 });

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -127,3 +127,10 @@ leak:WTF::RunLoop::dispatchAfter
 # LSAN's conservative stack scan no longer finds the pointers.
 leak:bun_runtime::cli::filter_run::run_scripts_with_filter
 leak:bun_runtime::cli::multi_run::run
+# bun test at exit: the test/describe/expect function wrappers of the final
+# (still gcProtected) global are alive, but their native ScopeFunctions boxes
+# are pointed to only from JSC heap cells, which LSan cannot scan, so it
+# reports them as leaks. They are freed by GC finalizers whenever a global
+# dies (isolation swap, BUN_DESTRUCT_VM_ON_EXIT teardown). Per-global, bounded.
+# https://github.com/oven-sh/bun/issues/32176
+leak:scope_functions::ScopeFunctions


### PR DESCRIPTION
Fixes #32176

### Problem

On the `13 x64-asan` lane, `test/regression/issue/30205.test.ts` intermittently fails with the inner `bun test --isolate` subprocess exiting 134 after a fully green run. The CI runner propagates `ASAN_OPTIONS=...detect_leaks=1:abort_on_error=1` and `LSAN_OPTIONS=...suppressions=test/leaksan.supp` into spawned processes via `bunEnv`, and LeakSanitizer's exit scan reports test-runner allocations that are still malloc-live, turning the report into SIGABRT.

Deterministic repro on main (debug ASAN build, no napi addon needed; also fails without `--isolate` and with `--parallel`):

```sh
# 4 files of: import { test, expect } from "bun:test";
#             test("t", () => { expect(1 + 1).toBe(2); });
ASAN_OPTIONS="allow_user_segv_handler=1:disable_coredump=0:detect_leaks=1:abort_on_error=1" \
LSAN_OPTIONS="malloc_context_size=30:print_suppressions=0:suppressions=$PWD/test/leaksan.supp" \
bun-debug test --isolate .   # exit 134, 10/10 runs
```

```
Direct leak of 48 byte(s): <bun_runtime::test_runner::expect_core::Expect>::call  expect.rs:656
Indirect leak of 448 byte(s): <bun_runtime::test_runner::bun_test::BunTest>::ref_  bun_test.rs:732
Indirect leak of 312 byte(s): RcInner<BunTestCell>, <BunTestRoot>::enter_file  bun_test.rs:530
```

### Cause

Three distinct allocation classes are live when LSan scans at exit:

1. The final file's `expect()` wrapper boxes are freed only by their GC finalizers (`Expect::finalize`, which also derefs the `RefData` pinning that file's `BunTestCell`), and no collection runs between the last test and `exit()`. Under `--isolate`, earlier files' wrappers are collected by GCs that happen while later files run; the last file has no later GC. Plain runs and `--parallel` workers have the same hole.
2. With a napi addon in the fixtures (the 30205 case), sweeping the wrapped objects defers each finalizer as a `NapiFinalizerTask`. `NapiFinalizerTask::schedule()` parks them on `RareData::cleanup_hooks` because `bun test`'s exit paths never call `on_exit()`, so `has_run_cleanup_hooks` is false and the list is never drained: every task box leaks (32000 bytes in 1000 allocations for the 30205 fixture). This is also why the lane failure is timing dependent on unpatched main: it needs `destructOnExit`'s conservative `collectNow()` to actually collect the wraps.
3. The final global's `ScopeFunctions` boxes (the native state of its `test`/`describe`/`expect` function wrappers) are genuinely alive at exit, rooted by the still-gcProtected global's `bun:test` exports. The only pointers to them live in JSC heap cells, which LSan cannot scan, so it reports them as leaks. They are freed whenever a global actually dies (isolation swap, `BUN_DESTRUCT_VM_ON_EXIT` teardown).

### Fix

- New `VirtualMachine::collect_for_leak_check_at_exit()`, called from the test runner's exit path (covers plain, `--isolate`, and the `--parallel` coordinator) and from the `--parallel` worker's exit path. No-op in non-ASAN builds, which keep skipping all teardown for exit speed. Under ASAN it sets `has_run_cleanup_hooks = true` first, so napi finalizers deferred by the sweep take `schedule()`'s existing drop-immediately branch (the documented shutdown semantics for `destructOnExit`'s collection) instead of being parked forever, then runs one synchronous full collection so the test-runner finalizers free their boxes. The load-bearing lines are the flag set and the `garbage_collect(true)` call.
- `test/leaksan.supp` entry for the `ScopeFunctions` allocation site (class 3 is a reachable-but-unscannable false positive, the exact thing the suppression file exists for; the file already suppresses the globals themselves).

### Verification

New `exit is leak-clean under LeakSanitizer` cases in `test/cli/test/isolation.test.ts` (serial, `--isolate`, `--parallel=2`), gated on `isASAN`. They spawn `bun test` with `detect_leaks=1:abort_on_error=1` and `BUN_DESTRUCT_VM_ON_EXIT` stripped, and assert no leak report, `4 pass`, exit 0. All three fail on the unfixed build (the serial and isolate children exit 134; a parallel worker's abort does not change the coordinator's exit code, so that case asserts on the report text in inherited stderr).

Verified on a debug ASAN build:

- the new tests fail 3/3 on unfixed main, pass 3/3 (x3 runs) with the fix
- the exact 30205 CI scenario (8 isolate files x 1000 `addon.wrap(...)`, `BUN_JSC_collectContinuously=1`, `BUN_DESTRUCT_VM_ON_EXIT=1`, leak checking on) exits 0 with no report, 5/5 runs; on the unfixed build it aborts with the `NapiFinalizerTask` leak
- `test/regression/issue/30205.test.ts` passes (4/4) under the CI lane's env
- full `test/cli/test/isolation.test.ts` passes (22/22)

### Note on #32146

#32146 fixes the napi half of the same lane flake (issue #32144) by draining the cleanup hooks inside `global_exit()` with a hooks-only restriction. The two changes are complementary but touch the same shutdown bookkeeping; whichever lands second needs a small rebase: with #32146 in, this PR's method should call `napi_internal_set_cleanup_hooks_only()` + `run_cleanup_hooks()` instead of setting `has_run_cleanup_hooks` directly, so the hooks-only restriction and the env cleanup hooks both still apply before the collection.


### Scope note

Exits after failures (`--bail` and ordinary failing runs) are intentionally excluded: they abort under the same env for additional reasons (a direct `Global::exit(1)` in the bail-on-test-failure path, and a `ParsedSourceMap` cache entry from printing the failure that LSan cannot see through), none of which have CI exposure today. Tracked in #32183.