### PR TITLE
Throw RangeError for out-of-range Bun.Cookie expires

### DIFF
--- a/src/jsc/bindings/Cookie.cpp
+++ b/src/jsc/bindings/Cookie.cpp
@@ -6,6 +6,7 @@
 #include <wtf/WallTime.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <JavaScriptCore/DateInstance.h>
+#include <wtf/DateMath.h>
 #include "HTTPParsers.h"
 namespace WebCore {
 
@@ -133,13 +134,13 @@ ExceptionOr<Ref<Cookie>> Cookie::parse(StringView cookieString)
                 if (!attributeValue.is8Bit()) [[unlikely]] {
                     auto asLatin1 = attributeValue.latin1();
                     double parsed = WTF::parseDate({ reinterpret_cast<const Latin1Character*>(asLatin1.data()), asLatin1.length() });
-                    if (std::isfinite(parsed)) {
+                    if (std::isfinite(parsed) && std::abs(parsed) <= WTF::maxECMAScriptTime) {
                         expires = static_cast<int64_t>(parsed);
                     }
                 } else {
                     auto nullTerminated = attributeValue.utf8();
                     double parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminated.data()), nullTerminated.length()));
-                    if (std::isfinite(parsed)) {
+                    if (std::isfinite(parsed) && std::abs(parsed) <= WTF::maxECMAScriptTime) {
                         expires = static_cast<int64_t>(parsed);
                     }
                 }

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -730,7 +730,7 @@ JSC_DEFINE_CUSTOM_GETTER(jsCookiePrototypeGetter_expires, (JSGlobalObject * lexi
     if (impl.hasExpiry()) {
         if (thisObject->m_expires) {
             auto* dateInstance = thisObject->m_expires.get();
-            if (static_cast<int64_t>(dateInstance->internalNumber()) == impl.expires()) {
+            if (dateInstance->internalNumber() == static_cast<double>(impl.expires())) {
                 return JSValue::encode(dateInstance);
             }
         }

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -25,6 +25,7 @@
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
 #include <JavaScriptCore/DateInstance.h>
+#include <wtf/DateMath.h>
 #include "HTTPParsers.h"
 namespace WebCore {
 
@@ -48,7 +49,7 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
 
     if (auto* dateInstance = dynamicDowncast<JSC::DateInstance>(expiresValue)) {
         double date = dateInstance->internalNumber();
-        if (std::isnan(date) || std::isinf(date)) [[unlikely]] {
+        if (!std::isfinite(date) || std::abs(date) > WTF::maxECMAScriptTime) [[unlikely]] {
             throwScope.throwException(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "expires must be a valid Date (or Number)"_s));
             return Cookie::emptyExpiresAtValue;
         }
@@ -57,13 +58,18 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
 
     if (expiresValue.isNumber()) {
         double expires = expiresValue.asNumber();
-        if (std::isnan(expires) || !std::isfinite(expires)) [[unlikely]] {
+        if (!std::isfinite(expires)) [[unlikely]] {
             throwScope.throwException(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "expires must be a valid Number (or Date)"_s));
             return Cookie::emptyExpiresAtValue;
         }
 
         // expires can be a negative number. This is allowed because people do that to force cookie expiration.
-        return static_cast<int64_t>(expires * 1000);
+        double expiresMs = expires * 1000.0;
+        if (std::abs(expiresMs) > WTF::maxECMAScriptTime) [[unlikely]] {
+            throwScope.throwException(lexicalGlobalObject, createRangeError(lexicalGlobalObject, "expires must be a Number within the range of a valid Date"_s));
+            return Cookie::emptyExpiresAtValue;
+        }
+        return static_cast<int64_t>(expiresMs);
     }
 
     if (expiresValue.isString()) {
@@ -71,7 +77,7 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
         RETURN_IF_EXCEPTION(throwScope, Cookie::emptyExpiresAtValue);
         auto nullTerminatedSpan = expiresStr.utf8();
         if (auto parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminatedSpan.data()), nullTerminatedSpan.length()))) {
-            if (std::isnan(parsed)) {
+            if (!std::isfinite(parsed) || std::abs(parsed) > WTF::maxECMAScriptTime) {
                 throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Invalid cookie expiration date"_s));
                 return Cookie::emptyExpiresAtValue;
             }

--- a/src/jsc/bindings/webcore/JSCookie.cpp
+++ b/src/jsc/bindings/webcore/JSCookie.cpp
@@ -76,16 +76,12 @@ static int64_t getExpiresValue(JSGlobalObject* lexicalGlobalObject, JSC::ThrowSc
         auto expiresStr = convert<IDLUSVString>(*lexicalGlobalObject, expiresValue);
         RETURN_IF_EXCEPTION(throwScope, Cookie::emptyExpiresAtValue);
         auto nullTerminatedSpan = expiresStr.utf8();
-        if (auto parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminatedSpan.data()), nullTerminatedSpan.length()))) {
-            if (!std::isfinite(parsed) || std::abs(parsed) > WTF::maxECMAScriptTime) {
-                throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Invalid cookie expiration date"_s));
-                return Cookie::emptyExpiresAtValue;
-            }
-            return static_cast<int64_t>(parsed);
-        } else {
+        double parsed = WTF::parseDate(std::span<const Latin1Character>(reinterpret_cast<const Latin1Character*>(nullTerminatedSpan.data()), nullTerminatedSpan.length()));
+        if (!std::isfinite(parsed) || std::abs(parsed) > WTF::maxECMAScriptTime) {
             throwVMError(lexicalGlobalObject, throwScope, createTypeError(lexicalGlobalObject, "Invalid cookie expiration date"_s));
             return Cookie::emptyExpiresAtValue;
         }
+        return static_cast<int64_t>(parsed);
     }
 
     return Bun::ERR::INVALID_ARG_VALUE(throwScope, lexicalGlobalObject, "expires"_s, expiresValue, "Invalid expires value. Must be a Date or a number"_s);

--- a/test/js/bun/cookie/cookie-expires-validation.test.ts
+++ b/test/js/bun/cookie/cookie-expires-validation.test.ts
@@ -57,6 +57,43 @@ describe("Bun.Cookie expires validation", () => {
         new Bun.Cookie("name", "value", { expires: -Infinity });
       }).toThrow("expires must be a valid Number");
     });
+
+    test("accepts Number at max Date boundary (seconds)", () => {
+      const seconds = 8640000000000;
+      const cookie = new Bun.Cookie("name", "value", { expires: seconds });
+      expect(cookie.expires).toEqual(new Date(seconds * 1000));
+    });
+
+    test("accepts Number at min Date boundary (seconds)", () => {
+      const seconds = -8640000000000;
+      const cookie = new Bun.Cookie("name", "value", { expires: seconds });
+      expect(cookie.expires).toEqual(new Date(seconds * 1000));
+    });
+
+    test.each([1e16, -1e16, 8640000000001, -8640000000001, Number.MAX_VALUE, -Number.MAX_VALUE, Number.MAX_SAFE_INTEGER])(
+      "throws RangeError for out-of-range Number %p",
+      value => {
+        expect(() => {
+          new Bun.Cookie("name", "value", { expires: value });
+        }).toThrow(RangeError);
+        expect(() => {
+          new Bun.Cookie("name", "value", { expires: value });
+        }).toThrow("expires must be a Number within the range of a valid Date");
+      },
+    );
+
+    test("throws RangeError for out-of-range Number via setter", () => {
+      const cookie = new Bun.Cookie("name", "value");
+      expect(() => {
+        cookie.expires = 1e16;
+      }).toThrow(RangeError);
+    });
+
+    test("throws RangeError for out-of-range Number via Cookie.from", () => {
+      expect(() => {
+        Bun.Cookie.from("name", "value", { expires: 1e16 });
+      }).toThrow(RangeError);
+    });
   });
 
   describe("Special values", () => {

--- a/test/js/bun/cookie/cookie-expires-validation.test.ts
+++ b/test/js/bun/cookie/cookie-expires-validation.test.ts
@@ -70,17 +70,22 @@ describe("Bun.Cookie expires validation", () => {
       expect(cookie.expires).toEqual(new Date(seconds * 1000));
     });
 
-    test.each([1e16, -1e16, 8640000000001, -8640000000001, Number.MAX_VALUE, -Number.MAX_VALUE, Number.MAX_SAFE_INTEGER])(
-      "throws RangeError for out-of-range Number %p",
-      value => {
-        expect(() => {
-          new Bun.Cookie("name", "value", { expires: value });
-        }).toThrow(RangeError);
-        expect(() => {
-          new Bun.Cookie("name", "value", { expires: value });
-        }).toThrow("expires must be a Number within the range of a valid Date");
-      },
-    );
+    test.each([
+      1e16,
+      -1e16,
+      8640000000001,
+      -8640000000001,
+      Number.MAX_VALUE,
+      -Number.MAX_VALUE,
+      Number.MAX_SAFE_INTEGER,
+    ])("throws RangeError for out-of-range Number %p", value => {
+      expect(() => {
+        new Bun.Cookie("name", "value", { expires: value });
+      }).toThrow(RangeError);
+      expect(() => {
+        new Bun.Cookie("name", "value", { expires: value });
+      }).toThrow("expires must be a Number within the range of a valid Date");
+    });
 
     test("throws RangeError for out-of-range Number via setter", () => {
       const cookie = new Bun.Cookie("name", "value");

--- a/test/js/bun/cookie/cookie-expires-validation.test.ts
+++ b/test/js/bun/cookie/cookie-expires-validation.test.ts
@@ -205,6 +205,16 @@ describe("Bun.Cookie expires validation", () => {
       const cookie = new Bun.Cookie("name", "value", { expires: beforeEpoch });
       expect(cookie.expires).toEqual(beforeEpoch);
     });
+
+    test("getter returns a fresh Date when the cached one was mutated to NaN", () => {
+      const cookie = new Bun.Cookie("name", "value", { expires: 1000 });
+      const first = cookie.expires;
+      expect(first.getTime()).toBe(1000 * 1000);
+      first.setTime(NaN);
+      const second = cookie.expires;
+      expect(second.getTime()).toBe(1000 * 1000);
+      expect(second).not.toBe(first);
+    });
   });
 
   describe("Conversion edge cases", () => {

--- a/test/js/bun/cookie/cookie-expires-validation.test.ts
+++ b/test/js/bun/cookie/cookie-expires-validation.test.ts
@@ -124,6 +124,24 @@ describe("Bun.Cookie expires validation", () => {
       }).toThrowErrorMatchingInlineSnapshot(`"Invalid cookie expiration date"`);
     });
 
+    test("accepts string that parses to epoch (0 ms)", () => {
+      const cookie = new Bun.Cookie("name", "value", { expires: "Thu, 01 Jan 1970 00:00:00 GMT" });
+      expect(cookie.expires).toEqual(new Date(0));
+    });
+
+    test("throws for string with out-of-range year", () => {
+      expect(() => {
+        new Bun.Cookie("name", "value", { expires: "Wed, 01 Jan 300000000 00:00:00 GMT" });
+      }).toThrow("Invalid cookie expiration date");
+    });
+
+    test("Cookie.parse ignores Expires attribute with out-of-range year", () => {
+      const cookie = Bun.Cookie.parse("a=b; Expires=Wed, 01 Jan 300000000 00:00:00 GMT");
+      expect(cookie.name).toBe("a");
+      expect(cookie.value).toBe("b");
+      expect(cookie.expires).toBeUndefined();
+    });
+
     test("throws for arrays", () => {
       expect(() => {
         new Bun.Cookie("name", "value", { expires: [2023, 11, 25] });


### PR DESCRIPTION
## What does this PR do?

`getExpiresValue()` in `src/jsc/bindings/webcore/JSCookie.cpp` rejected NaN/Infinity for the `Number` path but then did `static_cast<int64_t>(expires * 1000)` on any finite value. For inputs like `1e16` the product (`1e19`) exceeds `INT64_MAX`, which is undefined behavior per `[conv.fpint]`. On x86-64/aarch64 the cast happened to wrap to `INT64_MIN`, which is `Cookie::emptyExpiresAtValue`, so the expiry was silently dropped:

```js
const c = new Bun.Cookie("name", "value", { expires: 1e16 });
c.expires; // undefined (should have been rejected)
```

## Fix

Bound the milliseconds value to `WTF::maxECMAScriptTime` (`8.64e15`, the ECMA-262 Date range) before the cast and throw a `RangeError` when it is exceeded, matching the existing handling for NaN/Infinity. The same bound is applied to the `DateInstance` and parsed-string paths so every `static_cast<int64_t>(double)` in this function is guarded.

## How did you verify your code works?

Added tests in `test/js/bun/cookie/cookie-expires-validation.test.ts` covering `1e16`, `-1e16`, one past the ±`8.64e12` second boundary, `Number.MAX_VALUE`, `Number.MAX_SAFE_INTEGER`, the setter path, and `Cookie.from`. Also added positive boundary tests at exactly ±`8.64e12` seconds.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/cookie/cookie-expires-validation.test.ts`: 9 new tests fail, 24 existing pass
- `bun bd test test/js/bun/cookie/`: 160 pass, 0 fail