### PR TITLE
install: write failed lifecycle script output verbatim

### DIFF
--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -829,18 +829,23 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             Output::disable_buffering();
             Output::flush();
 
+            // Write the captured bytes verbatim. Routing through `format_args!` /
+            // `BStr`'s `Display` impl would replace every invalid-UTF-8 byte with
+            // U+FFFD, corrupting CP1252/Latin-1/binary output from the script.
             if stdout_len > 0 {
                 let stdout = self.stdout.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stdout.as_slice())));
+                let w = Output::error_writer();
+                let _ = w.write_all(stdout.as_slice());
+                let _ = w.write_all(b"\n");
                 stdout.clear();
                 stdout.shrink_to_fit();
             }
 
             if stderr_len > 0 {
                 let stderr = self.stderr.final_buffer();
-                let _ = Output::error_writer()
-                    .write_fmt(format_args!("{}\n", bstr::BStr::new(stderr.as_slice())));
+                let w = Output::error_writer();
+                let _ = w.write_all(stderr.as_slice());
+                let _ = w.write_all(b"\n");
                 stderr.clear();
                 stderr.shrink_to_fit();
             }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3999,3 +3999,61 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     });
   });
 }
+
+test.concurrent("failed lifecycle script output preserves non-UTF-8 bytes", async () => {
+  using ctx = await setupTest();
+  const { packageDir, packageJson, env } = ctx;
+
+  const depDir = join(packageDir, "dep");
+  await mkdir(depDir, { recursive: true });
+  await Promise.all([
+    write(
+      join(depDir, "emit.js"),
+      // 0xC0 and 0xC1 never appear in valid UTF-8.
+      `process.stdout.write(Buffer.from([0x41, 0x42, 0xC0, 0xC1, 0x43, 0x44]));\n` +
+        `process.stderr.write(Buffer.from([0x61, 0x62, 0xFE, 0xFF, 0x63, 0x64]));\n` +
+        `process.exit(1);\n`,
+    ),
+    write(
+      join(depDir, "package.json"),
+      JSON.stringify({
+        name: "dep",
+        version: "1.0.0",
+        scripts: {
+          postinstall: `${bunExe()} emit.js`,
+        },
+      }),
+    ),
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          dep: "file:./dep",
+        },
+        trustedDependencies: ["dep"],
+      }),
+    ),
+  ]);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stderrBytes, exitCode] = await Promise.all([proc.stderr.bytes(), proc.stdout.bytes(), proc.exited]);
+
+  const hex = Buffer.from(stderrBytes).toString("hex");
+  // Script stdout: must appear byte-for-byte (AB<C0><C1>CD).
+  expect(hex).toContain("4142c0c14344");
+  // Script stderr: must appear byte-for-byte (ab<FE><FF>cd).
+  expect(hex).toContain("6162feff6364");
+  // Must not contain U+FFFD (EF BF BD), the replacement char BStr's Display would emit.
+  expect(hex).not.toContain("efbfbd");
+  expect(exitCode).not.toBe(0);
+});

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -4046,7 +4046,7 @@ test.concurrent("failed lifecycle script output preserves non-UTF-8 bytes", asyn
     env,
   });
 
-  const [stderrBytes, exitCode] = await Promise.all([proc.stderr.bytes(), proc.stdout.bytes(), proc.exited]);
+  const [stderrBytes, , exitCode] = await Promise.all([proc.stderr.bytes(), proc.stdout.bytes(), proc.exited]);
 
   const hex = Buffer.from(stderrBytes).toString("hex");
   // Script stdout: must appear byte-for-byte (AB<C0><C1>CD).


### PR DESCRIPTION
## Problem

When a lifecycle script (postinstall etc.) exits non-zero, `print_output()` dumps the captured stdout/stderr to the terminal. The Rust port routed this through `format_args!("{}\n", bstr::BStr::new(...))`, and `bstr::BStr`'s `Display` impl replaces every invalid-UTF-8 sequence with U+FFFD (`0xEF 0xBF 0xBD`).

A postinstall that emits CP1252/Latin-1 (common from Windows child tools), raw terminal control bytes, or any high-bit/binary content had those bytes silently replaced in the printed failure output. The Zig reference uses `{s}` on `[]const u8`, which calls `writeAll` and passes every byte through unchanged.

## Repro

A trusted dependency whose postinstall writes `41 42 C0 C1 43 44` to stdout and exits 1. Before this change, `bun install` prints `41 42 EF BF BD EF BF BD 43 44` on stderr.

## Fix

Use `Output::error_writer().write_all(buf)` + `write_all(b"\n")` on the raw byte buffer, matching the Zig reference and the same byte-exact pattern `resolution.rs` uses via `write_to()` for persisted output.

## Verification

New test in `test/cli/install/bun-install-lifecycle-scripts.test.ts` spawns a trusted `file:` dep whose postinstall writes `0xC0 0xC1` (stdout) and `0xFE 0xFF` (stderr) and exits 1, then asserts the raw hex appears in `bun install` stderr with no `efbfbd`.

- fails on main: `expect(hex).toContain("4142c0c14344")` receives `...4142efbfbdefbfbd4344...`
- passes with this change