### PR TITLE
Fix Bun.Terminal termios flag NaN clamping

### DIFF
--- a/src/runtime/api/bun/Terminal.rs
+++ b/src/runtime/api/bun/Terminal.rs
@@ -1282,7 +1282,9 @@ impl Terminal {
                 return Ok(());
             };
             let max_val: f64 = libc::tcflag_t::MAX as f64;
-            let clamped = num.max(0.0).min(max_val);
+            // Match Zig's `@max(0, @min(num, max_val))`: apply min first so NaN
+            // resolves to max_val (f64::min returns the non-NaN operand), not 0.
+            let clamped = num.min(max_val).max(0.0);
             let bits = clamped as libc::tcflag_t;
             match FIELD {
                 TermiosField::Iflag => termios_data.c_iflag = bits,

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -381,6 +381,23 @@ describe("Bun.Terminal", () => {
       // Still 0
       expect(terminal.inputFlags).toBe(0);
     });
+
+    test.skipIf(isWindows)("NaN clamps to tcflag_t max, same as Infinity", async () => {
+      // Assigning NaN must clamp to the same value as Infinity (tcflag_t::MAX),
+      // matching the reference `@max(0, @min(num, max))` semantics. The kernel
+      // may mask some bits per field, so compare NaN against Infinity rather
+      // than a hard-coded constant.
+      await using terminal = new Bun.Terminal({ cols: 80, rows: 24 });
+
+      for (const prop of ["inputFlags", "outputFlags", "localFlags", "controlFlags"] as const) {
+        terminal[prop] = Infinity;
+        const fromInfinity = terminal[prop];
+        terminal[prop] = NaN;
+        const fromNaN = terminal[prop];
+        expect({ prop, fromNaN }).toEqual({ prop, fromNaN: fromInfinity });
+        expect(fromNaN).toBeGreaterThan(0);
+      }
+    });
   });
 
   describe("close", () => {


### PR DESCRIPTION
## Repro

```js
const t = new Bun.Terminal({ cols: 80, rows: 24 });
t.localFlags = NaN;
console.log(t.localFlags);
t.close();
```

Rust HEAD prints `0`; Zig 1.3.14 prints `tcflag_t::MAX` (`4294967295` on Linux, `18446744073709550000` on macOS).

## Cause

`set_termios_flag` in `src/runtime/api/bun/Terminal.rs` clamped with `num.max(0.0).min(max_val)`. Rust's `f64::max`/`f64::min` return the non-NaN operand, so `NaN.max(0.0)` yields `0.0` and all termios bits are cleared.

The Zig reference (`Terminal.zig:777`) evaluates `@max(0, @min(num, max_val))`. The inner `@min(NaN, max_val)` yields `max_val`, then `@max(0, max_val)` stays `max_val`, so all bits are set.

## Fix

Swap the order to `num.min(max_val).max(0.0)`, mirroring the Zig evaluation order. NaN now resolves to `max_val`; finite and infinite inputs are unchanged since min and max commute for non-NaN values already inside `[0, max_val]`.

## Verification

Added a test in `test/js/bun/terminal/terminal.test.ts` asserting that assigning `NaN` to each of `inputFlags`/`outputFlags`/`localFlags`/`controlFlags` reads back the same value as assigning `Infinity` (both clamp to `tcflag_t::MAX`, modulo kernel-enforced bits). Fails on main (`fromNaN: 0` vs `fromNaN: 2147483647`), passes with this change.