### PR TITLE
shell: replace, don't append, when a prefix assignment overrides an env var

### DIFF
--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1593,7 +1593,22 @@ impl<'a> SpawnArgs<'a> {
                 self.path = &line[b"PATH=".len()..len];
             }
 
-            self.env_array.push(line.as_ptr().cast::<c_char>());
+            // A var can arrive twice — e.g. from `export_env` and then
+            // `cmd_local_env` (`FOO=bar cmd` with FOO inherited or exported).
+            // POSIX tolerates duplicate environ entries but getenv returns
+            // the first match, so appending would make the child see the
+            // stale value. Replace the existing entry instead.
+            let line_ptr = line.as_ptr().cast::<c_char>();
+            let existing = self.env_array.iter().position(|&p| {
+                // SAFETY: every entry is a NUL-terminated `key=value` line
+                // pushed by `fill_env` (this call or an earlier one).
+                let e = unsafe { core::ffi::CStr::from_ptr(p).to_bytes() };
+                e.len() > key.len() && e[key.len()] == b'=' && &e[..key.len()] == key
+            });
+            match existing {
+                Some(i) => self.env_array[i] = line_ptr,
+                None => self.env_array.push(line_ptr),
+            }
         }
     }
 }

--- a/test/regression/issue/32202.test.ts
+++ b/test/regression/issue/32202.test.ts
@@ -1,0 +1,42 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { isWindows } from "harness";
+
+// Regression tests for https://github.com/oven-sh/bun/issues/32202
+// A `VAR=value cmd` prefix assignment of a variable that already exists in
+// the shell environment (inherited from the process, or set earlier via
+// `export`) appended a second environ entry instead of replacing the
+// existing one. POSIX tolerates duplicate environ entries but getenv
+// returns the first match, so the child effectively saw the stale value.
+//
+// The tests read the raw environ via the external `env` command: a bun
+// child can't detect the bug (its `process.env` parses environ last-wins),
+// and getenv-based children would see the first match. Hence posix-only.
+
+const envLines = async (cmd: $.ShellPromise, name: string) =>
+  (await cmd).text().split("\n").filter(l => l.startsWith(`${name}=`));
+
+test.skipIf(isWindows)("prefix assignment of an inherited var replaces the environ entry", async () => {
+  const saved = process.env.BUN_32202_INHERITED;
+  process.env.BUN_32202_INHERITED = "parent";
+  try {
+    const lines = await envLines($`BUN_32202_INHERITED=child env`.quiet(), "BUN_32202_INHERITED");
+    expect(lines).toEqual(["BUN_32202_INHERITED=child"]);
+  } finally {
+    if (saved === undefined) delete process.env.BUN_32202_INHERITED;
+    else process.env.BUN_32202_INHERITED = saved;
+  }
+});
+
+test.skipIf(isWindows)("prefix assignment of an exported var replaces the environ entry", async () => {
+  const lines = await envLines(
+    $`export BUN_32202_EXPORTED=first; BUN_32202_EXPORTED=second env`.quiet(),
+    "BUN_32202_EXPORTED",
+  );
+  expect(lines).toEqual(["BUN_32202_EXPORTED=second"]);
+});
+
+test.skipIf(isWindows)("prefix assignment of a fresh var stays a single entry", async () => {
+  const lines = await envLines($`BUN_32202_FRESH=only env`.quiet(), "BUN_32202_FRESH");
+  expect(lines).toEqual(["BUN_32202_FRESH=only"]);
+});


### PR DESCRIPTION
## Summary

`$`'s `VAR=value cmd` prefix assignment of a variable that already exists
in the shell environment (inherited, or set earlier via `export`) appended
a second environ entry instead of replacing the existing one:

```ts
console.log(await $`HOME=/tmp/zz env`.text());
// HOME=/home/me ... HOME=/tmp/zz — two entries; getenv returns the first
```

`SpawnArgs::fill_env` now replaces an existing `key=` entry in `env_array`
instead of pushing a duplicate, making the child environ last-write-wins
across `export_env` + `cmd_local_env`.

Fixes #32202.

## Test plan

`test/regression/issue/32202.test.ts`: prefix-overriding an inherited var,
prefix-overriding an exported var, and a fresh-var single-entry sanity
case. Reads the raw environ via the external `env` command (a bun child
masks the bug — its `process.env` parses environ last-wins), hence
posix-gated. The two override cases fail on unfixed bun (verified against
1.3.14).