### PR TITLE
tls: remove native hostname check from on_handshake to restore Node compat

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -383,16 +383,15 @@ const SocketHandlers: SocketHandler = {
       // will be handled in onConnectEnd
       return;
     }
-    // The second argument is "authorized" (handshake + verification +
-    // hostname), matching the public Bun.connect handshake callback. node:tls
-    // decides what to do with verification results in JS via the
-    // rejectUnauthorized / checkServerIdentity handling below, so a
-    // verification-class result (an X509 code such as
-    // UNABLE_TO_VERIFY_LEAF_SIGNATURE, or the native hostname verdict) still
-    // means the TLS session itself was established. Only a fatal TLS protocol
-    // failure tears the socket down here: those arrive as EPROTO carrying the
-    // OpenSSL "error:...:SSL routines:..." reason (or an already decomposed
-    // ERR_SSL_* / ERR_OSSL_* code).
+    // The second argument is "authorized" (handshake + chain verification),
+    // matching the public Bun.connect handshake callback. node:tls decides
+    // what to do with verification results in JS via the rejectUnauthorized /
+    // checkServerIdentity handling below, so a verification-class result (an
+    // X509 code such as UNABLE_TO_VERIFY_LEAF_SIGNATURE) still means the TLS
+    // session itself was established. Only a fatal TLS protocol failure tears
+    // the socket down here: those arrive as EPROTO carrying the OpenSSL
+    // "error:...:SSL routines:..." reason (or an already decomposed ERR_SSL_*
+    // / ERR_OSSL_* code).
     const isProtocolFailure =
       !success &&
       verifyError?.code != null &&
@@ -407,9 +406,7 @@ const SocketHandlers: SocketHandler = {
     self._securePending = false;
     self.secureConnecting = false;
     // ECONNRESET and protocol-level failures returned above, so reaching here
-    // means the TLS session itself was established - even when `success`
-    // (authorized) is false purely because of the native hostname verdict,
-    // which arrives with no error object.
+    // means the TLS session itself was established.
     self._secureEstablished = true;
 
     self.emit("secure", self);
@@ -1119,16 +1116,15 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
       // will be handled in onConnectEnd
       return;
     }
-    // The second argument is "authorized" (handshake + verification +
-    // hostname), matching the public Bun.connect handshake callback. node:tls
-    // decides what to do with verification results in JS via the
-    // rejectUnauthorized / checkServerIdentity handling below, so a
-    // verification-class result (an X509 code such as
-    // UNABLE_TO_VERIFY_LEAF_SIGNATURE, or the native hostname verdict) still
-    // means the TLS session itself was established. Only a fatal TLS protocol
-    // failure tears the socket down here: those arrive as EPROTO carrying the
-    // OpenSSL "error:...:SSL routines:..." reason (or an already decomposed
-    // ERR_SSL_* / ERR_OSSL_* code).
+    // The second argument is "authorized" (handshake + chain verification),
+    // matching the public Bun.connect handshake callback. node:tls decides
+    // what to do with verification results in JS via the rejectUnauthorized /
+    // checkServerIdentity handling below, so a verification-class result (an
+    // X509 code such as UNABLE_TO_VERIFY_LEAF_SIGNATURE) still means the TLS
+    // session itself was established. Only a fatal TLS protocol failure tears
+    // the socket down here: those arrive as EPROTO carrying the OpenSSL
+    // "error:...:SSL routines:..." reason (or an already decomposed ERR_SSL_*
+    // / ERR_OSSL_* code).
     const isProtocolFailure =
       !success &&
       verifyError?.code != null &&
@@ -1143,9 +1139,7 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     self._securePending = false;
     self.secureConnecting = false;
     // ECONNRESET and protocol-level failures returned above, so reaching here
-    // means the TLS session itself was established - even when `success`
-    // (authorized) is false purely because of the native hostname verdict,
-    // which arrives with no error object.
+    // means the TLS session itself was established.
     self._secureEstablished = true;
 
     self.emit("secure", self);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1627,36 +1627,9 @@ impl<const SSL: bool> NewSocket<SSL> {
             success
         );
 
-        let mut authorized = success == 1;
-        let mut hostname_mismatch = false;
+        let authorized = success == 1;
 
-        if SSL && authorized && !handlers.mode.is_server() {
-            if let Some(ssl_ptr) = this.socket.get().ssl() {
-                let hostname: &[u8] = if let Some(server_name) = this.server_name.get() {
-                    &server_name[..]
-                } else if let Some(super::listener::UnixOrHost::Host { host, .. }) =
-                    this.connection.get()
-                {
-                    &host[..]
-                } else {
-                    b""
-                };
-                if !hostname.is_empty()
-                    && !bun_boringssl::check_server_identity(
-                        boringssl_sys::SSL::opaque_mut(ssl_ptr),
-                        hostname,
-                    )
-                {
-                    authorized = false;
-                    hostname_mismatch = true;
-                }
-            }
-        }
-
-        this.update_flags(|f| {
-            f.set(Flags::AUTHORIZED, authorized);
-            f.set(Flags::HOSTNAME_MISMATCH, hostname_mismatch);
-        });
+        this.update_flags(|f| f.set(Flags::AUTHORIZED, authorized));
 
         let mut callback = handlers.on_handshake();
         let mut is_open = false;
@@ -2083,19 +2056,6 @@ impl<const SSL: bool> NewSocket<SSL> {
         // is very usefull to have this feature depending on the user workflow
         let ssl_error = this.socket.get().get_verify_error();
         if ssl_error.error_no == 0 {
-            if this.flags.get().contains(Flags::HOSTNAME_MISMATCH) {
-                let mismatch = SystemError {
-                    errno: 0,
-                    code: BunString::clone_utf8(b"HOSTNAME_MISMATCH"),
-                    message: BunString::clone_utf8(b"Hostname mismatch"),
-                    path: BunString::EMPTY,
-                    syscall: BunString::EMPTY,
-                    hostname: BunString::EMPTY,
-                    fd: c_int::MIN,
-                    dest: BunString::EMPTY,
-                };
-                return Ok(mismatch.to_error_instance(global));
-            }
             return Ok(JSValue::NULL);
         }
 
@@ -3831,7 +3791,6 @@ bitflags::bitflags! {
         /// `us_socket_raw_write` (bypassing the SSL layer) so node:net can pipe
         /// pre-handshake bytes / read the underlying TCP stream.
         const BYPASS_TLS           = 1 << 9;
-        const HOSTNAME_MISMATCH    = 1 << 11;
     }
 }
 

--- a/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
+++ b/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
@@ -103,16 +103,57 @@ describe("tls.connect hostname verification without explicit servername", () => 
       assert.strictEqual(await promise, "localhost");
     });
   });
+
+  // The native handshake reports only the cert-chain result; hostname
+  // verification is checkServerIdentity's job. A user-supplied override that
+  // accepts the mismatch must result in an authorized, secure-established
+  // socket, matching Node.
+  test("user checkServerIdentity that accepts a mismatch yields _secureEstablished=true, authorized=true", async () => {
+    await withServer(async port => {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        _secureEstablished: boolean;
+        authorized: boolean;
+        authorizationError: unknown;
+      }>();
+      const socket = tls.connect({
+        host: "localhost",
+        port,
+        ca,
+        rejectUnauthorized: true,
+        checkServerIdentity: () => undefined,
+      });
+      socket.on("secureConnect", () => {
+        resolve({
+          _secureEstablished: socket._secureEstablished,
+          authorized: socket.authorized,
+          authorizationError: socket.authorizationError,
+        });
+        socket.destroy();
+      });
+      socket.on("error", err => {
+        socket.destroy();
+        reject(err);
+      });
+      const result = await promise;
+      assert.deepStrictEqual(
+        { _secureEstablished: result._secureEstablished, authorized: result.authorized },
+        { _secureEstablished: true, authorized: true },
+      );
+      assert.ok(result.authorizationError == null, `authorizationError should be unset, got ${result.authorizationError}`);
+    });
+  });
 });
 
-describe("Bun.connect TLS hostname verification", () => {
+describe("Bun.connect TLS handshake reports chain verification only", () => {
   // The server presents the agent1 cert (CN=agent1, no SAN) signed by ca1.
-  // A client that trusts ca1 and connects to "localhost" passes chain
-  // validation, but the certificate is not valid for "localhost", so the
-  // socket must not be reported as authorized.
-  test("reports authorized=false when a CA-trusted cert does not match the connected hostname", async () => {
+  // The native handshake result reflects the BoringSSL cert-chain verify
+  // only; hostname verification is left to the caller (node:tls does it via
+  // checkServerIdentity). So a CA-trusted cert whose CN/SAN does not match
+  // the connected hostname still reports success=true / authorized=true, and
+  // getAuthorizationError() is null.
+  test("hostname mismatch with a CA-trusted cert still reports success=true, authorized=true", async () => {
     const listener = Bun.listen({
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: 0,
       tls: { key: serverKey, cert: serverCert },
       socket: {
@@ -124,16 +165,26 @@ describe("Bun.connect TLS hostname verification", () => {
       },
     });
     try {
-      // Mismatch: connect host "localhost" vs cert CN "agent1".
-      const mismatch = Promise.withResolvers<{ flag: boolean; arg: boolean; error: NodeJS.ErrnoException | null }>();
+      // Mismatch: serverName "localhost" vs cert CN "agent1".
+      const mismatch = Promise.withResolvers<{
+        success: boolean;
+        authorized: boolean;
+        authorizationError: NodeJS.ErrnoException | null;
+        verifyError: unknown;
+      }>();
       const badSocket = await Bun.connect({
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: listener.port,
-        tls: { ca },
+        tls: { ca, serverName: "localhost" },
         socket: {
           open() {},
-          handshake(s, success) {
-            mismatch.resolve({ flag: s.authorized, arg: success, error: s.getAuthorizationError() });
+          handshake(s, success, verifyError) {
+            mismatch.resolve({
+              success,
+              authorized: s.authorized,
+              authorizationError: s.getAuthorizationError(),
+              verifyError,
+            });
             s.end();
           },
           data() {},
@@ -149,16 +200,18 @@ describe("Bun.connect TLS hostname verification", () => {
       });
       const result = await mismatch.promise;
       badSocket.end();
-      assert.strictEqual(result.arg, false, "handshake callback must not report success for a hostname mismatch");
-      assert.strictEqual(result.flag, false, "socket.authorized must be false for a hostname mismatch");
-      assert.ok(result.error, "getAuthorizationError() must report why the socket is not authorized");
-      assert.strictEqual(result.error.code, "HOSTNAME_MISMATCH");
+      assert.deepStrictEqual(result, {
+        success: true,
+        authorized: true,
+        authorizationError: null,
+        verifyError: null,
+      });
 
-      // Legitimate case: same cert, but the client asks for server name
-      // "agent1", which matches the certificate. Must remain authorized.
+      // Same cert with serverName "agent1" (matches CN). Must also be
+      // authorized.
       const match = Promise.withResolvers<boolean>();
       const goodSocket = await Bun.connect({
-        hostname: "localhost",
+        hostname: "127.0.0.1",
         port: listener.port,
         tls: { ca, serverName: "agent1" },
         socket: {

--- a/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
+++ b/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
@@ -175,7 +175,7 @@ describe("Bun.connect TLS handshake reports chain verification only", () => {
         authorizationError: NodeJS.ErrnoException | null;
         verifyError: unknown;
       }>();
-      const badSocket = await Bun.connect({
+      const socket = await Bun.connect({
         hostname: "127.0.0.1",
         port: listener.port,
         tls: { ca, serverName: "localhost" },
@@ -202,41 +202,13 @@ describe("Bun.connect TLS handshake reports chain verification only", () => {
         },
       });
       const result = await mismatch.promise;
-      badSocket.end();
+      socket.end();
       assert.deepStrictEqual(result, {
         success: true,
         authorized: true,
         authorizationError: null,
         verifyError: null,
       });
-
-      // Same cert with serverName "agent1" (matches CN). Must also be
-      // authorized.
-      const match = Promise.withResolvers<boolean>();
-      const goodSocket = await Bun.connect({
-        hostname: "127.0.0.1",
-        port: listener.port,
-        tls: { ca, serverName: "agent1" },
-        socket: {
-          open() {},
-          handshake(s) {
-            match.resolve(s.authorized);
-            s.end();
-          },
-          data() {},
-          drain() {},
-          close() {},
-          error(_s, err) {
-            match.reject(err);
-          },
-          connectError(_s, err) {
-            match.reject(err);
-          },
-        },
-      });
-      const okAuthorized = await match.promise;
-      goodSocket.end();
-      assert.strictEqual(okAuthorized, true, "a certificate matching the requested server name must stay authorized");
     } finally {
       listener.stop(true);
     }

--- a/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
+++ b/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
@@ -139,7 +139,10 @@ describe("tls.connect hostname verification without explicit servername", () => 
         { _secureEstablished: result._secureEstablished, authorized: result.authorized },
         { _secureEstablished: true, authorized: true },
       );
-      assert.ok(result.authorizationError == null, `authorizationError should be unset, got ${result.authorizationError}`);
+      assert.ok(
+        result.authorizationError == null,
+        `authorizationError should be unset, got ${result.authorizationError}`,
+      );
     });
   });
 });


### PR DESCRIPTION
### Repro

Local server presents a cert for `CN=agent1` signed by `ca1`. Client trusts `ca1` and connects with a servername that does not match the cert.

For `Bun.connect` with `tls: { ca, serverName: "localhost" }`:

| | handshake `success` | `socket.authorized` | `getAuthorizationError()` |
|---|---|---|---|
| Bun 1.3.14 (Zig) | `true` | `true` | `null` |
| Bun main | **`false`** | **`false`** | **`{ code: "HOSTNAME_MISMATCH" }`** |

For `tls.connect` with `checkServerIdentity: () => undefined` (user override that accepts):

| | `_secureEstablished` | `authorized` |
|---|---|---|
| Node | `true` | `true` |
| Bun 1.3.14 (Zig) | `true` | `true` |
| Bun main | `true` (since #31155) | `true` |

#31155 already worked around the `_secureEstablished` side in `net.ts` by hardcoding it to `true` with a comment referencing "the native hostname verdict"; this PR removes the native verdict itself and drops that now-stale comment.

### Cause

The Rust `on_handshake` (`src/runtime/socket/socket_body.rs`) gained a `bun_boringssl::check_server_identity()` call in #31339 that the Zig reference (`socket.zig` `onHandshake`) never had. When the cert chain verifies but the peer cert's SAN/CN does not cover the connect hostname/servername, this flipped `authorized` to `false`, set a `HOSTNAME_MISMATCH` flag, and passed `success=false` to the JS handshake callback.

Hostname verification for `node:tls` is already performed in the JS layer (`src/js/node/net.ts` handshake handlers) via the user-overridable `checkServerIdentity` callback, which produces the Node-standard `ERR_TLS_CERT_ALTNAME_INVALID`. The native double-check means:

- `Bun.connect` `socket.authorized` is `false` where the Zig reference returned `true`
- `socket.getAuthorizationError()` returns an Error with the non-Node code `HOSTNAME_MISMATCH` instead of `null`
- the handshake callback receives `success=false`, so any consumer reading it (including the pre-#31155 `node:tls`) sees the session as not established

### Fix

Revert `on_handshake` and `get_authorization_error` to match the Zig reference (`authorized = success == 1`, no hostname check), drop the `HOSTNAME_MISMATCH` flag, and replace the `Bun.connect` test added in #31339 that locked in the divergent behavior with one asserting the Zig/Node semantics. Drop the stale "native hostname verdict" reference from the two `net.ts` client handshake comments.

### Verification

`test/js/node/tls/node-tls-connect-hostname-verification.test.ts`:
- new `user checkServerIdentity that accepts a mismatch yields _secureEstablished=true, authorized=true` (verified to pass under Node)
- rewritten `Bun.connect TLS handshake reports chain verification only` asserting `{success: true, authorized: true, authorizationError: null, verifyError: null}` on hostname mismatch with a CA-trusted cert

With `src/` at `origin/main`: 5 pass / 1 fail (the Bun.connect test). With the fix: 6 pass / 0 fail. The four pre-existing tests in the file, which cover the JS-side `checkServerIdentity` producing `ERR_TLS_CERT_ALTNAME_INVALID`, still pass.

### Rebase note

Conflicted with #31859 in the `Flags` bitflags block (that PR removed `OWNS_HANDLERS` at bit 10, this one removes `HOSTNAME_MISMATCH` at bit 11); resolution keeps neither.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect-hostname-verification.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5e4bcea91)

test/js/node/tls/node-tls-connect-hostname-verification.test.ts:
(pass) tls.connect hostname verification without explicit servername > rejects an IP address as options.servername [75.26ms]
(pass) tls.connect hostname verification without explicit servername > rejects a CA-trusted cert whose CN does not match host [625.39ms]
(pass) tls.connect hostname verification without explicit servername > reports authorized=false on hostname mismatch with rejectUnauthorized=false [306.44ms]
(pass) tls.connect hostname verification without explicit servername > invokes checkServerIdentity with host when servername is omitted [120.68ms]
(pass) tls.connect hostname verification without explicit servername
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (0c95909f4)

test/js/node/tls/node-tls-connect-hostname-verification.test.ts:
(pass) tls.connect hostname verification without explicit servername > rejects an IP address as options.servername [2.29ms]
(pass) tls.connect hostname verification without explicit servername > rejects a CA-trusted cert whose CN does not match host [29.78ms]
(pass) tls.connect hostname verification without explicit servername > reports authorized=false on hostname mismatch with rejectUnauthorized=false [7.96ms]
(pass) tls.connect hostname verification without explicit servername > invokes checkServerIdentity with host when servername is omitted [5.09ms]
(pass) tls.connect hostname verification without explicit servername > user checkServerIdentity that accepts a mismatch yields _secureEstablished=true, authorized=true [22.10ms]
(pass) Bun.connect TLS handshake reports chain verification only > hostname mismatch with a CA-trusted cert still reports success=true, authorized=true [9.98ms]

 6 pass
 0 fail
Ran 6 tests across 1 file. [442.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-connect-hostname-verification.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (5e4bcea91)

test/js/node/tls/node-tls-connect-hostname-verification.test.ts:
(pass) tls.connect hostname verification without explicit servername > rejects an IP address as options.servername [78.81ms]
(pass) tls.connect hostname verification without explicit servername > rejects a CA-trusted cert whose CN does not match host [687.21ms]
(pass) tls.connect hostname verification without explicit servername > reports authorized=false on hostname mismatch with rejectUnauthorized=false [172.00ms]
(pass) tls.connect hostname verification without explicit servername > invokes checkServerIdentity with host when servername is omitted [103.89ms]
(pass) tls.connect hostname verification without explicit servername
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 841ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/23] gen generated_host_exports.rs
generated_host_exports.rs: 90 exports (host=3, lazy=10, generic=77, rust=0); 254 extern-C blocks audited
[2/23] gen cpp.rs (cppbind)
[3/23] gen JS modules (bundle-modules)
Preprocess modules (7056ms)
Bundle modules (65ms)
Postprocesss modules (22ms)
Bundle Functions (889ms)
Generate Code (123ms)

[8.17s] Bundled "src/js" for production
  1888 kb
  161 internal modules
  12 native modules
  90 internal functions across 19 files
[3/8] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                                 |  46 ++++----
 src/runtime/socket/socket_body.rs                  |  45 +-------
 .../node-tls-connect-hostname-verification.test.ts | 118 +++++++++++++--------
 3 files changed, 95 insertions(+), 114 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/js/node/net.ts                                            6      3     13
src/runtime/socket/socket_body.rs                             7      6     12
…node/tls/node-tls-connect-hostname-verification.test.ts      3      4     12
```

</details>

<!-- robobun:evidence:end -->