### PR TITLE
fix(Bun.password): accept optional v= segment in PHC bcrypt hashes

### DIFF
--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -385,7 +385,7 @@ pub mod bcrypt {
         }
     }
 
-    /// Verify a PHC-encoded bcrypt hash: `$bcrypt$r=N$<b64 salt>$<b64 hash>`.
+    /// Verify a PHC-encoded bcrypt hash: `$bcrypt$[v=V$]r=N$<b64 salt>$<b64 hash>`.
     ///
     /// The Rust `bcrypt` crate has no PHC codec, so parse the string here,
     /// recompute via the raw block cipher, and compare the 23-byte digests.
@@ -398,6 +398,16 @@ pub mod bcrypt {
         if alg_id != "bcrypt" {
             return Err(bun_core::err!("PasswordVerificationFailed"));
         }
+
+        // Optional `v=<version>` segment (PHC string-format spec). bcrypt has
+        // no versioning that affects the digest, so accept and discard it.
+        let rest = match rest.strip_prefix("v=") {
+            Some(after_v) => {
+                let (_, rest) = after_v.split_once('$').ok_or_else(invalid)?;
+                rest
+            }
+            None => rest,
+        };
 
         // r=N (rounds must fit in 6 bits; checked below)
         let (params, rest) = rest.split_once('$').ok_or_else(invalid)?;

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -265,6 +265,20 @@ test.concurrent("bcrypt pre-hashing does not break compatibility across Bun vers
   expect(await password.verify(secret, hash)).toBeTrue();
 });
 
+test.concurrent("bcrypt PHC-format hashes accept the optional v= segment", async () => {
+  // $bcrypt$r=4$<salt>$<hash> derived from the modular-crypt hash of "hello" at cost 4.
+  const salt = "4/oeh1q2vAEB2Dxgn4q/UQ";
+  const dk = "sf22627z3ZZphiGZ2tAwdvbTHXSRk5g";
+  for (const v of ["", "v=19$", "v=2b$"]) {
+    const hash = `$bcrypt$${v}r=4$${salt}$${dk}`;
+    expect(password.verifySync("hello", hash)).toBeTrue();
+    expect(password.verifySync("wrong", hash)).toBeFalse();
+    expect(password.verifySync("hello", hash, "bcrypt")).toBeTrue();
+    expect(await password.verify("hello", hash)).toBeTrue();
+    expect(await password.verify("wrong", hash)).toBeFalse();
+  }
+});
+
 test.concurrent("argon2 memoryCost at the 8 minimum is encoded faithfully (regression for #30960)", async () => {
   const hashed = await password.hash("test", {
     algorithm: "argon2id",


### PR DESCRIPTION
## Repro

```js
Bun.password.verifySync("hello", "$bcrypt$v=19$r=4$MDEyMzQ1Njc4OWFiY2RlZg$AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")
```

Before: throws with `code: "PASSWORD_INVALID_ENCODING"`.
After: returns `false` (and returns `true` for a matching password).

## Cause

The PHC string format defines an optional `$v=<version>$` segment between the algorithm id and the parameters. Zig's `std.crypto.phc_format.deserialize` (used by `bcrypt.strVerify`) parsed and discarded it, so `$bcrypt$v=19$r=4$<salt>$<hash>` decoded and ran the comparison. The Rust port's hand-rolled parser in `src/runtime/crypto/pwhash.rs` went straight from `$bcrypt$` to `r=`, so `"v=19".strip_prefix("r=")` failed and surfaced as `InvalidEncoding`.

## Fix

Skip an optional `v=...$` segment before reading `r=`, mirroring what the argon2 path in the same file already does.

## Verification

Added a test in `test/js/bun/util/password.test.ts` covering `v=19` and `v=2b`, sync and async, auto-detected and explicit `"bcrypt"`. Fails on main with `PASSWORD_INVALID_ENCODING`, passes with this change. Full `password.test.ts` is green.