### PR TITLE
fs: restore platform mode_t range for numeric string flags

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1755,6 +1755,12 @@ impl FileSystemFlags {
                 )));
             }
 
+            // Numeric string flags parse into the platform's native `mode_t`
+            // width (u16 on Darwin, u32 on Linux) so the accepted range matches
+            // `std.fmt.parseInt(std.posix.mode_t, ...)` from the Zig reference.
+            // The widen→`try_from` step rejects values that don't fit in the
+            // resulting `c_int` instead of silently wrapping.
+            type FlagsInt = bun_sys::posix::mode_t;
             let flags: Option<i32> = 'brk: {
                 if str.is_16bit() {
                     let chars = str.utf16_slice_aligned();
@@ -1762,14 +1768,16 @@ impl FileSystemFlags {
                         // node allows "0o644" as a string :(
                         let slice = str.to_slice();
                         // slice.deinit() on Drop
-                        break 'brk strings::parse_int::<Mode>(slice.slice(), 10)
+                        break 'brk strings::parse_int::<FlagsInt>(slice.slice(), 10)
                             .ok()
-                            .map(|v| v as i32);
+                            .and_then(|v| i32::try_from(i64::from(v)).ok());
                     }
                 } else {
                     let chars = str.slice();
                     if chars[0].is_ascii_digit() {
-                        break 'brk strings::parse_int::<Mode>(chars, 10).ok().map(|v| v as i32);
+                        break 'brk strings::parse_int::<FlagsInt>(chars, 10)
+                            .ok()
+                            .and_then(|v| i32::try_from(i64::from(v)).ok());
                     }
                 }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4044,6 +4044,47 @@ describe("numeric flags produce same result as string flags", () => {
   });
 });
 
+describe("out-of-range numeric string flags are rejected", () => {
+  // FileSystemFlags::from_js parses a leading-digit string into the platform's
+  // native mode_t (u16 on Darwin, u32 on Linux) and then into c_int. Values that
+  // overflow either step must throw "Invalid flag" rather than being silently
+  // wrapped and handed to open(2).
+  it.each(["2147483648", "4294967295", "4294967296"])("openSync(devNull, %j) throws Invalid flag", flag => {
+    let fd: number | undefined;
+    try {
+      expect(() => {
+        fd = openSync(os.devNull, flag as any);
+      }).toThrow(
+        expect.objectContaining({
+          code: "ERR_INVALID_ARG_TYPE",
+          message: expect.stringContaining(`Invalid flag '${flag}'`),
+        }),
+      );
+    } finally {
+      if (fd !== undefined) closeSync(fd);
+    }
+  });
+
+  it.if(process.platform === "darwin").each(["65536", "2147483647"])(
+    "openSync(devNull, %j) throws Invalid flag (darwin mode_t is u16)",
+    flag => {
+      let fd: number | undefined;
+      try {
+        expect(() => {
+          fd = openSync(os.devNull, flag as any);
+        }).toThrow(
+          expect.objectContaining({
+            code: "ERR_INVALID_ARG_TYPE",
+            message: expect.stringContaining(`Invalid flag '${flag}'`),
+          }),
+        );
+      } finally {
+        if (fd !== undefined) closeSync(fd);
+      }
+    },
+  );
+});
+
 describe("synchronous I/O string flags", () => {
   it("'rs' opens existing file for reading", () => {
     using dir = tempDir("sync-flags", {


### PR DESCRIPTION
## Problem

`FileSystemFlags::from_js` in `src/runtime/node/types.rs` parses leading-digit flag strings (e.g. `fs.openSync(path, "65536")`) into an integer before handing it to `open(2)`. The Zig reference parsed into `std.posix.mode_t` (u16 on Darwin, u32 on Linux); the Rust port parsed into the cross-platform `Mode = u32` alias and then `as i32`-cast the result.

On **Darwin** this widened the accepted range from `0..=65535` to `0..=4294967295`:

```
fs.openSync('/dev/null', '65536')
  Zig 1.3.14/macOS → TypeError [ERR_INVALID_ARG_TYPE]: Invalid flag '65536'
  Rust HEAD/macOS  → returns a valid fd (65536 passed to open(2))
```

On **Linux**, values `>= 2^31` silently wrapped negative via `as i32` and reached `open(2)`:

```
fs.openSync('/dev/null', '2147483648')
  before → returns a valid fd (wraps to i32::MIN)
fs.openSync('/dev/null', '4294967295')
  before → ENOTDIR from open(2) (wraps to -1)
```

Node.js rejects all numeric string flags with `ERR_INVALID_ARG_VALUE`, so the Rust port had drifted further from Node than the Zig reference.

## Fix

Parse into `bun_sys::posix::mode_t` (the platform-native width: u16 on Darwin, u32 on Linux, i32 on Windows) to restore the Zig accepted range, and convert to `c_int` via `i32::try_from` instead of `as i32` so values that don't fit fall through to the existing `Invalid flag '...'` error on every platform rather than wrapping.

## Verification

```
"2147483648" → ERR_INVALID_ARG_TYPE: Invalid flag '2147483648'
"4294967295" → ERR_INVALID_ARG_TYPE: Invalid flag '4294967295'
"4294967296" → ERR_INVALID_ARG_TYPE: Invalid flag '4294967296'
```

New tests in `test/js/node/fs/fs.test.ts` cover the `>= 2^31` boundary on all platforms plus the `>= 2^16` boundary on Darwin.