### PR TITLE
node:http: emit 'upgrade' on ClientRequest for 101 responses

### DIFF
--- a/src/js/node/_http_client.ts
+++ b/src/js/node/_http_client.ts
@@ -52,7 +52,9 @@ const {
   reqSymbol,
   callCloseCallback,
   emitCloseNTAndComplete,
+  noBodySymbol,
 } = require("internal/http");
+const { Duplex } = require("internal/stream");
 
 const { globalAgent } = require("node:_http_agent");
 const { IncomingMessage } = require("node:_http_incoming");
@@ -62,6 +64,8 @@ const globalReportError = globalThis.reportError;
 const setTimeout = globalThis.setTimeout;
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const INVALID_HOST_CHAR_REGEX = /[/\\?#@\t\n\r]/;
+const kEmptyBuffer = Buffer.alloc(0);
+const nop = () => {};
 
 const { URL } = globalThis;
 
@@ -75,6 +79,146 @@ function emitErrorEventNT(self, err) {
   if (self.listenerCount("error") > 0) {
     self.emit("error", err);
   }
+}
+
+// The socket handed to 'upgrade' listeners after a 101 Switching Protocols
+// response. The readable side drains the fetch response body, which carries
+// the raw post-upgrade bytes (the native client stops HTTP-parsing once the
+// upgrade completes; see HTTPUpgradeState in src/http/lib.rs). The writable
+// side feeds the request's streaming body generator, whose bytes
+// FetchTasklet writes to the connection unframed after the 101 (see
+// skip_chunked_framing in src/runtime/webcore/fetch/FetchTasklet.rs).
+// Socket-shaped the same way FakeSocket is.
+class UpgradeSocket extends Duplex {
+  #reader;
+  #channel;
+  #pulling = false;
+  #ended = false;
+  #timer;
+  #timeoutMs = 0;
+
+  constructor(reader, channel) {
+    // allowHalfOpen: false matches net.Socket's default: when the peer
+    // closes its half, the writable side is ended automatically.
+    super({ allowHalfOpen: false });
+    this.#reader = reader;
+    this.#channel = channel;
+  }
+
+  // Idle timer, re-armed on read/write activity like net.Socket's.
+  #armTimeout() {
+    const timer = this.#timer;
+    if (timer) {
+      clearTimeout(timer);
+      this.#timer = undefined;
+    }
+    const msecs = this.#timeoutMs;
+    if (msecs > 0 && !this.destroyed) {
+      this.#timer = setTimeout(emitTimeoutNT, msecs, this);
+      this.#timer.unref();
+    }
+  }
+
+  setTimeout(msecs, callback) {
+    msecs = getTimerDuration(msecs, "msecs");
+    if (callback !== undefined) {
+      validateFunction(callback, "callback");
+      if (msecs === 0) {
+        this.removeListener("timeout", callback);
+      } else {
+        this.once("timeout", callback);
+      }
+    }
+    this.#timeoutMs = msecs;
+    this.#armTimeout();
+    return this;
+  }
+
+  async #pull() {
+    const reader = this.#reader;
+    if (!reader) {
+      this.#ended = true;
+      this.push(null);
+      return;
+    }
+    this.#pulling = true;
+    try {
+      while (!this.destroyed) {
+        let result = reader.readMany();
+        if ($isPromise(result)) {
+          result = await result;
+        }
+        if (this.destroyed || this.#ended) return;
+        const { done, value } = result;
+        let wantMore = true;
+        for (const chunk of value) {
+          if (this.#timeoutMs > 0) this.#armTimeout();
+          wantMore = this.push(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength));
+        }
+        if (done) {
+          this.#ended = true;
+          this.push(null);
+          return;
+        }
+        if (!wantMore) return;
+      }
+    } catch (err) {
+      if (!this.destroyed) this.destroy(err);
+    } finally {
+      this.#pulling = false;
+    }
+  }
+
+  _read(_size) {
+    if (!this.#pulling && !this.#ended) {
+      this.#pull();
+    }
+  }
+
+  _write(chunk, _encoding, callback) {
+    if (this.#timeoutMs > 0) this.#armTimeout();
+    this.#channel.write(chunk, callback);
+  }
+
+  _final(callback) {
+    this.#channel.end();
+    callback();
+  }
+
+  _destroy(err, callback) {
+    const timer = this.#timer;
+    if (timer) {
+      clearTimeout(timer);
+      this.#timer = undefined;
+    }
+    this.#channel.destroy(err);
+    const reader = this.#reader;
+    this.#reader = undefined;
+    reader?.cancel?.().catch(nop);
+    callback(err);
+  }
+
+  ref() {
+    return this;
+  }
+
+  unref() {
+    return this;
+  }
+
+  setNoDelay(_noDelay = true) {
+    return this;
+  }
+
+  setKeepAlive(_enable = false, _initialDelay = 0) {
+    return this;
+  }
+}
+
+Object.defineProperty(UpgradeSocket, "name", { value: "Socket" });
+
+function emitTimeoutNT(socket) {
+  socket.emit("timeout");
 }
 
 function ClientRequest(input, options, cb) {
@@ -100,6 +244,68 @@ function ClientRequest(input, options, cb) {
 
   let writeCount = 0;
   let resolveNextChunk: ((end: boolean) => void) | undefined = _end => {};
+
+  // Channel between the upgrade socket's writable side and the request body
+  // generator: after a 101 the generator is the only way to push raw bytes
+  // into the native connection. Writable calls _write one chunk at a time,
+  // so a single pending slot suffices; the generator invokes the callback
+  // only once the sink pulled the next chunk, which propagates the native
+  // socket's backpressure into the upgrade socket.
+  let upgradeWriteChunk;
+  let upgradeWriteCallback;
+  let upgradeWake;
+  let upgradeAccepted = false;
+  let upgradeBodyEnded = false;
+
+  const wakeUpgradeBody = () => {
+    const wake = upgradeWake;
+    upgradeWake = undefined;
+    wake?.();
+  };
+
+  const endUpgradeBody = () => {
+    if (upgradeBodyEnded) return;
+    upgradeBodyEnded = true;
+    wakeUpgradeBody();
+    // The generator may still be parked in the pre-upgrade loop when the
+    // server rejects the upgrade on a request that was never end()ed.
+    resolveNextChunk?.(true);
+  };
+
+  const createUpgradeSocket = response => {
+    const socket = new UpgradeSocket(response.body?.getReader?.(), {
+      write: (chunk, callback) => {
+        if (upgradeBodyEnded) {
+          callback($ERR_STREAM_DESTROYED("write"));
+          return;
+        }
+        upgradeWriteChunk = chunk;
+        upgradeWriteCallback = callback;
+        wakeUpgradeBody();
+      },
+      end: endUpgradeBody,
+      destroy: err => {
+        endUpgradeBody();
+        const callback = upgradeWriteCallback;
+        upgradeWriteChunk = upgradeWriteCallback = undefined;
+        callback?.(err);
+      },
+    });
+    if (response.url.startsWith("https:")) {
+      socket.encrypted = true;
+    }
+    // req.abort()/req.destroy()/timeouts/options.signal abort the underlying
+    // fetch; tear the hijacked socket down with it.
+    const signal = this[kAbortController]?.signal;
+    if (signal) {
+      if (signal.aborted) {
+        socket.destroy();
+      } else {
+        signal.addEventListener("abort", () => socket.destroy(), { once: true });
+      }
+    }
+    return socket;
+  };
 
   // Node sends headers + first chunk immediately on the first write(). We
   // defer by a tick so that `write(chunk); end();` in the same tick still
@@ -277,6 +483,7 @@ function ClientRequest(input, options, cb) {
   };
 
   let fetching = false;
+  let isUpgrade = false;
 
   const startFetch = (customBody?) => {
     if (fetching) {
@@ -284,6 +491,14 @@ function ClientRequest(input, options, cb) {
     }
 
     fetching = true;
+
+    // An Upgrade header other than h2/h2c makes the native client treat the
+    // request as an upgrade handshake and accept a 101 response (see
+    // upgraded_connection in src/runtime/webcore/fetch.rs and
+    // HTTPUpgradeState in src/http/lib.rs); mirror that check here so the JS
+    // side agrees on which requests can get hijacked.
+    const upgradeHeader = this.getHeader("upgrade");
+    isUpgrade = upgradeHeader !== undefined && !/^h2c?$/i.test(upgradeHeader);
 
     // Every entry point that dispatches the request (send(), flushHeaders(),
     // and the write() → pushChunk paths) must have an AbortController wired
@@ -345,8 +560,17 @@ function ClientRequest(input, options, cb) {
         keepalive,
       };
       let keepOpen = false;
+      if (isUpgrade && customBody !== undefined) {
+        // Upgrade requests always stream the body through the generator so
+        // the connection keeps a writable channel for the post-101 socket.
+        // send() leaves the chunks in kBodyChunks, so the generator still
+        // delivers them (the native client holds request body bytes back
+        // until the 101; see write_to_stream in src/http/lib.rs).
+        customBody = undefined;
+      }
+
       // no body and not finished
-      const isDuplex = customBody === undefined && !this.finished;
+      const isDuplex = customBody === undefined && (!this.finished || isUpgrade);
 
       if (isDuplex) {
         fetchOptions.duplex = "half";
@@ -359,8 +583,10 @@ function ClientRequest(input, options, cb) {
         fetchOptions.body = customBody;
       } else if (
         isDuplex &&
-        // Normal case: non-GET/HEAD/OPTIONS can use streaming
-        ((method !== "GET" && method !== "HEAD" && method !== "OPTIONS") ||
+        // Upgrade requests always stream so the post-101 socket can write
+        (isUpgrade ||
+          // Normal case: non-GET/HEAD/OPTIONS can use streaming
+          (method !== "GET" && method !== "HEAD" && method !== "OPTIONS") ||
           // Special case: GET/HEAD/OPTIONS with already-queued chunks should also stream
           this[kBodyChunks]?.length > 0)
       ) {
@@ -374,7 +600,7 @@ function ClientRequest(input, options, cb) {
             self.emit("drain");
           }
 
-          while (!self.finished) {
+          while (!self.finished && !upgradeAccepted && !upgradeBodyEnded) {
             yield await new Promise(resolve => {
               resolveNextChunk = end => {
                 resolveNextChunk = undefined;
@@ -388,6 +614,30 @@ function ClientRequest(input, options, cb) {
 
             if (self[kBodyChunks]?.length === 0) {
               self.emit("drain");
+            }
+          }
+
+          if (isUpgrade) {
+            // Keep the upload half of the connection open past req.end():
+            // bytes written to the upgrade socket flow through here and are
+            // written to the connection unframed once the server answered
+            // with a 101.
+            while (true) {
+              if (upgradeWriteCallback) {
+                const chunk = upgradeWriteChunk;
+                const callback = upgradeWriteCallback;
+                upgradeWriteChunk = upgradeWriteCallback = undefined;
+                yield chunk;
+                // Resumed on the sink's next pull, i.e. after it consumed
+                // the chunk; ack the socket write only now so native
+                // backpressure reaches the Writable side.
+                callback();
+                continue;
+              }
+              if (upgradeBodyEnded) break;
+              await new Promise(resolve => {
+                upgradeWake = resolve;
+              });
             }
           }
 
@@ -420,6 +670,23 @@ function ClientRequest(input, options, cb) {
           return;
         }
 
+        const isUpgradeResponse = isUpgrade && response.status === 101;
+        if (isUpgrade) {
+          if (isUpgradeResponse) {
+            // The upgrade socket owns the upload half now; move the
+            // generator out of the pre-upgrade loop (where it parks when
+            // the request was started by flushHeaders()/write() without
+            // end()) into the upgrade channel loop.
+            upgradeAccepted = true;
+            resolveNextChunk?.(true);
+          } else {
+            // The server rejected the upgrade; release the body generator
+            // so the request side of the connection can finish (it would
+            // otherwise stay open forever waiting for post-upgrade writes).
+            endUpgradeBody();
+          }
+        }
+
         handleResponse = () => {
           this[kFetchRequest] = null;
           this[kClearTimeout]();
@@ -434,6 +701,44 @@ function ClientRequest(input, options, cb) {
           setIsNextIncomingMessageHTTPS(prevIsHTTPS);
           res.req = this;
           res.setTimeout = clientResponseSetTimeout;
+
+          if (isUpgradeResponse) {
+            // A 101 response emits 'upgrade' instead of 'response', handing
+            // the connection over to the listener; with no listener the
+            // connection is destroyed, matching
+            // https://github.com/nodejs/node/blob/v24.3.0/lib/_http_client.js#L617-L657
+            // The IncomingMessage carries only the status line and headers;
+            // post-upgrade bytes flow through the hijacked socket.
+            res[noBodySymbol] = true;
+            res.complete = true;
+            process.nextTick(
+              (self, res) => {
+                if (self.aborted || self.listenerCount("upgrade") === 0) {
+                  endUpgradeBody();
+                  response.body?.cancel?.().catch(nop);
+                  self.destroyed = true;
+                  maybeEmitClose();
+                  return;
+                }
+                self[kUpgradeOrConnect] = true;
+                const socket = createUpgradeSocket(response);
+                self.socket = socket;
+                res.socket = socket;
+                // Node passes any bytes that followed the 101 in the same
+                // packet as `head`; here they are always delivered through
+                // the socket instead, so `head` is always empty. Upgrade
+                // consumers unshift `head` back onto the socket before
+                // reading, so both shapes behave the same.
+                self.emit("upgrade", res, socket, kEmptyBuffer);
+                self.destroyed = true;
+                maybeEmitClose();
+              },
+              this,
+              res,
+            );
+            return;
+          }
+
           process.nextTick(
             (self, res) => {
               // If the user did not listen for the 'response' event, then they

--- a/test/js/node/http/node-http-client-upgrade.test.ts
+++ b/test/js/node/http/node-http-client-upgrade.test.ts
@@ -30,7 +30,9 @@ function rawUpgradeServer(
     socket.on("data", onData);
     socket.on("error", () => {});
   };
-  const server = options?.tls ? tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, connect) : net.createServer(connect);
+  const server = options?.tls
+    ? tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, connect)
+    : net.createServer(connect);
   return new Promise(resolve => {
     server.listen(0, "127.0.0.1", () => {
       resolve({ port: (server.address() as net.AddressInfo).port, server });

--- a/test/js/node/http/node-http-client-upgrade.test.ts
+++ b/test/js/node/http/node-http-client-upgrade.test.ts
@@ -1,0 +1,308 @@
+// Tests for the client side of HTTP/1.1 upgrades: http.request() must emit
+// 'upgrade' (not 'response') for 101 Switching Protocols and hand over a
+// working duplex socket.
+// https://github.com/oven-sh/bun/issues/32195
+// https://github.com/oven-sh/bun/issues/18945
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+
+const HANDSHAKE = "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n";
+
+// Raw TCP server speaking just enough HTTP to answer an upgrade request, so
+// these tests exercise only the client (the node:http server has its own
+// upgrade handling).
+function rawUpgradeServer(
+  onRequest: (socket: net.Socket) => void,
+  options?: { tls?: boolean },
+): Promise<{ port: number; server: net.Server }> {
+  const connect = (socket: net.Socket) => {
+    let buffered = "";
+    const onData = (chunk: Buffer) => {
+      buffered += chunk.toString("latin1");
+      if (!buffered.includes("\r\n\r\n")) return;
+      socket.removeListener("data", onData);
+      onRequest(socket);
+    };
+    socket.on("data", onData);
+    socket.on("error", () => {});
+  };
+  const server = options?.tls ? tls.createServer({ key: tlsCert.key, cert: tlsCert.cert }, connect) : net.createServer(connect);
+  return new Promise(resolve => {
+    server.listen(0, "127.0.0.1", () => {
+      resolve({ port: (server.address() as net.AddressInfo).port, server });
+    });
+  });
+}
+
+const upgradeHeaders = { Connection: "Upgrade", Upgrade: "websocket" };
+
+describe.concurrent("http.ClientRequest upgrade", () => {
+  test("emits 'upgrade' with a working duplex socket", async () => {
+    const { port, server } = await rawUpgradeServer(socket => {
+      socket.write(HANDSHAKE);
+      socket.on("data", chunk => socket.write(chunk)); // echo
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ port, host: "127.0.0.1", headers: upgradeHeaders });
+      req.on("error", reject);
+      req.on("response", () => reject(new Error("unexpected 'response' event")));
+      req.end();
+
+      req.on("upgrade", (res, socket, head) => {
+        try {
+          expect(res.statusCode).toBe(101);
+          expect(res.headers.upgrade).toBe("websocket");
+          expect(res.complete).toBe(true);
+          expect(Buffer.isBuffer(head)).toBe(true);
+          expect(socket).toBe(req.socket);
+        } catch (err) {
+          reject(err);
+          return;
+        }
+
+        let received = "";
+        if (head.length > 0) socket.unshift(head);
+        socket.on("data", chunk => {
+          received += chunk.toString();
+          if (received === "helloworld") {
+            socket.end();
+          }
+        });
+        socket.on("error", reject);
+        socket.on("close", () => resolve(received));
+        // Two synchronous writes: both must arrive, in order.
+        socket.write("hello");
+        socket.write("world");
+      });
+
+      expect(await promise).toBe("helloworld");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("event order matches Node: socket, finish, upgrade, close", async () => {
+    const { port, server } = await rawUpgradeServer(socket => {
+      socket.write(HANDSHAKE);
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+      const events: string[] = [];
+      const req = http.request({ port, host: "127.0.0.1", headers: upgradeHeaders });
+      for (const name of ["socket", "finish", "response", "error", "abort"]) {
+        req.on(name, () => events.push(name));
+      }
+      req.on("upgrade", (_res, socket) => {
+        events.push("upgrade");
+        socket.destroy();
+      });
+      req.on("close", () => {
+        events.push("close");
+        resolve(events);
+      });
+      req.on("error", reject);
+      req.end();
+
+      expect(await promise).toEqual(["socket", "finish", "upgrade", "close"]);
+      expect(req.destroyed).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("destroys the connection when there is no 'upgrade' listener", async () => {
+    const serverSawClose = Promise.withResolvers<void>();
+    const { port, server } = await rawUpgradeServer(socket => {
+      socket.write(HANDSHAKE);
+      socket.on("close", () => serverSawClose.resolve());
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      const req = http.request({ port, host: "127.0.0.1", headers: upgradeHeaders });
+      req.on("response", () => reject(new Error("unexpected 'response' event")));
+      req.on("error", reject);
+      req.on("close", resolve);
+      req.end();
+
+      await promise;
+      await serverSawClose.promise;
+      expect(req.destroyed).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("bytes sent in the same packet as the 101 reach the socket", async () => {
+    const { port, server } = await rawUpgradeServer(socket => {
+      // handshake and first payload in a single write
+      socket.end(HANDSHAKE + "early-data");
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ port, host: "127.0.0.1", headers: upgradeHeaders });
+      req.on("error", reject);
+      req.end();
+      req.on("upgrade", (_res, socket, head) => {
+        let received = "";
+        if (head.length > 0) socket.unshift(head);
+        socket.on("data", chunk => (received += chunk.toString()));
+        socket.on("end", () => resolve(received));
+        socket.on("error", reject);
+      });
+
+      expect(await promise).toBe("early-data");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("a regular response to an upgrade request still emits 'response' and completes", async () => {
+    const { port, server } = await rawUpgradeServer(socket => {
+      socket.end("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 8\r\n\r\nrejected");
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<{ statusCode: number | undefined; body: string }>();
+      const req = http.request({ port, host: "127.0.0.1", headers: upgradeHeaders });
+      req.on("upgrade", () => reject(new Error("unexpected 'upgrade' event")));
+      req.on("error", reject);
+      req.on("response", res => {
+        let body = "";
+        res.on("data", chunk => (body += chunk.toString()));
+        res.on("end", () => resolve({ statusCode: res.statusCode, body }));
+        res.on("error", reject);
+      });
+      req.end();
+
+      expect(await promise).toEqual({ statusCode: 200, body: "rejected" });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("upgrade works on a request started with flushHeaders() and no end()", async () => {
+    const { port, server } = await rawUpgradeServer(socket => {
+      socket.write(HANDSHAKE);
+      socket.on("data", chunk => socket.write(chunk)); // echo
+    });
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = http.request({ port, host: "127.0.0.1", method: "POST", headers: upgradeHeaders });
+      req.on("error", reject);
+      req.on("response", () => reject(new Error("unexpected 'response' event")));
+      // dockerode-style: send the headers, keep the upload half open, never
+      // call req.end().
+      req.flushHeaders();
+
+      req.on("upgrade", (_res, socket) => {
+        let received = "";
+        socket.on("data", chunk => {
+          received += chunk.toString();
+          if (received === "hijacked") socket.end();
+        });
+        socket.on("error", reject);
+        socket.on("close", () => resolve(received));
+        socket.write("hijacked");
+      });
+
+      expect(await promise).toBe("hijacked");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("upgrade works over TLS", async () => {
+    const { port, server } = await rawUpgradeServer(
+      socket => {
+        socket.write(HANDSHAKE);
+        socket.on("data", chunk => socket.write(chunk)); // echo
+      },
+      { tls: true },
+    );
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      const req = https.request({
+        port,
+        host: "127.0.0.1",
+        headers: upgradeHeaders,
+        ca: tlsCert.cert,
+        rejectUnauthorized: false,
+      });
+      req.on("error", reject);
+      req.on("response", () => reject(new Error("unexpected 'response' event")));
+      req.end();
+      req.on("upgrade", (_res, socket) => {
+        expect(socket.encrypted).toBe(true);
+        let received = "";
+        socket.on("data", chunk => {
+          received += chunk.toString();
+          if (received === "secure-echo") socket.end();
+        });
+        socket.on("close", () => resolve(received));
+        socket.on("error", reject);
+        socket.write("secure-echo");
+      });
+
+      expect(await promise).toBe("secure-echo");
+    } finally {
+      server.close();
+    }
+  });
+
+  // The shape from the issue: the whole exchange in a child process, proving
+  // the runtime does not hang and exits on its own once the socket closes.
+  test("upgrade client does not hang the process", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const net = require("node:net");
+        const http = require("node:http");
+
+        const server = net.createServer(socket => {
+          let buffered = "";
+          socket.on("data", chunk => {
+            buffered += chunk;
+            if (!buffered.includes("\\r\\n\\r\\n")) return;
+            socket.write(${JSON.stringify(HANDSHAKE)});
+            socket.pipe(socket); // echo
+          });
+        });
+
+        server.listen(0, "127.0.0.1", () => {
+          const req = http.request({
+            port: server.address().port,
+            host: "127.0.0.1",
+            headers: { Connection: "Upgrade", Upgrade: "websocket" },
+          });
+          req.end();
+          req.on("upgrade", (res, socket, head) => {
+            console.log("got upgraded!");
+            socket.end();
+            server.close();
+          });
+        });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // stderr is drained but not asserted: debug/ASAN builds emit benign noise.
+    const [stdout, _stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "got upgraded!\n", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
This is the client half of #32195 (the server half, raw socket writes after the server's `'upgrade'` event, is #30664). Fixes #18945.

## Reproduction

```js
// raw TCP server stands in for any websocket server
const net = require("node:net");
const http = require("node:http");

const server = net.createServer(socket => {
  socket.once("data", () => {
    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n");
    socket.pipe(socket);
  });
});
server.listen(0, "127.0.0.1", () => {
  const req = http.request({
    port: server.address().port,
    headers: { Connection: "Upgrade", Upgrade: "websocket" },
  });
  req.end();
  req.on("upgrade", (res, socket, head) => {
    console.log("got upgraded!");
    socket.end();
    server.close();
  });
});
```

Node prints `got upgraded!` and exits. Bun emits `'response'` (status 101) instead, never fires `'upgrade'`, and hangs forever. This breaks every client that drives a websocket handshake through `http.request()`: the real `ws` package fails with `Unexpected server response: 101`, playwright's `connectOverCDP` times out, etc.

## Root cause

`ClientRequest` is fetch-based and has no 101 handling: the only delivery path is `self.emit("response", res)`. The native side already supports the whole flow (an `Upgrade:` header sets `upgrade_state = Pending` in src/http/lib.rs, a 101 stops HTTP parsing and streams the raw bytes as the response body, streaming request-body writes skip chunked framing after the upgrade, and ending the body stream shuts the connection down), but nothing on the JS side used it; `kUpgradeOrConnect` was initialized and never read.

## Fix

All in `src/js/node/_http_client.ts`:

- detect upgrade requests the same way the native client does (an `Upgrade` header other than h2/h2c)
- force such requests into streaming-body mode and keep the body generator alive past `req.end()`, so the connection retains a writable channel
- on a 101, emit `upgrade(res, socket, head)` instead of `response`: `socket` is a `Duplex` that reads from the fetch response body (the raw post-upgrade bytes) and writes through the body generator, which the native client writes unframed after the 101; write acks ride the sink's pulls so native backpressure reaches the socket
- with no `'upgrade'` listener, destroy the connection and emit no `'response'`, matching Node
- non-101 responses to upgrade requests release the generator so the request completes normally

Event order (`socket`, `finish`, `upgrade`, `close`), `res.complete`, `socket === req.socket`, and `req.destroyed` were verified side by side against Node v24.3.0 (reference: `lib/_http_client.js` `socketOnData`).

`head` is always empty: bytes that arrived together with the 101 flow through the socket instead. Upgrade consumers `unshift(head)` back onto the socket before reading, so both shapes behave the same.

## Verification

`test/js/node/http/node-http-client-upgrade.test.ts`, 8 tests against raw `net`/`tls` servers so that only the client side is exercised: echo roundtrip plus res/socket invariants, Node event order, no-listener destroy, 101+data in one packet, non-101 completion, flushHeaders-without-end, TLS, and a spawned child proving the process exits instead of hanging.

```
USE_SYSTEM_BUN=1 bun test test/js/node/http/node-http-client-upgrade.test.ts  # 7 fail, 1 pass (hangs / 'response' instead of 'upgrade')
bun bd test test/js/node/http/node-http-client-upgrade.test.ts               # 8 pass
```

Also verified the real `ws@8.18.3` client (required by path to bypass the bundled shim) completes open/send/echo/close against a Node ws server: fails with `Unexpected server response: 101` on bun 1.4.0, works with this change. `test/js/node/http/` suite has no new failures (the pre-existing proxy and uaf failures reproduce on main).

Not covered: request bodies sent before the 101 are still held back by the native client while the upgrade is pending (`write_to_stream` returns early in the `Pending` state), so the dockerode "send a chunked body, then read the 101" flow (#29012) still deadlocks. That part needs a native-side change.

Supersedes #28470 (reroutes upgrade requests through a JS-parsed `net.connect` path, stalled since March) and #29015 (same fetch-based approach, but its native half targets the dormant `.zig` reference files from before the Rust port).


## Related issues (scoped, not auto-closed)

Of the issues the bot flagged, none is fully closed by this PR alone:

- #20547 (`websocket` npm package): the client half is fixed here, verified locally (before: `connectFailed Error: Server responded with a non-101 status: 101 Switching Protocols`; after: connects and echoes, same output as Node). The issue also reports the library's server side broken, which is #30664.
- #10441, #14522, #16819 (node-http-proxy WebSocket proxying): a proxy is both an upgrade server and an upgrade client, so these need this PR and #30664 together.
- #31406, #5951, #24229: these hit the bundled `ws` shim (`ws.WebSocket 'upgrade' event is not implemented`), which wraps Bun's native WebSocket and never goes through `http.request()`; that is #31408's territory, not this PR.
