### PR TITLE
crypto: verify argon2 hashes with memoryCost < 8 from earlier Bun releases

### DIFF
--- a/src/runtime/crypto/pwhash.rs
+++ b/src/runtime/crypto/pwhash.rs
@@ -1,8 +1,10 @@
 //! Password hashing for `Bun.password` (argon2 / bcrypt). Neither algorithm is
 //! provided by BoringSSL, so this module implements the API surface that
 //! `PasswordObject` consumes (`str_hash` / `str_verify` / `Params` / `Mode` /
-//! `Encoding`) and routes to the pure-Rust `rust-argon2` and `bcrypt` crates
-//! from crates.io.
+//! `Encoding`) and routes to the pure-Rust `rust-argon2` and `bcrypt` crates.
+//! `rust-argon2` is fetched and patched at build time (`patches/rust-argon2/`):
+//! the patch only adds `verify_encoded_legacy_memory`, which `str_verify`
+//! routes `m < 8*p` hashes to so earlier Bun releases stay verifiable.
 //!
 //!   * argon2: PHC string format only (`str_hash` rejects `.crypt`), 32-byte
 //!     random salt, 32-byte tag, version 0x13.
@@ -217,6 +219,8 @@ pub mod argon2 {
             }
         };
 
+        let mut mem_cost: Option<u32> = None;
+        let mut parallelism: Option<u32> = None;
         if let Some(after_dollar) = normalised.strip_prefix('$') {
             if let Some(sep) = after_dollar.find('$') {
                 let mut rest = &after_dollar[sep + 1..];
@@ -235,9 +239,15 @@ pub mod argon2 {
                         continue;
                     };
                     let limit = match key {
-                        "m" => MAX_VERIFY_MEMORY_COST,
+                        "m" => {
+                            mem_cost = Some(value);
+                            MAX_VERIFY_MEMORY_COST
+                        }
                         "t" => MAX_VERIFY_TIME_COST,
-                        "p" => MAX_VERIFY_PARALLELISM,
+                        "p" => {
+                            parallelism = Some(value);
+                            MAX_VERIFY_PARALLELISM
+                        }
                         _ => continue,
                     };
                     if value > limit {
@@ -247,7 +257,19 @@ pub mod argon2 {
             }
         }
 
-        match vendor::verify_encoded(&normalised, password) {
+        // Earlier (Zig-backed) Bun accepted any `memoryCost >= 1`, so hashes
+        // with `m < 8*p` exist; `verify_encoded` would reject them up front.
+        // Route them to the legacy entry point. Hashing still floors `m` at 8.
+        let legacy_low_memory = match (mem_cost, parallelism) {
+            (Some(m), Some(p)) => m >= 1 && p >= 1 && m < 8 * p,
+            _ => false,
+        };
+        let result = if legacy_low_memory {
+            vendor::verify_encoded_legacy_memory(&normalised, password)
+        } else {
+            vendor::verify_encoded(&normalised, password)
+        };
+        match result {
             Ok(true) => Ok(()),
             // `rust-argon2` constant-time compares and returns `Ok(false)` on
             // mismatch; surface this as `PasswordVerificationFailed`.

--- a/test/js/bun/util/password.test.ts
+++ b/test/js/bun/util/password.test.ts
@@ -262,6 +262,34 @@ test("bcrypt pre-hashing does not break compatibility across Bun versions", asyn
   expect(await password.verify(secret, hash)).toBeTrue();
 });
 
+describe("argon2 verification accepts memoryCost < 8 from earlier Bun releases", () => {
+  // Earlier (Zig-backed) Bun accepted any `memoryCost >= 1`; the argon2
+  // crate's RFC 9106 floor (`m >= 8*p`) would lock such users out on upgrade.
+  // Hash from `hashSync("mypw", { algorithm: "argon2id", memoryCost: 5, timeCost: 1 })`.
+  const legacyHash =
+    "$argon2id$v=19$m=5,t=1,p=1$JJA3TrXOzpimHbQVvHUgXa412Kmo29q8zBHEWptN2h4$GvYy9WOUF64dYFsCjuUcqY90bCKxlV0j4BH/GCzpWa4";
+
+  test("verifySync", () => {
+    expect(password.verifySync("mypw", legacyHash)).toBeTrue();
+    expect(password.verifySync("mypw", legacyHash, "argon2id")).toBeTrue();
+    expect(password.verifySync("wrong", legacyHash)).toBeFalse();
+  });
+
+  test("verify", async () => {
+    expect(await password.verify("mypw", legacyHash)).toBeTrue();
+    expect(await password.verify("mypw", legacyHash, "argon2id")).toBeTrue();
+    expect(await password.verify("wrong", legacyHash)).toBeFalse();
+  });
+
+  test("hashing still rejects memoryCost < 8", () => {
+    // Only verification of legacy hashes is relaxed; creating new ones with a
+    // sub-minimum memory cost remains an error.
+    expect(() => password.hashSync("mypw", { algorithm: "argon2id", memoryCost: 5, timeCost: 1 })).toThrow(
+      "Memory cost must be at least 8",
+    );
+  });
+});
+
 test("argon2 memoryCost at the 8 minimum is encoded faithfully (regression for #30960)", async () => {
   const hashed = await password.hash("test", {
     algorithm: "argon2id",


### PR DESCRIPTION
Stacked on #33153, which carries all of the build and vendoring infrastructure. This PR is only the behavioral fix and its test.

## Repro

```console
$ bun -e 'console.log(Bun.password.verifySync("mypw","$argon2id$v=19$m=5,t=1,p=1$JJA3TrXOzpimHbQVvHUgXa412Kmo29q8zBHEWptN2h4$GvYy9WOUF64dYFsCjuUcqY90bCKxlV0j4BH/GCzpWa4"))'
error: Password verification failed with error "WeakParameters"
 code: "PASSWORD_WEAK_PARAMETERS"
```

The hash was produced by a Zig-backed Bun release via `Bun.password.hashSync("mypw", { algorithm: "argon2id", memoryCost: 5, timeCost: 1 })`. It should verify as `true`. Silent credential lockout on upgrade.

## Cause

Zig stdlib's argon2 accepted any `m >= 1`; the `rust-argon2` crate's `Context::new` enforces the RFC 9106 floor of `m >= 8 * lanes` and returns `MemoryTooLittle` before computing, which `pwhash.rs` surfaces as `WeakParameters`. The raw `mem_cost` is an input to H0, so only computing with the original value produces the right digest; the PHC string cannot be rewritten to a value the crate accepts.

## Fix

`str_verify` already pre-scans the PHC string's `m`/`t`/`p` to enforce the verification DoS ceilings. That same pass now captures `m` and `p`, and when `1 <= m < 8*p` it routes to `verify_encoded_legacy_memory`, the purely additive entry point #33153's vendored patch provides. Every other value, and all hashing, goes through the unmodified upstream functions, and `Bun.password.hash` still rejects `memoryCost < 8`, so only verification of legacy hashes is restored.

## Verification

New tests verify the `m=5` hash above returns `true` for the correct password and `false` for a wrong one, via both `verifySync` and `verify`, and that `hashSync` with `memoryCost: 5` still throws.

- with `src/runtime/crypto/pwhash.rs` reverted to the base -> 2 fail (`WeakParameters`)
- `bun bd test test/js/bun/util/password.test.ts` -> 71 pass / 0 fail
