### PR TITLE
Fix BroadcastChannel custom inspect crash with numeric option keys

### DIFF
--- a/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
+++ b/src/jsc/bindings/webcore/JSBroadcastChannel.cpp
@@ -199,7 +199,7 @@ JSC_DEFINE_HOST_FUNCTION(jsBroadcastChannelPrototype_inspectCustom, (JSC::JSGlob
         JSValue value = options->get(lexicalGlobalObject, name);
         RETURN_IF_EXCEPTION(throwScope, {});
 
-        newOptions->putDirect(vm, name, value, 0);
+        newOptions->putDirectMayBeIndex(lexicalGlobalObject, name, value);
         RETURN_IF_EXCEPTION(throwScope, {});
     }
 

--- a/test/js/web/broadcastchannel/broadcast-channel.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel.test.ts
@@ -222,3 +222,12 @@ test("user options are forwarded through custom inspect", () => {
     "BroadcastChannel { name:\n   'hello',\n  active:\n   true }",
   );
 });
+
+test("custom inspect handles options with numeric keys", () => {
+  const bc = new BroadcastChannel("hello");
+  bc.unref();
+  const inspectCustom = bc[Symbol.for("nodejs.util.inspect.custom")];
+  const opts = { 0: "a", 1: "b", depth: 2 };
+  expect(inspectCustom.call(bc, 2, opts, util.inspect)).toBe("BroadcastChannel { name: 'hello', active: true }");
+  bc.close();
+});


### PR DESCRIPTION
Fuzzilli found a debug assertion crash with fingerprint `JSObjectInlines.h(451)`:

```
ASSERTION FAILED: !parseIndex(propertyName)
JSObjectInlines.h(451) : JSC::JSObject::putDirectInternal
```

## Root cause

`BroadcastChannel.prototype[Symbol.for('nodejs.util.inspect.custom')]` copies the incoming inspect options into a fresh object by enumerating property names and calling `putDirect` for each. `putDirect` asserts that the property name is not an array index, so any numeric key on the options object (or reachable via its prototype chain, since `getPropertyNames` walks the chain) trips the assertion.

Minimal repro:

```js
const bc = new BroadcastChannel('test');
const sym = Symbol.for('nodejs.util.inspect.custom');
bc[sym](2, { 0: 'x', depth: 2 }, () => {});
```

## Fix

Use `putDirectMayBeIndex` instead of `putDirect`, matching the pattern already used by `JSDOMFormData`, `JSFetchHeaders`, `CookieMap`, and the structured clone slow path for the same situation.

## Test

Added a test to `test/js/web/broadcastchannel/broadcast-channel.test.ts` that calls the custom inspect with numeric-keyed options. On the unfixed debug build it aborts with the assertion above; with the fix it returns the expected inspect string.