### PR TITLE
install: preserve non-ASCII UTF-8 bytes in isolated store path names

### DIFF
--- a/src/semver/lib.rs
+++ b/src/semver/lib.rs
@@ -734,16 +734,31 @@ pub mod semver_string {
 
     impl<'a> fmt::Display for StorePathFormatter<'a> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            for &c in self.str.slice(self.buf) {
-                let n = match c {
-                    b'/' => b'+',
-                    b'\\' => b'+',
-                    b':' => b'+',
-                    b'#' => b'+',
-                    _ => c,
-                };
-                use core::fmt::Write;
-                f.write_char(n as char)?;
+            // The Zig reference emits each byte of the lockfile string verbatim via
+            // `writer.writeByte`. `f.write_char(byte as char)` is NOT equivalent: it treats
+            // the byte as a Latin-1 codepoint and re-encodes it as UTF-8, so any byte ≥ 0x80
+            // becomes two bytes (e.g. UTF-8 `c3 a9` → `c3 83 c2 a9`), producing a different
+            // on-disk `node_modules/.bun/<store-path>/` name than the Zig release.
+            //
+            // `core::fmt` cannot emit arbitrary bytes, but the mapped characters are all
+            // ASCII, so mapping preserves UTF-8 validity of the input. Emit each run between
+            // mapped bytes as a validated `&str` (byte-faithful for valid UTF-8 input). If the
+            // lockfile string buffer ever contains non-UTF-8 bytes we surface `fmt::Error`
+            // rather than silently corrupt the path — same contract as
+            // `install::StorePathFormatter`.
+            let bytes = self.str.slice(self.buf);
+            let mut start = 0;
+            for (i, &c) in bytes.iter().enumerate() {
+                if matches!(c, b'/' | b'\\' | b':' | b'#') {
+                    if start < i {
+                        f.write_str(bun_core::str_utf8(&bytes[start..i]).ok_or(fmt::Error)?)?;
+                    }
+                    f.write_str("+")?;
+                    start = i + 1;
+                }
+            }
+            if start < bytes.len() {
+                f.write_str(bun_core::str_utf8(&bytes[start..]).ok_or(fmt::Error)?)?;
             }
             Ok(())
         }

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -326,6 +326,47 @@ test("can install folder dependencies", async () => {
   ).toBe("module.exports = 'hello from pkg-1';");
 });
 
+test("store path preserves non-ASCII UTF-8 bytes verbatim", async () => {
+  // The semver String.StorePathFormatter must emit each lockfile-string byte verbatim
+  // (Zig: writer.writeByte). A Rust port that did `write_char(byte as char)` re-encoded
+  // each byte as Latin-1 -> UTF-8, so UTF-8 "é" (c3 a9) became "Ã©" (c3 83 c2 a9) and
+  // the on-disk node_modules/.bun/<store-path> name diverged from prior releases.
+  const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
+
+  // "café" = 63 61 66 c3 a9 (NFC). Use an explicit byte sequence so the assertion is
+  // independent of source-file normalization.
+  const caf_e = Buffer.from([0x63, 0x61, 0x66, 0xc3, 0xa9]).toString("utf8");
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "test-pkg-utf8-store-path",
+      dependencies: {
+        "mypkg": `file:./vendor/${caf_e}`,
+      },
+    }),
+  );
+  await write(join(packageDir, "vendor", caf_e, "package.json"), JSON.stringify({ name: "mypkg", version: "1.0.0" }));
+
+  await runBunInstall(bunEnv, packageDir);
+
+  const storeEntry = `mypkg@file+vendor+${caf_e}`;
+
+  // The .bun store directory name must be byte-identical to the Zig output.
+  // On a broken build this contains "mypkg@file+vendor+cafÃ©" instead.
+  expect(await readdirSorted(join(packageDir, "node_modules", ".bun"))).toEqual([storeEntry]);
+
+  expect(readlinkSync(join(packageDir, "node_modules", "mypkg"))).toBe(
+    join(".bun", storeEntry, "node_modules", "mypkg"),
+  );
+  expect(
+    await file(join(packageDir, "node_modules", ".bun", storeEntry, "node_modules", "mypkg", "package.json")).json(),
+  ).toEqual({
+    name: "mypkg",
+    version: "1.0.0",
+  });
+});
+
 test("can install folder dependencies on root package", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });
 


### PR DESCRIPTION
## Repro

```sh
REPRO=$(mktemp -d); mkdir -p "$REPRO/vendor/café"; cd "$REPRO"
printf '{"name":"app","dependencies":{"mypkg":"file:./vendor/caf\xc3\xa9"}}' > package.json
printf '{"name":"mypkg","version":"1.0.0"}' > "vendor/café/package.json"
printf '[install]\nlinker = "isolated"\n' > bunfig.toml
bun install
ls -1 node_modules/.bun | od -An -tx1
```

Before: `mypkg@file+vendor+cafÃ©` (hex `...636166 c383c2a9`)
After: `mypkg@file+vendor+café` (hex `...636166 c3a9`), matching the Zig reference.

## Cause

`semver::String::StorePathFormatter` ported Zig's `writer.writeByte(n)` as `f.write_char(n as char)`. `n as char` treats the `u8` as a Latin-1 codepoint and `write_char` emits its UTF-8 encoding, so every byte ≥ 0x80 becomes two bytes. UTF-8 `é` (`c3 a9`) turns into `Ã©` (`c3 83 c2 a9`).

This formatter feeds `entry::StorePathFormatter` in `isolated_install/Store.rs`, which is consumed via `format_args!` to build on-disk `node_modules/.bun/<store-path>/` directories. Any package name, folder path, tarball URL, workspace path, symlink path, or git owner/repo/committish containing a non-ASCII byte produced a different (mojibake) store directory than the Zig release, causing silent on-disk divergence and cache misses across an upgrade.

## Fix

Emit runs between the mapped ASCII bytes (`/ \ : #`) as validated `&str` slices so the output is byte-for-byte identical to `writer.writeByte`. The mapped characters are all ASCII so UTF-8 validity of the input is preserved. Non-UTF-8 input surfaces `fmt::Error` rather than corrupting the path, matching `install::StorePathFormatter` which already had this class fixed.

## Verification

New test in `test/cli/install/isolated-install.test.ts` installs a `file:./vendor/café` dependency with the isolated linker and asserts the `.bun` store directory name is byte-identical to the Zig output.