### PR TITLE
s3: release JSS3Error's BunString refs on drop

### DIFF
--- a/src/runtime/webcore/s3/error_jsc.rs
+++ b/src/runtime/webcore/s3/error_jsc.rs
@@ -1,7 +1,7 @@
 //! JSC bridges for S3 signing errors. The pure error-code/message tables
 //! stay in `s3_signing/`; the `*JSGlobalObject`-taking variants live here.
 
-use bun_core::String as BunString;
+use bun_core::{OwnedString, String as BunString};
 use bun_jsc::{ErrorCode, JSGlobalObject, JSPromise, JSValue, JsError};
 use bun_s3_signing::Error as SignError;
 use bun_s3_signing::error::{self as s3_error, get_sign_error_message};
@@ -116,51 +116,37 @@ pub fn throw_sign_error(err: SignError, global_this: &JSGlobalObject) -> JsError
     }
 }
 
+// `OwnedString` is `#[repr(transparent)]` over `bun_core::String`, so the
+// `#[repr(C)]` layout matches the three-`BunString` struct the C++ side reads
+// (`S3Error` in S3Error.cpp). Unlike raw `bun_core::String` (which is `Copy`
+// with no `Drop`), `OwnedString` derefs its +1 on drop, so the refs taken by
+// `create_atom_if_possible` are released when `to_error_instance` returns.
 #[repr(C)]
+#[derive(Default)]
 struct JSS3Error {
-    code: BunString,
-    message: BunString,
-    path: BunString,
-}
-
-impl Default for JSS3Error {
-    fn default() -> Self {
-        Self {
-            code: BunString::empty(),
-            message: BunString::empty(),
-            path: BunString::empty(),
-        }
-    }
+    code: OwnedString,
+    message: OwnedString,
+    path: OwnedString,
 }
 
 impl JSS3Error {
     pub(crate) fn init(code: &[u8], message: &[u8], path: Option<&[u8]>) -> Self {
         Self {
             // lets make sure we can reuse code and message and keep it service independent
-            code: BunString::create_atom_if_possible(code),
-            message: BunString::create_atom_if_possible(message),
-            path: if let Some(p) = path {
+            code: OwnedString::new(BunString::create_atom_if_possible(code)),
+            message: OwnedString::new(BunString::create_atom_if_possible(message)),
+            path: OwnedString::new(if let Some(p) = path {
                 BunString::init(p)
             } else {
                 BunString::empty()
-            },
+            }),
         }
     }
 
     pub(crate) fn to_error_instance(self, global: &JSGlobalObject) -> JSValue {
-        // `self` is consumed; `Drop` derefs the three strings after the FFI
-        // call returns (C++ only reads them, it does not consume the refs).
+        // `self` is consumed; `OwnedString` fields deref after the FFI call
+        // returns (C++ only reads the fields, it does not consume the refs).
         S3Error__toErrorInstance(&self, global)
-    }
-}
-
-impl Drop for JSS3Error {
-    fn drop(&mut self) {
-        // `bun_core::String` is `Copy` and has no `Drop`; release the +1 from
-        // `create_atom_if_possible` explicitly.
-        self.path.deref();
-        self.code.deref();
-        self.message.deref();
     }
 }
 

--- a/src/runtime/webcore/s3/error_jsc.rs
+++ b/src/runtime/webcore/s3/error_jsc.rs
@@ -147,12 +147,20 @@ impl JSS3Error {
         }
     }
 
-    // The three `bun_core::String` fields deref themselves via `Drop`, so no
-    // explicit `Drop` impl is needed here.
-
     pub(crate) fn to_error_instance(self, global: &JSGlobalObject) -> JSValue {
-        // `defer this.deinit()` → `self` is consumed and dropped at scope exit.
+        // `self` is consumed; `Drop` derefs the three strings after the FFI
+        // call returns (C++ only reads them, it does not consume the refs).
         S3Error__toErrorInstance(&self, global)
+    }
+}
+
+impl Drop for JSS3Error {
+    fn drop(&mut self) {
+        // `bun_core::String` is `Copy` and has no `Drop`; release the +1 from
+        // `create_atom_if_possible` explicitly.
+        self.path.deref();
+        self.code.deref();
+        self.message.deref();
     }
 }
 

--- a/test/js/bun/s3/s3-error-leak-fixture.ts
+++ b/test/js/bun/s3/s3-error-leak-fixture.ts
@@ -1,0 +1,79 @@
+// Each failed S3 request surfaces an `S3Error` to JS via `JSS3Error`, which
+// allocates two WTFStringImpls (code + message) with +1 refs. Those refs must
+// be released on the Rust side after the FFI call; if not, every failed
+// request leaks the message string forever.
+//
+// We force the <Message> over 64 bytes so `create_atom_if_possible` falls
+// through to a fresh `clone_utf8` allocation (atoms are interned and would
+// hide the leak behind a single refcount), and make each message unique so
+// leaked allocations accumulate visibly in RSS.
+
+import { S3Client } from "bun";
+
+const msgSize = 128 * 1024;
+const warmup = 200;
+const main = 200;
+
+let n = 0;
+const pad = Buffer.alloc(msgSize, "m").toString();
+const server = Bun.serve({
+  port: 0,
+  hostname: "127.0.0.1",
+  fetch() {
+    const msg = `req-${n++}-${pad}`;
+    const body = `<?xml version="1.0"?><Error><Code>NoSuchBucket</Code><Message>${msg}</Message></Error>`;
+    return new Response(body, {
+      status: 404,
+      headers: { "content-type": "application/xml" },
+    });
+  },
+});
+
+const s3 = new S3Client({
+  accessKeyId: "x",
+  secretAccessKey: "y",
+  endpoint: `http://127.0.0.1:${server.port}`,
+  bucket: "b",
+});
+
+async function hit() {
+  try {
+    await s3.file("k").text();
+    throw new Error("expected S3 request to fail");
+  } catch (e: any) {
+    if (e?.code !== "NoSuchBucket") throw e;
+  }
+}
+
+for (let i = 0; i < warmup; i++) await hit();
+Bun.gc(true);
+await Bun.sleep(10);
+Bun.gc(true);
+
+const before = process.memoryUsage.rss();
+
+for (let i = 0; i < main; i++) await hit();
+Bun.gc(true);
+await Bun.sleep(10);
+Bun.gc(true);
+
+const growth = process.memoryUsage.rss() - before;
+
+server.stop(true);
+
+// Expected leak on the unfixed build: `main * msgSize` ≈ 25 MB of message
+// strings. The threshold sits at half that so fixed builds (near-zero growth)
+// pass with room for allocator noise.
+const thresholdBytes = (main * msgSize) / 2;
+console.log(
+  JSON.stringify({
+    growth,
+    threshold: thresholdBytes,
+    leaked: growth > thresholdBytes,
+  }),
+);
+if (growth > thresholdBytes) {
+  throw new Error(
+    `S3 error path leaked ${(growth / 1024 / 1024).toFixed(1)} MB over ${main} failed requests`,
+  );
+}

--- a/test/js/bun/s3/s3-error-leak.test.ts
+++ b/test/js/bun/s3/s3-error-leak.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
+import path from "path";
+
+test(
+  "S3 error path does not leak WTFStringImpl refs",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", path.join(import.meta.dir, "s3-error-leak-fixture.ts")],
+      env: {
+        ...bunEnv,
+        // S3Client picks up HTTP_PROXY without consulting NO_PROXY, so clear
+        // it for the loopback mock.
+        HTTP_PROXY: undefined,
+        HTTPS_PROXY: undefined,
+        http_proxy: undefined,
+        https_proxy: undefined,
+        // ASAN's default quarantine retains freed allocations, which masks the
+        // fixed/unfixed RSS delta. Disable it so freed WTFStringImpls actually
+        // leave the process.
+        ...(isASAN && {
+          ASAN_OPTIONS:
+            "allow_user_segv_handler=1:disable_coredump=0:quarantine_size_mb=0:thread_local_quarantine_size_kb=0",
+        }),
+      },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    if (exitCode !== 0) console.error(stderr);
+    expect(stdout.trim()).toMatch(/"leaked":false/);
+    expect(exitCode).toBe(0);
+  },
+  60_000,
+);

--- a/test/js/bun/s3/s3-error-leak.test.ts
+++ b/test/js/bun/s3/s3-error-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe } from "harness";
 import path from "path";
 
 test("S3 error path does not leak WTFStringImpl refs", async () => {
@@ -13,13 +13,12 @@ test("S3 error path does not leak WTFStringImpl refs", async () => {
       HTTPS_PROXY: undefined,
       http_proxy: undefined,
       https_proxy: undefined,
-      // ASAN's default quarantine retains freed allocations, which masks the
-      // fixed/unfixed RSS delta. Disable it so freed WTFStringImpls actually
-      // leave the process.
-      ...(isASAN && {
-        ASAN_OPTIONS:
-          "allow_user_segv_handler=1:disable_coredump=0:quarantine_size_mb=0:thread_local_quarantine_size_kb=0",
-      }),
+      // ASAN's quarantine retains freed allocations, which masks the RSS
+      // delta this test measures. Disable it for the subprocess; harmless
+      // when the binary is not ASAN-built.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0", "thread_local_quarantine_size_kb=0"]
+        .filter(Boolean)
+        .join(":"),
     },
     stderr: "pipe",
     stdout: "pipe",
@@ -28,4 +27,4 @@ test("S3 error path does not leak WTFStringImpl refs", async () => {
   if (exitCode !== 0) console.error(stderr);
   expect(stdout.trim()).toMatch(/"leaked":false/);
   expect(exitCode).toBe(0);
-}, 60_000);
+});

--- a/test/js/bun/s3/s3-error-leak.test.ts
+++ b/test/js/bun/s3/s3-error-leak.test.ts
@@ -2,38 +2,30 @@ import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN } from "harness";
 import path from "path";
 
-test(
-  "S3 error path does not leak WTFStringImpl refs",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "--smol", path.join(import.meta.dir, "s3-error-leak-fixture.ts")],
-      env: {
-        ...bunEnv,
-        // S3Client picks up HTTP_PROXY without consulting NO_PROXY, so clear
-        // it for the loopback mock.
-        HTTP_PROXY: undefined,
-        HTTPS_PROXY: undefined,
-        http_proxy: undefined,
-        https_proxy: undefined,
-        // ASAN's default quarantine retains freed allocations, which masks the
-        // fixed/unfixed RSS delta. Disable it so freed WTFStringImpls actually
-        // leave the process.
-        ...(isASAN && {
-          ASAN_OPTIONS:
-            "allow_user_segv_handler=1:disable_coredump=0:quarantine_size_mb=0:thread_local_quarantine_size_kb=0",
-        }),
-      },
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
-    if (exitCode !== 0) console.error(stderr);
-    expect(stdout.trim()).toMatch(/"leaked":false/);
-    expect(exitCode).toBe(0);
-  },
-  60_000,
-);
+test("S3 error path does not leak WTFStringImpl refs", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", path.join(import.meta.dir, "s3-error-leak-fixture.ts")],
+    env: {
+      ...bunEnv,
+      // S3Client picks up HTTP_PROXY without consulting NO_PROXY, so clear
+      // it for the loopback mock.
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      http_proxy: undefined,
+      https_proxy: undefined,
+      // ASAN's default quarantine retains freed allocations, which masks the
+      // fixed/unfixed RSS delta. Disable it so freed WTFStringImpls actually
+      // leave the process.
+      ...(isASAN && {
+        ASAN_OPTIONS:
+          "allow_user_segv_handler=1:disable_coredump=0:quarantine_size_mb=0:thread_local_quarantine_size_kb=0",
+      }),
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout.trim()).toMatch(/"leaked":false/);
+  expect(exitCode).toBe(0);
+}, 60_000);

--- a/test/js/bun/s3/s3-error-leak.test.ts
+++ b/test/js/bun/s3/s3-error-leak.test.ts
@@ -27,4 +27,4 @@ test("S3 error path does not leak WTFStringImpl refs", async () => {
   if (exitCode !== 0) console.error(stderr);
   expect(stdout.trim()).toMatch(/"leaked":false/);
   expect(exitCode).toBe(0);
-});
+}, 30_000);


### PR DESCRIPTION
## What

`JSS3Error` is a `#[repr(C)]` struct holding three `bun_core::String` fields (`code`, `message`, `path`). `init()` populates `code` and `message` via `String::create_atom_if_possible`, which returns a +1 ref. The Zig reference (`error_jsc.zig`) releases those refs via `defer this.deinit()` after `S3Error__toErrorInstance` returns; the Rust port dropped `self` by value and left a comment claiming the `bun_core::String` fields deref themselves via `Drop`. They don't: `bun_core::String` is `#[derive(Copy)]` with no `Drop`.

So every failed S3 request surfaced to JS (NoSuchKey, AccessDenied, NoSuchBucket, any XML `<Error>` response) leaked the `code` and `message` `WTFStringImpl`s. The C++ side (`S3Error__toErrorInstance` in `S3Error.cpp`) only reads the fields via `toWTFString()` / `Bun::toJS()` and does not consume the refs.

## Fix

Add `impl Drop for JSS3Error` that calls `.deref()` on all three fields, mirroring the Zig `deinit()`. `to_error_instance(self)` already consumes `self` by value, so `Drop` runs after the FFI call returns, which is exactly `defer this.deinit()`.

## Verification

New RSS-based leak test (`test/js/bun/s3/s3-error-leak.test.ts`) points an `S3Client` at a local mock that returns 404 with a 128 KB unique `<Message>` (large enough to skip atom interning and hit `clone_utf8`). After a warmup phase to stabilise allocator pools, 200 failed requests:

| build | RSS growth |
| --- | --- |
| `bun bd` before fix | ~25 MB |
| `bun bd` after fix | ~0 MB |
| release (system bun) before fix | ~24 MB |

Threshold sits at 12.5 MB (half the expected leak).

## Related sites with the same mistaken assumption

Noted for follow-up, not changed here (different subsystems, each would need its own test):

- `src/sql/postgres/protocol/FieldMessage.rs` / `NegotiateProtocolVersion.rs`: `clone_utf8` into `Vec<String>` with no `.deref()`; comment claims Vec drops each element.
- `src/runtime/cli/pack_command.rs` `EntryInfo`: `clone_utf8` into struct fields with no `.deref()`.
- `src/runtime/webcore/Body.rs` `ValueError::reset()` `SystemError` arm: does not call `system_error.deref()`; `SystemError` has no `Drop`.
- Harmless but wrong comments (fields are borrows, no +1): `install_jsc/ini_jsc.rs:139`, `valkey_jsc/js_valkey.rs:496`, `test_runner/ScopeFunctions.rs:578`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 8 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-error-leak.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f56c4f77f)

test/js/bun/s3/s3-error-leak.test.ts:
71 |     threshold: thresholdBytes,
72 |     leaked: growth > thresholdBytes,
73 |   }),
74 | );
75 | if (growth > thresholdBytes) {
76 |   throw new Error(
                 ^
error: S3 error path leaked 24.9 MB over 200 failed requests
      at /workspace/bun/test/js/bun/s3/s3-error-leak-fixture.ts:76:13

Bun v1.4.0-debug+f56c4f77f (Linux x64)

23 |     stderr: "pipe",
24 |     stdout: "pipe",
25 |   });
26 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
27 |   if (exitCode !== 0) console.error(stderr);
28 |   expect(stdout.trim()).toMatch(/"leaked":false/);
                             ^
error: expect(received).t
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (1498d7b77)

test/js/bun/s3/s3-error-leak.test.ts:
71 |     threshold: thresholdBytes,
72 |     leaked: growth > thresholdBytes,
73 |   }),
74 | );
75 | if (growth > thresholdBytes) {
76 |   throw new Error(
                 ^
error: S3 error path leaked 25.0 MB over 200 failed requests
      at /workspace/bun/test/js/bun/s3/s3-error-leak-fixture.ts:76:13

Bun v1.4.0-canary.1+1498d7b77 (Linux x64)

23 |     stderr: "pipe",
24 |     stdout: "pipe",
25 |   });
26 |   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
27 |   if (exitCode !== 0) console.error(stderr);
28 |   expect(stdout.trim()).toMatch(/"leaked":false/);
                             ^
error: expect(received).toMatch(expected)

Expected substring or pattern: /"leaked":false/
Received: "{\"growth\":26214400,\"threshold\":13107200,\"leaked\":true}"

      at <anonymous> (/workspace/bun/test/js/bun/s3/s3-error-leak.test.ts:28:25)
(fail) S3 error path does not leak WTFStringImpl refs [256.44ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [415.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/bun/s3/s3-error-leak.test.ts"
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (f56c4f77f)

test/js/bun/s3/s3-error-leak.test.ts:
(pass) S3 error path does not leak WTFStringImpl refs [2920.71ms]

 1 pass
 0 fail
 2 expect() calls
Ran 1 test across 1 file. [5.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     f56c4f77f3
  features     (none)

22 deps, 106 codegen, 1168 objects in 827ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1231] install /workspace/bun
bun install v1.4.0-canary.1 (1498d7b77)

Checked 124 installs across 170 packages (no changes) [31.00ms]
[2/1231] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (1498d7b77)

Checked 1 install across 2 packages (no changes) [2.00ms]
[3/1231] fetch tinycc
[tinycc] up to date
[4/1230] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (1498d7b77)

Checked 129 installs across 147 packages (no changes) [15.00ms]
[5/1230] fetch zlib
[zlib] up to date
[6/1230] gen ErrorCode+*.h
[7/1230] gen bindgenv2
[8/1230] gen .bind.ts → Generate
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/webcore/s3/error_jsc.rs     | 38 +++++++---------
 test/js/bun/s3/s3-error-leak-fixture.ts | 79 +++++++++++++++++++++++++++++++++
 test/js/bun/s3/s3-error-leak.test.ts    | 30 +++++++++++++
 3 files changed, 125 insertions(+), 22 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 8

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/webcore/s3/error_jsc.rs          4      5     12
test/js/bun/s3/s3-error-leak-fixture.ts      1      2     18
test/js/bun/s3/s3-error-leak.test.ts         3      6     12
```

</details>

<!-- robobun:evidence:end -->