### PR TITLE
ErrorCodeCache: don't cast TerminationException's JSString value to JSObject

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -1773,6 +1773,7 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         RETURN_IF_EXCEPTION(scope, {});
         auto message = makeString("Invalid address family: "_s, str0, " "_s, str1, ":"_s, str2);
         auto err = createError(globalObject, ErrorCode::ERR_INVALID_ADDRESS_FAMILY, message);
+        RETURN_IF_EXCEPTION(scope, {});
         err->putDirect(vm, builtinNames(vm).hostPublicName(), arg1, 0);
         err->putDirect(vm, builtinNames(vm).portPublicName(), arg2, 0);
         return JSC::JSValue::encode(err);
@@ -2113,6 +2114,7 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         auto arg2 = callFrame->argument(3);
         auto message = makeString("Hostname/IP does not match certificate's altnames: "_s, str0);
         auto err = createError(globalObject, ErrorCode::ERR_TLS_CERT_ALTNAME_INVALID, message);
+        RETURN_IF_EXCEPTION(scope, {});
         err->putDirect(vm, Identifier::fromString(vm, "reason"_s), arg0);
         err->putDirect(vm, Identifier::fromString(vm, "host"_s), arg1);
         err->putDirect(vm, Identifier::fromString(vm, "cert"_s), arg2);
@@ -2202,6 +2204,7 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
         auto arg1 = callFrame->argument(2);
         // Don't include URL in message. (See https://github.com/nodejs/node/pull/38614)
         auto err = createError(globalObject, ErrorCode::ERR_INVALID_URL, "Invalid URL"_s);
+        RETURN_IF_EXCEPTION(scope, {});
         err->putDirect(vm, vm.propertyNames->input, arg0);
         if (!arg1.isUndefinedOrNull()) err->putDirect(vm, Identifier::fromString(vm, "base"_s), arg1);
         return JSC::JSValue::encode(err);
@@ -2382,6 +2385,7 @@ JSC_DEFINE_HOST_FUNCTION(Bun::jsFunctionMakeErrorWithCode, (JSC::JSGlobalObject 
 
     case ErrorCode::ERR_SSL_NO_CIPHER_MATCH: {
         auto err = createError(globalObject, ErrorCode::ERR_SSL_NO_CIPHER_MATCH, "No cipher match"_s);
+        RETURN_IF_EXCEPTION(scope, {});
         err->putDirect(vm, Identifier::fromString(vm, "reason"_s), jsString(vm, WTF::String("no cipher match"_s)));
         err->putDirect(vm, Identifier::fromString(vm, "library"_s), jsString(vm, WTF::String("SSL routines"_s)));
         return JSC::JSValue::encode(err);

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -208,16 +208,17 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* structure = uncheckedDowncast<Structure>(cache->internalField(static_cast<unsigned>(code)).get());
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, options, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
     if (auto* thrown_exception = scope.exception()) [[unlikely]] {
-        if (!scope.tryClearException()) {
-            // TerminationException: its value is a JSString, not a JSObject,
-            // and it must stay pending for the caller's RETURN_IF_EXCEPTION.
-            return nullptr;
-        }
-        // ErrorInstance::create can re-enter JS (stack capture, message
-        // coercion), so the thrown value is not guaranteed to be an object.
+        // ErrorInstance::create can re-enter JS (message.toWTFString,
+        // options.cause getter, stack capture). If that threw an object,
+        // clear it and hand the object back as the error to throw.
+        // Otherwise (TerminationException, whose value is a JSString, or a
+        // primitive thrown from coercion) leave the exception pending so
+        // the caller's RETURN_IF_EXCEPTION observes it; `created_error` is
+        // nullptr when the throw happened before the instance allocated.
         JSValue value = thrown_exception->value();
-        if (value.isObject())
+        if (value.isObject() && scope.tryClearException())
             return asObject(value);
+        return nullptr;
     }
     return created_error;
 }

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -208,11 +208,16 @@ JSObject* ErrorCodeCache::createError(VM& vm, Zig::GlobalObject* globalObject, E
     auto* structure = uncheckedDowncast<Structure>(cache->internalField(static_cast<unsigned>(code)).get());
     auto* created_error = JSC::ErrorInstance::create(globalObject, structure, message, options, nullptr, JSC::RuntimeType::TypeNothing, data.type, true);
     if (auto* thrown_exception = scope.exception()) [[unlikely]] {
-        (void)scope.tryClearException();
-        // TODO investigate what can throw here and whether it will throw non-objects
-        // (this is better than before where we would have returned nullptr from createError if any
-        // exception were thrown by ErrorInstance::create)
-        return uncheckedDowncast<JSObject>(thrown_exception->value());
+        if (!scope.tryClearException()) {
+            // TerminationException: its value is a JSString, not a JSObject,
+            // and it must stay pending for the caller's RETURN_IF_EXCEPTION.
+            return nullptr;
+        }
+        // ErrorInstance::create can re-enter JS (stack capture, message
+        // coercion), so the thrown value is not guaranteed to be an object.
+        JSValue value = thrown_exception->value();
+        if (value.isObject())
+            return asObject(value);
     }
     return created_error;
 }

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -128,11 +128,12 @@ test(
 // (Bun.secrets rejection → Secrets::Error::toJS → createError) after the
 // parent called terminate() and the VM termination trap was armed.
 //
-// Skipped on macOS: there Bun.secrets.get resolves with null (NotFound)
-// instead of rejecting so the createError path is not reached, and keychain
-// latency would expose the separate work-pool → freed-VM race tracked in
-// #32071 which this PR does not address.
-test.skipIf(isMacOS)(
+// Debug-only: reportZappedCellAndCrash is gated on ASSERT_ENABLED, and on
+// release builds worker shutdown outruns the fast-failing secrets jobs so
+// the separate work-pool → freed-VM race tracked in #32071 fires instead.
+// Skipped on macOS where Bun.secrets.get resolves with null (NotFound) and
+// never reaches createError.
+test.skipIf(isMacOS || !isDebug)(
   "creating a coded error while a TerminationException is pending does not crash",
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -119,3 +119,50 @@ test(
   },
   timeout,
 );
+
+// Regression: ErrorCodeCache::createError caught an exception thrown during
+// ErrorInstance::create and returned uncheckedDowncast<JSObject>(value). A
+// TerminationException's value is the JSString "JavaScript execution
+// terminated.", so the cast tripped reportZappedCellAndCrash in debug
+// builds. Triggered by a worker running the completion of a thread-pool job
+// (Bun.secrets rejection → Secrets::Error::toJS → createError) after the
+// parent called terminate() and the VM termination trap was armed.
+test(
+  "creating a coded error while a TerminationException is pending does not crash",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        // Bun.secrets.get rejects on the worker thread with a coded error
+        // built via ErrorCodeCache::createError. Queue enough jobs that
+        // some completions land after the termination trap is set.
+        const body = \`
+          for (let i = 0; i < 200; i++) {
+            Bun.secrets.get({ service: "bun-test-worker-termination-" + i, name: "x" }).catch(() => {});
+          }
+          self.postMessage(0);
+        \`;
+        for (let round = 0; round < ${slow ? 3 : 6}; round++) {
+          const w = new Worker("data:application/javascript," + encodeURIComponent(body));
+          await new Promise((resolve, reject) => {
+            w.onmessage = () => resolve();
+            w.onerror = e => reject(e.error ?? e.message ?? e);
+          });
+          w.terminate();
+          await new Promise(r => w.addEventListener("close", r, { once: true }));
+        }
+        console.log("OK");
+      `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "OK\n", stderr: "", exitCode: 0 });
+  },
+  timeout,
+);

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug, isMacOS } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux } from "harness";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
 // tests spawn many workers, so scale iteration counts and timeouts down.
@@ -131,9 +131,10 @@ test(
 // Debug-only: reportZappedCellAndCrash is gated on ASSERT_ENABLED, and on
 // release builds worker shutdown outruns the fast-failing secrets jobs so
 // the separate work-pool → freed-VM race tracked in #32071 fires instead.
-// Skipped on macOS where Bun.secrets.get resolves with null (NotFound) and
-// never reaches createError.
-test.skipIf(isMacOS || !isDebug)(
+// Linux-only: on macOS and Windows Bun.secrets.get for a missing item
+// resolves with null (NotFound) and never reaches createError; on Linux
+// without libsecret it rejects with ERR_SECRETS_PLATFORM_ERROR.
+test.skipIf(!isLinux || !isDebug)(
   "creating a coded error while a TerminationException is pending does not crash",
   async () => {
     await using proc = Bun.spawn({

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -161,7 +161,15 @@ test.skipIf(isMacOS)(
         console.log("OK");
       `,
       ],
-      env: bunEnv,
+      // Leak detection disabled for this subprocess: work-pool completions
+      // that re-queue onto the worker's concurrent queue after its last
+      // tick leak their ConcurrentTask / AnyTaskJob boxes until #32071
+      // lands. The regression under test is a crash, not a leak, so ASAN's
+      // UAF detection stays on.
+      env: {
+        ...bunEnv,
+        ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
+      },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/js/web/workers/worker-terminate-lifetime.test.ts
+++ b/test/js/web/workers/worker-terminate-lifetime.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isMacOS } from "harness";
 
 // Worker VM startup/teardown is much slower under debug and/or ASAN; these
 // tests spawn many workers, so scale iteration counts and timeouts down.
@@ -127,7 +127,12 @@ test(
 // builds. Triggered by a worker running the completion of a thread-pool job
 // (Bun.secrets rejection → Secrets::Error::toJS → createError) after the
 // parent called terminate() and the VM termination trap was armed.
-test(
+//
+// Skipped on macOS: there Bun.secrets.get resolves with null (NotFound)
+// instead of rejecting so the createError path is not reached, and keychain
+// latency would expose the separate work-pool → freed-VM race tracked in
+// #32071 which this PR does not address.
+test.skipIf(isMacOS)(
   "creating a coded error while a TerminationException is pending does not crash",
   async () => {
     await using proc = Bun.spawn({


### PR DESCRIPTION
### Crash

Terminating a Worker that has `Bun.secrets` jobs in flight aborts with `reportZappedCellAndCrash` on the worker thread in debug builds:

```
reportZappedCellAndCrash
  uncheckedDowncast<JSObject>(JSValue)
  ErrorCodeCache::createError
  Bun::createError
  Bun::Secrets::Error::toJS
  Bun__SecretsJobOptions__runFromJS
```

### Repro

```js
const body = `
  for (let i = 0; i < 200; i++)
    Bun.secrets.get({ service: "t" + i, name: "x" }).catch(() => {});
  self.postMessage(0);
`;
const w = new Worker("data:application/javascript," + encodeURIComponent(body));
await new Promise(r => (w.onmessage = () => r()));
w.terminate();
await new Promise(r => w.addEventListener("close", r, { once: true }));
```

On Linux without libsecret this aborts every run under `bun bd`.

### Cause

`ErrorCodeCache::createError` catches any exception thrown by `ErrorInstance::create` and returns `uncheckedDowncast<JSObject>(thrown_exception->value())`. `ErrorInstance::create` runs JS (stack capture, message coercion), so when invoked from a Worker whose parent has called `terminate()` it can observe a `TerminationException` at a VMTrap safepoint. The termination exception's `value()` is the `JSString` `"JavaScript execution terminated."`, not a `JSObject`; in `ASSERT_ENABLED` builds `uncheckedDowncast<JSObject>` verifies the inheritance and calls `reportZappedCellAndCrash` on mismatch.

The `Bun.secrets` path reaches this because its thread-pool completion rejects the promise on the worker thread via `Secrets::Error::toJS` → `Bun::createError` while the termination trap is already armed.

### Fix

If `tryClearException()` declines (termination exception), leave it pending and return `nullptr` so the caller's `RETURN_IF_EXCEPTION` picks it up. For any other exception, only cast when the value is actually an object; fall through to `created_error` otherwise.

### Related

The same `Bun.secrets` repro also exposes the cross-thread VM use-after-free tracked in #32071 (work-pool thread dereferences the worker's VM after `WebWorker::shutdown` has dealloc'd it). That is the broader fix for the reported ASAN heap-use-after-free in `AnyTaskJob::run_task`; this PR addresses the second crash the repro hits, which fires before shutdown is even entered on Linux CI.

Supersedes #28384, which targeted the same exception path on the pre-restructure `src/bun.js/bindings/` layout but still cast the exception value to `JSObject*` unconditionally.
