### PR TITLE
napi: capture Ref<NapiEnv> in node_api_create_external_string_* finalizers

### DIFF
--- a/src/jsc/bindings/napi.cpp
+++ b/src/jsc/bindings/napi.cpp
@@ -1475,7 +1475,7 @@ node_api_create_external_string_latin1(napi_env env,
     length = length == NAPI_AUTO_LENGTH ? strlen(str) : length;
     // WTF::ExternalStringImpl does not allow creating empty strings, so we have this limitation for now.
     NAPI_RETURN_EARLY_IF_FALSE(env, length > 0, napi_invalid_arg);
-    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const Latin1Character*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
+    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const Latin1Character*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env = WTF::Ref<NapiEnv>(*env)](void* hint, void* str, unsigned length) {
         NAPI_LOG("latin1 string finalizer");
         env->doFinalizer(finalize_callback, str, hint);
     });
@@ -1511,7 +1511,7 @@ node_api_create_external_string_utf16(napi_env env,
     // WTF::ExternalStringImpl does not allow creating empty strings, so we have this limitation for now.
     NAPI_RETURN_EARLY_IF_FALSE(env, length > 0, napi_invalid_arg);
 
-    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const char16_t*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env](void* hint, void* str, unsigned length) {
+    Ref<WTF::ExternalStringImpl> impl = WTF::ExternalStringImpl::create({ reinterpret_cast<const char16_t*>(str), static_cast<unsigned int>(length) }, finalize_hint, [finalize_callback, env = WTF::Ref<NapiEnv>(*env)](void* hint, void* str, unsigned length) {
         NAPI_LOG("utf16 string finalizer");
         env->doFinalizer(finalize_callback, str, hint);
     });

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -90,6 +90,18 @@
             ],
         },
         {
+            "target_name": "external_string_addon",
+            "sources": ["external_string_addon.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NAPI_VERSION=10",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
+        {
             "target_name": "ffi_addon_1",
             "sources": ["ffi_addon_1.c"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/external_string_addon.c
+++ b/test/napi/napi-app/external_string_addon.c
@@ -1,0 +1,85 @@
+// Exports createLatin1()/createUtf16() which return strings created via
+// node_api_create_external_string_{latin1,utf16} with a finalizer that frees
+// the backing buffer and increments a counter, plus finalizedCount() to read
+// it. Used by test/napi/napi-external-string-env.test.ts to exercise the
+// ExternalStringImpl finalizer path through env->doFinalizer() during worker
+// teardown.
+
+#include <js_native_api.h>
+#include <node_api.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define CALL(env, call)                                                        \
+  do {                                                                         \
+    if ((call) != napi_ok) {                                                   \
+      napi_throw_error((env), NULL, "napi call failed: " #call);              \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
+
+static int g_finalized = 0;
+
+static void finalize_latin1(napi_env env, void *data, void *hint) {
+  (void)env;
+  (void)hint;
+  g_finalized++;
+  free(data);
+}
+
+static void finalize_utf16(napi_env env, void *data, void *hint) {
+  (void)env;
+  (void)hint;
+  g_finalized++;
+  free(data);
+}
+
+static napi_value create_latin1(napi_env env, napi_callback_info info) {
+  (void)info;
+  // Each call allocates its own backing buffer so the JSString holds the only
+  // reference to the ExternalStringImpl; rooting the string on globalThis
+  // keeps the impl alive until worker teardown sweeps the global.
+  char *buf = (char *)malloc(32);
+  memcpy(buf, "external-latin1-string-xxxxxxxx", 32);
+  napi_value result;
+  bool copied;
+  CALL(env, node_api_create_external_string_latin1(env, buf, 31,
+                                                    finalize_latin1, NULL,
+                                                    &result, &copied));
+  return result;
+}
+
+static napi_value create_utf16(napi_env env, napi_callback_info info) {
+  (void)info;
+  static const char16_t src[] = u"external-utf16-string-xxxxxxxxx";
+  char16_t *buf = (char16_t *)malloc(sizeof(src));
+  memcpy(buf, src, sizeof(src));
+  napi_value result;
+  bool copied;
+  CALL(env, node_api_create_external_string_utf16(env, buf,
+                                                   (sizeof(src) / sizeof(char16_t)) - 1,
+                                                   finalize_utf16, NULL,
+                                                   &result, &copied));
+  return result;
+}
+
+static napi_value finalized_count(napi_env env, napi_callback_info info) {
+  (void)info;
+  napi_value result;
+  CALL(env, napi_create_int32(env, g_finalized, &result));
+  return result;
+}
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  napi_value fn;
+  CALL(env, napi_create_function(env, "createLatin1", NAPI_AUTO_LENGTH,
+                                  create_latin1, NULL, &fn));
+  CALL(env, napi_set_named_property(env, exports, "createLatin1", fn));
+  CALL(env, napi_create_function(env, "createUtf16", NAPI_AUTO_LENGTH,
+                                  create_utf16, NULL, &fn));
+  CALL(env, napi_set_named_property(env, exports, "createUtf16", fn));
+  CALL(env, napi_create_function(env, "finalizedCount", NAPI_AUTO_LENGTH,
+                                  finalized_count, NULL, &fn));
+  CALL(env, napi_set_named_property(env, exports, "finalizedCount", fn));
+  return exports;
+}

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -102,11 +102,7 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
       const expectedContent =
         fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -19,7 +19,7 @@
 
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
@@ -57,13 +57,9 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
     childEnv.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":");
   }
 
-  // collectContinuously is prohibitively slow under Windows CI; worker
-  // teardown is platform-agnostic so POSIX coverage is sufficient.
-  test.skipIf(isWindows).each(["createLatin1", "createUtf16"])(
-    "worker teardown runs the %s finalizer with a live env",
-    async fn => {
-      using dir = tempDir("napi-ext-string-env", {
-        "fixture.js": `
+  test.each(["createLatin1", "createUtf16"])("worker teardown runs the %s finalizer with a live env", async fn => {
+    using dir = tempDir("napi-ext-string-env", {
+      "fixture.js": `
           const { Worker, isMainThread, parentPort } = require("worker_threads");
           if (isMainThread) {
             const w = new Worker(__filename);
@@ -93,26 +89,24 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
               " sample=" + globalThis.__strings[0]);
           }
         `,
-      });
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "fixture.js"],
-        env: childEnv,
-        cwd: String(dir),
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: childEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      const expectedContent =
-        fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
-      expect(stderr).toBe("");
-      expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
-      // Every external string created in the worker must have had its
-      // finalizer invoked by the time the worker's VM is torn down.
-      expect(stdout).toContain("finalized=64");
-      expect(exitCode).toBe(0);
-    },
-    60_000,
-  );
+    const expectedContent =
+      fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
+    expect(stderr).toBe("");
+    expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
+    // Every external string created in the worker must have had its
+    // finalizer invoked by the time the worker's VM is torn down.
+    expect(stdout).toContain("finalized=64");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -57,9 +57,11 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
     childEnv.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":");
   }
 
-  test.each(["createLatin1", "createUtf16"])("worker teardown runs the %s finalizer with a live env", async fn => {
-    using dir = tempDir("napi-ext-string-env", {
-      "fixture.js": `
+  test.concurrent.each(["createLatin1", "createUtf16"])(
+    "worker teardown runs the %s finalizer with a live env",
+    async fn => {
+      using dir = tempDir("napi-ext-string-env", {
+        "fixture.js": `
           const { Worker, isMainThread, parentPort } = require("worker_threads");
           if (isMainThread) {
             const w = new Worker(__filename);
@@ -89,28 +91,29 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
               " sample=" + globalThis.__strings[0]);
           }
         `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "fixture.js"],
-      env: childEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.js"],
+        env: childEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    const expectedContent =
-      fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
-    // Every external string created in the worker must have had its finalizer
-    // invoked by the time the worker's VM is torn down. The combined-object
-    // assertion surfaces all three values in one diff when the child crashes
-    // or ASAN writes to stderr.
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: expect.stringContaining("finalized=64"),
-      stderr: "",
-      exitCode: 0,
-    });
-    expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
-  });
+      const expectedContent =
+        fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
+      // Every external string created in the worker must have had its finalizer
+      // invoked by the time the worker's VM is torn down. The combined-object
+      // assertion surfaces all three values in one diff when the child crashes
+      // or ASAN writes to stderr.
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: expect.stringContaining("finalized=64"),
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
+    },
+  );
 });

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -1,0 +1,122 @@
+// node_api_create_external_string_{latin1,utf16} install an ExternalStringImpl
+// free callback that calls env->doFinalizer(). The lambda must hold a
+// WTF::Ref<NapiEnv> (like napi_add_finalizer / napi_create_external_buffer do),
+// not the raw napi_env pointer: NapiEnv is RefCounted and its primary owner is
+// Zig::GlobalObject::m_napiEnvs, dropped in ~GlobalObject(). If the env is
+// freed before the string's ExternalStringImpl is released, the finalizer
+// dereferences a dead NapiEnv.
+//
+// Whether that ordering actually occurs depends on JSC heap layout:
+// ~GlobalObject runs from MarkedSpace::lastChanceToFinalize()'s
+// PreciseAllocation pass, which iterates m_preciseAllocations sorted by
+// pointer address (prepareForConservativeScan() re-sorts it every full GC).
+// Under current allocation patterns the GlobalObject's allocation sorts last,
+// so ~GlobalObject (and ~NapiEnv) run after every JSString/holder and the UAF
+// doesn't fire. The Ref capture makes the finalizer correct regardless of that
+// ordering. This test exercises both finalizer paths through worker teardown
+// with Malloc=1 so ASAN instruments the TZONE-allocated NapiEnv: if heap
+// layout ever reorders the sweep, the UAF surfaces here.
+
+import { spawnSync } from "bun";
+import { beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const napiAppDir = join(import.meta.dir, "napi-app");
+const addon = join(napiAppDir, "build", "Debug", "external_string_addon.node");
+
+describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () => {
+  beforeAll(() => {
+    if (existsSync(addon)) return;
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: napiAppDir,
+      env: bunEnv,
+      stderr: "inherit",
+      stdout: "inherit",
+      stdin: "inherit",
+    });
+    if (!install.success) throw new Error("node-gyp build failed");
+  }, 120_000);
+
+  // NapiEnv is WTF_MAKE_STRUCT_TZONE_ALLOCATED (bmalloc). `Malloc=1` routes
+  // bmalloc through the system allocator so ASAN observes its free; the
+  // bmalloc system-heap path misbehaves on Windows (see
+  // websocket-server-upgrade-reentrant.test.ts), and routing WTF allocations
+  // through system malloc surfaces unrelated process-lifetime leaks under
+  // LSan, so this is Linux-only with LSan disabled. Other platforms still
+  // assert the finalizers run and the worker exits cleanly.
+  const childEnv: Record<string, string | undefined> = {
+    ...bunEnv,
+    BUN_JSC_validateExceptionChecks: undefined,
+    BUN_JSC_dumpSimulatedThrows: undefined,
+  };
+  if (isLinux) {
+    childEnv.Malloc = "1";
+    childEnv.ASAN_OPTIONS = [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":");
+  }
+
+  // collectContinuously is prohibitively slow under Windows CI; worker
+  // teardown is platform-agnostic so POSIX coverage is sufficient.
+  test.skipIf(isWindows).each(["createLatin1", "createUtf16"])(
+    "worker teardown runs the %s finalizer with a live env",
+    async fn => {
+      using dir = tempDir("napi-ext-string-env", {
+        "fixture.js": `
+          const { Worker, isMainThread, parentPort } = require("worker_threads");
+          if (isMainThread) {
+            const w = new Worker(__filename);
+            w.on("message", m => console.log("worker: " + m));
+            w.on("error", e => { console.error("worker error", e); process.exit(1); });
+            w.on("exit", code => {
+              // Addon is shared across workers in one process; the counter
+              // persists, so the main thread can observe the worker-run
+              // finalizers after teardown.
+              const addon = require(${JSON.stringify(addon)});
+              console.log("finalized=" + addon.finalizedCount());
+              process.exit(code);
+            });
+          } else {
+            const addon = require(${JSON.stringify(addon)});
+            globalThis.__strings = [];
+            globalThis.__holders = [];
+            for (let i = 0; i < 64; i++) {
+              const s = addon.${fn}();
+              globalThis.__strings.push(s);
+              // DOMException stores the message as a WTF::String (shares the
+              // StringImpl), so the ExternalStringImpl's last ref can drop
+              // from ~DOMException during the PreciseAllocation sweep.
+              globalThis.__holders.push(new DOMException(s));
+            }
+            parentPort.postMessage("created " + globalThis.__strings.length +
+              " sample=" + globalThis.__strings[0]);
+          }
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "fixture.js"],
+        env: childEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+
+      const expectedContent =
+        fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
+      expect(stderr).toBe("");
+      expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
+      // Every external string created in the worker must have had its
+      // finalizer invoked by the time the worker's VM is torn down.
+      expect(stdout).toContain("finalized=64");
+      expect(exitCode).toBe(0);
+    },
+    60_000,
+  );
+});

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -102,11 +102,15 @@ describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () =>
 
     const expectedContent =
       fn === "createLatin1" ? "external-latin1-string-xxxxxxxx" : "external-utf16-string-xxxxxxxxx";
-    expect(stderr).toBe("");
+    // Every external string created in the worker must have had its finalizer
+    // invoked by the time the worker's VM is torn down. The combined-object
+    // assertion surfaces all three values in one diff when the child crashes
+    // or ASAN writes to stderr.
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: expect.stringContaining("finalized=64"),
+      stderr: "",
+      exitCode: 0,
+    });
     expect(stdout).toContain("worker: created 64 sample=" + expectedContent);
-    // Every external string created in the worker must have had its
-    // finalizer invoked by the time the worker's VM is torn down.
-    expect(stdout).toContain("finalized=64");
-    expect(exitCode).toBe(0);
   });
 });

--- a/test/napi/napi-external-string-env.test.ts
+++ b/test/napi/napi-external-string-env.test.ts
@@ -19,14 +19,14 @@
 
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, canBuildNodeAddons, isLinux, tempDir } from "harness";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 const napiAppDir = join(import.meta.dir, "napi-app");
 const addon = join(napiAppDir, "build", "Debug", "external_string_addon.node");
 
-describe("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () => {
+describe.skipIf(!canBuildNodeAddons())("node_api_create_external_string_* finalizer holds Ref<NapiEnv>", () => {
   beforeAll(() => {
     if (existsSync(addon)) return;
     const install = spawnSync({


### PR DESCRIPTION
## Summary

`node_api_create_external_string_latin1` and `node_api_create_external_string_utf16` (src/jsc/bindings/napi.cpp) install an `ExternalStringImpl` free callback that calls `env->doFinalizer(...)`. The lambda captured `env` (the raw `napi_env` pointer) by value:

```cpp
[finalize_callback, env](void* hint, void* str, unsigned length) {
    env->doFinalizer(finalize_callback, str, hint);
}
```

`NapiEnv` is `RefCounted`; its primary owner is `Zig::GlobalObject::m_napiEnvs`, dropped in `~GlobalObject()`. If the env's refcount reaches zero before the external string's `StringImpl` is dereferenced, the finalizer lambda calls `doFinalizer` (which reads `m_napiModule.nm_version`, `m_vm`, etc.) on freed memory.

The sibling finalizers in `napi_add_finalizer` (line 1167) and `napi_create_external_buffer` (line 2087) already capture `WTF::Ref<NapiEnv>(*env)` for exactly this reason. This change brings the two external-string paths in line.

## Why this can't be gate-proven

I tried to construct a deterministic fail-before and couldn't. The ordering between `~GlobalObject` (frees the `NapiEnv`) and the string finalizer depends on JSC heap layout:

- During worker teardown, `WebWorker__teardownJSCVM` runs `collectNow(Sync, Full)` while the Rust `shutdown` frame still has the global on its stack, so conservative roots keep the global (and anything rooted on it) marked through that collection.
- The cells are then destroyed in `~VM` → `Heap::lastChanceToFinalize()` → `MarkedSpace::lastChanceToFinalize()`, which runs `forEachDirectory` (block-directory cells, including the external-string `JSString`s) before iterating `m_preciseAllocations` (where the `GlobalObject`'s lower-tier precise allocation lives).
- `m_preciseAllocations` is sorted by pointer address before each full GC (`MarkedSpace::prepareForConservativeScan()`), so even holders like `DOMException` that keep a `WTF::String` ref to the `ExternalStringImpl` and are themselves lower-tier precise depend on where the allocator placed them relative to the global.

I ran 30+ iterations of a worker fixture that stashes external strings in `DOMException` / `Event` / `File` holders (which share the `StringImpl` via `toWTFString`), with `Malloc=1` + ASAN + `BUN_JSC_stealEmptyBlocksFromOtherAllocators=0`, and the `GlobalObject`'s `PreciseAllocation` consistently sorted last, so `~NapiEnv` ran after every string finalizer. Forcing the opposite order would require instrumenting `src/` to perturb allocation addresses, which the gate strips.

The fix is still correct regardless of ordering and matches the established pattern. Any future change to sweep order, `PreciseAllocation` layout, or `NapiEnv` ownership that exposes the window will be caught by the new test, which routes the `NapiEnv` allocation through the system heap on the Linux ASAN lane.

## Test

`test/napi/napi-external-string-env.test.ts` + a small C addon (`test/napi/napi-app/external_string_addon.c`):

- Worker loads the addon, creates 64 external strings per variant (`latin1` and `utf16`), roots them on `globalThis` plus a `DOMException` holder each, then exits.
- The addon's finalizer increments a process-global counter; the main thread reloads the addon after the worker exits and asserts all 64 finalizers ran through `env->doFinalizer()`.
- On Linux the child runs with `Malloc=1` so the TZONE-allocated `NapiEnv` is ASAN-visible.

```
bun bd test test/napi/napi-external-string-env.test.ts   # 2 pass
bun bd test test/napi/node-napi-tests/test/js-native-api/test_string/do.test.ts   # 3 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi-external-string-env.test.ts

<!-- robobun:evidence:end -->