### PR TITLE
os.networkInterfaces: fix IPv6 address/netmask/cidr formatting

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -2385,6 +2385,12 @@ pub fn format_ip<'a>(
         start += 1;
         end -= 1;
     }
+    // Strip `%<zone>` — Node formats addresses via uv_inet_ntop on the bare
+    // in6_addr and never includes the zone identifier; the scope is exposed
+    // separately (e.g. `scopeid` in os.networkInterfaces()).
+    if let Some(percent) = into[start..end].iter().position(|&b| b == b'%') {
+        end = start + percent;
+    }
     Ok(&mut into[start..end])
 }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8681,26 +8681,43 @@ pub mod net {
     }
     impl fmt::Display for Address {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            // Minimal: print family for now; full impl in `bun_dns::address_to_string`.
-            match self.as_in4() {
-                Some(v4) => {
-                    // `sin_addr` is `in_addr { s_addr: u32 }` on POSIX/ws2_32 but
-                    // `[u8; 4]` in `bun_libuv_sys::sockaddr_in`; reinterpret as
-                    // raw octets so both shapes resolve.
-                    // SAFETY: `sin_addr` is 4 bytes of POD on every target.
-                    let octets: [u8; 4] =
-                        unsafe { *core::ptr::addr_of!(v4.sin_addr).cast::<[u8; 4]>() };
-                    write!(
-                        f,
-                        "{}.{}.{}.{}:{}",
-                        octets[0],
-                        octets[1],
-                        octets[2],
-                        octets[3],
-                        u16::from_be(v4.sin_port)
-                    )
-                }
-                None => write!(f, "<addr family={}>", self.family()),
+            if let Some(v4) = self.as_in4() {
+                // `sin_addr` is `in_addr { s_addr: u32 }` on POSIX/ws2_32 but
+                // `[u8; 4]` in `bun_libuv_sys::sockaddr_in`; reinterpret as
+                // raw octets so both shapes resolve.
+                // SAFETY: `sin_addr` is 4 bytes of POD on every target.
+                let octets: [u8; 4] =
+                    unsafe { *core::ptr::addr_of!(v4.sin_addr).cast::<[u8; 4]>() };
+                write!(
+                    f,
+                    "{}.{}.{}.{}:{}",
+                    octets[0],
+                    octets[1],
+                    octets[2],
+                    octets[3],
+                    u16::from_be(v4.sin_port)
+                )
+            } else if let Some(v6) = self.as_in6() {
+                // `sin6_addr` is `in6_addr { s6_addr: [u8; 16] }` on every
+                // target; reinterpret as raw octets to stay independent of the
+                // wrapper struct name.
+                // SAFETY: `sin6_addr` is 16 bytes of POD on every target.
+                let octets: [u8; 16] =
+                    unsafe { *core::ptr::addr_of!(v6.sin6_addr).cast::<[u8; 16]>() };
+                // `SocketAddrV6`'s Display emits `[addr]:port` (with `%scope`
+                // when nonzero), matching Zig's `std.net.Ip6Address.format` —
+                // the shape `bun_core::fmt::format_ip` expects to strip.
+                fmt::Display::fmt(
+                    &std::net::SocketAddrV6::new(
+                        std::net::Ipv6Addr::from(octets),
+                        u16::from_be(v6.sin6_port),
+                        u32::from_be(v6.sin6_flowinfo),
+                        v6.sin6_scope_id,
+                    ),
+                    f,
+                )
+            } else {
+                write!(f, "<addr family={}>", self.family())
             }
         }
     }

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { realpathSync } from "fs";
 import { isWindows } from "harness";
+import { isIPv4, isIPv6 } from "node:net";
 import * as os from "node:os";
 
 it("arch", () => {
@@ -156,12 +157,44 @@ it("networkInterfaces", () => {
         // may be null
         expect(typeof nI.cidr).toBe("string");
 
+      if (nI.family === "IPv4") {
+        expect(isIPv4(nI.address)).toBeTrue();
+        expect(isIPv4(nI.netmask)).toBeTrue();
+      }
       if (nI.family === "IPv6") {
         expect(nI.scopeid).toBeNumber();
         expect(nI.scope_id).toBeUndefined();
+        // The address may carry a zone suffix (e.g. fe80::1%5) for link-local
+        // entries; strip it before validating with net.isIPv6().
+        expect(isIPv6(nI.address.split("%")[0])).toBeTrue();
+        expect(isIPv6(nI.netmask)).toBeTrue();
+        if (nI.cidr) {
+          const [addr, suffix] = nI.cidr.split("/");
+          expect(isIPv6(addr.split("%")[0])).toBeTrue();
+          expect(Number(suffix)).toBeWithin(0, 129);
+        }
       }
     }
   }
+});
+
+it("networkInterfaces IPv6 loopback", () => {
+  // Every supported platform has an IPv6 loopback entry (::1) on its loopback
+  // interface; its address/netmask/cidr must be the actual address, not a
+  // placeholder like "<addr family=...>".
+  const entries = Object.values(os.networkInterfaces())
+    .flat()
+    .filter(i => i.internal && i.family === "IPv6" && i.address === "::1");
+  expect(entries.length).toBeGreaterThan(0);
+  expect(entries[0]).toEqual({
+    address: "::1",
+    cidr: "::1/128",
+    netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+    family: "IPv6",
+    mac: expect.stringMatching(/^([0-9a-f]{2}:){5}[0-9a-f]{2}$/),
+    internal: true,
+    scopeid: 0,
+  });
 });
 
 it("machine", () => {

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -164,13 +164,15 @@ it("networkInterfaces", () => {
       if (nI.family === "IPv6") {
         expect(nI.scopeid).toBeNumber();
         expect(nI.scope_id).toBeUndefined();
-        // The address may carry a zone suffix (e.g. fe80::1%5) for link-local
-        // entries; strip it before validating with net.isIPv6().
-        expect(isIPv6(nI.address.split("%")[0])).toBeTrue();
+        expect(isIPv6(nI.address)).toBeTrue();
+        // Node exposes the zone only via the numeric `scopeid` field, never
+        // inline in `address`/`cidr`.
+        expect(nI.address).not.toContain("%");
         expect(isIPv6(nI.netmask)).toBeTrue();
         if (nI.cidr) {
           const [addr, suffix] = nI.cidr.split("/");
-          expect(isIPv6(addr.split("%")[0])).toBeTrue();
+          expect(isIPv6(addr)).toBeTrue();
+          expect(addr).not.toContain("%");
           expect(Number(suffix)).toBeWithin(0, 129);
         }
       }
@@ -179,13 +181,14 @@ it("networkInterfaces", () => {
 });
 
 it("networkInterfaces IPv6 loopback", () => {
-  // Every supported platform has an IPv6 loopback entry (::1) on its loopback
-  // interface; its address/netmask/cidr must be the actual address, not a
-  // placeholder like "<addr family=...>".
+  // The loopback interface's IPv6 address/netmask/cidr must be the actual
+  // address, not a placeholder like "<addr family=...>".
   const entries = Object.values(os.networkInterfaces())
     .flat()
-    .filter(i => i.internal && i.family === "IPv6" && i.address === "::1");
-  expect(entries.length).toBeGreaterThan(0);
+    .filter(i => i.internal && i.family === "IPv6" && i.scopeid === 0);
+  // Skip on hosts where IPv6 is disabled entirely (no ::1 on lo). The preceding
+  // test still catches the regression for any IPv6 entries that do exist.
+  if (entries.length === 0) return;
   expect(entries[0]).toEqual({
     address: "::1",
     cidr: "::1/128",

--- a/test/js/node/os/os.test.js
+++ b/test/js/node/os/os.test.js
@@ -189,7 +189,8 @@ it("networkInterfaces IPv6 loopback", () => {
   // Skip on hosts where IPv6 is disabled entirely (no ::1 on lo). The preceding
   // test still catches the regression for any IPv6 entries that do exist.
   if (entries.length === 0) return;
-  expect(entries[0]).toEqual({
+  const lo = entries.find(e => e.address === "::1") ?? entries[0];
+  expect(lo).toEqual({
     address: "::1",
     cidr: "::1/128",
     netmask: "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",


### PR DESCRIPTION
### Repro

```sh
bun -e 'const os=require("os");for(const [k,ifs] of Object.entries(os.networkInterfaces()))for(const i of ifs)if(i.family==="IPv6")console.log(JSON.stringify({iface:k,address:i.address,netmask:i.netmask,cidr:i.cidr}))'
```

Before:
```
{"iface":"lo","address":"<addr family=10>","netmask":"<addr family=10>","cidr":"<addr family=10>/128"}
```

After (matches Node.js):
```
{"iface":"lo","address":"::1","netmask":"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff","cidr":"::1/128"}
```

### Cause

`os.networkInterfaces()` formats every interface address/netmask via `bun_fmt::format_ip(&bun_sys::net::Address, ...)` (`src/runtime/node/node_os.rs:1076/1107/1288/1327`), which just delegates to the argument's `Display` impl and strips `:port` / `[..]`.

The `Display` impl for `bun_sys::net::Address` (`src/sys/lib.rs`) only handled `AF_INET`; any other family, including `AF_INET6`, fell through to `write!(f, "<addr family={}>", self.family())`. The Zig reference passed `std.net.Address` whose `format()` handles both IPv4 and IPv6.

Result: every IPv6 entry from `os.networkInterfaces()` had `address`/`netmask`/`cidr` set to the literal `"<addr family=10>"` (Linux) / `"<addr family=30>"` (macOS). Both the POSIX and Windows paths route through the same `Address::init_posix` + `format_ip` pair.

### Fix

- Add an `AF_INET6` arm to `impl Display for bun_sys::net::Address` that delegates to `std::net::SocketAddrV6`'s `Display`. That emits `[addr%scope]:port` (RFC 5952 compressed, scope only when nonzero), the same shape Zig's `std.net.Ip6Address.format` produced and what `format_ip` expects to strip.
- `format_ip` now also strips the `%zone` suffix. Node formats interface addresses via `uv_inet_ntop` on the bare `in6_addr` and never includes the zone; the scope is exposed only via the numeric `scopeid` field. Without this, link-local entries surfaced as `fe80::1%3`, which broke the vendored `test-dgram-udp6-link-local-address.js` (it appends its own `%ifname`, producing a doubled zone).

### Verification

`test/js/node/os/os.test.js`:
- the existing `networkInterfaces` test now asserts `net.isIPv4`/`net.isIPv6` on `address`/`netmask`/`cidr` and that IPv6 `address`/`cidr` contain no `%`
- new `networkInterfaces IPv6 loopback` test asserts the full shape of the `::1` entry (skips when the host has IPv6 disabled entirely)

Both fail on the current build (`<addr family=10>` is not a valid IPv6 string) and pass with this change. `cargo check -p bun_sys` passes on linux-gnu, apple-darwin and pc-windows-msvc.


Fixes #32408 (`portfinder` enumerates hosts via `os.networkInterfaces()`, receives `"<addr family=10>"` for the IPv6 loopback, then fails `server.listen(port, "<addr family=10>")`).
