### PR TITLE
Fix BunString ref leaks in Bun.JSON5.stringify

### DIFF
--- a/src/runtime/api/JSON5Object.rs
+++ b/src/runtime/api/JSON5Object.rs
@@ -2,7 +2,7 @@ use bun_ast::{E, Expr, expr::Data as ExprData};
 use bun_collections::HashMap;
 use bun_collections::VecExt;
 use bun_core::StackCheck;
-use bun_core::{String as BunString, ZigString};
+use bun_core::{OwnedString, String as BunString, ZigString};
 use bun_js_parser::lexer;
 use bun_jsc::{self as jsc, CallFrame, JSGlobalObject, JSValue, JsError, JsResult, StringJsc, wtf};
 use bun_parsers::json5;
@@ -109,7 +109,8 @@ type StringifyResult<T> = Result<T, StringifyError>;
 enum Space {
     Minified,
     Number(u32),
-    Str(BunString),
+    /// +1 WTF ref owned for the lifetime of the `Stringifier`.
+    Str(OwnedString),
 }
 
 impl Space {
@@ -126,9 +127,8 @@ impl Space {
             return Ok(Space::Number(if num_f > 10.0 { 10 } else { num_f as u32 }));
         }
         if space.is_string() {
-            let str = space.to_bun_string(global)?;
+            let str = OwnedString::new(space.to_bun_string(global)?);
             if str.length() == 0 {
-                // `str` drops here (deref)
                 return Ok(Space::Minified);
             }
             return Ok(Space::Str(str));
@@ -136,8 +136,6 @@ impl Space {
         Ok(Space::Minified)
     }
 }
-
-// NOTE: `Space::deinit` deleted — `BunString` field derefs via `Drop`.
 
 impl Stringifier {
     pub(crate) fn init(global: &JSGlobalObject, space_value: JSValue) -> JsResult<Stringifier> {
@@ -149,9 +147,6 @@ impl Stringifier {
             visiting: HashMap::default(),
         })
     }
-
-    // NOTE: `deinit` deleted — all fields (`builder`, `space`, `visiting`)
-    // free via `Drop`.
 
     pub(crate) fn stringify_value(
         &mut self,
@@ -203,7 +198,7 @@ impl Stringifier {
         }
 
         if unwrapped.is_string() {
-            let str = bun_core::OwnedString::new(unwrapped.to_bun_string(global)?);
+            let str = OwnedString::new(unwrapped.to_bun_string(global)?);
             self.append_quoted_string(&str);
             return Ok(());
         }
@@ -372,7 +367,7 @@ impl Stringifier {
         };
 
         if is_identifier {
-            self.builder.append_string(name.clone());
+            self.builder.append_string(*name);
         } else {
             self.append_quoted_string(name);
         }
@@ -419,13 +414,13 @@ impl Stringifier {
             }
             Space::Str(space_str) => {
                 self.builder.append_lchar(b'\n');
-                let clamped = if space_str.length() > 10 {
+                let clamped: BunString = if space_str.length() > 10 {
                     space_str.substring_with_len(0, 10)
                 } else {
-                    space_str.clone()
+                    **space_str
                 };
                 for _ in 0..self.indent {
-                    self.builder.append_string(clamped.clone());
+                    self.builder.append_string(clamped);
                 }
             }
         }
@@ -476,7 +471,7 @@ fn expr_to_js_with_check(
                     stack_check,
                 )?;
                 let key_js = expr_to_js_with_check(key_expr, global, stack_check)?;
-                let key_str = bun_core::OwnedString::new(key_js.to_bun_string(global)?);
+                let key_str = OwnedString::new(key_js.to_bun_string(global)?);
                 js_obj.put_may_be_index(global, &key_str, value)?;
             }
             Ok(js_obj)

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -2,7 +2,7 @@
 // Expected values verified against json5@2.2.3 reference implementation.
 import { JSON5 } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isASAN } from "harness";
 
 describe("escape sequences", () => {
   test("\\v vertical tab", () => {
@@ -1658,4 +1658,43 @@ describe("deeply nested parse results", () => {
     expect(stdout.replaceAll("\r\n", "\n").trim()).toBe("JSON5 probed\nJSONC probed\ndone");
     expect(exitCode).toBe(0);
   });
+});
+
+describe("stringify memory", () => {
+  // ASAN's quarantine retains freed allocations so RSS deltas run higher
+  // under bun-asan; widen the threshold there.
+  const thresholdMB = isASAN ? 80 : 30;
+
+  test(
+    "does not leak with a string space argument",
+    async () => {
+      // Unique >10-char space string per call so each iteration allocates a
+      // fresh WTFStringImpl for the stored space and hits the clamp branch in
+      // newline(). Nested object/array so indent > 0.
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--smol",
+          "-e",
+          /* js */ `
+          const obj = { a: [1, 2, 3], b: { c: 4 }, d: 5 };
+          const pad = Buffer.alloc(8000, " ").toString();
+          for (let i = 0; i < 500; i++) Bun.JSON5.stringify(obj, null, pad + i);
+          Bun.gc(true);
+          const before = process.memoryUsage.rss();
+          for (let i = 0; i < 20000; i++) Bun.JSON5.stringify(obj, null, pad + i);
+          Bun.gc(true);
+          const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+          if (growthMB > ${thresholdMB}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+        `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    },
+    60_000,
+  );
 });

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -1682,7 +1682,16 @@ describe("stringify memory", () => {
           if (growthMB > 64) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
         `,
       ],
-      env: bunEnv,
+      env: {
+        ...bunEnv,
+        // Under ASAN every freed allocation parks in the allocator quarantine
+        // (default quarantine_size_mb=256) instead of being returned, so the
+        // RSS-delta heuristic over-reports even when nothing leaks. Disable
+        // the quarantine for this measurement process so the 64 MB threshold
+        // keeps separating "fixed" from "leaking ~200 MB". Harmless when the
+        // binary is not ASAN-built.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -2,7 +2,7 @@
 // Expected values verified against json5@2.2.3 reference implementation.
 import { JSON5 } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe } from "harness";
 
 describe("escape sequences", () => {
   test("\\v vertical tab", () => {
@@ -1661,10 +1661,6 @@ describe("deeply nested parse results", () => {
 });
 
 describe("stringify memory", () => {
-  // ASAN's quarantine retains freed allocations so RSS deltas run higher
-  // under bun-asan; widen the threshold there.
-  const thresholdMB = isASAN ? 80 : 30;
-
   test("does not leak with a string space argument", async () => {
     // Unique >10-char space string per call so each iteration allocates a
     // fresh WTFStringImpl for the stored space and hits the clamp branch in
@@ -1676,14 +1672,14 @@ describe("stringify memory", () => {
         "-e",
         /* js */ `
           const obj = { a: [1, 2, 3], b: { c: 4 }, d: 5 };
-          const pad = Buffer.alloc(8000, " ").toString();
-          for (let i = 0; i < 500; i++) Bun.JSON5.stringify(obj, null, pad + i);
+          const pad = Buffer.alloc(1024 * 1024, " ").toString();
+          for (let i = 0; i < 20; i++) Bun.JSON5.stringify(obj, null, pad + i);
           Bun.gc(true);
           const before = process.memoryUsage.rss();
-          for (let i = 0; i < 20000; i++) Bun.JSON5.stringify(obj, null, pad + i);
+          for (let i = 0; i < 200; i++) Bun.JSON5.stringify(obj, null, pad + i);
           Bun.gc(true);
           const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
-          if (growthMB > ${thresholdMB}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
+          if (growthMB > 64) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
         `,
       ],
       env: bunEnv,
@@ -1692,5 +1688,5 @@ describe("stringify memory", () => {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-  }, 60_000);
+  });
 });

--- a/test/js/bun/json5/json5.test.ts
+++ b/test/js/bun/json5/json5.test.ts
@@ -1665,18 +1665,16 @@ describe("stringify memory", () => {
   // under bun-asan; widen the threshold there.
   const thresholdMB = isASAN ? 80 : 30;
 
-  test(
-    "does not leak with a string space argument",
-    async () => {
-      // Unique >10-char space string per call so each iteration allocates a
-      // fresh WTFStringImpl for the stored space and hits the clamp branch in
-      // newline(). Nested object/array so indent > 0.
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "--smol",
-          "-e",
-          /* js */ `
+  test("does not leak with a string space argument", async () => {
+    // Unique >10-char space string per call so each iteration allocates a
+    // fresh WTFStringImpl for the stored space and hits the clamp branch in
+    // newline(). Nested object/array so indent > 0.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "--smol",
+        "-e",
+        /* js */ `
           const obj = { a: [1, 2, 3], b: { c: 4 }, d: 5 };
           const pad = Buffer.alloc(8000, " ").toString();
           for (let i = 0; i < 500; i++) Bun.JSON5.stringify(obj, null, pad + i);
@@ -1687,14 +1685,12 @@ describe("stringify memory", () => {
           const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
           if (growthMB > ${thresholdMB}) throw new Error("leaked " + growthMB.toFixed(2) + "MB");
         `,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
-    },
-    60_000,
-  );
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
+  }, 60_000);
 });


### PR DESCRIPTION
## What

`Bun.JSON5.stringify` leaked `WTF::StringImpl` refs on every call with a string `space` argument, and on every identifier key written.

## Repro

```js
const obj = { a: [1, 2, 3], b: { c: 4 }, d: 5 };
const pad = Buffer.alloc(1024 * 1024, " ").toString();
for (let i = 0; i < 20; i++) Bun.JSON5.stringify(obj, null, pad + i);
Bun.gc(true);
const before = process.memoryUsage.rss();
for (let i = 0; i < 200; i++) Bun.JSON5.stringify(obj, null, pad + i);
Bun.gc(true);
console.log(((process.memoryUsage.rss() - before) / 1024 / 1024).toFixed(1), "MB");
// before: ~200 MB
// after:  ~2 MB
```

## Cause

`bun_core::String` is `#[derive(Copy)]` with no `Drop` impl; sites that receive a +1 ref must wrap it in `OwnedString` to get scope-exit `deref()`. `JSON5Object.rs` stored a raw `BunString` in `Space::Str` and called `.clone()` (which on a WTF-backed string is `dupe_ref()`, and on a ZigString-backed one allocates a fresh impl) when passing to `StringBuilder::append_string`, assuming `Drop` would balance the refs. It doesn't:

- `Space::init`: `to_bun_string()` +1 stored in `Space::Str(BunString)`, never released.
- `newline()`: `space_str.clone()` / `clamped.clone()` in the indent loop; for a >10 char space the clamped value is ZigString-backed so `.clone()` allocates a fresh `StringImpl` per indent level, all leaked.
- `append_key()`: `name.clone()` +1 per identifier key.

`YAMLObject.rs` already handles this correctly with `Str(OwnedString)` and passing the `Copy` value directly.

## Fix

- `Space::Str(BunString)` → `Space::Str(OwnedString)`; wrap the `to_bun_string()` result immediately so the early-return path also releases it.
- `append_key`: `append_string(*name)` instead of `name.clone()`.
- `newline`: borrow the `Copy` value via `**space_str` and pass `clamped` directly.
- Removed the two comments that incorrectly claimed `BunString` derefs via `Drop`.

## Verification

New RSS-delta regression test in `test/js/bun/json5/json5.test.ts`. Fails on the unfixed build (`leaked ~200MB`), passes with the fix. All 320 existing json5 tests and 113 json5-test-suite tests continue to pass.
