### PR TITLE
crypto: accept argon2 PHC params in any order in Bun.password.verify

### DIFF
--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -225,10 +225,14 @@ pub mod argon2 {
             let params = &rest[..params_end];
             let tail = &rest[params_end..];
 
-            // Parse m/t/p in any order, applying the verify-time DoS limits.
-            let mut m_pair: Option<&str> = None;
-            let mut t_pair: Option<&str> = None;
-            let mut p_pair: Option<&str> = None;
+            // Parse m/t/p in any order. The verify-time DoS limits are
+            // applied only after the segment is known to be structurally
+            // valid (exactly one of each, no unknowns), so a malformed
+            // segment that also happens to carry an oversized value is
+            // still reported as `InvalidEncoding` regardless of order.
+            let mut m_pair: Option<(&str, u32)> = None;
+            let mut t_pair: Option<(&str, u32)> = None;
+            let mut p_pair: Option<(&str, u32)> = None;
             let mut canonical = true;
             for (idx, pair) in params.split(',').enumerate() {
                 let Some((key, value)) = pair.split_once('=') else {
@@ -237,27 +241,32 @@ pub mod argon2 {
                 let Ok(value) = value.parse::<u32>() else {
                     break 'norm std::borrow::Cow::Borrowed(encoded);
                 };
-                let (slot, limit, expected_idx) = match key {
-                    "m" => (&mut m_pair, MAX_VERIFY_MEMORY_COST, 0),
-                    "t" => (&mut t_pair, MAX_VERIFY_TIME_COST, 1),
-                    "p" => (&mut p_pair, MAX_VERIFY_PARALLELISM, 2),
+                let (slot, expected_idx) = match key {
+                    "m" => (&mut m_pair, 0),
+                    "t" => (&mut t_pair, 1),
+                    "p" => (&mut p_pair, 2),
                     _ => break 'norm std::borrow::Cow::Borrowed(encoded),
                 };
                 if slot.is_some() {
                     break 'norm std::borrow::Cow::Borrowed(encoded);
                 }
-                if value > limit {
-                    return Err(crate::Error::WeakParameters);
-                }
                 if idx != expected_idx {
                     canonical = false;
                 }
-                *slot = Some(pair);
+                *slot = Some((pair, value));
             }
 
-            let (Some(m), Some(t), Some(p)) = (m_pair, t_pair, p_pair) else {
+            let (Some((m, m_value)), Some((t, t_value)), Some((p, p_value))) =
+                (m_pair, t_pair, p_pair)
+            else {
                 break 'norm std::borrow::Cow::Borrowed(encoded);
             };
+            if m_value > MAX_VERIFY_MEMORY_COST
+                || t_value > MAX_VERIFY_TIME_COST
+                || p_value > MAX_VERIFY_PARALLELISM
+            {
+                return Err(crate::Error::WeakParameters);
+            }
 
             if had_version && canonical {
                 std::borrow::Cow::Borrowed(encoded)

--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -181,71 +181,100 @@ pub mod argon2 {
         // failure.
         let encoded = super::phc_ascii_str(encoded_hash)?;
 
-        // Only version 0x13 is accepted: an explicit `v=` segment that isn't
-        // `19` is `InvalidEncoding`, and a missing `v=` segment still hashes
-        // with 0x13.
-        // rust-argon2's `verify_encoded` instead accepts `v=16` (computing
-        // with Version10) and defaults a missing segment to Version10, so
-        // pre-scan and normalise here before delegating.
+        // Encoded shape is `$<alg>$[v=N$]m=..,t=..,p=..$<salt>$<hash>`.
+        // rust-argon2's `decode_string` is stricter than Zig's phc_format:
+        //   * an explicit `v=` other than 19 is accepted as Version10 (we
+        //     reject it), and a missing `v=` segment defaults to Version10
+        //     (we want 0x13);
+        //   * `m=`/`t=`/`p=` must appear in exactly that positional order,
+        //     whereas phc_format deserialises key=value pairs by name in
+        //     any order — hashes emitted by other ecosystems (PHP, Go) do
+        //     not all use canonical order.
+        // Pre-scan and normalise here before delegating. Anything that
+        // doesn't fit the expected shape is passed through unchanged for
+        // rust-argon2 to reject.
         let normalised: std::borrow::Cow<'_, str> = 'norm: {
-            // Encoded shape is `$<alg>$[v=N$]m=..,t=..,p=..$<salt>$<hash>`.
-            // Locate the segment immediately after the alg-id.
             let Some(after_dollar) = encoded.strip_prefix('$') else {
                 // Malformed; let rust-argon2 reject it.
                 break 'norm std::borrow::Cow::Borrowed(encoded);
             };
-            let Some(sep) = after_dollar.find('$') else {
+            let Some(alg_sep) = after_dollar.find('$') else {
                 break 'norm std::borrow::Cow::Borrowed(encoded);
             };
-            // Absolute index of the '$' terminating the alg-id.
-            let alg_end = 1 + sep;
-            let rest = &encoded[alg_end + 1..];
-            if let Some(v) = rest.strip_prefix("v=") {
-                let end = v.find('$').unwrap_or(v.len());
+            let alg = &after_dollar[..alg_sep];
+            let mut rest = &after_dollar[alg_sep + 1..];
+
+            // Optional `v=N` segment.
+            let had_version = if let Some(v) = rest.strip_prefix("v=") {
+                let Some(end) = v.find('$') else {
+                    break 'norm std::borrow::Cow::Borrowed(encoded);
+                };
                 if &v[..end] != "19" {
                     return Err(crate::Error::InvalidEncoding);
                 }
+                rest = &v[end + 1..];
+                true
+            } else {
+                false
+            };
+
+            // `<params>$<salt>$<hash>` — `tail` keeps its leading '$'.
+            let Some(params_end) = rest.find('$') else {
+                break 'norm std::borrow::Cow::Borrowed(encoded);
+            };
+            let params = &rest[..params_end];
+            let tail = &rest[params_end..];
+
+            // Parse m/t/p in any order, applying the verify-time DoS limits.
+            let mut m_pair: Option<&str> = None;
+            let mut t_pair: Option<&str> = None;
+            let mut p_pair: Option<&str> = None;
+            let mut canonical = true;
+            for (idx, pair) in params.split(',').enumerate() {
+                let Some((key, value)) = pair.split_once('=') else {
+                    break 'norm std::borrow::Cow::Borrowed(encoded);
+                };
+                let Ok(value) = value.parse::<u32>() else {
+                    break 'norm std::borrow::Cow::Borrowed(encoded);
+                };
+                let (slot, limit, expected_idx) = match key {
+                    "m" => (&mut m_pair, MAX_VERIFY_MEMORY_COST, 0),
+                    "t" => (&mut t_pair, MAX_VERIFY_TIME_COST, 1),
+                    "p" => (&mut p_pair, MAX_VERIFY_PARALLELISM, 2),
+                    _ => break 'norm std::borrow::Cow::Borrowed(encoded),
+                };
+                if slot.is_some() {
+                    break 'norm std::borrow::Cow::Borrowed(encoded);
+                }
+                if value > limit {
+                    return Err(crate::Error::WeakParameters);
+                }
+                if idx != expected_idx {
+                    canonical = false;
+                }
+                *slot = Some(pair);
+            }
+
+            let (Some(m), Some(t), Some(p)) = (m_pair, t_pair, p_pair) else {
+                break 'norm std::borrow::Cow::Borrowed(encoded);
+            };
+
+            if had_version && canonical {
                 std::borrow::Cow::Borrowed(encoded)
             } else {
-                // No `v=` segment — splice in `v=19$` so rust-argon2 hashes
-                // with Version13.
                 let mut s = String::with_capacity(encoded.len() + 5);
-                s.push_str(&encoded[..=alg_end]);
-                s.push_str("v=19$");
-                s.push_str(rest);
+                s.push('$');
+                s.push_str(alg);
+                s.push_str("$v=19$");
+                s.push_str(m);
+                s.push(',');
+                s.push_str(t);
+                s.push(',');
+                s.push_str(p);
+                s.push_str(tail);
                 std::borrow::Cow::Owned(s)
             }
         };
-
-        if let Some(after_dollar) = normalised.strip_prefix('$') {
-            if let Some(sep) = after_dollar.find('$') {
-                let mut rest = &after_dollar[sep + 1..];
-                if let Some(after_version) = rest.strip_prefix("v=") {
-                    rest = match after_version.find('$') {
-                        Some(end) => &after_version[end + 1..],
-                        None => "",
-                    };
-                }
-                let params = &rest[..rest.find('$').unwrap_or(rest.len())];
-                for pair in params.split(',') {
-                    let Some((key, value)) = pair.split_once('=') else {
-                        continue;
-                    };
-                    let Ok(value) = value.parse::<u32>() else {
-                        continue;
-                    };
-                    let limit = match key {
-                        "m" => MAX_VERIFY_MEMORY_COST,
-                        "t" => MAX_VERIFY_TIME_COST,
-                        "p" => MAX_VERIFY_PARALLELISM,
-                        _ => continue,
-                    };
-                    if value > limit {
-                        return Err(crate::Error::WeakParameters);
-                    }
-                }
-            }
-        }
 
         match vendor::verify_encoded(&normalised, password) {
             Ok(true) => Ok(()),

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -392,6 +392,57 @@ for (let algorithmValue of algorithms) {
   });
 }
 
+test("verify accepts argon2 PHC strings with m/t/p in any order", async () => {
+  // PHC string format permits parameters in any order; hashes emitted by
+  // e.g. PHP's password_hash or some Go wrappers are not always in the
+  // canonical `m,t,p` order that rust-argon2's decoder requires.
+  const hashed = password.hashSync("password", {
+    algorithm: "argon2id",
+    memoryCost: 16,
+    timeCost: 2,
+  });
+  expect(hashed).toContain("$m=16,t=2,p=1$");
+
+  const reorder = (order: readonly ["m" | "t" | "p", "m" | "t" | "p", "m" | "t" | "p"]) => {
+    const parts = { m: "m=16", t: "t=2", p: "p=1" };
+    return hashed.replace("m=16,t=2,p=1", order.map(k => parts[k]).join(","));
+  };
+
+  // All 6 permutations verify for the correct password and reject the wrong
+  // one, via both the sync and async entry points.
+  for (const order of [
+    ["m", "t", "p"],
+    ["m", "p", "t"],
+    ["t", "m", "p"],
+    ["t", "p", "m"],
+    ["p", "m", "t"],
+    ["p", "t", "m"],
+  ] as const) {
+    const permuted = reorder(order);
+    expect(password.verifySync("password", permuted)).toBeTrue();
+    expect(await password.verify("password", permuted)).toBeTrue();
+    expect(password.verifySync("wrong", permuted)).toBeFalse();
+  }
+
+  // Reordering composes with a missing `v=` segment (both normalisations
+  // happen in the same pre-scan).
+  const noVersion = reorder(["t", "m", "p"]).replace("$v=19$", "$");
+  expect(noVersion).not.toContain("v=");
+  expect(password.verifySync("password", noVersion)).toBeTrue();
+  expect(password.verifySync("wrong", noVersion)).toBeFalse();
+
+  // The DoS limit check still applies to a reordered params segment.
+  const reorderedHugeTime = hashed.replace("m=16,t=2,p=1", "t=100000,m=16,p=1");
+  expect(() => password.verifySync("password", reorderedHugeTime)).toThrow("WeakParameters");
+
+  // Malformed / duplicate / unknown params are still rejected rather than
+  // being silently dropped by the reorder pass.
+  for (const bad of ["m=16,t=2", "m=16,t=2,p=1,p=1", "m=16,t=2,x=1"]) {
+    const tampered = hashed.replace("m=16,t=2,p=1", bad);
+    expect(() => password.verifySync("password", tampered)).toThrow("InvalidEncoding");
+  }
+});
+
 test("verify rejects encoded argon2 hashes with cost parameters above the supported maximums", async () => {
   // Hash with small, fast parameters so this test stays cheap on debug builds.
   const hashed = password.hashSync("correct horse", {

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -436,8 +436,17 @@ test("verify accepts argon2 PHC strings with m/t/p in any order", async () => {
   expect(() => password.verifySync("password", reorderedHugeTime)).toThrow("WeakParameters");
 
   // Malformed / duplicate / unknown params are still rejected rather than
-  // being silently dropped by the reorder pass.
-  for (const bad of ["m=16,t=2", "m=16,t=2,p=1,p=1", "m=16,t=2,x=1"]) {
+  // being silently dropped by the reorder pass. A malformed segment that
+  // also carries an oversized value is InvalidEncoding, not WeakParameters,
+  // regardless of where the oversized value sits.
+  for (const bad of [
+    "m=16,t=2",
+    "m=16,t=2,p=1,p=1",
+    "m=16,t=2,x=1",
+    "m=4294967294,t=2",
+    "t=2,m=4294967294",
+    "m=4294967294,x=1,t=2,p=1",
+  ]) {
     const tampered = hashed.replace("m=16,t=2,p=1", bad);
     expect(() => password.verifySync("password", tampered)).toThrow("InvalidEncoding");
   }


### PR DESCRIPTION
## Repro

```console
$ bun -e 'const h=Bun.password.hashSync("password",{algorithm:"argon2id",memoryCost:16,timeCost:2});const r=h.replace(/m=(\d+),t=(\d+),p=(\d+)/,"t=$2,m=$1,p=$3");console.log(Bun.password.verifySync("password",r))'
error: Password verification failed with error "InvalidEncoding"
 code: "PASSWORD_INVALID_ENCODING"
```

Bun 1.3.x (Zig) prints `true` for the same input.

## Cause

Zig std's `phc_format.deserialize` into `HashResult{m,t,p}` parses `key=value` pairs by field name and accepts them in any order. The Rust port delegates to `rust-argon2`'s `verify_encoded`, whose [`decode_options`](https://github.com/sru-systems/rust-argon2/blob/3.0.0/src/encoding.rs) requires the literal positional order `m,t,p` and returns `DecodingFail` (mapped to `InvalidEncoding`) otherwise.

Hashes emitted by other ecosystems (PHP `password_hash`, some Go argon2 wrappers) do not all use the canonical `m,t,p` order, so externally-generated hashes that verified on earlier Bun releases now fail.

## Fix

`str_verify` already pre-scans the PHC string to splice in a missing `v=19` segment and to enforce the verify-time DoS limits, iterating the params segment order-agnostically. Extend that single pass to capture each `m=`/`t=`/`p=` pair and, when the order is not already canonical (or `v=` is absent), rebuild the string as `$<alg>$v=19$<m>,<t>,<p>$<salt>$<hash>` before handing off to `rust-argon2`. The common case (`v=19` present, `m,t,p` already canonical) stays `Cow::Borrowed` with no allocation. Unknown / duplicate / malformed params fall through unchanged for `rust-argon2` to reject as before.

## Verification

New test in `test/js/bun/util/password.test.ts` covers all six `m/t/p` permutations (sync + async, correct and wrong password), the composition with a missing `v=` segment, the DoS limit check on a reordered segment, and rejection of missing/duplicate/unknown params.

- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/password.test.ts -t 'm/t/p in any order'` → fail (`InvalidEncoding`)
- `bun bd test test/js/bun/util/password.test.ts` → 69 pass / 0 fail

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 7 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/password.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (63d1ac564)

test/js/bun/util/password.test.ts:
(skip) does not leak > hashSync
(skip) does not leak > hash
(pass) hash > arguments parsing > no blank password allowed [3.92ms]
(pass) hash > arguments parsing > password is required [2.46ms]
(pass) hash > arguments parsing > invalid algorithm throws [19.54ms]
(pass) hash > arguments parsing > coercion throwing doesn't crash [5.34ms]
(pass) hash > arguments parsing > empty Uint8Array throws [2.98ms]
(pass) hash > arguments parsing > empty Uint16Array throws [1.00ms]
(pass) hash > arguments parsing > empty Uint32Array throws [0.79ms]
(pass) hash > arguments parsing > empty Int8Array throws [0.77ms]
(pass) hash > arguments parsing > empty Int16Array throws [0.68ms]
(pass) hash > argument
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (d06d93167)

test/js/bun/util/password.test.ts:
(pass) does not leak > hashSync [2063.48ms]
(pass) does not leak > hash [802.17ms]
(pass) hash > arguments parsing > no blank password allowed [0.24ms]
(pass) hash > arguments parsing > password is required [0.06ms]
(pass) hash > arguments parsing > invalid algorithm throws [0.46ms]
(pass) hash > arguments parsing > coercion throwing doesn't crash [0.11ms]
(pass) hash > arguments parsing > empty Uint8Array throws [0.06ms]
(pass) hash > arguments parsing > empty Uint16Array throws [0.01ms]
(pass) hash > arguments parsing > empty Uint32Array throws
(pass) hash > arguments parsing > empty Int8Array throws
(pass) hash > arguments parsing > empty Int16Array throws
(pass) hash > arguments parsing > empty Int32Array throws
(pass) hash > arguments parsing > empty Float16Array throws
(pass) hash > arguments parsing > empty Float32Array throws
(pass) hash > arguments parsing > empty Float64Array throws
(pass) hash > arguments parsing > empty ArrayBuffer throws [0.04ms]
(pass) hash > arguments parsing > no blank password allowed [0.01ms]
(pass) hash > arguments parsing > password is required
(pass) hash >
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 8 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/util/password.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (63d1ac564)

test/js/bun/util/password.test.ts:
(skip) does not leak > hashSync
(skip) does not leak > hash
(pass) hash > arguments parsing > no blank password allowed [4.17ms]
(pass) hash > arguments parsing > password is required [2.38ms]
(pass) hash > arguments parsing > invalid algorithm throws [19.95ms]
(pass) hash > arguments parsing > coercion throwing doesn't crash [5.22ms]
(pass) hash > arguments parsing > empty Uint8Array throws [2.92ms]
(pass) hash > arguments parsing > empty Uint16Array throws [0.72ms]
(pass) hash > arguments parsing > empty Uint32Array throws [0.55ms]
(pass) hash > arguments parsing > empty Int8Array throws [0.49ms]
(pass) hash > arguments parsing > empty Int16Array throws [0.47ms]
(pass) hash > argument
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 686ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version: 1.29.0)
[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/crypto/pwhash.rs      | 136 ++++++++++++++++++++++++--------------
 test/js/bun/util/password.test.ts |  60 +++++++++++++++++
 2 files changed, 147 insertions(+), 49 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 7

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
src/runtime/crypto/pwhash.rs           3      4      4
test/js/bun/util/password.test.ts      2      2      4
```

</details>

<!-- robobun:evidence:end -->