### PR TITLE
Propagate exception from _events getter in native EventEmitter

### DIFF
--- a/src/jsc/bindings/webcore/JSEventEmitter.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitter.cpp
@@ -575,6 +575,7 @@ JSC_DEFINE_HOST_FUNCTION(Events_functionGetEventListeners,
     if (callFrame->argumentCount() < 2) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     auto argument0 = jsEventEmitterCast(vm, lexicalGlobalObject, callFrame->uncheckedArgument(0));
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (!argument0) [[unlikely]] {
         throwException(lexicalGlobalObject, throwScope, createError(lexicalGlobalObject, "Expected EventEmitter"_s));
         return {};
@@ -599,6 +600,7 @@ JSC_DEFINE_HOST_FUNCTION(Events_functionListenerCount,
     if (callFrame->argumentCount() < 2) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     auto argument0 = jsEventEmitterCast(vm, lexicalGlobalObject, callFrame->uncheckedArgument(0));
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (!argument0) [[unlikely]] {
         throwException(lexicalGlobalObject, throwScope, createError(lexicalGlobalObject, "Expected EventEmitter"_s));
         return {};
@@ -618,6 +620,7 @@ JSC_DEFINE_HOST_FUNCTION(Events_functionOnce,
     if (callFrame->argumentCount() < 3) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     auto argument0 = jsEventEmitterCastFast(vm, lexicalGlobalObject, callFrame->uncheckedArgument(0));
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (!argument0) [[unlikely]] {
         throwException(lexicalGlobalObject, throwScope, createError(lexicalGlobalObject, "Expected EventEmitter"_s));
         return {};
@@ -642,6 +645,7 @@ JSC_DEFINE_HOST_FUNCTION(Events_functionOn,
     if (callFrame->argumentCount() < 3) [[unlikely]]
         return throwVMError(lexicalGlobalObject, throwScope, createNotEnoughArgumentsError(lexicalGlobalObject));
     auto argument0 = jsEventEmitterCastFast(vm, lexicalGlobalObject, callFrame->uncheckedArgument(0));
+    RETURN_IF_EXCEPTION(throwScope, {});
     if (!argument0) [[unlikely]] {
         throwException(lexicalGlobalObject, throwScope, createError(lexicalGlobalObject, "Expected EventEmitter"_s));
         return {};

--- a/src/jsc/bindings/webcore/JSEventEmitterCustom.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitterCustom.cpp
@@ -60,12 +60,11 @@ JSEventEmitter* jsEventEmitterCastFast(VM& vm, JSC::JSGlobalObject* lexicalGloba
     auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto clientData = WebCore::clientData(vm);
     auto name = clientData->builtinNames()._eventsPublicName();
-    if (JSValue _events = thisObject->getIfPropertyExists(lexicalGlobalObject, name)) {
-        if (_events.isCell() && _events.inherits<JSEventEmitter>()) {
-            return uncheckedDowncast<JSEventEmitter>(asObject(_events));
-        }
-    }
+    JSValue _events = thisObject->getIfPropertyExists(lexicalGlobalObject, name);
     RETURN_IF_EXCEPTION(throwScope, nullptr);
+    if (_events && _events.isCell() && _events.inherits<JSEventEmitter>()) {
+        return uncheckedDowncast<JSEventEmitter>(asObject(_events));
+    }
 
     auto* globalObject = static_cast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto impl = EventEmitter::create(*globalObject->scriptExecutionContext());

--- a/src/jsc/bindings/webcore/JSEventEmitterCustom.cpp
+++ b/src/jsc/bindings/webcore/JSEventEmitterCustom.cpp
@@ -57,6 +57,7 @@ JSEventEmitter* jsEventEmitterCastFast(VM& vm, JSC::JSGlobalObject* lexicalGloba
     if (thisObject->inherits<JSEventEmitter>())
         return uncheckedDowncast<JSEventEmitter>(thisObject);
 
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto clientData = WebCore::clientData(vm);
     auto name = clientData->builtinNames()._eventsPublicName();
     if (JSValue _events = thisObject->getIfPropertyExists(lexicalGlobalObject, name)) {
@@ -64,24 +65,16 @@ JSEventEmitter* jsEventEmitterCastFast(VM& vm, JSC::JSGlobalObject* lexicalGloba
             return uncheckedDowncast<JSEventEmitter>(asObject(_events));
         }
     }
-    // TODO: properly propagate exception upwards (^ getIfPropertyExists)
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
 
-    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* globalObject = static_cast<Zig::GlobalObject*>(lexicalGlobalObject);
     auto impl = EventEmitter::create(*globalObject->scriptExecutionContext());
     impl->setThisObject(thisObject);
 
-    auto throwScope = DECLARE_THROW_SCOPE(vm);
     auto result = toJSNewlyCreated<IDLInterface<EventEmitter>>(*lexicalGlobalObject, *globalObject, throwScope, WTF::move(impl));
+    RETURN_IF_EXCEPTION(throwScope, nullptr);
 
     thisObject->putDirect(vm, name, result, 0);
-
-    if (scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        return nullptr;
-    }
-
-    RETURN_IF_EXCEPTION(throwScope, nullptr);
 
     return uncheckedDowncast<JSEventEmitter>(asObject(result));
 }

--- a/src/jsc/bindings/webcore/JSEventEmitterCustom.h
+++ b/src/jsc/bindings/webcore/JSEventEmitterCustom.h
@@ -42,6 +42,7 @@ public:
 
         auto thisValue = callFrame.thisValue().toThis(&lexicalGlobalObject, JSC::ECMAMode::strict());
         auto* thisObject = jsEventEmitterCastFast(vm, &lexicalGlobalObject, thisValue);
+        RETURN_IF_EXCEPTION(throwScope, {});
         if (!thisObject) [[unlikely]] {
             return throwThisTypeError(lexicalGlobalObject, throwScope, "EventEmitter", operationName);
         }

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -1,5 +1,6 @@
 import { sleep } from "bun";
 import { describe, expect, mock, test } from "bun:test";
+import { bunEnv, bunExe, isDebug } from "harness";
 import { createRequire } from "module";
 
 // this is also testing that imports with default and named imports in the same statement work
@@ -975,4 +976,29 @@ describe("native EventEmitter propagates exception from _events getter", () => {
     }
     expect(caught).toBe(sentinel);
   });
+});
+
+test.skipIf(!isDebug)("native EventEmitter on plain object satisfies validateExceptionChecks", async () => {
+  // The second call reads back the JSEventEmitter stored on `_events` by the
+  // first call, exercising the early-return path in jsEventEmitterCastFast
+  // that follows getIfPropertyExists. The exception-scope check must be
+  // satisfied before that return.
+  const code = `
+    const nativeProto = Object.getPrototypeOf(process);
+    const obj = {};
+    let xFired = false;
+    nativeProto.on.call(obj, "x", () => { xFired = true; });
+    nativeProto.on.call(obj, "y", () => {});
+    nativeProto.emit.call(obj, "x");
+    if (!xFired) throw new Error("listener did not fire");
+    process.stdout.write("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: { ...bunEnv, BUN_JSC_validateExceptionChecks: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
 });

--- a/test/js/node/events/event-emitter.test.ts
+++ b/test/js/node/events/event-emitter.test.ts
@@ -912,3 +912,67 @@ test("getEventListeners", () => {
 test("EventEmitter.name", () => {
   expect(EventEmitter.name).toBe("EventEmitter");
 });
+
+describe("native EventEmitter propagates exception from _events getter", () => {
+  // The native EventEmitter implementation (used for e.g. `process`) reads the
+  // `_events` property via getIfPropertyExists, which can run a user getter.
+  // If that getter throws, the exception must propagate to the caller instead
+  // of being swallowed and replaced with a generic "invalid this" TypeError.
+  const nativeProto = Object.getPrototypeOf(process);
+
+  const cases: Array<[string, (obj: object) => void]> = [
+    ["on", obj => nativeProto.on.call(obj, "foo", () => {})],
+    ["addListener", obj => nativeProto.addListener.call(obj, "foo", () => {})],
+    ["once", obj => nativeProto.once.call(obj, "foo", () => {})],
+    ["emit", obj => nativeProto.emit.call(obj, "foo")],
+    ["removeListener", obj => nativeProto.removeListener.call(obj, "foo", () => {})],
+    ["removeAllListeners", obj => nativeProto.removeAllListeners.call(obj)],
+    ["eventNames", obj => nativeProto.eventNames.call(obj)],
+    ["listenerCount", obj => nativeProto.listenerCount.call(obj, "foo")],
+    ["listeners", obj => nativeProto.listeners.call(obj, "foo")],
+    ["getMaxListeners", obj => nativeProto.getMaxListeners.call(obj)],
+  ];
+
+  test.each(cases)("%s", (_name, invoke) => {
+    const sentinel = new Error("getter threw");
+    const obj = {};
+    Object.defineProperty(obj, "_events", {
+      get() {
+        throw sentinel;
+      },
+      configurable: true,
+    });
+
+    let caught: unknown;
+    try {
+      invoke(obj);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(sentinel);
+  });
+
+  test("Proxy _events getter that throws", () => {
+    const sentinel = new Error("proxy get threw");
+    const obj = new Proxy(
+      {},
+      {
+        has(_target, key) {
+          return key === "_events";
+        },
+        get(_target, key) {
+          if (key === "_events") throw sentinel;
+          return undefined;
+        },
+      },
+    );
+
+    let caught: unknown;
+    try {
+      nativeProto.on.call(obj, "foo", () => {});
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBe(sentinel);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`jsEventEmitterCastFast` in `src/jsc/bindings/webcore/JSEventEmitterCustom.cpp` reads the `_events` property on the receiver via `getIfPropertyExists`, which can run a user getter or Proxy trap. If that getter throws, the code previously fell through with a pending exception, created a fresh `EventEmitter` wrapper, called `putDirect`, and then cleared the pending exception via `DECLARE_TOP_EXCEPTION_SCOPE` + `tryClearException`. The user's error was silently dropped and each caller then threw its own `ERR_INVALID_THIS` TypeError.

### Repro

```js
const nativeOn = Object.getPrototypeOf(process).on;
const sentinel = new Error("getter threw");
const obj = {};
Object.defineProperty(obj, "_events", { get() { throw sentinel; } });
nativeOn.call(obj, "foo", () => {});
// before: TypeError: Can only call EventEmitter.addListener on instances of EventEmitter
// after:  Error: getter threw
```

### Fix

- Declare the throw scope before `getIfPropertyExists` and `RETURN_IF_EXCEPTION` immediately after it so the exception propagates instead of being cleared. This also removes the `DECLARE_TOP_EXCEPTION_SCOPE` / `tryClearException` block and the `TODO` comment that flagged the problem.
- Add `RETURN_IF_EXCEPTION` after every `jsEventEmitterCast` / `jsEventEmitterCastFast` call in `JSEventEmitter.cpp` and in `IDLOperation<JSEventEmitter>::call` so callers don't overwrite the pending exception with a generic "invalid this" error (`VM::throwException` replaces rather than preserves a pending exception).

### How did you verify your code works?

Added a regression test in `test/js/node/events/event-emitter.test.ts` covering `on`, `addListener`, `once`, `emit`, `removeListener`, `removeAllListeners`, `eventNames`, `listenerCount`, `listeners`, `getMaxListeners`, plus a Proxy variant. All 11 cases fail on the current release (received `ERR_INVALID_THIS` instead of the getter's error) and pass with this change. Also verified the full `event-emitter.test.ts` suite and the new cases pass under `BUN_JSC_validateExceptionChecks=1`.