### PR TITLE
Scale serve-body-leak end_memory cap for ASAN builds

### DIFF
--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -180,7 +180,9 @@ for (const test_info of [
         // under ASAN, so the cap needs ~2x headroom there (see #32179).
         expect(report.end_memory).toBeLessThanOrEqual((isASAN ? 1024 : 512) * 1024 * 1024);
       } catch (e) {
-        if (!isCI && process.platform !== "win32") {
+        // `process` here is the local subprocess from getURL(), which shadows the
+        // global, so use the harness helper for the platform check.
+        if (!isCI && !isWindows) {
           try {
             await fetch(`${url.origin}/heap-snapshot`);
             await Bun.sleep(10);

--- a/test/js/bun/http/serve-body-leak.test.ts
+++ b/test/js/bun/http/serve-body-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "bun:test";
-import { bunEnv, bunExe, isCI, isDebug, isFlaky, isLinux, isWindows } from "harness";
+import { bunEnv, bunExe, isASAN, isCI, isDebug, isFlaky, isLinux, isWindows } from "harness";
 import { join } from "path";
 
 const payload = Buffer.alloc(512 * 1024, "1").toString("utf-8"); // decent size payload to test memory leak
@@ -176,7 +176,9 @@ for (const test_info of [
         // acceptable memory leak
         expect(report.leak).toBeLessThanOrEqual(maxMemoryGrowth);
 
-        expect(report.end_memory).toBeLessThanOrEqual(512 * 1024 * 1024);
+        // ASAN redzones inflate RSS: the JSON-buffering case idles at ~490-515 MB
+        // under ASAN, so the cap needs ~2x headroom there (see #32179).
+        expect(report.end_memory).toBeLessThanOrEqual((isASAN ? 1024 : 512) * 1024 * 1024);
       } catch (e) {
         if (!isCI && process.platform !== "win32") {
           try {


### PR DESCRIPTION
Fixes #32179

### Problem

On the `13 x64-asan` CI lane, `test/js/bun/http/serve-body-leak.test.ts` intermittently fails its absolute end-memory cap:

```
expect(report.end_memory).toBeLessThanOrEqual(512 * 1024 * 1024);
Expected: <= 536870912
Received: 542494720
```

Example: [build 62074](https://buildkite.com/bun/bun/builds/62074), "should not leak memory when buffering a JSON body". In that run the growth metric the test exists for (`report.leak`, allowed up to 64 MB) was 1 MB, i.e. memory was flat; only the absolute RSS cap tripped.

### Cause

ASAN redzones inflate the fixture's RSS. Measured on unmodified main `885c44fea1` (release-asan build, CI's ASAN/LSAN env, JSON-buffering test only): 28 runs across two branches, end_memory 488-515 MB, 3 failures of the 512 MB cap, leak metric always under the 64 MB allowance. The steady state straddles the cap with 0-5% headroom, so it fails whichever run's noise lands a few MB higher.

### Fix

Test-only change. Scale the absolute cap to 1 GB when `isASAN` (roughly 2x the observed ASAN steady state), the same pattern sibling tests in `test/js/bun/http` use (`tls-bunfile-leak.test.ts`, `tls-keepalive.test.ts`, `bun-serve-static.test.ts`). The assertions that actually detect leaking are unchanged: `leak <= 64 MB` growth and `peak <= start * 2.5`, plus the 512 MB absolute cap on non-ASAN builds.

### Verification

- Non-ASAN (`isASAN` false, cap unchanged at 512 MB): all 7 tests in the file pass with this change (release build, 51s).
- ASAN branch: `isASANEnabled()` confirmed true on ASAN builds via the `bun:internal-for-testing` probe `harness.isASAN` uses, so the cap becomes 1 GB there; the failing run's 542494720 bytes and the full observed 488-515 MB range sit well under it.

### Review follow-up

Also fixed a pre-existing dead guard flagged in review: the subprocess destructured from `getURL()` shadows the global `process`, so `process.platform !== "win32"` in the catch block was always true. Now uses the `isWindows` harness helper (debug-only error path, non-CI).
