### PR TITLE
process: add regression tests for per-VM 'exit' event guard

### DIFF
--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -676,6 +676,112 @@ describe.concurrent(() => {
       expect(stderr).not.toInclude("error: boom");
       expect(exitCode).toBe(0);
     });
+
+    it("fires in main thread after a Worker that emitted 'exit' terminates", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            process.on("exit", code => console.log("main exit: " + code));
+            const w = new Worker(
+              'process.on("exit", code => console.log("worker exit: " + code));',
+              { eval: true },
+            );
+            w.on("exit", () => console.log("worker terminated"));
+          `,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+        stdout: ["worker exit: 0", "worker terminated", "main exit: 0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    it("fires in main thread after a Worker that touched process terminates", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            process.on("exit", code => console.log("main exit: " + code));
+            const w = new Worker('process.title;', { eval: true });
+            w.on("exit", () => console.log("worker terminated"));
+          `,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+        stdout: ["worker terminated", "main exit: 0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    it("fires in main thread after a Worker calls process.exit()", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            process.on("exit", code => console.log("main exit: " + code));
+            const w = new Worker(
+              'process.on("exit", code => console.log("worker exit: " + code)); process.exit(3);',
+              { eval: true },
+            );
+            w.on("exit", code => console.log("worker terminated: " + code));
+          `,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim().split("\n"), stderr, exitCode }).toEqual({
+        stdout: ["worker exit: 3", "worker terminated: 3", "main exit: 0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    it("fires once per thread, not once per process", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            process.on("exit", code => console.log("exit 0: " + code));
+            const src = 'const { threadId } = require("worker_threads");' +
+              'process.on("exit", code => console.log("exit " + threadId + ": " + code));';
+            let remaining = 3;
+            for (let i = 0; i < 3; i++) {
+              const w = new Worker(src, { eval: true });
+              w.on("exit", () => {
+                if (--remaining === 0) console.log("all workers terminated");
+              });
+            }
+          `,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout.trim().split("\n").sort();
+      expect({ lines, stderr, exitCode }).toEqual({
+        lines: ["all workers terminated", "exit 0: 0", "exit 1: 0", "exit 2: 0", "exit 3: 0"],
+        stderr: "",
+        exitCode: 0,
+      });
+    });
   });
 
   it("process.memoryUsage", () => {


### PR DESCRIPTION
The underlying fix (moving the `dispatchExitInternal` reentrancy guard from a function-local `static bool processIsExiting` to `Process::m_isExiting`) landed on main via #31824. This PR now carries only the Worker-specific regression tests, which #31824 did not include.

## Original repro

```js
const { Worker } = require("worker_threads");
process.on("exit", code => console.log("main exit: " + code));
const w = new Worker(
  'process.on("exit", code => console.log("worker exit: " + code));',
  { eval: true },
);
w.on("exit", () => console.log("worker terminated"));
```

Before #31824, the main thread's `process.on('exit')` handler was silently skipped whenever any Worker had touched `process` and exited first, because the function-local static was process-global (shared across every VM) and also an unsynchronized cross-thread read/write.

## What this PR adds

Four tests in the `process.onExit` describe block of `test/js/node/process/process.test.js`:

- main-thread `exit` fires after a Worker that registered its own `exit` handler
- main-thread `exit` fires after a Worker that merely touched `process`
- main-thread `exit` fires after a Worker called `process.exit(3)`
- three Workers plus main: all four `exit` handlers fire (previously only the first Worker's did)

All four match Node's output exactly.

```
bun bd test test/js/node/process/process.test.js -t process.onExit
  6 pass, 0 fail
```

These tests failed on bun prior to #31824 with `main exit: 0` missing from stdout; they pass on current main and on the released canary.
