### PR TITLE
shell: prefix assignment of an existing env var duplicated the environ entry

### DIFF
--- a/src/runtime/shell/EnvMap.rs
+++ b/src/runtime/shell/EnvMap.rs
@@ -108,6 +108,11 @@ impl EnvMap {
         Some(val)
     }
 
+    /// Unlike `get`, does not ref the value.
+    pub fn contains(&self, key: EnvStr) -> bool {
+        self.map.contains(&key)
+    }
+
     pub fn clone(&self) -> EnvMap {
         let new = EnvMap {
             map: self.map.clone().expect("OOM"),

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -544,13 +544,17 @@ impl Cmd {
         resolved.push(0);
         interp.as_cmd_mut(this).args[0] = resolved;
 
-        // Fill env from export_env + cmd_local_env.
+        // Fill env from export_env + cmd_local_env. A key present in both
+        // maps must yield a single environ entry with the cmd-local value
+        // (POSIX prefix-assignment semantics): skip the shadowed export_env
+        // entry, since a duplicate would make getenv-based children see the
+        // stale exported value (getenv returns the first match).
         {
             let env = interp.as_cmd_mut(this).base.shell_mut();
             let mut iter = env.export_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env::<false>(&mut iter, Some(&env.cmd_local_env));
             let mut iter = env.cmd_local_env.iterator();
-            spawn_args.fill_env::<false>(&mut iter);
+            spawn_args.fill_env::<false>(&mut iter, None);
         }
 
         // Convert shell IO → subprocess stdio.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1556,9 +1556,14 @@ impl<'a> SpawnArgs<'a> {
 
     /// `object_iter` should be a some type with the following fields:
     /// - `next() bool`
+    ///
+    /// Entries whose key is present in `skip` are omitted. `env_array` must
+    /// end up with at most one line per key: `getenv` returns the first
+    /// match, so a duplicate key would hand the child the stale value.
     pub fn fill_env<const DISABLE_PATH_LOOKUP_FOR_ARV0: bool>(
         &mut self,
         env_iter: &mut crate::shell::env_map::Iterator<'_>,
+        skip: Option<&crate::shell::EnvMap>,
     ) {
         self.override_env = true;
         // Note: `bun_collections::array_hash_map::Iter` doesn't impl
@@ -1572,6 +1577,9 @@ impl<'a> SpawnArgs<'a> {
         }
 
         while let Some(entry) = env_iter.next() {
+            if skip.is_some_and(|skip| skip.contains(*entry.key_ptr)) {
+                continue;
+            }
             let key = entry.key_ptr.slice();
             let value = entry.value_ptr.slice();
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -925,6 +925,31 @@ booga"
       });
     });
 
+    // A prefix assignment of a var that is already in the environment must
+    // replace the inherited entry, not append a duplicate one: getenv
+    // returns the first match, so the child would see the stale value.
+    // Asserted through `env` (raw environ dump) because process.env dedups.
+    // https://github.com/oven-sh/bun/issues/32202
+    test.skipIf(isWindows)("cmd_local_var replaces inherited environ entry", async () => {
+      const { stdout } = await $`FOO=second env`.env({ ...bunEnv, FOO: "first" });
+      expect(
+        stdout
+          .toString()
+          .split("\n")
+          .filter(line => line.startsWith("FOO=")),
+      ).toEqual(["FOO=second"]);
+    });
+
+    test.skipIf(isWindows)("cmd_local_var replaces exported var environ entry", async () => {
+      const { stdout } = await $`export FOO=first; FOO=second env`;
+      expect(
+        stdout
+          .toString()
+          .split("\n")
+          .filter(line => line.startsWith("FOO=")),
+      ).toEqual(["FOO=second"]);
+    });
+
     test("expand shell var", async () => {
       const { stdout } = await $`FOO=bar BAR=baz; echo $FOO $BAR`;
       const str = stdout.toString();


### PR DESCRIPTION
Fixes #32202

### Repro

```ts
import { $ } from "bun";
console.log(await $`HOME=/tmp/zz env`.text());
```

prints two `HOME=` lines: the inherited value first, then the assigned one. Since glibc `getenv` returns the first match, a getenv-based child sees the old value, so the prefix assignment is effectively inverted. Same thing for `export FOO=first; FOO=second env`. bash produces a single entry with the new value.

### Cause

`Cmd::init_spawn` builds the child environ with two `fill_env` passes, one over `export_env` and one over `cmd_local_env`, with no dedup between them. A key present in both maps (a prefix assignment of an existing var) lands in `env_array` twice. The `.zig` reference has the same two-pass logic, so this is longstanding behavior, not a port regression.

### Fix

`SpawnArgs::fill_env` takes an optional skip map; the `export_env` pass skips keys that `cmd_local_env` will write, so the environ ends up with exactly one entry per key and the cmd-local value wins (POSIX prefix-assignment semantics). Key comparison goes through the existing `EnvMap` context, so it stays case-insensitive on Windows. Added `EnvMap::contains`, which unlike `get` does not bump the value refcount.

### Verification

Two new tests in `test/js/bun/shell/bunshell.test.ts` assert via `env` (raw environ dump; `process.env` dedups and hides the duplicate) that exactly one `FOO=` line remains, for both the inherited-var and exported-var cases. Both fail on the unfixed build with an extra `FOO=first` entry and pass with the fix. Full `bunshell.test.ts` (378 pass), `env.positionals`, `assignments-in-pipeline`, and `exec` suites pass with the debug build.
