### PR TITLE
websocket: keep receive buffer capacity across fragmented message dispatch

### DIFF
--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -493,7 +493,10 @@ impl<const SSL: bool> WebSocket<SSL> {
                         LinearFifo::<u8, DynamicBuffer<u8>>::init(),
                     );
                     self.dispatch_compressed_data(buf.readable_slice(0), kind);
-                    drop(buf);
+                    // Restore the taken fifo so `clear_receive_buffers(false)`
+                    // can keep its capacity for the next message instead of
+                    // starting from a fresh zero-capacity `init()`.
+                    self.receive_buffer = buf;
                     self.clear_receive_buffers(false);
                     self.receiving_compressed = false;
                     self.message_is_compressed = false;
@@ -523,7 +526,10 @@ impl<const SSL: bool> WebSocket<SSL> {
                     LinearFifo::<u8, DynamicBuffer<u8>>::init(),
                 );
                 self.dispatch_data(buf.readable_slice(0), kind);
-                drop(buf);
+                // Restore the taken fifo so `clear_receive_buffers(false)`
+                // can keep its capacity for the next message instead of
+                // starting from a fresh zero-capacity `init()`.
+                self.receive_buffer = buf;
                 self.clear_receive_buffers(false);
                 self.message_is_compressed = false;
                 return 0;
@@ -556,7 +562,10 @@ impl<const SSL: bool> WebSocket<SSL> {
                     LinearFifo::<u8, DynamicBuffer<u8>>::init(),
                 );
                 self.dispatch_data(buf.readable_slice(0), kind);
-                drop(buf);
+                // Restore the taken fifo so `clear_receive_buffers(false)`
+                // can keep its capacity for the next message instead of
+                // starting from a fresh zero-capacity `init()`.
+                self.receive_buffer = buf;
                 self.clear_receive_buffers(false);
                 self.message_is_compressed = false;
             }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -355,11 +355,16 @@ impl<const SSL: bool> WebSocket<SSL> {
     }
 
     fn clear_receive_buffers(&mut self, free: bool) {
-        // LinearFifo's
-        // fields are private so discard everything readable
-        // (empty, head realigned to 0).
+        // LinearFifo's fields are private. `discard` only advances
+        // `head` (it does not rewind it), so pair it with
+        // `reset_head_if_empty` to match the Zig `head = 0; count = 0`
+        // semantics. Without the rewind, `head` would walk forward across
+        // messages and eventually wrap the ring, and `readable_slice(0)`
+        // (used to dispatch buffered messages) returns only the first
+        // contiguous segment.
         self.receive_buffer
             .discard(self.receive_buffer.readable_length());
+        self.receive_buffer.reset_head_if_empty();
 
         if free {
             self.receive_buffer = LinearFifo::<u8, DynamicBuffer<u8>>::init();

--- a/test/js/web/websocket/websocket-pong-fragmented.test.ts
+++ b/test/js/web/websocket/websocket-pong-fragmented.test.ts
@@ -1,4 +1,5 @@
 import { TCPSocketListener } from "bun";
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 
 const hostname = "127.0.0.1";
@@ -58,6 +59,23 @@ function makeTextFrame(text: string): Uint8Array {
     header = new Uint8Array([0x81, len]);
   } else if (len < 65536) {
     header = new Uint8Array([0x81, 126, (len >> 8) & 0xff, len & 0xff]);
+  } else {
+    throw new Error("Message too large for this test");
+  }
+  const frame = new Uint8Array(header.length + len);
+  frame.set(header);
+  frame.set(payload, header.length);
+  return frame;
+}
+
+function makeBinaryFrame(payload: Uint8Array, { fin, opcode }: { fin: boolean; opcode: number }): Uint8Array {
+  const len = payload.length;
+  const b0 = (fin ? 0x80 : 0) | opcode;
+  let header: Uint8Array;
+  if (len < 126) {
+    header = new Uint8Array([b0, len]);
+  } else if (len < 65536) {
+    header = new Uint8Array([b0, 126, (len >> 8) & 0xff, len & 0xff]);
   } else {
     throw new Error("Message too large for this test");
   }
@@ -214,6 +232,116 @@ describe("WebSocket", () => {
       });
 
       await promise;
+    } finally {
+      client?.close();
+      server?.stop(true);
+    }
+  });
+
+  test("fragmented binary message keeps receive buffer capacity", async () => {
+    // The client pre-allocates a receive buffer at connect time. Dispatching a
+    // message assembled from multiple fragments must not discard that
+    // allocation; the next fragmented message should reuse it instead of
+    // reallocating from zero. The reported memory cost of the WebSocket
+    // (via estimateShallowMemoryUsageOf) includes that buffer's capacity.
+    let server: TCPSocketListener | undefined;
+    let client: WebSocket | undefined;
+    let handshakeBuffer = new Uint8Array(0);
+    let handshakeComplete = false;
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        baseline: number;
+        after: number;
+        fragmented: Uint8Array;
+      }>();
+
+      server = Bun.listen({
+        socket: {
+          data(socket, data) {
+            if (handshakeComplete) return;
+
+            const result = doHandshake(socket, handshakeBuffer, new Uint8Array(data));
+            handshakeBuffer = result.buffer;
+            if (!result.done) return;
+
+            handshakeComplete = true;
+
+            // Three messages in one write so the client parses them in a
+            // single handle_data pass (no timing dependence):
+            //  1) single-frame binary "A"  -> fast path; baseline measured here
+            //  2) two-fragment binary 100B -> buffered in receive_buffer,
+            //     dispatched from the buffer
+            //  3) single-frame binary "Z"  -> fast path; measured again here
+            const msg1 = makeBinaryFrame(Uint8Array.of(0x41), { fin: true, opcode: 0x2 });
+            const frag = new Uint8Array(50);
+            for (let i = 0; i < frag.length; i++) frag[i] = i & 0xff;
+            const msg2a = makeBinaryFrame(frag, { fin: false, opcode: 0x2 });
+            const msg2b = makeBinaryFrame(frag, { fin: true, opcode: 0x0 });
+            const msg3 = makeBinaryFrame(Uint8Array.of(0x5a), { fin: true, opcode: 0x2 });
+
+            const all = new Uint8Array(msg1.length + msg2a.length + msg2b.length + msg3.length);
+            let off = 0;
+            for (const part of [msg1, msg2a, msg2b, msg3]) {
+              all.set(part, off);
+              off += part.length;
+            }
+            socket.write(all);
+            socket.flush();
+          },
+          error(_socket, err) {
+            reject(err);
+          },
+        },
+        hostname,
+        port: 0,
+      });
+
+      client = new WebSocket(`ws://${server.hostname}:${server.port}`);
+      const ws = client;
+      ws.binaryType = "arraybuffer";
+
+      let baseline = 0;
+      let fragmented: Uint8Array | undefined;
+      let received = 0;
+
+      ws.addEventListener("error", () => reject(new Error("WebSocket error")));
+      ws.addEventListener("close", ev => {
+        reject(new Error(`WebSocket closed unexpectedly: code=${ev.code} reason=${ev.reason}`));
+      });
+      ws.addEventListener("message", ev => {
+        received++;
+        const bytes = new Uint8Array(ev.data as ArrayBuffer);
+        if (received === 1) {
+          // fast-path dispatch; receive_buffer is untouched and still holds
+          // its initial pre-allocated capacity
+          baseline = estimateShallowMemoryUsageOf(ws);
+        } else if (received === 2) {
+          fragmented = bytes;
+        } else if (received === 3) {
+          // fast-path dispatch again; receive_buffer should still hold the
+          // capacity it had before the fragmented message
+          const after = estimateShallowMemoryUsageOf(ws);
+          resolve({ baseline, after, fragmented: fragmented! });
+        }
+      });
+
+      const { baseline: base, after, fragmented: reassembled } = await promise;
+
+      // Sanity: the fragmented message was reassembled correctly.
+      const expected = new Uint8Array(100);
+      for (let i = 0; i < 50; i++) {
+        expected[i] = i & 0xff;
+        expected[50 + i] = i & 0xff;
+      }
+      expect(reassembled).toEqual(expected);
+
+      // The receive buffer's pre-allocated capacity must survive the
+      // fragmented dispatch. estimateShallowMemoryUsageOf includes
+      // receive_buffer.capacity(); if the buffer was dropped and replaced
+      // with a fresh empty fifo, this drops by the pre-allocated amount.
+      expect(base).toBeGreaterThan(0);
+      expect(after).toBeGreaterThanOrEqual(base);
     } finally {
       client?.close();
       server?.stop(true);

--- a/test/js/web/websocket/websocket-pong-fragmented.test.ts
+++ b/test/js/web/websocket/websocket-pong-fragmented.test.ts
@@ -347,4 +347,93 @@ describe("WebSocket", () => {
       server?.stop(true);
     }
   });
+
+  test("many fragmented binary messages reassemble without truncation", async () => {
+    // The receive buffer is a ring. Clearing it between messages must rewind
+    // head to 0; if head only advances, a later message can wrap the ring
+    // and readable_slice(0) would hand dispatch only the first contiguous
+    // segment. The client pre-allocates 2048 bytes, so two 1000-byte
+    // fragmented messages advance head to 2000, and a third message split as
+    // 48 + 52 bytes writes across the wrap boundary.
+    let server: TCPSocketListener | undefined;
+    let client: WebSocket | undefined;
+    let handshakeBuffer = new Uint8Array(0);
+    let handshakeComplete = false;
+
+    const fill = (n: number, base: number) => {
+      const b = new Uint8Array(n);
+      for (let i = 0; i < n; i++) b[i] = (base + i) & 0xff;
+      return b;
+    };
+
+    const expected: Uint8Array[] = [
+      new Uint8Array([...fill(500, 0), ...fill(500, 1)]),
+      new Uint8Array([...fill(500, 2), ...fill(500, 3)]),
+      new Uint8Array([...fill(48, 4), ...fill(52, 5)]),
+    ];
+
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<Uint8Array[]>();
+
+      server = Bun.listen({
+        socket: {
+          data(socket, data) {
+            if (handshakeComplete) return;
+
+            const result = doHandshake(socket, handshakeBuffer, new Uint8Array(data));
+            handshakeBuffer = result.buffer;
+            if (!result.done) return;
+
+            handshakeComplete = true;
+
+            const frames = [
+              makeBinaryFrame(fill(500, 0), { fin: false, opcode: 0x2 }),
+              makeBinaryFrame(fill(500, 1), { fin: true, opcode: 0x0 }),
+              makeBinaryFrame(fill(500, 2), { fin: false, opcode: 0x2 }),
+              makeBinaryFrame(fill(500, 3), { fin: true, opcode: 0x0 }),
+              makeBinaryFrame(fill(48, 4), { fin: false, opcode: 0x2 }),
+              makeBinaryFrame(fill(52, 5), { fin: true, opcode: 0x0 }),
+            ];
+            const total = frames.reduce((n, f) => n + f.length, 0);
+            const all = new Uint8Array(total);
+            let off = 0;
+            for (const f of frames) {
+              all.set(f, off);
+              off += f.length;
+            }
+            socket.write(all);
+            socket.flush();
+          },
+          error(_socket, err) {
+            reject(err);
+          },
+        },
+        hostname,
+        port: 0,
+      });
+
+      client = new WebSocket(`ws://${server.hostname}:${server.port}`);
+      const ws = client;
+      ws.binaryType = "arraybuffer";
+
+      const received: Uint8Array[] = [];
+      ws.addEventListener("error", () => reject(new Error("WebSocket error")));
+      ws.addEventListener("close", ev => {
+        reject(new Error(`WebSocket closed unexpectedly: code=${ev.code} reason=${ev.reason}`));
+      });
+      ws.addEventListener("message", ev => {
+        received.push(new Uint8Array(ev.data as ArrayBuffer));
+        if (received.length === expected.length) resolve(received);
+      });
+
+      const got = await promise;
+      expect(got.map(b => b.length)).toEqual(expected.map(b => b.length));
+      for (let i = 0; i < expected.length; i++) {
+        expect(got[i]).toEqual(expected[i]);
+      }
+    } finally {
+      client?.close();
+      server?.stop(true);
+    }
+  });
 });


### PR DESCRIPTION
### Problem

The Rust port of `WebSocket::consume()` needs to pass `receive_buffer.readable_slice(0)` into `dispatch_data(&mut self, ...)`. To avoid aliasing `&mut self`, it `mem::replace`s the receive buffer with a fresh `LinearFifo::init()` (capacity 0), dispatches from the taken buffer, then `drop`s it. The following `clear_receive_buffers(false)` runs against the empty placeholder and is a no-op.

Result: after every multi-fragment or multi-chunk message, the 2048-byte preallocation from `init()` is freed and the next buffered message reallocates from zero via `writable_with_size()`. The Zig reference (`websocket_client.zig:374-381`) dispatches in place and only resets `head`/`count`, keeping the allocation for reuse. Correctness is unaffected; this is a per-message alloc/free that the original semantics avoided.

### Fix

Move the taken fifo back into `self.receive_buffer` after dispatch instead of dropping it, then let `clear_receive_buffers(false)` discard the readable contents while keeping capacity. This is the same restore pattern `send_buffer_out()` already uses for the send buffer at `websocket_client.rs:1274`. Applied to all three dispatch sites in `consume()`:

- uncompressed, buffered final chunk
- uncompressed, empty final fragment with buffered data
- compressed, final fragment

If `terminate` fires inside dispatch (clearing the placeholder via `clear_data`), the restored empty-but-allocated buffer is released with the rest of the struct shortly after.

`clear_receive_buffers` additionally now calls `reset_head_if_empty()` after `discard`. `discard` advances `head` rather than rewinding it, so once the fifo is reused across messages `head` would otherwise walk forward until a message wraps the ring, at which point `readable_slice(0)` returns only the first contiguous segment and dispatch receives a truncated payload. The Zig reference sets `head = 0` directly; `reset_head_if_empty()` restores that invariant.

### Test

`test/js/web/websocket/websocket-pong-fragmented.test.ts` gains two cases driven by a raw TCP server.

**Capacity retention**: sends, in a single write, a single-frame binary message (fast path; baseline `estimateShallowMemoryUsageOf(ws)` captured), a two-fragment binary message (buffered and dispatched from `receive_buffer`), and another single-frame binary message (fast path; sampled again). `memory_cost()` includes `receive_buffer.capacity()`, so on the unfixed build the third sample reports 2048 bytes less than the first:

```
Expected: >= 4701
Received: 2653
```

**Ring wrap**: two 1000-byte fragmented messages walk `head` to 2000 in the 2048-byte ring, then a 100-byte message split 48+52 writes across the wrap boundary. Without the `reset_head_if_empty()` call the third message arrives as 48 bytes:

```
  [
    1000,
    1000,
-   100,
+   48,
  ]
```

With both fixes, capacity is retained (`after >= baseline`) and all fragmented payloads reassemble correctly. Existing fragmented-frame and permessage-deflate tests continue to pass.
