### PR TITLE
webcore: clamp sink highWaterMark and reserve fallibly in start()

### DIFF
--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -37,8 +37,9 @@ impl ArrayBufferSink {
         } = *stream_start
         {
             if chunk_size > 0 {
-                self.bytes
-                    .ensure_total_capacity_precise(chunk_size as usize);
+                if self.bytes.try_reserve_exact(chunk_size as usize).is_err() {
+                    return Err(syscall::Error::oom());
+                }
             }
 
             self.as_uint8array = as_uint8array;

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -39,6 +39,19 @@ pub mod bun_s3 {
 // re-export (e.g. `sink::SinkSignal::init`).
 type BlobSizeType = crate::webcore::BlobSizeType;
 
+/// Upper bound on a JS-supplied `highWaterMark` used as an initial capacity
+/// hint. WHATWG permits `Infinity`; clamp here (monotonic, unlike the Zig
+/// `@truncate(i51)` wrap) and reserve fallibly at the allocation site.
+const MAX_HIGH_WATER_MARK: i64 = 256 * 1024 * 1024;
+
+#[inline]
+fn high_water_mark_from_js(value: JSValue, min: BlobSizeType) -> BlobSizeType {
+    // `to_int64` maps NaN→0 and saturates ±Infinity; clamp in i64 before the
+    // unsigned cast so Infinity/negatives/out-of-range never reach the allocator.
+    let n = value.to_int64();
+    (min as i64).max(n).min(MAX_HIGH_WATER_MARK) as BlobSizeType
+}
+
 // Compat: `webcore::Pipe` and Body refer to `streams::Result` / `streams::result::StreamError`.
 pub use StreamResult as Result;
 pub mod result {
@@ -117,9 +130,7 @@ impl Start {
 
         if let Some(chunk_size) = value.get(global_this, b"chunkSize")? {
             if chunk_size.is_number() {
-                // Low-32-bit wrap is correct for the in-range values JS can produce;
-                // revisit if exact i52 sign-extension semantics matter.
-                return Ok(Start::ChunkSize(chunk_size.to_int64() as BlobSizeType));
+                return Ok(Start::ChunkSize(high_water_mark_from_js(chunk_size, 0)));
             }
         }
 
@@ -194,7 +205,7 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         empty = false;
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = high_water_mark_from_js(chunk_size_val, 0);
                     }
                 }
 
@@ -213,7 +224,7 @@ impl Start {
                     value.fast_get(global_this, jsc::BuiltinName::HighWaterMark)?
                 {
                     if chunk_size_val.is_number() {
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = high_water_mark_from_js(chunk_size_val, 0);
                     }
                 }
 
@@ -276,7 +287,7 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         empty = false;
-                        chunk_size = 256i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = high_water_mark_from_js(chunk_size_val, 256);
                     }
                 }
 
@@ -1542,8 +1553,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         self.buffer.clear_retaining_capacity();
-        self.buffer
-            .ensure_total_capacity_precise(self.high_water_mark as usize);
+        if self
+            .buffer
+            .try_reserve_exact(self.high_water_mark as usize)
+            .is_err()
+        {
+            return Err(SysError::oom());
+        }
 
         self.done = false;
         self.signal.start();

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -1,6 +1,6 @@
 import { ArrayBufferSink } from "bun";
 import { describe, expect, it } from "bun:test";
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 
 describe("ArrayBufferSink", () => {
   const fixtures = [
@@ -61,4 +61,42 @@ describe("ArrayBufferSink", () => {
       expect(output.byteLength).toBe(expected.byteLength);
     });
   }
+
+  // WHATWG streams accept Infinity as a highWaterMark. Bun 1.3.14 clamped it
+  // and carried on; the Rust port passed i64::MAX to reserve_exact and aborted.
+  // Spawned as a subprocess because the failure mode is SIGABRT.
+  it.each([
+    ["Infinity", "Infinity"],
+    ["1e15", "1e15"],
+    ["Number.MAX_SAFE_INTEGER", "Number.MAX_SAFE_INTEGER"],
+    ["-1", "-1"],
+    ["NaN", "NaN"],
+  ])("start({ highWaterMark: %s }) does not abort the process", async (_, expr) => {
+    const src = `
+      const sink = new Bun.ArrayBufferSink();
+      let caught;
+      try {
+        sink.start({ highWaterMark: ${expr} });
+      } catch (err) {
+        caught = err?.code ?? err?.name;
+      }
+      sink.write("hello");
+      const out = new TextDecoder().decode(new Uint8Array(sink.end()));
+      process.stdout.write(JSON.stringify({ caught, out }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "allocator_may_return_null=1"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).not.toContain("memory allocation");
+    expect(JSON.parse(stdout)).toEqual({ out: "hello" });
+    expect({ exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: 0, signalCode: null });
+  });
 });


### PR DESCRIPTION
## What does this PR do?

`Infinity` is an explicitly legal `highWaterMark` under WHATWG streams (only `NaN` and negatives are rejected). In Bun 1.3.14 the sink `start()` path clamped it and carried on; in 1.4 it aborts the process with an uncatchable `SIGABRT`. Affects `ArrayBufferSink` directly and every sink reached through `Bun.serve` (`HTTPResponseSink` / `HTTPSResponseSink` / `H3ResponseSink` / `NetworkSink`).

### Repro

```js
const { ArrayBufferSink } = require("bun");
new ArrayBufferSink().start({ highWaterMark: Infinity });
console.log("never reached");
```

Before:
```
memory allocation of 9223372036854775807 bytes failed
Aborted (core dumped)
```

### Cause

Two Zig protections were dropped in the Rust port:

1. `streams.zig` passed `highWaterMark` through `@as(i51, @truncate(toInt64()))` before clamping, so `Infinity` (which `toInt64` saturates to `i64::MAX`) wrapped to `-1` and was then clamped to the minimum. `streams.rs` kept the clamp but dropped the truncate, so `i64::MAX` flowed straight into the allocator.
2. `ArrayBufferSink.zig` / `streams.zig` reserved via `ensureTotalCapacityPrecise` with `catch return .{ .err = Syscall.Error.oom }`. The Rust port calls `Vec::reserve_exact`, which invokes `handle_alloc_error` (process abort) on failure.

### Fix

- Add `high_water_mark_from_js(value, min)` in `streams.rs` and use it at all four parse sites (`ArrayBufferSink`, `FileSink`, the `NetworkSink`/`HTTPResponseSink` arm, and the generic `chunkSize` path). It validates the double in the wide type and clamps into `[min, 256 MiB]` before the unsigned cast, so `Infinity`, `1e15`, negatives and `NaN` all resolve to a bounded capacity. The bound is monotonic (values above the cap saturate to it), unlike the Zig `@truncate(i51)` wraparound which mapped `2**51` to 0 but left `2**50` untouched.
- Route both pre-allocation sites (`ArrayBufferSink::start`, `HTTPServerWritable::start`) through `Vec::try_reserve_exact` and return `bun_sys::Error::oom()` on failure, matching the fallible pattern the same sinks already use for `write()`. This guarantees no user-supplied `highWaterMark` can abort the process even if the clamped size cannot be allocated.

After:
```
never reached
```

Supersedes #30995 (restored the `@truncate` wraparound; credited via `Co-authored-by`).

## How did you verify your code works?

`test/js/bun/util/arraybuffersink.test.ts` gains a subprocess-isolated `it.each` over `Infinity`, `1e15`, `Number.MAX_SAFE_INTEGER`, `-1` and `NaN` that asserts the child exits 0 with `signalCode: null` and the sink remains usable (`write` + `end` round-trips `"hello"`).

- Fails on `main` (src/ stashed): the `Infinity` / `1e15` / `MAX_SAFE_INTEGER` cases abort with `memory allocation of ... bytes failed`.
- Passes with this change: all five cases exit 0 and round-trip the payload.
