### PR TITLE
fix(types): add jest return-matcher aliases to bun:test types

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1815,6 +1815,12 @@ declare module "bun:test" {
     toHaveReturned(): void;
 
     /**
+     * Ensures that a mock function has returned successfully at least once.
+     * @alias toHaveReturned
+     */
+    toReturn(): void;
+
+    /**
      * Ensures that a mock function has returned successfully `times` times.
      *
      * An unfulfilled promise counts as a failure, as does a thrown error.
@@ -1834,12 +1840,28 @@ declare module "bun:test" {
     toHaveLastReturnedWith(expected: unknown): void;
 
     /**
+     * Ensures that a mock function has returned a specific value on its last invocation.
+     * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
+     * @alias toHaveLastReturnedWith
+     */
+    lastReturnedWith(expected: unknown): void;
+
+    /**
      * Ensures that a mock function has returned a specific value on the nth invocation.
      * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
      * @param n The 1-based index of the function call
      * @param expected The expected return value
      */
     toHaveNthReturnedWith(n: number, expected: unknown): void;
+
+    /**
+     * Ensures that a mock function has returned a specific value on the nth invocation.
+     * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
+     * @param n The 1-based index of the function call
+     * @param expected The expected return value
+     * @alias toHaveNthReturnedWith
+     */
+    nthReturnedWith(n: number, expected: unknown): void;
 
     /**
      * Ensures that a mock function is called.

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -1,4 +1,4 @@
-import { jest, mock } from "bun:test";
+import { expect, jest, mock } from "bun:test";
 import { expectType } from "./utilities";
 
 const mock1 = mock((arg: string) => {
@@ -29,3 +29,7 @@ jest.fn<() => string>().mockResolvedValue("24");
 jest.fn().mockClear();
 jest.fn().mockReset();
 jest.fn().mockRejectedValueOnce(new Error());
+
+expect(jest.fn()).toReturn();
+expect(jest.fn()).lastReturnedWith(1);
+expect(jest.fn()).nthReturnedWith(1, 1);


### PR DESCRIPTION
## What does this PR do?

`bun:test` implements the Jest matcher aliases `toReturn`, `lastReturnedWith`, and `nthReturnedWith` at runtime, but only their long forms (`toHaveReturned`, `toHaveLastReturnedWith`, `toHaveNthReturnedWith`) were declared in `bun-types`. Using the aliases failed to type-check (`TS2339` / `TS2551`).

This declares each alias in `MatchersBuiltin` (`packages/bun-types/test.d.ts`) with an `@alias` tag, matching how the existing call-matcher aliases (`toBeCalled`, `toBeCalledTimes`, `toBeCalledWith`) are declared, and adds usage to the bun-types fixture.

Closes #32334

## How did you verify your code works?

Runtime (all three aliases exist and pass):

```
$ bun -e 'import {expect,mock} from "bun:test"; const f=mock(()=>1); f(); expect(f).toReturn(); expect(f).lastReturnedWith(1); expect(f).nthReturnedWith(1,1); console.log("ok")'
ok
```

Types — compiling a fixture against the package, no DOM lib (typical server tsconfig):

- Before: `Property 'toReturn' / 'lastReturnedWith' / 'nthReturnedWith' does not exist on type 'Matchers<...>'`
- After: compiles cleanly.

The new lines in `test/integration/bun-types/fixture/mocks.ts` exercise the aliases so the `bun-types` integration test (`bun test test/integration/bun-types/bun-types.test.ts`) covers them under the project tsconfigs.

I scoped this PR to the three return-value aliases; `toHaveBeenCalledOnce` (a separate missing matcher, not an alias) is handled in #32333.
