### PR TITLE
usockets: stop deriving eof from kqueue EV_EOF

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -710,11 +710,12 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
     #else
     /* A failed non-blocking connect() is reported as "writable" on every
      * platform; the actual errno lives in SO_ERROR. epoll also sets
-     * EPOLLERR/EPOLLHUP so the dispatch flag was enough there, but kqueue
+     * EPOLLERR/EPOLLHUP so the dispatch flag is non-zero there, but kqueue
      * signals it via EVFILT_WRITE + EV_EOF, which the dispatch loop no longer
      * maps (EV_EOF on an established socket is a half-close, not an error).
-     * Probe SO_ERROR unconditionally — it is the portable contract for async
-     * connect completion and costs one getsockopt on this cold path. */
+     * When the dispatch flag is zero, probe SO_ERROR — the portable contract
+     * for async connect completion — at the cost of one getsockopt on this
+     * cold path. */
     if (error == 0) {
         error = us_socket_get_error(s);
     }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -707,6 +707,17 @@ void us_internal_socket_after_open(struct us_socket_t *s, int error) {
             }
         }
     }
+    #else
+    /* A failed non-blocking connect() is reported as "writable" on every
+     * platform; the actual errno lives in SO_ERROR. epoll also sets
+     * EPOLLERR/EPOLLHUP so the dispatch flag was enough there, but kqueue
+     * signals it via EVFILT_WRITE + EV_EOF, which the dispatch loop no longer
+     * maps (EV_EOF on an established socket is a half-close, not an error).
+     * Probe SO_ERROR unconditionally — it is the portable contract for async
+     * connect completion and costs one getsockopt on this cold path. */
+    if (error == 0) {
+        error = us_socket_get_error(s);
+    }
     #endif
     if (error) {
         if (c) {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -224,8 +224,12 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
      * loop had drained the kernel buffer — e.g. an EVFILT_WRITE-only event carrying
      * EV_EOF skips recv entirely, and a busy-loop bail-out can leave bytes unread in
      * the same tick the flag arrived. EVFILT_READ is level-triggered and keeps
-     * firing after a FIN, so recv()==0 (loop.c) is the single source of `eof`, same
-     * as Linux. RST/hard errors remain covered by EV_ERROR and the recv-error path. */
+     * firing after a FIN, so recv()==0 (loop.c) is the single source of `eof`,
+     * same as Linux. RST/hard errors surface via the recv()/send() error paths;
+     * connect failures via getsockopt(SO_ERROR) in us_internal_socket_after_open.
+     * (EV_ERROR only flags changelist-processing failures — the wait kevent64
+     * calls below pass a NULL changelist, so `error` is effectively always 0
+     * here; it is kept for symmetry with the epoll path.) */
     struct kevent_flags {
         uint8_t readable : 1;
         uint8_t writable : 1;
@@ -461,7 +465,9 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
      * EVFILT_WRITE "to receive FIN" — that only ever worked via EV_EOF, which
      * the dispatch loop no longer maps. A paused socket now watches nothing on
      * kqueue, which is what it effectively did before anyway since the one-shot
-     * fired immediately on any idle-writable socket.) */
+     * fired immediately on any idle-writable socket. EV_DELETE on an
+     * already-fired one-shot returns ENOENT, which KEVENT_FLAG_ERROR_EVENTS
+     * routes into the result list and we ignore.) */
     if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
         EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     }

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -215,14 +215,23 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
     /* Kqueue delivers each filter (READ, WRITE, TIMER, etc.) as a separate kevent,
      * so the same fd/poll can appear twice in ready_polls. We coalesce them into a
      * single set of flags per poll before dispatching, matching epoll's behavior
-     * where each fd appears once with a combined bitmask. */
+     * where each fd appears once with a combined bitmask.
+     *
+     * EV_EOF is intentionally NOT mapped to dispatch's `eof`. Kqueue sets EV_EOF on
+     * EVFILT_READ for a half-close (peer FIN — analogous to EPOLLRDHUP, which the
+     * epoll path also does not map) and on EVFILT_WRITE when the peer's read side is
+     * gone. Treating either as `eof` made loop.c close the socket before the recv
+     * loop had drained the kernel buffer — e.g. an EVFILT_WRITE-only event carrying
+     * EV_EOF skips recv entirely, and a busy-loop bail-out can leave bytes unread in
+     * the same tick the flag arrived. EVFILT_READ is level-triggered and keeps
+     * firing after a FIN, so recv()==0 (loop.c) is the single source of `eof`, same
+     * as Linux. RST/hard errors remain covered by EV_ERROR and the recv-error path. */
     struct kevent_flags {
         uint8_t readable : 1;
         uint8_t writable : 1;
         uint8_t error    : 1;
-        uint8_t eof      : 1;
         uint8_t skip     : 1;
-        uint8_t _pad     : 3;
+        uint8_t _pad     : 4;
     };
 
     _Static_assert(sizeof(struct kevent_flags) == 1, "kevent_flags must be 1 byte");
@@ -246,7 +255,6 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
 #endif
             .writable = (filter == EVFILT_WRITE),
             .error = !!(flags & EV_ERROR),
-            .eof = !!(flags & EV_EOF),
         };
 
         /* Look backward for a prior entry with the same poll to coalesce into.
@@ -257,7 +265,6 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
                 coalesced[j].readable |= bits.readable;
                 coalesced[j].writable |= bits.writable;
                 coalesced[j].error |= bits.error;
-                coalesced[j].eof |= bits.eof;
                 coalesced[i] = (struct kevent_flags){ .skip = 1 };
                 merged = 1;
                 break;
@@ -286,8 +293,8 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
                    | (bits.writable ? LIBUS_SOCKET_WRITABLE : 0);
 
         events &= us_poll_events(poll);
-        if (events || bits.error || bits.eof) {
-            us_internal_dispatch_ready_poll(poll, bits.error, bits.eof, events);
+        if (events || bits.error) {
+            us_internal_dispatch_ready_poll(poll, bits.error, 0, events);
         }
     }
 #endif

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -450,19 +450,19 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
     int change_length = 0;
 
     /* Do they differ in readable? */
-    int is_readable =  (new_events & LIBUS_SOCKET_READABLE);
-    int is_writable =  (new_events & LIBUS_SOCKET_WRITABLE);
     if ((new_events & LIBUS_SOCKET_READABLE) != (old_events & LIBUS_SOCKET_READABLE)) {
-        EV_SET64(&change_list[change_length++], fd, EVFILT_READ, is_readable ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        EV_SET64(&change_list[change_length++], fd, EVFILT_READ, (new_events & LIBUS_SOCKET_READABLE) ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     }
 
-    if(!is_readable && !is_writable) {
-        if(!(old_events & LIBUS_SOCKET_WRITABLE)) {
-            // if we are not reading or writing, we need to add writable to receive FIN
-            EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0, (uint64_t)(void*)user_data, 0, 0);
-        }
-    } else if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
-        /* Do they differ in writable? */
+    /* Do they differ in writable? EVFILT_WRITE is always one-shot, so a stale
+     * registration self-removes; we still issue the explicit EV_DELETE so a
+     * pending one-shot doesn't fire after the caller asked to stop watching.
+     * (There used to be a `new_events == 0` branch here that armed a one-shot
+     * EVFILT_WRITE "to receive FIN" — that only ever worked via EV_EOF, which
+     * the dispatch loop no longer maps. A paused socket now watches nothing on
+     * kqueue, which is what it effectively did before anyway since the one-shot
+     * fired immediately on any idle-writable socket.) */
+    if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
         EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
     }
     int ret;

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -227,6 +227,14 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
      * firing after a FIN, so recv()==0 (loop.c) is the single source of `eof`,
      * same as Linux. RST/hard errors surface via the recv()/send() error paths;
      * connect failures via getsockopt(SO_ERROR) in us_internal_socket_after_open.
+     *
+     * The exception is a poll watching nothing (us_socket_pause followed by
+     * us_socket_shutdown — node:http does exactly this for an unconsumed
+     * request body). It will never recv(), so EV_EOF is the only close signal;
+     * kqueue_change arms an edge-triggered EVFILT_READ for that state and we
+     * forward EV_EOF as `eof` only when us_poll_events == 0. The recv loop is
+     * still skipped, so buffered data the caller paused for is left untouched.
+     *
      * (EV_ERROR only flags changelist-processing failures — the wait kevent64
      * calls below pass a NULL changelist, so `error` is effectively always 0
      * here; it is kept for symmetry with the epoll path.) */
@@ -234,8 +242,9 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         uint8_t readable : 1;
         uint8_t writable : 1;
         uint8_t error    : 1;
+        uint8_t ev_eof   : 1;
         uint8_t skip     : 1;
-        uint8_t _pad     : 4;
+        uint8_t _pad     : 3;
     };
 
     _Static_assert(sizeof(struct kevent_flags) == 1, "kevent_flags must be 1 byte");
@@ -259,6 +268,7 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
 #endif
             .writable = (filter == EVFILT_WRITE),
             .error = !!(flags & EV_ERROR),
+            .ev_eof = !!(flags & EV_EOF),
         };
 
         /* Look backward for a prior entry with the same poll to coalesce into.
@@ -269,6 +279,7 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
                 coalesced[j].readable |= bits.readable;
                 coalesced[j].writable |= bits.writable;
                 coalesced[j].error |= bits.error;
+                coalesced[j].ev_eof |= bits.ev_eof;
                 coalesced[i] = (struct kevent_flags){ .skip = 1 };
                 merged = 1;
                 break;
@@ -296,9 +307,13 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
         int events = (bits.readable ? LIBUS_SOCKET_READABLE : 0)
                    | (bits.writable ? LIBUS_SOCKET_WRITABLE : 0);
 
-        events &= us_poll_events(poll);
-        if (events || bits.error) {
-            us_internal_dispatch_ready_poll(poll, bits.error, 0, events);
+        const int watched = us_poll_events(poll);
+        events &= watched;
+        /* EV_EOF only stands in for eof when this poll watches nothing — see
+         * the comment above. Any READABLE poll discovers eof via recv()==0. */
+        const int eof = bits.ev_eof && watched == 0;
+        if (events || bits.error || eof) {
+            us_internal_dispatch_ready_poll(poll, bits.error, eof, events);
         }
     }
 #endif
@@ -453,23 +468,33 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
     struct kevent64_s change_list[2];
     int change_length = 0;
 
-    /* Do they differ in readable? */
-    if ((new_events & LIBUS_SOCKET_READABLE) != (old_events & LIBUS_SOCKET_READABLE)) {
-        EV_SET64(&change_list[change_length++], fd, EVFILT_READ, (new_events & LIBUS_SOCKET_READABLE) ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
-    }
+    if (new_events == 0 && user_data != NULL) {
+        /* A poll watching nothing still needs to learn about peer close — the
+         * epoll path gets EPOLLHUP for free here. Arm an edge-triggered
+         * EVFILT_READ: it fires once per state transition (data arrival or FIN)
+         * so buffered bytes the caller paused for don't cause a level-triggered
+         * spin, and the dispatch loop above forwards its EV_EOF as `eof` only
+         * for watched==0, never entering the recv loop. EV_ADD on an existing
+         * level-triggered registration just changes it to EV_CLEAR. */
+        EV_SET64(&change_list[change_length++], fd, EVFILT_READ, EV_ADD | EV_CLEAR, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        if (old_events & LIBUS_SOCKET_WRITABLE) {
+            EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        }
+    } else {
+        /* Do they differ in readable? Transitioning from new_events==0 lands
+         * here too: EV_ADD without EV_CLEAR returns the filter to level-
+         * triggered. (old_events==0 with READABLE in new_events always differs,
+         * so the EV_CLEAR sentinel is overwritten.) */
+        if ((new_events & LIBUS_SOCKET_READABLE) != (old_events & LIBUS_SOCKET_READABLE)) {
+            EV_SET64(&change_list[change_length++], fd, EVFILT_READ, (new_events & LIBUS_SOCKET_READABLE) ? EV_ADD : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        }
 
-    /* Do they differ in writable? EVFILT_WRITE is always one-shot, so a stale
-     * registration self-removes; we still issue the explicit EV_DELETE so a
-     * pending one-shot doesn't fire after the caller asked to stop watching.
-     * (There used to be a `new_events == 0` branch here that armed a one-shot
-     * EVFILT_WRITE "to receive FIN" — that only ever worked via EV_EOF, which
-     * the dispatch loop no longer maps. A paused socket now watches nothing on
-     * kqueue, which is what it effectively did before anyway since the one-shot
-     * fired immediately on any idle-writable socket. EV_DELETE on an
-     * already-fired one-shot returns ENOENT, which KEVENT_FLAG_ERROR_EVENTS
-     * routes into the result list and we ignore.) */
-    if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
-        EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        /* Do they differ in writable? EVFILT_WRITE is always one-shot;
+         * EV_DELETE on an already-fired one-shot returns ENOENT, which
+         * KEVENT_FLAG_ERROR_EVENTS routes into the result list and we ignore. */
+        if ((new_events & LIBUS_SOCKET_WRITABLE) != (old_events & LIBUS_SOCKET_WRITABLE)) {
+            EV_SET64(&change_list[change_length++], fd, EVFILT_WRITE, (new_events & LIBUS_SOCKET_WRITABLE) ? EV_ADD | EV_ONESHOT : EV_DELETE, 0, 0, (uint64_t)(void*)user_data, 0, 0);
+        }
     }
     int ret;
     do {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -309,9 +309,12 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
 
         const int watched = us_poll_events(poll);
         events &= watched;
-        /* EV_EOF only stands in for eof when this poll watches nothing — see
-         * the comment above. Any READABLE poll discovers eof via recv()==0. */
-        const int eof = bits.ev_eof && watched == 0;
+        /* EV_EOF only stands in for eof on a shut-down poll watching nothing —
+         * see the comment above. Any READABLE poll discovers eof via recv()==0;
+         * a non-SHUT_DOWN poll at watched==0 (allow_half_open after FIN, or a
+         * plain pause) must not re-enter on_end. */
+        const int eof = bits.ev_eof && watched == 0
+                     && us_internal_poll_type(poll) == POLL_TYPE_SOCKET_SHUT_DOWN;
         if (events || bits.error || eof) {
             us_internal_dispatch_ready_poll(poll, bits.error, eof, events);
         }

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -140,6 +140,9 @@ extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_re
 
 /* Loop related */
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events);
+#ifdef LIBUS_USE_KQUEUE
+int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_data);
+#endif
 void us_internal_timer_sweep(us_loop_r loop);
 void us_internal_enable_sweep_timer(struct us_loop_t *loop);
 void us_internal_disable_sweep_timer(struct us_loop_t *loop);

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -659,9 +659,12 @@ void us_socket_pause(struct us_socket_t *s) {
     if (s->flags.is_paused) return;
     // closed cannot be paused because it is already closed
     if (us_socket_is_closed(s)) return;
-    // we are readable and writable so we can just pause readable side
-    us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_WRITABLE);
     s->flags.is_paused = 1;
+    /* A shut-down socket can't write either; watch nothing so the kqueue
+     * watched==0 sentinel (or EPOLLHUP on epoll) detects peer close without
+     * reading the data the caller paused for. */
+    us_poll_change(&s->p, s->group->loop,
+        us_socket_is_shut_down(s) ? 0 : LIBUS_SOCKET_WRITABLE);
 }
 
 void us_socket_resume(struct us_socket_t *s) {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -662,9 +662,12 @@ void us_socket_pause(struct us_socket_t *s) {
     s->flags.is_paused = 1;
     /* A shut-down socket can't write either; watch nothing so the kqueue
      * watched==0 sentinel (or EPOLLHUP on epoll) detects peer close without
-     * reading the data the caller paused for. */
+     * reading the data the caller paused for. Test the raw poll type — the
+     * SSL-aware us_socket_is_shut_down() is true after close_notify even when
+     * us_internal_ssl_shutdown left the poll type at POLL_TYPE_SOCKET, and the
+     * sentinel's dispatch gate keys on the raw type. */
     us_poll_change(&s->p, s->group->loop,
-        us_socket_is_shut_down(s) ? 0 : LIBUS_SOCKET_WRITABLE);
+        us_internal_poll_type(&s->p) == POLL_TYPE_SOCKET_SHUT_DOWN ? 0 : LIBUS_SOCKET_WRITABLE);
 }
 
 void us_socket_resume(struct us_socket_t *s) {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -551,15 +551,7 @@ void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
      * so far, the app has to track this and call close as needed */
     if (!us_socket_is_closed(s) && us_internal_poll_type(&s->p) != POLL_TYPE_SOCKET_SHUT_DOWN) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
-        /* After SHUT_WR the only way this socket terminates is recv()==0 or a
-         * recv() error, so READABLE must be armed even if the socket was paused
-         * (which had cleared it). epoll could limp by on EPOLLHUP for the
-         * paused case, but kqueue has no equivalent once EV_EOF is no longer
-         * mapped — without READABLE the socket would never wake. Pause is
-         * meaningless after FIN anyway: we can't write, and the on_data path
-         * for a SHUT_DOWN socket discards what it reads. */
-        s->flags.is_paused = 0;
-        us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
+        us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
     }
 }
@@ -667,9 +659,6 @@ void us_socket_pause(struct us_socket_t *s) {
     if (s->flags.is_paused) return;
     // closed cannot be paused because it is already closed
     if (us_socket_is_closed(s)) return;
-    /* See us_internal_socket_raw_shutdown: dropping READABLE on a shut-down
-     * socket would leave it unable to observe the peer's FIN. */
-    if (us_socket_is_shut_down(s)) return;
     // we are readable and writable so we can just pause readable side
     us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_WRITABLE);
     s->flags.is_paused = 1;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -551,7 +551,15 @@ void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
      * so far, the app has to track this and call close as needed */
     if (!us_socket_is_closed(s) && us_internal_poll_type(&s->p) != POLL_TYPE_SOCKET_SHUT_DOWN) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
-        us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
+        /* After SHUT_WR the only way this socket terminates is recv()==0 or a
+         * recv() error, so READABLE must be armed even if the socket was paused
+         * (which had cleared it). epoll could limp by on EPOLLHUP for the
+         * paused case, but kqueue has no equivalent once EV_EOF is no longer
+         * mapped — without READABLE the socket would never wake. Pause is
+         * meaningless after FIN anyway: we can't write, and the on_data path
+         * for a SHUT_DOWN socket discards what it reads. */
+        s->flags.is_paused = 0;
+        us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_READABLE);
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
     }
 }
@@ -659,6 +667,9 @@ void us_socket_pause(struct us_socket_t *s) {
     if (s->flags.is_paused) return;
     // closed cannot be paused because it is already closed
     if (us_socket_is_closed(s)) return;
+    /* See us_internal_socket_raw_shutdown: dropping READABLE on a shut-down
+     * socket would leave it unable to observe the peer's FIN. */
+    if (us_socket_is_shut_down(s)) return;
     // we are readable and writable so we can just pause readable side
     us_poll_change(&s->p, s->group->loop, LIBUS_SOCKET_WRITABLE);
     s->flags.is_paused = 1;

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -551,6 +551,15 @@ void us_internal_socket_raw_shutdown(struct us_socket_t *s) {
      * so far, the app has to track this and call close as needed */
     if (!us_socket_is_closed(s) && us_internal_poll_type(&s->p) != POLL_TYPE_SOCKET_SHUT_DOWN) {
         us_internal_poll_set_type(&s->p, POLL_TYPE_SOCKET_SHUT_DOWN);
+#ifdef LIBUS_USE_KQUEUE
+        /* If the poll already watches nothing (us_socket_pause earlier and the
+         * one-shot WRITE has since fired so loop.c:475 stripped POLLING_OUT),
+         * us_poll_change(0) early-returns on old==new and never reaches
+         * kqueue_change to arm the watched==0 sentinel. Force it. */
+        if (us_poll_events(&s->p) == 0) {
+            kqueue_change(s->group->loop->fd, us_poll_fd(&s->p), 0, 0, &s->p);
+        } else
+#endif
         us_poll_change(&s->p, s->group->loop, us_poll_events(&s->p) & LIBUS_SOCKET_READABLE);
         bsd_shutdown_socket(us_poll_fd((struct us_poll_t *) s));
     }

--- a/test/js/web/fetch/fetch-chunked-fin-same-tick-fixture.ts
+++ b/test/js/web/fetch/fetch-chunked-fin-same-tick-fixture.ts
@@ -1,0 +1,79 @@
+// kqueue used to derive `eof` from EV_EOF on either filter. Two ways that
+// dropped bytes:
+//   (1) An EVFILT_WRITE-only event with EV_EOF skipped the recv loop and
+//       closed with the response still in the kernel buffer.
+//   (2) The recv loop bails after one ~512 KiB read when num_ready_polls ≥ 25,
+//       and the eof flag (already set by kqueue) then closed the socket with
+//       the rest of the chunked body unread.
+// Linux has neither: epoll only maps EPOLLHUP, so half-close is discovered via
+// recv()==0 after the buffer is drained.
+//
+// This fixture targets (2) deterministically: each response is one ~600 KiB
+// chunked body written in a single burst followed by FIN, and 32 requests run
+// at once so a kevent batch routinely carries ≥ 25 ready polls. Every request
+// must receive the full body.
+import net from "node:net";
+
+const payload = Buffer.alloc(600 * 1024, "x");
+const reply = Buffer.concat([
+  Buffer.from(
+    "HTTP/1.1 200 OK\r\n" +
+      "Connection: close\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      payload.length.toString(16) +
+      "\r\n",
+  ),
+  payload,
+  Buffer.from("\r\n0\r\n\r\n"),
+]);
+
+const server = net.createServer(socket => {
+  socket.on("error", () => {});
+  socket.once("data", () => {
+    // Single write + FIN so the data and EV_EOF land in the same kevent batch.
+    socket.end(reply);
+  });
+});
+
+await new Promise<void>((resolve, reject) => {
+  server.once("error", reject);
+  server.listen(0, "127.0.0.1", resolve);
+});
+const { port } = server.address() as net.AddressInfo;
+
+const ITERATIONS = 200;
+const CONCURRENCY = 32;
+let failures = 0;
+let firstError = "";
+
+async function once() {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/`, { keepalive: false });
+    const buf = await res.arrayBuffer();
+    if (buf.byteLength !== payload.length) {
+      failures++;
+      firstError ||= `body mismatch: got ${buf.byteLength} bytes, want ${payload.length}`;
+    }
+  } catch (e: any) {
+    failures++;
+    firstError ||= `${e?.code ?? e?.name}: ${e?.message}`;
+  }
+}
+
+let i = 0;
+async function worker() {
+  while (i < ITERATIONS) {
+    i++;
+    await once();
+  }
+}
+await Promise.all(Array.from({ length: CONCURRENCY }, worker));
+
+server.close();
+
+if (failures > 0) {
+  console.error(`FAIL ${failures}/${ITERATIONS}: ${firstError}`);
+  process.exit(1);
+}
+console.log(`OK ${ITERATIONS}`);

--- a/test/js/web/fetch/fetch-chunked-fin-same-tick.test.ts
+++ b/test/js/web/fetch/fetch-chunked-fin-same-tick.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+// kqueue used to map EV_EOF (from either filter) straight to dispatch's `eof`,
+// so an EVFILT_WRITE event carrying EV_EOF — peer fully closed while we were
+// still uploading — closed the socket before the recv loop drained the response
+// bytes the same FIN carried. Linux never hit this because the epoll path only
+// maps EPOLLHUP and discovers half-close via recv()==0.
+test("fetch() drains a chunked body when the server FINs in the same tick (kqueue EV_EOF)", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(import.meta.dir, "fetch-chunked-fin-same-tick-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr.trim()).toBe("");
+  expect(stdout.trim()).toBe("OK 200");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch-chunked-fin-same-tick.test.ts
+++ b/test/js/web/fetch/fetch-chunked-fin-same-tick.test.ts
@@ -15,7 +15,9 @@ test("fetch() drains a chunked body when the server FINs in the same tick (kqueu
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr.trim()).toBe("");
-  expect(stdout.trim()).toBe("OK 200");
-  expect(exitCode).toBe(0);
+  expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+    stdout: "OK 200",
+    stderr: "",
+    exitCode: 0,
+  });
 });


### PR DESCRIPTION
## What

On kqueue, stop deriving `eof` from `EV_EOF` for any socket that is polling READABLE — `recv()==0` becomes the single source of `eof` there, matching epoll (which maps `EPOLLHUP` but never `EPOLLRDHUP`).

To keep the two cases that legitimately depended on `EV_EOF` working:

- **Async-connect failure** is reported by kqueue via `EVFILT_WRITE + EV_EOF` (not `EV_ERROR`). `us_internal_socket_after_open` now probes `getsockopt(SO_ERROR)` on POSIX when the dispatch flag is zero — the portable contract for non-blocking connect completion, and what the Windows branch already effectively does.
- **A paused-then-shut-down socket** (`us_socket_pause` → `us_socket_shutdown`, which node:http does for every request with a body whose handler ends the socket) watches nothing and so never `recv()`s. `kqueue_change` now arms an **edge-triggered** `EVFILT_READ` for `events==0`, and the dispatch loop forwards its `EV_EOF` as `eof` only when `us_poll_events==0 && POLL_TYPE_SOCKET_SHUT_DOWN`. The recv loop is gated on `events & READABLE`, so no buffered data is read or discarded — parity with epoll's `EPOLLHUP` close. `us_socket_pause` on an already-raw-shut-down socket now goes to `events==0` (not `WRITABLE`) so the sentinel arms in either order.

## Why

kqueue sets `EV_EOF` on `EVFILT_READ` for a peer FIN (≈ `EPOLLRDHUP`) and on `EVFILT_WRITE` when the peer's read side is gone. The dispatch loop OR'd it from either filter into `eof`, which `loop.c` treats as "fire `on_end` and close after this tick". That diverged from Linux in two ways that could drop response bytes on macOS:

- **EVFILT_WRITE-only event with EV_EOF skips recv.** `events & LIBUS_SOCKET_READABLE` is false, so the recv loop never runs and the `eof` block at `loop.c:654` closes with the response still in the kernel buffer. The chunked decoder is mid-chunk → `ConnectionClosed` from `fetch()`.
- **Recv-loop bail-out with EV_EOF already flagged.** The continue gate at `loop.c:599-611` checks `error` but not `eof`; on a busy loop (`num_ready_polls ≥ 25`) it stops after one ~512 KiB read, and the kqueue-supplied `eof` then closes before the next tick can drain the rest.

`EVFILT_READ` is level-triggered and keeps firing after a FIN, so `recv()==0` reliably reports end-of-stream after the buffer is drained. RST and hard errors are still covered by the `recv()`-error branch.

## Test

`test/js/web/fetch/fetch-chunked-fin-same-tick.test.ts` runs 200 concurrent `fetch()`es against a raw `net` server that writes a single ~600 KiB chunked body and immediately FINs, with concurrency 32 so kevent batches routinely exceed the 25-ready-poll bail-out threshold. Every request must receive the full body. Passes on Linux unchanged; the kqueue path is exercised on macOS CI.

Fixes #12730
Fixes #29515