### PR TITLE
server: truncate Bun.serve hostname at first NUL byte

### DIFF
--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1156,12 +1156,14 @@ impl ServerConfig {
             let host = bun_core::OwnedString::new(host);
             let host_str = host.to_utf8();
 
-            if !host_str.slice().is_empty() {
-                // The C `bind()` consumer treats this as a NUL-terminated string,
-                // so store only the bytes before the first NUL. This keeps
-                // `server.hostname` / `server.url` consistent with what was
-                // actually bound.
-                let hostname = ZBox::from_bytes(bun_core::slice_to_nul(host_str.slice()));
+            // The C `bind()` consumer treats this as a NUL-terminated string,
+            // so store only the bytes before the first NUL. This keeps
+            // `server.hostname` / `server.url` consistent with what was
+            // actually bound. A leading NUL truncates to empty and is treated
+            // the same as `hostname: ""` (unset).
+            let truncated = bun_core::slice_to_nul(host_str.slice());
+            if !truncated.is_empty() {
+                let hostname = ZBox::from_bytes(truncated);
                 if let Address::Tcp { hostname: h, .. } = &mut args.address {
                     *h = Some(hostname);
                 }

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -1157,9 +1157,11 @@ impl ServerConfig {
             let host_str = host.to_utf8();
 
             if !host_str.slice().is_empty() {
-                // Does not reject interior
-                // NUL; the C `bind()` consumer will simply truncate at it.
-                let hostname = ZBox::from_bytes(host_str.slice());
+                // The C `bind()` consumer treats this as a NUL-terminated string,
+                // so store only the bytes before the first NUL. This keeps
+                // `server.hostname` / `server.url` consistent with what was
+                // actually bound.
+                let hostname = ZBox::from_bytes(bun_core::slice_to_nul(host_str.slice()));
                 if let Address::Tcp { hostname: h, .. } = &mut args.address {
                     *h = Some(hostname);
                 }

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -84,6 +84,20 @@ describe.each([
     },
   },
   {
+    // Interior NUL: the C bind() path truncates at the first NUL, so the
+    // reported hostname/url must match what was actually bound.
+    if: hasIPv4,
+    options: {
+      hostname: "127.0.0.1\0evil",
+      port: 0,
+    },
+    hostname: "127.0.0.1",
+    url: {
+      protocol: "http:",
+      hostname: "127.0.0.1",
+    },
+  },
+  {
     if: hasIPv6,
     options: {
       hostname: "::1",

--- a/test/js/bun/http/serve-listen.test.ts
+++ b/test/js/bun/http/serve-listen.test.ts
@@ -98,6 +98,16 @@ describe.each([
     },
   },
   {
+    // Leading NUL: truncates to empty and is treated as unset (same as hostname: "").
+    options: {
+      hostname: "\0evil",
+      port: 0,
+    },
+    url: {
+      protocol: "http:",
+    },
+  },
+  {
     if: hasIPv6,
     options: {
       hostname: "::1",


### PR DESCRIPTION
## Repro

```js
const s = Bun.serve({ hostname: "127.0.0.1\0evil", port: 0, fetch: () => new Response("") });
console.log(JSON.stringify(s.hostname)); // "127.0.0.1\u0000evil"
console.log(s.url.href);                 // TypeError: ERR_INVALID_URL
```

The socket binds to `127.0.0.1` (the C `bind()` path treats the hostname as a NUL-terminated string), but `server.hostname` and `server.url` report the full string including the bytes after the NUL.

## Cause

The Zig implementation stores `hostname` as `[*:0]const u8` and reads it via `bun.sliceTo(ptr, 0)` / `std.mem.span`, so every consumer stops at the first NUL. The Rust port stores it in a `ZBox` whose `.as_bytes()` returns everything before the *appended* terminator, passing interior NULs through to `get_hostname`, `get_url_as_string`, the `base_uri` builder, and the `EACCES` listen error message.

## Fix

Truncate the user-provided hostname at the first NUL when constructing the `ZBox` in `ServerConfig::from_js`. The stored value then matches what is actually bound, and every downstream `.as_bytes()` reader agrees automatically. The `unix` option is intentionally left untouched since abstract-namespace sockets begin with a NUL byte.

## Verification

Added an interior-NUL case to the `serve-listen.test.ts` matrix.

```
USE_SYSTEM_BUN=1 bun test serve-listen.test.ts   # 2 fail (.hostname, .url)
bun bd test serve-listen.test.ts                 # 30 pass
```