### PR TITLE
Fix segfault when a top-level-await module resumes inside AsyncLocalStorage

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "cd821fecca0d39c8bac874c283d956868c7f0de0";
+export const WEBKIT_VERSION = "f72c0151d39e40bec7755bcdcd9701f3d61b8e8b";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/regression/issue/32178.test.ts
+++ b/test/regression/issue/32178.test.ts
@@ -1,0 +1,97 @@
+// https://github.com/oven-sh/bun/issues/32178
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test.concurrent("top-level await resumes while an AsyncLocalStorage context is active", async () => {
+  using dir = tempDir("issue-32178", {
+    "entry.ts": `
+      import { AsyncLocalStorage } from "node:async_hooks";
+      const als = new AsyncLocalStorage();
+      als.enterWith({ v: 42 });
+      await Promise.resolve(1);
+      console.log("after microtask await:", JSON.stringify(als.getStore()));
+      await new Promise(r => setImmediate(r));
+      console.log("after macrotask await:", JSON.stringify(als.getStore()));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // The async context must also survive across the top-level awaits, like Node.
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: 'after microtask await: {"v":42}\nafter macrotask await: {"v":42}\n',
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+test.concurrent("imported top-level-await module entering an AsyncLocalStorage context", async () => {
+  using dir = tempDir("issue-32178-import", {
+    "main.ts": `
+      import { store } from "./tla.ts";
+      console.log("imported:", JSON.stringify(store));
+    `,
+    "tla.ts": `
+      import { AsyncLocalStorage } from "node:async_hooks";
+      const als = new AsyncLocalStorage();
+      als.enterWith({ id: 7 });
+      await Promise.resolve();
+      await Promise.resolve();
+      export const store = als.getStore();
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: 'imported: {"id":7}\n',
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/32694
+test.concurrent("dynamic import() after enterWith() at module top level", async () => {
+  using dir = tempDir("issue-32694", {
+    "minimal.mjs": `
+      import { AsyncLocalStorage } from "node:async_hooks";
+      const als = new AsyncLocalStorage();
+      als.enterWith("X");
+      const { value } = await import("./target.mjs");
+      console.log("done:", value, JSON.stringify(als.getStore()));
+    `,
+    "target.mjs": `export const value = 42;`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "minimal.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: 'done: 42 "X"\n',
+    stderr: "",
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fixes #32178
Fixes #32694

### Repro

```ts
import { AsyncLocalStorage } from "node:async_hooks";
new AsyncLocalStorage().enterWith({ v: 1 });
await Promise.resolve(1);
```

Crashes 100% deterministically on 1.3.14 through current main (`panic(main thread): Segmentation fault at address 0x10`, also seen as `0x0` / `0x600010071`); works on 1.3.13 and in Node. Any top-level `await` after `enterWith()` at module scope triggers it, including a dynamic `import()` as the awaited expression (#32694).

### Cause

Type confusion in the WebKit fork, not a GC bug. Since the 1.3.14 module-loader rewrite, async module resumption goes through `InternalMicrotask::AsyncModuleExecutionResume`. `JSPromise::resolveWithInternalMicrotaskForAsyncAwait` wraps the microtask context in an `InternalFieldTuple(context, asyncContext)` whenever Bun's async context is active at await time. Every other consumer of that wrapped context unwraps the tuple; the `AsyncModuleExecutionResume` dispatch did not, and ran `uncheckedDowncast<JSModuleRecord>` on the tuple.

```
JSC::reportZappedCellAndCrash                                 JSCell.cpp
WTF::uncheckedDowncast<JSC::JSModuleRecord>                   JSCast.h
JSC::runInternalMicrotask (task=AsyncModuleExecutionResume)   JSMicrotask.cpp
```

In asserting builds that surfaces as `JSC::reportZappedCellAndCrash`: the downcast's type check fails and its diagnostic assumes a swept cell, but nothing was collected. In release builds the check compiles out, so it reads `JSModuleRecord` fields past the end of the two-slot tuple and segfaults.

### Fix

Two parts:

1. oven-sh/WebKit#252 (merged): unwrap the tuple in the `AsyncModuleExecutionResume` dispatch and set/restore the async context around the resumption, mirroring the existing `AsyncFunctionResume` case. This also makes `AsyncLocalStorage` context survive across top-level await, matching Node.
2. This PR: the regression tests, plus the `WEBKIT_VERSION` bump to `f72c0151d39e40bec7755bcdcd9701f3d61b8e8b`, the oven-sh/WebKit main commit that carries #252. That commit is the previous pin (`cd821fecca`) plus only #252's one-function change; no header differs between the two, so nothing else can be affected by the bump.

### Verification

Against the bumped pin (`bun bd`, linux x64 debug+ASAN):

- `test/regression/issue/32178.test.ts`: 3 pass. Against stock bun (`USE_SYSTEM_BUN=1 bun test`) and against a build pinned to the unfixed `cd821fecca` (`bun bd --webkit-version=cd821fecca... test`): 0 pass, 3 fail (child segfaults).
- The exact reproductions from #32178 and #32694 exit 0 and their output matches Node 26.
- `test/js/node/async_hooks/` (117 pass, 3 pre-existing todo) and `test/js/bun/resolve/dynamic-import-tla-cycle.test.ts` (6 pass) are clean.

I also re-derived the root cause independently at the pure-JSC level: a debug `jsc` shell built from `cd821fecca` reproduces the identical `reportZappedCellAndCrash` stack from a script that only sets the async context and awaits at module top level, and passes once #252's change is applied.
