### PR TITLE
resolver: don't overflow PathBuffer on exports/imports targets with many "*"

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -2187,7 +2187,7 @@ impl<'a> Package<'a> {
     }
 }
 
-use bun_core::strings::{replace, replacement_size};
+use bun_core::strings::replace_owned;
 
 const INVALID_PERCENT_CHARS: [&[u8]; 4] = [b"%2f", b"%2F", b"%5c", b"%5C"];
 
@@ -2608,20 +2608,22 @@ impl<'a> ESModule<'a> {
                     {
                         if PATTERN {
                             // Return the URL resolution of resolvedTarget with every instance of "*" replaced with subpath.
-                            let len = replacement_size(str, b"*", subpath);
-                            let _ = replace(str, b"*", subpath, &mut resolve_target_buf2.0);
-                            let result = &resolve_target_buf2.0[0..len];
+                            // Nothing bounds the number of "*" in a target, so the substituted
+                            // result can exceed MAX_PATH_BYTES; write into a fresh Vec (which is
+                            // boxed into Resolution.path immediately anyway) instead of the
+                            // fixed-size threadlocal buffer.
+                            let result = replace_owned(str, b"*", subpath);
                             if let Some(log) = self.debug_logs.as_deref_mut() {
                                 log.add_note_fmt(format_args!(
                                     "Subsituted \"{}\" for \"*\" in \".{}\" to get \".{}\" ",
                                     bstr::BStr::new(subpath),
                                     bstr::BStr::new(str),
-                                    bstr::BStr::new(result)
+                                    bstr::BStr::new(&result)
                                 ));
                             }
                             dedent!();
                             return Resolution {
-                                path: Box::<[u8]>::from(result),
+                                path: result.into_boxed_slice(),
                                 status: Status::PackageResolve,
                                 debug: ResolutionDebug {
                                     token: target.first_token,
@@ -2722,29 +2724,31 @@ impl<'a> ESModule<'a> {
 
                 if PATTERN {
                     // Return the URL resolution of resolvedTarget with every instance of "*" replaced with subpath.
-                    let len = replacement_size(resolved_target, b"*", subpath);
-                    let _ = replace(resolved_target, b"*", subpath, &mut resolve_target_buf2.0);
-                    let result = &resolve_target_buf2.0[0..len];
+                    // Nothing bounds the number of "*" in a target, so the substituted
+                    // result can exceed MAX_PATH_BYTES; write into a fresh Vec (which is
+                    // boxed into Resolution.path immediately anyway) instead of the
+                    // fixed-size threadlocal buffer.
+                    let result = replace_owned(resolved_target, b"*", subpath);
                     if let Some(log) = self.debug_logs.as_deref_mut() {
                         log.add_note_fmt(format_args!(
                             "Substituted \"{}\" for \"*\" in \".{}\" to get \".{}\" ",
                             bstr::BStr::new(subpath),
                             bstr::BStr::new(resolved_target),
-                            bstr::BStr::new(result)
+                            bstr::BStr::new(&result)
                         ));
                     }
 
-                    if let Some(invalid) = find_invalid_segment(result) {
+                    if let Some(invalid) = find_invalid_segment(&result) {
                         if let Some(log) = self.debug_logs.as_deref_mut() {
                             log.add_note_fmt(format_args!(
                                 "The path \"{}\" is invalid because it contains an invalid segment \"{}\"",
-                                bstr::BStr::new(result),
+                                bstr::BStr::new(&result),
                                 bstr::BStr::new(invalid)
                             ));
                         }
                         dedent!();
                         return Resolution {
-                            path: Box::<[u8]>::from(result),
+                            path: result.into_boxed_slice(),
                             status: Status::InvalidModuleSpecifier,
                             debug: ResolutionDebug {
                                 token: target.first_token,
@@ -2753,8 +2757,8 @@ impl<'a> ESModule<'a> {
                         };
                     }
 
-                    let status: Status = if strings::ends_with_char_or_is_zero_length(result, b'*')
-                        && strings::index_of_char(result, b'*').unwrap() as usize
+                    let status: Status = if strings::ends_with_char_or_is_zero_length(&result, b'*')
+                        && strings::index_of_char(&result, b'*').unwrap() as usize
                             == result.len() - 1
                     {
                         Status::ExactEndsWithStar
@@ -2763,7 +2767,7 @@ impl<'a> ESModule<'a> {
                     };
                     dedent!();
                     return Resolution {
-                        path: Box::<[u8]>::from(result),
+                        path: result.into_boxed_slice(),
                         status,
                         debug: ResolutionDebug {
                             token: target.first_token,

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -621,7 +621,11 @@ describe("wildcard exports/imports target with many * does not crash the resolve
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "caught ERR_MODULE_NOT_FOUND", exitCode: 0 });
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "caught ERR_MODULE_NOT_FOUND",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
   });
 
   it.concurrent("imports: {'#*': 'dep/***…'} surfaces a catchable error", async () => {
@@ -645,7 +649,11 @@ describe("wildcard exports/imports target with many * does not crash the resolve
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "caught ERR_MODULE_NOT_FOUND", exitCode: 0 });
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "caught ERR_MODULE_NOT_FOUND",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
   });
 });
 

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -589,6 +589,66 @@ describe("wildcard exports with @ in matched subpath", () => {
   });
 });
 
+// Nothing in the Node.js packages spec limits an exports/imports target to a
+// single "*", so a target like "./****…" substitutes the matched subpath once
+// per star. The substituted result was written into a fixed MAX_PATH_BYTES
+// threadlocal buffer (1024 on macOS, 4096 on Linux); with enough stars a
+// malicious package.json could overflow it and panic the process instead of
+// surfacing a catchable resolution error. Node.js returns ERR_MODULE_NOT_FOUND
+// for the same input.
+describe("wildcard exports/imports target with many * does not crash the resolver", () => {
+  const stars = Buffer.alloc(50, "*").toString();
+  const subpath = Buffer.alloc(100, "a").toString();
+
+  it.concurrent("exports: {'./*': './***…'} surfaces a catchable error", async () => {
+    using dir = tempDir("resolver-wildcard-many-stars-exports", {
+      "package.json": JSON.stringify({ name: "host" }),
+      "node_modules/pkg/package.json": JSON.stringify({
+        name: "pkg",
+        exports: { "./*": "./" + stars },
+      }),
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-install",
+        "-e",
+        `import("pkg/${subpath}").then(() => console.log("resolved"), e => console.log("caught", e.code));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "caught ERR_MODULE_NOT_FOUND", exitCode: 0 });
+  });
+
+  it.concurrent("imports: {'#*': 'dep/***…'} surfaces a catchable error", async () => {
+    using dir = tempDir("resolver-wildcard-many-stars-imports", {
+      "package.json": JSON.stringify({
+        name: "host",
+        imports: { "#*": "dep/" + stars },
+      }),
+      "node_modules/.keep": "",
+    });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--no-install",
+        "-e",
+        `import("#${subpath}").then(() => console.log("resolved"), e => console.log("caught", e.code));`,
+      ],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "caught ERR_MODULE_NOT_FOUND", exitCode: 0 });
+  });
+});
+
 // A package.json `imports` entry whose value is a bare package specifier
 // (e.g. `"#res": "@myproject/resolver"`) is handed back to package-resolve
 // for a second pass. Per the Node.js packages spec these are URL-like


### PR DESCRIPTION
## Reproduction

```sh
mkdir -p /tmp/r/node_modules/pkg
printf '{"name":"pkg","exports":{"./*":"./**************************************************"}}' \
  > /tmp/r/node_modules/pkg/package.json
cd /tmp/r
bun -e "import('pkg/' + 'a'.repeat(100)).catch(e => console.log('caught', e.code))"
```

```
panic: range end index 4101 out of range for slice of length 4096
  bun_core::strings_impl::replace                 src/bun_core/lib.rs:1375
  <bun_resolver::package_json::ESModule>::resolve_target::<true>
                                                  src/resolver/package_json.rs:2726
```

Node.js for the same input:
```
caught ERR_MODULE_NOT_FOUND
```

## Cause

`ESModule::resolve_target<true>` substitutes the matched subpath for every `*` in the target string and writes the result into a fixed `MAX_PATH_BYTES` threadlocal `PathBuffer` (1024 on macOS, 4096 on Linux) via `bun_core::strings::replace`. Neither the parser nor the resolver bounds how many `*` a target may contain, so a target like `"./****…"` combined with a long matched subpath produces a result larger than the buffer and `replace`'s bounds-checked `copy_from_slice` panics. The same pattern exists on the `imports` PackageResolve branch. A malicious package's `package.json` can therefore crash any process that resolves into it via `import`/`require`.

## Fix

Both PATTERN sites immediately box the substituted result into `Resolution.path: Box<[u8]>`, so switch them from the fixed-buffer `replace` to `replace_owned` and box the `Vec` directly with `into_boxed_slice()`. Same allocation count, no fixed-size buffer, matches Node.js (catchable `ERR_MODULE_NOT_FOUND`).

## Verification

Added two tests in `test/js/bun/resolve/resolve.test.ts` covering both the `exports` path (package_json.rs:2726) and the `imports` → PackageResolve path (package_json.rs:2612). Both spawn a child so the unfixed build's panic is observed as a test failure rather than taking out the runner.