### PR TITLE
http: remove 1 GiB decompressed-body cap from fetch Decompressor

### DIFF
--- a/src/http/Decompressor.rs
+++ b/src/http/Decompressor.rs
@@ -52,11 +52,6 @@ unsafe fn seat<'a>(input: &'a [u8], out: &'a mut Vec<u8>) -> (&'static [u8], &'s
     }
 }
 
-/// Decompression-bomb guard for response bodies inflated on the HTTP thread:
-/// a hostile server must not be able to expand a tiny compressed payload into
-/// an unbounded allocation.
-const MAX_DECOMPRESSED_BODY_SIZE: usize = 1024 * 1024 * 1024;
-
 impl Decompressor {
     // Note: the boxed readers' `Drop` impls call `end()`, so an
     // explicit `Drop` is unnecessary. Callers that want a mid-lifecycle reset
@@ -78,7 +73,7 @@ impl Decompressor {
             let (input, out) = unsafe { seat(buffer, &mut body_out_str.list) };
             match encoding {
                 Encoding::Gzip | Encoding::Deflate => {
-                    let mut reader = ZlibReaderArrayList::init_with_options_and_list_allocator(
+                    let reader = ZlibReaderArrayList::init_with_options_and_list_allocator(
                         input,
                         out,
                         bun_zlib::Options {
@@ -96,20 +91,17 @@ impl Decompressor {
                             ..Default::default()
                         },
                     )?;
-                    reader.max_output_size = MAX_DECOMPRESSED_BODY_SIZE;
                     *self = Decompressor::Zlib(reader);
                     return Ok(());
                 }
                 Encoding::Brotli => {
-                    let mut reader =
+                    let reader =
                         BrotliReaderArrayList::new_with_options(input, out, &Default::default())?;
-                    reader.max_output_size = MAX_DECOMPRESSED_BODY_SIZE;
                     *self = Decompressor::Brotli(reader);
                     return Ok(());
                 }
                 Encoding::Zstd => {
-                    let mut reader = ZstdReaderArrayList::init_with_list_allocator(input, out)?;
-                    reader.max_output_size = MAX_DECOMPRESSED_BODY_SIZE;
+                    let reader = ZstdReaderArrayList::init_with_list_allocator(input, out)?;
                     *self = Decompressor::Zstd(reader);
                     return Ok(());
                 }

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -302,10 +302,8 @@ it("fetch() with a gzip response works (multiple chunks, TCP server)", async don
 // same as the original Zig implementation; only available memory limits it.
 // Run in a subprocess so the ~1 GiB output buffer does not linger in the test
 // process.
-it(
-  "fetch() with a buffered gzip response whose decompressed size exceeds 1 GiB works",
-  async () => {
-    const fixture = /* js */ `
+it("fetch() with a buffered gzip response whose decompressed size exceeds 1 GiB works", async () => {
+  const fixture = /* js */ `
       import { createGzip } from "node:zlib";
 
       const CHUNK = Buffer.alloc(1024 * 1024);
@@ -348,25 +346,19 @@ it(
         server.stop(true);
       }
     `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", fixture],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-      stdout: `OK ${1025 * 1024 * 1024}`,
-      stderr: expect.not.stringContaining("error"),
-      exitCode: 0,
-    });
-  },
-  60_000,
-);
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: `OK ${1025 * 1024 * 1024}`,
+    stderr: expect.not.stringContaining("error"),
+    exitCode: 0,
+  });
+}, 60_000);
 
 describe("empty compressed responses", () => {
   // A response that declares Content-Encoding but sends zero body bytes must

--- a/test/js/web/fetch/fetch-gzip.test.ts
+++ b/test/js/web/fetch/fetch-gzip.test.ts
@@ -1,6 +1,6 @@
 import { Socket } from "bun";
 import { beforeAll, describe, expect, it } from "bun:test";
-import { gcTick } from "harness";
+import { bunEnv, bunExe, gcTick } from "harness";
 import { once } from "node:events";
 import { createServer } from "node:http";
 import { createServer as createNetServer } from "node:net";
@@ -296,6 +296,77 @@ it("fetch() with a gzip response works (multiple chunks, TCP server)", async don
   server.stop();
   done();
 });
+
+// A buffered (non-streaming) fetch() must be able to decompress a response
+// body larger than 1 GiB. The HTTP client's Decompressor runs unbounded, the
+// same as the original Zig implementation; only available memory limits it.
+// Run in a subprocess so the ~1 GiB output buffer does not linger in the test
+// process.
+it(
+  "fetch() with a buffered gzip response whose decompressed size exceeds 1 GiB works",
+  async () => {
+    const fixture = /* js */ `
+      import { createGzip } from "node:zlib";
+
+      const CHUNK = Buffer.alloc(1024 * 1024);
+      const N = 1025; // 1 GiB + 1 MiB
+      const chunks = [];
+      await new Promise((resolve, reject) => {
+        const gz = createGzip();
+        gz.on("data", c => chunks.push(c));
+        gz.on("end", resolve);
+        gz.on("error", reject);
+        let i = 0;
+        const pump = () => {
+          while (i < N) {
+            i++;
+            if (!gz.write(CHUNK)) return void gz.once("drain", pump);
+          }
+          gz.end();
+        };
+        pump();
+      });
+      const body = Buffer.concat(chunks);
+
+      const server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch() {
+          return new Response(body, {
+            headers: {
+              "Content-Encoding": "gzip",
+              "Content-Length": String(body.length),
+            },
+          });
+        },
+      });
+      try {
+        const res = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+        const buf = await res.arrayBuffer();
+        console.log("OK", buf.byteLength);
+      } finally {
+        server.stop(true);
+      }
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `OK ${1025 * 1024 * 1024}`,
+      stderr: expect.not.stringContaining("error"),
+      exitCode: 0,
+    });
+  },
+  60_000,
+);
 
 describe("empty compressed responses", () => {
   // A response that declares Content-Encoding but sends zero body bytes must


### PR DESCRIPTION
## Repro

```js
import { gzipSync } from "node:zlib";
const gz = gzipSync(Buffer.alloc(1025 * 1024 * 1024)); // ~1 MB on the wire
const s = Bun.serve({ port: 0, fetch: () => new Response(gz, { headers: { "Content-Encoding": "gzip" } }) });
await (await fetch(s.url)).arrayBuffer();
// ZlibError fetching "http://..."
```

## Cause

`src/http/Decompressor.rs` sets `reader.max_output_size = 1024 * 1024 * 1024` on each of the zlib / brotli / zstd readers when constructing them. The reference `Decompressor.zig` never sets this field, so the readers run unbounded. In buffered (non-streaming) mode the output buffer accumulates across the whole response, so any compressed body whose decompressed size exceeds 1 GiB now errors out of `read_all` where the pre-port behavior would have completed, limited only by available memory.

The cap was introduced in #31175 as a generic decompression-bomb guard but it is a hard behavioral change that did not exist before the port.

## Fix

Drop the three `max_output_size` assignments and the `MAX_DECOMPRESSED_BODY_SIZE` constant. The readers' `max_output_size` defaults to `usize::MAX`, matching the unbounded Zig behavior.

## Verification

- `USE_SYSTEM_BUN=1 bun test test/js/web/fetch/fetch-gzip.test.ts -t "exceeds 1 GiB"` fails with `ZlibError`
- `bun bd test test/js/web/fetch/fetch-gzip.test.ts` passes (24/24)

The new test streams 1025 MiB of zeros through gzip (≈1 MB compressed), serves it with `Content-Encoding: gzip`, and asserts `arrayBuffer().byteLength` is the full decompressed size. It runs in a subprocess so the ~1 GiB output buffer does not linger in the test process.