### PR TITLE
Add missing exception checks in JSC bindings

### DIFF
--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -1157,6 +1157,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInNewContext, (JSGlobalObject * globalObject
     JSValue scriptDynamicImportCallback;
 
     ScriptOptions options(optionsArg.toWTFString(globalObject), OrdinalNumber::fromZeroBasedInt(0), OrdinalNumber::fromZeroBasedInt(0));
+    RETURN_IF_EXCEPTION(scope, {});
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
@@ -1207,6 +1208,7 @@ JSC_DEFINE_HOST_FUNCTION(vmModuleRunInThisContext, (JSGlobalObject * globalObjec
 
     JSValue optionsArg = callFrame->argument(1);
     ScriptOptions options(optionsArg.toWTFString(globalObject), OrdinalNumber::fromZeroBasedInt(0), OrdinalNumber::fromZeroBasedInt(0));
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (optionsArg.isString()) {
         options.filename = optionsArg.toWTFString(globalObject);
         RETURN_IF_EXCEPTION(throwScope, {});

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -485,10 +485,12 @@ AsymmetricMatcherResult matchAsymmetricMatcherAndGetFlags(JSGlobalObject* global
             // O(m*n) but works for now
             for (unsigned m = 0; m < expectedLength; m++) {
                 JSValue expectedValue = expectedArray->getIndex(globalObject, m);
+                RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                 bool found = false;
 
                 for (unsigned n = 0; n < otherLength; n++) {
                     JSValue otherValue = otherArray->getIndex(globalObject, n);
+                    RETURN_IF_EXCEPTION(throwScope, AsymmetricMatcherResult::FAIL);
                     Vector<std::pair<JSValue, JSValue>, 16> stack;
                     MarkedArgumentBuffer gcBuffer;
                     bool foundNow = Bun__deepEquals<false, true>(globalObject, expectedValue, otherValue, gcBuffer, stack, throwScope, true);

--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -2844,6 +2844,7 @@ extern "C" napi_status napi_instanceof(napi_env env, napi_value object, napi_val
         *result = false;
     } else {
         *result = constructorObject->hasInstance(globalObject, objectValue);
+        RETURN_IF_EXCEPTION(scope, napi_set_last_error(env, napi_pending_exception));
     }
 
     return napi_set_last_error(env, napi_ok);

--- a/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
+++ b/src/jsc/bindings/node/crypto/CryptoHkdf.cpp
@@ -147,6 +147,7 @@ KeyObject prepareKey(JSGlobalObject* globalObject, ThrowScope& scope, JSValue ke
 
         BufferEncodingType encoding = BufferEncodingType::utf8;
         JSValue buffer = JSValue::decode(WebCore::constructFromEncoding(globalObject, keyView, encoding));
+        RETURN_IF_EXCEPTION(scope, {});
         auto* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
 
         Vector<uint8_t> copy;

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -531,6 +531,7 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
             auto len = parent.paths->length();
             for (size_t i = 0; i < len; i++) {
                 auto path = parent.paths->getIndex(globalObject, i);
+                RETURN_IF_EXCEPTION(scope, {});
                 array->push(globalObject, path);
             }
             RELEASE_AND_RETURN(scope, array);
@@ -792,6 +793,7 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionRunMain, (JSGlobalObject * globalObject, JSC:
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto arg1 = callFrame->argument(0);
     auto name = makeAtomString(arg1.toWTFString(globalObject));
+    RETURN_IF_EXCEPTION(scope, {});
 
     auto* promise = JSC::loadAndEvaluateModule(globalObject, name, nullptr, nullptr);
     RETURN_IF_EXCEPTION(scope, {});


### PR DESCRIPTION
## Summary

Several binding functions used the result of a JS-entering call without first checking for a pending exception. When such a call threw, execution continued — re-entering JS or dereferencing an empty/null result while an exception was already pending. Each site gets a one-line `RETURN_IF_EXCEPTION` immediately after the throwing call.

- **`bindings.cpp`** (`expect.arrayContaining`): `expectedArray->getIndex` / `otherArray->getIndex` can run a user-defined index getter that throws; the values were passed into `Bun__deepEquals` (re-entering JS) before the existing check.
- **`napi.cpp`** (`napi_instanceof`): `constructorObject->hasInstance` can throw (custom `Symbol.hasInstance`, or `OrdinaryHasInstance` walking a Proxy prototype chain). The result was stored and `napi_ok` returned, swallowing the exception.
- **`NodeVM.cpp`** (`runInNewContext` / `runInThisContext`): the `options` argument was coerced via `toWTFString` (which can run `toString`/`Symbol.toPrimitive`) before the branch check.
- **`CryptoHkdf.cpp`** (`prepareKey`): `constructFromEncoding` can fail (e.g. allocation failure), returning an empty value; the code then did `dynamicDowncast<JSArrayBufferView>(...)->span()`, dereferencing null.
- **`NodeModuleModule.cpp`**: `resolveLookupPaths` read `parent.paths` via `getIndex`, and `runMain` coerced its argument via `toWTFString`, before re-entering JS.

These are defensive exception-safety fixes; the throwing inputs are adversarial/edge cases (throwing accessors, throwing coercions, allocation failure), so there is no observable behavior change on normal inputs.

## Test plan

- [x] Debug build compiles
- [x] Affected paths run clean under `BUN_JSC_validateExceptionChecks=1` (throwing options, throwing index getters on `arrayContaining`)
- [x] `test/js/node/vm/vm.test.ts` passes (206 pass, 0 fail)
- [ ] CI green