### PR TITLE
bake: deref html_bundle in DevServer Drop

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1247,6 +1247,10 @@ impl Drop for DevServer {
                     // SAFETY: stored ref from `init_from_any_blob`; no live borrow.
                     unsafe { StaticRoute::deref_(cached.as_ptr()) };
                 }
+                // SAFETY: paired with the `ref_` taken in
+                // `get_or_put_route_bundle` when this bundle was created; the
+                // raw `html_bundle` field has no Drop, so release it here.
+                unsafe { bun_ptr::RefCount::<HTMLBundleRoute>::deref(html.html_bundle) };
             }
         }
 
@@ -5376,8 +5380,8 @@ impl DevServer {
                     let file = &mut self.client_graph.bundled_files.values_mut()
                         [incremental_graph_index.get() as usize];
                     file.html_route_bundle_index = Some(bundle_index);
-                    // Bump the intrusive refcount; matched by
-                    // `RouteBundle::deinit`'s deref of `html_bundle`.
+                    // Bump the intrusive refcount; matched by the
+                    // `html_bundle` deref in `DevServer`'s `Drop`.
                     // SAFETY: `html` is a live IntrusiveRc-managed allocation.
                     unsafe { bun_ptr::RefCount::<HTMLBundleRoute>::ref_(html) };
                     break 'brk route_bundle::Data::Html(route_bundle::Html {

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -164,8 +164,9 @@ impl RouteBundle {
     }
 }
 
-// `deinit` is fully subsumed by Drop:
-//   - client_bundle / cached_response: Option<Arc<StaticRoute>> drop = .deref()
-//   - Framework: StrongOptional fields drop = .deinit()
-//   - Html: bundled_html_text Box<[u8]> drop = allocator.free()
-//           html_bundle RefPtr drop = .deref()
+// Zig `RouteBundle.deinit` equivalent, split across two mechanisms:
+//   - Drop: `Framework` StrongOptional fields (= .deinit()) and
+//     `Html.bundled_html_text` Box<[u8]> (= allocator.free()).
+//   - `DevServer`'s `Drop` (explicit): `client_bundle`, `Html.cached_response`
+//     (BackRef, no Drop) and `Html.html_bundle` (raw ptr, no Drop) each hold
+//     an intrusive ref that is deref'd there.


### PR DESCRIPTION
`get_or_put_route_bundle` takes an intrusive ref on `Route` when it creates a `RouteBundle`; the raw `html_bundle` field has no `Drop` and `DevServer::Drop` never released it. Zig `RouteBundle.deinit:112` does the deref; the Rust port missed it. One `Route` per HTML route per dev-server leaked.