### PR TITLE
resolver: store exports expansion_keys as indices instead of cloned subtrees

### DIFF
--- a/src/resolver/package_json.rs
+++ b/src/resolver/package_json.rs
@@ -1125,7 +1125,7 @@ impl<'a> Visitor<'a> {
     fn visit_object(&mut self, e_obj: &js_ast::E::ObjectJSON) -> Entry {
         let rows = e_obj.properties();
         let mut map_data: EntryDataMapList = Vec::with_capacity(rows.len());
-        let mut expansion_keys: Vec<MapEntry> = Vec::with_capacity(rows.len());
+        let mut expansion_keys: Vec<u32> = Vec::new();
         let mut is_conditional_sugar = false;
         for (i, prop) in rows.iter().enumerate() {
             let key: Box<[u8]> = Box::from(prop.key.slice());
@@ -1164,11 +1164,7 @@ impl<'a> Visitor<'a> {
 
             // safe to use "/" on windows. exports in package.json does not use "\\"
             if strings::ends_with(&key, b"/") || strings::contains_char(&key, b'*') {
-                expansion_keys.push(MapEntry {
-                    value: value.clone(),
-                    key: key.clone(),
-                    key_range,
-                });
+                expansion_keys.push(map_data.len() as u32);
             }
 
             map_data.push(MapEntry {
@@ -1178,12 +1174,12 @@ impl<'a> Visitor<'a> {
             });
         }
 
-        // this leaks a lil, but it's fine.
-
         // Let expansionKeys be the list of keys of matchObj either ending in "/"
         // or containing only a single "*", sorted by the sorting function
         // PATTERN_KEY_COMPARE which orders in descending order of specificity.
-        expansion_keys.sort_by(|a, b| strings::glob_length_compare(&a.key, &b.key));
+        expansion_keys.sort_by(|&a, &b| {
+            strings::glob_length_compare(&map_data[a as usize].key, &map_data[b as usize].key)
+        });
 
         Entry {
             data: EntryData::Map(EntryDataMap {
@@ -1272,7 +1268,10 @@ pub enum EntryDataTag {
 #[derive(Clone)]
 pub struct EntryDataMap {
     // This is not a std.ArrayHashMap because we also store the key_range which is a little weird
-    pub expansion_keys: Box<[MapEntry]>,
+    // expansion_keys holds sorted indices into `list`. The Zig original stored a second MapEntry
+    // slice whose payload pointers aliased `list`; indices express that same sharing without a
+    // deep clone of each wildcard key's subtree.
+    pub expansion_keys: Box<[u32]>,
     pub list: EntryDataMapList,
 }
 
@@ -1785,7 +1784,8 @@ impl<'a> ESModule<'a> {
 
         if let EntryData::Map(map) = &match_obj.data {
             let expansion_keys = &map.expansion_keys;
-            for expansion in expansion_keys.iter() {
+            for &idx in expansion_keys.iter() {
+                let expansion = &map.list[idx as usize];
                 // If expansionKey contains "*", set patternBase to the substring of
                 // expansionKey up to but excluding the first "*" character
                 if let Some(star) = strings::index_of_char(&expansion.key, b'*') {

--- a/test/js/bun/resolve/exports-map-memory.test.ts
+++ b/test/js/bun/resolve/exports-map-memory.test.ts
@@ -26,50 +26,54 @@ function makeExports(wildcard: boolean): string {
   return JSON.stringify({ name: wildcard ? "pkg-wild" : "pkg-flat", exports: exportsObj });
 }
 
-test("exports map with wildcard keys does not duplicate condition subtrees in memory", { timeout: 60_000 }, async () => {
-  using dir = tempDir("exports-map-memory", {
-    "node_modules/pkg-flat/package.json": makeExports(false),
-    "node_modules/pkg-wild/package.json": makeExports(true),
-    "probe.js": `
+test(
+  "exports map with wildcard keys does not duplicate condition subtrees in memory",
+  { timeout: 60_000 },
+  async () => {
+    using dir = tempDir("exports-map-memory", {
+      "node_modules/pkg-flat/package.json": makeExports(false),
+      "node_modules/pkg-wild/package.json": makeExports(true),
+      "probe.js": `
       Bun.gc(true);
       const before = process.memoryUsage().rss;
       try { Bun.resolveSync(process.argv[2], import.meta.dir); } catch {}
       Bun.gc(true);
       process.stdout.write(String(process.memoryUsage().rss - before));
     `,
-  });
-
-  async function measure(spec: string): Promise<number> {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "probe.js", spec],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const delta = parseInt(stdout.trim(), 10);
-    if (exitCode !== 0 || !Number.isFinite(delta)) {
-      throw new Error(`probe '${spec}' failed: exit=${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`);
+
+    async function measure(spec: string): Promise<number> {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "probe.js", spec],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const delta = parseInt(stdout.trim(), 10);
+      if (exitCode !== 0 || !Number.isFinite(delta)) {
+        throw new Error(`probe '${spec}' failed: exit=${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`);
+      }
+      return delta;
     }
-    return delta;
-  }
 
-  const flat = await measure("pkg-flat/p0");
-  const wild = await measure("pkg-wild/p0/x");
+    const flat = await measure("pkg-flat/p0");
+    const wild = await measure("pkg-wild/p0/x");
 
-  // Sanity: resolving a ~5.5MB package.json with ~260k Entry nodes must show
-  // up in RSS; if it doesn't, the probe didn't exercise the exports map.
-  expect(flat).toBeGreaterThan(4 << 20);
+    // Sanity: resolving a ~5.5MB package.json with ~260k Entry nodes must show
+    // up in RSS; if it doesn't, the probe didn't exercise the exports map.
+    expect(flat).toBeGreaterThan(4 << 20);
 
-  // Both packages hold byte-identical condition subtrees; the only structural
-  // difference is the "/*" suffix on each key. With expansion_keys as indices
-  // the wildcard package costs `flat + O(keys * sizeof(u32))`, so the diff is
-  // noise. Before the fix it cost `flat + (full deep copy of every subtree)`,
-  // which measured at (wild-flat)/flat of ~0.26 on release and ~0.17 on
-  // debug+ASAN (ASAN's fixed overhead on the JSON AST dilutes the ratio).
-  expect(wild - flat).toBeLessThan(flat * 0.1);
-});
+    // Both packages hold byte-identical condition subtrees; the only structural
+    // difference is the "/*" suffix on each key. With expansion_keys as indices
+    // the wildcard package costs `flat + O(keys * sizeof(u32))`, so the diff is
+    // noise. Before the fix it cost `flat + (full deep copy of every subtree)`,
+    // which measured at (wild-flat)/flat of ~0.26 on release and ~0.17 on
+    // debug+ASAN (ASAN's fixed overhead on the JSON AST dilutes the ratio).
+    expect(wild - flat).toBeLessThan(flat * 0.1);
+  },
+);
 
 // After switching expansion_keys to indices, wildcard + pattern resolution and
 // the PATTERN_KEY_COMPARE specificity ordering must be unchanged.

--- a/test/js/bun/resolve/exports-map-memory.test.ts
+++ b/test/js/bun/resolve/exports-map-memory.test.ts
@@ -64,6 +64,7 @@ test(
     // Sanity: resolving a ~5.5MB package.json with ~260k Entry nodes must show
     // up in RSS; if it doesn't, the probe didn't exercise the exports map.
     expect(flat).toBeGreaterThan(4 << 20);
+    expect(wild).toBeGreaterThan(4 << 20);
 
     // Both packages hold byte-identical condition subtrees; the only structural
     // difference is the "/*" suffix on each key. With expansion_keys as indices
@@ -126,5 +127,4 @@ test("exports map wildcard resolution still works", async () => {
     other: "node_modules/pkg/catchall.js",
     trailing: "node_modules/pkg/dir/thing.js",
   });
-  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/resolve/exports-map-memory.test.ts
+++ b/test/js/bun/resolve/exports-map-memory.test.ts
@@ -32,11 +32,13 @@ test(
   async () => {
     using dir = tempDir("exports-map-memory", {
       "node_modules/pkg-flat/package.json": makeExports(false),
+      "node_modules/pkg-flat/d.js": "",
       "node_modules/pkg-wild/package.json": makeExports(true),
+      "node_modules/pkg-wild/d.js": "",
       "probe.js": `
       Bun.gc(true);
       const before = process.memoryUsage().rss;
-      try { Bun.resolveSync(process.argv[2], import.meta.dir); } catch {}
+      Bun.resolveSync(process.argv[2], import.meta.dir);
       Bun.gc(true);
       process.stdout.write(String(process.memoryUsage().rss - before));
     `,

--- a/test/js/bun/resolve/exports-map-memory.test.ts
+++ b/test/js/bun/resolve/exports-map-memory.test.ts
@@ -1,0 +1,126 @@
+// The Rust port of the ExportsMap visitor deep-cloned the entire condition
+// subtree for every wildcard key into `expansion_keys`, where the Zig original
+// stored a shallow pointer-based copy. Packages with many `./*` exports and
+// nested condition maps (next, @mui/material, rxjs) paid roughly 2x the heap
+// for their exports map, and that PackageJSON lives in the process-lifetime
+// DirInfo cache so the duplicate was never freed.
+//
+// The fix stores `expansion_keys` as indices into `list`, matching the Zig
+// sharing semantics.
+
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import path from "path";
+
+// Build an identical condition subtree for every key: many small nested Maps so
+// the cloned Entry tree dominates over the JSON source bytes.
+function makeExports(wildcard: boolean): string {
+  const leaf: Record<string, unknown> = {};
+  for (let i = 0; i < 8; i++) leaf["c" + i] = { node: "./a.js", default: "./b.js" };
+  const mid: Record<string, unknown> = {};
+  for (let i = 0; i < 8; i++) mid["m" + i] = leaf;
+  const subtree = { import: mid, require: mid, default: "./d.js" };
+  const exportsObj: Record<string, unknown> = {};
+  const suffix = wildcard ? "/*" : "";
+  for (let i = 0; i < 1000; i++) exportsObj["./p" + i + suffix] = subtree;
+  return JSON.stringify({ name: wildcard ? "pkg-wild" : "pkg-flat", exports: exportsObj });
+}
+
+test("exports map with wildcard keys does not duplicate condition subtrees in memory", { timeout: 60_000 }, async () => {
+  using dir = tempDir("exports-map-memory", {
+    "node_modules/pkg-flat/package.json": makeExports(false),
+    "node_modules/pkg-wild/package.json": makeExports(true),
+    "probe.js": `
+      Bun.gc(true);
+      const before = process.memoryUsage().rss;
+      try { Bun.resolveSync(process.argv[2], import.meta.dir); } catch {}
+      Bun.gc(true);
+      process.stdout.write(String(process.memoryUsage().rss - before));
+    `,
+  });
+
+  async function measure(spec: string): Promise<number> {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "probe.js", spec],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const delta = parseInt(stdout.trim(), 10);
+    if (exitCode !== 0 || !Number.isFinite(delta)) {
+      throw new Error(`probe '${spec}' failed: exit=${exitCode}\nstdout: ${stdout}\nstderr: ${stderr}`);
+    }
+    return delta;
+  }
+
+  const flat = await measure("pkg-flat/p0");
+  const wild = await measure("pkg-wild/p0/x");
+
+  // Sanity: resolving a ~5.5MB package.json with ~260k Entry nodes must show
+  // up in RSS; if it doesn't, the probe didn't exercise the exports map.
+  expect(flat).toBeGreaterThan(4 << 20);
+
+  // Both packages hold byte-identical condition subtrees; the only structural
+  // difference is the "/*" suffix on each key. With expansion_keys as indices
+  // the wildcard package costs `flat + O(keys * sizeof(u32))`, so the diff is
+  // noise. Before the fix it cost `flat + (full deep copy of every subtree)`,
+  // which measured at (wild-flat)/flat of ~0.26 on release and ~0.17 on
+  // debug+ASAN (ASAN's fixed overhead on the JSON AST dilutes the ratio).
+  expect(wild - flat).toBeLessThan(flat * 0.1);
+});
+
+// After switching expansion_keys to indices, wildcard + pattern resolution and
+// the PATTERN_KEY_COMPARE specificity ordering must be unchanged.
+test("exports map wildcard resolution still works", async () => {
+  using dir = tempDir("exports-map-memory-resolve", {
+    "node_modules/pkg/package.json": JSON.stringify({
+      name: "pkg",
+      exports: {
+        // Declared in non-specific order; PATTERN_KEY_COMPARE must sort so
+        // "./feature/*" (longer base) wins over "./*" for "pkg/feature/x".
+        "./*": { default: "./catchall.js" },
+        "./feature/*": { import: { default: "./feat.js" } },
+        "./exact": "./exact.js",
+        "./trailing/": "./dir/",
+      },
+    }),
+    "node_modules/pkg/catchall.js": "module.exports = 'catchall';",
+    "node_modules/pkg/feat.js": "module.exports = 'feat';",
+    "node_modules/pkg/exact.js": "module.exports = 'exact';",
+    "node_modules/pkg/dir/thing.js": "module.exports = 'dir';",
+  });
+
+  const base = String(dir);
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const dir = ${JSON.stringify(base + path.sep)};
+        const r = s => Bun.resolveSync(s, dir).slice(dir.length).replaceAll("\\\\", "/");
+        console.log(JSON.stringify({
+          exact: r("pkg/exact"),
+          feature: r("pkg/feature/x"),
+          other: r("pkg/other"),
+          trailing: r("pkg/trailing/thing"),
+        }));
+      `,
+    ],
+    env: bunEnv,
+    cwd: base,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) throw new Error(`exit=${exitCode}\n${stderr}`);
+
+  expect(JSON.parse(stdout)).toEqual({
+    exact: "node_modules/pkg/exact.js",
+    feature: "node_modules/pkg/feat.js",
+    other: "node_modules/pkg/catchall.js",
+    trailing: "node_modules/pkg/dir/thing.js",
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

The Rust port of the `ExportsMap` visitor's `e_object` arm deep-cloned the entire condition subtree for every wildcard export key. In `src/resolver/package_json.rs` the loop did:

```rust
if strings::ends_with(&key, b"/") || strings::contains_char(&key, b'*') {
    expansion_keys.push(MapEntry {
        value: value.clone(),   // <- recursive deep copy of Box<[u8]> / Box<[Entry]> / EntryDataMap
        key: key.clone(),
        key_range,
    });
}
```

whereas the Zig reference at `package_json.zig:1192-1196` stores a shallow struct copy whose `string` / `[]const Entry` payload aliases the same heap data already held by `map_data.list`.

Packages with many wildcard exports and nested `import`/`require`/`node`/`default` conditions (next, @mui/material, rxjs) therefore paid roughly 2x the heap for their exports map, and `PackageJSON` is interned in the process-lifetime `DirInfo` cache so the duplicate is never freed. Pure memory regression vs the Zig reference; no correctness change.

## Fix

`EntryDataMap::expansion_keys` is now `Box<[u32]>` holding sorted indices into `list`, which expresses the same sharing the Zig code gets from aliased slices. The `PATTERN_KEY_COMPARE` sort looks keys up through `map_data`, and the single consumer in `ESModule` resolution dereferences the index before use.

## Verification

New `test/js/bun/resolve/exports-map-memory.test.ts` builds two packages with identical 1000-key exports maps, one with wildcard keys and one without, resolves each in a fresh subprocess, and asserts the RSS delta of the wildcard package does not exceed the flat package's by more than 10%. A second test verifies wildcard resolution and `PATTERN_KEY_COMPARE` specificity ordering are unchanged.

| build | (wild - flat) / flat, before | after |
| --- | --- | --- |
| release | ~0.26 | ~0.00 |
| debug+ASAN | ~0.17 | ~0.01 |

Existing `resolve.test.ts` wildcard tests, `import-custom-condition.test.ts`, and the bundler `packagejson/ExportsPattern*` suite all pass.