### PR TITLE
Fix Worker preload resolve error reporting 'undefined'

### DIFF
--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -490,14 +490,16 @@ impl WebWorker {
         // SAFETY: `parent` is the calling thread's live VM (BACKREF).
         let parent_ref = unsafe { &mut *parent };
         let prev_log = parent_ref.transpiler.log;
-        let mut temp_log = bun_ast::Log::default();
-        parent_ref.transpiler.set_log(&raw mut temp_log);
         // RAII: log pointer restored and temp log dropped on every return path.
-        let mut restore = scopeguard::guard((parent_ref, temp_log), |(p, log)| {
+        // `temp_log` is moved into the guard FIRST, then `set_log` targets its
+        // final address — the transpiler stores a raw `*mut Log`, so setting it
+        // before the move would leave a dangling pointer to moved-from stack.
+        let mut restore = scopeguard::guard((parent_ref, bun_ast::Log::default()), |(p, log)| {
             p.transpiler.set_log(prev_log);
             drop(log);
         });
         let (parent_ref, temp_log) = &mut *restore;
+        parent_ref.transpiler.set_log(&raw mut *temp_log);
 
         // SAFETY: caller passed valid (ptr,len) (or `(null,0)`); slice borrowed from C++.
         let preload_modules: &[BunString] =

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -511,12 +511,7 @@ impl WebWorker {
             // SAFETY: `parent_ref` is the live VM on the calling (parent)
             // thread — its `transpiler` is uniquely owned here.
             if let Some(preload) = unsafe {
-                resolve_entry_point_specifier(
-                    *parent_ref,
-                    utf8_slice.slice(),
-                    error_message,
-                    temp_log,
-                )
+                resolve_entry_point_specifier(*parent_ref, utf8_slice.slice(), error_message)
             } {
                 preloads.push(preload.to_vec().into_boxed_slice());
             }
@@ -1045,21 +1040,16 @@ impl WebWorker {
         // spin() goes through shutdown() which is noreturn, so a `defer free`
         // here would never run anyway.
         let mut resolve_error = BunString::empty();
-        let vm_log = vm.log_mut().unwrap();
         // SAFETY: `vm_ptr` is the live worker-thread VM; the fn takes a raw ptr
         // (no `&mut`) because `vm` is already published under `vm_lock` — see
         // `resolve_entry_point_specifier` Safety contract.
         let path = match unsafe {
-            resolve_entry_point_specifier(
-                vm_ptr,
-                &self.unresolved_specifier,
-                &mut resolve_error,
-                vm_log,
-            )
+            resolve_entry_point_specifier(vm_ptr, &self.unresolved_specifier, &mut resolve_error)
         } {
             Some(p) => p,
             None => {
                 vm.as_mut().exit_handler.exit_code = 1;
+                let vm_log = vm.log_mut().unwrap();
                 if vm_log.errors == 0 && !resolve_error.is_empty() {
                     let err = resolve_error.to_utf8();
                     // `Log::add_error` takes `impl IntoText`; pass an owned
@@ -1539,7 +1529,6 @@ unsafe fn resolve_entry_point_specifier<'s>(
     parent: *mut VirtualMachine,
     str: &'s [u8],
     error_message: &mut BunString,
-    log: &mut bun_ast::Log,
 ) -> Option<&'s [u8]> {
     // SAFETY: per fn contract; read-only field.
     if let Some(graph) = unsafe { (*parent).standalone_module_graph } {
@@ -1640,6 +1629,14 @@ unsafe fn resolve_entry_point_specifier<'s>(
         Err(_) => {
             // `global` valid for VM lifetime; safe ZST-handle deref (panics on null).
             let global = JSGlobalObject::opaque_ref(global);
+            // `resolve_entry_point` wrote the error to `transpiler.log`. Read
+            // it back through the same raw pointer — a separate `&mut Log`
+            // parameter would be `noalias` and miss the write under
+            // optimization (the two point at the same allocation).
+            // SAFETY: `transpiler.log` is non-null after init and outlives
+            // this call (both callers swap in a log that lives on their
+            // stack or VM for the duration).
+            let log = unsafe { &*(*parent).transpiler.log };
             let out: jsc::JsResult<BunString> = (|| {
                 let out = log.to_js(global, "Error resolving Worker entry point")?;
                 out.to_bun_string(global)

--- a/test/js/web/workers/worker-preload-resolve-error.test.ts
+++ b/test/js/web/workers/worker-preload-resolve-error.test.ts
@@ -1,35 +1,16 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
 
-test("Worker preload: unresolvable module surfaces the resolve error, not 'undefined'", async () => {
-  using dir = tempDir("worker-preload-resolve-error", {
-    "entry.js": `postMessage("unreachable");`,
-    "run.js": `
-      try {
-        new Worker(new URL("entry.js", import.meta.url).href, {
-          preload: ["./this-preload-does-not-exist.js"],
-        });
-        console.log("NO_THROW");
-      } catch (e) {
-        console.log(JSON.stringify({ isError: e instanceof Error, message: String(e.message) }));
-      }
-    `,
-  });
-
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "run.js"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-  expect({ stdout, stderr, exitCode }).toMatchObject({
-    stdout: expect.stringContaining('"isError":true'),
-    exitCode: 0,
-  });
-  const out = JSON.parse(stdout.trim());
-  expect(out.message).not.toBe("undefined");
-  expect(out.message).toContain("this-preload-does-not-exist");
+test("Worker preload: unresolvable module surfaces the resolve error, not 'undefined'", () => {
+  let caught: unknown;
+  try {
+    new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
+      preload: ["./this-preload-does-not-exist.js"],
+    });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(Error);
+  const message = String((caught as Error).message);
+  expect(message).not.toBe("undefined");
+  expect(message).toContain("this-preload-does-not-exist");
 });

--- a/test/js/web/workers/worker-preload-resolve-error.test.ts
+++ b/test/js/web/workers/worker-preload-resolve-error.test.ts
@@ -1,16 +1,33 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 
-test("Worker preload: unresolvable module surfaces the resolve error, not 'undefined'", () => {
-  let caught: unknown;
-  try {
-    new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
-      preload: ["./this-preload-does-not-exist.js"],
-    });
-  } catch (e) {
-    caught = e;
-  }
-  expect(caught).toBeInstanceOf(Error);
-  const message = String((caught as Error).message);
-  expect(message).not.toBe("undefined");
-  expect(message).toContain("this-preload-does-not-exist");
+test("Worker preload: unresolvable module surfaces the resolve error, not 'undefined'", async () => {
+  using dir = tempDir("worker-preload-resolve-error", {
+    "entry.js": `postMessage("unreachable");`,
+    "run.js": `
+      try {
+        new Worker(new URL("entry.js", import.meta.url).href, {
+          preload: ["./this-preload-does-not-exist.js"],
+        });
+        console.log("NO_THROW");
+      } catch (e) {
+        console.log(JSON.stringify({ isError: e instanceof Error, message: String(e.message) }));
+      }
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run.js"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  const out = JSON.parse(stdout.trim());
+  expect(out.isError).toBe(true);
+  expect(out.message).not.toBe("undefined");
+  expect(out.message).toContain("this-preload-does-not-exist");
+  expect(exitCode).toBe(0);
 });

--- a/test/js/web/workers/worker-preload-resolve-error.test.ts
+++ b/test/js/web/workers/worker-preload-resolve-error.test.ts
@@ -23,11 +23,13 @@ test("Worker preload: unresolvable module surfaces the resolve error, not 'undef
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
+  expect({ stdout, stderr, exitCode }).toMatchObject({
+    stdout: expect.stringContaining('"isError":true'),
+    exitCode: 0,
+  });
   const out = JSON.parse(stdout.trim());
-  expect(out.isError).toBe(true);
   expect(out.message).not.toBe("undefined");
   expect(out.message).toContain("this-preload-does-not-exist");
-  expect(exitCode).toBe(0);
 });

--- a/test/js/web/workers/worker-preload-resolve-error.test.ts
+++ b/test/js/web/workers/worker-preload-resolve-error.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test";
+
+test("Worker preload: unresolvable module surfaces the resolve error, not 'undefined'", () => {
+  let caught: unknown;
+  try {
+    new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
+      preload: ["./this-preload-does-not-exist.js"],
+    });
+  } catch (e) {
+    caught = e;
+  }
+  expect(caught).toBeInstanceOf(Error);
+  const message = String((caught as Error).message);
+  expect(message).not.toBe("undefined");
+  expect(message).toContain("this-preload-does-not-exist");
+});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -29,21 +29,6 @@ describe("web worker", () => {
       ).toThrow(/Invalid file URL/);
     });
 
-    test("unresolvable module surfaces the resolve error, not 'undefined'", () => {
-      let caught: unknown;
-      try {
-        new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
-          preload: ["./this-preload-does-not-exist.js"],
-        });
-      } catch (e) {
-        caught = e;
-      }
-      expect(caught).toBeInstanceOf(Error);
-      const message = String((caught as Error).message);
-      expect(message).not.toBe("undefined");
-      expect(message).toContain("this-preload-does-not-exist");
-    });
-
     test("string", async () => {
       const worker = new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
         preload: new URL("worker-fixture-preload.js", import.meta.url).href,

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -29,6 +29,21 @@ describe("web worker", () => {
       ).toThrow(/Invalid file URL/);
     });
 
+    test("unresolvable module surfaces the resolve error, not 'undefined'", () => {
+      let caught: unknown;
+      try {
+        new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
+          preload: ["./this-preload-does-not-exist.js"],
+        });
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = String((caught as Error).message);
+      expect(message).not.toBe("undefined");
+      expect(message).toContain("this-preload-does-not-exist");
+    });
+
     test("string", async () => {
       const worker = new Worker(new URL("worker-fixture-preload-entry.js", import.meta.url).href, {
         preload: new URL("worker-fixture-preload.js", import.meta.url).href,

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -394,6 +394,7 @@ test/js/node/fs/abort-signal-leak-read-write-file.test.ts
 test/js/node/process/process.test.js
 test/js/web/websocket/websocket.test.js
 test/js/web/workers/worker.test.ts
+test/js/web/workers/worker-preload-resolve-error.test.ts
 test/regression/issue/11664.test.ts
 
 # ASSERTION FAILED: m_cellState == CellState::DefinitelyWhite


### PR DESCRIPTION
### What does this PR do?

Fixes `new Worker(entry, { preload: ["./missing.js"] })` throwing `TypeError: undefined` instead of the actual resolve error.

**Repro:**
```sh
bun -e 'try { new Worker("./entry.js", { preload: ["./does-not-exist.js"] }); } catch (e) { console.log(e.constructor.name + ":", JSON.stringify(e.message)); }'
```
Before: `TypeError: "undefined"`
After: `TypeError: "BuildMessage: ModuleNotFound resolving \"./does-not-exist.js\" (entry point)"`

**Cause:** two compounding issues in `WebWorker::create` / `resolve_entry_point_specifier` (src/jsc/web_worker.rs):

1. `set_log(&raw mut temp_log)` stored the stack address of `temp_log` in the transpiler, and `temp_log` was then moved into a `scopeguard` tuple. The transpiler's raw `*mut Log` pointed at moved-from stack.
2. `resolve_entry_point_specifier` took `log: &mut Log` as a parameter that aliased `(*parent).transpiler.log`. `resolve_entry_point` writes the error through `transpiler.log`; under release optimization the `&mut` parameter's `noalias` lets the compiler assume `log.msgs` is still empty when `log.to_js()` reads it, so it returns `JSValue::UNDEFINED` (LogJsc::to_js, count == 0) and `to_bun_string()` yields `"undefined"`.

The Zig reference (web_worker.zig:288) avoids both: `&temp_log` with no move, and the log is passed as a raw `*Log` (no `noalias`).

**Fix:**
- Move `temp_log` into the guard first, then call `set_log` with its post-move address.
- Drop the `log` parameter from `resolve_entry_point_specifier`; read `(*parent).transpiler.log` directly after the resolve so the read and write share one provenance path.
- Move `spin()`'s `vm_log` binding into the `None` arm so it is not held as `&mut` across the resolve call (same aliasing class).

### How did you verify your code works?

New test `test/js/web/workers/worker-preload-resolve-error.test.ts`: constructs a Worker with a nonexistent preload module and asserts the caught error message is not `"undefined"` and contains the module specifier.

- `bun bd test` and `bun run build:release test` with main's src/: fails (message is `"undefined"`).
- `bun bd test` and `bun run build:release test` with the fix: passes.
- Full `worker.test.ts` on release: 23 pass, 1 pre-existing todo.

The test lives in its own file because `worker.test.ts` has two pre-existing 1000ms-timeout tests ("worker with event listeners doesn't close event loop") that flake on slow debug+ASAN runners independently of this change (also noted in #31951).
