### PR TITLE
node:fs: skip zero-fill of 256 KB pre-stat buffer in async readFile

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -7138,12 +7138,18 @@ impl NodeFS {
         // The sync case borrows `vm.rareData().pipeReadBuffer()` (a per-VM
         // 256 KB heap slab) when a VM is present, otherwise leaves the buffer
         // zero-length so the loop is skipped and we fall through to fstat.
-        // The async path heap-allocates a 256 KB buffer instead.
-        let mut async_stack_buffer: Vec<u8> = if flavor == Flavor::Sync {
-            Vec::new()
-        } else {
-            vec![0u8; 256 * 1024]
-        };
+        // The async path heap-allocates a 256 KB buffer instead (Zig used a
+        // comptime-sized stack array; Rust cannot size a stack array on
+        // `flavor`, so heap is forced, but the slab stays uninitialised: it
+        // is write-only, `Syscall::read` hands it straight to the kernel).
+        use bun_collections::vec_ext::VecExt as _;
+        let mut async_stack_buffer: Vec<u8> = Vec::new();
+        if flavor != Flavor::Sync && async_stack_buffer.try_reserve_exact(256 * 1024).is_ok() {
+            // SAFETY: `u8` has no validity invariant; the buffer is handed
+            // straight to the kernel which only stores into it. Only the
+            // `[..total]` prefix actually filled by `read` is ever observed.
+            unsafe { async_stack_buffer.expand_to_capacity() };
+        }
         let pre_stat_buf: &mut [u8] = if flavor == Flavor::Sync {
             match self.vm {
                 // SAFETY: `self.vm` is the live owning `*mut VirtualMachine`;
@@ -7285,7 +7291,6 @@ impl NodeFS {
         // specialisation), which dominated `readFileSync` of large files. Use
         // `VecExt::expand_to_capacity` (the tail is write-only — `Syscall::read`
         // hands it straight to the kernel, which only stores into it).
-        use bun_collections::vec_ext::VecExt as _;
         // SAFETY: `u8` has no validity invariant; the buffer is handed straight
         // to the kernel which only stores into it.
         unsafe { buf.expand_to_capacity() };


### PR DESCRIPTION
### What

The async flavor of `readFileWithOptions` allocates a 256 KB scratch buffer for the read-before-stat optimization. In Zig (`node_fs.zig:5193`) this was a comptime-sized uninitialised stack array:

```zig
var async_stack_buffer: [if (flavor == .sync) 0 else 256 * 1024]u8 = undefined;
```

The Rust port (`node_fs.rs:7145`) cannot size a stack array on `flavor`, so it heap-allocates, but used `vec![0u8; 256 * 1024]`, which also zero-fills the slab on every async `fs.readFile` / `fs.promises.readFile` call. The buffer is write-only: it is handed straight to `Syscall::read` and only the `[..total]` prefix the kernel filled is ever observed. The 256 KB memset is wasted work the Zig version did not do.

### Fix

Allocate via `try_reserve_exact` + `VecExt::expand_to_capacity`, matching the uninit-slab pattern already used in `copy_file_using_read_write_loop` (node_fs.rs:4896) and the post-stat read loop later in the same function. On allocation failure the buffer is left empty and the pre-stat loop is skipped, falling through to fstat (same behaviour as the sync-without-VM path already has).

### Verification

```
bun bd test test/js/node/fs/fs.test.ts -t readFile
# 20 pass, 1 skip (windows), 0 fail
```