### PR TITLE
test: give container-awaiting beforeAll hooks a 120s timeout

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1046,7 +1046,11 @@ export async function describeWithContainer(
       _port = info.ports[servicePort];
       console.log(`Container ready via docker-compose: ${image} at ${_host}:${_port}`);
       readyResolver!();
-    });
+      // Cold container start is bounded by `compose up --wait-timeout 60` plus
+      // a `compose build` step; the default 5s hook timeout fires first and the
+      // runner's auto-killer then SIGTERMs the in-flight compose subprocesses,
+      // surfacing as bogus `Failed to start service X: ... Creating` errors.
+    }, 120_000);
 
     fn(containerDescriptor);
   });

--- a/test/js/valkey/test-utils.ts
+++ b/test/js/valkey/test-utils.ts
@@ -436,7 +436,10 @@ if (isEnabled) {
     // if (!context.initialized) {
     //   console.warn("Test initialization failed - tests may be skipped");
     // }
-  });
+    // Cold container start is bounded by `compose up --wait-timeout 60` plus
+    // a `compose build` step; the default 5s hook timeout fires long before
+    // that on a cold cache.
+  }, 120_000);
 }
 
 if (isEnabled) {

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -26,7 +26,10 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
       if (!ctx.redis) {
         ctx.redis = createClient(connectionType);
       }
-    });
+      // setupDockerContainer() may cold-start the redis_unified container
+      // (compose up --wait-timeout 60); shielded by the file-level beforeAll's
+      // cached promise once that has run, but match its timeout for safety.
+    }, 120_000);
 
     beforeEach(async () => {
       if (!ctx.redis) {

--- a/test/js/web/websocket/autobahn.test.ts
+++ b/test/js/web/websocket/autobahn.test.ts
@@ -42,7 +42,10 @@ describe.skipIf(!isDockerEnabled())("autobahn", () => {
     wsOptions = process.env.BUN_AUTOBAHN_HOST_HEADER
       ? { headers: { Host: process.env.BUN_AUTOBAHN_HOST_HEADER } }
       : undefined;
-  });
+    // Cold container start is bounded by `compose up --wait-timeout 60` plus
+    // a `compose build` step; the default 5s hook timeout fires long before
+    // that on a cold cache.
+  }, 120_000);
 
   function getCaseStatus(testID: number) {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## What this does

`describeWithContainer` (and the valkey/autobahn tests' direct `ensure()` callers) await `compose up --wait-timeout 60` plus a `compose build` step inside `beforeAll`, but the hook had bun:test's default 5s timeout. On a cold or busy machine the hook fired first and **the runner's auto-killer SIGTERMed the in-flight compose subprocess**; compose then exited non-zero with stderr at whatever progress line it was on, which `doUp()` reported as `Failed to start service X: Container ... Creating`.

This bumps the four `beforeAll` hooks that await `ensure()` to 120s — matching the existing pattern at `websocket-proxy.test.ts:602`. `test/docker/index.ts` is unchanged.

## Why not the alternatives

- **Retry `compose up` once** (earlier version of this PR): wrong layer — the failure is bun:test killing compose, not compose actually failing. Retrying papers over the symptom.
- **Serialize `doUp()` across services**: not needed. 4 services brought up concurrently from cold all return `exit=0`. The coordinator (#32033) solved a *cross-process* race (warmup-ci.ts vs the first test process); within one `bun bd test` process the per-service in-flight dedup at `test/docker/index.ts:200-217` already covers same-service calls, and cross-service concurrency works.
- **Spawn a coordinator for local dev**: heavyweight when one process already owns all compose calls.

## Verification

2× `docker compose down` then `bun bd test sql-mysql.test.ts sql-onconnect-onclose-throw.test.ts sql-mysql.auth.test.ts` from cold: 0 hook timeouts, 0 'Failed to start service' across 5 services starting concurrently.

## Separate pre-existing flake (out of scope)

`sql-mysql.test.ts:325` 'should not timeout in long results' (10K inserts + 3 selects, 10s test timeout) can fail on a freshly-cold MySQL and pass warm. Unchanged by this PR; different timeout class (per-test 10s, not the 5s hook timeout fixed here).