### PR TITLE
Fix bun-types TextEncoder.encodeInto reference to a version-specific node:util export

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -229,7 +229,10 @@ interface TextEncoder extends Bun.__internal.LibEmptyOrNodeUtilTextEncoder {
    * @param src The text to encode.
    * @param dest The array to hold the encode result.
    */
-  encodeInto(src?: string, dest?: Bun.BufferSource): import("node:util").TextEncoderEncodeIntoResult;
+  // Inlined rather than referencing node:util so the type does not depend on a
+  // version-specific export name (EncodeIntoResult in @types/node <=24,
+  // TextEncoderEncodeIntoResult in >=25).
+  encodeInto(src?: string, dest?: Bun.BufferSource): { read: number; written: number };
 }
 declare var TextEncoder: Bun.__internal.UseLibDomIfAvailable<
   "TextEncoder",

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -817,6 +817,41 @@ describe("@types/bun integration test", () => {
       ],
     });
   });
+
+  describe("@types/node version compatibility", () => {
+    // https://github.com/oven-sh/bun/issues/32340
+    // bun-types must not reference @types/node export names that only exist in a
+    // specific major. node:util spells the encodeInto result shape as
+    // `EncodeIntoResult` in @types/node <=24 and `TextEncoderEncodeIntoResult` in
+    // >=25, so referencing either name leaves the other major with a dangling
+    // type. The rest of the suite pins @types/node to `latest` via the fixture's
+    // `resolutions`, so only a run against an older major catches the regression.
+    test("node:util references in bun-types resolve on @types/node@24", async () => {
+      const fixtureDir = join(TEMP_DIR, `fixture-node24-${fixtureCounter++}`);
+      await cp(BASE_FIXTURE_DIR, fixtureDir, { recursive: true });
+
+      const pkgPath = join(fixtureDir, "package.json");
+      const pkg = JSON.parse(readFileSync(pkgPath).toString());
+      pkg.dependencies = { ...pkg.dependencies, "@types/node": "24" };
+      pkg.resolutions = { ...pkg.resolutions, "@types/node": "24" };
+      await Bun.write(pkgPath, JSON.stringify(pkg, null, 2));
+
+      await $`cd ${fixtureDir} && bun install`.quiet();
+
+      // Guard against the resolution silently failing, which would make the
+      // assertion below vacuous (the bug only reproduces on @types/node <=24).
+      const installedNodeTypes = JSON.parse(
+        readFileSync(join(fixtureDir, "node_modules", "@types", "node", "package.json")).toString(),
+      );
+      expect(installedNodeTypes.version.split(".")[0]).toBe("24");
+
+      const { diagnostics } = await diagnose(fixtureDir);
+      const unresolvedNodeUtil = diagnostics.filter(
+        d => d.code === 2694 && d.message.includes("TextEncoderEncodeIntoResult"),
+      );
+      expect(unresolvedNodeUtil).toEqual([]);
+    });
+  });
 });
 
 const expectedEmptyInterfacesWhenNoDOM = new Set(["ThisType"]);

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -846,6 +846,13 @@ describe("@types/bun integration test", () => {
       expect(installedNodeTypes.version.split(".")[0]).toBe("24");
 
       const { diagnostics } = await diagnose(fixtureDir);
+
+      // Prove bun-types is actually loaded, otherwise the assertion below would
+      // pass vacuously. A TS2688 ("Cannot find type definition file") means
+      // `types: ["bun"]` (or its `/// <reference types="bun-types" />`) failed to
+      // resolve, so globals.d.ts was never type-checked in the first place.
+      expect(diagnostics.filter(d => d.code === 2688)).toEqual([]);
+
       const unresolvedNodeUtil = diagnostics.filter(
         d => d.code === 2694 && d.message.includes("TextEncoderEncodeIntoResult"),
       );


### PR DESCRIPTION
Fixes #32340

## Repro

`bun-types` fails to type-check against `@types/node@24` (or earlier), and any tool that resolves the symbol table (e.g. `dts-bundle-generator` via `bun-plugin-dts`) throws regardless of `skipLibCheck`:

```
error TS2694: Namespace '"node:util"' has no exported member 'TextEncoderEncodeIntoResult'.
  at node_modules/bun-types/globals.d.ts
```

## Cause

`packages/bun-types/globals.d.ts` typed `TextEncoder.encodeInto` as:

```ts
encodeInto(src?: string, dest?: Bun.BufferSource): import("node:util").TextEncoderEncodeIntoResult;
```

`node:util` only exports `TextEncoderEncodeIntoResult` in `@types/node@25+`. In `@types/node@24` and earlier the same shape is exported as `EncodeIntoResult`. Since `bun-types` declares `"@types/node": "*"`, consumers on `@types/node@24` have no such export and the reference dangles.

A normal Bun project hides this because the init tsconfig sets `skipLibCheck: true`, but `dts-bundle-generator` walks the symbol table regardless, which is the error in the issue.

## Fix

The result shape is stable across every major and in `lib.dom.d.ts`: `{ read: number; written: number }`. Inlining it removes the dependency on the version-specific export name.

```ts
encodeInto(src?: string, dest?: Bun.BufferSource): { read: number; written: number };
```

## Verification

Added a regression test that builds `bun-types`, installs it against `@types/node@24`, and type-checks with `skipLibCheck: false` (the condition that surfaces the dangling reference). It fails before the fix with the exact `TS2694` above and passes after.

The existing `@types/bun` integration suite pins `@types/node` to `latest` via the fixture's `resolutions`, so it could not catch this; the new test overrides that to the older major.

```
$ bun test test/integration/bun-types/bun-types.test.ts
 13 pass
 0 fail
```