### PR TITLE
fix(streams): restore i51 truncation of sink highWaterMark

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -285,7 +285,8 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         empty = false;
-                        chunk_size = 256i64.max(trunc_i51(chunk_size_val.to_int64())) as BlobSizeType;
+                        chunk_size =
+                            256i64.max(trunc_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -39,6 +39,15 @@ pub mod bun_s3 {
 // re-export (e.g. `sink::SinkSignal::init`).
 type BlobSizeType = crate::webcore::BlobSizeType;
 
+/// Zig's `@as(i51, @truncate(x))`: sign-extend the low 51 bits of an i64.
+/// Values with bit 50 set (e.g. `Number.MAX_SAFE_INTEGER`) become negative so the
+/// subsequent `max(0, ..)` clamp drops them to the floor instead of passing a
+/// multi-petabyte size to `ensure_total_capacity_precise`.
+#[inline]
+const fn trunc_i51(x: i64) -> i64 {
+    (x << (64 - 51)) >> (64 - 51)
+}
+
 // Compat: `webcore::Pipe` and Body refer to `streams::Result` / `streams::result::StreamError`.
 pub use StreamResult as Result;
 pub mod result {
@@ -194,7 +203,7 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         empty = false;
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 0i64.max(trunc_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -213,7 +222,7 @@ impl Start {
                     value.fast_get(global_this, jsc::BuiltinName::HighWaterMark)?
                 {
                     if chunk_size_val.is_number() {
-                        chunk_size = 0i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 0i64.max(trunc_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 
@@ -276,7 +285,7 @@ impl Start {
                 {
                     if chunk_size_val.is_number() {
                         empty = false;
-                        chunk_size = 256i64.max(chunk_size_val.to_int64()) as BlobSizeType;
+                        chunk_size = 256i64.max(trunc_i51(chunk_size_val.to_int64())) as BlobSizeType;
                     }
                 }
 

--- a/test/js/bun/util/arraybuffersink.test.ts
+++ b/test/js/bun/util/arraybuffersink.test.ts
@@ -1,6 +1,6 @@
 import { ArrayBufferSink } from "bun";
 import { describe, expect, it } from "bun:test";
-import { withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, withoutAggressiveGC } from "harness";
 
 describe("ArrayBufferSink", () => {
   const fixtures = [
@@ -61,4 +61,30 @@ describe("ArrayBufferSink", () => {
       expect(output.byteLength).toBe(expected.byteLength);
     });
   }
+
+  it("start({ highWaterMark: Number.MAX_SAFE_INTEGER }) does not abort", async () => {
+    const src = `
+      const sink = new Bun.ArrayBufferSink();
+      sink.start({ highWaterMark: Number.MAX_SAFE_INTEGER });
+      sink.write("hello");
+      process.stdout.write(new Uint8Array(sink.end()));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("hello");
+    expect(stderr).not.toContain("memory allocation");
+    expect(exitCode).toBe(0);
+  });
+
+  it.each([2 ** 50, 2 ** 51, 2 ** 52, -1])("start({ highWaterMark: %p }) is clamped and writable", hwm => {
+    const sink = new ArrayBufferSink();
+    sink.start({ highWaterMark: hwm });
+    sink.write("ok");
+    expect(new TextDecoder().decode(new Uint8Array(sink.end()))).toBe("ok");
+  });
 });


### PR DESCRIPTION
## Repro

```sh
bun -e 'new Bun.ArrayBufferSink().start({highWaterMark: Number.MAX_SAFE_INTEGER}); console.log("ok")'
```

Before:
```
memory allocation of 9007199254740991 bytes failed
Aborted (core dumped)
```

After: prints `ok`.

## Cause

Zig `Start.fromJSWithTag` parses `highWaterMark` as `@intCast(@max(0, @as(i51, @truncate(toInt64()))))`. The `i51` truncate makes any value with bit 50 set (e.g. `Number.MAX_SAFE_INTEGER = 2^53-1`) negative, which the `max(0, ..)` clamp then drops to the floor.

The Rust port in `src/runtime/webcore/streams.rs` dropped the truncation step (`0i64.max(v.to_int64()) as u64`), so `Number.MAX_SAFE_INTEGER` flowed through to `ArrayBufferSink::start` → `ensure_total_capacity_precise(9007199254740991)` → allocator abort. The `FileSink` and HTTP response sink arms had the same shape.

## Fix

Add `trunc_i51` (sign-extend the low 51 bits via `(x << 13) >> 13`) and apply it at all three `highWaterMark` sites before the floor clamp, matching the Zig reference.

## Verification

`test/js/bun/util/arraybuffersink.test.ts` gains a spawned-subprocess case for `Number.MAX_SAFE_INTEGER` plus in-process boundary checks for `2^50`, `2^51`, `2^52`, and `-1`.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/util/arraybuffersink.test.ts   # aborts, exit 134
bun bd test test/js/bun/util/arraybuffersink.test.ts                  # 11 pass
```