### PR TITLE
worker_threads: accept SHARE_ENV instead of throwing

### DIFF
--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -233,13 +233,26 @@ template<> JSC::EncodedJSValue JSC_HOST_CALL_ATTRIBUTES JSWorkerDOMConstructor::
 
         auto envValue = optionsObject->getIfPropertyExists(lexicalGlobalObject, Identifier::fromString(vm, "env"_s));
         RETURN_IF_EXCEPTION(throwScope, {});
-        // for now, we don't permit SHARE_ENV, because the behavior isn't implemented
-        if (envValue && !(envValue.isObject() || envValue.isUndefinedOrNull())) {
+
+        // `worker_threads.SHARE_ENV` is a unique symbol defined in
+        // worker_threads.ts. It tells the worker to use the parent's
+        // environment. The global `Worker` constructor path does not go through
+        // that module, so we identify the symbol here by its description.
+        bool isShareEnv = false;
+        if (envValue && envValue.isSymbol()) {
+            if (auto description = asSymbol(envValue)->tryGetDescriptiveString())
+                isShareEnv = *description == "Symbol(nodejs.worker_threads.SHARE_ENV)"_s;
+        }
+
+        if (!isShareEnv && envValue && !(envValue.isObject() || envValue.isUndefinedOrNull())) {
             return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "options.env"_s, "object or one of undefined, null, or worker_threads.SHARE_ENV"_s, envValue);
         }
         JSObject* envObject = nullptr;
 
-        if (envValue && envValue.isCell()) {
+        if (isShareEnv) {
+            // Initialize the worker with a snapshot of the parent's environment.
+            envObject = globalObject->processEnvObject();
+        } else if (envValue && envValue.isCell()) {
             envObject = dynamicDowncast<JSC::JSObject>(envValue);
         } else if (globalObject->m_processEnvObject.isInitialized()) {
             envObject = globalObject->processEnvObject();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -250,6 +250,44 @@ test("support worker eval that throws", async () => {
   await worker.terminate();
 });
 
+describe("SHARE_ENV", () => {
+  // https://github.com/oven-sh/bun/issues/32247
+  // Passing worker_threads.SHARE_ENV used to throw ERR_INVALID_ARG_TYPE even
+  // though the error message advertised it as a valid value.
+  test("the global Worker accepts { env: SHARE_ENV } without throwing", async () => {
+    const url = URL.createObjectURL(new Blob([`postMessage("ok")`], { type: "application/javascript" }));
+    try {
+      const worker = new globalThis.Worker(url, { env: SHARE_ENV });
+      const { promise, resolve, reject } = Promise.withResolvers();
+      worker.addEventListener("message", e => resolve(e.data));
+      worker.addEventListener("error", e => reject(e.error ?? new Error(e.message || "worker error")));
+      expect(await promise).toBe("ok");
+      worker.terminate();
+    } finally {
+      URL.revokeObjectURL(url);
+    }
+  });
+
+  test("a worker with { env: SHARE_ENV } inherits the parent environment", async () => {
+    const key = "BUN_TEST_SHARE_ENV_32247";
+    process.env[key] = "shared-value";
+    try {
+      const worker = new Worker(
+        `const { parentPort } = require("worker_threads"); parentPort.postMessage(process.env[${JSON.stringify(key)}]);`,
+        { eval: true, env: SHARE_ENV },
+      );
+      const { promise, resolve, reject } = Promise.withResolvers();
+      worker.on("message", resolve);
+      worker.on("error", reject);
+      worker.on("exit", code => reject(new Error(`worker exited early with code ${code}`)));
+      expect(await promise).toBe("shared-value");
+      await worker.terminate();
+    } finally {
+      delete process.env[key];
+    }
+  });
+});
+
 describe("execArgv option", async () => {
   // this needs to be a subprocess to ensure that the parent's execArgv is not empty
   // otherwise we could not distinguish between the worker inheriting the parent's execArgv


### PR DESCRIPTION
## What

`new Worker(url, { env: SHARE_ENV })` threw `ERR_INVALID_ARG_TYPE`, even though the error message itself listed `worker_threads.SHARE_ENV` as an accepted value.

Fixes #32247
Fixes #20451

### Reproduction

```ts
import { SHARE_ENV } from "worker_threads";

const url = URL.createObjectURL(new Blob([`console.log("foo")`], { type: "application/javascript" }));
new Worker(url, { env: SHARE_ENV });
```

```
TypeError: The "options.env" property must be of type object or one of undefined, null, or worker_threads.SHARE_ENV. Received type symbol (Symbol(nodejs.worker_threads.SHARE_ENV))
 code: "ERR_INVALID_ARG_TYPE"
```

This was a regression introduced by #18758 (the throw did not exist in v1.2.2, per #20451).

### Cause

In `src/jsc/bindings/webcore/JSWorker.cpp`, the constructor rejected any `env` value that was not an object or `null`/`undefined`. `SHARE_ENV` is a symbol (defined in `worker_threads.ts`), so it fell into the reject branch. The guard was shared by the global `Worker` and `node:worker_threads.Worker` constructors, so both threw.

### Fix

Detect the `SHARE_ENV` symbol and initialize the worker with the parent's environment instead of throwing. Other symbols are still rejected, matching Node. The fix is in the shared constructor path, so it covers both `Worker` entry points.

### Scope

This stops the erroneous rejection and gives the worker the parent's environment at spawn. It does **not** implement Node's live bidirectional propagation, where a `process.env` write in one thread becomes visible in the other. That requires a thread-safe shared env store plus a shared-backed `process.env` on both threads (Bun's `process.env` is per-VM today), and is a larger follow-up.

Because of that, this PR does not close #24439, whose repro specifically expects the parent to observe a variable the worker set. It removes the throw from that repro (a prerequisite), but the bidirectional behavior is still needed.

### Verification

Added two tests in `test/js/node/worker_threads/worker_threads.test.ts` (the exact issue repro via the global `Worker`, and a `node:worker_threads` worker that reads a parent-set variable). Both fail on the unfixed build with the `ERR_INVALID_ARG_TYPE` above and pass with the fix.