### PR TITLE
worker_threads: honor --no-addons in execArgv after value-taking flags

### DIFF
--- a/src/clap/comptime.rs
+++ b/src/clap/comptime.rs
@@ -504,13 +504,14 @@ pub fn convert_params<Id>(params: &[Param<Id>]) -> (Vec<Param<usize>>, usize, us
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Deprecated: Use `parse_ex` instead
-pub struct ComptimeClap<Id> {
-    // Inner `&'static [u8]` slices borrow argv (process-lifetime).
-    pub single_options: Box<[Option<&'static [u8]>]>,
-    pub multi_options: Box<[Box<[&'static [u8]]>]>,
+pub struct ComptimeClap<'a, Id> {
+    // Inner `&'a [u8]` slices borrow argv. `'a` is `'static` for `OsIterator`
+    // (process argv); a borrowed `SliceIterator` gets its own lifetime.
+    pub single_options: Box<[Option<&'a [u8]>]>,
+    pub multi_options: Box<[Box<[&'a [u8]]>]>,
     pub flags: Box<[bool]>,
-    pub pos: Box<[&'static [u8]]>,
-    pub passthrough_positionals: Box<[&'static [u8]]>,
+    pub pos: Box<[&'a [u8]]>,
+    pub passthrough_positionals: Box<[&'a [u8]]>,
 
     // The converted params are
     // carried as a `&'static` table — either rodata (`comptime_table!`) or
@@ -520,9 +521,9 @@ pub struct ComptimeClap<Id> {
     _id: PhantomData<Id>,
 }
 
-impl<Id> ComptimeClap<Id> {
-    /// `iter` must yield `&'static [u8]` (process-lifetime args, e.g. `OsIterator`)
-    /// because parsed values are stored by reference.
+impl<'a, Id> ComptimeClap<'a, Id> {
+    /// Parsed values are stored by reference into the `&'a [u8]` slices
+    /// yielded by `iter`; `'a` is `'static` for `OsIterator` (process argv).
     ///
     /// `params` must be `'static` (every in-tree table is a `static`/`const`
     /// item); the converted form is interned once per unique slice.
@@ -540,7 +541,7 @@ impl<Id> ComptimeClap<Id> {
         opt: ParseOptions<'_>,
     ) -> Result<Self, bun_core::Error>
     where
-        I: ArgIter<'static>,
+        I: ArgIter<'a>,
     {
         Self::parse_with_table(ConvertedTable::for_params(params), iter, opt)
     }
@@ -553,15 +554,15 @@ impl<Id> ComptimeClap<Id> {
         opt: ParseOptions<'_>,
     ) -> Result<Self, bun_core::Error>
     where
-        I: ArgIter<'static>,
+        I: ArgIter<'a>,
     {
         // `opt.allocator` dropped — global mimalloc.
-        let mut multis: Vec<Vec<&'static [u8]>> = (0..table.n_multi).map(|_| Vec::new()).collect();
+        let mut multis: Vec<Vec<&'a [u8]>> = (0..table.n_multi).map(|_| Vec::new()).collect();
 
-        let mut pos: Vec<&'static [u8]> = Vec::new();
-        let mut passthrough_positionals: Vec<&'static [u8]> = Vec::new();
+        let mut pos: Vec<&'a [u8]> = Vec::new();
+        let mut passthrough_positionals: Vec<&'a [u8]> = Vec::new();
 
-        let mut single_options: Box<[Option<&'static [u8]>]> =
+        let mut single_options: Box<[Option<&'a [u8]>]> =
             vec![None; table.n_single].into_boxed_slice();
         let mut flags: Box<[bool]> = vec![false; table.n_flags].into_boxed_slice();
 
@@ -637,7 +638,7 @@ impl<Id> ComptimeClap<Id> {
     }
 
     #[inline]
-    pub fn option(&self, name: &[u8]) -> Option<&'static [u8]> {
+    pub fn option(&self, name: &[u8]) -> Option<&'a [u8]> {
         let param = self.table.find(name);
         debug_assert!(
             param.takes_value != Values::None,
@@ -653,7 +654,7 @@ impl<Id> ComptimeClap<Id> {
     }
 
     #[inline]
-    pub fn options(&self, name: &[u8]) -> &[&'static [u8]] {
+    pub fn options(&self, name: &[u8]) -> &[&'a [u8]] {
         let param = self.table.find(name);
         debug_assert!(
             param.takes_value != Values::None,
@@ -675,19 +676,19 @@ impl<Id> ComptimeClap<Id> {
         self.flags[self.table.converted[converted_idx].id]
     }
     #[inline]
-    pub fn option_at(&self, converted_idx: usize) -> Option<&'static [u8]> {
+    pub fn option_at(&self, converted_idx: usize) -> Option<&'a [u8]> {
         self.single_options[self.table.converted[converted_idx].id]
     }
     #[inline]
-    pub fn options_at(&self, converted_idx: usize) -> &[&'static [u8]] {
+    pub fn options_at(&self, converted_idx: usize) -> &[&'a [u8]] {
         &self.multi_options[self.table.converted[converted_idx].id]
     }
 
-    pub fn positionals(&self) -> &[&'static [u8]] {
+    pub fn positionals(&self) -> &[&'a [u8]] {
         &self.pos
     }
 
-    pub fn remaining(&self) -> &[&'static [u8]] {
+    pub fn remaining(&self) -> &[&'a [u8]] {
         &self.passthrough_positionals
     }
 

--- a/src/clap/lib.rs
+++ b/src/clap/lib.rs
@@ -455,29 +455,29 @@ fn get_value_simple(param: &Param<Help>) -> &'static [u8] {
     param.id.value
 }
 
-pub struct Args<Id: 'static> {
-    pub clap: ComptimeClap<Id>,
-    pub exe_arg: Option<&'static [u8]>,
+pub struct Args<'a, Id: 'static> {
+    pub clap: ComptimeClap<'a, Id>,
+    pub exe_arg: Option<&'a [u8]>,
 }
 
-impl<Id: 'static> Args<Id> {
+impl<'a, Id: 'static> Args<'a, Id> {
     pub fn flag(&self, name: &'static [u8]) -> bool {
         self.clap.flag(name)
     }
 
-    pub fn option(&self, name: &'static [u8]) -> Option<&'static [u8]> {
+    pub fn option(&self, name: &'static [u8]) -> Option<&'a [u8]> {
         self.clap.option(name)
     }
 
-    pub fn options(&self, name: &'static [u8]) -> &[&'static [u8]] {
+    pub fn options(&self, name: &'static [u8]) -> &[&'a [u8]] {
         self.clap.options(name)
     }
 
-    pub fn positionals(&self) -> &[&'static [u8]] {
+    pub fn positionals(&self) -> &[&'a [u8]] {
         self.clap.positionals()
     }
 
-    pub fn remaining(&self) -> &[&'static [u8]] {
+    pub fn remaining(&self) -> &[&'a [u8]] {
         self.clap.remaining()
     }
 
@@ -497,7 +497,7 @@ impl<Id: 'static> Args<Id> {
 pub fn parse<Id: 'static>(
     params: &'static [Param<Id>],
     opt: ParseOptions<'_>,
-) -> Result<Args<Id>, bun_core::Error> {
+) -> Result<Args<'static, Id>, bun_core::Error> {
     let mut iter = args::OsIterator::init();
     let exe_arg = iter.exe_arg;
 
@@ -518,7 +518,7 @@ pub fn parse<Id: 'static>(
 pub fn parse_with_table<Id: 'static>(
     table: &'static ConvertedTable,
     opt: ParseOptions<'_>,
-) -> Result<Args<Id>, bun_core::Error> {
+) -> Result<Args<'static, Id>, bun_core::Error> {
     let mut iter = args::OsIterator::init();
     let exe_arg = iter.exe_arg;
     let clap = ComptimeClap::<Id>::parse_with_table(
@@ -538,13 +538,13 @@ pub fn parse_with_table<Id: 'static>(
 /// **Cold path** — see [`parse`]; the startup hot path is [`parse_with_table`].
 #[cold]
 #[inline(never)]
-pub fn parse_ex<Id: 'static, I>(
+pub fn parse_ex<'a, Id: 'static, I>(
     params: &'static [Param<Id>],
     iter: &mut I,
     opt: ParseOptions<'_>,
-) -> Result<ComptimeClap<Id>, bun_core::Error>
+) -> Result<ComptimeClap<'a, Id>, bun_core::Error>
 where
-    I: args::ArgIter<'static>,
+    I: args::ArgIter<'a>,
 {
     ComptimeClap::<Id>::parse(params, iter, opt)
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1457,8 +1457,10 @@ unsafe fn apply_standalone_runtime_flags(
 /// reads the single `--no-addons` flag from the result (per the in-tree
 /// `// TODO: currently this only checks for --no-addons`), so this body scans
 /// the converted argv directly with the same `stop_after_positional_at = 1`
-/// short-circuit. Full clap routing can return when `ComptimeClap` grows a
-/// borrowed-lifetime variant.
+/// short-circuit — consulting `RUN_PARAMS` so a value token following a
+/// value-taking flag (`-r x`, `--title x`, …) is consumed rather than treated
+/// as the first positional. Full clap routing can return when `ComptimeClap`
+/// grows a borrowed-lifetime variant.
 ///
 /// # Safety
 /// Each `WTFStringImpl` in `exec_argv` is a live WTF string (the C++
@@ -1466,7 +1468,30 @@ unsafe fn apply_standalone_runtime_flags(
 unsafe fn parse_worker_exec_argv_allow_addons(
     exec_argv: &[bun_core::WTFStringImpl],
 ) -> Option<bool> {
+    use crate::cli::arguments::RUN_PARAMS;
+    use bun_clap::Values;
+
+    // Does `bytes` name a `RUN_PARAMS` flag whose value is supplied by the
+    // *next* token? True only for the bare `--long` / `-s` spellings of a
+    // `One`/`Many` param; `--long=val`, `-s=val`, `-sval`, chained shorts and
+    // `OneOptional` params all carry their value (if any) inline and do not
+    // pull from the iterator in `StreamingClap`.
+    fn flag_consumes_next_token(bytes: &[u8]) -> bool {
+        let param = if let Some(long) = bytes.strip_prefix(b"--") {
+            RUN_PARAMS.iter().find(|p| p.names.matches_long(long))
+        } else if bytes.len() == 2 && bytes[0] == b'-' {
+            RUN_PARAMS.iter().find(|p| p.names.short == Some(bytes[1]))
+        } else {
+            None
+        };
+        matches!(
+            param.map(|p| p.takes_value),
+            Some(Values::One | Values::Many)
+        )
+    }
+
     let mut no_addons = false;
+    let mut prev_wants_value = false;
     for &arg in exec_argv {
         if arg.is_null() {
             continue;
@@ -1474,8 +1499,13 @@ unsafe fn parse_worker_exec_argv_allow_addons(
         // SAFETY: per fn contract — `arg` is a live `WTFStringImpl*`.
         let owned = unsafe { &*arg }.to_owned_slice_z();
         let bytes = owned.as_bytes();
-        // `stop_after_positional_at = 1` — first non-flag token ends parsing.
+        // `stop_after_positional_at = 1` — first positional ends parsing. A
+        // non-`-` token that the previous flag consumes as its value is not a
+        // positional.
         if bytes.first() != Some(&b'-') {
+            if core::mem::take(&mut prev_wants_value) {
+                continue;
+            }
             break;
         }
         if bytes == b"--" {
@@ -1484,6 +1514,7 @@ unsafe fn parse_worker_exec_argv_allow_addons(
         if bytes == b"--no-addons" {
             no_addons = true;
         }
+        prev_wants_value = flag_consumes_next_token(bytes);
     }
     // Override `allow_addons` unconditionally on successful parse.
     Some(!no_addons)

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1479,9 +1479,9 @@ unsafe fn parse_worker_exec_argv_allow_addons(
     // *next* token? `--long=val` and `OneOptional` params never pull from the
     // iterator. A bare `--long` / `-s` pulls when its `takes_value` is
     // `One`/`Many`. A chained-short cluster (`-br`) pulls when every prefix
-    // char is a `None`/`OneOptional` short and the last char is a
-    // `One`/`Many` short with nothing after it — `StreamingClap::chainging`
-    // calls `iter.next()` in exactly that case.
+    // char is a `None` short and the last char is a `One`/`Many` short with
+    // nothing after it — `StreamingClap::chainging` calls `iter.next()` in
+    // exactly that case.
     fn flag_consumes_next_token(bytes: &[u8]) -> bool {
         if let Some(long) = bytes.strip_prefix(b"--") {
             let param = RUN_PARAMS.iter().find(|p| p.names.matches_long(long));
@@ -1496,7 +1496,11 @@ unsafe fn parse_worker_exec_argv_allow_addons(
                     return false;
                 };
                 match param.takes_value {
-                    Values::None | Values::OneOptional => continue,
+                    Values::None => continue,
+                    // `StreamingClap::chainging` stops chaining at a
+                    // `OneOptional` short without pulling from the iterator;
+                    // remaining cluster chars are dropped.
+                    Values::OneOptional => return false,
                     // `One`/`Many`: pulls from the iterator only when this is
                     // the last char; otherwise the rest of the cluster (or
                     // the text after `=`) is the inline value.
@@ -1522,10 +1526,9 @@ unsafe fn parse_worker_exec_argv_allow_addons(
             continue;
         }
         // `stop_after_positional_at = 1` — first positional ends parsing.
-        if bytes.first() != Some(&b'-') {
-            break;
-        }
-        if bytes == b"--" {
+        // `StreamingClap::parse_next_arg` treats bare `-` and `--` as
+        // positionals.
+        if bytes.first() != Some(&b'-') || bytes == b"-" || bytes == b"--" {
             break;
         }
         if bytes == b"--no-addons" {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1471,23 +1471,40 @@ unsafe fn parse_worker_exec_argv_allow_addons(
     use crate::cli::arguments::RUN_PARAMS;
     use bun_clap::Values;
 
+    fn find_short(c: u8) -> Option<&'static bun_clap::Param<bun_clap::Help>> {
+        RUN_PARAMS.iter().find(|p| p.names.short == Some(c))
+    }
+
     // Does `bytes` name a `RUN_PARAMS` flag whose value is supplied by the
-    // *next* token? True only for the bare `--long` / `-s` spellings of a
-    // `One`/`Many` param; `--long=val`, `-s=val`, `-sval`, chained shorts and
-    // `OneOptional` params all carry their value (if any) inline and do not
-    // pull from the iterator in `StreamingClap`.
+    // *next* token? `--long=val` and `OneOptional` params never pull from the
+    // iterator. A bare `--long` / `-s` pulls when its `takes_value` is
+    // `One`/`Many`. A chained-short cluster (`-br`) pulls when every prefix
+    // char is a `None`/`OneOptional` short and the last char is a
+    // `One`/`Many` short with nothing after it — `StreamingClap::chainging`
+    // calls `iter.next()` in exactly that case.
     fn flag_consumes_next_token(bytes: &[u8]) -> bool {
-        let param = if let Some(long) = bytes.strip_prefix(b"--") {
-            RUN_PARAMS.iter().find(|p| p.names.matches_long(long))
-        } else if bytes.len() == 2 && bytes[0] == b'-' {
-            RUN_PARAMS.iter().find(|p| p.names.short == Some(bytes[1]))
-        } else {
-            None
-        };
-        matches!(
-            param.map(|p| p.takes_value),
-            Some(Values::One | Values::Many)
-        )
+        if let Some(long) = bytes.strip_prefix(b"--") {
+            let param = RUN_PARAMS.iter().find(|p| p.names.matches_long(long));
+            return matches!(
+                param.map(|p| p.takes_value),
+                Some(Values::One | Values::Many)
+            );
+        }
+        if let Some(shorts) = bytes.strip_prefix(b"-") {
+            for (i, &c) in shorts.iter().enumerate() {
+                let Some(param) = find_short(c) else {
+                    return false;
+                };
+                match param.takes_value {
+                    Values::None | Values::OneOptional => continue,
+                    // `One`/`Many`: pulls from the iterator only when this is
+                    // the last char; otherwise the rest of the cluster (or
+                    // the text after `=`) is the inline value.
+                    Values::One | Values::Many => return i + 1 == shorts.len(),
+                }
+            }
+        }
+        false
     }
 
     let mut no_addons = false;
@@ -1499,13 +1516,13 @@ unsafe fn parse_worker_exec_argv_allow_addons(
         // SAFETY: per fn contract — `arg` is a live `WTFStringImpl*`.
         let owned = unsafe { &*arg }.to_owned_slice_z();
         let bytes = owned.as_bytes();
-        // `stop_after_positional_at = 1` — first positional ends parsing. A
-        // non-`-` token that the previous flag consumes as its value is not a
-        // positional.
+        // The previous `One`/`Many` flag consumes this token as its value via
+        // raw `iter.next()` — regardless of a leading `-` or a literal `--`.
+        if core::mem::take(&mut prev_wants_value) {
+            continue;
+        }
+        // `stop_after_positional_at = 1` — first positional ends parsing.
         if bytes.first() != Some(&b'-') {
-            if core::mem::take(&mut prev_wants_value) {
-                continue;
-            }
             break;
         }
         if bytes == b"--" {

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1468,8 +1468,8 @@ unsafe fn parse_worker_exec_argv_allow_addons(
     let argv: Vec<&[u8]> = owned.iter().map(|s| s.as_bytes()).collect();
 
     let mut iter = bun_clap::args::SliceIterator::init(&argv);
-    let args = bun_clap::parse_ex::<bun_clap::Help, _>(
-        crate::cli::arguments::RUN_PARAMS,
+    let args = bun_clap::ComptimeClap::<bun_clap::Help>::parse_with_table(
+        crate::cli::arguments::RUN_TABLE,
         &mut iter,
         bun_clap::ParseOptions {
             diagnostic: None,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1451,16 +1451,7 @@ unsafe fn apply_standalone_runtime_flags(
 /// `RunCommand` param table and return `!args.flag("--no-addons")`, or `None`
 /// on parse error.
 ///
-/// Note: the Rust `bun_clap::parse_ex` port currently constrains
-/// `ArgIter<'static>` (parsed values are stored by reference), which would
-/// force leaking the per-call UTF-8 copies of `exec_argv`. Spec only ever
-/// reads the single `--no-addons` flag from the result (per the in-tree
-/// `// TODO: currently this only checks for --no-addons`), so this body scans
-/// the converted argv directly with the same `stop_after_positional_at = 1`
-/// short-circuit — consulting `RUN_PARAMS` so a value token following a
-/// value-taking flag (`-r x`, `--title x`, …) is consumed rather than treated
-/// as the first positional. Full clap routing can return when `ComptimeClap`
-/// grows a borrowed-lifetime variant.
+/// Currently only honours `--no-addons`.
 ///
 /// # Safety
 /// Each `WTFStringImpl` in `exec_argv` is a live WTF string (the C++
@@ -1468,76 +1459,27 @@ unsafe fn apply_standalone_runtime_flags(
 unsafe fn parse_worker_exec_argv_allow_addons(
     exec_argv: &[bun_core::WTFStringImpl],
 ) -> Option<bool> {
-    use crate::cli::arguments::RUN_PARAMS;
-    use bun_clap::Values;
+    let owned: Vec<_> = exec_argv
+        .iter()
+        .filter(|a| !a.is_null())
+        // SAFETY: per fn contract — each `arg` is a live `WTFStringImpl*`.
+        .map(|&a| unsafe { &*a }.to_owned_slice_z())
+        .collect();
+    let argv: Vec<&[u8]> = owned.iter().map(|s| s.as_bytes()).collect();
 
-    fn find_short(c: u8) -> Option<&'static bun_clap::Param<bun_clap::Help>> {
-        RUN_PARAMS.iter().find(|p| p.names.short == Some(c))
-    }
+    let mut iter = bun_clap::args::SliceIterator::init(&argv);
+    let args = bun_clap::parse_ex::<bun_clap::Help, _>(
+        crate::cli::arguments::RUN_PARAMS,
+        &mut iter,
+        bun_clap::ParseOptions {
+            diagnostic: None,
+            stop_after_positional_at: 1,
+        },
+    )
+    .ok()?;
 
-    // Does `bytes` name a `RUN_PARAMS` flag whose value is supplied by the
-    // *next* token? `--long=val` and `OneOptional` params never pull from the
-    // iterator. A bare `--long` / `-s` pulls when its `takes_value` is
-    // `One`/`Many`. A chained-short cluster (`-br`) pulls when every prefix
-    // char is a `None` short and the last char is a `One`/`Many` short with
-    // nothing after it — `StreamingClap::chainging` calls `iter.next()` in
-    // exactly that case.
-    fn flag_consumes_next_token(bytes: &[u8]) -> bool {
-        if let Some(long) = bytes.strip_prefix(b"--") {
-            let param = RUN_PARAMS.iter().find(|p| p.names.matches_long(long));
-            return matches!(
-                param.map(|p| p.takes_value),
-                Some(Values::One | Values::Many)
-            );
-        }
-        if let Some(shorts) = bytes.strip_prefix(b"-") {
-            for (i, &c) in shorts.iter().enumerate() {
-                let Some(param) = find_short(c) else {
-                    return false;
-                };
-                match param.takes_value {
-                    Values::None => continue,
-                    // `StreamingClap::chainging` stops chaining at a
-                    // `OneOptional` short without pulling from the iterator;
-                    // remaining cluster chars are dropped.
-                    Values::OneOptional => return false,
-                    // `One`/`Many`: pulls from the iterator only when this is
-                    // the last char; otherwise the rest of the cluster (or
-                    // the text after `=`) is the inline value.
-                    Values::One | Values::Many => return i + 1 == shorts.len(),
-                }
-            }
-        }
-        false
-    }
-
-    let mut no_addons = false;
-    let mut prev_wants_value = false;
-    for &arg in exec_argv {
-        if arg.is_null() {
-            continue;
-        }
-        // SAFETY: per fn contract — `arg` is a live `WTFStringImpl*`.
-        let owned = unsafe { &*arg }.to_owned_slice_z();
-        let bytes = owned.as_bytes();
-        // The previous `One`/`Many` flag consumes this token as its value via
-        // raw `iter.next()` — regardless of a leading `-` or a literal `--`.
-        if core::mem::take(&mut prev_wants_value) {
-            continue;
-        }
-        // `stop_after_positional_at = 1` — first positional ends parsing.
-        // `StreamingClap::parse_next_arg` treats bare `-` and `--` as
-        // positionals.
-        if bytes.first() != Some(&b'-') || bytes == b"-" || bytes == b"--" {
-            break;
-        }
-        if bytes == b"--no-addons" {
-            no_addons = true;
-        }
-        prev_wants_value = flag_consumes_next_token(bytes);
-    }
-    // Override `allow_addons` unconditionally on successful parse.
-    Some(!no_addons)
+    // override the existing even if it was set
+    Some(!args.flag(b"--no-addons"))
 }
 
 /// `jsc.API.cron.CronJob.clearAllForVM(vm, .teardown)` —

--- a/test/js/node/no-addons.test.ts
+++ b/test/js/node/no-addons.test.ts
@@ -41,8 +41,11 @@ describe("worker execArgv --no-addons parsing matches RunCommand clap", () => {
     const worker = new Worker(body, { eval: true, execArgv });
     try {
       const code = await new Promise((resolve, reject) => {
-        worker.on("message", resolve);
-        worker.on("error", reject);
+        worker.once("message", resolve);
+        worker.once("error", reject);
+        worker.once("exit", exitCode =>
+          reject(new Error(`worker exited (code=${exitCode}) before posting a message`)),
+        );
       });
       expect(code).toBe(expected);
     } finally {

--- a/test/js/node/no-addons.test.ts
+++ b/test/js/node/no-addons.test.ts
@@ -17,26 +17,34 @@ test("--no-addons throws an error on process.dlopen", () => {
   expect(err).toContain("\nerror: Cannot load native addon because loading addons is disabled.");
 });
 
-describe("worker execArgv honors --no-addons after value-taking flags", () => {
-  // The value token for `-r` / `--title` / `--port` / `-e` must not be
-  // treated as the first positional when parsing the worker's execArgv.
+describe("worker execArgv --no-addons parsing matches RunCommand clap", () => {
+  // A value token following a value-taking flag (`-r x`, `--title x`, ...)
+  // must not be treated as the first positional when scanning execArgv, and
+  // the value is consumed regardless of its own content (even `--` or a
+  // `-`-prefixed string).
   const body = `try { process.dlopen({ exports: {} }, "/nonexistent.node"); } catch (e) { require("node:worker_threads").parentPort.postMessage(e.code); }`;
   test.each([
-    [["--no-addons"]],
-    [["-r", "./preload.js", "--no-addons"]],
-    [["--require", "./preload.js", "--no-addons"]],
-    [["--title", "foo", "--no-addons"]],
-    [["--port", "3000", "--no-addons"]],
-    [["-e", "void 0", "--no-addons"]],
-    [["--no-addons", "-r", "./preload.js"]],
-  ])("%j", async execArgv => {
+    [["--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["-r", "./preload.js", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["--require", "./preload.js", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["--title", "foo", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["--port", "3000", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["-e", "void 0", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    [["--no-addons", "-r", "./preload.js"], "ERR_DLOPEN_DISABLED"],
+    // chained shorts ending in a value-taking short pull the next token
+    [["-br", "./preload.js", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    // the value is consumed via raw iter.next(), even if it is `--`
+    [["-r", "--", "--no-addons"], "ERR_DLOPEN_DISABLED"],
+    // here `--no-addons` is `-r`'s value, not a flag; addons stay enabled
+    [["-r", "--no-addons"], "ERR_DLOPEN_FAILED"],
+  ])("%j", async (execArgv, expected) => {
     const worker = new Worker(body, { eval: true, execArgv });
     try {
       const code = await new Promise((resolve, reject) => {
         worker.on("message", resolve);
         worker.on("error", reject);
       });
-      expect(code).toBe("ERR_DLOPEN_DISABLED");
+      expect(code).toBe(expected);
     } finally {
       await worker.terminate();
     }

--- a/test/js/node/no-addons.test.ts
+++ b/test/js/node/no-addons.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from "bun";
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunExe, bunEnv as env } from "harness";
+import { Worker } from "node:worker_threads";
 
 test("--no-addons throws an error on process.dlopen", () => {
   const { stdout, stderr, exitCode } = spawnSync({
@@ -14,4 +15,30 @@ test("--no-addons throws an error on process.dlopen", () => {
   expect(exitCode).toBe(1);
   expect(out).toBeEmpty();
   expect(err).toContain("\nerror: Cannot load native addon because loading addons is disabled.");
+});
+
+describe("worker execArgv honors --no-addons after value-taking flags", () => {
+  // The value token for `-r` / `--title` / `--port` / `-e` must not be
+  // treated as the first positional when parsing the worker's execArgv.
+  const body = `try { process.dlopen({ exports: {} }, "/nonexistent.node"); } catch (e) { require("node:worker_threads").parentPort.postMessage(e.code); }`;
+  test.each([
+    [["--no-addons"]],
+    [["-r", "./preload.js", "--no-addons"]],
+    [["--require", "./preload.js", "--no-addons"]],
+    [["--title", "foo", "--no-addons"]],
+    [["--port", "3000", "--no-addons"]],
+    [["-e", "void 0", "--no-addons"]],
+    [["--no-addons", "-r", "./preload.js"]],
+  ])("%j", async execArgv => {
+    const worker = new Worker(body, { eval: true, execArgv });
+    try {
+      const code = await new Promise((resolve, reject) => {
+        worker.on("message", resolve);
+        worker.on("error", reject);
+      });
+      expect(code).toBe("ERR_DLOPEN_DISABLED");
+    } finally {
+      await worker.terminate();
+    }
+  });
 });

--- a/test/js/node/no-addons.test.ts
+++ b/test/js/node/no-addons.test.ts
@@ -43,9 +43,7 @@ describe("worker execArgv --no-addons parsing matches RunCommand clap", () => {
       const code = await new Promise((resolve, reject) => {
         worker.once("message", resolve);
         worker.once("error", reject);
-        worker.once("exit", exitCode =>
-          reject(new Error(`worker exited (code=${exitCode}) before posting a message`)),
-        );
+        worker.once("exit", exitCode => reject(new Error(`worker exited (code=${exitCode}) before posting a message`)));
       });
       expect(code).toBe(expected);
     } finally {

--- a/test/js/node/no-addons.test.ts
+++ b/test/js/node/no-addons.test.ts
@@ -37,6 +37,8 @@ describe("worker execArgv --no-addons parsing matches RunCommand clap", () => {
     [["-r", "--", "--no-addons"], "ERR_DLOPEN_DISABLED"],
     // here `--no-addons` is `-r`'s value, not a flag; addons stay enabled
     [["-r", "--no-addons"], "ERR_DLOPEN_FAILED"],
+    // bare `-` is a positional; parsing stops before `--no-addons`
+    [["-", "--no-addons"], "ERR_DLOPEN_FAILED"],
   ])("%j", async (execArgv, expected) => {
     const worker = new Worker(body, { eval: true, execArgv });
     try {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -278,6 +278,32 @@ describe("execArgv option", async () => {
     await run('["--no-warnings"]', '["--no-warnings"]\n');
   });
   // TODO(@190n) get our handling of non-string array elements in line with Node's
+
+  describe("--no-addons is honored after a value-taking flag", () => {
+    // The value token for `-r` / `--title` / `--port` / `-e` must not be
+    // treated as the first positional when parsing the worker's execArgv.
+    const body = `try { process.dlopen({ exports: {} }, "/nonexistent.node"); } catch (e) { require("node:worker_threads").parentPort.postMessage(e.code); }`;
+    it.each([
+      [["--no-addons"]],
+      [["-r", "./preload.js", "--no-addons"]],
+      [["--require", "./preload.js", "--no-addons"]],
+      [["--title", "foo", "--no-addons"]],
+      [["--port", "3000", "--no-addons"]],
+      [["-e", "void 0", "--no-addons"]],
+      [["--no-addons", "-r", "./preload.js"]],
+    ])("%j", async execArgv => {
+      const worker = new Worker(body, { eval: true, execArgv });
+      try {
+        const code = await new Promise((resolve, reject) => {
+          worker.on("message", resolve);
+          worker.on("error", reject);
+        });
+        expect(code).toBe("ERR_DLOPEN_DISABLED");
+      } finally {
+        await worker.terminate();
+      }
+    });
+  });
 });
 
 test("eval does not leak source code", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -278,32 +278,6 @@ describe("execArgv option", async () => {
     await run('["--no-warnings"]', '["--no-warnings"]\n');
   });
   // TODO(@190n) get our handling of non-string array elements in line with Node's
-
-  describe("--no-addons is honored after a value-taking flag", () => {
-    // The value token for `-r` / `--title` / `--port` / `-e` must not be
-    // treated as the first positional when parsing the worker's execArgv.
-    const body = `try { process.dlopen({ exports: {} }, "/nonexistent.node"); } catch (e) { require("node:worker_threads").parentPort.postMessage(e.code); }`;
-    it.each([
-      [["--no-addons"]],
-      [["-r", "./preload.js", "--no-addons"]],
-      [["--require", "./preload.js", "--no-addons"]],
-      [["--title", "foo", "--no-addons"]],
-      [["--port", "3000", "--no-addons"]],
-      [["-e", "void 0", "--no-addons"]],
-      [["--no-addons", "-r", "./preload.js"]],
-    ])("%j", async execArgv => {
-      const worker = new Worker(body, { eval: true, execArgv });
-      try {
-        const code = await new Promise((resolve, reject) => {
-          worker.on("message", resolve);
-          worker.on("error", reject);
-        });
-        expect(code).toBe("ERR_DLOPEN_DISABLED");
-      } finally {
-        await worker.terminate();
-      }
-    });
-  });
 });
 
 test("eval does not leak source code", async () => {


### PR DESCRIPTION
### What does this PR do?

`WebWorker.startVM` parses the worker's `execArgv` to pick up `--no-addons`. The Zig implementation runs `bun.clap.parseEx` against the full RunCommand param table with `stop_after_positional_at = 1`, so value-taking flags like `-r <preload>`, `--title <name>`, `--port <n>` and `-e <code>` correctly consume their value token before the first positional ends parsing.

The Rust port's `parse_worker_exec_argv_allow_addons` replaced this with a hand-rolled scanner that breaks at the first token not prefixed with `-`, without knowing the previous flag may consume that token as its value. For `execArgv: ['-r', './preload.js', '--no-addons']` it stops at `'./preload.js'` and never sees `--no-addons`, so `transform_options.allow_addons` stays `true` and `process.dlopen` is not disabled.

**Repro**

```js
const { Worker } = require('node:worker_threads');
const w = new Worker(
  `try { process.dlopen({exports:{}}, '/x.node') } catch (e) { require('node:worker_threads').parentPort.postMessage(e.code) }`,
  { eval: true, execArgv: ['-r', './preload.js', '--no-addons'] },
);
w.on('message', m => { console.log(m); process.exit(0); });
```

Before: prints `ERR_DLOPEN_FAILED` (addons enabled, dlopen attempted).
After: prints `ERR_DLOPEN_DISABLED`.

Same divergence with `--title`, `--port`, `-e`, `--require`, chained shorts (`-br`), and `-`-prefixed values.

**Fix**

Generalize `bun_clap::ComptimeClap` / `Args` over the argv lifetime so `parse_ex` accepts a borrowed `SliceIterator` (the prior `'static` bound was why the Rust port hand-rolled the scan). `parse_worker_exec_argv_allow_addons` is now a direct port of the Zig `startVM` path: convert the WTF strings to owned UTF-8, run `parse_ex` against `RUN_PARAMS` with `stop_after_positional_at = 1`, read `args.flag("--no-addons")`. Existing `OsIterator` callers infer `'static` via elision, so no call sites change.

### How did you verify your code works?

New parameterised test in `test/js/node/no-addons.test.ts` covering `-r`, `--require`, `--title`, `--port`, `-e`, chained shorts (`-br`), `-`-prefixed values (`-r --`), bare `-`, and the case where `--no-addons` is itself consumed as a value. Nine of the twelve cases fail on main and all pass with the fix.
