### PR TITLE
resolver: guard tsconfig paths wildcard match against overlapping prefix/suffix

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -4807,7 +4807,8 @@ impl<'a> Resolver<'a> {
                 // because we want the output to always be deterministic
                 let plen = i32::try_from(prefix.len()).expect("int cast");
                 let slen = i32::try_from(suffix.len()).expect("int cast");
-                if path.starts_with(prefix)
+                if path.len() >= prefix.len() + suffix.len()
+                    && path.starts_with(prefix)
                     && path.ends_with(suffix)
                     && (plen > longest_match_prefix_length
                         || (plen == longest_match_prefix_length

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -182,3 +182,45 @@ describe.concurrent("long import path overflow", () => {
     await run(String(dir), `\`/\${"a/".repeat(300)}x\``);
   });
 });
+
+// matchTSConfigPaths sliced `path[prefix.len()..path.len() - suffix.len()]`
+// after only checking starts_with/ends_with. When the prefix and suffix bytes
+// overlap inside the import path (e.g. key "ab*ba" vs import "aba"), the slice
+// start exceeds the end and Rust panics.
+describe.concurrent("tsconfig paths wildcard with overlapping prefix/suffix", () => {
+  async function run(key: string, specifier: string) {
+    using dir = tempDir("tsconfig-paths-overlap", {
+      "package.json": `{"name": "test", "version": "0.0.0"}`,
+      "node_modules/.keep": "",
+      "tsconfig.json": JSON.stringify({
+        compilerOptions: { baseUrl: ".", paths: { [key]: ["./impl/*"] } },
+      }),
+      "main.ts": `try { require(${JSON.stringify(specifier)}); } catch (e) { console.log("ERR:" + e.code); }`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: "ERR:MODULE_NOT_FOUND",
+      stderr: "",
+      exitCode: 0,
+    });
+  }
+
+  it("ab*ba vs aba", async () => {
+    await run("ab*ba", "aba");
+  });
+
+  it("test*test vs testest", async () => {
+    await run("test*test", "testest");
+  });
+
+  it("xy*xy vs xy", async () => {
+    await run("xy*xy", "xy");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`match_tsconfig_paths` computes `matched_text = &path[prefix.len()..path.len() - suffix.len()]` after only checking `path.starts_with(prefix) && path.ends_with(suffix)`. When `prefix.len() + suffix.len() > path.len()` (the prefix and suffix bytes overlap inside the import specifier), the slice start exceeds the end and Rust panics with `slice index starts at N but ends at M`.

### Repro

```sh
D=$(mktemp -d) && cd "$D"
printf '{"compilerOptions":{"baseUrl":".","paths":{"ab*ba":["./impl/*"]}}}' > tsconfig.json
printf 'try{require("aba")}catch(e){console.log("ERR:",e.code)}' > main.ts
bun main.ts
```

Before:
```
panic: slice index starts at 2 but ends at 1
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

After:
```
ERR: MODULE_NOT_FOUND
```

### Fix

Add `path.len() >= prefix.len() + suffix.len()` to the match predicate, mirroring the guard already present in `matches_user_external_pattern` (resolver.rs:1016) and the package.json exports matcher (package_json.rs:2427).

### How did you verify your code works?

Added three regression tests in `test/js/bun/resolve/resolve-error.test.ts` covering overlap cases of varying lengths (`ab*ba`/`aba`, `test*test`/`testest`, `xy*xy`/`xy`). All three panic on the unfixed build and pass with the fix.