### PR TITLE
expect: fix panic in toBeArrayOfSize/toHaveBeenCalledTimes with length > i32 max

### DIFF
--- a/src/runtime/test_runner/expect/toBeArrayOfSize.rs
+++ b/src/runtime/test_runner/expect/toBeArrayOfSize.rs
@@ -34,7 +34,7 @@ pub(crate) fn to_be_array_of_size(
 
     let not = this.flags.get().not();
     let mut pass = value.js_type().is_array()
-        && i32::try_from(value.get_length(global)?).unwrap() == size.to_int32();
+        && value.get_length(global)? as i64 == size.to_int64();
 
     if not {
         pass = !pass;

--- a/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalledTimes.rs
@@ -23,9 +23,9 @@ pub(crate) fn to_have_been_called_times(
         )));
     }
 
-    let times = arguments[0].coerce::<i32>(global)?;
+    let times = arguments[0].to_int64();
 
-    let mut pass = i32::try_from(calls.get_length(global)?).unwrap() == times;
+    let mut pass = calls.get_length(global)? as i64 == times;
 
     let not = this.flags.get().not();
     if not {

--- a/test/js/bun/test/jest-extended.test.js
+++ b/test/js/bun/test/jest-extended.test.js
@@ -212,6 +212,10 @@ describe("jest-extended", () => {
     expect({}).not.toBeArrayOfSize(1);
     expect("").not.toBeArrayOfSize(1);
     expect(0).not.toBeArrayOfSize(1);
+    // Array length can be up to 2^32-1, which exceeds i32 range.
+    expect(new Array(3_000_000_000)).toBeArrayOfSize(3_000_000_000);
+    expect(new Array(3_000_000_000)).not.toBeArrayOfSize(5);
+    expect(new Array(2 ** 32 - 1)).toBeArrayOfSize(2 ** 32 - 1);
   });
 
   // test('toIncludeAllMembers()')

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -780,6 +780,15 @@ describe("mock()", () => {
     expect(fn).not.toHaveBeenNthCalledWith(5, 1);
   });
 
+  test("toHaveBeenCalledTimes with calls.length > i32 max", () => {
+    const fn = jest.fn();
+    // Array length can be up to 2^32-1; the matcher must not panic on the narrowed count.
+    fn.mock.calls.length = 3_000_000_000;
+    expect(fn).not.toHaveBeenCalledTimes(5);
+    expect(fn).toHaveBeenCalledTimes(3_000_000_000);
+    expect(() => expect(fn).toHaveBeenCalledTimes(5)).toThrow();
+  });
+
   it("no segmentation fault when passing jest.fn into another jest.fn, issue#5900", () => {
     function foo() {
       return true;


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in `toBeArrayOfSize()` and `toHaveBeenCalledTimes()` when the received array has a length that exceeds `i32::MAX`.

## Repro

```js
expect(new Array(3_000_000_000)).toBeArrayOfSize(5);
```

```
panic: called `Result::unwrap()` on an `Err` value: TryFromIntError(PosOverflow)
```

JS array length goes up to `2^32 - 1`, so a cheap sparse array like `new Array(3e9)` makes `i32::try_from(3_000_000_000)` return `Err` and the `.unwrap()` crashes the whole test process.

The same pattern existed in `toHaveBeenCalledTimes()`, reachable via `fn.mock.calls.length = 3_000_000_000; expect(fn).toHaveBeenCalledTimes(5)` since `fn.mock.calls` is a mutable `JSArray`.

## Fix

Compare the array length and the expected size as `i64` instead of narrowing both to `i32`. `get_length()` already clamps its result to the i52 range, so the `u64 -> i64` cast is lossless, and `to_int64()` handles the size argument (already guarded by `is_any_int()` / `is_uint32_as_any_int()`).

## How did you verify your code works?

Added regression cases to the existing matcher tests:

- `test/js/bun/test/jest-extended.test.js` (`toBeArrayOfSize()`): sparse arrays of length `3_000_000_000` and `2 ** 32 - 1`.
- `test/js/bun/test/mock-fn.test.js` (`toHaveBeenCalledTimes`): `fn.mock.calls.length = 3_000_000_000`.

Both tests panic on the released bun and pass with this change.
