### PR TITLE
server: release StringImpl ref for 'unix' option in ServerConfig

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1171,6 +1171,7 @@ impl ServerConfig {
         }
 
         if let Some(unix) = arg.get_stringish(global, "unix")? {
+            let unix = bun_core::OwnedString::new(unix);
             let unix_str = unix.to_utf8();
             if !unix_str.slice().is_empty() {
                 if has_hostname {

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,6 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "../../../harness";
+import { bunEnv, bunExe, isASAN, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -588,7 +588,7 @@ describe("Bun.serve unix socket validation", () => {
     // hostname+unix error path (no actual bind) with a large string and check
     // RSS growth stays bounded.
     const src = `
-      const base = Buffer.alloc(256 * 1024, "x").toString();
+      const base = Buffer.alloc(512 * 1024, "x").toString();
       function once(i) {
         try {
           Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/" + i + base, fetch: () => new Response("ok") });
@@ -613,8 +613,8 @@ describe("Bun.serve unix socket validation", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     if (exitCode !== 0) console.error(stderr);
     const { deltaMB } = JSON.parse(stdout);
-    // Leaking: 1000 * 256KB ≈ 250MB. Fixed: a few MB.
-    expect(deltaMB).toBeLessThan(64);
+    // Leaking: 1000 * 512KB ≈ 500MB. Fixed: ~22MB (flat, independent of string size).
+    expect(deltaMB).toBeLessThan(isASAN ? 192 : 64);
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/http/bun-serve-args.test.ts
+++ b/test/js/bun/http/bun-serve-args.test.ts
@@ -1,6 +1,6 @@
 import { serve } from "bun";
 import { describe, expect, test } from "bun:test";
-import { tmpdirSync } from "../../../harness";
+import { bunEnv, bunExe, tmpdirSync } from "../../../harness";
 
 const defaultHostname = "localhost";
 
@@ -581,6 +581,41 @@ describe("Bun.serve unix socket validation", () => {
         },
       }),
     ).toThrow();
+  });
+
+  test("unix option does not leak the string", async () => {
+    // The WTFStringImpl backing the 'unix' option was never deref'd. Drive the
+    // hostname+unix error path (no actual bind) with a large string and check
+    // RSS growth stays bounded.
+    const src = `
+      const base = Buffer.alloc(256 * 1024, "x").toString();
+      function once(i) {
+        try {
+          Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/" + i + base, fetch: () => new Response("ok") });
+        } catch {}
+      }
+      for (let i = 0; i < 50; i++) once(i);
+      Bun.gc(true);
+      Bun.gc(true);
+      const before = process.memoryUsage.rss();
+      for (let i = 0; i < 1000; i++) once(i);
+      Bun.gc(true);
+      Bun.gc(true);
+      const after = process.memoryUsage.rss();
+      console.log(JSON.stringify({ deltaMB: (after - before) / 1024 / 1024 }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error(stderr);
+    const { deltaMB } = JSON.parse(stdout);
+    // Leaking: 1000 * 256KB ≈ 250MB. Fixed: a few MB.
+    expect(deltaMB).toBeLessThan(64);
+    expect(exitCode).toBe(0);
   });
 
   describe("invalid unix socket paths should throw", () => {


### PR DESCRIPTION
## What

`get_stringish()` returns a `bun_core::String` carrying a +1 `WTFStringImpl` ref (via `to_bun_string`). `bun_core::String` is `#[derive(Copy)]` and has no `Drop` impl by design; callers must wrap it in `OwnedString` for scope-exit `deref()`.

The `hostname` branch in `ServerConfig::from_js` already does this. The `unix` branch did not, so every `Bun.serve({ unix: ... })` and `server.reload({ unix: ... })` leaked one `WTFStringImpl`. The Zig reference (`ServerConfig.zig:810`) has the explicit `defer unix.deref()`.

## Repro

Drive the hostname+unix error path so no server is actually created:

```js
const base = Buffer.alloc(256 * 1024, "x").toString();
for (let i = 0; i < 1000; i++) {
  try {
    Bun.serve({ hostname: "127.0.0.1", unix: "/tmp/" + i + base, fetch: () => new Response("ok") });
  } catch {}
}
```

RSS growth scales 1:1 with the `unix` string size per call.

## Fix

Wrap the returned string in `bun_core::OwnedString`, matching the `hostname` branch directly above.

## Verification

| | RSS delta (1000 iters, 256KB string) |
|---|---|
| before | ~258 MB |
| after | ~22 MB (flat, independent of string size) |

`bun-serve-args.test.ts`: 47 pass, 1 todo (pre-existing).