### PR TITLE
worker: populate ErrorEvent (message/filename/lineno/colno/error), make it cancelable, honor preventDefault

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -57,7 +57,10 @@ pub use bun_core::STRING_ALLOCATION_LIMIT;
 // Type aliases
 // ──────────────────────────────────────────────────────────────────────────
 
-pub(crate) type OnUnhandledRejection = fn(&mut VirtualMachine, &JSGlobalObject, JSValue);
+/// Returns true when a handler consumed the error (e.g. a worker's
+/// `self.onerror` listener called `preventDefault()`); the caller must then
+/// skip its fatal bookkeeping (unhandled counter, exit code).
+pub(crate) type OnUnhandledRejection = fn(&mut VirtualMachine, &JSGlobalObject, JSValue) -> bool;
 pub(crate) type MacroMap = bun_collections::ArrayHashMap<i32, JSValue>;
 /// `api::JsException` lives in
 /// [`crate::schema_api`] (not `bun_options_types::schema::api`) because its
@@ -1062,13 +1065,14 @@ impl VirtualMachine {
         this: &mut VirtualMachine,
         _: &JSGlobalObject,
         value: JSValue,
-    ) {
+    ) -> bool {
         this.unhandled_error_counter += 1;
         value.ensure_still_alive();
         if let Some(ptr) = this.unhandled_pending_rejection_to_capture {
             // SAFETY: caller passed &mut stack_var (see LIFETIMES.tsv)
             unsafe { *ptr = value };
         }
+        false
     }
 
     pub fn unhandled_rejection_scope(&self) -> UnhandledRejectionScope {
@@ -1090,12 +1094,13 @@ impl VirtualMachine {
         this: &mut VirtualMachine,
         _: &JSGlobalObject,
         value: JSValue,
-    ) {
+    ) -> bool {
         // SAFETY: BORROW_PARAM ptr set by caller; outlives this call.
         let list = this
             .on_unhandled_rejection_exception_list
             .map(|mut p| unsafe { p.as_mut() });
         this.run_error_handler(value, list);
+        false
     }
 
     #[cold]
@@ -1359,8 +1364,9 @@ impl VirtualMachine {
         }
 
         if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
-            self.unhandled_error_counter += 1;
-            (self.on_unhandled_rejection)(self, global_object, err);
+            if !(self.on_unhandled_rejection)(self, global_object, err) {
+                self.unhandled_error_counter += 1;
+            }
             return true;
         }
 
@@ -1373,7 +1379,7 @@ impl VirtualMachine {
                 // normal path; process_exit() RETURNS on a worker, so the
                 // main-thread process_exit(7)+panic below would crash.
                 self.exit_handler.exit_code = 1;
-                (self.on_unhandled_rejection)(self, global_object, err);
+                let _ = (self.on_unhandled_rejection)(self, global_object, err);
                 return false;
             }
             self.run_error_handler(err, None);
@@ -1383,7 +1389,7 @@ impl VirtualMachine {
             panic!("Uncaught exception while handling uncaught exception");
         }
         self.is_handling_uncaught_exception = true;
-        let handled = Bun__handleUncaughtException(
+        let mut handled = Bun__handleUncaughtException(
             global_object,
             err.to_error().unwrap_or(err),
             if is_rejection { 1 } else { 0 },
@@ -1405,9 +1411,19 @@ impl VirtualMachine {
                 panic!("made it past process.exit()");
             }
             // TODO maybe we want a separate code path for uncaught exceptions
-            self.unhandled_error_counter += 1;
+            // exit_code is set to 1 BEFORE the hook so 'exit' listeners run by a
+            // terminating worker observe it (node parity).
+            let prior_exit_code = self.exit_handler.exit_code;
             self.exit_handler.exit_code = 1;
-            (self.on_unhandled_rejection)(self, global_object, err);
+            handled = (self.on_unhandled_rejection)(self, global_object, err);
+            if handled {
+                // Restore the exit code unless the error handler changed it.
+                if self.exit_handler.exit_code == 1 {
+                    self.exit_handler.exit_code = prior_exit_code;
+                }
+            } else {
+                self.unhandled_error_counter += 1;
+            }
         }
         // Note: this reset must cover BOTH the FFI call and the
         // `onUnhandledRejection` callback above. The flag must stay raised
@@ -3299,8 +3315,9 @@ impl VirtualMachine {
         }
 
         if isBunTest.load(core::sync::atomic::Ordering::Relaxed) {
-            self.unhandled_error_counter += 1;
-            (self.on_unhandled_rejection)(self, global_object, reason);
+            if !(self.on_unhandled_rejection)(self, global_object, reason) {
+                self.unhandled_error_counter += 1;
+            }
             return;
         }
 
@@ -3384,8 +3401,9 @@ impl VirtualMachine {
                 }
             }
         }
-        self.unhandled_error_counter += 1;
-        (self.on_unhandled_rejection)(self, global_object, reason);
+        if !(self.on_unhandled_rejection)(self, global_object, reason) {
+            self.unhandled_error_counter += 1;
+        }
     }
 
     /// After a hot reload, surfaces the entry-point promise's rejection (if any) and re-arms the watcher.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -488,8 +488,8 @@ pub fn is_smol_mode() -> bool {
 #[derive(Default)]
 pub struct ExitHandler {
     pub exit_code: u8,
-    /// Bumped on every JS `process.exitCode` write; lets `uncaught_exception`
-    /// tell its own `exit_code = 1` apart from one the error handler set.
+    /// Bumped by [`Self::set_exit_code`]; lets `uncaught_exception` tell its
+    /// own restorable `exit_code = 1` apart from writes that must persist.
     pub writes: u32,
 }
 
@@ -501,8 +501,14 @@ impl ExitHandler {
 
     #[unsafe(no_mangle)]
     pub extern "C" fn Bun__setExitCode(vm: &mut VirtualMachine, code: u8) {
-        vm.exit_handler.exit_code = code;
-        vm.exit_handler.writes = vm.exit_handler.writes.wrapping_add(1);
+        vm.exit_handler.set_exit_code(code);
+    }
+
+    /// Set the exit code and record the write so `uncaught_exception` does not
+    /// undo it when an error handler consumes the error.
+    pub fn set_exit_code(&mut self, code: u8) {
+        self.exit_code = code;
+        self.writes = self.writes.wrapping_add(1);
     }
 
     /// Note: spec calls `this.exit_handler.dispatchOnExit()` from a
@@ -1382,7 +1388,8 @@ impl VirtualMachine {
                 // code 7). Report it to the parent + arm termination via the
                 // normal path; process_exit() RETURNS on a worker, so the
                 // main-thread process_exit(7)+panic below would crash.
-                self.exit_handler.exit_code = 1;
+                // set_exit_code: this write must survive the outer frame's restore.
+                self.exit_handler.set_exit_code(1);
                 let _ = (self.on_unhandled_rejection)(self, global_object, err);
                 return false;
             }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -488,6 +488,9 @@ pub fn is_smol_mode() -> bool {
 #[derive(Default)]
 pub struct ExitHandler {
     pub exit_code: u8,
+    /// Bumped on every JS `process.exitCode` write; lets `uncaught_exception`
+    /// tell its own `exit_code = 1` apart from one the error handler set.
+    pub writes: u32,
 }
 
 impl ExitHandler {
@@ -499,6 +502,7 @@ impl ExitHandler {
     #[unsafe(no_mangle)]
     pub extern "C" fn Bun__setExitCode(vm: &mut VirtualMachine, code: u8) {
         vm.exit_handler.exit_code = code;
+        vm.exit_handler.writes = vm.exit_handler.writes.wrapping_add(1);
     }
 
     /// Note: spec calls `this.exit_handler.dispatchOnExit()` from a
@@ -1414,11 +1418,12 @@ impl VirtualMachine {
             // exit_code is set to 1 BEFORE the hook so 'exit' listeners run by a
             // terminating worker observe it (node parity).
             let prior_exit_code = self.exit_handler.exit_code;
+            let prior_writes = self.exit_handler.writes;
             self.exit_handler.exit_code = 1;
             handled = (self.on_unhandled_rejection)(self, global_object, err);
             if handled {
-                // Restore the exit code unless the error handler changed it.
-                if self.exit_handler.exit_code == 1 {
+                // Restore the exit code unless the error handler set process.exitCode.
+                if self.exit_handler.writes == prior_writes {
                     self.exit_handler.exit_code = prior_exit_code;
                 }
             } else {

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -33,8 +33,10 @@
 #include "Event.h"
 #include "EventNames.h"
 #include "StructuredSerializeOptions.h"
+#include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/IteratorOperations.h>
 #include <JavaScriptCore/ScriptCallStack.h>
+#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Scope.h>
 #include "SerializedScriptValue.h"
@@ -517,14 +519,29 @@ void Worker::fireEarlyMessages(Zig::GlobalObject* workerGlobalObject)
     }
 }
 
-void Worker::dispatchErrorWithMessage(WTF::String message)
+void Worker::dispatchError(WTF::String message, WTF::String filename, unsigned lineno, unsigned colno, RefPtr<SerializedScriptValue>&& serializedError)
 {
-    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy()](ScriptExecutionContext&) {
+    postTaskToParent([protectedThis = Ref { *this }, message = message.isolatedCopy(), filename = filename.isolatedCopy(), lineno, colno, serializedError = WTF::move(serializedError)](ScriptExecutionContext& context) {
+        auto* globalObject = context.globalObject();
+        auto& vm = JSC::getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
         ErrorEvent::Init init;
         init.message = message;
+        init.filename = filename;
+        init.lineno = lineno;
+        init.colno = colno;
+        init.cancelable = true;
+        if (serializedError) {
+            JSValue deserialized = serializedError->deserialize(*globalObject, globalObject, SerializationErrorMode::NonThrowing);
+            CLEAR_IF_EXCEPTION(scope);
+            if (deserialized)
+                init.error = deserialized;
+        }
 
         auto event = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
         protectedThis->dispatchEvent(event);
+        CLEAR_IF_EXCEPTION(scope);
     });
 }
 
@@ -724,27 +741,68 @@ extern "C" void WebWorker__fireEarlyMessages(Worker* worker, Zig::GlobalObject* 
     worker->fireEarlyMessages(globalObject);
 }
 
-extern "C" void WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker* worker, BunString* message, JSC::EncodedJSValue errorValue)
+extern "C" bool WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker* worker, BunString* message, JSC::EncodedJSValue errorValue)
 {
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
     JSValue error = JSC::JSValue::decode(errorValue);
     WTF::String messageStr = message->transferToWTFString();
+
+    WTF::String filename;
+    unsigned lineno = 0;
+    unsigned colno = 0;
+    if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(error)) {
+        // materializeErrorInfoIfNeeded runs Bun's computeErrorInfo, which
+        // remaps the throw position through any source map and exposes it via
+        // line()/column() and the sourceURL own-property.
+        errorInstance->materializeErrorInfoIfNeeded(vm);
+        lineno = errorInstance->line();
+        colno = errorInstance->column();
+        if (JSValue sourceURLValue = errorInstance->getDirect(vm, vm.propertyNames->sourceURL); sourceURLValue && sourceURLValue.isString())
+            filename = sourceURLValue.toWTFString(globalObject);
+        scope.clearExceptionExceptTermination();
+        // The ErrorEvent message is a short description ("TypeError: foo"),
+        // not the multi-line console dump the caller may have passed.
+        WTF::String sanitized = errorInstance->sanitizedToString(globalObject);
+        scope.clearExceptionExceptTermination();
+        if (!sanitized.isEmpty())
+            messageStr = WTF::move(sanitized);
+    }
+
     ErrorEvent::Init init;
-    init.message = messageStr.isolatedCopy();
+    init.message = messageStr;
+    init.filename = filename;
+    init.lineno = lineno;
+    init.colno = colno;
     init.error = error;
-    init.cancelable = false;
+    init.cancelable = true;
     init.bubbles = false;
 
-    globalObject->globalEventScope->dispatchEvent(ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes));
+    auto workerScopeEvent = ErrorEvent::create(eventNames().errorEvent, init, EventIsTrusted::Yes);
+    globalObject->globalEventScope->dispatchEvent(workerScopeEvent);
+    scope.clearExceptionExceptTermination();
+    if (workerScopeEvent->defaultPrevented())
+        return true;
+
     switch (worker->options().kind) {
-    case WorkerOptions::Kind::Web:
-        return worker->dispatchErrorWithMessage(WTF::move(messageStr));
+    case WorkerOptions::Kind::Web: {
+        // Browsers leave `error` null on the parent event; Bun clones it so
+        // callers have structured data instead of only the message. Falls
+        // back to null if the value is not cloneable.
+        auto serialized = SerializedScriptValue::create(*globalObject, error, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
+        scope.clearExceptionExceptTermination();
+        worker->dispatchError(WTF::move(messageStr), WTF::move(filename), lineno, colno, WTF::move(serialized));
+        return false;
+    }
     case WorkerOptions::Kind::Node:
         if (!worker->dispatchErrorWithValue(globalObject, error)) {
             // If serialization threw an error, use the string instead
-            worker->dispatchErrorWithMessage(WTF::move(messageStr));
+            worker->dispatchError(WTF::move(messageStr), WTF::move(filename), lineno, colno, nullptr);
         }
-        return;
+        return false;
     }
+    return false;
 }
 
 extern "C" WebCore::Worker* WebWorker__getParentWorker(void* bunVM);

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -753,17 +753,14 @@ extern "C" bool WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
     unsigned lineno = 0;
     unsigned colno = 0;
     if (auto* errorInstance = dynamicDowncast<JSC::ErrorInstance>(error)) {
-        // materializeErrorInfoIfNeeded runs Bun's computeErrorInfo, which
-        // remaps the throw position through any source map and exposes it via
-        // line()/column() and the sourceURL own-property.
+        // Runs Bun's computeErrorInfo: source-map-remapped line()/column()/sourceURL.
         errorInstance->materializeErrorInfoIfNeeded(vm);
         lineno = errorInstance->line();
         colno = errorInstance->column();
         if (JSValue sourceURLValue = errorInstance->getDirect(vm, vm.propertyNames->sourceURL); sourceURLValue && sourceURLValue.isString())
             filename = sourceURLValue.toWTFString(globalObject);
         scope.clearExceptionExceptTermination();
-        // The ErrorEvent message is a short description ("TypeError: foo"),
-        // not the multi-line console dump the caller may have passed.
+        // ErrorEvent.message is the short "TypeError: foo" form, not the formatted console dump.
         WTF::String sanitized = errorInstance->sanitizedToString(globalObject);
         scope.clearExceptionExceptTermination();
         if (!sanitized.isEmpty())
@@ -787,9 +784,8 @@ extern "C" bool WebWorker__dispatchError(Zig::GlobalObject* globalObject, Worker
 
     switch (worker->options().kind) {
     case WorkerOptions::Kind::Web: {
-        // Browsers leave `error` null on the parent event; Bun clones it so
-        // callers have structured data instead of only the message. Falls
-        // back to null if the value is not cloneable.
+        // Browsers leave `error` null on the parent event; Bun clones the thrown
+        // value (null if it is not cloneable).
         auto serialized = SerializedScriptValue::create(*globalObject, error, SerializationForStorage::No, SerializationErrorMode::NonThrowing);
         scope.clearExceptionExceptTermination();
         worker->dispatchError(WTF::move(messageStr), WTF::move(filename), lineno, colno, WTF::move(serialized));

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -47,6 +47,7 @@ class JSPromise;
 namespace WebCore {
 
 class ScriptExecutionContext;
+class SerializedScriptValue;
 struct StructuredSerializeOptions;
 struct WorkerOptions;
 
@@ -132,7 +133,7 @@ public:
     // -- Worker-thread entry points (each posts to m_parentContextId) --------
     void dispatchOnline(Zig::GlobalObject* workerGlobalObject);
     void fireEarlyMessages(Zig::GlobalObject* workerGlobalObject);
-    void dispatchErrorWithMessage(WTF::String message);
+    void dispatchError(WTF::String message, WTF::String filename, unsigned lineno, unsigned colno, RefPtr<SerializedScriptValue>&& serializedError);
     bool dispatchErrorWithValue(Zig::GlobalObject* workerGlobalObject, JSValue value);
     bool dispatchExit(int32_t exitCode);
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1116,10 +1116,8 @@ impl WebWorker {
                     (*promise).result(vm.jsc_vm()),
                     true,
                 );
-                // `handled` reflects process.on('uncaughtException'). The
-                // self.onerror preventDefault() path instead returns from
-                // on_unhandled_rejection without arming termination, so also
-                // consult has_requested_terminate() before shutting down.
+                // `handled` only covers process.on('uncaughtException'); a self.onerror
+                // preventDefault() instead leaves has_requested_terminate() unset.
                 if !handled && self.has_requested_terminate() {
                     // exit_code is already 1 from uncaught_exception; re-setting it here
                     // would clobber a process.on('exit') change to process.exitCode.
@@ -1527,9 +1525,8 @@ fn on_unhandled_rejection(
     // `&mut`) — see worker-thread `&self` note.
     let worker = vm.worker_ref().expect("Assertion failure: no worker");
 
-    // Fallback ErrorEvent.message for values C++ can't summarize (not a
-    // JSC::ErrorInstance). C++ replaces it with `sanitizedToString` when the
-    // thrown value is an ErrorInstance.
+    // Fallback ErrorEvent.message; C++ replaces it with `sanitizedToString`
+    // when the thrown value is an ErrorInstance.
     let format_result = jsc::console_object::format2(
         jsc::console_object::MessageLevel::Debug,
         global_object,
@@ -1580,9 +1577,8 @@ fn on_unhandled_rejection(
         }
     };
     if handled {
-        // self.onerror called preventDefault(): undo uncaught_exception's
-        // side-effects so the worker continues running. Restoring the hook
-        // lets a subsequent uncaught error run through this path again.
+        // preventDefault(): undo uncaught_exception's side-effects (hook,
+        // counter, exit code) so the worker keeps running.
         vm.on_unhandled_rejection = on_unhandled_rejection;
         vm.unhandled_error_counter = vm.unhandled_error_counter.saturating_sub(1);
         vm.exit_handler.exit_code = 0;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -1116,8 +1116,8 @@ impl WebWorker {
                     (*promise).result(vm.jsc_vm()),
                     true,
                 );
-                // `handled` only covers process.on('uncaughtException'); a self.onerror
-                // preventDefault() instead leaves has_requested_terminate() unset.
+                // `handled` is false without termination armed only on the
+                // re-entrant (quiet-hook) path; shut down once it is armed.
                 if !handled && self.has_requested_terminate() {
                     // exit_code is already 1 from uncaught_exception; re-setting it here
                     // would clobber a process.on('exit') change to process.exitCode.
@@ -1499,7 +1499,7 @@ fn on_unhandled_rejection(
     vm: &mut VirtualMachine,
     global_object: &JSGlobalObject,
     error_instance_or_exception: JSValue,
-) {
+) -> bool {
     // Prevent recursion
     vm.on_unhandled_rejection = VirtualMachine::on_quiet_unhandled_rejection_handler_capture_value;
 
@@ -1577,12 +1577,10 @@ fn on_unhandled_rejection(
         }
     };
     if handled {
-        // preventDefault(): undo uncaught_exception's side-effects (hook,
-        // counter, exit code) so the worker keeps running.
+        // preventDefault(): restore the hook so the next uncaught error
+        // dispatches again; the caller skips its fatal bookkeeping.
         vm.on_unhandled_rejection = on_unhandled_rejection;
-        vm.unhandled_error_counter = vm.unhandled_error_counter.saturating_sub(1);
-        vm.exit_handler.exit_code = 0;
-        return;
+        return true;
     }
     // node runs the worker's process 'exit' handlers on an uncaught exception (code 1;
     // they may change process.exitCode). Run them before arming termination — a pending
@@ -1611,6 +1609,7 @@ fn on_unhandled_rejection(
     // `global_object`); `notify_need_termination` is documented thread-safe
     // (VMTraps).
     vm.jsc_vm().notify_need_termination();
+    false
 }
 
 /// Resolve a worker entry-point specifier to a path the module loader can

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -227,7 +227,7 @@ unsafe extern "C" {
         cpp_worker: *mut c_void,
         message: &mut BunString,
         err: JSValue,
-    );
+    ) -> bool;
 }
 
 /// Process-global registry of worker threads that have been spawned and
@@ -1116,7 +1116,11 @@ impl WebWorker {
                     (*promise).result(vm.jsc_vm()),
                     true,
                 );
-                if !handled {
+                // `handled` reflects process.on('uncaughtException'). The
+                // self.onerror preventDefault() path instead returns from
+                // on_unhandled_rejection without arming termination, so also
+                // consult has_requested_terminate() before shutting down.
+                if !handled && self.has_requested_terminate() {
                     // exit_code is already 1 from uncaught_exception; re-setting it here
                     // would clobber a process.on('exit') change to process.exitCode.
                     return self.shutdown();
@@ -1473,7 +1477,7 @@ impl WebWorker {
         let mut str = bun_core::OwnedString::new(str);
         let dispatch = jsc::host_fn::from_js_host_call_generic(global, || {
             // `cpp_worker` is the opaque C++-owned handle; `str` reffed for the call.
-            WebWorker__dispatchError(global, self.cpp_worker, &mut str, err)
+            WebWorker__dispatchError(global, self.cpp_worker, &mut str, err);
         });
         if let Err(e) = dispatch {
             // `take_exception` on a `JsError` always returns an Exception
@@ -1523,6 +1527,9 @@ fn on_unhandled_rejection(
     // `&mut`) — see worker-thread `&self` note.
     let worker = vm.worker_ref().expect("Assertion failure: no worker");
 
+    // Fallback ErrorEvent.message for values C++ can't summarize (not a
+    // JSC::ErrorInstance). C++ replaces it with `sanitizedToString` when the
+    // thrown value is an ErrorInstance.
     let format_result = jsc::console_object::format2(
         jsc::console_object::MessageLevel::Debug,
         global_object,
@@ -1546,6 +1553,7 @@ fn on_unhandled_rejection(
         error_instance = global_object.try_take_exception().unwrap();
     }
     jsc::mark_binding();
+    let mut error_message = bun_core::OwnedString::new(BunString::clone_utf8(&array));
     // We RETURN through
     // the live C++ frames after dispatching (see the note below), so the
     // simulated throw of the C++ `DECLARE_THROW_SCOPE` inside
@@ -1555,20 +1563,30 @@ fn on_unhandled_rejection(
     // `verifyExceptionCheckNeedIsSatisfied`. Wrap in `from_js_host_call_generic`
     // (declares + checks a TopExceptionScope around the FFI call, same as
     // `flush_logs` above) and discard any actual exception: we are already the
-    // last-resort error handler and about to arm termination.
-    let mut error_message = bun_core::OwnedString::new(BunString::clone_utf8(&array));
-    if jsc::host_fn::from_js_host_call_generic(global_object, || {
+    // last-resort error handler.
+    let handled = match jsc::host_fn::from_js_host_call_generic(global_object, || {
         // `cpp_worker` is the opaque C++-owned handle round-tripped via `safe fn`.
         WebWorker__dispatchError(
             global_object,
             worker.cpp_worker,
             &mut error_message,
             error_instance,
-        );
-    })
-    .is_err()
-    {
-        let _ = global_object.try_take_exception();
+        )
+    }) {
+        Ok(handled) => handled,
+        Err(_) => {
+            let _ = global_object.try_take_exception();
+            false
+        }
+    };
+    if handled {
+        // self.onerror called preventDefault(): undo uncaught_exception's
+        // side-effects so the worker continues running. Restoring the hook
+        // lets a subsequent uncaught error run through this path again.
+        vm.on_unhandled_rejection = on_unhandled_rejection;
+        vm.unhandled_error_counter = vm.unhandled_error_counter.saturating_sub(1);
+        vm.exit_handler.exit_code = 0;
+        return;
     }
     // node runs the worker's process 'exit' handlers on an uncaught exception (code 1;
     // they may change process.exitCode). Run them before arming termination — a pending

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1301,13 +1301,14 @@ impl Run {
         this: &mut VirtualMachine,
         _global: &JSGlobalObject,
         value: JSValue,
-    ) {
+    ) -> bool {
         // SAFETY: BORROW_PARAM ptr set by caller, outlives this call.
         let list = this
             .on_unhandled_rejection_exception_list
             .map(|p| unsafe { &mut *p.as_ptr() });
         this.run_error_handler(value, list);
         ANY_UNHANDLED.store(true, Ordering::Relaxed);
+        false
     }
 
     /// Wire `--eval`/`--print`

--- a/src/runtime/test_runner/jest.rs
+++ b/src/runtime/test_runner/jest.rs
@@ -589,7 +589,7 @@ pub mod on_unhandled_rejection {
         jsc_vm: &mut VirtualMachine,
         global_object: &JSGlobalObject,
         rejection: JSValue,
-    ) {
+    ) -> bool {
         if let Some(buntest_strong) = bun_test::clone_active_strong() {
             // `buntest_strong` released by Rc drop.
             // SAFETY: single-threaded JS VM; `buntest_strong` is the only handle
@@ -622,7 +622,7 @@ pub mod on_unhandled_rejection {
             // for `Terminated` (which carries no pending exception to take).
             use bun_jsc::JsResultExt as _;
             bun_test::BunTest::run(&buntest_strong, global_object).report_unhandled(global_object);
-            return;
+            return false;
         }
 
         // SAFETY: `on_unhandled_rejection_exception_list` is either None or a
@@ -632,6 +632,7 @@ pub mod on_unhandled_rejection {
             .on_unhandled_rejection_exception_list
             .map(|p| unsafe { &mut *p.as_ptr() });
         jsc_vm.run_error_handler(rejection, exception_list);
+        false
     }
 }
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -540,6 +540,36 @@ describe("web worker", () => {
       expect(stdout).toContain("EXITCODE:1");
       expect(exitCode).toBe(0);
     });
+
+    test("a throw after preventDefault() still exits the worker with code 1", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const script = [
+            "self.addEventListener('error', e => {",
+            "  e.preventDefault();",
+            "  throw new Error('handler-bug');",
+            "});",
+            "throw new Error('original');",
+          ].join("\\n");
+          const w = new Worker(URL.createObjectURL(new Blob([script], { type: "text/javascript" })));
+          let sawError = false;
+          w.onerror = e => { sawError = true; console.log("PARENT-ERROR:" + e.message); };
+          w.addEventListener("close", e => { console.log("CLOSE:" + e.code); process.exit(!sawError && e.code === 1 ? 0 : 1); });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).not.toContain("PARENT-ERROR");
+      expect(stdout).toContain("CLOSE:1");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -510,6 +510,36 @@ describe("web worker", () => {
       expect(stdout).toContain("EXITCODE:42");
       expect(exitCode).toBe(0);
     });
+
+    test("preventDefault() keeps a process.exitCode set inside the error handler", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const script = [
+            "self.addEventListener('error', e => {",
+            "  process.exitCode = 1;",
+            "  e.preventDefault();",
+            "  queueMicrotask(() => postMessage(process.exitCode));",
+            "});",
+            "throw new Error('handled-but-failed');",
+          ].join("\\n");
+          const w = new Worker(URL.createObjectURL(new Blob([script], { type: "text/javascript" })));
+          w.onmessage = e => { console.log("EXITCODE:" + e.data); w.terminate(); process.exit(e.data === 1 ? 0 : 1); };
+          w.onerror = e => { console.log("PARENT-ERROR:" + e.message); process.exit(1); };
+          w.addEventListener("close", e => { console.log("CLOSE:" + e.code); process.exit(1); });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("EXITCODE:1");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path from "path";
+import { pathToFileURL } from "url";
 import wt from "worker_threads";
 
 describe("web worker", () => {
@@ -332,7 +333,119 @@ describe("web worker", () => {
       const [err] = await once(worker, "error");
       expect(err.type).toBe("error");
       expect(err.message).toBe("5");
-      expect(err.error).toBe(null);
+      expect(err.error).toBe(5);
+      expect(err.cancelable).toBe(true);
+    });
+
+    test("thrown Error populates message/filename/lineno/colno/error and is cancelable", async () => {
+      const url = URL.createObjectURL(new Blob(["throw new Error('EE-BOOM');"], { type: "text/javascript" }));
+      const worker = new Worker(url);
+      try {
+        const [e] = await once(worker, "error");
+        expect({
+          type: e.type,
+          cancelable: e.cancelable,
+          multiline: /\n/.test(e.message),
+          message: e.message,
+          filename: e.filename,
+          lineno: e.lineno,
+          colno: e.colno,
+          errorIsError: e.error instanceof Error,
+          errorMessage: e.error?.message,
+        }).toEqual({
+          type: "error",
+          cancelable: true,
+          multiline: false,
+          message: "Error: EE-BOOM",
+          filename: url,
+          lineno: 1,
+          colno: 11,
+          errorIsError: true,
+          errorMessage: "EE-BOOM",
+        });
+      } finally {
+        worker.terminate();
+      }
+    });
+
+    test("thrown Error from a file populates filename/lineno", async () => {
+      using dir = tempDir("worker-error-event", {
+        "bad-worker.mjs": "\n\nthrow new TypeError('boom from file');\n",
+      });
+      const workerPath = path.join(String(dir), "bad-worker.mjs");
+      const worker = new Worker(pathToFileURL(workerPath).href, { type: "module" });
+      try {
+        const [e] = await once(worker, "error");
+        expect(e.message).toBe("TypeError: boom from file");
+        expect(e.filename).toEndWith("bad-worker.mjs");
+        expect(path.isAbsolute(e.filename)).toBe(true);
+        expect(e.lineno).toBe(3);
+        expect(e.colno).toBe(11);
+        expect(e.error).toBeInstanceOf(TypeError);
+        expect(e.error.message).toBe("boom from file");
+      } finally {
+        worker.terminate();
+      }
+    });
+
+    test("self.onerror inside the worker is cancelable and populated", async () => {
+      const script = [
+        "self.addEventListener('error', e => {",
+        "  self.postMessage({",
+        "    cancelable: e.cancelable,",
+        "    message: e.message,",
+        "    filename: e.filename,",
+        "    lineno: e.lineno,",
+        "    colno: e.colno,",
+        "    errorMessage: e.error && e.error.message,",
+        "  });",
+        "});",
+        "throw new Error('inside');",
+      ].join("\n");
+      const url = URL.createObjectURL(new Blob([script], { type: "text/javascript" }));
+      const worker = new Worker(url);
+      try {
+        const [msg] = await once(worker, "message");
+        expect(msg.data).toEqual({
+          cancelable: true,
+          message: "Error: inside",
+          filename: url,
+          lineno: 11,
+          colno: 11,
+          errorMessage: "inside",
+        });
+      } finally {
+        worker.terminate();
+      }
+    });
+
+    test("self.onerror preventDefault() keeps the worker alive and suppresses the parent error event", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const script = [
+            "self.addEventListener('error', e => { e.preventDefault(); });",
+            "setTimeout(() => self.postMessage('still-alive'), 0);",
+            "throw new Error('handled');",
+          ].join("\\n");
+          const w = new Worker(URL.createObjectURL(new Blob([script], { type: "text/javascript" })));
+          w.onerror = e => { console.log("PARENT-ERROR:" + e.message); process.exit(1); };
+          w.onmessage = e => { console.log("MSG:" + e.data); w.terminate(); };
+          w.addEventListener("close", e => { console.log("CLOSE:" + e.code); process.exit(e.code); });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).not.toContain("PARENT-ERROR");
+      expect(stdout).toContain("MSG:still-alive");
+      expect(stdout).toContain("CLOSE:0");
+      expect(exitCode).toBe(0);
     });
   });
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -447,6 +447,69 @@ describe("web worker", () => {
       expect(stdout).toContain("CLOSE:0");
       expect(exitCode).toBe(0);
     });
+
+    test("error event fires once per rejection under --unhandled-rejections=throw", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "--unhandled-rejections=throw",
+          "-e",
+          `
+          const script = [
+            "self.addEventListener('error', e => { e.preventDefault(); postMessage('errorevent'); });",
+            "self.onmessage = () => postMessage('pong');",
+            "Promise.reject(new Error('rejected-once'));",
+          ].join("\\n");
+          const w = new Worker(URL.createObjectURL(new Blob([script], { type: "text/javascript" })));
+          const events = [];
+          w.onmessage = e => {
+            events.push(e.data);
+            if (e.data === "errorevent") w.postMessage("ping");
+            if (e.data === "pong") { console.log(JSON.stringify(events)); w.terminate(); process.exit(0); }
+          };
+          w.addEventListener("close", e => { console.log("CLOSE:" + e.code); process.exit(1); });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      // A second "errorevent" here means the same rejection was dispatched twice.
+      expect(stdout.trim()).toBe('["errorevent","pong"]');
+      expect(exitCode).toBe(0);
+    });
+
+    test("preventDefault() preserves a user-set process.exitCode", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          const script = [
+            "process.exitCode = 42;",
+            "self.addEventListener('error', e => {",
+            "  e.preventDefault();",
+            "  queueMicrotask(() => postMessage(process.exitCode));",
+            "});",
+            "throw new Error('thrown-and-handled');",
+          ].join("\\n");
+          const w = new Worker(URL.createObjectURL(new Blob([script], { type: "text/javascript" })));
+          w.onmessage = e => { console.log("EXITCODE:" + e.data); w.terminate(); process.exit(e.data === 42 ? 0 : 1); };
+          w.onerror = e => { console.log("PARENT-ERROR:" + e.message); process.exit(1); };
+          w.addEventListener("close", e => { console.log("CLOSE:" + e.code); process.exit(1); });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout).toContain("EXITCODE:42");
+      expect(exitCode).toBe(0);
+    });
   });
 });
 


### PR DESCRIPTION
### What does this PR do?

Fixes the Web Worker `error` ErrorEvent contract. For an uncaught throw in a worker, the parent's `worker.onerror` event carried the whole pretty-printed console dump (source excerpt + caret + stack) as `message`, with `filename: ""`, `lineno: 0`, `colno: 0`, `error: null`, and `cancelable: false`. Inside the worker, `self.addEventListener('error', ...)` saw the same mangled shape and `preventDefault()` was a no-op, so the worker always exited with code 1.

Fixes #23473.

### Repro

```js
const w = new Worker(URL.createObjectURL(new Blob(["throw new Error('EE-BOOM');"], { type: "text/javascript" })));
w.onerror = e => {
  console.log(JSON.stringify({
    cancelable: e.cancelable, multiline: /\n/.test(e.message),
    filename: e.filename, lineno: e.lineno, colno: e.colno,
    error: e.error === null ? "null" : typeof e.error, message: e.message,
  }, null, 1));
  process.exit(/^(Uncaught )?(Error: )?EE-BOOM$/.test(e.message) && e.filename !== "" && e.lineno > 0 && e.error !== null ? 0 : 86);
};
```

Before:

```
{ "cancelable": false, "multiline": true, "filename": "", "lineno": 0, "colno": 0, "error": "null",
  "message": "1 | throw new Error('EE-BOOM');\n              ^\nerror: EE-BOOM\n      at blob:…:1:11\n" }
exit 86
```

After:

```
{ "cancelable": true, "multiline": false, "filename": "blob:…", "lineno": 1, "colno": 11, "error": "object",
  "message": "Error: EE-BOOM" }
exit 0
```

### How did you fix it?

`WebWorker__dispatchError` now:

- extracts `filename`/`lineno`/`colno` from the `ErrorInstance` via `materializeErrorInfoIfNeeded` (source-map-remapped position)
- uses `sanitizedToString` for `message` (e.g. `"TypeError: foo"`) when the thrown value is an `ErrorInstance`; other thrown values keep the formatted fallback
- fires the worker-global-scope event with `cancelable: true` and `error` set to the thrown value, and returns `true` to Rust if `preventDefault()` was called
- for Web workers, structured-clones the thrown value into the parent event's `error` property (falls back to `null` if the value is not cloneable)

`Worker::dispatchError` (was `dispatchErrorWithMessage`) now carries `filename`/`lineno`/`colno` and a serialized error to the parent and fires a cancelable event.

The `on_unhandled_rejection` hook now returns whether a handler consumed the error. Callers in `uncaught_exception` / `unhandled_rejection` skip or roll back their fatal bookkeeping (unhandled counter, exit code) when it did, so `preventDefault()` keeps the worker running without clobbering a user-set `process.exitCode`, and `--unhandled-rejections=throw` no longer re-dispatches the same rejection through the restored hook.

Browsers leave `error` null on the parent-side event; Bun now clones it so callers have structured data (the `node:worker_threads` error event already did this). If that's unwanted it's a one-line revert in `WebWorker__dispatchError`.

### How did you verify your code works?

New tests in `test/js/web/workers/worker.test.ts` cover the parent event shape for `throw new Error(...)` (blob URL and file), the worker-scope event shape, `preventDefault()` keeping the worker alive and suppressing the parent event, single dispatch per rejection under `--unhandled-rejections=throw`, and preservation of a user-set `process.exitCode`. All fail on stock bun and pass with this change; the existing worker and `node:worker_threads` suites still pass under `BUN_JSC_validateExceptionChecks=1`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
bun test v1.4.0 (82e96df92)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [12.55ms]
(pass) web worker > preload > string [184.61ms]
(pass) web worker > preload > array of 2 strings [376.93ms]
(pass) web worker > preload > array of string [148.11ms]
(pass) web worker > preload > error in preload doesn't crash parent [134.33ms]
(pass) web worker > worker [164.42ms]
(pass) web worker > worker-env [134.21ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1012.10ms]
(pass) web worker > worker-env with a lot of properties [377.03ms]
(pass) web worker > argv / execArgv defaults [141.42ms]
(pass) web worker > argv / execArgv options [146.77ms]
(pass) web worker > sending 50 messages should just work [165.35ms]
(pass) web worker > worker with event listeners doesn't close event loop [531.86ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [601.40ms]
(pass) web worker > worker with process.exit [189.60ms]
(pass) web
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4ecff5229)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [0.97ms]
(pass) web worker > preload > string [4.33ms]
(pass) web worker > preload > array of 2 strings [3.68ms]
(pass) web worker > preload > array of string [3.17ms]
(pass) web worker > preload > error in preload doesn't crash parent [2.81ms]
(pass) web worker > worker [3.27ms]
(pass) web worker > worker-env [3.66ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [23.12ms]
(pass) web worker > worker-env with a lot of properties [5.90ms]
(pass) web worker > argv / execArgv defaults [2.88ms]
(pass) web worker > argv / execArgv options [2.76ms]
(pass) web worker > sending 50 messages should just work [5.49ms]
(pass) web worker > worker with event listeners doesn't close event loop [17.13ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [16.45ms]
(pass) web worker > worker with process.exit [14.27ms]
(pass) web worker > worker event > is fired with the right object [0.26ms]
(pass) web worker > error event > is fired with a string of the error [3.79ms]
(pass) web worker > error event > thrown 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/worker.test.ts
bun test v1.4.0 (82e96df92)

test/js/web/workers/worker.test.ts:
(pass) web worker > preload > invalid file URL [12.52ms]
(pass) web worker > preload > string [143.52ms]
(pass) web worker > preload > array of 2 strings [379.04ms]
(pass) web worker > preload > array of string [195.85ms]
(pass) web worker > preload > error in preload doesn't crash parent [182.56ms]
(pass) web worker > worker [132.71ms]
(pass) web worker > worker-env [142.28ms]
(pass) web worker > worker-env: SHARE_ENV via the global Worker constructor [1069.21ms]
(pass) web worker > worker-env with a lot of properties [372.61ms]
(pass) web worker > argv / execArgv defaults [187.83ms]
(pass) web worker > argv / execArgv options [199.59ms]
(pass) web worker > sending 50 messages should just work [174.67ms]
(pass) web worker > worker with event listeners doesn't close event loop [544.71ms]
(pass) web worker > worker with event listeners doesn't close event loop 2 [584.37ms]
(pass) web worker > worker with process.exit [203.92ms]
(pass) web
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 795ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[2/13] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-4.cpp.o
[3/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[4/13] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[5/13] cxx obj/src/jsc/bindings/ZigGlobalObject.cpp.o
[6/13] gen cpp.rs (cppbind)
[7/13] gen generated_host_exports.rs
generated_host_exports.rs: 94 exports (host=3, lazy=10, generic=81, rust=0); 240 extern-C blocks audited
[7/13] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/VirtualMachine.rs           |  60 ++++++---
 src/jsc/bindings/webcore/Worker.cpp |  74 +++++++++--
 src/jsc/bindings/webcore/Worker.h   |   3 +-
 src/jsc/web_worker.rs               |  37 ++++--
 src/runtime/cli/run_command.rs      |   3 +-
 src/runtime/test_runner/jest.rs     |   5 +-
 test/js/web/workers/worker.test.ts  | 240 +++++++++++++++++++++++++++++++++++-
 7 files changed, 379 insertions(+), 43 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                 reads  edits  tests
src/jsc/VirtualMachine.rs                5      4      0
src/jsc/bindings/webcore/Worker.cpp      1      1      0
src/jsc/bindings/webcore/Worker.h        0      0      0
src/jsc/web_worker.rs                    3      3      0
src/runtime/cli/run_command.rs           1      2      0
src/runtime/test_runner/jest.rs          1      1      0
test/js/web/workers/worker.test.ts       1      3      0
```

</details>

**root cause** · written by the author bot

When a worker's error handler called preventDefault and then threw, the nested re-entry into uncaught_exception hit the recursion guard, which assigned exit_code directly without bumping the write counter used to distinguish persistent writes from the outer frame's own restorable one. The outer frame then saw an unchanged counter and a handled error, restored the exit code to 0, and the worker shut down silently with both errors swallowed. The fix routes the recursion guard's write through a new ExitHandler::set_exit_code method that records the write, so the outer frame preserves the exit …

<!-- robobun:evidence:end -->
