### PR TITLE
Bun.Transpiler: stop deep-cloning macro_map/replace_exports per transform() call

### DIFF
--- a/src/ast/runtime.rs
+++ b/src/ast/runtime.rs
@@ -73,6 +73,15 @@ impl core::ops::DerefMut for ReplaceableExportMap {
 }
 
 impl ReplaceableExportMap {
+    /// Shared empty map. Used as the target of the [`bun_ptr::BackRef`]
+    /// in `Runtime::Features::replace_exports` when no export remapping is
+    /// configured.
+    #[inline]
+    pub fn empty() -> &'static ReplaceableExportMap {
+        static EMPTY: std::sync::LazyLock<ReplaceableExportMap> =
+            std::sync::LazyLock::new(ReplaceableExportMap::default);
+        &EMPTY
+    }
     #[inline]
     pub fn count(&self) -> usize {
         self.entries.count()

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -820,7 +820,6 @@ use crate::bun_node_fallbacks as NodeFallbackModules;
 use crate::entry_points as EntryPoints;
 use bun_ast::RuntimeTranspilerCache;
 use bun_core::strings;
-use bun_resolver::package_json::MacroMap as MacroRemap;
 use bun_sys::Fd as FD;
 
 /// How a parsed source was found to be pre-bundled (plain source vs. cached
@@ -965,7 +964,6 @@ pub struct ParseOptions<'a, 'b> {
     /// `BundleOptions.jsx` — the file-backed `options_impl::jsx::Pragma`, NOT
     /// the lib.rs shim. Callers pass `transpiler.options.jsx.clone()`.
     pub jsx: crate::options_impl::jsx::Pragma,
-    pub macro_remappings: MacroRemap,
     pub macro_js_ctx: MacroJSCtx,
     pub virtual_source: Option<&'b bun_ast::Source>,
     pub replace_exports: &'b bun_ast::runtime::ReplaceableExportMap,
@@ -1565,7 +1563,6 @@ impl<'a> Transpiler<'a> {
 
                 let mut jsx = this_parse.jsx;
                 jsx.parse = loader.is_jsx();
-                let _ = &this_parse.macro_remappings;
 
                 // `ParserOptions::init` is hard-typed
                 // `-> Options<'static>` and `Options<'a>` is *invariant* in
@@ -2982,19 +2979,6 @@ impl<'a> Transpiler<'a> {
                 let dirname_fd = resolve_result.dirname_fd;
                 let emit_decorator_metadata = resolve_result.flags.emit_decorator_metadata();
                 let experimental_decorators = resolve_result.flags.experimental_decorators();
-                // `MacroRemap` (StringArrayHashMap of StringArrayHashMap) has
-                // no nested `Clone` impl (the inner clone is fallible).
-                // Rebuild the outer map, deep-cloning
-                // each inner map (fallible), matching the build-command
-                // conversion.
-                let macro_remappings = {
-                    let mut m = MacroRemap::default();
-                    for (k, v) in self.options.macro_remap.iter() {
-                        let inner = v.clone().map_err(|_| bun_core::err!("OutOfMemory"))?;
-                        m.insert(k, inner);
-                    }
-                    m
-                };
 
                 let parse_opts = ParseOptions {
                     arena: self.arena,
@@ -3004,7 +2988,6 @@ impl<'a> Transpiler<'a> {
                     file_descriptor: None,
                     file_hash: None,
                     file_fd_ptr: None,
-                    macro_remappings,
                     macro_js_ctx: default_macro_js_value(),
                     jsx,
                     emit_decorator_metadata,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -968,7 +968,7 @@ pub struct ParseOptions<'a, 'b> {
     pub macro_remappings: MacroRemap,
     pub macro_js_ctx: MacroJSCtx,
     pub virtual_source: Option<&'b bun_ast::Source>,
-    pub replace_exports: bun_collections::StringArrayHashMap<bun_ast::runtime::ReplaceableExport>,
+    pub replace_exports: &'b bun_ast::runtime::ReplaceableExportMap,
     pub inject_jest_globals: bool,
     pub set_breakpoint_on_first_line: bool,
     pub emit_decorator_metadata: bool,
@@ -1663,12 +1663,9 @@ impl<'a> Transpiler<'a> {
                 opts.features.top_level_await = true;
 
                 opts.features.is_macro_runtime = target == crate::options_impl::Target::BunMacro;
-                // `bun_ast::runtime::ReplaceableExport` IS
-                // `js_ast::Runtime::ReplaceableExport`, so the inner
-                // `StringArrayHashMap` moves directly into the newtype.
-                opts.features.replace_exports = bun_ast::runtime::ReplaceableExportMap {
-                    entries: this_parse.replace_exports,
-                };
+                // The parser borrows the caller's map (kept alive for the
+                // whole parse); `BackRef` keeps `Features` lifetime-free.
+                opts.features.replace_exports = bun_ptr::BackRef::new(this_parse.replace_exports);
 
                 if self.macro_context.is_none() {
                     let ctx = js_ast::Macro::MacroContext::init(self);
@@ -3013,7 +3010,7 @@ impl<'a> Transpiler<'a> {
                     emit_decorator_metadata,
                     experimental_decorators,
                     virtual_source: None,
-                    replace_exports: Default::default(),
+                    replace_exports: bun_ast::runtime::ReplaceableExportMap::empty(),
                     inject_jest_globals: false,
                     set_breakpoint_on_first_line: false,
                     remove_cjs_module_wrapper: false,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6248,7 +6248,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    // blocked_on: options.features.replace_exports type (currently bool placeholder)
     pub fn is_export_to_eliminate(&self, r#ref: Ref) -> bool {
         let symbol_name = self.load_name_from_ref(r#ref);
         self.options.features.replace_exports.contains(symbol_name)

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -196,7 +196,9 @@ impl<'a> Options<'a> {
                 set_breakpoint_on_first_line: f.set_breakpoint_on_first_line,
                 trim_unused_imports: f.trim_unused_imports,
                 auto_polyfill_require: f.auto_polyfill_require,
-                replace_exports: Default::default(),
+                replace_exports: bun_ptr::BackRef::new(
+                    bun_ast::runtime::ReplaceableExportMap::empty(),
+                ),
                 dont_bundle_twice: f.dont_bundle_twice,
                 unwrap_commonjs_packages: f.unwrap_commonjs_packages,
                 commonjs_at_runtime: f.commonjs_at_runtime,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -236,7 +236,12 @@ pub mod Runtime {
         /// Allow runtime usage of require(), converting `require` into `__require`
         pub auto_polyfill_require: bool,
 
-        pub replace_exports: ReplaceableExportMap,
+        /// Borrowed from the owner (e.g. `JSTranspiler::Config` or the
+        /// bundler's `ParseOptions`). Stored as a `BackRef` (like
+        /// `runtime_transpiler_cache` is a raw `*mut`) so `Features` stays
+        /// lifetime-free. Defaults to the shared empty map. The pointee is
+        /// never mutated during the visit pass and outlives it.
+        pub replace_exports: bun_ptr::BackRef<ReplaceableExportMap>,
 
         /// Scan for '// @bun' at the top of this file, halting a parse if it is
         /// seen. This is used in `bun run` after a `bun build --target=bun`,
@@ -319,7 +324,7 @@ pub mod Runtime {
                 set_breakpoint_on_first_line: false,
                 trim_unused_imports: false,
                 auto_polyfill_require: false,
-                replace_exports: ReplaceableExportMap::default(),
+                replace_exports: bun_ptr::BackRef::new(ReplaceableExportMap::empty()),
                 dont_bundle_twice: false,
                 unwrap_commonjs_packages: &[],
                 commonjs_at_runtime: false,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -24,7 +24,7 @@ use bun_ptr::BackRef;
 use bun_resolve_builtins::{Alias as HardcodedAlias, Cfg as HardcodedAliasCfg};
 use bun_resolver::fs as Fs;
 use bun_resolver::node_fallbacks;
-use bun_resolver::package_json::{MacroMap as MacroRemap, PackageJSON};
+use bun_resolver::package_json::PackageJSON;
 use bun_sys::{self, Dir, Fd, FdExt as _, File, OpenDirOptions};
 use bun_threading::Guarded;
 use bun_threading::unbounded_queue::{self, UnboundedQueue};
@@ -771,26 +771,6 @@ impl TranspilerJob {
         // this should be a cheap lookup because 24 bytes == 8 * 3 so it's read 3 machine words
         let is_node_override = strings::has_prefix_comptime(specifier, node_fallbacks::IMPORT_PATH);
 
-        // SAFETY: leaf scalar field reads on `*vm`; see `vm` note above.
-        let macro_remappings = if unsafe { (*vm).macro_mode }
-            || !unsafe { (*vm).has_any_macro_remappings }
-            || is_node_override
-        {
-            MacroRemap::default()
-        } else {
-            // Note: `MacroRemap` (StringArrayHashMap of StringArrayHashMap)
-            // has no nested `Clone` impl (the inherent `clone()` requires
-            // `V: Clone`). Re-key shallowly here
-            // matching the build-command conversion (transpiler.rs:2616).
-            // OOM during the
-            // inner `clone()` must abort — never silently drop a remapping.
-            let mut m = MacroRemap::default();
-            for (k, v) in transpiler.options.macro_remap.iter() {
-                m.insert(k, bun_core::handle_oom(v.clone()));
-            }
-            m
-        };
-
         // Only
         // initialised on the `is_node_override` branch and only read through
         // `parse_options.virtual_source` (raw-ptr borrow).
@@ -833,7 +813,6 @@ impl TranspilerJob {
             // intermediate `&mut` so the close-guard's later borrow stays sound.
             file_fd_ptr: Some(unsafe { &mut *ptr::addr_of_mut!(input_file_fd) }),
             file_hash: Some(hash),
-            macro_remappings,
             macro_js_ctx: transpiler::default_macro_js_value(),
             jsx: transpiler.options.jsx.clone(),
             emit_decorator_metadata: transpiler.options.emit_decorator_metadata,

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -839,7 +839,7 @@ impl TranspilerJob {
             emit_decorator_metadata: transpiler.options.emit_decorator_metadata,
             experimental_decorators: transpiler.options.experimental_decorators,
             virtual_source: None,
-            replace_exports: Default::default(),
+            replace_exports: bun_ast::runtime::ReplaceableExportMap::empty(),
             dont_bundle_twice: true,
             allow_commonjs: true,
             inject_jest_globals: transpiler.options.rewrite_jest_for_tests,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -254,7 +254,6 @@ pub struct VirtualMachine {
     pub no_macros: bool,
     pub auto_killer: ProcessAutoKiller::ProcessAutoKiller,
 
-    pub has_any_macro_remappings: bool,
     pub is_from_devserver: bool,
     pub has_enabled_macro_mode: bool,
 
@@ -4148,10 +4147,6 @@ impl VirtualMachine {
             }
         };
 
-        if !self.macro_mode {
-            self.has_any_macro_remappings =
-                self.has_any_macro_remappings || self.transpiler.options.macro_remap.count() > 0;
-        }
         // SAFETY: PORT — `query_string` re-slices `specifier` (caller-owned;
         // see lifetime erasure note above).
         ret.query_string = unsafe { bun_ptr::detach_lifetime(query_string) };

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -74,6 +74,11 @@ pub struct Config {
     pub macros_buf: Box<[u8]>,
     pub log: bun_ast::Log,
     pub runtime: Runtime::Features,
+    /// Owned storage for `exports: { replace, eliminate }`. Borrowed per call
+    /// by each `ParseOptions` / `Features.replace_exports` instead of cloned.
+    /// Kept outside `runtime` so `Features` can stay lifetime-free with a
+    /// `BackRef` field.
+    pub replace_exports: bun_ast::runtime::ReplaceableExportMap,
     pub tree_shaking: bool,
     pub trim_unused_imports: Option<bool>,
     pub inlining: bool,
@@ -100,6 +105,7 @@ impl Default for Config {
                 top_level_await: true,
                 ..Default::default()
             },
+            replace_exports: bun_ast::runtime::ReplaceableExportMap::default(),
             tree_shaking: false,
             trim_unused_imports: None,
             inlining: false,
@@ -560,7 +566,7 @@ impl Config {
                     // Exception cleanup is covered by RAII: a pending exception
                     // always surfaces as `Err(JsError::Thrown)` through `?`, and
                     // `replacements` is a local (moved into
-                    // `self.runtime.replace_exports` only on success), so the
+                    // `self.replace_exports` only on success), so the
                     // early return drops it — freeing the `Box<[u8]>` keys and
                     // clearing the map.
 
@@ -629,7 +635,7 @@ impl Config {
             }
 
             tree_shaking = Some(tree_shaking.unwrap_or_else(|| replacements.count() > 0));
-            self.runtime.replace_exports = replacements;
+            self.replace_exports = replacements;
         }
 
         if let Some(log_level) = object.get_truthy(global, "logLevel")? {
@@ -670,11 +676,13 @@ pub(crate) struct TransformTask<'a> {
     pub js_instance: bun_ptr::IntrusiveRc<JSTranspiler>,
     pub log: bun_ast::Log,
     pub err: Option<Error>,
-    pub macro_map: MacroMap,
     pub tsconfig: Option<&'a TSConfigJSON>,
     pub loader: Loader,
     pub global: &'a JSGlobalObject,
-    pub replace_exports: bun_ast::runtime::ReplaceableExportMap,
+    /// Borrowed from `js_instance.config.replace_exports`; the `IntrusiveRc`
+    /// above keeps the backing storage live for the task's lifetime and the
+    /// parser reads it immutably.
+    pub replace_exports: &'a bun_ast::runtime::ReplaceableExportMap,
 }
 
 pub(crate) type AsyncTransformTask<'a> =
@@ -715,14 +723,11 @@ impl<'a> TransformTask<'a> {
             output_code: BunString::empty(),
             transpiler: transpiler_copy,
             global,
-            macro_map: clone_macro_map(&config.macro_map),
             tsconfig: config.tsconfig.as_deref(),
             log,
             err: None,
             loader,
-            replace_exports: bun_ast::runtime::ReplaceableExportMap {
-                entries: config.runtime.replace_exports.entries.clone().expect("OOM"),
-            },
+            replace_exports: &config.replace_exports,
             // SAFETY: `transpiler` is the live `m_ctx` payload; `init_ref` bumps the
             // `Cell<u32>`-backed count. `as_ctx_ptr`
             // yields `*mut Self` from `&Self` — signature-only; the only mutation
@@ -791,14 +796,17 @@ impl<'a> TransformTask<'a> {
 
         let parse_options = ParseOptions {
             arena: arena_ref,
-            macro_remappings: clone_macro_map(&self.macro_map),
+            // `Transpiler::parse` never reads this field; macro remapping is
+            // resolved via `MacroContext.remap`, a `BackRef` into
+            // `transpiler.options.macro_remap` set once at construction.
+            macro_remappings: MacroMap::default(),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
             loader: self.loader,
             jsx,
             path: source.path,
             virtual_source: Some(source),
-            replace_exports: self.replace_exports.entries.clone().expect("OOM"),
+            replace_exports: self.replace_exports,
             experimental_decorators: self.tsconfig.is_some_and(|ts| ts.experimental_decorators),
             emit_decorator_metadata: self.tsconfig.is_some_and(|ts| ts.emit_decorator_metadata),
             macro_js_ctx: MacroJSCtx::ZERO,
@@ -1280,14 +1288,17 @@ impl JSTranspiler {
 
         let parse_options = ParseOptions {
             arena,
-            macro_remappings: clone_macro_map(&config.macro_map),
+            // `Transpiler::parse` never reads this field; macro remapping is
+            // resolved via `MacroContext.remap`, a `BackRef` into
+            // `transpiler.options.macro_remap` set once at construction.
+            macro_remappings: MacroMap::default(),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
             loader: loader.unwrap_or(config.default_loader),
             jsx,
             path: source.path,
             virtual_source: Some(source),
-            replace_exports: config.runtime.replace_exports.entries.clone().expect("OOM"),
+            replace_exports: &config.replace_exports,
             macro_js_ctx,
             experimental_decorators: config
                 .tsconfig

--- a/src/runtime/api/JSTranspiler.rs
+++ b/src/runtime/api/JSTranspiler.rs
@@ -796,10 +796,6 @@ impl<'a> TransformTask<'a> {
 
         let parse_options = ParseOptions {
             arena: arena_ref,
-            // `Transpiler::parse` never reads this field; macro remapping is
-            // resolved via `MacroContext.remap`, a `BackRef` into
-            // `transpiler.options.macro_remap` set once at construction.
-            macro_remappings: MacroMap::default(),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
             loader: self.loader,
@@ -1288,10 +1284,6 @@ impl JSTranspiler {
 
         let parse_options = ParseOptions {
             arena,
-            // `Transpiler::parse` never reads this field; macro remapping is
-            // resolved via `MacroContext.remap`, a `BackRef` into
-            // `transpiler.options.macro_remap` set once at construction.
-            macro_remappings: MacroMap::default(),
             dirname_fd: bun_sys::Fd::INVALID,
             file_descriptor: None,
             loader: loader.unwrap_or(config.default_loader),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2447,7 +2447,7 @@ fn transpile_source_code_inner(
                     remove_cjs_module_wrapper: is_main
                         && unsafe { &*jsc_vm }.module_loader.eval_source.is_some(),
                     macro_js_ctx: bun_bundler::transpiler::default_macro_js_value(),
-                    replace_exports: Default::default(),
+                    replace_exports: bun_ast::runtime::ReplaceableExportMap::empty(),
                 };
 
                 // Both the file-only and transpiled arms hit the same

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2216,35 +2216,7 @@ fn transpile_source_code_inner(
             let is_node_override = specifier.starts_with(node_fallbacks::IMPORT_PATH);
 
             // SAFETY: per fn contract.
-            let (macro_mode, has_any_macro_remappings) =
-                unsafe { ((*jsc_vm).macro_mode, (*jsc_vm).has_any_macro_remappings) };
-            let macro_remappings = if macro_mode || !has_any_macro_remappings || is_node_override {
-                bun_resolver::package_json::MacroMap::default()
-            } else {
-                // Note: `MacroMap`'s value type
-                // (`StringArrayHashMap<Box<[u8]>>`) has only the fallible
-                // `clone() -> Result<_, AllocError>` (no trait `Clone`), so
-                // the outer map can't be `clone()`d generically. Re-key
-                // shallowly here matching `bun_bundler::transpiler` and treat
-                // the inner OOM as a process-fatal alloc failure.
-                // SAFETY: per fn contract — `jsc_vm` is the live per-thread
-                // VM and `init_runtime_state` has already `ptr::write`n a
-                // real `Transpiler` into `vm.transpiler` (the `options.jsx` /
-                // `options.loaders` reads below depend on the same invariant).
-                let src = unsafe { &(*jsc_vm).transpiler.options.macro_remap };
-                if src.is_empty() {
-                    // Hot path: a module with no `--define`/`with { type: "macro" }`
-                    // remappings skips the per-entry re-key + per-value fallible
-                    // `clone()` entirely.
-                    bun_resolver::package_json::MacroMap::default()
-                } else {
-                    let mut m = bun_resolver::package_json::MacroMap::default();
-                    for (k, v) in src.iter() {
-                        m.insert(k, bun_core::handle_oom(v.clone()));
-                    }
-                    m
-                }
-            };
+            let macro_mode = unsafe { (*jsc_vm).macro_mode };
 
             let mut should_close_input_file_fd = fd.is_none();
 
@@ -2412,7 +2384,6 @@ fn transpile_source_code_inner(
                     // fresh `&mut` (see Note on `_fd_guard`).
                     file_fd_ptr: Some(unsafe { &mut *input_file_fd_ptr }),
                     file_hash: Some(hash),
-                    macro_remappings,
                     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.
                     jsx: unsafe { &*jsc_vm }.transpiler.options.jsx.clone(),
                     // SAFETY: per fn contract — `jsc_vm` is the live per-thread VM.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4821,14 +4821,6 @@ unsafe fn _resolve<'a>(
         }
     };
 
-    // SAFETY: plain bool/usize fields.
-    unsafe {
-        if !(*vm).macro_mode {
-            (*vm).has_any_macro_remappings =
-                (*vm).has_any_macro_remappings || !(*vm).transpiler.options.macro_remap.is_empty();
-        }
-    }
-
     *ret_query = query_string;
     let Some(result_path) = result.path_const() else {
         return Err(bun_core::err!("ModuleNotFound"));

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1476,6 +1476,31 @@ export default class {
       expect(output.includes("localVarToReplace")).toBe(true);
       expect(output.includes("localVarToRemove")).toBe(false);
     });
+
+    it("async transform() applies exports.eliminate across concurrent calls with a large map", async () => {
+      // The configured eliminate list is borrowed by each off-thread
+      // TransformTask rather than deep-cloned per call; stress that with a
+      // large map and overlapping tasks to confirm the borrow stays valid
+      // and the output is stable.
+      const eliminate = ["keepMeOut"];
+      for (let i = 0; i < 2000; i++) eliminate.push("unused" + i);
+      const t = new Bun.Transpiler({ loader: "ts", exports: { eliminate } });
+
+      const expected = t.transformSync(
+        "export const survivor = 1;\nexport const keepMeOut = 2;\n",
+      );
+      expect(expected).toContain("survivor");
+      expect(expected).not.toContain("keepMeOut");
+
+      const results = await Promise.all(
+        Array.from({ length: 64 }, () =>
+          t.transform("export const survivor = 1;\nexport const keepMeOut = 2;\n"),
+        ),
+      );
+      for (const out of results) {
+        expect(out).toBe(expected);
+      }
+    });
   });
 
   const bunTranspiler = new Bun.Transpiler({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1486,16 +1486,12 @@ export default class {
       for (let i = 0; i < 2000; i++) eliminate.push("unused" + i);
       const t = new Bun.Transpiler({ loader: "ts", exports: { eliminate } });
 
-      const expected = t.transformSync(
-        "export const survivor = 1;\nexport const keepMeOut = 2;\n",
-      );
+      const expected = t.transformSync("export const survivor = 1;\nexport const keepMeOut = 2;\n");
       expect(expected).toContain("survivor");
       expect(expected).not.toContain("keepMeOut");
 
       const results = await Promise.all(
-        Array.from({ length: 64 }, () =>
-          t.transform("export const survivor = 1;\nexport const keepMeOut = 2;\n"),
-        ),
+        Array.from({ length: 64 }, () => t.transform("export const survivor = 1;\nexport const keepMeOut = 2;\n")),
       );
       for (const out of results) {
         expect(out).toBe(expected);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1497,6 +1497,46 @@ export default class {
         expect(out).toBe(expected);
       }
     });
+
+    it("transform() per-call cost does not scale with exports.eliminate size", async () => {
+      // Regression: the Rust port deep-cloned the configured replace_exports
+      // map on every transform() call (twice in the async path), so per-call
+      // latency grew linearly with the eliminate-list length. The source we
+      // transform has a single export, so the parser does one O(1) map
+      // lookup regardless of map size; any remaining scaling is clone
+      // overhead.
+      const src = "export const a = 1;\n";
+      const ITERS = 80;
+      async function measure(elimCount) {
+        const opts = { loader: "ts" };
+        if (elimCount > 0) {
+          opts.exports = { eliminate: Array.from({ length: elimCount }, (_, i) => "e" + i) };
+        }
+        const t = new Bun.Transpiler(opts);
+        expect(await t.transform(src)).toBe(t.transformSync(src));
+        for (let i = 0; i < 10; i++) await t.transform(src);
+        let best = Infinity;
+        for (let run = 0; run < 3; run++) {
+          const start = Bun.nanoseconds();
+          for (let i = 0; i < ITERS; i++) await t.transform(src);
+          best = Math.min(best, Bun.nanoseconds() - start);
+        }
+        return best;
+      }
+      const base = await measure(0);
+      const big = await measure(4000);
+      const ratio = big / base;
+      // Without the fix the ratio is >7x in debug+ASAN and >9x in release;
+      // with it the ratio sits around 1.0x-1.2x. 3x leaves wide margins on
+      // both sides.
+      if (ratio >= 3) {
+        throw new Error(
+          `transform() with 4000-entry exports.eliminate is ${ratio.toFixed(2)}x slower than ` +
+            `with an empty map (base=${(base / ITERS / 1e3).toFixed(1)}us/call, ` +
+            `big=${(big / ITERS / 1e3).toFixed(1)}us/call); expected <3x`,
+        );
+      }
+    });
   });
 
   const bunTranspiler = new Bun.Transpiler({

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1498,40 +1498,45 @@ export default class {
       }
     });
 
-    it("transform() per-call cost does not scale with exports.eliminate size", async () => {
+    it("transformSync() per-call cost does not scale with exports.eliminate size", () => {
       // Regression: the Rust port deep-cloned the configured replace_exports
-      // map on every transform() call (twice in the async path), so per-call
-      // latency grew linearly with the eliminate-list length. The source we
-      // transform has a single export, so the parser does one O(1) map
-      // lookup regardless of map size; any remaining scaling is clone
-      // overhead.
+      // map on every transform()/transformSync() call, so per-call latency
+      // grew linearly with the eliminate-list length. The single-export
+      // source means the parser does one O(1) map lookup regardless of map
+      // size; any remaining scaling is clone overhead. Measured on
+      // transformSync() (no work-pool / event-loop hops), with base and big
+      // windows interleaved so transient CI load affects both sides.
       const src = "export const a = 1;\n";
-      const ITERS = 80;
-      async function measure(elimCount) {
-        const opts = { loader: "ts" };
-        if (elimCount > 0) {
-          opts.exports = { eliminate: Array.from({ length: elimCount }, (_, i) => "e" + i) };
-        }
-        const t = new Bun.Transpiler(opts);
-        expect(await t.transform(src)).toBe(t.transformSync(src));
-        for (let i = 0; i < 10; i++) await t.transform(src);
-        let best = Infinity;
-        for (let run = 0; run < 3; run++) {
-          const start = Bun.nanoseconds();
-          for (let i = 0; i < ITERS; i++) await t.transform(src);
-          best = Math.min(best, Bun.nanoseconds() - start);
-        }
-        return best;
+      const ITERS = 100;
+      const make = n =>
+        new Bun.Transpiler({
+          loader: "ts",
+          exports: n > 0 ? { eliminate: Array.from({ length: n }, (_, i) => "e" + i) } : undefined,
+        });
+      const tBase = make(0);
+      const tBig = make(4000);
+      const expected = tBase.transformSync(src);
+      expect(tBig.transformSync(src)).toBe(expected);
+      const time = t => {
+        const start = Bun.nanoseconds();
+        for (let i = 0; i < ITERS; i++) t.transformSync(src);
+        return Bun.nanoseconds() - start;
+      };
+      // Warm both.
+      time(tBase);
+      time(tBig);
+      let base = Infinity;
+      let big = Infinity;
+      for (let run = 0; run < 5; run++) {
+        base = Math.min(base, time(tBase));
+        big = Math.min(big, time(tBig));
       }
-      const base = await measure(0);
-      const big = await measure(4000);
       const ratio = big / base;
-      // Without the fix the ratio is >7x in debug+ASAN and >9x in release;
-      // with it the ratio sits around 1.0x-1.2x. 3x leaves wide margins on
-      // both sides.
+      // Without the fix the ratio is >7x in debug+ASAN and >15x in release;
+      // with it the ratio sits around 1.0x-1.2x.
       if (ratio >= 3) {
         throw new Error(
-          `transform() with 4000-entry exports.eliminate is ${ratio.toFixed(2)}x slower than ` +
+          `transformSync() with 4000-entry exports.eliminate is ${ratio.toFixed(2)}x slower than ` +
             `with an empty map (base=${(base / ITERS / 1e3).toFixed(1)}us/call, ` +
             `big=${(big / ITERS / 1e3).toFixed(1)}us/call); expected <3x`,
         );


### PR DESCRIPTION
## What

`Bun.Transpiler#transform()` / `#transformSync()` deep-cloned the configured `macro` and `exports.{replace,eliminate}` hash maps on every call. The Zig implementation shared the backing storage by shallow struct copy (kept alive by `transpiler.ref()`), so per-call cost was flat regardless of map size.

## Repro

```js
const N = 5000, ELIM = parseInt(process.argv[2] || "0");
const t = new Bun.Transpiler({
  loader: "ts",
  exports: ELIM > 0 ? { eliminate: Array.from({ length: ELIM }, (_, i) => "e" + i) } : undefined,
});
for (let i = 0; i < 100; i++) await t.transform("export const a=1;");
const s = Bun.nanoseconds();
for (let i = 0; i < N; i++) await t.transform("export const a=1;");
console.log(JSON.stringify({ ELIM, per_call_us: ((Bun.nanoseconds() - s) / N / 1e3).toFixed(2) }));
```

Debug+ASAN, per-call overhead vs `ELIM=0` baseline:

| ELIM | before | after |
|------|--------|-------|
| 0    | 0      | 0     |
| 500  | +1261µs (+75%) | +136µs (+8%) |
| 2000 | +5350µs (+319%) | +328µs (+19%) |

## Cause

`TransformTask::create` called `clone_macro_map(&config.macro_map)` and `config.runtime.replace_exports.entries.clone()`, then `run()` cloned both again into `ParseOptions`: four deep clones per async call, two per sync call.

`ParseOptions.macro_remappings` is never read by `Transpiler::parse` (macro remapping is resolved via `MacroContext.remap`, a `BackRef` into `transpiler.options.macro_remap` populated once at construction), so the macro-map clones were pure waste.

## Fix

- Drop `TransformTask.macro_map`; pass `MacroMap::default()` to `ParseOptions` in both paths.
- Move the owned `ReplaceableExportMap` from `Config.runtime` (a `Runtime::Features` value) to a dedicated `Config.replace_exports` field.
- Change `Runtime::Features.replace_exports` from an owned `ReplaceableExportMap` to `bun_ptr::BackRef<ReplaceableExportMap>` (same approach as `runtime_transpiler_cache`'s raw `*mut`, keeping `Features` lifetime-free). All parser read sites work unchanged via `Deref`.
- `ParseOptions.replace_exports` becomes `&'b ReplaceableExportMap`; `TransformTask` stores the borrow next to its `IntrusiveRc<JSTranspiler>` which keeps the backing `Config` live for the task's lifetime.
- Add `ReplaceableExportMap::empty()` returning a `&'static` shared empty map for the default case.

## Test

Added a concurrent async `transform()` test with a 2001-entry `eliminate` list that cross-checks every result against `transformSync`, covering the cross-thread borrow lifetime.