### PR TITLE
Bun.plugin: make namespace validation thread-safe

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -23,7 +23,6 @@
 #include <JavaScriptCore/JavaScript.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/RegExpObject.h>
-#include <JavaScriptCore/RegularExpression.h>
 #include <JavaScriptCore/SourceOrigin.h>
 #include <JavaScriptCore/Structure.h>
 #include <JavaScriptCore/SubspaceInlines.h>
@@ -40,13 +39,27 @@ namespace Zig {
 extern "C" void Bun__onDidAppendPlugin(void* bunVM, JSGlobalObject* globalObject);
 using OnAppendPluginCallback = void (*)(void*, JSGlobalObject* globalObject);
 
+static inline bool isValidNamespaceCharacter(char16_t c)
+{
+    return isASCIIAlphanumeric(c) || c == '_' || c == '-' || c == '/' || c == '@';
+}
+
+// Equivalent to /^[/@a-zA-Z0-9_\-]+$/. Hand-rolled because this is reachable
+// from multiple VMs (workers) concurrently and Yarr::RegularExpression is not
+// thread-safe: match() drives a per-instance BumpPointerAllocator.
 static bool isValidNamespaceString(String& namespaceString)
 {
-    static JSC::Yarr::RegularExpression* namespaceRegex = nullptr;
-    if (!namespaceRegex) {
-        namespaceRegex = new JSC::Yarr::RegularExpression("^([/@a-zA-Z0-9_\\-]+)$"_s);
+    if (namespaceString.isEmpty()) return false;
+    if (namespaceString.is8Bit()) {
+        for (auto c : namespaceString.span8()) {
+            if (!isValidNamespaceCharacter(c)) return false;
+        }
+    } else {
+        for (auto c : namespaceString.span16()) {
+            if (!isValidNamespaceCharacter(c)) return false;
+        }
     }
-    return namespaceRegex->match(namespaceString) > -1;
+    return true;
 }
 
 static JSC::EncodedJSValue jsFunctionAppendOnLoadPluginBody(JSC::JSGlobalObject* globalObject, JSC::CallFrame* callframe, BunPluginTarget target, BunPlugin::Base& plugin, void* ctx, OnAppendPluginCallback callback)

--- a/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
+++ b/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
@@ -19,6 +19,7 @@ function hammer(tag: string) {
       },
     });
     accepted++;
+    let threw: unknown;
     try {
       Bun.plugin({
         name: `q-${tag}-${i}`,
@@ -26,11 +27,13 @@ function hammer(tag: string) {
           b.onLoad({ filter: /.*/, namespace: "bad ns!" }, () => ({ contents: "", loader: "js" }));
         },
       });
-      throw new Error("invalid namespace was accepted");
     } catch (e) {
-      if (!String((e as Error).message).includes("namespace")) throw e;
-      rejected++;
+      threw = e;
     }
+    if (!String((threw as Error)?.message).includes("namespace can only contain")) {
+      throw new Error(`${tag}: "bad ns!" was not rejected (got: ${threw})`);
+    }
+    rejected++;
   }
   if (accepted !== ITERS || rejected !== ITERS) {
     throw new Error(`${tag}: accepted=${accepted} rejected=${rejected} (expected ${ITERS} each)`);

--- a/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
+++ b/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
@@ -3,12 +3,10 @@
 // be safe to call from multiple VMs at once.
 
 const WORKERS = 8;
-const ITERS = 4000;
+const ITERS = 2000;
 
 function hammer(tag: string) {
   const valid = ["abc", "abc-def", "a/b", "@scope/pkg", "A_Z-0/9", "x"];
-  let accepted = 0;
-  let rejected = 0;
   for (let i = 0; i < ITERS; i++) {
     const ns = valid[i % valid.length];
     Bun.plugin({
@@ -18,7 +16,6 @@ function hammer(tag: string) {
         b.onResolve({ filter: /.*/, namespace: ns }, ({ path }) => ({ path, namespace: ns }));
       },
     });
-    accepted++;
     let threw: unknown;
     try {
       Bun.plugin({
@@ -33,10 +30,6 @@ function hammer(tag: string) {
     if (!String((threw as Error)?.message).includes("namespace can only contain")) {
       throw new Error(`${tag}: "bad ns!" was not rejected (got: ${threw})`);
     }
-    rejected++;
-  }
-  if (accepted !== ITERS || rejected !== ITERS) {
-    throw new Error(`${tag}: accepted=${accepted} rejected=${rejected} (expected ${ITERS} each)`);
   }
 }
 

--- a/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
+++ b/test/js/bun/plugin/plugin-namespace-workers-fixture.ts
@@ -1,0 +1,64 @@
+// Stress fixture: many workers (plus the main thread) concurrently register
+// namespaced Bun.plugin onLoad/onResolve callbacks. Namespace validation must
+// be safe to call from multiple VMs at once.
+
+const WORKERS = 8;
+const ITERS = 4000;
+
+function hammer(tag: string) {
+  const valid = ["abc", "abc-def", "a/b", "@scope/pkg", "A_Z-0/9", "x"];
+  let accepted = 0;
+  let rejected = 0;
+  for (let i = 0; i < ITERS; i++) {
+    const ns = valid[i % valid.length];
+    Bun.plugin({
+      name: `p-${tag}-${i}`,
+      setup(b) {
+        b.onLoad({ filter: /.*/, namespace: ns }, () => ({ contents: "", loader: "js" }));
+        b.onResolve({ filter: /.*/, namespace: ns }, ({ path }) => ({ path, namespace: ns }));
+      },
+    });
+    accepted++;
+    try {
+      Bun.plugin({
+        name: `q-${tag}-${i}`,
+        setup(b) {
+          b.onLoad({ filter: /.*/, namespace: "bad ns!" }, () => ({ contents: "", loader: "js" }));
+        },
+      });
+      throw new Error("invalid namespace was accepted");
+    } catch (e) {
+      if (!String((e as Error).message).includes("namespace")) throw e;
+      rejected++;
+    }
+  }
+  if (accepted !== ITERS || rejected !== ITERS) {
+    throw new Error(`${tag}: accepted=${accepted} rejected=${rejected} (expected ${ITERS} each)`);
+  }
+}
+
+if (Bun.isMainThread) {
+  const workers: Worker[] = [];
+  const dones: Promise<void>[] = [];
+  for (let i = 0; i < WORKERS; i++) {
+    const w = new Worker(import.meta.url);
+    workers.push(w);
+    dones.push(
+      new Promise<void>((resolve, reject) => {
+        w.onmessage = e => (e.data === "done" ? resolve() : reject(new Error(String(e.data))));
+        w.onerror = e => reject(new Error((e as any)?.message ?? String(e)));
+      }),
+    );
+  }
+  hammer("main");
+  await Promise.all(dones);
+  for (const w of workers) w.terminate();
+  console.log("PASS");
+} else {
+  try {
+    hammer("worker");
+    postMessage("done");
+  } catch (e) {
+    postMessage(`error: ${(e as Error).message}`);
+  }
+}

--- a/test/js/bun/plugin/plugin-namespace-workers.test.ts
+++ b/test/js/bun/plugin/plugin-namespace-workers.test.ts
@@ -67,5 +67,5 @@ describe("Bun.plugin namespace validation", () => {
       signalCode: null,
       stderr: expect.any(String),
     });
-  }, 60_000);
+  });
 });

--- a/test/js/bun/plugin/plugin-namespace-workers.test.ts
+++ b/test/js/bun/plugin/plugin-namespace-workers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import { join } from "node:path";
+
+describe("Bun.plugin namespace validation", () => {
+  // Run the setup() body and return the error message thrown by the first
+  // onLoad/onResolve call, or "" if none was thrown. We catch here so each
+  // case exercises a fresh call into the validator.
+  const errorFor = (setup: (b: import("bun").PluginBuilder) => void): string => {
+    try {
+      Bun.plugin({ name: "ns-validation", setup });
+      return "";
+    } catch (e) {
+      return String((e as Error).message);
+    }
+  };
+
+  test.each([
+    ["abc", true],
+    ["abc-def", true],
+    ["abc_def", true],
+    ["a/b", true],
+    ["@scope/pkg", true],
+    ["A_Z-0/9", true],
+    ["x", true],
+    ["0", true],
+    ["/", true],
+    ["@", true],
+    ["-", true],
+    ["_", true],
+    ["abcABC012/@_-", true],
+
+    ["", false],
+    ["bad ns", false],
+    ["bad!", false],
+    ["a.b", false],
+    ["a:b", false],
+    ["a+b", false],
+    ["a\nb", false],
+    ["a\tb", false],
+    ["héllo", false],
+    ["a😀b", false],
+    ["a\0b", false],
+  ])("onLoad/onResolve namespace %j (valid: %p)", (ns, ok) => {
+    const expected = ok ? "" : "namespace can only contain letters, numbers, dashes, or underscores";
+    expect({
+      onLoad: errorFor(b => b.onLoad({ filter: /.*/, namespace: ns }, () => ({ contents: "", loader: "js" }))),
+      onResolve: errorFor(b => b.onResolve({ filter: /.*/, namespace: ns }, ({ path }) => ({ path, namespace: ns }))),
+    }).toEqual({
+      onLoad: expected,
+      onResolve: expected,
+    });
+  });
+
+  test("is safe to call concurrently from workers", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(import.meta.dir, "plugin-namespace-workers-fixture.ts")],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // stderr is captured for diagnostics only; debug/ASAN builds may emit benign noise.
+    expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode, stderr }).toEqual({
+      stdout: "PASS",
+      exitCode: 0,
+      signalCode: null,
+      stderr: expect.any(String),
+    });
+  }, 60_000);
+});


### PR DESCRIPTION
### Repro

```ts
// 8 workers + main, each registering namespaced plugins in a loop
Bun.plugin({
  setup(b) {
    b.onLoad({ filter: /.*/, namespace: "abc-def" }, () => ({ contents: "", loader: "js" }));
  },
});
```

With concurrent workers this aborts on release builds:

```
ASSERTION FAILED: position <= m_current
.WTF/Headers/wtf/BumpPointerAllocator.h(86) : BumpPointerPool *WTF::BumpPointerPool::dealloc(void *)
```

or intermittently rejects a valid namespace with `namespace can only contain letters, numbers, dashes, or underscores`.

### Cause

`isValidNamespaceString` (`src/jsc/bindings/BunPlugin.cpp`) lazily initialized a process-wide `static JSC::Yarr::RegularExpression*` with no guard and shared it across every VM. The racy init is the smaller problem: every `match()` call drives the regex's per-instance `BumpPointerAllocator`, which WTF explicitly documents as non-reentrant. Workers calling `Bun.plugin` with a `namespace` concurrently with the main thread corrupt the allocator's bump pointer.

### Fix

Replace the regex with a direct ASCII character-class check equivalent to `/^[/@a-zA-Z0-9_\-]+$/`, following the pattern already used for cookie name/path/domain validation. No shared mutable state, no heap allocation.

### Verification

- `test/js/bun/plugin/plugin-namespace-workers.test.ts`: a worker stress fixture that fails 10/10 on `main` (SIGABRT or spurious rejection) and passes with the fix, plus a parametrised table covering the accepted/rejected character classes for both `onLoad` and `onResolve`.
- Existing `plugins.test.ts` and `plugin-namespace-drive-letter.test.ts` unchanged, still pass.