### PR TITLE
napi: return real byte_offset from napi_get_typedarray_info / napi_get_dataview_info

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -84,6 +84,11 @@ unsafe extern "C" {
         object: jsc::c_api::JSObjectRef,
         exception: jsc::c_api::ExceptionRef,
     ) -> jsc::c_api::JSObjectRef;
+    fn JSObjectGetTypedArrayByteOffset(
+        ctx: *mut JSGlobalObject,
+        object: jsc::c_api::JSObjectRef,
+        exception: jsc::c_api::ExceptionRef,
+    ) -> usize;
     fn JSObjectMakeDate(
         ctx: *mut JSGlobalObject,
         argument_count: usize,
@@ -1429,7 +1434,7 @@ pub(super) extern "C" fn napi_get_typedarray_info(
     maybe_length: *mut usize,
     maybe_data: *mut *mut u8,
     maybe_arraybuffer: *mut napi_value,
-    maybe_byte_offset: *mut usize, // note: this is always 0
+    maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_typedarray_info");
     let env = get_env!(env_);
@@ -1473,9 +1478,17 @@ pub(super) extern "C" fn napi_get_typedarray_info(
         );
     }
 
-    // `jsc::ArrayBuffer` used to have an `offset` field, but it was always 0 because `ptr`
-    // already had the offset applied. See <https://github.com/oven-sh/bun/issues/561>.
-    write_out(maybe_byte_offset, 0);
+    // `array_buffer.ptr` already has the byte offset applied (it is `view->vector()`), which is
+    // the value N-API specifies for `data`. The `byte_offset` out-param is the view's offset into
+    // the returned `arraybuffer`; `jsc::ArrayBuffer` does not carry it, so query JSC directly.
+    // SAFETY: `typedarray` is a live typed-array object (kept by `_keep`); FFI reads its byte offset.
+    write_out(maybe_byte_offset, unsafe {
+        JSObjectGetTypedArrayByteOffset(
+            env.to_js().as_ptr(),
+            typedarray.as_object_ref(),
+            ptr::null_mut(),
+        )
+    });
     env.ok()
 }
 
@@ -1511,7 +1524,7 @@ pub(super) extern "C" fn napi_get_dataview_info(
     maybe_bytelength: *mut usize,
     maybe_data: *mut *mut u8,
     maybe_arraybuffer: *mut napi_value,
-    maybe_byte_offset: *mut usize, // note: this is always 0
+    maybe_byte_offset: *mut usize,
 ) -> napi_status {
     bun_output::scoped_log!(napi, "napi_get_dataview_info");
     let env = get_env!(env_);
@@ -1536,9 +1549,17 @@ pub(super) extern "C" fn napi_get_dataview_info(
             }),
         );
     }
-    // `jsc::ArrayBuffer` used to have an `offset` field, but it was always 0 because `ptr`
-    // already had the offset applied. See <https://github.com/oven-sh/bun/issues/561>.
-    write_out(maybe_byte_offset, 0);
+    // `array_buffer.ptr` already has the byte offset applied (it is `view->vector()`), which is
+    // the value N-API specifies for `data`. The `byte_offset` out-param is the view's offset into
+    // the returned `arraybuffer`; `jsc::ArrayBuffer` does not carry it, so query JSC directly.
+    // SAFETY: `dataview` is a live DataView object (held in handle scope); FFI reads its byte offset.
+    write_out(maybe_byte_offset, unsafe {
+        JSObjectGetTypedArrayByteOffset(
+            env.to_js().as_ptr(),
+            dataview.as_object_ref(),
+            ptr::null_mut(),
+        )
+    });
 
     env.ok()
 }

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -1827,6 +1827,161 @@ static napi_value test_napi_empty_buffer_info(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// napi_get_typedarray_info / napi_get_dataview_info must report the view's
+// real byteOffset into the returned ArrayBuffer. `data` is offset-adjusted
+// (points at the view's first element), so `data == arraybuffer_data +
+// byte_offset` must hold. Bun previously hardcoded byte_offset = 0 while
+// `arraybuffer` was the full backing buffer, so reconstructing the view via
+// `new TypedArray(arraybuffer, byte_offset, length)` produced a misaligned
+// view.
+static napi_value
+test_napi_typedarray_byte_offset(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  // Backing ArrayBuffer of 32 bytes filled with 0..31 so views see
+  // offset-dependent data.
+  void *ab_data = nullptr;
+  napi_value arraybuffer;
+  NODE_API_CALL(env, napi_create_arraybuffer(env, 32, &ab_data, &arraybuffer));
+  for (size_t i = 0; i < 32; i++) {
+    static_cast<uint8_t *>(ab_data)[i] = static_cast<uint8_t>(i);
+  }
+
+  // --- TypedArray with nonzero offset ---
+  {
+    const size_t expected_offset = 8;
+    const size_t expected_length = 4;
+    napi_value view;
+    NODE_API_CALL(env, napi_create_typedarray(env, napi_uint8_array,
+                                              expected_length, arraybuffer,
+                                              expected_offset, &view));
+
+    napi_typedarray_type type = static_cast<napi_typedarray_type>(-1);
+    size_t length = SIZE_MAX;
+    void *data = reinterpret_cast<void *>(0xDEADBEEF);
+    napi_value out_ab = nullptr;
+    size_t byte_offset = SIZE_MAX;
+    NODE_API_CALL(env, napi_get_typedarray_info(env, view, &type, &length,
+                                                &data, &out_ab, &byte_offset));
+
+    if (type != napi_uint8_array) {
+      printf("FAIL: napi_get_typedarray_info type = %d, expected "
+             "napi_uint8_array\n",
+             type);
+      return env.Undefined();
+    }
+    if (length != expected_length) {
+      printf("FAIL: napi_get_typedarray_info length = %zu, expected %zu\n",
+             length, expected_length);
+      return env.Undefined();
+    }
+    if (byte_offset != expected_offset) {
+      printf("FAIL: napi_get_typedarray_info byte_offset = %zu, expected "
+             "%zu\n",
+             byte_offset, expected_offset);
+      return env.Undefined();
+    }
+    void *out_ab_data = nullptr;
+    size_t out_ab_len = 0;
+    NODE_API_CALL(
+        env, napi_get_arraybuffer_info(env, out_ab, &out_ab_data, &out_ab_len));
+    if (out_ab_data != ab_data || out_ab_len != 32) {
+      printf("FAIL: napi_get_typedarray_info arraybuffer is not the full "
+             "backing buffer (data=%p expected %p, len=%zu expected 32)\n",
+             out_ab_data, ab_data, out_ab_len);
+      return env.Undefined();
+    }
+    if (data != static_cast<uint8_t *>(out_ab_data) + byte_offset) {
+      printf("FAIL: napi_get_typedarray_info data (%p) != arraybuffer data "
+             "(%p) + byte_offset (%zu)\n",
+             data, out_ab_data, byte_offset);
+      return env.Undefined();
+    }
+    if (static_cast<uint8_t *>(data)[0] != expected_offset) {
+      printf("FAIL: napi_get_typedarray_info data[0] = %u, expected %zu\n",
+             static_cast<uint8_t *>(data)[0], expected_offset);
+      return env.Undefined();
+    }
+
+    printf("PASS: napi_get_typedarray_info byte_offset = %zu, data = "
+           "arraybuffer + byte_offset\n",
+           byte_offset);
+  }
+
+  // --- TypedArray with zero offset (regression guard) ---
+  {
+    napi_value view;
+    NODE_API_CALL(env, napi_create_typedarray(env, napi_uint8_array, 4,
+                                              arraybuffer, 0, &view));
+    size_t byte_offset = SIZE_MAX;
+    void *data = nullptr;
+    NODE_API_CALL(env, napi_get_typedarray_info(env, view, nullptr, nullptr,
+                                                &data, nullptr, &byte_offset));
+    if (byte_offset != 0 || data != ab_data) {
+      printf("FAIL: napi_get_typedarray_info zero-offset view byte_offset = "
+             "%zu, data = %p (expected 0, %p)\n",
+             byte_offset, data, ab_data);
+      return env.Undefined();
+    }
+    printf("PASS: napi_get_typedarray_info zero-offset view byte_offset = 0\n");
+  }
+
+  // --- DataView with nonzero offset ---
+  {
+    const size_t expected_offset = 12;
+    const size_t expected_length = 6;
+    napi_value view;
+    NODE_API_CALL(env, napi_create_dataview(env, expected_length, arraybuffer,
+                                            expected_offset, &view));
+
+    size_t byte_length = SIZE_MAX;
+    void *data = reinterpret_cast<void *>(0xDEADBEEF);
+    napi_value out_ab = nullptr;
+    size_t byte_offset = SIZE_MAX;
+    NODE_API_CALL(env, napi_get_dataview_info(env, view, &byte_length, &data,
+                                              &out_ab, &byte_offset));
+
+    if (byte_length != expected_length) {
+      printf("FAIL: napi_get_dataview_info byte_length = %zu, expected %zu\n",
+             byte_length, expected_length);
+      return env.Undefined();
+    }
+    if (byte_offset != expected_offset) {
+      printf(
+          "FAIL: napi_get_dataview_info byte_offset = %zu, expected %zu\n",
+          byte_offset, expected_offset);
+      return env.Undefined();
+    }
+    void *out_ab_data = nullptr;
+    size_t out_ab_len = 0;
+    NODE_API_CALL(
+        env, napi_get_arraybuffer_info(env, out_ab, &out_ab_data, &out_ab_len));
+    if (out_ab_data != ab_data || out_ab_len != 32) {
+      printf("FAIL: napi_get_dataview_info arraybuffer is not the full "
+             "backing buffer (data=%p expected %p, len=%zu expected 32)\n",
+             out_ab_data, ab_data, out_ab_len);
+      return env.Undefined();
+    }
+    if (data != static_cast<uint8_t *>(out_ab_data) + byte_offset) {
+      printf("FAIL: napi_get_dataview_info data (%p) != arraybuffer data "
+             "(%p) + byte_offset (%zu)\n",
+             data, out_ab_data, byte_offset);
+      return env.Undefined();
+    }
+    if (static_cast<uint8_t *>(data)[0] != expected_offset) {
+      printf("FAIL: napi_get_dataview_info data[0] = %u, expected %zu\n",
+             static_cast<uint8_t *>(data)[0], expected_offset);
+      return env.Undefined();
+    }
+
+    printf("PASS: napi_get_dataview_info byte_offset = %zu, data = "
+           "arraybuffer + byte_offset\n",
+           byte_offset);
+  }
+
+  return ok(env);
+}
+
 // Test for napi_typeof with boxed primitive objects (String, Number, Boolean)
 // See: https://github.com/oven-sh/bun/issues/25351
 static napi_value napi_get_typeof(const Napi::CallbackInfo &info) {
@@ -2383,6 +2538,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, test_napi_freeze_seal_indexed);
   REGISTER_FUNCTION(env, exports, test_napi_create_external_buffer_empty);
   REGISTER_FUNCTION(env, exports, test_napi_empty_buffer_info);
+  REGISTER_FUNCTION(env, exports, test_napi_typedarray_byte_offset);
   REGISTER_FUNCTION(env, exports, napi_get_typeof);
   REGISTER_FUNCTION(env, exports, test_external_buffer_data_lifetime);
   REGISTER_FUNCTION(env, exports, test_external_arraybuffer_finalizer);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -318,6 +318,16 @@ describe.concurrent("napi", () => {
     });
   });
 
+  describe("napi_get_typedarray_info / napi_get_dataview_info", () => {
+    it("report the view's byte_offset into the returned arraybuffer", async () => {
+      const result = await checkSameOutput("test_napi_typedarray_byte_offset", []);
+      expect(result).toContain("PASS: napi_get_typedarray_info byte_offset = 8, data = arraybuffer + byte_offset");
+      expect(result).toContain("PASS: napi_get_typedarray_info zero-offset view byte_offset = 0");
+      expect(result).toContain("PASS: napi_get_dataview_info byte_offset = 12, data = arraybuffer + byte_offset");
+      expect(result).not.toContain("FAIL");
+    });
+  });
+
   describe("napi_async_work", () => {
     it("null checks execute callbacks", async () => {
       const output = await checkSameOutput("test_napi_async_work_execute_null_check", []);


### PR DESCRIPTION
## Problem

`napi_get_typedarray_info` and `napi_get_dataview_info` return three related out-params:

- `data`: pointer to the view's first element (offset-adjusted, i.e. `view->vector()`)
- `arraybuffer`: the full backing `ArrayBuffer`
- `byte_offset`: the view's offset into `arraybuffer`

Bun was hardcoding `byte_offset = 0` while returning the full backing buffer for `arraybuffer` and the offset-adjusted pointer for `data`. An addon that reconstructs the view via `new Uint8Array(arraybuffer, byte_offset, length)` (or the equivalent `napi_create_typedarray(env, type, length, arraybuffer, byte_offset, &out)`) would produce a view pointing at offset 0 instead of the original offset.

## Repro

```js
const ab = new ArrayBuffer(32);
const view = new Uint8Array(ab, 8, 4);
// pass `view` to a native addon that calls napi_get_typedarray_info:
//   byte_offset -> 0   (wrong; Node.js returns 8)
```

The new `test_napi_typedarray_byte_offset` in `test/napi/napi-app/standalone_tests.cpp` exercises this for both TypedArray and DataView with nonzero offsets and verifies `data == arraybuffer_data + byte_offset`. Under the released binary it fails with:

```
FAIL: napi_get_typedarray_info byte_offset = 0, expected 8
```

## Fix

`jsc::ArrayBuffer` does not carry the view's byte offset (its `ptr` field is already `view->vector()`, which has the offset applied). Query `JSObjectGetTypedArrayByteOffset` instead, which returns `JSArrayBufferView::byteOffset()` for both typed arrays and DataView (`JSDataView` is a `JSArrayBufferView` subclass). The `data` out-param stays offset-adjusted, matching Node.js and the N-API spec ("adjusted by the byte_offset value so that it points to the first element").

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/napi/napi.test.ts -t "byte_offset"
(fail) napi > napi_get_typedarray_info / napi_get_dataview_info > report the view's byte_offset into the returned arraybuffer
  - "PASS: napi_get_typedarray_info byte_offset = 8, data = arraybuffer + byte_offset"
  + "FAIL: napi_get_typedarray_info byte_offset = 0, expected 8"

$ bun bd test test/napi/napi.test.ts -t "byte_offset"
(pass) napi > napi_get_typedarray_info / napi_get_dataview_info > report the view's byte_offset into the returned arraybuffer
```

The existing `test/napi/node-napi-tests/test/js-native-api/{test_typedarray,test_dataview}` tests and the `test_napi_empty_buffer_info` test (which checks `byte_offset` for an empty buffer) continue to pass.