### PR TITLE
node:tls: accept Ed25519 server certificates during client verification

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -888,6 +888,44 @@ static void ssl_ctx_build_fail(SSL_CTX *ctx) {
   SSL_CTX_free(ctx);
 }
 
+/* BoringSSL's default accepted signature-algorithm list for verifying a peer's
+ * certificate (kVerifySignatureAlgorithms in its ssl/extensions.cc) omits
+ * Ed25519 and ECDSA P-521, so a client never advertises them in the
+ * signature_algorithms extension and cannot verify an Ed25519 or P-521 server
+ * certificate: the handshake fails and the peer certificate comes back empty,
+ * surfacing as a bogus hostname-verification failure. Node.js accepts both, so
+ * match Node's default verify list.
+ *
+ * This is the exact order Node.js (OpenSSL) advertises, restricted to the
+ * algorithms BoringSSL implements. Node additionally sends ed448,
+ * rsa_pss_pss_sha256/384/512, and the SHA-224/DSA legacy pairs, none of which
+ * BoringSSL has an SSL_SIGN_* value for, so they cannot be listed here. Node
+ * does not advertise rsa_pkcs1_sha1, so it is dropped too (BoringSSL's default
+ * kept it). The same list governs verifying client certificates when this
+ * mode-neutral CTX backs a server doing mTLS. */
+static const uint16_t us_verify_signature_algorithms[] = {
+    SSL_SIGN_ECDSA_SECP256R1_SHA256,
+    SSL_SIGN_ECDSA_SECP384R1_SHA384,
+    SSL_SIGN_ECDSA_SECP521R1_SHA512,
+    SSL_SIGN_ED25519,
+    SSL_SIGN_RSA_PSS_RSAE_SHA256,
+    SSL_SIGN_RSA_PSS_RSAE_SHA384,
+    SSL_SIGN_RSA_PSS_RSAE_SHA512,
+    SSL_SIGN_RSA_PKCS1_SHA256,
+    SSL_SIGN_RSA_PKCS1_SHA384,
+    SSL_SIGN_RSA_PKCS1_SHA512,
+};
+
+/* Shared so the QUIC client context (quic.c), which builds its own SSL_CTX
+ * instead of going through us_ssl_ctx_build_raw, advertises the same list.
+ * Returns 1 on success, 0 on failure (the caller must fail the context so it
+ * never silently falls back to BoringSSL's default, Ed25519/P-521-less list). */
+int us_ssl_ctx_set_verify_signature_algorithms(SSL_CTX *ssl_context) {
+  return SSL_CTX_set_verify_algorithm_prefs(
+      ssl_context, us_verify_signature_algorithms,
+      sizeof(us_verify_signature_algorithms) / sizeof(us_verify_signature_algorithms[0]));
+}
+
 /* Exported for quic.c (lsquic configures ALPN/transport-params on the SSL_CTX
  * directly) and as the body of us_ssl_ctx_from_options. */
 SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
@@ -908,6 +946,11 @@ SSL_CTX *us_ssl_ctx_build_raw(struct us_bun_socket_context_options_t options,
   SSL_CTX_set_min_proto_version(ssl_context, options.ssl_min_version ? options.ssl_min_version : TLS1_2_VERSION);
   if (options.ssl_max_version) {
     SSL_CTX_set_max_proto_version(ssl_context, options.ssl_max_version);
+  }
+  /* Advertise Ed25519/P-521 as accepted peer signatures (see note above). */
+  if (!us_ssl_ctx_set_verify_signature_algorithms(ssl_context)) {
+    ssl_ctx_build_fail(ssl_context);
+    return NULL;
   }
 
   if (options.ssl_prefer_low_memory_usage) {

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -27,6 +27,7 @@ extern SSL_CTX *us_ssl_ctx_build_raw(
     struct us_bun_socket_context_options_t options,
     enum create_bun_socket_error_t *err);
 extern X509_STORE *us_get_default_ca_store(void);
+extern int us_ssl_ctx_set_verify_signature_algorithms(SSL_CTX *ctx);
 
 #define US_QUIC_READ_BUF (16 * 1024)
 
@@ -1123,6 +1124,8 @@ us_quic_socket_context_t *us_create_quic_client_context(
      * the system store on macOS/Windows. */
     SSL_CTX_set_cert_store(ssl, us_get_default_ca_store());
     SSL_CTX_set_custom_verify(ssl, SSL_VERIFY_PEER, us_quic_client_verify);
+    /* Accept Ed25519/P-521 peer signatures, matching the H1/H2 client. */
+    if (!us_ssl_ctx_set_verify_signature_algorithms(ssl)) { SSL_CTX_free(ssl); return NULL; }
 
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *)
         calloc(1, sizeof(us_quic_socket_context_t) + ext_size);

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -747,3 +747,153 @@ it("https.request reports an impossible version window as a TLS error, not a cer
   await once(response, "end");
   expect(body).toBe("ok");
 });
+
+// Self-signed leaf certificates carrying subjectAltName=DNS:localhost,IP:127.0.0.1,
+// one per public-key algorithm. Before the fix the TLS client never advertised
+// Ed25519 or ECDSA P-521 in its signature_algorithms extension, so a handshake
+// against an Ed25519 or P-521 leaf could not complete: the peer certificate came
+// back empty and hostname verification failed with "Cert does not contain a DNS
+// name". RSA and ECDSA P-256 were unaffected and are included so the fix is
+// proven not to regress them. https://github.com/oven-sh/bun/issues/32234
+const algorithmCerts: Record<string, { cert: string; key: string }> = {
+  "ed25519": {
+    cert: `-----BEGIN CERTIFICATE-----
+MIIBazCCAR2gAwIBAgIUIRnW7d+/xEjATOwpaLufjVG3L50wBQYDK2VwMBwxGjAY
+BgNVBAMMEWVkMjU1MTktbG9jYWxob3N0MCAXDTI2MDYxMzE2NDA0MVoYDzIxMjYw
+NTIwMTY0MDQxWjAcMRowGAYDVQQDDBFlZDI1NTE5LWxvY2FsaG9zdDAqMAUGAytl
+cAMhAJctkaOzUhRwNmww05zPThcS3kxYat1D1u23etBE5afto28wbTAdBgNVHQ4E
+FgQUsKxmTSgWWCGVfig+r1ZpDskV/P0wHwYDVR0jBBgwFoAUsKxmTSgWWCGVfig+
+r1ZpDskV/P0wDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+BH8AAAEwBQYDK2VwA0EAwTZ5YJdRLVaHhonefLnfj3JZRMCkLy7sJh9PzaMMLmzy
+Ykda9Ma72YYRhxA17xJDrVHqbch3Xj0av7HdiBA1Dw==
+-----END CERTIFICATE-----`,
+    key: `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIPHkA+g5xFMMCoC3mdG4/P1fZklg3FWNUW79wAEkMQur
+-----END PRIVATE KEY-----`,
+  },
+  "rsa": {
+    cert: `-----BEGIN CERTIFICATE-----
+MIIDLzCCAhegAwIBAgIUSHG57QcKYNvy3F7bN+bn4rxfCJAwDQYJKoZIhvcNAQEL
+BQAwGDEWMBQGA1UEAwwNcnNhLWxvY2FsaG9zdDAgFw0yNjA2MTMxNjQwNDFaGA8y
+MTI2MDUyMDE2NDA0MVowGDEWMBQGA1UEAwwNcnNhLWxvY2FsaG9zdDCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALfCQhTCiyLUqmQdYnIIMdTSbzJanxQi
+NhxxX8T5tZnFrc/M3NBNLkNKxwCRsi4dSNvlrjoP2lBtLxcaXi4oEVfO955rJMPK
+ttw7YjVC3NTwoJXdIheXZtB1AXdv9NGcYwC9UC9aHW3rQuaK7T/ZilxKQZ9cDvYF
+Fa/aQyXGoUAcLNyu0IxKYHsPG6MIZP3LUQwqKr7CmWuMGsEAvN4p42RCaXdY6vnJ
+DZGHY9Dti+2EmbmRkAsAG+pMgGz3vpG7B1kLSRLXZAKXNFakDfXWsHTc1/htZCh4
+rAy0NX4TTs3fxtCpCdos+vlSvr3BAx3NLfv++as/eawpGz8i7Hf10+MCAwEAAaNv
+MG0wHQYDVR0OBBYEFP4rNEnchPJVC9xn751EgXU0kGnAMB8GA1UdIwQYMBaAFP4r
+NEnchPJVC9xn751EgXU0kGnAMA8GA1UdEwEB/wQFMAMBAf8wGgYDVR0RBBMwEYIJ
+bG9jYWxob3N0hwR/AAABMA0GCSqGSIb3DQEBCwUAA4IBAQAHuaSNPGEQS9EqKgb2
+G2ed6gfQ8H5JaFMFpKuAeL6L61PlF5keMu5ecXYDfWBQTvs9MfBmInz/S9hshbkQ
+9eMu2LhJGd4I6tLQ0ylucmrg0yGZACP1f2WDOthw1SGZGaRHdoMulUg8yKxWTnCM
+ypDC+NYBm/cqJphTCFKduB1jFQAOdIo4i3vUI/Gxd4IOZ+tlwFz9lS5GYQ6TugBA
+acYBZIpIzwhDSe0kpEcH3m1mRs41rs0XsoJ5vMDZFMuLP6l3H/Omtj8qljNIvRlY
+jb2eqycxFwhsWTt9mdBI2YIzwcmdNk+Kh71+B34wthbrNNdhxZ5DPIIJloSj3vD7
+0b6r
+-----END CERTIFICATE-----`,
+    key: `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC3wkIUwosi1Kpk
+HWJyCDHU0m8yWp8UIjYccV/E+bWZxa3PzNzQTS5DSscAkbIuHUjb5a46D9pQbS8X
+Gl4uKBFXzveeayTDyrbcO2I1QtzU8KCV3SIXl2bQdQF3b/TRnGMAvVAvWh1t60Lm
+iu0/2YpcSkGfXA72BRWv2kMlxqFAHCzcrtCMSmB7DxujCGT9y1EMKiq+wplrjBrB
+ALzeKeNkQml3WOr5yQ2Rh2PQ7YvthJm5kZALABvqTIBs976RuwdZC0kS12QClzRW
+pA311rB03Nf4bWQoeKwMtDV+E07N38bQqQnaLPr5Ur69wQMdzS37/vmrP3msKRs/
+Iux39dPjAgMBAAECggEAFtKgucqufzqh7bdHP9nMCUkYQyJwOY7vi47P5ztga7iF
+QuwzIgfupAWd5nCHYc+EpL3HwDGx2rqvgOi8eR0Zh6oOpSAHkUMUfRE/EasRRGfy
+efUyGR4BHgjk5WcD+s4NRHfphUgQTv5Lm9igvi+6+IVx1boYUu6vZ9ztlBEx0TAN
+fB/Y1dj4uS6SU9jyobK/AZq6BEmZCnbVwibpH/R/Z6WMTaMpI99smRBpj8kFnOQj
+6jWdL+Sy+AM8bLc+YsUbPaPYEjBSyMrMmnd1mT4z+I61RYJpxyuKfUvNN//SYBH5
+zSB0WbchI7znDgXxvXidS1jmWdQ4Al86Fx/CDF+1gQKBgQD8wdeaetqUA8xWOIYN
+I+L/yOao1u28X2L5DzADt8D81mcEQbceLWXhbEo6FtvTpWvkOwCrvC1HLTj/v66d
++mgB+GgsilOE8qo5kW+hKT5X0x8tlo3f57fXRQqjQmQpjKS35W40XehBPKh4jvPC
+fUVZz9lQ6m0wL7q9QN9OlhyGwQKBgQC6HcwO0QVUcb9lJw8qUkd8mgDVOqdlZVFE
+N7ZZInV1i+M3vHKRVYmfQu2iqO5bQ1WP5kjze5Twn6cT27UIP2dLyHmVmOjccArV
+w+RxeUmw9BmXa8pB2ikqIeLLs0JgYB1s0U5kUdYove6tCkbcEL8t5zNZjs6aFi/u
+2wiL5gzHowKBgQDcWGyKCqH0uV7wp3QNjoR9MnoLJNu6BXn14AyeoRnIEW1bY6Ks
+1yzjGRGYlIbtel+VZu6NyI28aCsxobwrkroLRbAjbC+lThuh9izX1Wm5DJ84kfB7
+CrnVHCZK7zz8j9SlUIkDc/5eqO/BsfXFToof4rfz93pasLFd/WjvTKPvwQKBgGXS
+zYRBqOfVP4BIyUw/Lasm2lPOPi0ELFzlGhdT+e0wdkRVDl0i7iM6y6YVRCqcASC0
+Pa8wKoEm55K+viFgBtR4PsSwnp2Tkun2vXGziLSOJ74nE8XJZIIPffQyA5uUmiSh
+soDCISezGfSDzdayNtYXSomxzqiQgPLt1JQtbUp/AoGBAKaqOj6FUdRD3ds2+tXt
+iCKq+qQLcFreAdaQ3OKJykKWX+xlgLhvnqrIfMHopGY5N3iEGp0irauYhDzbnpuY
+x8S3ommsHLhi3aeId5r+EIkJ9ll5BWxOcRgs/atLaT40CDM5Vx3qzSEC8auOE4B5
+EDnAN+SRORTO4epMgRiENIEZ
+-----END PRIVATE KEY-----`,
+  },
+  "ecdsa": {
+    cert: `-----BEGIN CERTIFICATE-----
+MIIBpjCCAU2gAwIBAgIUPWShsQtCuc97Hdm9I+ipbsKrgZcwCgYIKoZIzj0EAwIw
+GjEYMBYGA1UEAwwPZWNkc2EtbG9jYWxob3N0MCAXDTI2MDYxMzE2NDA0MVoYDzIx
+MjYwNTIwMTY0MDQxWjAaMRgwFgYDVQQDDA9lY2RzYS1sb2NhbGhvc3QwWTATBgcq
+hkjOPQIBBggqhkjOPQMBBwNCAAQQ7WHhvk5Icy1UuwgzzFfvQMfH3FnGNBcxvINX
+tRG6POticc4jqEDuZPXZo+FmvGDF7y9YvxDXjfZFLzIbL/smo28wbTAdBgNVHQ4E
+FgQU60sgbRi+E0NGG31Zq8KDQ9aSlagwHwYDVR0jBBgwFoAU60sgbRi+E0NGG31Z
+q8KDQ9aSlagwDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+BH8AAAEwCgYIKoZIzj0EAwIDRwAwRAIgHKpxMdB/cR9DUiHG9MxYgcu5MN/0rPJV
+T8mzSFQ5iyACIAnbr6sFD/rlTbh/ADrHGMOWv8uPcYly6JLr1OKGKgNt
+-----END CERTIFICATE-----`,
+    key: `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIMCrDw7RCsq66+trOkbw6yZLetWvA5QcSNzH4ecYr9aroAoGCCqGSM49
+AwEHoUQDQgAEEO1h4b5OSHMtVLsIM8xX70DHx9xZxjQXMbyDV7URujzrYnHOI6hA
+7mT12aPhZrxgxe8vWL8Q1432RS8yGy/7Jg==
+-----END EC PRIVATE KEY-----`,
+  },
+  "p521": {
+    cert: `-----BEGIN CERTIFICATE-----
+MIICLDCCAY6gAwIBAgIULMKSgCPMb6GMkhK/ZpfRas9lTPkwCgYIKoZIzj0EAwIw
+GTEXMBUGA1UEAwwOcDUyMS1sb2NhbGhvc3QwIBcNMjYwNjEzMTcwNDQyWhgPMjEy
+NjA1MjAxNzA0NDJaMBkxFzAVBgNVBAMMDnA1MjEtbG9jYWxob3N0MIGbMBAGByqG
+SM49AgEGBSuBBAAjA4GGAAQA/PIq4LR4n0p8/94YQowNcGwk6GAs625n0ufFQ/ib
+G7uEPD/KUhJTMg/SJRwrq6lOSebbdVjIindagm4mFJtOFpwBk46G1TDMOA8goAGZ
+qTp15B5Cte0AnedrSjJ8L24CQeh3P8jrzSpkf/FTKlWbvtl5Mlj4+PVMh+Q0hZkC
+UpJoPVWjbzBtMB0GA1UdDgQWBBT18yyESC3nxaPyz7oA8dyBGEHJ/TAfBgNVHSME
+GDAWgBT18yyESC3nxaPyz7oA8dyBGEHJ/TAPBgNVHRMBAf8EBTADAQH/MBoGA1Ud
+EQQTMBGCCWxvY2FsaG9zdIcEfwAAATAKBggqhkjOPQQDAgOBiwAwgYcCQSyY3lFD
+f0N7631iLceyvBQ62U1+cQyDTUNEt9B/YW1TPiUONCfbdHB0IOzBwUBhVPYUcwYR
+s+yBvABruLk1OzrQAkIB+twMGvX6ZD8llMA5Ac/lYrIvfL2RiAInaN8Oin194cKP
+A148UijZM1s3nxvhjqQZtX/NnS4VrIkmY4PtCY89Rr0=
+-----END CERTIFICATE-----`,
+    key: `-----BEGIN PRIVATE KEY-----
+MIHuAgEAMBAGByqGSM49AgEGBSuBBAAjBIHWMIHTAgEBBEIASR7GbUoVvpY4c+bL
+oPGX1Cd+K49MA3BD+pl/eukQuImXGa9PLDrJXyrVrKfjdoKF0EupRxoLOGqFfWO3
+A/lGId+hgYkDgYYABAD88irgtHifSnz/3hhCjA1wbCToYCzrbmfS58VD+Jsbu4Q8
+P8pSElMyD9IlHCurqU5J5tt1WMiKd1qCbiYUm04WnAGTjobVMMw4DyCgAZmpOnXk
+HkK17QCd52tKMnwvbgJB6Hc/yOvNKmR/8VMqVZu+2XkyWPj49UyH5DSFmQJSkmg9
+VQ==
+-----END PRIVATE KEY-----`,
+  },
+};
+
+describe("tls.connect verifies server certificates of every key algorithm (#32234)", () => {
+  for (const [algorithm, { cert, key }] of Object.entries(algorithmCerts)) {
+    it(`authorizes an ${algorithm} server certificate and reads its subjectAltName`, async () => {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        authorized: boolean;
+        san: string | undefined;
+      }>();
+      const server = tls.createServer({ cert, key }, socket => socket.end());
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const { port } = server.address() as AddressInfo;
+        // rejectUnauthorized defaults to true: a cert the client cannot verify
+        // makes the socket emit "error" and fail the test fast instead of ever
+        // reaching secureConnect.
+        const socket = tls.connect({ port, host: "127.0.0.1", servername: "localhost", ca: cert }, () => {
+          const peer = socket.getPeerCertificate(true);
+          resolve({ authorized: socket.authorized, san: peer?.subjectaltname });
+          socket.end();
+        });
+        socket.on("error", reject);
+      });
+
+      try {
+        const result = await promise;
+        expect(result.san).toBe("DNS:localhost, IP Address:127.0.0.1");
+        expect(result.authorized).toBe(true);
+      } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
+  }
+});

--- a/test/js/web/fetch/fetch-http3-client.test.ts
+++ b/test/js/web/fetch/fetch-http3-client.test.ts
@@ -795,3 +795,44 @@ test("custom TLS trust options are rejected on protocol: http3 and excluded from
   expect(stdout).toMatch(/second status=200 sessions=0\n$/);
   expect(exitCode).toBe(0);
 });
+
+// A self-signed Ed25519 server certificate (subjectAltName=DNS:localhost,IP:127.0.0.1).
+// The HTTP/3 client builds a process-global QUIC SSL_CTX; before the fix its
+// verify signature-algorithm list omitted Ed25519, so the TLS 1.3 handshake
+// against an Ed25519 server certificate failed during signature_algorithms
+// negotiation, before the verify callback ran (so rejectUnauthorized:false
+// could not mask it). https://github.com/oven-sh/bun/issues/32234
+const ed25519Tls = {
+  cert: `-----BEGIN CERTIFICATE-----
+MIIBazCCAR2gAwIBAgIUXx1d+m1qIfvFkQfDj83EgPtpiWEwBQYDK2VwMBwxGjAY
+BgNVBAMMEWVkMjU1MTktbG9jYWxob3N0MCAXDTI2MDYxMzE3MDAzOVoYDzIxMjYw
+NTIwMTcwMDM5WjAcMRowGAYDVQQDDBFlZDI1NTE5LWxvY2FsaG9zdDAqMAUGAytl
+cAMhAMMCjPccnWDCrbQbYljQdttVaNBXLPMbXNif77uAQ74jo28wbTAdBgNVHQ4E
+FgQUdDiLgr6rGXvtcb0iJOQG8UhtU28wHwYDVR0jBBgwFoAUdDiLgr6rGXvtcb0i
+JOQG8UhtU28wDwYDVR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SH
+BH8AAAEwBQYDK2VwA0EAkTJAjKuV75hiRCGJoLRLJw59ZbHFAcGch6yJwo27Z/xL
+Bjl/5AxuntMH6GFjzrhhyJj/K1JbXyLMGdR2iKFmCw==
+-----END CERTIFICATE-----`,
+  key: `-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIB0jQnQ25+PBL50z5GdZYH52qTBgdqTn8DRfFFMj88wv
+-----END PRIVATE KEY-----`,
+};
+
+test("connects to an Ed25519 server certificate over http3 (#32234)", async () => {
+  const edServer = Bun.serve({
+    port: 0,
+    tls: ed25519Tls,
+    http3: true,
+    http1: false,
+    fetch: () => new Response("ed25519 over h3"),
+  });
+  try {
+    const res = await fetch(`https://127.0.0.1:${edServer.port}/`, h3);
+    expect(await res.text()).toBe("ed25519 over h3");
+    expect(res.status).toBe(200);
+  } finally {
+    // Mirror afterAll: the pooled h3 session to this origin drains on lsquic's
+    // idle timeout, so stop(true) is not awaited.
+    edServer.stop(true);
+  }
+});


### PR DESCRIPTION
Fixes #32234

## Problem

A TLS client connecting to a server that presents an **Ed25519** certificate always fails hostname verification:

```
ed: ERROR Hostname/IP does not match certificate's altnames: Cert does not contain a DNS name
```

RSA and ECDSA P-256/P-384 certificates work; Node verifies all of them. The peer certificate comes back empty (`subjectaltname: undefined` even in detailed mode), so the internal `checkServerIdentity` finds no DNS names and rejects with `ERR_TLS_CERT_ALTNAME_INVALID`. Real-world impact: connecting to servers whose PKI issues Ed25519 certs (e.g. NATS behind cert-manager) works under Node but breaks under Bun.

During review this turned out to affect **ECDSA P-521** leaf certificates too, for the same underlying reason.

## Root cause

BoringSSL's default accepted signature-algorithm list for *verifying* a peer certificate (`kVerifySignatureAlgorithms` in `ssl/extensions.cc`) omits `SSL_SIGN_ED25519` and `SSL_SIGN_ECDSA_SECP521R1_SHA512`, even though its *signing* list (`kSignSignatureAlgorithms`) includes both. Bun never overrode this, so the client never advertised Ed25519 or P-521 in the `signature_algorithms` extension. A TLS 1.3 handshake against an Ed25519 or P-521 leaf then could not complete; the connection degraded with an empty peer certificate, which surfaced as the bogus hostname error. This also explains why Bun's *server* presents Ed25519 fine (it signs) while its *client* cannot verify it. OpenSSL (and therefore Node) accepts both by default.

## Fix

Set explicit verify signature-algorithm preferences on the client `SSL_CTX` (BoringSSL's default list plus `SSL_SIGN_ED25519` and `SSL_SIGN_ECDSA_SECP521R1_SHA512`), matching the OpenSSL defaults Node relies on. The list is applied once in the shared `us_ssl_ctx_build_raw` in `packages/bun-usockets/src/crypto/openssl.c`, which backs every node:tls / `Bun.connect` / fetch / node:https context, and reused for the QUIC client context in `quic.c` so HTTP/3 stays consistent. Because the `SSL_CTX` is mode-neutral, the same list governs verifying client certificates, so a Bun server doing mTLS now accepts these client certs too, matching Node.

The fixing line is the `SSL_CTX_set_verify_algorithm_prefs` call (via the shared `us_ssl_ctx_set_verify_signature_algorithms` helper); the rest is the algorithm list and its reuse in QUIC.

## Verification

- `test/js/node/tls/node-tls-connect.test.ts`: a matrix test stands up a `tls.createServer` with an Ed25519, RSA, ECDSA P-256, and ECDSA P-521 leaf (each `subjectAltName=DNS:localhost,IP:127.0.0.1`) and connects with `tls.connect({ ca, servername: "localhost" })`, asserting `authorized === true` and `getPeerCertificate(true).subjectaltname === "DNS:localhost, IP Address:127.0.0.1"`. Before the fix, Ed25519 and P-521 fail (`ERR_TLS_CERT_ALTNAME_INVALID`) while RSA and P-256 pass, proving the fix does not regress them.
- `test/js/web/fetch/fetch-http3-client.test.ts`: an HTTP/3 test connects to an Ed25519 server via `fetch(url, { protocol: "http3" })`, which exercises the QUIC client context. Without the fix the h3 handshake fails with `HTTP3HandshakeFailed` during `signature_algorithms` negotiation (before the verify callback, so `rejectUnauthorized: false` cannot mask it); with the fix it returns 200.

```
# USE_SYSTEM_BUN=1 (pre-fix):  ed25519 + p521 fail, rsa + p256 pass
# bun bd (post-fix):           full tls matrix + h3 ed25519 green
```

---

_Rebased onto main (resolving conflicts from #31155) and squashed into a single commit; the empty `ci: retrigger` commit was dropped. Conflict resolution: #31155 added explicit `minVersion`/`maxVersion` handling in `us_ssl_ctx_build_raw` at the same spot this PR adds the verify-sigalgs call, so its version handling is kept and the sigalgs call runs right after it (the previously-hardcoded `TLS1_2_VERSION` line is dropped in favor of #31155s option-aware one). In `node-tls-connect.test.ts` both branches appended tests at end-of-file; both are kept. Matrix + h3 tests verified green on the rebased tree._

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 failed, 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts "test/js/web/fetch/fetch-http3-client.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (68cca8065)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [36.31ms]
(pass) fetch protocol: http3 > 'h3' alias [8.17ms]
(pass) fetch protocol: http3 > POST echo with headers [24.01ms]
(pass) fetch protocol: http3 > JSON + query string [20.98ms]
(pass) fetch protocol: http3 > route params [9.79ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [18.52ms]
(pass) fetch protocol: http3 > large request body [20.05ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [24.10ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [15.09ms]
(p
... (truncated)

release without fix: 18 skipped
bun test v1.4.0-canary.1 (68cca8065)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [3.30ms]
(pass) fetch protocol: http3 > 'h3' alias [0.20ms]
(pass) fetch protocol: http3 > POST echo with headers [0.38ms]
(pass) fetch protocol: http3 > JSON + query string [0.38ms]
(pass) fetch protocol: http3 > route params [0.23ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [1.37ms]
(pass) fetch protocol: http3 > large request body [1.39ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [0.89ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [1.41ms]
(pass) fetch protocol: http3 > status 200 [0.23ms]
(pass) fetch protocol: http3 > status 204 [0.09ms]
(pass) fetch protocol: http3 > status 404 [0.08ms]
(pass) fetch protocol: http3 > status 500 [0.07ms]
(pass) fetch protocol: http3 > HEAD has no body [0.22ms]
(pass) fetch protocol: http3 > gzip response is decompressed [0.21ms]
(pass) fetch protocol: http3 > redirect follow [0.26ms]
(pass) fetch protocol: http3 > pull-driven response body [0.31ms]
(pass) fetch protocol: http
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect.test.ts "test/js/web/fetch/fetch-http3-client.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (68cca8065)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [37.70ms]
(pass) fetch protocol: http3 > 'h3' alias [13.55ms]
(pass) fetch protocol: http3 > POST echo with headers [23.35ms]
(pass) fetch protocol: http3 > JSON + query string [23.16ms]
(pass) fetch protocol: http3 > route params [14.46ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [18.94ms]
(pass) fetch protocol: http3 > large request body [19.56ms]
(pass) fetch protocol: http3 > compress: gzip request body — small (shared-buffer fast path) [23.62ms]
(pass) fetch protocol: http3 > compress: gzip request body — large (zlib-streaming spill path) [15.14ms]

... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 702ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/5] cc obj/packages/bun-usockets/src/quic.c.o
[2/5] link bun-profile
[3/5] bun-profile --revision
1.4.0-canary.1+68cca8065
[5/5] strip bun
[build] done
bun test v1.4.0-canary.1 (68cca8065)

test/js/web/fetch/fetch-http3-client.test.ts:
(pass) fetch protocol: http3 > GET text [3.23ms]
(pass) fetch protocol: http3 > 'h3' alias [0.20ms]
(pass) fetch protocol: http3 > POST echo with headers [0.40ms]
(pass) fetch protocol: http3 > JSON + query string [0.36ms]
(pass) fetch protocol: http3 > route params [0.22ms]
(pass) fetch protocol: http3 > large response body (multi-packet) [1.27ms]
(pass) fetch protocol: http3 > large request body [1.24ms]
(pass) fetch protocol: http3 > compress: gzip request bod
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c   |  43 ++++++++
 packages/bun-usockets/src/quic.c             |   3 +
 test/js/node/tls/node-tls-connect.test.ts    | 150 +++++++++++++++++++++++++++
 test/js/web/fetch/fetch-http3-client.test.ts |  41 ++++++++
 4 files changed, 237 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c        9      9     43
packages/bun-usockets/src/quic.c                  3      5     43
test/js/node/tls/node-tls-connect.test.ts         9     10     32
test/js/web/fetch/fetch-http3-client.test.ts      1      0     21
```

</details>

**root cause** · written by the author bot

The root cause is that Bun relied on BoringSSL's default list of accepted peer certificate signature algorithms, which omits Ed25519, so the signature verification path rejected Ed25519 certificates and their parsed fields, including subjectAltName, never reached the hostname check. The fix explicitly sets the verify signature algorithm preferences on every SSL context via SSL_CTX_set_verify_algorithm_prefs, adding Ed25519 and ECDSA P-521 and dropping the deprecated rsa_pkcs1_sha1 to match Node and OpenSSL defaults, verified against Node's actual ClientHello bytes. With Ed25519 signatures a…

<!-- robobun:evidence:end -->