### PR TITLE
fetch: release leaked WTFStringImpl refs on proxy href and file:/blob: response url

### DIFF
--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1027,9 +1027,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                             if !proxy_url_arg.is_undefined_or_null() {
                                 if proxy_url_arg.is_string() && proxy_url_arg.get_length(ctx)? > 0 {
                                     // +1 ref; see the string-format branch above.
-                                    let href = bun_core::OwnedString::new(
-                                        jsc::URL::href_from_js(proxy_url_arg, global_this)?,
-                                    );
+                                    let href = bun_core::OwnedString::new(jsc::URL::href_from_js(
+                                        proxy_url_arg,
+                                        global_this,
+                                    )?);
                                     if href.tag() == BunStringTag::Dead {
                                         let err = ctx.to_type_error(
                                             jsc::ErrorCode::INVALID_ARG_VALUE,

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -985,7 +985,13 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 if let Some(proxy_arg) = obj.get(global_this, "proxy")? {
                     // Handle string format: proxy: "http://proxy.example.com:8080"
                     if proxy_arg.is_string() && proxy_arg.get_length(ctx)? > 0 {
-                        let href = jsc::URL::href_from_js(proxy_arg, global_this)?;
+                        // `href_from_js` returns a +1 WTFStringImpl ref; `bun_core::String`
+                        // is `Copy` with no `Drop`, so wrap in `OwnedString` for scope-exit
+                        // deref (mirrors `defer href.deref()` in fetch.zig).
+                        let href = bun_core::OwnedString::new(jsc::URL::href_from_js(
+                            proxy_arg,
+                            global_this,
+                        )?);
                         if href.tag() == BunStringTag::Dead {
                             let err = ctx.to_type_error(
                                 jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -1020,7 +1026,10 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                         if let Some(proxy_url_arg) = proxy_arg.get(global_this, "url")? {
                             if !proxy_url_arg.is_undefined_or_null() {
                                 if proxy_url_arg.is_string() && proxy_url_arg.get_length(ctx)? > 0 {
-                                    let href = jsc::URL::href_from_js(proxy_url_arg, global_this)?;
+                                    // +1 ref; see the string-format branch above.
+                                    let href = bun_core::OwnedString::new(
+                                        jsc::URL::href_from_js(proxy_url_arg, global_this)?,
+                                    );
                                     if href.tag() == BunStringTag::Dead {
                                         let err = ctx.to_type_error(
                                             jsc::ErrorCode::INVALID_ARG_VALUE,
@@ -1032,7 +1041,6 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                                             ),
                                         );
                                     }
-                                    // `defer href.deref()` → Drop.
                                     let mut buffer: Vec<u8> =
                                         Vec::with_capacity(url_proxy_buffer.len());
                                     buffer.extend_from_slice(&url_proxy_buffer);

--- a/src/runtime/webcore/fetch.rs
+++ b/src/runtime/webcore/fetch.rs
@@ -1419,8 +1419,11 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
         };
         let url_path_decoded = &path_buf2[0..decoded_len as usize];
 
+        // Carries a +1 WTFStringImpl ref on both assignment arms (`create_format`
+        // for blob:, `file_url_from_string` → `Bun::toStringRef` for file:).
+        // `Response::init` wraps it in `OwnedString` and adopts that +1, so it
+        // is passed by value below without an extra `.clone()`.
         let url_string: BunString;
-        // `defer url_string.deref()` → Drop.
 
         // This can be a blob: url or a file: url.
         let blob_to_use: Blob = 'blob: {
@@ -1542,7 +1545,7 @@ fn fetch_impl<const ALLOW_GET_BODY: bool>(
                 ..Default::default()
             },
             Body::new(BodyValue::Blob(blob_to_use)),
-            url_string.clone(),
+            url_string,
             false,
         )));
 

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -504,24 +504,28 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
 // does dupe_ref(), so +2). Response::init adopts one ref; the local +1 was
 // never released, leaking one StringImpl ≈ "file://<path>".length per call.
 test("fetch(file://...) does not leak the response url WTFStringImpl", async () => {
-  // The leaked impl is "file://<resolved abs path>", capped at PATH_MAX, so
-  // use a ~3800-byte nonexistent absolute path (under Linux PATH_MAX 4096;
-  // Windows PathBuffer is 64 KiB so the same length is fine) and enough
-  // iterations for the small per-call leak to show in RSS.
+  // The leaked impl is "file://<resolved abs path>", and fetch_impl decodes
+  // url.path into a stack PathBuffer that is 1024 bytes on macOS/BSD, 4096 on
+  // Linux, ~98 KiB on Windows. Use a ~900-byte path so decode_into succeeds on
+  // every platform and url_string is actually assigned, with enough iterations
+  // for the small per-call leak to show in RSS.
   const script = /* js */ `
-    const pad = Buffer.alloc(3800, "a").toString();
+    const pad = Buffer.alloc(900, "a").toString();
     async function hit(i) {
       // Fresh path per iteration so each leaked ref pins a distinct impl.
       // The file does not exist; the Response is created (with url_string set)
       // and the lazy Blob body is never read, so no fs I/O happens.
       await fetch("file:///" + i + pad);
     }
-    for (let i = 0; i < 100; i++) { try { await hit(-i); } catch {} }
+    for (let i = 0; i < 200; i++) { try { await hit(-i); } catch {} }
     Bun.gc(true);
     const baseline = process.memoryUsage.rss();
 
-    const ITERS = 5000;
-    for (let i = 0; i < ITERS; i++) { try { await hit(i); } catch {} }
+    const ITERS = 20000;
+    for (let i = 0; i < ITERS; i++) {
+      try { await hit(i); } catch {}
+      if ((i & 1023) === 0) Bun.gc(true);
+    }
     Bun.gc(true);
     const final = process.memoryUsage.rss();
 
@@ -531,8 +535,8 @@ test("fetch(file://...) does not leak the response url WTFStringImpl", async () 
       finalMB: (final / 1024 / 1024) | 0,
       deltaMB: Math.round(deltaMB * 10) / 10,
     }));
-    // ~3.8 KiB × 5000 ≈ 18.6 MiB raw leak (measured ~33 MiB on debug+ASAN)
-    // when the extra ref is dropped on the floor; ~11 MiB noise with the fix.
+    // ~0.9 KiB × 20000 ≈ 18 MiB raw leak (measured ~32 MiB on debug+ASAN)
+    // when the extra ref is dropped on the floor; ~12 MiB noise with the fix.
     if (deltaMB > 20) {
       throw new Error("fetch(file://) leaked " + deltaMB.toFixed(1) + " MB over " + ITERS + " iterations");
     }
@@ -555,7 +559,7 @@ test("fetch(file://...) does not leak the response url WTFStringImpl", async () 
     stderr: "",
     exitCode: 0,
   });
-}, 90000);
+}, 120000);
 
 // Regression for src/runtime/webcore/fetch/FetchTasklet.zig:601,614 —
 // Holder.resolve/reject use `self.promise.swap()` which *consumes* (clears)

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -503,7 +503,7 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
 // that was passed to Response::init as url_string.clone() (inherent clone()
 // does dupe_ref(), so +2). Response::init adopts one ref; the local +1 was
 // never released, leaking one StringImpl ≈ "file://<path>".length per call.
-test("fetch(file://...) does not leak the response url WTFStringImpl", async () => {
+test.concurrent("fetch(file://...) does not leak the response url WTFStringImpl", async () => {
   // The leaked impl is "file://<resolved abs path>", and fetch_impl decodes
   // url.path into a stack PathBuffer that is 1024 bytes on macOS/BSD, 4096 on
   // Linux, ~98 KiB on Windows. Use a ~900-byte path so decode_into succeeds on
@@ -511,11 +511,14 @@ test("fetch(file://...) does not leak the response url WTFStringImpl", async () 
   // for the small per-call leak to show in RSS.
   const script = /* js */ `
     const pad = Buffer.alloc(900, "a").toString();
+    // Windows strips the leading "/" then asserts is_absolute_windows() in
+    // PosixToWinNormalizer under debug_assertions, which needs a drive letter.
+    const prefix = process.platform === "win32" ? "file:///C:/" : "file:///";
     async function hit(i) {
       // Fresh path per iteration so each leaked ref pins a distinct impl.
       // The file does not exist; the Response is created (with url_string set)
       // and the lazy Blob body is never read, so no fs I/O happens.
-      await fetch("file:///" + i + pad);
+      await fetch(prefix + i + pad);
     }
     for (let i = 0; i < 200; i++) { try { await hit(-i); } catch {} }
     Bun.gc(true);

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -503,13 +503,15 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
 // that was passed to Response::init as url_string.clone() (inherent clone()
 // does dupe_ref(), so +2). Response::init adopts one ref; the local +1 was
 // never released, leaking one StringImpl ≈ "file://<path>".length per call.
-test.concurrent("fetch(file://...) does not leak the response url WTFStringImpl", async () => {
-  // The leaked impl is "file://<resolved abs path>", and fetch_impl decodes
-  // url.path into a stack PathBuffer that is 1024 bytes on macOS/BSD, 4096 on
-  // Linux, ~98 KiB on Windows. Use a ~900-byte path so decode_into succeeds on
-  // every platform and url_string is actually assigned, with enough iterations
-  // for the small per-call leak to show in RSS.
-  const script = /* js */ `
+test.concurrent(
+  "fetch(file://...) does not leak the response url WTFStringImpl",
+  async () => {
+    // The leaked impl is "file://<resolved abs path>", and fetch_impl decodes
+    // url.path into a stack PathBuffer that is 1024 bytes on macOS/BSD, 4096 on
+    // Linux, ~98 KiB on Windows. Use a ~900-byte path so decode_into succeeds on
+    // every platform and url_string is actually assigned, with enough iterations
+    // for the small per-call leak to show in RSS.
+    const script = /* js */ `
     const pad = Buffer.alloc(900, "a").toString();
     // Windows strips the leading "/" then asserts is_absolute_windows() in
     // PosixToWinNormalizer under debug_assertions, which needs a drive letter.
@@ -545,24 +547,26 @@ test.concurrent("fetch(file://...) does not leak the response url WTFStringImpl"
     }
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--smol", "-e", script],
-    env: {
-      ...bunEnv,
-      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
-    },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  console.log(stdout.trim());
-  if (exitCode !== 0) console.error(stderr);
-  expect({ stdout: stdout.includes("deltaMB"), stderr, exitCode }).toEqual({
-    stdout: true,
-    stderr: "",
-    exitCode: 0,
-  });
-}, 120000);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", script],
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    console.log(stdout.trim());
+    if (exitCode !== 0) console.error(stderr);
+    expect({ stdout: stdout.includes("deltaMB"), stderr, exitCode }).toEqual({
+      stdout: true,
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  120000,
+);
 
 // Regression for src/runtime/webcore/fetch/FetchTasklet.zig:601,614 —
 // Holder.resolve/reject use `self.promise.swap()` which *consumes* (clears)

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -498,6 +498,65 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
   );
 });
 
+// fetch.rs url_type != Remote: url_string carries a +1 WTFStringImpl ref
+// (create_format for blob:, file_url_from_string → Bun::toStringRef for file:)
+// that was passed to Response::init as url_string.clone() (inherent clone()
+// does dupe_ref(), so +2). Response::init adopts one ref; the local +1 was
+// never released, leaking one StringImpl ≈ "file://<path>".length per call.
+test("fetch(file://...) does not leak the response url WTFStringImpl", async () => {
+  // The leaked impl is "file://<resolved abs path>", capped at PATH_MAX, so
+  // use a ~3800-byte nonexistent absolute path (under Linux PATH_MAX 4096;
+  // Windows PathBuffer is 64 KiB so the same length is fine) and enough
+  // iterations for the small per-call leak to show in RSS.
+  const script = /* js */ `
+    const pad = Buffer.alloc(3800, "a").toString();
+    async function hit(i) {
+      // Fresh path per iteration so each leaked ref pins a distinct impl.
+      // The file does not exist; the Response is created (with url_string set)
+      // and the lazy Blob body is never read, so no fs I/O happens.
+      await fetch("file:///" + i + pad);
+    }
+    for (let i = 0; i < 100; i++) { try { await hit(-i); } catch {} }
+    Bun.gc(true);
+    const baseline = process.memoryUsage.rss();
+
+    const ITERS = 5000;
+    for (let i = 0; i < ITERS; i++) { try { await hit(i); } catch {} }
+    Bun.gc(true);
+    const final = process.memoryUsage.rss();
+
+    const deltaMB = (final - baseline) / 1024 / 1024;
+    console.log(JSON.stringify({
+      baselineMB: (baseline / 1024 / 1024) | 0,
+      finalMB: (final / 1024 / 1024) | 0,
+      deltaMB: Math.round(deltaMB * 10) / 10,
+    }));
+    // ~3.8 KiB × 5000 ≈ 18.6 MiB raw leak (measured ~33 MiB on debug+ASAN)
+    // when the extra ref is dropped on the floor; ~11 MiB noise with the fix.
+    if (deltaMB > 20) {
+      throw new Error("fetch(file://) leaked " + deltaMB.toFixed(1) + " MB over " + ITERS + " iterations");
+    }
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", script],
+    env: {
+      ...bunEnv,
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  console.log(stdout.trim());
+  if (exitCode !== 0) console.error(stderr);
+  expect({ stdout: stdout.includes("deltaMB"), stderr, exitCode }).toEqual({
+    stdout: true,
+    stderr: "",
+    exitCode: 0,
+  });
+}, 90000);
+
 // Regression for src/runtime/webcore/fetch/FetchTasklet.zig:601,614 —
 // Holder.resolve/reject use `self.promise.swap()` which *consumes* (clears)
 // the jsc.Strong handle on the fetch() promise before calling resolve()/reject().

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -419,6 +419,83 @@ test("fetch() does not leak streaming decompressor state across fragmented compr
   expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
 }, 60000);
 
+// fetch.rs 'extract_proxy: jsc::URL::href_from_js() returns a +1 WTFStringImpl
+// ref into a bun_core::String, which is Copy and has no Drop. Without wrapping
+// in OwnedString the +1 is never released, leaking one WTFStringImpl (≈ the
+// proxy URL's byte length) per fetch({proxy}) call. Both the string form
+// (proxy: "http://...") and the object form (proxy: {url: "http://..."}) go
+// through href_from_js at separate call sites.
+describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the proxy href WTFStringImpl", form => {
+  test.concurrent(
+    "RSS stays bounded",
+    async () => {
+      // Target a non-existent blob: URL so each fetch() parses the proxy option
+      // (where the leak occurs) then rejects synchronously in the blob registry
+      // lookup, with no network I/O.
+      const script = /* js */ `
+        // ~256 KiB path so each leaked WTFStringImpl shows up in RSS well above
+        // allocator noise. Build a FRESH proxy string per iteration: reusing one
+        // JS string would make href_from_js return the same StringImpl every
+        // call (only the refcount grows, RSS stays flat) and hide the leak.
+        const pad = Buffer.alloc(256 * 1024, "a").toString();
+
+        async function hit(i) {
+          const proxyUrl = "http://127.0.0.1:1/" + i + "/" + pad;
+          const opts = ${form === "string" ? `{ proxy: proxyUrl }` : `{ proxy: { url: proxyUrl } }`};
+          try { await fetch("blob:not-a-real-blob", opts); } catch {}
+        }
+
+        // Warm up (JIT, allocator page commit).
+        for (let i = 0; i < 20; i++) await hit(-i);
+        Bun.gc(true);
+        const baseline = process.memoryUsage.rss();
+
+        const ITERS = 150;
+        for (let i = 0; i < ITERS; i++) await hit(i);
+        Bun.gc(true);
+        const final = process.memoryUsage.rss();
+
+        const deltaMB = (final - baseline) / 1024 / 1024;
+        console.log(JSON.stringify({
+          form: ${JSON.stringify(form)},
+          baselineMB: (baseline / 1024 / 1024) | 0,
+          finalMB: (final / 1024 / 1024) | 0,
+          deltaMB: Math.round(deltaMB * 10) / 10,
+        }));
+        // 150 × 256 KiB ≈ 37 MiB leaked when the +1 is dropped on the floor
+        // (measured ~43 MiB on debug+ASAN); with the deref in place the delta
+        // is URL-size-independent noise (~10 MiB on debug+ASAN, ~0 on release).
+        if (deltaMB > 20) {
+          throw new Error("fetch({proxy}) leaked " + deltaMB.toFixed(1) + " MB over " + ITERS + " iterations");
+        }
+      `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", script],
+        env: {
+          ...bunEnv,
+          // ASAN quarantine retains freed allocations; this path churns several
+          // 256 KiB buffers per iteration, which would dominate the RSS delta
+          // and mask the real signal. Disable quarantine in the child so only
+          // never-freed memory shows up.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      console.log(stdout.trim());
+      if (exitCode !== 0) console.error(stderr);
+      expect({ stdout: stdout.includes("deltaMB"), stderr, exitCode }).toEqual({
+        stdout: true,
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+    90000,
+  );
+});
+
 // Regression for src/runtime/webcore/fetch/FetchTasklet.zig:601,614 —
 // Holder.resolve/reject use `self.promise.swap()` which *consumes* (clears)
 // the jsc.Strong handle on the fetch() promise before calling resolve()/reject().

--- a/test/js/web/fetch/fetch-leak.test.ts
+++ b/test/js/web/fetch/fetch-leak.test.ts
@@ -442,7 +442,9 @@ describe.each(["string", "object"])("fetch({proxy}) %s form does not leak the pr
         async function hit(i) {
           const proxyUrl = "http://127.0.0.1:1/" + i + "/" + pad;
           const opts = ${form === "string" ? `{ proxy: proxyUrl }` : `{ proxy: { url: proxyUrl } }`};
-          try { await fetch("blob:not-a-real-blob", opts); } catch {}
+          // 41-byte blob: URL (5 + 36-char UUID) so ZigURL::is_blob() matches
+          // and fetch rejects from the blob registry with no FetchTasklet.
+          try { await fetch("blob:00000000-0000-0000-0000-000000000000", opts); } catch {}
         }
 
         // Warm up (JIT, allocator page commit).


### PR DESCRIPTION
## What

Three sites in `src/runtime/webcore/fetch.rs` held a +1 `WTF::StringImpl` ref in a bare `bun_core::String` local and never released it. `bun_core::String` is `#[derive(Copy)]` with no `Drop`, so a comment claiming "`defer x.deref()` → Drop" is a no-op.

- `fetch(url, { proxy: "http://..." })` leaked one StringImpl ≈ proxy URL byte length per call
- `fetch(url, { proxy: { url: "http://..." } })` same, separate call site
- `fetch("file://...")` and `fetch("blob:<registered>")` leaked one StringImpl ≈ response URL byte length per call

## Cause

**Proxy sites** (`'extract_proxy`): `jsc::URL::href_from_js()` returns a `bun_core::String` carrying a +1 ref (`Bun::toStringRef` in `URL__getHrefFromJS`). `let href = jsc::URL::href_from_js(...)` drops that +1 on the floor. The Zig reference has `defer href.deref();` at both sites.

**file:/blob: response URL** (`url_type != Remote` branch): `url_string` is assigned a +1 from `BunString::create_format` (blob:) or `jsc::URL::file_url_from_string` → `Bun::toStringRef` (file:), then passed to `Response::init` as `url_string.clone()`. The inherent `bun_core::String::clone` does `dupe_ref()` (+2); `Response::init` wraps in `OwnedString` and adopts one ref; the local +1 is never released. The Zig reference balances `url_string.clone()` with `defer url_string.deref()`.

Refcount trace of the proxy site (debug build, `Bun.gc(true)` between iterations):

```
[PROXY-DBG] tag=WTF ptr=0x723afe160560 rc=2   # just after href_from_js
[PROXY-DBG-PREV] ptr=0x723afe160560 rc=1      # next iteration, after GC: stuck at 1 forever
[PROXY-DBG-PREV] ptr=0x723afe1611f0 rc=1
[PROXY-DBG-PREV] ptr=0x723afe161e80 rc=1
```

## Fix

- Proxy sites: wrap `href_from_js` results in `bun_core::OwnedString::new(...)`, matching the existing pattern for the main request URL and `fetch.preconnect` in the same file.
- file:/blob: site: drop the `.clone()` so `Response::init` adopts the original +1 directly.
- Removed both misleading "`defer … deref()` → Drop" comments.

## Verification

`test/js/web/fetch/fetch-leak.test.ts` gains three RSS-delta cases. Each spawns a child under `ASAN_OPTIONS=quarantine_size_mb=0` (so freed churn on the same path does not mask never-freed impls) with a fresh URL per iteration (reusing one JS string would make `href_from_js` return the same impl every call; only the refcount grows, RSS stays flat, and the leak is hidden).

The proxy cases fetch an unregistered 41-byte `blob:` URL so `'extract_proxy` runs then `ObjectURLRegistry` rejects synchronously with no `FetchTasklet`. The file: case fetches a ~3800-byte nonexistent absolute path (near PATH_MAX); the lazy Blob body is never read, so no fs I/O happens.

| | proxy string | proxy object | file:// |
|-|-|-|-|
| `git checkout main -- src/` + `bun bd test` | 45.3 MB | 45.4 MB | 30.9 MB |
| `USE_SYSTEM_BUN=1 bun test` | 41.0 MB | 41.0 MB | (n/a) |
| `bun bd test` (this PR) | 11.6 MB | 10.6 MB | 14.7 MB |

Threshold is 20 MB. The pass-after residual is URL-size-independent (measured the same at 1 KiB and 256 KiB proxy URLs), i.e. baseline allocator/JSC growth rather than a remaining URL-sized leak.

All 45 tests in `test/js/bun/http/proxy.test.ts` and the `fetch() file:// works` test in `test/js/web/fetch/fetch.test.ts` pass unchanged.
