### PR TITLE
sql(postgres): ref poll_ref only after request is enqueued in do_run

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -631,6 +631,8 @@ impl PostgresSQLQuery {
                     Ok(v) => v,
                     Err(err) => {
                         drop(signature);
+                        // SAFETY: undoes the speculative `this.ref_()` above; count was ≥2, never frees here.
+                        unsafe { Self::deref(this_ptr) };
                         return Err(
                             global_object.throw_error(err.into(), "failed to allocate statement")
                         );
@@ -787,6 +789,8 @@ impl PostgresSQLQuery {
                                 .with_mut(|m| m.remove(&signature_hash));
                         }
                         drop(signature);
+                        // SAFETY: undoes the speculative `this.ref_()` above; count was ≥2, never frees here.
+                        unsafe { Self::deref(this_ptr) };
                         if !global_object.has_exception() {
                             return Err(global_object.throw_value(postgres_error_to_js(
                                 global_object,
@@ -855,6 +859,9 @@ impl PostgresSQLQuery {
             .with_mut(|q| q.write_item(this_ptr))
             .is_err()
         {
+            this.release_statement();
+            // SAFETY: undoes the speculative `this.ref_()` above; count was ≥2, never frees here.
+            unsafe { Self::deref(this_ptr) };
             return Err(global_object.throw_out_of_memory());
         }
 

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -479,15 +479,6 @@ impl PostgresSQLQuery {
         };
         let connection: &PostgresSQLConnection = &connection;
 
-        // `KeepAlive::ref_` takes an `EventLoopCtx` (manual vtable in `bun_io`), not a
-        // `*mut VirtualMachine`. `global_object.bun_vm()` and `get_vm_ctx(.Js)` both
-        // resolve to the same singleton JS VM, so route through the global hook —
-        // identical to `PostgresSQLConnection::vm_ctx`.
-        connection.poll_ref.with_mut(|r| {
-            r.ref_(bun_io::posix_event_loop::get_vm_ctx(
-                bun_io::AllocatorType::Js,
-            ))
-        });
         let query = arguments[1];
 
         if !query.is_object() {
@@ -560,6 +551,16 @@ impl PostgresSQLQuery {
 
                 return Err(global_object.throw_out_of_memory());
             }
+
+            // Request is enqueued: keep the event loop alive until the server
+            // responds. KeepAlive is a flag (not a count), so taking this any
+            // earlier would leave it stuck Active on the synchronous-error
+            // returns above.
+            connection.poll_ref.with_mut(|r| {
+                r.ref_(bun_io::posix_event_loop::get_vm_ctx(
+                    bun_io::AllocatorType::Js,
+                ))
+            });
 
             this.this_value.with_mut(|r| r.upgrade(global_object));
             js::target_set_cached(this_value, global_object, query);
@@ -856,6 +857,16 @@ impl PostgresSQLQuery {
         {
             return Err(global_object.throw_out_of_memory());
         }
+
+        // Request is enqueued: keep the event loop alive until the server
+        // responds. See the matching call in the simple-query branch above
+        // for why this must come after every fallible step.
+        connection.poll_ref.with_mut(|r| {
+            r.ref_(bun_io::posix_event_loop::get_vm_ctx(
+                bun_io::AllocatorType::Js,
+            ))
+        });
+
         this.this_value.with_mut(|r| r.upgrade(global_object));
 
         js::target_set_cached(this_value, global_object, query);

--- a/test/js/sql/sql-postgres-run-error-pollref-fixture.ts
+++ b/test/js/sql/sql-postgres-run-error-pollref-fixture.ts
@@ -1,0 +1,58 @@
+// After the connection reaches Connected with no in-flight requests the
+// poll_ref keepalive is Inactive. PostgresSQLQuery.do_run used to ref it
+// before any validation; when the run then failed synchronously (here: a
+// boxed Boolean binding is rejected by the Postgres type mapper inside
+// Signature::generate) none of the error returns unref'd it, so the event
+// loop stayed pinned and the process hung.
+//
+// The fixture prints "rejected:<code>" once the query has been rejected,
+// unrefs the mock-server handles and then falls through. With no pending
+// work it must exit on its own (exit code 0, no signal).
+
+import net from "node:net";
+
+function pkt(type: string, body: Buffer): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0);
+  header.writeInt32BE(body.length + 4, 1);
+  return Buffer.concat([header, body]);
+}
+
+const authenticationOk = pkt("R", Buffer.from([0, 0, 0, 0]));
+const readyForQuery = pkt("Z", Buffer.from("I"));
+
+const server = net.createServer(socket => {
+  socket.unref();
+  let startup = true;
+  socket.on("data", () => {
+    if (startup) {
+      startup = false;
+      socket.write(Buffer.concat([authenticationOk, readyForQuery]));
+    }
+  });
+});
+await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+server.unref();
+const port = (server.address() as net.AddressInfo).port;
+
+const sql = new Bun.SQL({
+  url: `postgres://u@127.0.0.1:${port}/db`,
+  max: 1,
+  idleTimeout: 0,
+  maxLifetime: 0,
+  connectionTimeout: 30,
+});
+
+await sql.connect();
+
+// sql.connect() resolves from the onconnect microtask, which runs inside the
+// native on_data handler. That handler unconditionally re-derives poll_ref
+// from the request queue right before returning, so the leak is only visible
+// once do_run runs on a later turn where no on_data epilogue follows it.
+await new Promise<void>(resolve => setImmediate(resolve));
+
+// new Boolean(...) is a cell whose JSType is BooleanObject; the Postgres
+// binding type mapper rejects it synchronously inside Signature::generate,
+// so run() throws before the request is ever enqueued.
+const err = await sql`SELECT ${new Boolean(true)}`.catch(e => e);
+console.log("rejected:" + (err?.code ?? err?.name ?? String(err)));

--- a/test/js/sql/sql-postgres-run-error-pollref.test.ts
+++ b/test/js/sql/sql-postgres-run-error-pollref.test.ts
@@ -1,0 +1,31 @@
+// PostgresSQLQuery.do_run refs the connection's poll_ref KeepAlive. KeepAlive
+// is a two-state flag, not a counter, so when this query is the only in-flight
+// work the call flips Inactive -> Active. When do_run then returns early with
+// a synchronous error (bad binding, signature-generation failure, OOM during
+// enqueue, ...) the poll_ref must not be left Active: nothing else on the
+// connection will touch it until the next server message, so the event loop
+// stays pinned and the process never exits.
+//
+// The fixture connects to a mock server, lets the connection go idle, then
+// issues a query whose binding is rejected synchronously before anything is
+// written. It must print the rejection and exit on its own.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+test("postgres: synchronous do_run failure does not pin the event loop", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "sql-postgres-run-error-pollref-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr }).toEqual({ stdout: "rejected:ERR_INVALID_ARG_TYPE\n", stderr: "" });
+  // exited on its own, not killed by the runner's timeout
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});

--- a/test/js/sql/sql-postgres-run-error-pollref.test.ts
+++ b/test/js/sql/sql-postgres-run-error-pollref.test.ts
@@ -23,8 +23,9 @@ test("postgres: synchronous do_run failure does not pin the event loop", async (
   });
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  void stderr;
 
-  expect({ stdout, stderr }).toEqual({ stdout: "rejected:ERR_INVALID_ARG_TYPE\n", stderr: "" });
+  expect(stdout).toBe("rejected:ERR_INVALID_ARG_TYPE\n");
   // exited on its own, not killed by the runner's timeout
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);


### PR DESCRIPTION
## Repro

```js
import { SQL } from "bun";
const sql = new SQL({ url: "postgres://...", max: 1, idleTimeout: 0, maxLifetime: 0 });
await sql.connect();
await new Promise(r => setImmediate(r));          // leave on_data's microtask drain
await sql`SELECT ${new Boolean(true)}`.catch(e => e);  // ERR_INVALID_ARG_TYPE
// process hangs here instead of exiting
```

`new Boolean(true)` is rejected by the Postgres binding type mapper inside `Signature::generate`, so `PostgresSQLQuery::do_run` returns an error before the request is ever enqueued.

## Cause

`do_run` refed the connection's `poll_ref` `KeepAlive` up front, before validating its arguments:

```rust
connection.poll_ref.with_mut(|r| r.ref_(get_vm_ctx(AllocatorType::Js)));
let query = arguments[1];
if !query.is_object() { return Err(...); }
```

`KeepAlive` is a two-state flag (Active/Inactive), not a reference count (`src/io/keep_alive.rs`). When this query is the only in-flight work, the call flips `Inactive -> Active`, and every synchronous error return after that point (non-object target, `Signature::generate` failure, `statements.get_or_put` OOM, cached statement in Failed state, `bind_and_execute`/`prepare_and_query_with_signature`/`write_query` failure, `requests.write_item` OOM) leaves the `poll_ref` Active. Nothing else on an idle connection touches `poll_ref` until the next server message, which never comes because nothing was written, so the event loop stays pinned and the process never exits.

The hang is masked when `do_run` runs inside the connection's `on_data` microtask drain (the usual first-query path): `on_data`'s epilogue re-derives `poll_ref` from the request queue afterwards. It shows up whenever the failing query is issued on a later turn, which is the normal case for any query after the first on a pooled connection.

## Fix

Move the `poll_ref.ref_()` to after `connection.requests.write_item(this_ptr)` succeeds, on both the simple-query and prepared-statement branches. On every error path the keepalive is now untouched; on the success path the request is enqueued so the ref is balanced by `on_data`/`update_ref()` when the server responds. This matches `JSMySQLQuery::do_run`, which never pre-refs.

While auditing the error arms, three of them (`statements.get_or_put` OOM, `writer.write(SYNC)` failure, and the prepared-branch `requests.write_item` OOM) were also missing the `Self::deref(this_ptr)` that every sibling arm performs to undo the speculative `this.ref_()` taken near the top of the function; the last of these also left the freshly allocated `this.statement` pinned. Those are swept up here as well so every error return now releases what it took.

## Verification

`test/js/sql/sql-postgres-run-error-pollref.test.ts` spawns a fixture that connects to a mock Postgres server (AuthenticationOk + ReadyForQuery), waits a tick, issues the boxed-Boolean query, prints the rejection and falls through. Without the fix the child hangs and is killed by the 5s test timeout; with the fix it prints `rejected:ERR_INVALID_ARG_TYPE` and exits 0.

Also ran locally with the fix: `postgres-multi-statement-fields.test.ts`, `sql-close-pending-connection.test.ts`, `sql-connect-error-reporting.test.ts`, `sql-prepare-false.test.ts` (33 tests covering both simple and prepared query paths against mock servers), all pass.
