### PR TITLE
Bun.markdown: don't apply 999-char cap to reference labels before normalizing whitespace

### DIFF
--- a/src/md/ref_defs.rs
+++ b/src/md/ref_defs.rs
@@ -89,10 +89,21 @@ impl Parser<'_> {
         if raw_label.is_empty() || self.ref_defs.is_empty() {
             return None;
         }
-        // Labels longer than the spec cap can never match a stored definition
-        // (parse_ref_def enforces the same limit), so skip normalizing them.
-        if raw_label.len() > MAX_LINK_LABEL_LEN {
-            return None;
+        // A link label cannot contain an unescaped '[': parse_ref_def rejects
+        // such definitions, and normalize_label does not process escapes, so no
+        // stored normalized label contains one either. Rejecting here keeps the
+        // nested-bracket family (`[x]: /url` + `[[[...]]]`) from normalizing an
+        // O(n) label for each of n openers. The 999-character spec cap is
+        // intentionally not applied to the raw lookup label: matching is on the
+        // normalized form, so a reference whose raw bytes exceed the cap only
+        // because of collapsible whitespace must still resolve.
+        let mut i = 0;
+        while i < raw_label.len() {
+            match raw_label[i] {
+                b'\\' if i + 1 < raw_label.len() => i += 2,
+                b'[' => return None,
+                _ => i += 1,
+            }
         }
         let normalized = self.normalize_label(raw_label);
         if normalized.is_empty() {

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -671,6 +671,32 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.html(`[${label1000}]: /url\n\n[${label1000}]\n`)).not.toContain("<a href=");
   });
 
+  test("reference label length cap is not applied to lookup before whitespace normalization", () => {
+    // Label matching compares normalized labels (whitespace collapsed), so a
+    // reference whose raw bytes exceed 999 only because of leading, trailing,
+    // or interior whitespace must still match the definition it normalizes to.
+    // commonmark.js agrees.
+    const a = Buffer.alloc(998, "a").toString();
+    const def = `[${a}]: /url\n\n`;
+    // shortcut reference, trailing whitespace (raw label 1001 bytes)
+    expect(Markdown.html(def + `[${a}   ]\n`)).toContain('<a href="/url">');
+    // shortcut reference, leading whitespace
+    expect(Markdown.html(def + `[   ${a}]\n`)).toContain('<a href="/url">');
+    // full reference form
+    expect(Markdown.html(def + `[text][${a}   ]\n`)).toContain('<a href="/url">');
+    // collapsed reference form
+    expect(Markdown.html(def + `[${a}   ][]\n`)).toContain('<a href="/url">');
+    // interior whitespace run: definition label is 998 bytes, reference label
+    // is 1006 raw bytes, both normalize to "x <994 a's> x"
+    const mid = Buffer.alloc(994, "a").toString();
+    expect(Markdown.html(`[x ${mid} x]: /u\n\n[x     ${mid}     x]\n`)).toContain('<a href="/u">');
+    // exactly at the cap with trailing whitespace still resolves
+    const label999 = Buffer.alloc(999, "y").toString();
+    expect(Markdown.html(`[${label999}]: /url\n\n[${label999} ]\n`)).toContain('<a href="/url">');
+    // escaped '[' in the label is not a disqualifier
+    expect(Markdown.html(`[\\[z]: /u\n\n[  \\[z  ]\n`)).toContain('<a href="/u">');
+  });
+
   test("wiki link bracket nesting is capped", () => {
     const wiki = (depth: number) => "[[t|" + "[".repeat(depth) + "x" + "]".repeat(depth) + "]]\n";
     // Within the cap the whole construct is one wiki link targeting "t".


### PR DESCRIPTION
### Problem

`lookup_ref_def()` in `src/md/ref_defs.rs` rejects a reference label whose raw byte length exceeds `MAX_LINK_LABEL_LEN` (999) before `normalize_label()` has collapsed leading/trailing/interior whitespace. A reference whose raw bytes exceed the cap only because of whitespace no longer matches the definition it normalizes to:

```js
const a = 'a'.repeat(998);
Bun.markdown.html(`[${a}]: /url\n\n[${a}   ]`);
// HEAD:          <p>[aaa...aaa   ]</p>
// commonmark.js: <p><a href="/url">aaa...aaa   </a></p>
```

The Zig reference `lookupRefDef` (`src/md/ref_defs.zig:55-63`) has no such check; this was introduced in #31241 as a guard against normalizing an O(n) label for each of n nested-bracket candidates. The in-code comment's premise ("Labels longer than the spec cap can never match a stored definition") does not hold for whitespace-padded labels because matching is on the normalized form.

### Fix

Replace the raw-length check with a scan for an unescaped `[`. `parse_ref_def` rejects definition labels containing an unescaped `[`, and `normalize_label` does not process escapes, so no stored normalized label can contain one; a lookup label that does can never match. For the nested-bracket DoS family (`[x]: /url` + `[[[...]]]`) every candidate label's first byte is `[`, so lookup stays O(1) per candidate. Whitespace-padded labels pass through to `normalize_label` and resolve.

### Verification

- New test in `test/js/bun/md/md-edge-cases.test.ts` covers shortcut/full/collapsed reference forms with trailing, leading, and interior whitespace padding, the 999-char boundary, and an escaped `[` in the label.
- The existing "bracket floods render in linear time" test (which includes `[x]: /url` + 60000 nested brackets) still passes in ~3.3s under debug+ASAN.
- All 1056 tests across `test/js/bun/md/` pass, including the 792 CommonMark spec cases.