### PR TITLE
valkey/sql: skip non-callable onclose/onconnect instead of asserting

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1280,7 +1280,9 @@ impl JSValkeyClient {
             };
             Js::hello_set_cached(this_value, &global_object, hello_value);
             // Call onConnect callback if defined by the user
-            if let Some(on_connect) = Js::onconnect_get_cached(this_value) {
+            if let Some(on_connect) =
+                Js::onconnect_get_cached(this_value).filter(|v| v.is_callable())
+            {
                 let js_value = this_value;
                 js_value.ensure_still_alive();
                 global_object.queue_microtask(on_connect, &[js_value, hello_value]);
@@ -1445,7 +1447,7 @@ impl JSValkeyClient {
         }
 
         // Call onClose callback if it exists
-        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue) {
+        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue).filter(|v| v.is_callable()) {
             if let Err(e) = on_close.call(&global_object, this_jsvalue, &[error_value]) {
                 global_object.report_active_exception_as_unhandled(e);
             }
@@ -1470,7 +1472,7 @@ impl JSValkeyClient {
             return;
         };
         let global_object = self.global_object;
-        if let Some(on_close) = Js::onclose_get_cached(this_value) {
+        if let Some(on_close) = Js::onclose_get_cached(this_value).filter(|v| v.is_callable()) {
             let _exit = self.vm().enter_event_loop_scope();
             if let Err(e) = on_close.call(&global_object, this_value, &[value]) {
                 global_object.report_active_exception_as_unhandled(e);

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -662,7 +662,7 @@ impl JSMySQLConnection {
             return None;
         }
         if let Some(value) = self.js_value.get().try_get() {
-            return js::onconnect_take_cached(value, global_object);
+            return js::onconnect_take_cached(value, global_object).filter(|v| v.is_callable());
         }
         None
     }
@@ -672,7 +672,7 @@ impl JSMySQLConnection {
             return None;
         }
         if let Some(value) = self.js_value.get().try_get() {
-            return js::onclose_take_cached(value, global_object);
+            return js::onclose_take_cached(value, global_object).filter(|v| v.is_callable());
         }
         None
     }

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -3027,7 +3027,7 @@ impl PostgresSQLConnection {
         debug!("consumeOnConnectCallback exists");
 
         js::onconnect_set_cached(js_value, global_object, JSValue::ZERO);
-        Some(on_connect)
+        Some(on_connect).filter(|v| v.is_callable())
     }
 
     pub fn consume_on_close_callback(&self, global_object: &JSGlobalObject) -> Option<JSValue> {
@@ -3036,6 +3036,6 @@ impl PostgresSQLConnection {
         let on_close = js::onclose_get_cached(js_value)?;
         debug!("consumeOnCloseCallback exists");
         js::onclose_set_cached(js_value, global_object, JSValue::ZERO);
-        Some(on_close)
+        Some(on_close).filter(|v| v.is_callable())
     }
 }

--- a/test/js/valkey/valkey.test.ts
+++ b/test/js/valkey/valkey.test.ts
@@ -1,6 +1,6 @@
 import { randomUUIDv7, RedisClient, spawn } from "bun";
 import { beforeAll, beforeEach, describe, expect, test } from "bun:test";
-import { bunExe, bunRun } from "harness";
+import { bunEnv, bunExe, bunRun } from "harness";
 import { join } from "node:path";
 import {
   ctx as _ctx,
@@ -6901,3 +6901,33 @@ for (const connectionType of [ConnectionType.TLS, ConnectionType.TCP]) {
     });
   });
 }
+
+test("non-callable onclose/onconnect does not crash on connection failure", async () => {
+  const src = `
+    const { RedisClient } = Bun;
+    const bad = [{}, null, 123, "str", true, []];
+    const pending = [];
+    for (const v of bad) {
+      const client = new RedisClient("redis://127.0.0.1:1", { connectionTimeout: 50, maxRetries: 0 });
+      client.onclose = v;
+      client.onconnect = v;
+      pending.push(client.connect().then(() => 0, () => 1));
+    }
+    Promise.all(pending).then(results => {
+      console.log("rejected " + results.reduce((a, b) => a + b, 0) + "/" + bad.length);
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+    stdout: "rejected 6/6\n",
+    stderr: "",
+    signalCode: null,
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
Fuzzilli fingerprint: `3153c31c63a5fda1`

Fixes #29145

## What

`RedisClient.onclose` / `.onconnect` (and the equivalent properties on `PostgresSQLConnection` / `MySQLConnection`) are user-writable cached properties with no type validation at assignment time. The published type definitions document `null` as a valid value for both. When the connection closed or failed, the stored value was passed directly to `JSValue::call()` or `queue_microtask()`, both of which `ASSERT(isCallable())` in debug builds. In release, `Bun__JSValue__call` returns an empty `JSValue` from the `CallData::Type::None` branch which then panics downstream with "A JavaScript exception was thrown, but it was cleared before it could be read."

Minimal repro (aborts on current main):
```js
const client = new Bun.RedisClient("redis://127.0.0.1:1", { connectionTimeout: 50, maxRetries: 0 });
client.onclose = {};
client.connect().catch(() => {});
```

The #29145 repro (`c.onclose = null; c.close()` against a live server) hits the same path via `on_valkey_close`.

## Fix

Filter the cached value through `is_callable()` at each call site so a non-function assignment (including `null`) is simply ignored. The same guard is applied to the Postgres and MySQL connection classes since they share the `cached_prop_hostfns!` setter and have identical call paths.

## Test

Added a subprocess test in `test/js/valkey/valkey.test.ts` that sets `onclose`/`onconnect` to several non-callable values (`{}`, `null`, `123`, `"str"`, `true`, `[]`) on clients pointed at an unroutable port, waits for all connect promises to reject, and asserts a clean exit. Fails on main with the `jsObject.isCallable()` assertion (debug) or a panic (release), passes with this change.
