### PR TITLE
node:module: implement stripTypeScriptTypes

### DIFF
--- a/src/ast/ast_result.rs
+++ b/src/ast/ast_result.rs
@@ -92,6 +92,26 @@ pub struct Ast<'a> {
     pub has_commonjs_export_names: bool,
     pub has_import_meta: bool,
     pub import_meta_ref: Ref,
+
+    /// First non-ambient TypeScript construct with runtime semantics (not
+    /// erasable by type stripping). `node:module`'s `stripTypeScriptTypes`
+    /// rejects these in `'strip'` mode, matching Node's amaro/swc strip-only
+    /// behavior. `declare` contexts never set this.
+    pub ts_runtime_syntax: Option<TsRuntimeSyntax>,
+    /// An identifier-named `module Foo {}` declaration was parsed. Node's
+    /// `stripTypeScriptTypes` rejects the `module` keyword in both modes
+    /// (string-named `declare module "foo"` is ambient and allowed).
+    pub uses_ts_module_keyword: bool,
+}
+
+/// TypeScript syntax with runtime semantics; see `Ast::ts_runtime_syntax`.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum TsRuntimeSyntax {
+    Enum,
+    Namespace,
+    ParameterProperty,
+    ImportEquals,
+    ExportAssignment,
 }
 
 // `parts`/`symbols`/`import_records` are now `ArenaVec`s and need an allocator,
@@ -137,6 +157,8 @@ impl<'a> Ast<'a> {
             has_commonjs_export_names: false,
             has_import_meta: false,
             import_meta_ref: Ref::NONE,
+            ts_runtime_syntax: None,
+            uses_ts_module_keyword: false,
         }
     }
 }

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3212,7 +3212,7 @@ pub mod target;
 
 pub use ast_result::{
     Ast, CommonJSNamedExport, CommonJSNamedExports, ConstValuesMap, NamedExports, NamedImports,
-    TopLevelSymbolToParts, TsEnumsMap,
+    TopLevelSymbolToParts, TsEnumsMap, TsRuntimeSyntax,
 };
 pub use import_record::{
     Flags as ImportRecordFlags, ImportRecord, PrintMode as ImportRecordPrintMode,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -232,6 +232,10 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     pub latest_return_had_semicolon: bool,
     pub has_import_meta: bool,
     pub has_es_module_syntax: bool,
+    /// See `Ast::ts_runtime_syntax`; records the first occurrence.
+    pub ts_runtime_syntax: Option<bun_ast::TsRuntimeSyntax>,
+    /// See `Ast::uses_ts_module_keyword`.
+    pub uses_ts_module_keyword: bool,
     pub top_level_await_keyword: bun_ast::Range,
     pub fn_or_arrow_data_parse: FnOrArrowDataParse,
     pub fn_or_arrow_data_visit: FnOrArrowDataVisit,
@@ -8236,6 +8240,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 // P::to_ast — final assembly P→Ast.
 // ═══════════════════════════════════════════════════════════════════════════
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
+    /// Record the first non-ambient TS runtime-syntax construct in the file;
+    /// see `Ast::ts_runtime_syntax`.
+    #[inline]
+    pub fn record_ts_runtime_syntax(&mut self, kind: bun_ast::TsRuntimeSyntax) {
+        if self.ts_runtime_syntax.is_none() {
+            self.ts_runtime_syntax = Some(kind);
+        }
+    }
+
     pub fn to_ast(
         &mut self,
         parts: &mut ListManaged<'a, js_ast::Part>,
@@ -8809,6 +8822,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             has_top_level_return: false,
             redirect_import_record_index: None,
             target: js_ast::Target::Browser,
+            ts_runtime_syntax: self.ts_runtime_syntax,
+            uses_ts_module_keyword: self.uses_ts_module_keyword,
         }))
     }
 
@@ -9096,6 +9111,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             latest_return_had_semicolon: false,
             has_import_meta: false,
             has_es_module_syntax: false,
+            ts_runtime_syntax: None,
+            uses_ts_module_keyword: false,
             top_level_await_keyword: bun_ast::Range::NONE,
             fn_or_arrow_data_parse,
             fn_or_arrow_data_visit: FnOrArrowDataVisit::default(),

--- a/src/js_parser/parse/parse_stmt.rs
+++ b/src/js_parser/parse/parse_stmt.rs
@@ -1342,6 +1342,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     p.lexer.next()?;
                     let value = p.parse_expr(Level::Lowest)?;
                     p.lexer.expect_or_insert_semicolon()?;
+                    if !opts.is_typescript_declare {
+                        p.record_ts_runtime_syntax(js_ast::TsRuntimeSyntax::ExportAssignment);
+                    }
                     return Ok(p.s(S::ExportEquals { value }, loc));
                 }
                 p.lexer.unexpected()?;
@@ -1760,6 +1763,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     && (p.lexer.token == T::TIdentifier
                         || (p.lexer.token == T::TStringLiteral && opts.is_typescript_declare))
                 {
+                    if matches!(ts_stmt, js_lexer::TypescriptStmtKeyword::TsStmtModule)
+                        && p.lexer.token == T::TIdentifier
+                    {
+                        p.uses_ts_module_keyword = true;
+                    }
                     return Ok(Some(p.parse_type_script_namespace_stmt(loc, opts)?));
                 }
             }

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -212,7 +212,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             if !p.stack_check.is_safe_to_recurse() {
                 return Err(err!("StackOverflow"));
             }
-            stmts.push(p.parse_type_script_namespace_stmt(dot_loc, &mut _opts)?);
+            // Mirror `parse_stmts_up_to`: a type-only inner namespace is
+            // erased to `S::TypeScript`, which must not make the outer
+            // `namespace A.B` look instantiated.
+            let inner = p.parse_type_script_namespace_stmt(dot_loc, &mut _opts)?;
+            if !matches!(inner.data, StmtData::STypeScript(_)) {
+                stmts.push(inner);
+            }
         } else if opts.is_typescript_declare && p.lexer.token != T::TOpenBrace {
             p.lexer.expect_or_insert_semicolon()?;
         } else {

--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -421,6 +421,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .insert(name.ref_, ns_member_data);
         }
 
+        p.record_ts_runtime_syntax(bun_ast::TsRuntimeSyntax::Namespace);
+
         // S::Namespace.stmts is `StoreSlice<Stmt>` (arena slice). BumpVec → bump slice.
         let stmts_slice: &'a mut [Stmt] = stmts.into_bump_slice_mut();
         Ok(p.s(
@@ -508,6 +510,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // "import type foo = bar.baz;"
             return Ok(p.s(S::TypeScript {}, loc));
         }
+
+        p.record_ts_runtime_syntax(bun_ast::TsRuntimeSyntax::ImportEquals);
 
         let ref_ = p
             .declare_symbol(SymbolKind::Constant, default_name_loc, default_name)
@@ -717,6 +721,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `scope_order_to_visit` may alias the same arena slice freely.
         let prev = p.scopes_in_order_for_enum.insert(loc, scope_order_clone);
         debug_assert!(prev.is_none());
+
+        p.record_ts_runtime_syntax(bun_ast::TsRuntimeSyntax::Enum);
 
         Ok(p.s(
             S::Enum {

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -1046,6 +1046,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             to_add += 1;
                         }
                     }
+                    if to_add > 0 {
+                        // `declare class` statements never reach the visit
+                        // pass, so this only fires for real (runtime)
+                        // parameter properties.
+                        self.record_ts_runtime_syntax(bun_ast::TsRuntimeSyntax::ParameterProperty);
+                    }
 
                     // if this is an expression, we can move statements after super() because there will be 0 decorators
                     let mut super_index: Option<usize> = None;

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -186,17 +186,15 @@ fn strip_typescript_types(
     // `parse()` lazily allocates `macro_context`, whose `data` pointer is
     // only freed by an explicit `deinit()`; this one-shot transpiler must
     // reclaim it on every return path (mirrors `TransformTask::run`).
-    let _macro_ctx_guard = scopeguard::guard(
-        core::ptr::addr_of_mut!(transpiler.macro_context),
-        |slot| {
+    let _macro_ctx_guard =
+        scopeguard::guard(core::ptr::addr_of_mut!(transpiler.macro_context), |slot| {
             // SAFETY: `slot` points at the stack-owned `transpiler`, which is
             // still alive when this guard drops (declared after it), and the
             // parser's `&mut MacroContext` borrow ended with `parse()`.
             if let Some(ctx) = unsafe { (*slot).take() } {
                 ctx.deinit();
             }
-        },
-    );
+        });
     // `LoadAllWithoutInlining` skips the implicit `process.env.NODE_ENV` /
     // `process.env.BUN_ENV` / `process.browser` defines, so `process.env.*`
     // reads survive the transform verbatim.

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -2,11 +2,15 @@ use crate::{
     self as jsc, ErrorableString, JSArray, JSGlobalObject, JSValue, JsError, JsResult, StringJsc,
     Strong, VirtualMachineRef as VirtualMachine,
 };
+use bun_alloc::Arena;
 use bun_ast::Loader;
 use bun_bundler::options::DEFAULT_LOADERS;
+use bun_bundler::transpiler::{MacroJSCtx, ParseOptions, Transpiler};
 use bun_core::{OwnedString, String as BunString, strings};
+use bun_js_printer as JSPrinter;
 use bun_options_types::LoaderExt as _;
 use bun_options_types::schema::api;
+use bun_resolver::package_json::MacroMap as MacroRemap;
 
 // `bun.schema.api.Loader` — bindgen-emitted schema enum.
 // Mirrored as a transparent `u8` because the schema enum is *open*
@@ -123,6 +127,265 @@ pub fn _stat(path: &[u8]) -> i32 {
         Ok(bun_sys::ExistsAtType::File) => 0, // Returns 0 for files.
         Ok(bun_sys::ExistsAtType::Directory) => 1, // Returns 1 for directories.
         Err(_) => -1, // Returns a negative integer for any other kind of strings.
+    }
+}
+
+// The C++ caller (NodeModuleModule.cpp `jsFunctionStripTypeScriptTypes`)
+// validates the arguments Node-style and passes plain coerced data.
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn NodeModuleModule__stripTypeScriptTypes(
+    global: &JSGlobalObject,
+    code: BunString,
+    transform_mode: bool,
+    source_map: bool,
+    source_url: BunString,
+) -> JSValue {
+    jsc::host_fn::to_js_host_call(global, || {
+        strip_typescript_types(global, code, transform_mode, source_map, source_url)
+    })
+}
+
+/// `module.stripTypeScriptTypes(code, options)`: transpile a TypeScript
+/// source string with Bun's transpiler.
+///
+/// In `'strip'` mode (`transform_mode == false`), TypeScript syntax with
+/// runtime semantics (enums, instantiated namespaces, parameter properties,
+/// `import =`, `export =`) throws `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`, and an
+/// identifier-named `module` declaration throws in both modes, matching
+/// Node's amaro/swc contract. Unlike Node, the output is re-printed from the
+/// AST rather than blanked in place, so original line/column positions are
+/// not preserved and comments are dropped.
+fn strip_typescript_types(
+    global: &JSGlobalObject,
+    code: BunString,
+    transform_mode: bool,
+    source_map: bool,
+    source_url: BunString,
+) -> JsResult<JSValue> {
+    let mut log = bun_ast::Log::init();
+    let arena = Arena::new();
+    // SAFETY: `arena` outlives every use through `transpiler` in this fn body;
+    // `Transpiler<'static>` forces the borrow to 'static, so launder through a
+    // raw ptr (same pattern as JSTranspiler / TransformTask).
+    let arena_ref: &'static Arena = unsafe { bun_ptr::detach_lifetime_ref(&arena) };
+
+    // SAFETY: VirtualMachine::get() returns the live singleton on the JS thread.
+    let vm = crate::virtual_machine::VirtualMachine::get().as_mut();
+
+    let transform = api::TransformOptions {
+        // `using` / `await using` are only kept verbatim (not lowered) when
+        // targeting Bun; JavaScriptCore implements them natively.
+        target: Some(api::Target::Bun),
+        ..Default::default()
+    };
+    let mut transpiler =
+        match Transpiler::init(arena_ref, &raw mut log, transform, Some(vm.transpiler.env)) {
+            Ok(t) => t,
+            Err(err) => return Err(global.throw_error(err, "Failed to create transpiler")),
+        };
+    // `parse()` lazily allocates `macro_context`, whose `data` pointer is
+    // only freed by an explicit `deinit()`; this one-shot transpiler must
+    // reclaim it on every return path (mirrors `TransformTask::run`).
+    let _macro_ctx_guard = scopeguard::guard(
+        core::ptr::addr_of_mut!(transpiler.macro_context),
+        |slot| {
+            // SAFETY: `slot` points at the stack-owned `transpiler`, which is
+            // still alive when this guard drops (declared after it), and the
+            // parser's `&mut MacroContext` borrow ended with `parse()`.
+            if let Some(ctx) = unsafe { (*slot).take() } {
+                ctx.deinit();
+            }
+        },
+    );
+    // `LoadAllWithoutInlining` skips the implicit `process.env.NODE_ENV` /
+    // `process.env.BUN_ENV` / `process.browser` defines, so `process.env.*`
+    // reads survive the transform verbatim.
+    transpiler.options.env.behavior = api::DotEnvBehavior::LoadAllWithoutInlining;
+    transpiler.options.env.disable_default_env_files = true;
+    if let Err(err) = transpiler.configure_defines() {
+        return Err(global.throw_error(err, "Failed to configure transpiler"));
+    }
+    // A plain type-stripping transform: no macros, no dead-code elimination,
+    // no import trimming (Node keeps value imports even when only used as
+    // types), no minification.
+    transpiler.options.no_macros = true;
+    transpiler.options.dead_code_elimination = false;
+    transpiler.options.tree_shaking = false;
+    transpiler.options.trim_unused_imports = Some(false);
+    transpiler.options.inlining = false;
+    transpiler.options.minify_whitespace = false;
+    transpiler.options.minify_syntax = false;
+    transpiler.options.minify_identifiers = false;
+    transpiler.options.auto_import_jsx = false;
+    transpiler.options.transform_only = false;
+    transpiler.options.hot_module_reloading = false;
+    transpiler.options.react_fast_refresh = false;
+
+    let mut ast_memory_allocator = bun_ast::ASTMemoryAllocator::borrowing(&arena);
+    let _ast_scope = ast_memory_allocator.enter();
+
+    // Borrowed view; must stay alive until printing finishes because the
+    // arena-allocated `Source` (and AST string slices) point into it.
+    let code_utf8 = code.to_utf8();
+    let source: &bun_ast::Source = arena_ref.alloc(bun_ast::Source::init_path_string(
+        Loader::Ts.stdin_name(),
+        code_utf8.slice(),
+    ));
+
+    let parse_options = ParseOptions {
+        arena: arena_ref,
+        macro_remappings: MacroRemap::default(),
+        dirname_fd: bun_sys::Fd::INVALID,
+        file_descriptor: None,
+        loader: Loader::Ts,
+        jsx: transpiler.options.jsx.clone(),
+        path: source.path,
+        virtual_source: Some(source),
+        replace_exports: Default::default(),
+        experimental_decorators: false,
+        emit_decorator_metadata: false,
+        macro_js_ctx: MacroJSCtx::ZERO,
+        file_hash: None,
+        file_fd_ptr: None,
+        inject_jest_globals: false,
+        set_breakpoint_on_first_line: false,
+        remove_cjs_module_wrapper: false,
+        dont_bundle_twice: false,
+        allow_commonjs: false,
+        module_type: Default::default(),
+        runtime_transpiler_cache: None,
+        keep_json_and_toml_as_one_statement: false,
+        allow_bytecode_cache: false,
+    };
+
+    let parse_result = transpiler.parse(parse_options, None);
+
+    if log.errors > 0 {
+        // Node maps parser errors to ERR_INVALID_TYPESCRIPT_SYNTAX (a
+        // SyntaxError); the message text comes from Bun's parser.
+        let text: &[u8] = log
+            .msgs
+            .iter()
+            .find(|m| matches!(m.kind, bun_ast::Kind::Err))
+            .map(|m| m.data.text.as_ref())
+            .unwrap_or(b"Failed to parse TypeScript");
+        return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
+            .throw(global, format_args!("{}", String::from_utf8_lossy(text))));
+    }
+    let Some(parse_result) = parse_result else {
+        return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
+            .throw(global, format_args!("Failed to parse TypeScript")));
+    };
+
+    // amaro rejects the `module` keyword in both modes.
+    if parse_result.ast.uses_ts_module_keyword {
+        return Err(jsc::ErrorCode::ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX.throw(
+            global,
+            format_args!("`module` keyword is not supported. Use `namespace` instead."),
+        ));
+    }
+    if !transform_mode {
+        if let Some(kind) = parse_result.ast.ts_runtime_syntax {
+            let what = match kind {
+                bun_ast::TsRuntimeSyntax::Enum => "TypeScript enum",
+                bun_ast::TsRuntimeSyntax::Namespace => "TypeScript namespace declaration",
+                bun_ast::TsRuntimeSyntax::ParameterProperty => "TypeScript parameter property",
+                bun_ast::TsRuntimeSyntax::ImportEquals => "TypeScript import equals declaration",
+                bun_ast::TsRuntimeSyntax::ExportAssignment => "TypeScript export assignment",
+            };
+            return Err(jsc::ErrorCode::ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX.throw(
+                global,
+                format_args!("{what} is not supported in strip-only mode"),
+            ));
+        }
+    }
+
+    let was_empty = parse_result.empty;
+    let mut printer = JSPrinter::BufferPrinter::init(JSPrinter::BufferWriter::init());
+    let mut map_vlq = bun_core::MutableString::init_empty();
+    if !was_empty {
+        if source_map {
+            let mut capture = VlqCapture { vlq: &mut map_vlq };
+            let handler = JSPrinter::SourceMapHandler::for_(&mut capture);
+            if let Err(err) = transpiler.print_with_source_map(
+                &arena,
+                parse_result,
+                &mut printer,
+                JSPrinter::Format::EsmAscii,
+                handler,
+                None,
+            ) {
+                return Err(global.throw_error(err, "Failed to print code"));
+            }
+        } else if let Err(err) = transpiler.print(
+            &arena,
+            parse_result,
+            &mut printer,
+            JSPrinter::Format::EsmAscii,
+        ) {
+            return Err(global.throw_error(err, "Failed to print code"));
+        }
+    }
+    let printed: &[u8] = printer.ctx.written();
+
+    let source_url_utf8 = source_url.to_utf8();
+    let mut out: Vec<u8> = Vec::with_capacity(printed.len() + 64);
+    out.extend_from_slice(printed);
+    if source_map {
+        // Node's shape: {"version":3,"sources":[<sourceUrl>],"names":[],
+        // "mappings":"..."}; an empty input produces "sources":[].
+        let mut json = bun_core::MutableString::init_empty();
+        bun_core::handle_oom(json.append(b"{\"version\":3,\"sources\":["));
+        if !was_empty {
+            bun_core::handle_oom(bun_core::quote_for_json(
+                source_url_utf8.slice(),
+                &mut json,
+                true,
+            ));
+        }
+        bun_core::handle_oom(json.append(b"],\"names\":[],\"mappings\":"));
+        bun_core::handle_oom(bun_core::quote_for_json(
+            map_vlq.list.as_slice(),
+            &mut json,
+            true,
+        ));
+        bun_core::handle_oom(json.append(b"}"));
+
+        out.extend_from_slice(b"\n\n//# sourceMappingURL=data:application/json;base64,");
+        let json_bytes = json.list.as_slice();
+        let old_len = out.len();
+        out.resize(old_len + bun_base64::encode_len(json_bytes), 0);
+        let written = bun_base64::encode(&mut out[old_len..], json_bytes);
+        out.truncate(old_len + written);
+    } else if !source_url_utf8.slice().is_empty() {
+        out.extend_from_slice(b"\n\n//# sourceURL=");
+        out.extend_from_slice(source_url_utf8.slice());
+    }
+
+    let mut result = BunString::clone_utf8(&out);
+    result.transfer_to_js(global)
+}
+
+struct VlqCapture<'m> {
+    vlq: &'m mut bun_core::MutableString,
+}
+
+impl JSPrinter::OnSourceMapChunk for VlqCapture<'_> {
+    fn on_source_map_chunk(
+        &mut self,
+        chunk: bun_sourcemap::Chunk,
+        _source: &bun_ast::Source,
+    ) -> Result<(), bun_core::Error> {
+        // Target is Bun, so `chunk.buffer` holds an InternalSourceMap blob;
+        // re-encode it to a standard VLQ "mappings" string. An empty buffer
+        // (source-map feature flag disabled) yields empty mappings.
+        if !chunk.buffer.list.is_empty() {
+            let ism = bun_sourcemap::InternalSourceMap {
+                data: chunk.buffer.list.as_ptr(),
+            };
+            ism.append_vlq_to(self.vlq);
+        }
+        Ok(())
     }
 }
 

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -268,7 +268,7 @@ fn strip_typescript_types(
             .map(|m| m.data.text.as_ref())
             .unwrap_or(b"Failed to parse TypeScript");
         return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
-            .throw(global, format_args!("{}", String::from_utf8_lossy(text))));
+            .throw(global, format_args!("{}", bstr::BStr::new(text))));
     }
     let Some(parse_result) = parse_result else {
         return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
@@ -299,6 +299,11 @@ fn strip_typescript_types(
     }
 
     let was_empty = parse_result.empty;
+    // A leading `#!` line is not part of the printed AST; carry it through
+    // like the bundler's entry-point handling (Node preserves hashbangs in
+    // both modes). The slice points into the source text (`code_utf8`).
+    let hashbang_store = parse_result.ast.hashbang;
+    let hashbang: &[u8] = hashbang_store.slice();
     let mut printer = JSPrinter::BufferPrinter::init(JSPrinter::BufferWriter::init());
     let mut map_vlq = bun_core::MutableString::init_empty();
     if !was_empty {
@@ -327,7 +332,13 @@ fn strip_typescript_types(
     let printed: &[u8] = printer.ctx.written();
 
     let source_url_utf8 = source_url.to_utf8();
-    let mut out: Vec<u8> = Vec::with_capacity(printed.len() + 64);
+    let mut out: Vec<u8> = Vec::with_capacity(hashbang.len() + 1 + printed.len() + 64);
+    if !hashbang.is_empty() {
+        out.extend_from_slice(hashbang);
+        if !printed.is_empty() {
+            out.push(b'\n');
+        }
+    }
     out.extend_from_slice(printed);
     if source_map {
         // Node's shape: {"version":3,"sources":[<sourceUrl>],"names":[],
@@ -342,11 +353,13 @@ fn strip_typescript_types(
             ));
         }
         bun_core::handle_oom(json.append(b"],\"names\":[],\"mappings\":"));
-        bun_core::handle_oom(bun_core::quote_for_json(
-            map_vlq.list.as_slice(),
-            &mut json,
-            true,
-        ));
+        let mut mappings: Vec<u8> = Vec::with_capacity(map_vlq.list.len() + 1);
+        if !hashbang.is_empty() && !map_vlq.list.is_empty() {
+            // The prepended hashbang occupies generated line 0.
+            mappings.push(b';');
+        }
+        mappings.extend_from_slice(map_vlq.list.as_slice());
+        bun_core::handle_oom(bun_core::quote_for_json(&mappings, &mut json, true));
         bun_core::handle_oom(json.append(b"}"));
 
         out.extend_from_slice(b"\n\n//# sourceMappingURL=data:application/json;base64,");

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -308,6 +308,12 @@ fn strip_typescript_types(
     // both modes). The slice points into the source text (`code_utf8`).
     let hashbang_store = parse_result.ast.hashbang;
     let hashbang: &[u8] = hashbang_store.slice();
+    // A top-level `"use strict"` is extracted from the statement list at
+    // parse time and recorded on the AST; re-emit it (Node preserves it).
+    let directive: &[u8] = match parse_result.ast.directive {
+        Some(d) => d.slice(),
+        None => b"",
+    };
     let mut printer = JSPrinter::BufferPrinter::init(JSPrinter::BufferWriter::init());
     let mut map_vlq = bun_core::MutableString::init_empty();
     if !was_empty {
@@ -336,9 +342,18 @@ fn strip_typescript_types(
     let printed: &[u8] = printer.ctx.written();
 
     let source_url_utf8 = source_url.to_utf8();
-    let mut out: Vec<u8> = Vec::with_capacity(hashbang.len() + 1 + printed.len() + 64);
+    let mut out: Vec<u8> =
+        Vec::with_capacity(hashbang.len() + directive.len() + 8 + printed.len() + 64);
     if !hashbang.is_empty() {
         out.extend_from_slice(hashbang);
+        if !directive.is_empty() || !printed.is_empty() {
+            out.push(b'\n');
+        }
+    }
+    if !directive.is_empty() {
+        out.push(b'"');
+        out.extend_from_slice(directive);
+        out.extend_from_slice(b"\";");
         if !printed.is_empty() {
             out.push(b'\n');
         }
@@ -357,10 +372,15 @@ fn strip_typescript_types(
             ));
         }
         bun_core::handle_oom(json.append(b"],\"names\":[],\"mappings\":"));
-        let mut mappings: Vec<u8> = Vec::with_capacity(map_vlq.list.len() + 1);
-        if !hashbang.is_empty() && !map_vlq.list.is_empty() {
-            // The prepended hashbang occupies generated line 0.
-            mappings.push(b';');
+        let mut mappings: Vec<u8> = Vec::with_capacity(map_vlq.list.len() + 2);
+        if !map_vlq.list.is_empty() {
+            // Each prepended line (hashbang, directive) shifts the mappings.
+            if !hashbang.is_empty() {
+                mappings.push(b';');
+            }
+            if !directive.is_empty() {
+                mappings.push(b';');
+            }
         }
         mappings.extend_from_slice(map_vlq.list.as_slice());
         bun_core::handle_oom(bun_core::quote_for_json(&mappings, &mut json, true));

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -270,10 +270,14 @@ fn strip_typescript_types(
         return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
             .throw(global, format_args!("{}", bstr::BStr::new(text))));
     }
-    let Some(parse_result) = parse_result else {
+    let Some(mut parse_result) = parse_result else {
         return Err(jsc::ErrorCode::ERR_INVALID_TYPESCRIPT_SYNTAX
             .throw(global, format_args!("Failed to parse TypeScript")));
     };
+    // The output is returned to the caller as portable JS, not executed by
+    // Bun's module loader: suppress the Bun-runtime `var {require}=import.meta;`
+    // hoist the printer emits for ESM trees with an unbound `require`.
+    parse_result.ast.uses_require_ref = false;
 
     // amaro rejects the `module` keyword in both modes.
     if parse_result.ast.uses_ts_module_keyword {

--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -278,6 +278,13 @@ fn strip_typescript_types(
     // Bun's module loader: suppress the Bun-runtime `var {require}=import.meta;`
     // hoist the printer emits for ESM trees with an unbound `require`.
     parse_result.ast.uses_require_ref = false;
+    // Same class: the parser injects `var __dirname = ...; var __filename =
+    // ...` declarations for unbound uses; Node leaves them as bare references.
+    for part in parse_result.ast.parts.as_mut_slice() {
+        if part.tag == bun_ast::PartTag::DirnameFilename {
+            part.stmts = Default::default();
+        }
+    }
 
     // amaro rejects the `module` keyword in both modes.
     if parse_result.ast.uses_ts_module_keyword {

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -345,5 +345,7 @@ const errors: ErrorCodeMapping = [
   ["ERR_INVALID_BUFFER_SIZE", RangeError],
   ["ERR_TRACE_EVENTS_CATEGORY_REQUIRED", TypeError],
   ["ERR_TRACE_EVENTS_UNAVAILABLE", Error],
+  ["ERR_INVALID_TYPESCRIPT_SYNTAX", SyntaxError],
+  ["ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX", SyntaxError],
 ];
 export default errors;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -20,6 +20,7 @@
 #include "ZigGlobalObject.h"
 #include "headers.h"
 #include "ErrorCode.h"
+#include "NodeValidator.h"
 
 #include "GeneratedNodeModuleModule.h"
 #include "ZigGeneratedClasses.h"
@@ -879,6 +880,87 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionGetCompileCacheDir,
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
+extern "C" JSC::EncodedJSValue NodeModuleModule__stripTypeScriptTypes(JSGlobalObject*,
+    BunString code, bool transformMode, bool sourceMap, BunString sourceUrl);
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionStripTypeScriptTypes,
+    (JSGlobalObject * globalObject,
+        JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue codeValue = callFrame->argument(0);
+    Bun::V::validateString(scope, globalObject, codeValue, "code"_s);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    bool transformMode = false;
+    bool sourceMapEnabled = false;
+    String sourceUrl = emptyString();
+
+    JSValue optionsValue = callFrame->argument(1);
+    if (!optionsValue.isUndefined()) {
+        Bun::V::validateObject(scope, globalObject, optionsValue, "options"_s);
+        RETURN_IF_EXCEPTION(scope, {});
+
+        JSObject* options = asObject(optionsValue);
+        // Property read order matches Node's destructuring: sourceMap,
+        // sourceUrl, then mode.
+        JSValue sourceMapValue = options->get(globalObject, Identifier::fromString(vm, "sourceMap"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        JSValue sourceUrlValue = options->get(globalObject, Identifier::fromString(vm, "sourceUrl"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+        JSValue modeValue = options->get(globalObject, Identifier::fromString(vm, "mode"_s));
+        RETURN_IF_EXCEPTION(scope, {});
+
+        // validateOneOf(mode, 'options.mode', ['strip', 'transform'])
+        if (!modeValue.isUndefined()) {
+            bool isTransform = false;
+            bool isValid = false;
+            if (modeValue.isString()) {
+                auto modeView = asString(modeValue)->view(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (modeView == "strip"_s) {
+                    isValid = true;
+                } else if (modeView == "transform"_s) {
+                    isValid = true;
+                    isTransform = true;
+                }
+            }
+            if (!isValid) {
+                return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "options.mode"_s, modeValue, "must be one of: 'strip', 'transform'"_s);
+            }
+            transformMode = isTransform;
+        }
+
+        if (!sourceMapValue.isUndefined()) {
+            Bun::V::validateBoolean(scope, globalObject, sourceMapValue, "options.sourceMap"_s);
+            RETURN_IF_EXCEPTION(scope, {});
+            sourceMapEnabled = sourceMapValue.asBoolean();
+        }
+
+        if (!sourceUrlValue.isUndefined()) {
+            Bun::V::validateString(scope, globalObject, sourceUrlValue, "options.sourceUrl"_s);
+            RETURN_IF_EXCEPTION(scope, {});
+            sourceUrl = asString(sourceUrlValue)->value(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+        }
+
+        // Source maps are only valid in transform mode; strip mode preserves
+        // no positions so Node rejects sourceMap: true there.
+        if (!transformMode && sourceMapEnabled) {
+            return Bun::ERR::INVALID_ARG_VALUE(scope, globalObject, "options.sourceMap"_s, sourceMapValue, "must be one of: false, undefined"_s);
+        }
+    }
+
+    String code = asString(codeValue)->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    BunString codeBun = Bun::toString(code);
+    BunString sourceUrlBun = Bun::toString(sourceUrl);
+
+    return NodeModuleModule__stripTypeScriptTypes(globalObject, codeBun, transformMode, sourceMapEnabled, sourceUrlBun);
+}
+
 static JSValue getModuleObject(VM& vm, JSObject* moduleObject)
 {
     return moduleObject;
@@ -910,6 +992,7 @@ prototype               getModulePrototypeObject          PropertyCallback
 register                jsFunctionRegister                Function 1
 runMain                 moduleRunMain                        CustomAccessor
 SourceMap               getSourceMapFunction              PropertyCallback
+stripTypeScriptTypes    jsFunctionStripTypeScriptTypes    Function 1
 syncBuiltinESMExports   jsFunctionSyncBuiltinESMExports   Function 0
 wrap                    jsFunctionWrap                    Function 1
 wrapper                 nodeModuleWrapper                 CustomAccessor

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -958,7 +958,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionStripTypeScriptTypes,
     BunString codeBun = Bun::toString(code);
     BunString sourceUrlBun = Bun::toString(sourceUrl);
 
-    return NodeModuleModule__stripTypeScriptTypes(globalObject, codeBun, transformMode, sourceMapEnabled, sourceUrlBun);
+    RELEASE_AND_RETURN(scope, NodeModuleModule__stripTypeScriptTypes(globalObject, codeBun, transformMode, sourceMapEnabled, sourceUrlBun));
 }
 
 static JSValue getModuleObject(VM& vm, JSObject* moduleObject)

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -60,6 +60,27 @@ test("does not inline process.env", () => {
   expect(stripTypeScriptTypes("console.log(process.env.NODE_ENV);")).toBe("console.log(process.env.NODE_ENV);\n");
 });
 
+test("preserves a leading hashbang", () => {
+  const src = "#!/usr/bin/env node\nconst x: number = 1;";
+  expect(stripTypeScriptTypes(src)).toBe("#!/usr/bin/env node\nconst x = 1;\n");
+  expect(stripTypeScriptTypes(src, { mode: "transform" })).toBe("#!/usr/bin/env node\nconst x = 1;\n");
+  const withUrl = stripTypeScriptTypes(src, { sourceUrl: "cli.ts" });
+  expect(withUrl).toBe("#!/usr/bin/env node\nconst x = 1;\n\n\n//# sourceURL=cli.ts");
+});
+
+test("source map accounts for the hashbang line", () => {
+  const out = stripTypeScriptTypes("#!/usr/bin/env node\nconst x: number = 1;", {
+    mode: "transform",
+    sourceMap: true,
+  });
+  expect(out).toStartWith("#!/usr/bin/env node\nconst x = 1;\n");
+  const base64 = out.split("base64,")[1];
+  const map = JSON.parse(Buffer.from(base64, "base64").toString());
+  // generated line 0 is the hashbang; mappings begin on line 1, matching
+  // Node's output for the same input
+  expect(map.mappings).toBe(";AACA,MAAM,IAAY");
+});
+
 test("validates code argument", () => {
   for (const bad of [42, null, undefined, {}, Symbol()] as const) {
     const err = errorFrom(() => stripTypeScriptTypes(bad as any));

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -1,0 +1,241 @@
+// https://github.com/oven-sh/bun/issues/32196
+import { expect, test } from "bun:test";
+import { stripTypeScriptTypes } from "node:module";
+import { bunEnv, bunExe } from "harness";
+
+function errorFrom(fn: () => unknown): any {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error("expected function to throw");
+}
+
+test("named ESM import from node:module works (issue repro)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `import { stripTypeScriptTypes } from 'node:module'; console.log(typeof stripTypeScriptTypes);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("function\n");
+  expect(exitCode).toBe(0);
+});
+
+test("is exported from require('node:module') and require('module')", () => {
+  expect(require("node:module").stripTypeScriptTypes).toBe(stripTypeScriptTypes);
+  expect(require("module").stripTypeScriptTypes).toBe(stripTypeScriptTypes);
+  expect(typeof stripTypeScriptTypes).toBe("function");
+});
+
+test("strips type annotations", () => {
+  expect(stripTypeScriptTypes("const x: number = 1;")).toBe("const x = 1;\n");
+  expect(stripTypeScriptTypes("")).toBe("");
+  expect(stripTypeScriptTypes("interface A { x: number }\nconst y = 1;")).toBe("const y = 1;\n");
+  expect(stripTypeScriptTypes("function id<T>(x: T): T { return x satisfies T as T; }")).toBe(
+    "function id(x) {\n  return x;\n}\n",
+  );
+});
+
+test("stripped output evaluates", () => {
+  const out = stripTypeScriptTypes("const x: number = 2;\nconst y = x * 21;\nresult(y);");
+  let captured: unknown;
+  new Function("result", out)((v: unknown) => (captured = v));
+  expect(captured).toBe(42);
+});
+
+test("keeps value imports that are only used as types", () => {
+  // Node's strip mode does not know T is type-only, so the import survives.
+  expect(stripTypeScriptTypes('import { T } from "x"; const a: T = 1;')).toBe('import { T } from "x";\nconst a = 1;\n');
+  // `import type` is erasable.
+  expect(stripTypeScriptTypes('import type { T } from "x"; const a: T = 1;')).toBe("const a = 1;\n");
+});
+
+test("does not inline process.env", () => {
+  expect(stripTypeScriptTypes("console.log(process.env.NODE_ENV);")).toBe("console.log(process.env.NODE_ENV);\n");
+});
+
+test("validates code argument", () => {
+  for (const bad of [42, null, undefined, {}, Symbol()] as const) {
+    const err = errorFrom(() => stripTypeScriptTypes(bad as any));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toStartWith('The "code" argument must be of type string.');
+  }
+  expect(errorFrom(() => stripTypeScriptTypes(42 as any)).message).toBe(
+    'The "code" argument must be of type string. Received type number (42)',
+  );
+});
+
+test("validates options argument", () => {
+  for (const bad of [null, [], "strip", 42, () => {}] as const) {
+    const err = errorFrom(() => stripTypeScriptTypes("", bad as any));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+    expect(err.message).toStartWith('The "options" argument must be of type object.');
+  }
+  // undefined means "use defaults"
+  expect(stripTypeScriptTypes("", undefined)).toBe("");
+});
+
+test("validates options.mode", () => {
+  for (const bad of ["bogus", 42, null, true] as const) {
+    const err = errorFrom(() => stripTypeScriptTypes("", { mode: bad as any }));
+    expect(err).toBeInstanceOf(TypeError);
+    expect(err.code).toBe("ERR_INVALID_ARG_VALUE");
+    expect(err.message).toStartWith("The property 'options.mode' must be one of: 'strip', 'transform'.");
+  }
+  expect(errorFrom(() => stripTypeScriptTypes("", { mode: "bogus" as any })).message).toBe(
+    "The property 'options.mode' must be one of: 'strip', 'transform'. Received 'bogus'",
+  );
+  // undefined falls back to 'strip'
+  expect(stripTypeScriptTypes("let a: string;", { mode: undefined })).toBe("let a;\n");
+});
+
+test("validates options.sourceMap", () => {
+  const err = errorFrom(() => stripTypeScriptTypes("", { sourceMap: "yes" as any }));
+  expect(err).toBeInstanceOf(TypeError);
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message).toBe(`The "options.sourceMap" property must be of type boolean. Received type string ('yes')`);
+
+  // sourceMap: true is rejected in strip mode
+  const stripErr = errorFrom(() => stripTypeScriptTypes("", { sourceMap: true }));
+  expect(stripErr).toBeInstanceOf(TypeError);
+  expect(stripErr.code).toBe("ERR_INVALID_ARG_VALUE");
+  expect(stripErr.message).toBe("The property 'options.sourceMap' must be one of: false, undefined. Received true");
+
+  // false/undefined are fine in strip mode
+  expect(stripTypeScriptTypes("let x: number = 1", { sourceMap: false })).toBe("let x = 1;\n");
+  expect(stripTypeScriptTypes("let x: number = 1", { sourceMap: undefined })).toBe("let x = 1;\n");
+});
+
+test("validates options.sourceUrl", () => {
+  const err = errorFrom(() => stripTypeScriptTypes("", { sourceUrl: 42 as any }));
+  expect(err).toBeInstanceOf(TypeError);
+  expect(err.code).toBe("ERR_INVALID_ARG_TYPE");
+  expect(err.message).toBe(`The "options.sourceUrl" property must be of type string. Received type number (42)`);
+  expect(errorFrom(() => stripTypeScriptTypes("", { sourceUrl: null as any })).code).toBe("ERR_INVALID_ARG_TYPE");
+});
+
+test.each([
+  ["enum", "enum E { A }", "TypeScript enum is not supported in strip-only mode"],
+  ["const enum", "const enum E { A }", "TypeScript enum is not supported in strip-only mode"],
+  [
+    "namespace",
+    "namespace N { export const x = 1 }",
+    "TypeScript namespace declaration is not supported in strip-only mode",
+  ],
+  [
+    "parameter properties",
+    "class C { constructor(public x: number) {} }",
+    "TypeScript parameter property is not supported in strip-only mode",
+  ],
+  [
+    "import equals",
+    'import x = require("y");',
+    "TypeScript import equals declaration is not supported in strip-only mode",
+  ],
+  ["export assignment", "export = 1;", "TypeScript export assignment is not supported in strip-only mode"],
+  ["module keyword", "module N { export const x = 1 }", "`module` keyword is not supported. Use `namespace` instead."],
+])("strip mode rejects %s", (_label, code, message) => {
+  const err = errorFrom(() => stripTypeScriptTypes(code));
+  expect(err).toBeInstanceOf(SyntaxError);
+  expect(err.code).toBe("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
+  expect(err.message).toBe(message);
+});
+
+test("module keyword is rejected in transform mode too", () => {
+  const err = errorFrom(() => stripTypeScriptTypes("module N { export const x = 1 }", { mode: "transform" }));
+  expect(err).toBeInstanceOf(SyntaxError);
+  expect(err.code).toBe("ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX");
+  expect(err.message).toBe("`module` keyword is not supported. Use `namespace` instead.");
+});
+
+test.each([
+  ["declare enum", "declare enum E { A }"],
+  ["declare namespace containing an enum", "declare namespace N { enum E { A } }"],
+  ["type-only namespace", "namespace N { export type T = 1 }"],
+  ['declare module "name"', 'declare module "foo" { export = 1 }'],
+  ["declare class parameter properties", "declare class C { constructor(public x: number); }"],
+  ["declare global", "declare global { interface W {} }"],
+  ["import type equals", 'import type x = require("y");'],
+])("strip mode allows ambient %s", (_label, code) => {
+  expect(stripTypeScriptTypes(code)).toBe("");
+});
+
+test("strip mode reports invalid syntax as ERR_INVALID_TYPESCRIPT_SYNTAX", () => {
+  for (const code of ["const const", "const x = <div/>;"]) {
+    const err = errorFrom(() => stripTypeScriptTypes(code));
+    expect(err).toBeInstanceOf(SyntaxError);
+    expect(err.code).toBe("ERR_INVALID_TYPESCRIPT_SYNTAX");
+  }
+});
+
+test("transform mode lowers enums", () => {
+  const out = stripTypeScriptTypes("enum E { A, B }\nresult(E);", { mode: "transform" });
+  let captured: any;
+  new Function("result", out)((e: any) => (captured = e));
+  expect(captured.A).toBe(0);
+  expect(captured.B).toBe(1);
+  expect(captured[0]).toBe("A");
+});
+
+test("transform mode lowers namespaces", () => {
+  const out = stripTypeScriptTypes("namespace N { export const x = 42 }\nresult(N.x);", { mode: "transform" });
+  let captured: unknown;
+  new Function("result", out)((v: unknown) => (captured = v));
+  expect(captured).toBe(42);
+});
+
+test("transform mode lowers parameter properties", () => {
+  const out = stripTypeScriptTypes("class C { constructor(public x: number) {} }\nresult(new C(7).x);", {
+    mode: "transform",
+  });
+  let captured: unknown;
+  new Function("result", out)((v: unknown) => (captured = v));
+  expect(captured).toBe(7);
+});
+
+test("transform mode lowers export assignment and import equals", () => {
+  const out = stripTypeScriptTypes("import y = require('y');\nexport = y;", { mode: "transform" });
+  const mod = { exports: {} as unknown };
+  new Function("module", "exports", "require", out)(mod, mod.exports, (id: string) => `required:${id}`);
+  expect(mod.exports).toBe("required:y");
+});
+
+test("sourceUrl appends a sourceURL comment", () => {
+  const out = stripTypeScriptTypes("const x: number = 1;", { sourceUrl: "foo.ts" });
+  expect(out).toBe("const x = 1;\n\n\n//# sourceURL=foo.ts");
+  // empty sourceUrl appends nothing
+  expect(stripTypeScriptTypes("const x: number = 1;", { sourceUrl: "" })).toBe("const x = 1;\n");
+});
+
+test("transform mode emits an inline source map", () => {
+  const out = stripTypeScriptTypes("enum E { A }\nconst q: number = 1;", {
+    mode: "transform",
+    sourceMap: true,
+    sourceUrl: "foo.ts",
+  });
+  const match = out.match(/\n\n\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)$/);
+  expect(match).not.toBeNull();
+  const map = JSON.parse(Buffer.from(match![1], "base64").toString());
+  expect(map.version).toBe(3);
+  expect(map.sources).toEqual(["foo.ts"]);
+  expect(map.names).toEqual([]);
+  expect(typeof map.mappings).toBe("string");
+  expect(map.mappings.length).toBeGreaterThan(0);
+  // when a source map is generated, no sourceURL comment is appended
+  expect(out).not.toContain("//# sourceURL=");
+});
+
+test("source map without sourceUrl uses an empty source name", () => {
+  const out = stripTypeScriptTypes("const x: number = 1;", { mode: "transform", sourceMap: true });
+  const base64 = out.split("base64,")[1];
+  const map = JSON.parse(Buffer.from(base64, "base64").toString());
+  expect(map.sources).toEqual([""]);
+});

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/oven-sh/bun/issues/32196
 import { expect, test } from "bun:test";
-import { stripTypeScriptTypes } from "node:module";
 import { bunEnv, bunExe } from "harness";
+import { stripTypeScriptTypes } from "node:module";
 
 function errorFrom(fn: () => unknown): any {
   try {

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -152,6 +152,11 @@ test.each([
     "TypeScript namespace declaration is not supported in strip-only mode",
   ],
   [
+    "dotted namespace with a value",
+    "namespace A.B { export const x = 1 }",
+    "TypeScript namespace declaration is not supported in strip-only mode",
+  ],
+  [
     "parameter properties",
     "class C { constructor(public x: number) {} }",
     "TypeScript parameter property is not supported in strip-only mode",
@@ -181,6 +186,7 @@ test.each([
   ["declare enum", "declare enum E { A }"],
   ["declare namespace containing an enum", "declare namespace N { enum E { A } }"],
   ["type-only namespace", "namespace N { export type T = 1 }"],
+  ["dotted type-only namespace", "namespace A.B { export type T = 1 }"],
   ['declare module "name"', 'declare module "foo" { export = 1 }'],
   ["declare class parameter properties", "declare class C { constructor(public x: number); }"],
   ["declare global", "declare global { interface W {} }"],

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -191,6 +191,13 @@ test.each([
   ["declare class parameter properties", "declare class C { constructor(public x: number); }"],
   ["declare global", "declare global { interface W {} }"],
   ["import type equals", 'import type x = require("y");'],
+  // Permissive divergence from Node: a non-declare namespace whose body is
+  // only ambient members has no runtime emit (tsc erases it), so Bun strips
+  // it to "" where Node's syntactic allowlist throws. See the PR's "Known
+  // divergences" note.
+  ["namespace with only a declared const", "namespace N { declare const x: number }"],
+  ["namespace with only a declared function", "namespace N { declare function f(): void }"],
+  ["namespace with only an import type", "namespace N { import type x = y }"],
 ])("strip mode allows ambient %s", (_label, code) => {
   expect(stripTypeScriptTypes(code)).toBe("");
 });

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -74,6 +74,31 @@ test("preserves a leading hashbang", () => {
   expect(withUrl).toBe("#!/usr/bin/env node\nconst x = 1;\n\n\n//# sourceURL=cli.ts");
 });
 
+test('preserves a top-level "use strict" directive', () => {
+  const src = '"use strict"; let x: number = 1;';
+  expect(stripTypeScriptTypes(src)).toBe('"use strict";\nlet x = 1;\n');
+  expect(stripTypeScriptTypes(src, { mode: "transform" })).toBe('"use strict";\nlet x = 1;\n');
+  expect(stripTypeScriptTypes('"use strict";')).toBe('"use strict";');
+  // directive after a hashbang, and the strictness is observable
+  expect(stripTypeScriptTypes('#!/usr/bin/env node\n"use strict"; let x: number = 1;')).toBe(
+    '#!/usr/bin/env node\n"use strict";\nlet x = 1;\n',
+  );
+  const out = stripTypeScriptTypes('"use strict"; function f() { return this; }');
+  expect(new Function(`${out}; return f();`)()).toBeUndefined();
+});
+
+test("source map accounts for the directive line", () => {
+  const out = stripTypeScriptTypes('"use strict";\nlet x: number = 1;', {
+    mode: "transform",
+    sourceMap: true,
+  });
+  expect(out).toStartWith('"use strict";\nlet x = 1;\n');
+  const base64 = out.split("base64,")[1];
+  const map = JSON.parse(Buffer.from(base64, "base64").toString());
+  // leading ';' skips the directive line; then let/x/1 map to source line 1
+  expect(map.mappings).toBe(";AACA,IAAI,IAAY");
+});
+
 test("source map accounts for the hashbang line", () => {
   const out = stripTypeScriptTypes("#!/usr/bin/env node\nconst x: number = 1;", {
     mode: "transform",

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -62,6 +62,14 @@ test("does not inject the Bun require shim for ESM code calling require()", () =
   expect(stripTypeScriptTypes(src, { mode: "transform" })).toBe('export const x = require("y");\n');
 });
 
+test("does not inject __dirname/__filename declarations", () => {
+  // Node leaves unbound __dirname/__filename as bare references, so a CJS
+  // wrapper can supply the real values.
+  const src = "const f: string = __filename;\nconst d: string = __dirname;";
+  expect(stripTypeScriptTypes(src)).toBe("const f = __filename;\nconst d = __dirname;\n");
+  expect(stripTypeScriptTypes(src, { mode: "transform" })).toBe("const f = __filename;\nconst d = __dirname;\n");
+});
+
 test("does not inline process.env", () => {
   expect(stripTypeScriptTypes("console.log(process.env.NODE_ENV);")).toBe("console.log(process.env.NODE_ENV);\n");
 });

--- a/test/js/node/module/strip-typescript-types.test.ts
+++ b/test/js/node/module/strip-typescript-types.test.ts
@@ -56,6 +56,12 @@ test("keeps value imports that are only used as types", () => {
   expect(stripTypeScriptTypes('import type { T } from "x"; const a: T = 1;')).toBe("const a = 1;\n");
 });
 
+test("does not inject the Bun require shim for ESM code calling require()", () => {
+  const src = 'export const x: number = require("y");';
+  expect(stripTypeScriptTypes(src)).toBe('export const x = require("y");\n');
+  expect(stripTypeScriptTypes(src, { mode: "transform" })).toBe('export const x = require("y");\n');
+});
+
 test("does not inline process.env", () => {
   expect(stripTypeScriptTypes("console.log(process.env.NODE_ENV);")).toBe("console.log(process.env.NODE_ENV);\n");
 });


### PR DESCRIPTION
Fixes #32196
Fixes #25058 (the docs listed `stripTypeScriptTypes` as supported; it now is)

### Problem

`node:module` did not export or implement `stripTypeScriptTypes` (added in Node v22.13.0):

```js
import { stripTypeScriptTypes } from 'node:module';
```

```
SyntaxError: Export named 'stripTypeScriptTypes' not found in module 'node:module'.
```

### Fix

Implements `module.stripTypeScriptTypes(code[, options])` backed by Bun's native transpiler, exported from `node:module` for both `require` and named ESM imports. The contract was verified empirically against Node v24.3.0:

- Argument validation matches Node exactly, including error codes, classes, message text, and property read order: `ERR_INVALID_ARG_TYPE` for non-string `code`/`sourceUrl` and non-boolean `sourceMap`, `ERR_INVALID_ARG_VALUE` for bad `mode` and for `sourceMap: true` in strip mode.
- `mode: 'strip'` (default) rejects TypeScript syntax with runtime semantics, with Node's exact messages and new error codes `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` / `ERR_INVALID_TYPESCRIPT_SYNTAX` (both `SyntaxError`): enums, instantiated namespaces, parameter properties, `import x = require(...)`, `export = ...`. Ambient constructs (`declare enum`, `declare namespace`, `declare module "x"`, type-only namespaces, `import type x = require(...)`) are stripped as erasable. The identifier-named `module N {}` keyword is rejected in both modes, like amaro.
- `mode: 'transform'` lowers enums, namespaces, parameter properties, `import =` and `export =`.
- `sourceUrl` appends `\n\n//# sourceURL=...`; `sourceMap: true` (transform mode only) appends an inline base64 map shaped like Node's: `{"version":3,"sources":[<sourceUrl>],"names":[],"mappings":"..."}`.
- Parse errors throw `ERR_INVALID_TYPESCRIPT_SYNTAX` with Bun's parser message.
- Value imports only used as types are kept (`trim_unused_imports` off), `process.env.*` is not inlined, no dead-code elimination, macros disabled.

To support the strip-mode rejections, the parser records the first non-ambient TS runtime-syntax construct (`Ast::ts_runtime_syntax`) and whether an identifier-named `module` declaration was used (`Ast::uses_ts_module_keyword`). Recording happens exactly where the parser materializes these constructs, so `declare` contexts (which return `S::TypeScript` earlier or never reach the visit pass) never set the flags.

### Known divergences from Node

Node's amaro blanks types in place; Bun re-prints from the AST. So:

- Original line/column positions are not preserved in strip mode (Node documents strip mode as position-preserving); output is re-printed JS.
- Comments are dropped.
- Decorators are lowered (Node passes them through as syntax).
- Parse error message text comes from Bun's parser, not swc (same code and class).
- Param props in ambient/overload-only positions (`declare class C { constructor(public x); }`) are stripped instead of throwing `ERR_INVALID_TYPESCRIPT_SYNTAX` (the input is invalid TS per tsc).
- A non-`declare` namespace whose body contains only ambient members (`namespace N { declare const x: number }`, `namespace N { import type x = y }`) is stripped to `""` instead of throwing `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`. These namespaces have no runtime emit (tsc erases them too), so this is the permissive, semantically-correct direction: nothing that works on Node breaks. Node's amaro uses a stricter syntactic allowlist that rejects them.
- A function-level `"use strict"` directive is dropped (a top-level one is preserved). Re-emitting nested directives needs a parser/printer change; follow-up material.

### Verification

`test/js/node/module/strip-typescript-types.test.ts` (34 tests): the issue repro via named ESM import in a subprocess, CJS export, validation errors with exact Node messages, all strip-mode rejections and ambient allowances, transform-mode lowering verified by evaluating the output, sourceURL/sourceMap output shape including decoding the base64 map. All fail on the unfixed build with the error above.

Existing suites pass: `test/bundler/transpiler/transpiler.test.js` (188), `test/bundler/esbuild/ts.test.ts` (67), `test/bundler/esbuild/importstar_ts.test.ts` (23), `test/bundler/bundler_edgecase.test.ts` (119), decorator suites (78), `test/js/node/module/` (98).

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 21 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/strip-typescript-types.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (12f0a1ddf)

test/js/node/module/strip-typescript-types.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'stripTypeScriptTypes' not found in module 'node:module'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [2.06s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (0a0e9af16)

test/js/node/module/strip-typescript-types.test.ts:
(pass) named ESM import from node:module works (issue repro) [19.13ms]
(pass) is exported from require('node:module') and require('module') [0.08ms]
(pass) strips type annotations [0.95ms]
(pass) stripped output evaluates [0.15ms]
(pass) keeps value imports that are only used as types [0.14ms]
(pass) does not inject the Bun require shim for ESM code calling require() [0.12ms]
64 | 
65 | test("does not inject __dirname/__filename declarations", () => {
66 |   // Node leaves unbound __dirname/__filename as bare references, so a CJS
67 |   // wrapper can supply the real values.
68 |   const src = "const f: string = __filename;\nconst d: string = __dirname;";
69 |   expect(stripTypeScriptTypes(src)).toBe("const f = __filename;\nconst d = __dirname;\n");
                                         ^
error: expect(received).toBe(expected)

- "const f = __filename;
+ "var __dirname = "", __filename = "input.ts";
+ const f = __filename;
  const d = __dirname;
  "

- Expected  - 1
+ Received  + 2

      at <anonymous> (/workspace/bun/test/js/node/module/strip-typescript-types.test.ts:69:37
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/module/strip-typescript-types.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (12f0a1ddf)

test/js/node/module/strip-typescript-types.test.ts:
(pass) named ESM import from node:module works (issue repro) [454.50ms]
(pass) is exported from require('node:module') and require('module') [5.33ms]
(pass) strips type annotations [20.01ms]
(pass) stripped output evaluates [11.58ms]
(pass) keeps value imports that are only used as types [10.74ms]
(pass) does not inject the Bun require shim for ESM code calling require() [11.67ms]
(pass) does not inject __dirname/__filename declarations [10.77ms]
(pass) does not inline process.env [6.52ms]
(pass) preserves a leading hashbang [16.32ms]
(pass) preserves a top-level "use strict" directive [30.26ms]
(pass) source map accounts for the directive line [9.81ms]
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 774ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/76] gen ErrorCode+*.h
[2/25] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/25] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[4/25] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[5/25] gen cpp.rs (cppbind)
[6/25] gen JS modules (bundle-modules)
Preprocess modules (7087ms)
Bundle modules (34ms)
Postprocesss modules (148ms)
Bundle Functions (800ms)
Generate Code (96ms)

[8.18s] Bundled "src/js" for production
  1913 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[6/12] cargo bun_b
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/ast_result.rs                              |  22 ++
 src/ast/lib.rs                                     |   2 +-
 src/js_parser/p.rs                                 |  17 ++
 src/js_parser/parse/parse_stmt.rs                  |   8 +
 src/js_parser/parse/parse_typescript.rs            |  14 +-
 src/js_parser/visit/mod.rs                         |   6 +
 src/jsc/NodeModuleModule.rs                        | 305 ++++++++++++++++++++
 src/jsc/bindings/ErrorCode.ts                      |   2 +
 src/jsc/modules/NodeModuleModule.cpp               |  83 ++++++
 test/js/node/module/strip-typescript-types.test.ts | 314 +++++++++++++++++++++
 10 files changed, 771 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 21

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/ast/ast_result.rs                                   1      2     14
src/ast/lib.rs                                          0      1     14
src/js_parser/p.rs                                      1      2     14
src/js_parser/parse/parse_stmt.rs                       0      0     14
src/js_parser/parse/parse_typescript.rs                 1      2     14
src/js_parser/visit/mod.rs                              0      0     14
src/jsc/NodeModuleModule.rs                             4      8     14
src/jsc/bindings/ErrorCode.ts                           1      2     14
src/jsc/modules/NodeModuleModule.cpp                    0      0     14
test/js/node/module/strip-typescript-types.test.ts      6      9     14
```

</details>

**root cause** · written by the author bot

The root cause was that the `__dirname`/`__filename` compatibility shim, which the parser injects as a dedicated part at parse time, was being emitted into the stripped output even though stripTypeScriptTypes must preserve the source verbatim apart from type erasure. The fix filters out the statements of the part tagged `PartTag::DirnameFilename` before printing, so the injected shim never reaches the output while leaving exports detection and other parser behavior untouched. Tests pin the exact printed output in both strip and transform modes to prevent regression.

<!-- robobun:evidence:end -->
