### PR TITLE
install: reject bun.lockb with cyclic tree parents instead of returning a wrong path

### DIFF
--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -356,6 +356,19 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
             depth_buf_len += 1;
         }
 
+        if parent_id != 0 {
+            // A well-formed parent chain always terminates at the root
+            // (id 0). Exiting the loop via the `parent_id < trees.len()`
+            // guard means a non-root node's parent points past the end of
+            // the trees buffer, so the path built below would be missing
+            // every segment above the break.
+            Output::err_generic(
+                "Lockfile is malformed (dependency tree parent is out of bounds)",
+                (),
+            );
+            bun_core::Global::crash();
+        }
+
         depth_buf_len -= 1;
 
         depth = depth_buf_len;

--- a/src/install/lockfile/Tree.rs
+++ b/src/install/lockfile/Tree.rs
@@ -338,8 +338,18 @@ pub(crate) fn relative_path_and_depth<'b, const PATH_STYLE: IteratorPathStyle>(
 
         while parent_id > 0 && (parent_id as usize) < trees.len() {
             if depth_buf_len == MAX_DEPTH {
-                path_buf[path_written] = 0;
-                return (ZStr::from_buf(path_buf, path_written), 0);
+                // The parent chain cannot legitimately be this long: MAX_DEPTH
+                // segments of "node_modules" alone would already overflow
+                // MAX_PATH_BYTES. Reaching it means the on-disk trees form a
+                // parent cycle (a corrupted bun.lockb). Returning a truncated
+                // path here would let the caller install/link into the wrong
+                // directory, so fail loudly like the other malformed-lockfile
+                // checks below.
+                Output::err_generic(
+                    "Lockfile is malformed (dependency tree has a cycle or exceeds the maximum depth)",
+                    (),
+                );
+                bun_core::Global::crash();
             }
             depth_buf[depth_buf_len] = parent_id;
             parent_id = trees[parent_id as usize].parent;

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -176,6 +176,81 @@ it("recovers from a corrupted binary lockfile instead of panicking", async () =>
   expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
 });
 
+it("fails loudly when a binary lockfile's tree parents form a cycle", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
+
+  // Folder deps are never hoisted (Tree.rs places them in their own tree
+  // unconditionally), so pkg-a → pkg-b gives a second Tree node without
+  // touching any registry.
+  await Promise.all([
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "tree-cycle-lockb",
+        version: "1.0.0",
+        dependencies: { "pkg-a": "file:./pkg-a" },
+      }),
+    ),
+    write(
+      join(packageDir, "pkg-a", "package.json"),
+      JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: { "pkg-b": "file:../pkg-b" },
+      }),
+    ),
+    write(join(packageDir, "pkg-b", "package.json"), JSON.stringify({ name: "pkg-b", version: "1.0.0" })),
+  ]);
+
+  await runBunInstall(env, packageDir);
+  const lockbPath = join(packageDir, "bun.lockb");
+  expect(await exists(lockbPath)).toBe(true);
+
+  // Each `writeArray` record in bun.lockb is
+  //   [start:u64][end:u64]\n<type> <size> sizeof, <align> alignof\n[pad][payload]
+  // with start/end as absolute file offsets. Trees are 20-byte records
+  // laid out id|dep_id|parent|off|len (all u32 LE).
+  const lockb = Buffer.from(await file(lockbPath).arrayBuffer());
+  const marker = lockb.indexOf("\n<install.lockfile.Tree> 20 sizeof, 4 alignof\n");
+  expect(marker).toBeGreaterThan(0);
+  const treesStart = Number(lockb.readBigUInt64LE(marker - 16));
+  const treesEnd = Number(lockb.readBigUInt64LE(marker - 8));
+  const treeCount = (treesEnd - treesStart) / 20;
+  expect(treeCount).toBeGreaterThanOrEqual(2);
+
+  // Sanity: well-formed tree[i].id == i; tree[1].parent == 0.
+  const tree1 = treesStart + 1 * 20;
+  expect(lockb.readUInt32LE(treesStart + 0)).toBe(0);
+  expect(lockb.readUInt32LE(tree1 + 0)).toBe(1);
+  expect(lockb.readUInt32LE(tree1 + 8)).toBe(0);
+
+  // Make tree[1] its own parent. Walking the parent chain now never
+  // reaches the root and hits the MAX_DEPTH guard.
+  lockb.writeUInt32LE(1, tree1 + 8);
+  await write(lockbPath, lockb);
+
+  // `bun pm ls` iterates the on-disk trees directly (no re-hoist) so it
+  // reaches `relative_path_and_depth` with the corrupted parent.
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  const err = stderrForInstall(rawErr);
+
+  // Previously the Rust port silently returned the bare "node_modules"
+  // path with depth=0 for the cyclic node and `bun pm ls` exited 0 having
+  // dropped the nested dependencies. The corrupted lockfile must be
+  // reported instead of producing a wrong path.
+  expect(err).toContain("Lockfile is malformed");
+  expect(err).toContain("cycle");
+  expect(out).toBeDefined();
+  expect(code).not.toBe(0);
+});
+
 it("rejects a binary lockfile whose patched-dependency flag byte is out of range", async () => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 

--- a/test/cli/install/bun-lockb.test.ts
+++ b/test/cli/install/bun-lockb.test.ts
@@ -176,7 +176,15 @@ it("recovers from a corrupted binary lockfile instead of panicking", async () =>
   expect(await exists(join(packageDir, "node_modules", "a-dep"))).toBe(true);
 });
 
-it("fails loudly when a binary lockfile's tree parents form a cycle", async () => {
+it.each([
+  // tree[1].parent = 1: a self-cycle. Walking the parent chain never reaches
+  // the root and hits the MAX_DEPTH guard.
+  { name: "form a cycle", parent: 1, reason: "cycle" },
+  // tree[1].parent = 99: points past trees.len(). The parent walk exits via
+  // the bounds guard without reaching the root, so the built path would be
+  // missing every segment above the break.
+  { name: "point out of bounds", parent: 99, reason: "out of bounds" },
+])("fails loudly when a binary lockfile's tree parents $name", async ({ parent, reason }) => {
   const { packageDir, packageJson } = await registry.createTestDir({ bunfigOpts: { saveTextLockfile: false } });
 
   // Folder deps are never hoisted (Tree.rs places them in their own tree
@@ -186,7 +194,7 @@ it("fails loudly when a binary lockfile's tree parents form a cycle", async () =
     write(
       packageJson,
       JSON.stringify({
-        name: "tree-cycle-lockb",
+        name: "tree-parent-lockb",
         version: "1.0.0",
         dependencies: { "pkg-a": "file:./pkg-a" },
       }),
@@ -224,9 +232,7 @@ it("fails loudly when a binary lockfile's tree parents form a cycle", async () =
   expect(lockb.readUInt32LE(tree1 + 0)).toBe(1);
   expect(lockb.readUInt32LE(tree1 + 8)).toBe(0);
 
-  // Make tree[1] its own parent. Walking the parent chain now never
-  // reaches the root and hits the MAX_DEPTH guard.
-  lockb.writeUInt32LE(1, tree1 + 8);
+  lockb.writeUInt32LE(parent, tree1 + 8);
   await write(lockbPath, lockb);
 
   // `bun pm ls` iterates the on-disk trees directly (no re-hoist) so it
@@ -241,13 +247,15 @@ it("fails loudly when a binary lockfile's tree parents form a cycle", async () =
   const [out, rawErr, code] = await Promise.all([stdout.text(), stderr.text(), exited]);
   const err = stderrForInstall(rawErr);
 
-  // Previously the Rust port silently returned the bare "node_modules"
-  // path with depth=0 for the cyclic node and `bun pm ls` exited 0 having
-  // dropped the nested dependencies. The corrupted lockfile must be
-  // reported instead of producing a wrong path.
-  expect(err).toContain("Lockfile is malformed");
-  expect(err).toContain("cycle");
-  expect(out).toBeDefined();
+  // Previously the tree iterator silently returned a truncated path for
+  // the corrupted node and `bun pm ls` exited 0 having dropped the nested
+  // dependencies. The corrupted lockfile must be reported instead of
+  // producing a wrong path.
+  expect({ out, err }).toEqual({
+    out: expect.any(String),
+    err: expect.stringContaining("Lockfile is malformed"),
+  });
+  expect(err).toContain(reason);
   expect(code).not.toBe(0);
 });
 


### PR DESCRIPTION
## What

`relative_path_and_depth` in `src/install/lockfile/Tree.rs` walks a tree node's parent chain to build its `node_modules/...` path. The Zig original wrote into `depth_buf[depth_buf_len]` with no bounds check, so a parent-pointer cycle in a corrupted `bun.lockb` panicked (index out of bounds in safe builds). The Rust port added a `depth_buf_len == MAX_DEPTH` guard but handled it by returning early with the bare `"node_modules"` path and `depth = 0`:

```rust
if depth_buf_len == MAX_DEPTH {
    path_buf[path_written] = 0;
    return (ZStr::from_buf(path_buf, path_written), 0);
}
```

At that point the path-building loop has not run yet, so callers (`bun pm ls`, `PackageInstaller::link_remaining_bins`, `Lockfile::eql`) silently receive the root `node_modules` path for a node that is actually nested and proceed to list/link into the wrong directory. A loud crash became silent wrong output.

## Fix

Report the corruption and crash, matching the adjacent `path_too_long` and `folder_name_is_safe` checks in the same function. `MAX_DEPTH` segments of `node_modules` alone already overflow `MAX_PATH_BYTES`, so reaching the guard can only mean the on-disk trees are cyclic; there is no well-formed lockfile this rejects.

## Repro

```sh
mkdir -p t/pkg-a t/pkg-b
printf '%s' '{"name":"r","dependencies":{"pkg-a":"file:./pkg-a"}}' > t/package.json
printf '%s' '{"name":"pkg-a","dependencies":{"pkg-b":"file:../pkg-b"}}' > t/pkg-a/package.json
printf '%s' '{"name":"pkg-b"}' > t/pkg-b/package.json
printf '%s\n' '[install]' 'saveTextLockfile = false' > t/bunfig.toml
cd t && bun install
# patch tree[1].parent = 1 (self-cycle) in bun.lockb, then:
bun pm ls
```

Before: exits 0, silently drops `pkg-b` from the listing.
After: `error: Lockfile is malformed (dependency tree has a cycle or exceeds the maximum depth)`, exit 1.

## Test

`test/cli/install/bun-lockb.test.ts` generates a two-tree `bun.lockb` via folder deps (no registry needed), patches `tree[1].parent = 1` via the `<install.lockfile.Tree>` array marker, and asserts `bun pm ls` now reports the malformed lockfile and exits non-zero.