### PR TITLE
fs.readdir: don't drop recursive entries whose relative path exceeds MAX_PATH_BYTES

### DIFF
--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1430,10 +1430,7 @@ pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts))
 }
 
-/// Size of the thread-local buffer used by [`join`] / [`join_z`]. Callers that
-/// want to keep the zero-alloc fast path but fall back to their own buffer
-/// when the concatenation would not fit can gate on this.
-pub const JOIN_BUF_LEN: usize = 4096;
+const JOIN_BUF_LEN: usize = 4096;
 
 thread_local! {
     pub(crate) static JOIN_BUF: UnsafeCell<[u8; JOIN_BUF_LEN]> =
@@ -1446,6 +1443,43 @@ pub fn join<P: PlatformT>(parts: &[&[u8]]) -> &'static [u8] {
 
 pub fn join_z<P: PlatformT>(parts: &[&[u8]]) -> &'static ZStr {
     JOIN_BUF.with(|b| join_z_buf::<P>(tl_buf_mut(b), parts))
+}
+
+#[inline]
+fn join_needed(parts: &[&[u8]]) -> usize {
+    parts.iter().map(|p| p.len() + 1).sum::<usize>() + 1
+}
+
+/// [`join_z_buf`] into `buf` when the result fits, otherwise into `spill`
+/// (grown as needed). `spill` is untouched in the common case.
+pub fn join_z_buf_spill<'a, P: PlatformT>(
+    buf: &'a mut [u8],
+    spill: &'a mut Vec<u8>,
+    parts: &[&[u8]],
+) -> &'a ZStr {
+    let needed = join_needed(parts);
+    let out: &mut [u8] = if needed <= buf.len() {
+        buf
+    } else {
+        if spill.len() < needed {
+            spill.resize(needed, 0);
+        }
+        &mut spill[..]
+    };
+    join_z_buf::<P>(out, parts)
+}
+
+/// [`join`] (thread-local buffer) when the result fits, otherwise into
+/// `spill` (grown as needed). `spill` is untouched in the common case.
+pub fn join_spill<'a, P: PlatformT>(spill: &'a mut Vec<u8>, parts: &[&[u8]]) -> &'a [u8] {
+    let needed = join_needed(parts);
+    if needed <= JOIN_BUF_LEN {
+        return join::<P>(parts);
+    }
+    if spill.len() < needed {
+        spill.resize(needed, 0);
+    }
+    join_string_buf::<P>(&mut spill[..], parts)
 }
 
 pub fn join_z_buf<'a, P: PlatformT>(buf: &'a mut [u8], parts: &[&[u8]]) -> &'a ZStr {

--- a/src/paths/resolve_path.rs
+++ b/src/paths/resolve_path.rs
@@ -1430,8 +1430,14 @@ pub fn join_abs_string_z<'a, P: PlatformT>(cwd: &'a [u8], parts: &[&[u8]]) -> &'
     PARSER_JOIN_INPUT_BUFFER.with(|b| join_abs_string_buf_z::<P>(cwd, tl_buf_mut(b), parts))
 }
 
+/// Size of the thread-local buffer used by [`join`] / [`join_z`]. Callers that
+/// want to keep the zero-alloc fast path but fall back to their own buffer
+/// when the concatenation would not fit can gate on this.
+pub const JOIN_BUF_LEN: usize = 4096;
+
 thread_local! {
-    pub(crate) static JOIN_BUF: UnsafeCell<[u8; 4096]> = const { UnsafeCell::new([0u8; 4096]) };
+    pub(crate) static JOIN_BUF: UnsafeCell<[u8; JOIN_BUF_LEN]> =
+        const { UnsafeCell::new([0u8; JOIN_BUF_LEN]) };
 }
 
 pub fn join<P: PlatformT>(parts: &[&[u8]]) -> &'static [u8] {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6623,6 +6623,8 @@ impl NodeFS {
 
         let mut iterator = DirIterator::WrappedIterator::init(fd);
         let mut dirent_path_prev = BunString::EMPTY;
+        let mut name_heap: Vec<u8> = Vec::new();
+        let mut dirent_heap: Vec<u8> = Vec::new();
 
         loop {
             let current = match iterator.next() {
@@ -6647,23 +6649,33 @@ impl NodeFS {
 
             // The root subtask's basename *is* root_path; the caller passes
             // `is_root` explicitly.
-            if !is_root
-                && basename.as_bytes().len() + 1 + utf8_name.len() + 1 >= paths::MAX_PATH_BYTES
-            {
-                continue;
-            }
+            // name_to_copy: bare name at root, else `basename/utf8_name`. Both
+            // inputs are already normalized (basename came from a prior join,
+            // utf8_name is a single readdir component with `.`/`..` filtered),
+            // so the join is a plain concatenation. When it fits, reuse the
+            // PathBuffer via join_z_buf; when it doesn't, fall back to a heap Vec
+            // so the entry is still reported rather than silently dropped.
             let name_to_copy: &[u8] = if is_root {
                 utf8_name
-            } else {
+            } else if basename.as_bytes().len() + 1 + utf8_name.len() + 1 < buf.len() {
                 paths::resolve_path::join_z_buf::<paths::platform::Auto>(
                     &mut buf[..],
                     &[basename.as_bytes(), utf8_name],
                 )
                 .as_bytes()
+            } else {
+                name_heap.clear();
+                name_heap.reserve(basename.as_bytes().len() + 1 + utf8_name.len() + 1);
+                name_heap.extend_from_slice(basename.as_bytes());
+                name_heap.push(paths::SEP);
+                name_heap.extend_from_slice(utf8_name);
+                name_heap.push(0);
+                &name_heap[..name_heap.len() - 1]
             };
-            // SAFETY: both branches yield NUL-terminated storage — `utf8_name` is a
-            // slice over the iterator's NUL-terminated dirent name, and
-            // `join_z_buf` writes a sentinel.
+            // SAFETY: all three branches yield NUL-terminated storage — `utf8_name`
+            // is a slice over the iterator's NUL-terminated dirent name,
+            // `join_z_buf` writes a sentinel, and the heap fallback pushes an
+            // explicit NUL past the returned slice.
             let name_to_copy_z =
                 unsafe { ZStr::from_raw(name_to_copy.as_ptr(), name_to_copy.len()) };
 
@@ -6707,10 +6719,15 @@ impl NodeFS {
             }
 
             if T::IS_DIRENT {
-                let joined = paths::resolve_path::join::<paths::platform::Auto>(&[
-                    root_basename,
-                    name_to_copy,
-                ]);
+                let parts: [&[u8]; 2] = [root_basename, name_to_copy];
+                let needed = parts[0].len() + 1 + parts[1].len() + 1;
+                if dirent_heap.len() < needed {
+                    dirent_heap.resize(needed, 0);
+                }
+                let joined = paths::resolve_path::join_string_buf::<paths::platform::Auto>(
+                    &mut dirent_heap[..],
+                    &parts,
+                );
                 let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                 if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                     dirent_path_prev.deref();
@@ -6759,6 +6776,9 @@ impl NodeFS {
         let root_fd: &mut FD = *_close_root;
         // The close guard captures `&mut root_fd`, so all reads below go
         // through the same place.
+
+        let mut name_heap: Vec<u8> = Vec::new();
+        let mut dirent_heap: Vec<u8> = Vec::new();
 
         while let Some(item) = stack.pop_front() {
             let is_root = first_is_root && item.is_empty();
@@ -6831,20 +6851,29 @@ impl NodeFS {
                 };
                 let utf8_name = current.name.slice();
 
-                // name_to_copy: bare name at root, else `basename/utf8_name` joined into `buf`.
-                if !is_root
-                    && basename_bytes.len() + 1 + utf8_name.len() + 1 >= paths::MAX_PATH_BYTES
-                {
-                    continue;
-                }
+                // name_to_copy: bare name at root, else `basename/utf8_name`. Both
+                // inputs are already normalized (basename came from a prior join,
+                // utf8_name is a single readdir component with `.`/`..` filtered),
+                // so the join is a plain concatenation. When it fits, reuse the
+                // caller's PathBuffer via join_z_buf; when it doesn't, fall back to
+                // a heap Vec so the entry is still reported rather than silently
+                // dropped from the listing.
                 let name_to_copy: &[u8] = if is_root {
                     utf8_name
-                } else {
+                } else if basename_bytes.len() + 1 + utf8_name.len() + 1 < buf.len() {
                     paths::resolve_path::join_z_buf::<paths::platform::Auto>(
                         &mut buf[..],
                         &[basename_bytes, utf8_name],
                     )
                     .as_bytes()
+                } else {
+                    name_heap.clear();
+                    name_heap.reserve(basename_bytes.len() + 1 + utf8_name.len() + 1);
+                    name_heap.extend_from_slice(basename_bytes);
+                    name_heap.push(paths::SEP);
+                    name_heap.extend_from_slice(utf8_name);
+                    name_heap.push(0);
+                    &name_heap[..name_heap.len() - 1]
                 };
 
                 // Track effective kind - may be resolved from .unknown via stat
@@ -6888,10 +6917,15 @@ impl NodeFS {
                 }
 
                 if T::IS_DIRENT {
-                    let joined = paths::resolve_path::join::<paths::platform::Auto>(&[
-                        root_basename.as_bytes(),
-                        name_to_copy,
-                    ]);
+                    let parts: [&[u8]; 2] = [root_basename.as_bytes(), name_to_copy];
+                    let needed = parts[0].len() + 1 + parts[1].len() + 1;
+                    if dirent_heap.len() < needed {
+                        dirent_heap.resize(needed, 0);
+                    }
+                    let joined = paths::resolve_path::join_string_buf::<paths::platform::Auto>(
+                        &mut dirent_heap[..],
+                        &parts,
+                    );
                     let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                     if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                         dirent_path_prev.deref();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6721,13 +6721,17 @@ impl NodeFS {
             if T::IS_DIRENT {
                 let parts: [&[u8]; 2] = [root_basename, name_to_copy];
                 let needed = parts[0].len() + 1 + parts[1].len() + 1;
-                if dirent_heap.len() < needed {
-                    dirent_heap.resize(needed, 0);
-                }
-                let joined = paths::resolve_path::join_string_buf::<paths::platform::Auto>(
-                    &mut dirent_heap[..],
-                    &parts,
-                );
+                let joined: &[u8] = if needed <= paths::resolve_path::JOIN_BUF_LEN {
+                    paths::resolve_path::join::<paths::platform::Auto>(&parts)
+                } else {
+                    if dirent_heap.len() < needed {
+                        dirent_heap.resize(needed, 0);
+                    }
+                    paths::resolve_path::join_string_buf::<paths::platform::Auto>(
+                        &mut dirent_heap[..],
+                        &parts,
+                    )
+                };
                 let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                 if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                     dirent_path_prev.deref();
@@ -6919,13 +6923,17 @@ impl NodeFS {
                 if T::IS_DIRENT {
                     let parts: [&[u8]; 2] = [root_basename.as_bytes(), name_to_copy];
                     let needed = parts[0].len() + 1 + parts[1].len() + 1;
-                    if dirent_heap.len() < needed {
-                        dirent_heap.resize(needed, 0);
-                    }
-                    let joined = paths::resolve_path::join_string_buf::<paths::platform::Auto>(
-                        &mut dirent_heap[..],
-                        &parts,
-                    );
+                    let joined: &[u8] = if needed <= paths::resolve_path::JOIN_BUF_LEN {
+                        paths::resolve_path::join::<paths::platform::Auto>(&parts)
+                    } else {
+                        if dirent_heap.len() < needed {
+                            dirent_heap.resize(needed, 0);
+                        }
+                        paths::resolve_path::join_string_buf::<paths::platform::Auto>(
+                            &mut dirent_heap[..],
+                            &parts,
+                        )
+                    };
                     let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                     if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                         dirent_path_prev.deref();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6623,8 +6623,8 @@ impl NodeFS {
 
         let mut iterator = DirIterator::WrappedIterator::init(fd);
         let mut dirent_path_prev = BunString::EMPTY;
-        let mut name_heap: Vec<u8> = Vec::new();
-        let mut dirent_heap: Vec<u8> = Vec::new();
+        let mut spill: Vec<u8> = Vec::new();
+        let mut dirent_spill: Vec<u8> = Vec::new();
 
         loop {
             let current = match iterator.next() {
@@ -6649,33 +6649,19 @@ impl NodeFS {
 
             // The root subtask's basename *is* root_path; the caller passes
             // `is_root` explicitly.
-            // name_to_copy: bare name at root, else `basename/utf8_name`. Both
-            // inputs are already normalized (basename came from a prior join,
-            // utf8_name is a single readdir component with `.`/`..` filtered),
-            // so the join is a plain concatenation. When it fits, reuse the
-            // PathBuffer via join_z_buf; when it doesn't, fall back to a heap Vec
-            // so the entry is still reported rather than silently dropped.
             let name_to_copy: &[u8] = if is_root {
                 utf8_name
-            } else if basename.as_bytes().len() + 1 + utf8_name.len() + 1 < buf.len() {
-                paths::resolve_path::join_z_buf::<paths::platform::Auto>(
+            } else {
+                paths::resolve_path::join_z_buf_spill::<paths::platform::Auto>(
                     &mut buf[..],
+                    &mut spill,
                     &[basename.as_bytes(), utf8_name],
                 )
                 .as_bytes()
-            } else {
-                name_heap.clear();
-                name_heap.reserve(basename.as_bytes().len() + 1 + utf8_name.len() + 1);
-                name_heap.extend_from_slice(basename.as_bytes());
-                name_heap.push(paths::SEP);
-                name_heap.extend_from_slice(utf8_name);
-                name_heap.push(0);
-                &name_heap[..name_heap.len() - 1]
             };
-            // SAFETY: all three branches yield NUL-terminated storage — `utf8_name`
-            // is a slice over the iterator's NUL-terminated dirent name,
-            // `join_z_buf` writes a sentinel, and the heap fallback pushes an
-            // explicit NUL past the returned slice.
+            // SAFETY: both branches yield NUL-terminated storage — `utf8_name` is a
+            // slice over the iterator's NUL-terminated dirent name, and
+            // `join_z_buf_spill` writes a sentinel.
             let name_to_copy_z =
                 unsafe { ZStr::from_raw(name_to_copy.as_ptr(), name_to_copy.len()) };
 
@@ -6719,19 +6705,10 @@ impl NodeFS {
             }
 
             if T::IS_DIRENT {
-                let parts: [&[u8]; 2] = [root_basename, name_to_copy];
-                let needed = parts[0].len() + 1 + parts[1].len() + 1;
-                let joined: &[u8] = if needed <= paths::resolve_path::JOIN_BUF_LEN {
-                    paths::resolve_path::join::<paths::platform::Auto>(&parts)
-                } else {
-                    if dirent_heap.len() < needed {
-                        dirent_heap.resize(needed, 0);
-                    }
-                    paths::resolve_path::join_string_buf::<paths::platform::Auto>(
-                        &mut dirent_heap[..],
-                        &parts,
-                    )
-                };
+                let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
+                    &mut dirent_spill,
+                    &[root_basename, name_to_copy],
+                );
                 let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                 if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                     dirent_path_prev.deref();
@@ -6781,8 +6758,8 @@ impl NodeFS {
         // The close guard captures `&mut root_fd`, so all reads below go
         // through the same place.
 
-        let mut name_heap: Vec<u8> = Vec::new();
-        let mut dirent_heap: Vec<u8> = Vec::new();
+        let mut spill: Vec<u8> = Vec::new();
+        let mut dirent_spill: Vec<u8> = Vec::new();
 
         while let Some(item) = stack.pop_front() {
             let is_root = first_is_root && item.is_empty();
@@ -6855,29 +6832,15 @@ impl NodeFS {
                 };
                 let utf8_name = current.name.slice();
 
-                // name_to_copy: bare name at root, else `basename/utf8_name`. Both
-                // inputs are already normalized (basename came from a prior join,
-                // utf8_name is a single readdir component with `.`/`..` filtered),
-                // so the join is a plain concatenation. When it fits, reuse the
-                // caller's PathBuffer via join_z_buf; when it doesn't, fall back to
-                // a heap Vec so the entry is still reported rather than silently
-                // dropped from the listing.
                 let name_to_copy: &[u8] = if is_root {
                     utf8_name
-                } else if basename_bytes.len() + 1 + utf8_name.len() + 1 < buf.len() {
-                    paths::resolve_path::join_z_buf::<paths::platform::Auto>(
+                } else {
+                    paths::resolve_path::join_z_buf_spill::<paths::platform::Auto>(
                         &mut buf[..],
+                        &mut spill,
                         &[basename_bytes, utf8_name],
                     )
                     .as_bytes()
-                } else {
-                    name_heap.clear();
-                    name_heap.reserve(basename_bytes.len() + 1 + utf8_name.len() + 1);
-                    name_heap.extend_from_slice(basename_bytes);
-                    name_heap.push(paths::SEP);
-                    name_heap.extend_from_slice(utf8_name);
-                    name_heap.push(0);
-                    &name_heap[..name_heap.len() - 1]
                 };
 
                 // Track effective kind - may be resolved from .unknown via stat
@@ -6921,19 +6884,10 @@ impl NodeFS {
                 }
 
                 if T::IS_DIRENT {
-                    let parts: [&[u8]; 2] = [root_basename.as_bytes(), name_to_copy];
-                    let needed = parts[0].len() + 1 + parts[1].len() + 1;
-                    let joined: &[u8] = if needed <= paths::resolve_path::JOIN_BUF_LEN {
-                        paths::resolve_path::join::<paths::platform::Auto>(&parts)
-                    } else {
-                        if dirent_heap.len() < needed {
-                            dirent_heap.resize(needed, 0);
-                        }
-                        paths::resolve_path::join_string_buf::<paths::platform::Auto>(
-                            &mut dirent_heap[..],
-                            &parts,
-                        )
-                    };
+                    let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
+                        &mut dirent_spill,
+                        &[root_basename.as_bytes(), name_to_copy],
+                    );
                     let path_u8 = paths::resolve_path::dirname::<paths::platform::Auto>(joined);
                     if dirent_path_prev.is_empty() || dirent_path_prev.byte_slice() != path_u8 {
                         dirent_path_prev.deref();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6,6 +6,7 @@ import {
   getMaxFD,
   isBroken,
   isIntelMacOS,
+  isLinux,
   isPosix,
   isWindows,
   tempDir,
@@ -2880,6 +2881,83 @@ describe("fs/promises", () => {
       it("readdirSync(path, {recursive: true} should work x 100", doIt, 10_000);
     }
   }
+
+  // Linux-only: uses /proc/self/fd/<n> to build entries whose relative path
+  // from the readdir root reaches MAX_PATH_BYTES without ever handing a long
+  // path to a single syscall. On Linux MAX_PATH_BYTES = 4096 and NAME_MAX = 255,
+  // so 16 levels of 255-byte dir names puts the deepest relative path at 4095.
+  it.skipIf(!isLinux).concurrent(
+    "readdir(path, {recursive: true}) reports entries whose relative path reaches MAX_PATH_BYTES",
+    async () => {
+      const script = `
+        const fs = require("fs");
+        const root = process.env.DEEP_ROOT;
+        const seg = Buffer.alloc(255, "d").toString();
+        const longName = Buffer.alloc(255, "x").toString();
+        let cur = fs.openSync(root, "r");
+        for (let i = 0; i < 16; i++) {
+          const base = "/proc/self/fd/" + cur;
+          fs.mkdirSync(base + "/" + seg);
+          const next = fs.openSync(base + "/" + seg, "r");
+          fs.closeSync(cur);
+          cur = next;
+        }
+        // cur = depth 16 (relative path 4095). Up one -> depth 15 (relative 3839).
+        const d15 = fs.openSync("/proc/self/fd/" + cur + "/..", "r");
+        fs.closeSync(cur);
+        // At depth 15 the iterator sees three entries: the depth-16 dir (name
+        // len 255), longName (file, len 255) and "short" (file, len 5). The
+        // former two have relative paths of 4095 bytes from root.
+        fs.writeFileSync("/proc/self/fd/" + d15 + "/" + longName, "");
+        fs.writeFileSync("/proc/self/fd/" + d15 + "/short", "");
+        fs.closeSync(d15);
+
+        function report(label, entries) {
+          const rel = entries.map(e => {
+            if (typeof e === "string") return e;
+            return require("path").join(e.parentPath, e.name).slice(root.length + 1);
+          });
+          const long = rel.filter(n => n.endsWith("/" + longName)).length;
+          const deepDir = rel.filter(n => n.length === 4095 && n.endsWith("/" + seg)).length;
+          const short = rel.filter(n => n.endsWith("/short")).length;
+          console.log(JSON.stringify({ label, count: entries.length, long, deepDir, short }));
+        }
+
+        report("sync", fs.readdirSync(root, { recursive: true }));
+        report("syncDirent", fs.readdirSync(root, { recursive: true, withFileTypes: true }));
+        fs.promises.readdir(root, { recursive: true }).then(r => {
+          report("async", r);
+          return fs.promises.readdir(root, { recursive: true, withFileTypes: true });
+        }).then(r => report("asyncDirent", r));
+      `;
+      using dir = tempDir("readdir-deep", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...bunEnv, DEEP_ROOT: String(dir) },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const lines = stdout
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map(l => JSON.parse(l));
+      // 16 dirs + 2 files = 18 entries; every mode must see the depth-16 dir
+      // and the 255-byte file whose relative paths are 4095 bytes.
+      const want = { count: 18, long: 1, deepDir: 1, short: 1 };
+      expect({ stderr, lines }).toEqual({
+        stderr: "",
+        lines: [
+          { label: "sync", ...want },
+          { label: "syncDirent", ...want },
+          { label: "async", ...want },
+          { label: "asyncDirent", ...want },
+        ],
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
 
   it("readdir() no args doesnt segfault", async () => {
     const fizz = [


### PR DESCRIPTION
## Problem

`readdir_with_entries_recursive_sync` / `_async` in `src/runtime/node/node_fs.rs` gained a pre-join length guard in 13bbb38597 that does `continue` when `basename.len() + 1 + utf8_name.len() + 1 >= MAX_PATH_BYTES`. That drops the entry from the result entirely: it is neither appended to the listing nor enqueued for descent. The Zig reference (`node_fs.zig:4916-4923`) has no such guard before `bun.path.joinZBuf`; the entry is always appended, and only the descent enqueue is length-gated.

Net effect: files and directories whose relative path from the readdir root approaches `MAX_PATH_BYTES` are silently omitted from `fs.readdirSync(root, { recursive: true })` and `fs.promises.readdir(root, { recursive: true })`, with and without `withFileTypes`. On macOS (`MAX_PATH_BYTES=1024`) this trips at ~1022-byte relative paths; on Linux (`MAX_PATH_BYTES=4096`) at ~4094 bytes.

## Repro

On Linux, build 16 nested directories with 255-byte names (relative path of the deepest entry is 4095 bytes) via `/proc/self/fd/<n>` so no single syscall sees a long path. At depth 15, place a 255-byte-named file alongside a short one:

```
sync        count=16  long=0  deepDir=0  short=1   // current: drops 2 of 18
syncDirent  count=16  long=0  deepDir=0  short=1
async       count=16  long=0  deepDir=0  short=1
asyncDirent count=16  long=0  deepDir=0  short=1
```

## Fix

The Zig original calls `joinZBuf(buf, ..)` unconditionally and relies on `buf` being large enough; in Rust that would panic on overflow, which is why 13bbb38597 added the `continue`. Instead of dropping the entry, spill to a caller-provided `Vec<u8>` when the join would not fit:

- `resolve_path::join_z_buf_spill(buf, spill, parts)`: writes into `buf` when it fits, otherwise grows and writes into `spill`. Drop-in for the existing `join_z_buf` call with one extra argument.
- `resolve_path::join_spill(spill, parts)`: same for the thread-local `join` used by the `withFileTypes` parent-path computation.

Both spill vecs are declared once per `readdir` call (sync) or per directory subtask (async), stay empty in the common case, and are reused across iterations. The call sites in `node_fs.rs` are otherwise unchanged from the pre-13bbb385 shape.

## Verification

New test in `test/js/node/fs/fs.test.ts` (Linux only, needs `/proc/self/fd` to create entries whose absolute paths exceed `PATH_MAX`). Before the fix all four modes report 16 entries with the 4095-byte dir and file missing; after, all four report 18 and see both. The existing "produces the same result as Node.js" recursive-readdir tests and `readdirSync-recursive-error-leak.test.ts` continue to pass.
