### PR TITLE
docs: rewrite Discord.js bot guide around a working slash command

### DIFF
--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -77,7 +77,7 @@ const commands = [new SlashCommandBuilder().setName("ping").setDescription("Repl
 
 const rest = new REST().setToken(DISCORD_TOKEN);
 
-// register them in your server, where they appear instantly
+// register them in your test server
 await rest.put(Routes.applicationGuildCommands(DISCORD_CLIENT_ID, DISCORD_GUILD_ID), { body: commands });
 
 console.log("Registered /ping");
@@ -89,7 +89,7 @@ Run it once.
 bun run deploy-commands.ts
 ```
 
-You only run this again when you add a command or change its name or description, not every time the bot starts. Registering to your server instead of globally is what makes the command show up right away.
+You only run this again when you add a command or change its name or description, not every time the bot starts. Registering to your server instead of globally keeps the command scoped to where you're testing.
 
 ---
 

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -4,7 +4,7 @@ sidebarTitle: "Discord.js with Bun"
 mode: center
 ---
 
-Discord.js runs on Bun with no extra setup. This guide builds a bot that answers a `/ping` slash command, then shows how to keep it running once you deploy. If this is your first bot, copy each block as you reach it and you'll have something working by the end.
+Discord.js runs on Bun with no extra setup. This guide builds a bot that answers a `/ping` slash command: you register the command once, then start the bot and use it in your server. If this is your first bot, copy each block as you reach it.
 
 ---
 
@@ -28,18 +28,27 @@ bun add discord.js
 
 Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/legacy/preparations/app-setup#creating-your-bot) has screenshots if you get lost.
 
-On that **Bot** tab, find the token and copy it. It's the password your code uses to log in as the bot, so treat it like one and keep it to yourself.
+Copy two values from the portal:
+
+- The **token** on the **Bot** tab. It's the password your code uses to log in, so treat it like one and keep it to yourself.
+- The **Application ID** on the **General Information** tab. Discord uses it to tie your commands to this app.
 
 ---
 
-A bot can't do anything in a server until you invite it. In the portal, open the **OAuth2** section and generate an invite URL with the `bot` and `applications.commands` scopes. Open that URL and add the bot to a server you manage. A personal server you make just for testing is the easiest place to start.
+A bot can't do anything in a server until you invite it. In the portal's **OAuth2** section, generate an invite URL with the `bot` and `applications.commands` scopes, open it, and add the bot to a server you manage. Slash commands need the `applications.commands` scope, so don't skip it. A personal server you make for testing is the easiest place to start.
 
 ---
 
-Save the token in a file named `.env.local`. Bun reads this file on startup and loads it into `process.env`, so the token stays out of your code.
+You also need your server's ID to register the command there. In Discord, turn on **Settings > Advanced > Developer Mode**, then right-click your server's icon and choose **Copy Server ID**.
+
+---
+
+Save all three values in `.env.local`. Bun reads this file on startup and loads it into `process.env`, so nothing secret lives in your code.
 
 ```ini .env.local icon="settings"
 DISCORD_TOKEN=your-bot-token
+DISCORD_CLIENT_ID=your-application-id
+DISCORD_GUILD_ID=your-server-id
 ```
 
 ---
@@ -53,27 +62,47 @@ node_modules
 
 ---
 
-Here's the whole bot. Save it as `bot.ts`.
+Discord has to know about a command before anyone can use it. Register `/ping` with a short script named `deploy-commands.ts`.
+
+```ts deploy-commands.ts icon="/icons/typescript.svg"
+import { REST, Routes, SlashCommandBuilder } from "discord.js";
+
+// the commands you want to register
+const commands = [new SlashCommandBuilder().setName("ping").setDescription("Replies with Pong!").toJSON()];
+
+const rest = new REST().setToken(process.env.DISCORD_TOKEN!);
+
+// register them in your server, where they appear instantly
+await rest.put(Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID!, process.env.DISCORD_GUILD_ID!), {
+  body: commands,
+});
+
+console.log("Registered /ping");
+```
+
+Run it once.
+
+```sh terminal icon="terminal"
+bun run deploy-commands.ts
+```
+
+You only run this again when you add a command or change its name or description, not every time the bot starts. Registering to your server instead of globally is what makes the command show up right away.
+
+---
+
+Now the bot itself. Save it as `bot.ts`.
 
 ```ts bot.ts icon="/icons/typescript.svg"
-import { Client, Events, GatewayIntentBits, SlashCommandBuilder } from "discord.js";
+import { Client, Events, GatewayIntentBits } from "discord.js";
 
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-// the command people see when they type "/" in your server
-const ping = new SlashCommandBuilder().setName("ping").setDescription("Replies with Pong!");
-
 // runs once, right after the bot connects
-client.once(Events.ClientReady, async readyClient => {
+client.once(Events.ClientReady, readyClient => {
   console.log(`Logged in as ${readyClient.user.tag}`);
-
-  // add the command to every server the bot is in so it shows up right away
-  for (const guild of readyClient.guilds.cache.values()) {
-    await guild.commands.set([ping]);
-  }
 });
 
-// runs every time someone uses one of your slash commands
+// runs every time someone uses a slash command
 client.on(Events.InteractionCreate, async interaction => {
   if (!interaction.isChatInputCommand()) return;
 
@@ -85,7 +114,7 @@ client.on(Events.InteractionCreate, async interaction => {
 client.login(process.env.DISCORD_TOKEN);
 ```
 
-When the bot connects, the ready handler registers `/ping` in every server it has joined, so the command appears right away. After that, `interactionCreate` runs whenever someone uses a command; it checks that the command was `/ping` and replies with `Pong!`. The last line signs in with the token Bun loaded from `.env.local`.
+The ready handler logs a line once the bot connects. After that, `interactionCreate` runs whenever someone uses a slash command; it confirms the command was `/ping` and replies with `Pong!`.
 
 ---
 
@@ -95,7 +124,7 @@ Start the bot with `bun run`.
 bun run bot.ts
 ```
 
-The first connection takes a few seconds. Once the login line prints, switch to Discord, type `/ping` in your server, and send it.
+The first connection takes a few seconds. Once the login line prints, switch to Discord and type `/ping` in your server.
 
 ```txt
 Logged in as my-bot#1234
@@ -105,13 +134,13 @@ The bot replies with `Pong!`. You've got a working Discord bot.
 
 ---
 
-Adding more commands follows the same shape: build another `SlashCommandBuilder`, pass it to the `set` call next to `ping`, and add an `if` branch in `interactionCreate` for its name. The [Discord.js docs](https://discord.js.org/docs) cover command options, permissions, buttons, embeds, and the rest of the API.
+To add another command, define it in `deploy-commands.ts`, run that script again, and add an `if` branch for its name in `bot.ts`. The [Discord.js docs](https://discord.js.org/docs) cover command options, permissions, buttons, embeds, and the rest of the API.
 
 ---
 
 When you deploy, there's no build or bundling step. Bun runs `bot.ts` and every file it imports directly, so you ship your source as-is and start it with the same `bun run bot.ts` you use while developing.
 
-One thing to know for production: this bot registers `/ping` in each server on startup, which is fine while you're testing in one. For a bot that joins many servers, register commands globally instead. Global commands work everywhere but can take up to an hour to update, so per-server registration is the friendlier choice while you build.
+`deploy-commands.ts` registers `/ping` in your test server, which is the right scope while you're building. To publish the bot to every server it joins, register globally instead: change the route from `Routes.applicationGuildCommands(...)` to `Routes.applicationCommands(...)`, passing just the application ID.
 
 To keep the bot online and bring it back after a crash or reboot, run it under a process manager.
 

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -4,7 +4,11 @@ sidebarTitle: "Discord.js with Bun"
 mode: center
 ---
 
-Discord.js works out of the box with Bun. Let's write a bot. First create a directory and initialize it with `bun init`.
+Discord.js runs on Bun with no extra setup. This guide builds a bot that answers a `/ping` slash command, then shows how to keep it running once you deploy. If this is your first bot, copy each block as you reach it and you'll have something working by the end.
+
+---
+
+Create a folder for your bot and set it up with `bun init`. Pick the defaults when it asks.
 
 ```sh terminal icon="terminal"
 mkdir my-bot
@@ -14,7 +18,7 @@ bun init
 
 ---
 
-Now install Discord.js.
+Add Discord.js to the project.
 
 ```sh terminal icon="terminal"
 bun add discord.js
@@ -22,21 +26,25 @@ bun add discord.js
 
 ---
 
-Before we go further, we need to go to the [Discord developer portal](https://discord.com/developers/applications), login/signup, create a new _Application_, then create a new _Bot_ within that application. Follow the [official guide](https://discordjs.guide/legacy/preparations/app-setup#creating-your-bot) for step-by-step instructions.
+Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/legacy/preparations/app-setup#creating-your-bot) has screenshots if you get lost.
+
+On that **Bot** tab, find the token and copy it. It's the password your code uses to log in as the bot, so treat it like one and keep it to yourself.
 
 ---
 
-Once complete, you'll be presented with your bot's _private key_. Let's add this to a file called `.env.local`. Bun automatically reads this file and loads it into `process.env`.
+A bot can't do anything in a server until you invite it. In the portal, open the **OAuth2** section and generate an invite URL with the `bot` and `applications.commands` scopes. Open that URL and add the bot to a server you manage. A personal server you make just for testing is the easiest place to start.
 
-<Note>This is an example token that has already been invalidated.</Note>
+---
+
+Save the token in a file named `.env.local`. Bun reads this file on startup and loads it into `process.env`, so the token stays out of your code.
 
 ```ini .env.local icon="settings"
-DISCORD_TOKEN=NzkyNzE1NDU0MTk2MDg4ODQy.X-hvzA.Ovy4MCQywSkoMRRclStW4xAYK7I
+DISCORD_TOKEN=your-bot-token
 ```
 
 ---
 
-Be sure to add `.env.local` to your `.gitignore`! It is dangerous to check your bot's private key into version control.
+Add `.env.local` to your `.gitignore` before you commit anything. Anyone who reads the token can control your bot, so it should never land in version control.
 
 ```txt .gitignore icon="file-code"
 node_modules
@@ -45,45 +53,69 @@ node_modules
 
 ---
 
-Now let's actually write our bot in a new file called `bot.ts`.
+Here's the whole bot. Save it as `bot.ts`.
 
 ```ts bot.ts icon="/icons/typescript.svg"
-// import discord.js
-import { Client, Events, GatewayIntentBits } from "discord.js";
+import { Client, Events, GatewayIntentBits, SlashCommandBuilder } from "discord.js";
 
-// create a new Client instance
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
-// listen for the client to be ready
-client.once(Events.ClientReady, c => {
-  console.log(`Ready! Logged in as ${c.user.tag}`);
+// the command people see when they type "/" in your server
+const ping = new SlashCommandBuilder()
+  .setName("ping")
+  .setDescription("Replies with Pong!");
+
+// runs once, right after the bot connects
+client.once(Events.ClientReady, async readyClient => {
+  console.log(`Logged in as ${readyClient.user.tag}`);
+
+  // add the command to every server the bot is in so it shows up right away
+  for (const guild of readyClient.guilds.cache.values()) {
+    await guild.commands.set([ping]);
+  }
 });
 
-// login with the token from .env.local
+// runs every time someone uses one of your slash commands
+client.on(Events.InteractionCreate, async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+
+  if (interaction.commandName === "ping") {
+    await interaction.reply("Pong!");
+  }
+});
+
 client.login(process.env.DISCORD_TOKEN);
 ```
 
+When the bot connects, the ready handler registers `/ping` in every server it has joined, so the command appears right away. After that, `interactionCreate` runs whenever someone uses a command; it checks that the command was `/ping` and replies with `Pong!`. The last line signs in with the token Bun loaded from `.env.local`.
+
 ---
 
-Now we can run our bot with `bun run`. It may take several seconds for the client to initialize the first time you run the file.
+Start the bot with `bun run`.
 
 ```sh terminal icon="terminal"
 bun run bot.ts
 ```
 
+The first connection takes a few seconds. Once the login line prints, switch to Discord, type `/ping` in your server, and send it.
+
 ```txt
-Ready! Logged in as my-bot#1234
+Logged in as my-bot#1234
 ```
 
----
-
-You're up and running with a bare-bones Discord.js bot! This is a basic guide to setting up your bot with Bun; we recommend the [official discord.js docs](https://discordjs.guide/) for complete information on the `discord.js` API.
+The bot replies with `Pong!`. You've got a working Discord bot.
 
 ---
 
-When you're ready to deploy, you don't need a bundling or build step. Bun runs `bot.ts` and every file it imports directly, so you can ship your source as-is and start the bot with the same `bun run bot.ts` command you use in development.
+Adding more commands follows the same shape: build another `SlashCommandBuilder`, pass it to the `set` call next to `ping`, and add an `if` branch in `interactionCreate` for its name. The [Discord.js docs](https://discord.js.org/docs) cover command options, permissions, buttons, embeds, and the rest of the API.
 
-To keep the bot online and restart it after a crash or reboot, run it under a process manager:
+---
+
+When you deploy, there's no build or bundling step. Bun runs `bot.ts` and every file it imports directly, so you ship your source as-is and start it with the same `bun run bot.ts` you use while developing.
+
+One thing to know for production: this bot registers `/ping` in each server on startup, which is fine while you're testing in one. For a bot that joins many servers, register commands globally instead. Global commands work everywhere but can take up to an hour to update, so per-server registration is the friendlier choice while you build.
+
+To keep the bot online and bring it back after a crash or reboot, run it under a process manager.
 
 <Columns cols={2}>
   <Card title="systemd" href="/guides/ecosystem/systemd" icon="server">

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -26,7 +26,7 @@ bun add discord.js
 
 ---
 
-Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/legacy/preparations/app-setup#creating-your-bot) has screenshots if you get lost.
+Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/preparations/setting-up-a-bot-application) has screenshots if you get lost.
 
 Copy two values from the portal:
 
@@ -35,7 +35,7 @@ Copy two values from the portal:
 
 ---
 
-A bot can't do anything in a server until you invite it. In the portal's **OAuth2** section, generate an invite URL with the `bot` and `applications.commands` scopes, open it, and add the bot to a server you manage. Slash commands need the `applications.commands` scope, so don't skip it. A personal server you make for testing is the easiest place to start.
+A bot can't do anything in a server until you invite it. In the portal's **OAuth2** section, generate an invite URL with the `bot` and `applications.commands` scopes, open it, and add the bot to a server you manage. Slash commands need the `applications.commands` scope, so don't skip it. A personal server you make for testing is the easiest place to start, and Discord's [guide to adding a bot](https://discordjs.guide/preparations/adding-your-bot-to-servers) walks through it with screenshots.
 
 ---
 
@@ -67,15 +67,18 @@ Discord has to know about a command before anyone can use it. Register `/ping` w
 ```ts deploy-commands.ts icon="/icons/typescript.svg"
 import { REST, Routes, SlashCommandBuilder } from "discord.js";
 
+const { DISCORD_TOKEN, DISCORD_CLIENT_ID, DISCORD_GUILD_ID } = process.env;
+if (!DISCORD_TOKEN || !DISCORD_CLIENT_ID || !DISCORD_GUILD_ID) {
+  throw new Error("Set DISCORD_TOKEN, DISCORD_CLIENT_ID, and DISCORD_GUILD_ID in .env.local");
+}
+
 // the commands you want to register
 const commands = [new SlashCommandBuilder().setName("ping").setDescription("Replies with Pong!").toJSON()];
 
-const rest = new REST().setToken(process.env.DISCORD_TOKEN!);
+const rest = new REST().setToken(DISCORD_TOKEN);
 
 // register them in your server, where they appear instantly
-await rest.put(Routes.applicationGuildCommands(process.env.DISCORD_CLIENT_ID!, process.env.DISCORD_GUILD_ID!), {
-  body: commands,
-});
+await rest.put(Routes.applicationGuildCommands(DISCORD_CLIENT_ID, DISCORD_GUILD_ID), { body: commands });
 
 console.log("Registered /ping");
 ```
@@ -95,6 +98,11 @@ Now the bot itself. Save it as `bot.ts`.
 ```ts bot.ts icon="/icons/typescript.svg"
 import { Client, Events, GatewayIntentBits } from "discord.js";
 
+const { DISCORD_TOKEN } = process.env;
+if (!DISCORD_TOKEN) {
+  throw new Error("Set DISCORD_TOKEN in .env.local");
+}
+
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // runs once, right after the bot connects
@@ -111,7 +119,7 @@ client.on(Events.InteractionCreate, async interaction => {
   }
 });
 
-client.login(process.env.DISCORD_TOKEN);
+client.login(DISCORD_TOKEN);
 ```
 
 The ready handler logs a line once the bot connects. After that, `interactionCreate` runs whenever someone uses a slash command; it confirms the command was `/ping` and replies with `Pong!`.

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -148,7 +148,7 @@ To add another command, define it in `deploy-commands.ts`, run that script again
 
 When you deploy, there's no build or bundling step. Bun runs `bot.ts` and every file it imports directly, so you ship your source as-is and start it with the same `bun run bot.ts` you use while developing.
 
-`deploy-commands.ts` registers `/ping` in your test server, which is the right scope while you're building. To publish the bot to every server it joins, register globally instead: change the route from `Routes.applicationGuildCommands(...)` to `Routes.applicationCommands(...)`, passing just the application ID.
+`deploy-commands.ts` registers `/ping` in your test server, which is the right scope while you're building. To publish the bot to every server it joins, register globally instead: change the route to `Routes.applicationCommands(DISCORD_CLIENT_ID)`. Global registration doesn't use a server, so you can also drop `DISCORD_GUILD_ID` from the script's check and from `.env.local`.
 
 To keep the bot online and bring it back after a crash or reboot, run it under a process manager.
 

--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -61,9 +61,7 @@ import { Client, Events, GatewayIntentBits, SlashCommandBuilder } from "discord.
 const client = new Client({ intents: [GatewayIntentBits.Guilds] });
 
 // the command people see when they type "/" in your server
-const ping = new SlashCommandBuilder()
-  .setName("ping")
-  .setDescription("Replies with Pong!");
+const ping = new SlashCommandBuilder().setName("ping").setDescription("Replies with Pong!");
 
 // runs once, right after the bot connects
 client.once(Events.ClientReady, async readyClient => {


### PR DESCRIPTION
## What

Rewrites the Discord.js guide so it ends with a bot that actually does something: a `/ping` slash command that replies `Pong!`. The previous version stopped at a bot that logged in and then sat idle.

The guide now follows the structure discord.js's own guide recommends:

- `deploy-commands.ts`: a standalone script that registers `/ping` with Discord using the REST route (`Routes.applicationGuildCommands`), run once.
- `bot.ts`: the runtime, with the `interactionCreate` handler that replies.

It also spells out the steps a first-timer needs: inviting the bot with the `applications.commands` scope, copying the application ID and server ID, and storing `DISCORD_TOKEN`, `DISCORD_CLIENT_ID`, and `DISCORD_GUILD_ID` in `.env.local`. The existing "no build step" deployment note and the systemd/PM2 links are kept.

## Why

Slash commands are how bots are built on Discord today, and they need no privileged intents, so the bot runs with just `GatewayIntentBits.Guilds`. The old guide's `ready`-only example left readers with a connected bot and no way to make it respond.

Command registration lives in a separate REST script rather than running on every `ready` event, which is what the official guide recommends (commands only need registering when their definition changes, and there is a daily command-creation limit). Registration is guild-scoped so the command appears instantly while developing; the deploy section explains switching to the global route for production.

This also points the API reference link at `https://discord.js.org/docs`, the same correction made in #31187 (that PR can be closed once this lands). An earlier revision carried a "global commands can take up to an hour to update" note; that was removed because Discord dropped the global command cache in 2022 and the current official guide no longer claims it.

## Verification

Both `deploy-commands.ts` and `bot.ts` shown in the guide were checked against `discord.js@14.26.4` (latest):

- `tsc --noEmit` under `strict` passes for both files.
- Both run on Bun and issue the real API calls; with invalid credentials they fail with the expected `DiscordAPIError`, confirming imports, REST registration, client construction, and login all work.
- `Events.ClientReady` resolves to `'clientReady'` and `Events.InteractionCreate` to `'interactionCreate'` in 14.26.
- `new SlashCommandBuilder().setName("ping").setDescription(...).toJSON()` produces a valid command payload, and `Routes.applicationGuildCommands(clientId, guildId)` builds the correct REST path.

Live behavior (registering against real Discord and receiving a `/ping` interaction) was not exercised: it needs a real bot token and test server.

Docs-only change, no native code touched.

Fixes #31186 (the stale `discordjs.guide` API link).