### PR TITLE
jsc: use 'property' wording in get_optional_slice type error

### DIFF
--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1210,7 +1210,7 @@ impl JSValue {
         match self.get(global, property)? {
             Some(v) if !v.is_undefined_or_null() => {
                 if !v.is_string() {
-                    return Err(global.throw_invalid_argument_type_value(property, b"string", v));
+                    return Err(global.throw_invalid_property_type(property, "string", v));
                 }
                 Ok(Some(v.to_slice(global)?))
             }

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -33,10 +33,7 @@ fn get_optional_slice(
     match target.get(global, property)? {
         Some(v) if !v.is_undefined_or_null() => {
             if !v.is_string() {
-                // SAFETY: `property` is a `&'static [u8]` literal supplied by
-                // the call-site (`b"algorithm"` etc.) — always ASCII.
-                let prop = unsafe { core::str::from_utf8_unchecked(property) };
-                return Err(global.throw_invalid_argument_type_value(prop, "string", v));
+                return Err(global.throw_invalid_property_type(property, "string", v));
             }
             Ok(Some(v.to_slice(global)?))
         }

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -23,24 +23,6 @@ fn algorithm_from_js_case_insensitive(
     Ok(evp::lookup_ignore_case(slice.slice()))
 }
 
-/// Local shim until `bun_jsc` grows a typed `get_optional`.
-/// Returns `None` for missing/null/undefined.
-fn get_optional_slice(
-    target: JSValue,
-    global: &JSGlobalObject,
-    property: &'static [u8],
-) -> JsResult<Option<ZigStringSlice>> {
-    match target.get(global, property)? {
-        Some(v) if !v.is_undefined_or_null() => {
-            if !v.is_string() {
-                return Err(global.throw_invalid_property_type(property, "string", v));
-            }
-            Ok(Some(v.to_slice(global)?))
-        }
-        _ => Ok(None),
-    }
-}
-
 /// Local shim: validates an integer in `[0, MAX_SAFE_INTEGER]`.
 /// `validateIntegerRange` is defined on the cfg-gated `JSGlobalObject` impl,
 /// so inline the minimal u64 path here.
@@ -106,7 +88,7 @@ pub(crate) fn csrf__generate(global: &JSGlobalObject, frame: &CallFrame) -> JsRe
         }
 
         // Extract sessionId (optional)
-        if let Some(session_id_slice) = get_optional_slice(options_value, global, b"sessionId")? {
+        if let Some(session_id_slice) = options_value.get_optional_slice(global, b"sessionId")? {
             if session_id_slice.slice().is_empty() {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "sessionId must be a non-empty string"
@@ -247,7 +229,7 @@ pub(crate) fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         let options_value = args[1];
 
         // Extract the secret (required)
-        if let Some(secret_slice) = get_optional_slice(options_value, global, b"secret")? {
+        if let Some(secret_slice) = options_value.get_optional_slice(global, b"secret")? {
             if secret_slice.slice().is_empty() {
                 return Err(global
                     .throw_invalid_arguments(format_args!("Secret must be a non-empty string")));
@@ -256,7 +238,7 @@ pub(crate) fn csrf__verify(global: &JSGlobalObject, frame: &CallFrame) -> JsResu
         }
 
         // Extract sessionId (optional)
-        if let Some(session_id_slice) = get_optional_slice(options_value, global, b"sessionId")? {
+        if let Some(session_id_slice) = options_value.get_optional_slice(global, b"sessionId")? {
             if session_id_slice.slice().is_empty() {
                 return Err(global.throw_invalid_arguments(format_args!(
                     "sessionId must be a non-empty string"

--- a/test/js/bun/terminal/terminal.test.ts
+++ b/test/js/bun/terminal/terminal.test.ts
@@ -100,6 +100,20 @@ describe("Bun.Terminal", () => {
       expect(() => new Bun.Terminal(1n as any)).toThrow();
       expect(() => new Bun.Terminal(Symbol() as any)).toThrow();
     });
+
+    test("throws ERR_INVALID_ARG_TYPE with 'property' wording when name is not a string", () => {
+      let caught: any;
+      try {
+        new Bun.Terminal({ name: 12345 as any });
+      } catch (e) {
+        caught = e;
+      }
+      expect({ code: caught?.code, name: caught?.name, message: caught?.message }).toEqual({
+        code: "ERR_INVALID_ARG_TYPE",
+        name: "TypeError",
+        message: 'The "name" property must be of type string, got number',
+      });
+    });
   });
 
   describe("write", () => {


### PR DESCRIPTION
## Repro

```js
try { new Bun.Terminal({ name: 12345 }) } catch (e) { console.log(e.message) }
```

Before:
```
The "name" argument must be of type string. Received type number (12345)
```

After (matches Zig 1.3.14):
```
The "name" property must be of type string, got number
```

## Cause

`JSValue::get_optional_slice` in `src/jsc/JSValue.rs` reads a property from an options object but called `throw_invalid_argument_type_value`, which produces the "argument ... Received" format. The Zig reference (`getOptional(... ZigString.Slice)` in `src/jsc/JSValue.zig`) routes through `jsc.Node.validators.throwErrInvalidArgType`, which produces the "property ... got" format.

This affects every caller of `get_optional_slice`: `Bun.Terminal` (`name`), `Bun.build` (`target`, `outdir`, `banner`, `footer`, `root`, `publicPath`, `naming.*`, `jsx.*`), `Bun.serve` static routes (`index`, `dir`), and `Bun.CSRF` (`sessionId`, `secret`).

## Fix

Route through `throw_invalid_property_type`, which already exists and is what `get_boolean_strict` uses for the identical situation. Also fixed the local `get_optional_slice` shim in `src/runtime/api/csrf_jsc.rs` which had the same bug.

## Verification

Added a test to `test/js/bun/terminal/terminal.test.ts` asserting the exact `{code, name, message}` shape.

```
$ bun bd test test/js/bun/terminal/terminal.test.ts
 88 pass
 1 todo
 0 fail

$ bun bd test test/js/bun/util/csrf.test.ts
 24 pass
 0 fail
```