### PR TITLE
udp: use coerce_to_i32 for connect() port argument

### DIFF
--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1761,7 +1761,7 @@ impl UDPSocket {
                 .throw_invalid_arguments(format_args!("Expected \"port\" to be an integer")));
         }
 
-        let connect_port = connect_port_js.as_int32();
+        let connect_port = connect_port_js.coerce_to_i32(global_this)?;
         let port: u16 = if connect_port < 1 || connect_port > 0xffff {
             0
         } else {

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -78,6 +78,70 @@ describe("udpSocket()", () => {
     expect(exitCode).toBe(0);
   });
 
+  // connect() checked `is_number()` then read the port via `as_int32()`, which
+  // only works for int32-encoded JSValues. Float64Array element reads use
+  // `jsDoubleNumber` and never canonicalize to int32, and validatePort returns
+  // the original value, so a double-encoded port reaches the native path. In
+  // debug builds the `debug_assert!(is_int32())` fires; in release the low 32
+  // bits of the IEEE-754 encoding (always 0 for integers in the port range)
+  // become the port and the socket connects to port 0.
+  test("connect with a double-encoded port connects to the right port", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const dgram = require("node:dgram");
+        function once(socket, event) {
+          return new Promise((resolve, reject) => {
+            socket.once("error", reject);
+            socket.once(event, (...args) => {
+              socket.removeListener("error", reject);
+              resolve(args);
+            });
+          });
+        }
+
+        const server = dgram.createSocket("udp4");
+        server.bind(0, "127.0.0.1");
+        await once(server, "listening");
+        const serverPort = server.address().port;
+
+        const client = dgram.createSocket("udp4");
+        client.bind(0, "127.0.0.1");
+        await once(client, "listening");
+
+        // Float64Array reads return jsDoubleNumber(), never an int32-encoded value.
+        const doublePort = new Float64Array([serverPort])[0];
+        if (doublePort !== serverPort) throw new Error("precondition: double round-trip changed value");
+
+        client.connect(doublePort, "127.0.0.1");
+        await once(client, "connect");
+
+        const remote = client.remoteAddress();
+        if (remote.port !== serverPort) {
+          throw new Error("connected to wrong port: expected " + serverPort + ", got " + remote.port);
+        }
+
+        client.close();
+        server.close();
+        console.log("OK");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, rawStderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const stderr = rawStderr
+      .split("\n")
+      .filter(l => l && !l.startsWith("WARNING: ASAN interferes"))
+      .join("\n");
+    expect(stderr).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
+
   test("connect with invalid hostname rejects", async () => {
     expect(async () =>
       udpSocket({


### PR DESCRIPTION
## What does this PR do?

`UDPSocket.jsConnect` (reached via `node:dgram` `Socket#connect`) validated the port with `is_number()` but then called `as_int32()`, which requires an int32-encoded `JSValue`. Numbers stored as doubles pass `is_number()` but not `is_int32()`.

JSC's `Float64Array` element reads return `jsDoubleNumber()` and never canonicalize to int32 even for whole numbers, and `validatePort` in `node:dgram` returns the original `JSValue` unchanged. So a double-encoded port value reaches the native path:

```js
const dgram = require("node:dgram");
const sock = dgram.createSocket("udp4");
sock.bind(0, "127.0.0.1", () => {
  const port = new Float64Array([12345])[0]; // double-encoded 12345
  sock.connect(port, "127.0.0.1", () => {
    sock.remoteAddress(); // throws ERR_SOCKET_DGRAM_NOT_CONNECTED
  });
});
```

In debug builds this fires `debug_assert!(self.is_int32())`:

```
panic: assertion failed: self.is_int32()
<bun_jsc::js_value::JSValue>::as_int32
/workspace/bun/src/jsc/JSValue.rs:721:9
<bun_runtime::socket::udp_socket_draft::UDPSocket>::js_connect
/workspace/bun/src/runtime/socket/udp_socket.rs:1764:44
```

In release builds `as_int32()` masks the low 32 bits of the encoded `JSValue`. For any integer in `[1, 65535]` the low 32 bits of the IEEE-754 representation are zero, so the port is read as `0`, the clamp keeps it at `0`, and the socket connects to port 0. `remoteAddress()` then reports the socket as not connected.

The sibling paths (the `connect:` option in `Bun.udpSocket()` and `parseAddr` for `send`) already use `coerce_to_i32`; this brings `jsConnect` in line.

## How did you verify your code works?

Added a regression test that creates a `dgram` server, connects a client using a `Float64Array`-sourced port, and asserts `remoteAddress().port` matches. Before the fix the subprocess panics (debug) or throws `ERR_SOCKET_DGRAM_NOT_CONNECTED` (release); after the fix it connects to the correct port.

```
bun bd test test/js/bun/udp/udp_socket.test.ts
 179 pass
 0 fail
```