### PR TITLE
Deflake streams-leak pull-buffer test by pacing writes on a per-chunk ack

### DIFF
--- a/test/js/web/streams/streams-leak.test.ts
+++ b/test/js/web/streams/streams-leak.test.ts
@@ -11,6 +11,16 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
   // the scavenger releases them, so commit charge ran ahead of RSS
   // until VirtualAlloc(MEM_COMMIT) failed in
   // pas_compact_heap_reservation_try_allocate.
+  //
+  // The server and the consumer below share this event loop, so the pull
+  // callback paces itself on an ack per chunk: it writes chunk i+1 only
+  // after the consumer has read chunk i. At most one chunk is ever in
+  // flight, so writes cannot coalesce on the wire and the consumer
+  // observes one small read per write regardless of machine load (on
+  // busy CI runners, unpaced writes coalesced into as few as 10 reads
+  // and starved the sample-size assertion below).
+  const CHUNKS_TO_WRITE = 64;
+  let ack: (() => void) | undefined;
   using server = Bun.serve({
     port: 0,
     fetch() {
@@ -18,10 +28,12 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
         new ReadableStream({
           type: "direct",
           async pull(controller) {
-            for (let i = 0; i < 1000; i++) {
+            for (let i = 0; i < CHUNKS_TO_WRITE; i++) {
+              const { promise, resolve } = Promise.withResolvers<void>();
+              ack = resolve;
               controller.write("x\n");
               await controller.flush();
-              await Bun.sleep(0);
+              await promise;
             }
             controller.close();
           },
@@ -32,14 +44,17 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
 
   const resp = await fetch(server.url);
   const chunks: Uint8Array[] = [];
-  for await (const chunk of resp.body!) chunks.push(chunk);
+  for await (const chunk of resp.body!) {
+    chunks.push(chunk);
+    ack!();
+  }
 
-  // Some chunks coalesce on the wire; we just need a meaningful sample
-  // of small reads through the native pull path.
+  // One read per paced write; a meaningful sample of small reads through
+  // the native pull path.
   expect(chunks.length).toBeGreaterThan(20);
 
   // Consecutive small reads should land in the same backing buffer (the
-  // tail subarray is reused until a read fills it). 2KB of ~few-byte
+  // tail subarray is reused until a read fills it). 128 bytes of 2-byte
   // chunks fits well inside one 256KB buffer, so the whole stream should
   // share a handful at most. Pre-fix every chunk had its own 256KB
   // buffer, so this was ~chunks.length.
@@ -48,7 +63,7 @@ test("native ReadableStream reuses the pull buffer across small reads", async ()
 
   let backingBytes = 0;
   for (const buf of distinctBuffers) backingBytes += buf.byteLength;
-  // Pre-fix this was ~chunks.length * 256KB ≈ 25–250 MB.
+  // Pre-fix this was ~chunks.length * 256KB ≈ 16 MB.
   expect(backingBytes).toBeLessThan(4 * 1024 * 1024);
 });
 


### PR DESCRIPTION
Fixes #32190

### Problem

`test/js/web/streams/streams-leak.test.ts` > "native ReadableStream reuses the pull buffer across small reads" flakes on loaded CI runners, failing all 4 retry attempts when it triggers (build 61700 debian x64, build 62104 alpine x64):

```
error: expect(received).toBeGreaterThan(expected)
Expected: > 20
Received: 14   (also 10, 11, 13, 19 across attempts)
    at streams-leak.test.ts:39:25
```

The fixture had the server write "x\n" 1000 times with only `flush()` + `sleep(0)` between writes, and relied on the client keeping up so each write became its own read. On a busy runner the consumer lags, flushed writes pile up in the TCP buffer and coalesce, and the 2000 bytes arrive in as few as 10 reads, starving the `chunks.length > 20` sample-size precondition. The buffer-reuse assertions themselves (the point of the test, from #30593) were never the ones failing.

Simply lowering the threshold would gut the test: at ~10 chunks the pre-fix behavior (one fresh 256KB buffer per read) only barely trips `distinctBuffers.size < 8` and no longer trips the 4MB backing-bytes bound at all.

### Fix

Strengthen the fixture instead of weakening the assertions. The server and the consumer share one event loop, so the pull callback now paces itself on an ack per chunk: it writes chunk i+1 only after the consumer has read chunk i and resolved the ack promise. At most one chunk is ever in flight, so writes cannot coalesce regardless of machine load, and the read count is deterministic (64 paced writes, observed as exactly 64 reads in every run, idle and under 8 busy-loop CPU load). The assertions are unchanged; the sample they run on is now guaranteed by construction, and the pre-fix signal is much stronger (64 distinct buffers vs the previous marginal ~10).

The test also got faster: 64 acked round trips instead of 1000 `sleep(0)` turns (~9ms release, ~500ms debug ASAN).

### Verification

- Fails on the pre-fix `#getInternalBuffer` rotation (reverted `chunk.buffer.byteLength` back to `chunk.length` locally): `Expected: < 8, Received: 64`, with the sample-size precondition passing.
- Passes 30/30 with release bun under 8 busy-loop CPU load, 10/10 with the debug ASAN build; chunk count is exactly 64 in every observation, including with an artificially lagging consumer.