### PR TITLE
bun:test: declare toReturn/lastReturnedWith/nthReturnedWith aliases in bun-types

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -1810,6 +1810,15 @@ declare module "bun:test" {
     toHaveReturned(): void;
 
     /**
+     * Ensures that a mock function has returned successfully at least once.
+     *
+     * A promise that is unfulfilled will be considered a failure. If the
+     * function threw an error, it will be considered a failure.
+     * @alias toHaveReturned
+     */
+    toReturn(): void;
+
+    /**
      * Ensures that a mock function has returned successfully at `times` times.
      *
      * A promise that is unfulfilled will be considered a failure. If the
@@ -1830,12 +1839,28 @@ declare module "bun:test" {
     toHaveLastReturnedWith(expected: unknown): void;
 
     /**
+     * Ensures that a mock function has returned a specific value on its last invocation.
+     * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
+     * @alias toHaveLastReturnedWith
+     */
+    lastReturnedWith(expected: unknown): void;
+
+    /**
      * Ensures that a mock function has returned a specific value on the nth invocation.
      * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
      * @param n The 1-based index of the function call
      * @param expected The expected return value
      */
     toHaveNthReturnedWith(n: number, expected: unknown): void;
+
+    /**
+     * Ensures that a mock function has returned a specific value on the nth invocation.
+     * This matcher uses deep equality, like toEqual(), and supports asymmetric matchers.
+     * @param n The 1-based index of the function call
+     * @param expected The expected return value
+     * @alias toHaveNthReturnedWith
+     */
+    nthReturnedWith(n: number, expected: unknown): void;
 
     /**
      * Ensures that a mock function is called.

--- a/test/integration/bun-types/fixture/test.ts
+++ b/test/integration/bun-types/fixture/test.ts
@@ -77,6 +77,17 @@ describe("bun:test", () => {
     expect(null).toBeNull();
     expect(undefined).toBeUndefined();
     expect(undefined).not.toBeDefined();
+
+    // https://github.com/oven-sh/bun/issues/32334
+    // Jest return-matcher aliases must type-check alongside their long forms.
+    const returnMock = mock(() => 42);
+    returnMock();
+    expect(returnMock).toReturn();
+    expect(returnMock).toHaveReturned();
+    expect(returnMock).lastReturnedWith(42);
+    expect(returnMock).toHaveLastReturnedWith(42);
+    expect(returnMock).nthReturnedWith(1, 42);
+    expect(returnMock).toHaveNthReturnedWith(1, 42);
   });
 });
 


### PR DESCRIPTION
### What

`bun:test` registers the Jest aliases `toReturn`, `lastReturnedWith`, and `nthReturnedWith` at runtime, but only their long forms (`toHaveReturned`, `toHaveLastReturnedWith`, `toHaveNthReturnedWith`) were declared in `bun-types`. The aliases pass at runtime but fail `tsc`.

Fixes #32334.

### Repro

```ts
import { expect, mock } from "bun:test";

const fn = mock(() => 42);
fn();

expect(fn).toReturn();             // runtime: passes
expect(fn).lastReturnedWith(42);   // runtime: passes
expect(fn).nthReturnedWith(1, 42); // runtime: passes
```

Type-checking (no DOM lib, typical server project):

```
error TS2339: Property 'toReturn' does not exist on type 'Matchers<...>'.
error TS2339: Property 'lastReturnedWith' does not exist on type 'Matchers<...>'.
error TS2551: Property 'nthReturnedWith' does not exist on type 'Matchers<...>'. Did you mean 'toHaveReturnedWith'?
```

### Cause

The alias <-> long-form mapping lives in `src/runtime/test_runner/jest.classes.ts` (`toReturn` -> `toHaveReturned`, `lastReturnedWith` -> `toHaveLastReturnedWith`, `nthReturnedWith` -> `toHaveNthReturnedWith`). These three aliases had no declaration in `packages/bun-types/test.d.ts`, unlike the call-matcher aliases (`toBeCalled`, `lastCalledWith`, `nthCalledWith`) which are declared.

### Fix

Declare each alias next to its long form in `MatchersBuiltin`, tagged `@alias`, matching the existing call-matcher alias pattern. Scope is limited to the three aliases actually registered at runtime (no `toReturnWith`/`toReturnTimes`, which don't exist).

### Verification

Added the three aliases (plus their long forms as controls) to the `expect()` block in the bun-types type-check fixture (`test/integration/bun-types/fixture/test.ts`). Run with:

```
bun test test/integration/bun-types/bun-types.test.ts
```

Without the declarations, the fixture produces exactly the three errors from the issue (`test.ts:85` TS2339, `test.ts:87` TS2339, `test.ts:89` TS2551). With them, all 12 type-check variants pass.