### PR TITLE
server: tee cached body stream in new Request(req, init) instead of creating a second one

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4083,12 +4083,9 @@ where
         let this = unsafe { bun_ptr::callback_ctx::<Self>(ptr) };
         debug_assert!(!this.request_body_readable_stream_ref.has());
 
-        // `on_start_streaming_request_body` is the normal drain path, but it
-        // is consumed via `.take()` in `Body::Value::{to_readable_stream,tee}`
-        // and this callback can fire again later without a preceding drain.
-        // Flush any bytes that slipped into `request_body_buf` in the interim
-        // so the streaming branch of `on_buffered_body_chunk` never observes
-        // a non-empty buffer, instead of silently dropping them.
+        // `on_start_streaming_request_body` is the normal drain but is consumed
+        // via `.take()`; flush anything that slipped into `request_body_buf`
+        // since so `on_buffered_body_chunk` never sees a non-empty buffer.
         if !this.request_body_buf.is_empty() {
             if let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr {
                 // BACKREF: `Source::Bytes` payload is the live non-null

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -4082,6 +4082,32 @@ where
         // `*mut RequestContext` registered as the body callback context.
         let this = unsafe { bun_ptr::callback_ctx::<Self>(ptr) };
         debug_assert!(!this.request_body_readable_stream_ref.has());
+
+        // `on_start_streaming_request_body` is the normal drain path, but it
+        // is consumed via `.take()` in `Body::Value::{to_readable_stream,tee}`
+        // and this callback can fire again later without a preceding drain.
+        // Flush any bytes that slipped into `request_body_buf` in the interim
+        // so the streaming branch of `on_buffered_body_chunk` never observes
+        // a non-empty buffer, instead of silently dropping them.
+        if !this.request_body_buf.is_empty() {
+            if let readable_stream::Source::Bytes(bytes_ptr) = readable.ptr {
+                // BACKREF: `Source::Bytes` payload is the live non-null
+                // `m_ctx` heap `ByteStream` kept alive by `readable`.
+                let bytes = bun_ptr::BackRef::from(
+                    NonNull::new(bytes_ptr).expect("Source::Bytes payload is non-null"),
+                );
+                let buffered = core::mem::take(&mut this.request_body_buf);
+                this.request_body_streamed_len = this
+                    .request_body_streamed_len
+                    .saturating_add(buffered.len());
+                let _ = bytes.on_data(WebCore::streams::Result::Owned(buffered));
+            }
+        }
+
+        // Deinit any previous strong ref before overwriting so the GC handle
+        // is released. Callers should tee the existing stream instead of
+        // reaching this path; the debug_assert above guards regressions.
+        this.request_body_readable_stream_ref.deinit();
         this.request_body_readable_stream_ref =
             readable_stream::Strong::init(readable, global_this);
     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1180,10 +1180,8 @@ impl Request {
                             Ok(()) => {}
                             Err(e) => bail!(Err(e)),
                         }
-                        // `clone_into` teed the source body; migrate the
-                        // source's parked tee branch out of `locked.readable`
-                        // (see the two-arg branch below). `do_clone` does
-                        // this via `sync_cloned_body_stream_caches`.
+                        // Migrate the source's parked tee branch out of
+                        // `locked.readable` (see the two-arg branch below).
                         request.check_body_stream_ref(global_this);
                         success = true;
                         cleanup(&mut req, body_seed_ptr, success);
@@ -1229,28 +1227,18 @@ impl Request {
                         match request.body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
-                                // Route through the JS-side cached stream so we tee the
-                                // existing readable instead of creating a second
-                                // disconnected ByteStream after `check_body_stream_ref`
-                                // has already migrated `locked.readable` into the
-                                // `js.gc.stream` slot. Going through `Value::clone(None)`
-                                // re-enters `tee()` with `on_start_streaming` consumed and
-                                // re-fires `on_readable_stream_available`, which overwrites
-                                // the server's `request_body_readable_stream_ref` and
-                                // orphans any reader of the previous stream.
+                                // Tee via the JS-side cached stream: `Value::clone(None)`
+                                // would create a second disconnected ByteStream and
+                                // re-fire `on_readable_stream_available`.
                                 match request.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
                                     }
                                     Err(e) => bail!(Err(e)),
                                 }
-                                // `tee()` parked the source's branch in
-                                // `locked.readable`; migrate it into the
-                                // source's `js.gc.stream` (as `do_clone` does
-                                // via `sync_cloned_body_stream_caches`) so an
-                                // unreachable `Strong` isn't left buffering
-                                // every body chunk until the source is
-                                // finalized.
+                                // Migrate the source's parked tee branch into its
+                                // `js.gc.stream` (as `do_clone` does) so an unreachable
+                                // `Strong` isn't left buffering every body chunk.
                                 request.check_body_stream_ref(global_this);
                                 fields.insert(Fields::Body);
                             }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1224,7 +1224,16 @@ impl Request {
                         match request.body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
-                                match request.body_value_mut().clone(global_this) {
+                                // Route through the JS-side cached stream so we tee the
+                                // existing readable instead of creating a second
+                                // disconnected ByteStream after `check_body_stream_ref`
+                                // has already migrated `locked.readable` into the
+                                // `js.gc.stream` slot. Going through `Value::clone(None)`
+                                // re-enters `tee()` with `on_start_streaming` consumed and
+                                // re-fires `on_readable_stream_available`, which overwrites
+                                // the server's `request_body_readable_stream_ref` and
+                                // orphans any reader of the previous stream.
+                                match request.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
                                     }
@@ -1273,11 +1282,13 @@ impl Request {
                     }
 
                     if !fields.contains(Fields::Body) {
-                        let body_value = response.get_body_value();
-                        match body_value {
+                        match response.get_body_value() {
                             BodyValue::Null | BodyValue::Empty | BodyValue::Used => {}
                             _ => {
-                                match body_value.clone(global_this) {
+                                // See the `Request` branch above: tee through the
+                                // JS-side cached stream rather than creating a second
+                                // disconnected one.
+                                match response.clone_body_value_via_cached_stream(global_this) {
                                     Ok(v) => {
                                         *req.body_value_mut() = v;
                                     }

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -1180,6 +1180,11 @@ impl Request {
                             Ok(()) => {}
                             Err(e) => bail!(Err(e)),
                         }
+                        // `clone_into` teed the source body; migrate the
+                        // source's parked tee branch out of `locked.readable`
+                        // (see the two-arg branch below). `do_clone` does
+                        // this via `sync_cloned_body_stream_caches`.
+                        request.check_body_stream_ref(global_this);
                         success = true;
                         cleanup(&mut req, body_seed_ptr, success);
                         return Ok(req);
@@ -1239,6 +1244,14 @@ impl Request {
                                     }
                                     Err(e) => bail!(Err(e)),
                                 }
+                                // `tee()` parked the source's branch in
+                                // `locked.readable`; migrate it into the
+                                // source's `js.gc.stream` (as `do_clone` does
+                                // via `sync_cloned_body_stream_caches`) so an
+                                // unreachable `Strong` isn't left buffering
+                                // every body chunk until the source is
+                                // finalized.
+                                request.check_body_stream_ref(global_this);
                                 fields.insert(Fields::Body);
                             }
                         }
@@ -1294,6 +1307,11 @@ impl Request {
                                     }
                                     Err(e) => bail!(Err(e)),
                                 }
+                                // See the `Request` branch above.
+                                <Response as BodyMixin>::check_body_stream_ref(
+                                    response,
+                                    global_this,
+                                );
                                 fields.insert(Fields::Body);
                             }
                         }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2685,6 +2685,122 @@ it.concurrent("#20283", async () => {
   expect(json).toEqual({ cookies: {}, clonedCookies: {} });
 });
 
+// The two-arg `new Request(req, init)` path must tee the source body through
+// the JS-side cached stream, the same way `req.clone()` does. Cloning first
+// migrates the readable into the JS cache and consumes `onStartStreaming`, so
+// a later `new Request(req, { ... })` that bypasses the cache would create a
+// second disconnected ByteStream and re-fire `onReadableStreamAvailable`,
+// overwriting the server's `request_body_readable_stream_ref`. In debug builds
+// that trips an assertion in `on_request_body_readable_stream_available`; in
+// release builds the first clone's body never completes because subsequent
+// chunks are routed to the wrong stream. Run in a subprocess so the debug
+// assertion surfaces as a clean test failure instead of killing the runner.
+it.concurrent("req.clone() then new Request(req, init) tees the in-flight server request body", async () => {
+  const script = `
+    const net = require("node:net");
+
+    const chunk1 = Buffer.alloc(1000, "A").toString();
+    const chunk2 = Buffer.alloc(1000, "B").toString();
+    const chunk3 = Buffer.alloc(1000, "C").toString();
+    const total = chunk1.length + chunk2.length + chunk3.length;
+
+    let sendRest;
+    const restReady = new Promise(r => { sendRest = r; });
+
+    const server = Bun.serve({
+      port: 0,
+      error(e) {
+        console.error("server error:", e?.stack ?? e);
+        process.exit(1);
+      },
+      async fetch(req) {
+        // Both operations run while the body is still Locked and streaming.
+        const cloned = req.clone();
+        const wrapped = new Request(req, { headers: { "x-forwarded": "1" } });
+
+        // Only now let the remaining body chunks arrive, so they must flow
+        // through the already-established stream ref.
+        sendRest();
+
+        const [a, b] = await Promise.all([cloned.text(), wrapped.text()]);
+        return Response.json({ cloned: a.length, wrapped: b.length, match: a === b && a.length === total });
+      },
+    });
+
+    const sock = net.connect(server.port, "127.0.0.1");
+    await new Promise((res, rej) => { sock.once("connect", res); sock.once("error", rej); });
+
+    sock.write(
+      "POST / HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: " + total + "\\r\\nConnection: close\\r\\n\\r\\n" + chunk1,
+    );
+    await restReady;
+    sock.write(chunk2 + chunk3);
+
+    let raw = "";
+    for await (const d of sock) raw += d;
+    const body = raw.split("\\r\\n\\r\\n")[1] ?? "";
+    console.log(body);
+    server.stop(true);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ cloned: 3000, wrapped: 3000, match: true }),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
+}, 20_000);
+
+// Same scenario without the raw-socket choreography: a plain fetch() body is
+// small enough to arrive in one read, but the handler still calls clone()
+// followed by new Request(req, init) while the body value is Locked. This is
+// the minimal reproducer for the debug assertion in
+// on_request_body_readable_stream_available.
+it.concurrent("req.clone() then new Request(req, init) with a buffered body does not crash", async () => {
+  const script = `
+    const server = Bun.serve({
+      port: 0,
+      error(e) {
+        console.error("server error:", e?.stack ?? e);
+        process.exit(1);
+      },
+      async fetch(req) {
+        const cloned = req.clone();
+        const wrapped = new Request(req, { headers: { "x-forwarded": "1" } });
+        const [a, b] = await Promise.all([cloned.text(), wrapped.text()]);
+        return Response.json({ cloned: a, wrapped: b });
+      },
+    });
+
+    const res = await fetch(server.url, { method: "POST", body: "hello world" });
+    console.log(JSON.stringify(await res.json()));
+    server.stop(true);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({ cloned: "hello world", wrapped: "hello world" }),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
+}, 20_000);
+
 // Regression: hostname containing an interior NUL byte must not abort the process.
 // Zig reference: src/runtime/server/ServerConfig.zig — `bun.default_allocator.dupeZ(u8, host_str.slice())`
 // copies the raw bytes and the underlying C socket layer truncates at the first NUL, so

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2695,8 +2695,10 @@ it.concurrent("#20283", async () => {
 // release builds the first clone's body never completes because subsequent
 // chunks are routed to the wrong stream. Run in a subprocess so the debug
 // assertion surfaces as a clean test failure instead of killing the runner.
-it.concurrent("req.clone() then new Request(req, init) tees the in-flight server request body", async () => {
-  const script = `
+it.concurrent(
+  "req.clone() then new Request(req, init) tees the in-flight server request body",
+  async () => {
+    const script = `
     const net = require("node:net");
 
     const chunk1 = Buffer.alloc(1000, "A").toString();
@@ -2743,29 +2745,33 @@ it.concurrent("req.clone() then new Request(req, init) tees the in-flight server
     server.stop(true);
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: JSON.stringify({ cloned: 3000, wrapped: 3000, match: true }),
-    stderr: expect.any(String),
-    exitCode: 0,
-  });
-}, 20_000);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ cloned: 3000, wrapped: 3000, match: true }),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+  20_000,
+);
 
 // Same scenario without the raw-socket choreography: a plain fetch() body is
 // small enough to arrive in one read, but the handler still calls clone()
 // followed by new Request(req, init) while the body value is Locked. This is
 // the minimal reproducer for the debug assertion in
 // on_request_body_readable_stream_available.
-it.concurrent("req.clone() then new Request(req, init) with a buffered body does not crash", async () => {
-  const script = `
+it.concurrent(
+  "req.clone() then new Request(req, init) with a buffered body does not crash",
+  async () => {
+    const script = `
     const server = Bun.serve({
       port: 0,
       error(e) {
@@ -2785,21 +2791,23 @@ it.concurrent("req.clone() then new Request(req, init) with a buffered body does
     server.stop(true);
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--debug-crash-handler-use-trace-string", "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-    stdout: JSON.stringify({ cloned: "hello world", wrapped: "hello world" }),
-    stderr: expect.any(String),
-    exitCode: 0,
-  });
-}, 20_000);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ cloned: "hello world", wrapped: "hello world" }),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+  20_000,
+);
 
 // Regression: hostname containing an interior NUL byte must not abort the process.
 // Zig reference: src/runtime/server/ServerConfig.zig — `bun.default_allocator.dupeZ(u8, host_str.slice())`

--- a/test/js/web/request/request.test.ts
+++ b/test/js/web/request/request.test.ts
@@ -175,3 +175,27 @@ describe("RequestInit signal presence", () => {
     });
   });
 });
+
+// https://github.com/oven-sh/bun/issues/28928
+// `new Request(input, { body: undefined })` must inherit the streaming body
+// from `input` by teeing the readable that `check_body_stream_ref` already
+// migrated into the JS-side cache. Going through `Value::clone(None)` here
+// creates an empty disconnected ByteStream instead, so `.text()` on the copy
+// never resolves.
+test("new Request(input, init) with a streaming body inherits it when init.body is undefined", async () => {
+  const body = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("hello world"));
+      controller.close();
+    },
+  });
+  const original = new Request("http://localhost/test", {
+    method: "POST",
+    body,
+    duplex: "half",
+  });
+
+  const copy = new Request(original, { body: undefined });
+  expect(copy.method).toBe("POST");
+  expect(await copy.text()).toBe("hello world");
+});


### PR DESCRIPTION
Fixes #28928

Sentry BUN-389W (`Internal assertion failure` in `onBufferedBodyChunk`, 125 events on 1.3.14, Windows-dominant, http_server).

## Repro

```js
Bun.serve({
  port: 0,
  async fetch(req) {
    const cloned = req.clone();
    const wrapped = new Request(req, { headers: { 'x-forwarded': '1' } });
    const [a, b] = await Promise.all([cloned.text(), wrapped.text()]);
    return Response.json({ cloned: a, wrapped: b });
  },
});
await fetch(url, { method: 'POST', body: 'hello world' });
```

Debug build on main:

```
panic: assertion failed: !this.request_body_readable_stream_ref.has()
  at on_request_body_readable_stream_available (RequestContext.rs:3807)
  at Value::tee (Body.rs:1572)
  at Value::clone (Body.rs:1591)
  at Request::construct_into (Request.rs:1185)
```

Release build: `cloned.text()` never resolves when the body arrives in multiple reads, because subsequent chunks are routed to the second stream.

## Cause

`req.clone()` creates the request body's native ByteStream via `on_start_streaming` (draining `request_body_buf`), stores it in `request_body_readable_stream_ref`, tees it, and then `check_body_stream_ref` migrates the teed branch from `locked.readable` into the JS-side `js.gc.stream` cache to break the GC cycle. After that, the source body's `PendingValue` has `on_start_streaming = None` and `locked.readable = empty`.

The two-arg `new Request(req, init)` at `Request::construct_into` cloned the source body via `body_value_mut().clone(global_this)`, which is `Value::clone(None)` and does not consult the JS cache. `tee(None)` then sees an empty `locked.readable` and no `on_start_streaming`, falls through to the fresh-stream branch, creates a second disconnected ByteStream, and re-fires `on_readable_stream_available`. That overwrites `request_body_readable_stream_ref`, orphaning the first stream (and any reader of it). Release builds silently leaked the old strong ref; the Rust port downgraded the assert to `debug_assert!`, so on current main the symptom is a hung body read instead of a panic.

The `Response` branch of the constructor had the same shape.

## Fix

- `Request::construct_into`: route the body clone for both the `Request` and `Response` source branches through `clone_body_value_via_cached_stream`, the same helper `clone_into` (single-arg `new Request(req)` / `req.clone()`) already uses. That tees the existing cached readable instead of allocating a second underlying stream.
- `RequestContext::on_request_body_readable_stream_available`: if `request_body_buf` is non-empty when the callback fires (because `on_start_streaming` was already consumed on an earlier pass), flush those bytes into the incoming ByteStream before storing the ref so the streaming branch of `on_buffered_body_chunk` never observes a non-empty buffer. Also `deinit` any previous strong ref before overwriting so the GC handle is released. The `debug_assert!` is kept as a regression guard.

## Verification

Two new subprocess tests in `test/js/bun/http/serve.test.ts`:

- `req.clone() then new Request(req, init) with a buffered body does not crash`: the minimal repro above.
- `req.clone() then new Request(req, init) tees the in-flight server request body`: raw-socket client that sends the body in two writes, the second only after the handler has run both `clone()` and `new Request(req, init)`, and asserts both the clone and the wrapped copy see all 3000 bytes.

Both fail on the unfixed debug build with the `!request_body_readable_stream_ref.has()` panic (and the multi-chunk variant hangs on release); both pass with the fix. A third test in `test/js/web/request/request.test.ts` covers the client-side #28928 repro (hangs on main, passes with the fix). `body.test.ts`, `body-stream.test.ts`, `body-clone.test.ts`, and the rest of `request.test.ts` are unchanged.
