### PR TITLE
install: fix stale global-store links on disable and peer edge drift across bun.lock loads

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2764,23 +2764,7 @@ fn resolution_satisfies_dependency(
     dependency: &dependency::Version,
 ) -> bool {
     let buf = this.lockfile.buffers.string_bytes.as_slice();
-    if resolution.tag == ResolutionTag::Npm && dependency.tag == dependency::version::Tag::Npm {
-        return dependency
-            .npm()
-            .version
-            .satisfies(resolution.npm().version, buf, buf);
-    }
-
-    if resolution.tag == ResolutionTag::Git && dependency.tag == dependency::version::Tag::Git {
-        return resolution.git().eql(dependency.git(), buf, buf);
-    }
-
-    if resolution.tag == ResolutionTag::Github && dependency.tag == dependency::version::Tag::Github
-    {
-        return resolution.github().eql(dependency.github(), buf, buf);
-    }
-
-    false
+    resolution.satisfies_dependency_version(dependency, buf, buf)
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2192,51 +2192,12 @@ pub(crate) fn install_isolated_packages(
 
                     let uses_global_store = installer.entry_uses_global_store(entry_id);
 
-                    // An entry that lost global-store eligibility since the
-                    // previous install (newly patched, newly trusted, a dep
-                    // that became a workspace package) still has a stale
-                    // `node_modules/.bun/<storepath>` symlink/junction into
-                    // `<cache>/links/`. The existence check below would pass
-                    // *through* it and skip the task, leaving the project to
-                    // run against the shared entry (and, if the task did run,
-                    // write the new project-local tree through the link into
-                    // the shared cache). Treat the stale link as
-                    // needs-install so `link_package` detaches and rebuilds.
-                    let has_stale_gvs_link = !uses_global_store
-                        && 'stale: {
-                            if installer.global_store_path.is_none() {
-                                break 'stale false;
-                            }
-                            let mut local: paths::AutoAbsPath =
-                                paths::AutoAbsPath::init_top_level_dir();
-                            installer.append_local_store_entry_path(&mut local, entry_id);
-                            #[cfg(windows)]
-                            {
-                                break 'stale if let Some(a) =
-                                    sys::get_file_attributes(local.slice_z())
-                                {
-                                    a.is_reparse_point
-                                } else {
-                                    false
-                                };
-                            }
-                            #[cfg(not(windows))]
-                            {
-                                break 'stale if let Ok(st) = sys::lstat(local.slice_z()) {
-                                    sys::posix::s_islnk(st.st_mode as u32)
-                                } else {
-                                    false
-                                };
-                            }
-                        };
-
                     let needs_install = installer.manager().options.enable.force_install()
                         // A freshly-created `node_modules/.bun` only implies the
                         // *project-local* entries are missing; global virtual-
                         // store entries persist across `rm -rf node_modules` and
                         // should still take the cheap symlink-only path.
                         || (is_new_bun_modules && !uses_global_store)
-                        || has_stale_gvs_link
                         || matches!(patch_info, installer::PatchInfo::Remove(_))
                         || 'needs_install: {
                             let mut store_path: AbsPath = AbsPath::init_top_level_dir();
@@ -2273,7 +2234,42 @@ pub(crate) fn install_isolated_packages(
                                     !sys::exists_z(store_path.slice_z())
                                 }
                             };
-                        };
+                        }
+                        // An entry that lost global-store eligibility since the
+                        // previous install (newly patched, newly trusted, a dep
+                        // that became a workspace package, or `globalStore`
+                        // turned off entirely) still has a stale
+                        // `node_modules/.bun/<storepath>` symlink/junction into
+                        // `<cache>/links/`. The existence check above passes
+                        // *through* it, so a skipped entry would keep running
+                        // against the shared store (and a later rebuild would
+                        // write the project-local tree through the link into
+                        // the shared cache). Treat the stale link as
+                        // needs-install so `link_package` detaches and rebuilds.
+                        // Evaluated last so only entries about to be skipped
+                        // pay the lstat; rebuilt entries are detached by the
+                        // build path regardless.
+                        || (!uses_global_store && {
+                            let mut local: paths::AutoAbsPath =
+                                paths::AutoAbsPath::init_top_level_dir();
+                            installer.append_local_store_entry_path(&mut local, entry_id);
+                            #[cfg(windows)]
+                            {
+                                if let Some(a) = sys::get_file_attributes(local.slice_z()) {
+                                    a.is_reparse_point
+                                } else {
+                                    false
+                                }
+                            }
+                            #[cfg(not(windows))]
+                            {
+                                if let Ok(st) = sys::lstat(local.slice_z()) {
+                                    sys::posix::s_islnk(st.st_mode as u32)
+                                } else {
+                                    false
+                                }
+                            }
+                        });
 
                     if !needs_install {
                         if uses_global_store {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -41,8 +41,8 @@ use bun_install_types::DependencyVersionTag;
 use super::PackageIDSlice;
 use super::package::{Meta, PackageColumns as _, value_loc_of};
 use super::{
-    DependencySlice, LoadResult, Lockfile as BinaryLockfile, Package, PatchedDep,
-    TrustedDependenciesSet, VersionHashMap, tree,
+    DependencySlice, LoadResult, Lockfile as BinaryLockfile, Package, PackageIndexEntry,
+    PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
 };
 
 use bun_io::AsFmt;
@@ -2789,6 +2789,11 @@ pub fn parse_into_binary_lockfile(
         let pkg_names = pkgs.items_name();
         let pkg_resolutions: &[Resolution] = pkgs.items_resolution();
 
+        // Populated by `append_package_dedupe` while the packages object was
+        // parsed above; used to bind peer edges by version rather than by
+        // tree path (see `resolve_peer_dep_version_based`).
+        let package_index = &lockfile.package_index;
+
         // Disjoint-field split of `lockfile.buffers` so each loop body can hold
         // `&mut dependencies[i]` and `&mut resolutions[i]` together with a shared
         // `string_bytes` view.
@@ -2803,7 +2808,14 @@ pub fn parse_into_binary_lockfile(
                 let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
-                let Some(&res_id) = pkg_map.get(dep.name.slice(string_buf)) else {
+                let peer_res_id = if is_deferred_peer(dep) {
+                    resolve_peer_dep_version_based(dep, package_index, pkg_resolutions, string_buf)
+                } else {
+                    None
+                };
+                let Some(res_id) =
+                    peer_res_id.or_else(|| pkg_map.get(dep.name.slice(string_buf)).copied())
+                else {
                     if dep.behavior.contains(Behavior::OPTIONAL) {
                         continue;
                     }
@@ -2875,10 +2887,22 @@ pub fn parse_into_binary_lockfile(
                         &buf_slice[..needed]
                     };
 
-                    let Some(&res_id) = pkg_map
-                        .get(workspace_node_modules)
-                        .or_else(|| pkg_map.get(dep_name))
-                    else {
+                    let peer_res_id = if is_deferred_peer(dep) {
+                        resolve_peer_dep_version_based(
+                            dep,
+                            package_index,
+                            pkg_resolutions,
+                            string_buf,
+                        )
+                    } else {
+                        None
+                    };
+                    let Some(res_id) = peer_res_id.or_else(|| {
+                        pkg_map
+                            .get(workspace_node_modules)
+                            .or_else(|| pkg_map.get(dep_name))
+                            .copied()
+                    }) else {
                         if dep.behavior.contains(Behavior::OPTIONAL) {
                             continue;
                         }
@@ -2931,28 +2955,38 @@ pub fn parse_into_binary_lockfile(
                 let dep_id: DependencyID = _dep_id;
                 let dep = &mut dependencies[dep_id as usize];
 
-                let res_id =
-                    match pkg_map.find_resolution(pkg_path, dep, string_buf, &mut path_buf[..]) {
-                        Ok(&id) => id,
-                        Err(ResolveError::InvalidPackageKey) => {
-                            log.add_error(Some(source), row.key_loc, b"Invalid package path");
-                            return Err(ParseError::InvalidPackageKey);
-                        }
-                        Err(ResolveError::Unresolvable) => {
-                            if dep.behavior.contains(Behavior::OPTIONAL) {
-                                continue 'deps;
+                let peer_res_id = if is_deferred_peer(dep) {
+                    resolve_peer_dep_version_based(dep, package_index, pkg_resolutions, string_buf)
+                } else {
+                    None
+                };
+                let res_id = match peer_res_id {
+                    Some(id) => id,
+                    None => {
+                        match pkg_map.find_resolution(pkg_path, dep, string_buf, &mut path_buf[..])
+                        {
+                            Ok(&id) => id,
+                            Err(ResolveError::InvalidPackageKey) => {
+                                log.add_error(Some(source), row.key_loc, b"Invalid package path");
+                                return Err(ParseError::InvalidPackageKey);
                             }
-                            dependency_resolution_failure(
-                                dep,
-                                Some(pkg_path),
-                                string_buf,
-                                source,
-                                log,
-                                row.key_loc,
-                            )?;
-                            return Err(ParseError::InvalidPackageInfo);
+                            Err(ResolveError::Unresolvable) => {
+                                if dep.behavior.contains(Behavior::OPTIONAL) {
+                                    continue 'deps;
+                                }
+                                dependency_resolution_failure(
+                                    dep,
+                                    Some(pkg_path),
+                                    string_buf,
+                                    source,
+                                    log,
+                                    row.key_loc,
+                                )?;
+                                return Err(ParseError::InvalidPackageInfo);
+                            }
                         }
-                    };
+                    }
+                };
 
                 map_dep_to_pkg(
                     dep,
@@ -2974,6 +3008,72 @@ pub fn parse_into_binary_lockfile(
     }
 
     Ok(())
+}
+
+/// True for peer edges the fresh resolver defers to its second phase
+/// (`install_peer`) and binds by version there. `*` peers are exempt:
+/// they express no version preference and bind to whatever sibling pin
+/// existed first, which the printed tree's path walk reproduces.
+fn is_deferred_peer(dep: &Dependency) -> bool {
+    dep.behavior.is_peer()
+        && !(dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().version.is_star())
+}
+
+/// Resolve a peer dependency edge the way the fresh resolver's
+/// deferred-peer phase does (`get_or_put_resolved_package` with
+/// `install_peer`): scan the package ids recorded for the dependency's
+/// name — `package_index` lists are kept ordered by descending
+/// `Resolution::order` — and take the first whose resolution satisfies
+/// the range, falling back to the highest same-kind resolution (the
+/// "incorrect peer dependency" case). Returns `None` when no package
+/// with the name exists or no same-kind candidate is available; the
+/// caller then falls back to the path walk.
+///
+/// Peer edges cannot be resolved from the printed tree the way regular
+/// edges are: a peer never materializes its own `node_modules` path when
+/// the version hoisted at an enclosing path satisfies its range, so the
+/// path walk rebinds the edge to the hoisted version rather than the one
+/// the fresh resolve chose. That flips `buffers.resolutions` between the
+/// install that wrote the lockfile and every install that loads it, which
+/// re-keys isolated-linker store entries (and global-store entry hashes)
+/// on warm installs.
+fn resolve_peer_dep_version_based(
+    dep: &Dependency,
+    package_index: &PackageIndexMap,
+    pkg_resolutions: &[Resolution],
+    string_buf: &[u8],
+) -> Option<PackageID> {
+    let entry = package_index.get(&dep.name_hash)?;
+    let candidates: &[PackageID] = match entry {
+        PackageIndexEntry::Id(id) => core::slice::from_ref(id),
+        PackageIndexEntry::Ids(ids) => ids.as_slice(),
+    };
+
+    for &id in candidates {
+        if (id as usize) < pkg_resolutions.len()
+            && pkg_resolutions[id as usize].satisfies_dependency_version(
+                &dep.version,
+                string_buf,
+                string_buf,
+            )
+        {
+            return Some(id);
+        }
+    }
+
+    let &first = candidates.first()?;
+    if (first as usize) < pkg_resolutions.len() {
+        let res_tag = pkg_resolutions[first as usize].tag;
+        let ver_tag = dep.version.tag;
+        if (res_tag == ResolutionTag::Npm && ver_tag == DependencyVersionTag::Npm)
+            || (res_tag == ResolutionTag::Git && ver_tag == DependencyVersionTag::Git)
+            || (res_tag == ResolutionTag::Github && ver_tag == DependencyVersionTag::Github)
+        {
+            return Some(first);
+        }
+    }
+
+    None
 }
 
 // Taking `&mut BinaryLockfile` plus a `&mut Dependency` that

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3059,6 +3059,19 @@ fn is_deferred_peer(dep: &Dependency) -> bool {
 /// install that wrote the lockfile and every install that loads it, which
 /// re-keys isolated-linker store entries (and global-store entry hashes)
 /// on warm installs.
+///
+/// `catalog:` peer ranges are left on the path walk: the version scan
+/// cannot satisfy them (no catalog branch below), so they resolve exactly
+/// as before this helper existed. Closing that residual would mean
+/// replicating the catalog rewrite chain here.
+///
+/// Peers whose name matches a workspace package need no special casing
+/// even though the fresh resolver binds them to the workspace before any
+/// deferral (`'resolve_from_workspace`): the version scan below picks an
+/// npm candidate for such an edge, but workspaces are root dependencies,
+/// so the isolated store's ancestor walk and the hoisted tree's dedupe
+/// both resolve the name through the root's workspace entry before the
+/// edge value is ever consulted.
 fn resolve_peer_dep_version_based(
     dep: &Dependency,
     package_index: &PackageIndexMap,

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -42,8 +42,8 @@ use bun_install_types::DependencyVersionTag;
 use super::PackageIDSlice;
 use super::package::{Meta, PackageColumns as _, value_loc_of};
 use super::{
-    DependencySlice, LoadResult, Lockfile as BinaryLockfile, Package, PackageIndexEntry,
-    PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
+    DependencySlice, LoadResult, Lockfile as BinaryLockfile, OverrideMap, Package,
+    PackageIndexEntry, PackageIndexMap, PatchedDep, TrustedDependenciesSet, VersionHashMap, tree,
 };
 
 use bun_io::AsFmt;
@@ -2794,6 +2794,7 @@ pub fn parse_into_binary_lockfile(
         // parsed above; used to bind peer edges by version rather than by
         // tree path (see `resolve_peer_dep_version_based`).
         let package_index = &lockfile.package_index;
+        let overrides = &lockfile.overrides;
 
         // Disjoint-field split of `lockfile.buffers` so each loop body can hold
         // `&mut dependencies[i]` and `&mut resolutions[i]` together with a shared
@@ -2810,7 +2811,13 @@ pub fn parse_into_binary_lockfile(
                 let dep = &mut dependencies[dep_id as usize];
 
                 let peer_res_id = if is_deferred_peer(dep) {
-                    resolve_peer_dep_version_based(dep, package_index, pkg_resolutions, string_buf)
+                    resolve_peer_dep_version_based(
+                        dep,
+                        package_index,
+                        overrides,
+                        pkg_resolutions,
+                        string_buf,
+                    )
                 } else {
                     None
                 };
@@ -2892,6 +2899,7 @@ pub fn parse_into_binary_lockfile(
                         resolve_peer_dep_version_based(
                             dep,
                             package_index,
+                            overrides,
                             pkg_resolutions,
                             string_buf,
                         )
@@ -2957,7 +2965,13 @@ pub fn parse_into_binary_lockfile(
                 let dep = &mut dependencies[dep_id as usize];
 
                 let peer_res_id = if is_deferred_peer(dep) {
-                    resolve_peer_dep_version_based(dep, package_index, pkg_resolutions, string_buf)
+                    resolve_peer_dep_version_based(
+                        dep,
+                        package_index,
+                        overrides,
+                        pkg_resolutions,
+                        string_buf,
+                    )
                 } else {
                     None
                 };
@@ -3012,11 +3026,15 @@ pub fn parse_into_binary_lockfile(
 }
 
 /// True for peer edges the fresh resolver defers to its second phase
-/// (`install_peer`) and binds by version there. `*` peers are exempt:
-/// they express no version preference and bind to whatever sibling pin
-/// existed first, which the printed tree's path walk reproduces.
+/// (`install_peer`) and binds by version there. Two exemptions, matching
+/// `enqueue_dependency_with_main_and_success_fn`: optional peers return
+/// before the deferred phase and are bound to the hoisted-tree sibling by
+/// `process_subtree` instead, and `*` peers express no version preference
+/// and bind to whatever sibling pin existed first. Both of those are
+/// exactly what the printed tree's path walk reproduces, so they keep it.
 fn is_deferred_peer(dep: &Dependency) -> bool {
     dep.behavior.is_peer()
+        && !dep.behavior.is_optional_peer()
         && !(dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().version.is_star())
 }
 
@@ -3044,6 +3062,7 @@ fn is_deferred_peer(dep: &Dependency) -> bool {
 fn resolve_peer_dep_version_based(
     dep: &Dependency,
     package_index: &PackageIndexMap,
+    overrides: &OverrideMap,
     pkg_resolutions: &[Resolution],
     string_buf: &[u8],
 ) -> Option<PackageID> {
@@ -3062,6 +3081,21 @@ fn resolve_peer_dep_version_based(
         }
         _ => dep.name_hash,
     };
+
+    // The fresh resolver rewrites the name and range through
+    // `lockfile.overrides` (and any catalog entry an override points at)
+    // before its scan, so filtering candidates with the raw manifest range
+    // here would pick a version the override replaced. The printed tree
+    // already reflects the overridden resolution, so overridden edges keep
+    // the path walk. The exemptions mirror
+    // `enqueue_dependency_with_main_and_success_fn`: `npm:` aliases and
+    // workspace-only edges are never overridden.
+    let overridable = !dep.behavior.is_workspace()
+        && (dep.version.tag != DependencyVersionTag::Npm || !dep.version.npm().is_alias);
+    if overridable && overrides.get(name_hash).is_some() {
+        return None;
+    }
+
     let entry = package_index.get(&name_hash)?;
     let candidates: &[PackageID] = match entry {
         PackageIndexEntry::Id(id) => core::slice::from_ref(id),

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -19,7 +19,8 @@ use crate::{
     bin::{Bin, Tag as BinTag},
     dependency,
     dependency::{
-        Behavior, Dependency, Value as DependencyVersionValue, Version as DependencyVersion,
+        Behavior, Dependency, DependencyExt as _, Value as DependencyVersionValue,
+        Version as DependencyVersion,
     },
     invalid_package_id,
     resolution::Tag as ResolutionTag,
@@ -3024,10 +3025,13 @@ fn is_deferred_peer(dep: &Dependency) -> bool {
 /// `install_peer`): scan the package ids recorded for the dependency's
 /// name — `package_index` lists are kept ordered by descending
 /// `Resolution::order` — and take the first whose resolution satisfies
-/// the range, falling back to the highest same-kind resolution (the
-/// "incorrect peer dependency" case). Returns `None` when no package
-/// with the name exists or no same-kind candidate is available; the
-/// caller then falls back to the path walk.
+/// the range. When nothing satisfies, fall back to the highest-ordered
+/// candidate, and only when it is the same kind as the dependency (the
+/// "incorrect peer dependency" case; the fresh resolver inspects only
+/// `list[0]` there, and reproducing its choice exactly is the point of
+/// this helper). Returns `None` when no package with the name exists
+/// or the fallback is a different kind; the caller then falls back to
+/// the path walk.
 ///
 /// Peer edges cannot be resolved from the printed tree the way regular
 /// edges are: a peer never materializes its own `node_modules` path when
@@ -3043,7 +3047,22 @@ fn resolve_peer_dep_version_based(
     pkg_resolutions: &[Resolution],
     string_buf: &[u8],
 ) -> Option<PackageID> {
-    let entry = package_index.get(&dep.name_hash)?;
+    // `package_index` is keyed by *real* package names while `dep.name_hash`
+    // holds the alias, so an `npm:`-aliased peer must be looked up under the
+    // aliased name. Mirrors the realname hashing in
+    // `enqueue_dependency_with_main_and_success_fn`.
+    let name_hash = match dep.version.tag {
+        DependencyVersionTag::DistTag
+        | DependencyVersionTag::Git
+        | DependencyVersionTag::Github
+        | DependencyVersionTag::Npm
+        | DependencyVersionTag::Tarball
+        | DependencyVersionTag::Workspace => {
+            StringBuilder::string_hash(dep.realname().slice(string_buf))
+        }
+        _ => dep.name_hash,
+    };
+    let entry = package_index.get(&name_hash)?;
     let candidates: &[PackageID] = match entry {
         PackageIndexEntry::Id(id) => core::slice::from_ref(id),
         PackageIndexEntry::Ids(ids) => ids.as_slice(),

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3048,9 +3048,9 @@ fn resolve_peer_dep_version_based(
     string_buf: &[u8],
 ) -> Option<PackageID> {
     // `package_index` is keyed by *real* package names while `dep.name_hash`
-    // holds the alias, so an `npm:`-aliased peer must be looked up under the
-    // aliased name. Mirrors the realname hashing in
-    // `enqueue_dependency_with_main_and_success_fn`.
+    // may hold an alias, so an `npm:`-aliased peer must be looked up under
+    // the real package name (`dep.realname()`). Mirrors the realname hashing
+    // in `enqueue_dependency_with_main_and_success_fn`.
     let name_hash = match dep.version.tag {
         DependencyVersionTag::DistTag
         | DependencyVersionTag::Git

--- a/src/install/resolution.rs
+++ b/src/install/resolution.rs
@@ -16,6 +16,40 @@ use crate::versioned_url::VersionedURLType;
 
 pub type Resolution = ResolutionType<u64>;
 
+impl Resolution {
+    /// True when this resolution can satisfy `version`: npm ranges by
+    /// semver, git/github by exact repo equality. Any other kind pairing
+    /// (workspace, folder, tarball, dist-tag, …) never satisfies. This is
+    /// the comparison the resolver's deferred-peer phase uses to bind peer
+    /// edges against already-resolved packages.
+    pub fn satisfies_dependency_version(
+        &self,
+        version: &dependency::Version,
+        version_buf: &[u8],
+        resolution_buf: &[u8],
+    ) -> bool {
+        if self.tag == Tag::Npm && version.tag == dependency::VersionTag::Npm {
+            return version.npm().version.satisfies(
+                self.npm().version,
+                version_buf,
+                resolution_buf,
+            );
+        }
+
+        if self.tag == Tag::Git && version.tag == dependency::VersionTag::Git {
+            return self.git().eql(version.git(), resolution_buf, version_buf);
+        }
+
+        if self.tag == Tag::Github && version.tag == dependency::VersionTag::Github {
+            return self
+                .github()
+                .eql(version.github(), resolution_buf, version_buf);
+        }
+
+        false
+    }
+}
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ResolutionType<SemverInt: VersionInt> {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -819,6 +819,92 @@ test("aliased peer dependency binds to its real package across installs from bun
   expect(await file(aliasLink).json()).toEqual(fresh);
 });
 
+test("optional ranged peer keeps its hoisted-tree binding across installs from bun.lock", async () => {
+  // Optional peers never reach the fresh resolver's deferred-peer phase: it
+  // returns before the version scan and the edge is bound to the
+  // hoisted-tree sibling during tree resolution, which the printed tree's
+  // path walk reproduces exactly. With both no-deps@1.0.1 and no-deps@1.1.0
+  // in the graph, binding the optional peer by version on load would pick
+  // the highest satisfying (1.1.0) while the fresh install bound the hoisted
+  // 1.0.1, re-keying the entry on the first reinstall.
+  const { packageJson, packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+  });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "stable-optional-peers",
+      dependencies: {
+        "one-optional-peer-dep": "1.0.2",
+        "normal-dep-and-dev-dep": "1.0.0",
+        "two-range-deps": "1.0.0",
+      },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = join(packageDir, "node_modules", ".bun");
+  const freshEntries = (await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"));
+  expect(freshEntries).toHaveLength(1);
+  const freshVersion = (
+    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()
+  ).version;
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect((await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"))).toEqual(freshEntries);
+  expect(
+    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: freshVersion });
+});
+
+test("overridden peer dependency keeps the override across installs from bun.lock", async () => {
+  // `overrides` rewrites the peer range before the fresh resolver's version
+  // scan, binding the peer to no-deps@1.0.1 even though the graph also
+  // contains no-deps@1.1.0 (via an override-exempt npm: alias). Loading
+  // bun.lock must not re-filter candidates with the raw ^1.0.0 manifest
+  // range, which the override replaced; that would rebind the edge to 1.1.0
+  // and re-key the entry on the first reinstall.
+  const { packageJson, packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+  });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "stable-overridden-peers",
+      dependencies: {
+        "peer-deps-fixed": "1.0.0",
+        "nd11": "npm:no-deps@1.1.0",
+        // provides no-deps@1.0.1 so the overridden peer range resolves to an
+        // installed package
+        "normal-dep-and-dev-dep": "1.0.0",
+      },
+      overrides: { "no-deps": "1.0.1" },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = join(packageDir, "node_modules", ".bun");
+  const entryName = "peer-deps-fixed@1.0.0+f8a822eca018d0a1";
+  expect(await readdirSorted(bunDir)).toContain(entryName);
+  expect(
+    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.0.1" });
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual([entryName]);
+  expect(
+    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.0.1" });
+});
+
 describe("existing node_modules, missing node_modules/.bun", () => {
   test("root and workspace node_modules are reset", async () => {
     const { packageDir } = await registry.createTestDir({

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -1944,6 +1944,55 @@ describe("global virtual store", () => {
     expect(existsSync(join(entry, "node_modules", "no-deps", "package.json"))).toBe(true);
   });
 
+  test("disabling the global store detaches entries on the next install", async () => {
+    // The reverse of the upgrade test above: a project installed with the
+    // global store enabled has `node_modules/.bun/<X>` symlinks into
+    // `<cache>/links/`. Re-running install with the store disabled must
+    // replace those links with real project-local directories — the
+    // warm-path existence check passes *through* a live link, so without
+    // stale-link detection the project would silently keep running against
+    // (and a later rebuild would write into) the shared store.
+    const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: gvsBunfigOpts });
+
+    await write(
+      packageJson,
+      JSON.stringify({
+        name: "test-pkg-global-store-disable",
+        dependencies: { "two-range-deps": "1.0.0" },
+      }),
+    );
+
+    await runBunInstall(bunEnv, packageDir);
+    const entry = join(packageDir, "node_modules", ".bun", "two-range-deps@1.0.0");
+    expect(lstatSync(entry).isSymbolicLink()).toBe(true);
+    const globalTarget = readlinkSync(entry);
+
+    await runBunInstall({ ...bunEnv, BUN_INSTALL_GLOBAL_STORE: "0" }, packageDir, { savesLockfile: false });
+
+    // Every entry is detached into a real project-local directory.
+    expect(lstatSync(entry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(entry).isDirectory()).toBe(true);
+    const depEntry = join(packageDir, "node_modules", ".bun", "no-deps@1.1.0");
+    expect(lstatSync(depEntry).isSymbolicLink()).toBe(false);
+    expect(lstatSync(depEntry).isDirectory()).toBe(true);
+
+    // The rebuilt project-local tree resolves, including dep links between
+    // detached entries.
+    expect(await file(join(entry, "node_modules", "two-range-deps", "package.json")).json()).toMatchObject({
+      name: "two-range-deps",
+      version: "1.0.0",
+    });
+    expect(await file(join(entry, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+      name: "no-deps",
+    });
+    expect(await file(join(packageDir, "node_modules", "two-range-deps", "package.json")).json()).toMatchObject({
+      name: "two-range-deps",
+    });
+
+    // The shared global entry is left untouched for other projects.
+    expect(existsSync(join(globalTarget, "node_modules", "two-range-deps", "package.json"))).toBe(true);
+  });
+
   test("preserves bun patch workspace when install runs before --commit", async () => {
     // Regression: `bun patch <pkg>` detaches the project store entry from the
     // global virtual store (symlink → real directory) so the user can edit it.

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -734,6 +734,52 @@ for (const backend of ["clonefile", "hardlink", "copyfile"]) {
   });
 }
 
+test("ranged peer dependency resolution is stable across installs from bun.lock", async () => {
+  // `peer-deps-fixed` has a peer on `no-deps@^1.0.0`. The graph contains both
+  // no-deps@1.0.1 (exact pin via normal-dep-and-dev-dep, hoisted to the root
+  // of the saved tree) and no-deps@1.1.0 (via two-range-deps). The fresh
+  // resolve binds the peer edge to the highest satisfying version (1.1.0) in
+  // its deferred-peer phase; reloading bun.lock used to re-derive the edge
+  // from the saved tree paths instead, rebinding it to the hoisted 1.0.1.
+  // That silently changed the runtime dependency tree on the second install
+  // and re-keyed the isolated store entry (`+<peer hash>` suffix) on every
+  // warm install.
+  const { packageJson, packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+  });
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "stable-ranged-peers",
+      dependencies: {
+        "peer-deps-fixed": "1.0.0",
+        "normal-dep-and-dev-dep": "1.0.0",
+        "two-range-deps": "1.0.0",
+      },
+    }),
+  );
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = join(packageDir, "node_modules", ".bun");
+  const entryName = (await readdirSorted(bunDir)).find(e => e.startsWith("peer-deps-fixed@"))!;
+  // highest satisfying ^1.0.0 in the graph
+  expect(entryName).toBe("peer-deps-fixed@1.0.0+7ff199101204a65d");
+  expect(
+    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
+
+  // reinstall from bun.lock: same peer variant, same resolved version
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual([entryName]);
+  expect(
+    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.1.0" });
+});
+
 describe("existing node_modules, missing node_modules/.bun", () => {
   test("root and workspace node_modules are reset", async () => {
     const { packageDir } = await registry.createTestDir({

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -910,6 +910,51 @@ test("overridden peer dependency keeps the override across installs from bun.loc
   });
 });
 
+test("peer satisfied by a workspace package keeps the workspace across installs from bun.lock", async () => {
+  // The fresh resolver binds an npm-range peer to a same-named workspace
+  // package before any deferral when linkWorkspacePackages is on and the
+  // workspace version satisfies the range. The graph also contains npm
+  // no-deps@1.0.1 (normal-dep-and-dev-dep's exact pin, which the workspace's
+  // 1.0.0 cannot satisfy), and that version satisfies the peer's ^1.0.0 too;
+  // loading bun.lock must not rebind the peer from the workspace to the npm
+  // package through the version scan.
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "workspace-peer-root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "peer-deps-fixed": "1.0.0",
+          "normal-dep-and-dev-dep": "1.0.0",
+        },
+      }),
+      "packages/no-deps/package.json": JSON.stringify({
+        name: "no-deps",
+        version: "1.0.0",
+        workspaceMarker: true,
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const bunDir = join(packageDir, "node_modules", ".bun");
+  const freshEntries = (await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"));
+  expect(freshEntries).toHaveLength(1);
+  expect(
+    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.0.0", workspaceMarker: true });
+
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+
+  expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual(freshEntries);
+  expect(
+    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
+  ).toMatchObject({ version: "1.0.0", workspaceMarker: true });
+});
+
 describe("existing node_modules, missing node_modules/.bun", () => {
   test("root and workspace node_modules are reset", async () => {
     const { packageDir } = await registry.createTestDir({

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -766,18 +766,18 @@ test("ranged peer dependency resolution is stable across installs from bun.lock"
   const entryName = (await readdirSorted(bunDir)).find(e => e.startsWith("peer-deps-fixed@"))!;
   // highest satisfying ^1.0.0 in the graph
   expect(entryName).toBe("peer-deps-fixed@1.0.0+7ff199101204a65d");
-  expect(
-    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.1.0" });
+  expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.1.0",
+  });
 
   // reinstall from bun.lock: same peer variant, same resolved version
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual([entryName]);
-  expect(
-    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.1.0" });
+  expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.1.0",
+  });
 });
 
 describe("existing node_modules, missing node_modules/.bun", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -763,9 +763,10 @@ test("ranged peer dependency resolution is stable across installs from bun.lock"
   await runBunInstall(bunEnv, packageDir);
 
   const bunDir = join(packageDir, "node_modules", ".bun");
-  const entryName = (await readdirSorted(bunDir)).find(e => e.startsWith("peer-deps-fixed@"))!;
-  // highest satisfying ^1.0.0 in the graph
-  expect(entryName).toBe("peer-deps-fixed@1.0.0+7ff199101204a65d");
+  // highest satisfying ^1.0.0 in the graph; `toContain` prints the full
+  // listing when the entry is missing or keyed with a different peer hash
+  const entryName = "peer-deps-fixed@1.0.0+7ff199101204a65d";
+  expect(await readdirSorted(bunDir)).toContain(entryName);
   expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
     version: "1.1.0",
   });
@@ -778,6 +779,44 @@ test("ranged peer dependency resolution is stable across installs from bun.lock"
   expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
     version: "1.1.0",
   });
+});
+
+test("aliased peer dependency binds to its real package across installs from bun.lock", async () => {
+  // The peer alias `no-deps` points at `npm:a-dep@^1.0.2` while the real
+  // no-deps package (in two versions) is also in the graph. Loading bun.lock
+  // must look the edge up under the aliased *real* name (a-dep) the way the
+  // fresh resolver does; a lookup under the alias would find the real
+  // no-deps packages, whose versions also satisfy ^1.0.2, and rebind the
+  // edge to the wrong package.
+  const { packageDir } = await registry.createTestDir({
+    bunfigOpts: { linker: "isolated" },
+    files: {
+      "package.json": JSON.stringify({
+        name: "aliased-peer-root",
+        workspaces: ["packages/*"],
+        dependencies: {
+          "normal-dep-and-dev-dep": "1.0.0",
+          "two-range-deps": "1.0.0",
+        },
+      }),
+      "packages/m/package.json": JSON.stringify({
+        name: "m",
+        version: "1.0.0",
+        peerDependencies: { "no-deps": "npm:a-dep@^1.0.2" },
+      }),
+    },
+  });
+
+  await runBunInstall(bunEnv, packageDir);
+  const aliasLink = join(packageDir, "packages", "m", "node_modules", "no-deps", "package.json");
+  const fresh = await file(aliasLink).json();
+  expect(fresh).toMatchObject({ name: "a-dep" });
+
+  // reinstall from bun.lock: still the aliased package, same version
+  await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+  await rm(join(packageDir, "packages", "m", "node_modules"), { recursive: true, force: true });
+  await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
+  expect(await file(aliasLink).json()).toEqual(fresh);
 });
 
 describe("existing node_modules, missing node_modules/.bun", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -942,17 +942,19 @@ test("peer satisfied by a workspace package keeps the workspace across installs 
   const bunDir = join(packageDir, "node_modules", ".bun");
   const freshEntries = (await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"));
   expect(freshEntries).toHaveLength(1);
-  expect(
-    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.0.0", workspaceMarker: true });
+  expect(await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.0",
+    workspaceMarker: true,
+  });
 
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual(freshEntries);
-  expect(
-    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.0.0", workspaceMarker: true });
+  expect(await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.0",
+    workspaceMarker: true,
+  });
 });
 
 describe("existing node_modules, missing node_modules/.bun", () => {

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -848,15 +848,17 @@ test("optional ranged peer keeps its hoisted-tree binding across installs from b
   const bunDir = join(packageDir, "node_modules", ".bun");
   const freshEntries = (await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"));
   expect(freshEntries).toHaveLength(1);
-  const freshVersion = (await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json())
-    .version;
+  // the hoisted candidate, not the highest satisfying (1.1.0)
+  expect(await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.1",
+  });
 
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"))).toEqual(freshEntries);
   expect(await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
-    version: freshVersion,
+    version: "1.0.1",
   });
 });
 
@@ -890,6 +892,9 @@ test("overridden peer dependency keeps the override across installs from bun.loc
 
   const bunDir = join(packageDir, "node_modules", ".bun");
   const entryName = "peer-deps-fixed@1.0.0+f8a822eca018d0a1";
+  // the override-exempt alias keeps the competing 1.1.0 candidate in the graph
+  const aliasManifest = join(packageDir, "node_modules", "nd11", "package.json");
+  expect(await file(aliasManifest).json()).toMatchObject({ name: "no-deps", version: "1.1.0" });
   expect(await readdirSorted(bunDir)).toContain(entryName);
   expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
     version: "1.0.1",
@@ -898,6 +903,7 @@ test("overridden peer dependency keeps the override across installs from bun.loc
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
+  expect(await file(aliasManifest).json()).toMatchObject({ name: "no-deps", version: "1.1.0" });
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual([entryName]);
   expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
     version: "1.0.1",

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -848,17 +848,16 @@ test("optional ranged peer keeps its hoisted-tree binding across installs from b
   const bunDir = join(packageDir, "node_modules", ".bun");
   const freshEntries = (await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"));
   expect(freshEntries).toHaveLength(1);
-  const freshVersion = (
-    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()
-  ).version;
+  const freshVersion = (await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json())
+    .version;
 
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("one-optional-peer-dep@"))).toEqual(freshEntries);
-  expect(
-    await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: freshVersion });
+  expect(await file(join(bunDir, freshEntries[0], "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: freshVersion,
+  });
 });
 
 test("overridden peer dependency keeps the override across installs from bun.lock", async () => {
@@ -892,17 +891,17 @@ test("overridden peer dependency keeps the override across installs from bun.loc
   const bunDir = join(packageDir, "node_modules", ".bun");
   const entryName = "peer-deps-fixed@1.0.0+f8a822eca018d0a1";
   expect(await readdirSorted(bunDir)).toContain(entryName);
-  expect(
-    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.0.1" });
+  expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.1",
+  });
 
   await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
   await runBunInstall(bunEnv, packageDir, { savesLockfile: false });
 
   expect((await readdirSorted(bunDir)).filter(e => e.startsWith("peer-deps-fixed@"))).toEqual([entryName]);
-  expect(
-    await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json(),
-  ).toMatchObject({ version: "1.0.1" });
+  expect(await file(join(bunDir, entryName, "node_modules", "no-deps", "package.json")).json()).toMatchObject({
+    version: "1.0.1",
+  });
 });
 
 describe("existing node_modules, missing node_modules/.bun", () => {


### PR DESCRIPTION
Two bugs in the isolated linker's global virtual store (`install.globalStore`, the shared `<cache>/links/` store), both of the form "the second install disagrees with the first".

### 1. Disabling `globalStore` left the project wired into the shared store

Repro:

```bash
# bunfig: linker = "isolated", globalStore = true
bun install
# flip to globalStore = false (or BUN_INSTALL_GLOBAL_STORE=0)
bun install
readlink node_modules/.bun/<pkg>@<version>   # still -> ~/.bun/install/cache/links/...
```

Cause: the warm path's stale-link detection bailed out when `global_store_path` was `None`, i.e. exactly when the store is disabled. The per-entry existence check then passed *through* the live symlink, every entry was skipped, and the project kept resolving into the shared store. A later rebuild (version bump, `--force`) would detach correctly, but a plain reinstall never did; the workaround in #29614 ("stale symlinks into /links/ persist otherwise") documents users hitting this with `rm -rf node_modules`.

Fix: run the stale-link check for any entry that does not use the global store and is about to be skipped. Moving it after the existence check also removes the lstat from the cold path for ineligible entries while the store is enabled.

### 2. `bun.lock` loading rebinds ranged peer edges, re-keying store entries on every reinstall

Repro (registry fixtures): `peer-deps-fixed` has `peerDependencies: { "no-deps": "^1.0.0" }`, and the graph contains both no-deps@1.0.1 (exact pin, hoisted to the root of the saved tree) and no-deps@1.1.0.

```
run1 (fresh resolve):   .bun/peer-deps-fixed@1.0.0+7ff199101204a65d -> no-deps@1.1.0
run2 (loads bun.lock):  .bun/peer-deps-fixed@1.0.0+f8a822eca018d0a1 -> no-deps@1.0.1
```

Cause: fresh resolution binds ranged peer edges in its deferred phase to the highest satisfying version in the lockfile. The printed tree cannot round-trip that choice: a peer edge never materializes its own `node_modules` path when the version hoisted at an enclosing path satisfies its range, so `parse_into_binary_lockfile`'s path walk rebinds the edge to the hoisted version. The resolved tree silently changes on the first reinstall, the `+<peer hash>` store suffix changes with it, and every affected isolated-store entry is discarded and rebuilt. With `globalStore = true` those entries re-stage into `<cache>/links/` on reinstall, which is the warm-install re-materialization reported in #29614 (at cal.com scale, thousands of peer-variant entries).

Fix: resolve deferred peer edges during text-lockfile load the way the fresh resolver's deferred phase does: scan the package ids recorded for the edge's real name (kept in descending resolution order) for the first satisfying match, falling back to the highest same-kind resolution. Edges the fresh resolver does not version-bind keep the path walk, which reproduces its choice: `*` peers (no version preference, bound to whatever pin existed first), optional peers (never deferred; bound to the hoisted-tree sibling during tree resolution), and edges whose effective name has an `overrides` entry (the override rewrites the range before the fresh scan, and the printed tree reflects the overridden resolution). The satisfies comparison is shared with the resolver via `Resolution::satisfies_dependency_version`, and `npm:`-aliased peers are looked up under their real package name, mirroring the resolver's realname hashing.

Known residuals, intentionally out of scope: `*` peers are bound order-dependently during *fresh* resolution (deliberate, per the determinism comment in `get_or_put_resolved_package_with_find_result`; the "peer `*`" hoisting tests depend on it), so when the early-bird pick differs from the hoisted-root version the first reinstall can still re-key those entries once; `catalog:` peer ranges stay on the path walk (closing that would mean replicating the catalog rewrite chain in the parser); and peers whose effective range is rewritten by the resolver's `known_npm_aliases` session state also stay on the path walk, since that state does not exist at parse time. All three behave exactly as before this PR. Peers satisfied by a same-named workspace package need no loader change: the isolated store's ancestor walk and the hoisted tree's dedupe both resolve them through the root's workspace entry regardless of the edge value (verified empirically, pinned by a test).

### Verification

- `test/cli/install/isolated-install.test.ts`: five new tests covering the global-store detach on disable, ranged peer stability across installs from bun.lock, and the review-hardened cases (aliased peers bind to their real package, optional ranged peers keep their hoisted-tree binding, overridden peers keep the override). Each fails on the code before its fixing commit and passes after.
- Full suites green with the fix: isolated-install (49), bun-lock (12), bun-lockb (5), bun-workspaces (63), bun-install-registry (223 pass; 2 git-network failures also fail on unmodified main in this environment), catalogs, bun-update, bun-pm-why, bun-install-patch. `cargo check` passes for linux and windows targets.
- Behavior sweep with `globalStore = true` while hunting (all passing, not committed): warm reuse with peers/cycles/scoped/bins/tarball deps, cross-project entry sharing, SCC hash stability for dependency loops, `bun pm cache rm` healing, `bun add --trust` and `trustedDependencies` detach with scripts writing project-locally, `bun patch` isolation between projects, `--force` twice, `--backend=copyfile|symlink`, override flips re-keying parents and reusing old entries on flip-back.


