### PR TITLE
bun:test: declare toHaveBeenCalledOnce() matcher in bun-types

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1849,6 +1849,11 @@ declare module "bun:test" {
     toBeCalled(): void;
 
     /**
+     * Ensures that a mock function is called exactly one time.
+     */
+    toHaveBeenCalledOnce(): void;
+
+    /**
      * Ensures that a mock function is called an exact number of times.
      */
     toHaveBeenCalledTimes(expected: number): void;

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -1,4 +1,4 @@
-import { jest, mock } from "bun:test";
+import { expect, jest, mock } from "bun:test";
 import { expectType } from "./utilities";
 
 const mock1 = mock((arg: string) => {
@@ -8,6 +8,12 @@ const mock1 = mock((arg: string) => {
 const arg1 = mock1("1");
 expectType<number>(arg1);
 mock;
+
+// Call-count matchers should be declared on Matchers (issue #32332)
+expect(mock1).toHaveBeenCalled();
+expect(mock1).toHaveBeenCalledOnce();
+expect(mock1).not.toHaveBeenCalledOnce();
+expect(mock1).toHaveBeenCalledTimes(1);
 
 type arg2 = jest.Spied<() => string>;
 declare var arg2: arg2;


### PR DESCRIPTION
Fixes #32332

### Repro

`bun:test` implements `expect(fn).toHaveBeenCalledOnce()` at runtime, but the matcher was never declared in `bun-types`, so type-checking a file that uses it fails:

```ts
import { expect, mock } from "bun:test";

const fn = mock(() => 42);
fn();

expect(fn).toHaveBeenCalledOnce();
// error TS2551: Property 'toHaveBeenCalledOnce' does not exist on type
// 'Matchers<Mock<() => number>>'. Did you mean 'toHaveBeenCalled'?
```

Runtime confirms it works:

```console
$ bun -e 'import {expect,mock} from "bun:test"; const f=mock(()=>1); f(); expect(f).toHaveBeenCalledOnce(); console.log("ok")'
ok
```

### Cause

The matcher is wired up on the runtime side (registered in `src/runtime/test_runner/jest.classes.ts`, implemented in `src/runtime/test_runner/expect/toHaveBeenCalledOnce.rs`) but was missing from the `MatchersBuiltin<T>` interface in `packages/bun-types/test.d.ts`, where the sibling call matchers (`toHaveBeenCalled`, `toHaveBeenCalledTimes`) are declared.

### Fix

Declare `toHaveBeenCalledOnce(): void;` alongside the other `toHaveBeenCalled*` matchers. It takes no arguments and returns `void`, matching the runtime (returns `undefined`, supports `.not`). This is also a standard matcher in Vitest and jest-extended.

### Verification

Added coverage to the bun-types type fixture (`test/integration/bun-types/fixture/mocks.ts`). Without the type change, the fixture reproduces the issue's error exactly:

```
mocks.ts:14:15 - error TS2551: Property 'toHaveBeenCalledOnce' does not exist on type
'Matchers<Mock<(arg: string) => number>>'. Did you mean 'toHaveBeenCalled'?
```

With the fix, the full integration test passes:

```console
$ bun test test/integration/bun-types/bun-types.test.ts
 12 pass
 0 fail
```