### PR TITLE
node:module: release StringImpl refs in _nodeModulePaths

### DIFF
--- a/src/jsc/resolver_jsc.rs
+++ b/src/jsc/resolver_jsc.rs
@@ -4,7 +4,7 @@
 use bstr::BStr;
 
 use crate::{CallFrame, JSGlobalObject, JSValue, JsResult};
-use bun_core::String as BunString;
+use bun_core::{OwnedString, String as BunString};
 use bun_paths::resolve_path;
 use bun_paths::{Platform, SEP, SEP_STR};
 
@@ -20,8 +20,8 @@ pub(crate) fn node_module_paths_for_js(
         return Err(global.throw_invalid_argument_type("nodeModulePaths", "path", "string"));
     }
 
-    let in_str = argument.to_bun_string(global)?;
-    Ok(node_module_paths_js_value(in_str, global, false))
+    let in_str = OwnedString::new(argument.to_bun_string(global)?);
+    Ok(node_module_paths_js_value(in_str.get(), global, false))
 }
 
 #[unsafe(no_mangle)]
@@ -41,7 +41,7 @@ pub(crate) extern "C" fn node_module_paths_js_value(
     global: &JSGlobalObject,
     use_dirname: bool,
 ) -> JSValue {
-    let mut list: Vec<BunString> = Vec::new();
+    let mut list: Vec<OwnedString> = Vec::new();
 
     let sliced = in_str.to_utf8();
     let base_path: &[u8] = if use_dirname {
@@ -94,12 +94,12 @@ pub(crate) extern "C" fn node_module_paths_js_value(
                 None => 0,
             } + part.len();
 
-            list.push(BunString::create_format(format_args!(
+            list.push(OwnedString::new(BunString::create_format(format_args!(
                 "{}{}{}node_modules",
                 BStr::new(root_path),
                 BStr::new(&suffix[..prefix_len]),
                 SEP_STR,
-            )));
+            ))));
         }
     }
 
@@ -107,13 +107,15 @@ pub(crate) extern "C" fn node_module_paths_js_value(
         root_path = &root_path[..root_path.len() - 1];
     }
 
-    list.push(BunString::create_format(format_args!(
+    list.push(OwnedString::new(BunString::create_format(format_args!(
         "{}{}node_modules",
         BStr::new(root_path),
         SEP_STR,
-    )));
+    ))));
 
-    list.as_slice().to_js_array(global).unwrap_or(JSValue::ZERO)
+    OwnedString::as_raw_slice(&list)
+        .to_js_array(global)
+        .unwrap_or(JSValue::ZERO)
 }
 
 /// `[bun.String]::to_js_array` lives on the `StringArrayJsc` ext trait below.

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -88,6 +88,41 @@ describe.concurrent("node-module-module", () => {
     ]);
   });
 
+  test(
+    "_nodeModulePaths() does not leak the input string",
+    async () => {
+      const code = /* js */ `
+        const m = require("module");
+        const pad = Buffer.alloc(2000, "a").toString();
+        for (let i = 0; i < 2000; i++) m._nodeModulePaths("/" + pad + i);
+        Bun.gc(true); Bun.gc(true);
+        const before = process.memoryUsage.rss();
+        for (let i = 0; i < 30000; i++) m._nodeModulePaths("/" + pad + i);
+        Bun.gc(true); Bun.gc(true); Bun.gc(true);
+        process.stdout.write(String((process.memoryUsage.rss() - before) / 1024 / 1024));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "--smol", "-e", code],
+        env: {
+          ...bunEnv,
+          // Disable ASAN's free-quarantine so the RSS delta reflects live
+          // allocations only; harmless on non-ASAN builds.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const growthMB = Number(stdout.trim());
+      if (!Number.isFinite(growthMB)) {
+        throw new Error(`subprocess did not report growth\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+      }
+      expect(growthMB).toBeLessThan(64);
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
+
   test("Module.wrap", () => {
     var mod = { exports: {} };
     expect(eval(wrap("exports.foo = 1; return 42"))(mod.exports, mod)).toBe(42);

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -89,13 +89,17 @@ describe.concurrent("node-module-module", () => {
   });
 
   test("_nodeModulePaths() does not leak the input string", async () => {
+    // 20 components keeps the joined path well under macOS PATH_MAX (1024)
+    // while generating 21 result strings per call, so the leak signal
+    // dominates RSS noise within a few thousand iterations.
     const code = /* js */ `
         const m = require("module");
-        const pad = Buffer.alloc(2000, "a").toString();
-        for (let i = 0; i < 2000; i++) m._nodeModulePaths("/" + pad + i);
+        const comp = Buffer.alloc(30, "a").toString();
+        const base = "/" + Array(20).fill(comp).join("/");
+        for (let i = 0; i < 200; i++) m._nodeModulePaths(base + i);
         Bun.gc(true); Bun.gc(true);
         const before = process.memoryUsage.rss();
-        for (let i = 0; i < 30000; i++) m._nodeModulePaths("/" + pad + i);
+        for (let i = 0; i < 5000; i++) m._nodeModulePaths(base + i);
         Bun.gc(true); Bun.gc(true); Bun.gc(true);
         process.stdout.write(String((process.memoryUsage.rss() - before) / 1024 / 1024));
       `;
@@ -115,9 +119,9 @@ describe.concurrent("node-module-module", () => {
     if (!Number.isFinite(growthMB)) {
       throw new Error(`subprocess did not report growth\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
     }
-    expect(growthMB).toBeLessThan(64);
+    expect(growthMB).toBeLessThan(25);
     expect(exitCode).toBe(0);
-  }, 30_000);
+  }, 20_000);
 
   test("Module.wrap", () => {
     var mod = { exports: {} };

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -88,10 +88,8 @@ describe.concurrent("node-module-module", () => {
     ]);
   });
 
-  test(
-    "_nodeModulePaths() does not leak the input string",
-    async () => {
-      const code = /* js */ `
+  test("_nodeModulePaths() does not leak the input string", async () => {
+    const code = /* js */ `
         const m = require("module");
         const pad = Buffer.alloc(2000, "a").toString();
         for (let i = 0; i < 2000; i++) m._nodeModulePaths("/" + pad + i);
@@ -101,27 +99,25 @@ describe.concurrent("node-module-module", () => {
         Bun.gc(true); Bun.gc(true); Bun.gc(true);
         process.stdout.write(String((process.memoryUsage.rss() - before) / 1024 / 1024));
       `;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "--smol", "-e", code],
-        env: {
-          ...bunEnv,
-          // Disable ASAN's free-quarantine so the RSS delta reflects live
-          // allocations only; harmless on non-ASAN builds.
-          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      const growthMB = Number(stdout.trim());
-      if (!Number.isFinite(growthMB)) {
-        throw new Error(`subprocess did not report growth\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
-      }
-      expect(growthMB).toBeLessThan(64);
-      expect(exitCode).toBe(0);
-    },
-    30_000,
-  );
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--smol", "-e", code],
+      env: {
+        ...bunEnv,
+        // Disable ASAN's free-quarantine so the RSS delta reflects live
+        // allocations only; harmless on non-ASAN builds.
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const growthMB = Number(stdout.trim());
+    if (!Number.isFinite(growthMB)) {
+      throw new Error(`subprocess did not report growth\nstdout: ${stdout}\nstderr: ${stderr}\nexit: ${exitCode}`);
+    }
+    expect(growthMB).toBeLessThan(64);
+    expect(exitCode).toBe(0);
+  }, 30_000);
 
   test("Module.wrap", () => {
     var mod = { exports: {} };

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -78,7 +78,6 @@ leak:JSC::intlSegmenterAvailableLocales
 leak:URL__getHref
 leak:runtime.dns_jsc.dns.Resolver.globalLookupService
 leak:jsHTTPParser_execute
-leak:Resolver__nodeModulePathsJSValue
 leak:URL__host
 leak:runtime.node.node_os.version
 leak:runtime.node.node_os.release


### PR DESCRIPTION
## What

`require('module')._nodeModulePaths(path)` leaked one `WTFStringImpl` ref per call for the input string, and one per returned array element.

## Repro

```js
const m = require('module');
const pad = Buffer.alloc(2000, 'a').toString();
for (let i = 0; i < 2000; i++) m._nodeModulePaths('/' + pad + i);
Bun.gc(true);
const before = process.memoryUsage.rss();
for (let i = 0; i < 30000; i++) m._nodeModulePaths('/' + pad + i);
Bun.gc(true); Bun.gc(true);
console.log((process.memoryUsage.rss() - before) / 1024 / 1024, 'MB');
// before: ~127 MB (release) / ~139 MB (debug+ASAN, quarantine disabled)
// after:  ~11 MB
```

## Cause

`bun_core::String` is `#[derive(Copy)]` with no `Drop`; sites that receive a +1 ref must wrap it in `OwnedString` for the scope-exit `deref()`.

- `node_module_paths_for_js`: `argument.to_bun_string(global)?` returns +1, passed by value to `node_module_paths_js_value` (which does not consume it), never released. The Zig original has `defer in_str.deref()` (`resolver_jsc.zig:13`).
- `node_module_paths_js_value`: each `BunString::create_format(...)` result (+1) was pushed into a `Vec<BunString>`. `BunString__createArray` refs each element into a `JSString` but does not consume the caller's ref, and `Vec<BunString>` drop is a no-op. This path also leaked for the C++ callers (`JSCommonJSModule.cpp`, `NodeModuleModule.cpp`).

## Fix

- Wrap the `to_bun_string` result in `OwnedString` and pass the borrowed `Copy` value to the C-ABI function.
- Change the result list to `Vec<OwnedString>` and feed `BunString__createArray` via `OwnedString::as_raw_slice`.

## Verification

New RSS-delta regression test in `test/js/node/module/node-module-module.test.js` (fails at ~139 MB without the fix, passes at ~11 MB with it). All 30 tests in the file pass.