### PR TITLE
shell: empty-string argv[0] should fail with "command not found"

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -445,17 +445,19 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → exit
-        // with the exit code from a sole command-substitution (stashed by
-        // `child_done` from `Expansion::out_exit_code`), else 0.
+        // No argv[0] at all → exit with the exit code from a sole
+        // command-substitution (stashed by `child_done` from
+        // `Expansion::out_exit_code`), else 0. An empty-string argv[0] is a
+        // real word (e.g. `""` or `"$empty"`) and falls through to `which()`
+        // → "command not found".
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
-                Some(a) if a.len() > 1 => {
+                Some(a) => {
                     // strip the trailing NUL we just added
                     a[..a.len() - 1].to_vec()
                 }
-                _ => {
+                None => {
                     let exit = me.exit_code.unwrap_or(0);
                     let parent = me.base.parent;
                     return interp.child_done(parent, this, exit);

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -463,6 +463,18 @@ describe("bunshell", () => {
     TestBuilder.command`$(exit 0) && echo hi`.stdout("hi\n").runAsTest("empty command subst");
     TestBuilder.command`$(exit 1) && echo hi`.exitCode(1).runAsTest("empty command subst 2");
     TestBuilder.command`FOO="" $FOO`.runAsTest("empty var");
+    TestBuilder.command`"" arg`
+      .exitCode(1)
+      .stderr("bun: command not found: \n")
+      .runAsTest("empty string literal as argv[0]");
+    TestBuilder.command`${""} arg`
+      .exitCode(1)
+      .stderr("bun: command not found: \n")
+      .runAsTest("empty JS string as argv[0]");
+    TestBuilder.command`"" && echo hi`
+      .exitCode(1)
+      .stderr("bun: command not found: \n")
+      .runAsTest("empty string argv[0] short-circuits &&");
   });
 
   describe("tilde_expansion", () => {


### PR DESCRIPTION
## Repro

```js
const r = await Bun.$`"" arg`.nothrow();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()));
// before: 0 ""
// after:  1 "bun: command not found: \n"
```

bash reference: `"" arg` → `bash: : command not found`, exit 127.

## Cause

In `Cmd::transition_to_exec` (`src/runtime/shell/states/Cmd.rs`), argv[0] was read as:

```rust
match me.args.first() {
    Some(a) if a.len() > 1 => a[..a.len() - 1].to_vec(),
    _ => return interp.child_done(parent, this, exit_code.unwrap_or(0)),
}
```

After NUL-termination an empty-string word is `[0u8]` (len 1), so it fell into the `_` arm and silently exited 0. The Zig reference (`Cmd.zig` `initSubproc`) only takes the early-exit when `args.items[0]` is the Optional-null sentinel (args was empty before the trailing-null append); an empty *string* still flows to `which()` → `"bun: command not found:"` with exit 1.

## Fix

Only take the early-exit when `args.first()` is `None`. An empty-string argv[0] now reaches `bun_which::which(&[])` → `None` → `cmd_write_failing_error("bun: command not found: \n")` with exit 1. Both `which()` and `which_win()` already return `None` for empty input.

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/shell/bunshell.test.ts -t empty_expansion  # 3 pass, 3 fail
bun bd test test/js/bun/shell/bunshell.test.ts -t empty_expansion                # 6 pass
bun bd test test/js/bun/shell/bunshell.test.ts                                   # 379 pass, 0 fail
```

The existing `$(exit N)` and unquoted `$FOO` tests in the same block still pass, confirming the no-args path is unchanged.