### PR TITLE
Fix debug assertion when Glob scanSync is called with globalThis receiver

### DIFF
--- a/src/jsc/bindings/ImportMetaObject.cpp
+++ b/src/jsc/bindings/ImportMetaObject.cpp
@@ -296,7 +296,7 @@ extern "C" JSC::EncodedJSValue functionImportMeta__resolveSyncPrivate(JSC::JSGlo
 
     JSC::JSValue moduleName = callFrame->argument(0);
     JSValue from = callFrame->argument(1);
-    bool isESM = callFrame->argument(2).asBoolean();
+    bool isESM = callFrame->argument(2).isTrue();
     bool isRequireDotResolve = callFrame->argument(3).isTrue();
     JSValue userPathList = callFrame->argument(4);
 

--- a/test/js/bun/glob/scan.test.ts
+++ b/test/js/bun/glob/scan.test.ts
@@ -1083,3 +1083,27 @@ describe.skipIf(!canCreateDirSymlink)("literal path segment through a symlinked 
     expect(norm(result)).toEqual(["linkdir/file.txt"]);
   });
 });
+
+test("scanSync/scan with globalThis receiver does not crash", async () => {
+  const script = `
+    for (const fn of ["scanSync", "scan"]) {
+      try {
+        new Bun.Glob("x")[fn].call(globalThis, 512);
+      } catch (e) {
+        console.log(fn + ": " + e.constructor.name);
+      }
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "scanSync: TypeError\nscan: TypeError",
+    stderr: expect.not.stringContaining("ASSERTION FAILED"),
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
Fuzzilli found a debug-build assertion crash (`ASSERTION FAILED: isBoolean()` in `JSCJSValue.h`).

### Root cause

`functionImportMeta__resolveSyncPrivate` reads its third argument with `.asBoolean()`, which asserts in debug builds when the value is not a boolean. This function is installed on `globalThis` under the private name `@resolveSync`, which is the same private name `Bun.Glob.prototype.scanSync` uses to call its native implementation. So:

```js
new Bun.Glob("x").scanSync.call(globalThis, 512);
```

ends up calling `functionImportMeta__resolveSyncPrivate(512)` where argument 2 is `undefined`, tripping the assertion.

### Fix

Use `.isTrue()` instead of `.asBoolean()`, matching how argument 3 is already read on the next line. All legitimate internal callers (CommonJS `require` / `require.resolve` builtins) pass boolean literals, so behavior is unchanged. Release builds were already unaffected since the assertion is debug-only and `asBoolean()` happens to produce the same result as `isTrue()` for non-boolean inputs.

### Test

Added a regression test to `test/js/bun/glob/scan.test.ts` that spawns a subprocess calling both `scanSync` and `scan` with `globalThis` as the receiver. The test fails with SIGABRT on the unfixed debug build and passes with the fix.