### PR TITLE
css: fix rem() sign semantics to match CSS Values 4

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -443,13 +443,9 @@ impl<V: CalcValue> Calc<V> {
                 Self::parse_math_fn(
                     i,
                     (),
-                    |_, a, b| {
-                        // Floored modulo: result takes the sign of the divisor.
-                        // Equivalent to `a - b * floor(a / b)`. Rust `%` is truncated (sign of
-                        // dividend) and `rem_euclid` is non-negative, so neither matches for
-                        // negative `b` — use the explicit floor formula.
-                        a - b * (a / b).floor()
-                    },
+                    // CSS Values 4: rem(A, B) takes the sign of A (truncated division),
+                    // which is exactly Rust's `%` on f32.
+                    |_, a, b| a % b,
                     |_, a, b| MathFunction::Rem {
                         dividend: a,
                         divisor: b,

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -149,6 +149,22 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("calc rem() and mod()", () => {
+    // rem(A, B): result takes the sign of A (truncated division).
+    minify_test(`.a{width:rem(7px,-3px)}`, `.a{width:1px}`);
+    minify_test(`.a{width:rem(-7px,3px)}`, `.a{width:-1px}`);
+    minify_test(`.a{width:rem(-7px,-3px)}`, `.a{width:-1px}`);
+    minify_test(`.a{width:rem(7px,3px)}`, `.a{width:1px}`);
+    minify_test(`.a{transition-duration:rem(7s,-3s)}`, `.a{transition-duration:1s}`);
+    minify_test(`.a{transition-duration:rem(-7s,3s)}`, `.a{transition-duration:-1s}`);
+    minify_test(`.a{transform:rotate(rem(-7deg,3deg))}`, `.a{transform:rotate(-1deg)}`);
+    minify_test(`.a{transform:rotate(rem(7deg,-3deg))}`, `.a{transform:rotate(1deg)}`);
+    // mod(A, B): result takes the sign of B (floored division).
+    minify_test(`.a{width:mod(7px,-3px)}`, `.a{width:-2px}`);
+    minify_test(`.a{width:mod(-7px,3px)}`, `.a{width:2px}`);
+    minify_test(`.a{width:mod(-7px,-3px)}`, `.a{width:-1px}`);
+    minify_test(`.a{width:mod(7px,3px)}`, `.a{width:1px}`);
+  });
   describe("border_spacing", () => {
     minify_test(
       `


### PR DESCRIPTION
## Repro

```css
.a { width: rem(7px, -3px) }  /* expected 1px, got -2px */
.b { width: rem(-7px, 3px) }  /* expected -1px, got 2px */
```

## Cause

`CalcUnit::Rem` in `src/css/values/calc.rs` computed `a - b * (a / b).floor()` (floored modulo, sign of divisor). Per [CSS Values 4 §11.5](https://www.w3.org/TR/css-values-4/#round-func), `rem(A, B)` takes the sign of **A** (truncated division). The Zig reference used `@mod(a, b)`, which falls through to LLVM `frem` (truncated) for the negative-divisor case, so the original behavior was spec-correct and regressed in the Rust port. Affects Length, Time, and Angle uniformly since all three flow through the same `parse_math_fn` closure.

`mod(A, B)` (floored, sign of B) was already correct and is unchanged.

## Fix

Use Rust's `%` operator, which is truncated remainder on `f32` (sign of dividend).

## Verification

Added `calc rem() and mod()` cases to `test/js/bun/css/css.test.ts` covering all four sign combinations for `rem()` over `px`/`s`/`deg` plus the `mod()` sign matrix as a guard. With `src/` reverted the 6 mixed-sign `rem()` cases fail; with the fix all 12 pass. Full `css.test.ts` passes (1105 pass / 67 skip).