### PR TITLE
Error on unbound strict-mode reserved words when bundling to ESM

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -315,6 +315,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
+        // An unbound reference to a strict-mode reserved word is printed
+        // verbatim (the renamer only remaps declared symbols via
+        // `strict_mode_reserved_word_remap`), so it would make the
+        // always-strict ESM output unparsable. Fail the build instead.
+        // Deliberate deviation from the Zig/esbuild reference, which emits
+        // the broken output silently.
+        if !p.is_strict_mode()
+            && p.is_strict_mode_output_format()
+            && p.symbols[e_.ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Unbound
+            && js_lexer::is_strict_mode_reserved_word(name)
+        {
+            p.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(p.source, expr.loc),
+                name,
+            )
+            .expect("unreachable");
+        }
+
         *e = p.handle_identifier(
             expr.loc,
             e_,

--- a/test/bundler/bundler_cjs2esm.test.ts
+++ b/test/bundler/bundler_cjs2esm.test.ts
@@ -392,4 +392,65 @@ describe("bundler", () => {
       stdout: '[[{"xyz":456},456],[{"xyz":123},123],[{"xyz":456},456],[{"xyz":123},123]]',
     },
   });
+  // https://github.com/oven-sh/bun/issues/32193
+  itBundled("cjs2esm/UnboundReservedWordErrorsWithEsmOutput", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(package);
+        static = 2;
+      `,
+    },
+    format: "esm",
+    bundleErrors: {
+      "/entry.cjs": [
+        '"package" is a reserved word and cannot be used with the ESM output format due to strict mode',
+        '"static" is a reserved word and cannot be used with the ESM output format due to strict mode',
+      ],
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/32193
+  itBundled("cjs2esm/BoundReservedWordRenamedWithEsmOutput", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        var package = 5;
+        function f(interface) { return interface + 1; }
+        console.log(package, f(6));
+      `,
+    },
+    format: "esm",
+    run: {
+      stdout: "5 7",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/32193
+  itBundled("cjs2esm/UnboundReservedWordAllowedWithCjsOutput", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(typeof package);
+      `,
+    },
+    format: "cjs",
+    run: {
+      stdout: "undefined",
+    },
+  });
+  // https://github.com/oven-sh/bun/issues/32193
+  itBundled("cjs2esm/UnboundReservedWordReplacedByDefine", {
+    files: {
+      "/entry.cjs": /* js */ `
+        exports.x = 1;
+        console.log(package);
+      `,
+    },
+    format: "esm",
+    define: {
+      package: "123",
+    },
+    run: {
+      stdout: "123",
+    },
+  });
 });


### PR DESCRIPTION
Fixes #32193

### Problem

A CommonJS-classified file that references an unbound strict-mode reserved word bundles without error, but the emitted ESM output cannot be loaded by bun or node:

```console
$ cat u.cjs
exports.x = 1;
console.log(package);
$ bun build u.cjs --format=esm --outfile=out.mjs
$ bun out.mjs
error: "package" is a reserved word and cannot be used in strict mode
```

The renamer remaps bound reserved-word symbols (`var package` becomes `_package` via `strict_mode_reserved_word_remap`), but an unbound reference is not a declared symbol, so it survives verbatim into the always-strict ESM output. Both `ReservedWord` call sites gate on `p.is_strict_mode()` before calling `mark_strict_mode_feature`, so for a sloppy (CJS-classified) file the ESM-output-format arm of that function was unreachable for reserved words. The eval/arguments call sites do not have that gate, which is why `var eval = 1` in the same file already failed the build with "Declarations with the name \"eval\" cannot be used with the ESM output format due to strict mode".

Not a regression: reproduces on 1.3.14 and current main. Node rejects the emitted output identically, so no working use case depends on the current behavior.

### Fix

In `e_identifier` (`src/js_parser/visit/visit_expr.rs`), after `find_symbol` resolves the reference and after define/require substitution, fail the build when the symbol kind is `Unbound` and the name is a strict-mode reserved word, reusing the existing ESM-output-format arm of `mark_strict_mode_feature`:

```
error: "package" is a reserved word and cannot be used with the ESM output format due to strict mode
```

Placement details:

- Bound references are exempt (the renamer remaps those), and declarations keep their existing strict-mode-only check, so `var package = 5` in a CJS file still bundles and runs.
- The check runs after define substitution, so `--define package=123` still replaces the identifier and bundles cleanly.
- Gated on `is_strict_mode_output_format()` (`bundle && format.is_esm()`): `--format=cjs`, `--format=iife`, `--no-bundle`, and the runtime transpiler are unchanged.
- This deliberately deviates from the Zig reference and from esbuild, both of which emit the broken output silently (noted in a comment).

### Tests

Added to `test/bundler/bundler_cjs2esm.test.ts`:

- `UnboundReservedWordErrorsWithEsmOutput`: unbound `package` read and unbound `static` assignment each fail the build (fails on the unfixed build because the bundle succeeds when errors are expected)
- `BoundReservedWordRenamedWithEsmOutput`: `var package` and a parameter named `interface` still bundle, and the output runs
- `UnboundReservedWordAllowedWithCjsOutput`: same input with `--format=cjs` still bundles and runs
- `UnboundReservedWordReplacedByDefine`: `--define package=123` still substitutes and runs

Verified no false positives on legitimate sloppy inputs: `bundler_cjs`, `bundler_cjs2esm`, `bundler_npm`, `bundler_edgecase`, `bundler_minify`, `bundler_browser`, `esbuild/default`, and `transpiler/transpiler.test.js` all pass with the fix.
