### PR TITLE
docs: fix dead discordjs.guide links in Discord.js bot guide

### DIFF
--- a/docs/guides/ecosystem/discordjs.mdx
+++ b/docs/guides/ecosystem/discordjs.mdx
@@ -26,7 +26,7 @@ bun add discord.js
 
 ---
 
-Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/preparations/setting-up-a-bot-application) has screenshots if you get lost.
+Your bot needs its own account, which you create in Discord's developer portal. Open the [developer portal](https://discord.com/developers/applications), sign in, and create an **Application**. Inside it, open the **Bot** tab to create the bot user. Discord's [setup walkthrough](https://discordjs.guide/legacy/preparations/app-setup) has screenshots if you get lost.
 
 Copy two values from the portal:
 
@@ -35,7 +35,7 @@ Copy two values from the portal:
 
 ---
 
-A bot can't do anything in a server until you invite it. In the portal's **OAuth2** section, generate an invite URL with the `bot` and `applications.commands` scopes, open it, and add the bot to a server you manage. Slash commands need the `applications.commands` scope, so don't skip it. A personal server you make for testing is the easiest place to start, and Discord's [guide to adding a bot](https://discordjs.guide/preparations/adding-your-bot-to-servers) walks through it with screenshots.
+A bot can't do anything in a server until you invite it. In the portal's **OAuth2** section, generate an invite URL with the `bot` and `applications.commands` scopes, open it, and add the bot to a server you manage. Slash commands need the `applications.commands` scope, so don't skip it. A personal server you make for testing is the easiest place to start, and Discord's [guide to adding a bot](https://discordjs.guide/legacy/preparations/adding-your-app) walks through it with screenshots.
 
 ---
 


### PR DESCRIPTION
## What

Fixes two dead links to `discordjs.guide` in the Discord.js ecosystem guide introduced by #32237.

| Before (404) | After |
| --- | --- |
| `discordjs.guide/preparations/setting-up-a-bot-application` | `discordjs.guide/legacy/preparations/app-setup` |
| `discordjs.guide/preparations/adding-your-bot-to-servers` | `discordjs.guide/legacy/preparations/adding-your-app` |

## Why

discordjs.guide was rebuilt and moved into the discord.js monorepo at [`apps/guide`](https://github.com/discordjs/discord.js/tree/main/apps/guide), served via fumadocs with a different route layout. The v14 material now lives under `/legacy/` and several pages were renamed (`setting-up-a-bot-application` → `app-setup`, `adding-your-bot-to-servers` → `adding-your-app`).

The replacement pages contain the same content and the same screenshots the guide text references: `app-setup.mdx` walks through creating the application and copying the token (images `create-app.png`, `created-bot.png`), and `adding-your-app.mdx` walks through the OAuth2 invite flow (images `bot-auth-page.png`, `bot-authorized.png`, `bot-in-memberlist.png`).

The other external links in the guide (`https://discord.com/developers/applications` and `https://discord.js.org/docs`, which redirects to the latest package docs via [middleware](https://github.com/discordjs/discord.js/blob/main/apps/website/src/middleware.ts)) are unchanged and still valid.

## Verification

Confirmed the new paths exist in the discord.js repo tree:

- [`apps/guide/content/docs/legacy/preparations/app-setup.mdx`](https://github.com/discordjs/discord.js/blob/main/apps/guide/content/docs/legacy/preparations/app-setup.mdx)
- [`apps/guide/content/docs/legacy/preparations/adding-your-app.mdx`](https://github.com/discordjs/discord.js/blob/main/apps/guide/content/docs/legacy/preparations/adding-your-app.mdx)

fumadocs `baseUrl` is [`/`](https://github.com/discordjs/discord.js/blob/main/apps/guide/src/lib/source.ts) and the docs dir is `content/docs`, so these map to `/legacy/preparations/app-setup` and `/legacy/preparations/adding-your-app` on the live site. The guide's own index also links to [`./legacy/preparations/app-setup`](https://github.com/discordjs/discord.js/blob/main/apps/guide/content/docs/legacy/index.mdx).

Docs-only change.