### PR TITLE
worker: run process.on('exit') after uncaught error in event loop

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3195,6 +3195,10 @@ extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* g
     auto& vm = JSC::getVM(globalObject);
     // Clear the request for the termination exception to be thrown
     vm.clearHasTerminationRequest();
+    // If a NeedTermination trap is still pending (notifyNeedTermination fired
+    // but no safepoint has been reached yet), drop it so the next JS entry
+    // does not immediately re-raise the termination exception.
+    vm.traps().clearTrap(JSC::VMTraps::NeedTermination);
     // In case it actually has been thrown, clear the exception itself as well.
     // tryClearException() refuses to clear termination exceptions, so use
     // TopExceptionScope::clearException() which clears unconditionally —

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -181,6 +181,15 @@ pub struct WebWorker {
     /// observed concurrently by `terminate_all_and_wait` / parent-thread FFI;
     /// producing `&mut WebWorker` while another thread holds `&WebWorker` is UB).
     exit_called: AtomicBool,
+    /// Set by `on_unhandled_rejection` when it arms the JSC termination trap
+    /// to halt JS while unwinding to `spin()`. `shutdown()` reads this to
+    /// decide whether to clear the pending TerminationException before
+    /// `on_exit()` so `process.on('exit')` handlers run — the parent-initiated
+    /// `terminate()` path leaves it unset and keeps the pending exception so
+    /// `dispatchExitInternal` short-circuits (matching Node). Worker-thread
+    /// only; atomic for the same `&self`-under-concurrent-observation reason
+    /// as `exit_called` above.
+    terminate_from_unhandled_error: AtomicBool,
 }
 
 #[repr(u8)]
@@ -558,6 +567,7 @@ impl WebWorker {
             worker_env_map: Cell::new(core::ptr::null_mut()),
             worker_env_loader: Cell::new(core::ptr::null_mut()),
             exit_called: AtomicBool::new(false),
+            terminate_from_unhandled_error: AtomicBool::new(false),
         }));
         // `worker` is non-null (just heap-allocated). Wrap once for the safe
         // shared reborrows below; the raw `worker` is still used for
@@ -1224,6 +1234,21 @@ impl WebWorker {
             // clear it so process.on('exit') handlers can run. teardownJSCVM
             // re-sets it for the JSC VM teardown.
             vm.jsc_vm().clear_has_termination_request();
+            if self.terminate_from_unhandled_error.load(Ordering::Relaxed) {
+                // `on_unhandled_rejection` armed the JSC trap so JS halted
+                // while the stack unwound to `spin()`; by the time we get
+                // here the trap may have fired and left a pending
+                // TerminationException (and/or the NeedTermination trap bit
+                // is still set). Clearing only the request flag above is
+                // insufficient: `dispatchExitInternal`'s
+                // `hasExceptionsAfterHandlingTraps()` guard would observe
+                // the exception (or re-raise it from the trap bit) and skip
+                // the `process.on('exit')` handlers. Clear the exception and
+                // trap bit as well so the handlers run. The parent-initiated
+                // `terminate()` path does not set this flag; its pending
+                // exception stays and the guard short-circuits there.
+                vm.global().clear_termination_exception();
+            }
             vm.is_shutting_down = true;
             vm.on_exit();
             if let Some(hooks) = runtime_hooks() {
@@ -1496,6 +1521,9 @@ fn on_unhandled_rejection(
         let _ = global_object.try_take_exception();
     }
     let _ = worker.set_requested_terminate();
+    worker
+        .terminate_from_unhandled_error
+        .store(true, Ordering::Relaxed);
     // Do NOT call `worker.shutdown()` here —
     // `shutdown()` RETURNS, so calling it here would destroy
     // the `JSC::VM`, free the Bun `VirtualMachine` + arena, and post

--- a/test/js/node/worker_threads/worker-exit-after-uncaught-error.test.ts
+++ b/test/js/node/worker_threads/worker-exit-after-uncaught-error.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("process.on('exit') runs in worker after an uncaught error in a timer", async () => {
+  // An uncaught error thrown from a timer callback (not top-level) should
+  // still let the worker's process.on('exit') handlers run before the
+  // worker exits, and those handlers can postMessage to the parent.
+  const src = /* js */ `
+    const { Worker } = require("node:worker_threads");
+    const w = new Worker(
+      \`
+        const { parentPort } = require("node:worker_threads");
+        process.on("exit", code => parentPort.postMessage("exit:" + code));
+        parentPort.postMessage("ready");
+        setTimeout(() => { throw new Error("boom"); }, 1);
+        setInterval(() => {}, 1e6);
+      \`,
+      { eval: true },
+    );
+    const msgs = [];
+    w.on("message", m => msgs.push(m));
+    w.on("error", e => msgs.push("error:" + e.message));
+    w.on("exit", code => {
+      console.log(JSON.stringify({ msgs, code }));
+      process.exit(0);
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const line = stdout.trim();
+  expect(line).not.toBe("");
+  const { msgs, code } = JSON.parse(line) as { msgs: string[]; code: number };
+  // The exit handler's postMessage must reach the parent; message ordering
+  // relative to the error event is not guaranteed across threads, so sort.
+  expect(msgs.toSorted()).toEqual(["error:boom", "exit:1", "ready"]);
+  expect(code).toBe(1);
+  expect(exitCode).toBe(0);
+});

--- a/test/js/node/worker_threads/worker-exit-after-uncaught-error.test.ts
+++ b/test/js/node/worker_threads/worker-exit-after-uncaught-error.test.ts
@@ -31,13 +31,22 @@ test("process.on('exit') runs in worker after an uncaught error in a timer", asy
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const line = stdout.trim();
-  expect(line).not.toBe("");
-  const { msgs, code } = JSON.parse(line) as { msgs: string[]; code: number };
+  let parsed: { msgs: string[]; code: number };
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    parsed = { msgs: [], code: -1 };
+  }
   // The exit handler's postMessage must reach the parent; message ordering
   // relative to the error event is not guaranteed across threads, so sort.
-  expect(msgs.toSorted()).toEqual(["error:boom", "exit:1", "ready"]);
-  expect(code).toBe(1);
-  expect(exitCode).toBe(0);
+  // stderr carries the worker's uncaught-error trace and is expected to be
+  // non-empty; it is surfaced here so a failure diff is self-diagnosing.
+  expect({ msgs: parsed.msgs.toSorted(), code: parsed.code, exitCode, stderr }).toEqual({
+    msgs: ["error:boom", "exit:1", "ready"],
+    code: 1,
+    exitCode: 0,
+    stderr: expect.any(String),
+  });
 });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -423,6 +423,47 @@ describe("error event", () => {
   });
 });
 
+test("process.on('exit') runs in worker after an uncaught error in a timer", async () => {
+  // An uncaught error thrown from a timer callback (not top-level) should
+  // still let the worker's process.on('exit') handlers run before the
+  // worker exits, and those handlers can postMessage to the parent.
+  const src = /* js */ `
+    const { Worker } = require("node:worker_threads");
+    const w = new Worker(
+      \`
+        const { parentPort } = require("node:worker_threads");
+        process.on("exit", code => parentPort.postMessage("exit:" + code));
+        parentPort.postMessage("ready");
+        setTimeout(() => { throw new Error("boom"); }, 1);
+        setInterval(() => {}, 1e6);
+      \`,
+      { eval: true },
+    );
+    const msgs = [];
+    w.on("message", m => msgs.push(m));
+    w.on("error", e => msgs.push("error:" + e.message));
+    w.on("exit", code => {
+      console.log(JSON.stringify({ msgs, code }));
+      process.exit(0);
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const line = stdout.trim();
+  expect(line).not.toBe("");
+  const { msgs, code } = JSON.parse(line) as { msgs: string[]; code: number };
+  // The exit handler's postMessage must reach the parent; message ordering
+  // relative to the error event is not guaranteed across threads, so sort.
+  expect(msgs.toSorted()).toEqual(["error:boom", "exit:1", "ready"]);
+  expect(code).toBe(1);
+  expect(exitCode).toBe(0);
+});
+
 describe("getHeapSnapshot", () => {
   test("throws if the wrong options are passed", () => {
     const worker = new Worker("", { eval: true });

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -423,47 +423,6 @@ describe("error event", () => {
   });
 });
 
-test("process.on('exit') runs in worker after an uncaught error in a timer", async () => {
-  // An uncaught error thrown from a timer callback (not top-level) should
-  // still let the worker's process.on('exit') handlers run before the
-  // worker exits, and those handlers can postMessage to the parent.
-  const src = /* js */ `
-    const { Worker } = require("node:worker_threads");
-    const w = new Worker(
-      \`
-        const { parentPort } = require("node:worker_threads");
-        process.on("exit", code => parentPort.postMessage("exit:" + code));
-        parentPort.postMessage("ready");
-        setTimeout(() => { throw new Error("boom"); }, 1);
-        setInterval(() => {}, 1e6);
-      \`,
-      { eval: true },
-    );
-    const msgs = [];
-    w.on("message", m => msgs.push(m));
-    w.on("error", e => msgs.push("error:" + e.message));
-    w.on("exit", code => {
-      console.log(JSON.stringify({ msgs, code }));
-      process.exit(0);
-    });
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", src],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const line = stdout.trim();
-  expect(line).not.toBe("");
-  const { msgs, code } = JSON.parse(line) as { msgs: string[]; code: number };
-  // The exit handler's postMessage must reach the parent; message ordering
-  // relative to the error event is not guaranteed across threads, so sort.
-  expect(msgs.toSorted()).toEqual(["error:boom", "exit:1", "ready"]);
-  expect(code).toBe(1);
-  expect(exitCode).toBe(0);
-});
-
 describe("getHeapSnapshot", () => {
   test("throws if the wrong options are passed", () => {
     const worker = new Worker("", { eval: true });


### PR DESCRIPTION
## What

A worker that throws an uncaught error from a timer callback no longer skips its `process.on('exit')` handlers.

## Repro

```js
const { Worker } = require("node:worker_threads");
const w = new Worker(`
  const { parentPort } = require("node:worker_threads");
  process.on("exit", c => parentPort.postMessage("exitH:" + c));
  parentPort.postMessage("ready");
  setTimeout(() => { throw new Error("x") }, 20);
  setInterval(() => {}, 1e4);
`, { eval: true });
let m = [];
w.on("message", x => m.push(x));
w.on("error", () => m.push("err"));
w.on("exit", c => { console.log(JSON.stringify(m), c); process.exit(0) });
```

| | output |
|---|---|
| Node | `["ready","exitH:1","err"] 1` |
| Bun before | `["ready","err"] 1` |
| Bun after | `["ready","err","exitH:1"] 1` |

## Cause

`on_unhandled_rejection` in `web_worker.rs` cannot call `shutdown()` directly (it returns and would UAF through live JSC frames), so it arms the JSC `NeedTermination` trap via `notify_need_termination()` and lets the stack unwind to `spin()`. During the unwind the trap fires and raises a `TerminationException`. When `shutdown()` then calls `vm.jsc_vm().clear_has_termination_request()` it only clears `m_hasTerminationRequest`, not the pending exception (nor an unfired `NeedTermination` trap bit). `dispatchExitInternal` then sees `vm.hasExceptionsAfterHandlingTraps()` and returns early, skipping `process.on('exit')`.

The Zig reference (`web_worker.zig`) calls `shutdown()` directly from `onUnhandledRejection` without ever arming the trap, so it reaches `onExit()` with no termination state and the handlers run.

## Fix

Record that the worker terminated itself due to an unhandled error. In `shutdown()`, when that flag is set, additionally call `JSGlobalObject__clearTerminationException` to clear the pending `TerminationException` and the `NeedTermination` trap bit so the exit handlers can run. The parent-initiated `worker.terminate()` path leaves the flag unset and keeps its pending exception so `dispatchExitInternal` still short-circuits there, matching Node.

`JSGlobalObject__clearTerminationException` now also clears the `NeedTermination` trap bit so a not-yet-fired trap does not immediately re-raise the exception on the next JS entry. Existing callers (REPL, test timeout) use `requestTermination`, which does not fire that trap, so the extra clear is a no-op for them.

## Verification

```
# without src/ changes
bun bd test test/js/node/worker_threads/worker_threads.test.ts -t "process.on.'exit'. runs in worker after an uncaught error"
(fail) ... expected ["error:boom","exit:1","ready"], received ["error:boom","ready"]

# with src/ changes
(pass) process.on('exit') runs in worker after an uncaught error in a timer
```
