### PR TITLE
shell: use the shell environment's PATH to resolve external commands

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -492,6 +492,21 @@ impl Cmd {
         // SAFETY: `shell_ptr` is the live env owned by this Cmd's scope chain.
         spawn_args.cwd = unsafe { &*shell_ptr }.cwd();
 
+        // Fill env from export_env + cmd_local_env. Must happen BEFORE
+        // argv[0] resolution: `fill_env` updates `spawn_args.path` when it
+        // copies a PATH entry, so resolution honors PATH set via `.env()`,
+        // `export`, or a `PATH=… cmd` prefix (cmd_local_env filled last, so
+        // it wins). The `which` builtin already resolves through the shell
+        // environment; this keeps external commands consistent with it.
+        // Fixes #25885.
+        {
+            let env = interp.as_cmd_mut(this).base.shell_mut();
+            let mut iter = env.export_env.iterator();
+            spawn_args.fill_env::<false>(&mut iter);
+            let mut iter = env.cmd_local_env.iterator();
+            spawn_args.fill_env::<false>(&mut iter);
+        }
+
         // Resolve argv[0] via PATH (`bun_which::which`).
         let resolved: Option<Vec<u8>> = {
             let mut path_buf = bun_paths::path_buffer_pool::get();
@@ -543,15 +558,6 @@ impl Cmd {
         // `execve`).
         resolved.push(0);
         interp.as_cmd_mut(this).args[0] = resolved;
-
-        // Fill env from export_env + cmd_local_env.
-        {
-            let env = interp.as_cmd_mut(this).base.shell_mut();
-            let mut iter = env.export_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
-            let mut iter = env.cmd_local_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
-        }
 
         // Convert shell IO → subprocess stdio.
         let mut shellio = ShellIO::default();

--- a/test/regression/issue/25885.test.ts
+++ b/test/regression/issue/25885.test.ts
@@ -1,0 +1,65 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { chmod } from "node:fs/promises";
+import { delimiter, join } from "node:path";
+import { isWindows, tempDir } from "harness";
+
+// Regression tests for shell command resolution ignoring PATH changes:
+// https://github.com/oven-sh/bun/issues/25885 (.env() PATH ignored)
+// https://github.com/oven-sh/bun/issues/9747 (same, oldest report)
+// https://github.com/oven-sh/bun/issues/10865 (runtime process.env.PATH mutation ignored)
+//
+// The `which` builtin resolved through the shell environment, but spawning an
+// external command resolved through the process-startup PATH snapshot, so a
+// PATH set via `.env()`, `export`, a `PATH=… cmd` prefix, or a runtime
+// `process.env.PATH` mutation found commands with `which` yet failed to run
+// them.
+
+// A directory containing one executable `name` that prints `message`.
+const cmdDir = async (base: string, name: string, message: string) => {
+  const dir = isWindows
+    ? tempDir(base, { [`${name}.cmd`]: `@echo ${message}\r\n` })
+    : tempDir(base, { [name]: `#!/bin/sh\necho ${message}\n` });
+  if (!isWindows) await chmod(join(String(dir), name), 0o755);
+  return dir;
+};
+
+test("PATH set via .env() is used for command resolution", async () => {
+  using dir = await cmdDir("shell-path-env", "mytest-env", "hello from env");
+  const PATH = `${String(dir)}${delimiter}${process.env.PATH}`;
+  const result = await $`mytest-env`.env({ ...process.env, PATH }).quiet();
+  expect(result.stdout.toString().trim()).toBe("hello from env");
+  expect(result.exitCode).toBe(0);
+});
+
+test("PATH set via export is used for command resolution", async () => {
+  using dir = await cmdDir("shell-path-export", "mytest-export", "hello from export");
+  const PATH = `${String(dir)}${delimiter}${process.env.PATH}`;
+  const result = await $`export PATH=${PATH}; mytest-export`.quiet();
+  expect(result.stdout.toString().trim()).toBe("hello from export");
+  expect(result.exitCode).toBe(0);
+});
+
+test("PATH prefix assignment is used for command resolution, beating export", async () => {
+  using dir1 = await cmdDir("shell-path-prefix-1", "mytest-priority", "from prefix");
+  using dir2 = await cmdDir("shell-path-prefix-2", "mytest-priority", "from export");
+  const path1 = `${String(dir1)}${delimiter}${process.env.PATH}`;
+  const path2 = `${String(dir2)}${delimiter}${process.env.PATH}`;
+  // cmd_local_env (the `PATH=… cmd` prefix) takes priority over export_env
+  const result = await $`export PATH=${path2}; PATH=${path1} mytest-priority`.quiet();
+  expect(result.stdout.toString().trim()).toBe("from prefix");
+  expect(result.exitCode).toBe(0);
+});
+
+test("runtime process.env.PATH mutation is used for command resolution", async () => {
+  using dir = await cmdDir("shell-path-mutate", "mytest-mutate", "hello from mutation");
+  const saved = process.env.PATH;
+  process.env.PATH = `${String(dir)}${delimiter}${saved}`;
+  try {
+    const result = await $`mytest-mutate`.quiet();
+    expect(result.stdout.toString().trim()).toBe("hello from mutation");
+    expect(result.exitCode).toBe(0);
+  } finally {
+    process.env.PATH = saved;
+  }
+});


### PR DESCRIPTION
## Summary

The Bun shell resolves an external command's argv[0] before it fills the
child environment from the shell's `export_env` / `cmd_local_env` — but
`fill_env` is what updates `spawn_args.path` from those maps. So PATH set
via `.env()`, `export`, a `PATH=… cmd` prefix, or a runtime
`process.env.PATH` mutation was visible to the `which` builtin (which
resolves through the shell environment) yet ignored when actually spawning
the command:

```ts
process.env.PATH = `/some/dir:${process.env.PATH}`;
await $`which mycmd`; // /some/dir/mycmd
await $`mycmd`;       // bun: command not found: mycmd
```

Moving the env fill above the resolution fixes the inconsistency; lookup
priority becomes `cmd_local_env` > `export_env` > process PATH, matching
the `which` builtin.

Fixes #25885, #9747, #10865.

## Test plan

`test/regression/issue/25885.test.ts` covers all four reported shapes
(`.env()`, `export`, prefix assignment beating export, runtime
`process.env.PATH` mutation), with `.cmd` shims on Windows. All four fail
on unfixed bun (verified against 1.3.14) and exercise the moved code path.