### PR TITLE
test: don't increment expect() counter on matcher argument-validation errors

### DIFF
--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1732,6 +1732,12 @@ impl Expect {
     /// Returns `(guard, received_value, not)`. The guard derefs to `&Expect`
     /// and runs `post_match` on drop; `not` is `flags.not()` snapshotted once.
     /// Callers that don't need `not` until later destructure as `(this, v, _)`.
+    ///
+    /// This helper calls `get_value` and then `increment_expect_call_counter`
+    /// before returning. Matchers whose Zig reference validates argument count
+    /// or argument type *before* either of those steps must NOT use this helper
+    /// and instead open-code the sequence so `expect.assertions(n)` observes the
+    /// same count on invalid-argument errors.
     #[inline]
     pub fn matcher_prelude<'a>(
         &'a self,

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -3040,18 +3040,18 @@ pub mod mock {
     #[derive(Clone, Copy)]
     pub enum MockKind {
         /// `mock.calls`; not-a-mock → `global.throw("Expected value must be a mock function: …")`.
-        /// toHaveBeenCalled / toHaveBeenCalledOnce / toHaveBeenCalledTimes.
+        /// toHaveBeenCalledOnce / toHaveBeenCalledTimes.
         Calls,
         /// `mock.calls`; not-a-mock → `this.throw(signature, "Matcher error: received value must be a mock function …")`.
         /// toHaveBeenCalledWith / toHaveBeenLastCalledWith / toHaveBeenNthCalledWith.
         CallsWithSig,
         /// `mock.results`; not-a-mock → `global.throw("Expected value must be a mock function: …")`.
-        /// toHaveReturned* / toHave*ReturnedWith.
+        /// toHaveReturned / toHaveReturnedTimes / toHaveReturnedWith / toHaveLastReturnedWith.
         Returns,
     }
 
     impl Expect {
-        /// Shared prologue for every `expect(mockFn).toHave*` matcher: arms the
+        /// Shared prologue for most `expect(mockFn).toHave*` matchers: arms the
         /// `post_match` guard, resolves the captured value (handling `.resolves`/
         /// `.rejects`), bumps the assertion counter, fetches the requested
         /// mock-backed array, and emits the kind-appropriate "not a mock" error.
@@ -3059,6 +3059,11 @@ pub mod mock {
         /// Returns the [`PostMatchGuard`] (so `post_match` runs when the caller
         /// drops it), the `mock.calls` / `mock.results` JSArray, and the raw
         /// received value (some matchers print it again on later error paths).
+        ///
+        /// Delegates to [`Self::matcher_prelude`] and inherits its ordering
+        /// constraint: matchers whose Zig reference validates arguments before
+        /// `incrementExpectCallCounter` (`toHaveBeenCalled`,
+        /// `toHaveNthReturnedWith`) must open-code the sequence instead.
         pub fn mock_prologue<'a>(
             &'a self,
             global: &'a JSGlobalObject,

--- a/src/runtime/test_runner/expect/toBe.rs
+++ b/src/runtime/test_runner/expect/toBe.rs
@@ -11,9 +11,8 @@ impl Expect {
         global_this: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, left, not) =
-            self.matcher_prelude(global_this, callframe.this(), "toBe", "<green>expected<r>")?;
-
+        let this = self.post_match_guard(global_this);
+        let this_value = callframe.this();
         let arguments_ = callframe.arguments_old::<2>();
         let arguments = arguments_.slice();
 
@@ -21,8 +20,12 @@ impl Expect {
             return Err(global_this.throw_invalid_arguments(format_args!("toBe() takes 1 argument")));
         }
 
+        this.increment_expect_call_counter();
         let right = arguments[0];
         right.ensure_still_alive();
+        let left = this.get_value(global_this, this_value, "toBe", "<green>expected<r>")?;
+
+        let not = this.flags.get().not();
         let mut pass = right.is_same_value(left, global_this)?;
 
         if not {

--- a/src/runtime/test_runner/expect/toBeOneOf.rs
+++ b/src/runtime/test_runner/expect/toBeOneOf.rs
@@ -36,9 +36,8 @@ pub(crate) fn to_be_one_of(
     global_this: &JSGlobalObject,
     call_frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, expected, not) =
-        this.matcher_prelude(global_this, call_frame.this(), "toBeOneOf", "<green>expected<r>")?;
-
+    let this = this.post_match_guard(global_this);
+    let this_value = call_frame.this();
     let arguments_ = call_frame.arguments_old::<1>();
     let arguments = arguments_.slice();
 
@@ -46,7 +45,12 @@ pub(crate) fn to_be_one_of(
         return Err(global_this.throw_invalid_arguments(format_args!("toBeOneOf() takes 1 argument")));
     }
 
+    this.increment_expect_call_counter();
+
+    let expected = this.get_value(global_this, this_value, "toBeOneOf", "<green>expected<r>")?;
     let list_value: JSValue = arguments[0];
+
+    let not = this.flags.get().not();
     let mut pass = false;
 
     if list_value.js_type().is_array_like() {

--- a/src/runtime/test_runner/expect/toBeTypeOf.rs
+++ b/src/runtime/test_runner/expect/toBeTypeOf.rs
@@ -22,13 +22,16 @@ pub(crate) fn to_be_type_of(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, value, not) = this.matcher_prelude(global, frame.this(), "toBeTypeOf", "")?;
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
     let _arguments = frame.arguments_old::<1>();
     let arguments = _arguments.slice();
 
     if arguments.len() < 1 {
         return Err(global.throw_invalid_arguments(format_args!("toBeTypeOf() requires 1 argument")));
     }
+
+    let value: JSValue = this.get_value(global, this_value, "toBeTypeOf", "")?;
 
     let expected = arguments[0];
     expected.ensure_still_alive();
@@ -38,7 +41,9 @@ pub(crate) fn to_be_type_of(
     }
 
     let expected_type = bun_core::OwnedString::new(expected.to_bun_string(global)?);
+    this.increment_expect_call_counter();
 
+    let not = this.flags.get().not();
     let expected_utf8 = expected_type.to_utf8();
     let Some(typeof_) = JS_TYPE_OF_MAP.get(expected_utf8.slice()).copied() else {
         return Err(global.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect/toBeWithin.rs
+++ b/src/runtime/test_runner/expect/toBeWithin.rs
@@ -9,13 +9,8 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, value, not) = self.matcher_prelude(
-            global,
-            frame.this(),
-            "toBeWithin",
-            "<green>start<r><d>, <r><green>end<r>",
-        )?;
-
+        let this = self.post_match_guard(global);
+        let this_value = frame.this();
         let _arguments = frame.arguments_old::<2>();
         let arguments = _arguments.slice();
 
@@ -24,6 +19,13 @@ impl Expect {
                 "toBeWithin() requires 2 arguments"
             )));
         }
+
+        let value: JSValue = this.get_value(
+            global,
+            this_value,
+            "toBeWithin",
+            "<green>start<r><d>, <r><green>end<r>",
+        )?;
 
         let start_value = arguments[0];
         start_value.ensure_still_alive();
@@ -43,6 +45,9 @@ impl Expect {
             )));
         }
 
+        this.increment_expect_call_counter();
+
+        let not = this.flags.get().not();
         let mut pass = value.is_number();
         if pass {
             let num = value.as_number();

--- a/src/runtime/test_runner/expect/toContain.rs
+++ b/src/runtime/test_runner/expect/toContain.rs
@@ -13,9 +13,8 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toContain", "<green>expected<r>")?;
-
+        let this = self.post_match_guard(global);
+        let this_value = frame.this();
         let arguments_ = frame.arguments_old::<1>();
         let arguments = arguments_.slice();
 
@@ -23,8 +22,13 @@ impl Expect {
             return Err(global.throw_invalid_arguments(format_args!("toContain() takes 1 argument")));
         }
 
+        this.increment_expect_call_counter();
+
         let expected = arguments[0];
         expected.ensure_still_alive();
+        let value: JSValue = this.get_value(global, this_value, "toContain", "<green>expected<r>")?;
+
+        let not = this.flags.get().not();
         let mut pass = false;
 
         // FFI/BACKREF: erased to *mut c_void for for_each userdata; raw ptrs

--- a/src/runtime/test_runner/expect/toContainEqual.rs
+++ b/src/runtime/test_runner/expect/toContainEqual.rs
@@ -35,9 +35,8 @@ pub(crate) fn to_contain_equal(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
+    let this = this.post_match_guard(global);
     let this_value = frame.this();
-    let (this, value, not) =
-        this.matcher_prelude(global, this_value, "toContainEqual", "<green>expected<r>")?;
     let arguments_ = frame.arguments_old::<1>();
     let arguments = arguments_.slice();
 
@@ -45,8 +44,13 @@ pub(crate) fn to_contain_equal(
         return Err(global.throw_invalid_arguments(format_args!("toContainEqual() takes 1 argument")));
     }
 
+    this.increment_expect_call_counter();
+
     let expected = arguments[0];
     expected.ensure_still_alive();
+    let value: JSValue = this.get_value(global, this_value, "toContainEqual", "<green>expected<r>")?;
+
+    let not = this.flags.get().not();
     let mut pass = false;
 
     let value_type = value.js_type();

--- a/src/runtime/test_runner/expect/toEqual.rs
+++ b/src/runtime/test_runner/expect/toEqual.rs
@@ -10,9 +10,8 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toEqual", "<green>expected<r>")?;
-
+        let this = self.post_match_guard(global);
+        let this_value = frame.this();
         let _arguments = frame.arguments_old::<1>();
         let arguments: &[JSValue] = _arguments.slice();
 
@@ -20,7 +19,12 @@ impl Expect {
             return Err(global.throw_invalid_arguments(format_args!("toEqual() requires 1 argument")));
         }
 
+        this.increment_expect_call_counter();
+
         let expected = arguments[0];
+        let value: JSValue = this.get_value(global, this_value, "toEqual", "<green>expected<r>")?;
+
+        let not = this.flags.get().not();
         let mut pass = value.jest_deep_equals(expected, global)?;
 
         if not {

--- a/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
+++ b/src/runtime/test_runner/expect/toEqualIgnoringWhitespace.rs
@@ -15,9 +15,8 @@ pub(crate) fn to_equal_ignoring_whitespace(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toEqualIgnoringWhitespace", "<green>expected<r>")?;
-
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
     let arguments_ = frame.arguments_old::<1>(); let arguments: &[JSValue] = arguments_.slice();
 
     if arguments.len() < 1 {
@@ -26,7 +25,10 @@ pub(crate) fn to_equal_ignoring_whitespace(
         )));
     }
 
+    this.increment_expect_call_counter();
+
     let expected = arguments[0];
+    let value: JSValue = this.get_value(global, this_value, "toEqualIgnoringWhitespace", "<green>expected<r>")?;
 
     if !expected.is_string() {
         return Err(global.throw(format_args!(
@@ -34,6 +36,7 @@ pub(crate) fn to_equal_ignoring_whitespace(
         )));
     }
 
+    let not = this.flags.get().not();
     let mut pass = value.is_string() && expected.is_string();
 
     if pass {

--- a/src/runtime/test_runner/expect/toHaveBeenCalled.rs
+++ b/src/runtime/test_runner/expect/toHaveBeenCalled.rs
@@ -7,12 +7,24 @@ pub(crate) fn to_have_been_called(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
-    let (this, calls, _value) =
-        this.mock_prologue(global, frame.this(), "toHaveBeenCalled", "", super::mock::MockKind::Calls)?;
-    // arg-check after prologue: counter bump + post_match still fire on bad-arity.
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
+
     if !frame.arguments_as_array::<1>()[0].is_undefined() {
         return Err(global.throw_invalid_arguments(format_args!(
             "toHaveBeenCalled() must not have an argument"
+        )));
+    }
+
+    let value: JSValue = this.get_value(global, this_value, "toHaveBeenCalled", "")?;
+
+    let calls = super::mock::JSMockFunction__getCalls(global, value)?;
+    this.increment_expect_call_counter();
+    if !calls.js_type().is_array() {
+        let mut formatter = super::make_formatter(global);
+        return Err(global.throw(format_args!(
+            "Expected value must be a mock function: {}",
+            value.to_fmt(&mut formatter),
         )));
     }
 

--- a/src/runtime/test_runner/expect/toHaveLength.rs
+++ b/src/runtime/test_runner/expect/toHaveLength.rs
@@ -8,9 +8,8 @@ pub(crate) fn to_have_length(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toHaveLength", "<green>expected<r>")?;
-
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
     let arguments_ = frame.arguments_old::<1>();
     let arguments = arguments_.slice();
 
@@ -18,7 +17,12 @@ pub(crate) fn to_have_length(
         return Err(global.throw_invalid_arguments(format_args!("toHaveLength() takes 1 argument")));
     }
 
+    this.increment_expect_call_counter();
+
     let expected: JSValue = arguments[0];
+    let value: JSValue = this.get_value(global, this_value, "toHaveLength", "<green>expected<r>")?;
+
+    let not = this.flags.get().not();
 
     if !value.is_object() && !value.is_string() {
         let mut fmt = super::make_formatter(global);

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -9,14 +9,16 @@ pub(crate) fn to_have_nth_returned_with(
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
     bun_jsc::mark_binding!();
-    let [nth_arg, expected] = frame.arguments_as_array::<2>();
-    let (this, returns, _value) = this.mock_prologue(
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
+    let value: JSValue = this.get_value(
         global,
-        frame.this(),
+        this_value,
         "toHaveNthReturnedWith",
         "<green>n<r>, <green>expected<r>",
-        super::mock::MockKind::Returns,
     )?;
+
+    let [nth_arg, expected] = frame.arguments_as_array::<2>();
 
     // Validate n is a number
     if !nth_arg.is_any_int() {
@@ -28,6 +30,16 @@ pub(crate) fn to_have_nth_returned_with(
     if n <= 0 {
         return Err(global.throw_invalid_arguments(format_args!(
             "toHaveNthReturnedWith() n must be greater than 0"
+        )));
+    }
+
+    this.increment_expect_call_counter();
+    let returns = super::mock::JSMockFunction__getReturns(global, value)?;
+    if !returns.js_type().is_array() {
+        let mut formatter = super::make_formatter(global);
+        return Err(global.throw(format_args!(
+            "Expected value must be a mock function: {}",
+            value.to_fmt(&mut formatter),
         )));
     }
 

--- a/src/runtime/test_runner/expect/toMatch.rs
+++ b/src/runtime/test_runner/expect/toMatch.rs
@@ -8,14 +8,15 @@ pub(crate) fn to_match(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, value, not) =
-        this.matcher_prelude(global, frame.this(), "toMatch", "<green>expected<r>")?;
-
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
     let arguments: &[JSValue] = frame.arguments();
 
     if arguments.len() < 1 {
         return Err(global.throw_invalid_arguments(format_args!("toMatch() requires 1 argument")));
     }
+
+    this.increment_expect_call_counter();
 
     let mut formatter = super::make_formatter(global);
 
@@ -28,6 +29,8 @@ pub(crate) fn to_match(
     }
     expected_value.ensure_still_alive();
 
+    let value: JSValue = this.get_value(global, this_value, "toMatch", "<green>expected<r>")?;
+
     if !value.is_string() {
         return Err(global.throw(format_args!(
             "Received value must be a string: {}",
@@ -35,6 +38,7 @@ pub(crate) fn to_match(
         )));
     }
 
+    let not = this.flags.get().not();
     let mut pass: bool = 'brk: {
         if expected_value.is_string() {
             break 'brk value.string_includes(global, expected_value)?;

--- a/src/runtime/test_runner/expect/toMatchObject.rs
+++ b/src/runtime/test_runner/expect/toMatchObject.rs
@@ -7,10 +7,16 @@ pub(crate) fn to_match_object(
     global: &JSGlobalObject,
     frame: &CallFrame,
 ) -> JsResult<JSValue> {
-    let (this, received_object, not) =
-        this.matcher_prelude(global, frame.this(), "toMatchObject", "<green>expected<r>")?;
+    let this = this.post_match_guard(global);
+    let this_value = frame.this();
     let args_buf = frame.arguments_old::<1>();
     let args = args_buf.slice();
+
+    this.increment_expect_call_counter();
+
+    let not = this.flags.get().not();
+
+    let received_object: JSValue = this.get_value(global, this_value, "toMatchObject", "<green>expected<r>")?;
 
     if !received_object.is_object() {
         let matcher_error =

--- a/src/runtime/test_runner/expect/toStrictEqual.rs
+++ b/src/runtime/test_runner/expect/toStrictEqual.rs
@@ -10,9 +10,8 @@ impl Expect {
         global: &JSGlobalObject,
         frame: &CallFrame,
     ) -> JsResult<JSValue> {
-        let (this, value, not) =
-            self.matcher_prelude(global, frame.this(), "toStrictEqual", "<green>expected<r>")?;
-
+        let this = self.post_match_guard(global);
+        let this_value = frame.this();
         let _arguments = frame.arguments_old::<1>();
         let arguments: &[JSValue] = _arguments.slice();
 
@@ -22,7 +21,12 @@ impl Expect {
             ));
         }
 
+        this.increment_expect_call_counter();
+
         let expected = arguments[0];
+        let value: JSValue = this.get_value(global, this_value, "toStrictEqual", "<green>expected<r>")?;
+
+        let not = this.flags.get().not();
         let mut pass = value.jest_strict_deep_equals(expected, global)?;
 
         if not {

--- a/test/js/bun/test/expect-assertions-invalid-args-fixture.ts
+++ b/test/js/bun/test/expect-assertions-invalid-args-fixture.ts
@@ -1,0 +1,221 @@
+import { expect, jest, test } from "bun:test";
+
+// Each test asserts that a matcher throwing an *argument-validation* error
+// (wrong arity or wrong argument type) does not increment the assertion
+// counter, matching Jest and the original implementation.
+
+test("toBe argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toBe();
+  } catch {}
+});
+
+test("toBeOneOf argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toBeOneOf();
+  } catch {}
+});
+
+test("toBeTypeOf argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toBeTypeOf();
+  } catch {}
+});
+
+test("toBeTypeOf type", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toBeTypeOf(123);
+  } catch {}
+});
+
+test("toBeWithin argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(5).toBeWithin();
+  } catch {}
+});
+
+test("toBeWithin type start", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(5).toBeWithin("a", 10);
+  } catch {}
+});
+
+test("toBeWithin type end", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(5).toBeWithin(0, "z");
+  } catch {}
+});
+
+test("toContain argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect([1]).toContain();
+  } catch {}
+});
+
+test("toContainEqual argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect([1]).toContainEqual();
+  } catch {}
+});
+
+test("toEqual argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toEqual();
+  } catch {}
+});
+
+test("toEqualIgnoringWhitespace argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect("x").toEqualIgnoringWhitespace();
+  } catch {}
+});
+
+test("toHaveLength argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect([1]).toHaveLength();
+  } catch {}
+});
+
+test("toMatch argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect("x").toMatch();
+  } catch {}
+});
+
+test("toStrictEqual argcount", () => {
+  expect.assertions(0);
+  try {
+    // @ts-expect-error
+    expect(1).toStrictEqual();
+  } catch {}
+});
+
+test("toHaveBeenCalled argcount", () => {
+  expect.assertions(0);
+  const fn = jest.fn();
+  try {
+    // @ts-expect-error
+    expect(fn).toHaveBeenCalled(1);
+  } catch {}
+});
+
+test("toHaveNthReturnedWith type", () => {
+  expect.assertions(0);
+  const fn = jest.fn(() => 1);
+  fn();
+  try {
+    // @ts-expect-error
+    expect(fn).toHaveNthReturnedWith("x", 1);
+  } catch {}
+});
+
+test("toHaveNthReturnedWith n<=0", () => {
+  expect.assertions(0);
+  const fn = jest.fn(() => 1);
+  fn();
+  try {
+    expect(fn).toHaveNthReturnedWith(0, 1);
+  } catch {}
+});
+
+// Valid calls must still count: one assertion each.
+
+test("toBe valid counts", () => {
+  expect.assertions(1);
+  expect(1).toBe(1);
+});
+
+test("toBeWithin valid counts", () => {
+  expect.assertions(1);
+  expect(5).toBeWithin(0, 10);
+});
+
+test("toBeTypeOf valid counts", () => {
+  expect.assertions(1);
+  expect(5).toBeTypeOf("number");
+});
+
+test("toEqual valid counts", () => {
+  expect.assertions(1);
+  expect(1).toEqual(1);
+});
+
+test("toStrictEqual valid counts", () => {
+  expect.assertions(1);
+  expect(1).toStrictEqual(1);
+});
+
+test("toContain valid counts", () => {
+  expect.assertions(1);
+  expect([1]).toContain(1);
+});
+
+test("toContainEqual valid counts", () => {
+  expect.assertions(1);
+  expect([{ a: 1 }]).toContainEqual({ a: 1 });
+});
+
+test("toEqualIgnoringWhitespace valid counts", () => {
+  expect.assertions(1);
+  expect("a b").toEqualIgnoringWhitespace("a  b");
+});
+
+test("toHaveLength valid counts", () => {
+  expect.assertions(1);
+  expect([1, 2]).toHaveLength(2);
+});
+
+test("toMatch valid counts", () => {
+  expect.assertions(1);
+  expect("abc").toMatch("b");
+});
+
+test("toBeOneOf valid counts", () => {
+  expect.assertions(1);
+  expect(1).toBeOneOf([1, 2, 3]);
+});
+
+test("toMatchObject valid counts", () => {
+  expect.assertions(1);
+  expect({ a: 1, b: 2 }).toMatchObject({ a: 1 });
+});
+
+test("toHaveBeenCalled valid counts", () => {
+  expect.assertions(1);
+  const fn = jest.fn();
+  fn();
+  expect(fn).toHaveBeenCalled();
+});
+
+test("toHaveNthReturnedWith valid counts", () => {
+  expect.assertions(1);
+  const fn = jest.fn(() => 7);
+  fn();
+  expect(fn).toHaveNthReturnedWith(1, 7);
+});

--- a/test/js/bun/test/expect-assertions-invalid-args-fixture.ts
+++ b/test/js/bun/test/expect-assertions-invalid-args-fixture.ts
@@ -3,145 +3,124 @@ import { expect, jest, test } from "bun:test";
 // Each test asserts that a matcher throwing an *argument-validation* error
 // (wrong arity or wrong argument type) does not increment the assertion
 // counter, matching Jest and the original implementation.
+//
+// The `threw` check uses a plain `throw` (not `expect`) so the counter stays
+// at 0 while still failing the test if the matcher stops rejecting bad args.
+
+function mustThrow(name: string, fn: () => void) {
+  let threw = false;
+  try {
+    fn();
+  } catch {
+    threw = true;
+  }
+  if (!threw) throw new Error(`${name} with invalid args must throw`);
+}
 
 test("toBe argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toBe();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBe()", () => expect(1).toBe());
 });
 
 test("toBeOneOf argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toBeOneOf();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeOneOf()", () => expect(1).toBeOneOf());
 });
 
 test("toBeTypeOf argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toBeTypeOf();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeTypeOf()", () => expect(1).toBeTypeOf());
 });
 
 test("toBeTypeOf type", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toBeTypeOf(123);
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeTypeOf(number)", () => expect(1).toBeTypeOf(123));
 });
 
 test("toBeWithin argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(5).toBeWithin();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeWithin()", () => expect(5).toBeWithin());
 });
 
 test("toBeWithin type start", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(5).toBeWithin("a", 10);
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeWithin(str, num)", () => expect(5).toBeWithin("a", 10));
 });
 
 test("toBeWithin type end", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(5).toBeWithin(0, "z");
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toBeWithin(num, str)", () => expect(5).toBeWithin(0, "z"));
 });
 
 test("toContain argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect([1]).toContain();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toContain()", () => expect([1]).toContain());
 });
 
 test("toContainEqual argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect([1]).toContainEqual();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toContainEqual()", () => expect([1]).toContainEqual());
 });
 
 test("toEqual argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toEqual();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toEqual()", () => expect(1).toEqual());
 });
 
 test("toEqualIgnoringWhitespace argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect("x").toEqualIgnoringWhitespace();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toEqualIgnoringWhitespace()", () => expect("x").toEqualIgnoringWhitespace());
 });
 
 test("toHaveLength argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect([1]).toHaveLength();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toHaveLength()", () => expect([1]).toHaveLength());
 });
 
 test("toMatch argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect("x").toMatch();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toMatch()", () => expect("x").toMatch());
 });
 
 test("toStrictEqual argcount", () => {
   expect.assertions(0);
-  try {
-    // @ts-expect-error
-    expect(1).toStrictEqual();
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toStrictEqual()", () => expect(1).toStrictEqual());
 });
 
 test("toHaveBeenCalled argcount", () => {
   expect.assertions(0);
   const fn = jest.fn();
-  try {
-    // @ts-expect-error
-    expect(fn).toHaveBeenCalled(1);
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toHaveBeenCalled(arg)", () => expect(fn).toHaveBeenCalled(1));
 });
 
 test("toHaveNthReturnedWith type", () => {
   expect.assertions(0);
   const fn = jest.fn(() => 1);
   fn();
-  try {
-    // @ts-expect-error
-    expect(fn).toHaveNthReturnedWith("x", 1);
-  } catch {}
+  // @ts-expect-error
+  mustThrow("toHaveNthReturnedWith(str, ...)", () => expect(fn).toHaveNthReturnedWith("x", 1));
 });
 
 test("toHaveNthReturnedWith n<=0", () => {
   expect.assertions(0);
   const fn = jest.fn(() => 1);
   fn();
-  try {
-    expect(fn).toHaveNthReturnedWith(0, 1);
-  } catch {}
+  mustThrow("toHaveNthReturnedWith(0, ...)", () => expect(fn).toHaveNthReturnedWith(0, 1));
 });
 
 // Valid calls must still count: one assertion each.

--- a/test/js/bun/test/expect-assertions.test.ts
+++ b/test/js/bun/test/expect-assertions.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 
-import { bunEnv, bunExe, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
 import path from "path";
 
 test("expect.assertions causes the test to fail when it should", async () => {
@@ -27,4 +27,29 @@ test("expect.assertions causes the test to fail when it should", async () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr.toString()).toContain("5 fail\n");
   expect(result.stderr.toString()).toContain("0 pass\n");
+});
+
+test("expect.assertions: matcher argument-validation errors do not count as assertions", async () => {
+  const dir = tempDirWithFiles("expect-assertions-invalid-args", {
+    "invalid-args.test.ts": await Bun.file(
+      path.join(import.meta.dir, "expect-assertions-invalid-args-fixture.ts"),
+    ).text(),
+    "package.json": JSON.stringify({ name: "expect-assertions-invalid-args", version: "0.0.0" }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "invalid-args.test.ts"],
+    env: bunEnv,
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const failing = [...stderr.matchAll(/\(fail\) (.+?)(?: \[|$)/gm)].map(m => m[1]);
+  expect(failing).toEqual([]);
+  expect(normalizeBunSnapshot(stderr, dir)).toContain(" 0 fail\n");
+  expect(stderr).toContain(" 31 pass\n");
+  expect(stderr).toContain(" 14 expect() calls\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
## Problem

The shared `matcher_prelude` helper in `expect.rs` runs `get_value` followed by `increment_expect_call_counter()` before returning to the individual matcher. A number of matchers call this helper first and only then validate argument count / argument type. In the Zig reference implementations those same matchers validate arguments *before* `incrementExpectCallCounter()` (and in most cases before `getValue` as well).

Consequence: when one of these matchers is called with a missing or wrong-type argument, the Rust build increments the assertion counter and the Zig build does not, which is observable through `expect.assertions(n)` and the `N expect() calls` summary.

### Repro

```js
import { expect, test } from "bun:test";
test("counter", () => {
  expect.assertions(0);
  try { expect(5).toBeWithin("a", 10); } catch {}
});
```

Passes on bun 1.3.x (Zig), fails on Rust HEAD with `expected 0 assertions, but test ended with 1 assertion`.

## Fix

For each affected matcher, inline the prelude and reorder `post_match_guard` / argument-count check / `get_value` / argument-type checks / `increment_expect_call_counter` to match the `.zig` sibling exactly. The `matcher_prelude` helper itself is kept for matchers whose Zig order already matches (the zero-arg predicates and most mock matchers), with a doc note about when it is not appropriate.

Matchers updated: `toBe`, `toBeOneOf`, `toBeTypeOf`, `toBeWithin`, `toContain`, `toContainEqual`, `toEqual`, `toEqualIgnoringWhitespace`, `toHaveLength`, `toMatch`, `toMatchObject`, `toStrictEqual`, `toHaveBeenCalled`, `toHaveNthReturnedWith`.

This also restores the original `get_value` vs argument-count error precedence, so when both would fail the user sees the same error as before the port.

## Verification

New test in `test/js/bun/test/expect-assertions.test.ts` spawns a fixture with 17 invalid-argument cases (each under `expect.assertions(0)`) and 14 valid-call cases (each under `expect.assertions(1)`). Before the fix, all 17 invalid-argument cases fail; after, all 31 pass with exactly 14 `expect()` calls reported.

```
bun bd test test/js/bun/test/expect-assertions.test.ts
 2 pass
 0 fail
```

`jest-extended.test.js` (57 pass), `mock-fn.test.js` (72 pass), and `expect.test.js` (397 pass; the one pre-existing `deepEquals Set/Map stress test` timeout reproduces on main without this diff).