### PR TITLE
bindings: fix toUInt64NoTruncate dropping doubles >= 2^51 to zero

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4335,7 +4335,7 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
     // condition folds NaN (both comparisons false) and ±Inf into the reject
     // branch without a separate isfinite() check.
     double d = value.asDouble();
-    if (!(d >= 0.0 && d < 18446744073709551616.0))
+    if (!(d >= 0.0 && d < 0x1p64))
         return 0;
     return truncateDoubleToUint64(d);
 }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -4326,18 +4326,18 @@ uint64_t JSC__JSValue__toUInt64NoTruncate(JSC::EncodedJSValue val)
     }
 
     if (value.isInt32()) {
-        return static_cast<uint64_t>(value.asInt32());
+        int32_t i = value.asInt32();
+        return i < 0 ? 0 : static_cast<uint64_t>(i);
     }
     ASSERT(value.isDouble());
 
-    int64_t result = JSC::tryConvertToInt52(value.asDouble());
-    if (result != JSC::JSValue::notInt52) {
-        if (result < 0)
-            return 0;
-
-        return static_cast<uint64_t>(result);
-    }
-    return 0;
+    // Accept finite non-negative values below 2^64. The negated compound
+    // condition folds NaN (both comparisons false) and ±Inf into the reject
+    // branch without a separate isfinite() check.
+    double d = value.asDouble();
+    if (!(d >= 0.0 && d < 18446744073709551616.0))
+        return 0;
+    return truncateDoubleToUint64(d);
 }
 
 JSC::EncodedJSValue JSC__JSValue__createObject2(JSC::JSGlobalObject* globalObject, const ZigString* arg1,

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -232,6 +232,66 @@ describe("xxHash32 / xxHash64 reference vectors", () => {
   });
 });
 
+// JSC__JSValue__toUInt64NoTruncate previously routed doubles through
+// tryConvertToInt52, which rejects |x| >= 2^51 and fell through to `return 0`.
+// A Number seed >= 2^51 therefore silently became seed 0, colliding with the
+// unseeded hash and diverging from the BigInt path for the same value.
+describe("Bun.hash seed as Number matches the same seed as BigInt", () => {
+  // Seeds that are exactly representable as both double and u64, spanning the
+  // int32 boundary, the old 2^51 cutoff, MAX_SAFE_INTEGER, and powers of two
+  // up to just below 2^64.
+  const seeds = [
+    0,
+    1,
+    42,
+    0x7fffffff, // int32 max
+    0x80000000, // int32 max + 1 (first double-only positive)
+    0xffffffff,
+    2 ** 51 - 1, // last value the old int52 path accepted
+    2 ** 51, // first value the old path silently zeroed
+    2 ** 51 + 2,
+    2 ** 52,
+    Number.MAX_SAFE_INTEGER, // 2^53 - 1
+    2 ** 53,
+    2 ** 60,
+    2 ** 63,
+    2 ** 64 - 2048, // largest double strictly below 2^64
+  ];
+  // Hashers whose seed is a u64 read via toUInt64NoTruncate.
+  const hashers = {
+    wyhash: Bun.hash.wyhash,
+    xxHash64: Bun.hash.xxHash64,
+    cityHash64: Bun.hash.cityHash64,
+    murmur64v2: Bun.hash.murmur64v2,
+    rapidhash: Bun.hash.rapidhash,
+  };
+  const input = new TextEncoder().encode("hello world");
+
+  it.each(Object.entries(hashers))("%s", (_name, hash) => {
+    const zero = hash(input, 0);
+    for (const seed of seeds) {
+      const fromNumber = hash(input, seed);
+      const fromBigInt = hash(input, BigInt(seed));
+      expect({ seed, fromNumber }).toEqual({ seed, fromNumber: fromBigInt });
+      if (seed !== 0) {
+        expect({ seed, fromNumber }).not.toEqual({ seed, fromNumber: zero });
+      }
+    }
+  });
+
+  it("out-of-range Number seeds (negative / non-finite / >= 2^64) fall back to 0", () => {
+    const zero = Bun.hash.wyhash(input, 0);
+    // `| 0` keeps the value on the Int32 fast path; the array literal below
+    // (containing NaN/Infinity) is stored as a double array, so its -1 entry
+    // is a double. Both representations of -1 must take the same branch.
+    expect(Bun.hash.wyhash(input, -1 | 0)).toBe(zero);
+    expect(Bun.hash.wyhash(input, -0x7fffffff | 0)).toBe(zero);
+    for (const seed of [-1, -1e10, -(2 ** 51), NaN, Infinity, -Infinity, 2 ** 64, 2 ** 65]) {
+      expect({ seed, hash: Bun.hash.wyhash(input, seed) }).toEqual({ seed, hash: zero });
+    }
+  });
+});
+
 it("does not crash when changing Int32Array constructor with Bun.hash.xxHash32 as species", () => {
   const arr = new Int32Array();
   function foo(a4) {

--- a/test/js/bun/util/hash.test.js
+++ b/test/js/bun/util/hash.test.js
@@ -290,6 +290,11 @@ describe("Bun.hash seed as Number matches the same seed as BigInt", () => {
       expect({ seed, hash: Bun.hash.wyhash(input, seed) }).toEqual({ seed, hash: zero });
     }
   });
+
+  it("fractional Number seeds truncate toward zero", () => {
+    expect(Bun.hash.wyhash(input, 42.7)).toBe(Bun.hash.wyhash(input, 42n));
+    expect(Bun.hash.wyhash(input, 2 ** 51 + 0.5)).toBe(Bun.hash.wyhash(input, 2n ** 51n));
+  });
 });
 
 it("does not crash when changing Int32Array constructor with Bun.hash.xxHash32 as species", () => {


### PR DESCRIPTION
## Problem

`JSC__JSValue__toUInt64NoTruncate` (src/jsc/bindings/bindings.cpp) routed doubles through `JSC::tryConvertToInt52`, which returns `notInt52` for any `|x| >= 2^51`, then fell through to `return 0`. Any finite double in `[2^51, 2^64)` was silently read as `0`.

The int32 branch also sign-extended negatives (`-1` -> `0xFFFFFFFFFFFFFFFF`) while the double branch clamped them to `0`. The same JS value `-1` therefore produced different u64s depending on whether JSC happened to store it as an Int32 or a double (e.g. when it came out of a double-backed array).

## Repro

```js
const d = "hello world";
Bun.hash(d, 2 ** 51) === Bun.hash(d, 0);           // true (seed silently zeroed)
Bun.hash(d, 2 ** 51) === Bun.hash(d, 2n ** 51n);   // false (Number vs BigInt diverge)
```

Reached from:
- `Bun.hash*` seed (`src/runtime/api/HashObject.rs`)
- http2 `maxOutstandingPings` / `maxSessionMemory` / `maxHeaderListPairs` / `maxRejectedStreams` / `maxOutstandingSettings` (`src/runtime/api/bun/h2_frame_parser.rs`)
- `Stat.ino` (`src/runtime/node/Stat.rs`)

The FFI/JSGlobalObject call sites gate on `is_big_int()` before calling this helper, so the number-path change does not affect them.

## Fix

- Double path: accept finite non-negative values in `[0, 2^64)` and convert with `truncateDoubleToUint64` (wtf/MathExtras.h). The negated `(d >= 0.0 && d < 2^64)` check rejects NaN and +/-Inf without a separate `isfinite()`.
- Int32 path: clamp negatives to `0` so both number representations agree with each other and with the documented "non-negative integer" contract.

BigInt still goes through `JSBigInt::toBigUInt64` unchanged.

## Tests

Added to `test/js/bun/util/hash.test.js`:
- For every 64-bit hasher, `hash(input, seed)` with a `Number` seed equals the same seed as `BigInt`, across the int32 boundary, the old 2^51 cutoff, `MAX_SAFE_INTEGER`, and powers of two up to `2^64 - 2048`, and none of those collapse onto seed 0.
- Negative / NaN / +/-Inf / `>= 2^64` seeds fall back to 0, including `-1` forced onto both the Int32 and double fast paths.

Before: 6 new tests fail; after: 26 pass, 0 fail.