### PR TITLE
install: re-raise raw signal when lifecycle script is signaled

### DIFF
--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -1015,14 +1015,9 @@ impl<'a> LifecycleScriptSubprocess<'a> {
                     signal_code.fmt(Output::enable_ansi_colors_stderr()),
                 );
 
-                // `Status::signal_code()` range-checks 1..=31 (`bun_core::SignalCode` is
-                // exhaustive); RT signals (>31) fall back to SIGTERM so the diverging
-                // `raise_ignoring_panic_handler` path is preserved.
-                Global::raise_ignoring_panic_handler(
-                    Status::Signaled(signal)
-                        .signal_code()
-                        .unwrap_or(bun_core::SignalCode::SIGTERM),
-                );
+                // Forward the raw byte so Linux RT signals (>31, outside the
+                // `bun_core::SignalCode` range) are re-raised unchanged.
+                Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(signal));
             }
             Status::Err(err) => {
                 if self.optional {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3348,6 +3348,48 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
   });
+
+  // RT signals (>= 32) only exist on Linux.
+  test.skipIf(!isLinux)(
+    "re-raises the same real-time signal the lifecycle script was terminated by" +
+      (forceWaiterThread ? " (waiter thread)" : ""),
+    async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          scripts: {
+            postinstall: "kill -35 $$",
+          },
+        }),
+      );
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const [out, err, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(err).toContain("terminated by");
+      // `exited` resolves to 128 + WTERMSIG for a signaled child. 128 + 35 = 163.
+      // The bug re-raised SIGTERM instead, giving { exited: 143, signalCode: "SIGTERM" }.
+      expect({ out, exited, signalCode: proc.signalCode }).toEqual({
+        out: expect.any(String),
+        exited: 163,
+        signalCode: null,
+      });
+    },
+  );
 }
 
 test.concurrent("ignore-scripts is read from npmrc", async () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3235,6 +3235,43 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(proc.resourceUsage()?.cpuTime.total).toBeLessThan(750_000 * (isWindows ? 5 : 1));
       });
     });
+
+    // RT signals (>= 32) only exist on Linux.
+    test.skipIf(!isLinux)("re-raises the same real-time signal the lifecycle script was terminated by", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.0.0",
+          scripts: {
+            postinstall: "kill -35 $$",
+          },
+        }),
+      );
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env: testEnv,
+      });
+
+      const [out, err, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(err).toContain("terminated by");
+      // `exited` resolves to 128 + WTERMSIG for a signaled child. 128 + 35 = 163.
+      expect({ out, exited, signalCode: proc.signalCode }).toEqual({
+        out: expect.any(String),
+        exited: 163,
+        signalCode: null,
+      });
+    });
   });
 
   describe.concurrent("stdout/stderr is inherited from root scripts during install", async () => {
@@ -3348,48 +3385,6 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
   });
-
-  // RT signals (>= 32) only exist on Linux.
-  test.skipIf(!isLinux)(
-    "re-raises the same real-time signal the lifecycle script was terminated by" +
-      (forceWaiterThread ? " (waiter thread)" : ""),
-    async () => {
-      using ctx = await setupTest();
-      const { packageDir, packageJson, env } = ctx;
-      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
-
-      await writeFile(
-        packageJson,
-        JSON.stringify({
-          name: "foo",
-          version: "1.0.0",
-          scripts: {
-            postinstall: "kill -35 $$",
-          },
-        }),
-      );
-
-      await using proc = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: packageDir,
-        stdout: "pipe",
-        stdin: "ignore",
-        stderr: "pipe",
-        env: testEnv,
-      });
-
-      const [out, err, exited] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(err).toContain("terminated by");
-      // `exited` resolves to 128 + WTERMSIG for a signaled child. 128 + 35 = 163.
-      // The bug re-raised SIGTERM instead, giving { exited: 143, signalCode: "SIGTERM" }.
-      expect({ out, exited, signalCode: proc.signalCode }).toEqual({
-        out: expect.any(String),
-        exited: 163,
-        signalCode: null,
-      });
-    },
-  );
 }
 
 test.concurrent("ignore-scripts is read from npmrc", async () => {


### PR DESCRIPTION
## Problem

When a lifecycle script subprocess terminates via a Linux real-time signal (SIGRTMIN..SIGRTMAX, i.e. 32..64), `bun install` re-raises SIGTERM instead of the original signal. A CI orchestrator that kills lifecycle scripts with `SIGRTMIN+n` and inspects the install process's termination signal sees 15 instead of the actual RT signal.

## Repro (Linux only)

```json
{
  "name": "foo",
  "version": "1.0.0",
  "scripts": { "postinstall": "kill -35 $$" }
}
```
```
$ bun install
...
error: postinstall script from "foo" terminated by code 35
Terminated
$ echo $?
143        # 128 + SIGTERM, should be 163 (128 + 35)
```

## Cause

`handle_exit` in `src/install/lifecycle_script_runner.rs` routed the raw signal byte through `Status::Signaled(signal).signal_code()`, which range-checks 1..=31 (`bun_core::SignalCode` is exhaustive over named POSIX signals) and returns `None` for RT signals. The fallback was `unwrap_or(SignalCode::SIGTERM)`, so the parent re-raised 15. The Zig reference (`lifecycle_script_runner.zig:451`) forwards the raw value unchanged.

## Fix

Call `Global::raise_ignoring_panic_handler_raw(c_int::from(signal))` with the raw byte, the same pattern `bunx_command.rs` and `run_command.rs` already use for this exact case.

## Verification

Added a Linux-only test in `bun-install-lifecycle-scripts.test.ts` (both the default and waiter-thread exit paths) that spawns `bun install` with a `postinstall` which kills itself via signal 35 and asserts the install process itself terminates with `128 + 35 = 163` (`signalCode: null`). Before the fix it terminated with `{ exited: 143, signalCode: "SIGTERM" }`.