### PR TITLE
shell: restore hex-float and underscore parsing for seq positional args

### DIFF
--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -276,6 +276,11 @@ fn parse_f32(bytes: &[u8]) -> Option<f32> {
 
 /// Parse the body of a C99 hex float (caller has already consumed `0x`).
 /// Hex mantissa with at most one `.`, optional `p`/`P` binary exponent.
+///
+/// All exponent/index arithmetic saturates: Bun.$ argv is in-process (no OS
+/// ARG_MAX), so input length is unbounded. Any saturated exponent is far
+/// outside f64 range; the caller's `is_finite()` handles the overflow side and
+/// underflow correctly yields 0.
 fn parse_hex_float(s: &[u8]) -> Option<f64> {
     let mut mantissa: u64 = 0;
     let mut frac_digits: i32 = 0;
@@ -300,12 +305,9 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         if mantissa >> 60 == 0 {
             mantissa = (mantissa << 4) | d as u64;
             if seen_dot {
-                frac_digits += 1;
+                frac_digits = frac_digits.saturating_add(1);
             }
         } else if !seen_dot {
-            // Bun.$ argv is in-process (no OS ARG_MAX); saturate so a
-            // ~537M-digit mantissa can't overflow i32. Anything past ~2100
-            // overflows f64 and is rejected by the caller's is_finite().
             dropped_int_bits = dropped_int_bits.saturating_add(4);
         }
         i += 1;
@@ -316,10 +318,20 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
     let mut exp: i32 = 0;
     if i < s.len() {
         let exp_bytes = &s[i + 1..];
-        if exp_bytes.is_empty() {
+        let (exp_neg, exp_digits) = match exp_bytes.first() {
+            Some(b'-') => (true, &exp_bytes[1..]),
+            Some(b'+') => (false, &exp_bytes[1..]),
+            _ => (false, exp_bytes),
+        };
+        if exp_digits.is_empty() || !exp_digits.iter().all(u8::is_ascii_digit) {
             return None;
         }
-        exp = bun_core::fmt::parse_int::<i32>(exp_bytes, 10).ok()?;
+        for &d in exp_digits {
+            exp = exp.saturating_mul(10).saturating_add((d - b'0') as i32);
+        }
+        if exp_neg {
+            exp = exp.saturating_neg();
+        }
     }
     if mantissa == 0 {
         // Short-circuit so a huge exponent (`0x0p1024`) doesn't reach
@@ -327,8 +339,8 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         return Some(0.0);
     }
     let exp = exp
-        .checked_sub(frac_digits.checked_mul(4)?)?
-        .checked_add(dropped_int_bits)?;
+        .saturating_sub(frac_digits.saturating_mul(4))
+        .saturating_add(dropped_int_bits);
     // powi on 2.0 is exact (repeated squaring of exact powers of two).
     Some(mantissa as f64 * 2.0_f64.powi(exp))
 }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -318,6 +318,11 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         }
         exp = bun_core::fmt::parse_int::<i32>(exp_bytes, 10).ok()?;
     }
+    if mantissa == 0 {
+        // Short-circuit so a huge exponent (`0x0p1024`) doesn't reach
+        // `0.0 * inf = NaN` below.
+        return Some(0.0);
+    }
     let exp = exp
         .checked_sub(frac_digits.checked_mul(4)?)?
         .checked_add(dropped_int_bits)?;

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -277,10 +277,11 @@ fn parse_f32(bytes: &[u8]) -> Option<f32> {
 /// Parse the body of a C99 hex float (caller has already consumed `0x`).
 /// Hex mantissa with at most one `.`, optional `p`/`P` binary exponent.
 ///
-/// All exponent/index arithmetic saturates: Bun.$ argv is in-process (no OS
-/// ARG_MAX), so input length is unbounded. Any saturated exponent is far
-/// outside f64 range; the caller's `is_finite()` handles the overflow side and
-/// underflow correctly yields 0.
+/// Bun.$ argv is in-process (no OS ARG_MAX), so input length is unbounded.
+/// Per-digit accumulators saturate in i32 and are combined in i64 before the
+/// final clamp so two saturated terms can't cancel; a clamped exponent is far
+/// outside f64 range (overflow is rejected by the caller's `is_finite()`,
+/// underflow yields 0).
 fn parse_hex_float(s: &[u8]) -> Option<f64> {
     let mut mantissa: u64 = 0;
     let mut frac_digits: i32 = 0;
@@ -338,9 +339,8 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         // `0.0 * inf = NaN` below.
         return Some(0.0);
     }
-    let exp = exp
-        .saturating_sub(frac_digits.saturating_mul(4))
-        .saturating_add(dropped_int_bits);
+    let exp = (exp as i64 - frac_digits as i64 * 4 + dropped_int_bits as i64)
+        .clamp(i32::MIN as i64, i32::MAX as i64) as i32;
     // powi on 2.0 is exact (repeated squaring of exact powers of two).
     Some(mantissa as f64 * 2.0_f64.powi(exp))
 }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -249,8 +249,7 @@ fn parse_f32(bytes: &[u8]) -> Option<f32> {
     }
 
     let hex = rest.len() >= 2 && rest[0] == b'0' && matches!(rest[1], b'x' | b'X');
-    let is_digit =
-        |b: u8| b.is_ascii_digit() || (hex && matches!(b, b'a'..=b'f' | b'A'..=b'F'));
+    let is_digit = |b: u8| b.is_ascii_digit() || (hex && matches!(b, b'a'..=b'f' | b'A'..=b'F'));
 
     // Zig rule: every `_` must sit between two digits of the active base.
     let mut stripped: &[u8] = rest;
@@ -258,10 +257,7 @@ fn parse_f32(bytes: &[u8]) -> Option<f32> {
     if rest.contains(&b'_') {
         for (i, &b) in rest.iter().enumerate() {
             if b == b'_'
-                && !(i > 0
-                    && i + 1 < rest.len()
-                    && is_digit(rest[i - 1])
-                    && is_digit(rest[i + 1]))
+                && !(i > 0 && i + 1 < rest.len() && is_digit(rest[i - 1]) && is_digit(rest[i + 1]))
             {
                 return None;
             }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -277,15 +277,17 @@ fn parse_f32(bytes: &[u8]) -> Option<f32> {
 /// Parse the body of a C99 hex float (caller has already consumed `0x`).
 /// Hex mantissa with at most one `.`, optional `p`/`P` binary exponent.
 ///
-/// Bun.$ argv is in-process (no OS ARG_MAX), so input length is unbounded.
-/// Per-digit accumulators saturate in i32 and are combined in i64 before the
-/// final clamp so two saturated terms can't cancel; a clamped exponent is far
-/// outside f64 range (overflow is rejected by the caller's `is_finite()`,
-/// underflow yields 0).
+/// Bun.$ argv is in-process (no OS ARG_MAX), so input length is bounded only
+/// by the address space. `frac_digits` and `dropped_int_bits` advance at most
+/// 4 per input byte, so they cannot reach i64 saturation for any addressable
+/// input and are exact when combined. `exp` is parsed from decimal and can
+/// saturate at i64::MAX, but then dwarfs the other two terms so the combined
+/// sign is preserved; the final clamp to i32 for powi yields inf (rejected by
+/// the caller's `is_finite()`) or underflows to 0.
 fn parse_hex_float(s: &[u8]) -> Option<f64> {
     let mut mantissa: u64 = 0;
-    let mut frac_digits: i32 = 0;
-    let mut dropped_int_bits: i32 = 0;
+    let mut frac_digits: i64 = 0;
+    let mut dropped_int_bits: i64 = 0;
     let mut seen_dot = false;
     let mut seen_digit = false;
     let mut i = 0;
@@ -306,17 +308,17 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         if mantissa >> 60 == 0 {
             mantissa = (mantissa << 4) | d as u64;
             if seen_dot {
-                frac_digits = frac_digits.saturating_add(1);
+                frac_digits += 1;
             }
         } else if !seen_dot {
-            dropped_int_bits = dropped_int_bits.saturating_add(4);
+            dropped_int_bits += 4;
         }
         i += 1;
     }
     if !seen_digit {
         return None;
     }
-    let mut exp: i32 = 0;
+    let mut exp: i64 = 0;
     if i < s.len() {
         let exp_bytes = &s[i + 1..];
         let (exp_neg, exp_digits) = match exp_bytes.first() {
@@ -328,7 +330,7 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
             return None;
         }
         for &d in exp_digits {
-            exp = exp.saturating_mul(10).saturating_add((d - b'0') as i32);
+            exp = exp.saturating_mul(10).saturating_add((d - b'0') as i64);
         }
         if exp_neg {
             exp = exp.saturating_neg();
@@ -339,7 +341,9 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
         // `0.0 * inf = NaN` below.
         return Some(0.0);
     }
-    let exp = (exp as i64 - frac_digits as i64 * 4 + dropped_int_bits as i64)
+    let exp = exp
+        .saturating_sub(frac_digits.saturating_mul(4))
+        .saturating_add(dropped_int_bits)
         .clamp(i32::MIN as i64, i32::MAX as i64) as i32;
     // powi on 2.0 is exact (repeated squaring of exact powers of two).
     Some(mantissa as f64 * 2.0_f64.powi(exp))

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -303,7 +303,10 @@ fn parse_hex_float(s: &[u8]) -> Option<f64> {
                 frac_digits += 1;
             }
         } else if !seen_dot {
-            dropped_int_bits += 4;
+            // Bun.$ argv is in-process (no OS ARG_MAX); saturate so a
+            // ~537M-digit mantissa can't overflow i32. Anything past ~2100
+            // overflows f64 and is rejected by the caller's is_finite().
+            dropped_int_bits = dropped_int_bits.saturating_add(4);
         }
         i += 1;
     }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -228,7 +228,103 @@ impl Seq {
     }
 }
 
-#[inline]
+/// Parse a positional `seq` argument as `f32`.
+///
+/// Grammar matches Zig's `std.fmt.parseFloat(f32, ...)` (the pre-Rust
+/// implementation): decimal floats, C99 hex floats (`0x1p4`, `0x1.8`), and
+/// `_` digit separators. `bun_core::fmt::parse_f32` is JS-number semantics
+/// (`WTF::parseDouble`) and rejects the latter two; both macOS and GNU
+/// coreutils `seq` accept hex.
 fn parse_f32(bytes: &[u8]) -> Option<f32> {
-    bun_core::fmt::parse_f32(bytes)
+    if bytes.is_empty() {
+        return None;
+    }
+    let (neg, rest) = match bytes[0] {
+        b'-' => (true, &bytes[1..]),
+        b'+' => (false, &bytes[1..]),
+        _ => (false, bytes),
+    };
+    if rest.is_empty() || matches!(rest[0], b'+' | b'-') {
+        return None;
+    }
+
+    let hex = rest.len() >= 2 && rest[0] == b'0' && matches!(rest[1], b'x' | b'X');
+    let is_digit =
+        |b: u8| b.is_ascii_digit() || (hex && matches!(b, b'a'..=b'f' | b'A'..=b'F'));
+
+    // Zig rule: every `_` must sit between two digits of the active base.
+    let mut stripped: &[u8] = rest;
+    let buf: Vec<u8>;
+    if rest.contains(&b'_') {
+        for (i, &b) in rest.iter().enumerate() {
+            if b == b'_'
+                && !(i > 0
+                    && i + 1 < rest.len()
+                    && is_digit(rest[i - 1])
+                    && is_digit(rest[i + 1]))
+            {
+                return None;
+            }
+        }
+        buf = rest.iter().copied().filter(|&b| b != b'_').collect();
+        stripped = &buf;
+    }
+
+    let mag = if hex {
+        parse_hex_float(&stripped[2..])?
+    } else {
+        bun_core::fmt::parse_f64(stripped)?
+    };
+    Some(if neg { -mag } else { mag } as f32)
+}
+
+/// Parse the body of a C99 hex float (caller has already consumed `0x`).
+/// Hex mantissa with at most one `.`, optional `p`/`P` binary exponent.
+fn parse_hex_float(s: &[u8]) -> Option<f64> {
+    let mut mantissa: u64 = 0;
+    let mut frac_digits: i32 = 0;
+    let mut dropped_int_bits: i32 = 0;
+    let mut seen_dot = false;
+    let mut seen_digit = false;
+    let mut i = 0;
+    while i < s.len() {
+        let d = match s[i] {
+            b @ b'0'..=b'9' => b - b'0',
+            b @ b'a'..=b'f' => b - b'a' + 10,
+            b @ b'A'..=b'F' => b - b'A' + 10,
+            b'.' if !seen_dot => {
+                seen_dot = true;
+                i += 1;
+                continue;
+            }
+            b'p' | b'P' => break,
+            _ => return None,
+        };
+        seen_digit = true;
+        if mantissa >> 60 == 0 {
+            mantissa = (mantissa << 4) | d as u64;
+            if seen_dot {
+                frac_digits += 1;
+            }
+        } else if !seen_dot {
+            dropped_int_bits += 4;
+        }
+        i += 1;
+    }
+    if !seen_digit {
+        return None;
+    }
+    let mut exp: i32 = 0;
+    if i < s.len() {
+        let exp_bytes = &s[i + 1..];
+        if exp_bytes.is_empty() {
+            return None;
+        }
+        exp = bun_core::fmt::parse_int::<i32>(exp_bytes, 10).ok()?;
+    }
+    let exp = exp
+        .checked_sub(frac_digits.checked_mul(4)?)?
+        .checked_add(dropped_int_bits)?;
+    // powi on 2.0 is exact (repeated squaring of exact powers of two).
+    Some(mantissa as f64 * 2.0_f64.powi(exp))
 }

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -95,6 +95,58 @@ describe("seq", async () => {
 
   TestBuilder.command`seq 4 7 ba`.exitCode(1).stdout("").stderr("seq: invalid argument\n").runAsTest("invalid arg 3");
 
+  TestBuilder.command`seq 0x10 0x10`.exitCode(0).stdout("16\n").stderr("").runAsTest("hex arg");
+
+  TestBuilder.command`seq 0X10 0X10`.exitCode(0).stdout("16\n").stderr("").runAsTest("hex arg uppercase prefix");
+
+  TestBuilder.command`seq 0x1p4 0x1p4`.exitCode(0).stdout("16\n").stderr("").runAsTest("hex float with p exponent");
+
+  TestBuilder.command`seq 0x1.8p1 0x1.8p1`.exitCode(0).stdout("3\n").stderr("").runAsTest("hex float with fraction");
+
+  TestBuilder.command`seq -0x3 0x2 0x3`
+    .exitCode(0)
+    .stdout("-3\n-1\n1\n3\n")
+    .stderr("")
+    .runAsTest("hex in start/increment/end with sign");
+
+  TestBuilder.command`seq 1_0 1_0`.exitCode(0).stdout("10\n").stderr("").runAsTest("underscore digit separator");
+
+  TestBuilder.command`seq 0x1_0 0x1_0`
+    .exitCode(0)
+    .stdout("16\n")
+    .stderr("")
+    .runAsTest("underscore digit separator in hex");
+
+  TestBuilder.command`seq 0x`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("bare 0x is invalid");
+
+  TestBuilder.command`seq 0xg`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("non-hex digit after 0x is invalid");
+
+  TestBuilder.command`seq _1`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("leading underscore is invalid");
+
+  TestBuilder.command`seq 1_`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("trailing underscore is invalid");
+
+  TestBuilder.command`seq 1__0`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("consecutive underscores are invalid");
+
   TestBuilder.command`seq 4 0 7`.exitCode(1).stdout("").stderr("seq: zero increment\n").runAsTest("zero increment");
 
   TestBuilder.command`seq 4 -2 7`

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -117,6 +117,12 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("underscore digit separator in hex");
 
+  TestBuilder.command`seq 0x0p1024 0x0p1024`
+    .exitCode(0)
+    .stdout("0\n")
+    .stderr("")
+    .runAsTest("hex zero with out-of-range exponent");
+
   TestBuilder.command`seq 0x`.exitCode(1).stdout("").stderr("seq: invalid argument\n").runAsTest("bare 0x is invalid");
 
   TestBuilder.command`seq 0xg`
@@ -124,6 +130,12 @@ describe("seq", async () => {
     .stdout("")
     .stderr("seq: invalid argument\n")
     .runAsTest("non-hex digit after 0x is invalid");
+
+  TestBuilder.command`seq 0x0p`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("hex p with no exponent is invalid");
 
   TestBuilder.command`seq _1`
     .exitCode(1)

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -173,6 +173,12 @@ describe("seq", async () => {
     .stderr("seq: invalid argument\n")
     .runAsTest("consecutive underscores are invalid");
 
+  TestBuilder.command`seq 0x_10`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("underscore after hex prefix is invalid");
+
   TestBuilder.command`seq 4 0 7`.exitCode(1).stdout("").stderr("seq: zero increment\n").runAsTest("zero increment");
 
   TestBuilder.command`seq 4 -2 7`

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -117,11 +117,7 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("underscore digit separator in hex");
 
-  TestBuilder.command`seq 0x`
-    .exitCode(1)
-    .stdout("")
-    .stderr("seq: invalid argument\n")
-    .runAsTest("bare 0x is invalid");
+  TestBuilder.command`seq 0x`.exitCode(1).stdout("").stderr("seq: invalid argument\n").runAsTest("bare 0x is invalid");
 
   TestBuilder.command`seq 0xg`
     .exitCode(1)

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -123,6 +123,18 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("hex zero with out-of-range exponent");
 
+  TestBuilder.command`seq 0x0p9999999999 0x0p9999999999`
+    .exitCode(0)
+    .stdout("0\n")
+    .stderr("")
+    .runAsTest("hex zero with exponent past i32 range");
+
+  TestBuilder.command`seq 0x1p-9999999999 0x1p-9999999999`
+    .exitCode(0)
+    .stdout("0\n")
+    .stderr("")
+    .runAsTest("hex with huge negative exponent underflows to zero");
+
   TestBuilder.command`seq 0x`.exitCode(1).stdout("").stderr("seq: invalid argument\n").runAsTest("bare 0x is invalid");
 
   TestBuilder.command`seq 0xg`
@@ -136,6 +148,12 @@ describe("seq", async () => {
     .stdout("")
     .stderr("seq: invalid argument\n")
     .runAsTest("hex p with no exponent is invalid");
+
+  TestBuilder.command`seq 0x0pZ`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: invalid argument\n")
+    .runAsTest("non-digit hex exponent is invalid");
 
   TestBuilder.command`seq _1`
     .exitCode(1)


### PR DESCRIPTION
## What

`seq.zig` parsed its positional args with `std.fmt.parseFloat(f32, ...)`, which accepts C99 hex floats (`0x10` → 16, `0x1p4` → 16) and `_` digit separators (`1_0` → 10). `seq.rs` swapped in `bun_core::fmt::parse_f32`, which delegates to `WTF::parseDouble` (JS-number semantics) and rejects both forms.

## Repro

```sh
$ bun -e 'await Bun.$`seq 0x10 0x10`'
seq: invalid argument
```

macOS `/usr/bin/seq 0x10 0x10` and GNU coreutils both print `16`.

## Cause

`bun_core::fmt::parse_f64` is JS-semantics by design (used for JS-number parsing elsewhere); the bug is the call-site choice in `seq.rs`, not the shared helper.

## Fix

Replace the thin wrapper in `seq.rs` with a local `parse_f32` that matches the Zig grammar:

- Optional leading `+`/`-`.
- Each `_` must sit between two digits of the active base (Zig's `validUnderscores` rule); validated then stripped.
- `0x`/`0X` prefix → hex mantissa with at most one `.`, optional `p`/`P` decimal binary-exponent.
- Decimal input delegates to `bun_core::fmt::parse_f64` as before (so `nan`/`inf`, `e` exponents, `.5` etc. are unchanged).

`bun_core::fmt::parse_f32` is left unchanged.

## Verification

New cases in `test/js/bun/shell/commands/seq.test.ts`: `0x10`, `0X10`, `0x1p4`, `0x1.8p1`, signed hex across all three positions, `1_0`, `0x1_0`, plus rejection of `0x`, `0xg`, `_1`, `1_`, `1__0`.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/seq.test.ts   # 7 fail
bun bd test test/js/bun/shell/commands/seq.test.ts                 # 43 pass
```