### PR TITLE
node:fs: fix GC root leak for Buffer path arguments in async ops

### DIFF
--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -124,7 +124,10 @@ fn run_async<A: FsArgument>(
 
     // The `cp` / `readdir` operations are handled by their dedicated
     // bindings below.
-    // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
+    // SAFETY: re-borrow `vm` mutably. `slice` holds a shared `&vm` but is
+    // touched again only by the `Drop` below, which reads its bitset/`all` and
+    // never dereferences `slice.vm`; this exclusive borrow's last use is inside
+    // `create_task`, before that drop.
     let vm: &mut VirtualMachine = global.bun_vm().as_mut();
     let result = create_task(global, this, args, vm);
     // SAFETY: not yet dropped; only drop site for this path. Releases the
@@ -208,7 +211,10 @@ impl Binding {
             return Ok(JSValue::ZERO);
         }
 
-        // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
+        // Re-borrow `vm` mutably. `slice` holds a shared `&vm` but is used
+        // again only by its scope-exit `Drop` (bitset unprotect over `all`),
+        // which never dereferences `slice.vm`, and that drop runs after this
+        // exclusive borrow's last use in `create`.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         Ok(AsyncCpTask::create(global, this, cp_args, vm))
     }
@@ -250,7 +256,10 @@ impl Binding {
             return Ok(JSValue::ZERO);
         }
 
-        // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
+        // Re-borrow `vm` mutably. `slice` holds a shared `&vm` but is used
+        // again only by its scope-exit `Drop` (bitset unprotect over `all`),
+        // which never dereferences `slice.vm`, and that drop runs after this
+        // exclusive borrow's last use in `create`.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         let result = if rd_args.recursive {
             AsyncReaddirRecursiveTask::create(global, rd_args, vm)

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -78,7 +78,7 @@ fn run_async<A: FsArgument>(
 
     // A JS-backed path buffer is rooted at parse time by `protect_eat` (so a
     // `toString`/`valueOf` coercion while parsing a *later* argument cannot
-    // allocate and collect it — the call frame does not visit values produced
+    // allocate and collect it: the call frame does not visit values produced
     // after the call begins). On success the Task takes a second root via
     // `to_thread_safe` for the async window, released by `Drop for
     // ThreadSafe<A>` on completion; `slice`'s `Drop` then releases the
@@ -190,37 +190,27 @@ impl Binding {
 
     // ── Hand-written bindings for ops outside `NodeFSFunctionEnum` ────────
 
-    /// `callAsync(.cp)` — `AsyncCpTask::create` copies its paths via
-    /// `to_thread_safe()`, so the arena is dropped with `slice`.
+    /// `callAsync(.cp)`. `AsyncCpTask::create` takes the async-window roots
+    /// via `to_thread_safe()`; `slice`'s `Drop` releases the parse-time roots.
     pub fn cp(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
+        let mut slice = ArgumentsSlice::init(vm, frame.arguments());
         slice.will_be_async = true;
 
-        let cp_args = match args::Cp::from_js(global, &mut slice) {
-            Ok(a) => a,
-            Err(err) => {
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
-                return Err(err);
-            }
-        };
+        // Every path-buffer root lives in `slice`'s bitset (no out-of-bitset
+        // roots like `run_async`'s `WriteFile.data`), so `slice`'s scope-exit
+        // `Drop` releases them on every branch, after `create` has taken the
+        // async-window roots on the success path.
+        let cp_args = args::Cp::from_js(global, &mut slice)?;
 
         if global.has_exception() {
-            drop(cp_args);
-            // SAFETY: not yet dropped; only drop site for this path.
-            unsafe { ManuallyDrop::drop(&mut slice) };
             return Ok(JSValue::ZERO);
         }
 
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let result = AsyncCpTask::create(global, this, cp_args, vm);
-        // SAFETY: not yet dropped; only drop site for this path. Releases the
-        // parse-time roots now that the Task holds the async-window roots.
-        unsafe { ManuallyDrop::drop(&mut slice) };
-        Ok(result)
+        Ok(AsyncCpTask::create(global, this, cp_args, vm))
     }
 
     /// `callSync(.cp)`.
@@ -248,22 +238,15 @@ impl Binding {
     pub fn readdir(this: &Self, global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
         // SAFETY: JS-thread borrow of the per-thread VM; outlives `slice`.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
+        let mut slice = ArgumentsSlice::init(vm, frame.arguments());
         slice.will_be_async = true;
 
-        let rd_args = match args::Readdir::from_js(global, &mut slice) {
-            Ok(a) => a,
-            Err(err) => {
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
-                return Err(err);
-            }
-        };
+        // As in `cp`, every path root lives in `slice`'s bitset, so `slice`'s
+        // scope-exit `Drop` releases them on every branch, after `create` has
+        // taken the async-window root on the success path.
+        let rd_args = args::Readdir::from_js(global, &mut slice)?;
 
         if global.has_exception() {
-            drop(rd_args);
-            // SAFETY: not yet dropped; only drop site for this path.
-            unsafe { ManuallyDrop::drop(&mut slice) };
             return Ok(JSValue::ZERO);
         }
 
@@ -274,9 +257,6 @@ impl Binding {
         } else {
             async_::Readdir::create(global, this, rd_args, vm)
         };
-        // SAFETY: not yet dropped; only drop site for this path. Releases the
-        // parse-time root now that the Task holds the async-window root.
-        unsafe { ManuallyDrop::drop(&mut slice) };
         Ok(result)
     }
 

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -76,17 +76,26 @@ fn run_async<A: FsArgument>(
     let mut slice = ManuallyDrop::new(ArgumentsSlice::init(vm, frame.arguments()));
     slice.will_be_async = true;
 
-    // `ManuallyDrop` keeps `slice` alive past return when ownership transfers
-    // to the Task: dropped only on the early-return
-    // error/abort branches; on the success path the Task owns `args` (whose
-    // protected JSValues are released by `Drop for ThreadSafe<A>` when the
-    // Task completes), and `slice` is intentionally not dropped — its
-    // `Drop`-unprotect would race that.
+    // A JS-backed path buffer is rooted at parse time by `protect_eat` (so a
+    // `toString`/`valueOf` coercion while parsing a *later* argument cannot
+    // allocate and collect it — the call frame does not visit values produced
+    // after the call begins). On success the Task takes a second root via
+    // `to_thread_safe` for the async window, released by `Drop for
+    // ThreadSafe<A>` on completion; `slice`'s `Drop` then releases the
+    // parse-time root, so the buffer stays rooted continuously.
+    //
+    // The early-exit branches below release everything through
+    // `args.unprotect()` instead: besides the `protect_eat` roots it also
+    // covers parse-time roots taken *outside* `slice`'s bitset (e.g.
+    // `WriteFile.data`, protected directly when `is_async`). `slice` is left
+    // undropped on those branches so its bitset does not double-release the
+    // paths `args.unprotect()` already released.
 
     let mut args = match <A as FsArgument>::from_js(global, &mut slice) {
         Ok(a) => a,
         Err(err) => {
-            // SAFETY: not yet dropped; only drop site for this path.
+            // `args` was never built; release any `protect_eat` roots via the
+            // bitset. SAFETY: not yet dropped; only drop site for this path.
             unsafe { ManuallyDrop::drop(&mut slice) };
             return Err(err);
         }
@@ -95,8 +104,6 @@ fn run_async<A: FsArgument>(
     if global.has_exception() {
         args.unprotect();
         drop(args);
-        // SAFETY: not yet dropped; only drop site for this path.
-        unsafe { ManuallyDrop::drop(&mut slice) };
         return Ok(JSValue::ZERO);
     }
 
@@ -110,8 +117,6 @@ fn run_async<A: FsArgument>(
                     );
                 args.unprotect();
                 drop(args);
-                // SAFETY: not yet dropped; only drop site for this path.
-                unsafe { ManuallyDrop::drop(&mut slice) };
                 return Ok(promise);
             }
         }
@@ -121,7 +126,11 @@ fn run_async<A: FsArgument>(
     // bindings below.
     // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
     let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-    Ok(create_task(global, this, args, vm))
+    let result = create_task(global, this, args, vm);
+    // SAFETY: not yet dropped; only drop site for this path. Releases the
+    // parse-time root now that the Task holds the async-window root.
+    unsafe { ManuallyDrop::drop(&mut slice) };
+    Ok(result)
 }
 
 #[inline(always)]
@@ -207,7 +216,11 @@ impl Binding {
 
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        Ok(AsyncCpTask::create(global, this, cp_args, vm))
+        let result = AsyncCpTask::create(global, this, cp_args, vm);
+        // SAFETY: not yet dropped; only drop site for this path. Releases the
+        // parse-time roots now that the Task holds the async-window roots.
+        unsafe { ManuallyDrop::drop(&mut slice) };
+        Ok(result)
     }
 
     /// `callSync(.cp)`.
@@ -256,10 +269,15 @@ impl Binding {
 
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
-        if rd_args.recursive {
-            return Ok(AsyncReaddirRecursiveTask::create(global, rd_args, vm));
-        }
-        Ok(async_::Readdir::create(global, this, rd_args, vm))
+        let result = if rd_args.recursive {
+            AsyncReaddirRecursiveTask::create(global, rd_args, vm)
+        } else {
+            async_::Readdir::create(global, this, rd_args, vm)
+        };
+        // SAFETY: not yet dropped; only drop site for this path. Releases the
+        // parse-time root now that the Task holds the async-window root.
+        unsafe { ManuallyDrop::drop(&mut slice) };
+        Ok(result)
     }
 
     /// `callSync(.watch)` — `args::Watch` borrows `globalThis` so it can't go

--- a/test/js/node/fs/fs-leak.test.js
+++ b/test/js/node/fs/fs-leak.test.js
@@ -196,6 +196,11 @@ test("async fs ops with Buffer path arguments do not leak the path argument", as
       readv(vfd, [Buffer.alloc(8), Buffer.alloc(8)], 0),
     );
     fs.closeSync(vfd);
+    // readdir is a separate hand-written binding (Binding::readdir) from the
+    // generic run_async path above, so exercise its Buffer-path root too.
+    // (cp is the other hand-written binding, but its JS wrapper rejects
+    // non-string paths, so a Buffer path never reaches the native binding.)
+    deltas.readdirBufferPath = await measure("Uint8Array", i => fs.promises.readdir(Buffer.from(".")));
     if (!fs.existsSync("out-0.txt") || !fs.existsSync("out-1.txt")) {
       throw new Error("writeFile segment did not write its files");
     }
@@ -230,6 +235,7 @@ test("async fs ops with Buffer path arguments do not leak the path argument", as
     abortedWriteFileBufferPath: "ok",
     writevBuffers: "ok",
     readvBuffers: "ok",
+    readdirBufferPath: "ok",
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/fs/fs-leak.test.js
+++ b/test/js/node/fs/fs-leak.test.js
@@ -3,6 +3,7 @@ const { expect, test } = require("bun:test");
 const fs = require("fs");
 const { tmpdir, devNull } = require("os");
 const { fsStreamInternals } = require("bun:internal-for-testing");
+const { bunExe, bunEnv, tempDir } = require("harness");
 
 function getMaxFd() {
   const dev_null = fs.openSync(devNull, "r");
@@ -125,4 +126,110 @@ test("createReadStream file handle does not leak file descriptors", async () => 
   // If this is larger than the start value, it means that the file descriptor was not closed
   expect(getMaxFd()).toBe(start);
   expect(n_bytes).toBe("hello world\n".repeat(1000).length);
+});
+
+// https://github.com/oven-sh/bun/issues/32191
+test("async fs ops with Buffer path arguments do not leak the path argument", async () => {
+  const N = 64;
+  const WARM = 16;
+  const script = `
+    const fs = require("node:fs");
+    const util = require("node:util");
+    const { heapStats } = require("bun:jsc");
+
+    const N = ${N};
+    const WARM = ${WARM};
+
+    function liveCounts(types) {
+      Bun.gc(true);
+      const counts = heapStats().objectTypeCounts;
+      return types.map(t => counts[t] ?? 0);
+    }
+
+    // Returns the worst delta across the observed heap types.
+    async function measure(types, op) {
+      if (!Array.isArray(types)) types = [types];
+      for (let i = 0; i < WARM; i++) await op(N + i);
+      const before = liveCounts(types);
+      for (let i = 0; i < N; i++) await op(i);
+      const after = liveCounts(types);
+      return Math.max(...after.map((v, idx) => v - before[idx]));
+    }
+
+    // Expect the exact error so a parse-time rejection cannot silently skip
+    // the async path and make a segment vacuous.
+    const expectEnoent = e => {
+      if (e.code !== "ENOENT") throw e;
+    };
+    const expectAborted = e => {
+      if (e.name !== "AbortError") throw e;
+    };
+
+    const deltas = {};
+    deltas.accessBufferPath = await measure("Uint8Array", i =>
+      fs.promises.access(Buffer.from("missing-" + i)).catch(expectEnoent),
+    );
+    deltas.accessArrayBufferPath = await measure("ArrayBuffer", i => {
+      const bytes = Buffer.from("missing-" + i);
+      const path = new ArrayBuffer(bytes.length);
+      new Uint8Array(path).set(bytes);
+      return fs.promises.access(path).catch(expectEnoent);
+    });
+    deltas.writeFileBufferPath = await measure("Uint8Array", i =>
+      fs.promises.writeFile(Buffer.from("out-" + (i % 2) + ".txt"), "x"),
+    );
+    deltas.abortedWriteFileBufferPath = await measure("Uint8Array", i =>
+      fs.promises
+        .writeFile(Buffer.from("out-aborted.txt"), Buffer.from("data-" + i), { signal: AbortSignal.abort() })
+        .catch(expectAborted),
+    );
+    // writev/readv buffers take per-element roots at parse and the array root
+    // at schedule; both must be released at completion, so watch both the
+    // element buffers and the array wrapper.
+    const writev = util.promisify(fs.writev);
+    const readv = util.promisify(fs.readv);
+    const vfd = fs.openSync("vec.txt", "w+");
+    deltas.writevBuffers = await measure(["Uint8Array", "Array"], i =>
+      writev(vfd, [Buffer.from("vec-a-" + i), Buffer.from("vec-b-" + i)], 0),
+    );
+    deltas.readvBuffers = await measure(["Uint8Array", "Array"], i =>
+      readv(vfd, [Buffer.alloc(8), Buffer.alloc(8)], 0),
+    );
+    fs.closeSync(vfd);
+    if (!fs.existsSync("out-0.txt") || !fs.existsSync("out-1.txt")) {
+      throw new Error("writeFile segment did not write its files");
+    }
+    console.log(JSON.stringify(deltas));
+  `;
+
+  using dir = tempDir("fs-buffer-path-leak", {});
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  let deltas;
+  try {
+    deltas = JSON.parse(stdout.trim());
+  } catch {
+    throw new Error(`fixture did not produce JSON (exit ${exitCode}):\nstdout: ${stdout}\nstderr: ${stderr}`);
+  }
+
+  // Before the fix, every async call with a Buffer/ArrayBuffer path argument
+  // left the argument permanently gcProtect'ed, so each delta equaled N.
+  const verdict = Object.fromEntries(
+    Object.entries(deltas).map(([op, delta]) => [op, delta < N / 4 ? "ok" : `leaked ${delta} objects over ${N} calls`]),
+  );
+  expect(verdict).toEqual({
+    accessBufferPath: "ok",
+    accessArrayBufferPath: "ok",
+    writeFileBufferPath: "ok",
+    abortedWriteFileBufferPath: "ok",
+    writevBuffers: "ok",
+    readvBuffers: "ok",
+  });
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #32191

Every async `node:fs` operation that received a Buffer/TypedArray/ArrayBuffer path argument leaked one GC root for that argument, permanently pinning the path buffer (and, for small Buffers, the shared Buffer pool chunk behind it).

## Repro

```js
import fs from "node:fs";
import { heapStats } from "bun:jsc";

for (let i = 0; i < 5000; i++) {
  await fs.promises.access(Buffer.from("nonexistent-" + i)).catch(() => {});
}
Bun.gc(true);
console.log(heapStats().objectTypeCounts.Uint8Array);
```

On 1.4.0-canary this reports one leaked `Uint8Array` per call (5000+), surviving `Bun.gc(true)`. The sync equivalent does not leak.

## Cause

A Buffer path argument is rooted twice but released once on the async success path:

1. `PathLike::from_js_with_allocator` (src/runtime/node/types.rs) roots the argument at parse time via `arguments.protect_eat()`, recorded in `ArgumentsSlice`'s bitset. This is load-bearing: a `toString`/`valueOf` coercion while parsing a later argument can allocate, and the call frame does not keep values produced after the call begins alive.
2. At schedule time `PathLike::to_thread_safe` (src/jsc/node_path.rs) takes a second root for the async window, released once by `Drop for ThreadSafe<A>` when the task completes.
3. `run_async`/`cp`/`readdir` (src/runtime/node/node_fs_binding.rs) wrapped the `ArgumentsSlice` in `ManuallyDrop` and never dropped it on the success path, so the parse-time root (step 1) was never released.

Net +1 permanent root per call; `gcProtect` is refcounted so they accumulate. The sync path was balanced (the `ArgumentsSlice` drops at the end of the host call and releases the parse-time root). The Zig implementation shipped in 1.3.x had the same accounting, so this is not a port regression.

## Fix

Keep the parse-time `protect_eat` root and release it at the end of the host call, after the task has taken its own `to_thread_safe` root, so the buffer stays rooted continuously and both roots balance. Changes are confined to `src/runtime/node/node_fs_binding.rs`:

- `run_async` success path: drop the `ArgumentsSlice` after `create_task` returns (the task now holds the async-window root). Previously the slice was leaked.
- `run_async` early-exit paths (pending exception, pre-aborted signal): release through `args.unprotect()` alone and leave the slice undropped. `args.unprotect()` covers both the `protect_eat` roots and parse-time roots taken outside the bitset (e.g. `WriteFile.data`, protected directly when `is_async`); dropping the slice as well would double-release the paths. These paths previously called both `args.unprotect()` and the slice `Drop`, over-releasing the path root.
- `cp`/`readdir`: with the success-path drop in place, every arm releases the slice exactly once, so the `ManuallyDrop` wrapper is no longer needed there. Use a plain `ArgumentsSlice` with scope-exit `Drop` and `?`, matching `cp_sync`. `run_async` keeps `ManuallyDrop` because its early-exit arms deliberately leave the slice undropped.

## Verification

New test in test/js/node/fs/fs-leak.test.js measures `heapStats().objectTypeCounts` deltas across 64 async calls each for: `access` with a Buffer path, `access` with an ArrayBuffer path, `writeFile` with a Buffer path, pre-aborted `writeFile` with Buffer path and data, and `writev`/`readv` with Buffer element arrays (watching both the element buffers and the array wrapper). On the unfixed build the access/writeFile/writev/readv buffer-path deltas equal the call count; with the fix all deltas are ~0.

Confirmed both directions on the gate's own check (debug + ASAN) against current main: fail-before leaks one object per call on the path segments, fail-after passes. Also ran promises.test.js, cp.test.ts, and the abort-signal leak fixture.
