### PR TITLE
shell: release SystemError string refs on IOWriter error paths

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -589,6 +589,7 @@ impl Builtin {
                     match shell_openat(cwd_fd, path, redirect.to_flags(), perm) {
                         Err(e) => {
                             let sys = e.to_shell_system_error();
+                            scopeguard::defer! { sys.deref(); }
                             return Some(Self::cmd_write_failing_error(
                                 interp,
                                 cmd,
@@ -619,6 +620,7 @@ impl Builtin {
                     match result {
                         Err(e) => {
                             let sys = e.to_shell_system_error();
+                            scopeguard::defer! { sys.deref(); }
                             return Some(Self::cmd_write_failing_error(
                                 interp,
                                 cmd,
@@ -639,6 +641,7 @@ impl Builtin {
                                 ) {
                                     Err(e) => {
                                         let sys = e.to_shell_system_error();
+                                        scopeguard::defer! { sys.deref(); }
                                         return Some(Self::cmd_write_failing_error(
                                             interp,
                                             cmd,

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -362,6 +362,9 @@ impl IOReader {
 
     fn run_yield(&self, y: Yield) {
         let Some(interp) = self.state().interp else {
+            if let Yield::OnIoWriterChunk { err: Some(e), .. } = &y {
+                e.deref();
+            }
             debug_assert!(
                 matches!(y, Yield::Done | Yield::Suspended),
                 "IOReader async callback fired without interp backref"

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -324,6 +324,9 @@ impl IOReader {
         let _keepalive = self.keepalive();
         self.set_reading(false);
         let s = self.state();
+        if let Some(old) = s.err.take() {
+            old.deref();
+        }
         s.err = Some(err.to_shell_system_error());
         s.raw_err = Some(err.clone());
         // NOTE: reshaped for borrowck — copy out before dispatching.
@@ -423,6 +426,9 @@ impl Drop for IOReader {
                 let _ = sys::close(s.fd);
             }
         }
+        if let Some(e) = s.err.take() {
+            e.deref();
+        }
         r.disable_keeping_process_alive(());
         // `reader` Drop handles its own deinit.
     }
@@ -456,6 +462,9 @@ fn dispatch_reader_done(
     interp: Option<bun_ptr::ParentRef<Interpreter>>,
 ) -> Yield {
     let Some(interp) = interp else {
+        if let Some(e) = err {
+            e.deref();
+        }
         return Yield::suspended();
     };
     let interp = interp.get();

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -918,6 +918,9 @@ impl IOWriter {
     /// to have been set; if not, the chunk-complete is dropped (debug-asserts).
     fn run_yield(&self, y: Yield) {
         let Some(interp) = self.state().interp else {
+            if let Yield::OnIoWriterChunk { err: Some(e), .. } = &y {
+                e.deref();
+            }
             debug_assert!(
                 matches!(y, Yield::Done),
                 "IOWriter async callback fired without interp backref"

--- a/src/runtime/shell/builtin/cd.rs
+++ b/src/runtime/shell/builtin/cd.rs
@@ -106,8 +106,11 @@ impl Cd {
         interp: &Interpreter,
         cmd: NodeId,
         _: usize,
-        _err: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         Self::state_mut(interp, cmd).state = State::Done;
         Builtin::done(interp, cmd, 1)
     }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -250,7 +250,10 @@ impl Cp {
             match next {
                 Some((t, true)) => {
                     // SAFETY: paired with `heap::alloc` in `create()`.
-                    drop(unsafe { bun_core::heap::take(t) });
+                    let mut task = unsafe { bun_core::heap::take(t) };
+                    if let Some(e) = task.err.take() {
+                        e.deinit();
+                    }
                 }
                 Some((t, false)) => return Self::print_shell_cp_task(interp, cmd, t),
                 None => break,

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -115,7 +115,9 @@ impl Cp {
                 if exec.started {
                     if exec.tasks_count == 0 && exec.output_done >= exec.output_waiting {
                         let exit_code: ExitCode = if exec.err.is_some() { 1 } else { 0 };
-                        exec.err = None;
+                        if let Some(e) = exec.err.take() {
+                            e.deinit();
+                        }
                         #[cfg(windows)]
                         let act = if !exec.ebusy.tasks.is_empty() {
                             Action::Ebusy(exit_code)
@@ -314,9 +316,12 @@ impl Cp {
         let errstr: Option<Vec<u8>> = task.err.take().map(|e| {
             let s = Builtin::shell_err_to_string(interp, cmd, Kind::Cp, &e).to_vec();
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.err = Some(e);
+                if let Some(old) = exec.err.replace(e) {
+                    old.deinit();
+                }
+            } else {
+                e.deinit();
             }
-            // `e` drops here when not stored.
             s
         });
         OutputTask::<Cp>::start(output_task, interp, errstr.as_deref())

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -199,13 +199,16 @@ impl Cp {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(err) = e {
+            err.deref();
+        }
         if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
             return Builtin::done(interp, cmd, 1);
         }
         if let Some(task) = Self::state_mut(interp, cmd).output_queue.pop_front() {
             // SAFETY: `task` was heap-allocated in `OutputTask::new` and
             // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e) };
+            return unsafe { OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, None) };
         }
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/echo.rs
+++ b/src/runtime/shell/builtin/echo.rs
@@ -110,11 +110,15 @@ impl Echo {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(
-            interp,
-            cmd,
-            err.map(|e| e.errno as crate::shell::ExitCode).unwrap_or(0),
-        )
+        let exit = match err {
+            Some(e) => {
+                let code = e.errno as crate::shell::ExitCode;
+                e.deref();
+                code
+            }
+            None => 0,
+        };
+        Builtin::done(interp, cmd, exit)
     }
 }
 

--- a/src/runtime/shell/builtin/exit.rs
+++ b/src/runtime/shell/builtin/exit.rs
@@ -47,8 +47,11 @@ impl Exit {
         interp: &Interpreter,
         cmd: NodeId,
         _: usize,
-        _err: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         Self::state_mut(interp, cmd).state = State::Done;
         Builtin::done(interp, cmd, 1)
     }

--- a/src/runtime/shell/builtin/export.rs
+++ b/src/runtime/shell/builtin/export.rs
@@ -81,6 +81,13 @@ impl Export {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         Self::state_mut(interp, cmd).state = State::Done;
-        Builtin::done(interp, cmd, err.map_or(0, |_| 1))
+        let exit = match err {
+            Some(e) => {
+                e.deref();
+                1
+            }
+            None => 0,
+        };
+        Builtin::done(interp, cmd, exit)
     }
 }

--- a/src/runtime/shell/builtin/false_.rs
+++ b/src/runtime/shell/builtin/false_.rs
@@ -14,8 +14,11 @@ impl False {
         _interp: &Interpreter,
         _cmd: NodeId,
         _: usize,
-        _: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         Yield::done()
     }
 }

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -190,6 +190,9 @@ impl Ls {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(err) = e {
+            err.deref();
+        }
         if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
             return Builtin::done(interp, cmd, 1);
         }
@@ -201,7 +204,7 @@ impl Ls {
         if let Some(task) = pending {
             // SAFETY: `task` was heap-allocated in `OutputTask::new` and
             // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e) };
+            return unsafe { OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, None) };
         }
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -143,6 +143,9 @@ impl Mkdir {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(err) = e {
+            err.deref();
+        }
         let pending = match &mut Self::state_mut(interp, cmd).state {
             State::WaitingWriteErr => return Builtin::done(interp, cmd, 1),
             State::Exec(exec) => exec.output_queue.pop_front(),
@@ -151,7 +154,7 @@ impl Mkdir {
         if let Some(task) = pending {
             // SAFETY: `task` was heap-allocated in `OutputTask::new` and
             // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e) };
+            return unsafe { OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, None) };
         }
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/pwd.rs
+++ b/src/runtime/shell/builtin/pwd.rs
@@ -67,7 +67,8 @@ impl Pwd {
         _: usize,
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        if let Some(_err) = err {
+        if let Some(e) = err {
+            e.deref();
             Self::state_mut(interp, cmd).state = State::Err;
             return Builtin::done(interp, cmd, 1);
         }

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -132,6 +132,9 @@ impl Touch {
         written: usize,
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(err) = e {
+            err.deref();
+        }
         if matches!(Self::state_mut(interp, cmd).state, State::WaitingWriteErr) {
             return Builtin::done(interp, cmd, 1);
         }
@@ -143,7 +146,7 @@ impl Touch {
         if let Some(task) = pending {
             // SAFETY: `task` was heap-allocated in `OutputTask::new` and
             // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e) };
+            return unsafe { OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, None) };
         }
         Self::next(interp, cmd)
     }

--- a/src/runtime/shell/builtin/true_.rs
+++ b/src/runtime/shell/builtin/true_.rs
@@ -13,8 +13,11 @@ impl True {
         _interp: &Interpreter,
         _cmd: NodeId,
         _: usize,
-        _: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         Yield::done()
     }
 }

--- a/src/runtime/shell/builtin/which.rs
+++ b/src/runtime/shell/builtin/which.rs
@@ -181,7 +181,9 @@ impl Which {
         e: Option<bun_sys::SystemError>,
     ) -> Yield {
         if let Some(err) = e {
-            return Builtin::done(interp, cmd, err.errno as crate::shell::ExitCode);
+            let exit = err.errno as crate::shell::ExitCode;
+            err.deref();
+            return Builtin::done(interp, cmd, exit);
         }
         match Self::state_mut(interp, cmd).state {
             State::OneArg => Builtin::done(interp, cmd, 1),

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2753,8 +2753,11 @@ impl<P: OutputTaskVTable> OutputTask<P> {
         this: *mut Self,
         interp: &Interpreter,
         _written: usize,
-        _err: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         log!("OutputTask(0x{:x}) onIOWriterChunk", this as usize);
         // SAFETY: `this` is the live heap-allocated `OutputTask` guaranteed by
         // this fn's caller contract; forwarded unchanged to `next`.

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -838,6 +838,7 @@ impl Cmd {
                     Ok(f) => f,
                     Err(e) => {
                         let sys_err = e.to_shell_system_error();
+                        scopeguard::defer! { sys_err.deref(); }
                         return Ok(Some(Builtin::cmd_write_failing_error(
                             interp,
                             this,
@@ -979,6 +980,7 @@ impl Cmd {
         log!("cmd close buffered stdout");
         if let Some(e) = err {
             self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
+            e.deref();
         }
         let redirect = self.ast_node().redirect;
         let Exec::Subproc(sub) = &mut self.exec else {
@@ -1015,6 +1017,7 @@ impl Cmd {
         log!("cmd close buffered stderr");
         if let Some(e) = err {
             self.exit_code = Some(e.errno.unsigned_abs() as ExitCode);
+            e.deref();
         }
         let redirect = self.ast_node().redirect;
         let Exec::Subproc(sub) = &mut self.exec else {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -642,7 +642,9 @@ impl Cmd {
             drop(arena);
             // Revert exec so `deinit` doesn't free a null `child`.
             interp.as_cmd_mut(this).exec = Exec::None;
-            return Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", e));
+            let y = Builtin::cmd_write_failing_error(interp, this, format_args!("{}\n", e));
+            e.deinit();
+            return y;
         }
 
         // Read the subprocess back via the arena instead of holding `child_out`

--- a/src/runtime/shell/states/CondExpr.rs
+++ b/src/runtime/shell/states/CondExpr.rs
@@ -185,6 +185,7 @@ impl CondExpr {
         if let Some(e) = err {
             // Recover the positive errno (`to_shell_system_error` negated it).
             let exit_code: ExitCode = e.errno.unsigned_abs() as ExitCode;
+            e.deref();
             return interp.child_done(parent, this, exit_code);
         }
         if matches!(

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -724,6 +724,9 @@ impl Expansion {
             interp.deinit_node(c);
         }
         let me = interp.as_expansion_mut(this);
+        if let ExpansionState::Err(e) = core::mem::replace(&mut me.state, ExpansionState::Done) {
+            e.deinit();
+        }
         me.out.buf.clear();
         me.out.bounds.clear();
         me.current_out.clear();

--- a/src/runtime/shell/states/Subshell.rs
+++ b/src/runtime/shell/states/Subshell.rs
@@ -111,8 +111,11 @@ impl Subshell {
         interp: &Interpreter,
         this: NodeId,
         _written: usize,
-        _err: Option<bun_sys::SystemError>,
+        err: Option<bun_sys::SystemError>,
     ) -> Yield {
+        if let Some(e) = err {
+            e.deref();
+        }
         debug_assert!(matches!(
             interp.as_subshell(this).state,
             SubshellState::WaitWriteErr

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -2319,7 +2319,10 @@ impl PipeReader {
                 unsafe { (*me).state = PipeReaderState::Done(Box::default()) };
                 ReadableStream::from_owned_slice(global_object, bytes.into_vec(), 0)
             }
-            PipeReaderState::Err(_err) => {
+            PipeReaderState::Err(err) => {
+                if let Some(e) = err {
+                    e.deref();
+                }
                 let empty = ReadableStream::empty(global_object)?;
                 ReadableStream::cancel(
                     &ReadableStream::from_js(empty, global_object)

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1824,7 +1824,9 @@ impl CapturedWriter {
                 e.fd,
                 e.syscall
             );
-            self.err = Some(e);
+            if let Some(old) = self.err.replace(e) {
+                old.deref();
+            }
             // SAFETY: `parent_mut` recovers the embedding `PipeReader` via
             // `container_of`; raw-ptr form per `try_signal_done_to_cmd`
             // contract (no `&mut PipeReader` held across the Cmd re-entry).
@@ -1839,7 +1841,9 @@ impl CapturedWriter {
     }
 
     pub fn on_error(&mut self, err: &bun_sys::Error) {
-        self.err = Some(err.to_system_error());
+        if let Some(old) = self.err.replace(err.to_system_error()) {
+            old.deref();
+        }
     }
 
     pub fn on_close(&mut self) {
@@ -1856,8 +1860,9 @@ impl CapturedWriter {
 
 impl Drop for CapturedWriter {
     fn drop(&mut self) {
-        // `bun_sys::SystemError` strings drop themselves.
-        let _ = self.err.take();
+        if let Some(e) = self.err.take() {
+            e.deref();
+        }
         // self.writer Arc drops automatically.
     }
 }
@@ -2207,6 +2212,7 @@ impl PipeReader {
                             me.state = PipeReaderState::Err(Some(Box::new(e)));
                         }
                         old @ PipeReaderState::Err(_) => {
+                            e.deref();
                             me.state = old;
                         }
                         PipeReaderState::Pending => {
@@ -2351,10 +2357,10 @@ impl PipeReader {
             // SAFETY: see `arc_as_mut_ptr`; short-lived `&mut` for the
             // `state` write ends before `finish_after_state_set` re-enters.
             let me = unsafe { &mut *arc_as_mut_ptr(&guard) };
-            if let PipeReaderState::Done(buf) =
-                core::mem::replace(&mut me.state, PipeReaderState::Err(None))
-            {
-                drop(buf);
+            match core::mem::replace(&mut me.state, PipeReaderState::Err(None)) {
+                PipeReaderState::Done(buf) => drop(buf),
+                PipeReaderState::Err(Some(old)) => old.deref(),
+                PipeReaderState::Err(None) | PipeReaderState::Pending => {}
             }
             me.state = PipeReaderState::Err(Some(Box::new(err.to_system_error())));
         }
@@ -2441,7 +2447,9 @@ impl Drop for PipeReader {
         }
 
         if let PipeReaderState::Err(slot) = &mut self.state {
-            *slot = None;
+            if let Some(e) = slot.take() {
+                e.deref();
+            }
         }
 
         // buffered_output drops automatically.

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1919,6 +1919,9 @@ impl PipeReader {
     /// re-derive `&PipeReader` via the `Readable::Pipe` `Arc`).
     pub(crate) fn run_yield_with(interp: *mut crate::shell::interpreter::Interpreter, y: Yield) {
         if interp.is_null() {
+            if let Yield::OnIoWriterChunk { err: Some(e), .. } = &y {
+                e.deref();
+            }
             debug_assert!(
                 matches!(y, Yield::Done | Yield::Suspended | Yield::Failed),
                 "PipeReader async callback fired without interp backref"

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -444,9 +444,11 @@ describe.concurrent("fd leak", () => {
   // rooted at `to_shell_system_error`/`to_system_error` is reported as leaked.
   //
   // Windows has no ASAN lane and `Malloc=1` is unimplemented there.
-  test.skipIf(!isASAN || isWindows)("SystemError strings are released on shell error paths", async () => {
-    using dir = tempDir("shell-syserr-leak", {
-      "run.ts": /* ts */ `
+  test.skipIf(!isASAN || isWindows)(
+    "SystemError strings are released on shell error paths",
+    async () => {
+      using dir = tempDir("shell-syserr-leak", {
+        "run.ts": /* ts */ `
         import { $ } from "bun";
         $.nothrow();
         const bun = process.execPath;
@@ -466,42 +468,44 @@ describe.concurrent("fd leak", () => {
         }
         console.error("ran");
       `,
-    });
+      });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), join(String(dir), "run.ts")],
-      env: {
-        ...bunEnv,
-        // Route bmalloc through the system allocator so LSan can observe
-        // WTF::StringImpl allocations.
-        Malloc: "1",
-        ASAN_OPTIONS: "detect_leaks=1:allow_user_segv_handler=1:disable_coredump=0",
-        // LSan always reports some process-lifetime allocations (VM
-        // identifiers, sourcemap buffers). exitcode=0 keeps those from
-        // failing the process; the assertion below inspects the report
-        // for frames specific to this leak.
-        LSAN_OPTIONS: "exitcode=0",
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), join(String(dir), "run.ts")],
+        env: {
+          ...bunEnv,
+          // Route bmalloc through the system allocator so LSan can observe
+          // WTF::StringImpl allocations.
+          Malloc: "1",
+          ASAN_OPTIONS: "detect_leaks=1:allow_user_segv_handler=1:disable_coredump=0",
+          // LSan always reports some process-lifetime allocations (VM
+          // identifiers, sourcemap buffers). exitcode=0 keeps those from
+          // failing the process; the assertion below inspects the report
+          // for frames specific to this leak.
+          LSAN_OPTIONS: "exitcode=0",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    // The script itself must have run to completion.
-    expect(stderr).toContain("ran");
+      // The script itself must have run to completion.
+      expect(stderr).toContain("ran");
 
-    // What must be absent is any leak whose allocation stack runs through the
-    // SystemError constructors: those are exactly the WTF::StringImpl refs
-    // this fix releases.
-    const leakedSystemError = stderr
-      .split("\n")
-      .filter(l => l.includes("to_shell_system_error") || l.includes("to_system_error"));
-    if (leakedSystemError.length) {
-      console.error("LSan reported SystemError leak frames:\n" + leakedSystemError.join("\n"));
-    }
-    expect(leakedSystemError).toEqual([]);
-    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
-  }, 100_000);
+      // What must be absent is any leak whose allocation stack runs through the
+      // SystemError constructors: those are exactly the WTF::StringImpl refs
+      // this fix releases.
+      const leakedSystemError = stderr
+        .split("\n")
+        .filter(l => l.includes("to_shell_system_error") || l.includes("to_system_error"));
+      if (leakedSystemError.length) {
+        console.error("LSan reported SystemError leak frames:\n" + leakedSystemError.join("\n"));
+      }
+      expect(leakedSystemError).toEqual([]);
+      expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
+    },
+    100_000,
+  );
 
   describe.serial("not leaking ParsedShellScript when ShellInterpreter never runs", () => {
     function doit(builtin: boolean) {

--- a/test/js/bun/shell/leak.test.ts
+++ b/test/js/bun/shell/leak.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { heapStats } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, isASAN, isPosix, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, isASAN, isPosix, isWindows, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 import { bunExe } from "./test_builder";
 import { createTestBuilder } from "./util";
@@ -433,6 +433,75 @@ describe.concurrent("fd leak", () => {
     doit(false);
     doit(true);
   });
+
+  // Shell builtins and Cmd build a `bun_sys::SystemError` on redirect/write
+  // failure whose `path`/`dest`/`message` fields are heap `WTF::StringImpl`s.
+  // `SystemError` has no `Drop`, so every receiver of a by-value SystemError
+  // must call `.deref()` to release those strings. The Zig reference did
+  // `defer err.deref()` in every `onIOWriterChunk` arm; the Rust port dropped
+  // it in a number of places. Run the failing paths under LSan with `Malloc=1`
+  // (so WTF allocations go through the system heap) and assert no allocation
+  // rooted at `to_shell_system_error`/`to_system_error` is reported as leaked.
+  //
+  // Windows has no ASAN lane and `Malloc=1` is unimplemented there.
+  test.skipIf(!isASAN || isWindows)("SystemError strings are released on shell error paths", async () => {
+    using dir = tempDir("shell-syserr-leak", {
+      "run.ts": /* ts */ `
+        import { $ } from "bun";
+        $.nothrow();
+        const bun = process.execPath;
+        for (let i = 0; i < 30; i++) {
+          // builtin stdout-redirect open failure (Builtin::init_redirections)
+          await $\`echo hi > /nonexistent-dir-xyz/out.txt\`.quiet();
+          // builtin stdin-redirect open failure
+          await $\`echo hi < /nonexistent-file-xyz.txt\`.quiet();
+          // subprocess redirect open failure (Cmd::init_subproc_redirections)
+          await $\`\${bun} -e "" > /nonexistent-dir-xyz/out.txt\`.quiet();
+          // IOWriter write failure → on_io_writer_chunk(Some(err))
+          if (process.platform === "linux") {
+            await $\`echo hi > /dev/full\`.quiet();
+            await $\`pwd > /dev/full\`.quiet();
+            await $\`which ls > /dev/full\`.quiet();
+          }
+        }
+        console.error("ran");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), join(String(dir), "run.ts")],
+      env: {
+        ...bunEnv,
+        // Route bmalloc through the system allocator so LSan can observe
+        // WTF::StringImpl allocations.
+        Malloc: "1",
+        ASAN_OPTIONS: "detect_leaks=1:allow_user_segv_handler=1:disable_coredump=0",
+        // LSan always reports some process-lifetime allocations (VM
+        // identifiers, sourcemap buffers). exitcode=0 keeps those from
+        // failing the process; the assertion below inspects the report
+        // for frames specific to this leak.
+        LSAN_OPTIONS: "exitcode=0",
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The script itself must have run to completion.
+    expect(stderr).toContain("ran");
+
+    // What must be absent is any leak whose allocation stack runs through the
+    // SystemError constructors: those are exactly the WTF::StringImpl refs
+    // this fix releases.
+    const leakedSystemError = stderr
+      .split("\n")
+      .filter(l => l.includes("to_shell_system_error") || l.includes("to_system_error"));
+    if (leakedSystemError.length) {
+      console.error("LSan reported SystemError leak frames:\n" + leakedSystemError.join("\n"));
+    }
+    expect(leakedSystemError).toEqual([]);
+    expect({ stdout, exitCode }).toEqual({ stdout: "", exitCode: 0 });
+  }, 100_000);
 
   describe.serial("not leaking ParsedShellScript when ShellInterpreter never runs", () => {
     function doit(builtin: boolean) {


### PR DESCRIPTION
## What does this PR do?

`bun_sys::SystemError` owns six `bun_core::String` fields. `bun_core::String` is `Copy` (so it stays bit-identical to C++ `BunString` for FFI by-value passing) and therefore has no `Drop`; `SystemError` has no `Drop` either. Every site that receives a `SystemError` by value with a +1 string ref must call `.deref()` before letting it go out of scope.

The Zig reference does this in every `onIOWriterChunk` handler:

```zig
// which.zig
if (e) |err| {
    defer err.deref();
    return this.bltn().done(err.getErrno());
}
```

The Rust port dropped the `.deref()` in most `on_io_writer_chunk` handlers and in a handful of adjacent sites that build or store a `SystemError`.

### Repro

```js
import { $ } from "bun";
$.nothrow();
for (let i = 0; i < 30; i++) {
  await $`echo hi > /nonexistent-dir-xyz/out.txt`.quiet();
  await $`echo hi < /nonexistent-file-xyz.txt`.quiet();
}
```

Under `Malloc=1 ASAN_OPTIONS=detect_leaks=1` LSan reports leaks rooted at `to_shell_system_error`:

```
#18 BunString__fromLatin1   .../BunString.cpp:442
#19 BunString__fromBytes    .../BunString.cpp:483
#22 <bun_sys::error::Error>::to_shell_system_error  src/sys/Error.rs:393
#23 <...::Builtin>::init_redirections  src/runtime/shell/Builtin.rs:621
```

The `bun_sys::Error` returned by `open_for_writing_impl` / `shell_openat` carries the redirect target path; `to_shell_system_error()` clones it into a fresh `WTF::StringImpl` which is then dropped without a `.deref()`.

### Fix

Add the missing `.deref()` at each receiver, matching the Zig reference and the already-correct Rust ports (`yes`, `basename`, `cat`, `dirname`, `seq`, `rm`, `mv`):

- `on_io_writer_chunk` in `cd`, `cp`, `echo`, `exit`, `export`, `ls`, `mkdir`, `pwd`, `touch`, `which`, `true_`, `false_`, `Subshell`, `CondExpr`, `OutputTask`
- `Builtin::init_redirections` and `Cmd::init_subproc_redirections` (via `scopeguard::defer!`)
- `Cmd::buffered_output_close_stdout` / `_stderr`
- `IOWriter::on_error` (deref the previously-stored error before overwriting) and `IOWriter::Drop`
- `CapturedWriter::on_iowriter_chunk` / `on_error` / `Drop` (the old `Drop` had a comment claiming the strings drop themselves; they do not)
- `PipeReader::on_reader_error` / `try_signal_done_to_cmd` / `Drop`

### Verification

The regression test in `test/js/bun/shell/leak.test.ts` spawns a child with `Malloc=1` (routes bmalloc through the system heap so LSan can observe `WTF::StringImpl` allocations) and `ASAN_OPTIONS=detect_leaks=1`, runs the failing redirect paths, and asserts no leak stack is rooted at `to_shell_system_error` / `to_system_error`.

<details>
<summary>Fail-before output</summary>

```
LSan reported SystemError leak frames:
    #22 <bun_sys::error::Error>::to_shell_system_error src/sys/Error.rs:393:18
    #22 <bun_sys::error::Error>::to_shell_system_error src/sys/Error.rs:393:18
    #22 <bun_sys::error::Error>::to_shell_system_error src/sys/Error.rs:393:18
error: expect(received).toEqual(expected)
- []
+ [
+   "    #22 ... to_shell_system_error ...",
+   ...
+ ]
```
</details>

Note: the `on_io_writer_chunk` handlers currently receive errors from `IOWriter::on_error` built via `to_shell_system_error()` on a path-less `sys::write` error, so their strings happen to be static today; the `.deref()` is still required by the ownership contract (and matches the reference implementation) so any future caller that passes a heap-backed `SystemError` is handled correctly.

There may be a minor textual conflict with #32278 in `echo.rs` / `which.rs` (that PR fixes the exit-code value on the same arm; this PR only adds the `.deref()`).