### PR TITLE
css: fix clamp() simplification to preserve min argument

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -384,14 +384,12 @@ impl<V: CalcValue> Calc<V> {
                 })?;
 
                 // According to the spec, the minimum should "win" over the maximum if they are in the wrong order.
-                let cmp = if let (Some(mx), Calc::Value(cv)) = (&max, &center) {
-                    if let Calc::Value(mv) = mx {
+                let cmp = match (&max, &center) {
+                    (Some(Calc::Value(mv)), Calc::Value(cv)) => {
                         protocol::PartialCmp::partial_cmp(&**cv, &**mv)
-                    } else {
-                        None
                     }
-                } else {
-                    None
+                    (Some(Calc::Number(mv)), Calc::Number(cv)) => cv.partial_cmp(mv),
+                    _ => None,
                 };
 
                 // If center is known to be greater than the maximum, replace it with maximum and remove the max argument.
@@ -406,10 +404,12 @@ impl<V: CalcValue> Calc<V> {
                 }
 
                 if cmp.is_some() {
-                    let cmp = if let (Some(Calc::Value(mv)), Calc::Value(cv)) = (&min, &center) {
-                        protocol::PartialCmp::partial_cmp(&**cv, &**mv)
-                    } else {
-                        None
+                    let cmp = match (&min, &center) {
+                        (Some(Calc::Value(mv)), Calc::Value(cv)) => {
+                            protocol::PartialCmp::partial_cmp(&**cv, &**mv)
+                        }
+                        (Some(Calc::Number(mv)), Calc::Number(cv)) => cv.partial_cmp(mv),
+                        _ => None,
                     };
 
                     // If center is known to be less than the minimum, replace it with minimum and remove the min argument.

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -401,7 +401,26 @@ impl<V: CalcValue> Calc<V> {
                         let val = max.take().unwrap();
                         center = val;
                     } else {
-                        min = None;
+                        max = None;
+                    }
+                }
+
+                if cmp.is_some() {
+                    let cmp = if let (Some(Calc::Value(mv)), Calc::Value(cv)) = (&min, &center) {
+                        protocol::PartialCmp::partial_cmp(&**cv, &**mv)
+                    } else {
+                        None
+                    };
+
+                    // If center is known to be less than the minimum, replace it with minimum and remove the min argument.
+                    // Otherwise, if center is known to be greater than the minimum, remove the min argument.
+                    if let Some(cmp_val) = cmp {
+                        if cmp_val == Ordering::Less {
+                            let val = min.take().unwrap();
+                            center = val;
+                        } else {
+                            min = None;
+                        }
                     }
                 }
 

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -149,6 +149,15 @@ describe("css tests", () => {
     ); // ideally -400% - 8vh + 3ic
     minify_test(`a { top: calc(100% - 1 * 2 - 8 * 2); }`, `a{top:calc(100% - 2 - 16)}`); // ideally 100% - 18
   });
+  describe("clamp simplification", () => {
+    minify_test(".foo{width:clamp(10px,15px,20px)}", ".foo{width:15px}");
+    minify_test(".foo{width:clamp(10px,5px,20px)}", ".foo{width:10px}");
+    minify_test(".foo{width:clamp(10px,30px,20px)}", ".foo{width:20px}");
+    minify_test(".foo{width:clamp(10vw,5px,20px)}", ".foo{width:max(10vw,5px)}");
+    minify_test(".foo{width:clamp(10vw,30px,20px)}", ".foo{width:max(10vw,20px)}");
+    minify_test(".foo{width:clamp(10px,5vw,20px)}", ".foo{width:clamp(10px,5vw,20px)}");
+    minify_test(".foo{width:clamp(10px,15px,20vw)}", ".foo{width:clamp(10px,15px,20vw)}");
+  });
   describe("border_spacing", () => {
     minify_test(
       `

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -157,6 +157,9 @@ describe("css tests", () => {
     minify_test(".foo{width:clamp(10vw,30px,20px)}", ".foo{width:max(10vw,20px)}");
     minify_test(".foo{width:clamp(10px,5vw,20px)}", ".foo{width:clamp(10px,5vw,20px)}");
     minify_test(".foo{width:clamp(10px,15px,20vw)}", ".foo{width:clamp(10px,15px,20vw)}");
+    minify_test(".foo{line-height:clamp(1,1.5,2)}", ".foo{line-height:1.5}");
+    minify_test(".foo{line-height:clamp(2,1.5,4)}", ".foo{line-height:2}");
+    minify_test(".foo{line-height:clamp(1,5,4)}", ".foo{line-height:4}");
   });
   describe("border_spacing", () => {
     minify_test(


### PR DESCRIPTION
## Repro

```sh
printf '.a{width:clamp(10px,5px,20px)}.b{width:clamp(10vw,5px,20px)}' > /tmp/c.css
bun build /tmp/c.css
```

Before:
```css
.a, .b {
  width: min(20px, 5px);
}
```

After:
```css
.a {
  width: 10px;
}
.b {
  width: max(10vw, 5px);
}
```

## Cause

In `CalcUnit::Clamp` (`src/css/values/calc.rs`), when `center` and `max` are both comparable values and `center <= max`, the code set `min = None` where the comment and lightningcss both say to remove the `max` argument. The result hit the `(None, Some(max))` match arm and emitted `min(max, center)`, discarding the lower bound.

The Zig reference at `calc.zig:470` has the same `min = null` typo, but a second bug at `calc.zig:474` (`switch_val` checks `min != null` for both bits) masked it by only ever producing `0b00` or `0b11`. The Rust port fixed the switch discriminant (`match (min, max)`), which exposed the first bug as a behavior change: `clamp(10vw, 5px, 20px)` went from `5px` (Zig, wrong) to `min(20px, 5px)` (Rust, also wrong, and longer).

## Fix

Set `max = None` on the Less/Equal branch, matching the comment and [lightningcss](https://github.com/parcel-bundler/lightningcss/blob/master/src/values/calc.rs). Also restores the second reduction step from lightningcss that compares `center` against `min` after the first reduction, so fully comparable inputs collapse to a single value instead of a two-argument `max()`.

## Verification

Added a `clamp simplification` block to `test/js/bun/css/css.test.ts` covering in-range, below-min, above-max, mixed-unit min, and incomparable-center/max cases. With `src/` reverted 4 of 7 fail (including the `10vw` repro); with the fix all 7 pass. Full `css.test.ts` passes (1100 pass / 67 skip).