### PR TITLE
bun:ffi: handle negative byteOffset in read.* instead of panicking

### DIFF
--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -262,12 +262,23 @@ pub mod reader {
         if arguments.is_empty() || !arguments[0].is_number() {
             return Err(global_object.throw_invalid_arguments(format_args!("Expected a pointer")));
         }
-        let off = if arguments.len() > 1 {
-            usize::try_from(arguments[1].to_int32()).expect("int cast")
-        } else {
-            0usize
-        };
-        Ok(arguments[0].as_ptr_address() + off)
+        let mut addr = arguments[0].as_ptr_address();
+        if arguments.len() > 1 {
+            let byte_off = arguments[1];
+            if !byte_off.is_empty_or_undefined_or_null() {
+                if !byte_off.is_number() {
+                    return Err(global_object
+                        .throw_invalid_arguments(format_args!("Expected number for byteOffset")));
+                }
+                let off = byte_off.to_int64();
+                if off < 0 {
+                    addr = addr.saturating_sub(off.unsigned_abs() as usize);
+                } else {
+                    addr = addr.saturating_add(off as usize);
+                }
+            }
+        }
+        Ok(addr)
     }
 
     /// Read a `T` from a user-supplied raw address (unaligned).

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -459,17 +459,17 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
                 return global_this
                     .to_invalid_arguments(format_args!("Expected number for byteOffset"));
             }
-        }
 
-        let bytei64 = off.to_int64();
-        if bytei64 < 0 {
-            addr = addr.saturating_sub(bytei64.unsigned_abs() as usize);
-        } else {
-            addr = addr.saturating_add(bytei64 as usize);
-        }
+            let bytei64 = off.to_int64();
+            if bytei64 < 0 {
+                addr = addr.saturating_sub(bytei64.unsigned_abs() as usize);
+            } else {
+                addr = addr.saturating_add(bytei64 as usize);
+            }
 
-        if addr > array_buffer.ptr as usize + array_buffer.byte_len as usize {
-            return global_this.to_invalid_arguments(format_args!("byteOffset out of bounds"));
+            if addr > array_buffer.ptr as usize + array_buffer.byte_len as usize {
+                return global_this.to_invalid_arguments(format_args!("byteOffset out of bounds"));
+            }
         }
     }
 

--- a/src/runtime/ffi/FFIObject.rs
+++ b/src/runtime/ffi/FFIObject.rs
@@ -463,9 +463,9 @@ fn ptr_(global_this: &JSGlobalObject, value: JSValue, byte_offset: Option<JSValu
 
         let bytei64 = off.to_int64();
         if bytei64 < 0 {
-            addr = addr.saturating_sub(usize::try_from(-bytei64).expect("int cast"));
+            addr = addr.saturating_sub(bytei64.unsigned_abs() as usize);
         } else {
-            addr += usize::try_from(bytei64).expect("int cast");
+            addr = addr.saturating_add(bytei64 as usize);
         }
 
         if addr > array_buffer.ptr as usize + array_buffer.byte_len as usize {
@@ -535,9 +535,9 @@ fn get_ptr_slice(
         if byte_off.is_number() {
             let off = byte_off.to_int64();
             if off < 0 {
-                addr = addr.saturating_sub(usize::try_from(-off).expect("int cast"));
+                addr = addr.saturating_sub(off.unsigned_abs() as usize);
             } else {
-                addr = addr.saturating_add(usize::try_from(off).expect("int cast"));
+                addr = addr.saturating_add(off as usize);
             }
 
             if addr == 0 {

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -681,6 +681,10 @@ it("read.* with negative byteOffset does not abort the process", async () => {
     try { read.u8(base, "not a number"); } catch { threw = true; }
     if (!threw) throw new Error("expected read.u8 to throw on non-number byteOffset");
 
+    // ptr(buf, null) previously reached JSC__JSValue__toInt64 on a non-number
+    // (debug ASSERT / release UB). A null offset must behave like no offset.
+    assert("ptr(buf, null)", ptr(buf, null), ptr(buf));
+
     // Sibling helpers (ptr / toArrayBuffer / toBuffer / CString) share the same
     // signed-offset shape; a huge negative offset saturates to i64::MIN in
     // to_int64() and must not abort on the negation. The calls below may throw

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -681,6 +681,20 @@ it("read.* with negative byteOffset does not abort the process", async () => {
     try { read.u8(base, "not a number"); } catch { threw = true; }
     if (!threw) throw new Error("expected read.u8 to throw on non-number byteOffset");
 
+    // Sibling helpers (ptr / toArrayBuffer / toBuffer / CString) share the same
+    // signed-offset shape; a huge negative offset saturates to i64::MIN in
+    // to_int64() and must not abort on the negation. The calls below may throw
+    // or return an error value; either is fine as long as the process survives.
+    const { toArrayBuffer, toBuffer, CString } = require("bun:ffi");
+    for (const fn of [
+      () => ptr(buf, -1e300),
+      () => toArrayBuffer(base, -1e300, 4),
+      () => toBuffer(base, -1e300, 4),
+      () => new CString(base, -1e300, 4),
+    ]) {
+      try { fn(); } catch {}
+    }
+
     console.log("ok");
   `;
   await using proc = Bun.spawn({

--- a/test/js/bun/ffi/ffi.test.js
+++ b/test/js/bun/ffi/ffi.test.js
@@ -647,6 +647,52 @@ it("read", () => {
   delete globalThis.buffer;
 });
 
+it("read.* with negative byteOffset does not abort the process", async () => {
+  // A negative offset previously hit `usize::try_from(-1).expect(...)` in the
+  // slow-path reader, aborting the process. Run in a subprocess so a panic
+  // surfaces as a non-zero exit instead of killing this test file.
+  const src = `
+    const { ptr, read } = require("bun:ffi");
+    const buf = new Uint8Array(32);
+    for (let i = 0; i < buf.length; i++) buf[i] = i;
+    const base = ptr(buf);
+    const dv = new DataView(buf.buffer);
+    const at = 8;
+    const p = base + at;
+
+    const assert = (name, got, want) => {
+      if (!Object.is(got, want)) throw new Error(name + ": got " + got + " want " + want);
+    };
+
+    assert("u8",  read.u8(p, -1),  dv.getUint8(at - 1));
+    assert("i8",  read.i8(p, -1),  dv.getInt8(at - 1));
+    assert("u16", read.u16(p, -2), dv.getUint16(at - 2, true));
+    assert("i16", read.i16(p, -2), dv.getInt16(at - 2, true));
+    assert("u32", read.u32(p, -4), dv.getUint32(at - 4, true));
+    assert("i32", read.i32(p, -4), dv.getInt32(at - 4, true));
+    assert("f32", read.f32(p, -4), dv.getFloat32(at - 4, true));
+    assert("f64", read.f64(p, -8), dv.getFloat64(at - 8, true));
+    assert("i64", read.i64(p, -8), dv.getBigInt64(at - 8, true));
+    assert("u64", read.u64(p, -8), dv.getBigUint64(at - 8, true));
+    assert("ptr",    read.ptr(p, -8),    Number(dv.getBigUint64(at - 8, true)));
+    assert("intptr", read.intptr(p, -8), Number(dv.getBigInt64(at - 8, true)));
+
+    let threw = false;
+    try { read.u8(base, "not a number"); } catch { threw = true; }
+    if (!threw) throw new Error("expected read.u8 to throw on non-number byteOffset");
+
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok\n", stderr: "", exitCode: 0 });
+});
+
 if (ok) {
   describe("run ffi", () => {
     ffiRunner(false);


### PR DESCRIPTION
## Repro

```js
import { ptr, read } from "bun:ffi";
const buf = new Uint8Array(16);
read.u8(ptr(buf) + 4, -1);
```

```
panic: int cast: TryFromIntError(NegOverflow)
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

## Cause

`addr_from_args` in `src/runtime/ffi/FFIObject.rs` computed the offset as `usize::try_from(arguments[1].to_int32()).expect("int cast")` with no `is_number()` guard and no sign handling. Any negative offset (or a non-number argument whose `toInt32` coercion yields a negative) makes `try_from` return `Err` and `.expect` aborts the process.

The sibling helpers `ptr_` and `get_ptr_slice` in the same file already branch on sign, but their negative branch computes `usize::try_from(-off).expect("int cast")`, which still aborts when `off == i64::MIN` (reachable from any JS number `<= -2^63`, e.g. `ptr(buf, -1e300)` or `toArrayBuffer(p, -Infinity, n)`).

## Fix

`addr_from_args` now rejects non-number offsets with a `TypeError`, treats `undefined`/`null` as 0, and computes the effective address via `to_int64()` with a signed branch (`saturating_sub(off.unsigned_abs() as usize)` for negatives, `saturating_add` for positives). All twelve `read.*` slow-path readers route through this helper.

`ptr_` and `get_ptr_slice` are updated to the same `unsigned_abs()` shape so `ptr`/`toArrayBuffer`/`toBuffer`/`CString` no longer abort on the `i64::MIN` edge either. This removes every `usize::try_from(...).expect("int cast")` on a user-supplied `byteOffset` in the file.

## Verification

New test `read.* with negative byteOffset does not abort the process` in `test/js/bun/ffi/ffi.test.js` spawns a subprocess that exercises every `read.*` variant with a negative offset (asserting the value matches the equivalent `DataView` read), checks that a non-number offset throws, and calls `ptr`/`toArrayBuffer`/`toBuffer`/`CString` with `-1e300`. On the unfixed build the subprocess panics with `int cast: TryFromIntError(NegOverflow)` and exits non-zero; with the fix it prints `ok` and exits 0. The existing `read` test continues to pass.
