### PR TITLE
net: stop re-emitting post-upgrade bytes on the original socket after tls.connect({ socket })

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1944,6 +1944,12 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   // pulled off the fd into the connection's readable buffer; hand them to the
   // TLS engine so the handshake doesn't stall.
   const pending = connection.read();
+  // Set before upgradeTLS: with non-empty initialData the native side enables
+  // the ciphertext tap and synchronously feeds those bytes inside this call,
+  // firing ServerHandlers.data on the original accepted socket before it returns.
+  // The flag must already be set so the guard suppresses that re-emission; once
+  // TLS owns the stream those bytes belong to the TLS layer, not this socket.
+  connection[kupgradedToTLS] = true;
   const result = socket.upgradeTLS({
     data: this,
     tls,
@@ -1952,15 +1958,12 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     initialData: pending || undefined,
   });
   if (!result) {
+    connection[kupgradedToTLS] = false;
     this._handle = null;
     throw new Error("Invalid socket");
   }
   const [raw, tlsHandle] = result;
   connection._handle = raw;
-  // The raw half keeps delivering post-upgrade ciphertext to the original
-  // accepted socket's handlers. Once TLS owns the stream, stop surfacing those
-  // bytes as cleartext `data` on the original socket (matches the client path).
-  connection[kupgradedToTLS] = true;
   this.once("end", this[kCloseRawConnection]);
   raw.connecting = false;
   this._handle = tlsHandle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -266,11 +266,13 @@ const SocketHandlers: SocketHandler = {
   data(socket, buffer) {
     const { data: self } = socket;
     if (!self) return;
-    // Post-upgrade ciphertext belongs to the TLS layer, not this socket.
-    if (self[kupgradedToTLS]) return;
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // After `tls.connect({ socket })` the raw half still sees the post-upgrade
+    // ciphertext. This socket is the transport, so keep its idle timer and byte
+    // count live, but don't re-emit those bytes as cleartext `data`.
+    if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) {
       socket.pause();
     }
@@ -1011,12 +1013,12 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   data(socket, buffer) {
     $debug("Bun.Socket data");
     const { self } = socket.data;
-    // After `tls.connect({ socket })` the raw half still sees the
-    // post-upgrade ciphertext; the TLS layer owns those bytes now, so don't
-    // re-emit them as cleartext `data` on the original socket.
-    if (self[kupgradedToTLS]) return;
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // After `tls.connect({ socket })` the raw half still sees the post-upgrade
+    // ciphertext. This socket is the transport, so keep its idle timer and byte
+    // count live, but don't re-emit those bytes as cleartext `data`.
+    if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) socket.pause();
   },
   drain(socket) {
@@ -1369,9 +1371,10 @@ function Socket(options?) {
       data(socket, buffer) {
         const { self } = socket.data;
         if (!self) return;
-        // Post-upgrade ciphertext belongs to the TLS layer, not this socket.
-        if (self[kupgradedToTLS]) return;
         self._unrefTimer();
+        // Post-upgrade ciphertext belongs to the TLS layer. Keep the idle timer
+        // live (this socket is the transport) but don't surface the bytes.
+        if (self[kupgradedToTLS]) return;
         try {
           onread.callback(buffer.length, buffer);
         } catch (e) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3523,6 +3523,9 @@ function initSocketHandle(self) {
   self._sockname = null;
   self[kclosed] = false;
   self[kended] = false;
+  // A reused socket may have been adopted by a TLS wrapper on a prior connect;
+  // clear the latch so its data handlers aren't silenced on the new connection.
+  self[kupgradedToTLS] = false;
 
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -600,6 +600,11 @@ const ServerHandlers: SocketHandler<NetSocket> = {
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // Server-side `new tls.TLSSocket(accepted, { isServer: true })` upgrades the
+    // accepted socket via bunUpgradeServerTLS; the raw half still sees the
+    // post-upgrade ciphertext. This socket is the transport, so keep its idle
+    // timer and byte count live, but don't re-emit those bytes as cleartext.
+    if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) {
       socket.pause();
     }
@@ -1952,6 +1957,10 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   }
   const [raw, tlsHandle] = result;
   connection._handle = raw;
+  // The raw half keeps delivering post-upgrade ciphertext to the original
+  // accepted socket's handlers. Once TLS owns the stream, stop surfacing those
+  // bytes as cleartext `data` on the original socket (matches the client path).
+  connection[kupgradedToTLS] = true;
   this.once("end", this[kCloseRawConnection]);
   raw.connecting = false;
   this._handle = tlsHandle;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -151,6 +151,7 @@ const kUserUnrefed = Symbol("kUserUnrefed");
 // only restore a hold they actually removed - re-refing a handle that never
 // held the loop (a wrapped duplex with no fd) would pin the process.
 const kPausedUnref = Symbol("kPausedUnref");
+const kupgradedToTLS = Symbol("kupgradedToTLS");
 const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
@@ -265,6 +266,8 @@ const SocketHandlers: SocketHandler = {
   data(socket, buffer) {
     const { data: self } = socket;
     if (!self) return;
+    // Post-upgrade ciphertext belongs to the TLS layer, not this socket.
+    if (self[kupgradedToTLS]) return;
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
@@ -1008,6 +1011,10 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
   data(socket, buffer) {
     $debug("Bun.Socket data");
     const { self } = socket.data;
+    // After `tls.connect({ socket })` the raw half still sees the
+    // post-upgrade ciphertext; the TLS layer owns those bytes now, so don't
+    // re-emit them as cleartext `data` on the original socket.
+    if (self[kupgradedToTLS]) return;
     self._unrefTimer();
     self.bytesRead += buffer.length;
     if (!self.push(buffer)) socket.pause();
@@ -1309,6 +1316,7 @@ function Socket(options?) {
   this._parentWrap = null;
   this[kpendingRead] = undefined;
   this[kupgraded] = null;
+  this[kupgradedToTLS] = false;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
@@ -1361,6 +1369,8 @@ function Socket(options?) {
       data(socket, buffer) {
         const { self } = socket.data;
         if (!self) return;
+        // Post-upgrade ciphertext belongs to the TLS layer, not this socket.
+        if (self[kupgradedToTLS]) return;
         self._unrefTimer();
         try {
           onread.callback(buffer.length, buffer);
@@ -1630,6 +1640,11 @@ Socket.prototype.connect = function connect(...args) {
               const [raw, tls] = result;
               // replace socket
               connection._handle = raw;
+              // The raw half keeps delivering post-upgrade bytes (ciphertext)
+              // to the original socket's handlers. Once TLS owns the stream,
+              // those bytes belong to the TLS layer, so stop surfacing them as
+              // cleartext `data` on the original socket (matches Node).
+              connection[kupgradedToTLS] = true;
               this.once("end", this[kCloseRawConnection]);
               raw.connecting = false;
               this._handle = tls;
@@ -1676,6 +1691,8 @@ Socket.prototype.connect = function connect(...args) {
                   const [raw, tls] = result;
                   // replace socket
                   connection._handle = raw;
+                  // See the comment on the synchronous branch above.
+                  connection[kupgradedToTLS] = true;
                   this.once("end", this[kCloseRawConnection]);
                   raw.connecting = false;
                   this._handle = tls;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1950,13 +1950,22 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   // The flag must already be set so the guard suppresses that re-emission; once
   // TLS owns the stream those bytes belong to the TLS layer, not this socket.
   connection[kupgradedToTLS] = true;
-  const result = socket.upgradeTLS({
-    data: this,
-    tls,
-    socket: serverHandlersFor(this),
-    isServer: true,
-    initialData: pending || undefined,
-  });
+  let result;
+  try {
+    result = socket.upgradeTLS({
+      data: this,
+      tls,
+      socket: serverHandlersFor(this),
+      isServer: true,
+      initialData: pending || undefined,
+    });
+  } catch (error) {
+    // A thrown upgrade (e.g. bad cert/key/cipher) must not leave the accepted
+    // socket latched, or its data handlers stay silent for a socket that was
+    // never actually wrapped.
+    connection[kupgradedToTLS] = false;
+    throw error;
+  }
   if (!result) {
     connection[kupgradedToTLS] = false;
     this._handle = null;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -269,9 +269,7 @@ const SocketHandlers: SocketHandler = {
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
-    // After `tls.connect({ socket })` the raw half still sees the post-upgrade
-    // ciphertext. This socket is the transport, so keep its idle timer and byte
-    // count live, but don't re-emit those bytes as cleartext `data`.
+    // Post-upgrade ciphertext belongs to the TLS layer; don't re-emit it as cleartext.
     if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) {
       socket.pause();
@@ -600,10 +598,7 @@ const ServerHandlers: SocketHandler<NetSocket> = {
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
-    // Server-side `new tls.TLSSocket(accepted, { isServer: true })` upgrades the
-    // accepted socket via bunUpgradeServerTLS; the raw half still sees the
-    // post-upgrade ciphertext. This socket is the transport, so keep its idle
-    // timer and byte count live, but don't re-emit those bytes as cleartext.
+    // Post-upgrade ciphertext belongs to the TLS layer; don't re-emit it as cleartext.
     if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) {
       socket.pause();
@@ -1020,9 +1015,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     const { self } = socket.data;
     self._unrefTimer();
     self.bytesRead += buffer.length;
-    // After `tls.connect({ socket })` the raw half still sees the post-upgrade
-    // ciphertext. This socket is the transport, so keep its idle timer and byte
-    // count live, but don't re-emit those bytes as cleartext `data`.
+    // Post-upgrade ciphertext belongs to the TLS layer; don't re-emit it as cleartext.
     if (self[kupgradedToTLS]) return;
     if (!self.push(buffer)) socket.pause();
   },
@@ -1377,8 +1370,7 @@ function Socket(options?) {
         const { self } = socket.data;
         if (!self) return;
         self._unrefTimer();
-        // Post-upgrade ciphertext belongs to the TLS layer. Keep the idle timer
-        // live (this socket is the transport) but don't surface the bytes.
+        // Post-upgrade ciphertext belongs to the TLS layer; don't surface it.
         if (self[kupgradedToTLS]) return;
         try {
           onread.callback(buffer.length, buffer);
@@ -1648,10 +1640,7 @@ Socket.prototype.connect = function connect(...args) {
               const [raw, tls] = result;
               // replace socket
               connection._handle = raw;
-              // The raw half keeps delivering post-upgrade bytes (ciphertext)
-              // to the original socket's handlers. Once TLS owns the stream,
-              // those bytes belong to the TLS layer, so stop surfacing them as
-              // cleartext `data` on the original socket (matches Node).
+              // Stop surfacing post-upgrade bytes on the original socket (matches Node).
               connection[kupgradedToTLS] = true;
               this.once("end", this[kCloseRawConnection]);
               raw.connecting = false;
@@ -1944,11 +1933,8 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   // pulled off the fd into the connection's readable buffer; hand them to the
   // TLS engine so the handshake doesn't stall.
   const pending = connection.read();
-  // Set before upgradeTLS: with non-empty initialData the native side enables
-  // the ciphertext tap and synchronously feeds those bytes inside this call,
-  // firing ServerHandlers.data on the original accepted socket before it returns.
-  // The flag must already be set so the guard suppresses that re-emission; once
-  // TLS owns the stream those bytes belong to the TLS layer, not this socket.
+  // Must be set before upgradeTLS: native feeds initialData through the
+  // ciphertext tap synchronously inside this call.
   connection[kupgradedToTLS] = true;
   let result;
   try {
@@ -1960,9 +1946,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
       initialData: pending || undefined,
     });
   } catch (error) {
-    // A thrown upgrade (e.g. bad cert/key/cipher) must not leave the accepted
-    // socket latched, or its data handlers stay silent for a socket that was
-    // never actually wrapped.
+    // TLS never took ownership; don't leave the socket latched.
     connection[kupgradedToTLS] = false;
     throw error;
   }
@@ -3547,8 +3531,7 @@ function initSocketHandle(self) {
   self._sockname = null;
   self[kclosed] = false;
   self[kended] = false;
-  // A reused socket may have been adopted by a TLS wrapper on a prior connect;
-  // clear the latch so its data handlers aren't silenced on the new connection.
+  // Clear the TLS-upgrade latch for socket reuse.
   self[kupgradedToTLS] = false;
 
   // Handle creation may be deferred to bind() or connect() time.

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1933,8 +1933,7 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
   // pulled off the fd into the connection's readable buffer; hand them to the
   // TLS engine so the handshake doesn't stall.
   const pending = connection.read();
-  // Must be set before upgradeTLS: native feeds initialData through the
-  // ciphertext tap synchronously inside this call.
+  // Set before upgradeTLS: it feeds initialData through the ciphertext tap synchronously.
   connection[kupgradedToTLS] = true;
   let result;
   try {

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -60,3 +60,64 @@ test("should be able to upgrade a paused socket and also have backpressure on it
 
   expect().pass();
 });
+
+test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the original socket (STARTTLS) #32239", async () => {
+  // Mock STARTTLS server: greet, reply PROCEED to STARTTLS, then send mock TLS
+  // bytes in reply to the client's ClientHello. Those mock bytes must reach
+  // the TLS layer (OpenSSL rejects them) rather than re-surface as cleartext
+  // `data` on the original socket, which in the issue re-entered the handler
+  // and threw "Invalid socket".
+  const server = net.createServer(serverSocket => {
+    serverSocket.on("error", () => {});
+    serverSocket.write("SERVER_GREETING");
+    let phase = "greeting";
+    serverSocket.on("data", data => {
+      if (phase === "greeting" && data.toString().includes("STARTTLS")) {
+        phase = "proceed";
+        serverSocket.write("PROCEED");
+      } else if (phase === "proceed") {
+        phase = "done";
+        serverSocket.write(Buffer.alloc(50, 0x16));
+      }
+    });
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const { promise, resolve } = Promise.withResolvers<{ upgrades: number; dataEvents: number; message: string }>();
+
+  let dataEvents = 0;
+  let upgrades = 0;
+  let upgraded = false;
+
+  const socket = net.connect(port, "127.0.0.1");
+  socket.on("error", () => {});
+  socket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+
+  socket.on("data", data => {
+    dataEvents++;
+    if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
+      socket.write("STARTTLS");
+      return;
+    }
+    // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
+    // re-emitted ciphertext) both land here, mirroring the issue's handler.
+    upgraded = true;
+    upgrades++;
+    const tlsSocket = tls.connect({ socket, host: "127.0.0.1", rejectUnauthorized: false });
+    tlsSocket.on("error", err => resolve({ upgrades, dataEvents, message: err.message }));
+    tlsSocket.on("secureConnect", () => resolve({ upgrades, dataEvents, message: "" }));
+    tlsSocket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+  });
+
+  const result = await promise;
+  server.close();
+  socket.destroy();
+
+  // The original socket must go quiet after the upgrade: the upgrade is
+  // attempted exactly once and never fails with "Invalid socket".
+  expect(result.message).not.toContain("Invalid socket");
+  expect(result.upgrades).toBe(1);
+  expect(result.dataEvents).toBe(2);
+});

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -134,7 +134,11 @@ test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrad
   // negotiation the server wraps the accepted socket with an isServer TLSSocket.
   // The client's ClientHello (ciphertext) must reach the TLS layer, not resurface
   // as cleartext `data` on the accepted socket and re-enter the server's handler.
-  const { promise, resolve } = Promise.withResolvers<{ wrapped: boolean; dataAfterUpgrade: boolean; message: string }>();
+  const { promise, resolve } = Promise.withResolvers<{
+    wrapped: boolean;
+    dataAfterUpgrade: boolean;
+    message: string;
+  }>();
 
   let dataAfterUpgrade = false;
   let wrapped = false;

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -92,32 +92,39 @@ test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the origina
   let upgraded = false;
 
   const socket = net.connect(port, "127.0.0.1");
-  socket.on("error", () => {});
-  socket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+  try {
+    // Errors are an expected outcome here: OpenSSL rejects the mock handshake
+    // bytes (the TLS socket emits `error`) and the underlying socket may reset
+    // during teardown. Every terminal event settles `promise`, so a regression
+    // surfaces as a failed assertion on the resolved values rather than a hang.
+    socket.on("error", () => {});
+    socket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
 
-  socket.on("data", data => {
-    dataEvents++;
-    if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
-      socket.write("STARTTLS");
-      return;
-    }
-    // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
-    // re-emitted ciphertext) both land here, mirroring the issue's handler.
-    upgraded = true;
-    upgrades++;
-    const tlsSocket = tls.connect({ socket, host: "127.0.0.1", rejectUnauthorized: false });
-    tlsSocket.on("error", err => resolve({ upgrades, dataEvents, message: err.message }));
-    tlsSocket.on("secureConnect", () => resolve({ upgrades, dataEvents, message: "" }));
-    tlsSocket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
-  });
+    socket.on("data", data => {
+      dataEvents++;
+      if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
+        socket.write("STARTTLS");
+        return;
+      }
+      // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
+      // re-emitted ciphertext) both land here, mirroring the issue's handler.
+      upgraded = true;
+      upgrades++;
+      const tlsSocket = tls.connect({ socket, host: "127.0.0.1", rejectUnauthorized: false });
+      tlsSocket.on("error", err => resolve({ upgrades, dataEvents, message: err.message }));
+      tlsSocket.on("secureConnect", () => resolve({ upgrades, dataEvents, message: "" }));
+      tlsSocket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+    });
 
-  const result = await promise;
-  server.close();
-  socket.destroy();
+    const result = await promise;
 
-  // The original socket must go quiet after the upgrade: the upgrade is
-  // attempted exactly once and never fails with "Invalid socket".
-  expect(result.message).not.toContain("Invalid socket");
-  expect(result.upgrades).toBe(1);
-  expect(result.dataEvents).toBe(2);
+    // The original socket must go quiet after the upgrade: the upgrade is
+    // attempted exactly once and never fails with "Invalid socket".
+    expect(result.message).not.toContain("Invalid socket");
+    expect(result.upgrades).toBe(1);
+    expect(result.dataEvents).toBe(2);
+  } finally {
+    socket.destroy();
+    server.close();
+  }
 });

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -85,9 +85,8 @@ test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the origina
   await once(server.listen(0, "127.0.0.1"), "listening");
   const { port } = server.address() as net.AddressInfo;
 
-  const { promise, resolve } = Promise.withResolvers<{ upgrades: number; dataEvents: number; message: string }>();
+  const { promise, resolve } = Promise.withResolvers<{ upgrades: number; message: string }>();
 
-  let dataEvents = 0;
   let upgrades = 0;
   let upgraded = false;
 
@@ -98,10 +97,9 @@ test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the origina
     // during teardown. Every terminal event settles `promise`, so a regression
     // surfaces as a failed assertion on the resolved values rather than a hang.
     socket.on("error", () => {});
-    socket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+    socket.on("close", () => resolve({ upgrades, message: "" }));
 
     socket.on("data", data => {
-      dataEvents++;
       if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
         socket.write("STARTTLS");
         return;
@@ -111,18 +109,20 @@ test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the origina
       upgraded = true;
       upgrades++;
       const tlsSocket = tls.connect({ socket, host: "127.0.0.1", rejectUnauthorized: false });
-      tlsSocket.on("error", err => resolve({ upgrades, dataEvents, message: err.message }));
-      tlsSocket.on("secureConnect", () => resolve({ upgrades, dataEvents, message: "" }));
-      tlsSocket.on("close", () => resolve({ upgrades, dataEvents, message: "" }));
+      tlsSocket.on("error", err => resolve({ upgrades, message: err.message }));
+      tlsSocket.on("secureConnect", () => resolve({ upgrades, message: "" }));
+      tlsSocket.on("close", () => resolve({ upgrades, message: "" }));
     });
 
     const result = await promise;
 
-    // The original socket must go quiet after the upgrade: the upgrade is
-    // attempted exactly once and never fails with "Invalid socket".
+    // The original socket must go quiet after the upgrade: once TLS owns the
+    // stream no further `data` event re-enters the handler, so exactly one
+    // upgrade is attempted and it never fails with "Invalid socket". (A
+    // re-emitted post-upgrade chunk would land in the upgrade branch and push
+    // `upgrades` past 1.)
     expect(result.message).not.toContain("Invalid socket");
     expect(result.upgrades).toBe(1);
-    expect(result.dataEvents).toBe(2);
   } finally {
     socket.destroy();
     server.close();

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -134,9 +134,10 @@ test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrad
   // negotiation the server wraps the accepted socket with an isServer TLSSocket.
   // The client's ClientHello (ciphertext) must reach the TLS layer, not resurface
   // as cleartext `data` on the accepted socket and re-enter the server's handler.
-  const { promise, resolve } = Promise.withResolvers<{ dataAfterUpgrade: boolean; message: string }>();
+  const { promise, resolve } = Promise.withResolvers<{ wrapped: boolean; dataAfterUpgrade: boolean; message: string }>();
 
   let dataAfterUpgrade = false;
+  let wrapped = false;
 
   const server = net.createServer(accepted => {
     let upgraded = false;
@@ -152,8 +153,9 @@ test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrad
         upgraded = true;
         accepted.write("PROCEED");
         const tlsSock = new tls.TLSSocket(accepted, { isServer: true, key: certs.key, cert: certs.cert });
-        tlsSock.on("error", () => resolve({ dataAfterUpgrade, message: "" }));
-        tlsSock.on("secure", () => resolve({ dataAfterUpgrade, message: "" }));
+        wrapped = true;
+        tlsSock.on("error", () => resolve({ wrapped, dataAfterUpgrade, message: "" }));
+        tlsSock.on("secure", () => resolve({ wrapped, dataAfterUpgrade, message: "" }));
       }
     });
   });
@@ -164,20 +166,23 @@ test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrad
   const socket = net.connect(port, "127.0.0.1");
   try {
     socket.on("error", () => {});
-    socket.on("close", () => resolve({ dataAfterUpgrade, message: "" }));
+    socket.on("close", () => resolve({ wrapped, dataAfterUpgrade, message: "" }));
     socket.on("data", data => {
       const text = data.toString("latin1");
       if (text.includes("SERVER_GREETING")) {
         socket.write("STARTTLS");
       } else if (text.includes("PROCEED")) {
         const tlsSocket = tls.connect({ socket, servername: "localhost", rejectUnauthorized: false });
-        tlsSocket.on("error", err => resolve({ dataAfterUpgrade, message: err.message }));
-        tlsSocket.on("secureConnect", () => resolve({ dataAfterUpgrade, message: "" }));
+        tlsSocket.on("error", err => resolve({ wrapped, dataAfterUpgrade, message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ wrapped, dataAfterUpgrade, message: "" }));
       }
     });
 
     const result = await promise;
 
+    // The server must actually have wrapped the accepted socket (guards against
+    // an early close settling the promise before the upgrade ran).
+    expect(result.wrapped).toBe(true);
     // The accepted socket must go quiet once the server TLS layer owns the stream.
     expect(result.dataAfterUpgrade).toBe(false);
     expect(result.message).not.toContain("Invalid socket");
@@ -193,7 +198,7 @@ test("server-side TLS upgrade does not re-inject buffered ClientHello (initialDa
   // side feeds it synchronously during upgradeTLS and fires the raw tap before
   // upgradeTLS returns. The flag must be set before that call so the buffered
   // bytes are not re-pushed back into the accepted socket's readable buffer.
-  const { promise, resolve } = Promise.withResolvers<{ reinjected: boolean }>();
+  const { promise, resolve } = Promise.withResolvers<{ wrapped: boolean; reinjected: boolean }>();
 
   const server = net.createServer(accepted => {
     accepted.on("error", () => {});
@@ -212,7 +217,7 @@ test("server-side TLS upgrade does not re-inject buffered ClientHello (initialDa
         tlsSock.on("error", () => {});
         // On the unfixed build the buffered ClientHello is synchronously
         // re-pushed into the accepted socket's readable buffer during the wrap.
-        resolve({ reinjected: accepted.readableLength > 0 });
+        resolve({ wrapped: true, reinjected: accepted.readableLength > 0 });
       });
     });
   });
@@ -223,7 +228,9 @@ test("server-side TLS upgrade does not re-inject buffered ClientHello (initialDa
   const socket = net.connect(port, "127.0.0.1");
   try {
     socket.on("error", () => {});
-    socket.on("close", () => resolve({ reinjected: false }));
+    // An early close resolves wrapped:false so the assertion fails rather than
+    // vacuously passing before the wrap ran.
+    socket.on("close", () => resolve({ wrapped: false, reinjected: false }));
     socket.on("data", data => {
       const text = data.toString("latin1");
       if (text.includes("SERVER_GREETING")) {
@@ -236,6 +243,9 @@ test("server-side TLS upgrade does not re-inject buffered ClientHello (initialDa
 
     const result = await promise;
 
+    // The wrap must have actually run (guards against an early close settling
+    // the promise with the passing default).
+    expect(result.wrapped).toBe(true);
     // The buffered ClientHello must reach the TLS engine, not resurface as
     // readable bytes on the accepted socket.
     expect(result.reinjected).toBe(false);

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -186,3 +186,61 @@ test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrad
     server.close();
   }
 });
+
+test("server-side TLS upgrade does not re-inject buffered ClientHello (initialData) #32239", async () => {
+  // When the ClientHello is already buffered on the accepted socket at wrap time
+  // (readable/paused-mode STARTTLS with an async gap before the wrap), the native
+  // side feeds it synchronously during upgradeTLS and fires the raw tap before
+  // upgradeTLS returns. The flag must be set before that call so the buffered
+  // bytes are not re-pushed back into the accepted socket's readable buffer.
+  const { promise, resolve } = Promise.withResolvers<{ reinjected: boolean }>();
+
+  const server = net.createServer(accepted => {
+    accepted.on("error", () => {});
+    accepted.write("SERVER_GREETING");
+    let negotiated = false;
+    accepted.on("data", function onData(chunk) {
+      if (negotiated || !chunk.toString("latin1").includes("STARTTLS")) return;
+      negotiated = true;
+      accepted.write("PROCEED");
+      // Switch to paused mode so the client's ClientHello buffers instead of
+      // flowing; the wrap then sees it as non-empty initialData.
+      accepted.removeListener("data", onData);
+      accepted.pause();
+      accepted.once("readable", () => {
+        const tlsSock = new tls.TLSSocket(accepted, { isServer: true, key: certs.key, cert: certs.cert });
+        tlsSock.on("error", () => {});
+        // On the unfixed build the buffered ClientHello is synchronously
+        // re-pushed into the accepted socket's readable buffer during the wrap.
+        resolve({ reinjected: accepted.readableLength > 0 });
+      });
+    });
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const socket = net.connect(port, "127.0.0.1");
+  try {
+    socket.on("error", () => {});
+    socket.on("close", () => resolve({ reinjected: false }));
+    socket.on("data", data => {
+      const text = data.toString("latin1");
+      if (text.includes("SERVER_GREETING")) {
+        socket.write("STARTTLS");
+      } else if (text.includes("PROCEED")) {
+        const tlsSocket = tls.connect({ socket, servername: "localhost", rejectUnauthorized: false });
+        tlsSocket.on("error", () => {});
+      }
+    });
+
+    const result = await promise;
+
+    // The buffered ClientHello must reach the TLS engine, not resurface as
+    // readable bytes on the accepted socket.
+    expect(result.reinjected).toBe(false);
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -128,3 +128,61 @@ test("tls.connect({ socket }) does not re-emit post-upgrade bytes on the origina
     server.close();
   }
 });
+
+test("new tls.TLSSocket(socket, { isServer: true }) does not re-emit post-upgrade bytes on the accepted socket (server STARTTLS) #32239", async () => {
+  // Server-side STARTTLS (SMTP/IMAP/FTPS pattern): after the plaintext
+  // negotiation the server wraps the accepted socket with an isServer TLSSocket.
+  // The client's ClientHello (ciphertext) must reach the TLS layer, not resurface
+  // as cleartext `data` on the accepted socket and re-enter the server's handler.
+  const { promise, resolve } = Promise.withResolvers<{ dataAfterUpgrade: boolean; message: string }>();
+
+  let dataAfterUpgrade = false;
+
+  const server = net.createServer(accepted => {
+    let upgraded = false;
+    accepted.on("error", () => {});
+    accepted.write("SERVER_GREETING");
+    accepted.on("data", data => {
+      if (upgraded) {
+        // Post-upgrade ciphertext must not resurface here.
+        dataAfterUpgrade = true;
+        return;
+      }
+      if (data.toString("latin1").includes("STARTTLS")) {
+        upgraded = true;
+        accepted.write("PROCEED");
+        const tlsSock = new tls.TLSSocket(accepted, { isServer: true, key: certs.key, cert: certs.cert });
+        tlsSock.on("error", () => resolve({ dataAfterUpgrade, message: "" }));
+        tlsSock.on("secure", () => resolve({ dataAfterUpgrade, message: "" }));
+      }
+    });
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const socket = net.connect(port, "127.0.0.1");
+  try {
+    socket.on("error", () => {});
+    socket.on("close", () => resolve({ dataAfterUpgrade, message: "" }));
+    socket.on("data", data => {
+      const text = data.toString("latin1");
+      if (text.includes("SERVER_GREETING")) {
+        socket.write("STARTTLS");
+      } else if (text.includes("PROCEED")) {
+        const tlsSocket = tls.connect({ socket, servername: "localhost", rejectUnauthorized: false });
+        tlsSocket.on("error", err => resolve({ dataAfterUpgrade, message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ dataAfterUpgrade, message: "" }));
+      }
+    });
+
+    const result = await promise;
+
+    // The accepted socket must go quiet once the server TLS layer owns the stream.
+    expect(result.dataAfterUpgrade).toBe(false);
+    expect(result.message).not.toContain("Invalid socket");
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -258,3 +258,56 @@ test("server-side TLS upgrade does not re-inject buffered ClientHello (initialDa
     server.close();
   }
 });
+
+test("tls.connect({ socket }) does not retain post-upgrade ciphertext in the original socket's readable buffer #32239", async () => {
+  // Second failure mode of the same bug: with no data listener on the original
+  // socket and the stream non-flowing (the postgres.js pattern, which calls
+  // removeAllListeners() before upgrading), the re-emitted ciphertext does not
+  // re-enter a handler; it silently accumulates in _readableState.buffer, one
+  // retained byte per transferred byte for the life of the connection.
+  const TOTAL = 4 * 1024 * 1024;
+  const CHUNK = Buffer.alloc(256 * 1024, 0x61);
+
+  const server = tls.createServer({ key: certs.key, cert: certs.cert }, s => {
+    s.on("error", () => {});
+    let sent = 0;
+    const pump = () => {
+      while (sent < TOTAL) {
+        sent += CHUNK.length;
+        if (!s.write(CHUNK)) return s.once("drain", pump);
+      }
+      s.end();
+    };
+    pump();
+  });
+
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as net.AddressInfo;
+
+  const socket = net.connect(port, "127.0.0.1");
+  try {
+    socket.on("error", () => {});
+    await once(socket, "connect");
+
+    // Mirror a driver that negotiated in plaintext, then detached everything
+    // and left the socket non-flowing before handing it to tls.connect.
+    socket.on("data", () => {});
+    socket.removeAllListeners("data");
+    socket.pause();
+
+    const tlsSocket = tls.connect({ socket, ca: certs.cert, servername: "localhost" });
+    tlsSocket.on("error", () => {});
+
+    let received = 0;
+    tlsSocket.on("data", d => (received += d.length));
+    await once(tlsSocket, "end");
+
+    expect(received).toBe(TOTAL);
+    // Pre-fix this retained >= TOTAL bytes of ciphertext.
+    expect(socket.readableLength).toBe(0);
+    tlsSocket.destroy();
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});


### PR DESCRIPTION
Fixes #32239

### Repro

```js
import net from "node:net";
import tls from "node:tls";

const server = net.createServer(serverSocket => {
  serverSocket.write("SERVER_GREETING");
  serverSocket.on("data", data => {
    if (data.toString().includes("STARTTLS")) {
      serverSocket.write("PROCEED");
      setTimeout(() => serverSocket.write(Buffer.alloc(50, 0x16)), 20); // mock TLS bytes
    }
  });
});

server.listen(0, "127.0.0.1", () => {
  const socket = new net.Socket();
  socket.connect(server.address().port, "127.0.0.1");
  let x = 0;
  socket.on("data", () => {
    if (++x < 2) return socket.write("STARTTLS");
    tls.connect({ socket, host: "127.0.0.1" }).on("error", err => {
      if (err.message.includes("Invalid socket")) process.exit(1);
      process.exit(0);
    });
  });
});
```

Node upgrades once and the original socket goes quiet. Bun re-enters the `data` handler with the post-upgrade bytes and throws `Invalid socket`:

```
Attempting TLS Upgrade (Event execution #2)...
Attempting TLS Upgrade (Event execution #3)...

CRASHED ON EXECUTION #3 WITH: Invalid socket
```

### Cause

`tls.connect({ socket })` routes through `node:net`s `socket.upgradeTLS(...)`, which builds the native `[raw, tls]` pair. Per the native contract the `raw` half keeps the pre-upgrade handlers and sees post-upgrade bytes as ciphertext via the `ssl_raw_tap` hook, and its cached `data` still points at the original `net.Socket`. So after the upgrade the raw tap fires the net.Socket data handler (`SocketHandlers2.data` in `src/js/node/net.ts`), which does `self.push(buffer)` on the original socket, emitting a cleartext `data` event carrying ciphertext.

In the STARTTLS pattern the user data listener is still attached, so it re-enters `tls.connect({ socket })` on the already-upgraded socket; the second `upgradeTLS` returns falsy and `net.ts` throws `new Error("Invalid socket")`. That throw is the symptom; the root cause is the original socket staying wired to the post-upgrade byte stream.

Node consumes the post-upgrade bytes inside the TLS layer and never fires the original socket data listener again.

### Fix

Mark the original socket with `kupgradedToTLS` the moment it is adopted by a TLS wrapper (both the synchronous and the deferred `socket.upgradeTLS` branches in `Socket.prototype.connect`), and short-circuit the net.Socket `data` handlers when that flag is set. This keeps the post-upgrade bytes in the TLS layer, matching Node. The guard is applied to all three client-reachable data handlers (`SocketHandlers`, `SocketHandlers2`, and the `onread` variant) so the fd and `onread` socket forms are covered too.

The native `socket.upgradeTLS()` / `Bun.connect` `[raw, tls]` ciphertext contract is untouched: those paths use user-supplied handler objects, never the `node:net` handlers, and the `kupgradedToTLS` flag is only ever set from `node:net`.

### Verification

New test `tls.connect({ socket }) does not re-emit post-upgrade bytes on the original socket (STARTTLS) #32239` in `test/js/node/tls/node-tls-upgrade.test.ts` drives the STARTTLS flow and asserts the original socket goes quiet after the upgrade (the upgrade is attempted exactly once and never fails with `Invalid socket`).

- Fails on the unfixed build: `error: expect(received).not.toContain(expected)` / `Received: "Invalid socket"`.
- Passes with the fix.
- `test/regression/issue/12117.test.ts` (raw-socket leak) and the `socket.upgradeTLS` contract tests in `test/js/bun/net/socket.test.ts` still pass.

### Server-side STARTTLS

The rebase onto main picked up #31155, which added a third `socket.upgradeTLS` site: `Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")]`, reached via `new tls.TLSSocket(acceptedSocket, { isServer: true })` (the server-side STARTTLS pattern used by SMTP/IMAP/FTPS servers). The native `upgradeTLS` honors the `isServer` option and still enables the `ssl_raw_tap` ciphertext hook, and the raw half keeps the accepted socket's `ServerHandlers`, so this path had the same re-emission bug on the server side. It is now covered: `kupgradedToTLS` is set at the server upgrade site and `ServerHandlers.data` is guarded, with a dedicated server-side regression test that fails on the unfixed build (`dataAfterUpgrade` true) and passes with the fix.

### Second failure mode: silent ciphertext retention (memory leak)

As documented with measurements in the PR discussion by @YevheniiKotyrlo: when the original socket has no `data` listener and the stream is non-flowing at upgrade time (the postgres.js pattern, which removes its plaintext-negotiation listeners before handing the socket to `tls.connect`), the pre-fix push did not re-enter a handler; it silently accumulated the ciphertext stream in `_readableState.buffer`, one retained byte per transferred byte for the life of the connection (unbounded, shows up as `external` memory growth while `heapTotal` stays flat). Reproduced: a 4 MB TLS transfer retains 4,201,798 bytes on the unfixed build (the excess over 4 MB is TLS record framing) and 0 bytes with the fix. Covered by a dedicated regression test asserting `socket.readableLength === 0` after the transfer.

### Known limitation

The fix covers the fd path (`socket.upgradeTLS`) on both the client and server sides. The sibling `upgradeDuplexToTLS` path is still not addressed: it is taken for a `net.Socket` backed by a Windows named pipe (`isNamedPipeSocket` is always false on POSIX) and for a no-fd/`Duplex` transport on either side. That path feeds the TLS layer through the connection's public `data` event, so the `kupgradedToTLS` flag cannot be reused there without starving the feeder. It is pre-existing and needs a separate structural fix, tracked in #32242.


