### PR TITLE
css: compare Angle by degrees in PartialEq

### DIFF
--- a/src/css/values/angle.rs
+++ b/src/css/values/angle.rs
@@ -18,7 +18,7 @@ const TAG_TURN: u8 = 8;
 /// Angles may be explicit or computed by `calc()`, but are always stored and serialized
 /// as their computed value.
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, crate::generics::CssHash, crate::generics::DeepClone)]
+#[derive(Clone, Copy, crate::generics::CssHash, crate::generics::DeepClone)]
 pub enum Angle {
     /// An angle in degrees. There are 360 degrees in a full circle.
     Deg(CSSNumber) = TAG_DEG,
@@ -179,7 +179,7 @@ impl Angle {
     }
 
     pub(crate) fn eql(self, rhs: Angle) -> bool {
-        self.to_degrees() == rhs.to_degrees()
+        self == rhs
     }
 
     pub(crate) fn mul_f32(self, other: f32) -> Angle {
@@ -219,11 +219,21 @@ impl Angle {
     // `#[derive(CssHash, DeepClone)]` above (POD f32 payload → bitwise).
 }
 
+// NOT structural variant comparison: Deg(180) == Turn(0.5) == Grad(200).
+// Containers holding an `Angle` (Transform, Rotate, LineDirection, ConicGradient,
+// FontStyle, ...) reach this through their own `#[derive(PartialEq)]`, so the
+// rule merger and declaration deduper see cross-unit angles as equal.
+impl PartialEq for Angle {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.to_degrees() == other.to_degrees()
+    }
+}
+
 impl crate::generics::CssEql for Angle {
     #[inline]
     fn eql(&self, other: &Self) -> bool {
-        // NOT structural variant comparison: Deg(180) eql Rad(PI) eql Turn(0.5).
-        self.to_degrees() == other.to_degrees()
+        *self == *other
     }
 }
 

--- a/src/css/values/angle.rs
+++ b/src/css/values/angle.rs
@@ -217,6 +217,9 @@ impl Angle {
 
     // css.implementHash / css.implementDeepClone — provided by
     // `#[derive(CssHash, DeepClone)]` above (POD f32 payload → bitwise).
+    // `CssHash` is intentionally structural (matching `angle.zig`, which pairs
+    // a structural `implementHash` with a degrees-based `eql`); nothing keys a
+    // `CssHash` map on an `Angle`-containing value with `CssEql` as equality.
 }
 
 // NOT structural variant comparison: Deg(180) == Turn(0.5) == Grad(200).

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7236,14 +7236,8 @@ describe("css tests", () => {
 
     // Angles compare by degrees, not by unit: adjacent rules whose
     // declarations differ only in angle unit merge their selectors.
-    minify_test(
-      ".a{transform:rotateZ(180deg)}.b{transform:rotateZ(0.5turn)}",
-      ".a,.b{transform:rotate(180deg)}",
-    );
-    minify_test(
-      ".a{transform:skew(90deg)}.b{transform:skew(100grad)}",
-      ".a,.b{transform:skew(90deg)}",
-    );
+    minify_test(".a{transform:rotateZ(180deg)}.b{transform:rotateZ(0.5turn)}", ".a,.b{transform:rotate(180deg)}");
+    minify_test(".a{transform:skew(90deg)}.b{transform:skew(100grad)}", ".a,.b{transform:skew(90deg)}");
     minify_test(".a{rotate:180deg}.b{rotate:0.5turn}", ".a,.b{rotate:180deg}");
     minify_test(
       ".a{background:linear-gradient(90deg,red,blue)}.b{background:linear-gradient(100grad,red,blue)}",
@@ -7253,10 +7247,7 @@ describe("css tests", () => {
       ".a{background:conic-gradient(from 90deg,red,blue)}.b{background:conic-gradient(from 0.25turn,red,blue)}",
       ".a,.b{background:conic-gradient(from 90deg,red,#00f)}",
     );
-    minify_test(
-      ".a{font-style:oblique 45deg}.b{font-style:oblique 50grad}",
-      ".a,.b{font-style:oblique 45deg}",
-    );
+    minify_test(".a{font-style:oblique 45deg}.b{font-style:oblique 50grad}", ".a,.b{font-style:oblique 45deg}");
     // Same unit, different value: still distinct.
     minify_test(
       ".a{transform:rotateZ(180deg)}.b{transform:rotateZ(90deg)}",

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7233,6 +7233,35 @@ describe("css tests", () => {
       }
       `,
     );
+
+    // Angles compare by degrees, not by unit: adjacent rules whose
+    // declarations differ only in angle unit merge their selectors.
+    minify_test(
+      ".a{transform:rotateZ(180deg)}.b{transform:rotateZ(0.5turn)}",
+      ".a,.b{transform:rotate(180deg)}",
+    );
+    minify_test(
+      ".a{transform:skew(90deg)}.b{transform:skew(100grad)}",
+      ".a,.b{transform:skew(90deg)}",
+    );
+    minify_test(".a{rotate:180deg}.b{rotate:0.5turn}", ".a,.b{rotate:180deg}");
+    minify_test(
+      ".a{background:linear-gradient(90deg,red,blue)}.b{background:linear-gradient(100grad,red,blue)}",
+      ".a,.b{background:linear-gradient(90deg,red,#00f)}",
+    );
+    minify_test(
+      ".a{background:conic-gradient(from 90deg,red,blue)}.b{background:conic-gradient(from 0.25turn,red,blue)}",
+      ".a,.b{background:conic-gradient(from 90deg,red,#00f)}",
+    );
+    minify_test(
+      ".a{font-style:oblique 45deg}.b{font-style:oblique 50grad}",
+      ".a,.b{font-style:oblique 45deg}",
+    );
+    // Same unit, different value: still distinct.
+    minify_test(
+      ".a{transform:rotateZ(180deg)}.b{transform:rotateZ(90deg)}",
+      ".a{transform:rotate(180deg)}.b{transform:rotate(90deg)}",
+    );
   });
 
   describe("color-scheme", () => {


### PR DESCRIPTION
## Problem

`Angle::eql` in `angle.zig` compares via `toDegrees()`, and Zig's `css.implementEql` recursively calls `.eql()` on nested fields, so any container holding an `Angle` (`Transform`, `Rotate`, `LineDirection`, `ConicGradient`, `FontStyle`, ...) treats `Deg(180)` and `Turn(0.5)` as equal.

The Rust port kept that semantics in `impl CssEql for Angle`, but the enum also `#[derive(PartialEq)]`, which is structural (`Deg(180.0) != Turn(0.5)`). The containers use `#[derive(PartialEq)]` on themselves and then `css_eql_partialeq!(...)` to bridge `CssEql` to `==`, so a nested `Angle` is compared structurally. The rule merger / declaration deduper compares declaration values through these paths, so adjacent rules whose values contain semantically equal angles in different units stopped merging under `--minify`. Output is still correct CSS, just larger than the Zig build produced.

```
.a{transform:rotateZ(180deg)}.b{transform:rotateZ(0.5turn)}
  before: .a{transform:rotate(180deg)}.b{transform:rotate(.5turn)}
  after:  .a,.b{transform:rotate(180deg)}
```

## Fix

Replace the derived `PartialEq` on `Angle` with a manual impl that compares `to_degrees()`, matching `angle.zig:200`. This propagates through every container's derived `PartialEq` (and therefore their `CssEql`) without touching any of them. The inherent `Angle::eql` and the `CssEql` impl now forward to `==` so there is a single source of truth.

## Tests

Added `minify_test` cases in `test/js/bun/css/css.test.ts` covering `transform` (rotateZ, skew), the `rotate` property, `linear-gradient` direction, `conic-gradient` from-angle, and `font-style: oblique`, plus a negative case (same unit, different value stays unmerged). All fail on the unfixed build and pass with this change; the existing 1093 css tests continue to pass.