### PR TITLE
test(sql): bound spawned fixture lifetime so a test timeout cannot leave orphans

### DIFF
--- a/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
+++ b/test/js/sql/sql-mysql-bind-blob-borrow.test.ts
@@ -23,6 +23,7 @@ async function runFixture(url: string, caPath = "") {
     env: { ...bunEnv, MYSQL_URL: url, CA_PATH: caPath },
     stdout: "pipe",
     stderr: "pipe",
+    timeout: 60_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };

--- a/test/js/sql/sql-mysql-bind-oob.test.ts
+++ b/test/js/sql/sql-mysql-bind-oob.test.ts
@@ -18,6 +18,7 @@ async function runFixture(url: string, caPath = "") {
     env: { ...bunEnv, MYSQL_URL: url, CA_PATH: caPath },
     stdout: "pipe",
     stderr: "pipe",
+    timeout: 60_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };

--- a/test/js/sql/sql-mysql-clean-reentry.test.ts
+++ b/test/js/sql/sql-mysql-clean-reentry.test.ts
@@ -138,6 +138,7 @@ test.skipIf(!isDebug && !isASAN)(
       cwd: String(dir),
       stdout: "pipe",
       stderr: "pipe",
+      timeout: 60_000,
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/sql/sql-mysql-column-name-digits.test.ts
+++ b/test/js/sql/sql-mysql-column-name-digits.test.ts
@@ -28,6 +28,7 @@ async function runFixture(url: string) {
     env: { ...bunEnv, MYSQL_URL: url },
     stdout: "pipe",
     stderr: "pipe",
+    timeout: 60_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
@@ -87,6 +88,7 @@ if (isDockerEnabled()) {
       stdout: "ignore",
       stderr: "ignore",
       stdin: "ignore",
+      timeout: 60_000,
     }).unref();
     return waitForSocket(30_000);
   }

--- a/test/js/sql/sql-mysql-columns-realloc-oom.test.ts
+++ b/test/js/sql/sql-mysql-columns-realloc-oom.test.ts
@@ -167,6 +167,7 @@ test("MySQL: OOM reallocating statement.columns does not leave a dangling slice"
     env: bunEnv,
     stdout: "pipe",
     stderr: "pipe",
+    timeout: 60_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 

--- a/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
+++ b/test/js/sql/sql-mysql-datetime-roundtrip.test.ts
@@ -52,6 +52,7 @@ describe.each(TIMEZONES)("text protocol via mock server, TZ=%s", TZ => {
       env: { ...bunEnv, TZ },
       stdout: "pipe",
       stderr: "pipe",
+      timeout: 60_000,
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 

--- a/test/js/sql/sql-mysql-query-string-leak.test.ts
+++ b/test/js/sql/sql-mysql-query-string-leak.test.ts
@@ -108,6 +108,7 @@ test("MySQL: query string is not leaked across query lifecycle", async () => {
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
+    timeout: 60_000,
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);

--- a/test/js/sql/sql-onconnect-onclose-throw.test.ts
+++ b/test/js/sql/sql-onconnect-onclose-throw.test.ts
@@ -22,6 +22,7 @@ async function runFixture(code: string, env: Record<string, string> = {}) {
     env: { ...bunEnv, ...env },
     cwd: String(dir),
     stderr: "pipe",
+    timeout: 60_000,
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };


### PR DESCRIPTION
When a test that does `await using proc = Bun.spawn(...)` times out before the using-scope exits, the dispose never runs and the subprocess survives indefinitely. The sql fixture subprocesses connect to a (mock or real) database and await the pool draining; under a regression that hangs the pool (e.g. while iterating on #32145), the fixture never exits, the test times out, and the fixture is orphaned.

Locally observed 16 such orphans pinning the machine at load ~100 for hours after a `bun bd test test/js/sql/` run that exercised a buggy intermediate commit.

Adding `timeout` to the `Bun.spawn` options gives the child its own hard deadline independent of the test runner, so an abandoned fixture self-kills within a minute even when the parent test has already moved on.

`sql.test.ts` already had `timeout` on all three of its spawns; this brings the other 8 files in line.