### PR TITLE
sys(fd): anchor EBADF debug stack trace at close() caller

### DIFF
--- a/src/glob/GlobWalker.rs
+++ b/src/glob/GlobWalker.rs
@@ -190,7 +190,9 @@ impl Accessor for SyscallAccessor {
     }
 
     fn close(handle: SyscallHandle) -> Option<SysError> {
-        handle.value.close_allowing_bad_file_descriptor(None)
+        handle
+            .value
+            .close_allowing_bad_file_descriptor(Some(bun_core::return_address()))
     }
 
     fn getcwd(path_buf: &mut PathBuffer) -> Maybe<&[u8]> {

--- a/src/sys/fd.rs
+++ b/src/sys/fd.rs
@@ -76,7 +76,7 @@ pub trait FdExt: Copy + Sized {
 
 impl FdExt for Fd {
     fn close(self) {
-        let err = self.close_allowing_bad_file_descriptor(None);
+        let err = self.close_allowing_bad_file_descriptor(Some(bun_core::return_address()));
         debug_assert!(err.is_none()); // use after close!
     }
 
@@ -88,6 +88,12 @@ impl FdExt for Fd {
             log!("close({}) SKIPPED", self);
             return None;
         }
+        // Not `or_else`: the default trim anchor must be read from this frame,
+        // not a closure's (popped before the stack walk runs).
+        let return_address = match return_address {
+            Some(addr) => Some(addr),
+            None => Some(bun_core::return_address()),
+        };
         self.close_allowing_standard_io(return_address)
     }
 
@@ -208,6 +214,12 @@ impl FdExt for Fd {
                         "close({}) = EBADF. This is an indication of a file descriptor UAF",
                         bstr::BStr::new(fd_fmt),
                     );
+                    // Not `or_else`: the default trim anchor must be read from
+                    // this frame, not a closure's.
+                    let return_address = match return_address {
+                        Some(addr) => Some(addr),
+                        None => Some(bun_core::return_address()),
+                    };
                     bun_core::dump_current_stack_trace(
                         return_address,
                         bun_core::DumpStackTraceOptions {

--- a/src/sys/sys_uv.rs
+++ b/src/sys/sys_uv.rs
@@ -553,11 +553,11 @@ pub fn lstat(path: &ZStr) -> Result<Stat> {
 }
 
 pub fn close(fd: Fd) -> Option<Error> {
-    fd.close_allowing_bad_file_descriptor(None)
+    fd.close_allowing_bad_file_descriptor(Some(bun_core::return_address()))
 }
 
 pub fn close_allowing_stdout_and_stderr(fd: Fd) -> Option<Error> {
-    fd.close_allowing_standard_io(None)
+    fd.close_allowing_standard_io(Some(bun_core::return_address()))
 }
 
 /// Maximum number of iovec buffers that can be passed to uv_fs_read/uv_fs_write.

--- a/test/js/bun/sys/fd-close-ebadf-trace.test.ts
+++ b/test/js/bun/sys/fd-close-ebadf-trace.test.ts
@@ -1,0 +1,86 @@
+// The debug-build EBADF warning printed by `Fd::close_allowing_standard_io`
+// dumps a short (4-frame) stack trace anchored at the close() call site so fd
+// use-after-free bugs are diagnosable. The Zig `FD.close()` threaded
+// `@returnAddress()` through each close wrapper so the trace starts at the
+// caller; the Rust port forwarded `None` and the anchor resolved inside
+// `bun_core::dump_current_stack_trace` instead, so all 4 frames pointed at the
+// dump/close plumbing and the actual caller never appeared.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isPosix } from "harness";
+
+test.skipIf(!isDebug || !isPosix)(
+  "EBADF debug stack trace is anchored at the close() caller, not inside the dump helper",
+  async () => {
+    const exe = bunExe();
+
+    // Locate the close/dump plumbing in the binary's static symbol table. The
+    // Rust v0 mangling crate-hash varies between builds, so match on the stable
+    // suffix. `__bun_crash_handler_dump_stack_trace` is #[no_mangle]. Filter in
+    // the child (full `nm -S` output is >100 MB on an ASAN debug binary).
+    await using nm = Bun.spawn({
+      cmd: [
+        "sh",
+        "-c",
+        `nm -S "$1" | grep -E ' (__bun_crash_handler_dump_stack_trace|_R[[:alnum:]_]*8bun_core6Global24dump_current_stack_trace|_R[[:alnum:]_]*7bun_sys[[:alnum:]_]*26close_allowing_standard_io|_R[[:alnum:]_]*7bun_sys[[:alnum:]_]*34close_allowing_bad_file_descriptor)$'`,
+        "sh",
+        exe,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [nmOut, nmErr, nmExit] = await Promise.all([nm.stdout.text(), nm.stderr.text(), nm.exited]);
+    expect({ nmErr, nmExit }).toEqual({ nmErr: "", nmExit: 0 });
+
+    type Range = { lo: bigint; hi: bigint; name: string };
+    const ranges: Range[] = [];
+    for (const line of nmOut.split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length !== 4) continue;
+      const lo = BigInt("0x" + parts[0]);
+      const size = BigInt("0x" + parts[1]);
+      ranges.push({ lo, hi: lo + size, name: parts[3] });
+    }
+    // Precondition: all four plumbing symbols must resolve, otherwise this
+    // test cannot assert anything.
+    expect(ranges.map(r => r.name).sort()).toHaveLength(4);
+
+    // Trigger an EBADF close via fs.closeSync on an already-closed fd.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const fs=require("fs");const fd=fs.openSync("/dev/null","r");fs.closeSync(fd);try{fs.closeSync(fd)}catch(e){}`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("EBADF. This is an indication of a file descriptor UAF");
+
+    // Parse the dumped frame addresses: lines like
+    //   "1   0xd3d3c80 ./build/debug/bun-debug() [0xd3d3c80]"
+    const frames: bigint[] = [];
+    for (const line of stderr.split("\n")) {
+      const m = line.match(/^\s*\d+\s+0x([0-9a-fA-F]+)\s/);
+      if (m) frames.push(BigInt("0x" + m[1]));
+    }
+    expect(frames.length).toBeGreaterThanOrEqual(1);
+
+    // None of the dumped frames may lie inside the dump/close plumbing. With
+    // the anchor threaded through correctly, frame 1 is the fs.closeSync
+    // handler in node_fs.rs and deeper frames are its callers.
+    const hits = frames
+      .map((addr, i) => {
+        const r = ranges.find(r => addr >= r.lo && addr < r.hi);
+        return r ? `frame ${i + 1} @ 0x${addr.toString(16)} is inside ${r.name}` : null;
+      })
+      .filter(Boolean);
+    expect(hits).toEqual([]);
+
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/sys/fd-close-ebadf-trace.test.ts
+++ b/test/js/bun/sys/fd-close-ebadf-trace.test.ts
@@ -7,9 +7,11 @@
 // dump/close plumbing and the actual caller never appeared.
 
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isPosix } from "harness";
+import { bunEnv, bunExe, isDebug, isLinux } from "harness";
 
-test.skipIf(!isDebug || !isPosix)(
+// Linux-only: relies on ELF `nm -S` emitting a size column with no extra
+// Mach-O underscore prefix on symbol names.
+test.skipIf(!isDebug || !isLinux)(
   "EBADF debug stack trace is anchored at the close() caller, not inside the dump helper",
   async () => {
     const exe = bunExe();


### PR DESCRIPTION
## Problem

In debug builds, `Fd::close_allowing_standard_io` prints a 4-frame stack trace when a close hits `EBADF`, to help diagnose file-descriptor use-after-free. The Zig `FD.close()` threads `@returnAddress()` through each close wrapper so the trace is trimmed to the caller of `close()`. The Rust port forwarded `None` at every layer, so the trim anchor resolved inside `dump_current_stack_trace_from_core`'s own caller and all four frames pointed at the dump/close plumbing:

```
$ bun-debug -e 'const fs=require("fs");const fd=fs.openSync("/dev/null","r");fs.closeSync(fd);try{fs.closeSync(fd)}catch{}'
debug warn: close(11[BADF]) = EBADF. This is an indication of a file descriptor UAF
1   __bun_crash_handler_dump_stack_trace           src/crash_handler/lib.rs:62
2   bun_core::Global::dump_current_stack_trace     src/bun_core/Global.rs:207
3   <Fd as FdExt>::close_allowing_standard_io      src/sys/fd.rs
4   <Fd as FdExt>::close_allowing_bad_file_descriptor  src/sys/fd.rs
```

The actual `closeSync` call site never appears. Debug-only diagnostic regression; release builds discard `return_address` entirely.

## Fix

Mirror the Zig reference (`src/sys/fd.zig:236-250,305`): `Fd::close()` passes `Some(bun_core::return_address())`, and both `close_allowing_bad_file_descriptor` / `close_allowing_standard_io` substitute `bun_core::return_address()` when handed `None`, using an explicit `match` so the `#[inline(always)]` intrinsic reads this frame rather than a closure's. The `sys_uv` and `GlobWalker` thin wrappers are brought in line with their `.zig` siblings which pass `@returnAddress()` explicitly.

After:

```
1   NodeFS::close                 src/runtime/node/node_fs.rs:4852
2   Op<Close>::run                src/runtime/node/node_fs.rs:9254
3   NodeFS::dispatch              src/runtime/node/node_fs.rs:9193
4   node_fs_binding::run_sync     src/runtime/node/node_fs_binding.rs:54
```

## Test

`test/js/bun/sys/fd-close-ebadf-trace.test.ts` (debug + POSIX only) resolves the four plumbing symbols via `nm -S` on the debug binary, triggers an EBADF via a double `fs.closeSync`, and asserts none of the dumped frame addresses fall inside those symbol ranges. Without the fix all four frames land in the plumbing ranges.