### PR TITLE
crypto: encode base64url digests directly into the WTF string buffer

### DIFF
--- a/src/base64/lib.rs
+++ b/src/base64/lib.rs
@@ -142,17 +142,6 @@ pub fn encode_url_safe(dest: &mut [u8], source: &[u8]) -> usize {
     simdutf::base64::encode(source, dest, true)
 }
 
-/// `encode_url_safe` into a freshly-allocated `Vec<u8>` sized exactly via
-/// `simdutf_encode_len_url_safe` (simdutf computes the exact no-padding length, so
-/// the trailing `truncate` is a no-op kept for symmetry with `encode_alloc`).
-pub fn simdutf_encode_url_safe_alloc(source: &[u8]) -> Vec<u8> {
-    let len = simdutf_encode_len_url_safe(source.len());
-    let mut destination = vec![0u8; len];
-    let encoded_len = encode_url_safe(&mut destination, source);
-    destination.truncate(encoded_len);
-    destination
-}
-
 pub fn decode_len_upper_bound(len: usize) -> usize {
     match zig_base64::STANDARD.decoder.calc_size_upper_bound(len) {
         Ok(v) => v,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -5,7 +5,7 @@ use crate::jsc::{self, CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{self, fmt as bun_fmt};
 use bun_core::{WStr, ZStr, ZigString};
-use bun_jsc::{SliceWithUnderlyingStringJsc as _, StringJsc as _, ZigStringJsc as _};
+use bun_jsc::{SliceWithUnderlyingStringJsc as _, StringJsc as _};
 use bun_paths::{MAX_PATH_BYTES, OSPathBuffer, OSPathSliceZ, PathBuffer, WPathBuffer};
 use bun_sys::{self, Fd, Mode, O};
 
@@ -808,8 +808,6 @@ impl Encoding {
             input.len(),
             max_size,
         );
-        // Stable Rust forbids const-generic arithmetic in array lengths, so
-        // we heap-allocate.
         match self {
             Self::Base64 => {
                 let encoded_len = bun_core::base64::encode_len(input);
@@ -823,8 +821,15 @@ impl Encoding {
                 encoded.transfer_to_js(global_object)
             }
             Self::Base64url => {
-                let buf = bun_base64::simdutf_encode_url_safe_alloc(input);
-                Ok(jsc::zig_string::ZigString::init(&buf).to_js(global_object))
+                let encoded_len = bun_base64::url_safe_encode_len(input);
+                let (mut encoded, bytes) =
+                    bun_core::String::create_uninitialized_latin1(encoded_len);
+                if encoded.is_dead() {
+                    return encoded.transfer_to_js(global_object);
+                }
+                let n = bun_base64::encode_url_safe(bytes, input);
+                debug_assert_eq!(n, encoded_len);
+                encoded.transfer_to_js(global_object)
             }
             Self::Hex => {
                 // The byte-by-byte `write!` formatting machinery is pathologically

--- a/test/js/bun/util/base64-url-safe-encode.test.ts
+++ b/test/js/bun/util/base64-url-safe-encode.test.ts
@@ -87,7 +87,8 @@ describe("URL-safe base64 encoding", () => {
   // Encoding::encode_with_max_size sizes the destination WTF string via
   // url_safe_encode_len before encoding in place; cover every mod-3 digest
   // length the crypto callers actually produce so a mis-sized buffer (trailing
-  // garbage or truncation) would show up here.
+  // garbage or truncation) would show up here. Bun.CryptoHasher routes through
+  // encode_with_max_size; node:crypto's createHash takes the C++ JSHash path.
   const digestCases = [
     ["md5", 16],
     ["sha1", 20],
@@ -98,10 +99,10 @@ describe("URL-safe base64 encoding", () => {
     ["sha512-224", 28],
     ["sha512-256", 32],
   ] as const;
-  test.each(digestCases)("Hash.digest('base64url') is exact for %s (%d bytes)", (algo, size) => {
-    const raw = createHash(algo).update("bun").digest();
+  test.each(digestCases)("Bun.CryptoHasher digest('base64url') is exact for %s (%d bytes)", (algo, size) => {
+    const raw = new Uint8Array(new Bun.CryptoHasher(algo).update("bun").digest());
     expect(raw.length).toBe(size);
-    const enc = createHash(algo).update("bun").digest("base64url");
+    const enc = new Bun.CryptoHasher(algo).update("bun").digest("base64url");
     expect(enc).toBe(base64UrlReference(raw));
     expect(enc.length).toBe(Math.ceil((size * 4) / 3));
   });

--- a/test/js/bun/util/base64-url-safe-encode.test.ts
+++ b/test/js/bun/util/base64-url-safe-encode.test.ts
@@ -83,4 +83,26 @@ describe("URL-safe base64 encoding", () => {
       base64UrlReference(new Uint8Array(raw)),
     );
   });
+
+  // Encoding::encode_with_max_size sizes the destination WTF string via
+  // url_safe_encode_len before encoding in place; cover every mod-3 digest
+  // length the crypto callers actually produce so a mis-sized buffer (trailing
+  // garbage or truncation) would show up here.
+  const digestCases = [
+    ["md5", 16],
+    ["sha1", 20],
+    ["sha224", 28],
+    ["sha256", 32],
+    ["sha384", 48],
+    ["sha512", 64],
+    ["sha512-224", 28],
+    ["sha512-256", 32],
+  ] as const;
+  test.each(digestCases)("Hash.digest('base64url') is exact for %s (%d bytes)", (algo, size) => {
+    const raw = createHash(algo).update("bun").digest();
+    expect(raw.length).toBe(size);
+    const enc = createHash(algo).update("bun").digest("base64url");
+    expect(enc).toBe(base64UrlReference(raw));
+    expect(enc.length).toBe(Math.ceil((size * 4) / 3));
+  });
 });


### PR DESCRIPTION
## What

`Encoding::encode_with_max_size`'s `Base64url` arm allocated an intermediate `Vec<u8>` via `simdutf_encode_url_safe_alloc`, then copied that into the JS string via `ZigString::init(&buf).to_js()`, then dropped the Vec. One extra heap alloc+free per call relative to the original Zig, which encoded into a comptime-sized stack buffer.

The sibling `Base64` and `Hex` arms in the same match already encode directly into the `String::create_uninitialized_latin1` destination buffer. This change makes `Base64url` do the same using the existing `bun_base64::url_safe_encode_len` + `bun_base64::encode_url_safe`.

Also deletes `simdutf_encode_url_safe_alloc`; this was its only caller.

## Affected paths

`encode_with_max_size` is called from:
- `Bun.CryptoHasher#digest('base64url')` and the `Bun.SHA*` family (CryptoHasher.rs)
- `Bun.CSRF.generate(secret, { encoding: 'base64url' })` (csrf_jsc.rs)
- `Bun.randomUUIDv7('base64url')` (Crypto.rs)

(`node:crypto`'s `createHash(...).digest('base64url')` takes the C++ `JSHash` / `StringBytes::encode` path, not this one.)

## Verification

Output is byte-identical; the change is alloc-count only. Correctness covered by existing tests plus new per-algorithm sizing checks through `Bun.CryptoHasher`:

```
bun bd test test/js/bun/util/base64-url-safe-encode.test.ts   # 13 pass
bun bd test test/js/bun/util/bun-cryptohasher.test.ts         # 397 pass
bun bd test test/js/bun/util/csrf.test.ts                     # 24 pass
```

## Note on testing

This change is alloc-count only; output is byte-identical before and after (both implementations call the same `simdutf::base64::encode(.., true)` on the same input, only the destination buffer's provenance differs). There is no JS-observable difference to assert on, so the added tests are correctness guards for the in-place sizing (`url_safe_encode_len` must exactly match what simdutf writes for every digest length) rather than a fail-before regression test. The allocation removal is verifiable by inspection: `types.rs` no longer calls `simdutf_encode_url_safe_alloc`, and that helper (whose `vec![0u8; len]` was the extra allocation) is deleted.
