### PR TITLE
spawn: don't panic on Blob/ReadableStream stdio at index >= 3

### DIFF
--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -617,9 +617,8 @@ impl Stdio {
         if i != 0 {
             // The parent-side writer that pumps Blob bytes into the child's
             // pipe (`Writable::Buffer` / memfd) is only wired up for stdin.
-            return Err(global.throw_invalid_arguments(format_args!(
-                "Blob cannot be used for stdio[{i}] yet"
-            )));
+            return Err(global
+                .throw_invalid_arguments(format_args!("Blob cannot be used for stdio[{i}] yet")));
         }
 
         *self = Stdio::Blob(blob);

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -227,13 +227,13 @@ impl Stdio {
 
         let result = match self {
             Self::Blob(blob) => 'brk: {
-                let fd = FdStdio::from_int(i).unwrap().fd();
+                let fd = FdStdio::from_int(i).map(FdStdio::fd);
                 if blob.needs_to_read_file() {
                     if let Some(store) = blob.store() {
                         if let StoreData::File(ref file) = store.data {
                             match file.pathlike {
                                 PathOrFileDescriptor::Fd(store_fd) => {
-                                    if store_fd == fd {
+                                    if Some(store_fd) == fd {
                                         break 'brk SpawnOptionsStdio::Inherit;
                                     }
 
@@ -546,14 +546,14 @@ impl Stdio {
         blob: webcore::blob::Any,
         i: i32,
     ) -> JsResult<()> {
-        let fd = FdStdio::from_int(i).unwrap().fd();
+        let fd = FdStdio::from_int(i).map(FdStdio::fd);
 
         if blob.needs_to_read_file() {
             if let Some(store) = blob.store() {
                 if let StoreData::File(ref file) = store.data {
                     match file.pathlike {
                         PathOrFileDescriptor::Fd(store_fd) => {
-                            if store_fd == fd {
+                            if Some(store_fd) == fd {
                                 *self = Stdio::Inherit;
                             } else {
                                 // TODO: is this supposed to be `store.data.file.pathlike.fd`?

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -361,7 +361,11 @@ impl Stdio {
                             "ReadableStream cannot be used for stderr yet. For now, do .stderr"
                         )));
                     }
-                    _ => unreachable!(),
+                    _ => {
+                        return Err(global.throw_invalid_arguments(format_args!(
+                            "ReadableStream cannot be used for stdio[{i}] yet"
+                        )));
+                    }
                 }
 
                 let stream_value = body.to_readable_stream(global)?;
@@ -491,7 +495,11 @@ impl Stdio {
                 0 => b"stdin",
                 1 => b"stdout",
                 2 => b"stderr",
-                _ => unreachable!(),
+                _ => {
+                    return Err(global.throw_invalid_arguments(format_args!(
+                        "ReadableStream cannot be used for stdio[{i}] yet"
+                    )));
+                }
             };
 
             if is_sync {

--- a/src/runtime/api/bun/spawn/stdio.rs
+++ b/src/runtime/api/bun/spawn/stdio.rs
@@ -614,6 +614,14 @@ impl Stdio {
             return Ok(());
         }
 
+        if i != 0 {
+            // The parent-side writer that pumps Blob bytes into the child's
+            // pipe (`Writable::Buffer` / memfd) is only wired up for stdin.
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Blob cannot be used for stdio[{i}] yet"
+            )));
+        }
+
         *self = Stdio::Blob(blob);
         Ok(())
     }

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -929,21 +929,15 @@ describe("close handling", () => {
       }
     });
 
-    for (const [label, make] of [
-      ["Blob", () => new Blob(["from-blob"])],
-      ["Response", () => new Response("from-response")],
-      ["Request", () => new Request("http://x", { method: "POST", body: "from-request" })],
-    ] as const) {
-      it(`${label} at index >= 3 does not panic`, async () => {
-        await using proc = spawn({
-          cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
-          env: bunEnv,
-          stdio: ["ignore", "pipe", "pipe", make()],
-        });
-        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+    it.skipIf(isWindows)("empty Blob at index >= 3 is treated as ignore", async () => {
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe", new Blob([])],
       });
-    }
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+    });
 
     const pullStream = () =>
       new ReadableStream({
@@ -952,10 +946,21 @@ describe("close handling", () => {
           c.close();
         },
       });
-    for (const [label, make] of [
-      ["ReadableStream", () => pullStream()],
-      ["Response(ReadableStream)", () => new Response(pullStream())],
-      ["Request(ReadableStream)", () => new Request("http://x", { method: "POST", body: pullStream() })],
+    for (const [label, make, msg] of [
+      ["Blob", () => new Blob(["from-blob"]), "Blob cannot be used for stdio[3] yet"],
+      ["Response", () => new Response("from-response"), "Blob cannot be used for stdio[3] yet"],
+      [
+        "Request",
+        () => new Request("http://x", { method: "POST", body: "from-request" }),
+        "Blob cannot be used for stdio[3] yet",
+      ],
+      ["ReadableStream", () => pullStream(), "ReadableStream cannot be used for stdio[3] yet"],
+      ["Response(ReadableStream)", () => new Response(pullStream()), "ReadableStream cannot be used for stdio[3] yet"],
+      [
+        "Request(ReadableStream)",
+        () => new Request("http://x", { method: "POST", body: pullStream() }),
+        "ReadableStream cannot be used for stdio[3] yet",
+      ],
     ] as const) {
       it(`${label} at index >= 3 throws instead of panicking`, () => {
         expect(() =>
@@ -964,7 +969,7 @@ describe("close handling", () => {
             env: bunEnv,
             stdio: ["ignore", "pipe", "pipe", make()],
           }),
-        ).toThrow("ReadableStream cannot be used for stdio[3] yet");
+        ).toThrow(msg);
       });
     }
   });

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -944,6 +944,29 @@ describe("close handling", () => {
         expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
       });
     }
+
+    const pullStream = () =>
+      new ReadableStream({
+        pull(c) {
+          c.enqueue(new Uint8Array([1]));
+          c.close();
+        },
+      });
+    for (const [label, make] of [
+      ["ReadableStream", () => pullStream()],
+      ["Response(ReadableStream)", () => new Response(pullStream())],
+      ["Request(ReadableStream)", () => new Request("http://x", { method: "POST", body: pullStream() })],
+    ] as const) {
+      it(`${label} at index >= 3 throws instead of panicking`, () => {
+        expect(() =>
+          spawn({
+            cmd: [bunExe(), "-e", ""],
+            env: bunEnv,
+            stdio: ["ignore", "pipe", "pipe", make()],
+          }),
+        ).toThrow("ReadableStream cannot be used for stdio[3] yet");
+      });
+    }
   });
 });
 

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -896,6 +896,55 @@ describe("close handling", () => {
       expect(exitCode).toBe(0);
     });
   }
+
+  describe("stdio[N>=3] blob-like inputs", () => {
+    const readFd3 = `const fs = require("fs"); const b = Buffer.alloc(64); const n = fs.readSync(3, b); process.stdout.write(b.subarray(0, n));`;
+
+    it.skipIf(isWindows)("Bun.file(path) at index >= 3 is readable in the child", async () => {
+      const file = join(tmp, "stdio-extra-bunfile.txt");
+      writeFileSync(file, "from-bun-file");
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", readFd3],
+        env: bunEnv,
+        stdio: ["ignore", "pipe", "pipe", Bun.file(file)],
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "from-bun-file", stderr: "", exitCode: 0 });
+    });
+
+    it.skipIf(isWindows)("Bun.file(fd) at index >= 3 is readable in the child", async () => {
+      const file = join(tmp, "stdio-extra-bunfile-fd.txt");
+      writeFileSync(file, "from-bun-file-fd");
+      const fd = openSync(file, "r");
+      try {
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", readFd3],
+          env: bunEnv,
+          stdio: ["ignore", "pipe", "pipe", Bun.file(fd)],
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "from-bun-file-fd", stderr: "", exitCode: 0 });
+      } finally {
+        closeSync(fd);
+      }
+    });
+
+    for (const [label, make] of [
+      ["Blob", () => new Blob(["from-blob"])],
+      ["Response", () => new Response("from-response")],
+      ["Request", () => new Request("http://x", { method: "POST", body: "from-request" })],
+    ] as const) {
+      it(`${label} at index >= 3 does not panic`, async () => {
+        await using proc = spawn({
+          cmd: [bunExe(), "-e", "process.stdout.write('ok')"],
+          env: bunEnv,
+          stdio: ["ignore", "pipe", "pipe", make()],
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+      });
+    }
+  });
 });
 
 it("dispose keyword works", async () => {


### PR DESCRIPTION
## Repro

```js
// /tmp/x.txt contains "hello"
const p = Bun.spawn(["sh", "-c", "cat <&3"], {
  stdio: ["ignore", "pipe", "inherit", Bun.file("/tmp/x.txt")],
});
console.log(await p.stdout.text()); // expected: "hello"
```

```
panic: called `Option::unwrap()` on a `None` value
```

Same panic for `new Blob([...])`, `new Request(...)`, `new Response(...)` at any `stdio` index >= 3, and `panic: internal error: entered unreachable code` for a user-constructed `ReadableStream` (or a `Request`/`Response` wrapping one) at the same positions.

## Cause

Four sites in `stdio.rs` assumed `i < 3`:

- `Stdio::extract_blob` (line 549) and the `Blob` arm of `Stdio::as_spawn_option` (line 230) compute `FdStdio::from_int(i).unwrap().fd()`; `from_int` returns `None` for `i > 2`.
- The `Locked` arm of `Stdio::extract_body_value` (line 364) and the ReadableStream branch of `Stdio::extract` (line 494) match `i` against `0 | 1 | 2` with `_ => unreachable!()`.

All four are reachable from the extra-stdio loop in `js_bun_spawn_bindings.rs` with `i >= 3`.

The Zig reference had the equivalent `.?` / `unreachable` at the same spots; in a ReleaseFast build those are UB rather than panics, and on the commonly-taken paths (file-path Blob, in-memory Blob) the undefined value is dead, so execution continued. The Rust port turned the latent UB into hard panics.

## Fix

- **`Bun.file(path)` / `Bun.file(fd)` at `i >= 3`**: keep the standard-fd lookup as an `Option<Fd>` and compare with `Some(store_fd) == fd`. For `i >= 3` the comparison is always false and control falls through to `Stdio::Path` / `Stdio::Fd`, which the spawn machinery already handles (opens the file / dups the fd into the child). This restores the 1.3.x behavior.
- **In-memory `Blob` / `Response` / `Request` / `ReadableStream` at `i >= 3`**: throw `{Blob,ReadableStream} cannot be used for stdio[N] yet`, matching the existing stdout/stderr rejections. The parent-side writer that pumps bytes into the child's pipe (`Writable::Buffer` / memfd) is only wired up for stdin, and for extra slots the `Stdio` value is a loop-local dropped right after `as_spawn_option` returns the payload-less `Buffer`, so letting it through would silently hand the child an empty socketpair end. An empty Blob still becomes `Ignore`.

## Verification

New tests in `test/js/bun/spawn/spawn.test.ts` under `stdio[N>=3] blob-like inputs`:

- `Bun.file(path)` / `Bun.file(fd)` at index 3: child reads the file contents via fd 3
- empty `Blob` at index 3: treated as ignore, spawn succeeds
- `Blob` / `Response` / `Request` / `ReadableStream` / `Response(ReadableStream)` / `Request(ReadableStream)` at index 3: throws a clear error instead of panicking

```
# without fix: panics the test runner
USE_SYSTEM_BUN=1 bun test spawn.test.ts -t "stdio\[N>=3\] blob-like"
# panic: called `Option::unwrap()` on a `None` value

# with fix
bun bd test spawn.test.ts -t "stdio\[N>=3\] blob-like"
# 9 pass, 0 fail
```

Existing `Blob works as stdin` / `Bun.file() works as stdin` / `spawn-stdin-readable-stream.test.ts` / `spawn-empty-arrayBufferOrBlob.test.ts` still pass.
