### PR TITLE
fix(napi): leak of WTFStringImpl in napi_create_string_latin1

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -678,11 +678,10 @@ pub(super) extern "C" fn napi_create_string_latin1(
         return env.ok();
     }
 
-    let (string, bytes) = bun_core::String::create_uninitialized_latin1(slice.len());
-    // `string` derefs on Drop.
+    let (mut string, bytes) = bun_core::String::create_uninitialized_latin1(slice.len());
     bytes.copy_from_slice(slice);
 
-    let js = match string.to_js(env.to_js()) {
+    let js = match string.transfer_to_js(env.to_js()) {
         Ok(v) => v,
         Err(_) => return NapiEnv::set_last_error(Some(env), NapiStatus::generic_failure),
     };

--- a/src/runtime/webcore/Crypto.rs
+++ b/src/runtime/webcore/Crypto.rs
@@ -127,8 +127,7 @@ impl Crypto {
 
     // DOMJIT fast path.
     pub fn random_uuid_without_type_checks(&self, global: &JSGlobalObject) -> JSValue {
-        let (str, bytes) = BunString::create_uninitialized_latin1(36);
-        // `defer str.deref()` — BunString's Drop handles the deref.
+        let (mut str, bytes) = BunString::create_uninitialized_latin1(36);
 
         // randomUUID must have been called already many times before this kicks
         // in so we can skip the rare_data pointer check.
@@ -142,7 +141,7 @@ impl Crypto {
                 .expect("infallible: size matches"),
         );
         // DOMJIT fast path returns bare JSValue; OOM here is unrecoverable.
-        str.to_js(global).unwrap_or(JSValue::ZERO)
+        str.transfer_to_js(global).unwrap_or(JSValue::ZERO)
     }
 
     // `#[JsClass]` emits `CryptoClass__construct` calling this.

--- a/test/napi/napi-app/js_test_helpers.cpp
+++ b/test/napi/napi-app/js_test_helpers.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 #include <map>
 #include <string>
+#include <vector>
 
 namespace napitests {
 
@@ -226,6 +227,19 @@ static napi_value perform_set(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// create_latin1_string(byte_length): returns a JS string created via
+// napi_create_string_latin1. Used by the leak test in napi.test.ts.
+static napi_value create_latin1_string(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  uint32_t len;
+  NODE_API_CALL(env, napi_get_value_uint32(env, info[0], &len));
+  std::vector<char> buf(len, 'a');
+  napi_value result;
+  NODE_API_CALL(env,
+                napi_create_string_latin1(env, buf.data(), buf.size(), &result));
+  return result;
+}
+
 static napi_value make_empty_array(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
   napi_value js_size = info[0];
@@ -430,6 +444,7 @@ void register_js_test_helpers(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, perform_set);
   REGISTER_FUNCTION(env, exports, throw_error);
   REGISTER_FUNCTION(env, exports, create_and_throw_error);
+  REGISTER_FUNCTION(env, exports, create_latin1_string);
   REGISTER_FUNCTION(env, exports, make_empty_array);
   REGISTER_FUNCTION(env, exports, make_empty_object);
   REGISTER_FUNCTION(env, exports, add_tag);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -241,44 +241,6 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
   });
 
-  describe("napi_create_string_latin1", () => {
-    it("does not leak the WTFStringImpl", async () => {
-      const fixture = /* js */ `
-        const nativeTests = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"))});
-        const size = 64 * 1024;
-        for (let i = 0; i < 100; i++) {
-          const s = nativeTests.create_latin1_string(size);
-          if (s.length !== size) throw new Error("wrong length: " + s.length);
-        }
-        Bun.gc(true);
-        const before = process.memoryUsage.rss();
-        for (let i = 0; i < 2000; i++) {
-          const s = nativeTests.create_latin1_string(size);
-          if (s.length !== size) throw new Error("wrong length: " + s.length);
-        }
-        Bun.gc(true);
-        const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
-        console.error("RSS growth: " + growthMB.toFixed(1) + " MB");
-        process.exit(growthMB > Number(process.env.THRESHOLD_MB) ? 1 : 0);
-      `;
-      // 2000 iterations * 64 KiB = 128 MB if every WTFStringImpl leaks.
-      // ASAN's quarantine inflates RSS; widen the threshold there.
-      const thresholdMB = isASAN ? 80 : 40;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "--smol", "-e", fixture],
-        env: { ...bunEnv, THRESHOLD_MB: String(thresholdMB) },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, exitCode }).toEqual({
-        stdout: "",
-        stderr: expect.stringContaining("RSS growth:"),
-        exitCode: 0,
-      });
-    });
-  });
-
   it("#1288", async () => {
     const result = await checkSameOutput("self", []);
     expect(result).toBe("hello world!");
@@ -891,6 +853,46 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     },
     25_000,
   );
+});
+
+// Kept outside describe.concurrent("napi") so RSS measurement isn't skewed by
+// the other tests' subprocesses and doesn't add load to the --compile tests.
+describe("napi_create_string_latin1", () => {
+  it("does not leak the WTFStringImpl", async () => {
+    const fixture = /* js */ `
+      const nativeTests = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"))});
+      const size = 256 * 1024;
+      for (let i = 0; i < 20; i++) {
+        const s = nativeTests.create_latin1_string(size);
+        if (s.length !== size) throw new Error("wrong length: " + s.length);
+      }
+      Bun.gc(true);
+      const before = process.memoryUsage.rss();
+      for (let i = 0; i < 300; i++) {
+        const s = nativeTests.create_latin1_string(size);
+        if (s.length !== size) throw new Error("wrong length: " + s.length);
+      }
+      Bun.gc(true);
+      const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+      console.error("RSS growth: " + growthMB.toFixed(1) + " MB");
+      process.exit(growthMB > Number(process.env.THRESHOLD_MB) ? 1 : 0);
+    `;
+    // 300 iterations * 256 KiB = 75 MB if every WTFStringImpl leaks.
+    // ASAN's quarantine inflates RSS; widen the threshold there.
+    const thresholdMB = isASAN ? 48 : 24;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", fixture],
+      env: { ...bunEnv, THRESHOLD_MB: String(thresholdMB) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "",
+      stderr: expect.stringContaining("RSS growth:"),
+      exitCode: 0,
+    });
+  });
 });
 
 async function checkSameOutput(test: string, args: any[] | string, envArgs: Record<string, string> = {}) {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -5,6 +5,7 @@ import {
   bunEnv,
   bunExe,
   canBuildNodeAddons,
+  isASAN,
   isCI,
   isMacOS,
   isMusl,
@@ -237,6 +238,44 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   describe("napi_get_value_string_*", () => {
     it("behaves like node on edge cases", async () => {
       await checkSameOutput("test_get_value_string", []);
+    });
+  });
+
+  describe("napi_create_string_latin1", () => {
+    it("does not leak the WTFStringImpl", async () => {
+      const fixture = /* js */ `
+        const nativeTests = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"))});
+        const size = 64 * 1024;
+        for (let i = 0; i < 100; i++) {
+          const s = nativeTests.create_latin1_string(size);
+          if (s.length !== size) throw new Error("wrong length: " + s.length);
+        }
+        Bun.gc(true);
+        const before = process.memoryUsage.rss();
+        for (let i = 0; i < 2000; i++) {
+          const s = nativeTests.create_latin1_string(size);
+          if (s.length !== size) throw new Error("wrong length: " + s.length);
+        }
+        Bun.gc(true);
+        const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+        console.error("RSS growth: " + growthMB.toFixed(1) + " MB");
+        process.exit(growthMB > Number(process.env.THRESHOLD_MB) ? 1 : 0);
+      `;
+      // 2000 iterations * 64 KiB = 128 MB if every WTFStringImpl leaks.
+      // ASAN's quarantine inflates RSS; widen the threshold there.
+      const thresholdMB = isASAN ? 80 : 40;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", fixture],
+        env: { ...bunEnv, THRESHOLD_MB: String(thresholdMB) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "",
+        stderr: expect.stringContaining("RSS growth:"),
+        exitCode: 0,
+      });
     });
   });
 

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -39,33 +39,37 @@ function needsInstall(): boolean {
   return false;
 }
 
-describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
-  beforeAll(async () => {
-    // Resolve (and possibly download) the ABI-matching node here, under the
-    // generous hook timeout, instead of inside the first test that needs it.
-    await nodeExeMatchingAbi();
-    // build gyp
-    if (needsInstall()) {
-      console.time("Building node-gyp");
-      const install = spawnSync({
-        cmd: [bunExe(), "install", "--verbose"],
-        cwd: join(__dirname, "napi-app"),
-        stderr: "inherit",
-        env: bunEnv,
-        stdout: "inherit",
-        stdin: "inherit",
-      });
-      if (!install.success) {
-        console.error("build failed, bailing out!");
-        process.exit(1);
-      }
-      console.timeEnd("Building node-gyp");
+// File-scoped so every describe block below (including the non-concurrent
+// `napi_create_string_latin1` and `cleanup hooks` blocks) gets a built addon
+// even when `-t` filters out every test in describe.concurrent("napi").
+beforeAll(async () => {
+  if (!canBuildNodeAddons()) return;
+  // Resolve (and possibly download) the ABI-matching node here, under the
+  // generous hook timeout, instead of inside the first test that needs it.
+  await nodeExeMatchingAbi();
+  // build gyp
+  if (needsInstall()) {
+    console.time("Building node-gyp");
+    const install = spawnSync({
+      cmd: [bunExe(), "install", "--verbose"],
+      cwd: join(__dirname, "napi-app"),
+      stderr: "inherit",
+      env: bunEnv,
+      stdout: "inherit",
+      stdin: "inherit",
+    });
+    if (!install.success) {
+      console.error("build failed, bailing out!");
+      process.exit(1);
     }
-    // node-gyp rebuild can take a while under a debug/ASAN binary (and the
-    // hook may first download an ABI-matching node); default 5s hook timeout
-    // kills the install subprocess mid-build.
-  }, 300_000);
+    console.timeEnd("Building node-gyp");
+  }
+  // node-gyp rebuild can take a while under a debug/ASAN binary (and the
+  // hook may first download an ABI-matching node); default 5s hook timeout
+  // kills the install subprocess mid-build.
+}, 300_000);
 
+describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   describe.each(["esm", "cjs"])("bundle .node files to %s via", format => {
     describe.each(["node", "bun"])("target %s", target => {
       it("Bun.build", async () => {
@@ -857,7 +861,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
 
 // Kept outside describe.concurrent("napi") so RSS measurement isn't skewed by
 // the other tests' subprocesses and doesn't add load to the --compile tests.
-describe("napi_create_string_latin1", () => {
+describe.skipIf(!canBuildNodeAddons())("napi_create_string_latin1", () => {
   it("does not leak the WTFStringImpl", async () => {
     const fixture = /* js */ `
       const nativeTests = require(${JSON.stringify(join(__dirname, "napi-app/build/Debug/napitests.node"))});


### PR DESCRIPTION
### Problem

Every call to `napi_create_string_latin1` with a non-empty string leaks one `WTFStringImpl`.

### Cause

`src/runtime/napi/napi_body.rs`:

```rust
let (string, bytes) = bun_core::String::create_uninitialized_latin1(slice.len());
// `string` derefs on Drop.
bytes.copy_from_slice(slice);
let js = match string.to_js(env.to_js()) { ... };
```

The comment is wrong. `bun_core::String` is `#[derive(Copy)]` and has no `Drop` impl (by design, for FFI by-value passing; see `src/bun_core/string/mod.rs:1249`). `create_uninitialized_latin1` returns a `+1` ref on a fresh `WTFStringImpl`, and `to_js()` only borrows. The `+1` is never released.

The Zig reference (`napi.zig:418-419`) does `defer string.deref();` after the create, which the Rust port dropped.

The `crypto.randomUUID` DOMJIT fast path (`random_uuid_without_type_checks` in `src/runtime/webcore/Crypto.rs:130`) has the identical bug with an identical incorrect comment.

### Fix

Use `transfer_to_js()` instead of `to_js()` at both sites, which consumes the `+1`. This matches the `napi_create_string_utf16` sibling immediately below, and the slow-path `random_uuid` immediately above.

Audited every other `create_uninitialized_{latin1,utf16}` caller in the tree (23 sites); all others already use `transfer_to_js`, `OwnedString`, explicit `.deref()`, or return the String to a caller that owns it.

### Verification

Added `create_latin1_string(len)` to the napi test addon and an RSS-growth test that calls it 2000 times with 64 KiB strings.

Before: `RSS growth: 134.0 MB`, test fails.
After: passes (bounded growth).