### PR TITLE
git: add `bun git-clone` — parallel-fetch git client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -770,6 +770,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bun_git"
+version = "0.0.0"
+dependencies = [
+ "bstr",
+ "bun_alloc",
+ "bun_boringssl_sys",
+ "bun_collections",
+ "bun_core",
+ "bun_errno",
+ "bun_http",
+ "bun_libdeflate_sys",
+ "bun_paths",
+ "bun_ptr",
+ "bun_sys",
+ "bun_threading",
+ "bun_url",
+ "bun_wyhash",
+ "itoa",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
 name = "bun_glob"
 version = "0.0.0"
 dependencies = [
@@ -1646,6 +1669,7 @@ dependencies = [
  "bun_dns",
  "bun_dotenv",
  "bun_event_loop",
+ "bun_git",
  "bun_glob",
  "bun_hash",
  "bun_highway",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "src/dotenv",
   "src/event_loop",
   "src/exe_format",
+  "src/git",
   "src/highway",
   "src/http_jsc",
   "src/http_types",
@@ -386,6 +387,7 @@ bun_dns = { path = "src/dns" }
 bun_dotenv = { path = "src/dotenv" }
 bun_event_loop = { path = "src/event_loop" }
 bun_exe_format = { path = "src/exe_format" }
+bun_git = { path = "src/git" }
 bun_highway = { path = "src/highway" }
 bun_http_jsc = { path = "src/http_jsc" }
 bun_http_types = { path = "src/http_types" }

--- a/src/git/Cargo.toml
+++ b/src/git/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "bun_git"
+version.workspace = true
+edition.workspace = true
+
+[lib]
+path = "lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror.workspace = true
+libc.workspace = true
+itoa.workspace = true
+bstr.workspace = true
+bun_errno.workspace = true
+bun_core.workspace = true
+bun_libdeflate_sys.workspace = true
+bun_boringssl_sys.workspace = true
+bun_alloc.workspace = true
+bun_sys.workspace = true
+bun_paths.workspace = true
+bun_threading.workspace = true
+bun_collections.workspace = true
+bun_http.workspace = true
+bun_url.workspace = true
+bun_ptr.workspace = true
+bun_wyhash.workspace = true

--- a/src/git/checkout.rs
+++ b/src/git/checkout.rs
@@ -1,0 +1,544 @@
+//! Working-tree checkout from a [`PackIndex`](crate::pack::PackIndex).
+//!
+//! Walks the root tree breadth-first to collect every blob path, then writes
+//! blobs in parallel. Directory creation is serialised in the walk (cheap) so
+//! workers only ever `open(O_CREAT)` regular files.
+//!
+//! Path safety: tree entry names are attacker-controlled. We refuse any name
+//! that is empty, `"."`, `".."`, contains `'/'` or NUL, or case-folds to
+//! `".git"` (the last would let a malicious repo write into our own `.git` on
+//! a case-insensitive FS — CVE-2014-9390 family). Symlinks are written as
+//! regular files containing the target on platforms without `symlink`
+//! (Windows by default); on Unix we call `symlink(2)`.
+
+use crate::fs::{mkdirp, write_worktree_file};
+use crate::index::IndexEntry;
+use crate::odb::{Odb, TreeEntry, TreeIter};
+use crate::pack::{Inflate, ObjKind};
+use crate::{Error, Oid, Result};
+use bun_threading::{Guarded, WorkPool};
+
+const MODE_DIR: u32 = 0o040000;
+const MODE_LINK: u32 = 0o120000;
+const MODE_GITLINK: u32 = 0o160000;
+const MODE_EXEC: u32 = 0o100755;
+
+struct BlobJob {
+    /// Absolute path bytes (POSIX `/`; `validate_name` already rejected
+    /// separators inside components).
+    path: Vec<u8>,
+    oid: Oid,
+    mode: u32,
+    eol: Eol,
+}
+
+/// Materialise `tree` under `root` (absolute byte path). Returns one
+/// [`IndexEntry`] per blob/symlink/gitlink in tree order so the caller can
+/// write `.git/index` once all files are on disk.
+pub(crate) fn checkout(odb: &Odb, tree: Oid, root: &[u8]) -> Result<Vec<IndexEntry>> {
+    let mut inf = Inflate::new();
+    let mut jobs: Vec<BlobJob> = Vec::new();
+    let mut entries: Vec<IndexEntry> = Vec::new();
+    walk(odb, tree, root, &mut inf, &mut jobs, &mut entries)?;
+
+    struct Ctx<'a> {
+        odb: &'a Odb,
+        jobs: &'a [BlobJob],
+        err: Guarded<Option<Error>>,
+    }
+    let ctx = Ctx {
+        odb,
+        jobs: &jobs,
+        err: Guarded::new(None),
+    };
+    // `each` needs a `&mut [V: Copy]`; hand it indices.
+    let mut indices: Vec<u32> = (0..jobs.len() as u32).collect();
+    WorkPool::get().each(
+        &ctx,
+        |ctx, i: u32, _| {
+            crate::pack::with_inflate(|inf| {
+                let mut buf = Vec::new();
+                let mut conv = Vec::new();
+                if let Err(e) = write_blob(ctx.odb, &ctx.jobs[i as usize], inf, &mut buf, &mut conv) {
+                    *ctx.err.lock() = Some(e);
+                }
+            });
+        },
+        &mut indices,
+    );
+    let Ctx { mut err, .. } = ctx;
+    if let Some(e) = err.get_mut().take() {
+        return Err(e);
+    }
+    Ok(entries)
+}
+
+fn walk(
+    odb: &Odb,
+    tree: Oid,
+    dir: &[u8],
+    inf: &mut Inflate,
+    out: &mut Vec<BlobJob>,
+    entries: &mut Vec<IndexEntry>,
+) -> Result<()> {
+    let root_len = dir.len();
+    mkdirp(dir)?;
+    // BFS with an explicit queue so we don't recurse a million frames on deep
+    // trees. Each queue item owns its inflated tree bytes so iteration borrows
+    // stable memory.
+    let mut buf = Vec::new();
+    let kind = odb.read(&tree, inf, &mut buf)?;
+    if kind != ObjKind::Tree {
+        return Err(Error::Pack(format!("{tree} is {kind:?}, not a tree")));
+    }
+    let mut queue: Vec<(Vec<u8>, Vec<u8>, Vec<Rule>)> = vec![(dir.to_vec(), buf, Vec::new())];
+    while let Some((base, data, mut attrs)) = queue.pop() {
+        if let Some(oid) = find_gitattributes(&data)? {
+            let mut ab = Vec::new();
+            if odb.read(&oid, inf, &mut ab)? == ObjKind::Blob {
+                parse_attrs(&ab, &mut attrs);
+            }
+        }
+        for entry in TreeIter::new(&data) {
+            let TreeEntry { mode, name, oid } = entry?;
+            validate_name(name)?;
+            // validate_name rejected separators, NUL and dot-segments, so a
+            // simple byte join cannot escape `base`.
+            let mut path = Vec::with_capacity(base.len() + 1 + name.len());
+            path.extend_from_slice(&base);
+            path.push(b'/');
+            path.extend_from_slice(name);
+            match mode {
+                MODE_DIR => {
+                    mkdirp(&path)?;
+                    let mut sub = Vec::new();
+                    let k = odb.read(&oid, inf, &mut sub)?;
+                    if k != ObjKind::Tree {
+                        return Err(Error::Pack(format!("{oid} is {k:?}, not a tree")));
+                    }
+                    queue.push((path, sub, attrs.clone()));
+                }
+                MODE_GITLINK => {
+                    // Submodule placeholder: create the empty dir and record
+                    // the commit oid in the index (no blob to write).
+                    mkdirp(&path)?;
+                    entries.push(IndexEntry {
+                        mode,
+                        oid,
+                        path: path[root_len + 1..].to_vec(),
+                    });
+                }
+                _ => {
+                    let eol = if mode == MODE_LINK {
+                        Eol::None
+                    } else {
+                        eol_for(&attrs, name)
+                    };
+                    entries.push(IndexEntry {
+                        mode,
+                        oid,
+                        path: path[root_len + 1..].to_vec(),
+                    });
+                    out.push(BlobJob { path, oid, mode, eol });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Reject any tree-entry name that could resolve to a path component outside
+/// the working tree or into `.git/` on **any** filesystem we might be writing
+/// to. Mirrors git's `verify_path()` / `is_ntfs_dotgit()` / `is_hfs_dotgit()`
+/// (path.c) — the CVE-2014-9390 family showed that a case-insensitive or
+/// normalising FS turns several non-obvious spellings into `.git`, and writing
+/// `.git/hooks/post-checkout` from a malicious tree is RCE.
+///
+/// We check NTFS *and* HFS+ rules unconditionally (git gates them on
+/// `core.protectNTFS`/`core.protectHFS`, both default-on); a clone tool has no
+/// config, and the only cost is rejecting a handful of pathological names that
+/// no legitimate repo uses.
+fn validate_name(name: &[u8]) -> Result<()> {
+    if name.is_empty()
+        || name == b"."
+        || name == b".."
+        || name.contains(&b'/')
+        || name.contains(&b'\\')
+        || name.contains(&0)
+        // NTFS alternate data streams (`foo::$DATA`) and drive-letter syntax;
+        // also blocks `.git::$INDEX_ALLOCATION`. Harmless to reject on POSIX.
+        || name.contains(&b':')
+        || is_ntfs_dotgit(name)
+        || is_hfs_dotgit(name)
+    {
+        return Err(Error::UnsafePath(name.to_vec()));
+    }
+    Ok(())
+}
+
+/// NTFS canonicalisation: trailing `.`/` ` are stripped, and the 8.3 short
+/// name `GIT~1` (and `~2`…) maps to whatever long name sorts first — which
+/// for a fresh directory is `.git`. Case-insensitive.
+fn is_ntfs_dotgit(name: &[u8]) -> bool {
+    // Strip every trailing '.' or ' ' (NTFS does this on every component).
+    let mut end = name.len();
+    while end > 0 && matches!(name[end - 1], b'.' | b' ') {
+        end -= 1;
+    }
+    let core = &name[..end];
+    if core.eq_ignore_ascii_case(b".git") {
+        return true;
+    }
+    // 8.3 short name: `git~` followed by one or more digits (no leading dot —
+    // NTFS short names never carry one).
+    if core.len() >= 5
+        && core[..4].eq_ignore_ascii_case(b"git~")
+        && core[4..].iter().all(u8::is_ascii_digit)
+    {
+        return true;
+    }
+    false
+}
+
+/// HFS+ decomposes names and **ignores** a fixed set of Unicode "ignorable"
+/// code points when comparing — so `.g\u{200c}it` and `.git` are the same
+/// directory. The set is exactly the one git's `is_hfs_dotgit` checks
+/// (utf8.c): U+200C–200F, U+202A–202E, U+206A–206F, U+FEFF.
+fn is_hfs_dotgit(name: &[u8]) -> bool {
+    // Walk UTF-8, skipping ignorables, matching `.git` case-insensitively.
+    const TARGET: &[u8] = b".git";
+    let mut ti = 0usize;
+    let mut i = 0usize;
+    while i < name.len() {
+        // The ignorable set is entirely 3-byte UTF-8 sequences (U+200C..U+206F
+        // → E2 80/81 xx; U+FEFF → EF BB BF).
+        if name.len() - i >= 3 {
+            let s = &name[i..i + 3];
+            let skip = matches!(
+                s,
+                // U+200C..=U+200F
+                [0xe2, 0x80, 0x8c..=0x8f]
+                // U+202A..=U+202E
+                | [0xe2, 0x80, 0xaa..=0xae]
+                // U+206A..=U+206F
+                | [0xe2, 0x81, 0xaa..=0xaf]
+                // U+FEFF (BOM)
+                | [0xef, 0xbb, 0xbf]
+            );
+            if skip {
+                i += 3;
+                continue;
+            }
+        }
+        if ti >= TARGET.len() {
+            // More non-ignorable bytes after `.git` → not a match.
+            return false;
+        }
+        if !name[i].eq_ignore_ascii_case(&TARGET[ti]) {
+            return false;
+        }
+        ti += 1;
+        i += 1;
+    }
+    ti == TARGET.len()
+}
+
+/// Line-ending treatment resolved from `.gitattributes` for one blob.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Eol {
+    /// `-text` / `binary` / no matching rule — write bytes verbatim.
+    None,
+    /// `eol=lf` — convert CRLF → LF.
+    Lf,
+    /// `eol=crlf` — convert lone LF → CRLF.
+    Crlf,
+    /// Bare `text` with no explicit `eol=` — convert LF → CRLF only when the
+    /// blob looks textual (no NUL bytes, no CRLF already present).
+    Auto,
+}
+
+#[derive(Clone, Copy)]
+enum EolAttr {
+    Crlf,
+    Lf,
+}
+
+#[derive(Clone)]
+enum Pat {
+    Any,
+    Suffix(Vec<u8>),
+    Exact(Vec<u8>),
+}
+
+impl Pat {
+    fn parse(p: &[u8]) -> Option<Self> {
+        // Only the subset we need: `*`, `*suffix`, exact name. Anything with
+        // `/`, `**`, or a non-leading `*` falls back to verbatim writes.
+        if p.contains(&b'/') || p.windows(2).any(|w| w == b"**") {
+            return None;
+        }
+        if p == b"*" {
+            return Some(Pat::Any);
+        }
+        if let Some(rest) = p.strip_prefix(b"*") {
+            return if rest.contains(&b'*') {
+                None
+            } else {
+                Some(Pat::Suffix(rest.to_vec()))
+            };
+        }
+        if p.contains(&b'*') {
+            return None;
+        }
+        Some(Pat::Exact(p.to_vec()))
+    }
+
+    fn matches(&self, name: &[u8]) -> bool {
+        match self {
+            Pat::Any => true,
+            Pat::Suffix(s) => name.ends_with(s),
+            Pat::Exact(e) => name == e.as_slice(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct Rule {
+    pat: Pat,
+    /// `Some(true)` = `text`, `Some(false)` = `-text` / `binary`.
+    text: Option<bool>,
+    eol: Option<EolAttr>,
+}
+
+/// Scan a tree's entries for a regular-file `.gitattributes` blob (symlinked
+/// `.gitattributes` is ignored, matching git's CVE-2021-21300 hardening).
+fn find_gitattributes(tree: &[u8]) -> Result<Option<Oid>> {
+    for entry in TreeIter::new(tree) {
+        let TreeEntry { mode, name, oid } = entry?;
+        if name == b".gitattributes" && mode != MODE_DIR && mode != MODE_GITLINK && mode != MODE_LINK {
+            return Ok(Some(oid));
+        }
+    }
+    Ok(None)
+}
+
+/// Parse a `.gitattributes` blob, appending rules to `out`. Rules from inner
+/// directories are appended after their parent's, so a single forward scan in
+/// [`eol_for`] yields git's nearest-wins / last-line-wins semantics. Only
+/// `text`, `-text`, `binary`, `eol=crlf` and `eol=lf` are recognised
+/// (`text=auto`, `!text`, `-eol` are intentionally out of scope).
+fn parse_attrs(data: &[u8], out: &mut Vec<Rule>) {
+    for line in data.split(|&b| b == b'\n') {
+        let line = match line.last() {
+            Some(b'\r') => &line[..line.len() - 1],
+            _ => line,
+        };
+        let mut it = line
+            .split(|&b| b == b' ' || b == b'\t')
+            .filter(|s| !s.is_empty());
+        let Some(pat) = it.next() else { continue };
+        if pat.starts_with(b"#") {
+            continue;
+        }
+        let Some(pat) = Pat::parse(pat) else { continue };
+        let mut text = None;
+        let mut eol = None;
+        for tok in it {
+            match tok {
+                b"text" => text = Some(true),
+                b"-text" | b"binary" => text = Some(false),
+                b"eol=crlf" => eol = Some(EolAttr::Crlf),
+                b"eol=lf" => eol = Some(EolAttr::Lf),
+                _ => {}
+            }
+        }
+        if text.is_some() || eol.is_some() {
+            out.push(Rule { pat, text, eol });
+        }
+    }
+}
+
+fn eol_for(rules: &[Rule], name: &[u8]) -> Eol {
+    let mut text: Option<bool> = None;
+    let mut eol: Option<EolAttr> = None;
+    for r in rules {
+        if r.pat.matches(name) {
+            if let Some(t) = r.text {
+                text = Some(t);
+            }
+            if let Some(e) = r.eol {
+                eol = Some(e);
+            }
+        }
+    }
+    match (text, eol) {
+        (Some(false), _) => Eol::None,
+        (_, Some(EolAttr::Crlf)) => Eol::Crlf,
+        (_, Some(EolAttr::Lf)) => Eol::Lf,
+        (Some(true), None) => Eol::Auto,
+        (None, None) => Eol::None,
+    }
+}
+
+/// `text` auto-detection: no NUL bytes and no existing CRLF.
+fn is_text_auto(buf: &[u8]) -> bool {
+    let mut prev_cr = false;
+    for &b in buf {
+        if b == 0 || (b == b'\n' && prev_cr) {
+            return false;
+        }
+        prev_cr = b == b'\r';
+    }
+    true
+}
+
+/// In-place CRLF → LF. Lone CR is left untouched.
+fn crlf_to_lf(buf: &mut Vec<u8>) {
+    let mut w = 0;
+    let mut i = 0;
+    let len = buf.len();
+    while i < len {
+        if buf[i] == b'\r' && i + 1 < len && buf[i + 1] == b'\n' {
+            i += 1;
+        }
+        buf[w] = buf[i];
+        w += 1;
+        i += 1;
+    }
+    buf.truncate(w);
+}
+
+/// LF → CRLF into `dst` (cleared first). LF already preceded by CR is left
+/// alone so existing CRLF is not doubled.
+fn lf_to_crlf(src: &[u8], dst: &mut Vec<u8>) {
+    dst.clear();
+    dst.reserve(src.len() + src.iter().filter(|&&b| b == b'\n').count());
+    let mut prev_cr = false;
+    for &b in src {
+        if b == b'\n' && !prev_cr {
+            dst.push(b'\r');
+        }
+        dst.push(b);
+        prev_cr = b == b'\r';
+    }
+}
+
+fn write_blob(
+    odb: &Odb,
+    job: &BlobJob,
+    inf: &mut Inflate,
+    buf: &mut Vec<u8>,
+    conv: &mut Vec<u8>,
+) -> Result<()> {
+    let kind = odb.read(&job.oid, inf, buf)?;
+    if kind != ObjKind::Blob {
+        return Err(Error::Pack(format!("{} is {kind:?}, not a blob", job.oid)));
+    }
+    #[cfg(unix)]
+    if job.mode == MODE_LINK {
+        crate::fs::symlink(buf, &job.path)?;
+        return Ok(());
+    }
+    let data: &[u8] = match job.eol {
+        Eol::None => buf.as_slice(),
+        Eol::Lf => {
+            crlf_to_lf(buf);
+            buf.as_slice()
+        }
+        Eol::Crlf => {
+            lf_to_crlf(buf, conv);
+            conv.as_slice()
+        }
+        Eol::Auto if is_text_auto(buf) => {
+            lf_to_crlf(buf, conv);
+            conv.as_slice()
+        }
+        Eol::Auto => buf.as_slice(),
+    };
+    let mode = if job.mode == MODE_EXEC { 0o755 } else { 0o644 };
+    write_worktree_file(&job.path, data, mode)?;
+    Ok(())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_dotgit_spellings() {
+        for bad in [
+            &b".git"[..],
+            b".GIT",
+            b".Git",
+            b".git ",
+            b".git.",
+            b".git . . ",
+            b"GIT~1",
+            b"git~1",
+            b"GiT~42",
+            // .g<ZWNJ>it
+            b".g\xe2\x80\x8cit",
+            // <BOM>.git
+            b"\xef\xbb\xbf.git",
+            // .git<LRO>
+            b".git\xe2\x80\xad",
+            b"..",
+            b".",
+            b"",
+            b"a/b",
+            b"a\\b",
+            b"a:b",
+            b"a\x00b",
+        ] {
+            assert!(validate_name(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn accepts_benign_names() {
+        for ok in [
+            &b".gitignore"[..],
+            b".gitmodules",
+            b".github",
+            b"git~", // no digits
+            b"git",
+            b"a.git",
+            b"normal_file.rs",
+            // U+00E9 (é) — non-ignorable, must not be stripped
+            b".g\xc3\xa9it",
+        ] {
+            assert!(validate_name(ok).is_ok(), "should accept {ok:?}");
+        }
+    }
+
+    #[test]
+    fn attrs_parse_and_match() {
+        let mut rules = Vec::new();
+        parse_attrs(
+            b"# comment\n\
+              *           text\n\
+              *.bin       binary\n\
+              *.sh        eol=lf\n\
+              win.bat     eol=crlf\r\n\
+              **/deep     eol=lf\n",
+            &mut rules,
+        );
+        assert_eq!(eol_for(&rules, b"README"), Eol::Auto);
+        assert_eq!(eol_for(&rules, b"a.bin"), Eol::None);
+        assert_eq!(eol_for(&rules, b"run.sh"), Eol::Lf);
+        assert_eq!(eol_for(&rules, b"win.bat"), Eol::Crlf);
+        assert_eq!(eol_for(&rules, b"deep"), Eol::Auto); // `**` pattern ignored
+        parse_attrs(b"*.sh -text\n", &mut rules);
+        assert_eq!(eol_for(&rules, b"run.sh"), Eol::None); // later rule wins per-attribute
+    }
+
+    #[test]
+    fn eol_conversions() {
+        let mut out = Vec::new();
+        lf_to_crlf(b"a\nb\r\nc\n", &mut out);
+        assert_eq!(out, b"a\r\nb\r\nc\r\n");
+        let mut v = b"a\r\nb\nc\r".to_vec();
+        crlf_to_lf(&mut v);
+        assert_eq!(v, b"a\nb\nc\r");
+        assert!(is_text_auto(b"a\nb\n") && !is_text_auto(b"a\r\nb") && !is_text_auto(b"a\0b"));
+    }
+}

--- a/src/git/checkout.rs
+++ b/src/git/checkout.rs
@@ -59,7 +59,8 @@ pub(crate) fn checkout(odb: &Odb, tree: Oid, root: &[u8]) -> Result<Vec<IndexEnt
             crate::pack::with_inflate(|inf| {
                 let mut buf = Vec::new();
                 let mut conv = Vec::new();
-                if let Err(e) = write_blob(ctx.odb, &ctx.jobs[i as usize], inf, &mut buf, &mut conv) {
+                if let Err(e) = write_blob(ctx.odb, &ctx.jobs[i as usize], inf, &mut buf, &mut conv)
+                {
                     *ctx.err.lock() = Some(e);
                 }
             });
@@ -139,7 +140,12 @@ fn walk(
                         oid,
                         path: path[root_len + 1..].to_vec(),
                     });
-                    out.push(BlobJob { path, oid, mode, eol });
+                    out.push(BlobJob {
+                        path,
+                        oid,
+                        mode,
+                        eol,
+                    });
                 }
             }
         }
@@ -315,7 +321,11 @@ struct Rule {
 fn find_gitattributes(tree: &[u8]) -> Result<Option<Oid>> {
     for entry in TreeIter::new(tree) {
         let TreeEntry { mode, name, oid } = entry?;
-        if name == b".gitattributes" && mode != MODE_DIR && mode != MODE_GITLINK && mode != MODE_LINK {
+        if name == b".gitattributes"
+            && mode != MODE_DIR
+            && mode != MODE_GITLINK
+            && mode != MODE_LINK
+        {
             return Ok(Some(oid));
         }
     }

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -72,10 +72,16 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
     if jobs == 1 {
         // Single-connection path: one full pack, identical to `git clone`.
         let buf = fetch_pack(&remote, &wants, &[], None, opts.quiet)?;
-        log(opts, format_args!("\nReceived {} bytes in {:.2}s", buf.len(), s(t0)));
+        log(
+            opts,
+            format_args!("\nReceived {} bytes in {:.2}s", buf.len(), s(t0)),
+        );
         let t1 = Timer::start().unwrap();
         odb.push(PackIndex::build(buf, &mut Default::default())?);
-        log(opts, format_args!("Indexed {} objects in {:.2}s", odb.packs()[0].len(), s(t1)));
+        log(
+            opts,
+            format_args!("Indexed {} objects in {:.2}s", odb.packs()[0].len(), s(t1)),
+        );
     } else {
         // ── Phase A: skeleton (commits + trees + tags) ────────────────────
         // Partition history at semver-sorted tags so the skeleton downloads
@@ -128,10 +134,10 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
         let mut wave1_sent = false;
 
         let index_one = |buf: Vec<u8>,
-                             all: &mut crate::pack::OidMap<u32>,
-                             odb: &mut Odb,
-                             total_objs: &mut usize,
-                             skel_bytes: &mut usize|
+                         all: &mut crate::pack::OidMap<u32>,
+                         odb: &mut Odb,
+                         total_objs: &mut usize,
+                         skel_bytes: &mut usize|
          -> Result<()> {
             *skel_bytes += buf.len();
             let mut sink = crate::pack::BlobSink {
@@ -163,7 +169,13 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
                 let buckets = bucket_blobs(&all, jobs, None);
                 blob_wg.add(buckets.len());
                 dispatch_blob_fetches(
-                    &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+                    &remote,
+                    &git_dir,
+                    buckets,
+                    opts.quiet,
+                    &blob_wg,
+                    &blob_out,
+                    &blob_bytes,
                 );
                 wave1_sent = true;
                 // Wave-2: index this batch into a *fresh* map, then dispatch
@@ -175,7 +187,13 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
                 let buckets = bucket_blobs(&tail, jobs, Some(&all));
                 blob_wg.add(buckets.len());
                 dispatch_blob_fetches(
-                    &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+                    &remote,
+                    &git_dir,
+                    buckets,
+                    opts.quiet,
+                    &blob_wg,
+                    &blob_out,
+                    &blob_bytes,
                 );
                 break;
             }
@@ -188,7 +206,13 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
             let buckets = bucket_blobs(&all, jobs, None);
             blob_wg.add(buckets.len());
             dispatch_blob_fetches(
-                &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+                &remote,
+                &git_dir,
+                buckets,
+                opts.quiet,
+                &blob_wg,
+                &blob_out,
+                &blob_bytes,
             );
         }
         let t2 = Timer::start().unwrap();
@@ -201,7 +225,11 @@ pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
                 n_slices,
                 s(t0),
                 jobs,
-                if wave1_sent { " (wave-1 fired pre-index)" } else { "" }
+                if wave1_sent {
+                    " (wave-1 fired pre-index)"
+                } else {
+                    ""
+                }
             ),
         );
         // Skeleton packs to disk while blobs download.
@@ -439,8 +467,8 @@ fn write_pack_and_idx(git_dir: &[u8], p: &PackIndex) -> Result<()> {
 /// Standalone index-pack: read `pack_path`, write `<pack_path%.pack>.idx`.
 /// Same work `git index-pack` does — used for apples-to-apples benchmarking.
 pub fn index_pack_file(pack_path: &[u8]) -> Result<Oid> {
-    let pack =
-        bun_sys::File::openat(bun_core::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)?.read_to_end()?;
+    let pack = bun_sys::File::openat(bun_core::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)?
+        .read_to_end()?;
     let mut tm = crate::pack::Timings::default();
     let t = Timer::start().unwrap();
     let idx = PackIndex::build(pack, &mut tm)?;

--- a/src/git/clone.rs
+++ b/src/git/clone.rs
@@ -1,0 +1,544 @@
+//! `clone(url, dir)` — wires `bun_http` transport → protocol → pack indexer →
+//! checkout, and lays down a `.git` (incl. v2 index) that `git status` reads clean.
+
+use crate::fs::{dir_nonempty, mkdirp, write_trusted};
+use crate::odb::Odb;
+use crate::pack::{Inflate, PackIndex};
+use crate::transport::Remote;
+use crate::{Error, Oid, Result, checkout, odb, protocol};
+use bstr::BStr;
+use bun_core::time::Timer;
+use bun_threading::{Guarded, WaitGroup, WorkPool};
+use core::fmt::Write as _;
+
+#[derive(Default)]
+pub struct CloneOptions {
+    /// Skip working-tree checkout.
+    pub no_checkout: bool,
+    /// Suppress server progress (band 2) and our own timing lines.
+    pub quiet: bool,
+    /// Parallel blob-fetch connections (0 = auto = 8). 1 = single-connection
+    /// path (one full pack, like `git clone`).
+    pub jobs: usize,
+    /// Skeleton history slices (0 = auto). 1 = single skeleton stream.
+    pub skeleton_slices: usize,
+}
+
+/// Clone `url` (`http[s]://…`) into `dest` (absolute byte path). `dest` must
+/// not exist or must be an empty directory. Returns the HEAD commit oid.
+pub fn clone(url: &str, dest: &[u8], opts: &CloneOptions) -> Result<Oid> {
+    let remote = Remote::parse(url)?;
+
+    if dir_nonempty(dest)? {
+        return Err(Error::Http(format!(
+            "destination {:?} exists and is not empty",
+            BStr::new(dest)
+        )));
+    }
+    mkdirp(dest)?;
+    let git_dir = join(dest, b".git");
+    init_git_dir(&git_dir)?;
+
+    // ── handshake + ls-refs ────────────────────────────────────────────────
+    let caps = protocol::handshake(&remote)?;
+    let refs = protocol::ls_refs(&remote)?;
+    if refs.is_empty() {
+        return Err(Error::Protocol("remote has no refs".into()));
+    }
+    let head = refs
+        .iter()
+        .find(|r| r.name == "HEAD")
+        .ok_or_else(|| Error::Protocol("remote has no HEAD".into()))?;
+    let head_oid = head.oid;
+    let head_target = head.symref_target.clone();
+    write_config(&git_dir, url, head_target.as_deref())?;
+
+    // Want every distinct branch/tag tip + HEAD.
+    let mut wants: Vec<Oid> = refs.iter().map(|r| r.oid).collect();
+    wants.sort_unstable();
+    wants.dedup();
+
+    // Parallel path needs server-side `filter` support (GitHub, GitLab,
+    // Gitea, any `uploadpack.allowFilter=true` backend). Fall back to one
+    // full pack otherwise.
+    let jobs = match (opts.jobs, caps.filter) {
+        (0, true) => 8,
+        (0, false) | (_, false) => 1,
+        (n, true) => n,
+    };
+    let mut odb = Odb::new();
+    let t0 = Timer::start().unwrap();
+
+    if jobs == 1 {
+        // Single-connection path: one full pack, identical to `git clone`.
+        let buf = fetch_pack(&remote, &wants, &[], None, opts.quiet)?;
+        log(opts, format_args!("\nReceived {} bytes in {:.2}s", buf.len(), s(t0)));
+        let t1 = Timer::start().unwrap();
+        odb.push(PackIndex::build(buf, &mut Default::default())?);
+        log(opts, format_args!("Indexed {} objects in {:.2}s", odb.packs()[0].len(), s(t1)));
+    } else {
+        // ── Phase A: skeleton (commits + trees + tags) ────────────────────
+        // Partition history at semver-sorted tags so the skeleton downloads
+        // in parallel slices. We don't advertise `thin-pack`, so each
+        // `want pt[i], have pt[0..i]` slice is self-contained.
+        //
+        // Slices are pushed to `queue` as each fetch completes; main drains
+        // the queue and indexes (full `WorkPool` parallelism per slice)
+        // **while later slices are still in flight** — so phase A wall-clock
+        // is `max(slowest-fetch, Σ index)` instead of `slowest-fetch + Σ index`.
+        // 4 slices is the measured sweet spot: enough to beat per-conn
+        // bandwidth caps when slices are even (git/git: 4.96 s vs 5.99 s
+        // single-stream), few enough that server-side per-slice graph walks
+        // don't dominate when they're not (node: ~flat across 1–4).
+        let k = if opts.skeleton_slices == 0 {
+            4
+        } else {
+            opts.skeleton_slices
+        };
+        let pts = if k <= 1 {
+            Vec::new()
+        } else {
+            partition_points(&refs, k - 1)
+        };
+        // Tried per-slice blob dispatch (fire blob buckets as each skeleton
+        // slice lands): it loses. Early blob streams compete with the
+        // remaining skeleton streams for the same ~150 MB/s link, so the
+        // last skeleton slice — the one gating *full* blob knowledge —
+        // arrives later, and the net is 2-3× slower than two clean phases.
+        // The link is the bottleneck, not idle time; reordering work on a
+        // saturated pipe doesn't help.
+        let n_slices = pts.len() + 1;
+        let queue: Guarded<Vec<Result<Vec<u8>>>> = Guarded::new(Vec::new());
+        let cv = bun_threading::Condvar::new();
+        dispatch_skeleton_fetches(&remote, &wants, &pts, opts.quiet, &queue, &cv);
+
+        // Phase-B state lives here so wave-1 can fire from inside the drain
+        // loop the moment the last skeleton *fetch* completes (before that
+        // last batch is indexed). Wave-2 carries whatever the last batch
+        // adds. No bandwidth contention: skeleton bytes are all received
+        // before any blob byte is requested.
+        let blob_wg = WaitGroup::init_with_count(0);
+        let blob_out: Guarded<Vec<Result<PackIndex>>> = Guarded::new(Vec::new());
+        let blob_bytes = Guarded::new(0usize);
+
+        let mut all = crate::pack::OidMap::<u32>::default();
+        let mut total_objs = 0usize;
+        let mut skel_bytes = 0usize;
+        let mut done = 0usize;
+        let mut wave1_sent = false;
+
+        let index_one = |buf: Vec<u8>,
+                             all: &mut crate::pack::OidMap<u32>,
+                             odb: &mut Odb,
+                             total_objs: &mut usize,
+                             skel_bytes: &mut usize|
+         -> Result<()> {
+            *skel_bytes += buf.len();
+            let mut sink = crate::pack::BlobSink {
+                want: true,
+                ..Default::default()
+            };
+            let p = PackIndex::build_with(buf, &mut Default::default(), &mut sink, false)?;
+            *total_objs += p.len();
+            all.ensure_total_capacity(all.len() + sink.seen.len())
+                .expect("OOM");
+            sink.merge_into(all);
+            odb.push(p);
+            Ok(())
+        };
+
+        while done < n_slices {
+            let batch: Vec<Result<Vec<u8>>> = {
+                let mut g = queue.lock();
+                while g.is_empty() {
+                    cv.wait_guarded(&mut g);
+                }
+                core::mem::take(&mut *g)
+            };
+            done += batch.len();
+            let last = done == n_slices;
+            // Last fetch in hand → link is idle. Fire wave-1 from everything
+            // already indexed *before* paying the index cost of this batch.
+            if last && !all.is_empty() {
+                let buckets = bucket_blobs(&all, jobs, None);
+                blob_wg.add(buckets.len());
+                dispatch_blob_fetches(
+                    &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+                );
+                wave1_sent = true;
+                // Wave-2: index this batch into a *fresh* map, then dispatch
+                // only oids not already in `all` (= not in wave-1).
+                let mut tail = crate::pack::OidMap::<u32>::default();
+                for buf in batch {
+                    index_one(buf?, &mut tail, &mut odb, &mut total_objs, &mut skel_bytes)?;
+                }
+                let buckets = bucket_blobs(&tail, jobs, Some(&all));
+                blob_wg.add(buckets.len());
+                dispatch_blob_fetches(
+                    &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+                );
+                break;
+            }
+            for buf in batch {
+                index_one(buf?, &mut all, &mut odb, &mut total_objs, &mut skel_bytes)?;
+            }
+        }
+        if !wave1_sent {
+            // All slices arrived in one batch — single dispatch.
+            let buckets = bucket_blobs(&all, jobs, None);
+            blob_wg.add(buckets.len());
+            dispatch_blob_fetches(
+                &remote, &git_dir, buckets, opts.quiet, &blob_wg, &blob_out, &blob_bytes,
+            );
+        }
+        let t2 = Timer::start().unwrap();
+        log(
+            opts,
+            format_args!(
+                "\nSkeleton: {} bytes / {} objs in {} slices, fetched ‖ indexed in {:.2}s; blobs → {} streams{}",
+                skel_bytes,
+                total_objs,
+                n_slices,
+                s(t0),
+                jobs,
+                if wave1_sent { " (wave-1 fired pre-index)" } else { "" }
+            ),
+        );
+        // Skeleton packs to disk while blobs download.
+        for p in odb.packs() {
+            write_pack_and_idx(&git_dir, p)?;
+        }
+        write_refs(&git_dir, &refs, head_target.as_deref())?;
+        blob_wg.wait();
+        for r in core::mem::take(&mut *blob_out.lock()) {
+            odb.push(r?);
+        }
+        log(
+            opts,
+            format_args!(
+                "Blobs: {} bytes, tail {:.2}s after skeleton",
+                *blob_bytes.lock(),
+                s(t2)
+            ),
+        );
+    }
+
+    // -j1 path writes here; the parallel path already wrote everything
+    // overlapped with phase B.
+    if jobs == 1 {
+        for p in odb.packs() {
+            write_pack_and_idx(&git_dir, p)?;
+        }
+        write_refs(&git_dir, &refs, head_target.as_deref())?;
+    }
+
+    // ── checkout ───────────────────────────────────────────────────────────
+    if !opts.no_checkout {
+        let tc = Timer::start().unwrap();
+        let mut inf = Inflate::new();
+        let tree = odb::read_commit_tree(&odb, &head_oid, &mut inf)?;
+        let entries = checkout::checkout(&odb, tree, dest)?;
+        crate::index::write(dest, entries)?;
+        log(opts, format_args!("Checked out HEAD in {:.2}s", s(tc)));
+    }
+    log(opts, format_args!("Total: {:.2}s", s(t0)));
+
+    Ok(head_oid)
+}
+
+#[inline]
+fn s(t: Timer) -> f64 {
+    t.read() as f64 / 1e9
+}
+fn log(opts: &CloneOptions, args: core::fmt::Arguments<'_>) {
+    if !opts.quiet {
+        bun_core::pretty_errorln!("{}", args);
+    }
+}
+
+/// Partition `set` into `n` path-hash buckets, optionally skipping oids
+/// already present in `exclude` (wave-2's "new since wave-1" delta).
+fn bucket_blobs(
+    set: &crate::pack::OidMap<u32>,
+    n: usize,
+    exclude: Option<&crate::pack::OidMap<u32>>,
+) -> Vec<Vec<Oid>> {
+    let mut buckets: Vec<Vec<Oid>> = (0..n).map(|_| Vec::new()).collect();
+    for (oid, h) in set.iter() {
+        if exclude.is_some_and(|e| e.get(oid).is_some()) {
+            continue;
+        }
+        buckets[(*h as usize) % n].push(*oid);
+    }
+    buckets
+}
+
+/// One blocking fetch → buffered pack bytes.
+fn fetch_pack(
+    remote: &Remote,
+    wants: &[Oid],
+    haves: &[Oid],
+    filter: Option<&str>,
+    quiet: bool,
+) -> Result<Vec<u8>> {
+    let buf = Guarded::new(Vec::<u8>::new());
+    protocol::fetch(remote, wants, haves, filter, quiet, |data| {
+        buf.lock().extend_from_slice(data);
+        Ok(())
+    })?;
+    Ok(core::mem::take(&mut *buf.lock()))
+}
+
+/// Pick `k` evenly-spaced tag oids as history partition points. Tags sort
+/// roughly chronologically (semver-ish) so each `want pt[i], have pt[i-1]`
+/// slice is a contiguous span of history. If a repo's tags aren't linear the
+/// slices just overlap a bit — still correct, only less compressed.
+fn partition_points(refs: &[protocol::Ref], k: usize) -> Vec<Oid> {
+    let mut tags: Vec<&protocol::Ref> = refs
+        .iter()
+        .filter(|r| r.name.starts_with("refs/tags/"))
+        .collect();
+    if tags.len() < k * 2 {
+        return Vec::new();
+    }
+    // Semver-aware: split the tag name on non-digit runs and compare each
+    // numeric run as an integer (so v2 < v10).
+    tags.sort_by_cached_key(|r| version_key(&r.name));
+    // Bias toward recent: commit density grows over a project's life, so the
+    // last slice (newest) is the fattest under uniform spacing. Place point i
+    // at fraction `1 - ((k+1-i)/(k+1))²` instead of `i/(k+1)` — quadratic
+    // toward the tail packs more cuts into recent history.
+    let n = tags.len();
+    (1..=k)
+        .map(|i| {
+            let r = (k + 1 - i) as f64 / (k + 1) as f64;
+            let frac = 1.0 - r * r;
+            tags[((frac * n as f64) as usize).min(n - 1)].oid
+        })
+        .collect()
+}
+
+fn version_key(name: &str) -> Vec<u64> {
+    let mut out = Vec::with_capacity(4);
+    let mut n = 0u64;
+    let mut in_num = false;
+    for b in name.bytes() {
+        if b.is_ascii_digit() {
+            n = n.saturating_mul(10).saturating_add(u64::from(b - b'0'));
+            in_num = true;
+        } else if in_num {
+            out.push(n);
+            n = 0;
+            in_num = false;
+        }
+    }
+    if in_num {
+        out.push(n);
+    }
+    out
+}
+
+/// Dispatch `pts.len()+1` skeleton-slice fetches; each worker pushes its raw
+/// pack bytes to `queue` and signals `cv` as soon as the stream completes.
+/// Caller drains the queue concurrently (index-while-fetching).
+///
+/// Lifetime: `queue`/`cv` live on the caller's stack; the caller's drain loop
+/// doesn't return until it has popped exactly `pts.len()+1` items, and each
+/// worker's last action is `cv.notify_one()` *after* its push — so by the
+/// time the caller exits the loop, every worker has returned and no longer
+/// holds the `BackRef`s. That's the same guarantee `WaitGroup` gave, just
+/// expressed through the queue count.
+fn dispatch_skeleton_fetches(
+    remote: &Remote,
+    all_tips: &[Oid],
+    pts: &[Oid],
+    quiet: bool,
+    queue: &Guarded<Vec<Result<Vec<u8>>>>,
+    cv: &bun_threading::Condvar,
+) {
+    let n = pts.len() + 1;
+    for i in 0..n {
+        let want: Vec<Oid> = if i == n - 1 {
+            all_tips.to_vec()
+        } else {
+            vec![pts[i]]
+        };
+        // Every earlier partition point as `have` — tags aren't always a
+        // straight line, and an extra `have` only shrinks the slice.
+        let have: Vec<Oid> = pts[..i].to_vec();
+        let remote = remote.clone();
+        let q = bun_ptr::BackRef::from(core::ptr::NonNull::from(queue));
+        let c = bun_ptr::BackRef::from(core::ptr::NonNull::from(cv));
+        WorkPool::go(
+            (remote, want, have, quiet, q, c),
+            move |(remote, want, have, quiet, q, c)| {
+                let r = fetch_pack(&remote, &want, &have, Some("blob:none"), quiet);
+                q.lock().push(r);
+                c.notify_one();
+            },
+        )
+        .unwrap();
+    }
+}
+
+/// Dispatch `buckets.len()` blob fetches; each worker fetches → indexes
+/// (`build_serial` — no nested pool) → writes `.pack`/`.idx` to `git_dir`,
+/// then signals. Everything hides under the slowest stream.
+#[allow(clippy::too_many_arguments)]
+fn dispatch_blob_fetches(
+    remote: &Remote,
+    git_dir: &[u8],
+    buckets: Vec<Vec<Oid>>,
+    quiet: bool,
+    wg: &WaitGroup,
+    out: &Guarded<Vec<Result<PackIndex>>>,
+    bytes: &Guarded<usize>,
+) {
+    for wants in buckets {
+        if wants.is_empty() {
+            wg.finish();
+            continue;
+        }
+        let remote = remote.clone();
+        let git_dir = git_dir.to_vec();
+        let wg_ref = bun_ptr::BackRef::from(core::ptr::NonNull::from(wg));
+        let out_ref = bun_ptr::BackRef::from(core::ptr::NonNull::from(out));
+        let bytes_ref = bun_ptr::BackRef::from(core::ptr::NonNull::from(bytes));
+        WorkPool::go(
+            (remote, git_dir, wants, quiet, wg_ref, out_ref, bytes_ref),
+            move |(remote, git_dir, wants, quiet, wg, out, bytes)| {
+                let r = fetch_pack(&remote, &wants, &[], None, quiet).and_then(|buf| {
+                    *bytes.lock() += buf.len();
+                    let p = PackIndex::build_serial(buf)?;
+                    write_pack_and_idx(&git_dir, &p)?;
+                    Ok(p)
+                });
+                out.lock().push(r);
+                wg.finish();
+            },
+        )
+        .unwrap();
+    }
+}
+
+fn write_pack_and_idx(git_dir: &[u8], p: &PackIndex) -> Result<()> {
+    let name = p.pack_hash();
+    write_trusted(
+        &join(git_dir, format!("objects/pack/pack-{name}.pack").as_bytes()),
+        p.pack_bytes(),
+    )?;
+    let mut idx_buf = Vec::new();
+    p.write_idx(&mut idx_buf);
+    write_trusted(
+        &join(git_dir, format!("objects/pack/pack-{name}.idx").as_bytes()),
+        &idx_buf,
+    )?;
+    Ok(())
+}
+
+/// Standalone index-pack: read `pack_path`, write `<pack_path%.pack>.idx`.
+/// Same work `git index-pack` does — used for apples-to-apples benchmarking.
+pub fn index_pack_file(pack_path: &[u8]) -> Result<Oid> {
+    let pack =
+        bun_sys::File::openat(bun_core::Fd::cwd(), pack_path, bun_sys::O::RDONLY, 0)?.read_to_end()?;
+    let mut tm = crate::pack::Timings::default();
+    let t = Timer::start().unwrap();
+    let idx = PackIndex::build(pack, &mut tm)?;
+    bun_core::pretty_errorln!(
+        "Indexed {} objects in {:.3}s (trailer {:.3}s, scan {:.3}s, resolve {:.3}s, {} deltas)",
+        idx.len(),
+        t.read() as f64 / 1e9,
+        tm.trailer_sha as f64 / 1e9,
+        tm.pass1_scan as f64 / 1e9,
+        tm.pass2_resolve as f64 / 1e9,
+        tm.n_deltas,
+    );
+    let mut idx_buf = Vec::new();
+    idx.write_idx(&mut idx_buf);
+    let idx_path: Vec<u8> = pack_path
+        .strip_suffix(b".pack")
+        .unwrap_or(pack_path)
+        .iter()
+        .copied()
+        .chain(*b".idx")
+        .collect();
+    write_trusted(&idx_path, &idx_buf)?;
+    Ok(idx.pack_hash())
+}
+
+fn join(a: &[u8], b: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(a.len() + 1 + b.len());
+    out.extend_from_slice(a);
+    out.push(b'/');
+    out.extend_from_slice(b);
+    out
+}
+
+fn init_git_dir(git: &[u8]) -> Result<()> {
+    for sub in [
+        &b"objects/pack"[..],
+        b"objects/info",
+        b"refs/heads",
+        b"refs/tags",
+        b"refs/remotes/origin",
+        b"info",
+    ] {
+        mkdirp(&join(git, sub))?;
+    }
+    write_trusted(&join(git, b"HEAD"), b"ref: refs/heads/master\n")?;
+    write_trusted(&join(git, b"description"), b"unnamed repository\n")?;
+    Ok(())
+}
+
+fn write_config(git: &[u8], url: &str, head_target: Option<&str>) -> Result<()> {
+    let mut cfg = format!(
+        "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n\
+         [remote \"origin\"]\n\turl = {url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+    );
+    if let Some(branch) = head_target
+        .and_then(|t| t.strip_prefix("refs/heads/"))
+        // `\` is already rejected by check_ref_format; `"` would need escaping
+        // in the subsection header — skip the stanza for that exotic case.
+        .filter(|b| !b.contains('"'))
+    {
+        write!(
+            cfg,
+            "[branch \"{branch}\"]\n\tremote = origin\n\tmerge = refs/heads/{branch}\n"
+        )
+        .unwrap();
+    }
+    write_trusted(&join(git, b"config"), cfg.as_bytes())
+}
+
+fn write_refs(git: &[u8], refs: &[protocol::Ref], head_target: Option<&str>) -> Result<()> {
+    // Packed refs: every advertised ref plus a refs/remotes/origin/* mirror of
+    // each branch tip, so `git branch -r` and `git pull` see an upstream.
+    let mut lines: Vec<(String, Oid)> = Vec::with_capacity(refs.len() * 2);
+    for r in refs {
+        if r.name == "HEAD" || r.symref_target.is_some() {
+            continue;
+        }
+        lines.push((r.name.clone(), r.oid));
+        if let Some(branch) = r.name.strip_prefix("refs/heads/") {
+            lines.push((format!("refs/remotes/origin/{branch}"), r.oid));
+        }
+    }
+    lines.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut packed = String::from("# pack-refs with: peeled fully-peeled sorted \n");
+    for (name, oid) in &lines {
+        writeln!(packed, "{oid} {name}").unwrap();
+    }
+    write_trusted(&join(git, b"packed-refs"), packed.as_bytes())?;
+
+    let head = head_target.unwrap_or("refs/heads/master");
+    write_trusted(&join(git, b"HEAD"), format!("ref: {head}\n").as_bytes())?;
+    // refs/remotes/origin/HEAD is a symbolic ref — loose file, never packed.
+    // Only write it when the server actually told us what HEAD points at.
+    if let Some(branch) = head_target.and_then(|t| t.strip_prefix("refs/heads/")) {
+        write_trusted(
+            &join(git, b"refs/remotes/origin/HEAD"),
+            format!("ref: refs/remotes/origin/{branch}\n").as_bytes(),
+        )?;
+    }
+    Ok(())
+}

--- a/src/git/delta.rs
+++ b/src/git/delta.rs
@@ -1,0 +1,215 @@
+//! Git delta encoding — `diff-delta.c` / `patch-delta.c`.
+//!
+//! A delta stream is:
+//!   * base object size   (LE varint, 7 bits per byte, MSB = continue)
+//!   * result object size (same encoding)
+//!   * a sequence of instructions until the stream is exhausted:
+//!       - **copy** (`op & 0x80`): low 7 bits are a presence mask for up to
+//!         4 little-endian offset bytes (bits 0‥3) and 3 length bytes
+//!         (bits 4‥6). A decoded length of 0 means **0x10000** (special-cased
+//!         in git so a 64 KiB copy fits in zero length bytes).
+//!       - **insert** (`op < 0x80`, `op != 0`): the next `op` bytes are
+//!         literal data to append.
+//!       - `op == 0` is reserved; git's `patch-delta.c` rejects it.
+//!
+//! Every offset/length is bounds-checked against the declared sizes before any
+//! copy — the delta stream is attacker-controlled (it came off the wire).
+
+use crate::{Error, Result};
+
+/// Decoded varint header `(base_size, result_size, header_len)`.
+pub(crate) fn header(delta: &[u8]) -> Result<(u64, u64, usize)> {
+    let (base, n0) = read_varint(delta)?;
+    let (res, n1) = read_varint(&delta[n0..])?;
+    Ok((base, res, n0 + n1))
+}
+
+/// Apply `delta` to `base`, writing into `out` (cleared first). `out.len()` on
+/// return equals the header's result size.
+pub(crate) fn apply(base: &[u8], delta: &[u8], out: &mut Vec<u8>) -> Result<()> {
+    let (base_size, result_size, hdr) = header(delta)?;
+    if base_size != base.len() as u64 {
+        return Err(Error::Pack(format!(
+            "delta base size mismatch: header says {base_size}, base is {}",
+            base.len()
+        )));
+    }
+    // Refuse absurd result sizes before reserving — `result_size` is
+    // attacker-controlled.
+    let result_size = usize::try_from(result_size)
+        .map_err(|_| Error::Pack("delta result size overflows usize".into()))?;
+    out.clear();
+    out.reserve_exact(result_size);
+
+    let mut i = hdr;
+    while i < delta.len() {
+        let op = delta[i];
+        i += 1;
+        if op & 0x80 != 0 {
+            // copy-from-base
+            let mut off: u64 = 0;
+            let mut len: u64 = 0;
+            for bit in 0..4 {
+                if op & (1 << bit) != 0 {
+                    let b = *delta.get(i).ok_or_else(trunc)?;
+                    i += 1;
+                    off |= u64::from(b) << (8 * bit);
+                }
+            }
+            for bit in 0..3 {
+                if op & (1 << (4 + bit)) != 0 {
+                    let b = *delta.get(i).ok_or_else(trunc)?;
+                    i += 1;
+                    len |= u64::from(b) << (8 * bit);
+                }
+            }
+            if len == 0 {
+                len = 0x10000;
+            }
+            let end = off
+                .checked_add(len)
+                .ok_or_else(|| Error::Pack("delta copy range overflow".into()))?;
+            if end > base.len() as u64 {
+                return Err(Error::Pack(format!(
+                    "delta copy [{off}, {end}) out of base bounds {}",
+                    base.len()
+                )));
+            }
+            if out.len() as u64 + len > result_size as u64 {
+                return Err(Error::Pack("delta copy overruns result size".into()));
+            }
+            out.extend_from_slice(&base[off as usize..end as usize]);
+        } else if op > 0 {
+            // insert-literal
+            let n = usize::from(op);
+            let lit = delta.get(i..i + n).ok_or_else(trunc)?;
+            i += n;
+            if out.len() + n > result_size {
+                return Err(Error::Pack("delta insert overruns result size".into()));
+            }
+            out.extend_from_slice(lit);
+        } else {
+            return Err(Error::Pack("delta op 0x00 is reserved".into()));
+        }
+    }
+
+    if out.len() != result_size {
+        return Err(Error::Pack(format!(
+            "delta produced {} bytes, header says {result_size}",
+            out.len()
+        )));
+    }
+    Ok(())
+}
+
+fn read_varint(buf: &[u8]) -> Result<(u64, usize)> {
+    let mut val = 0u64;
+    let mut shift = 0u32;
+    for (i, &b) in buf.iter().enumerate() {
+        if shift >= 64 {
+            return Err(Error::Pack("delta varint too long".into()));
+        }
+        val |= u64::from(b & 0x7f) << shift;
+        if b & 0x80 == 0 {
+            return Ok((val, i + 1));
+        }
+        shift += 7;
+    }
+    Err(trunc())
+}
+
+#[cold]
+fn trunc() -> Error {
+    Error::Pack("truncated delta stream".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn varint(mut n: u64, out: &mut Vec<u8>) {
+        loop {
+            let mut b = (n & 0x7f) as u8;
+            n >>= 7;
+            if n != 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+            if n == 0 {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn insert_only() {
+        // base="" result="hello": [base_size=0][result=5][insert 5 "hello"]
+        let mut d = Vec::new();
+        varint(0, &mut d);
+        varint(5, &mut d);
+        d.push(5);
+        d.extend_from_slice(b"hello");
+        let mut out = Vec::new();
+        apply(b"", &d, &mut out).unwrap();
+        assert_eq!(out, b"hello");
+    }
+
+    #[test]
+    fn copy_and_insert() {
+        // base="hello world" → "world!"
+        let base = b"hello world";
+        let mut d = Vec::new();
+        varint(base.len() as u64, &mut d);
+        varint(6, &mut d);
+        // copy off=6 len=5: op=0x80|0x01(off0)|0x10(len0), off0=6, len0=5
+        d.extend_from_slice(&[0x91, 6, 5]);
+        // insert "!"
+        d.extend_from_slice(&[1, b'!']);
+        let mut out = Vec::new();
+        apply(base, &d, &mut out).unwrap();
+        assert_eq!(out, b"world!");
+    }
+
+    #[test]
+    fn zero_len_means_64k() {
+        let base = vec![0xab; 0x10000];
+        let mut d = Vec::new();
+        varint(0x10000, &mut d);
+        varint(0x10000, &mut d);
+        // copy off=0 len=0 (→ 0x10000): op has no offset/len bytes present
+        d.push(0x80);
+        let mut out = Vec::new();
+        apply(&base, &d, &mut out).unwrap();
+        assert_eq!(out, base);
+    }
+
+    #[test]
+    fn rejects_oob_copy() {
+        let mut d = Vec::new();
+        varint(4, &mut d);
+        varint(4, &mut d);
+        d.extend_from_slice(&[0x91, 2, 4]); // copy [2,6) from 4-byte base
+        let mut out = Vec::new();
+        assert!(apply(b"abcd", &d, &mut out).is_err());
+    }
+
+    #[test]
+    fn rejects_reserved_op() {
+        let mut d = Vec::new();
+        varint(0, &mut d);
+        varint(0, &mut d);
+        d.push(0x00);
+        let mut out = Vec::new();
+        assert!(apply(b"", &d, &mut out).is_err());
+    }
+
+    #[test]
+    fn rejects_short_result() {
+        let mut d = Vec::new();
+        varint(0, &mut d);
+        varint(5, &mut d);
+        d.extend_from_slice(&[3, b'a', b'b', b'c']);
+        let mut out = Vec::new();
+        assert!(apply(b"", &d, &mut out).is_err());
+    }
+}

--- a/src/git/fs.rs
+++ b/src/git/fs.rs
@@ -1,0 +1,74 @@
+//! Thin `bun_sys` wrappers for the handful of filesystem ops the clone path
+//! needs. Paths are byte slices throughout (`bun_sys` is fd-relative + bytes;
+//! we always pass `Fd::cwd()` and absolute byte paths).
+
+use crate::{Error, Result};
+use bun_core::{Fd, ZStr};
+use bun_paths::path_buffer_pool;
+use bun_sys::{self as sys, File, O};
+
+/// `mkdir -p`. Absolute byte path.
+pub(crate) fn mkdirp(path: &[u8]) -> Result<()> {
+    sys::mkdir_recursive(path).map_err(Error::from)
+}
+
+/// Create/truncate `path` and write `data`. For paths **we** construct
+/// (`.git/…`, the `.idx`); never used for tree-derived worktree paths.
+pub(crate) fn write_trusted(path: &[u8], data: &[u8]) -> Result<()> {
+    let f = File::make_open(path, O::WRONLY | O::CREAT | O::TRUNC, 0o644)?;
+    f.write_all(data)?;
+    Ok(())
+}
+
+/// Create `path` (which must not already exist) and write `data`. Used for
+/// worktree files whose path components came from a tree object.
+///
+/// `O_EXCL | O_NOFOLLOW`: a fresh clone target is empty, so every worktree
+/// file is genuinely new — refusing to overwrite means a case-folding
+/// collision between a symlink we just wrote and a same-named file fails
+/// closed instead of writing through the link (the CVE-2024-32002 vector).
+/// Parent components are real directories by construction: every `mkdirp`
+/// ran in the serial walk before any symlink job was scheduled.
+pub(crate) fn write_worktree_file(path: &[u8], data: &[u8], mode: u32) -> Result<()> {
+    let f = File::make_open(path, O::WRONLY | O::CREAT | O::EXCL | O::NOFOLLOW, mode)?;
+    f.write_all(data)?;
+    #[cfg(unix)]
+    {
+        let _ = sys::fchmod(f.fd(), mode);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn symlink(target: &[u8], link: &[u8]) -> Result<()> {
+    let mut a = path_buffer_pool::get();
+    let mut b = path_buffer_pool::get();
+    sys::symlink(zstr_in(&mut a, target), zstr_in(&mut b, link)).map_err(Error::from)
+}
+
+/// `lstat(2)` on an absolute byte path. Returns `None` on any error — callers
+/// (the index writer) treat a missing stat as "zero the cache fields".
+pub(crate) fn lstat(path: &[u8]) -> Option<sys::PosixStat> {
+    let mut buf = path_buffer_pool::get();
+    sys::lstatat(Fd::cwd(), zstr_in(&mut buf, path))
+        .ok()
+        .map(|s| sys::PosixStat::init(&s))
+}
+
+/// `true` if `path` exists and is a non-empty directory.
+pub(crate) fn dir_nonempty(path: &[u8]) -> Result<bool> {
+    let dir = match sys::open_dir_at(Fd::cwd(), path) {
+        Ok(fd) => fd,
+        Err(e) if e.get_errno() == bun_errno::E::ENOENT => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    let mut it = sys::dir_iterator::iterate(dir);
+    let nonempty = it.next()?.is_some();
+    Ok(nonempty)
+}
+
+fn zstr_in<'a>(buf: &'a mut bun_paths::PathBuffer, s: &[u8]) -> &'a ZStr {
+    buf[..s.len()].copy_from_slice(s);
+    buf[s.len()] = 0;
+    ZStr::from_buf(buf, s.len())
+}

--- a/src/git/hash.rs
+++ b/src/git/hash.rs
@@ -1,0 +1,73 @@
+//! Thin wrappers over the BoringSSL/zlib FFI hashers so the rest of the crate
+//! stays `unsafe`-free.
+//!
+//! Goes through `bun_boringssl_sys` directly (not `bun_sha_hmac`) to keep this
+//! crate's `cargo test` link free of the `bun_sys → bun_windows_sys` chain —
+//! see the dependency note in `Cargo.toml`.
+
+use crate::Oid;
+use bun_boringssl_sys::{SHA_CTX, SHA1_Final, SHA1_Init, SHA1_Update};
+use core::ffi::{c_uint, c_ulong, c_void};
+use core::mem::MaybeUninit;
+
+unsafe extern "C" {
+    /// zlib-ng `crc32` (linked via the same archive build.rs assembles).
+    fn crc32(crc: c_ulong, buf: *const u8, len: c_uint) -> c_ulong;
+}
+
+/// Incremental SHA-1. BoringSSL's `SHA1_*` — runtime-dispatched to
+/// SHA-NI / ARMv8-SHA where available.
+pub(crate) struct Sha1(SHA_CTX);
+
+impl Sha1 {
+    #[inline]
+    pub(crate) fn new() -> Self {
+        bun_boringssl_sys::CRYPTO_library_init();
+        let mut ctx = MaybeUninit::<SHA_CTX>::uninit();
+        // SAFETY: SHA1_Init only writes to the context (no reads of prior
+        // state); ctx is sized exactly as SHA_CTX.
+        unsafe { SHA1_Init(ctx.as_mut_ptr()) };
+        // SAFETY: SHA1_Init fully initialises every field of SHA_CTX.
+        Self(unsafe { ctx.assume_init() })
+    }
+
+    #[inline]
+    pub(crate) fn update(&mut self, data: &[u8]) {
+        // SAFETY: self.0 was initialised by SHA1_Init; data is readable for
+        // `len` bytes.
+        unsafe { SHA1_Update(&raw mut self.0, data.as_ptr().cast::<c_void>(), data.len()) };
+    }
+
+    #[inline]
+    pub(crate) fn finish(mut self) -> Oid {
+        let mut out = [0u8; 20];
+        // SAFETY: out is exactly SHA1_DIGEST_LENGTH bytes; ctx is initialised.
+        unsafe { SHA1_Final(out.as_mut_ptr(), &raw mut self.0) };
+        Oid(out)
+    }
+}
+
+/// `sha1("<type> <size>\0" || data)` — the loose-object id.
+pub(crate) fn object_id(kind: crate::pack::ObjKind, data: &[u8]) -> Oid {
+    let mut h = Sha1::new();
+    let mut hdr = itoa::Buffer::new();
+    h.update(kind.name());
+    h.update(b" ");
+    h.update(hdr.format(data.len()).as_bytes());
+    h.update(&[0]);
+    h.update(data);
+    h.finish()
+}
+
+/// zlib-ng `crc32` (used for the pack-index per-object CRC column).
+#[inline]
+pub(crate) fn crc32_of(prev: u32, data: &[u8]) -> u32 {
+    let mut crc = c_ulong::from(prev);
+    // zlib's `len` is `uInt`; chunk so >4 GiB inputs are still correct.
+    for chunk in data.chunks(u32::MAX as usize) {
+        // SAFETY: chunk is a valid readable slice; len fits in c_uint by
+        // construction.
+        crc = unsafe { crc32(crc, chunk.as_ptr(), chunk.len() as c_uint) };
+    }
+    crc as u32
+}

--- a/src/git/index.rs
+++ b/src/git/index.rs
@@ -1,0 +1,137 @@
+//! `.git/index` (dircache) writer — format version 2, no extensions.
+//!
+//! Reference: gitformat-index(5). We emit the 12-byte `DIRC` header, one
+//! fixed-62-byte entry per path (NUL-padded to an 8-byte multiple), and a
+//! trailing SHA-1 of everything before it. Stat fields are filled from an
+//! `lstat` of the just-written worktree file so `git status` sees a clean
+//! tree without re-reading every blob.
+
+use crate::fs::{lstat, write_trusted};
+use crate::hash::Sha1;
+use crate::{Oid, Result};
+
+const MODE_GITLINK: u32 = 0o160000;
+
+/// One path destined for the index. `path` is relative to the worktree root,
+/// `/`-separated, no leading slash.
+pub(crate) struct IndexEntry {
+    pub(crate) mode: u32,
+    pub(crate) oid: Oid,
+    pub(crate) path: Vec<u8>,
+}
+
+/// Serialise `entries` as a v2 index and write to `<dest>/.git/index`.
+pub(crate) fn write(dest: &[u8], mut entries: Vec<IndexEntry>) -> Result<()> {
+    // Index sort order is raw-byte memcmp on the full path.
+    entries.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let mut buf = Vec::with_capacity(12 + entries.len() * 80 + 20);
+    buf.extend_from_slice(b"DIRC");
+    buf.extend_from_slice(&2u32.to_be_bytes());
+    buf.extend_from_slice(&(entries.len() as u32).to_be_bytes());
+
+    let mut abs = Vec::with_capacity(dest.len() + 256);
+    for e in &entries {
+        // Gitlinks have no worktree file to stat (the placeholder dir's
+        // metadata is meaningless to git's ie_match_stat); zero the cache.
+        let st = if e.mode == MODE_GITLINK {
+            None
+        } else {
+            abs.clear();
+            abs.extend_from_slice(dest);
+            abs.push(b'/');
+            abs.extend_from_slice(&e.path);
+            lstat(&abs)
+        };
+        emit_entry(&mut buf, e, st.as_ref());
+    }
+
+    let mut sha = Sha1::new();
+    sha.update(&buf);
+    buf.extend_from_slice(&sha.finish().0);
+
+    let mut out = Vec::with_capacity(dest.len() + 11);
+    out.extend_from_slice(dest);
+    out.extend_from_slice(b"/.git/index");
+    write_trusted(&out, &buf)
+}
+
+fn emit_entry(buf: &mut Vec<u8>, e: &IndexEntry, st: Option<&bun_sys::PosixStat>) {
+    macro_rules! be32 {
+        ($v:expr) => {
+            buf.extend_from_slice(&(($v) as u32).to_be_bytes())
+        };
+    }
+    // gitformat-index(5): only 0755 and 0644 are valid for regular files.
+    let mode = match e.mode {
+        m if m & 0o170000 == 0o100000 => {
+            if m & 0o100 != 0 { 0o100755 } else { 0o100644 }
+        }
+        m => m,
+    };
+    // Stat cache. All fields are 32-bit BE, truncated — git compares them as
+    // opaque cookies, so wraparound on large dev/ino/size is by design.
+    match st {
+        Some(s) => {
+            be32!(s.ctim.sec);
+            be32!(s.ctim.nsec);
+            be32!(s.mtim.sec);
+            be32!(s.mtim.nsec);
+            be32!(s.dev);
+            be32!(s.ino);
+            be32!(mode);
+            be32!(s.uid);
+            be32!(s.gid);
+            be32!(s.size);
+        }
+        None => {
+            buf.extend_from_slice(&[0u8; 24]);
+            be32!(mode);
+            buf.extend_from_slice(&[0u8; 12]);
+        }
+    }
+    buf.extend_from_slice(&e.oid.0);
+    // Flags: assume-valid=0, extended=0, stage=0, name length capped at 0xFFF.
+    let flags = e.path.len().min(0xFFF) as u16;
+    buf.extend_from_slice(&flags.to_be_bytes());
+    buf.extend_from_slice(&e.path);
+    // 1–8 NUL bytes: NUL-terminate the name and pad the (62-byte fixed part +
+    // name) to an 8-byte multiple.
+    let pad = 8 - ((62 + e.path.len()) & 7);
+    buf.extend_from_slice(&[0u8; 8][..pad]);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_layout_and_padding() {
+        let mut buf = Vec::new();
+        let e = IndexEntry {
+            mode: 0o100644,
+            oid: Oid([0xab; 20]),
+            path: b"a".to_vec(),
+        };
+        emit_entry(&mut buf, &e, None);
+        // 62 fixed + "a" + 1 NUL = 64 (next multiple of 8).
+        assert_eq!(buf.len(), 64);
+        assert_eq!(&buf[24..28], &0o100644u32.to_be_bytes());
+        assert_eq!(&buf[40..60], &[0xab; 20]);
+        assert_eq!(&buf[60..62], &[0x00, 0x01]);
+        assert_eq!(buf[62], b'a');
+        assert_eq!(buf[63], 0);
+
+        // 62 + 10 = 72 ⇒ pad 8 (always at least one NUL).
+        let mut buf = Vec::new();
+        let e = IndexEntry {
+            mode: 0o100644,
+            oid: Oid::ZERO,
+            path: b"0123456789".to_vec(),
+        };
+        emit_entry(&mut buf, &e, None);
+        assert_eq!(buf.len(), 80);
+        assert_eq!(&buf[60..62], &[0x00, 0x0a]);
+        assert!(buf[72..80].iter().all(|&b| b == 0));
+    }
+}

--- a/src/git/index.rs
+++ b/src/git/index.rs
@@ -65,7 +65,11 @@ fn emit_entry(buf: &mut Vec<u8>, e: &IndexEntry, st: Option<&bun_sys::PosixStat>
     // gitformat-index(5): only 0755 and 0644 are valid for regular files.
     let mode = match e.mode {
         m if m & 0o170000 == 0o100000 => {
-            if m & 0o100 != 0 { 0o100755 } else { 0o100644 }
+            if m & 0o100 != 0 {
+                0o100755
+            } else {
+                0o100644
+            }
         }
         m => m,
     };

--- a/src/git/lib.rs
+++ b/src/git/lib.rs
@@ -1,0 +1,67 @@
+//! From-scratch git client focused on fast clones over the standard smart-HTTP
+//! transport (no GitHub-specific APIs — works against any
+//! `git-http-backend`/upload-pack endpoint, including GitHub).
+//!
+//! Runs entirely on bun's infrastructure: HTTP via `bun_http` (uSockets event
+//! loop, BoringSSL, H1/H2), file I/O via `bun_sys`, parallelism via
+//! `bun_threading::WorkPool`, hashes via `bun_boringssl_sys`/libdeflate.
+//!
+//! Speed comes from three things git either doesn't do or doesn't do by
+//! default:
+//!
+//! * **libdeflate** for every zlib stream in the pack. The pack is held as one
+//!   contiguous buffer, so each object is a single
+//!   `libdeflate_zlib_decompress_ex` call (≈2–3× faster than zlib-ng's
+//!   streaming inflate).
+//! * **Parallel delta resolution** — each independent delta-chain root is one
+//!   `WorkPool` task; bases are inflated once per chain.
+//! * **Parallel checkout** — every blob write is a `WorkPool` task.
+//! * **Two-wave blob dispatch** — wave-1 fires from already-indexed skeleton
+//!   slices the moment the last skeleton fetch lands; wave-2 adds only the
+//!   final batch's delta, so blob streams start before skeleton indexing ends.
+
+mod checkout;
+mod clone;
+mod delta;
+mod fs;
+mod hash;
+mod index;
+mod odb;
+mod oid;
+mod pack;
+mod pktline;
+mod protocol;
+mod transport;
+
+pub use clone::{CloneOptions, clone, index_pack_file};
+pub use oid::Oid;
+pub use pack::{ObjKind, PackIndex, Timings};
+
+/// Errors surfaced by the clone pipeline. Every variant is reachable from
+/// untrusted server input or filesystem state — none are internal-invariant
+/// panics.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("{0}")]
+    Sys(bun_sys::Error),
+    #[error("malformed pkt-line: {0}")]
+    PktLine(&'static str),
+    #[error("git protocol error: {0}")]
+    Protocol(String),
+    #[error("malformed packfile: {0}")]
+    Pack(String),
+    #[error("server error (side-band 3): {0}")]
+    Remote(String),
+    #[error("HTTP error: {0}")]
+    Http(String),
+    #[error("unsafe path in tree object: {0:?}")]
+    UnsafePath(Vec<u8>),
+}
+
+impl From<bun_sys::Error> for Error {
+    fn from(e: bun_sys::Error) -> Self {
+        Error::Sys(e)
+    }
+}
+
+pub(crate) type Result<T> = core::result::Result<T, Error>;

--- a/src/git/odb.rs
+++ b/src/git/odb.rs
@@ -112,4 +112,3 @@ impl Odb {
         Err(Error::Pack(format!("object {oid} not in any pack")))
     }
 }
-

--- a/src/git/odb.rs
+++ b/src/git/odb.rs
@@ -1,0 +1,115 @@
+//! Tiny object-layer over [`PackIndex`](crate::pack::PackIndex): typed reads
+//! for the three kinds checkout needs.
+
+use crate::pack::{Inflate, ObjKind, PackIndex};
+use crate::{Error, Oid, Result};
+
+/// `<mode> SP <name> NUL <sha1[20]>` repeated.
+pub(crate) struct TreeIter<'a> {
+    rest: &'a [u8],
+}
+
+pub(crate) struct TreeEntry<'a> {
+    pub(crate) mode: u32,
+    pub(crate) name: &'a [u8],
+    pub(crate) oid: Oid,
+}
+
+impl<'a> TreeIter<'a> {
+    pub(crate) fn new(data: &'a [u8]) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl<'a> Iterator for TreeIter<'a> {
+    type Item = Result<TreeEntry<'a>>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.rest.is_empty() {
+            return None;
+        }
+        let sp = match self.rest.iter().position(|&b| b == b' ') {
+            Some(i) => i,
+            None => return Some(Err(Error::Pack("tree entry: missing SP".into()))),
+        };
+        let mode = match parse_octal(&self.rest[..sp]) {
+            Some(m) => m,
+            None => return Some(Err(Error::Pack("tree entry: bad mode".into()))),
+        };
+        let after = &self.rest[sp + 1..];
+        let nul = match after.iter().position(|&b| b == 0) {
+            Some(i) => i,
+            None => return Some(Err(Error::Pack("tree entry: missing NUL".into()))),
+        };
+        let name = &after[..nul];
+        let oid_bytes = match after.get(nul + 1..nul + 21) {
+            Some(b) => b,
+            None => return Some(Err(Error::Pack("tree entry: truncated oid".into()))),
+        };
+        let mut oid = [0u8; 20];
+        oid.copy_from_slice(oid_bytes);
+        self.rest = &after[nul + 21..];
+        Some(Ok(TreeEntry {
+            mode,
+            name,
+            oid: Oid(oid),
+        }))
+    }
+}
+
+fn parse_octal(s: &[u8]) -> Option<u32> {
+    let mut n = 0u32;
+    for &b in s {
+        if !(b'0'..=b'7').contains(&b) {
+            return None;
+        }
+        n = n.checked_mul(8)?.checked_add(u32::from(b - b'0'))?;
+    }
+    Some(n)
+}
+
+/// Extract the `tree <oid>` line from a commit object.
+pub(crate) fn commit_tree(commit: &[u8]) -> Result<Oid> {
+    // First line is always `tree <40hex>\n`.
+    let line = commit
+        .strip_prefix(b"tree ")
+        .ok_or_else(|| Error::Pack("commit object missing 'tree ' header".into()))?;
+    Oid::from_hex(&line[..40.min(line.len())])
+        .ok_or_else(|| Error::Pack("commit tree id is not 40-hex".into()))
+}
+
+/// Read a commit's root tree oid from the pack.
+pub(crate) fn read_commit_tree(odb: &Odb, commit: &Oid, inf: &mut Inflate) -> Result<Oid> {
+    let mut buf = Vec::new();
+    let kind = odb.read(commit, inf, &mut buf)?;
+    if kind != ObjKind::Commit {
+        return Err(Error::Pack(format!("{commit} is {kind:?}, not a commit")));
+    }
+    commit_tree(&buf)
+}
+
+/// Object database backed by one or more indexed packs. Lookups try each pack
+/// in turn (the skeleton pack first, then blob packs).
+pub(crate) struct Odb {
+    packs: Vec<PackIndex>,
+}
+
+impl Odb {
+    pub(crate) fn new() -> Self {
+        Self { packs: Vec::new() }
+    }
+    pub(crate) fn push(&mut self, p: PackIndex) {
+        self.packs.push(p);
+    }
+    pub(crate) fn packs(&self) -> &[PackIndex] {
+        &self.packs
+    }
+    pub(crate) fn read(&self, oid: &Oid, inf: &mut Inflate, out: &mut Vec<u8>) -> Result<ObjKind> {
+        for p in &self.packs {
+            if p.contains(oid) {
+                return p.read(oid, inf, out);
+            }
+        }
+        Err(Error::Pack(format!("object {oid} not in any pack")))
+    }
+}
+

--- a/src/git/oid.rs
+++ b/src/git/oid.rs
@@ -1,0 +1,93 @@
+use core::fmt;
+
+/// A 20-byte SHA-1 git object id. Ordering is bytewise (matches the sort order
+/// of the pack-index name table and `git rev-list --objects`).
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Oid(pub [u8; 20]);
+
+impl Oid {
+    pub const ZERO: Oid = Oid([0u8; 20]);
+
+    /// Parse 40 lowercase hex bytes. Uppercase is accepted (git itself emits
+    /// lowercase, but ref advertisements from non-git servers occasionally
+    /// uppercase).
+    pub fn from_hex(s: &[u8]) -> Option<Oid> {
+        if s.len() != 40 {
+            return None;
+        }
+        let mut out = [0u8; 20];
+        for (i, pair) in s.chunks_exact(2).enumerate() {
+            out[i] = (nibble(pair[0])? << 4) | nibble(pair[1])?;
+        }
+        Some(Oid(out))
+    }
+
+    pub fn to_hex(&self) -> [u8; 40] {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut out = [0u8; 40];
+        for (i, b) in self.0.iter().enumerate() {
+            out[i * 2] = HEX[(b >> 4) as usize];
+            out[i * 2 + 1] = HEX[(b & 0xf) as usize];
+        }
+        out
+    }
+}
+
+#[inline]
+fn nibble(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+impl fmt::Display for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let hex = self.to_hex();
+        // SAFETY: to_hex() emits only [0-9a-f], which is ASCII and thus valid UTF-8.
+        f.write_str(unsafe { core::str::from_utf8_unchecked(&hex) })
+    }
+}
+
+impl fmt::Debug for Oid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_round_trip() {
+        let s = b"e83c5163316f89bfbde7d9ab23ca2e25604af290";
+        let oid = Oid::from_hex(s).unwrap();
+        assert_eq!(&oid.to_hex(), s);
+        assert_eq!(format!("{oid}").as_bytes(), s);
+    }
+
+    #[test]
+    fn rejects_bad_hex() {
+        assert!(Oid::from_hex(b"").is_none());
+        assert!(Oid::from_hex(b"zz3c5163316f89bfbde7d9ab23ca2e25604af290").is_none());
+        assert!(Oid::from_hex(b"e83c5163316f89bfbde7d9ab23ca2e25604af29").is_none());
+        assert!(Oid::from_hex(b"e83c5163316f89bfbde7d9ab23ca2e25604af2900").is_none());
+    }
+
+    #[test]
+    fn accepts_uppercase() {
+        let lo = Oid::from_hex(b"e83c5163316f89bfbde7d9ab23ca2e25604af290").unwrap();
+        let up = Oid::from_hex(b"E83C5163316F89BFBDE7D9AB23CA2E25604AF290").unwrap();
+        assert_eq!(lo, up);
+    }
+
+    #[test]
+    fn ordering_is_bytewise() {
+        let a = Oid::from_hex(b"00000000000000000000000000000000000000ff").unwrap();
+        let b = Oid::from_hex(b"0100000000000000000000000000000000000000").unwrap();
+        assert!(a < b);
+    }
+}

--- a/src/git/pack.rs
+++ b/src/git/pack.rs
@@ -303,7 +303,9 @@ impl PackIndex {
         serial: bool,
     ) -> Result<Self> {
         if pack.len() < 12 + TRAILER {
-            return Err(Error::Pack("truncated (shorter than header+trailer)".into()));
+            return Err(Error::Pack(
+                "truncated (shorter than header+trailer)".into(),
+            ));
         }
         if pack[..4] != SIGNATURE {
             return Err(Error::Pack("bad signature (not 'PACK')".into()));
@@ -470,9 +472,7 @@ impl PackIndex {
                 oid_to_idx.insert(e.oid.get(), i as u32);
             }
             if !pending_ref.is_empty() {
-                return Err(Error::Pack(
-                    "REF_DELTA in blob pack (serial path)".into(),
-                ));
+                return Err(Error::Pack("REF_DELTA in blob pack (serial path)".into()));
             }
             return Ok(PackIndex {
                 pack,
@@ -537,10 +537,7 @@ impl PackIndex {
             mut err, mut sinks, ..
         } = ctx;
         if blob_sink.want {
-            blob_sink
-                .seen
-                .ensure_total_capacity(nobjects)
-                .expect("OOM");
+            blob_sink.seen.ensure_total_capacity(nobjects).expect("OOM");
             for s in core::mem::take(sinks.get_mut()) {
                 s.merge_into(&mut blob_sink.seen);
             }
@@ -635,7 +632,6 @@ impl PackIndex {
     pub(crate) fn pack_bytes(&self) -> &[u8] {
         &self.pack
     }
-
 
     /// Look up an object by id and inflate it. Delta chains are walked to the
     /// root. `inflate` is caller-owned so a hot loop (checkout) reuses it.
@@ -818,9 +814,10 @@ fn resolve_subtree(
     let Base::None(kind) = root_e.base else {
         unreachable!("resolve_subtree called on a delta root")
     };
-    root_e
-        .crc32
-        .set(crc32_of(0, &pack[root_e.offset as usize..root_e.next_offset as usize]));
+    root_e.crc32.set(crc32_of(
+        0,
+        &pack[root_e.offset as usize..root_e.next_offset as usize],
+    ));
     let mut base = Vec::new();
     inflate.inflate_into(
         &pack[root_e.data_offset as usize..end],
@@ -845,9 +842,10 @@ fn resolve_subtree(
             continue;
         };
         let child = &entries[child_idx as usize];
-        child
-            .crc32
-            .set(crc32_of(0, &pack[child.offset as usize..child.next_offset as usize]));
+        child.crc32.set(crc32_of(
+            0,
+            &pack[child.offset as usize..child.next_offset as usize],
+        ));
         inflate.inflate_into(
             &pack[child.data_offset as usize..end],
             child.inflated_size as usize,

--- a/src/git/pack.rs
+++ b/src/git/pack.rs
@@ -1,0 +1,955 @@
+//! Packfile parsing and indexing — `gitformat-pack(5)`.
+//!
+//! Layout: `"PACK"` · u32be version (2) · u32be nobjects · objects… ·
+//! sha1(everything before). Each object is a type+size header followed by one
+//! zlib stream. Type is 3 bits in the first header byte; size is the remaining
+//! 4 bits plus 7-bit continuation bytes (LE). `OFS_DELTA` inserts a negative
+//! offset varint between header and zlib body; `REF_DELTA` inserts a 20-byte
+//! base oid.
+//!
+//! Indexing is two passes:
+//!
+//! 1. **Sequential scan.** Walk the buffer once. For each entry decode the
+//!    header, then `libdeflate_zlib_decompress_ex` the payload — we know the
+//!    inflated size from the header, and the `_ex` variant reports how many
+//!    input bytes it consumed, which is the only way to learn where the next
+//!    object starts. Non-deltas are SHA-1'd immediately; deltas just record
+//!    `{offset, base, inflated-delta}` for pass 2. Per-entry CRC-32 is
+//!    computed here (over the on-disk bytes, header included — that's what
+//!    `.idx` v2 stores).
+//!
+//! 2. **Parallel resolve.** Build the delta forest (children grouped under
+//!    their base entry), then resolve each root's subtree on a worker thread.
+//!    Within a subtree, a base is inflated/applied once and reused for every
+//!    child (depth-first, so the working set is one chain, not the whole
+//!    tree).
+//!
+//! Everything operates on a single contiguous `&[u8]` — the caller has either
+//! buffered the download or mmap'd the file.
+
+use crate::hash::{Sha1, crc32_of, object_id};
+use crate::{Error, Oid, Result, delta};
+use bun_collections::{HashContext, HashMap};
+use bun_libdeflate_sys::libdeflate::{Decompressor, Status};
+use bun_threading::{Guarded, WorkPool};
+
+const SIGNATURE: [u8; 4] = *b"PACK";
+const TRAILER: usize = 20;
+
+/// Hash an `Oid` by reinterpreting its first 8 bytes — SHA-1 is already a
+/// uniform hash, so running wyhash on top is wasted work (and the hot
+/// `BlobSink` probe loop does this tens of millions of times).
+pub(crate) struct OidCtx;
+impl HashContext<Oid> for OidCtx {
+    #[inline]
+    fn ctx_hash(key: &Oid) -> u64 {
+        u64::from_ne_bytes(key.0[..8].try_into().unwrap())
+    }
+    #[inline]
+    fn ctx_eql(a: &Oid, b: &Oid) -> bool {
+        a == b
+    }
+}
+
+pub(crate) type OidMap<V> = HashMap<Oid, V, OidCtx>;
+
+/// Object kind as stored in the pack header (and as the loose-object type
+/// string for hashing).
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum ObjKind {
+    Commit,
+    Tree,
+    Blob,
+    Tag,
+}
+
+impl ObjKind {
+    pub(crate) fn name(self) -> &'static [u8] {
+        match self {
+            ObjKind::Commit => b"commit",
+            ObjKind::Tree => b"tree",
+            ObjKind::Blob => b"blob",
+            ObjKind::Tag => b"tag",
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum RawType {
+    Base(ObjKind),
+    OfsDelta,
+    RefDelta,
+}
+
+impl RawType {
+    fn from_bits(b: u8) -> Result<Self> {
+        Ok(match b {
+            1 => RawType::Base(ObjKind::Commit),
+            2 => RawType::Base(ObjKind::Tree),
+            3 => RawType::Base(ObjKind::Blob),
+            4 => RawType::Base(ObjKind::Tag),
+            6 => RawType::OfsDelta,
+            7 => RawType::RefDelta,
+            // 5 is reserved; 0 is invalid.
+            n => return Err(Error::Pack(format!("invalid object type {n}"))),
+        })
+    }
+}
+
+/// What an entry's payload deltas against.
+#[derive(Copy, Clone, Debug)]
+enum Base {
+    /// Non-delta — payload is the full object.
+    None(ObjKind),
+    /// Base lives at this absolute pack offset (same pack, by construction).
+    Ofs(u64),
+    /// Base named by oid. For a fresh clone (no `have`s) the server only ever
+    /// sends bases that are themselves in the pack (a "thin" pack would
+    /// reference objects we already have — we have none).
+    Ref(Oid),
+}
+
+/// One pack entry. Pass 1 fills the offsets/base; pass 2 fills oid/kind/crc32
+/// in parallel via interior mutability (each worker owns a disjoint subset of
+/// indices, so no two threads write the same `Entry`).
+struct Entry {
+    /// Absolute byte offset of the entry header in the pack.
+    offset: u64,
+    /// Absolute offset of the **next** entry's header (= this entry's end).
+    next_offset: u64,
+    /// Absolute offset where the zlib body starts (after header + base ref).
+    data_offset: u64,
+    /// Inflated size from the header (for deltas: the delta-stream size, not
+    /// the result size).
+    inflated_size: u64,
+    base: Base,
+    // ── pass-2 outputs ────────────────────────────────────────────────────
+    oid: core::cell::Cell<Oid>,
+    kind: core::cell::Cell<ObjKind>,
+    crc32: core::cell::Cell<u32>,
+    /// Index into `entries` of every delta whose base is this entry.
+    children: Vec<u32>,
+}
+
+// SAFETY: pass 2 partitions `entries` by index — each worker writes a
+// disjoint set of `Cell`s (proved by the `roots`/subtree partition; see
+// `resolve_subtree`). `Cell<T>` is `Send` for `T: Copy`; we only need `Sync`
+// for the shared `&[Entry]` borrow, and the algorithm guarantees no aliased
+// writes.
+unsafe impl Sync for Entry {}
+
+/// A parsed + indexed pack, ready for random-access reads and `.idx` emission.
+pub struct PackIndex {
+    /// Pack bytes (owned — the download buffer, or a `Vec` read from disk).
+    pack: Vec<u8>,
+    /// `entries[i]` is the i-th object in pack order.
+    entries: Vec<Entry>,
+    /// `by_oid[&oid] = entry index`. Built after pass 2.
+    by_oid: OidMap<u32>,
+    /// SHA-1 of the pack body (the trailer value) — also the pack/idx filename.
+    pack_hash: Oid,
+}
+
+/// Per-thread inflate scratch. libdeflate decompressors aren't `Sync` and
+/// allocating one per object would dominate small-object cost.
+pub(crate) struct Inflate {
+    dec: *mut Decompressor,
+}
+
+impl Inflate {
+    pub(crate) fn new() -> Self {
+        let dec = Decompressor::alloc();
+        assert!(!dec.is_null(), "libdeflate_alloc_decompressor OOM");
+        Self { dec }
+    }
+
+    /// Inflate one zlib stream whose **inflated size is exactly `size`** from
+    /// `input` (which may extend past the stream). On success `out.len() ==
+    /// size` and the return value is the number of input bytes the stream
+    /// occupied (header + deflate body + adler32).
+    pub(crate) fn inflate_into(
+        &mut self,
+        input: &[u8],
+        size: usize,
+        out: &mut Vec<u8>,
+    ) -> Result<usize> {
+        out.clear();
+        if size == 0 {
+            // libdeflate happily decodes a zero-length zlib stream, but the
+            // git pack writer emits one too (2-byte header + empty stored
+            // block + adler32). Let libdeflate tell us how long it was.
+        }
+        out.reserve(size);
+        // SAFETY: `self.dec` is non-null for the lifetime of `self` (checked
+        // in `new`, freed in `Drop`).
+        let dec = unsafe { &mut *self.dec };
+        let spare = &mut out.spare_capacity_mut()[..size];
+        let r = dec.decompress_into(input, spare, bun_libdeflate_sys::libdeflate::Encoding::Zlib);
+        match r.status {
+            Status::Success => {}
+            Status::BadData => return Err(Error::Pack("zlib stream corrupt".into())),
+            Status::ShortOutput => {
+                return Err(Error::Pack("zlib stream shorter than declared size".into()));
+            }
+            Status::InsufficientSpace => {
+                return Err(Error::Pack("zlib stream longer than declared size".into()));
+            }
+        }
+        if r.written != size {
+            return Err(Error::Pack(format!(
+                "inflated {} bytes, header said {size}",
+                r.written
+            )));
+        }
+        // SAFETY: libdeflate wrote exactly `r.written` bytes into spare.
+        unsafe { out.set_len(size) };
+        Ok(r.read)
+    }
+}
+
+impl Drop for Inflate {
+    fn drop(&mut self) {
+        // SAFETY: alloc'd in `new`, freed exactly once here.
+        unsafe { Decompressor::destroy(self.dec) };
+    }
+}
+
+// `*mut Decompressor` is a unique heap handle; libdeflate has no global state.
+// SAFETY: we never alias the pointer across threads — each `Inflate` is owned
+// by one worker.
+unsafe impl Send for Inflate {}
+
+thread_local! {
+    /// Per-worker libdeflate decompressor + scratch. `WorkPool::each` runs
+    /// the closure once per item across a fixed worker set, so reusing one
+    /// decompressor per OS thread avoids ~N allocs of a 32 KiB context.
+    static TLS_INFLATE: core::cell::RefCell<Inflate> =
+        core::cell::RefCell::new(Inflate::new());
+}
+
+/// Run `f` with this thread's [`Inflate`].
+pub(crate) fn with_inflate<R>(f: impl FnOnce(&mut Inflate) -> R) -> R {
+    TLS_INFLATE.with(|c| f(&mut c.borrow_mut()))
+}
+
+/// Per-phase timings (ns) from [`PackIndex::build`].
+#[derive(Default, Debug)]
+pub struct Timings {
+    pub trailer_sha: u64,
+    pub pass1_scan: u64,
+    pub pass2_resolve: u64,
+    pub n_deltas: u32,
+}
+
+/// Per-worker accumulator passed through `resolve_subtree`. When `want`,
+/// every resolved tree's blob entries are recorded as `oid → wyhash(name)`
+/// (riding the inflated bytes pass-2 already has). Dedup is local — the same
+/// blob recurs thousands of times across historical trees, so a per-chunk map
+/// keeps the merged result small. Path-hash bucketing is **load-bearing**:
+/// the server only reuses an on-disk delta if both object and base land in
+/// the same request, and same-path blobs are exactly each other's delta
+/// bases. With random (oid-prefix) bucketing total blob bytes ~double.
+#[derive(Default)]
+pub(crate) struct BlobSink {
+    pub(crate) want: bool,
+    pub(crate) seen: OidMap<u32>,
+}
+
+impl BlobSink {
+    #[inline]
+    fn maybe(&mut self, kind: ObjKind, data: &[u8]) {
+        if !self.want || kind != ObjKind::Tree {
+            return;
+        }
+        for entry in crate::odb::TreeIter::new(data) {
+            let Ok(e) = entry else { return };
+            if e.mode != 0o040000 && e.mode != 0o160000 {
+                let gop = self.seen.get_or_put(e.oid).expect("OOM");
+                if !gop.found_existing {
+                    *gop.value_ptr = bun_wyhash::hash(e.name) as u32;
+                }
+            }
+        }
+    }
+    pub(crate) fn merge_into(&self, out: &mut OidMap<u32>) {
+        for (oid, h) in self.seen.iter() {
+            let gop = out.get_or_put(*oid).expect("OOM");
+            if !gop.found_existing {
+                *gop.value_ptr = *h;
+            }
+        }
+    }
+}
+
+impl PackIndex {
+    /// Parse and index `pack`, fanning pass-2 across `WorkPool`.
+    pub fn build(pack: Vec<u8>, timing: &mut Timings) -> Result<Self> {
+        let mut sink = BlobSink::default();
+        Self::build_with(pack, timing, &mut sink, false)
+    }
+
+    /// Parse and index `pack` on the calling thread only — no `WorkPool` use.
+    /// Safe to call from inside a `WorkPool` task (the parallel blob-pack
+    /// indexing path).
+    pub(crate) fn build_serial(pack: Vec<u8>) -> Result<Self> {
+        let mut sink = BlobSink::default();
+        Self::build_with(pack, &mut Timings::default(), &mut sink, true)
+    }
+
+    pub(crate) fn build_with(
+        pack: Vec<u8>,
+        timing: &mut Timings,
+        blob_sink: &mut BlobSink,
+        serial: bool,
+    ) -> Result<Self> {
+        if pack.len() < 12 + TRAILER {
+            return Err(Error::Pack("truncated (shorter than header+trailer)".into()));
+        }
+        if pack[..4] != SIGNATURE {
+            return Err(Error::Pack("bad signature (not 'PACK')".into()));
+        }
+        let version = u32::from_be_bytes(pack[4..8].try_into().unwrap());
+        if version != 2 {
+            return Err(Error::Pack(format!("unsupported pack version {version}")));
+        }
+        let nobjects = u32::from_be_bytes(pack[8..12].try_into().unwrap()) as usize;
+
+        let tmr = bun_core::time::Timer::start().unwrap();
+        let mut last = 0u64;
+        let mut lap = || {
+            let now = tmr.read();
+            let d = now - last;
+            last = now;
+            d
+        };
+        let claimed = Oid({
+            let mut t = [0u8; 20];
+            t.copy_from_slice(&pack[pack.len() - TRAILER..]);
+            t
+        });
+        // Trailer SHA-1 runs on a worker concurrently with the boundary scan
+        // below — both are read-only over `pack`. Skipped when `serial`
+        // (caller is itself a worker; nested `go` would risk pool deadlock).
+        let trailer_hash = Guarded::new(Oid::ZERO);
+        let trailer_wg = bun_threading::WaitGroup::init_with_count(1);
+        if serial {
+            let mut h = Sha1::new();
+            h.update(&pack[..pack.len() - TRAILER]);
+            *trailer_hash.lock() = h.finish();
+            trailer_wg.finish();
+        } else {
+            WorkPool::go(
+                (
+                    // SAFETY: `pack` and `trailer_hash` outlive the WaitGroup
+                    // wait below; the worker only reads `pack` and writes the
+                    // result.
+                    unsafe { bun_ptr::detach_lifetime(&pack[..pack.len() - TRAILER]) },
+                    bun_ptr::BackRef::from(core::ptr::NonNull::from(&trailer_hash)),
+                    bun_ptr::BackRef::from(core::ptr::NonNull::from(&trailer_wg)),
+                ),
+                |(body, out, wg)| {
+                    let mut h = Sha1::new();
+                    h.update(body);
+                    *out.lock() = h.finish();
+                    wg.finish();
+                },
+            )
+            .unwrap();
+        }
+
+        // ── Pass 1: sequential boundary scan ──────────────────────────────
+        // Inflate-only — the irreducibly serial step (each object's start is
+        // the previous object's end). SHA-1 and CRC-32 are deferred to pass 2
+        // so they parallelise.
+        let mut entries: Vec<Entry> = Vec::with_capacity(nobjects);
+        let mut inflate = Inflate::new();
+        let mut buf = Vec::new();
+
+        let mut pos = 12usize;
+        let end = pack.len() - TRAILER;
+        for _ in 0..nobjects {
+            let offset = pos as u64;
+            let (raw, size, hdr_len) = read_entry_header(&pack[pos..end])?;
+            pos += hdr_len;
+            let (base, extra) = match raw {
+                RawType::Base(k) => (Base::None(k), 0),
+                RawType::OfsDelta => {
+                    let (neg, n) = read_ofs_varint(&pack[pos..end])?;
+                    let base_off = offset
+                        .checked_sub(neg)
+                        .filter(|&b| b >= 12)
+                        .ok_or_else(|| Error::Pack("OFS_DELTA points before pack start".into()))?;
+                    (Base::Ofs(base_off), n)
+                }
+                RawType::RefDelta => {
+                    let raw = pack
+                        .get(pos..pos + 20)
+                        .ok_or_else(|| Error::Pack("truncated REF_DELTA oid".into()))?;
+                    let mut oid = [0u8; 20];
+                    oid.copy_from_slice(raw);
+                    (Base::Ref(Oid(oid)), 20)
+                }
+            };
+            pos += extra;
+            let data_offset = pos as u64;
+            let size = usize::try_from(size)
+                .map_err(|_| Error::Pack("object size overflows usize".into()))?;
+            let consumed = inflate.inflate_into(&pack[pos..end], size, &mut buf)?;
+            pos += consumed;
+
+            entries.push(Entry {
+                offset,
+                next_offset: pos as u64,
+                data_offset,
+                inflated_size: size as u64,
+                base,
+                oid: core::cell::Cell::new(Oid::ZERO),
+                kind: core::cell::Cell::new(ObjKind::Blob),
+                crc32: core::cell::Cell::new(0),
+                children: Vec::new(),
+            });
+        }
+        if pos != end {
+            return Err(Error::Pack(format!(
+                "pack has {} trailing bytes before trailer",
+                end - pos
+            )));
+        }
+        timing.pass1_scan = lap();
+
+        // Join the trailer-SHA worker before pass 2 (which reuses the pool).
+        trailer_wg.wait();
+        let actual = *trailer_hash.lock();
+        if claimed != actual {
+            return Err(Error::Pack(format!(
+                "pack trailer mismatch: claimed {claimed}, computed {actual}"
+            )));
+        }
+        timing.trailer_sha = lap();
+
+        // ── Build delta forest ────────────────────────────────────────────
+        // Work units = every non-delta entry (its subtree may be empty). Each
+        // worker hashes the root and resolves its descendants — that puts
+        // **all** SHA-1, CRC-32, and delta application in the parallel phase.
+        // OFS_DELTA parents resolve via binary search on the offset-sorted
+        // entries; REF_DELTA defers to a fixed-point sweep after pass 2 (we
+        // advertise `ofs-delta`, so this is empty in practice).
+        let mut roots: Vec<u32> = Vec::new();
+        let mut pending_ref: Vec<u32> = Vec::new();
+        for i in 0..entries.len() {
+            match entries[i].base {
+                Base::None(_) => roots.push(i as u32),
+                Base::Ofs(off) => {
+                    let parent = offset_to_idx(&entries, off).ok_or_else(|| {
+                        Error::Pack(format!("OFS_DELTA base @{off} is not an object boundary"))
+                    })?;
+                    entries[parent as usize].children.push(i as u32);
+                    timing.n_deltas += 1;
+                }
+                Base::Ref(_) => {
+                    pending_ref.push(i as u32);
+                    timing.n_deltas += 1;
+                }
+            }
+        }
+
+        // ── Pass 2: hash + resolve ────────────────────────────────────────
+        if serial {
+            // Caller is itself a `WorkPool` worker — nested `each()` could
+            // starve the pool. Resolve on this thread; the outer `each` over
+            // packs supplies the parallelism.
+            with_inflate(|inf| {
+                for &root in &roots {
+                    resolve_subtree(&pack, &entries, root, inf, blob_sink)?;
+                }
+                Ok::<_, Error>(())
+            })?;
+            timing.pass2_resolve = lap();
+            let mut oid_to_idx: OidMap<u32> = HashMap::with_capacity(nobjects);
+            for (i, e) in entries.iter().enumerate() {
+                oid_to_idx.insert(e.oid.get(), i as u32);
+            }
+            if !pending_ref.is_empty() {
+                return Err(Error::Pack(
+                    "REF_DELTA in blob pack (serial path)".into(),
+                ));
+            }
+            return Ok(PackIndex {
+                pack,
+                entries,
+                by_oid: oid_to_idx,
+                pack_hash: actual,
+            });
+        }
+        // Chunk roots into ~ncpu×8 ranges so `each` schedules O(hundreds) of
+        // tasks, not O(hundreds-of-thousands).
+        struct ResolveCtx<'a> {
+            pack: &'a [u8],
+            entries: &'a [Entry],
+            roots: &'a [u32],
+            want_blobs: bool,
+            sinks: Guarded<Vec<BlobSink>>,
+            err: Guarded<Option<Error>>,
+        }
+        let ctx = ResolveCtx {
+            pack: &pack,
+            entries: &entries,
+            roots: &roots,
+            want_blobs: blob_sink.want,
+            sinks: Guarded::new(Vec::new()),
+            err: Guarded::new(None),
+        };
+        let ncpu = WorkPool::get().max_threads.max(1) as usize;
+        let chunk = (roots.len() / (ncpu * 8)).max(1);
+        let mut ranges: Vec<(u32, u32)> = (0..roots.len())
+            .step_by(chunk)
+            .map(|s| (s as u32, (s + chunk).min(roots.len()) as u32))
+            .collect();
+        WorkPool::get().each(
+            &ctx,
+            |ctx, (lo, hi): (u32, u32), _i| {
+                let mut sink = BlobSink {
+                    want: ctx.want_blobs,
+                    // Reserve once: avoids ~log₂ rehashes/chunk (the previous
+                    // 2 s overhead was almost entirely rehash copies).
+                    seen: if ctx.want_blobs {
+                        OidMap::with_capacity(65536)
+                    } else {
+                        OidMap::default()
+                    },
+                };
+                with_inflate(|inf| {
+                    for &root in &ctx.roots[lo as usize..hi as usize] {
+                        if let Err(e) = resolve_subtree(ctx.pack, ctx.entries, root, inf, &mut sink)
+                        {
+                            *ctx.err.lock() = Some(e);
+                            return;
+                        }
+                    }
+                });
+                if sink.want {
+                    ctx.sinks.lock().push(sink);
+                }
+            },
+            &mut ranges,
+        );
+        let ResolveCtx {
+            mut err, mut sinks, ..
+        } = ctx;
+        if blob_sink.want {
+            blob_sink
+                .seen
+                .ensure_total_capacity(nobjects)
+                .expect("OOM");
+            for s in core::mem::take(sinks.get_mut()) {
+                s.merge_into(&mut blob_sink.seen);
+            }
+        }
+        if let Some(e) = err.get_mut().take() {
+            return Err(e);
+        }
+        timing.pass2_resolve = lap();
+
+        // ── oid → index map ───────────────────────────────────────────────
+        let mut oid_to_idx: OidMap<u32> = HashMap::with_capacity(nobjects);
+        for (i, e) in entries.iter().enumerate() {
+            if !matches!(e.base, Base::Ref(_)) {
+                oid_to_idx.insert(e.oid.get(), i as u32);
+            }
+        }
+
+        // ── REF_DELTAs whose base was itself a delta ─────────────────────
+        // Iterate to a fixed point. In practice `pending_ref` is empty (we
+        // advertise `ofs-delta`); this is the correctness fallback.
+        while !pending_ref.is_empty() {
+            let mut still: Vec<u32> = Vec::new();
+            let before = pending_ref.len();
+            for i in pending_ref {
+                let Base::Ref(base_oid) = entries[i as usize].base else {
+                    unreachable!()
+                };
+                let Some(&parent) = oid_to_idx.get(&base_oid) else {
+                    still.push(i);
+                    continue;
+                };
+                // Resolve this single delta now (its base's oid is known).
+                // The parent's *data* may still need a chain walk; if that
+                // walk hits another unresolved Ref, defer to the next outer
+                // iteration.
+                let mut base_data = Vec::new();
+                if walk_ofs_chain(&pack, &entries, parent, &mut inflate, &mut base_data).is_err() {
+                    still.push(i);
+                    continue;
+                }
+                let mut delta_buf = Vec::new();
+                let e = &entries[i as usize];
+                inflate.inflate_into(
+                    &pack[e.data_offset as usize..pack.len() - TRAILER],
+                    e.inflated_size as usize,
+                    &mut delta_buf,
+                )?;
+                let mut out = Vec::new();
+                delta::apply(&base_data, &delta_buf, &mut out)?;
+                let kind = entries[parent as usize].kind.get();
+                let oid = object_id(kind, &out);
+                entries[i as usize].oid.set(oid);
+                entries[i as usize].kind.set(kind);
+                entries[i as usize].crc32.set(crc32_of(
+                    0,
+                    &pack[entries[i as usize].offset as usize
+                        ..entries[i as usize].next_offset as usize],
+                ));
+                oid_to_idx.insert(oid, i);
+            }
+            if still.len() == before {
+                return Err(Error::Pack(format!(
+                    "{} REF_DELTA object(s) reference oids not in pack (thin pack not supported for initial clone)",
+                    still.len()
+                )));
+            }
+            pending_ref = still;
+        }
+
+        Ok(PackIndex {
+            pack,
+            entries,
+            by_oid: oid_to_idx,
+            pack_hash: actual,
+        })
+    }
+
+    pub fn pack_hash(&self) -> Oid {
+        self.pack_hash
+    }
+
+    /// Number of objects in the pack.
+    #[allow(clippy::len_without_is_empty)] // a 0-object pack is a protocol error we reject earlier
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(crate) fn contains(&self, oid: &Oid) -> bool {
+        self.by_oid.get(oid).is_some()
+    }
+
+    pub(crate) fn pack_bytes(&self) -> &[u8] {
+        &self.pack
+    }
+
+
+    /// Look up an object by id and inflate it. Delta chains are walked to the
+    /// root. `inflate` is caller-owned so a hot loop (checkout) reuses it.
+    pub(crate) fn read(
+        &self,
+        oid: &Oid,
+        inflate: &mut Inflate,
+        out: &mut Vec<u8>,
+    ) -> Result<ObjKind> {
+        let &idx = self
+            .by_oid
+            .get(oid)
+            .ok_or_else(|| Error::Pack(format!("object {oid} not in pack")))?;
+        self.read_idx(idx, inflate, out)
+    }
+
+    fn read_idx(&self, idx: u32, inflate: &mut Inflate, out: &mut Vec<u8>) -> Result<ObjKind> {
+        let end = self.pack.len() - TRAILER;
+        // Collect chain idx → … → root, resolving Ofs by binary search and
+        // Ref via `by_oid` (both are populated post-build).
+        let mut chain = vec![idx];
+        loop {
+            let e = &self.entries[*chain.last().unwrap() as usize];
+            let parent = match e.base {
+                Base::None(_) => break,
+                Base::Ofs(off) => offset_to_idx(&self.entries, off)
+                    .ok_or_else(|| Error::Pack("delta base offset not found".into()))?,
+                Base::Ref(oid) => *self
+                    .by_oid
+                    .get(&oid)
+                    .ok_or_else(|| Error::Pack(format!("REF_DELTA base {oid} not in pack")))?,
+            };
+            if chain.contains(&parent) {
+                return Err(Error::Pack("delta cycle".into()));
+            }
+            chain.push(parent);
+        }
+        let root = chain.pop().unwrap();
+        let re = &self.entries[root as usize];
+        let kind = re.kind.get();
+        inflate.inflate_into(
+            &self.pack[re.data_offset as usize..end],
+            re.inflated_size as usize,
+            out,
+        )?;
+        let mut delta_buf = Vec::new();
+        let mut tmp = Vec::new();
+        while let Some(i) = chain.pop() {
+            let e = &self.entries[i as usize];
+            inflate.inflate_into(
+                &self.pack[e.data_offset as usize..end],
+                e.inflated_size as usize,
+                &mut delta_buf,
+            )?;
+            delta::apply(out, &delta_buf, &mut tmp)?;
+            core::mem::swap(out, &mut tmp);
+        }
+        Ok(kind)
+    }
+
+    /// Emit a v2 `.idx` (`gitformat-pack(5)` §pack-*.idx) into `w`.
+    pub fn write_idx(&self, w: &mut Vec<u8>) {
+        // Sorted permutation of entry indices by oid.
+        let mut order: Vec<u32> = (0..self.entries.len() as u32).collect();
+        order.sort_unstable_by_key(|&i| self.entries[i as usize].oid.get());
+
+        let mut sha = Sha1::new();
+        let mut put = |buf: &[u8]| {
+            sha.update(buf);
+            w.extend_from_slice(buf);
+        };
+
+        // Header: magic + version 2.
+        put(&[0xff, 0x74, 0x4f, 0x63]);
+        put(&2u32.to_be_bytes());
+
+        // 256-entry first-level fanout: fanout[i] = #oids with first byte ≤ i.
+        let mut fanout = [0u32; 256];
+        for &i in &order {
+            fanout[self.entries[i as usize].oid.get().0[0] as usize] += 1;
+        }
+        let mut acc = 0u32;
+        for f in &mut fanout {
+            acc += *f;
+            *f = acc;
+        }
+        for f in fanout {
+            put(&f.to_be_bytes());
+        }
+
+        // Name table.
+        for &i in &order {
+            put(&self.entries[i as usize].oid.get().0);
+        }
+        // CRC32 table.
+        for &i in &order {
+            put(&self.entries[i as usize].crc32.get().to_be_bytes());
+        }
+        // 4-byte offset table; offsets ≥ 2^31 get bit 31 set and index into
+        // the 8-byte table.
+        let mut large: Vec<u64> = Vec::new();
+        for &i in &order {
+            let off = self.entries[i as usize].offset;
+            if off < (1u64 << 31) {
+                put(&(off as u32).to_be_bytes());
+            } else {
+                let idx = large.len() as u32 | 0x8000_0000;
+                large.push(off);
+                put(&idx.to_be_bytes());
+            }
+        }
+        for off in large {
+            put(&off.to_be_bytes());
+        }
+        // Pack checksum, then idx checksum.
+        put(&self.pack_hash.0);
+        let idx_hash = sha.finish();
+        w.extend_from_slice(&idx_hash.0);
+    }
+}
+
+/// Decode the type+size header. Returns `(type, inflated_size, header_bytes)`.
+fn read_entry_header(buf: &[u8]) -> Result<(RawType, u64, usize)> {
+    let b0 = *buf.first().ok_or_else(trunc)?;
+    let raw = RawType::from_bits((b0 >> 4) & 0x7)?;
+    let mut size = u64::from(b0 & 0x0f);
+    let mut shift = 4u32;
+    let mut i = 1usize;
+    let mut cont = b0 & 0x80 != 0;
+    while cont {
+        let b = *buf.get(i).ok_or_else(trunc)?;
+        i += 1;
+        if shift >= 64 {
+            return Err(Error::Pack("object size varint too long".into()));
+        }
+        size |= u64::from(b & 0x7f) << shift;
+        shift += 7;
+        cont = b & 0x80 != 0;
+    }
+    Ok((raw, size, i))
+}
+
+/// OFS_DELTA negative-offset varint: big-endian 7-bit groups, MSB = continue,
+/// with a `+1` per continuation (so no redundant encodings). Returns
+/// `(offset, bytes_consumed)`.
+fn read_ofs_varint(buf: &[u8]) -> Result<(u64, usize)> {
+    let b0 = *buf.first().ok_or_else(trunc)?;
+    let mut val = u64::from(b0 & 0x7f);
+    let mut i = 1usize;
+    let mut b = b0;
+    while b & 0x80 != 0 {
+        b = *buf.get(i).ok_or_else(trunc)?;
+        i += 1;
+        val = val
+            .checked_add(1)
+            .and_then(|v| v.checked_shl(7))
+            .ok_or_else(|| Error::Pack("OFS_DELTA varint overflow".into()))?
+            | u64::from(b & 0x7f);
+    }
+    Ok((val, i))
+}
+
+#[cold]
+fn trunc() -> Error {
+    Error::Pack("truncated object header".into())
+}
+
+/// Hash `root` (a non-delta) and DFS-resolve every delta under it, writing
+/// `oid`/`kind`/`crc32` into each entry's `Cell`s. Runs on a worker thread;
+/// the index partition guarantees no other worker touches the same entries.
+fn resolve_subtree(
+    pack: &[u8],
+    entries: &[Entry],
+    root: u32,
+    inflate: &mut Inflate,
+    sink: &mut BlobSink,
+) -> Result<()> {
+    let end = pack.len() - TRAILER;
+    let root_e = &entries[root as usize];
+    let Base::None(kind) = root_e.base else {
+        unreachable!("resolve_subtree called on a delta root")
+    };
+    root_e
+        .crc32
+        .set(crc32_of(0, &pack[root_e.offset as usize..root_e.next_offset as usize]));
+    let mut base = Vec::new();
+    inflate.inflate_into(
+        &pack[root_e.data_offset as usize..end],
+        root_e.inflated_size as usize,
+        &mut base,
+    )?;
+    root_e.oid.set(object_id(kind, &base));
+    root_e.kind.set(kind);
+    sink.maybe(kind, &base);
+    if root_e.children.is_empty() {
+        return Ok(());
+    }
+    // (parent_data, children_iter) — one inflated buffer per stack level so
+    // siblings reuse their parent's data without re-inflating.
+    let mut stack: Vec<(Vec<u8>, core::slice::Iter<'_, u32>)> =
+        vec![(base, root_e.children.iter())];
+    let mut delta_buf = Vec::new();
+
+    while let Some((parent_data, iter)) = stack.last_mut() {
+        let Some(&child_idx) = iter.next() else {
+            stack.pop();
+            continue;
+        };
+        let child = &entries[child_idx as usize];
+        child
+            .crc32
+            .set(crc32_of(0, &pack[child.offset as usize..child.next_offset as usize]));
+        inflate.inflate_into(
+            &pack[child.data_offset as usize..end],
+            child.inflated_size as usize,
+            &mut delta_buf,
+        )?;
+        let mut data = Vec::new();
+        delta::apply(parent_data, &delta_buf, &mut data)?;
+        child.oid.set(object_id(kind, &data));
+        child.kind.set(kind);
+        sink.maybe(kind, &data);
+        if !child.children.is_empty() {
+            stack.push((data, child.children.iter()));
+        }
+    }
+    Ok(())
+}
+
+/// Build-time helper: inflate entry `idx` by walking only `Ofs`/`None` links
+/// (used when resolving a late REF_DELTA whose parent is already known). A
+/// `Ref` link here means the parent is itself an unresolved REF_DELTA — caller
+/// defers to the next fixed-point iteration.
+fn walk_ofs_chain(
+    pack: &[u8],
+    entries: &[Entry],
+    idx: u32,
+    inflate: &mut Inflate,
+    out: &mut Vec<u8>,
+) -> Result<()> {
+    let end = pack.len() - TRAILER;
+    let mut chain = vec![idx];
+    loop {
+        let e = &entries[*chain.last().unwrap() as usize];
+        match e.base {
+            Base::None(_) => break,
+            Base::Ofs(off) => {
+                let parent = offset_to_idx(entries, off)
+                    .ok_or_else(|| Error::Pack("delta base offset not found".into()))?;
+                if chain.contains(&parent) {
+                    return Err(Error::Pack("delta cycle".into()));
+                }
+                chain.push(parent);
+            }
+            Base::Ref(_) => {
+                return Err(Error::Pack(
+                    "REF_DELTA parent not yet resolved (deferred)".into(),
+                ));
+            }
+        }
+    }
+    let root = chain.pop().unwrap();
+    let re = &entries[root as usize];
+    inflate.inflate_into(
+        &pack[re.data_offset as usize..end],
+        re.inflated_size as usize,
+        out,
+    )?;
+    let mut delta_buf = Vec::new();
+    let mut tmp = Vec::new();
+    while let Some(i) = chain.pop() {
+        let e = &entries[i as usize];
+        inflate.inflate_into(
+            &pack[e.data_offset as usize..end],
+            e.inflated_size as usize,
+            &mut delta_buf,
+        )?;
+        delta::apply(out, &delta_buf, &mut tmp)?;
+        core::mem::swap(out, &mut tmp);
+    }
+    Ok(())
+}
+
+/// Entries are in pack order, i.e. sorted by `offset`. Binary search.
+fn offset_to_idx(entries: &[Entry], off: u64) -> Option<u32> {
+    entries
+        .binary_search_by_key(&off, |e| e.offset)
+        .ok()
+        .map(|i| i as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_header_roundtrip() {
+        // type=blob(3), size=300: b0 = 1_011_1100 (cont,type=3,low4=0xc=12),
+        // b1 = 0_0010010 (18); 12 + 18<<4 = 12+288 = 300.
+        let buf = [0b1011_1100u8, 0b0001_0010, 0xff];
+        let (t, s, n) = read_entry_header(&buf).unwrap();
+        assert!(matches!(t, RawType::Base(ObjKind::Blob)));
+        assert_eq!(s, 300);
+        assert_eq!(n, 2);
+    }
+
+    #[test]
+    fn ofs_varint() {
+        // Single byte: value = low7.
+        assert_eq!(read_ofs_varint(&[0x42]).unwrap(), (0x42, 1));
+        // Two bytes: ((b0&7f)+1)<<7 | (b1&7f).
+        // [0x80, 0x01] → (0+1)<<7 | 1 = 129.
+        assert_eq!(read_ofs_varint(&[0x80, 0x01]).unwrap(), (129, 2));
+        // [0x81, 0x48] → (1+1)<<7 | 0x48 = 328.
+        assert_eq!(read_ofs_varint(&[0x81, 0x48]).unwrap(), (328, 2));
+    }
+}

--- a/src/git/pktline.rs
+++ b/src/git/pktline.rs
@@ -1,0 +1,217 @@
+//! pkt-line framing — `gitprotocol-common(5)`.
+//!
+//! Each line is a 4-byte lowercase-hex length prefix that **includes the
+//! prefix itself**, followed by `len - 4` payload bytes. Three magic lengths
+//! carry no payload:
+//!
+//! * `0000` — flush-pkt (section delimiter / end of request)
+//! * `0001` — delim-pkt (protocol-v2 section separator)
+//! * `0002` — response-end-pkt (protocol-v2 stateless-connect; unused here)
+//!
+//! The maximum payload is 65516 bytes (`0xfff0` total) per the spec; git
+//! itself caps at 65520 (`LARGE_PACKET_MAX`). We accept up to `0xffff` on
+//! read (the prefix can encode it, and rejecting would just be a DoS on
+//! ourselves) and never emit above 65516.
+
+use crate::{Error, Result};
+
+pub(crate) const FLUSH: &[u8; 4] = b"0000";
+pub(crate) const DELIM: &[u8; 4] = b"0001";
+const MAX_DATA: usize = 65516;
+
+/// One framed line. `Data` borrows the reader's internal buffer until the next
+/// `read()` call.
+#[derive(Debug)]
+pub(crate) enum Pkt<'a> {
+    Flush,
+    Delim,
+    ResponseEnd,
+    Data(&'a [u8]),
+}
+
+/// pkt-line reader over an in-memory slice. Both v2 responses we parse with
+/// this (`info/refs`, `ls-refs`) are small and already buffered; the large
+/// `fetch` body is handled by [`crate::protocol::SidebandDemux`] instead.
+pub(crate) struct PktReader<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> PktReader<'a> {
+    pub(crate) fn new(buf: &'a [u8]) -> Self {
+        Self { rest: buf }
+    }
+
+    /// Read exactly one pkt-line. Missing bytes mean the server hung up
+    /// mid-stream (every exchange is flush-terminated).
+    pub(crate) fn read(&mut self) -> Result<Pkt<'a>> {
+        let hdr: [u8; 4] = self
+            .rest
+            .get(..4)
+            .ok_or(Error::PktLine("truncated header"))?
+            .try_into()
+            .unwrap();
+        let len = parse_len(hdr)?;
+        match len {
+            0 => {
+                self.rest = &self.rest[4..];
+                Ok(Pkt::Flush)
+            }
+            1 => {
+                self.rest = &self.rest[4..];
+                Ok(Pkt::Delim)
+            }
+            2 => {
+                self.rest = &self.rest[4..];
+                Ok(Pkt::ResponseEnd)
+            }
+            3 => Err(Error::PktLine("reserved length 0003")),
+            _ => {
+                let payload = self
+                    .rest
+                    .get(4..len)
+                    .ok_or(Error::PktLine("truncated payload"))?;
+                self.rest = &self.rest[len..];
+                Ok(Pkt::Data(payload))
+            }
+        }
+    }
+
+    /// Read one line, stripping a single trailing LF (the spec says the LF is
+    /// optional and part of the framing, not the payload).
+    pub(crate) fn read_text(&mut self) -> Result<Pkt<'a>> {
+        match self.read()? {
+            Pkt::Data(d) => Ok(Pkt::Data(d.strip_suffix(b"\n").unwrap_or(d))),
+            other => Ok(other),
+        }
+    }
+}
+
+fn parse_len(hdr: [u8; 4]) -> Result<usize> {
+    let mut n = 0usize;
+    for b in hdr {
+        let d = match b {
+            b'0'..=b'9' => b - b'0',
+            b'a'..=b'f' => b - b'a' + 10,
+            // Spec says lowercase; git accepts uppercase, so we do too.
+            b'A'..=b'F' => b - b'A' + 10,
+            _ => return Err(Error::PktLine("non-hex length prefix")),
+        };
+        n = (n << 4) | usize::from(d);
+    }
+    Ok(n)
+}
+
+/// Builder for a pkt-line request body. Lines are accumulated into a `Vec`
+/// (every request we send is small — capability advertisement, ls-refs, or a
+/// fetch with a handful of `want`s).
+#[derive(Default)]
+pub(crate) struct PktWriter {
+    out: Vec<u8>,
+}
+
+impl PktWriter {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Append one data line. A trailing LF is **not** added — callers include
+    /// it where the protocol wants one (text commands) and omit it where it
+    /// doesn't (binary side-band, though we never write that).
+    pub(crate) fn data(&mut self, payload: &[u8]) -> &mut Self {
+        assert!(
+            payload.len() <= MAX_DATA,
+            "pkt-line payload {} > {}",
+            payload.len(),
+            MAX_DATA
+        );
+        let len = payload.len() + 4;
+        let hdr = [
+            HEX[(len >> 12) & 0xf],
+            HEX[(len >> 8) & 0xf],
+            HEX[(len >> 4) & 0xf],
+            HEX[len & 0xf],
+        ];
+        self.out.extend_from_slice(&hdr);
+        self.out.extend_from_slice(payload);
+        self
+    }
+
+    pub(crate) fn text(&mut self, s: &str) -> &mut Self {
+        // Text lines in v2 carry a trailing LF.
+        let mut buf = Vec::with_capacity(s.len() + 1);
+        buf.extend_from_slice(s.as_bytes());
+        buf.push(b'\n');
+        self.data(&buf)
+    }
+
+    pub(crate) fn flush(&mut self) -> &mut Self {
+        self.out.extend_from_slice(FLUSH);
+        self
+    }
+
+    pub(crate) fn delim(&mut self) -> &mut Self {
+        self.out.extend_from_slice(DELIM);
+        self
+    }
+
+    pub(crate) fn finish(self) -> Vec<u8> {
+        self.out
+    }
+}
+
+const HEX: [u8; 16] = *b"0123456789abcdef";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_read_roundtrip() {
+        let mut w = PktWriter::new();
+        w.text("command=ls-refs");
+        w.delim();
+        w.data(b"peel");
+        w.flush();
+        let bytes = w.finish();
+        assert_eq!(
+            bytes,
+            b"0014command=ls-refs\n00010008peel0000".as_slice(),
+            "got {:?}",
+            bstr::BStr::new(&bytes)
+        );
+
+        let mut r = PktReader::new(bytes.as_slice());
+        match r.read_text().unwrap() {
+            Pkt::Data(d) => assert_eq!(d, b"command=ls-refs"),
+            other => panic!("{other:?}"),
+        }
+        assert!(matches!(r.read().unwrap(), Pkt::Delim));
+        match r.read().unwrap() {
+            Pkt::Data(d) => assert_eq!(d, b"peel"),
+            other => panic!("{other:?}"),
+        }
+        assert!(matches!(r.read().unwrap(), Pkt::Flush));
+    }
+
+    #[test]
+    fn rejects_garbage_prefix() {
+        let mut r = PktReader::new(&b"zzzz"[..]);
+        assert!(matches!(r.read(), Err(Error::PktLine(_))));
+    }
+
+    #[test]
+    fn empty_data_line() {
+        // "0004" = 4-byte header + 0 payload bytes. Legal per spec.
+        let mut r = PktReader::new(&b"0004"[..]);
+        match r.read().unwrap() {
+            Pkt::Data(d) => assert!(d.is_empty()),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncated_payload_is_error() {
+        let mut r = PktReader::new(&b"0010short"[..]);
+        assert!(matches!(r.read(), Err(Error::PktLine(_))));
+    }
+}

--- a/src/git/protocol.rs
+++ b/src/git/protocol.rs
@@ -122,7 +122,6 @@ fn check_ref_format(raw: &[u8]) -> Result<&str> {
     Ok(s)
 }
 
-
 #[cold]
 fn unsupported(first: &[u8]) -> Error {
     Error::Protocol(format!(
@@ -314,16 +313,11 @@ impl<P: FnMut(&[u8]) -> Result<()>> SidebandDemux<P> {
                                     // Band 2 is human progress text; runs on
                                     // the HTTP thread, so go straight to the
                                     // raw fd rather than the buffered Output.
-                                    let _ = bun_sys::write(
-                                        bun_core::Fd::stderr(),
-                                        data,
-                                    );
+                                    let _ = bun_sys::write(bun_core::Fd::stderr(), data);
                                 }
                             }
                             3 => {
-                                return Err(Error::Remote(
-                                    bstr::BStr::new(data).to_string(),
-                                ));
+                                return Err(Error::Remote(bstr::BStr::new(data).to_string()));
                             }
                             n => {
                                 return Err(Error::Protocol(format!("invalid side-band {n}")));

--- a/src/git/protocol.rs
+++ b/src/git/protocol.rs
@@ -1,0 +1,421 @@
+//! Git wire protocol v2 — `gitprotocol-v2(5)`.
+//!
+//! v2 is a request/response RPC over the same pkt-line framing as v0/v1. The
+//! client opens with `GET …/info/refs?service=git-upload-pack` carrying
+//! `Git-Protocol: version=2`; a v2-capable server replies with a capability
+//! advertisement (no refs — that's the point of v2). Subsequent commands are
+//! `POST …/git-upload-pack` bodies of the form:
+//!
+//! ```text
+//!   command=<name> LF
+//!   [capability lines]
+//!   0001                    -- delim-pkt
+//!   [command args]
+//!   0000                    -- flush-pkt
+//! ```
+//!
+//! We use exactly two commands:
+//!   * `ls-refs` → `<oid> <refname>\n` lines, flush-terminated.
+//!   * `fetch`   → sectioned response; we consume `packfile` (side-band).
+//!
+//! v2 is chosen over v0 because `ls-refs` can be filtered server-side
+//! (`ref-prefix`) — on repos with hundreds of thousands of refs (every PR
+//! head on a big GitHub repo) the v0 advertisement alone is tens of MB.
+
+use crate::pktline::{Pkt, PktReader, PktWriter};
+use crate::transport::Remote;
+use crate::{Error, Oid, Result};
+
+pub(crate) const AGENT: &str = "agent=bun-git/0";
+
+/// One advertised ref. `target` is set when the server sent
+/// `symref-target:<ref>` (HEAD only, in practice).
+#[derive(Debug, Clone)]
+pub(crate) struct Ref {
+    pub(crate) name: String,
+    pub(crate) oid: Oid,
+    pub(crate) symref_target: Option<String>,
+}
+
+/// Server capabilities relevant to the clone path.
+#[derive(Default)]
+pub(crate) struct Caps {
+    /// `fetch=… filter` — server accepts `filter <spec>` (partial clone).
+    pub(crate) filter: bool,
+}
+
+/// Read the v2 capability advertisement and confirm the server speaks v2.
+pub(crate) fn handshake(remote: &Remote) -> Result<Caps> {
+    let body = remote.handshake()?;
+    let mut r = PktReader::new(body.as_slice());
+    // smart-HTTP prefixes the v2 advertisement with
+    // `# service=git-upload-pack\n` + flush. The `--stateless-rpc
+    // --advertise-refs` form (used by LocalTransport) does **not**. Accept
+    // both: peek the first line.
+    match r.read_text()? {
+        Pkt::Data(d) if d == b"# service=git-upload-pack" => {
+            // flush, then the real advertisement
+            match r.read()? {
+                Pkt::Flush => {}
+                _ => return Err(Error::Protocol("expected flush after service line".into())),
+            }
+            match r.read_text()? {
+                Pkt::Data(d) if d == b"version 2" => {}
+                Pkt::Data(d) => return Err(unsupported(d)),
+                _ => return Err(Error::Protocol("empty capability advertisement".into())),
+            }
+        }
+        Pkt::Data(d) if d == b"version 2" => {}
+        Pkt::Data(d) => return Err(unsupported(d)),
+        _ => return Err(Error::Protocol("empty info/refs response".into())),
+    }
+    // Drain capability lines until flush, recording the few we act on.
+    let mut caps = Caps::default();
+    loop {
+        match r.read_text()? {
+            Pkt::Flush => return Ok(caps),
+            Pkt::Data(d) => {
+                if let Some(v) = d.strip_prefix(b"fetch=") {
+                    caps.filter = v.split(|&b| b == b' ').any(|w| w == b"filter");
+                }
+            }
+            _ => return Err(Error::Protocol("unexpected delim in capabilities".into())),
+        }
+    }
+}
+
+/// `git check-ref-format` (refs.c:check_refname_component) — the subset that
+/// matters for what we write to disk: no control bytes (incl. LF — would
+/// inject into packed-refs), no SP / `~^:?*[\\` / `..` / `@{` / leading `.`
+/// or `/` / trailing `.` `/` `.lock`, must be `HEAD` or under `refs/`.
+fn check_ref_format(raw: &[u8]) -> Result<&str> {
+    let bad = |why: &str| {
+        Err(Error::Protocol(format!(
+            "ls-refs: refusing refname {:?}: {why}",
+            bstr::BStr::new(raw)
+        )))
+    };
+    let Ok(s) = core::str::from_utf8(raw) else {
+        return bad("not UTF-8");
+    };
+    if s != "HEAD" && !s.starts_with("refs/") {
+        return bad("not HEAD or refs/*");
+    }
+    // `"` isn't in git's own reject set, but a server-supplied
+    // `symref-target:` lands inside `[branch "<name>"]` in `.git/config`;
+    // rejecting it here keeps the defence at the parse layer instead of the
+    // writer.
+    if s.bytes()
+        .any(|b| b <= 0x20 || b == 0x7f || b" ~^:?*[\\\"".contains(&b))
+    {
+        return bad("contains control or reserved character");
+    }
+    if s.contains("..") || s.contains("@{") || s.contains("//") {
+        return bad("contains '..', '@{', or '//'");
+    }
+    if s.ends_with(['/', '.']) || s.ends_with(".lock") || s.starts_with('/') {
+        return bad("invalid leading/trailing component");
+    }
+    if s.split('/').any(|c| c.is_empty() || c.starts_with('.')) {
+        return bad("empty or dot-leading component");
+    }
+    Ok(s)
+}
+
+
+#[cold]
+fn unsupported(first: &[u8]) -> Error {
+    Error::Protocol(format!(
+        "server does not speak protocol v2 (first line: {:?})",
+        bstr::BStr::new(first)
+    ))
+}
+
+/// `ls-refs` filtered to `HEAD` + `refs/heads/*` + `refs/tags/*`.
+pub(crate) fn ls_refs(remote: &Remote) -> Result<Vec<Ref>> {
+    let mut w = PktWriter::new();
+    w.text("command=ls-refs");
+    w.text(AGENT);
+    w.text("object-format=sha1");
+    w.delim();
+    w.text("peel");
+    w.text("symrefs");
+    w.text("ref-prefix HEAD");
+    w.text("ref-prefix refs/heads/");
+    w.text("ref-prefix refs/tags/");
+    w.flush();
+    let body = w.finish();
+
+    let mut resp = Vec::new();
+    remote.request(&body, |c| {
+        resp.extend_from_slice(c);
+        Ok(())
+    })?;
+
+    let mut out = Vec::new();
+    let mut r = PktReader::new(resp.as_slice());
+    loop {
+        match r.read_text()? {
+            Pkt::Flush => break,
+            Pkt::Data(line) => out.push(parse_ref_line(line)?),
+            other => {
+                return Err(Error::Protocol(format!("unexpected {other:?} in ls-refs")));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn parse_ref_line(line: &[u8]) -> Result<Ref> {
+    // `<oid> <refname>[ symref-target:<ref>][ peeled:<oid>]`
+    let mut parts = line.split(|&b| b == b' ');
+    let oid = parts
+        .next()
+        .and_then(Oid::from_hex)
+        .ok_or_else(|| Error::Protocol("ls-refs: bad oid".into()))?;
+    // The server controls refnames; they go straight into `.git/packed-refs`
+    // and `.git/HEAD`, so anything outside `git check-ref-format` rules is a
+    // ref-injection (a `\n` would let the server append arbitrary lines).
+    let raw = parts
+        .next()
+        .ok_or_else(|| Error::Protocol("ls-refs: missing refname".into()))?;
+    let name = check_ref_format(raw)?.to_owned();
+    let mut symref_target = None;
+    for attr in parts {
+        if let Some(t) = attr.strip_prefix(b"symref-target:") {
+            symref_target = Some(check_ref_format(t)?.to_owned());
+        }
+        // `peeled:<oid>` ignored — we don't write peeled tags into
+        // packed-refs yet.
+    }
+    Ok(Ref {
+        name,
+        oid,
+        symref_target,
+    })
+}
+
+/// `fetch` for the given wants (no haves — fresh clone). Side-band pack data
+/// is streamed to `pack_sink` on the bun HTTP thread.
+///
+/// `filter` is the protocol-v2 object filter (`blob:none`, `tree:0`, …) or
+/// `None` for a full fetch. When set, the resulting pack is a *promisor* pack
+/// — objects the filter excluded are simply absent.
+pub(crate) fn fetch<S>(
+    remote: &Remote,
+    wants: &[Oid],
+    haves: &[Oid],
+    filter: Option<&str>,
+    quiet: bool,
+    pack_sink: S,
+) -> Result<()>
+where
+    S: FnMut(&[u8]) -> Result<()> + Send,
+{
+    let mut w = PktWriter::new();
+    w.text("command=fetch");
+    w.text(AGENT);
+    w.text("object-format=sha1");
+    w.delim();
+    // No `have` lines → server packs from roots. `done` tells the server not
+    // to wait for negotiation rounds.
+    w.text("ofs-delta");
+    if let Some(f) = filter {
+        w.text(&format!("filter {f}"));
+    }
+    for oid in wants {
+        w.text(&format!("want {oid}"));
+    }
+    for oid in haves {
+        w.text(&format!("have {oid}"));
+    }
+    if quiet {
+        w.text("no-progress");
+    }
+    w.text("done");
+    w.flush();
+    let body = w.finish();
+
+    // Demux side-band as bytes arrive. The closure borrows `demux` from this
+    // frame; sound because `Remote::request` blocks until the last callback
+    // has returned, so the borrow is live for every invocation.
+    let mut demux = SidebandDemux::new(pack_sink, quiet);
+    remote.request(&body, |chunk| demux.feed(chunk))?;
+    demux.finish()
+}
+
+/// Incremental pkt-line + side-band-64k demuxer for the `fetch` response.
+///
+/// State machine:
+///   1. Section headers (`packfile\n`, optionally preceded by
+///      `acknowledgments`/`shallow-info` we don't request) until we see
+///      `packfile`.
+///   2. Side-band data lines: first payload byte is the band (1/2/3).
+///   3. Flush ends the response.
+struct SidebandDemux<P> {
+    /// Bytes not yet forming a complete pkt-line.
+    buf: Vec<u8>,
+    in_pack_section: bool,
+    saw_flush: bool,
+    quiet: bool,
+    pack: P,
+}
+
+impl<P: FnMut(&[u8]) -> Result<()>> SidebandDemux<P> {
+    fn new(pack: P, quiet: bool) -> Self {
+        Self {
+            buf: Vec::with_capacity(65536),
+            in_pack_section: false,
+            saw_flush: false,
+            quiet,
+            pack,
+        }
+    }
+
+    fn feed(&mut self, chunk: &[u8]) -> Result<()> {
+        self.buf.extend_from_slice(chunk);
+        // Drain every complete pkt-line in `buf`. Work with offsets, not
+        // slices, so the disjoint borrows of `self.buf` vs `self.pack`/
+        // `self.progress` are visible to the borrow checker.
+        let mut consumed = 0usize;
+        loop {
+            let avail = self.buf.len() - consumed;
+            if avail < 4 {
+                break;
+            }
+            let len = parse_hex4(&self.buf[consumed..consumed + 4])?;
+            match len {
+                0 => {
+                    consumed += 4;
+                    self.saw_flush = true;
+                    // Response is over; any trailing bytes are reported by
+                    // `finish`.
+                }
+                1 => consumed += 4, // delim-pkt between sections
+                2 => {
+                    consumed += 4; // response-end-pkt; treat as terminator
+                    self.saw_flush = true;
+                }
+                3 => return Err(Error::PktLine("reserved length 0003")),
+                _ => {
+                    if avail < len {
+                        break; // need more bytes
+                    }
+                    let payload = &self.buf[consumed + 4..consumed + len];
+                    consumed += len;
+                    if self.in_pack_section {
+                        let (&band, data) = payload
+                            .split_first()
+                            .ok_or_else(|| Error::Protocol("empty side-band line".into()))?;
+                        match band {
+                            1 => (self.pack)(data)?,
+                            2 => {
+                                if !self.quiet {
+                                    // Band 2 is human progress text; runs on
+                                    // the HTTP thread, so go straight to the
+                                    // raw fd rather than the buffered Output.
+                                    let _ = bun_sys::write(
+                                        bun_core::Fd::stderr(),
+                                        data,
+                                    );
+                                }
+                            }
+                            3 => {
+                                return Err(Error::Remote(
+                                    bstr::BStr::new(data).to_string(),
+                                ));
+                            }
+                            n => {
+                                return Err(Error::Protocol(format!("invalid side-band {n}")));
+                            }
+                        }
+                    } else {
+                        let line = payload.strip_suffix(b"\n").unwrap_or(payload);
+                        if line == b"packfile" {
+                            self.in_pack_section = true;
+                        } else if let Some(err) = line.strip_prefix(b"ERR ") {
+                            return Err(Error::Remote(bstr::BStr::new(err).to_string()));
+                        }
+                        // Any other section header (`acknowledgments`, `NAK`,
+                        // `wanted-refs`, …) is skipped — we sent `done` with
+                        // no haves, so the server goes straight to `packfile`.
+                    }
+                }
+            }
+        }
+        if consumed > 0 {
+            self.buf.drain(..consumed);
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Result<()> {
+        if !self.saw_flush {
+            return Err(Error::Protocol(
+                "fetch response ended without flush-pkt".into(),
+            ));
+        }
+        if !self.in_pack_section {
+            return Err(Error::Protocol(
+                "fetch response contained no packfile section".into(),
+            ));
+        }
+        if !self.buf.is_empty() {
+            return Err(Error::Protocol(format!(
+                "{} trailing bytes after fetch flush-pkt",
+                self.buf.len()
+            )));
+        }
+        Ok(())
+    }
+}
+
+fn parse_hex4(b: &[u8]) -> Result<usize> {
+    let mut n = 0usize;
+    for &c in &b[..4] {
+        let d = match c {
+            b'0'..=b'9' => c - b'0',
+            b'a'..=b'f' => c - b'a' + 10,
+            b'A'..=b'F' => c - b'A' + 10,
+            _ => return Err(Error::PktLine("non-hex length prefix")),
+        };
+        n = (n << 4) | usize::from(d);
+    }
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_ref_format;
+
+    #[test]
+    fn refname_rejects_injection() {
+        for bad in [
+            &b"refs/heads/main\nevil 0000000000000000000000000000000000000000"[..],
+            b"refs/heads/ma\x00in",
+            b"refs/heads/ma in",
+            b"refs/heads/..",
+            b"refs/heads/.hidden",
+            b"refs/heads/x.lock",
+            b"main",
+            b"refs/heads/a~b",
+            b"refs/heads/a:b",
+            b"refs/heads/a\\b",
+            b"refs/heads//double",
+        ] {
+            assert!(check_ref_format(bad).is_err(), "should reject {bad:?}");
+        }
+    }
+
+    #[test]
+    fn refname_accepts_normal() {
+        for ok in [
+            "HEAD",
+            "refs/heads/main",
+            "refs/tags/v1.2.3-rc.1",
+            "refs/remotes/origin/feat/x",
+        ] {
+            assert!(check_ref_format(ok.as_bytes()).is_ok(), "{ok}");
+        }
+    }
+}

--- a/src/git/transport.rs
+++ b/src/git/transport.rs
@@ -1,0 +1,649 @@
+//! Git wire transports. Everything above this layer (pkt-line, protocol v2,
+//! pack indexing, parallel-fetch orchestration) is byte-identical across
+//! transports — only [`Remote::handshake`] and [`Remote::request`] differ.
+//!
+//! [`Remote`] is the seam: HTTP today, subprocess `ssh` today, native libssh2
+//! later. A new transport implements those two methods and nothing else.
+//!
+//! ### HTTP — `bun_http::AsyncHTTP`
+//!
+//! Everything runs on the bun HTTP thread (uSockets event loop, BoringSSL,
+//! H1/H2). This file is just glue: build a request, hand it to the HTTP
+//! thread, block the calling thread on a `Guarded<…>` + `Condvar` until the
+//! result lands.
+//!
+//! Two shapes:
+//!   * [`get_buffered`] — `GET …/info/refs` and the `ls-refs` POST. Body is a
+//!     few KiB, so let `send_sync` collect it whole.
+//!   * [`post_streamed`] — the `fetch` POST. The packfile can be GiBs, so the
+//!     response-body-streaming signal is set and each chunk is processed in
+//!     the HTTP-thread callback (the same pattern `bun install` uses for
+//!     tarballs in `NetworkTask::notify`). The caller passes a `Send` sink
+//!     that runs **on the HTTP thread**; for git-clone that sink is the
+//!     side-band demux + pack file write + in-memory append.
+
+use crate::{Error, Result};
+use bun_core::MutableString;
+use bun_http::{self as http, AsyncHTTP, FetchRedirect, HTTPClientResult, Method};
+use bun_threading::{Condvar, Guarded, thread_pool::Batch};
+use core::mem::ManuallyDrop;
+use core::ptr::{self, NonNull};
+use core::sync::atomic::Ordering;
+
+/// Headers every git smart-HTTP request carries. The HTTP client adds `Host`,
+/// `User-Agent`, `Connection`, `Accept-Encoding`, `Content-Length` itself.
+const GIT_PROTOCOL: (&str, &str) = ("Git-Protocol", "version=2");
+
+/// Buffered `GET`/small-`POST`: returns `(status, body)`.
+pub(crate) fn get_buffered(
+    url: &[u8],
+    method: Method,
+    content_type: Option<&str>,
+    body: &[u8],
+) -> Result<(u16, Vec<u8>)> {
+    let mut hb = build_headers(content_type);
+    // SAFETY: `hb.content` is heap-owned by this stack frame, which outlives
+    // the `send_sync` call below; detach the borrow so `hb` can be moved.
+    let headers_buf: &[u8] = unsafe { bun_ptr::detach_lifetime(hb.content.written_slice()) };
+    let entries = core::mem::take(&mut hb.entries);
+    let _hold_buf = ManuallyDrop::new(core::mem::take(&mut hb.content));
+
+    let mut out = MutableString::init(0).map_err(|_| Error::Http("OOM".into()))?;
+    let mut req = Box::new(AsyncHTTP::init_sync(
+        method,
+        bun_url::URL::parse(url),
+        entries,
+        headers_buf,
+        ptr::from_mut(&mut out),
+        body,
+        None,
+        None,
+        FetchRedirect::Follow,
+    ));
+    let resp = req
+        .send_sync()
+        .map_err(|e| Error::Http(format!("{}: {e:?}", bstr::BStr::new(url))))?;
+    let status = resp.status_code as u16;
+    // `_hold_buf` was leaked above only to outlive the request; reclaim it now
+    // that `send_sync` returned.
+    drop(ManuallyDrop::into_inner(_hold_buf));
+    Ok((status, core::mem::take(&mut out.list)))
+}
+
+/// Streaming `POST`. `sink` is invoked **on the HTTP thread** once per body
+/// chunk; this function blocks until the response completes (or `sink`
+/// returns an error, which is propagated). Returns the response status.
+pub(crate) fn post_streamed<S>(url: &[u8], content_type: &str, body: &[u8], sink: S) -> Result<u16>
+where
+    S: FnMut(&[u8]) -> Result<()> + Send,
+{
+    // Heap context shared with the HTTP-thread callback. Layout is fixed for
+    // the request's lifetime, so raw pointers into it stay valid.
+    struct Ctx<S> {
+        /// HTTP client appends each chunk here; callback consumes + resets.
+        response_buffer: MutableString,
+        /// Set on the first callback that carries headers.
+        status: u16,
+        sink: S,
+        /// `Some` once the final callback has fired.
+        done: Guarded<Option<Result<()>>>,
+        cv: Condvar,
+        /// Backing store for the streaming flag the HTTP client polls.
+        signal_store: http::signals::Store,
+        /// The `headers_buf` slice the client borrows; owned here so it
+        /// outlives the request running on another thread.
+        _header_content: bun_core::StringBuilder,
+    }
+
+    let mut hb = build_headers(Some(content_type));
+    let header_content = core::mem::take(&mut hb.content);
+    let entries = core::mem::take(&mut hb.entries);
+
+    let mut ctx = Box::new(Ctx {
+        response_buffer: MutableString::init(0).map_err(|_| Error::Http("OOM".into()))?,
+        status: 0,
+        sink,
+        done: Guarded::new(None),
+        cv: Condvar::new(),
+        signal_store: http::signals::Store::default(),
+        _header_content: header_content,
+    });
+    ctx.signal_store
+        .response_body_streaming
+        .store(true, Ordering::Relaxed);
+    let ctx_ptr: *mut Ctx<S> = &raw mut *ctx;
+
+    // SAFETY: `_header_content` lives in the heap `ctx` and is dropped only
+    // after the request completes (we block on `cv` below).
+    let headers_buf: &'static [u8] =
+        unsafe { bun_ptr::detach_lifetime(ctx._header_content.written_slice()) };
+
+    fn on_chunk<S: FnMut(&[u8]) -> Result<()>>(
+        this: *mut Ctx<S>,
+        _async_http: *mut AsyncHTTP<'static>,
+        mut result: HTTPClientResult<'_>,
+    ) {
+        // SAFETY: `this` is the `ctx_ptr` we registered; the calling thread is
+        // parked on `cv` and touches none of these fields until we set `done`.
+        let this = unsafe { &mut *this };
+        if let Some(m) = result.metadata.take() {
+            this.status = m.response.status_code as u16;
+        }
+        let mut chunk_result: Result<()> = Ok(());
+        let chunk = this.response_buffer.list.as_slice();
+        if !chunk.is_empty() && this.status >= 200 && this.status < 300 {
+            chunk_result = (this.sink)(chunk);
+        }
+        // Hand the buffer back empty so the next chunk starts at offset 0.
+        this.response_buffer.reset();
+        if result.has_more && chunk_result.is_ok() {
+            return;
+        }
+        // Final (or sink errored): wake the caller.
+        let outcome = match (chunk_result, result.fail) {
+            (Err(e), _) => Err(e),
+            (Ok(()), Some(e)) => Err(Error::Http(format!("{e:?}"))),
+            (Ok(()), None) => Ok(()),
+        };
+        let mut g = this.done.lock();
+        *g = Some(outcome);
+        this.cv.notify_one();
+    }
+
+    let signals = http::Signals {
+        response_body_streaming: Some(NonNull::from(&ctx.signal_store.response_body_streaming)),
+        ..Default::default()
+    };
+    let opts = http::async_http::Options {
+        signals: Some(signals),
+        disable_decompression: Some(true),
+        // Leave the HTTP-thread idle timeout enabled — a stalled connection
+        // would otherwise hang the whole clone (we block on the final
+        // callback's condvar).
+        ..Default::default()
+    };
+    // `AsyncHTTP` borrows `url`/`body`/`headers_buf` for `'a`. The request
+    // runs on the HTTP thread while this frame is parked on `cv`, so those
+    // stack borrows are live for the entire request — but the type wants
+    // `'static` once it crosses to the HTTP thread. Mirror `NetworkTask`:
+    // detach the lifetimes; the borrows are sound because we block.
+    // SAFETY: this stack frame (and `ctx`) outlive the request — we don't
+    // return until `done` is set by the final callback.
+    let url_s: &'static [u8] = unsafe { bun_ptr::detach_lifetime(url) };
+    // SAFETY: same as `url_s`.
+    let body_s: &'static [u8] = unsafe { bun_ptr::detach_lifetime(body) };
+    let mut req = Box::new(AsyncHTTP::init(
+        Method::POST,
+        bun_url::URL::parse(url_s),
+        entries,
+        headers_buf,
+        ptr::addr_of_mut!(ctx.response_buffer),
+        body_s,
+        http::HTTPClientResultCallback::new::<Ctx<S>>(ctx_ptr, on_chunk::<S>),
+        FetchRedirect::Follow,
+        opts,
+    ));
+    // The HTTP thread copies `*req` into its threadlocal slot, then writes
+    // back via `real`; keep the heap one alive so that pointer stays valid.
+    req.real = Some(NonNull::from(&mut *req).cast());
+
+    http::http_thread::init(&Default::default());
+    let mut batch = Batch::default();
+    req.schedule(&mut batch);
+    http::HTTPThread::schedule(batch);
+
+    // Park until the final callback fires.
+    let outcome = {
+        let mut g = ctx.done.lock();
+        loop {
+            if let Some(r) = g.take() {
+                break r;
+            }
+            ctx.cv.wait_guarded(&mut g);
+        }
+    };
+    let status = ctx.status;
+    // Past this point the HTTP thread will not touch `ctx`/`req` again (the
+    // final callback is the last reference), so dropping is safe.
+    drop(req);
+    drop(ctx);
+    outcome.map(|()| status)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Remote — transport-agnostic seam
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A git endpoint reachable over some wire. Everything above this type is
+/// transport-agnostic; adding libssh2 (or a unix-socket transport, or git://)
+/// means adding a variant here and matching in two methods.
+#[derive(Clone)]
+pub(crate) enum Remote {
+    /// `http[s]://host/path` — stateless smart-HTTP.
+    Http { base: String },
+    /// `ssh://[user@]host[:port]/path` or `[user@]host:path` (scp-like).
+    /// Spawns `ssh … git-upload-pack '<path>'` per request. Swap this arm's
+    /// body for libssh2 to go native — callers won't notice.
+    Ssh {
+        user_host: String,
+        port: Option<u16>,
+        path: String,
+    },
+}
+
+impl Remote {
+    pub(crate) fn parse(url: &str) -> crate::Result<Self> {
+        // The URL is written verbatim into `.git/config` (`url = <url>`), so
+        // any control byte — LF in particular — would let the caller inject
+        // arbitrary config keys (e.g. `core.sshCommand`). git-config's value
+        // grammar also reserves `"` and `\` unless quoted; we don't quote, so
+        // reject those too. This also covers HTTP header-splitting and ssh
+        // argv weirdness in one place.
+        if let Some(b) = url
+            .bytes()
+            .find(|&b| b < 0x20 || b == 0x7f || b == b'"' || b == b'\\')
+        {
+            return Err(Error::Http(format!(
+                "refusing URL with control/reserved byte 0x{b:02x}: {:?}",
+                bstr::BStr::new(url.as_bytes())
+            )));
+        }
+        if url.starts_with("https://") || url.starts_with("http://") {
+            return Ok(Remote::Http {
+                base: url.trim_end_matches('/').to_owned(),
+            });
+        }
+        if let Some(rest) = url.strip_prefix("ssh://") {
+            // ssh://[user@]host[:port]/path
+            let (auth, path) = rest
+                .split_once('/')
+                .ok_or_else(|| Error::Http(format!("ssh URL missing path: {url}")))?;
+            let (user_host, port) = match auth.rsplit_once(':') {
+                Some((h, p)) if p.bytes().all(|b| b.is_ascii_digit()) => {
+                    (h.to_owned(), p.parse().ok())
+                }
+                _ => (auth.to_owned(), None),
+            };
+            // Absolute path → cannot become an option to git-upload-pack.
+            return Self::ssh_checked(user_host, port, format!("/{path}"));
+        }
+        // scp-like: [user@]host:path  (no scheme, exactly one ':' before path)
+        if let Some((uh, path)) = url.split_once(':') {
+            if !uh.contains('/') && !path.starts_with("//") {
+                // scp-style paths are relative to the remote home; prefix
+                // `./` so a path like `-foo` can't reach upload-pack as a
+                // flag (git does the same — `transport.c:prepare_ssh_command`).
+                let path = if path.starts_with(['/', '.', '~']) {
+                    path.to_owned()
+                } else {
+                    format!("./{path}")
+                };
+                return Self::ssh_checked(uh.to_owned(), None, path);
+            }
+        }
+        Err(Error::Http(format!(
+            "unsupported URL scheme (http/https/ssh): {url}"
+        )))
+    }
+
+    /// Reject inputs that could smuggle an option into `ssh` or
+    /// `git-upload-pack` (CVE-2017-1000117). `ssh` treats anything starting
+    /// with `-` in the host position as an option (`-oProxyCommand=…` is
+    /// arbitrary code exec); `--` alone isn't sufficient because OpenSSH
+    /// only honours it for *operands after the host*, so the dash check is
+    /// load-bearing. The host part after `user@` is checked too — `ssh`
+    /// splits on `@` itself.
+    fn ssh_checked(user_host: String, port: Option<u16>, path: String) -> crate::Result<Self> {
+        let host = user_host.rsplit('@').next().unwrap_or("");
+        if user_host.starts_with('-') || host.starts_with('-') || user_host.is_empty() {
+            return Err(Error::Http(format!(
+                "refusing suspicious ssh host (starts with '-'): {user_host:?}"
+            )));
+        }
+        if path.starts_with('-') {
+            return Err(Error::Http(format!(
+                "refusing suspicious ssh path (starts with '-'): {path:?}"
+            )));
+        }
+        Ok(Remote::Ssh {
+            user_host,
+            port,
+            path,
+        })
+    }
+
+    /// Capability advertisement (protocol-v2 `version 2` + caps + flush).
+    pub(crate) fn handshake(&self) -> crate::Result<Vec<u8>> {
+        match self {
+            Remote::Http { base } => {
+                let url = format!("{base}/info/refs?service=git-upload-pack");
+                let (status, body) = get_buffered(url.as_bytes(), Method::GET, None, &[])?;
+                if status != 200 {
+                    return Err(Error::Http(format!("GET {url} → HTTP {status}")));
+                }
+                Ok(body)
+            }
+            Remote::Ssh { .. } => {
+                // Over SSH the server sends caps unsolicited on connect; an
+                // empty body just opens, reads caps, closes.
+                let mut out = Vec::new();
+                self.request(&[], |c| {
+                    out.extend_from_slice(c);
+                    Ok(())
+                })?;
+                Ok(out)
+            }
+        }
+    }
+
+    /// One protocol-v2 command: send `body`, stream the response to `sink`.
+    /// Stateless per call (HTTP semantics) — each call is a fresh connection.
+    pub(crate) fn request<S>(&self, body: &[u8], sink: S) -> crate::Result<()>
+    where
+        S: FnMut(&[u8]) -> crate::Result<()> + Send,
+    {
+        match self {
+            Remote::Http { base } => {
+                let url = format!("{base}/git-upload-pack");
+                let status = post_streamed(
+                    url.as_bytes(),
+                    "application/x-git-upload-pack-request",
+                    body,
+                    sink,
+                )?;
+                if status != 200 {
+                    return Err(Error::Http(format!("POST {url} → HTTP {status}")));
+                }
+                Ok(())
+            }
+            #[cfg(unix)]
+            Remote::Ssh {
+                user_host,
+                port,
+                path,
+            } => ssh::request(user_host, *port, path, body, sink),
+            #[cfg(not(unix))]
+            Remote::Ssh { .. } => Err(Error::Http(
+                "ssh transport not yet implemented on this platform".into(),
+            )),
+        }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SSH via subprocess `ssh`
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// One `ssh` per request — same stateless shape as HTTP, so the parallel-fetch
+// orchestration works unchanged (each bucket spawns its own `ssh`).
+// `ControlMaster` is forced off so N spawns are N TCP connections (otherwise
+// they'd multiplex over one and we'd lose the bandwidth fan-out).
+//
+// **libssh2 swap-point**: replace this module's `request()` body with a
+// libssh2 session+channel; the signature and call sites stay identical.
+#[cfg(unix)]
+mod ssh {
+    use super::*;
+    use bun_core::Fd;
+    use bun_sys as sys;
+    use core::ffi::{CStr, c_char};
+
+    pub(super) fn request<S>(
+        user_host: &str,
+        port: Option<u16>,
+        path: &str,
+        body: &[u8],
+        mut sink: S,
+    ) -> crate::Result<()>
+    where
+        S: FnMut(&[u8]) -> crate::Result<()> + Send,
+    {
+        // Two pipes: child's stdin (we write), child's stdout (we read).
+        let [in_r, in_w] = sys::pipe()?;
+        let [out_r, out_w] = sys::pipe()?;
+
+        let port_s;
+        let mut argv: Vec<&str> = vec![
+            "ssh",
+            "-o",
+            "ControlMaster=no",
+            "-o",
+            "ControlPath=none",
+            "-o",
+            "SendEnv=GIT_PROTOCOL",
+        ];
+        if let Some(p) = port {
+            port_s = p.to_string();
+            argv.push("-p");
+            argv.push(&port_s);
+        }
+        // `--` ends ssh's own option parsing. `Remote::ssh_checked` already
+        // rejected a leading-dash host, but defence in depth costs nothing.
+        argv.push("--");
+        argv.push(user_host);
+        argv.push("git-upload-pack");
+        argv.push(path);
+
+        let pid = spawn_with_pipes(&argv, in_r, out_w)?;
+        // Parent doesn't need the child's ends.
+        let _ = sys::close(in_r);
+        let _ = sys::close(out_w);
+
+        // Server sends caps unsolicited; drain them to the first flush-pkt
+        // before writing the command (avoids deadlock if caps fill the pipe
+        // buffer — they won't, but this is the protocol-correct order).
+        let mut pre = Vec::with_capacity(4096);
+        drain_until_flush(out_r, &mut pre)?;
+        if body.is_empty() {
+            // Handshake-only call: caps are the response.
+            sink(&pre)?;
+            let _ = sys::close(in_w);
+        } else {
+            // Discard caps (caller already did handshake), send the command,
+            // then stream the response.
+            write_all(in_w, body)?;
+            let _ = sys::close(in_w);
+            stream(out_r, &mut sink)?;
+        }
+        let _ = sys::close(out_r);
+        wait(pid)?;
+        Ok(())
+    }
+
+    /// posix_spawnp `ssh` with the given argv, dup2'ing the pipe fds to its
+    /// stdin/stdout. stderr is inherited so auth/host-key prompts surface.
+    ///
+    /// This is the **libssh2 swap-point**: a native impl replaces this body
+    /// with `Session::handshake` + `Channel::exec("git-upload-pack …")`; the
+    /// caller's read/write loop on the returned handle stays the same shape.
+    #[allow(clippy::as_ptr_cast_mut, clippy::ptr_cast_constness)]
+    fn spawn_with_pipes(argv: &[&str], child_stdin: Fd, child_stdout: Fd) -> crate::Result<i32> {
+        // NUL-terminate argv strings (own the storage; posix_spawnp copies).
+        let mut cstrs: Vec<Vec<u8>> = argv
+            .iter()
+            .map(|s| {
+                let mut v = s.as_bytes().to_vec();
+                v.push(0);
+                v
+            })
+            .collect();
+        let mut argv_ptrs: Vec<*mut c_char> = cstrs
+            .iter_mut()
+            .map(|s| s.as_mut_ptr().cast::<c_char>())
+            .collect();
+        argv_ptrs.push(core::ptr::null_mut());
+        // env: inherit + GIT_PROTOCOL=version=2. `environ` is process-global.
+        unsafe extern "C" {
+            static mut environ: *const *const c_char;
+        }
+        let proto = c"GIT_PROTOCOL=version=2";
+        // SAFETY: `environ` is the libc-maintained env array; we copy its
+        // pointers (read-only) and append one static literal. posix_spawnp
+        // reads argv/envp before returning, so the borrowed pointers only
+        // need to live for this call.
+        let mut envp: Vec<*mut c_char> = unsafe {
+            let mut v = Vec::new();
+            let mut p = environ;
+            while !(*p).is_null() {
+                v.push((*p).cast_mut());
+                p = p.add(1);
+            }
+            v
+        };
+        envp.push(proto.as_ptr().cast_mut());
+        envp.push(core::ptr::null_mut());
+
+        let mut actions = core::mem::MaybeUninit::<libc::posix_spawn_file_actions_t>::zeroed();
+        // SAFETY: zero-init is the documented starting state before *_init;
+        // init/adddup2/destroy are paired below.
+        unsafe {
+            libc::posix_spawn_file_actions_init(actions.as_mut_ptr());
+            libc::posix_spawn_file_actions_adddup2(actions.as_mut_ptr(), child_stdin.native(), 0);
+            libc::posix_spawn_file_actions_adddup2(actions.as_mut_ptr(), child_stdout.native(), 1);
+        }
+        let mut pid: libc::pid_t = 0;
+        // SAFETY: argv/envp are NUL-terminated arrays of C strings valid for
+        // the call; `actions` was initialised above.
+        let rc = unsafe {
+            libc::posix_spawnp(
+                &raw mut pid,
+                argv_ptrs[0],
+                actions.as_ptr(),
+                core::ptr::null(),
+                argv_ptrs.as_ptr(),
+                envp.as_ptr(),
+            )
+        };
+        // SAFETY: paired with init above.
+        unsafe { libc::posix_spawn_file_actions_destroy(actions.as_mut_ptr()) };
+        if rc != 0 {
+            // SAFETY: strerror returns a static C string for any errno.
+            let msg = unsafe { CStr::from_ptr(libc::strerror(rc)) };
+            return Err(Error::Http(format!(
+                "posix_spawnp ssh failed: {}",
+                bstr::BStr::new(msg.to_bytes())
+            )));
+        }
+        Ok(pid)
+    }
+
+    fn write_all(fd: Fd, mut buf: &[u8]) -> crate::Result<()> {
+        while !buf.is_empty() {
+            let n = sys::write(fd, buf)?;
+            buf = &buf[n..];
+        }
+        Ok(())
+    }
+
+    fn stream<S: FnMut(&[u8]) -> crate::Result<()>>(fd: Fd, sink: &mut S) -> crate::Result<()> {
+        let mut buf = [0u8; 65536];
+        loop {
+            let n = sys::read(fd, &mut buf)?;
+            if n == 0 {
+                return Ok(());
+            }
+            sink(&buf[..n])?;
+        }
+    }
+
+    /// Read until a flush-pkt (`0000`) is seen; returns everything read
+    /// including the flush.
+    fn drain_until_flush(fd: Fd, out: &mut Vec<u8>) -> crate::Result<()> {
+        let mut buf = [0u8; 4096];
+        loop {
+            let n = sys::read(fd, &mut buf)?;
+            if n == 0 {
+                return Ok(());
+            }
+            out.extend_from_slice(&buf[..n]);
+            if out.windows(4).any(|w| w == b"0000") {
+                return Ok(());
+            }
+        }
+    }
+
+    fn wait(pid: i32) -> crate::Result<()> {
+        let mut status = 0i32;
+        // SAFETY: pid was returned by posix_spawnp; status is a valid out-ptr.
+        let rc = unsafe { libc::waitpid(pid, &raw mut status, 0) };
+        if rc < 0 {
+            return Err(Error::Http("waitpid failed".into()));
+        }
+        if !libc::WIFEXITED(status) || libc::WEXITSTATUS(status) != 0 {
+            return Err(Error::Http(format!(
+                "ssh exited with status {}",
+                libc::WEXITSTATUS(status)
+            )));
+        }
+        Ok(())
+    }
+}
+
+
+fn build_headers(content_type: Option<&str>) -> http::HeaderBuilder {
+    let mut hb = http::HeaderBuilder::default();
+    hb.count(GIT_PROTOCOL.0, GIT_PROTOCOL.1);
+    if let Some(ct) = content_type {
+        hb.count("Content-Type", ct);
+        hb.count("Accept", "application/x-git-upload-pack-result");
+    }
+    hb.allocate().expect("OOM");
+    hb.append(GIT_PROTOCOL.0, GIT_PROTOCOL.1);
+    if let Some(ct) = content_type {
+        hb.append("Content-Type", ct);
+        hb.append("Accept", "application/x-git-upload-pack-result");
+    }
+    hb
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Remote;
+
+    #[test]
+    fn ssh_rejects_option_smuggling() {
+        // CVE-2017-1000117 vectors: host position becomes an ssh option.
+        for url in [
+            "ssh://-oProxyCommand=id/x",
+            "ssh://user@-oProxyCommand=id/x",
+            "-oProxyCommand=id:path",
+            "git@-oProxyCommand=id:path",
+        ] {
+            assert!(Remote::parse(url).is_err(), "should reject {url}");
+        }
+        // Path that would become a flag: scp-style gets `./` prefixed.
+        match Remote::parse("git@github.com:-upload-pack-flag").unwrap() {
+            Remote::Ssh { path, .. } => assert_eq!(path, "./-upload-pack-flag"),
+            _ => panic!(),
+        }
+        // ssh:// path is always absolute.
+        match Remote::parse("ssh://h/-x").unwrap() {
+            Remote::Ssh { path, .. } => assert_eq!(path, "/-x"),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn rejects_config_injection() {
+        for url in [
+            "https://h/\n[core]\n\tsshCommand = id",
+            "https://h/x\r\nfoo",
+            "ssh://h/p\"x",
+            "git@h:p\\x",
+            "https://h/p\tx",
+        ] {
+            assert!(Remote::parse(url).is_err(), "should reject {url:?}");
+        }
+    }
+
+    #[test]
+    fn ssh_accepts_normal_urls() {
+        for url in [
+            "ssh://git@github.com/owner/repo.git",
+            "ssh://git@github.com:22/owner/repo.git",
+            "git@github.com:owner/repo.git",
+        ] {
+            assert!(matches!(Remote::parse(url), Ok(Remote::Ssh { .. })), "{url}");
+        }
+    }
+}

--- a/src/git/transport.rs
+++ b/src/git/transport.rs
@@ -579,7 +579,6 @@ mod ssh {
     }
 }
 
-
 fn build_headers(content_type: Option<&str>) -> http::HeaderBuilder {
     let mut hb = http::HeaderBuilder::default();
     hb.count(GIT_PROTOCOL.0, GIT_PROTOCOL.1);
@@ -643,7 +642,10 @@ mod tests {
             "ssh://git@github.com:22/owner/repo.git",
             "git@github.com:owner/repo.git",
         ] {
-            assert!(matches!(Remote::parse(url), Ok(Remote::Ssh { .. })), "{url}");
+            assert!(
+                matches!(Remote::parse(url), Ok(Remote::Ssh { .. })),
+                "{url}"
+            );
         }
     }
 }

--- a/src/options_types/command_tag.rs
+++ b/src/options_types/command_tag.rs
@@ -43,6 +43,7 @@ pub enum Tag {
     AuditCommand,
     WhyCommand,
     FuzzilliCommand,
+    GitCloneCommand,
 }
 
 impl Tag {
@@ -83,6 +84,7 @@ impl Tag {
             Tag::AuditCommand => b'A',
             Tag::WhyCommand => b'W',
             Tag::FuzzilliCommand => b'F',
+            Tag::GitCloneCommand => b'q',
         }
     }
 
@@ -204,5 +206,6 @@ pub static USES_GLOBAL_OPTIONS: TagTable<bool> = TagTable({
     a[Tag::RemoveCommand as usize] = false;
     a[Tag::UnlinkCommand as usize] = false;
     a[Tag::UpdateCommand as usize] = false;
+    a[Tag::GitCloneCommand as usize] = false;
     a
 });

--- a/src/runtime/Cargo.toml
+++ b/src/runtime/Cargo.toml
@@ -46,6 +46,7 @@ bun_css.workspace = true
 bun_dns.workspace = true
 bun_dotenv.workspace = true
 bun_event_loop.workspace = true
+bun_git.workspace = true
 bun_glob.workspace = true
 bun_highway.workspace = true
 bun_http.workspace = true

--- a/src/runtime/cli/git_clone_command.rs
+++ b/src/runtime/cli/git_clone_command.rs
@@ -1,0 +1,90 @@
+use bstr::BStr;
+
+pub(crate) struct GitCloneCommand;
+
+impl GitCloneCommand {
+    pub(crate) fn exec() -> Result<(), bun_core::Error> {
+        // argv: [bun, git-clone, <url>, [<dir>], [--no-checkout], [-jN]]
+        let argv = bun_core::util::argv();
+        let mut url: Option<&'static [u8]> = None;
+        let mut dir: Option<&'static [u8]> = None;
+        let mut opts = bun_git::CloneOptions::default();
+        let mut i = 2;
+        while let Some(a) = argv.get(i) {
+            i += 1;
+            let a = a.as_bytes();
+            if a == b"--index-pack" {
+                // Benchmark mode: `bun git-clone --index-pack <file.pack>`
+                let path = argv.get(i).map(|z| z.as_bytes()).unwrap_or(b"");
+                match bun_git::index_pack_file(path) {
+                    Ok(h) => {
+                        bun_core::prettyln!("{}", h);
+                        return Ok(());
+                    }
+                    Err(e) => {
+                        bun_core::pretty_errorln!("<red>error<r>: {}", e);
+                        bun_core::Global::exit(1);
+                    }
+                }
+            }
+            if let Some(n) = a.strip_prefix(b"-j") {
+                opts.jobs = core::str::from_utf8(n)
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                continue;
+            }
+            if let Some(n) = a.strip_prefix(b"-s") {
+                opts.skeleton_slices = core::str::from_utf8(n)
+                    .ok()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                continue;
+            }
+            if a == b"--no-checkout" {
+                opts.no_checkout = true;
+            } else if a == b"-q" || a == b"--quiet" {
+                opts.quiet = true;
+            } else if url.is_none() {
+                url = Some(a);
+            } else if dir.is_none() {
+                dir = Some(a);
+            } else {
+                bun_core::pretty_errorln!("<red>error<r>: unexpected argument: {}", BStr::new(a));
+                bun_core::Global::exit(1);
+            }
+        }
+        let Some(url) = url.and_then(|u| core::str::from_utf8(u).ok()) else {
+            bun_core::pretty_errorln!(
+                "<r>usage: <b>bun git-clone<r> <cyan>\\<url\\><r> [<cyan>\\<dir\\><r>] [--no-checkout]"
+            );
+            bun_core::Global::exit(1);
+        };
+        let dir_buf;
+        let dir: &[u8] = match dir {
+            Some(d) => d,
+            None => {
+                dir_buf = url
+                    .trim_end_matches('/')
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or("repo")
+                    .trim_end_matches(".git")
+                    .to_owned();
+                dir_buf.as_bytes()
+            }
+        };
+        match bun_git::clone(url, dir, &opts) {
+            Ok(head) => {
+                if !opts.quiet {
+                    bun_core::prettyln!("HEAD is now at <green>{}<r>", head);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                bun_core::pretty_errorln!("<red>error<r>: clone failed: {}", e);
+                bun_core::Global::exit(1);
+            }
+        }
+    }
+}

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -216,6 +216,8 @@ pub mod add_completions;
 pub mod colon_list_type;
 #[path = "discord_command.rs"]
 pub mod discord_command;
+#[path = "git_clone_command.rs"]
+pub mod git_clone_command;
 #[path = "list-of-yarn-commands.rs"]
 pub mod list_of_yarn_commands;
 #[path = "shell_completions.rs"]
@@ -988,6 +990,9 @@ pub mod command {
         if x == RootCommandMatcher::case(b"discord") {
             return Tag::DiscordCommand;
         }
+        if x == RootCommandMatcher::case(b"git-clone") {
+            return Tag::GitCloneCommand;
+        }
         if x == RootCommandMatcher::case(b"upgrade") {
             return Tag::UpgradeCommand;
         }
@@ -1308,6 +1313,7 @@ pub mod command {
             Tag::HelpCommand => HelpCommand::exec(),
             Tag::ReservedCommand => ReservedCommand::exec(),
             Tag::DiscordCommand => super::discord_command::DiscordCommand::exec(),
+            Tag::GitCloneCommand => super::git_clone_command::GitCloneCommand::exec(),
             Tag::InitCommand => exec_init(),
             Tag::InstallCompletionsCommand => exec_install_completions(),
             Tag::PackageManagerCommand => exec_pm(log),

--- a/test/cli/git-clone.test.ts
+++ b/test/cli/git-clone.test.ts
@@ -4,7 +4,7 @@
 // pack indexing, and checkout are all exercised against bytes a real git
 // server produced — without touching the network.
 
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";

--- a/test/cli/git-clone.test.ts
+++ b/test/cli/git-clone.test.ts
@@ -1,0 +1,153 @@
+// End-to-end test for `bun git-clone` over real smart-HTTP. A bare repo is
+// served by `git http-backend` (the same CGI GitHub fronts) behind a tiny
+// Bun.serve proxy, so the HTTP transport, pkt-line framing, side-band demux,
+// pack indexing, and checkout are all exercised against bytes a real git
+// server produced — without touching the network.
+
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+
+const httpBackend = ["/usr/libexec/git-core/git-http-backend", "/usr/lib/git-core/git-http-backend"].find(existsSync);
+
+function git(cwd: string, args: string[]) {
+  const r = spawnSync("git", args, {
+    cwd,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t",
+      GIT_CONFIG_NOSYSTEM: "1",
+    },
+  });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed:\n${r.stdout}\n${r.stderr}`);
+  }
+  return r.stdout.toString();
+}
+
+test.skipIf(!httpBackend)("bun git-clone over smart-HTTP", async () => {
+  using dir = tempDir("git-clone", {
+    "src/README.md": "hello world\n",
+    "src/dir/a.txt": "alpha\n",
+  });
+  const root = String(dir);
+  const src = `${root}/src`;
+
+  // Build a repo with enough history that upload-pack emits OFS_DELTA entries.
+  git(src, ["init", "-q", "-b", "main"]);
+  let big = Buffer.alloc(16384);
+  for (let i = 0; i < big.length; i++) big[i] = i % 251;
+  await Bun.write(`${src}/dir/b.bin`, big);
+  git(src, ["add", "-A"]);
+  git(src, ["commit", "-qm", "one"]);
+  for (let i = 0; i < 5; i++) {
+    big.set(Buffer.from("zzzzzzzzzzzzzzzz"), 1000 + i * 200);
+    await Bun.write(`${src}/dir/b.bin`, big);
+    await Bun.write(`${src}/README.md`, `hello world\nv${i + 2}\n`);
+    git(src, ["commit", "-aqm", `c${i}`]);
+  }
+  git(root, ["clone", "-q", "--bare", "src", "src.git"]);
+  git(`${root}/src.git`, ["repack", "-adq", "--depth=50", "--window=50"]);
+  // Required for http-backend to serve `git-upload-pack`.
+  git(`${root}/src.git`, ["config", "http.uploadpack", "true"]);
+
+  // Serve the bare repo over smart-HTTP via the git CGI.
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      const body = req.body ? Buffer.from(await req.arrayBuffer()) : Buffer.alloc(0);
+      const proc = Bun.spawn({
+        cmd: [httpBackend!],
+        env: {
+          GIT_PROJECT_ROOT: root,
+          GIT_HTTP_EXPORT_ALL: "1",
+          PATH_INFO: url.pathname,
+          REQUEST_METHOD: req.method,
+          QUERY_STRING: url.search.slice(1),
+          CONTENT_TYPE: req.headers.get("content-type") ?? "",
+          CONTENT_LENGTH: String(body.length),
+          GIT_PROTOCOL: req.headers.get("git-protocol") ?? "",
+          REMOTE_ADDR: "127.0.0.1",
+          SERVER_PROTOCOL: "HTTP/1.1",
+        },
+        stdin: body,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [out, err, code] = await Promise.all([
+        new Response(proc.stdout).arrayBuffer(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      if (code !== 0) return new Response(`http-backend failed: ${err}`, { status: 500 });
+      // CGI: split headers from body at first CRLFCRLF.
+      const buf = Buffer.from(out);
+      const sep = buf.indexOf("\r\n\r\n");
+      const hdrs: Record<string, string> = {};
+      for (const line of buf.subarray(0, sep).toString().split("\r\n")) {
+        const i = line.indexOf(": ");
+        if (i > 0) hdrs[line.slice(0, i)] = line.slice(i + 2);
+      }
+      const status = hdrs["Status"] ? parseInt(hdrs["Status"]) : 200;
+      delete hdrs["Status"];
+      return new Response(buf.subarray(sep + 4), { status, headers: hdrs });
+    },
+  });
+
+  const dest = `${root}/out`;
+  await using proc = Bun.spawn({
+    // -j1: single-connection path (the local http-backend doesn't enable
+    // uploadpack.allowFilter, so the parallel filter=blob:none path can't be
+    // exercised here — that's covered by the GitHub-compatibility contract).
+    cmd: [bunExe(), "git-clone", `http://127.0.0.1:${server.port}/src.git`, dest, "-q", "-j1"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Worktree must match the source HEAD.
+  expect(readFileSync(`${dest}/README.md`, "utf8")).toBe("hello world\nv6\n");
+  expect(readFileSync(`${dest}/dir/a.txt`, "utf8")).toBe("alpha\n");
+  expect(Buffer.compare(readFileSync(`${dest}/dir/b.bin`), big)).toBe(0);
+  expect(readFileSync(`${dest}/.git/HEAD`, "utf8")).toBe("ref: refs/heads/main\n");
+
+  // System git must consider the resulting .git valid and complete.
+  const fsck = spawnSync("git", ["-C", dest, "fsck", "--full", "--strict"]);
+  expect({
+    fsck_stdout: fsck.stdout.toString(),
+    fsck_stderr: fsck.stderr.toString(),
+    fsck_status: fsck.status,
+  }).toEqual({ fsck_stdout: "", fsck_stderr: "", fsck_status: 0 });
+
+  // The .idx must match what `git index-pack` produces — proves every object
+  // SHA, CRC, offset, and the fanout table are byte-correct.
+  const packDir = `${dest}/.git/objects/pack`;
+  const pack = (await Array.fromAsync(new Bun.Glob("*.pack").scan({ cwd: packDir }))).map(f => `${packDir}/${f}`)[0];
+  const altIdx = `${root}/alt.idx`;
+  const ip = spawnSync("git", ["index-pack", "-o", altIdx, pack]);
+  expect(ip.status).toBe(0);
+  expect(Buffer.compare(readFileSync(pack.replace(/\.pack$/, ".idx")), readFileSync(altIdx))).toBe(0);
+
+  expect(normalizeBunSnapshot(stdout, dir)).toMatchInlineSnapshot(`""`);
+  expect(stderr).not.toContain("error");
+  expect(exitCode).toBe(0);
+});
+
+test("bun git-clone rejects unknown scheme", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "git-clone", "ftp://example.com/x.git", "/tmp/never"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain("unsupported URL scheme");
+  expect(stdout).toBe("");
+  expect(exitCode).toBe(1);
+});


### PR DESCRIPTION
New `bun_git` crate (`src/git/`) implementing a from-scratch protocol-v2 git client over `bun_http`/`bun_sys`/`bun_threading`, exposed as a hidden `bun git-clone` subcommand.

## What

A drop-in `git clone` for http(s)/ssh: working tree, `.git/index` v2, packed-refs, `refs/remotes/origin/*`, `[branch]` upstream, `.gitattributes` eol — `git status`/`git pull`/`git branch -r` work out of the box. `git fsck --full --strict` clean; every `.idx` byte-identical to `git index-pack`.

## Why it's faster

GitHub caps each connection at ~45 MB/s while a typical CI/DC link does 150+. `git clone` is one connection → one pack; this fans out:

- 4-slice parallel skeleton via `filter=blob:none` + tag-partitioned `have` lines (no `thin-pack` → self-contained slices)
- 24-way blob fan-out, path-hash bucketed so the server's delta reuse still works
- libdeflate inflate; SHA-1/CRC-32/delta-resolve all in the parallel phase
- Slices index as they arrive; each blob worker does fetch→index→write end-to-end; wave-1 blobs fire the instant the last skeleton byte lands

## Numbers (3 runs each, github.com)

| repo | bun -j24 | git | best / median |
|---|---|---|---|
| redis/redis | 2.43 / 2.68 s | 7.53 / 9.13 s | 3.1× / 3.4× |
| git/git | 4.84 / 4.96 s | 16.95 / 18.75 s | 3.5× / 3.8× |
| nodejs/node | 16.00 / 16.25 s | 55.05 / 70.70 s | 3.4× / 4.35× |

index-pack alone: 8.5× vs `git index-pack --stdin`, 24× vs file-mode (same packfile, byte-identical `.idx`).

## Security

Hardened against `.git`-spelling (NTFS/HFS+, CVE-2014-9390), symlink-race `O_EXCL|O_NOFOLLOW` (CVE-2024-32002), ssh argv injection (CVE-2017-1000117), refname CRLF, config-URL injection, symlinked `.gitattributes` (CVE-2021-21300). All unit-tested.

## Tests

- `test/cli/git-clone.test.ts` — full clone over real smart-HTTP via Bun.serve + `git-http-backend`; asserts worktree bytes, fsck, idx-byte-equality
- Unit tests: pkt-line, delta apply (incl. adversarial), oid, pack varint, `validate_name` CVE vectors, `check_ref_format`, `Remote::parse` injection vectors

## Not in this PR

Credential helpers, sparse-checkout, smudge/LFS, Windows ssh.