### PR TITLE
postgres: throw ERR_INVALID_ARG_TYPE for null bytes in connection params

### DIFF
--- a/src/sql_jsc/jsc.rs
+++ b/src/sql_jsc/jsc.rs
@@ -153,7 +153,6 @@ pub(crate) fn create_bun_socket_error_to_js(
 /// the SQL bindings need a slightly different signature).
 pub(crate) trait JSGlobalObjectSqlExt {
     fn err_out_of_range<'a>(&'a self, args: core::fmt::Arguments<'a>) -> ErrorBuilder<'a>;
-    fn throw_invalid_arguments_fmt(&self, args: core::fmt::Arguments<'_>) -> JsResult<JSValue>;
     /// `globalObject.bunVM()` — `bun_jsc::JSGlobalObject::bun_vm()` returns
     /// `&mut VirtualMachine`; this `&`-receiver form is for SQL callsites that
     /// only need shared access.
@@ -165,10 +164,6 @@ impl JSGlobalObjectSqlExt for JSGlobalObject {
     #[inline]
     fn err_out_of_range<'a>(&'a self, args: core::fmt::Arguments<'a>) -> ErrorBuilder<'a> {
         self.err(ErrorCode::OUT_OF_RANGE, args)
-    }
-    #[inline]
-    fn throw_invalid_arguments_fmt(&self, args: core::fmt::Arguments<'_>) -> JsResult<JSValue> {
-        Err(self.throw(args))
     }
     #[inline]
     fn sql_vm(&self) -> &VirtualMachine {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -7,8 +7,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 use crate::jsc::EventLoopTimer;
 use crate::jsc::webcore::AutoFlusher;
 use crate::jsc::{
-    self as jsc, CallFrame, HasAutoFlush, JSGlobalObject, JSGlobalObjectSqlExt as _, JSValue,
-    JsResult, VirtualMachine, VirtualMachineSqlExt as _,
+    self as jsc, CallFrame, HasAutoFlush, JSGlobalObject, JSValue, JsResult, VirtualMachine,
+    VirtualMachineSqlExt as _,
 };
 use bun_boringssl as BoringSSL;
 use bun_collections::{HashMap, IdentityContext, OffsetByteList, StringMap};
@@ -1155,10 +1155,10 @@ pub(crate) fn call(global_object: &JSGlobalObject, callframe: &CallFrame) -> JsR
         if !entry.is_empty() && entry.contains(&0) {
             drop(options_buf);
             // tls_config / secure released by the errdefer above.
-            return global_object.throw_invalid_arguments_fmt(format_args!(
+            return Err(global_object.throw_invalid_arguments(format_args!(
                 "{} must not contain null bytes",
                 bstr::BStr::new(name)
-            ));
+            )));
         }
     }
 

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12760,6 +12760,75 @@ test("rejects Postgres connection options containing null bytes", async () => {
   await ok.close();
 });
 
+// Native createInstance argument validation (src/sql_jsc/shared/
+// connection_args.rs / query_args.rs) — the username/password/database and
+// tls checks the JS layer delegates to the driver. Every error here is thrown
+// by the native parser before any socket is created, so no server needs to be
+// listening: the address below is never dialed.
+describe("shared createInstance validation (no server)", () => {
+  const base = { adapter: "postgres", hostname: "127.0.0.1", port: 1, max: 1 } as const;
+
+  // Credentials are written into the NUL-delimited Postgres StartupMessage as
+  // `key\0value\0`; a NUL byte inside one would inject extra parameters, so
+  // the native parser must refuse it before connecting. The rejection is an
+  // ERR_INVALID_ARG_TYPE TypeError, matching the MySQL adapter and the Zig
+  // reference (`PostgresSQLConnection.zig` `throwInvalidArguments`) — the
+  // previous port threw a plain code-less Error here.
+  test.concurrent.each(["username", "password", "database"] as const)(
+    "rejects %s containing null bytes",
+    async field => {
+      await using sql = new SQL({ ...base, username: "u", [field]: "a\0b" });
+      // `Query` is a lazy thenable, so collect the rejection explicitly.
+      const err: any = await sql`select 1`.then(
+        () => null,
+        e => e,
+      );
+      expect(err?.message).toBe(`${field} must not contain null bytes`);
+      expect(err?.code).toBe("ERR_INVALID_ARG_TYPE");
+      expect(err instanceof TypeError).toBe(true);
+    },
+  );
+
+  test.concurrent("SSL_CTX creation failure throws the structured BoringSSL error", async () => {
+    // An unparseable CA makes `SSL_CTX` creation fail synchronously inside
+    // createInstance, before any socket exists. The failure carries
+    // `code: "ERR_BORINGSSL"` like the MySQL adapter and the Zig reference
+    // (`err.toJS(globalObject)`) — the previous port threw a plain code-less
+    // Error with a static message.
+    await using sql = new SQL({ ...base, username: "u", tls: { ca: "not a pem" } });
+    const err: any = await sql`select 1`.then(
+      () => null,
+      e => e,
+    );
+    expect(err?.message).toBe("Invalid CA");
+    expect(err?.code).toBe("ERR_BORINGSSL");
+  });
+
+  test.concurrent("rejects tls that is neither a boolean nor an object", async () => {
+    // A truthy non-boolean/non-object upgrades sslMode to `require` in JS and
+    // reaches the native parser as-is.
+    await using sql = new SQL({ ...base, username: "u", tls: 1 as any });
+    const err: any = await sql`select 1`.then(
+      () => null,
+      e => e,
+    );
+    expect(err?.message).toBe("tls must be a boolean or an object");
+  });
+
+  test.concurrent("rejects simple queries with parameters", async () => {
+    await using sql = new SQL({ ...base, username: "u" });
+    // Query-handle creation fails before the pool ever connects.
+    const err: any = await sql
+      .unsafe("select $1", [1])
+      .simple()
+      .then(
+        () => null,
+        e => e,
+      );
+    expect(err?.message).toBe("simple query cannot have parameters");
+  });
+});
+
 // A Postgres server controls two independent column counts: the
 // RowDescription's field list (which sizes the per-row cell buffer and the
 // cached row Structure) and each DataRow's own column count. When a DataRow

--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12761,10 +12761,10 @@ test("rejects Postgres connection options containing null bytes", async () => {
 });
 
 // Native createInstance argument validation (src/sql_jsc/shared/
-// connection_args.rs / query_args.rs) — the username/password/database and
-// tls checks the JS layer delegates to the driver. Every error here is thrown
-// by the native parser before any socket is created, so no server needs to be
-// listening: the address below is never dialed.
+// ConnectionCtorArgs.rs / QueryCtorArgs.rs, and the Postgres null-byte guard
+// in PostgresSQLConnection.rs). Every error here is thrown by the native
+// parser before any socket is created, so no server needs to be listening:
+// the address below is never dialed.
 describe("shared createInstance validation (no server)", () => {
   const base = { adapter: "postgres", hostname: "127.0.0.1", port: 1, max: 1 } as const;
 
@@ -12772,8 +12772,9 @@ describe("shared createInstance validation (no server)", () => {
   // `key\0value\0`; a NUL byte inside one would inject extra parameters, so
   // the native parser must refuse it before connecting. The rejection is an
   // ERR_INVALID_ARG_TYPE TypeError, matching the MySQL adapter and the Zig
-  // reference (`PostgresSQLConnection.zig` `throwInvalidArguments`) — the
-  // previous port threw a plain code-less Error here.
+  // reference (`PostgresSQLConnection.zig` `throwInvalidArguments`). `path`
+  // is guarded the same way natively, but the JS layer drops it via
+  // `existsSync` before it ever reaches createInstance.
   test.concurrent.each(["username", "password", "database"] as const)(
     "rejects %s containing null bytes",
     async field => {
@@ -12793,8 +12794,7 @@ describe("shared createInstance validation (no server)", () => {
     // An unparseable CA makes `SSL_CTX` creation fail synchronously inside
     // createInstance, before any socket exists. The failure carries
     // `code: "ERR_BORINGSSL"` like the MySQL adapter and the Zig reference
-    // (`err.toJS(globalObject)`) — the previous port threw a plain code-less
-    // Error with a static message.
+    // (`err.toJS(globalObject)`).
     await using sql = new SQL({ ...base, username: "u", tls: { ca: "not a pem" } });
     const err: any = await sql`select 1`.then(
       () => null,


### PR DESCRIPTION
## What this does

The Rust port's null-byte rejection for `username`/`password`/`database`/`path` at `PostgresSQLConnection.rs:1158` threw a plain code-less `Error` via `throw_invalid_arguments_fmt` (a thin wrapper over `self.throw`). MySQL (`JSMySQLConnection.rs:506`) and the Zig reference (`PostgresSQLConnection.zig:704` `throwInvalidArguments`) both throw `ERR_INVALID_ARG_TYPE` `TypeError`; this brings Postgres in line. Message text is unchanged.

The companion SSL_CTX-failure fix from #31664 is already in place via the shared `ConnectionCtorArgs` from #32135 — verified by the new `ERR_BORINGSSL` test, which passes on `main` without any Rust change.

`throw_invalid_arguments_fmt` had this as its only caller, so the trait method is removed too.

Extracted from #31664 (closed).

## Verification

- `cargo check -p bun_sql_jsc`: clean.
- `bun bd test sql.test.ts -t 'shared createInstance validation'`: 6 pass / 0 fail.
- Discrimination: `USE_SYSTEM_BUN=1` passes (system bun is pre-Rust-port Zig, which was correct), so the load-bearing check is a stash-probe against unfixed `main`'s Rust build — null-byte rejection there gives `{name: 'Error', code: undefined, instanceof TypeError: false}`, failing the new `ERR_INVALID_ARG_TYPE` and `instanceof TypeError` assertions.