### PR TITLE
console.timeEnd(""): remove doubled trailing newline

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6007,7 +6007,7 @@ pub extern "C" fn Bun__ConsoleObject__timeEnd(
         (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
     );
     match len {
-        0 => Output::print_errorln(format_args!("\n")),
+        0 => Output::print_errorln(format_args!("")),
         _ => Output::print_errorln(format_args!(" {}", bstr::BStr::new(slice))),
     }
 

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1469,7 +1469,7 @@ impl CreateCommand {
             bun_core::pretty!("<r>\n");
             Output::flush();
             scopeguard::defer! {
-                Output::print_errorln("\n");
+                Output::print_errorln("");
                 Output::print_start_end(start_time, bun_core::time::nano_timestamp());
                 bun_core::pretty_error!(
                     " <r><d>{} install<r>\n",

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -2,6 +2,33 @@ import { file, spawn } from "bun";
 import { expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
+
+it("console.timeEnd with empty label emits exactly one trailing newline", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time(""); console.timeEnd("");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\]\n$/);
+  expect(exitCode).toBe(0);
+});
+
+it("console.timeEnd with non-empty label emits exactly one trailing newline", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time("abc"); console.timeEnd("abc");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stdout).toBe("");
+  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\] abc\n$/);
+  expect(exitCode).toBe(0);
+});
+
 it("should log to console correctly", async () => {
   const { stderr, exited } = spawn({
     cmd: [bunExe(), join(import.meta.dir, "console-timeLog.js")],

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -3,7 +3,7 @@ import { expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { join } from "node:path";
 
-it("console.timeEnd with empty label emits exactly one trailing newline", async () => {
+it.concurrent("console.timeEnd with empty label emits exactly one trailing newline", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `console.time(""); console.timeEnd("");`],
     env: bunEnv,
@@ -16,7 +16,7 @@ it("console.timeEnd with empty label emits exactly one trailing newline", async 
   expect(exitCode).toBe(0);
 });
 
-it("console.timeEnd with non-empty label emits exactly one trailing newline", async () => {
+it.concurrent("console.timeEnd with non-empty label emits exactly one trailing newline", async () => {
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", `console.time("abc"); console.timeEnd("abc");`],
     env: bunEnv,


### PR DESCRIPTION
## Repro

```console
$ bun -e 'console.time(""); console.timeEnd(""); process.stderr.write("MARKER");' 2>&1 | od -c
0000000   [   0   .   0   0   m   s   ]  \n  \n   M   A   R   K   E   R
```

The empty-label `console.timeEnd("")` writes two trailing newlines instead of one.

## Cause

Zig's `Output.printErrorln(fmt, args)` inspects the comptime `fmt` and only appends `\n` when the template does not already end in one (`src/bun_core/output.zig:1096`). The Rust function-form `Output::print_errorln(args)` cannot inspect its argument and unconditionally appends `\n`; its doc comment explicitly warns callers not to pass a template that already ends in `\n`.

`Bun__ConsoleObject__timeEnd` in `src/jsc/ConsoleObject.rs` was ported verbatim from the Zig and passes `format_args!("\n")` for the empty-label branch, producing `\n\n`. The Zig original (`src/jsc/ConsoleObject.zig:3665`) emits a single `\n`.

## Fix

Pass an empty template instead; `print_errorln` appends the newline.

The same port pattern appears once more in `src/runtime/cli/create_command.rs:1472` (spacing after the npm install step in `bun create`), where the Zig reference likewise emits a single newline; fixed in the same way.

## Verification

New tests in `test/js/web/console/console-timeLog.test.ts` assert the exact stderr shape for `console.timeEnd("")` and `console.timeEnd("abc")`:

- `USE_SYSTEM_BUN=1 bun test` → empty-label case fails (`Received: "[0.00ms]\n\n"`)
- `bun bd test` → 3 pass

```console
$ ./build/debug/bun-debug -e 'console.time(""); console.timeEnd(""); process.stderr.write("MARKER");' 2>&1 | od -c
0000000   [   0   .   0   4   m   s   ]  \n   M   A   R   K   E   R
```