### PR TITLE
napi: write copied=false in node_api_create_external_string_utf16

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1504,6 +1504,10 @@ node_api_create_external_string_utf16(napi_env env,
     *result = toNapi(out, globalObject);
     ensureStillAliveHere(out);
 
+    if (copied) {
+        *copied = false;
+    }
+
     NAPI_RETURN_SUCCESS(env);
 }
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2243,6 +2243,9 @@ static napi_value
 test_node_api_create_external_string_copied(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
 
+  // The finalizer owns cleanup regardless of `copied`: when copied=true the
+  // finalizer has already run synchronously; when copied=false it runs when
+  // the string is collected.
   {
     char *buf = static_cast<char *>(malloc(6));
     memcpy(buf, "hello", 6);
@@ -2252,9 +2255,6 @@ test_node_api_create_external_string_copied(const Napi::CallbackInfo &info) {
                            env, buf, 5, free_external_utf16, nullptr, &out,
                            &copied));
     printf("latin1 copied=%s\n", copied ? "true" : "false");
-    if (copied) {
-      free(buf);
-    }
   }
 
   {
@@ -2267,9 +2267,6 @@ test_node_api_create_external_string_copied(const Napi::CallbackInfo &info) {
                            env, buf, 5, free_external_utf16, nullptr, &out,
                            &copied));
     printf("utf16 copied=%s\n", copied ? "true" : "false");
-    if (copied) {
-      free(buf);
-    }
   }
 
   return ok(env);

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -2230,6 +2230,51 @@ static napi_value test_napi_get_named_property_copied_string(const Napi::Callbac
   return ok(env);
 }
 
+static void free_external_utf16(napi_env env, void *data, void *hint) {
+  free(data);
+}
+
+// node_api_create_external_string_{latin1,utf16} must write false to the
+// `copied` out-parameter when the string is not copied. The utf16 variant
+// previously left it uninitialized, so an addon that pre-set it to a nonzero
+// value would believe the string was copied and free the buffer while the
+// ExternalStringImpl still referenced it.
+static napi_value
+test_node_api_create_external_string_copied(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  {
+    char *buf = static_cast<char *>(malloc(6));
+    memcpy(buf, "hello", 6);
+    bool copied = true;
+    napi_value out;
+    NODE_API_CALL(env, node_api_create_external_string_latin1(
+                           env, buf, 5, free_external_utf16, nullptr, &out,
+                           &copied));
+    printf("latin1 copied=%s\n", copied ? "true" : "false");
+    if (copied) {
+      free(buf);
+    }
+  }
+
+  {
+    static const char16_t src[] = u"hello";
+    char16_t *buf = static_cast<char16_t *>(malloc(sizeof(src)));
+    memcpy(buf, src, sizeof(src));
+    bool copied = true;
+    napi_value out;
+    NODE_API_CALL(env, node_api_create_external_string_utf16(
+                           env, buf, 5, free_external_utf16, nullptr, &out,
+                           &copied));
+    printf("utf16 copied=%s\n", copied ? "true" : "false");
+    if (copied) {
+      free(buf);
+    }
+  }
+
+  return ok(env);
+}
+
 // https://github.com/oven-sh/bun/issues/25933
 // When a threadsafe function is created inside AsyncLocalStorage.run(),
 // the js_callback gets wrapped in AsyncContextFrame. napi_typeof must
@@ -2391,6 +2436,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports,
                     test_external_buffer_with_pending_exception);
   REGISTER_FUNCTION(env, exports, test_napi_get_named_property_copied_string);
+  REGISTER_FUNCTION(env, exports, test_node_api_create_external_string_copied);
   REGISTER_FUNCTION(env, exports, test_issue_25933);
   REGISTER_FUNCTION(env, exports, test_napi_make_callback_async_context_frame);
   REGISTER_FUNCTION(env, exports, test_napi_create_tsfn_async_context_frame);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -200,6 +200,14 @@ describe.concurrent("napi", () => {
     });
   });
 
+  describe("node_api_create_external_string_*", () => {
+    it("writes false to the copied out-parameter", async () => {
+      const result = await checkSameOutput("test_node_api_create_external_string_copied", []);
+      expect(result).toContain("latin1 copied=false");
+      expect(result).toContain("utf16 copied=false");
+    });
+  });
+
   it("#1288", async () => {
     const result = await checkSameOutput("self", []);
     expect(result).toBe("hello world!");


### PR DESCRIPTION
## Problem

`node_api_create_external_string_utf16` never writes its `*copied` out-parameter, leaving the caller's bool uninitialized. The latin1 variant correctly sets `*copied = false`.

Per the [Node-API docs](https://nodejs.org/api/n-api.html#node_api_create_external_string_utf16), `copied` tells the addon whether the runtime copied the string. If it was copied, the finalizer has already been invoked and the addon should free the original buffer. If the uninitialized value happens to be nonzero, an addon following this contract frees a buffer that the `ExternalStringImpl` still references, leading to a use-after-free on string read or finalize.

## Fix

Add `if (copied) { *copied = false; }` before the return, mirroring the latin1 path. Bun always uses `ExternalStringImpl` (no copy), so `copied` is always false.

## Verification

New test `test_node_api_create_external_string_copied` initializes `copied = true`, calls both the latin1 and utf16 variants, and prints the resulting value. The test compares Bun's output against Node's via `checkSameOutput`.

```
node v24.3.0:  latin1 copied=false, utf16 copied=false
bun (before):  latin1 copied=false, utf16 copied=true
bun (after):   latin1 copied=false, utf16 copied=false
```