### PR TITLE
Bun.serve: reject sign-prefixed Range header bounds

### DIFF
--- a/src/runtime/server/RangeRequest.rs
+++ b/src/runtime/server/RangeRequest.rs
@@ -91,21 +91,21 @@ pub fn parse_raw(header: &[u8]) -> Raw {
     let end_s = strings::trim(&rest[dash + 1..], b" \t");
 
     if start_s.is_empty() {
-        let Some(n) = bun_core::fmt::parse_decimal::<u64>(end_s) else {
+        let Ok(n) = bun_core::fmt::parse_unsigned::<u64>(end_s, 10) else {
             return Raw::None;
         };
         return Raw::Suffix(n);
     }
 
-    let Some(start) = bun_core::fmt::parse_decimal::<u64>(start_s) else {
+    let Ok(start) = bun_core::fmt::parse_unsigned::<u64>(start_s, 10) else {
         return Raw::None;
     };
     let end: Option<u64> = if end_s.is_empty() {
         None
     } else {
-        match bun_core::fmt::parse_decimal::<u64>(end_s) {
-            Some(v) => Some(v),
-            None => return Raw::None,
+        match bun_core::fmt::parse_unsigned::<u64>(end_s, 10) {
+            Ok(v) => Some(v),
+            Err(_) => return Raw::None,
         }
     };
     Raw::Bounded { start, end }

--- a/test/js/bun/http/bun-serve-file.test.ts
+++ b/test/js/bun/http/bun-serve-file.test.ts
@@ -676,6 +676,20 @@ describe("Bun.file in serve routes", () => {
       expect(await res.text()).toBe(body);
     });
 
+    // RFC 9110 §14.1.2: range bounds are 1*DIGIT. A leading '+' is not a digit,
+    // so the header is unparseable and falls back to full-body 200.
+    it.each(["bytes=+5-", "bytes=+0-+3", "bytes=0-+3", "bytes=-+4"])(
+      "rejects sign-prefixed bound %j and serves full body",
+      async range => {
+        const res = await fetch(new URL(path, server.url), { headers: { Range: range } });
+        expect({
+          status: res.status,
+          contentRange: res.headers.get("content-range"),
+          body: await res.text(),
+        }).toEqual({ status: 200, contentRange: null, body });
+      },
+    );
+
     it("ignores Range for non-GET/HEAD methods", async () => {
       // RFC 9110 §14.2: Range is only defined for GET.
       const res = await fetch(new URL(path, server.url), { method: "POST", headers: { Range: "bytes=0-3" } });


### PR DESCRIPTION
## Repro

Serve a static file route and request it with a Range header whose bound has a leading `+`:

```
Range: bytes=+5-
```

On main this responds `206 Partial Content` with `Content-Range: bytes 5-15/16`. Bun 1.3.x, WebKit's `parseRange`, and RFC 9110 §14.1.2 (range bounds are `1*DIGIT`) all treat this as unparseable and serve `200` with the full body.

## Cause

`parse_raw` in `src/runtime/server/RangeRequest.rs` parses each bound via `bun_core::fmt::parse_decimal`, which delegates to `parse_int`. `parse_int` strips a leading `+`/`-` before the digit loop, so `+5` parses as `5`. The Zig reference (`RangeRequest.zig`) used `std.fmt.parseUnsigned`, which rejects any sign character.

## Fix

Use `bun_core::fmt::parse_unsigned` (the existing sign-rejecting parser) for all three bound parses.

## Verification

Added parameterized cases in `test/js/bun/http/bun-serve-file.test.ts` covering `bytes=+5-`, `bytes=+0-+3`, `bytes=0-+3`, and `bytes=-+4` across both the static `FileRoute` and fetch-handler paths.

<details>
<summary>fail-before on main</summary>

```
(fail) Range requests via FileRoute > rejects sign-prefixed bound "bytes=+0-+3" and serves full body
  {
-   "status": 200,
-   "contentRange": null,
-   "body": "0123456789ABCDEF",
+   "status": 206,
+   "contentRange": "bytes 0-3/16",
+   "body": "0123",
  }
```

</details>

With the fix, all 8 new cases pass and the 23 existing Range tests in the file remain green.