### PR TITLE
Check strict-mode reserved words at declaration sites in implicitly strict files

### DIFF
--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -46,6 +46,11 @@ pub struct Scope {
 
     pub strict_mode: StrictModeKind,
 
+    // Location of the "use strict" directive when `strict_mode` is
+    // `ExplicitStrictMode`. Inherited by child scopes along with
+    // `strict_mode` so error notes can point at the directive.
+    pub use_strict_loc: crate::Loc,
+
     pub is_after_const_local_prefix: bool,
 
     // This will be non-null if this is a TypeScript "namespace" or "enum"
@@ -75,6 +80,7 @@ impl Scope {
         contains_direct_eval: false,
         forbid_arguments: false,
         strict_mode: StrictModeKind::SloppyMode,
+        use_strict_loc: crate::Loc::EMPTY,
         is_after_const_local_prefix: false,
         ts_namespace: None,
     };
@@ -133,6 +139,7 @@ impl Scope {
         self.label_stmt_is_loop = false;
         self.contains_direct_eval = false;
         self.strict_mode = StrictModeKind::SloppyMode;
+        self.use_strict_loc = crate::Loc::EMPTY;
         self.kind = Kind::Block;
     }
 

--- a/src/ast/scope.rs
+++ b/src/ast/scope.rs
@@ -245,11 +245,17 @@ impl Scope {
         SymbolMergeResult::Forbidden
     }
 
-    pub fn recursive_set_strict_mode(&mut self, kind: StrictModeKind) {
+    /// `use_strict_loc` is the directive location to stamp when `kind` is
+    /// `ExplicitStrictMode`; pass `Loc::EMPTY` for implicit-strict kinds (their
+    /// diagnostic location comes from the ESM/class keyword, not the scope).
+    /// Set together with `strict_mode` so child scopes already pushed for
+    /// parameter-default expressions carry the directive location too.
+    pub fn recursive_set_strict_mode(&mut self, kind: StrictModeKind, use_strict_loc: crate::Loc) {
         if self.strict_mode == StrictModeKind::SloppyMode {
             self.strict_mode = kind;
+            self.use_strict_loc = use_strict_loc;
             for child in self.children.slice_mut() {
-                child.recursive_set_strict_mode(kind);
+                child.recursive_set_strict_mode(kind, use_strict_loc);
             }
         }
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4736,11 +4736,19 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         name: &[u8],
     ) -> Result<(), bun_core::Error> {
         if bun_ast::lexer_tables::is_strict_mode_reserved_word(name) {
-            self.mark_strict_mode_feature(
-                StrictModeFeature::ReservedWord,
-                js_lexer::range_of_identifier(self.source, loc),
-                name,
-            )
+            // Gated on strictness like the reference check in `e_identifier`:
+            // in sloppy code bundled to the ESM output format, the renamer
+            // renames reserved-word bindings to valid names, so the
+            // output-format error in `mark_strict_mode_feature` must not
+            // fire for them.
+            if self.is_strict_mode() {
+                self.mark_strict_mode_feature(
+                    StrictModeFeature::ReservedWord,
+                    js_lexer::range_of_identifier(self.source, loc),
+                    name,
+                )?;
+            }
+            Ok(())
         } else if is_eval_or_arguments(name) {
             self.mark_strict_mode_feature(
                 StrictModeFeature::EvalOrArguments,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -470,7 +470,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub delete_target: js_ast::ExprData,
     pub loop_body: js_ast::StmtData,
     pub module_scope: js_ast::StoreRef<js_ast::Scope>,
-    pub module_scope_directive_loc: bun_ast::Loc,
     pub is_control_flow_dead: bool,
 
     /// We must be careful to avoid revisiting nodes that have scopes.
@@ -3592,6 +3591,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `parent != scope` (fresh alloc) so the two `&mut` do not alias.
         VecExt::append(&mut parent.children, scope);
         scope.strict_mode = parent.strict_mode;
+        scope.use_strict_loc = parent.use_strict_loc;
 
         self.current_scope = scope;
 
@@ -4689,7 +4689,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     why = b"All code inside a class is implicitly in strict mode";
                     where_ = self.enclosing_class_keyword;
                 }
-                _ => {}
+                js_ast::StrictModeKind::ExplicitStrictMode => {
+                    why = b"Strict mode is triggered by the \"use strict\" directive here";
+                    where_ = self.source.range_of_string(scope.use_strict_loc);
+                }
+                js_ast::StrictModeKind::SloppyMode => {}
             }
             if why.is_empty() {
                 why = bun_alloc::arena_format!(
@@ -4720,6 +4724,32 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
         Ok(())
+    }
+
+    /// Forbid declaring a symbol with a strict-mode reserved word or with the
+    /// name "eval" or "arguments". Must run during the visit pass: implicit
+    /// strict mode (ESM keywords, class bodies) is not yet applied to scopes
+    /// while parsing.
+    pub fn validate_declared_symbol_name(
+        &mut self,
+        loc: bun_ast::Loc,
+        name: &[u8],
+    ) -> Result<(), bun_core::Error> {
+        if bun_ast::lexer_tables::is_strict_mode_reserved_word(name) {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )
+        } else if is_eval_or_arguments(name) {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::EvalOrArguments,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )
+        } else {
+            Ok(())
+        }
     }
 
     #[inline]
@@ -4872,17 +4902,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     ) -> Result<Ref, bun_core::Error> {
         // p.checkForNonBMPCodePoint(loc, name)
 
-        // Forbid declaring a symbol with a reserved word in strict mode
-        if self.is_strict_mode()
-            && name.as_ptr() != arguments_str.as_ptr()
-            && bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
-        {
-            self.mark_strict_mode_feature(
-                StrictModeFeature::ReservedWord,
-                js_lexer::range_of_identifier(self.source, loc),
-                name,
-            )?;
-        }
+        // Reserved-word and "eval"/"arguments" name checks happen in the visit
+        // pass (`validate_declared_symbol_name`), not here: implicit strict
+        // mode (ESM keywords, class bodies) is only applied to scopes after
+        // parsing, in `prepare_for_visit_pass` and `visit_class`.
 
         // Allocate a new symbol
         let mut ref_ = self.new_symbol(kind, name)?;
@@ -8566,7 +8589,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         S::Directive {
                             value: b"use strict".into(),
                         },
-                        self.module_scope_directive_loc,
+                        self.module_scope().use_strict_loc,
                     );
                     remaining_stmts = &mut remaining_stmts[1..];
                 }
@@ -9169,7 +9192,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             is_import_item: Default::default(),
             import_namespace_cc_map: Default::default(),
             scope_order_to_visit: &[],
-            module_scope_directive_loc: bun_ast::Loc::default(),
             is_control_flow_dead: false,
             is_revisit_for_substitution: false,
             method_call_must_be_replaced_with_undefined: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3116,14 +3116,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // ECMAScript modules are always interpreted as strict mode. This has to be
         // done before "hoistSymbols" because strict mode can alter hoisting (!).
         if self.esm_import_keyword.len > 0 {
-            self.module_scope_mut()
-                .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeImport);
+            self.module_scope_mut().recursive_set_strict_mode(
+                js_ast::StrictModeKind::ImplicitStrictModeImport,
+                bun_ast::Loc::EMPTY,
+            );
         } else if self.esm_export_keyword.len > 0 {
-            self.module_scope_mut()
-                .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeExport);
+            self.module_scope_mut().recursive_set_strict_mode(
+                js_ast::StrictModeKind::ImplicitStrictModeExport,
+                bun_ast::Loc::EMPTY,
+            );
         } else if self.top_level_await_keyword.len > 0 {
-            self.module_scope_mut()
-                .recursive_set_strict_mode(js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait);
+            self.module_scope_mut().recursive_set_strict_mode(
+                js_ast::StrictModeKind::ImplicitStrictModeTopLevelAwait,
+                bun_ast::Loc::EMPTY,
+            );
         }
 
         self.hoist_symbols(self.module_scope_ref());

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1487,11 +1487,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             if str_.eql_comptime(b"use strict") {
                                 skip = true;
                                 // Track "use strict" directives
-                                p.current_scope_mut().strict_mode =
-                                    StrictModeKind::ExplicitStrictMode;
-                                if p.current_scope == p.module_scope {
-                                    p.module_scope_directive_loc = stmt.loc;
-                                }
+                                let scope = p.current_scope_mut();
+                                scope.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                scope.use_strict_loc = stmt.loc;
                             } else if str_.eql_comptime(b"use asm") {
                                 skip = true;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1490,6 +1490,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 let scope = p.current_scope_mut();
                                 scope.strict_mode = StrictModeKind::ExplicitStrictMode;
                                 scope.use_strict_loc = stmt.loc;
+
+                                // Inside a function, strict mode propagates
+                                // from the function-body scope to the
+                                // parameter scope:
+                                //
+                                //   // This is a syntax error
+                                //   function fn(arguments) {
+                                //     "use strict";
+                                //   }
+                                //
+                                if scope.kind == js_ast::scope::Kind::FunctionBody {
+                                    if let Some(mut parent) = scope.parent {
+                                        if parent.kind == js_ast::scope::Kind::FunctionArgs
+                                            && parent.strict_mode == StrictModeKind::SloppyMode
+                                        {
+                                            parent.strict_mode = StrictModeKind::ExplicitStrictMode;
+                                            parent.use_strict_loc = stmt.loc;
+                                        }
+                                    }
+                                }
                             } else if str_.eql_comptime(b"use asm") {
                                 skip = true;
                                 stmt.data = js_ast::stmt::Data::SEmpty(S::Empty {});

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1516,9 +1516,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                         if parent.kind == js_ast::scope::Kind::FunctionArgs
                                             && parent.strict_mode == StrictModeKind::SloppyMode
                                         {
-                                            parent.use_strict_loc = stmt.loc;
                                             parent.recursive_set_strict_mode(
                                                 StrictModeKind::ExplicitStrictMode,
+                                                stmt.loc,
                                             );
                                         }
                                     }

--- a/src/js_parser/parse/mod.rs
+++ b/src/js_parser/parse/mod.rs
@@ -1500,13 +1500,26 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                 //     "use strict";
                                 //   }
                                 //
+                                // Use `recursive_set_strict_mode` rather than a
+                                // flat write so scopes already pushed for
+                                // parameter-default expressions (arrows, etc.)
+                                // are marked strict too. A flat write would
+                                // leave them sloppy, and the later
+                                // `recursive_set_strict_mode` for implicit
+                                // strictness stops at the now-strict parameter
+                                // scope. The function-body scope set above is
+                                // already strict, so recursion stops there
+                                // without revisiting it.
+                                let scope = p.current_scope;
                                 if scope.kind == js_ast::scope::Kind::FunctionBody {
                                     if let Some(mut parent) = scope.parent {
                                         if parent.kind == js_ast::scope::Kind::FunctionArgs
                                             && parent.strict_mode == StrictModeKind::SloppyMode
                                         {
-                                            parent.strict_mode = StrictModeKind::ExplicitStrictMode;
                                             parent.use_strict_loc = stmt.loc;
+                                            parent.recursive_set_strict_mode(
+                                                StrictModeKind::ExplicitStrictMode,
+                                            );
                                         }
                                     }
                                 }

--- a/src/js_parser/parse/parse_import_export.rs
+++ b/src/js_parser/parse/parse_import_export.rs
@@ -221,7 +221,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     original_name = p.lexer.identifier;
                     name = LocRef {
-                        loc: alias_loc,
+                        loc: p.lexer.loc(),
                         ref_: p.store_name_in_ref(original_name)?,
                     };
                     p.lexer.expect(T::TIdentifier)?;

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -803,10 +803,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .expect("unreachable");
         let old_enclosing_class_keyword = self.enclosing_class_keyword;
         self.enclosing_class_keyword = class.class_keyword;
-        self.vis_scope().recursive_set_strict_mode(
-            StrictModeKind::ImplicitStrictModeClass,
-            js_ast::Loc::EMPTY,
-        );
+        self.vis_scope()
+            .recursive_set_strict_mode(StrictModeKind::ImplicitStrictModeClass, js_ast::Loc::EMPTY);
         // The class name is part of the class, which is always strict mode
         // code, so validate it inside the class-name scope.
         if let Some(name) = class.class_name {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -10,8 +10,7 @@ use crate::lexer as js_lexer;
 use crate::p::{LowerUsingDeclarationsContext, P};
 use crate::parser::{
     ExprIn, FnOnlyDataVisit, FnOrArrowDataVisit, ImportItemForNamespaceMap, PrependTempRefsOpts,
-    Ref, RelocateVarsMode, ScopeOrder, StmtsKind, StrictModeFeature, StringVoidMap, TempRef,
-    VisitArgsOpts, is_eval_or_arguments,
+    Ref, RelocateVarsMode, ScopeOrder, StmtsKind, StringVoidMap, TempRef, VisitArgsOpts,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast as js_ast;
@@ -106,15 +105,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if let Some(name) = func.name {
             if let Some(name_ref) = name.ref_.to_nullable() {
                 self.record_declared_symbol(name_ref);
-                let symbol_name = self.load_name_from_ref(name_ref);
-                if is_eval_or_arguments(symbol_name) {
-                    self.mark_strict_mode_feature(
-                        StrictModeFeature::EvalOrArguments,
-                        js_lexer::range_of_identifier(self.source, name.loc),
-                        symbol_name,
-                    )
-                    .expect("unreachable");
-                }
             }
         }
 
@@ -135,6 +125,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         self.push_scope_for_visit_pass(ScopeKind::FunctionBody, body_loc)
             .expect("unreachable");
+        // Validate the function name inside the function-body scope: the name
+        // is subject to the function's own strictness, including a
+        // "use strict" directive in the body.
+        if let Some(name) = func.name {
+            if let Some(name_ref) = name.ref_.to_nullable() {
+                let symbol_name = self.load_name_from_ref(name_ref);
+                self.validate_declared_symbol_name(name.loc, symbol_name)
+                    .expect("unreachable");
+            }
+        }
         // Stmt is Copy — copy the slice into a bump-backed Vec.
         let mut stmts = BumpVec::with_capacity_in(body_stmts.len(), self.arena);
         stmts.extend_from_slice(body_stmts);
@@ -629,14 +629,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 let name: &'a [u8] = self.symbols[bind.r#ref.inner_index() as usize]
                     .original_name
                     .slice();
-                if is_eval_or_arguments(name) {
-                    self.mark_strict_mode_feature(
-                        StrictModeFeature::EvalOrArguments,
-                        js_lexer::range_of_identifier(self.source, binding.loc),
-                        name,
-                    )
+                self.validate_declared_symbol_name(binding.loc, name)
                     .expect("unreachable");
-                }
                 if let Some(dup) = duplicate_arg_check {
                     if dup.get_or_put_contains(name) {
                         self.log().add_range_error_fmt(
@@ -811,6 +805,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.enclosing_class_keyword = class.class_keyword;
         self.vis_scope()
             .recursive_set_strict_mode(StrictModeKind::ImplicitStrictModeClass);
+        // The class name is part of the class, which is always strict mode
+        // code, so validate it inside the class-name scope.
+        if let Some(name) = class.class_name {
+            let name_ref = name.ref_;
+            let symbol_name: &'a [u8] = self.symbols[name_ref.inner_index() as usize]
+                .original_name
+                .slice();
+            self.validate_declared_symbol_name(name.loc, symbol_name)
+                .expect("unreachable");
+        }
         // `FnOnlyDataVisit::class_name_ref` is `Option<&'a Cell<Ref>>`, so the
         // shadow ref must outlive the parser borrow. Allocate it in the bump arena.
         // `Cell` lets us hand out a shared `&'a Cell<Ref>` to nested frames while

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -803,8 +803,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .expect("unreachable");
         let old_enclosing_class_keyword = self.enclosing_class_keyword;
         self.enclosing_class_keyword = class.class_keyword;
-        self.vis_scope()
-            .recursive_set_strict_mode(StrictModeKind::ImplicitStrictModeClass);
+        self.vis_scope().recursive_set_strict_mode(
+            StrictModeKind::ImplicitStrictModeClass,
+            js_ast::Loc::EMPTY,
+        );
         // The class name is part of the class, which is always strict mode
         // code, so validate it inside the class-name scope.
         if let Some(name) = class.class_name {

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -3,7 +3,7 @@ use crate::lexer as js_lexer;
 use crate::p::{P, ReactRefreshExportKind};
 use crate::parser::{
     PrependTempRefsOpts, ReactRefresh, Ref, RelocateVarsMode, SideEffects, StmtsKind,
-    statement_cares_about_scope,
+    StrictModeFeature, statement_cares_about_scope,
 };
 use bun_alloc::{ArenaVec as BumpVec, ArenaVecExt as _};
 use bun_ast::flags;
@@ -134,15 +134,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::Import,
     ) -> Result<(), Error> {
         p.record_declared_symbol(data.namespace_ref);
+        if let Some(star_name_loc) = data.star_name_loc.to_nullable() {
+            let name = p.load_name_from_ref(data.namespace_ref);
+            p.validate_declared_symbol_name(star_name_loc, name)?;
+        }
 
         if let Some(default_name) = data.default_name {
-            p.record_declared_symbol(default_name.ref_);
+            let name_ref = default_name.ref_;
+            p.record_declared_symbol(name_ref);
+            let name = p.load_name_from_ref(name_ref);
+            p.validate_declared_symbol_name(default_name.loc, name)?;
         }
 
         let items = data.items.slice();
         if !items.is_empty() {
             for item in items.iter() {
-                p.record_declared_symbol(item.name.ref_);
+                let name_ref = item.name.ref_;
+                p.record_declared_symbol(name_ref);
+                let name = p.load_name_from_ref(name_ref);
+                p.validate_declared_symbol_name(item.name.loc, name)?;
             }
         }
 
@@ -1331,6 +1341,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Label, stmt.loc)
             .expect("unreachable");
         let name = p.load_name_from_ref(data.name.ref_);
+        if js_lexer::is_strict_mode_reserved_word(name) {
+            p.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(p.source, data.name.loc),
+                name,
+            )?;
+        }
         let ref_ = p
             .new_symbol(js_ast::symbol::Kind::Label, name)
             .expect("unreachable");
@@ -2150,11 +2167,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // referencing, `esbuild` builds a separate hash map of hash
         // maps. We are avoiding that to reduce memory usage, since
         // enum inlining already uses alot of hash maps.
+        let name_ref = data.name.ref_;
         if p.current_scope == p.module_scope && p.options.bundle {
-            p.top_level_enums.push(data.name.ref_);
+            p.top_level_enums.push(name_ref);
         }
 
-        p.record_declared_symbol(data.name.ref_);
+        p.record_declared_symbol(name_ref);
+        // The enum lowers to a "var" declaration with this name.
+        let enum_name = p.load_name_from_ref(name_ref);
+        p.validate_declared_symbol_name(data.name.loc, enum_name)?;
         p.push_scope_for_visit_pass(js_ast::scope::Kind::Entry, stmt.loc)?;
         p.record_declared_symbol(data.arg);
 
@@ -2347,7 +2368,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         stmt: &mut Stmt,
         data: &mut S::Namespace,
     ) -> Result<(), Error> {
-        p.record_declared_symbol(data.name.ref_);
+        let name_ref = data.name.ref_;
+        p.record_declared_symbol(name_ref);
+        // The namespace lowers to a "var" declaration with this name.
+        let namespace_name = p.load_name_from_ref(name_ref);
+        p.validate_declared_symbol_name(data.name.loc, namespace_name)?;
 
         // Scan ahead for any variables inside this namespace. This must be done
         // ahead of time before visiting any statements inside the namespace

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -392,4 +392,26 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  itBundled("cjs2esm/ReservedWordBindingsInSloppyModeCJS", {
+    // Reserved words are valid binding names in sloppy-mode CommonJS. The
+    // renamer renames them, so bundling to the ESM output format must not
+    // error and must produce valid strict-mode output.
+    // https://github.com/oven-sh/bun/pull/32188
+    files: {
+      "/entry.js": /* js */ `
+        import dep from './dep.cjs';
+        console.log(dep);
+      `,
+      "/dep.cjs": /* js */ `
+        var package = { value: 40 };
+        function interface(x) { return x + 1; }
+        var static = interface(package.value) + 1;
+        module.exports = static;
+      `,
+    },
+    format: "esm",
+    run: {
+      stdout: "42",
+    },
+  });
 });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2859,6 +2859,90 @@ class Foo {
     expectParseError("class Foo { #x() { this.#x += 1 } }", 'Writing to read-only method "#x" will throw');
   });
 
+  // https://github.com/oven-sh/bun/issues/32185
+  it("strict mode reserved words in declarations", () => {
+    const reservedPackage = '"package" is a reserved word and cannot be used in strict mode';
+
+    const expectParseErrorWithNote = (code, message, note) => {
+      let err;
+      try {
+        parsed(code, false, false);
+      } catch (e) {
+        if (e instanceof AggregateError) {
+          expect(e.errors.length).toBe(1);
+          err = e.errors[0];
+        } else {
+          err = e;
+        }
+      }
+      expect(err?.message).toBe(message);
+      expect(err?.notes?.[0]?.message).toBe(note);
+    };
+
+    // Implicit strict mode from ESM keywords applies to declarations, not
+    // just references, even when the declaration comes before the keyword
+    const exportNote = 'This file is implicitly in strict mode because of the "export" keyword here';
+    expectParseErrorWithNote("export {}; let package = 1", reservedPackage, exportNote);
+    expectParseErrorWithNote("let package = 1; export {}", reservedPackage, exportNote);
+    expectParseErrorWithNote(
+      'import "x"; let package = 1',
+      reservedPackage,
+      'This file is implicitly in strict mode because of the "import" keyword here',
+    );
+    expectParseErrorWithNote(
+      "await 1; let package = 1",
+      reservedPackage,
+      'This file is implicitly in strict mode because of the "await" keyword here',
+    );
+
+    // Every declaration position is checked
+    expectParseError("export {}; var static = 1", '"static" is a reserved word and cannot be used in strict mode');
+    expectParseError("export {}; function package() {}", reservedPackage);
+    expectParseError("export {}; (function package() {})", reservedPackage);
+    expectParseError("export {}; class package {}", reservedPackage);
+    expectParseError("export {}; function f(package) {}", reservedPackage);
+    expectParseError("export {}; try {} catch (package) {}", reservedPackage);
+    expectParseError("export {}; var { package } = p", reservedPackage);
+    expectParseError("export {}; package: ;", reservedPackage);
+    expectParseError('import package from "x"', reservedPackage);
+    expectParseError('import * as package from "x"', reservedPackage);
+    expectParseError('import { a as package } from "x"', reservedPackage);
+    expectParseError("export {}; let eval = 1", 'Declarations with the name "eval" cannot be used in strict mode');
+    expectParseError(
+      "export {}; function arguments() {}",
+      'Declarations with the name "arguments" cannot be used in strict mode',
+    );
+
+    // Class code is always strict mode code, including the class name
+    const classNote = "All code inside a class is implicitly in strict mode";
+    expectParseErrorWithNote("class package {}", reservedPackage, classNote);
+    expectParseErrorWithNote("(class package {})", reservedPackage, classNote);
+    expectParseErrorWithNote("class C { m() { var package; } }", reservedPackage, classNote);
+
+    // Explicit "use strict", with the note pointing at the directive
+    const useStrictNote = 'Strict mode is triggered by the "use strict" directive here';
+    expectParseErrorWithNote('"use strict"; let package = 1', reservedPackage, useStrictNote);
+    expectParseErrorWithNote('"use strict"; package: ;', reservedPackage, useStrictNote);
+    // A function name is subject to the function's own strictness
+    expectParseErrorWithNote('function package() { "use strict" }', reservedPackage, useStrictNote);
+
+    // TypeScript constructs that lower to "var" declarations
+    ts.expectParseError('"use strict"; enum package { A }', reservedPackage);
+    ts.expectParseError("export {}; enum package { A }", reservedPackage);
+    ts.expectParseError('"use strict"; namespace package { export const x = 1 }', reservedPackage);
+    ts.expectParseError('"use strict"; import package = require("x")', reservedPackage);
+
+    // Still allowed in sloppy mode
+    expect(() => parsed("let package = 1", false, false)).not.toThrow();
+    expect(() => parsed("function package() {}", false, false)).not.toThrow();
+    expect(() => parsed("package: ;", false, false)).not.toThrow();
+    expect(() => parsed("var eval = 1", false, false)).not.toThrow();
+    // Reserved words are valid export aliases
+    expect(() => parsed("const x = 1; export { x as package }", false, false)).not.toThrow();
+    // Method names are not bindings
+    expect(() => parsed("export {}; class C { static package() {} }", false, false)).not.toThrow();
+  });
+
   describe("simplification", () => {
     const transpiler = new Bun.Transpiler({
       loader: "tsx",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2946,8 +2946,19 @@ class Foo {
       'function f(arguments) { "use strict" }',
       'Declarations with the name "arguments" cannot be used in strict mode',
     );
-    // Body "use strict" also reaches scopes pushed for parameter defaults
-    expectParseErrorWithNote('function f(x = (() => package)()) { "use strict" }', reservedPackage, useStrictNote);
+    // Body "use strict" also reaches scopes pushed for parameter defaults, and
+    // the note keeps a source location pointing at the directive there
+    {
+      let err;
+      try {
+        parsed('function f(x = (() => package)()) { "use strict" }', false, false);
+      } catch (e) {
+        err = e instanceof AggregateError ? e.errors[0] : e;
+      }
+      expect(err?.message).toBe(reservedPackage);
+      expect(err?.notes?.[0]?.message).toBe(useStrictNote);
+      expect(err?.notes?.[0]?.position).toMatchObject({ column: 37, length: 12 });
+    }
 
     // TypeScript constructs that lower to "var" declarations
     ts.expectParseError('"use strict"; enum package { A }', reservedPackage);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2947,11 +2947,7 @@ class Foo {
       'Declarations with the name "arguments" cannot be used in strict mode',
     );
     // Body "use strict" also reaches scopes pushed for parameter defaults
-    expectParseErrorWithNote(
-      'function f(x = (() => package)()) { "use strict" }',
-      reservedPackage,
-      useStrictNote,
-    );
+    expectParseErrorWithNote('function f(x = (() => package)()) { "use strict" }', reservedPackage, useStrictNote);
 
     // TypeScript constructs that lower to "var" declarations
     ts.expectParseError('"use strict"; enum package { A }', reservedPackage);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2925,6 +2925,17 @@ class Foo {
     expectParseErrorWithNote('"use strict"; package: ;', reservedPackage, useStrictNote);
     // A function name is subject to the function's own strictness
     expectParseErrorWithNote('function package() { "use strict" }', reservedPackage, useStrictNote);
+    // A "use strict" directive in the body makes the parameter list strict too
+    expectParseErrorWithNote('function f(package) { "use strict" }', reservedPackage, useStrictNote);
+    expectParseErrorWithNote('((package) => { "use strict" })', reservedPackage, useStrictNote);
+    expectParseError(
+      'function f(eval) { "use strict" }',
+      'Declarations with the name "eval" cannot be used in strict mode',
+    );
+    expectParseError(
+      'function f(arguments) { "use strict" }',
+      'Declarations with the name "arguments" cannot be used in strict mode',
+    );
 
     // TypeScript constructs that lower to "var" declarations
     ts.expectParseError('"use strict"; enum package { A }', reservedPackage);
@@ -2935,6 +2946,7 @@ class Foo {
     // Still allowed in sloppy mode
     expect(() => parsed("let package = 1", false, false)).not.toThrow();
     expect(() => parsed("function package() {}", false, false)).not.toThrow();
+    expect(() => parsed("function f(package) {}", false, false)).not.toThrow();
     expect(() => parsed("package: ;", false, false)).not.toThrow();
     expect(() => parsed("var eval = 1", false, false)).not.toThrow();
     // Reserved words are valid export aliases

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2906,7 +2906,17 @@ class Foo {
     expectParseError("export {}; package: ;", reservedPackage);
     expectParseError('import package from "x"', reservedPackage);
     expectParseError('import * as package from "x"', reservedPackage);
-    expectParseError('import { a as package } from "x"', reservedPackage);
+    {
+      // The caret points at the local binding name, not the import alias
+      let err;
+      try {
+        parsed('import { a as package } from "x"', false, false);
+      } catch (e) {
+        err = e instanceof AggregateError ? e.errors[0] : e;
+      }
+      expect(err?.message).toBe(reservedPackage);
+      expect(err?.position).toMatchObject({ column: 15, length: 7 });
+    }
     expectParseError("export {}; let eval = 1", 'Declarations with the name "eval" cannot be used in strict mode');
     expectParseError(
       "export {}; function arguments() {}",

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2946,6 +2946,12 @@ class Foo {
       'function f(arguments) { "use strict" }',
       'Declarations with the name "arguments" cannot be used in strict mode',
     );
+    // Body "use strict" also reaches scopes pushed for parameter defaults
+    expectParseErrorWithNote(
+      'function f(x = (() => package)()) { "use strict" }',
+      reservedPackage,
+      useStrictNote,
+    );
 
     // TypeScript constructs that lower to "var" declarations
     ts.expectParseError('"use strict"; enum package { A }', reservedPackage);


### PR DESCRIPTION
Fixes #32185

### Problem

The transpiler's reserved-word check for declared names ran in `declare_symbol` during the parse pass, but implicit strict mode (import/export/top-level-await keywords, class bodies) is only applied to scopes after parsing, in `prepare_for_visit_pass` and `visit_class`. So declarations in implicitly strict files produced no transpiler diagnostic and failed at runtime with a bare JSC error instead:

```console
$ cat a.js
export {};
let package = 1;
$ bun a.js
SyntaxError: Cannot use the reserved word 'package' as a lexical variable name in strict mode.
```

The visit-pass check (`e_identifier`) only covered references, not binding positions. This affected every declaration position (var/let/const, function and class names, parameters, catch bindings, destructuring, labels, import clause names, TS enums/namespaces) and every implicit strict kind. It predates the Rust port.

### Fix

Move the check to the visit pass, where scope strictness is known, mirroring esbuild's `validateDeclaredSymbolName` (modern esbuild made the same move: it removed the check from `declareSymbol` and validates declared names during the visit pass). A new `P::validate_declared_symbol_name` checks strict-mode reserved words and folds in the existing eval/arguments checks, and is called from:

- `visit_binding` (var/let/const, params, catch bindings, destructuring), replacing the eval/arguments-only check
- `visit_func`, inside the function-body scope, so a `"use strict"` directive in the body counts toward the function's own name (matches esbuild and the spec; `function package() { "use strict"; }` is a SyntaxError)
- `visit_class`, inside the class-name scope, which is always strict (`class package {}` is a SyntaxError even in sloppy files)
- `s_label` (reserved words only, matching esbuild; labels are not eval/arguments-restricted)
- parameter lists of functions whose body has a `"use strict"` directive: the directive makes the whole function strict, including its parameters (`function f(package) { "use strict" }` is a SyntaxError), so the directive handler also marks the parent parameter scope strict, matching esbuild
- `s_import` (default, namespace, and clause item names; unlike esbuild, Bun does not rename symbols in transform output, so `import package from "x"` must be rejected rather than silently renamed)
- `s_enum` / `s_namespace` (TS constructs that lower to `var` declarations; these were previously caught by the parse-time check in explicit-strict files, so visit-pass checks are needed to avoid regressing that)

Also fixes the diagnostic note for explicit strict mode, which printed an empty keyword name with no location:

```
note: This file is implicitly in strict mode because of the "" keyword here
```

now:

```
1 | "use strict";
    ^
note: Strict mode is triggered by the "use strict" directive here
```

The directive location is stored per-scope (`Scope.use_strict_loc`, inherited by child scopes like `strict_mode`, same as esbuild's `UseStrictLoc`), which makes `module_scope_directive_loc` on the parser redundant; it's removed and its one read (CommonJS wrapper directive re-emission) now reads the module scope.

### Behavior notes

- Sloppy-mode code is unaffected. The reserved-word check is additionally gated on scope strictness (like the reference check in `e_identifier`), so sloppy CommonJS bundled with `--format=esm` keeps its previous behavior: the renamer renames reserved-word bindings (`var package` -> `var _package`) instead of erroring. The eval/arguments arm keeps its pre-existing ungated behavior, and the new label check stays ungated because labels are not renamed (the old output was invalid strict-mode code that failed at load).
- Diagnostics for `import { a as package }` now point at the local binding name instead of the alias (the clause item's `name.loc` was left as the alias location in the parser; fixed to match the TypeScript branches and esbuild).
- Export aliases stay legal (`export { x as package }` is valid JS and still parses).
- TS ambient declarations (`declare const package: ...`) are erased before the visit pass and still produce no error, matching previous behavior.
- Intentionally excluded: files forced to ESM only by `.mjs` or `package.json` `"type": "module"` (no import/export/TLA keyword in the source). No implicit strict mode exists for them on main; #32177 adds it with a deliberate carve-out for CommonJS-classified forced-ESM files. Once that lands, the visit-pass checks here cover those files automatically, since they consume whatever strictness is applied to scopes.

### Tests

Added `strict mode reserved words in declarations` to `test/bundler/transpiler/transpiler.test.js`: declarations across all positions and all implicit-strict kinds (including declaration-before-keyword ordering), note contents per strict-mode reason, eval/arguments declarations, TS enum/namespace/import-equals, and negative cases for sloppy mode. Fails on the unfixed build (no parse error is produced), passes with the fix.

Also added `cjs2esm/ReservedWordBindingsInSloppyModeCJS` to `test/bundler/bundler_cjs2esm.test.ts`, which bundles a sloppy CJS file declaring `package`/`interface`/`static` to ESM format and runs the output.

Verified no behavior change against the previous build for: sloppy CJS inputs (including `bun build --format=esm` renaming), `require()` of sloppy files, export aliases, JSX-generated imports, and the `test/bundler` + `test/bundler/esbuild` + `test/bundler/transpiler` suites.



