### PR TITLE
fix(types): add toHaveBeenCalledOnce matcher to bun:test types

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1860,6 +1860,11 @@ declare module "bun:test" {
     toBeCalledTimes(expected: number): void;
 
     /**
+     * Ensures that a mock function is called exactly once.
+     */
+    toHaveBeenCalledOnce(): void;
+
+    /**
      * Ensure that a mock function is called with specific arguments.
      */
     toHaveBeenCalledWith(...expected: unknown[]): void;

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -1,4 +1,4 @@
-import { jest, mock } from "bun:test";
+import { expect, jest, mock } from "bun:test";
 import { expectType } from "./utilities";
 
 const mock1 = mock((arg: string) => {
@@ -29,3 +29,5 @@ jest.fn<() => string>().mockResolvedValue("24");
 jest.fn().mockClear();
 jest.fn().mockReset();
 jest.fn().mockRejectedValueOnce(new Error());
+
+expect(jest.fn()).toHaveBeenCalledOnce();


### PR DESCRIPTION
## What does this PR do?

`expect(fn).toHaveBeenCalledOnce()` is implemented in `bun:test` at runtime, but the matcher was not declared in `bun-types`, so calling it failed to type-check (`TS2551: Property 'toHaveBeenCalledOnce' does not exist`).

This declares it in `MatchersBuiltin` (`packages/bun-types/test.d.ts`), next to the other call matchers, and adds usage to the bun-types fixture. It's also a standard matcher in Vitest and jest-extended.

Closes #32332

## How did you verify your code works?

Runtime (matcher exists and passes):

```
$ bun -e 'import {expect,mock} from "bun:test"; const f=mock(()=>1); f(); expect(f).toHaveBeenCalledOnce(); console.log("ok")'
ok
```

Types — compiling a fixture against the package, no DOM lib (typical server tsconfig):

- Before: `error TS2551: Property 'toHaveBeenCalledOnce' does not exist on type 'Matchers<...>'`
- After: compiles cleanly.

The new line in `test/integration/bun-types/fixture/mocks.ts` exercises the matcher so the `bun-types` integration test (`bun test test/integration/bun-types/bun-types.test.ts`) covers it under the project tsconfigs.
