### PR TITLE
process: emit beforeExit and exit through the JS-level process.emit

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -276,26 +276,76 @@ static JSValue constructProcessReleaseObject(VM& vm, JSObject* processObject)
     return release;
 }
 
+// Emit a process lifecycle event. When user code has replaced `process.emit`
+// with a callable own property (a monkey-patch, as signal-exit and similar
+// libraries do), invoke that override so it observes the event, matching Node,
+// which dispatches `beforeExit`/`exit` via `process.emit`. Otherwise emit
+// directly on the internal EventEmitter, which reaches the same listeners and
+// preserves the exact "a listener fired" signal the caller uses to gate the
+// nextTick/microtask drain (routing the common no-override case through the JS
+// emit instead would always report "fired" and drain on every shutdown, which
+// perturbs pending-rejection timing). A `process.emit` replaced with a
+// non-callable value also falls through to the internal emitter so lifecycle
+// events still fire instead of throwing at shutdown.
+//
+// Returns whether the caller should drain afterward: the native "a listener
+// fired" signal on the internal path, or true once an override ran (it may have
+// scheduled continuation work). Listener exceptions are reported inside
+// EventEmitter::fireEventListeners; a throwing override leaves a pending
+// exception for the caller to report.
+static bool emitProcessExitEvent(JSC::JSGlobalObject* globalObject, Process* process, ASCIILiteral eventName, int exitCode)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue emitOverride = process->getDirect(vm, Identifier::fromString(vm, "emit"_s));
+    if (emitOverride) {
+        // getDirect returns the raw slot, so an `emit` defined as an accessor
+        // (Object.defineProperty) yields a GetterSetter; invoke the getter with a
+        // full [[Get]] to reach the actual function, matching Node.
+        if (emitOverride.isGetterSetter() || emitOverride.isCustomGetterSetter()) [[unlikely]] {
+            emitOverride = process->get(globalObject, Identifier::fromString(vm, "emit"_s));
+            RETURN_IF_EXCEPTION(scope, false);
+        }
+
+        auto callData = JSC::getCallData(emitOverride);
+        if (callData.type != CallData::Type::None) {
+            MarkedArgumentBuffer arguments;
+            arguments.append(jsString(vm, String(eventName)));
+            arguments.append(jsNumber(exitCode));
+            ASSERT(!arguments.hasOverflowed());
+
+            JSC::call(globalObject, emitOverride, callData, process, arguments);
+            RETURN_IF_EXCEPTION(scope, false);
+            return true;
+        }
+        // A non-callable override falls through to the internal emitter.
+    }
+
+    MarkedArgumentBuffer arguments;
+    arguments.append(jsNumber(exitCode));
+    ASSERT(!arguments.hasOverflowed());
+    RELEASE_AND_RETURN(scope, process->wrapped().emit(Identifier::fromString(vm, eventName), arguments));
+}
+
 static void dispatchExitInternal(JSC::JSGlobalObject* globalObject, Process* process, int exitCode)
 {
     if (process->m_isExiting)
         return;
     process->m_isExiting = true;
-    auto& emitter = process->wrapped();
     auto& vm = JSC::getVM(globalObject);
 
     if (vm.hasTerminationRequest() || vm.hasExceptionsAfterHandlingTraps())
         return;
 
-    auto event = Identifier::fromString(vm, "exit"_s);
-    if (!emitter.hasEventListeners(event)) {
-        return;
-    }
     process->putDirect(vm, Identifier::fromString(vm, "_exiting"_s), jsBoolean(true), 0);
 
-    MarkedArgumentBuffer arguments;
-    arguments.append(jsNumber(exitCode));
-    emitter.emit(event, arguments);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    emitProcessExitEvent(globalObject, process, "exit"_s, exitCode);
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        Bun__reportUnhandledError(globalObject, JSValue::encode(exception));
+    }
 }
 
 JSC_DEFINE_CUSTOM_SETTER(Process_defaultSetter, (JSC::JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, JSC::PropertyName propertyName))
@@ -826,14 +876,25 @@ extern "C" void Process__dispatchOnBeforeExit(Zig::GlobalObject* globalObject, u
     }
     auto& vm = JSC::getVM(globalObject);
     auto* process = globalObject->processObject();
-    MarkedArgumentBuffer arguments;
-    arguments.append(jsNumber(exitCode));
     Bun__VirtualMachine__exitDuringUncaughtException(bunVM(vm));
-    auto fired = process->wrapped().emit(Identifier::fromString(vm, "beforeExit"_s), arguments);
+
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    bool fired = emitProcessExitEvent(globalObject, process, "beforeExit"_s, exitCode);
+    if (auto* exception = scope.exception()) [[unlikely]] {
+        (void)scope.tryClearException();
+        Bun__reportUnhandledError(globalObject, JSValue::encode(exception));
+        return;
+    }
+
     if (fired) {
-        if (globalObject->m_nextTickQueue) {
-            auto nextTickQueue = globalObject->m_nextTickQueue.get();
+        if (auto* nextTickQueue = globalObject->m_nextTickQueue.get()) {
+            // drain() enters JS (nextTick callbacks, microtasks) and can leave a
+            // pending exception, so report and clear it the same way as the emit.
             nextTickQueue->drain(vm, globalObject);
+            if (auto* exception = scope.exception()) [[unlikely]] {
+                (void)scope.tryClearException();
+                Bun__reportUnhandledError(globalObject, JSValue::encode(exception));
+            }
         }
     }
 }

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -506,6 +506,192 @@ describe.concurrent(() => {
     });
   });
 
+  describe("process.emit lifecycle events", () => {
+    // https://github.com/oven-sh/bun/issues/32227
+    // beforeExit and exit are emitted through the user-replaceable
+    // process.emit property, so a monkey-patched process.emit is invoked as in Node.
+    it("invokes a monkey-patched process.emit for beforeExit and exit without listeners", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          process.emit = function (event, ...args) {
+            if (event === "beforeExit" || event === "exit") {
+              console.log("patched:" + event + ":" + args[0]);
+            }
+            return originalEmit.call(this, event, ...args);
+          };
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      expect({ lines, stderr, exitCode }).toEqual({
+        lines: ["patched:beforeExit:0", "patched:exit:0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    it("composes a monkey-patched process.emit with process.on('exit') listeners", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          process.emit = function (event, ...args) {
+            if (event === "exit") console.log("patched:exit");
+            return originalEmit.call(this, event, ...args);
+          };
+          process.on("exit", () => console.log("listener:exit"));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      // The patched emit runs before delegating to the original, which fires the registered listener.
+      expect({ lines, stderr, exitCode }).toEqual({
+        lines: ["patched:exit", "listener:exit"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    it("forwards the exit code to a monkey-patched process.emit", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          process.emit = function (event, ...args) {
+            if (event === "exit") console.log("patched:exit:" + args[0]);
+            return originalEmit.call(this, event, ...args);
+          };
+          process.exitCode = 3;
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      expect({ lines, stderr, exitCode }).toEqual({ lines: ["patched:exit:3"], stderr: "", exitCode: 3 });
+    });
+
+    it("invokes a monkey-patched process.emit for an explicit process.exit(code)", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          process.emit = function (event, ...args) {
+            if (event === "exit") console.log("patched:exit:" + args[0]);
+            return originalEmit.call(this, event, ...args);
+          };
+          process.exit(2);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      expect({ lines, stderr, exitCode }).toEqual({ lines: ["patched:exit:2"], stderr: "", exitCode: 2 });
+    });
+
+    it("drains nextTick scheduled by a monkey-patched process.emit during beforeExit", async () => {
+      // A replacement process.emit can schedule process.nextTick work while
+      // handling beforeExit even with no registered beforeExit listener; that
+      // callback must still run before the process exits.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          process.emit = function (event, ...args) {
+            if (event === "beforeExit") {
+              process.nextTick(() => console.log("nexttick:ran"));
+              return false;
+            }
+            return originalEmit.call(this, event, ...args);
+          };
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      expect({ lines, stderr, exitCode }).toEqual({ lines: ["nexttick:ran"], stderr: "", exitCode: 0 });
+    });
+
+    it("invokes a process.emit override defined as an accessor property", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const originalEmit = process.emit;
+          Object.defineProperty(process, "emit", {
+            configurable: true,
+            get() {
+              return function (event, ...args) {
+                if (event === "beforeExit" || event === "exit") {
+                  console.log("accessor:" + event + ":" + args[0]);
+                }
+                return originalEmit.call(this, event, ...args);
+              };
+            },
+          });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .split("\n")
+        .map(line => line.trim())
+        .filter(Boolean);
+      expect({ lines, stderr, exitCode }).toEqual({
+        lines: ["accessor:beforeExit:0", "accessor:exit:0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
   it("process.memoryUsage", () => {
     expect(process.memoryUsage()).toEqual({
       rss: expect.any(Number),


### PR DESCRIPTION
Fixes #32227
Fixes #29194

Supersedes #29196 (same change on a current-`main` branch; #29196's branch predated the bun.js to jsc restructure, so it could not build).

## Problem

Node emits the `beforeExit` and `exit` lifecycle events by calling `process.emit(event, code)`, so a user-replaced `process.emit` is invoked. Bun emitted them through the internal EventEmitter (`process->wrapped().emit(...)`), which bypasses any user override, so libraries that monkey-patch `process.emit` (for example signal-exit) never observed these events.

```js
const originalEmit = process.emit;
process.emit = function (event, ...args) {
  if (event === "beforeExit" || event === "exit") console.log("patched:" + event);
  return originalEmit.call(this, event, ...args);
};
```

```console
$ node repro.mjs
patched:beforeExit
patched:exit
$ bun repro.mjs      # before this change
(no output)
```

## Cause

`dispatchExitInternal` and `Process__dispatchOnBeforeExit` in `src/jsc/bindings/BunProcess.cpp` called `process->wrapped().emit(...)` directly, walking the internal listener list without consulting a user-installed `process.emit`. `dispatchExitInternal` additionally early-returned when no `exit` listener was registered, so a patched `emit` was never called in the zero-listener case.

## Fix

Add an `emitProcessExitEvent` helper that detects a user replacement of `process.emit` as an own property (`getDirect`) and, when callable, invokes it so a monkey-patch observes the event (matching Node, which dispatches `beforeExit`/`exit` via `process.emit`). An accessor-defined override is resolved with a full `[[Get]]` so its getter runs.

Otherwise (no override, or a non-callable one) it emits directly on the internal EventEmitter. This reaches the same listeners and preserves the native "a listener fired" return value that gates the post-`beforeExit` nextTick/microtask drain. Routing the common no-override path through the JS emit instead would report "fired" unconditionally (the prototype `emit` always does) and drain on every shutdown, which perturbs pending-rejection timing; prototype-level `process.emit` replacements are intentionally not honored for that reason.

Both `beforeExit` and `exit` route through the helper. The `exit` early-return on "no listeners" is removed and `_exiting` is set unconditionally, both matching Node. `beforeExit` drains the nextTick queue when the emit reported a listener fired (or an override ran), reporting any exception from the drain the same way as the emit itself.

## Verification

`test/js/node/process/process.test.js` (describe "process.emit lifecycle events") spawns children that monkey-patch `process.emit` and asserts:
- `beforeExit` and `exit` reach the patch with no registered listeners
- the patch composes with a `process.on('exit')` listener
- the exit code is forwarded (`process.exitCode = 3`, and explicit `process.exit(2)`)
- nextTick work scheduled by a replacement emit during `beforeExit` still runs
- an accessor-defined (`Object.defineProperty`) override is invoked for both `beforeExit` and `exit`

The monkey-patch tests fail on the unfixed build (`USE_SYSTEM_BUN=1`) and pass with the fix. `test/js/node/worker_threads/worker_threads.test.ts` covers the non-callable `process.emit` fall-back.
