### PR TITLE
docs: add production deployment note to Discord.js bot guide

### DIFF
--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -65,7 +65,7 @@ client.login(process.env.DISCORD_TOKEN);
 
 ---
 
-Now we can run our bot with `bun run`. It may take a several seconds for the client to initialize the first time you run the file.
+Now we can run our bot with `bun run`. It may take several seconds for the client to initialize the first time you run the file.
 
 ```sh terminal icon="terminal"
 bun run bot.ts
@@ -78,3 +78,18 @@ Ready! Logged in as my-bot#1234
 ---
 
 You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official discord.js docs](https://discordjs.guide/) for complete information on the `discord.js` API.
+
+---
+
+When you're ready to deploy, you don't need a bundling or build step. Bun runs `bot.ts` and every file it imports directly, so you can ship your source as-is and start the bot with the same `bun run bot.ts` command you use in development.
+
+To keep the bot online and restart it after a crash or reboot, run it under a process manager:
+
+<Columns cols={2}>
+  <Card title="systemd" href="/guides/ecosystem/systemd" icon="server">
+    Run your bot as a Linux daemon
+  </Card>
+  <Card title="PM2" href="/guides/ecosystem/pm2" icon="cog">
+    Manage your bot with PM2
+  </Card>
+</Columns>


### PR DESCRIPTION
## Summary

Reviewed the [Discord.js guide](https://bun.com/docs/guides/ecosystem/discordjs) for accuracy after users asked whether a bundling/build step is needed to run a bot in production. The guide stops once the bot logs in and never answers that, so people assume bundling is required. It is not: Bun runs the `bot.ts` entrypoint and everything it imports directly, so the source deploys as-is.

## Changes

`docs/guides/ecosystem/discordjs.mdx`:
- Add a closing section stating no build step is needed and linking the existing `systemd` and `PM2` guides for keeping the bot process alive and restarting it after a crash or reboot.
- Fix a grammar error: "It may take a several seconds" -> "several seconds".

## Review notes (verified current, left unchanged)

- The sample code uses the `Events.ClientReady` enum, which resolves to `'clientReady'` in discord.js 14.26.4. Only the legacy `'ready'` string event is deprecated, so the snippet runs clean with no deprecation warning.
- The `.env.local` auto-loading claim is accurate (Bun loads it except when `NODE_ENV=test`).

The stale "official discord.js docs" link on line 80 is already handled separately in #31187, so this PR deliberately leaves that line alone. Both touch this file but on different lines and concerns; if #31187 merges first this branch takes a trivial rebase.

## Verification

- Ran the guide's `bot.ts` setup on discord.js 14.26.4 + Bun 1.4.0: imports resolve, client constructs, no deprecation warning.
- Both new `<Card>` hrefs (`/guides/ecosystem/systemd`, `/guides/ecosystem/pm2`) match their entries in `docs/docs.json`.
- `prettier` reports the file formatted.