### PR TITLE
crypto: throw ERR_INVALID_THIS in Hmac native update() on bad receiver

### DIFF
--- a/src/jsc/bindings/node/crypto/JSHmac.cpp
+++ b/src/jsc/bindings/node/crypto/JSHmac.cpp
@@ -114,8 +114,10 @@ JSC_DEFINE_HOST_FUNCTION(jsHmacProtoFuncUpdate, (JSC::JSGlobalObject * globalObj
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // Get the HMAC instance
-    JSValue thisHmac = callFrame->thisValue();
-    JSHmac* hmac = dynamicDowncast<JSHmac>(thisHmac);
+    JSHmac* hmac = dynamicDowncast<JSHmac>(callFrame->thisValue());
+    if (!hmac) [[unlikely]] {
+        return Bun::ERR::INVALID_THIS(scope, globalObject, "Hmac"_s);
+    }
 
     // Check if the HMAC is already finalized
     if (hmac->m_finalized) {

--- a/test/js/node/crypto/crypto-invalid-this.test.ts
+++ b/test/js/node/crypto/crypto-invalid-this.test.ts
@@ -18,6 +18,16 @@ test("Hmac native digest() throws ERR_INVALID_THIS instead of segfaulting on bad
   expect(() => nativeDigest.call(42)).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
 });
 
+test("Hmac native update() throws ERR_INVALID_THIS instead of segfaulting on bad this", () => {
+  const hmac = createHmac("sha256", "key");
+  const native = getNativeHandle(hmac);
+  const nativeUpdate = native.update;
+
+  expect(() => nativeUpdate.call({}, hmac, "x")).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+  expect(() => nativeUpdate.call(null, hmac, "x")).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+  expect(() => nativeUpdate.call(42, hmac, "x")).toThrow(expect.objectContaining({ code: "ERR_INVALID_THIS" }));
+});
+
 test("DiffieHellmanGroup verifyError getter throws ERR_INVALID_THIS instead of segfaulting on bad this", () => {
   const dhg = getDiffieHellman("modp14");
   const desc =


### PR DESCRIPTION
## What does this PR do?

`jsHmacProtoFuncUpdate` called `dynamicDowncast<JSHmac>(thisValue)` and immediately dereferenced the result as `hmac->m_finalized` without a null check. `dynamicDowncast` returns `nullptr` when the receiver is not a `JSHmac`, so extracting the native prototype's `update` via the `kHandle` symbol and calling it with an arbitrary receiver segfaulted the process instead of throwing a catchable error.

Every sibling prototype method — `jsHmacProtoFuncDigest` in the same file, `jsHashProtoFuncUpdate` in `JSHash.cpp`, and the `JSSign.cpp`/`JSVerify.cpp` prototype methods — already performs this check and throws `ERR_INVALID_THIS`; this function alone omitted it.

## How did you verify your code works?

Added a test in `test/js/node/crypto/crypto-invalid-this.test.ts` next to the existing `digest()` test for the same bug class. Verified it segfaults on system bun (`Segmentation fault at address 0x20`) and passes with this change.