### PR TITLE
css: render full token shape in parse error messages

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5768,11 +5768,15 @@ impl Token {
                 writer.write_all(b"@")?;
                 serializer::serialize_identifier(v, writer)
             }
-            Token::UnrestrictedHash(v) | Token::IdHash(v) => {
+            Token::UnrestrictedHash(v) => {
                 writer.write_all(b"#")?;
                 serializer::serialize_name(v, writer)
             }
-            Token::QuotedString(x) => serializer::serialize_name(x, writer),
+            Token::IdHash(v) => {
+                writer.write_all(b"#")?;
+                serializer::serialize_identifier(v, writer)
+            }
+            Token::QuotedString(x) => serializer::serialize_string(x, writer),
             Token::UnquotedUrl(x) => {
                 writer.write_all(b"url(")?;
                 serializer::serialize_unquoted_url(x, writer)?;
@@ -5939,9 +5943,8 @@ impl Token {
     }
 }
 
-// `impl Display for Token` lives at crate root (lib.rs) — minimal rendering
-// for error messages only. The CSS-serialization-correct form is
-// `Token::to_css_generic` above.
+// `impl Display for Token` lives at crate root (lib.rs) and delegates to
+// `Token::to_css_generic` above so error messages render the full token shape.
 
 /// Byte-writer trait for `serializer` and `to_css_generic`.
 /// Aliased to the canonical `bun_io::Write`; the associated

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -5944,7 +5944,7 @@ impl Token {
 }
 
 // `impl Display for Token` lives at crate root (lib.rs) and delegates to
-// `Token::to_css_generic` above so error messages render the full token shape.
+// `Token::to_css_generic` above.
 
 /// Byte-writer trait for `serializer` and `to_css_generic`.
 /// Aliased to the canonical `bun_io::Write`; the associated

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -435,9 +435,7 @@ pub enum Token {
 
 impl core::fmt::Display for Token {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Render the full CSS token shape so `Unexpected token: …` diagnostics
-        // show `#foo`, `@foo`, `url(a b)`, `"…"`, `foo(` instead of the bare
-        // inner slice. Matches `Token.format` in css_parser.zig.
+        // Matches `Token.format` in css_parser.zig.
         let mut w = bun_io::FmtAdapter::new(f);
         self.to_css_generic(&mut w).map_err(|_| core::fmt::Error)
     }

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -435,43 +435,10 @@ pub enum Token {
 
 impl core::fmt::Display for Token {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        // Minimal rendering for error messages. Full CSS serialization
-        // lives in `css_parser.rs` via `serializer::*`.
-        use bstr::BStr;
-        match self {
-            Token::Ident(v)
-            | Token::Function(v)
-            | Token::AtKeyword(v)
-            | Token::UnrestrictedHash(v)
-            | Token::IdHash(v)
-            | Token::QuotedString(v)
-            | Token::BadString(v)
-            | Token::UnquotedUrl(v)
-            | Token::BadUrl(v)
-            | Token::Whitespace(v)
-            | Token::Comment(v) => {
-                write!(f, "{}", BStr::new(v))
-            }
-            Token::Delim(c) => write!(f, "{}", char::from_u32(*c).unwrap_or('\u{FFFD}')),
-            Token::Number(n) => write!(f, "{}", n.value),
-            Token::Percentage { unit_value, .. } => write!(f, "{}%", *unit_value * 100.0),
-            Token::Dimension(d) => write!(f, "{}{}", d.num.value, BStr::new(d.unit)),
-            Token::Cdo => f.write_str("<!--"),
-            Token::Cdc => f.write_str("-->"),
-            Token::IncludeMatch => f.write_str("~="),
-            Token::DashMatch => f.write_str("|="),
-            Token::PrefixMatch => f.write_str("^="),
-            Token::SuffixMatch => f.write_str("$="),
-            Token::SubstringMatch => f.write_str("*="),
-            Token::Colon => f.write_str(":"),
-            Token::Semicolon => f.write_str(";"),
-            Token::Comma => f.write_str(","),
-            Token::OpenSquare => f.write_str("["),
-            Token::CloseSquare => f.write_str("]"),
-            Token::OpenParen => f.write_str("("),
-            Token::CloseParen => f.write_str(")"),
-            Token::OpenCurly => f.write_str("{"),
-            Token::CloseCurly => f.write_str("}"),
-        }
+        // Render the full CSS token shape so `Unexpected token: …` diagnostics
+        // show `#foo`, `@foo`, `url(a b)`, `"…"`, `foo(` instead of the bare
+        // inner slice. Matches `Token.format` in css_parser.zig.
+        let mut w = bun_io::FmtAdapter::new(f);
+        self.to_css_generic(&mut w).map_err(|_| core::fmt::Error)
     }
 }

--- a/test/js/bun/css/token-display-error-message.test.ts
+++ b/test/js/bun/css/token-display-error-message.test.ts
@@ -4,13 +4,6 @@ import { bunEnv, bunExe, tempDir } from "harness";
 
 const { minifyTest } = cssInternals;
 
-// `impl Display for Token` used to collapse every string-carrying token variant
-// to its bare inner slice, so `Unexpected token: …` diagnostics lost the
-// structural context (`#foo` → `foo`, `@foo` → `foo`, `url(a b)` → `a b`,
-// `"bar"` → `bar`, `foo(` → `foo`). The Display impl now delegates to
-// `Token::to_css_generic`, which renders the full CSS token shape (matching
-// the Zig `Token.format` reference).
-
 function parseError(src: string): string {
   try {
     minifyTest(src, "");

--- a/test/js/bun/css/token-display-error-message.test.ts
+++ b/test/js/bun/css/token-display-error-message.test.ts
@@ -1,0 +1,75 @@
+import { cssInternals } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+const { minifyTest } = cssInternals;
+
+// `impl Display for Token` used to collapse every string-carrying token variant
+// to its bare inner slice, so `Unexpected token: …` diagnostics lost the
+// structural context (`#foo` → `foo`, `@foo` → `foo`, `url(a b)` → `a b`,
+// `"bar"` → `bar`, `foo(` → `foo`). The Display impl now delegates to
+// `Token::to_css_generic`, which renders the full CSS token shape (matching
+// the Zig `Token.format` reference).
+
+function parseError(src: string): string {
+  try {
+    minifyTest(src, "");
+  } catch (e) {
+    return (e as Error).message;
+  }
+  throw new Error(`expected parse error for: ${src}`);
+}
+
+describe("CSS parse errors render the full token shape", () => {
+  test("hash token (#foo, #123)", () => {
+    expect(parseError("@media screen and #foo {}")).toBe("parsing failed: Unexpected token: #foo");
+    expect(parseError("@media screen and #123 {}")).toBe("parsing failed: Unexpected token: #123");
+  });
+
+  test("at-keyword token (@foo)", () => {
+    expect(parseError("@media screen and @foo {}")).toBe("parsing failed: Unexpected token: @foo");
+  });
+
+  test("function token (foo()", () => {
+    expect(parseError("@media screen and foo() {}")).toBe("parsing failed: Unexpected token: foo(");
+  });
+
+  test('quoted-string token ("bar")', () => {
+    expect(parseError('@media screen and "bar" {}')).toBe('parsing failed: Unexpected token: "bar"');
+  });
+
+  test("bad-url token (url(a b))", () => {
+    expect(parseError("a { background: url(a b) }")).toBe("parsing failed: Unexpected token: url(a b)");
+  });
+
+  test("selector errors that embed a token", () => {
+    expect(parseError("[@foo] {}")).toBe(
+      "parsing failed: Invalid selector. Missing qualified name in attribute selector: @foo",
+    );
+    expect(parseError("a[b=#foo] {}")).toBe(
+      "parsing failed: Invalid selector. Invalid value in attribute selector: #foo",
+    );
+  });
+});
+
+test("`bun build` surfaces the full token shape in the CLI diagnostic", async () => {
+  using dir = tempDir("css-token-display", {
+    "entry.css": "@media screen and #foo { a { b: 1 } }\n",
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "entry.css"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "",
+    stderr: expect.stringContaining("error: Unexpected token: #foo"),
+    exitCode: 1,
+  });
+});


### PR DESCRIPTION
## Repro

```sh
printf '@media screen and #foo{a{b:1}}' > /tmp/x.css
bun build /tmp/x.css
```

Before:
```
error: Unexpected token: foo
```

After (matches the Zig `Token.format` reference and prior releases):
```
error: Unexpected token: #foo
```

Same loss of context for `@foo` (at-keyword), `foo(` (function), `"bar"` (quoted string), `url(a b)` (bad-url), and every selector error that embeds a `Token`.

## Cause

`impl Display for Token` in `src/css/lib.rs` collapsed every string-carrying variant (`Ident`, `Function`, `AtKeyword`, `UnrestrictedHash`, `IdHash`, `QuotedString`, `BadString`, `UnquotedUrl`, `BadUrl`, `Whitespace`, `Comment`) into a single arm that printed only the inner byte slice. The Zig reference `Token.format` (`src/css/css_parser.zig`) renders the full CSS token shape: `#name`, `@name`, `name(`, `"…"`, `url(…)`, `/*…*/`.

## Fix

`Display` now delegates to the existing `Token::to_css_generic` (the faithful port of `Token.format`) via `bun_io::FmtAdapter`. While aligning with the Zig reference, two adjacent divergences in `to_css_generic` were fixed: `QuotedString` now calls `serialize_string` (was `serialize_name`), and `IdHash` is split from `UnrestrictedHash` to use `serialize_identifier`.

## Verification

`test/js/bun/css/token-display-error-message.test.ts` asserts the exact diagnostic text for each affected token variant through both `bun:internal-for-testing` and `bun build`. All 7 cases fail on `main` and pass with this change. `test/js/bun/css/css.test.ts` (1093 tests) still passes.