### PR TITLE
Return Subprocess resourceUsage() as a plain object of numbers

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -677,22 +677,6 @@ impl JSValue {
     pub fn from_uint64_no_truncate(global: &JSGlobalObject, i: u64) -> JSValue {
         JSC__JSValue__fromUInt64NoTruncate(global, i)
     }
-    /// `JSValue.fromTimevalNoTruncate` — encode a `struct timeval`
-    /// as a BigInt (`sec * 1_000_000 + nsec`) without precision loss. May allocate
-    /// a heap BigInt, so wrapped in `from_js_host_call` for exception checking.
-    pub fn from_timeval_no_truncate(
-        global: &JSGlobalObject,
-        nsec: i64,
-        sec: i64,
-    ) -> JsResult<JSValue> {
-        host_fn::from_js_host_call(global, || {
-            JSC__JSValue__fromTimevalNoTruncate(global, nsec, sec)
-        })
-    }
-    /// `JSValue.bigIntSum` — `a + b` where both are BigInt.
-    pub fn big_int_sum(global: &JSGlobalObject, a: JSValue, b: JSValue) -> JSValue {
-        JSC__JSValue__bigIntSum(global, a, b)
-    }
     /// `JSValue.fromEntries` — build a plain object from
     /// parallel `keys`/`values` `ZigString` arrays. When `clone` is true the
     /// C++ side copies the string bytes (caller may free `keys`/`values`).
@@ -1974,12 +1958,6 @@ unsafe extern "C" {
     safe fn JSC__JSValue__dateInstanceFromNumber(global: &JSGlobalObject, n: f64) -> JSValue;
     safe fn JSC__JSValue__fromInt64NoTruncate(global: &JSGlobalObject, i: i64) -> JSValue;
     safe fn JSC__JSValue__fromUInt64NoTruncate(global: &JSGlobalObject, i: u64) -> JSValue;
-    safe fn JSC__JSValue__fromTimevalNoTruncate(
-        global: &JSGlobalObject,
-        nsec: i64,
-        sec: i64,
-    ) -> JSValue;
-    safe fn JSC__JSValue__bigIntSum(global: &JSGlobalObject, a: JSValue, b: JSValue) -> JSValue;
     fn JSC__JSValue__fromEntries(
         global: *const JSGlobalObject,
         keys: *mut bun_core::ZigString,

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4122,41 +4122,6 @@ JSC::EncodedJSValue JSC__JSValue__fromInt64NoTruncate(JSC::JSGlobalObject* globa
     return JSC::JSValue::encode(JSC::JSBigInt::createFrom(globalObject, val));
 }
 
-JSC::EncodedJSValue JSC__JSValue__fromTimevalNoTruncate(JSC::JSGlobalObject* globalObject, int64_t nsec, int64_t sec)
-{
-    auto& vm = JSC::getVM(globalObject);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    auto big_nsec = JSC::JSBigInt::createFrom(globalObject, nsec);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto big_sec = JSC::JSBigInt::createFrom(globalObject, sec);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto big_1e6 = JSC::JSBigInt::createFrom(globalObject, 1e6);
-    RETURN_IF_EXCEPTION(scope, {});
-    auto sec_as_nsec = JSC::JSBigInt::multiply(globalObject, big_1e6, big_sec);
-    RETURN_IF_EXCEPTION(scope, {});
-    ASSERT(sec_as_nsec.isHeapBigInt());
-    auto* big_sec_as_nsec = sec_as_nsec.asHeapBigInt();
-    ASSERT(big_sec_as_nsec);
-    auto result = JSC::JSBigInt::add(globalObject, big_sec_as_nsec, big_nsec);
-    RETURN_IF_EXCEPTION(scope, {});
-    return JSC::JSValue::encode(result);
-}
-
-JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue a, JSC::EncodedJSValue b)
-{
-    JSC::JSValue a_value = JSC::JSValue::decode(a);
-    JSC::JSValue b_value = JSC::JSValue::decode(b);
-
-    ASSERT(a_value.isHeapBigInt());
-    auto* big_a = a_value.asHeapBigInt();
-    ASSERT(big_a);
-
-    ASSERT(b_value.isHeapBigInt());
-    auto* big_b = b_value.asHeapBigInt();
-    ASSERT(big_b);
-    return JSC::JSValue::encode(JSC::JSBigInt::add(globalObject, big_a, big_b));
-}
-
 JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* globalObject, uint64_t val)
 {
     return JSC::JSValue::encode(JSC::JSBigInt::createFrom(globalObject, val));

--- a/src/jsc/bindings/headers.h
+++ b/src/jsc/bindings/headers.h
@@ -228,8 +228,6 @@ CPP_DECL void JSC__JSValue__forEachPropertyOrdered(JSC::EncodedJSValue JSValue0,
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromEntries(JSC::JSGlobalObject* arg0, ZigString* arg1, ZigString* arg2, size_t arg3, bool arg4);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromInt64NoTruncate(JSC::JSGlobalObject* arg0, int64_t arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromUInt64NoTruncate(JSC::JSGlobalObject* arg0, uint64_t arg1);
-CPP_DECL JSC::EncodedJSValue JSC__JSValue__fromTimevalNoTruncate(JSC::JSGlobalObject* arg0, int64_t nsec, int64_t sec);
-CPP_DECL JSC::EncodedJSValue JSC__JSValue__bigIntSum(JSC::JSGlobalObject* arg0, JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1);
 CPP_DECL void JSC__JSValue__getClassName(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, ZigString* arg2);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getErrorsProperty(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1);
 CPP_DECL JSC::EncodedJSValue JSC__JSValue__getIfPropertyExistsFromPath(JSC::EncodedJSValue JSValue0, JSC::JSGlobalObject* arg1, JSC::EncodedJSValue JSValue2);

--- a/src/jsc/generated_classes_list.rs
+++ b/src/jsc/generated_classes_list.rs
@@ -54,7 +54,6 @@ pub mod Classes {
     // codegen sees the correct payload.
     pub use crate::api::bun::h2_frame_parser::H2FrameParser;
     pub use crate::api::bun::subprocess as Subprocess;
-    pub use crate::api::bun::subprocess::ResourceUsage;
     pub use crate::api::bun::terminal as Terminal;
     pub use crate::api::cron::CronJob;
     pub use crate::api::filesystem_router::MatchedRoute;

--- a/src/runtime/api/BunObject.classes.ts
+++ b/src/runtime/api/BunObject.classes.ts
@@ -2,46 +2,6 @@ import { define } from "../../codegen/class-definitions";
 
 export default [
   define({
-    name: "ResourceUsage",
-    construct: true,
-    noConstructor: true,
-    finalize: true,
-    configurable: false,
-    hasPendingActivity: false,
-    klass: {},
-    JSType: "0b11101110",
-    proto: {
-      maxRSS: {
-        getter: "getMaxRSS",
-      },
-      shmSize: {
-        getter: "getSharedMemorySize",
-      },
-      swapCount: {
-        getter: "getSwapCount",
-      },
-      messages: {
-        getter: "getMessages",
-      },
-      signalCount: {
-        getter: "getSignalCount",
-      },
-      contextSwitches: {
-        getter: "getContextSwitches",
-        cache: true,
-      },
-      cpuTime: {
-        getter: "getCPUTime",
-        cache: true,
-      },
-      ops: {
-        getter: "getOps",
-        cache: true,
-      },
-    },
-    values: [],
-  }),
-  define({
     name: "Subprocess",
     // R-2 Phase 2: user impls take `&self`; emit `this: &T` shims.
     sharedThis: true,

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -36,7 +36,6 @@ use bun_libuv_sys::UvHandle as _;
 
 #[path = "subprocess/ResourceUsage.rs"]
 pub mod resource_usage;
-pub use resource_usage::ResourceUsage;
 
 #[path = "subprocess/SubprocessPipeReader.rs"]
 pub mod subprocess_pipe_reader;
@@ -398,7 +397,7 @@ impl Subprocess<'_> {
 
             return Ok(JSValue::UNDEFINED);
         };
-        ResourceUsage::create(&rusage, global_object)
+        Ok(resource_usage::create(&rusage, global_object))
     }
 
     pub fn has_exited(&self) -> bool {

--- a/src/runtime/api/bun/subprocess/ResourceUsage.rs
+++ b/src/runtime/api/bun/subprocess/ResourceUsage.rs
@@ -1,95 +1,44 @@
 use crate::api::bun::Rusage;
-use bun_jsc::{JSGlobalObject, JSValue, JsClass, JsResult};
-use bun_spawn::RusageFields as _; // trait + impls now live in bun_spawn_sys::spawn_process
+use bun_jsc::{JSGlobalObject, JSValue};
+use bun_spawn::RusageFields as _;
 
-// `#[repr(C)]` only to satisfy the `improper_ctypes` lint on the generated
-// `extern "C" fn(..., *mut ResourceUsage)` shims — C++ never reads this layout
-// (it round-trips `m_ctx` as `void*`).
-#[bun_jsc::JsClass(no_construct, no_constructor)]
-#[repr(C)]
-pub struct ResourceUsage {
-    pub rusage: Rusage,
-}
+/// Builds the `ResourceUsage` object returned by `Subprocess.resourceUsage()`
+/// and `Bun.spawnSync().resourceUsage`: own enumerable number properties, so it
+/// serializes and spreads like `process.resourceUsage()`.
+pub fn create(rusage: &Rusage, global: &JSGlobalObject) -> JSValue {
+    // Microseconds fit exactly in a double (2^53 us is ~285 years of CPU time).
+    let user = (rusage.utime_sec() * 1_000_000 + rusage.utime_usec()) as f64;
+    let system = (rusage.stime_sec() * 1_000_000 + rusage.stime_usec()) as f64;
 
-impl ResourceUsage {
-    pub fn create(rusage: &Rusage, global: &JSGlobalObject) -> JsResult<JSValue> {
-        Ok(Box::new(ResourceUsage { rusage: *rusage }).to_js(global))
-    }
+    let context_switches = JSValue::create_empty_object_with_null_prototype(global);
+    context_switches.put(global, b"voluntary", JSValue::js_number(rusage.nvcsw_()));
+    context_switches.put(global, b"involuntary", JSValue::js_number(rusage.nivcsw_()));
 
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_cpu_time(this: &Self, global: &JSGlobalObject) -> JsResult<JSValue> {
-        let cpu = JSValue::create_empty_object_with_null_prototype(global);
-        let rusage = &this.rusage;
+    let cpu_time = JSValue::create_empty_object_with_null_prototype(global);
+    cpu_time.put(global, b"user", JSValue::js_number(user));
+    cpu_time.put(global, b"system", JSValue::js_number(system));
+    cpu_time.put(global, b"total", JSValue::js_number(user + system));
 
-        let usr_time =
-            JSValue::from_timeval_no_truncate(global, rusage.utime_usec(), rusage.utime_sec())?;
-        let sys_time =
-            JSValue::from_timeval_no_truncate(global, rusage.stime_usec(), rusage.stime_sec())?;
+    let messages = JSValue::create_empty_object_with_null_prototype(global);
+    messages.put(global, b"sent", JSValue::js_number(rusage.msgsnd_()));
+    messages.put(global, b"received", JSValue::js_number(rusage.msgrcv_()));
 
-        cpu.put(global, b"user", usr_time);
-        cpu.put(global, b"system", sys_time);
-        cpu.put(
-            global,
-            b"total",
-            JSValue::big_int_sum(global, usr_time, sys_time),
-        );
+    let ops = JSValue::create_empty_object_with_null_prototype(global);
+    ops.put(global, b"in", JSValue::js_number(rusage.inblock_()));
+    ops.put(global, b"out", JSValue::js_number(rusage.oublock_()));
 
-        Ok(cpu)
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_max_rss(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.maxrss_())
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_shared_memory_size(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.ixrss_())
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_swap_count(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.nswap_())
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_ops(this: &Self, global: &JSGlobalObject) -> JSValue {
-        let ops = JSValue::create_empty_object_with_null_prototype(global);
-        ops.put(global, b"in", JSValue::js_number(this.rusage.inblock_()));
-        ops.put(global, b"out", JSValue::js_number(this.rusage.oublock_()));
-        ops
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_messages(this: &Self, global: &JSGlobalObject) -> JSValue {
-        let msgs = JSValue::create_empty_object_with_null_prototype(global);
-        msgs.put(global, b"sent", JSValue::js_number(this.rusage.msgsnd_()));
-        msgs.put(
-            global,
-            b"received",
-            JSValue::js_number(this.rusage.msgrcv_()),
-        );
-        msgs
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_signal_count(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        JSValue::js_number(this.rusage.nsignals_())
-    }
-
-    #[bun_jsc::host_fn(getter)]
-    pub fn get_context_switches(this: &Self, global: &JSGlobalObject) -> JSValue {
-        let ctx = JSValue::create_empty_object_with_null_prototype(global);
-        ctx.put(
-            global,
-            b"voluntary",
-            JSValue::js_number(this.rusage.nvcsw_()),
-        );
-        ctx.put(
-            global,
-            b"involuntary",
-            JSValue::js_number(this.rusage.nivcsw_()),
-        );
-        ctx
-    }
+    let usage = JSValue::create_empty_object(global, 8);
+    usage.put(global, b"contextSwitches", context_switches);
+    usage.put(global, b"cpuTime", cpu_time);
+    usage.put(global, b"maxRSS", JSValue::js_number(rusage.maxrss_()));
+    usage.put(global, b"messages", messages);
+    usage.put(global, b"ops", ops);
+    usage.put(global, b"shmSize", JSValue::js_number(rusage.ixrss_()));
+    usage.put(
+        global,
+        b"signalCount",
+        JSValue::js_number(rusage.nsignals_()),
+    );
+    usage.put(global, b"swapCount", JSValue::js_number(rusage.nswap_()));
+    usage
 }

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -1,4 +1,4 @@
-import { ArrayBufferSink, readableStreamToText, spawn, spawnSync } from "bun";
+import { ArrayBufferSink, readableStreamToText, spawn, spawnSync, type ResourceUsage } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
 import {
   gcTick as _gcTick,
@@ -1253,5 +1253,73 @@ describe("uid/gid", () => {
       thrown = e;
     }
     expect(thrown?.code).toBe("EPERM");
+  });
+});
+
+describe("resourceUsage", () => {
+  // https://github.com/oven-sh/bun/issues/32254
+  const resourceUsageKeys = [
+    "contextSwitches",
+    "cpuTime",
+    "maxRSS",
+    "messages",
+    "ops",
+    "shmSize",
+    "signalCount",
+    "swapCount",
+  ];
+
+  const burnCPU = "let x = 0; for (let i = 0; i < 1e6; i++) x += i;";
+
+  function checkResourceUsage(usage: ResourceUsage) {
+    expect(Object.keys(usage).sort()).toEqual(resourceUsageKeys);
+
+    const { user, system, total } = usage.cpuTime;
+    expect({ user: typeof user, system: typeof system, total: typeof total }).toEqual({
+      user: "number",
+      system: "number",
+      total: "number",
+    });
+    expect(user).toBeGreaterThanOrEqual(0);
+    expect(system).toBeGreaterThanOrEqual(0);
+    expect(total).toBe(user + system);
+
+    expect(typeof usage.maxRSS).toBe("number");
+
+    const roundTripped = JSON.parse(JSON.stringify(usage));
+    expect(Object.keys(roundTripped).sort()).toEqual(resourceUsageKeys);
+    expect(roundTripped.cpuTime).toEqual({ user, system, total });
+    expect(roundTripped.maxRSS).toBe(usage.maxRSS);
+    expect(roundTripped.contextSwitches).toEqual({ ...usage.contextSwitches });
+  }
+
+  it("spawn().resourceUsage() has own number fields that serialize", async () => {
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", burnCPU],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    const usage = proc.resourceUsage();
+    expect(usage).toBeDefined();
+    checkResourceUsage(usage!);
+  });
+
+  it("spawnSync().resourceUsage has own number fields that serialize", () => {
+    const { stdout, stderr, exitCode, resourceUsage } = spawnSync({
+      cmd: [bunExe(), "-e", burnCPU],
+      env: bunEnv,
+    });
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    checkResourceUsage(resourceUsage);
   });
 });

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -30,7 +30,7 @@ async function run(withWaiterThread: boolean) {
 
   // Assert we didn't use 100% of CPU time
   console.log(resourceUsage.cpuTime);
-  expect(resourceUsage?.cpuTime.total).toBeLessThan(750_000n * (isWindows ? 5n : 1n));
+  expect(resourceUsage?.cpuTime.total).toBeLessThan(750_000 * (isWindows ? 5 : 1));
 }
 
 test(

--- a/test/js/web/timers/setTimeout.test.js
+++ b/test/js/web/timers/setTimeout.test.js
@@ -400,7 +400,7 @@ it("setTimeout CPU usage #7790", async () => {
   const code = await process.exited;
   expect(code).toBe(0);
   const stats = process.resourceUsage();
-  expect(stats.cpuTime.total / BigInt(1e6)).toBeLessThan(1);
+  expect(stats.cpuTime.total / 1e6).toBeLessThan(1);
 });
 
 it("Returning a Promise in setTimeout doesnt keep the event loop alive forever", async () => {


### PR DESCRIPTION
Fixes #32254

## Problem

`Subprocess.resourceUsage()` and `Bun.spawnSync().resourceUsage` do not behave like the `Bun.ResourceUsage` type and the docs describe:

```js
const usage = Bun.spawnSync({ cmd: ["true"] }).resourceUsage;

typeof usage.cpuTime.user; // "bigint"  (declared: number)
usage.cpuTime.user / 1000; // TypeError: Cannot mix BigInt and other types
JSON.stringify(usage); // "{}"
Object.keys(usage); // []
({ ...usage }); // {}
```

Two things are wrong:

1. `cpuTime.user`, `.system` and `.total` are BigInt, while `Bun.ResourceUsage` in `packages/bun-types/bun.d.ts` and the table in `docs/runtime/child-process.mdx` declare every field as `number`, and every sibling field (`maxRSS`, `ops`, `shmSize`, ...) already is one. Ordinary arithmetic on them throws.
2. The returned value is a native class instance whose eight fields are accessors on `ResourceUsage.prototype`. They are enumerable, so `for...in` lists them, but they are not *own* properties, so `Object.keys`, `JSON.stringify`, spread and `structuredClone` all see an empty object. Logging or snapshotting the usage object records nothing.

The two are coupled: own properties alone would not be enough, since `JSON.stringify` throws on BigInt.

## Cause

`ResourceUsage::create` in `src/runtime/api/bun/subprocess/ResourceUsage.rs` wrapped the `rusage` struct in a generated JS class and exposed the fields as lazy prototype getters. `get_cpu_time` built `user`/`system` with `JSValue::from_timeval_no_truncate` (a heap `JSBigInt`) and `total` with `JSValue::big_int_sum`.

## Fix

Build the plain object the type declares, the same way `process.resourceUsage()` already does in `BunProcess.cpp`: own enumerable properties, microsecond CPU times as JS numbers. Microseconds fit exactly in a double (2^53 us is about 285 years of CPU time), so no precision is lost.

The `ResourceUsage` class is now unused and is removed (`BunObject.classes.ts`, `generated_classes_list.rs`), and with it the last callers of the `fromTimevalNoTruncate` / `bigIntSum` bindings, which are removed from `JSValue.rs`, `bindings.cpp` and `headers.h`. Field names, order and values are unchanged, so `console.log(usage)` prints the same thing minus the `ResourceUsage` class name.

## Verification

`test/js/bun/spawn/spawn.test.ts` gains a `resourceUsage` block covering both entry points (`spawn().resourceUsage()` and `spawnSync().resourceUsage`): the eight documented keys are own properties, the `cpuTime` fields are numbers with `total === user + system`, and the object round-trips through `JSON.stringify`. Both tests fail on the released binary (`Object.keys(usage)` is `[]`) and pass with this change.

Two existing assertions compared against BigInt literals (`750_000n`, `BigInt(1e6)`) and now use numbers: `test/js/bun/spawn/spawn_waiter_thread.test.ts` and `test/js/web/timers/setTimeout.test.js`.

Not filed under `test/regression/issue/`: `cpuTime` has returned BigInt since the feature landed while the declared type always said `number`, so this was never correct rather than a break.
