### PR TITLE
Bun.Transpiler: release output_code when async transform() rejects

### DIFF
--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -903,6 +903,9 @@ impl<'a> TransformTask<'a> {
 // released explicitly or the `JSTranspiler` never reaches refcount 0.
 impl<'a> Drop for TransformTask<'a> {
     fn drop(&mut self) {
+        // `BunString` is `Copy` (no Drop); release the +1 WTFStringImpl from
+        // `clone_utf8` in `run()`. No-op after `transfer_to_js` (tag = Dead).
+        self.output_code.deref();
         // Release the +1 taken in `TransformTask::create`.
         bun_ptr::RefPtr::deref(&self.js_instance);
     }

--- a/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
+++ b/test/js/bun/transpiler/transpiler-transform-output-leak.test.ts
@@ -1,0 +1,69 @@
+// Bun.Transpiler().transform() runs on a work-pool TransformTask that owns a
+// +1 WTFStringImpl for the printed output (BunString::clone_utf8 in run()).
+// On the success path transfer_to_js consumes that ref, but when parsing
+// succeeds and printing succeeds while the log has a warning (e.g. the
+// legacy HTML "-->" single-line-comment lexer warning), then() rejects
+// without calling transfer_to_js. BunString is Copy with no Drop, so the
+// task's Drop must deref output_code explicitly or the whole printed source
+// leaks per rejected call.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+const fixture = /* ts */ `
+const t = new Bun.Transpiler({ loader: "js" });
+// A single large string literal: trivial to parse, and the printed output is
+// ~256 KB so the leaked WTFStringImpl is large enough to move RSS measurably.
+const payload = Buffer.alloc(256 * 1024, "a").toString();
+// "-->" at the start of a line is the legacy HTML single-line close comment:
+// the lexer logs a warning (not an error), so parse+print succeed and then()
+// takes the reject path with output_code already populated.
+const code = 'var big = "' + payload + '";\\n--> trailing\\nbig;\\n';
+
+let rejected = 0;
+async function once() {
+  try { await t.transform(code); } catch { rejected++; }
+}
+
+// Warm up: let the WTF allocator / mimalloc reach steady state before
+// measuring.
+for (let i = 0; i < 100; i++) await once();
+Bun.gc(true);
+const before = process.memoryUsage.rss();
+
+for (let i = 0; i < 600; i++) await once();
+Bun.gc(true);
+const growthMB = (process.memoryUsage.rss() - before) / 1024 / 1024;
+
+// The test is meaningless if transform() did not reject (e.g. the warning
+// was removed or the source no longer triggers it).
+if (rejected < 700) throw new Error("expected every transform() to reject, got " + rejected + "/700");
+// Without the fix: 600 * ~256 KB = ~150 MB retained.
+// With the fix: < 5 MB.
+if (growthMB > 60) throw new Error("leaked " + growthMB.toFixed(2) + " MB");
+console.log("OK growth=" + growthMB.toFixed(2) + "MB");
+`;
+
+test("transform() reject path releases the printed output string", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--smol", "-e", fixture],
+    env: {
+      ...bunEnv,
+      // RSS-delta leak tests measure retained bytes; ASAN's quarantine
+      // (default quarantine_size_mb=256) holds every freed allocation
+      // poisoned-but-resident, which in this test is 700 * ~256 KB of freed
+      // output strings and dominates the delta even when nothing leaks.
+      // Disable quarantine for the measurement subprocess only.
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "quarantine_size_mb=0"].filter(Boolean).join(":"),
+    },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  if (exitCode !== 0) {
+    expect(stderr).toBe("");
+  }
+  expect(stdout.trim()).toStartWith("OK ");
+  expect(exitCode).toBe(0);
+}, 60_000);


### PR DESCRIPTION
## Problem

`Bun.Transpiler().transform()` leaks the printed output string whenever the async task rejects after a successful parse+print.

`TransformTask::run()` stores the printed output as a +1 `WTFStringImpl` via `BunString::clone_utf8`. On the success path `finish()` calls `transfer_to_js`, which consumes the ref and sets the tag to `Dead`. But when `then()` takes the reject path (`self.log.has_any() || self.err.is_some()`), `transfer_to_js` is never called. `bun_core::String` is `#[derive(Copy)]` with no `Drop`, and the existing `Drop for TransformTask` only released `js_instance`, so the whole printed source leaks per rejected call.

The Zig reference (`JSTranspiler.zig` `TransformTask.deinit`) calls `this.output_code.deref()` unconditionally; the Rust port dropped this line.

## Repro

The legacy HTML `-->` single-line-comment lexer warning is a warning (not an error), so parse and print both succeed and `then()` rejects with `output_code` already populated:

```js
const t = new Bun.Transpiler({ loader: "js" });
const payload = Buffer.alloc(256 * 1024, "a").toString();
const code = 'var big = "' + payload + '";\n--> trailing\nbig;\n';
for (let i = 0; i < 100; i++) { try { await t.transform(code); } catch {} }
Bun.gc(true);
const before = process.memoryUsage.rss();
for (let i = 0; i < 600; i++) { try { await t.transform(code); } catch {} }
Bun.gc(true);
console.log(((process.memoryUsage.rss() - before) / 1048576).toFixed(2), "MB");
```

Before: ~152 MB retained (600 iterations * ~256 KB output). After: ~2 MB.

## Fix

Add `self.output_code.deref()` to `Drop for TransformTask`. After `transfer_to_js` the tag is `Dead` so `deref()` is a no-op on the success path; on the reject path it releases the retained `WTFStringImpl`. This matches the Zig `deinit()`.

## Verification

```
# without src/ fix
(fail) transform() reject path releases the printed output string
error: leaked 152.00 MB

# with fix
(pass) transform() reject path releases the printed output string [6394.61ms]
```

All existing `test/js/bun/transpiler/` and `test/bundler/transpiler/transpiler.test.js` pass.