### PR TITLE
css: fix An+B keyword matching in :nth-child and reuse the parent arena

### DIFF
--- a/src/bun_alloc/MimallocArena.rs
+++ b/src/bun_alloc/MimallocArena.rs
@@ -37,6 +37,21 @@ pub(crate) static HEAP_NEW_COUNT: core::sync::atomic::AtomicUsize =
 pub(crate) static HEAP_DESTROY_COUNT: core::sync::atomic::AtomicUsize =
     core::sync::atomic::AtomicUsize::new(0);
 
+/// Cumulative `mi_heap_new` calls made through `MimallocArena` since process
+/// start. Debug-only instrumentation for allocation-regression tests; returns
+/// 0 in release builds.
+#[inline]
+pub fn heap_new_count() -> usize {
+    #[cfg(debug_assertions)]
+    {
+        HEAP_NEW_COUNT.load(core::sync::atomic::Ordering::Relaxed)
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        0
+    }
+}
+
 // ── Debug-only thread-ownership guard ─────────────────────────────────────
 //
 // `bun_alloc` sits below `bun_core` in the crate graph, so we cannot reuse

--- a/src/bun_alloc/lib.rs
+++ b/src/bun_alloc/lib.rs
@@ -257,7 +257,7 @@ impl<'a> FixedBufferAllocator<'a> {
 // `bumpalo::Bump` is kept as `Bump` for genuinely bump-only scratch (parser
 // node stores that are never resized and where the no-op `deallocate` is the
 // point).
-pub use mimalloc_arena::MimallocArena;
+pub use mimalloc_arena::{MimallocArena, heap_new_count};
 pub type Arena = MimallocArena;
 /// `bumpalo::Bump` — kept for genuinely bump-only scratch that's never resized.
 pub type Bump = bumpalo::Bump;

--- a/src/codegen/generate-js2native.ts
+++ b/src/codegen/generate-js2native.ts
@@ -51,6 +51,7 @@ const rustIdentifierPaths: Record<string, string> = {
   "MarkdownObject.rs": "runtime/api/MarkdownObject.rs",
   "SecureContext.rs": "runtime/api/bun/SecureContext.rs",
   "Stat.rs": "runtime/node/Stat.rs",
+  "UnsafeObject.rs": "runtime/api/UnsafeObject.rs",
   "bindgen_test.rs": "jsc/bindgen_test.rs",
   "collections/linear_fifo.rs": "collections/linear_fifo.rs",
   "crash_handler.rs": "crash_handler/crash_handler.rs",

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -4294,6 +4294,10 @@ pub mod nth {
 
     /// Parse the *An+B* notation, as found in the `:nth-child()` selector.
     pub fn parse_nth(input: &mut Parser) -> CssResult<NthResult> {
+        // SAFETY: `input.arena()` re-borrows the parser arena through `&self`;
+        // detach that borrow so `input` can be re-borrowed mutably below. The
+        // arena outlives the parser (it owns all parsed allocations).
+        let arena: &Bump = unsafe { bun_ptr::detach_lifetime_ref(input.arena()) };
         let tok = input.next()?;
         match tok {
             Token::Number(n) => {
@@ -4309,7 +4313,7 @@ pub mod nth {
                     } else if strings::eql_case_insensitive_asciii_check_length(unit, b"n-") {
                         return parse_signless_b(input, a, -1);
                     } else {
-                        if let Ok(b) = parse_n_dash_digits(unit) {
+                        if let Ok(b) = parse_n_dash_digits(arena, unit) {
                             return Ok((a, b));
                         } else {
                             return Err(input.new_unexpected_token_error(Token::Ident(unit)));
@@ -4337,7 +4341,7 @@ pub mod nth {
                     } else {
                         (value, 1)
                     };
-                    if let Ok(b) = parse_n_dash_digits(slice) {
+                    if let Ok(b) = parse_n_dash_digits(arena, slice) {
                         return Ok((a, b));
                     }
                     return Err(input.new_unexpected_token_error(Token::Ident(value)));
@@ -4352,7 +4356,7 @@ pub mod nth {
                     } else if strings::eql_case_insensitive_asciii_check_length(value, b"-n") {
                         return parse_signless_b(input, 1, -1);
                     } else {
-                        if let Ok(b) = parse_n_dash_digits(value) {
+                        if let Ok(b) = parse_n_dash_digits(arena, value) {
                             return Ok((1, b));
                         } else {
                             return Err(input.new_unexpected_token_error(Token::Ident(value)));
@@ -4407,21 +4411,20 @@ pub mod nth {
         Err(input.new_unexpected_token_error(tok))
     }
 
-    fn parse_n_dash_digits(str: &[u8]) -> Maybe<i32, ()> {
+    fn parse_n_dash_digits(arena: &Bump, str: &[u8]) -> Maybe<i32, ()> {
         let bytes = str;
         if bytes.len() >= 3
             && strings::eql_case_insensitive_asciii_check_length(&bytes[0..2], b"n-")
             && bytes[2..].iter().all(|&b| b >= b'0' && b <= b'9')
         {
-            parse_number_saturate(&str[1..]) // Include the minus sign
+            parse_number_saturate(arena, &str[1..]) // Include the minus sign
         } else {
             Err(())
         }
     }
 
-    fn parse_number_saturate(string: &[u8]) -> Maybe<i32, ()> {
-        let arena = Bump::new();
-        let mut input = ParserInput::new(string, &arena);
+    fn parse_number_saturate(arena: &Bump, string: &[u8]) -> Maybe<i32, ()> {
+        let mut input = ParserInput::new(string, arena);
         let mut parser = Parser::new(&mut input, None, ParserOpts::default(), None);
         let tok = match parser.next_including_whitespace_and_comments() {
             Ok(v) => v,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -4323,17 +4323,17 @@ pub mod nth {
             }
             Token::Ident(value) => {
                 let value = *value;
-                if strings::eql_case_insensitive_ascii_ignore_length(value, b"even") {
+                if strings::eql_case_insensitive_asciii_check_length(value, b"even") {
                     return Ok((2, 0));
-                } else if strings::eql_case_insensitive_ascii_ignore_length(value, b"odd") {
+                } else if strings::eql_case_insensitive_asciii_check_length(value, b"odd") {
                     return Ok((2, 1));
-                } else if strings::eql_case_insensitive_ascii_ignore_length(value, b"n") {
+                } else if strings::eql_case_insensitive_asciii_check_length(value, b"n") {
                     return parse_b(input, 1);
-                } else if strings::eql_case_insensitive_ascii_ignore_length(value, b"-n") {
+                } else if strings::eql_case_insensitive_asciii_check_length(value, b"-n") {
                     return parse_b(input, -1);
-                } else if strings::eql_case_insensitive_ascii_ignore_length(value, b"n-") {
+                } else if strings::eql_case_insensitive_asciii_check_length(value, b"n-") {
                     return parse_signless_b(input, 1, -1);
-                } else if strings::eql_case_insensitive_ascii_ignore_length(value, b"-n-") {
+                } else if strings::eql_case_insensitive_asciii_check_length(value, b"-n-") {
                     return parse_signless_b(input, -1, -1);
                 } else {
                     let (slice, a): (&[u8], i32) = if value.first() == Some(&b'-') {
@@ -4347,13 +4347,15 @@ pub mod nth {
                     return Err(input.new_unexpected_token_error(Token::Ident(value)));
                 }
             }
-            Token::Delim(_) => {
+            // Only `'+'` may precede the `n...` ident; a leading `-` is part of
+            // the ident itself (`-n`, `-n-3`) and is handled by the Ident arm.
+            Token::Delim(d) if *d == u32::from(b'+') => {
                 let next_tok = input.next_including_whitespace()?;
                 if let Token::Ident(value) = next_tok {
                     let value = *value;
                     if strings::eql_case_insensitive_asciii_check_length(value, b"n") {
                         return parse_b(input, 1);
-                    } else if strings::eql_case_insensitive_asciii_check_length(value, b"-n") {
+                    } else if strings::eql_case_insensitive_asciii_check_length(value, b"n-") {
                         return parse_signless_b(input, 1, -1);
                     } else {
                         if let Ok(b) = parse_n_dash_digits(arena, value) {

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -54,6 +54,8 @@ export const sslCtxLiveCount = $newRustFunction("SecureContext.rs", "jsLiveCount
 
 export const napiThreadsafeFunctionLiveCount = $newRustFunction("napi_body.rs", "jsThreadsafeFunctionLiveCount", 0);
 
+export const mimallocHeapNewCount = $newRustFunction("UnsafeObject.rs", "jsMimallocHeapNewCount", 0);
+
 export const escapeRegExp = $newRustFunction("escapeRegExp.rs", "jsEscapeRegExp", 1);
 export const escapeRegExpForPackageNameMatching = $newRustFunction(
   "escapeRegExp.rs",

--- a/src/runtime/api/UnsafeObject.rs
+++ b/src/runtime/api/UnsafeObject.rs
@@ -81,6 +81,16 @@ fn memory_footprint(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JS
     Ok(JSValue::js_number(bytes as f64))
 }
 
+/// Exposed via `bun:internal-for-testing` so allocation-regression tests can
+/// assert a code path creates O(1) mimalloc heaps, not O(n). Debug-only; reads
+/// a zero constant in release builds.
+pub(crate) fn js_mimalloc_heap_new_count(
+    _global: &JSGlobalObject,
+    _frame: &CallFrame,
+) -> JsResult<JSValue> {
+    Ok(JSValue::js_number(bun_alloc::heap_new_count() as f64))
+}
+
 #[bun_jsc::host_fn]
 fn dump_mimalloc(_global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
     // Print the process-wide mimalloc stats to stderr via

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -1,7 +1,8 @@
-import { cssInternals } from "bun:internal-for-testing";
+import * as internals from "bun:internal-for-testing";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isDebug } from "harness";
 
+const { cssInternals, mimallocHeapNewCount } = internals;
 const { minifyTest } = cssInternals;
 
 // An+B idents longer than the keyword literals ("n", "n-", ...) used to make the
@@ -19,6 +20,26 @@ test("An+B idents longer than the keyword literals parse deterministically", () 
   );
   expect(minifyTest(":nth-child(N) {width: 20px}", ":nth-child(n){width:20px}")).toBe(":nth-child(n){width:20px}");
   expect(() => minifyTest(":nth-child(NN) {width: 20px}", "")).toThrow("Unexpected token");
+});
+
+// `parse_number_saturate` builds a temporary Parser to tokenize the `-B` part
+// of `An-B`. That Parser must borrow the outer parser's arena, not create a
+// fresh mimalloc heap per selector. The counter is debug-only.
+test.skipIf(!isDebug)("An-B parse does not create a mimalloc heap per selector", () => {
+  const N = 2000;
+  let css = "";
+  for (let i = 0; i < N; i++) css += `.x${i}:nth-child(2n-${(i % 9) + 1}){color:red}`;
+  // Warm the code path once so any one-time lazy heaps are already counted.
+  minifyTest(":nth-child(2n-1){color:red}", ":nth-child(2n-1){color:red}");
+
+  const before = mimallocHeapNewCount();
+  const out = minifyTest(css, "");
+  const after = mimallocHeapNewCount();
+
+  expect(out.startsWith(".x0:nth-child(2n-1),")).toBe(true);
+  // O(1) heaps for the whole parse, not O(N). Without the fix this is N+1.
+  expect(after - before).toBeLessThan(N);
+  expect(after - before).toBeLessThan(100);
 });
 
 // `An-B` without spaces reaches `parse_n_dash_digits` via three different token

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -21,6 +21,26 @@ test("An+B idents longer than the keyword literals parse deterministically", () 
   expect(() => minifyTest(":nth-child(NN) {width: 20px}", "")).toThrow("Unexpected token");
 });
 
+// `An-B` without spaces reaches `parse_n_dash_digits` via three different token
+// shapes. All three reuse the outer parser's arena for the inner number parse.
+test("An-B without spaces parses via all three token shapes", () => {
+  // Dimension{value:2, unit:"n-3"}
+  expect(minifyTest(":nth-child(2n-3) {width: 20px}", ":nth-child(2n-3){width:20px}")).toBe(
+    ":nth-child(2n-3){width:20px}",
+  );
+  // Ident("n-5") / Ident("-n-5")
+  expect(minifyTest(":nth-child(n-5) {width: 20px}", ":nth-child(n-5){width:20px}")).toBe(
+    ":nth-child(n-5){width:20px}",
+  );
+  expect(minifyTest(":nth-child(-n-5) {width: 20px}", ":nth-child(-n-5){width:20px}")).toBe(
+    ":nth-child(-n-5){width:20px}",
+  );
+  // Delim('+') then Ident("n-7")
+  expect(minifyTest(":nth-child(+n-7) {width: 20px}", ":nth-child(n-7){width:20px}")).toBe(
+    ":nth-child(n-7){width:20px}",
+  );
+});
+
 test("fuzzer-minimized input: unterminated :nth-child( with an `Nn` ident", async () => {
   // Run in a child process so a crash doesn't take down the test runner.
   await using proc = Bun.spawn({

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -29,9 +29,7 @@ test("An+B idents shorter than a keyword are rejected, not prefix-matched", () =
     expect(() => minifyTest(`:nth-child(${sel}) {width: 20px}`, "")).toThrow("Unexpected token");
   }
   // Exact matches (any case) still work.
-  expect(minifyTest(":nth-child(EVEN) {width: 20px}", ":nth-child(2n){width:20px}")).toBe(
-    ":nth-child(2n){width:20px}",
-  );
+  expect(minifyTest(":nth-child(EVEN) {width: 20px}", ":nth-child(2n){width:20px}")).toBe(":nth-child(2n){width:20px}");
   expect(minifyTest(":nth-child(ODD) {width: 20px}", ":nth-child(odd){width:20px}")).toBe(
     ":nth-child(odd){width:20px}",
   );

--- a/test/js/bun/css/nth-anplusb-ident.test.ts
+++ b/test/js/bun/css/nth-anplusb-ident.test.ts
@@ -22,6 +22,35 @@ test("An+B idents longer than the keyword literals parse deterministically", () 
   expect(() => minifyTest(":nth-child(NN) {width: 20px}", "")).toThrow("Unexpected token");
 });
 
+// The `even`/`odd`/`n`/... keyword checks must be exact-length, not prefix
+// matches: `e` is not `even`, `o` is not `odd`.
+test("An+B idents shorter than a keyword are rejected, not prefix-matched", () => {
+  for (const sel of ["e", "ev", "eve", "o", "od"]) {
+    expect(() => minifyTest(`:nth-child(${sel}) {width: 20px}`, "")).toThrow("Unexpected token");
+  }
+  // Exact matches (any case) still work.
+  expect(minifyTest(":nth-child(EVEN) {width: 20px}", ":nth-child(2n){width:20px}")).toBe(
+    ":nth-child(2n){width:20px}",
+  );
+  expect(minifyTest(":nth-child(ODD) {width: 20px}", ":nth-child(odd){width:20px}")).toBe(
+    ":nth-child(odd){width:20px}",
+  );
+});
+
+// Only `'+'` may precede the `n...` ident in An+B. Any other leading delimiter
+// is a parse error, and after `+` the `n-` form (not `-n`) takes a signless B.
+test("An+B explicit leading sign is '+' only", () => {
+  expect(() => minifyTest(":nth-child(*n-3) {width: 20px}", "")).toThrow("Unexpected token");
+  expect(() => minifyTest(":nth-child(~n) {width: 20px}", "")).toThrow("Unexpected token");
+  // `+ -n 5` is two consecutive signs: invalid.
+  expect(() => minifyTest(":nth-child(+-n 5) {width: 20px}", "")).toThrow("Unexpected token");
+  // `+n- 5` is the `'+'? n- <signless-integer>` production: valid, equals n-5.
+  expect(minifyTest(":nth-child(+n- 5) {width: 20px}", ":nth-child(n-5){width:20px}")).toBe(
+    ":nth-child(n-5){width:20px}",
+  );
+  expect(minifyTest(":nth-child(+n) {width: 20px}", ":nth-child(n){width:20px}")).toBe(":nth-child(n){width:20px}");
+});
+
 // `parse_number_saturate` builds a temporary Parser to tokenize the `-B` part
 // of `An-B`. That Parser must borrow the outer parser's arena, not create a
 // fresh mimalloc heap per selector. The counter is debug-only.


### PR DESCRIPTION
Three fixes in the CSS `:nth-child(An+B)` parser (`nth::parse_nth` in `src/css/css_parser.rs`). All verified against servo's `nth.rs` (the reference this code was ported from) and the An+B grammar in css-syntax-3.

## 1. Per-selector arena allocation

`parse_number_saturate` was constructing a fresh `MimallocArena` (`mi_heap_new()` / `mi_heap_destroy()`) on every call. It is reached from `parse_n_dash_digits`, which fires for every `:nth-child(An-B)` selector whose `An` and `-B` are written without spaces:

- `:nth-child(2n-3)` tokenizes as `Dimension{value:2, unit:"n-3"}`
- `:nth-child(n-5)` / `:nth-child(-n-5)` tokenize as `Ident("n-5")` / `Ident("-n-5")`
- `:nth-child(+n-7)` tokenizes as `Delim('+')` then `Ident("n-7")`

So a stylesheet with many such selectors did one heap create/destroy per selector. Fix: thread `input.arena()` from `parse_nth` down through `parse_n_dash_digits` to `parse_number_saturate`, using the `bun_ptr::detach_lifetime_ref` pattern this file already uses for the same split-borrow. Output is unchanged; this part is a pure allocation fix.

To make it testable, the existing debug-only `HEAP_NEW_COUNT` counter in `bun_alloc::MimallocArena` is exposed via `bun:internal-for-testing` as `mimallocHeapNewCount()` (following the `sslCtxLiveCount` precedent; `UnsafeObject.rs` registered in `rustIdentifierPaths`). The test asserts that minifying 2000 such selectors creates O(1) mimalloc heaps, not O(N):

```
without the fix: Expected: < 2000, Received: 2001
with the fix:    delta = 1
```

## 2. An+B keywords were prefix-matched, not exact-matched

The `Token::Ident` arm compared `even`/`odd`/`n`/`-n`/`n-`/`-n-` with `eql_case_insensitive_ascii_ignore_length`, which only rejects when the ident is *longer* than the keyword and otherwise compares `ident.len()` bytes. So any prefix of a keyword was accepted:

```
:nth-child(e)  -> :nth-child(2n)   (parsed as even)
:nth-child(o)  -> :nth-child(odd)
```

The sibling `Dimension` and `Delim` arms already used the exact-length `_check_length` variant, and servo's `match_ignore_ascii_case!` is exact-length. These six calls were the only `_ignore_length` uses in the whole `bun_css` crate. Fix: switch them to `eql_case_insensitive_asciii_check_length`.

## 3. The explicit leading sign accepted any delimiter, and checked `-n` instead of `n-`

The `Token::Delim(_)` arm matched any delimiter, so `:nth-child(*n-3)` and `:nth-child(~n)` were silently accepted; the grammar only allows `+`. It also checked `b"-n"` where the `'+'? n- <signless-integer>` production needs `b"n-"` (compare the parallel Dimension and Ident arms), so the valid `:nth-child(+n- 5)` was rejected with `Unexpected token: n-` while the invalid `:nth-child(+-n 5)` (two consecutive signs) was accepted as `n-5`. Fix: gate the arm on `Token::Delim(d) if *d == u32::from(b'+')` and correct the literal.

Items 2 and 3 predate the Rust port; the Zig implementation had both. They were flagged in review while item 1 was already touching this exact function, and the fixes are a few lines each.

## Verification

`test/js/bun/css/nth-anplusb-ident.test.ts` covers all three: the heap-count assertion (debug-only), the prefix-match rejections (`e`/`ev`/`eve`/`o`/`od` reject, `EVEN`/`ODD` still parse), and the leading-sign cases (`*n-3` / `~n` / `+-n 5` reject, `+n- 5` parses as `n-5`, `+n` / `+n-7` still parse). The correctness tests fail on the unfixed build (2 fail) and pass with the fix.

`css.test.ts` (1093 tests) and `doesnt_crash.test.ts` (61 tests) pass unchanged.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 9 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/nth-anplusb-ident.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (04edac259)

test/js/bun/css/nth-anplusb-ident.test.ts:
(pass) An+B idents longer than the keyword literals parse deterministically [13.42ms]
24 | 
25 | // The `even`/`odd`/`n`/... keyword checks must be exact-length, not prefix
26 | // matches: `e` is not `even`, `o` is not `odd`.
27 | test("An+B idents shorter than a keyword are rejected, not prefix-matched", () => {
28 |   for (const sel of ["e", "ev", "eve", "o", "od"]) {
29 |     expect(() => minifyTest(`:nth-child(${sel}) {width: 20px}`, "")).toThrow("Unexpected token");
                                                                          ^
error: expect(received).toThrow(expected)

Expected substring: "Unexpected token"

Received function did not throw
Received va
... (truncated)

release without fix: 2 failed, 1 skipped
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/css/nth-anplusb-ident.test.ts:
(pass) An+B idents longer than the keyword literals parse deterministically [1.02ms]
24 | 
25 | // The `even`/`odd`/`n`/... keyword checks must be exact-length, not prefix
26 | // matches: `e` is not `even`, `o` is not `odd`.
27 | test("An+B idents shorter than a keyword are rejected, not prefix-matched", () => {
28 |   for (const sel of ["e", "ev", "eve", "o", "od"]) {
29 |     expect(() => minifyTest(`:nth-child(${sel}) {width: 20px}`, "")).toThrow("Unexpected token");
                                                                          ^
error: expect(received).toThrow(expected)

Expected substring: "Unexpected token"

Received function did not throw
Received value: ":nth-child(2n){width:20px}"

      at <anonymous> (/workspace/bun/test/js/bun/css/nth-anplusb-ident.test.ts:29:70)
(fail) An+B idents shorter than a keyword are rejected, not prefix-matched [0.25ms]
36 | });
37 | 
38 | // Only `'+'` may precede the `n...` ident in An+B. Any other leading delimiter
39 | // is a parse error, and after `+` the `n-` form (not `-n`) takes a signless B.
40 | test("An+B explicit leading si
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/nth-anplusb-ident.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (04edac259)

test/js/bun/css/nth-anplusb-ident.test.ts:
(pass) An+B idents longer than the keyword literals parse deterministically [12.94ms]
(pass) An+B idents shorter than a keyword are rejected, not prefix-matched [8.27ms]
(pass) An+B explicit leading sign is '+' only [7.54ms]
(pass) An-B parse does not create a mimalloc heap per selector [309.76ms]
(pass) An-B without spaces parses via all three token shapes [4.65ms]
(pass) fuzzer-minimized input: unterminated :nth-child( with an `Nn` ident [851.51ms]

 6 pass
 0 fail
 27 expect() calls
Ran 6 tests across 1 file. [3.20s]
__F:0:S:0

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     04edac2594
  features     (none)

22 deps, 106 codegen, 1168 objects in 758ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [15.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [7.00ms]
[3/1231] gen bindgenv2
[4/1231] fetch picohttpparser
[picohttpparser] up to date
[5/1231] gen ErrorCode+*.h
[6/1231] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[7/1231] gen .bind.ts → GeneratedBindings.cpp
[8/1231]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bun_alloc/MimallocArena.rs            | 15 +++++++
 src/bun_alloc/lib.rs                      |  2 +-
 src/codegen/generate-js2native.ts         |  1 +
 src/css/css_parser.rs                     | 37 +++++++++-------
 src/js/internal-for-testing.ts            |  2 +
 src/runtime/api/UnsafeObject.rs           | 10 +++++
 test/js/bun/css/nth-anplusb-ident.test.ts | 72 ++++++++++++++++++++++++++++++-
 7 files changed, 120 insertions(+), 19 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/bun_alloc/MimallocArena.rs                 3      1     17
src/bun_alloc/lib.rs                           1      1     17
src/codegen/generate-js2native.ts              1      1     18
src/css/css_parser.rs                          6      7     17
src/js/internal-for-testing.ts                 3      3     17
src/runtime/api/UnsafeObject.rs                2      1     17
test/js/bun/css/nth-anplusb-ident.test.ts      3      7     17
```

</details>

<!-- robobun:evidence:end -->