### PR TITLE
s3: remove dead endpoint_owned clone in sign_request

### DIFF
--- a/src/s3_signing/credentials.rs
+++ b/src/s3_signing/credentials.rs
@@ -382,7 +382,6 @@ impl S3Credentials {
         let protocol: &str = if self.insecure_http { "http" } else { "https" };
 
         // detect service name and host from region or endpoint
-        let mut endpoint_owned: Option<Vec<u8>> = None;
         let mut extra_path: &[u8] = b"";
         let host: Box<[u8]> = 'brk_host: {
             if !self.endpoint.is_empty() {
@@ -416,18 +415,15 @@ impl S3Credentials {
                         BStr::new(bucket),
                         BStr::new(region)
                     )
-                    .unwrap();
-                    endpoint_owned = Some(v.clone());
+                    .expect("infallible: in-memory write");
                     break 'brk_host v.into_boxed_slice();
                 }
                 let mut v = Vec::new();
                 write!(&mut v, "s3.{}.amazonaws.com", BStr::new(region))
                     .expect("infallible: in-memory write");
-                endpoint_owned = Some(v.clone());
                 break 'brk_host v.into_boxed_slice();
             }
         };
-        let _ = endpoint_owned; // not read after this point.
         // `host` (Box<[u8]>) drops on `?`.
 
         let normalized_path: &[u8] = 'brk: {


### PR DESCRIPTION
## What

Removes the `endpoint_owned` local in `S3Credentials::sign_request`. It was written via `v.clone()` in both default-endpoint branches and then immediately dropped:

```rust
endpoint_owned = Some(v.clone());
break 'brk_host v.into_boxed_slice();
// ...
let _ = endpoint_owned; // not read after this point.
```

That is an extra heap alloc + memcpy + free on every `sign_request` call that takes the default `s3.<region>.amazonaws.com` / `<bucket>.s3.<region>.amazonaws.com` path (i.e. whenever no `endpoint` is configured).

## Why

The Zig reference does a single `allocPrint` and returns that one allocation as `host`:

https://github.com/oven-sh/bun/blob/e0acad3182/src/s3_signing/credentials.zig#L440-L444

The local `endpoint` in Zig aliases `host` and has no readers after the block either. The Rust port mirrored the assignment as a separate owned clone, then noticed it had no reader and suppressed the warning instead of deleting it. This change drops the dead variable so the Rust path allocates once, matching Zig.

Perf-only; no behavioral change. Existing presign coverage in `test/js/bun/s3/s3.test.ts` exercises both default-endpoint branches (virtual-hosted and path-style) and still asserts the resulting hostnames.