### PR TITLE
Bun.plugin.clearAll(): clear namespaces and groups together

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -979,10 +979,8 @@ JSC::JSValue runVirtualModule(Zig::GlobalObject* globalObject, BunString* specif
 BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callframe))
 {
     Zig::GlobalObject* global = static_cast<Zig::GlobalObject*>(globalObject);
-    global->onLoadPlugins.fileNamespace.clear();
-    global->onResolvePlugins.fileNamespace.clear();
-    global->onLoadPlugins.groups.clear();
-    global->onResolvePlugins.namespaces.clear();
+    global->onLoadPlugins.clear();
+    global->onResolvePlugins.clear();
 
     delete global->onLoadPlugins.virtualModules;
     global->onLoadPlugins.virtualModules = nullptr;

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -984,6 +984,7 @@ BUN_DEFINE_HOST_FUNCTION(jsFunctionBunPluginClear, (JSC::JSGlobalObject * global
 
     delete global->onLoadPlugins.virtualModules;
     global->onLoadPlugins.virtualModules = nullptr;
+    global->onLoadPlugins.mustDoExpensiveRelativeLookup = false;
 
     return JSC::JSValue::encode(JSC::jsUndefined());
 }

--- a/src/jsc/bindings/BunPlugin.h
+++ b/src/jsc/bindings/BunPlugin.h
@@ -59,6 +59,13 @@ public:
         }
 
         void append(JSC::VM& vm, JSC::RegExp* filter, JSC::JSObject* func, String& namespaceString);
+
+        void clear()
+        {
+            fileNamespace.clear();
+            namespaces.clear();
+            groups.clear();
+        }
     };
 
     class OnLoad final : public Base {

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -803,3 +803,63 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+// Spawned in a subprocess because clearAll() would wipe the plugins the rest of this file relies on.
+describe.concurrent("Bun.plugin.clearAll()", () => {
+  async function run(src: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
+  }
+
+  it("re-registering a namespaced onLoad plugin after clearAll() works", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      function register() {
+        Bun.plugin({
+          name: "p",
+          setup(b) {
+            b.onResolve({ filter: /.*/, namespace: "myns" }, ({ path }) => ({ path, namespace: "myns" }));
+            b.onLoad({ filter: /.*/, namespace: "myns" }, () => ({ contents: "export default 1;", loader: "js" }));
+          },
+        });
+      }
+      for (let i = 0; i < 50; i++) {
+        register();
+        Bun.plugin.clearAll();
+      }
+      register();
+      const m = await import("myns:hello");
+      console.log("result=" + m.default);
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=1", stderr, exitCode: 0 });
+  });
+
+  it("re-registering a namespaced onResolve plugin after clearAll() drops the old callback", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      Bun.plugin({
+        name: "old",
+        setup(b) {
+          b.onResolve({ filter: /.*/, namespace: "myns" }, () => {
+            throw new Error("stale onResolve callback ran");
+          });
+        },
+      });
+      Bun.plugin.clearAll();
+      Bun.plugin({
+        name: "new",
+        setup(b) {
+          b.onResolve({ filter: /.*/, namespace: "myns" }, ({ path }) => ({ path, namespace: "myns" }));
+          b.onLoad({ filter: /.*/, namespace: "myns" }, () => ({ contents: "export default 2;", loader: "js" }));
+        },
+      });
+      const m = await import("myns:hello");
+      console.log("result=" + m.default);
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=2", stderr, exitCode: 0 });
+  });
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -862,4 +862,77 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
     `);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=2", stderr, exitCode: 0 });
   });
+
+  // A namespace registered after clearAll() takes the index of a namespace that
+  // was cleared, so it must not inherit that namespace's callbacks.
+  it("a fresh namespace does not inherit a cleared plugin's callbacks", async () => {
+    const { stdout, stderr, exitCode } = await run(`
+      const calls = { oldResolve: 0, newResolve: 0, newLoad: 0 };
+
+      Bun.plugin({
+        name: "old",
+        setup(b) {
+          b.onResolve({ filter: /.*/, namespace: "aa" }, ({ path }) => {
+            calls.oldResolve++;
+            return { path, namespace: "aa" };
+          });
+          b.onLoad({ filter: /.*/, namespace: "aa" }, () => ({ contents: "export default 'old';", loader: "js" }));
+        },
+      });
+
+      Bun.plugin.clearAll();
+
+      Bun.plugin({
+        name: "new",
+        setup(b) {
+          b.onResolve({ filter: /.*/, namespace: "bb" }, ({ path }) => {
+            calls.newResolve++;
+            return { path, namespace: "bb" };
+          });
+          b.onLoad({ filter: /.*/, namespace: "bb" }, () => {
+            calls.newLoad++;
+            return { contents: "export default 'new';", loader: "js" };
+          });
+        },
+      });
+
+      const loaded = (await import("bb:hello")).default;
+      console.log(JSON.stringify({ calls, loaded }));
+    `);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ calls: { oldResolve: 0, newResolve: 1, newLoad: 1 }, loaded: "new" }),
+      stderr,
+      exitCode: 0,
+    });
+  });
+
+  // clearAll() frees the virtual module map, so the flag selecting how that map
+  // is keyed goes with it. A stale flag trips an assertion on the next resolve.
+  it("resets the virtual module lookup mode", async () => {
+    using dir = tempDir("plugin-clear-all-virtual", {
+      "sibling.mjs": `export default 1;`,
+      "entry.mjs": `
+        import { mock } from "bun:test";
+        mock.module(new URL("./virtual-module.js", import.meta.url).href, () => ({ default: 1 }));
+        Bun.plugin.clearAll();
+        await import("./sibling.mjs");
+        console.log("ok");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
+      stdout: "ok",
+      stderr: stderr.trim(),
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -836,7 +836,7 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
       const m = await import("myns:hello");
       console.log("result=" + m.default);
     `);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=1", stderr, exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=1", stderr: "", exitCode: 0 });
   });
 
   it("re-registering a namespaced onResolve plugin after clearAll() drops the old callback", async () => {
@@ -860,7 +860,7 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
       const m = await import("myns:hello");
       console.log("result=" + m.default);
     `);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=2", stderr, exitCode: 0 });
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "result=2", stderr: "", exitCode: 0 });
   });
 
   // A namespace registered after clearAll() takes the index of a namespace that
@@ -901,7 +901,7 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
     `);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: JSON.stringify({ calls: { oldResolve: 0, newResolve: 1, newLoad: 1 }, loaded: "new" }),
-      stderr,
+      stderr: "",
       exitCode: 0,
     });
   });
@@ -931,7 +931,7 @@ describe.concurrent("Bun.plugin.clearAll()", () => {
 
     expect({ stdout: stdout.trim(), stderr: stderr.trim(), exitCode }).toEqual({
       stdout: "ok",
-      stderr: stderr.trim(),
+      stderr: "",
       exitCode: 0,
     });
   });


### PR DESCRIPTION
### Repro

```js
function register() {
  Bun.plugin({
    name: "p",
    setup(b) {
      b.onResolve({ filter: /.*/, namespace: "myns" }, ({ path }) => ({ path, namespace: "myns" }));
      b.onLoad({ filter: /.*/, namespace: "myns" }, () => ({ contents: "export default 1;", loader: "js" }));
    },
  });
}
register();
Bun.plugin.clearAll();
register();
await import("myns:hello"); // SIGABRT
```

### Cause

`jsFunctionBunPluginClear` cleared `onLoadPlugins.groups` but not `onLoadPlugins.namespaces`, and `onResolvePlugins.namespaces` but not `onResolvePlugins.groups`. `Base::namespaces` and `Base::groups` are parallel-indexed: `Base::group()` looks up `namespaces[i]` and returns `&groups[i]`.

After `clearAll()`:
- **onLoad**: `namespaces.size() == N`, `groups.size() == 0`. Re-registering the same namespace hits the `group()` lookup branch in `Base::append`, which returns `&groups[i]` past the end of an empty vector and trips the `WTF::Vector` bounds assert (SIGABRT, exit 134).
- **onResolve**: `namespaces.size() == 0`, `groups.size() == N`. Re-registering appends a fresh entry to both, but `groups[0]` is still the stale pre-`clearAll()` group, so the next resolve for that namespace runs the old callback.

### Fix

Add `Base::clear()` that resets `fileNamespace`, `namespaces`, and `groups` together, and call it for both `onLoadPlugins` and `onResolvePlugins`.

### Verification

Two new subprocess tests in `test/js/bun/plugin/plugins.test.ts` cover both paths. Without the fix the onLoad test aborts with exit 134 and the onResolve test fails with `stale onResolve callback ran`; with the fix both pass. Full `plugins.test.ts` suite: 33 pass, 1 pre-existing todo.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 10 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1254.41ms]
(pass) require > beep:boop returns 42 [10.45ms]
(pass) require > object module works [8.11ms]
(pass) module > throws with require() [12.78ms]
(pass) module > async module works with async import [26.54ms]
(pass) module > sync module module works with require() [4.48ms]
(pass) module > sync module module works with require.resolve() [3.08ms]
(pass) module > sync module module works with import [4.88ms]
(pass) module > modules are overridable [90.66ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [6.21ms]
(pass) dynamic import > beep:boop returns 42 [4.69ms]
(pass) dynamic import > async:onLoad return
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [21.71ms]
(pass) require > beep:boop returns 42 [0.18ms]
(pass) require > object module works [0.10ms]
(pass) module > throws with require() [0.19ms]
(pass) module > async module works with async import [1.29ms]
(pass) module > sync module module works with require() [0.07ms]
(pass) module > sync module module works with require.resolve() [0.06ms]
(pass) module > sync module module works with import [0.08ms]
(pass) module > modules are overridable [0.22ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [0.12ms]
(pass) dynamic import > beep:boop returns 42 [0.06ms]
(pass) dynamic import > async:onLoad returns 42 [1.37ms]
(pass) dynamic import > async object loader returns 42 [1.25ms]
(pass) import statement > SSRs `<h1>Hello world!</h1>` with Svelte [1.82ms]
(pass) erro
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/plugin/plugins.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-env for tips on setting conditions in popular bundlers and runtimes.
(pass) require > SSRs `<h1>Hello world!</h1>` with Svelte [1252.23ms]
(pass) require > beep:boop returns 42 [10.17ms]
(pass) require > object module works [8.00ms]
(pass) module > throws with require() [12.88ms]
(pass) module > async module works with async import [26.29ms]
(pass) module > sync module module works with require() [4.47ms]
(pass) module > sync module module works with require.resolve() [3.15ms]
(pass) module > sync module module works with import [5.02ms]
(pass) module > modules are overridable [86.03ms]
(pass) dynamic import > SSRs `<h1>Hello world!</h1>` with Svelte [6.29ms]
(pass) dynamic import > beep:boop returns 42 [3.85ms]
(pass) dynamic import > async:onLoad return
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 618ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/124] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[2/124] gen cpp.rs (cppbind)
[2/124] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m   Compiling[0m bun_bin v0.0.0 (/workspace/bun/src/bun_bin)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 4m 19s
[120/124] cxx obj/codegen/GeneratedFakeTimersConfig.cpp.o
[121/124] link bun-profile
[123/124] strip bun
[123/124] bun-profile --revision
1.4.0-canary.1+ce16ca657
[build] done
bun test v1.4.0-canary.1 (ce16ca657)

test/js/bun/plugin/plugins.test.ts:
If bundling, conditions should include development or production. If not bundling, conditions or NODE_ENV should include development or production. See https://www.npmjs.com/package/esm-e
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/BunPlugin.cpp     |   7 +-
 src/jsc/bindings/BunPlugin.h       |   7 ++
 test/js/bun/plugin/plugins.test.ts | 133 +++++++++++++++++++++++++++++++++++++
 3 files changed, 143 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 10

<details><summary>evidence per changed file</summary>

```
file                                reads  edits  tests
src/jsc/bindings/BunPlugin.cpp          4      2     11
src/jsc/bindings/BunPlugin.h            1      1     11
test/js/bun/plugin/plugins.test.ts      3      8     11
```

</details>

**root cause** · written by the author bot

`Bun.plugin.clearAll()` cleared only one of the two parallel-indexed vectors in each plugin registry, emptying `onLoadPlugins.groups` while leaving `namespaces` populated and doing the reverse for `onResolvePlugins`, so a later registration in a previously used namespace made `Base::group()` index past the end of `groups` and append `Strong` handles into unowned memory. The fix adds a single `BunPlugin::Base::clear()` that resets namespaces, groups, and the remaining per-registry state together and calls it for both the onLoad and onResolve registries, with the host function also removing v…

<!-- robobun:evidence:end -->