### PR TITLE
fix(parser): encoding-aware compare for UTF-16 object key in ({k:v}).k folding

### DIFF
--- a/src/js_parser/fold.rs
+++ b/src/js_parser/fold.rs
@@ -41,8 +41,7 @@ fn e_string_eql_bytes(s: &E::EString, other: &[u8]) -> bool {
     if !s.is_utf16 {
         s.data == other
     } else {
-        let s16 = s.slice16();
-        s16.len() == other.len() && s16.iter().zip(other).all(|(&c, &b)| c == b as u16)
+        bun_core::strings::utf16_eql_string(s.slice16(), other)
     }
 }
 

--- a/test/bundler/bundler_minify.test.ts
+++ b/test/bundler/bundler_minify.test.ts
@@ -341,6 +341,38 @@ describe("bundler", () => {
     minifySyntax: true,
     minifyWhitespace: true,
   });
+  itBundled("minify/InlineSingleObjectPropertyNonAscii", {
+    files: {
+      "/entry.js": /* js */ `
+        // key "\\u00c3\\u00a9" is the two-char string "Ã©"; accessor .é is one char "é".
+        // The UTF-8 bytes of "é" (0xC3 0xA9) numerically match the key's UTF-16 code
+        // units, but the strings are different and this must NOT be inlined.
+        const a = ({ "\\u00c3\\u00a9": 0x1001 }).é;
+        // key is "é" via escape; accessor is "é". Same string, should inline.
+        const b = ({ "\\u00e9": 0x2002 }).é;
+        // key is a literal "é"; accessor is "é". Same string, should inline.
+        const c = ({ "é": 0x3003 }).é;
+        // ascii baseline still inlines.
+        const d = ({ "e": 0x4004 }).e;
+        console.log(JSON.stringify([a, b, c, d]));
+      `,
+    },
+    minifySyntax: true,
+    target: "bun",
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // the mismatched key must not fold to its value: 4097 should still
+      // live inside an object literal, not as a bare expression
+      expect(out).toMatch(/:\s*4097\s*\}/);
+      // the matching non-ascii keys must fold: their object literals are gone
+      expect(out).not.toMatch(/:\s*8194\b/);
+      expect(out).not.toMatch(/:\s*12291\b/);
+      expect(out).not.toMatch(/:\s*16388\b/);
+    },
+    run: {
+      stdout: "[null,8194,12291,16388]",
+    },
+  });
   itBundled("minify/ForAndWhileLoopsWithMissingBlock", {
     files: {
       "/entry.js": /* js */ `


### PR DESCRIPTION
## Repro

```sh
printf 'let x = ({"\\u00c3\\u00a9": 42}).\303\251;\nconsole.log(x);\n' > /tmp/t.js
node /tmp/t.js                                    # undefined
bun build --no-bundle --minify-syntax /tmp/t.js   # let x = 42;  ← wrong
```

## Cause

`e_string_eql_bytes` in `src/js_parser/fold.rs` handled the UTF-16 branch by widening each UTF-8 byte of the property name to `u16` and comparing element-wise against the key's UTF-16 code units. The Zig reference (`EString.eql` → `strings.utf16EqlString`) decodes to codepoints before comparing.

Under `--minify-syntax`, the `({key: v}).name → v` rewrite then misfires:

- **Miscompile:** `({"\u00c3\u00a9": 42}).é` folds to `42`. The key is the two-char string `Ã©` (code units `[0xC3, 0xA9]`) and the accessor is `é` (UTF-8 bytes `[0xC3, 0xA9]`); byte-widening makes them look equal but they are different strings. Node evaluates the original to `undefined`.
- **Missed fold:** `({"\u00e9": 42}).é` does not fold. Key `[0x00E9]` has length 1, name bytes `[0xC3, 0xA9]` have length 2, so the length check rejects the match even though both are `é`.

## Fix

Call `bun_core::strings::utf16_eql_string` for the UTF-16 branch, matching `EString::eql_bytes` in `src/ast/e.rs` and the original Zig.

## Verification

`test/bundler/bundler_minify.test.ts` → `minify/InlineSingleObjectPropertyNonAscii` fails on the released build, passes on this branch. Full `bundler_minify.test.ts` (40 tests) and `bundler_string.test.ts` (59 tests) pass.