### PR TITLE
http: reject fetch() instead of panicking when the HTTP client thread fails to spawn

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -272,6 +272,8 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS, "BUN_FEATURE_FLAG_FORCE_WINDOWS_JUNCTIONS", {});
     new_feature_flag!(pub BUN_INSTRUMENTS, "BUN_INSTRUMENTS", {});
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
+    // Debug-only fault injection for test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts.
+    new_feature_flag!(pub BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN, "BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -372,9 +372,7 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
     // `init` is idempotent (`Once`) and every other JS-side entry point
     // (`send_sync`, `FetchTasklet::start`, S3) passes default opts too.
     if crate::http_thread::init(&Default::default()).is_err() {
-        // Preconnect is a best-effort hint; drop it silently if the HTTP
-        // client thread could not be started. The first real fetch() will
-        // surface the error to JS.
+        // Best-effort hint; the first real fetch() surfaces the error.
         if is_url_owned {
             // SAFETY: `is_url_owned` is the caller's promise that `url.href` is a
             // global-allocator `Box<[u8]>` we now own.

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -371,7 +371,17 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
     // fields) if `fetch.preconnect()` is the process's first HTTP operation.
     // `init` is idempotent (`Once`) and every other JS-side entry point
     // (`send_sync`, `FetchTasklet::start`, S3) passes default opts too.
-    crate::http_thread::init(&Default::default());
+    if crate::http_thread::init(&Default::default()).is_err() {
+        // Preconnect is a best-effort hint; drop it silently if the HTTP
+        // client thread could not be started. The first real fetch() will
+        // surface the error to JS.
+        if is_url_owned {
+            // SAFETY: `is_url_owned` is the caller's promise that `url.href` is a
+            // global-allocator `Box<[u8]>` we now own.
+            unsafe { free_owned_href(url.href) };
+        }
+        return;
+    }
 
     let this: *mut Preconnect = bun_core::heap::into_raw(Box::new(Preconnect {
         async_http: None,
@@ -617,7 +627,9 @@ impl<'a> AsyncHTTP<'a> {
         &mut self,
         response_buffer: &mut MutableString,
     ) -> crate::Result<crate::HTTPResponseMetadata> {
-        crate::http_thread::init(&Default::default());
+        if crate::http_thread::init(&Default::default()).is_err() {
+            return Err(crate::Error::FailedToStartHTTPClientThread);
+        }
 
         // Note: `Box::leak` is forbidden (PORTING.md §Forbidden);
         // allocate via `heap::alloc` and reclaim once

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1186,9 +1186,18 @@ mod _event_loop_draft {
     // root, keeping detach semantics without the false positive.
     static HTTP_THREAD_HANDLE: std::sync::OnceLock<std::thread::JoinHandle<()>> =
         std::sync::OnceLock::new();
+    // Set once by `init_once` if `Builder::spawn` fails, so every subsequent
+    // `init()` caller observes the same failure. The stored message is the
+    // `Display` of the `io::Error`, which on Windows/POSIX includes the OS
+    // error code and text (e.g. "Not enough memory resources ... (os error 8)").
+    static SPAWN_ERROR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
-    pub(super) fn init(opts: &InitOpts) {
+    pub(super) fn init(opts: &InitOpts) -> Result<(), &'static str> {
         INIT_ONCE.call_once(|| init_once(opts));
+        match SPAWN_ERROR.get() {
+            Some(msg) => Err(msg.as_str()),
+            None => Ok(()),
+        }
     }
 
     fn init_once(opts: &InitOpts) {
@@ -1204,15 +1213,42 @@ mod _event_loop_draft {
         crate::HTTP_THREAD_INIT.store(true, core::sync::atomic::Ordering::Release);
         bun_libdeflate_sys::libdeflate::load();
         let opts_copy = opts.clone();
-        let thread = std::thread::Builder::new()
-            .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
-            .spawn(move || on_start(opts_copy));
+        let thread = if cfg!(debug_assertions)
+            && bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN.get()
+                == Some(true)
+        {
+            // Debug-build test hook: simulate CreateThread/pthread_create
+            // failure so the fetch()/S3 rejection path can be exercised
+            // without exhausting real OS thread limits (which is not reliably
+            // reproducible in CI). Gated on `cfg!(debug_assertions)` so
+            // release binaries compile it out entirely and never read the env
+            // var; tests that set it are `skipIf(!isDebug)`.
+            Err(std::io::Error::from_raw_os_error(
+                #[cfg(windows)]
+                8, // ERROR_NOT_ENOUGH_MEMORY
+                #[cfg(not(windows))]
+                (bun_errno::SystemErrno::EAGAIN as i32),
+            ))
+        } else {
+            std::thread::Builder::new()
+                .stack_size(bun_threading::thread_pool::DEFAULT_THREAD_STACK_SIZE as usize)
+                .spawn(move || on_start(opts_copy))
+        };
         match thread {
             // detach — see HTTP_THREAD_HANDLE note above re: LSAN reachability
             Ok(t) => {
                 let _ = HTTP_THREAD_HANDLE.set(t);
             }
-            Err(err) => Output::panic(format_args!("Failed to start HTTP Client thread: {}", err)),
+            Err(err) => {
+                // Record instead of panicking so JS-side callers (fetch, S3)
+                // can reject with a catchable error rather than aborting the
+                // whole process. On Windows the `io::Error` Display includes
+                // `GetLastError()` so crash reports distinguish commit-limit
+                // exhaustion (ERROR_NOT_ENOUGH_MEMORY) from sandbox/AV denial
+                // (ERROR_ACCESS_DENIED). CLI callers still crash via
+                // `init_or_crash`.
+                let _ = SPAWN_ERROR.set(format!("Failed to start HTTP Client thread: {}", err));
+            }
         }
     }
 
@@ -1418,6 +1454,20 @@ pub fn shutdown_for_exit() -> bool {
 /// `_event_loop_draft` below (depends on `bun_event_loop::MiniEventLoop`,
 /// which is outside this crate's dep set). Call sites in AsyncHTTP.rs hit
 /// this until that tier boundary is resolved.
-pub fn init(opts: &InitOpts) {
+///
+/// Returns `Err` with a formatted message (including the OS error) if the
+/// HTTP client thread could not be spawned. The error is latched on the
+/// `Once`, so every subsequent call observes the same failure.
+#[must_use = "HTTP requests will hang forever if the thread failed to start"]
+pub fn init(opts: &InitOpts) -> Result<(), &'static str> {
     _event_loop_draft::init(opts)
+}
+
+/// Variant of [`init`] for CLI entrypoints that cannot usefully recover from
+/// thread-spawn failure. Keeps the pre-existing abort-the-process behaviour
+/// but with the OS error surfaced in the panic message.
+pub fn init_or_crash(opts: &InitOpts) {
+    if let Err(msg) = _event_loop_draft::init(opts) {
+        Output::panic(format_args!("{}", msg));
+    }
 }

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1186,10 +1186,7 @@ mod _event_loop_draft {
     // root, keeping detach semantics without the false positive.
     static HTTP_THREAD_HANDLE: std::sync::OnceLock<std::thread::JoinHandle<()>> =
         std::sync::OnceLock::new();
-    // Set once by `init_once` if `Builder::spawn` fails, so every subsequent
-    // `init()` caller observes the same failure. The stored message is the
-    // `Display` of the `io::Error`, which on Windows/POSIX includes the OS
-    // error code and text (e.g. "Not enough memory resources ... (os error 8)").
+    // Latched spawn failure; every subsequent `init()` caller observes it.
     static SPAWN_ERROR: std::sync::OnceLock<String> = std::sync::OnceLock::new();
 
     pub(super) fn init(opts: &InitOpts) -> Result<(), &'static str> {
@@ -1217,12 +1214,8 @@ mod _event_loop_draft {
             && bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN.get()
                 == Some(true)
         {
-            // Debug-build test hook: simulate CreateThread/pthread_create
-            // failure so the fetch()/S3 rejection path can be exercised
-            // without exhausting real OS thread limits (which is not reliably
-            // reproducible in CI). Gated on `cfg!(debug_assertions)` so
-            // release binaries compile it out entirely and never read the env
-            // var; tests that set it are `skipIf(!isDebug)`.
+            // Debug-only test hook: a real spawn failure is not reproducible
+            // in CI. Release builds compile this branch out.
             Err(std::io::Error::from_raw_os_error(
                 #[cfg(windows)]
                 8, // ERROR_NOT_ENOUGH_MEMORY
@@ -1240,13 +1233,9 @@ mod _event_loop_draft {
                 let _ = HTTP_THREAD_HANDLE.set(t);
             }
             Err(err) => {
-                // Record instead of panicking so JS-side callers (fetch, S3)
-                // can reject with a catchable error rather than aborting the
-                // whole process. On Windows the `io::Error` Display includes
-                // `GetLastError()` so crash reports distinguish commit-limit
-                // exhaustion (ERROR_NOT_ENOUGH_MEMORY) from sandbox/AV denial
-                // (ERROR_ACCESS_DENIED). CLI callers still crash via
-                // `init_or_crash`.
+                // `io::Error` Display carries the OS error code (GetLastError
+                // on Windows), so reports can tell ERROR_NOT_ENOUGH_MEMORY
+                // from ERROR_ACCESS_DENIED.
                 let _ = SPAWN_ERROR.set(format!("Failed to start HTTP Client thread: {}", err));
             }
         }
@@ -1455,17 +1444,14 @@ pub fn shutdown_for_exit() -> bool {
 /// which is outside this crate's dep set). Call sites in AsyncHTTP.rs hit
 /// this until that tier boundary is resolved.
 ///
-/// Returns `Err` with a formatted message (including the OS error) if the
-/// HTTP client thread could not be spawned. The error is latched on the
-/// `Once`, so every subsequent call observes the same failure.
+/// `Err` means the thread could not be spawned; the failure is latched, so
+/// every subsequent call observes it.
 #[must_use = "HTTP requests will hang forever if the thread failed to start"]
 pub fn init(opts: &InitOpts) -> Result<(), &'static str> {
     _event_loop_draft::init(opts)
 }
 
-/// Variant of [`init`] for CLI entrypoints that cannot usefully recover from
-/// thread-spawn failure. Keeps the pre-existing abort-the-process behaviour
-/// but with the OS error surfaced in the panic message.
+/// [`init`] for CLI entrypoints that cannot recover from spawn failure.
 pub fn init_or_crash(opts: &InitOpts) {
     if let Err(msg) = _event_loop_draft::init(opts) {
         Output::panic(format_args!("{}", msg));

--- a/src/http/error.rs
+++ b/src/http/error.rs
@@ -93,6 +93,8 @@ pub enum Error {
     HTTP3ContentLengthMismatch,
     #[error("FailedToOpenSocket")]
     FailedToOpenSocket,
+    #[error("FailedToStartHTTPClientThread")]
+    FailedToStartHTTPClientThread,
     #[error("InvalidCRL")]
     InvalidCRL,
     #[error("UnsupportedProxyProtocol")]
@@ -306,6 +308,7 @@ impl Error {
             Self::HTTP3StreamReset => "HTTP3StreamReset",
             Self::HTTP3ContentLengthMismatch => "HTTP3ContentLengthMismatch",
             Self::FailedToOpenSocket => "FailedToOpenSocket",
+            Self::FailedToStartHTTPClientThread => "FailedToStartHTTPClientThread",
             Self::InvalidCRL => "InvalidCRL",
             Self::UnsupportedProxyProtocol => "UnsupportedProxyProtocol",
             Self::Cert(e) => <&'static str>::from(e),

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -2330,7 +2330,7 @@ pub fn init(
             holder::ABS_CA_FILE_NAME.set(abs_ca_file_name.into_vec_with_nul().into_boxed_slice());
         holder::ABS_CA_FILE_NAME.get().map(|b| &**b).unwrap_or(b"")
     };
-    http::http_thread::init(&http::http_thread::InitOpts {
+    http::http_thread::init_or_crash(&http::http_thread::InitOpts {
         ca: ca_ptrs,
         abs_ca_file_name: abs_ca_file_name_static,
         on_init_error: http_thread_on_init_error,

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -459,8 +459,11 @@ unsafe fn __bun_resolver_init_package_manager(
     // real errno name so resolve.test.ts sees `EACCES` not `Unexpected`). Keep
     // both sides byte-identical or the `Result` layout diverges.
     //
-    // Idempotent.
-    bun_http::http_thread::init(&Default::default());
+    // Idempotent. EAGAIN mirrors the errno pthread_create/CreateThread report
+    // under resource exhaustion, the only way init() fails.
+    if bun_http::http_thread::init(&Default::default()).is_err() {
+        return Err(bun_errno::SystemErrno::EAGAIN);
+    }
 
     // SAFETY: when `Some`, `install` points at a live `Api::BunInstall`
     // (see `run_command::wire_transpiler_from_ctx`); read-only borrow.

--- a/src/install/auto_installer.rs
+++ b/src/install/auto_installer.rs
@@ -459,8 +459,7 @@ unsafe fn __bun_resolver_init_package_manager(
     // real errno name so resolve.test.ts sees `EACCES` not `Unexpected`). Keep
     // both sides byte-identical or the `Result` layout diverges.
     //
-    // Idempotent. EAGAIN mirrors the errno pthread_create/CreateThread report
-    // under resource exhaustion, the only way init() fails.
+    // Idempotent. EAGAIN is what pthread_create reports for the spawn failure.
     if bun_http::http_thread::init(&Default::default()).is_err() {
         return Err(bun_errno::SystemErrno::EAGAIN);
     }

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -269,7 +269,7 @@ impl CreateCommand {
             long_running: false,
             ..Default::default()
         });
-        HTTP::http_thread::init(&Default::default());
+        HTTP::http_thread::init_or_crash(&Default::default());
 
         let mut create_options = CreateOptions::parse(ctx)?;
         let positionals = &create_options.positionals;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -832,8 +832,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
             return;
         }
         if bun_http::http_thread::init(&Default::default()).is_err() {
-            // Preconnect is a best-effort hint; the first real fetch() will
-            // surface the spawn failure to JS.
+            // Best-effort hint; the first real fetch() surfaces the error.
             return;
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -831,7 +831,11 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         if preconnect.is_empty() {
             return;
         }
-        bun_http::http_thread::init(&Default::default());
+        if bun_http::http_thread::init(&Default::default()).is_err() {
+            // Preconnect is a best-effort hint; the first real fetch() will
+            // surface the spawn failure to JS.
+            return;
+        }
 
         for url_str in preconnect {
             // SAFETY: `ctx.runtime_options.preconnect` is process-lifetime
@@ -3136,7 +3140,10 @@ impl RunCommand {
             return;
         }
 
-        bun_http::http_thread::init(&Default::default());
+        if bun_http::http_thread::init(&Default::default()).is_err() {
+            // Best-effort prefetch; markdown renders with alt-text fallback.
+            return;
+        }
 
         // Heap-allocate each Download so AsyncHTTP.task has a stable
         // address (see RemoteImageDownload doc comment).

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2132,7 +2132,7 @@ impl TestCommand {
         // outlives all observers.
         let mut env_loader: Box<DotEnv::Loader> = Box::new(DotEnv::Loader::init());
         jsc::initialize_with(false, ctx.test_options.isolate);
-        bun_http::http_thread::init(&Default::default());
+        bun_http::http_thread::init_or_crash(&Default::default());
 
         let enable_random = ctx.test_options.randomize;
         let seed: u32 = if enable_random {

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -536,7 +536,7 @@ impl UpgradeCommand {
     }
 
     fn _exec(ctx: Command::Context) -> crate::Result<()> {
-        HTTP::http_thread::init(&Default::default());
+        HTTP::http_thread::init_or_crash(&Default::default());
 
         // SAFETY: FileSystem::init returns the process-global singleton; valid for 'static.
         let filesystem = unsafe { &mut *fs::FileSystem::init(None)? };

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2039,14 +2039,9 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
-    // The HTTP client thread is lazily started on first use. If the OS refused
-    // to create it (Windows `CreateThread` failing under commit-limit pressure
-    // or sandbox/AV denial is the common case in crash reports), reject this
-    // fetch with a TypeError instead of aborting the whole process.
     if let Err(msg) = http::http_thread::init(&http::http_thread::InitOpts::default()) {
-        // `HTTPRequestBody` has no Drop impl; by this point `body` may own a
-        // Sendfile fd, a ReadableStream Strong handle, or an AnyBlob store ref.
-        // Match every other post-body error path in this function.
+        // `HTTPRequestBody` has no Drop; `body` may own a Sendfile fd, a
+        // ReadableStream Strong, or an AnyBlob store ref.
         body.detach();
         let err = global_this.create_type_error_instance(format_args!("fetch() failed: {}", msg));
         return Ok(

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -2039,6 +2039,24 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         }
     }
 
+    // The HTTP client thread is lazily started on first use. If the OS refused
+    // to create it (Windows `CreateThread` failing under commit-limit pressure
+    // or sandbox/AV denial is the common case in crash reports), reject this
+    // fetch with a TypeError instead of aborting the whole process.
+    if let Err(msg) = http::http_thread::init(&http::http_thread::InitOpts::default()) {
+        // `HTTPRequestBody` has no Drop impl; by this point `body` may own a
+        // Sendfile fd, a ReadableStream Strong handle, or an AnyBlob store ref.
+        // Match every other post-body error path in this function.
+        body.detach();
+        let err = global_this.create_type_error_instance(format_args!("fetch() failed: {}", msg));
+        return Ok(
+            JSPromise::dangerously_create_rejected_promise_value_without_notifying_vm(
+                global_this,
+                err,
+            ),
+        );
+    }
+
     // Only create this after we have validated all the input.
     // or else we will leak it
     let promise = jsc::JSPromiseStrong::init(global_this);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2478,10 +2478,8 @@ impl FetchTasklet {
         fetch_options: FetchOptions,
         promise: jsc::JSPromiseStrong,
     ) -> crate::Result<*mut FetchTasklet> {
-        // The sole caller (`fetch_impl`) calls `http_thread::init()` and
-        // rejects the promise on failure before reaching here, so the HTTP
-        // thread is known to be running. Any future caller must do the same;
-        // `init()` is `#[must_use]`.
+        // The caller checks `http_thread::init()` and rejects the promise on
+        // failure before reaching here.
         let node = Self::get(global, fetch_options, promise)?;
 
         let node_ref = Self::from_raw_mut(node);

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2478,7 +2478,10 @@ impl FetchTasklet {
         fetch_options: FetchOptions,
         promise: jsc::JSPromiseStrong,
     ) -> crate::Result<*mut FetchTasklet> {
-        http::http_thread::init(&http::http_thread::InitOpts::default());
+        // The sole caller (`fetch_impl`) calls `http_thread::init()` and
+        // rejects the promise on failure before reaching here, so the HTTP
+        // thread is known to be running. Any future caller must do the same;
+        // `init()` is `#[must_use]`.
         let node = Self::get(global, fetch_options, promise)?;
 
         let node_ref = Self::from_raw_mut(node);

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -182,6 +182,16 @@ pub(crate) fn list_objects(
     callback_context: *mut c_void,
     proxy_url: Option<&[u8]>,
 ) -> JsResult<()> {
+    if let Err(msg) = bun_http::http_thread::init(&Default::default()) {
+        callback(
+            S3ListObjectsResult::Failure(Error::S3Error {
+                code: b"FailedToStartHTTPClientThread",
+                message: msg.as_bytes(),
+            }),
+            callback_context,
+        )?;
+        return Ok(());
+    }
     let mut search_params: Vec<u8> = Vec::<u8>::default();
 
     let _ = search_params.append_slice(b"?"); // OOM/capacity: fire-and-forget
@@ -365,7 +375,6 @@ pub(crate) fn list_objects(
     ));
 
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = bun_threading::thread_pool::Batch::default();
     // SAFETY: `http` was initialised by `task.http.write(...)` immediately above.
     unsafe { task.http.assume_init_mut() }.schedule(&mut batch);
@@ -1158,6 +1167,18 @@ fn download_stream(
     ),
     callback_context: *mut c_void,
 ) -> *mut S3HttpDownloadStreamingTask {
+    if let Err(msg) = bun_http::http_thread::init(&Default::default()) {
+        callback(
+            &MutableString::default(),
+            false,
+            Some(Error::S3Error {
+                code: b"FailedToStartHTTPClientThread",
+                message: msg.as_bytes(),
+            }),
+            callback_context,
+        );
+        return core::ptr::null_mut();
+    }
     let range: Option<Vec<u8>> = 'brk: {
         if let Some(size_) = size {
             let mut end = offset + size_;
@@ -1313,7 +1334,6 @@ fn download_stream(
     // enable streaming
     http.enable_response_body_streaming();
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = bun_threading::thread_pool::Batch::default();
     http.schedule(&mut batch);
     // Out on the HTTP thread until its final callback: the VM aborts it at

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -566,6 +566,15 @@ pub(crate) fn execute_simple_s3_request(
         )?;
         return Ok(());
     }
+    if let Err(msg) = bun_http::http_thread::init(&Default::default()) {
+        drop(options.range);
+        callback.fail(
+            b"FailedToStartHTTPClientThread",
+            msg.as_bytes(),
+            callback_context,
+        )?;
+        return Ok(());
+    }
     let result = match this.sign_request::<false>(
         &SignOptions {
             path: options.path,
@@ -697,7 +706,6 @@ pub(crate) fn execute_simple_s3_request(
     // `schedule` below); scoped exclusive write of the `http` field.
     unsafe { (*task_ptr).http.write(async_http) };
     // queue http request
-    bun_http::http_thread::init(&Default::default());
     let mut batch = thread_pool::Batch::default();
     // SAFETY: `http` was initialised immediately above; scoped exclusive access.
     unsafe { (*task_ptr).http.assume_init_mut() }.schedule(&mut batch);

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1725,7 +1725,7 @@ pub(crate) fn download_to_path(
     env: &mut bun_dotenv::Loader,
     dest_z: &ZStr,
 ) -> crate::Result<()> {
-    bun_http::http_thread::init(&Default::default());
+    bun_http::http_thread::init_or_crash(&Default::default());
     let mut refresher = bun_core::Progress::Progress::default();
 
     {

--- a/test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts
+++ b/test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts
@@ -1,0 +1,160 @@
+// When the OS refuses to create the HTTP client thread (Windows CreateThread
+// failing under commit-limit pressure or sandbox/AV denial is the common case
+// in crash reports), fetch() should reject with a catchable error instead of
+// panicking the whole process.
+//
+// Sentry: BUN-2V2S "Failed to start HTTP Client thread: Unexpected"
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
+
+// There is no portable way to force CreateThread/pthread_create to fail
+// deterministically in CI, so exercise the same error path via the
+// BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN hook (shares the code path with a real
+// spawn failure: init() latches the io::Error and every HTTP entry point
+// observes it). The hook is compiled out of release builds
+// (cfg!(debug_assertions) gate in HTTPThread.rs), so these tests only run
+// against debug binaries.
+const failEnv = {
+  ...bunEnv,
+  BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN: "1",
+};
+
+async function run(src: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: failEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+describe.concurrent.skipIf(!isDebug)("fetch() when the HTTP client thread cannot be spawned", () => {
+  test("rejects with a TypeError containing the OS error instead of panicking", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      let err;
+      try {
+        await fetch("http://127.0.0.1:1/");
+        console.log("UNEXPECTED: fetch resolved");
+      } catch (e) {
+        err = e;
+      }
+      if (!err) {
+        console.log("UNEXPECTED: fetch did not reject");
+        process.exit(1);
+      }
+      console.log(JSON.stringify({
+        name: err?.name,
+        message: String(err?.message ?? ""),
+        isTypeError: err instanceof TypeError,
+      }));
+    `);
+
+    // On the unfixed build the env var is unknown, so the HTTP thread starts
+    // normally and fetch rejects with ConnectionRefused (different message),
+    // or the process aborts via Output::panic if spawn genuinely fails.
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`child did not emit JSON; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
+    }
+    expect(parsed).toEqual({
+      name: "TypeError",
+      isTypeError: true,
+      message: expect.stringContaining("Failed to start HTTP Client thread"),
+    });
+    // io::Error Display includes "(os error N)" on Windows and POSIX; this
+    // is the diagnosability half of the fix.
+    expect(parsed.message).toMatch(/os error \d+/);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("subsequent fetch() calls observe the same latched failure", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const msgs = [];
+      for (let i = 0; i < 3; i++) {
+        try {
+          await fetch("http://127.0.0.1:1/");
+          msgs.push("resolved");
+        } catch (e) {
+          msgs.push(String(e?.message ?? e));
+        }
+      }
+      console.log(JSON.stringify(msgs));
+    `);
+
+    let msgs;
+    try {
+      msgs = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`child did not emit JSON; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
+    }
+    expect(msgs).toEqual([
+      expect.stringContaining("Failed to start HTTP Client thread"),
+      expect.stringContaining("Failed to start HTTP Client thread"),
+      expect.stringContaining("Failed to start HTTP Client thread"),
+    ]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("fetch.preconnect() falls through without crashing and fetch() still surfaces the error", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      fetch.preconnect("http://127.0.0.1:1/");
+      fetch.preconnect("http://127.0.0.1:1/");
+      let msg = "none";
+      try {
+        await fetch("http://127.0.0.1:1/");
+      } catch (e) {
+        msg = String(e?.message ?? e);
+      }
+      console.log(JSON.stringify({ msg }));
+    `);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`child did not emit JSON; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
+    }
+    expect(parsed).toEqual({
+      msg: expect.stringContaining("Failed to start HTTP Client thread"),
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  test("S3 operations surface the failure as an error instead of panicking", async () => {
+    const { stdout, stderr, exitCode } = await run(/* js */ `
+      const client = new Bun.S3Client({
+        accessKeyId: "x",
+        secretAccessKey: "y",
+        bucket: "b",
+        endpoint: "http://127.0.0.1:1",
+      });
+      try {
+        await client.list();
+        console.log(JSON.stringify({ message: "UNEXPECTED: list resolved" }));
+      } catch (e) {
+        console.log(JSON.stringify({
+          message: String(e?.message ?? ""),
+        }));
+      }
+    `);
+
+    let parsed;
+    try {
+      parsed = JSON.parse(stdout.trim());
+    } catch {
+      throw new Error(`child did not emit JSON; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
+    }
+    expect(parsed).toEqual({
+      message: expect.stringContaining("Failed to start HTTP Client thread"),
+    });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`HTTPThread::init_once` aborts the whole process with

```
panic(main thread): Failed to start HTTP Client thread: Unexpected
```

when `std::thread::Builder::spawn` returns an error. On Windows this is reachable whenever `CreateThread` fails: commit-limit exhaustion reserving the thread stack (`ERROR_NOT_ENOUGH_MEMORY`), job-object / AppContainer / AV hook denying the call (`ERROR_ACCESS_DENIED`), or the system thread cap. Every one of these surfaces to the user as a hard crash from the first `fetch()` call.

Sentry BUN-2V2S (plus siblings BUN-2V5E, BUN-2W9M): ~3.6k events all-time, ~77/24h, all Windows. Stack:

```
fetch → fetchImpl → FetchTasklet.queue
  → HTTPThread.init → Once::call_once → init_once
```

`src/jsc/web_worker.rs:605-614` already handles the identical `std::thread::Builder::spawn` failure by returning `"Failed to spawn worker thread"` as a JS error; the HTTP thread never got the same treatment.

## Fix

Make `http_thread::init()` fallible: instead of `Output::panic`, store the formatted `io::Error` in a `OnceLock<String>` and return `Err(&'static str)` to every subsequent caller. The `io::Error` `Display` includes the OS error code and text on both Windows and POSIX, so crash reports now distinguish `ERROR_NOT_ENOUGH_MEMORY` from `ERROR_ACCESS_DENIED` instead of the opaque `Unexpected`.

Callers:
- `fetch()` (`fetch_impl`): reject the returned promise with a `TypeError` carrying the message. This is the fix that eliminates the crash volume.
- `fetch.preconnect()` / `--preconnect` / markdown remote-image prefetch: best-effort, drop silently; the markdown renders with alt-text and the first real `fetch()` surfaces the error.
- S3 `execute_simple_s3_request` / `list_objects` / `download_stream`: the `init()` call moves to the top of each function (before any task allocation) and failure routes through the existing `S3Error` callback path.
- `AsyncHTTP::send_sync`, `__bun_resolver_init_package_manager`: propagate via their existing `Result` returns.
- CLI entrypoints (`bun install`, `bun upgrade`, `bun create`, `bun test` startup, `bun build --compile` cross-target download): keep aborting via `init_or_crash`, same behaviour as before but with the OS error in the message.

## Verification

`test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts` spawns child processes with `BUN_INTERNAL_FAIL_HTTP_THREAD_SPAWN=1`, which makes `init_once` take the same `Err(io::Error)` branch a real spawn failure would, and asserts:
- `fetch()` rejects with a `TypeError` whose message contains `Failed to start HTTP Client thread` and `(os error N)`,
- repeated calls observe the same latched failure,
- `fetch.preconnect()` does not crash and a subsequent `fetch()` still surfaces the error,
- `Bun.S3Client#list()` rejects with the same message.

There is no portable way to force `CreateThread`/`pthread_create` to fail deterministically in CI (thread limits are per-UID and address-space limits break unrelated startup allocations), hence the `BUN_INTERNAL_*` hook following the existing `BUN_INTERNAL_SUPPRESS_CRASH_*` precedent. The hook only swaps the `Result` the real spawn would return; everything downstream is production code.

Fails on the unfixed build (the env var is unknown so `fetch("http://127.0.0.1:1/")` yields `ConnectionRefused` instead of the spawn-failure message); passes on this branch.

## Rebase notes

Rebased (squashed) onto main twice as main moved. First rebase, across the typed-error refactor that replaced `bun_core::err!` with per-crate `Error` enums:

- `AsyncHTTP::send_sync` now returns `Err(crate::Error::FailedToStartHTTPClientThread)`, a new variant added to `src/http/error.rs` (plus its `name()` arm).
- `__bun_resolver_init_package_manager` maps the spawn failure to `bun_errno::SystemErrno::EAGAIN` per its errno ABI contract (the errno `pthread_create`/`CreateThread` report under resource exhaustion).
- `upgrade_command::_exec`, `download_to_path`, and `FetchTasklet::queue` keep main's new `crate::Result<...>` signatures with this PR's `init_or_crash`/comment changes applied.

Second rebase (head 5bbc402495):

- `send_sync` kept main's newer signature (`&mut MutableString` out-param, returns `HTTPResponseMetadata`) with the init check applied.
- `execute_simple_s3_request` keeps main's new VM-shutdown guard first, then the init check; S3 callbacks keep main's `JsResult` signatures.
- The debug hook uses `SystemErrno::EAGAIN as i32` for the synthetic errno since main dropped `libc` from `bun_http`'s dependencies.
- `FailedToStartHTTPClientThread` sits next to main's new `InvalidCRL` variant in `src/http/error.rs`.

## Related

Supersedes #29934, which targeted only the diagnosability half and touches `src/http/HTTPThread.zig` (no longer compiled since the Rust rewrite).

Fixes #20797 (`bun run` script calling `fetch()` under resource pressure on Linux; now rejects instead of aborting).

Related user reports that get improved diagnostics but intentionally still abort, since there is no useful recovery for `bun install`/`bun add` when the HTTP thread cannot start: #15249, #24028. Windows reports with the opaque `Unexpected` message: #29933, #24878, #22080, #19085, #14424.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 16 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts:
58 |     try {
59 |       parsed = JSON.parse(stdout.trim());
60 |     } catch {
61 |       throw new Error(`child did not emit JSON; stdout=${JSON.stringify(stdout)} stderr=${JSON.stringify(stderr)}`);
62 |     }
63 |     expect(parsed).toEqual({
                        ^
error: expect(received).toEqual(expected)

  {
    "isTypeError": true,
-   "message": StringContaining "Failed to start HTTP Client thread",
+   "message": "Unable to connect. Is the computer able to access the url?",
    "name": "TypeError",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts:63:20)
(fail) fetch() when the HTTP client thread cannot be spawned > rejects with a TypeError containing the OS error instead of panicking [329.55ms]
90 |     try {
91 |       msgs = JSON.parse(stdout.trim());
92 |     } catch {
93 |       throw new Err
... (truncated)

release without fix: 4 skipped
bun test v1.4.0-canary.1 (6e906e468)

test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts:
(skip) fetch() when the HTTP client thread cannot be spawned > rejects with a TypeError containing the OS error instead of panicking
(skip) fetch() when the HTTP client thread cannot be spawned > subsequent fetch() calls observe the same latched failure
(skip) fetch() when the HTTP client thread cannot be spawned > fetch.preconnect() falls through without crashing and fetch() still surfaces the error
(skip) fetch() when the HTTP client thread cannot be spawned > S3 operations surface the failure as an error instead of panicking

 0 pass
 4 skip
 0 fail
Ran 4 tests across 1 file. [187.00ms]
__F:0:S:4
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts
bun test v1.4.0 (6e906e468)

test/js/web/fetch/fetch-http-thread-spawn-failure.test.ts:
(pass) fetch() when the HTTP client thread cannot be spawned > rejects with a TypeError containing the OS error instead of panicking [320.75ms]
(pass) fetch() when the HTTP client thread cannot be spawned > fetch.preconnect() falls through without crashing and fetch() still surfaces the error [279.12ms]
(pass) fetch() when the HTTP client thread cannot be spawned > subsequent fetch() calls observe the same latched failure [293.94ms]
(pass) fetch() when the HTTP client thread cannot be spawned > S3 operations surface the failure as an error instead of panicking [279.76ms]

 4 pass
 0 fail
 13 expect() calls
Ran 4 tests across 1 file. [2.82s]
__F:0:S:0

release with fix: 4 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     807dea661e
  features     baseline

23 deps, 129 codegen, 1172 objects in 712ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (6e906e468)

Checked 26 installs across 63 packages (no changes) [11.00ms]
[2/1244] gen ErrorCode+*.h
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (6e906e468)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1244] gen bindgenv2
[5/1244] fetch zlib
[zlib] up to date
[6/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (6e906e468)

Checked 111 installs across 104 packages (no changes) [8.00ms]
[8/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 6ms

  react-refresh.js  4.81 KB  (entry point)

[9/1217] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/Process
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_core/env_var.rs                            |   2 +
 src/http/AsyncHTTP.rs                              |  14 +-
 src/http/HTTPThread.rs                             |  48 ++++++-
 src/http/error.rs                                  |   3 +
 src/install/PackageManager.rs                      |   2 +-
 src/install/auto_installer.rs                      |   6 +-
 src/runtime/cli/create_command.rs                  |   2 +-
 src/runtime/cli/run_command.rs                     |  10 +-
 src/runtime/cli/test_command.rs                    |   2 +-
 src/runtime/cli/upgrade_command.rs                 |   2 +-
 src/runtime/webcore/fetch.rs                       |  13 ++
 src/runtime/webcore/fetch/FetchTasklet.rs          |   3 +-
 src/runtime/webcore/s3/client.rs                   |  24 +++-
 src/runtime/webcore/s3/simple_request.rs           |  10 +-
 src/standalone_graph/StandaloneModuleGraph.rs      |   2 +-
 .../fetch/fetch-http-thread-spawn-failure.test.ts  | 160 +++++++++++++++++++++
 16 files changed, 282 insertions(+), 21 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bun_core/env_var.rs                                       2      2     12
src/http/AsyncHTTP.rs                                         4      6     12
src/http/HTTPThread.rs                                        6      9     12
src/http/error.rs                                             3      4     12
src/install/PackageManager.rs                                 2      1     12
src/install/auto_installer.rs                                 4      4     12
src/runtime/cli/create_command.rs                             1      1     12
src/runtime/cli/run_command.rs                                4      4     12
src/runtime/cli/test_command.rs                               2      2     12
src/runtime/cli/upgrade_command.rs                            3      3     12
src/runtime/webcore/fetch.rs                                  7      3     12
src/runtime/webcore/fetch/FetchTasklet.rs                     8      6     12
src/runtime/webcore/s3/client.rs                              4      5     12
src/runtime/webcore/s3/simple_request.rs                      4      3     12
src/standalone_graph/StandaloneModuleGraph.rs                 2      2     12
…st/js/web/fetch/fetch-http-thread-spawn-failure.test.ts      1      8     12
```

</details>

**root cause** · written by the author bot

On Windows, a failure in CreateThread while spawning the HTTP client thread surfaced as an opaque error and triggered an unconditional panic in HTTPThread.init, so transient resource pressure such as commit-limit exhaustion or sandbox restrictions during a single fetch() call crashed the entire process. The fix makes HTTPThread.init fallible and latches any spawn failure, allowing the fetch path to reject the promise with a TypeError instead of aborting, while CLI callers that cannot proceed without the thread retain their existing behavior. It also formats the underlying OS error code into…

<!-- robobun:evidence:end -->
