### PR TITLE
shell: exit 1 on builtin failure instead of raw errno; fix cd ENOENT message

### DIFF
--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -22,7 +22,6 @@ pub enum CatState {
         in_done: bool,
         chunks_queued: usize,
         chunks_done: usize,
-        errno: ExitCode,
     },
     ExecFilepathArgs {
         /// Index into argv where filepath args start.
@@ -80,7 +79,6 @@ impl Cat {
                 in_done: false,
                 chunks_queued: 0,
                 chunks_done: 0,
-                errno: 0,
             }
         } else {
             CatState::ExecFilepathArgs {
@@ -242,8 +240,7 @@ impl Cat {
         _: usize,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if let Some(e) = err {
-            let errno = e.get_errno() as ExitCode;
+        if err.is_some() {
             let rchild = ReaderChildPtr {
                 node: cmd,
                 tag: ReaderTag::Cat,
@@ -252,12 +249,7 @@ impl Cat {
             // Pull the reader `Arc` out of
             // state before calling `remove_reader`, then drop it.
             match &mut Self::state_mut(interp, cmd).state {
-                CatState::ExecStdin {
-                    in_done,
-                    errno: st_errno,
-                    ..
-                } => {
-                    *st_errno = errno;
+                CatState::ExecStdin { in_done, .. } => {
                     let was_done = core::mem::replace(in_done, true);
                     if !was_done {
                         if let BuiltinInput::Fd(r) = &Builtin::of(interp, cmd).stdin {
@@ -273,7 +265,7 @@ impl Cat {
                 CatState::WaitingWriteErr => {}
                 _ => panic!("Invalid state"),
             }
-            return Builtin::done(interp, cmd, errno);
+            return Builtin::done(interp, cmd, 1);
         }
 
         let step = match &mut Self::state_mut(interp, cmd).state {
@@ -343,7 +335,7 @@ impl Cat {
         cmd: NodeId,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        let errno: ExitCode = err.map(|e| e.get_errno() as ExitCode).unwrap_or(0);
+        let exit_code: ExitCode = err.map_or(0, |_| 1);
         let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io().is_some();
         let mut cancel = false;
         let step = match &mut Self::state_mut(interp, cmd).state {
@@ -351,13 +343,11 @@ impl Cat {
                 chunks_queued,
                 chunks_done,
                 in_done,
-                errno: st_errno,
             } => {
-                *st_errno = errno;
                 *in_done = true;
-                if errno != 0 {
+                if exit_code != 0 {
                     if *chunks_done >= *chunks_queued || !stdout_needs_io {
-                        Step::Done(errno)
+                        Step::Done(exit_code)
                     } else {
                         cancel = true;
                         Step::Suspend
@@ -377,11 +367,11 @@ impl Cat {
                 ..
             } => {
                 *in_done = true;
-                if errno != 0 {
+                if exit_code != 0 {
                     if *out_done || !stdout_needs_io {
                         // Drop the reader ref.
                         *reader = None;
-                        Step::Done(errno)
+                        Step::Done(exit_code)
                     } else {
                         cancel = true;
                         Step::Suspend

--- a/src/runtime/shell/builtin/cd.rs
+++ b/src/runtime/shell/builtin/cd.rs
@@ -73,11 +73,17 @@ impl Cd {
         use bun_sys::E;
         let errno = err.get_errno();
         match errno {
-            E::ENOTDIR | E::ENOENT => Self::write_stderr_non_blocking(
+            E::ENOTDIR => Self::write_stderr_non_blocking(
                 interp,
                 cmd,
-                format_args!("not a directory: {}\n", bstr::BStr::new(new_cwd)),
+                format_args!("{}: Not a directory\n", bstr::BStr::new(new_cwd)),
             ),
+            E::ENOENT => Self::write_stderr_non_blocking(
+                interp,
+                cmd,
+                format_args!("{}: No such file or directory\n", bstr::BStr::new(new_cwd)),
+            ),
+            // The path itself is the oversized thing; do not echo it back.
             E::ENAMETOOLONG => {
                 Self::write_stderr_non_blocking(interp, cmd, format_args!("file name too long\n"))
             }
@@ -88,8 +94,8 @@ impl Cd {
                     cmd,
                     format_args!(
                         "{}: {}\n",
-                        bstr::BStr::new(errmsg),
                         bstr::BStr::new(new_cwd),
+                        bstr::BStr::new(errmsg),
                     ),
                 )
             }

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -110,11 +110,7 @@ impl Echo {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(
-            interp,
-            cmd,
-            err.map(|e| e.errno as crate::shell::ExitCode).unwrap_or(0),
-        )
+        Builtin::done(interp, cmd, err.map_or(0, |_| 1))
     }
 }
 

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -329,10 +329,8 @@ impl Mv {
                     MvState::Executing { err, .. } => err.take().unwrap(),
                     _ => unreachable!(),
                 };
-                // The failing rename's errno becomes the shell exit code.
-                let exit_code = e.errno as ExitCode;
                 let buf = Builtin::task_error_to_string(interp, cmd, Kind::Mv, &e).to_vec();
-                Self::write_failing_error(interp, cmd, &buf, exit_code).run(interp);
+                Self::write_failing_error(interp, cmd, &buf, 1).run(interp);
                 return;
             }
             Self::state_mut(interp, cmd).state = MvState::Done;

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -41,6 +41,8 @@ pub struct ExecState {
     pub(crate) error_signal: AtomicBool,
     pub(crate) output_done: AtomicUsize,
     pub(crate) output_count: AtomicUsize,
+    /// A verbose (`-v`) stdout write failed; the removals still happened.
+    pub(crate) output_err: bool,
     pub(crate) tasks_done: usize,
     pub(crate) started: bool,
 }
@@ -49,6 +51,15 @@ impl ExecState {
     #[inline]
     fn output_drained(&self) -> bool {
         self.output_done.load(Ordering::SeqCst) >= self.output_count.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    fn exit_code(&self) -> ExitCode {
+        if self.err.is_some() || self.output_err {
+            1
+        } else {
+            0
+        }
     }
 }
 
@@ -251,6 +262,7 @@ impl Rm {
                                 error_signal: AtomicBool::new(false),
                                 output_done: AtomicUsize::new(0),
                                 output_count: AtomicUsize::new(0),
+                                output_err: false,
                                 tasks_done: 0,
                                 started: false,
                             });
@@ -358,21 +370,21 @@ impl Rm {
     ) -> Yield {
         let outcome: Option<ExitCode> = match &mut Self::state_mut(interp, cmd).state {
             RmState::Exec(exec) => {
+                if e.is_some() {
+                    exec.output_err = true;
+                }
                 exec.output_done.fetch_add(1, Ordering::SeqCst);
                 if exec.tasks_done >= exec.total_tasks && exec.output_drained() {
-                    Some(if exec.err.is_some() { 1 } else { 0 })
+                    Some(exec.exit_code())
                 } else {
                     None
                 }
             }
             state => {
-                if let Some(err) = &e {
-                    let code = err.get_errno() as ExitCode;
-                    *state = RmState::Err(code);
-                    Some(code)
-                } else {
-                    Some(1)
+                if e.is_some() {
+                    *state = RmState::Err(1);
                 }
+                Some(1)
             }
         };
         drop(e);
@@ -434,13 +446,7 @@ impl Rm {
         };
         if tasks_done >= total && all_out {
             let code = match &Self::state_mut(interp, cmd).state {
-                RmState::Exec(exec) => {
-                    if exec.err.is_some() {
-                        1
-                    } else {
-                        0
-                    }
-                }
+                RmState::Exec(exec) => exec.exit_code(),
                 _ => 0,
             };
             Self::state_mut(interp, cmd).state = RmState::Done { exit_code: code };
@@ -489,13 +495,7 @@ impl Rm {
         };
         if done {
             let code = match &Self::state_mut(interp, cmd).state {
-                RmState::Exec(exec) => {
-                    if exec.err.is_some() {
-                        1
-                    } else {
-                        0
-                    }
-                }
+                RmState::Exec(exec) => exec.exit_code(),
                 _ => 0,
             };
             return Builtin::done(interp, cmd, code);

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -178,8 +178,8 @@ impl Which {
         _: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if let Some(err) = e {
-            return Builtin::done(interp, cmd, err.errno as crate::shell::ExitCode);
+        if e.is_some() {
+            return Builtin::done(interp, cmd, 1);
         }
         match Self::state_mut(interp, cmd).state {
             State::OneArg => Builtin::done(interp, cmd, 1),

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -436,6 +436,8 @@ impl Cmd {
                 }
             }
         };
+        // A command name resolved; the stashed substitution status would otherwise be kept by `on_exit`.
+        interp.as_cmd_mut(this).exit_code = None;
 
         if let Some(kind) = BuiltinKind::from_argv0(&first_arg) {
             log!("Cmd {} exec builtin={:?}", this, kind);
@@ -973,7 +975,7 @@ impl Cmd {
     /// Called by `ShellSubprocess::on_process_exit`.
     pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
         log!("cmd exit code={}", exit_code);
-        // Keep the errno a stdio error already recorded.
+        // Keep the status a stdio error already recorded.
         if self.exit_code.is_none() {
             self.exit_code = Some(exit_code);
         }
@@ -1002,8 +1004,9 @@ impl Cmd {
     fn buffered_output_close_stdout(&mut self, err: Option<bun_sys::SystemError>) {
         debug_assert!(matches!(self.exec, Exec::Subproc(_)));
         log!("cmd close buffered stdout");
-        if let Some(e) = err {
-            self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
+        // The relayed output was lost: the command failed whatever the child reports.
+        if err.is_some() {
+            self.exit_code = Some(1);
         }
         let redirect = self.ast_node().redirect;
         let Exec::Subproc(sub) = &mut self.exec else {
@@ -1038,8 +1041,9 @@ impl Cmd {
     fn buffered_output_close_stderr(&mut self, err: Option<bun_sys::SystemError>) {
         debug_assert!(matches!(self.exec, Exec::Subproc(_)));
         log!("cmd close buffered stderr");
-        if let Some(e) = err {
-            self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
+        // The relayed output was lost: the command failed whatever the child reports.
+        if err.is_some() {
+            self.exit_code = Some(1);
         }
         let redirect = self.ast_node().redirect;
         let Exec::Subproc(sub) = &mut self.exec else {

--- a/src/runtime/shell/states/CondExpr.rs
+++ b/src/runtime/shell/states/CondExpr.rs
@@ -156,9 +156,7 @@ impl CondExpr {
         }
     }
 
-    /// IOWriter completion callback for the error message written in
-    /// `WaitingWriteErr`: on write failure finish with the errno as the exit
-    /// code, otherwise finish with exit code 1.
+    /// IOWriter completion for the `WaitingWriteErr` message: always finish 1.
     pub(crate) fn on_io_writer_chunk(
         interp: &Interpreter,
         this: NodeId,
@@ -166,10 +164,8 @@ impl CondExpr {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         let parent = interp.as_condexpr(this).base.parent;
-        if let Some(e) = err {
-            // Recover the positive errno (`to_shell_system_error` negated it).
-            let exit_code: ExitCode = e.errno.unsigned_abs() as ExitCode;
-            return interp.child_done(parent, this, exit_code);
+        if err.is_some() {
+            return interp.child_done(parent, this, 1);
         }
         if matches!(
             interp.as_condexpr(this).state,

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -6,9 +6,19 @@
  */
 import { $ } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
-import { chmodSync, mkdirSync } from "fs";
+import { chmodSync, mkdirSync, readdirSync } from "fs";
 import { mkdir, rm, stat } from "fs/promises";
-import { bunExe, isPosix, isWindows, rss, runWithErrorPromise, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import {
+  bunExe,
+  isLinux,
+  isPosix,
+  isWindows,
+  rss,
+  runWithErrorPromise,
+  tempDir,
+  tempDirWithFiles,
+  tmpdirSync,
+} from "harness";
 import { join, sep } from "path";
 import { createTestBuilder, sortedShellOutput } from "./util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -89,6 +99,83 @@ describe("bunshell", () => {
             .runAsTest(cmdstr)
         : "",
     );
+
+    // Every write to /dev/full fails with ENOSPC. Like bash, the builtin exits 1;
+    // the errno is not the exit code (it was 65508 for echo and which, 28 for rm).
+    test.skipIf(!isLinux)("builtins exit 1 when an output write fails", async () => {
+      const exitCodes = {
+        echo: (await $`echo hi > /dev/full`.nothrow()).exitCode,
+        which: (await $`which sh > /dev/full`.nothrow()).exitCode,
+        export: (await $`export FOO=bar; export > /dev/full`.nothrow()).exitCode,
+        cd: (await $`cd /nonexistent-dir 2> /dev/full`.nothrow()).exitCode,
+        rm: (await $`rm 2> /dev/full`.nothrow()).exitCode,
+      };
+      expect(exitCodes).toEqual({ echo: 1, which: 1, export: 1, cd: 1, rm: 1 });
+    });
+
+    // `rm -v` removes the file, then its verbose listing fails to write: the
+    // removal is real but the command must still report the lost output.
+    test.skipIf(!isLinux)("rm -v exits 1 when the verbose write fails", async () => {
+      using dir = tempDir("rm-verbose-dead-stdout", { "a.txt": "", "b.txt": "" });
+      const { exitCode } = await $`rm -v a.txt b.txt > /dev/full`.cwd(String(dir)).nothrow();
+      expect({ exitCode, remaining: readdirSync(String(dir)) }).toEqual({ exitCode: 1, remaining: [] });
+    });
+
+    // The substitution's own status only stands in when it yields no command
+    // name; once it names one, that command's status is $? (bash agrees).
+    test.skipIf(!isPosix)("a command named by a failing substitution reports its own status", async () => {
+      const subproc = (await $`$(echo env; exit 5)`.quiet().nothrow()).exitCode;
+      const builtin = (await $`$(echo true; exit 5)`.quiet().nothrow()).exitCode;
+      const noName = (await $`$(echo; exit 5)`.quiet().nothrow()).exitCode;
+      // The other direction: a substitution that exits 0 must not hide the named command's failure.
+      const failingSubproc = (await $`$(echo "sh -c false")`.quiet().nothrow()).exitCode;
+      expect({ subproc, builtin, noName, failingSubproc }).toEqual({
+        subproc: 0,
+        builtin: 0,
+        noName: 5,
+        failingSubproc: 1,
+      });
+    });
+
+    // `[[ ]]` takes no redirect and `cat` reads stdin, so their failing write
+    // needs the process stdio itself to be /dev/full.
+    test.skipIf(!isLinux)("builtins exit 1 when a write to the process stdio fails", async () => {
+      using dir = tempDir("dead-stdio", {
+        "stderr-dead.ts": `
+          import { $ } from "bun";
+          const glob = import.meta.dir + "/nomatch/*.zz";
+          const condexpr = (await $\`[[ -f \${{ raw: glob }} ]]\`.throws(false)).exitCode;
+          console.log(JSON.stringify({ condexpr }));
+        `,
+        "stdout-dead.ts": `
+          import { $ } from "bun";
+          const cat = (await $\`echo hi | cat\`.throws(false)).exitCode;
+          console.error(JSON.stringify({ cat }));
+        `,
+      });
+      await using stderrDead = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "stderr-dead.ts")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: Bun.file("/dev/full"),
+      });
+      // `cat` is a builtin only on Windows unless opted in; without the flag
+      // this would run /bin/cat and never reach the builtin's writer path.
+      await using stdoutDead = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "stdout-dead.ts")],
+        env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+        stdout: Bun.file("/dev/full"),
+        stderr: "pipe",
+      });
+      const [fromStdout, fromStderr, exitA, exitB] = await Promise.all([
+        stderrDead.stdout.text(),
+        stdoutDead.stderr.text(),
+        stderrDead.exited,
+        stdoutDead.exited,
+      ]);
+      expect({ ...JSON.parse(fromStdout), ...JSON.parse(fromStderr) }).toEqual({ condexpr: 1, cat: 1 });
+      expect([exitA, exitB]).toEqual([0, 0]);
+    });
   });
 
   describe("concurrency", () => {
@@ -1330,6 +1417,25 @@ booga"
       expect((err as Error).message).toContain("No such file or directory");
     });
 
+    test("cd distinguishes ENOENT from ENOTDIR", async () => {
+      using dir = tempDir("cd-enoent-enotdir", {
+        "afile.txt": "",
+      });
+      const missing = join(String(dir), "does-not-exist");
+      const afile = join(String(dir), "afile.txt");
+
+      {
+        const { stderr, exitCode } = await $`cd ${missing}`.quiet().nothrow();
+        expect(stderr.toString()).toBe(`cd: ${missing}: No such file or directory\n`);
+        expect(exitCode).toBe(1);
+      }
+      {
+        const { stderr, exitCode } = await $`cd ${afile}`.quiet().nothrow();
+        expect(stderr.toString()).toBe(`cd: ${afile}: Not a directory\n`);
+        expect(exitCode).toBe(1);
+      }
+    });
+
     // handleChangeCwdErr's `else` arm previously returned `.failed` without writing
     // to stderr or calling done(), so any errno other than NOTDIR/NOENT/NAMETOOLONG
     // (e.g. EACCES, ELOOP) left the shell promise unresolved forever.
@@ -1340,7 +1446,7 @@ booga"
       chmodSync(noaccess, 0o000);
       try {
         const { stderr, exitCode } = await $`cd ${noaccess}`.quiet().nothrow();
-        expect(stderr.toString()).toBe(`cd: Permission denied: ${noaccess}\n`);
+        expect(stderr.toString()).toBe(`cd: ${noaccess}: Permission denied\n`);
         expect(exitCode).toBe(1);
       } finally {
         chmodSync(noaccess, 0o755);

--- a/test/js/bun/shell/commands/echo.test.ts
+++ b/test/js/bun/shell/commands/echo.test.ts
@@ -1,4 +1,6 @@
-import { describe } from "bun:test";
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { isLinux } from "harness";
 import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -91,4 +93,9 @@ describe("echo special cases", async () => {
     .stdout("a\n")
     .stderr("")
     .runAsTest("mixed trailing newlines still collapse to one");
+
+  test.if(isLinux)("write error exits 1", async () => {
+    const { exitCode } = await $`echo hello > /dev/full`.nothrow().quiet();
+    expect(exitCode).toBe(1);
+  });
 });

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -63,7 +63,7 @@ describe("mv", async () => {
 
   TestBuilder.command`touch a; mkdir -p foo; mv foo/ a`
     .ensureTempDir()
-    .exitCode(20 /* ENOTDIR */)
+    .exitCode(1)
     .stderr("mv: a: Not a directory\n")
     .runAsTest("move dir -> file fails");
 
@@ -207,7 +207,7 @@ describe("mv", async () => {
           expect(lstatSync(join(dst, "tree"), { throwIfNoEntry: false })).toBeUndefined();
           chmodSync(srcDir, 0o700);
           expect(readFileSync(join(srcDir, "a.txt"), "utf8")).toBe("A\n");
-          expect(r.exitCode).toBe(13);
+          expect(r.exitCode).toBe(1);
         } finally {
           if (existsSync(srcDir)) chmodSync(srcDir, 0o700);
           rmSync(src, { recursive: true, force: true });
@@ -234,4 +234,16 @@ describe("mv", async () => {
       }
     });
   });
+
+  TestBuilder.command`mv nosuchsrc dst`
+    .ensureTempDir()
+    .exitCode(1)
+    .stderr_contains("No such file or directory")
+    .runAsTest("missing source exits 1 (not ENOENT)");
+
+  TestBuilder.command`mkdir -p d/x; mv d d/inside`
+    .ensureTempDir()
+    .exitCode(1)
+    .stderr_contains("mv:")
+    .runAsTest("move dir into own subdir exits 1 (not EINVAL)");
 });

--- a/test/js/bun/shell/commands/which.test.ts
+++ b/test/js/bun/shell/commands/which.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { chmodSync } from "node:fs";
 import { join } from "node:path";
 
@@ -83,4 +83,9 @@ test("which rlly long", async () => {
 test("which PATH rlly long", async () => {
   const longstr = "a".repeat(100000);
   expect(async () => await $`PATH=${longstr} slkdfjlsdkfj`.throws(true)).toThrow();
+});
+
+test.if(isLinux)("which write error exits 1", async () => {
+  const { exitCode } = await $`which ls > /dev/full`.nothrow().quiet();
+  expect(exitCode).toBe(1);
 });

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -1,7 +1,7 @@
 // An LD_PRELOAD shim injects ENOMEM into a shell command's pipe setup (recv()
 // on the eager read, or epoll_ctl() registering the pipe) so the reader error
 // surfaces synchronously from inside the spawn call. The command must finish
-// with the syscall errno as its exit code, not tear state down under the spawn.
+// cleanly (exit code 1), not tear state down under the spawn.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isLinux, tempDir } from "harness";
 import { join } from "node:path";
@@ -305,9 +305,6 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-// The shell surfaces the failed syscall's errno as the command's exit code.
-const ENOMEM = 12;
-
 const MODES = [
   "SHELL_FAIL_RECV",
   "SHELL_FAIL_EPOLL",
@@ -363,7 +360,7 @@ async function expectShellFault(
   }
   // One combined assertion so a crash surfaces stderr and the exit code in the diff.
   expect({ parsed, stderr, exitCode }).toEqual({
-    parsed: { exitCode: ENOMEM },
+    parsed: { exitCode: 1 },
     stderr: expect.any(String),
     exitCode: 0,
   });
@@ -435,7 +432,7 @@ test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
 //
 // With the re-arm removed from on_read_chunk, epoll_ctl #3 is instead the read
 // loop's own EAGAIN re-registration, whose failure path already returns
-// without touching the (freed) reader, so the command just reports ENOMEM.
+// without touching the (freed) reader, so the command just reports the failure.
 test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
   "shell survives a poll re-registration failure raised from on_read_chunk's mid-read flush",
   async () => {
@@ -504,7 +501,7 @@ test.concurrent.skipIf(!isLinux || !cc || !mkfifo || !cat)(
     }).toEqual({
       teedIsAllA: true,
       teedLength: 256 * 1024 + "AAAA".length,
-      parsed: { exitCode: ENOMEM },
+      parsed: { exitCode: 1 },
       stderr: "",
       readerStderr: "",
       exitCode: 0,
@@ -548,7 +545,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
 );
 
 // Only the readers fail to register; the stdin writer is still busy when the
-// reader error records ENOMEM as the exit code. The child then exits (EPIPE on
+// reader error records the failing exit code. The child then exits (EPIPE on
 // its closed stdout), but the exit handler skipped the command because an exit
 // code was already set, and the stdin close never re-checked either. The
 // command never finished and kept the shell's promise pending forever.
@@ -556,7 +553,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell finishes a command whose reader failed to register while stdin was still being written",
   async () => {
     expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "single")).toEqual({
-      parsed: { exitCode: ENOMEM, stderr: "", leaked: [] },
+      parsed: { exitCode: 1, stderr: "", leaked: [] },
       stderr: expect.any(String),
       exitCode: 0,
     });
@@ -570,7 +567,7 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "shell finishes a pipeline whose first stage's reader failed to register while stdin was still being written",
   async () => {
     expect(await runStdinBlobFixture(["SHELL_FAIL_EPOLL_IN"], "pipeline")).toEqual({
-      parsed: { exitCode: ENOMEM, stderr: "", leaked: [] },
+      parsed: { exitCode: 1, stderr: "", leaked: [] },
       stderr: expect.any(String),
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- A failing builtin reports the raw errno as its exit code. `echo hi > /dev/full` and `which sh > /dev/full` exit 65508 (`ShellError: Failed with exit code 65508`). `mv nosuchsrc dst` exits 2.
- `echo.rs:113` and `which.rs:182` cast the negated `SystemError.errno` to the `u16` exit code, so ENOSPC (-28) wraps. `mv.rs:332`, `cat.rs`, `rm.rs`, `CondExpr.rs` and the `Cmd.rs` output relay use the positive errno.
- `cd /nonexistent` prints `cd: not a directory: /nonexistent` (`cd.rs:76`).

### Fix
- Each of these sites exits 1, as `pwd`, `export`, `basename` and the other builtins already do. The errno text still goes to stderr. `rm -v` also exits 1 when its verbose output is lost (it exited 0).
- bash, dash, zsh and coreutils `mv`, `cat` and `rm` all exit 1 here. Bun Shell is bash-like and its builtins stand in for those programs, so `$?` means the same thing. An errno is not a portable exit code: it differs by platform, and values above 125 collide with the shell's 126, 127 and 128+n.
- `Cmd.rs`: a lost relay of captured subprocess output records exit 1 (it recorded the errno), and #41436's `on_exit` keeps it whichever event lands first. A sole command substitution's status no longer hides the named command's: `$(echo "sh -c false")` exits 1, `$(echo env; exit 5)` exits 0, as in bash.
- `cd` prints `cd: {path}: No such file or directory` or `cd: {path}: Not a directory`, like bash (folds in #36336).
- Verified: `test/js/bun/shell/bunshell.test.ts` (new tests for every site above), `commands/{echo,which,mv}.test.ts`, `shell-pipe-read-fault.test.ts` (now expects 1). Also the rest of `test/js/bun/shell`.

### Background
- A builtin writes to a real fd through `IOWriter`, the shell's write queue. The result reaches its `on_io_writer_chunk` as an `Option<bun_sys::SystemError>`.
- `SystemError.errno` is negated to match Node's `err.errno`. `ExitCode` is a `u16`, so the negated field wraps: -28 becomes 65508.
- When output is captured, `Cmd.rs` relays the child's stdout and stderr into the shell's buffers. The Cmd finishes once it has an exit status and both relays are closed.

<details><summary>Notes</summary>

Exit codes before and after, Linux:

| command | before | after | bash / coreutils |
|---|---|---|---|
| `echo hi > /dev/full` | 65508 | 1 | 1 |
| `which sh > /dev/full` | 65508 | 1 | 1 |
| `export FOO=bar; export > /dev/full` | 1 | 1 | 1 |
| `cd /nonexistent 2> /dev/full` | 1 | 1 | 1 |
| `rm 2> /dev/full` (usage message) | 28 | 1 | 1 |
| `echo hi \| cat`, process stdout on `/dev/full` | 28 | 1 | 1 |
| `[[ -f <glob, no match> ]]`, process stderr on `/dev/full` | 28 | 1 | 1 |
| `rm -v a b > /dev/full` | 0 | 1 | 1 |
| `mv nosuchsrc dst` | 2 | 1 | 1 |
| `mv d d/inside` | 22 | 1 | 1 |
| `mv d plain` | 20 | 1 | 1 |
| `$(echo "sh -c false")` | 0 | 1 | 1 |
| `$(echo env; exit 5)` | 5 | 0 | 0 |
| `cd /nonexistent` (stderr) | `cd: not a directory: /nonexistent` | `cd: /nonexistent: No such file or directory` | same as after |

Not changed here: `ls`, `mkdir -v` and `cp -v` still exit 0 when their verbose output write fails, because `OutputTask::on_io_writer_chunk` drops the error. #40033 fixes that site and adds the bash-style `name: write error: ...` report. `rm <missing file>` already exits 1 (the task path reports its own error).

The pre-Rust Zig builtins (`src/shell/builtin/*.zig` at `23427dbc12^`) did not agree with each other: `echo`, `which`, `export`, `cd` and `cat` returned `e.getErrno()`, `basename`, `dirname`, `seq`, `yes` and `mkdir` returned 1, `pwd` and `ls` ignored the write error. So there is no single old behavior to restore, and exit 1 is the one the Rust port already uses for half of the builtins.

#40702 proposed the positive errno for `echo`, `which`, `export` and `cd` and is closed in favor of this PR. Its test cases for `export > /dev/full` and `cd /nonexistent 2> /dev/full` are carried over here as exit 1 assertions (they already exit 1 on main, so they guard the invariant).

#40033 (open) adds the stderr report for every builtin write failure, also with exit 1. It overlaps this PR on `echo.rs`, `which.rs`, `cat.rs`, `rm.rs`, `Cmd.rs` and `CondExpr.rs`. Whichever lands second needs a rebase. The two do not disagree on the exit code.

Relay ordering in `Cmd.rs`: rebased onto #41436, which routes exit, stdin close, stdout close and stderr close through one `finish_if_done` and makes `on_exit` keep a status a stdio error already recorded. This PR now only changes what that recorded status is (1, not the errno), so a relay failure yields 1 in either event order, including over a child that exits nonzero after its output was lost. The earlier `output_relay_failed` flag and `is_done()` guard from review are gone because #41436 settles the ordering itself. A relay failure only happens when a pipe read or the shell's own stdout write fails (ENOMEM, ENOSPC, EPIPE).

Rebase onto #41436 resolved three conflicts: `Cmd.rs` (took main's `on_exit`/`finish_if_done`, kept the exit-1 assignment in the two relay-close handlers and the substitution-stash clear), `subproc.rs` (took main's `on_process_exit` unchanged), `bunshell.test.ts` (two adjacent added tests, kept both). #41436's two new `SHELL_FAIL_EPOLL_IN` tests asserted `exitCode: ENOMEM`; they now expect 1.

Tests on main that pinned the old errno-valued exit codes and were updated to expect 1: the `shell-pipe-read-fault.test.ts` cases (previously `ENOMEM`, 12, including the two added by #41436) and the `mv` cross-device "unreadable directory" case (previously `EACCES`, 13).

Tests are Linux only where they use `/dev/full`, which does not exist on macOS and Windows.

Suites run on the debug build: `bunshell`, `commands/*`, `shell-pipe-read-fault`, `epipe`, `shell-write-fault`, `exec`, `throw`, `file-io`, `lazy`, `pipeline_stack`, `shelloutput`, `yield`, `shell-seq-condexpr`, `shell-hang`. The `ls` permission-denied tests fail as root on stock bun too. The `leak`, `shell-load` and `shell-leak-args` tests time out or hit the pid cap of the build container and do not touch an error exit path.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 17 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/shell/shell-pipe-read-fault.test.ts, test/js/bun/shell/commands/which.test.ts, test/js/bun/shell/commands/echo.test.ts, test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->
