### PR TITLE
worker: discard ReadFileUV completions against a shutting-down VM

### DIFF
--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1369,6 +1369,24 @@ impl<'a> ReadBytesHandler for BlobReadChain<'a> {
         let boxed = unsafe { bun_core::heap::take(std::ptr::from_mut::<Self>(self)) };
         boxed.on_read_bytes_impl(result);
     }
+
+    unsafe fn on_read_discard(ctx: *mut Self) {
+        // SAFETY: `ctx` is the `heap::into_raw` from `start()`; we reclaim
+        // ownership here. The JSC `HandleSet` is already freed when this
+        // runs on Windows `Loop::shutdown`'s final `uv_run`, so the Strong
+        // handles must be leaked rather than dropped.
+        let mut chain = unsafe { bun_core::heap::take(ctx) };
+        #[allow(clippy::mem_forget)]
+        {
+            core::mem::forget(core::mem::take(&mut chain.outer));
+            if let Deliver::WriteDest(strong) =
+                core::mem::replace(&mut chain.deliver, Deliver::Uint8Array)
+            {
+                core::mem::forget(strong);
+            }
+        }
+        drop(chain);
+    }
 }
 
 /// `jsc.ConcurrentPromiseTask(PipelineTask)` — the heap object the event-loop

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -93,8 +93,9 @@ pub enum ReadBytesResult {
     Err(Box<bun_jsc::SystemError>),
 }
 
-/// Handler trait for `read_bytes_to_handler` — the body only requires
-/// `on_read_bytes`.
+/// Handler trait for `read_bytes_to_handler`. Exactly one of
+/// `on_read_bytes` (normal completion) or `on_read_discard` (Windows
+/// worker-shutdown path) is called per read.
 pub trait ReadBytesHandler {
     fn on_read_bytes(&mut self, result: ReadBytesResult);
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -97,6 +97,17 @@ pub enum ReadBytesResult {
 /// `on_read_bytes`.
 pub trait ReadBytesHandler {
     fn on_read_bytes(&mut self, result: ReadBytesResult);
+
+    /// Windows worker-shutdown discard path: release the handler pointer
+    /// passed to `read_bytes_to_handler` without entering JS. Implementors
+    /// that leak a `Box` into the read dispatch reclaim it here and
+    /// `mem::forget` any JSC `Strong` handles (the JSC `HandleSet` is
+    /// already freed when this runs).
+    ///
+    /// # Safety
+    /// `ctx` is the exact pointer originally passed to
+    /// `read_bytes_to_handler`; this call consumes it.
+    unsafe fn on_read_discard(ctx: *mut Self);
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -145,7 +156,8 @@ pub trait BlobExt {
     fn do_read_file<F: read_file::ReadFileToJs>(&self, global: &JSGlobalObject) -> JSValue;
     /// # Safety
     /// `ctx` must be a valid, exclusively-accessible `*mut H` that stays alive
-    /// until `H::on_read_bytes` is invoked (synchronously or via the async task).
+    /// until `H::on_read_bytes` or `H::on_read_discard` is invoked
+    /// (synchronously or via the async task).
     unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
         ctx: *mut H,
@@ -525,7 +537,7 @@ impl BlobExt for Blob {
     ///
     /// # Safety
     /// `ctx` must be a valid, exclusively-accessible `*mut H` that stays alive
-    /// until `H::on_read_bytes` is invoked.
+    /// until `H::on_read_bytes` or `H::on_read_discard` is invoked.
     unsafe fn read_bytes_to_handler<H: ReadBytesHandler>(
         &self,
         ctx: *mut H,
@@ -551,6 +563,11 @@ impl BlobExt for Blob {
                             }
                         },
                     );
+                }
+                unsafe fn discard(c: *mut H) {
+                    // SAFETY: `c` is the `*mut H` passed by the caller;
+                    // forwarded unchanged per `ReadBytesHandler::on_read_discard`.
+                    unsafe { H::on_read_discard(c) };
                 }
             }
             self.do_read_file_internal::<H, Adapter<H>>(ctx, global);
@@ -3933,6 +3950,15 @@ pub enum FormDataEntry<'a> {
 /// plain `fn(*mut c_void, ReadFileResultType)` thunk, monomorphized per `(C, F)`.
 pub trait InternalReadFileFn<C> {
     fn call(ctx: *mut C, bytes: read_file::ReadFileResultType);
+
+    /// Windows worker-shutdown discard path: release `ctx` without entering
+    /// JS. Borrow-style callers (ctx owned elsewhere) implement this as a
+    /// no-op; heap-allocated callers reclaim the Box and `mem::forget` any
+    /// JSC `Strong` handles.
+    ///
+    /// # Safety
+    /// Same `ctx` ownership contract as [`Self::call`].
+    unsafe fn discard(ctx: *mut C);
 }
 
 pub struct NewInternalReadFileHandler<C, F>(core::marker::PhantomData<(C, F)>);
@@ -3949,14 +3975,18 @@ where
         F::call(handler.cast::<C>(), bytes);
     }
 
-    /// Worker-shutdown discard path. `handler` is caller-owned (not
-    /// heap-allocated by this layer), so there is nothing to free here;
-    /// the caller's storage is reclaimed by the worker teardown that
-    /// triggered the discard.
+    /// Worker-shutdown discard path. Forwards to the concrete
+    /// `InternalReadFileFn::discard`, which knows whether `ctx` is
+    /// heap-allocated (e.g. `BlobReadChain`) or borrow-style
+    /// (e.g. `ValueBufferer`).
     ///
     /// # Safety
     /// See [`read_file::ReadFileOnDiscardCallback`].
-    pub unsafe fn discard(_handler: *mut c_void) {}
+    pub unsafe fn discard(handler: *mut c_void) {
+        // SAFETY: every call site passes a `*mut C` round-tripped
+        // through `*mut c_void`; this is the inverse pointer cast.
+        unsafe { F::discard(handler.cast::<C>()) };
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -689,6 +689,7 @@ impl BlobExt for Blob {
                 self.offset.get(),
                 self.size.get(),
                 NewInternalReadFileHandler::<C, F>::run,
+                NewInternalReadFileHandler::<C, F>::discard,
                 ctx.cast::<c_void>(),
             );
         }
@@ -3947,6 +3948,15 @@ where
         // through `*mut c_void`; this is the inverse pointer cast.
         F::call(handler.cast::<C>(), bytes);
     }
+
+    /// Worker-shutdown discard path. `handler` is caller-owned (not
+    /// heap-allocated by this layer), so there is nothing to free here;
+    /// the caller's storage is reclaimed by the worker teardown that
+    /// triggered the discard.
+    ///
+    /// # Safety
+    /// See [`read_file::ReadFileOnDiscardCallback`].
+    pub unsafe fn discard(_handler: *mut c_void) {}
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -2262,6 +2262,11 @@ impl<'a> ValueBufferer<'a> {
                                 // outlives the read (ValueBufferer is heap-pinned by caller).
                                 unsafe { &mut *sink }.on_finished_loading_file(bytes);
                             }
+                            unsafe fn discard(_sink: *mut ValueBufferer<'b>) {
+                                // `sink` is `&mut self` of a caller-pinned
+                                // `ValueBufferer`; nothing to free on the
+                                // Windows worker-shutdown discard path.
+                            }
                         }
                         let global = self.global;
                         blob.do_read_file_internal::<Self, LoadFileAdapter>(

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -84,6 +84,13 @@ pub trait ReadFileCompletion {
     /// `ctx` must be a heap-allocated `Self` whose ownership is transferred to
     /// this call (it is reclaimed via `bun_core::heap::take`).
     unsafe fn run(ctx: *mut Self, bytes: ReadFileResultType) -> jsc::JsTerminatedResult<()>;
+
+    /// Frees `ctx` without touching the JSC heap. Called from the Windows
+    /// worker-shutdown discard path instead of [`Self::run`].
+    ///
+    /// # Safety
+    /// Same ownership contract as [`Self::run`].
+    unsafe fn discard(ctx: *mut Self);
 }
 
 impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
@@ -124,6 +131,18 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
         }
         Ok(())
     }
+
+    unsafe fn discard(handler: *mut Self) {
+        // SAFETY: handler was heap-allocated by doReadFile(); we take ownership here.
+        let mut handler = unsafe { bun_core::heap::take(handler) };
+        // SAFETY: intentional leak — the JSC `HandleSet` that backs the
+        // Strong handle is already freed when this runs on Windows
+        // `Loop::shutdown`'s final `uv_run`; dropping it would dereference
+        // freed memory. `context` (a `Blob`/`StoreRef`) drops normally.
+        #[allow(clippy::mem_forget)]
+        core::mem::forget(core::mem::take(&mut handler.promise));
+        drop(handler);
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -131,6 +150,14 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub type ReadFileOnReadFileCallback = fn(ctx: *mut c_void, bytes: ReadFileResultType);
+
+/// Frees the `ctx` passed alongside [`ReadFileOnReadFileCallback`] without
+/// resolving the promise or entering JS. Called on the Windows
+/// worker-shutdown discard path.
+///
+/// # Safety
+/// Must match the concrete `ctx` type the paired run callback expects.
+pub type ReadFileOnDiscardCallback = unsafe fn(ctx: *mut c_void);
 
 pub struct ReadFileRead {
     /// Always a `Box::<[u8]>::into_raw` from the producer's read buffer
@@ -935,6 +962,7 @@ pub struct ReadFileUV<'a> {
     pub errno: Option<Error>,
     pub on_complete_data: *mut c_void,
     pub on_complete_fn: ReadFileOnReadFileCallback,
+    pub on_complete_discard: ReadFileOnDiscardCallback,
     pub is_regular_file: bool,
 
     pub req: libuv::fs_t,
@@ -1040,6 +1068,7 @@ impl<'a> ReadFileUV<'a> {
             max_len,
             // Erase the typed handler to the C ABI cb.
             H::run as ReadFileOnReadFileCallback,
+            H::discard as ReadFileOnDiscardCallback,
             handler,
         )
     }
@@ -1052,6 +1081,7 @@ impl<'a> ReadFileUV<'a> {
         off: SizeType,
         max_len: SizeType,
         on_complete_fn: ReadFileOnReadFileCallback,
+        on_complete_discard: ReadFileOnDiscardCallback,
         handler: *mut c_void,
     ) {
         log!("ReadFileUV.start");
@@ -1081,6 +1111,7 @@ impl<'a> ReadFileUV<'a> {
             errno: None,
             on_complete_data: handler,
             on_complete_fn,
+            on_complete_discard,
             is_regular_file: false,
             req: bun_core::ffi::zeroed(),
             open_callback: Self::on_file_open,
@@ -1099,6 +1130,32 @@ impl<'a> ReadFileUV<'a> {
         // SAFETY: `this` was heap-allocated in start(); we reclaim ownership here.
         let mut this_box = unsafe { bun_core::heap::take(this) };
         let event_loop = this_box.event_loop;
+
+        // SAFETY: `virtual_machine` back-references the VM that owns
+        // `event_loop`; it is still allocated (the VM box is freed only after
+        // `Loop::shutdown` returns, see `WebWorker::shutdown`).
+        let is_shutting_down = unsafe {
+            event_loop
+                .virtual_machine
+                .is_some_and(|vm| vm.as_ref().is_shutting_down())
+        };
+        if is_shutting_down {
+            // JSC VM (and its `HandleSet` / `JSLock`) is already torn down by
+            // the time this fires on Windows `Loop::shutdown`'s final
+            // `uv_run`. Discard the handler without touching JS, free the
+            // read buffer via normal Drop of `this_box`, and release the
+            // event-loop ref.
+            log!("ReadFileUV.finalize discard (worker shutting down)");
+            let discard = this_box.on_complete_discard;
+            let cb_ctx = this_box.on_complete_data;
+            // SAFETY: `cb_ctx` is the handler pointer paired with `discard`
+            // at `start`/`start_with_ctx`; `discard` consumes it.
+            unsafe { discard(cb_ctx) };
+            this_box.req.deinit();
+            drop(this_box);
+            event_loop.unref_concurrently();
+            return;
+        }
 
         let cb = this_box.on_complete_fn;
         let cb_ctx = this_box.on_complete_data;
@@ -1425,6 +1482,10 @@ impl<'a> ReadFileUV<'a> {
 /// implementor supplies the already-erased thunk.
 pub trait ReadFileUvHandler {
     fn run(ctx: *mut c_void, bytes: ReadFileResultType);
+
+    /// # Safety
+    /// See [`ReadFileOnDiscardCallback`].
+    unsafe fn discard(ctx: *mut c_void);
 }
 
 /// Any `ReadFileCompletion` is usable as a `ReadFileUV` handler — the libuv
@@ -1435,5 +1496,11 @@ impl<C: ReadFileCompletion> ReadFileUvHandler for C {
         // SAFETY: `ctx` is the `*mut C` passed unmodified through
         // `on_complete_data`; ownership transfers per `ReadFileCompletion::run`.
         let _ = unsafe { <C as ReadFileCompletion>::run(ctx.cast::<C>(), bytes) };
+    }
+
+    unsafe fn discard(ctx: *mut c_void) {
+        // SAFETY: `ctx` is the `*mut C` passed unmodified through
+        // `on_complete_data`; ownership transfers per `ReadFileCompletion::discard`.
+        unsafe { <C as ReadFileCompletion>::discard(ctx.cast::<C>()) };
     }
 }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows, tempDir } from "harness";
+import path from "node:path";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
 // tests spawn many workers, so scale iteration counts and timeouts down.
@@ -114,6 +115,66 @@ test(
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
+// Regression: BUN-2WBH. Windows worker with an in-flight Bun.file().text()
+// during shutdown used to crash in JSLock::currentThreadIsHoldingLock from
+// ReadFileUV::finalize — the uv_fs_read completion fired in Loop::shutdown's
+// final uv_run after the worker's JSC VM was already torn down.
+//
+// The ReadFileUV path is #[cfg(windows)]-only; on POSIX the read completion
+// goes through the concurrent task queue which is not dispatched past worker
+// shutdown, so the hazard is unreachable there.
+test.skipIf(!isWindows)(
+  "worker with in-flight Bun.file read during shutdown does not crash",
+  async () => {
+    using dir = tempDir("worker-readfile-shutdown", {
+      "data.bin": Buffer.alloc(2 * 1024 * 1024, 0x61).toString("binary"),
+    });
+    const dataPath = path.join(String(dir), "data.bin");
+
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const workerSrc = \`
+          // Start several reads so at least one is still on the libuv
+          // threadpool when process.exit(0) begins worker shutdown. If any
+          // completion runs JS past VM teardown it would segfault; the then()
+          // sentinel additionally catches a completion that runs late but
+          // without crashing.
+          const p = process.env.READFILE_SHUTDOWN_DATA;
+          for (let i = 0; i < 8; i++) {
+            Bun.file(p).text().then(() => {
+              console.error("readfile microtask ran after worker shutdown");
+              process.exit(42);
+            }, () => {});
+          }
+          process.exit(0);
+        \`;
+        const workers = [];
+        for (let i = 0; i < ${perRound}; i++) {
+          workers.push(new Worker("data:text/javascript," + encodeURIComponent(workerSrc)));
+        }
+        const codes = await Promise.all(workers.map(w => new Promise(r => {
+          w.addEventListener("close", e => r(e.code ?? e.exitCode ?? 0), { once: true });
+        })));
+        for (const c of codes) if (c !== 0) { console.error("bad exit", c); process.exit(1); }
+      `,
+      ],
+      env: { ...bunEnv, READFILE_SHUTDOWN_DATA: dataPath },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("readfile microtask ran after worker shutdown");
+    expect(stderr).not.toContain("bad exit");
     expect(stdout).toBe("");
     expect(exitCode).toBe(0);
   },

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -173,8 +173,7 @@ test.skipIf(!isWindows)(
     });
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).not.toContain("readfile microtask ran after worker shutdown");
-    expect(stderr).not.toContain("bad exit");
+    expect(stderr).toBe("");
     expect(stdout).toBe("");
     expect(exitCode).toBe(0);
   },


### PR DESCRIPTION
Sentry: BUN-2WBH (517 events, Windows only)

## Crash

```
JSC::JSLock::currentThreadIsHoldingLock   JSLock.h:107   (segfault at 0xA)
JSC::VM::currentThreadIsHoldingAPILock
sanitizeStackForVM
JSC::JSString::create / tryAllocateCellHelper
ZigString__toExternalValue
Blob::toStringWithBytes
AnyPromise::wrap                          (resolves the promise)
NewReadFileHandler::run
ReadFileUV::finalize                      read_file.rs
uv__work_done                             threadpool.c:340
uv_run                                    win/core.c:737
libuv::Loop::shutdown                     (uv_loop_close -> EBUSY -> uv_run)
WebWorker::shutdown                       web_worker.rs
```

## Repro

On Windows, in a Worker:

```js
for (let i = 0; i < 8; i++) Bun.file(largePath).text();
process.exit(0);
```

If any `uv_fs_read` completion lands after `WebWorker__teardownJSCVM` has run, the final `uv_run` in `Loop::shutdown` delivers it and `ReadFileUV::finalize` resolves the promise against a destroyed `JSC::VM`.

## Cause

`WebWorker::shutdown` (Windows) runs in this order:

1. `vm.is_shutting_down = true` and `vm.on_exit()`
2. `WebWorker__teardownJSCVM(global)`: full sync GC then `~JSC::VM`, which frees the `JSLock`
3. `libuv::Loop::shutdown()`: `uv_loop_close` returns `EBUSY` when threadpool work is pending, so it does `uv_walk(close)` + `uv_run(loop, Default)` to flush

Any `uv__work_done` completion delivered in step 3 runs on a thread whose `JSC::VM` no longer exists. `ReadFileUV::finalize` unconditionally called `cb(cb_ctx, result)`, which for `NewReadFileHandler` wraps `AnyPromise::wrap` and allocates a `JSString`, hitting `sanitizeStackForVM` and dereferencing the dangling `JSLock*` at offset 0xA.

This is the read-side analogue of #31232 (write side, same mechanism for `WriteFileWindows::on_finish` / `FileSink::run_pending`).

## Fix

Mirror #31232's design for the read side:

- `ReadFileUV` gains an `on_complete_discard: ReadFileOnDiscardCallback` paired with the existing `on_complete_fn`.
- `ReadFileUV::finalize` checks `event_loop.virtual_machine.is_shutting_down()` before invoking the completion. When true it calls `discard(ctx)` instead, frees the read buffer via normal `Drop` of the `ReadFileUV` box, and releases the event-loop ref without entering JS.
- `NewReadFileHandler::discard` reclaims the boxed handler and `mem::forget`s its `JSPromiseStrong` (the JSC `HandleSet` is already freed; dropping the Strong would dereference it). The `Blob`/`StoreRef` drops normally.
- `NewInternalReadFileHandler::discard` forwards to `InternalReadFileFn::discard`, which each concrete handler implements: `LoadFileAdapter` (borrow-style `ValueBufferer`) is a no-op; `Adapter<H>` forwards to `ReadBytesHandler::on_read_discard`.
- `BlobReadChain::on_read_discard` reclaims its Box and `mem::forget`s its `JSPromiseStrong` and any `Deliver::WriteDest` Strong.

POSIX is unaffected: `ReadFile` completions go through a `WorkTask` posted to the event loop's concurrent task queue, which is not dispatched past worker shutdown.

## Verification

`test/js/web/workers/worker-terminate-lifetime.test.ts` gets a new `skipIf(!isWindows)` case that spawns a batch of workers each starting several `Bun.file(path).text()` reads then `process.exit(0)`, and asserts every worker closes with exit code 0 and never prints the "microtask ran after worker shutdown" sentinel.

The entire `ReadFileUV` type is `#[cfg(windows)]`, so the Linux gate cannot exercise the fail-before path (the crashing code is not compiled there). The new test covers the regression on Windows CI lanes; existing worker-terminate-lifetime and blob tests continue to pass on Linux (3 pass, 1 skip / 26 pass).

`cargo check -p bun_runtime` is clean on `x86_64-pc-windows-msvc`, `aarch64-apple-darwin`, and the host Linux target.
