### PR TITLE
Make CPU profiler state per-VM instead of process-global

### DIFF
--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -51,12 +51,13 @@ unsafe extern "C" {
         out_json: Option<&mut BunString>,
         out_text: Option<&mut BunString>,
     );
-    /// Plain by-value `c_int`; sets a global sampler interval, no pointer invariants.
-    safe fn Bun__setSamplingInterval(interval_microseconds: c_int);
+    /// Sets the per-VM sampler interval. `&mut VM` is ABI-identical to a
+    /// non-null `VM*` (see `Bun__startCPUProfiler`).
+    safe fn Bun__setSamplingInterval(vm: &mut VM, interval_microseconds: c_int);
 }
 
-pub fn set_sampling_interval(interval: u32) {
-    Bun__setSamplingInterval(c_int::try_from(interval).expect("int cast"));
+pub fn set_sampling_interval(vm: &mut VM, interval: u32) {
+    Bun__setSamplingInterval(vm, c_int::try_from(interval).expect("int cast"));
 }
 
 pub fn start_cpu_profiler(vm: &mut VM) {

--- a/src/jsc/bindings/BunCPUProfiler.cpp
+++ b/src/jsc/bindings/BunCPUProfiler.cpp
@@ -1,5 +1,6 @@
 #include "root.h"
 #include "BunCPUProfiler.h"
+#include "BunClientData.h"
 #include "ZigGlobalObject.h"
 #include "helpers.h"
 #include "BunString.h"
@@ -20,46 +21,42 @@
 
 extern "C" void Bun__startCPUProfiler(JSC::VM* vm);
 extern "C" void Bun__stopCPUProfiler(JSC::VM* vm, BunString* outJSON, BunString* outText);
-extern "C" void Bun__setSamplingInterval(int intervalMicroseconds);
+extern "C" void Bun__setSamplingInterval(JSC::VM* vm, int intervalMicroseconds);
 
-void Bun__setSamplingInterval(int intervalMicroseconds)
+void Bun__setSamplingInterval(JSC::VM* vm, int intervalMicroseconds)
 {
-    Bun::setSamplingInterval(intervalMicroseconds);
+    Bun::setSamplingInterval(*vm, intervalMicroseconds);
 }
 
 namespace Bun {
 
-// Store the profiling start time in microseconds since Unix epoch
-static thread_local double s_profilingStartTime = 0.0;
-// Set sampling interval to 1ms (1000 microseconds) to match Node.js
-static thread_local int s_samplingInterval = 1000;
-static thread_local bool s_isProfilerRunning = false;
-
-void setSamplingInterval(int intervalMicroseconds)
+void setSamplingInterval(JSC::VM& vm, int intervalMicroseconds)
 {
-    s_samplingInterval = intervalMicroseconds;
+    WebCore::clientData(vm)->cpuSamplingInterval = intervalMicroseconds;
 }
 
-bool isCPUProfilerRunning()
+bool isCPUProfilerRunning(JSC::VM& vm)
 {
-    return s_isProfilerRunning;
+    return WebCore::clientData(vm)->cpuProfilerRunning;
 }
 
 void startCPUProfiler(JSC::VM& vm)
 {
+    auto* clientData = WebCore::clientData(vm);
+
     // Capture the wall clock time when profiling starts (before creating stopwatch)
     // This will be used as the profile's startTime
-    s_profilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
+    clientData->cpuProfilingStartTime = MonotonicTime::now().approximate<WTF::WallTime>().secondsSinceEpoch().value() * 1000000.0;
 
     // Create a stopwatch and start it
     auto stopwatch = WTF::Stopwatch::create();
     stopwatch->start();
 
     JSC::SamplingProfiler& samplingProfiler = vm.ensureSamplingProfiler(WTF::move(stopwatch));
-    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(s_samplingInterval));
+    samplingProfiler.setTimingInterval(WTF::Seconds::fromMicroseconds(clientData->cpuSamplingInterval));
     samplingProfiler.noticeCurrentThreadAsJSCExecutionThread();
     samplingProfiler.start();
-    s_isProfilerRunning = true;
+    clientData->cpuProfilerRunning = true;
 }
 
 struct ProfileNode {
@@ -270,13 +267,13 @@ static WTF::String formatCodeSpan(const WTF::String& str)
 }
 
 // Helper to generate a minimal valid cpuprofile JSON with no samples
-static WTF::String generateEmptyProfileJSON()
+static WTF::String generateEmptyProfileJSON(double profilingStartTime)
 {
     // Return a minimal valid Chrome DevTools CPU profile format
-    // Use s_profilingStartTime if available, otherwise fall back to current time
+    // Use the recorded start time if available, otherwise fall back to current time
     long long timestamp;
-    if (s_profilingStartTime > 0)
-        timestamp = static_cast<long long>(s_profilingStartTime);
+    if (profilingStartTime > 0)
+        timestamp = static_cast<long long>(profilingStartTime);
     else
         timestamp = static_cast<long long>(WTF::WallTime::now().secondsSinceEpoch().value() * 1000000.0);
 
@@ -292,7 +289,10 @@ static WTF::String generateEmptyProfileJSON()
 // Unified function that stops the profiler and generates requested output formats
 void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 {
-    s_isProfilerRunning = false;
+    auto* clientData = WebCore::clientData(vm);
+    clientData->cpuProfilerRunning = false;
+    double profilingStartTime = clientData->cpuProfilingStartTime;
+    int samplingInterval = clientData->cpuSamplingInterval;
 
     JSC::SamplingProfiler* profiler = vm.samplingProfiler();
     if (!profiler) {
@@ -321,7 +321,7 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         return;
 
     if (stackTraces.isEmpty()) {
-        if (outJSON) *outJSON = generateEmptyProfileJSON();
+        if (outJSON) *outJSON = generateEmptyProfileJSON(profilingStartTime);
         if (outText) *outText = "No samples collected.\n"_s;
         return;
     }
@@ -357,8 +357,8 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         WTF::Vector<int> samples;
         WTF::Vector<long long> timeDeltas;
 
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double startTime = profilingStartTime;
+        double lastTime = profilingStartTime;
 
         for (size_t idx : sortedIndices) {
             auto& stackTrace = stackTraces[idx];
@@ -617,8 +617,8 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
 
     // Generate text format if requested
     if (outText) {
-        double startTime = s_profilingStartTime;
-        double lastTime = s_profilingStartTime;
+        double startTime = profilingStartTime;
+        double lastTime = profilingStartTime;
         double endTime = startTime;
 
         WTF::HashMap<WTF::String, FunctionStats> functionStatsMap;
@@ -746,7 +746,7 @@ void stopCPUProfiler(JSC::VM& vm, WTF::String* outJSON, WTF::String* outText)
         output.append(" | "_s);
         output.append(totalSamples);
         output.append(" | "_s);
-        output.append(formatTime(s_samplingInterval));
+        output.append(formatTime(samplingInterval));
         output.append(" | "_s);
         output.append(numFunctions);
         output.append(" |\n\n"_s);

--- a/src/jsc/bindings/BunCPUProfiler.h
+++ b/src/jsc/bindings/BunCPUProfiler.h
@@ -10,8 +10,8 @@ class VM;
 
 namespace Bun {
 
-void setSamplingInterval(int intervalMicroseconds);
-bool isCPUProfilerRunning();
+void setSamplingInterval(JSC::VM& vm, int intervalMicroseconds);
+bool isCPUProfilerRunning(JSC::VM& vm);
 
 // Start the CPU profiler
 void startCPUProfiler(JSC::VM& vm);

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -127,6 +127,14 @@ public:
     void* bunVM;
     Bun::JSCTaskScheduler deferredWorkTimer;
 
+    // Per-VM CPU profiler state. JSC::SamplingProfiler is per-VM, so the
+    // running flag / start time / sampling interval must be too; a
+    // process-global would race across workers and let one VM's start/stop
+    // clobber another's.
+    double cpuProfilingStartTime = 0.0;
+    int cpuSamplingInterval = 1000;
+    bool cpuProfilerRunning = false;
+
     // Backing storage for Bun::IsolatedModuleCache (see IsolatedModuleCache.h).
     // All access should go through that class. Stored as the JSC base type to
     // avoid pulling ZigSourceProvider.h into this header; the cache class

--- a/src/jsc/bindings/JSInspectorProfiler.cpp
+++ b/src/jsc/bindings/JSInspectorProfiler.cpp
@@ -39,12 +39,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_setCPUSamplingInterval, (JSGlobalObject * gl
     Bun::V::validateInteger(scope, globalObject, callFrame->uncheckedArgument(0), "interval"_s, jsNumber(1), jsUndefined(), &interval);
     RETURN_IF_EXCEPTION(scope, {});
 
-    Bun::setSamplingInterval(interval);
+    Bun::setSamplingInterval(vm, interval);
     return JSValue::encode(jsUndefined());
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning);
-JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject*, CallFrame*))
+JSC_DEFINE_HOST_FUNCTION(jsFunction_isCPUProfilerRunning, (JSGlobalObject * globalObject, CallFrame*))
 {
-    return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning()));
+    return JSValue::encode(jsBoolean(Bun::isCPUProfilerRunning(globalObject->vm())));
 }

--- a/src/jsc/bindings/webcore/JSWorker.cpp
+++ b/src/jsc/bindings/webcore/JSWorker.cpp
@@ -812,7 +812,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_startCpuProfileInter
     uint64_t reqId = worker.registerCrossVMRequest(vm, promise);
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([reqId, parentId, protectedWorker = Ref { worker }](ScriptExecutionContext& workerCtx) mutable {
-        if (!Bun::isCPUProfilerRunning())
+        if (!Bun::isCPUProfilerRunning(workerCtx.vm()))
             Bun::startCPUProfiler(workerCtx.vm());
         ScriptExecutionContext::postTaskTo(parentId, [reqId, protectedWorker = WTF::move(protectedWorker)](ScriptExecutionContext& parentCtx) {
             resolveCrossVMRequest(protectedWorker.get(), reqId, parentCtx, jsUndefined());
@@ -837,7 +837,7 @@ static inline JSC::EncodedJSValue jsWorkerPrototypeFunction_stopCpuProfileIntern
     auto parentId = globalObject->scriptExecutionContext()->identifier();
     bool accepted = worker.postTaskToWorkerGlobalScope([reqId, parentId, protectedWorker = Ref { worker }](ScriptExecutionContext& workerCtx) mutable {
         WTF::String result;
-        if (Bun::isCPUProfilerRunning())
+        if (Bun::isCPUProfilerRunning(workerCtx.vm()))
             Bun::stopCPUProfiler(workerCtx.vm(), &result, nullptr);
         if (result.isEmpty())
             result = kEmptyCpuProfileJSON;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1378,7 +1378,10 @@ impl Run {
                 interval: opts.interval,
             });
             // SAFETY: `vm.jsc_vm` set in `init`.
-            bun_jsc::bun_cpu_profiler::set_sampling_interval(unsafe { &mut *vm.jsc_vm }, opts.interval);
+            bun_jsc::bun_cpu_profiler::set_sampling_interval(
+                unsafe { &mut *vm.jsc_vm },
+                opts.interval,
+            );
             // SAFETY: `vm.jsc_vm` set in `init`.
             bun_jsc::bun_cpu_profiler::start_cpu_profiler(unsafe { &mut *vm.jsc_vm });
             bun_analytics::features::cpu_profile.fetch_add(1, Ordering::Relaxed);

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1377,7 +1377,8 @@ impl Run {
                 json_format: opts.json_format,
                 interval: opts.interval,
             });
-            bun_jsc::bun_cpu_profiler::set_sampling_interval(opts.interval);
+            // SAFETY: `vm.jsc_vm` set in `init`.
+            bun_jsc::bun_cpu_profiler::set_sampling_interval(unsafe { &mut *vm.jsc_vm }, opts.interval);
             // SAFETY: `vm.jsc_vm` set in `init`.
             bun_jsc::bun_cpu_profiler::start_cpu_profiler(unsafe { &mut *vm.jsc_vm });
             bun_analytics::features::cpu_profile.fetch_add(1, Ordering::Relaxed);

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -336,6 +336,8 @@ describe("node:inspector", () => {
 
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+      expect(stderr).toBe("");
+
       let result;
       try {
         result = JSON.parse(stdout.trim());

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import inspector from "node:inspector";
 import inspectorPromises from "node:inspector/promises";
 
@@ -251,6 +252,104 @@ describe("node:inspector", () => {
       // Both profiles should be valid
       expect(result1.profile.nodes.length).toBeGreaterThanOrEqual(1);
       expect(result2.profile.nodes.length).toBeGreaterThanOrEqual(1);
+    });
+
+    test("profiler state is per-VM, not shared across workers", async () => {
+      // Each worker has its own JSC::VM with its own SamplingProfiler; the
+      // running flag / start time / sampling interval must be per-VM too.
+      // Run in a subprocess so the test file's own VM isn't left with a
+      // sampling profiler attached.
+      const script = `
+        const inspector = require("node:inspector");
+        const { Worker } = require("node:worker_threads");
+
+        const session = new inspector.Session();
+        session.connect();
+        session.post("Profiler.enable");
+        session.post("Profiler.start");
+
+        const worker = new Worker(
+          \`
+          const inspector = require("node:inspector");
+          const { parentPort } = require("node:worker_threads");
+          const session = new inspector.Session();
+          session.connect();
+          session.post("Profiler.enable");
+
+          let setIntervalError = null;
+          try {
+            session.post("Profiler.setSamplingInterval", { interval: 500 });
+          } catch (e) {
+            setIntervalError = e.message;
+          }
+
+          session.post("Profiler.start");
+          let sum = 0;
+          for (let i = 0; i < 10000; i++) sum += Math.sqrt(i);
+
+          let stopError = null;
+          let hasProfile = false;
+          try {
+            const result = session.post("Profiler.stop");
+            hasProfile = !!(result && result.profile && Array.isArray(result.profile.nodes));
+          } catch (e) {
+            stopError = e.message;
+          }
+
+          session.disconnect();
+          parentPort.postMessage({ setIntervalError, stopError, hasProfile });
+          \`,
+          { eval: true },
+        );
+
+        const msg = await new Promise((resolve, reject) => {
+          worker.on("message", resolve);
+          worker.on("error", reject);
+        });
+        await worker.terminate();
+
+        let mainStopError = null;
+        let mainHasProfile = false;
+        try {
+          const result = session.post("Profiler.stop");
+          mainHasProfile = !!(result && result.profile && Array.isArray(result.profile.nodes));
+        } catch (e) {
+          mainStopError = e.message;
+        }
+        session.disconnect();
+
+        console.log(JSON.stringify({
+          workerSetIntervalError: msg.setIntervalError,
+          workerStopError: msg.stopError,
+          workerHasProfile: msg.hasProfile,
+          mainStopError,
+          mainHasProfile,
+        }));
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      let result;
+      try {
+        result = JSON.parse(stdout.trim());
+      } catch {
+        throw new Error(`subprocess did not emit JSON\nstdout: ${stdout}\nstderr: ${stderr}`);
+      }
+      expect(result).toEqual({
+        workerSetIntervalError: null,
+        workerStopError: null,
+        workerHasProfile: true,
+        mainStopError: null,
+        mainHasProfile: true,
+      });
+      expect(exitCode).toBe(0);
     });
 
     test("disconnect() stops running profiler", () => {


### PR DESCRIPTION
## Problem

`BunCPUProfiler.cpp` kept `s_isProfilerRunning`, `s_profilingStartTime`, and `s_samplingInterval` as file-scope statics shared by every VM, but `JSC::SamplingProfiler` is per-VM (`vm.ensureSamplingProfiler`). `node:inspector` is usable from workers and calls these directly, so two VMs profiling concurrently raced on plain `bool`/`double`/`int` and clobbered each other's state.

#31216 landed an interim `thread_local` fix for these statics that resolves the observable race in Bun's current one-thread-per-VM worker model. This PR completes the migration by moving the state onto `WebCore::JSVMClientData` so it is keyed by VM rather than by thread, matching where the underlying `SamplingProfiler` lives and following the "never back per-VM state with globals or thread-locals" guideline.

## Repro

Main thread starts `Profiler.start`, then a worker does the same:

```js
// main
session.post("Profiler.enable");
session.post("Profiler.start");
new Worker(`
  session.post("Profiler.enable");
  session.post("Profiler.setSamplingInterval", { interval: 500 }); // throws "while profiler is running"
  session.post("Profiler.start");                                  // no-op: shared flag already true
  session.post("Profiler.stop");                                   // "Failed to parse profile JSON"
`, { eval: true });
// after worker: main's Profiler.stop -> "Profiler is not started"
```

Observed on releases before #31216:
- Worker's `setSamplingInterval` throws `Cannot change sampling interval while profiler is running` (it sees the main thread's flag).
- Worker's `Profiler.start` no-ops because `isCPUProfilerRunning()` is already `true`, so the worker's VM never gets a `SamplingProfiler`; `Profiler.stop` then returns an empty string and JSON parsing fails.
- Worker's `stopCPUProfiler` sets `s_isProfilerRunning = false`, so the main thread's subsequent `Profiler.stop` errors with `Profiler is not started`.

## Fix

Move the three fields onto `WebCore::JSVMClientData` (the per-VM client data attached to `vm.clientData`) and thread `VM&` through `setSamplingInterval` / `isCPUProfilerRunning`. The Rust-side `Bun__setSamplingInterval` extern now takes a `VM*` to match; its one caller in `run_command.rs` is updated, as are the two `worker.startCpuProfile` / `worker.stopCpuProfile` callers in `JSWorker.cpp` that #31216 added.

## Verification

```
bun bd test test/js/node/inspector/inspector-profiler.test.ts   # 39 pass
bun bd test test/cli/run/cpu-prof.test.ts                        # 9 pass
bun bd test/js/node/test/parallel/test-worker-cpu-profile.js     # exit 0
```

The new worker-isolation test passes against both this PR and current main (since #31216's `thread_local` change), but fails against releases before it, so it is kept as regression coverage. Because main already passes the test, the automated fail-before gate is expected to bounce this PR; the change is a state-locality refactor of an already-mitigated race.

Supersedes #28473, which targets the pre-Rust-port `.zig` sources and puts the state on `ZigGlobalObject`.

Fixes #28472

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7a83dca35)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [10.90ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.76ms]
(pass) node:inspector > Session > connect() establishes connection [4.02ms]
(pass) node:inspector > Session > connect() throws if already connected [3.51ms]
(pass) node:inspector > Session > connectToMainThread() works like connect() [3.20ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [3.63ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.41ms]
(pass) node:inspector > Session > post() throws if not connected [7.18ms]
(pass) node:inspector > Session > post(
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [0.29ms]
(pass) node:inspector > Session > Session extends EventEmitter [0.07ms]
(pass) node:inspector > Session > connect() establishes connection [0.11ms]
(pass) node:inspector > Session > connect() throws if already connected [0.09ms]
(pass) node:inspector > Session > connectToMainThread() works like connect() [0.05ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [0.05ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [0.06ms]
(pass) node:inspector > Session > post() throws if not connected [0.15ms]
(pass) node:inspector > Session > post() with callback calls callback with error if not connected [0.24ms]
(pass) node:inspector > Profiler > Profiler.enable succeeds [0.34ms]
(pass) node:inspector > Profiler > Profiler.disable succeeds [0.05ms]
(pass) node:inspector > Profiler > Profiler.start without enable throws [0.06ms]
(pass) node:inspector > Profiler > Profiler.start after enable succeeds [0.37ms]
(pass) node:inspector > Profiler > Profiler.stop without start t
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/inspector/inspector-profiler.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (7a83dca35)

test/js/node/inspector/inspector-profiler.test.ts:
(pass) node:inspector > Session > Session is a constructor [10.74ms]
(pass) node:inspector > Session > Session extends EventEmitter [2.72ms]
(pass) node:inspector > Session > connect() establishes connection [3.85ms]
(pass) node:inspector > Session > connect() throws if already connected [3.34ms]
(pass) node:inspector > Session > connectToMainThread() works like connect() [3.66ms]
(pass) node:inspector > Session > disconnect() closes connection cleanly [3.09ms]
(pass) node:inspector > Session > disconnect() is a no-op if not connected [2.41ms]
(pass) node:inspector > Session > post() throws if not connected [7.13ms]
(pass) node:inspector > Session > post(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     7a83dca356
  features     (none)

22 deps, 106 codegen, 1168 objects in 820ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [7.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1231] gen bindgenv2
[4/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [8.00ms]
[5/1231] fetch picohttpparser
[picohttpparser] up to date
[6/1231] gen ErrorCode+*.h
[7/1231] fetch tinycc
[tinycc] up to date
[8/1230] fetch z
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/BunCPUProfiler.rs                         |   9 +-
 src/jsc/bindings/BunCPUProfiler.cpp               |  54 ++++++------
 src/jsc/bindings/BunCPUProfiler.h                 |   4 +-
 src/jsc/bindings/BunClientData.h                  |   8 ++
 src/jsc/bindings/JSInspectorProfiler.cpp          |   6 +-
 src/jsc/bindings/webcore/JSWorker.cpp             |   4 +-
 src/runtime/cli/run_command.rs                    |   6 +-
 test/js/node/inspector/inspector-profiler.test.ts | 101 ++++++++++++++++++++++
 8 files changed, 153 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/jsc/BunCPUProfiler.rs                              1      1      8
src/jsc/bindings/BunCPUProfiler.cpp                    2      9      8
src/jsc/bindings/BunCPUProfiler.h                      1      1      8
src/jsc/bindings/BunClientData.h                       1      1      8
src/jsc/bindings/JSInspectorProfiler.cpp               1      1      8
src/jsc/bindings/webcore/JSWorker.cpp                  1      2      8
src/runtime/cli/run_command.rs                         1      1      8
test/js/node/inspector/inspector-profiler.test.ts      1      4      8
```

</details>

<!-- robobun:evidence:end -->