### PR TITLE
Bun.embeddedFiles: borrow embedded bytes instead of heap-copying

### DIFF
--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -1990,6 +1990,7 @@ pub(crate) fn get_terminal_constructor(global_this: &JSGlobalObject, _: &JSObjec
 }
 
 pub(crate) fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {
+    use crate::api::standalone_graph_jsc::FileJsc as _;
     use crate::webcore::blob::{Blob, BlobExt as _};
     use bun_standalone_graph::{File as GraphFile, Graph as StandaloneModuleGraph};
     // SAFETY: bun_vm() returns the live thread-local VM for a Bun-owned global.
@@ -2037,54 +2038,19 @@ pub(crate) fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> 
     for (i, index) in sort_indices.iter().enumerate() {
         let file: &mut GraphFile = &mut unsorted_files[*index as usize];
         // NOTE (layering): the crate defining `StandaloneModuleGraph.File`
-        // can't depend on `bun_runtime::webcore::Blob`, so build the blob
-        // here from the file's `cached_blob` slot / contents.
-        let input_blob: *mut Blob = standalone_file_blob(file, global_this);
+        // can't depend on `bun_runtime::webcore::Blob`, so the blob is built
+        // via the `FileJsc` extension trait, which borrows the embedded
+        // `'static` section bytes zero-copy and caches the result.
+        let input_blob: &mut Blob = file.file_blob(global_this);
         // We call .dupe() on this to ensure that we don't return a blob that might get freed later.
-        // SAFETY: `standalone_file_blob` returns a non-null heap allocation.
-        let blob = Blob::new(unsafe { (*input_blob).dupe_with_content_type(true) });
+        let blob = Blob::new(input_blob.dupe_with_content_type(true));
         // SAFETY: `Blob::new` returned a fresh heap allocation.
-        unsafe { (*blob).name.set((*input_blob).name.get().dupe_ref()) };
+        unsafe { (*blob).name.set(input_blob.name.get().dupe_ref()) };
         // SAFETY: `blob` is heap-allocated and lives until JS owns it via to_js.
         array.put_index(global_this, i as u32, unsafe { (*blob).to_js(global_this) })?;
     }
 
     Ok(array)
-}
-
-/// `StandaloneModuleGraph.File.blob()` — ported here (rather than upstream in
-/// `bun_standalone_graph`) because `Blob`/`Store` live in `bun_runtime::webcore`
-/// and would otherwise create a crate cycle.
-fn standalone_file_blob(
-    file: &mut bun_standalone_graph::File,
-    global: &JSGlobalObject,
-) -> *mut crate::webcore::blob::Blob {
-    use crate::webcore::blob::{Blob, Store, StoreRef};
-    if let Some(cached) = file.cached_blob {
-        return cached.as_ptr().cast::<Blob>();
-    }
-    let store: StoreRef = Store::init(file.contents.as_bytes().to_vec());
-    let blob_body = Blob::init_with_store(store, global);
-    // NOTE (cyclebreak): `MimeType::by_loader` takes the `#[repr(u8)]`
-    // discriminant and an extension.
-    let mime =
-        bun_http_types::MimeType::by_loader(file.loader as u8, bun_paths::extension(file.name));
-    // SAFETY: `mime.value` is `Cow<'static, [u8]>`; the slice pointer is
-    // stable for the life of `mime` (`'static` for the table-backed loaders).
-    blob_body
-        .content_type
-        .set(std::ptr::from_ref::<[u8]>(mime.value.as_ref()));
-    // Hold the (potentially owned) `Cow` for the lifetime of the cached blob.
-    // The `by_loader` table only returns `Borrowed(&'static ..)`, so leaking
-    // is a no-op for the static case and correct for the owned `OTHER` case.
-    let _mime = core::mem::ManuallyDrop::new(mime);
-    blob_body
-        .name
-        .set(BunString::clone_utf8(bun_paths::basename(file.name)));
-    let blob = Blob::new(blob_body);
-    // SAFETY: `Blob::new` heap-allocates; never null.
-    file.cached_blob = core::ptr::NonNull::new(blob.cast());
-    blob
 }
 
 pub(crate) fn get_semver(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {

--- a/test/js/bun/compile/embedded-files-zero-copy.test.ts
+++ b/test/js/bun/compile/embedded-files-zero-copy.test.ts
@@ -1,0 +1,99 @@
+// Bun.embeddedFiles must borrow the embedded executable section directly
+// (the same zero-copy path Bun.file() uses for embedded paths) rather than
+// heap-copying every file's bytes on first access.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { writeFileSync } from "node:fs";
+import path from "node:path";
+
+// Windows RSS accounting for the mapped executable section is too noisy for
+// the threshold below to be meaningful there.
+test.skipIf(isWindows)(
+  "Bun.embeddedFiles does not heap-copy embedded file bytes",
+  async () => {
+    const SIZE = 20 * 1024 * 1024;
+
+    using dir = tempDir("embedded-files-zero-copy", {
+      "entry.ts": `
+        // @ts-nocheck
+        import p from "./big.bin" with { type: "file" };
+        if (p.length === 0) throw new Error("asset import dropped");
+
+        Bun.gc(true);
+        const before = process.memoryUsage().rss;
+        const files = Bun.embeddedFiles;
+        Bun.gc(true);
+        const after = process.memoryUsage().rss;
+
+        if (files.length !== 1) throw new Error("expected 1 embedded file, got " + files.length);
+        const f = files[0];
+        // Verify the borrowed bytes are correct without forcing the whole
+        // section resident: slice head and tail only.
+        const head = new Uint8Array(await f.slice(0, 4).arrayBuffer());
+        const tail = new Uint8Array(await f.slice(f.size - 4, f.size).arrayBuffer());
+        console.log(JSON.stringify({
+          delta: after - before,
+          size: f.size,
+          head: Array.from(head),
+          tail: Array.from(tail),
+        }));
+      `,
+    });
+
+    // Distinct head/tail markers so a wrong-offset borrow would be caught.
+    const big = Buffer.alloc(SIZE, 0x42);
+    big[0] = 0xde;
+    big[1] = 0xad;
+    big[2] = 0xbe;
+    big[3] = 0xef;
+    big[SIZE - 4] = 0xca;
+    big[SIZE - 3] = 0xfe;
+    big[SIZE - 2] = 0xba;
+    big[SIZE - 1] = 0xbe;
+    writeFileSync(path.join(String(dir), "big.bin"), big);
+
+    const out = path.join(String(dir), "app");
+    {
+      await using build = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", path.join(String(dir), "entry.ts"), "--outfile", out],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [bout, berr, bcode] = await Promise.all([build.stdout.text(), build.stderr.text(), build.exited]);
+      expect(berr).not.toContain("error:");
+      expect({ stdout: bout, exitCode: bcode }).toMatchObject({ exitCode: 0, stdout: expect.any(String) });
+    }
+
+    await using proc = Bun.spawn({
+      cmd: [out],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).not.toContain("error:");
+
+    const result = JSON.parse(stdout.trim());
+    expect({
+      size: result.size,
+      head: result.head,
+      tail: result.tail,
+    }).toEqual({
+      size: SIZE,
+      head: [0xde, 0xad, 0xbe, 0xef],
+      tail: [0xca, 0xfe, 0xba, 0xbe],
+    });
+    // A heap copy of the bytes costs at least SIZE (and in practice ~2x SIZE
+    // since reading the section to copy it also pages it in). Borrowing the
+    // 'static slice touches none of it. Allow generous slack for allocator /
+    // JS-array overhead.
+    expect(result.delta).toBeLessThan(SIZE / 2);
+    expect(exitCode).toBe(0);
+  },
+  // `bun build --compile` copies + rewrites the full bun executable, which
+  // under a debug build takes several seconds on its own.
+  60_000,
+);


### PR DESCRIPTION
## What

`get_embedded_files()` in `src/runtime/api/BunObject.rs` had its own `standalone_file_blob()` helper that built each embedded file's `Blob` store via

```rust
let store: StoreRef = Store::init(file.contents.as_bytes().to_vec());
```

which heap-allocates a full copy of the embedded file's bytes. That copy is then stashed in `file.cached_blob` for the process lifetime.

The canonical port already exists in `src/runtime/api/standalone_graph_jsc.rs` (`FileJsc::file_blob`, matching `standalone_graph_jsc.zig::fileBlob`): it borrows the `'static` executable-section slice via `Bytes::from_raw_parts(...)` and pins the store refcount so the borrowed bytes are never freed. `Bun.file()` for embedded paths already went through that path; only `Bun.embeddedFiles` used the copying duplicate.

## Repro

```sh
# app.ts embeds a 20 MB asset, then reads Bun.embeddedFiles
bun build --compile ./app.ts --outfile ./app
./app
```

Before: RSS jumps by ~40 MB on `Bun.embeddedFiles` access (the `to_vec()` copy plus paging in the section it reads from).
After: RSS delta is ~2 MB.

## Fix

Route `get_embedded_files()` through `FileJsc::file_blob` and delete the duplicate `standalone_file_blob()`.

## Verification

New test `test/js/bun/compile/embedded-files-zero-copy.test.ts` compiles a binary with a 20 MB embedded asset and asserts:
- `Bun.embeddedFiles` RSS delta is well under half the asset size
- the blob's head/tail bytes match the original data

Fails on main with `Received: 44204032 / Expected: < 10485760`; passes with this change. Existing `bundler > compile/Bun.embeddedFiles` continues to pass.