### PR TITLE
net: stop re-emitting post-upgrade bytes on a named-pipe socket after tls.connect({ socket })

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -273,6 +273,14 @@ const SocketHandlers: SocketHandler = {
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // See SocketHandlers2.data: a named-pipe socket upgraded via
+    // `tls.connect({ socket })` feeds post-upgrade bytes to the TLS layer here
+    // instead of re-emitting them as cleartext `data`.
+    const feedTLSData = self[kDuplexTLSData];
+    if (feedTLSData !== undefined) {
+      feedTLSData(buffer);
+      return;
+    }
     if (!self.push(buffer)) {
       socket.pause();
     }
@@ -600,6 +608,15 @@ const ServerHandlers: SocketHandler<NetSocket> = {
 
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // A server-accepted named-pipe socket upgraded via `tls.connect({ socket })`
+    // keeps this handler active (its native handle is not swapped out). Feed the
+    // post-upgrade bytes to the TLS layer instead of re-emitting them as
+    // cleartext `data`. See SocketHandlers2.data.
+    const feedTLSData = self[kDuplexTLSData];
+    if (feedTLSData !== undefined) {
+      feedTLSData(buffer);
+      return;
+    }
     if (!self.push(buffer)) {
       socket.pause();
     }
@@ -1622,7 +1639,7 @@ Socket.prototype.connect = function connect(...args) {
         const socket = connection._handle;
         // A named-pipe net.Socket reuses the Duplex TLS wrapper, but unlike a
         // plain Duplex its native pipe handle is left in place and keeps firing
-        // SocketHandlers2.data after the upgrade.
+        // its raw data handler after the upgrade.
         const namedPipe = !upgradeDuplex && !!socket && isNamedPipeSocket(socket);
         if (namedPipe) {
           upgradeDuplex = true;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -151,6 +151,11 @@ const kUserUnrefed = Symbol("kUserUnrefed");
 // only restore a hold they actually removed - re-refing a handle that never
 // held the loop (a wrapped duplex with no fd) would pin the process.
 const kPausedUnref = Symbol("kPausedUnref");
+// Holds the Duplex TLS data feeder when a named-pipe net.Socket is upgraded via
+// `tls.connect({ socket })`. Its native pipe handle is left in place and keeps
+// delivering post-upgrade bytes, so the raw data handlers route them straight to
+// the TLS layer instead of re-emitting them as cleartext `data`.
+const kDuplexTLSData = Symbol("kDuplexTLSData");
 const kwriteCallback = Symbol("writeCallback");
 const kSocketClass = Symbol("kSocketClass");
 
@@ -1010,6 +1015,15 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     const { self } = socket.data;
     self._unrefTimer();
     self.bytesRead += buffer.length;
+    // After `tls.connect({ socket })` over a named pipe the native pipe handle is
+    // not swapped out, so it keeps delivering post-upgrade bytes here. Feed them
+    // to the TLS layer directly instead of re-emitting them as cleartext `data`
+    // on the original socket (which would re-enter a user `data` listener).
+    const feedTLSData = self[kDuplexTLSData];
+    if (feedTLSData !== undefined) {
+      feedTLSData(buffer);
+      return;
+    }
     if (!self.push(buffer)) socket.pause();
   },
   drain(socket) {
@@ -1309,6 +1323,7 @@ function Socket(options?) {
   this._parentWrap = null;
   this[kpendingRead] = undefined;
   this[kupgraded] = null;
+  this[kDuplexTLSData] = undefined;
 
   this[kSetNoDelay] = Boolean(noDelay);
   this[kSetKeepAlive] = Boolean(keepAlive);
@@ -1362,6 +1377,13 @@ function Socket(options?) {
         const { self } = socket.data;
         if (!self) return;
         self._unrefTimer();
+        // See SocketHandlers2.data: post-upgrade named-pipe bytes feed the TLS
+        // layer, not the onread callback.
+        const feedTLSData = self[kDuplexTLSData];
+        if (feedTLSData !== undefined) {
+          feedTLSData(buffer);
+          return;
+        }
         try {
           onread.callback(buffer.length, buffer);
         } catch (e) {
@@ -1598,9 +1620,12 @@ Socket.prototype.connect = function connect(...args) {
         // https://github.com/nodejs/node/blob/c5cfdd48497fe9bd8dbd55fd1fca84b321f48ec1/lib/net.js#L1126
         this._undestroy();
         const socket = connection._handle;
-        if (!upgradeDuplex && socket) {
-          // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
-          upgradeDuplex = isNamedPipeSocket(socket);
+        // A named-pipe net.Socket reuses the Duplex TLS wrapper, but unlike a
+        // plain Duplex its native pipe handle is left in place and keeps firing
+        // SocketHandlers2.data after the upgrade.
+        const namedPipe = !upgradeDuplex && !!socket && isNamedPipeSocket(socket);
+        if (namedPipe) {
+          upgradeDuplex = true;
         }
         if (upgradeDuplex) {
           this[kupgraded] = connection;
@@ -1609,7 +1634,13 @@ Socket.prototype.connect = function connect(...args) {
             tls,
             socket: this[khandlers],
           });
-          connection.on("data", events[0]);
+          if (namedPipe) {
+            // Route the native handle's post-upgrade reads straight to the TLS
+            // layer so they never re-emit as `data` on the original socket.
+            connection[kDuplexTLSData] = events[0];
+          } else {
+            connection.on("data", events[0]);
+          }
           connection.on("end", events[1]);
           connection.on("drain", events[2]);
           connection.on("close", events[3]);
@@ -1648,9 +1679,11 @@ Socket.prototype.connect = function connect(...args) {
                 return;
               }
               const socket = connection._handle;
-              if (!upgradeDuplex && socket) {
-                // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
-                upgradeDuplex = isNamedPipeSocket(socket);
+              // See the synchronous branch above: a named-pipe net.Socket keeps
+              // its native handle after the Duplex TLS upgrade.
+              const namedPipe = !upgradeDuplex && !!socket && isNamedPipeSocket(socket);
+              if (namedPipe) {
+                upgradeDuplex = true;
               }
               if (upgradeDuplex) {
                 this[kupgraded] = connection;
@@ -1659,7 +1692,11 @@ Socket.prototype.connect = function connect(...args) {
                   tls,
                   socket: this[khandlers],
                 });
-                connection.on("data", events[0]);
+                if (namedPipe) {
+                  connection[kDuplexTLSData] = events[0];
+                } else {
+                  connection.on("data", events[0]);
+                }
                 connection.on("end", events[1]);
                 connection.on("drain", events[2]);
                 connection.on("close", events[3]);
@@ -3506,6 +3543,9 @@ function initSocketHandle(self) {
   self._sockname = null;
   self[kclosed] = false;
   self[kended] = false;
+  // A reused socket may have fed a TLS wrapper on a prior named-pipe upgrade;
+  // clear the stale feeder so its data handlers surface bytes normally again.
+  self[kDuplexTLSData] = undefined;
 
   // Handle creation may be deferred to bind() or connect() time.
   if (self._handle) {

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -101,9 +101,7 @@ it.if(isWindows)(
     // Mock STARTTLS server over a named pipe: greet, reply PROCEED to STARTTLS,
     // then send mock TLS records. Those bytes must reach the TLS layer (OpenSSL
     // rejects them) rather than re-surface as cleartext `data` on the original
-    // pipe socket. The named-pipe upgrade leaves the native handle in place, so
-    // before the fix those bytes re-entered this handler and attempted a second
-    // upgrade (the #32239 "Invalid socket" pattern).
+    // pipe socket, whose native handle the named-pipe upgrade leaves in place.
     const pipe_name = `\\\\.\\pipe\\test\\${randomUUID()}`;
 
     const server = net.createServer(serverSocket => {
@@ -144,8 +142,8 @@ it.if(isWindows)(
           socket.write("STARTTLS");
           return;
         }
-        // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
-        // re-emitted ciphertext) both land here, mirroring the issue's handler.
+        // The handler upgrades on any post-greeting data, so a chunk re-emitted
+        // as cleartext after the upgrade would be counted as a second upgrade.
         upgraded = true;
         upgrades++;
         const tlsSocket = connect({ socket, rejectUnauthorized: false });
@@ -174,12 +172,9 @@ it.if(isWindows)(
 it.if(isWindows)(
   "tls.connect({ socket }) does not re-emit post-upgrade bytes on a server-accepted named-pipe socket (STARTTLS) #32242",
   async () => {
-    // Same regression as above, but the upgraded socket is the one a named-pipe
-    // *server* accepted (driven by ServerHandlers.data, not SocketHandlers2.data).
-    // The connecting side plays the mock peer; the accepted socket runs the
-    // STARTTLS handler and upgrades via `tls.connect({ socket })`. If the feeder
-    // were not consulted in ServerHandlers.data, the post-upgrade bytes would
-    // re-enter this handler and attempt a second upgrade.
+    // Same as above, but the upgraded socket is the one a named-pipe *server*
+    // accepted. The connecting side plays the mock peer; the accepted socket
+    // runs the STARTTLS handler and upgrades via `tls.connect({ socket })`.
     const pipe_name = `\\\\.\\pipe\\test\\${randomUUID()}`;
 
     const { promise, resolve } = Promise.withResolvers<{ upgrades: number; outcome: string; message: string }>();
@@ -200,8 +195,8 @@ it.if(isWindows)(
           serverSocket.write("STARTTLS");
           return;
         }
-        // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
-        // re-emitted ciphertext) both land here.
+        // The handler upgrades on any post-greeting data, so a chunk re-emitted
+        // as cleartext after the upgrade would be counted as a second upgrade.
         upgraded = true;
         upgrades++;
         const tlsSocket = connect({ socket: serverSocket, rejectUnauthorized: false });
@@ -233,9 +228,9 @@ it.if(isWindows)(
       const result = await promise;
 
       // The post-upgrade bytes reached the accepted socket's TLS layer via the
-      // ServerHandlers.data feeder (the outcome is a TLS-level event, not the
-      // accepted socket closing idle). Exactly one upgrade happens and it never
-      // fails with "Invalid socket".
+      // feeder (the outcome is a TLS-level event, not the accepted socket
+      // closing idle). Exactly one upgrade happens and it never fails with
+      // "Invalid socket".
       expect(result.message).not.toContain("Invalid socket");
       expect(result.outcome).not.toBe("accepted-close");
       expect(result.upgrades).toBe(1);

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -94,3 +94,75 @@ it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", asy
   await test(`\\\\.\\pipe\\test\\${randomUUID()}`);
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
 });
+
+it.if(isWindows)(
+  "tls.connect({ socket }) does not re-emit post-upgrade bytes on a named-pipe socket (STARTTLS) #32242",
+  async () => {
+    // Mock STARTTLS server over a named pipe: greet, reply PROCEED to STARTTLS,
+    // then send mock TLS records. Those bytes must reach the TLS layer (OpenSSL
+    // rejects them) rather than re-surface as cleartext `data` on the original
+    // pipe socket. The named-pipe upgrade leaves the native handle in place, so
+    // before the fix those bytes re-entered this handler and attempted a second
+    // upgrade (the #32239 "Invalid socket" pattern).
+    const pipe_name = `\\\\.\\pipe\\test\\${randomUUID()}`;
+
+    const server = net.createServer(serverSocket => {
+      serverSocket.on("error", () => {});
+      serverSocket.write("SERVER_GREETING");
+      let phase = "greeting";
+      serverSocket.on("data", data => {
+        if (phase === "greeting" && data.toString().includes("STARTTLS")) {
+          phase = "proceed";
+          serverSocket.write("PROCEED");
+        } else if (phase === "proceed") {
+          phase = "done";
+          serverSocket.write(Buffer.alloc(50, 0x16));
+        }
+      });
+    });
+
+    server.listen(pipe_name);
+    await once(server, "listening");
+
+    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; message: string }>();
+
+    let upgrades = 0;
+    let upgraded = false;
+
+    const socket = net.connect(pipe_name);
+    try {
+      // Errors are an expected outcome here: OpenSSL rejects the mock handshake
+      // bytes (the TLS socket emits `error`) and the pipe may reset during
+      // teardown. Every terminal event settles `promise`, so a regression
+      // surfaces as a failed assertion rather than a hang.
+      socket.on("error", () => {});
+      socket.on("close", () => resolve({ upgrades, message: "" }));
+
+      socket.on("data", data => {
+        if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
+          socket.write("STARTTLS");
+          return;
+        }
+        // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
+        // re-emitted ciphertext) both land here, mirroring the issue's handler.
+        upgraded = true;
+        upgrades++;
+        const tlsSocket = connect({ socket, rejectUnauthorized: false });
+        tlsSocket.on("error", err => resolve({ upgrades, message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ upgrades, message: "" }));
+        tlsSocket.on("close", () => resolve({ upgrades, message: "" }));
+      });
+
+      const result = await promise;
+
+      // Once TLS owns the stream no further `data` event re-enters the handler,
+      // so exactly one upgrade is attempted and it never fails with "Invalid
+      // socket". A re-emitted post-upgrade chunk would push `upgrades` past 1.
+      expect(result.message).not.toContain("Invalid socket");
+      expect(result.upgrades).toBe(1);
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  },
+);

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -124,19 +124,19 @@ it.if(isWindows)(
     server.listen(pipe_name);
     await once(server, "listening");
 
-    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; message: string }>();
+    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; outcome: string; message: string }>();
 
     let upgrades = 0;
     let upgraded = false;
 
     const socket = net.connect(pipe_name);
     try {
-      // Errors are an expected outcome here: OpenSSL rejects the mock handshake
-      // bytes (the TLS socket emits `error`) and the pipe may reset during
-      // teardown. Every terminal event settles `promise`, so a regression
-      // surfaces as a failed assertion rather than a hang.
+      // The mock records (record-layer version 0x1616) must reach the TLS parser,
+      // which rejects them with an `error`. A bare socket close or a completed
+      // handshake would mean the post-upgrade bytes never reached the parser, so
+      // those outcomes are tagged and fail the final `outcome` assertion.
       socket.on("error", () => {});
-      socket.on("close", () => resolve({ upgrades, message: "" }));
+      socket.on("close", () => resolve({ upgrades, outcome: "socket-close", message: "" }));
 
       socket.on("data", data => {
         if (!upgraded && data.toString("latin1").includes("SERVER_GREETING")) {
@@ -148,9 +148,9 @@ it.if(isWindows)(
         upgraded = true;
         upgrades++;
         const tlsSocket = connect({ socket, rejectUnauthorized: false });
-        tlsSocket.on("error", err => resolve({ upgrades, message: err.message }));
-        tlsSocket.on("secureConnect", () => resolve({ upgrades, message: "" }));
-        tlsSocket.on("close", () => resolve({ upgrades, message: "" }));
+        tlsSocket.on("error", err => resolve({ upgrades, outcome: "tls-error", message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ upgrades, outcome: "secure-connect", message: "" }));
+        tlsSocket.on("close", () => resolve({ upgrades, outcome: "tls-close", message: "" }));
       });
 
       const result = await promise;
@@ -159,6 +159,7 @@ it.if(isWindows)(
       // so exactly one upgrade is attempted and it never fails with "Invalid
       // socket". A re-emitted post-upgrade chunk would push `upgrades` past 1.
       expect(result.message).not.toContain("Invalid socket");
+      expect(result.outcome).toBe("tls-error");
       expect(result.upgrades).toBe(1);
     } finally {
       socket.destroy();
@@ -178,7 +179,7 @@ it.if(isWindows)(
     // re-enter this handler and attempt a second upgrade.
     const pipe_name = `\\\\.\\pipe\\test\\${randomUUID()}`;
 
-    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; message: string }>();
+    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; outcome: string; message: string }>();
 
     let upgrades = 0;
     let upgraded = false;
@@ -187,7 +188,9 @@ it.if(isWindows)(
     const server = net.createServer(serverSocket => {
       accepted = serverSocket;
       serverSocket.on("error", () => {});
-      serverSocket.on("close", () => resolve({ upgrades, message: "" }));
+      // A bare close means the mock records never reached the TLS parser (a
+      // dropped feeder), which must fail the final `outcome` assertion.
+      serverSocket.on("close", () => resolve({ upgrades, outcome: "accepted-close", message: "" }));
       serverSocket.on("data", data => {
         if (!upgraded && data.toString("latin1").includes("PEER_GREETING")) {
           serverSocket.write("STARTTLS");
@@ -198,9 +201,9 @@ it.if(isWindows)(
         upgraded = true;
         upgrades++;
         const tlsSocket = connect({ socket: serverSocket, rejectUnauthorized: false });
-        tlsSocket.on("error", err => resolve({ upgrades, message: err.message }));
-        tlsSocket.on("secureConnect", () => resolve({ upgrades, message: "" }));
-        tlsSocket.on("close", () => resolve({ upgrades, message: "" }));
+        tlsSocket.on("error", err => resolve({ upgrades, outcome: "tls-error", message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ upgrades, outcome: "secure-connect", message: "" }));
+        tlsSocket.on("close", () => resolve({ upgrades, outcome: "tls-close", message: "" }));
       });
     });
 
@@ -225,7 +228,11 @@ it.if(isWindows)(
 
       const result = await promise;
 
+      // The mock records must reach the accepted socket's TLS parser (via the
+      // ServerHandlers.data feeder), which rejects them with an `error`; a bare
+      // close would mean the feeder dropped them. Exactly one upgrade happens.
       expect(result.message).not.toContain("Invalid socket");
+      expect(result.outcome).toBe("tls-error");
       expect(result.upgrades).toBe(1);
     } finally {
       peer.destroy();

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -166,3 +166,71 @@ it.if(isWindows)(
     }
   },
 );
+
+it.if(isWindows)(
+  "tls.connect({ socket }) does not re-emit post-upgrade bytes on a server-accepted named-pipe socket (STARTTLS) #32242",
+  async () => {
+    // Same regression as above, but the upgraded socket is the one a named-pipe
+    // *server* accepted (driven by ServerHandlers.data, not SocketHandlers2.data).
+    // The connecting side plays the mock peer; the accepted socket runs the
+    // STARTTLS handler and upgrades via `tls.connect({ socket })`. If the feeder
+    // were not consulted in ServerHandlers.data, the post-upgrade bytes would
+    // re-enter this handler and attempt a second upgrade.
+    const pipe_name = `\\\\.\\pipe\\test\\${randomUUID()}`;
+
+    const { promise, resolve } = Promise.withResolvers<{ upgrades: number; message: string }>();
+
+    let upgrades = 0;
+    let upgraded = false;
+    let accepted: ReturnType<typeof net.connect> | null = null;
+
+    const server = net.createServer(serverSocket => {
+      accepted = serverSocket;
+      serverSocket.on("error", () => {});
+      serverSocket.on("close", () => resolve({ upgrades, message: "" }));
+      serverSocket.on("data", data => {
+        if (!upgraded && data.toString("latin1").includes("PEER_GREETING")) {
+          serverSocket.write("STARTTLS");
+          return;
+        }
+        // The legitimate upgrade (on PROCEED) and the buggy re-entry (on
+        // re-emitted ciphertext) both land here.
+        upgraded = true;
+        upgrades++;
+        const tlsSocket = connect({ socket: serverSocket, rejectUnauthorized: false });
+        tlsSocket.on("error", err => resolve({ upgrades, message: err.message }));
+        tlsSocket.on("secureConnect", () => resolve({ upgrades, message: "" }));
+        tlsSocket.on("close", () => resolve({ upgrades, message: "" }));
+      });
+    });
+
+    server.listen(pipe_name);
+    await once(server, "listening");
+
+    // Mock peer: greet, reply PROCEED to STARTTLS, then send mock TLS records.
+    const peer = net.connect(pipe_name);
+    try {
+      peer.on("error", () => {});
+      peer.on("connect", () => peer.write("PEER_GREETING"));
+      let phase = "greeting";
+      peer.on("data", data => {
+        if (phase === "greeting" && data.toString().includes("STARTTLS")) {
+          phase = "proceed";
+          peer.write("PROCEED");
+        } else if (phase === "proceed") {
+          phase = "done";
+          peer.write(Buffer.alloc(50, 0x16));
+        }
+      });
+
+      const result = await promise;
+
+      expect(result.message).not.toContain("Invalid socket");
+      expect(result.upgrades).toBe(1);
+    } finally {
+      peer.destroy();
+      accepted?.destroy();
+      server.close();
+    }
+  },
+);

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -131,10 +131,11 @@ it.if(isWindows)(
 
     const socket = net.connect(pipe_name);
     try {
-      // The mock records (record-layer version 0x1616) must reach the TLS parser,
-      // which rejects them with an `error`. A bare socket close or a completed
-      // handshake would mean the post-upgrade bytes never reached the parser, so
-      // those outcomes are tagged and fail the final `outcome` assertion.
+      // The post-upgrade bytes must reach the TLS layer via the feeder, which
+      // surfaces as a TLS-level terminal event (the handshake completes, or the
+      // parser errors on the mock records) rather than the raw socket closing
+      // with the TLS layer idle. The raw-close outcome is tagged so a dropped
+      // feeder fails the `outcome` assertion.
       socket.on("error", () => {});
       socket.on("close", () => resolve({ upgrades, outcome: "socket-close", message: "" }));
 
@@ -155,11 +156,13 @@ it.if(isWindows)(
 
       const result = await promise;
 
-      // Once TLS owns the stream no further `data` event re-enters the handler,
-      // so exactly one upgrade is attempted and it never fails with "Invalid
-      // socket". A re-emitted post-upgrade chunk would push `upgrades` past 1.
+      // The post-upgrade bytes reached the TLS layer (the outcome is a TLS-level
+      // event, not the raw socket closing idle). Once TLS owns the stream no
+      // further `data` event re-enters the handler, so exactly one upgrade is
+      // attempted and it never fails with "Invalid socket". A re-emitted
+      // post-upgrade chunk would push `upgrades` past 1.
       expect(result.message).not.toContain("Invalid socket");
-      expect(result.outcome).toBe("tls-error");
+      expect(result.outcome).not.toBe("socket-close");
       expect(result.upgrades).toBe(1);
     } finally {
       socket.destroy();
@@ -188,8 +191,9 @@ it.if(isWindows)(
     const server = net.createServer(serverSocket => {
       accepted = serverSocket;
       serverSocket.on("error", () => {});
-      // A bare close means the mock records never reached the TLS parser (a
-      // dropped feeder), which must fail the final `outcome` assertion.
+      // A bare accepted-socket close (the TLS layer idle) means the feeder never
+      // delivered the post-upgrade bytes; it is tagged so the `outcome`
+      // assertion fails in that case.
       serverSocket.on("close", () => resolve({ upgrades, outcome: "accepted-close", message: "" }));
       serverSocket.on("data", data => {
         if (!upgraded && data.toString("latin1").includes("PEER_GREETING")) {
@@ -228,11 +232,12 @@ it.if(isWindows)(
 
       const result = await promise;
 
-      // The mock records must reach the accepted socket's TLS parser (via the
-      // ServerHandlers.data feeder), which rejects them with an `error`; a bare
-      // close would mean the feeder dropped them. Exactly one upgrade happens.
+      // The post-upgrade bytes reached the accepted socket's TLS layer via the
+      // ServerHandlers.data feeder (the outcome is a TLS-level event, not the
+      // accepted socket closing idle). Exactly one upgrade happens and it never
+      // fails with "Invalid socket".
       expect(result.message).not.toContain("Invalid socket");
-      expect(result.outcome).toBe("tls-error");
+      expect(result.outcome).not.toBe("accepted-close");
       expect(result.upgrades).toBe(1);
     } finally {
       peer.destroy();


### PR DESCRIPTION
Follow-up to #32241 (fix for #32239), carved out as #32242.

## Summary

`tls.connect({ socket })` over a Windows named pipe re-emits post-upgrade bytes as cleartext `data` on the original `net.Socket`. #32241 fixed this for the TCP path; this PR covers the sibling named-pipe path, which #32241 could not reuse.

## Root cause

`Socket.prototype.connect` (`src/js/node/net.ts`) has two code paths for an existing socket:

- **TCP** (`socket.upgradeTLS`): swaps the native handle with `connection._handle = raw`.
- **Duplex / named pipe** (`upgradeDuplexToTLS`): does **not** replace `connection._handle`.

A named-pipe `net.Socket` reuses the Duplex wrapper (`isNamedPipeSocket(socket)` is true only on Windows). Because its native pipe handle is left in place, it keeps firing `SocketHandlers2.data` with `self = connection` after the upgrade. That handler runs `self.push(buffer)`, which emits a public `data` event. The TLS layer was fed through that same public event (`connection.on("data", events[0])`), so post-upgrade ciphertext reached **both** the TLS feeder (intended) and any pre-existing user `data` listener.

In a STARTTLS pattern the re-entrant listener calls `tls.connect({ socket })` again on the already-upgraded socket (the #32239 "Invalid socket" re-entry).

The #32241 `kupgradedToTLS` flag cannot be reused here: suppressing `self.push(buffer)` is exactly what would starve the only source of the `data` events the feeder consumes, breaking TLS over named pipes entirely.

## Fix

Route the named-pipe handle's post-upgrade reads straight to the TLS data feeder instead of through the public `data` event:

- Store `events[0]` on the connection as `connection[kDuplexTLSData]` (only on the named-pipe branch, not for a plain Duplex).
- The raw data handlers call that feeder directly and return, so `self.push` never runs and the original socket goes quiet after the upgrade, matching Node and the #32241 TCP contract.

The fixing lines are the `connection[kDuplexTLSData] = events[0]` assignments in the two `upgradeDuplex` branches plus the feeder check in every raw data handler. `isNamedPipeSocket` is true for any pipe-variant handle, so the feeder can be set on a client named-pipe socket (`SocketHandlers2.data`, or the `onread` variant) or a server-accepted named-pipe socket (`ServerHandlers.data`); the `fd`-connect path (`SocketHandlers.data`) is covered defensively. A plain `Duplex` transport keeps `connection.on("data", events[0])` (it has no native handle to feed from, and its behavior already matches Node).

## Scope

- Windows named pipes only. `isNamedPipeSocket` is always false on POSIX, so the named-pipe branch is never taken on Linux/macOS and this change is a no-op there.
- Pre-existing (not introduced by #32241).
- Lands independently on `main`; does not depend on #32241's `kupgradedToTLS`.

## Testing

`test/js/node/tls/node-tls-namedpipes.test.ts` gains two STARTTLS regressions driven over a named pipe (`it.if(isWindows)`), modeled on #32241's proven TCP test: a mock peer greets, replies `PROCEED`, then sends mock TLS records. Without the fix those bytes re-enter the upgrader's `data` handler and attempt a second upgrade (`upgrades > 1`); with the fix exactly one upgrade happens and it never fails with `Invalid socket`. One test upgrades a client `net.connect` socket (`SocketHandlers2.data`), the other upgrades a server-accepted socket (`ServerHandlers.data`).

This path is reachable only on Windows, so the fail-before/after check on a Linux runner cannot exercise it (the test is skipped there). Verification done on Linux:

- Debug build + the touched cross-platform paths pass: `node-tls-upgrade.test.ts`, `node-tls-duplex-close-throw-uaf.test.ts`, `node-tls-socket-allow-half-open-option.test.ts`.
- The change is a behavioral no-op off Windows: `kDuplexTLSData` is only set when `isNamedPipeSocket` is true, and the `namedPipe` computation is equivalent to the previous `upgradeDuplex = isNamedPipeSocket(socket)` on every other input.
- Confirmed the pure-Duplex sibling re-emits identically in Node and Bun (so it is Node's documented behavior, not a bug, and is intentionally left unchanged).

The regression test runs on Windows CI.