### PR TITLE
sql: guard pool connection scans against unassigned slots during pool start

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -908,6 +908,10 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
 
   constructor(connectionInfo: Bun.SQL.__internal.DefinedPostgresOrMySQLOptions) {
     this.connectionInfo = connectionInfo;
+    // Slots are filled one at a time in connect()'s pool-start loop, and
+    // createPooledConnection can synchronously run user code (for example a
+    // function-valued `password`) that re-enters methods scanning this array,
+    // so every scan must tolerate unassigned holes.
     this.connections = new Array(connectionInfo.max);
   }
 
@@ -1128,7 +1132,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
       const pollSize = this.connections.length;
       for (let i = 0; i < pollSize; i++) {
         const connection = this.connections[i];
-        if (connection.state === PooledConnectionState.connected) {
+        if (connection?.state === PooledConnectionState.connected) {
           return true;
         }
       }
@@ -1143,7 +1147,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
       const pollSize = this.connections.length;
       for (let i = 0; i < pollSize; i++) {
         const connection = this.connections[i];
-        if (connection.state === PooledConnectionState.connected) {
+        if (connection?.state === PooledConnectionState.connected) {
           connection.connection?.flush();
         }
       }
@@ -1169,7 +1173,7 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
       const pollSize = this.connections.length;
       for (let i = 0; i < pollSize; i++) {
         const connection = this.connections[i];
-        switch (connection.state) {
+        switch (connection?.state) {
           case PooledConnectionState.pending:
           case PooledConnectionState.connected: {
             // cancelRetry only returns true while a connect retry is parked
@@ -1272,7 +1276,9 @@ abstract class BaseSQLAdapter<PooledConnection extends BasePooledConnection, Con
         for (let i = 0; i < pollSize; i++) {
           const connection = this.connections[i];
           // we need a new connection and we have some connections that can retry
-          if (connection.state === PooledConnectionState.closed) {
+          // (an unassigned hole is a connection still being created, so it
+          // lands in the "pending" branch below)
+          if (connection?.state === PooledConnectionState.closed) {
             if (connection.retry()) {
               // lets wait for connection to be released
               if (!retry_in_progress) {

--- a/test/js/sql/sql-close-pending-connection.test.ts
+++ b/test/js/sql/sql-close-pending-connection.test.ts
@@ -67,3 +67,50 @@ for (const [name, scheme, closedCode] of drivers) {
     }
   });
 }
+
+// https://github.com/oven-sh/bun/issues/32198
+//
+// The pool's connection array is allocated as `new Array(max)` and filled one
+// slot at a time when the pool starts. A function-valued `password` option
+// runs synchronously during that fill, so pool methods re-entered from it
+// used to dereference unassigned slots and throw a raw TypeError.
+test("pool scans tolerate unassigned connection slots during pool start", async () => {
+  const { port, server, sockets } = await neverAnsweringServer();
+  let passwordCalls = 0;
+  const errors: unknown[] = [];
+  const sql = new SQL({
+    adapter: "postgres",
+    hostname: "127.0.0.1",
+    port,
+    username: "u",
+    database: "d",
+    max: 2,
+    connectionTimeout: 0,
+    password: () => {
+      passwordCalls++;
+      try {
+        sql.flush();
+      } catch (e) {
+        errors.push(e);
+      }
+      try {
+        sql.connect().catch(() => {});
+      } catch (e) {
+        errors.push(e);
+      }
+      return "";
+    },
+  });
+  try {
+    sql.connect().catch(() => {});
+    // the pool-start fill loop runs synchronously inside connect(), invoking
+    // password() once per pool slot
+    expect(passwordCalls).toBe(2);
+    expect(errors).toEqual([]);
+  } finally {
+    // force an immediate close even with waiters queued
+    await sql.close({ timeout: "0" });
+    for (const socket of sockets) socket.destroy();
+    server.close();
+  }
+});


### PR DESCRIPTION
First item of #32198. The second item there (the `close({ timeout })` validation mismatch) is already addressed by the open #32100, which bounds the timeout at setTimeout's real millisecond limit and rewords the message, so it is deliberately not touched here.

### Repro

No database server needed:

```js
const sql = new Bun.SQL({
  adapter: "postgres",
  hostname: "127.0.0.1",
  port: 5432,
  username: "u",
  database: "d",
  max: 2,
  password: () => {
    sql.flush(); // TypeError: undefined is not an object (evaluating 'this.closed')
    return "";
  },
});
sql.connect().catch(() => {});
```

### Cause

`BaseSQLAdapter.connections` is allocated as `new Array(max)` and filled one slot at a time in `connect()`'s pool-start loop. `createPooledConnection` can synchronously run user code: a function-valued `password` option is invoked synchronously by `createPooledConnectionHandle`. If that user code re-enters a pool method that scans `this.connections`, the scan hits slots that are still unassigned holes.

`hasConnectionsAvailable()` already guards for this (`if (connection && ...)`) and documents the scenario, but the equivalent loops in `isConnected()`, `flush()`, `#close()`, and the retry scan in `connect()` read `connection.state` unguarded and throw a raw `TypeError: undefined is not an object (evaluating 'connection.state')`. (In the observed errors JSC quotes a nearby expression, `this.closed` / `this.readyConnections`, due to line skew between the embedded and on-disk bundle source; the stack points at the `connection.state` reads.)

### Fix

Optional-chain the state reads in those four loops (`connection?.state`), matching the guard `hasConnectionsAvailable()` already has, and document the hole invariant where the array is created. In the retry scan a hole counts as a connection still being created (`all_closed = false`), so the caller is queued and served when the pool finishes connecting. `#close()` does not appear reachable with holes today (pool start always queues a waiter first, so close defers), but it gets the same guard for consistency, which also covers the `connections[i] = null` slots it writes.

### Verification

New test in `test/js/sql/sql-close-pending-connection.test.ts` re-enters `sql.flush()` and `sql.connect()` from a function-valued `password` during pool start, against a local TCP server that never answers (no database needed). On the unfixed build it fails with the TypeErrors above captured from both re-entry points; with the fix the whole file passes (`bun bd test test/js/sql/sql-close-pending-connection.test.ts`, 5 pass).
