### PR TITLE
jsc: use saturating coerce::<i32> for Map/Set size display

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4790,7 +4790,7 @@ pub mod formatter {
             let length_value = value
                 .get(self.global_this, "size")?
                 .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-            let length = length_value.coerce_to_i32(self.global_this)?;
+            let length = length_value.coerce::<i32>(self.global_this)?;
 
             let prev_quote_strings = self.quote_strings;
             self.quote_strings = true;
@@ -4932,7 +4932,7 @@ pub mod formatter {
             let length_value = value
                 .get(self.global_this, "size")?
                 .unwrap_or_else(|| JSValue::js_number_from_int32(0));
-            let length = length_value.coerce_to_i32(self.global_this)?;
+            let length = length_value.coerce::<i32>(self.global_this)?;
 
             let prev_quote_strings = self.quote_strings;
             self.quote_strings = true;

--- a/src/runtime/crypto/PasswordObject.rs
+++ b/src/runtime/crypto/PasswordObject.rs
@@ -93,7 +93,7 @@ impl AlgorithmValue {
                                     .throw_invalid_argument_type("hash", "cost", "number"));
                             }
 
-                            let rounds = rounds_value.coerce_to_i32(global_object)?;
+                            let rounds = rounds_value.coerce::<i32>(global_object)?;
 
                             if rounds < 4 || rounds > 31 {
                                 return Err(global_object.throw_invalid_arguments(format_args!(
@@ -117,7 +117,7 @@ impl AlgorithmValue {
                                     .throw_invalid_argument_type("hash", "timeCost", "number"));
                             }
 
-                            let time_cost = time_value.coerce_to_i32(global_object)?;
+                            let time_cost = time_value.coerce::<i32>(global_object)?;
 
                             if time_cost < 1 {
                                 return Err(global_object.throw_invalid_arguments(format_args!(
@@ -137,7 +137,7 @@ impl AlgorithmValue {
                                 ));
                             }
 
-                            let memory_cost = memory_value.coerce_to_i32(global_object)?;
+                            let memory_cost = memory_value.coerce::<i32>(global_object)?;
 
                             // argon2 requires `memoryCost >= 8 * parallelism`;
                             // Bun hard-codes `parallelism = 1` (see

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1339,7 +1339,7 @@ impl ServerWebSocket {
                 )));
             }
 
-            break 'brk args.ptr[0].coerce_to_i32(global_this)?;
+            break 'brk args.ptr[0].coerce::<i32>(global_this)?;
         };
 
         let message_value: ZigStringSlice = 'brk: {

--- a/src/sourcemap_jsc/JSSourceMap.rs
+++ b/src/sourcemap_jsc/JSSourceMap.rs
@@ -329,8 +329,8 @@ fn get_line_column(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<[i32;
 
     Ok([
         // Node.js does no validations.
-        line_number_value.coerce_to_i32(global)?,
-        column_number_value.coerce_to_i32(global)?,
+        line_number_value.coerce::<i32>(global)?,
+        column_number_value.coerce::<i32>(global)?,
     ])
 }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -377,6 +377,10 @@ it("inspect", () => {
   const mapWithInfiniteSize = new Map([[1, 1]]);
   Object.defineProperty(mapWithInfiniteSize, "size", { value: Infinity });
   expect(Bun.inspect(mapWithInfiniteSize)).toBe("Map(2147483647) {\n  1: 1,\n}");
+
+  const setWithInfiniteSize = new Set([1]);
+  Object.defineProperty(setWithInfiniteSize, "size", { value: Infinity });
+  expect(Bun.inspect(setWithInfiniteSize)).toBe("Set(2147483647) {\n  1,\n}");
   expect(Bun.inspect(<div>foo</div>)).toBe("<div>foo</div>");
   expect(Bun.inspect(<div hello>foo</div>)).toBe("<div hello=true>foo</div>");
   expect(Bun.inspect(<div hello={1}>foo</div>)).toBe("<div hello=1>foo</div>");

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -364,6 +364,19 @@ it("inspect", () => {
     value: "not a number",
   });
   expect(Bun.inspect(mapWithOverriddenSize)).toBe("Map {}");
+
+  // Size values >= 2^31 saturate to i32::MAX instead of wrapping negative.
+  const mapWithHugeSize = new Map([[1, 1]]);
+  Object.defineProperty(mapWithHugeSize, "size", { value: 3000000000 });
+  expect(Bun.inspect(mapWithHugeSize)).toBe("Map(2147483647) {\n  1: 1,\n}");
+
+  const setWithHugeSize = new Set([1]);
+  Object.defineProperty(setWithHugeSize, "size", { value: 3000000000 });
+  expect(Bun.inspect(setWithHugeSize)).toBe("Set(2147483647) {\n  1,\n}");
+
+  const mapWithInfiniteSize = new Map([[1, 1]]);
+  Object.defineProperty(mapWithInfiniteSize, "size", { value: Infinity });
+  expect(Bun.inspect(mapWithInfiniteSize)).toBe("Map(2147483647) {\n  1: 1,\n}");
   expect(Bun.inspect(<div>foo</div>)).toBe("<div>foo</div>");
   expect(Bun.inspect(<div hello>foo</div>)).toBe("<div hello=true>foo</div>");
   expect(Bun.inspect(<div hello={1}>foo</div>)).toBe("<div hello=1>foo</div>");


### PR DESCRIPTION
## Repro

```console
$ bun -e 'const m=new Map([[1,1]]); Object.defineProperty(m,"size",{value:3000000000}); console.log(m)'
Map(-1294967296) {      # before
Map(2147483647) {       # after (matches 1.3.x / Zig)
  1: 1,
}
```

## Cause

`ConsoleObject.rs` reads the Map/Set `.size` property and coerces it to `i32` via `JSValue::coerce_to_i32`, which is the JSC `ToInt32` path (ECMA modular wrap: `3000000000` becomes `-1294967296`). The Zig reference (`ConsoleObject.zig:2761,2868`) used `length_value.coerce(i32, ...)`, which is the saturating-truncation helper (NaN→0, overflow→`i32::MIN`/`MAX`). The Rust equivalent of Zig's `coerce(i32, ...)` is `JSValue::coerce::<i32>`, not `coerce_to_i32`.

Low real-world impact since a real `Map.prototype.size` cannot exceed available memory, but it is observable via `defineProperty`, a `size` getter on a subclass, or a Proxy, and the negative number is plainly wrong.

## Fix

Switch the two sites in `ConsoleObject.rs` to `coerce::<i32>`.

Auditing every remaining `coerce_to_i32` call site against its `.zig` sibling turned up more sites with the same swap; all are corrected to match the Zig reference:

| file | value | zig ref |
| --- | --- | --- |
| `ConsoleObject.rs` | Map/Set `size` | `ConsoleObject.zig:2761,2868` |
| `PasswordObject.rs` | bcrypt `cost`, argon2 `timeCost`/`memoryCost` | `PasswordObject.zig:44,63,77` |
| `ServerWebSocket.rs` | `close()` code | `ServerWebSocket.zig:1080` |
| `JSSourceMap.rs` | `findEntry` line/column | `JSSourceMap.zig:198,199` |

`udp_socket.rs` and `dns.rs` were checked and already match (the Zig reference uses `coerceToInt32` there). Reverse-direction spot checks of existing `coerce::<i32>` sites found no mismatches. `node/types.rs` `FileSystemFlags` originally had the same swap but was superseded by #32506 on main (now uses `validate_int32`); the rebase took main's version.

### Note on `PasswordObject.rs`

For argon2 `timeCost`/`memoryCost`, this intentionally reverts to 1.3.x behavior: `timeCost: Infinity` now saturates to `i32::MAX` and passes the `>= 1` guard instead of wrapping to `0` and throwing. Neither version has an upper-bound check (e.g. `timeCost: 1e8` already runs for an impractical duration on both 1.3.x and main), so the lack of an upper bound is a pre-existing, orthogonal concern. bcrypt `cost` is unaffected since it already has `> 31 → throw`.

## Verification

New assertions in `test/js/bun/util/inspect.test.js` cover Map/Set with `size` = `3000000000` and `Infinity`, expecting `Map(2147483647)` / `Set(2147483647)`.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/inspect.test.js -t "^inspect$"` → fail (`Map(-1294967296)`)
- `bun bd test test/js/bun/util/inspect.test.js` → 72 pass
- `bun bd test test/js/bun/util/password.test.ts` → 68 pass
- `bun bd test test/js/node/module/module-sourcemap.test.js` → 3 pass
