### PR TITLE
ci: bump darwin test timeout 40→45 min

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -834,7 +834,7 @@ function getTestBunStep(platform, options, testOptions = {}) {
     retry: getRetry(),
     cancel_on_build_failing: isMergeQueue(),
     parallelism: os === "darwin" ? 2 : os === "windows" ? 8 : 20,
-    timeout_in_minutes: profile === "asan" || os === "windows" ? 45 : os === "darwin" ? 40 : 30,
+    timeout_in_minutes: profile === "asan" || os === "windows" || os === "darwin" ? 45 : 30,
     env: {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       // Platform smoke check: runner.node.mjs asserts the agent matches what


### PR DESCRIPTION
## What
darwin test timeout 40 → 45 min (matching windows/asan).

## Why
The Tart fleet's larger shard (~2175 tests) takes ~43 min on some hosts — a healthy run gets killed ~2 minutes from the finish line.

This is temporary debt: when more darwin slots come online (hardware order pending), `parallelism` increases → shards shrink → this comes back down. Same rationale as the prior 30→40 bump.