### PR TITLE
dgram: add Socket.prototype.bindSync()

### DIFF
--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -389,11 +389,23 @@ Socket.prototype.bindSync = function (options) {
     address = this.type === "udp4" ? "0.0.0.0" : "::";
   } else {
     validateString(address, "options.address");
-    if (isIP(address) === 0) {
+    const ipType = isIP(address);
+    if (ipType === 0) {
       throw $ERR_INVALID_ARG_VALUE(
         "options.address",
         address,
         "must be a numeric IP address; bindSync does not perform DNS resolution",
+      );
+    }
+    // Bun.udpSocket infers the address family from the hostname; Node's
+    // handle has a fixed family and rejects a mismatch with EINVAL at bind
+    // time. Reject here so a udp4 socket can't silently bind to an IPv6
+    // address (or vice versa).
+    if (ipType !== (this.type === "udp4" ? 4 : 6)) {
+      throw $ERR_INVALID_ARG_VALUE(
+        "options.address",
+        address,
+        `must be an ${this.type === "udp4" ? "IPv4" : "IPv6"} address for a ${this.type} socket`,
       );
     }
   }

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -49,6 +49,7 @@ const {
   validateString,
   validateNumber,
   validateFunction,
+  validateObject,
   validatePort,
   validateAbortSignal,
 } = require("internal/validators");
@@ -358,6 +359,89 @@ Socket.prototype.bind = function (port_, address_ /* , callback */) {
   });
 
   return this;
+};
+
+function emitListeningNT(self) {
+  // Ensure the socket was not closed before the next tick.
+  if (self[kStateSymbol].handle) self.emit("listening");
+}
+
+// Synchronous counterpart of bind(). bind(2) is a local, non-blocking system
+// call, so this binds inline and returns the resolved address (including the
+// OS-assigned ephemeral port when port is 0), throwing synchronously on bind
+// errors such as EADDRINUSE. The address must be a numeric IP literal:
+// asynchronous name resolution is the only genuinely blocking part of bind(),
+// so callers resolve names separately. Message delivery stays asynchronous
+// ('message' events flow as usual); the 'listening' event is emitted on the
+// next tick.
+Socket.prototype.bindSync = function (options) {
+  healthCheck(this);
+  if (options !== undefined) validateObject(options, "options");
+  const state = this[kStateSymbol];
+
+  if (state.bindState !== BIND_STATE_UNBOUND) throw $ERR_SOCKET_ALREADY_BOUND();
+
+  // Validate arguments before mutating state so a bad argument leaves the
+  // socket unbound and reusable.
+  const port = validatePort(options?.port ?? 0, "options.port");
+  let address = options?.address;
+  if (!address) {
+    address = this.type === "udp4" ? "0.0.0.0" : "::";
+  } else {
+    validateString(address, "options.address");
+    if (isIP(address) === 0) {
+      throw $ERR_INVALID_ARG_VALUE(
+        "options.address",
+        address,
+        "must be a numeric IP address; bindSync does not perform DNS resolution",
+      );
+    }
+  }
+
+  state.bindState = BIND_STATE_BINDING;
+
+  let flags = uSockets.LISTEN_DISALLOW_REUSE_PORT_FAILURE;
+  if (state.reuseAddr) flags |= uSockets.LISTEN_REUSE_ADDR;
+  if (state.ipv6Only) flags |= uSockets.SOCKET_IPV6_ONLY;
+  if (state.reusePort) flags |= uSockets.LISTEN_REUSE_PORT;
+
+  const family = this.type === "udp4" ? "IPv4" : "IPv6";
+  let socket;
+  try {
+    socket = Bun.udpSocket({
+      hostname: address,
+      port: port || 0,
+      flags,
+      sync: true,
+      socket: {
+        data: (_socket, data, port, addr) => {
+          this.emit("message", data, {
+            port: port,
+            address: addr,
+            size: data.length,
+            family,
+          });
+        },
+        error: err => {
+          this.emit("error", err);
+        },
+      },
+    });
+  } catch (err) {
+    state.bindState = BIND_STATE_UNBOUND;
+    throw err;
+  }
+
+  if (state.unrefOnBind) {
+    socket.unref();
+    state.unrefOnBind = false;
+  }
+  state.handle.socket = socket;
+  state.receiving = true;
+  state.bindState = BIND_STATE_BOUND;
+
+  process.nextTick(emitListeningNT, this);
+  return this.address();
 };
 
 Socket.prototype.connect = function (port, address, callback) {

--- a/src/js/node/dgram.ts
+++ b/src/js/node/dgram.ts
@@ -378,6 +378,8 @@ Socket.prototype.bindSync = function (options) {
   healthCheck(this);
   if (options !== undefined) validateObject(options, "options");
   const state = this[kStateSymbol];
+  const type = this.type;
+  const udp4 = type === "udp4";
 
   if (state.bindState !== BIND_STATE_UNBOUND) throw $ERR_SOCKET_ALREADY_BOUND();
 
@@ -386,7 +388,7 @@ Socket.prototype.bindSync = function (options) {
   const port = validatePort(options?.port ?? 0, "options.port");
   let address = options?.address;
   if (!address) {
-    address = this.type === "udp4" ? "0.0.0.0" : "::";
+    address = udp4 ? "0.0.0.0" : "::";
   } else {
     validateString(address, "options.address");
     const ipType = isIP(address);
@@ -401,11 +403,11 @@ Socket.prototype.bindSync = function (options) {
     // handle has a fixed family and rejects a mismatch with EINVAL at bind
     // time. Reject here so a udp4 socket can't silently bind to an IPv6
     // address (or vice versa).
-    if (ipType !== (this.type === "udp4" ? 4 : 6)) {
+    if (ipType !== (udp4 ? 4 : 6)) {
       throw $ERR_INVALID_ARG_VALUE(
         "options.address",
         address,
-        `must be an ${this.type === "udp4" ? "IPv4" : "IPv6"} address for a ${this.type} socket`,
+        `must be an ${udp4 ? "IPv4" : "IPv6"} address for a ${type} socket`,
       );
     }
   }
@@ -417,7 +419,7 @@ Socket.prototype.bindSync = function (options) {
   if (state.ipv6Only) flags |= uSockets.SOCKET_IPV6_ONLY;
   if (state.reusePort) flags |= uSockets.LISTEN_REUSE_PORT;
 
-  const family = this.type === "udp4" ? "IPv4" : "IPv6";
+  const family = udp4 ? "IPv4" : "IPv6";
   let socket;
   try {
     socket = Bun.udpSocket({

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -624,7 +624,11 @@ impl UDPSocket {
                     dest: BunString::empty(),
                 };
                 let error_value = sys_err.to_error_instance(global_this);
-                error_value.put(global_this, b"syscall", BunString::static_("bind").to_js(global_this)?);
+                error_value.put(
+                    global_this,
+                    b"syscall",
+                    BunString::static_("bind").to_js(global_this)?,
+                );
                 error_value.put(global_this, b"address", config.hostname.to_js(global_this)?);
                 error_value.put(global_this, b"port", JSValue::js_number(config.port as f64));
 

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -623,17 +623,12 @@ impl UDPSocket {
                     code: BunString::static_(code),
                     message,
                     path: BunString::empty(),
-                    syscall: BunString::empty(),
+                    syscall: BunString::static_("bind"),
                     hostname: BunString::empty(),
                     fd: c_int::MIN,
                     dest: BunString::empty(),
                 };
                 let error_value = sys_err.to_error_instance(global_this);
-                error_value.put(
-                    global_this,
-                    b"syscall",
-                    BunString::static_("bind").to_js(global_this)?,
-                );
                 error_value.put(global_this, b"address", config.hostname.to_js(global_this)?);
                 // Node's ExceptionWithHostPort only sets `port` when it's > 0;
                 // test-dgram-error-message-address.js asserts `e.port === undefined`

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -610,13 +610,18 @@ impl UDPSocket {
                 let code: &'static str = SystemErrno::init(err as i64)
                     .map(Into::into)
                     .unwrap_or("UNKNOWN");
+                let message = if config.port > 0 {
+                    BunString::create_format(format_args!(
+                        "bind {} {}:{}",
+                        code, config.hostname, config.port
+                    ))
+                } else {
+                    BunString::create_format(format_args!("bind {} {}", code, config.hostname))
+                };
                 let sys_err = SystemError {
                     errno: err,
                     code: BunString::static_(code),
-                    message: BunString::create_format(format_args!(
-                        "bind {} {}",
-                        code, config.hostname
-                    )),
+                    message,
                     path: BunString::empty(),
                     syscall: BunString::empty(),
                     hostname: BunString::empty(),
@@ -630,7 +635,12 @@ impl UDPSocket {
                     BunString::static_("bind").to_js(global_this)?,
                 );
                 error_value.put(global_this, b"address", config.hostname.to_js(global_this)?);
-                error_value.put(global_this, b"port", JSValue::js_number(config.port as f64));
+                // Node's ExceptionWithHostPort only sets `port` when it's > 0;
+                // test-dgram-error-message-address.js asserts `e.port === undefined`
+                // for a port-0 bind failure.
+                if config.port > 0 {
+                    error_value.put(global_this, b"port", JSValue::js_number(config.port as f64));
+                }
 
                 return Err(global_this.throw_value(error_value));
             }

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -506,6 +506,17 @@ impl UDPSocket {
     pub fn udp_socket(global_this: &JSGlobalObject, options: JSValue) -> JsResult<JSValue> {
         bun_output::scoped_log!(UdpSocket, "udpSocket");
 
+        // node:dgram's `bindSync()` needs the bound socket synchronously. The
+        // bind itself is already synchronous; this only skips the
+        // resolved-Promise wrap on return.
+        let sync = if options.is_object() {
+            options
+                .get_boolean_loose(global_this, "sync")?
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
         let vm = global_this.bun_vm_ptr();
         let this_ptr = Self::new(Self {
             socket: Cell::new(None),
@@ -613,7 +624,9 @@ impl UDPSocket {
                     dest: BunString::empty(),
                 };
                 let error_value = sys_err.to_error_instance(global_this);
+                error_value.put(global_this, b"syscall", BunString::static_("bind").to_js(global_this)?);
                 error_value.put(global_this, b"address", config.hostname.to_js(global_this)?);
+                error_value.put(global_this, b"port", JSValue::js_number(config.port as f64));
 
                 return Err(global_this.throw_value(error_value));
             }
@@ -650,6 +663,9 @@ impl UDPSocket {
         scopeguard::ScopeGuard::into_inner(guard);
 
         this.poll_ref.with_mut(|p| p.ref_(bun_io::js_vm_ctx()));
+        if sync {
+            return Ok(this_value);
+        }
         Ok(bun_jsc::JSPromise::resolved_promise_value(
             global_this,
             this_value,

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -178,9 +178,7 @@ describe("Socket.prototype.bindSync", () => {
     const sock = dgram.createSocket("udp4");
     try {
       sock.bindSync({ port: 0 });
-      expect(() => sock.bindSync({ port: 0 })).toThrow(
-        expect.objectContaining({ code: "ERR_SOCKET_ALREADY_BOUND" }),
-      );
+      expect(() => sock.bindSync({ port: 0 })).toThrow(expect.objectContaining({ code: "ERR_SOCKET_ALREADY_BOUND" }));
     } finally {
       sock.close();
     }

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -139,7 +139,13 @@ describe("Socket.prototype.bindSync", () => {
     try {
       const addr = first.bindSync({ address: "127.0.0.1", port: 0 });
       expect(() => second.bindSync({ address: "127.0.0.1", port: addr.port })).toThrow(
-        expect.objectContaining({ code: "EADDRINUSE", syscall: "bind" }),
+        expect.objectContaining({
+          code: "EADDRINUSE",
+          syscall: "bind",
+          address: "127.0.0.1",
+          port: addr.port,
+          message: `bind EADDRINUSE 127.0.0.1:${addr.port}`,
+        }),
       );
     } finally {
       first.close();

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -164,6 +164,22 @@ describe("Socket.prototype.bindSync", () => {
     }
   });
 
+  it("rejects an address whose family does not match the socket type", () => {
+    const sock4 = dgram.createSocket("udp4");
+    const sock6 = dgram.createSocket("udp6");
+    try {
+      expect(() => sock4.bindSync({ address: "::1", port: 0 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+      expect(() => sock6.bindSync({ address: "127.0.0.1", port: 0 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+    } finally {
+      sock4.close();
+      sock6.close();
+    }
+  });
+
   it("rejects a non-string address", () => {
     const sock = dgram.createSocket("udp4");
     try {

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -61,28 +61,35 @@ describe("Socket.prototype.bindSync", () => {
   it("binds synchronously and returns the resolved address", async () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     const sock = dgram.createSocket("udp4");
-    const addr = sock.bindSync({ address: "127.0.0.1", port: 0 });
+    try {
+      const addr = sock.bindSync({ address: "127.0.0.1", port: 0 });
 
-    expect(addr.address).toBe("127.0.0.1");
-    expect(addr.family).toBe("IPv4");
-    expect(typeof addr.port).toBe("number");
-    expect(addr.port).toBeGreaterThan(0);
+      expect(addr.address).toBe("127.0.0.1");
+      expect(addr.family).toBe("IPv4");
+      expect(typeof addr.port).toBe("number");
+      expect(addr.port).toBeGreaterThan(0);
 
-    // address() is valid synchronously and matches the returned address.
-    expect(sock.address()).toEqual(addr);
+      // address() is valid synchronously and matches the returned address.
+      expect(sock.address()).toEqual(addr);
 
-    // The 'listening' event still fires on the next tick.
-    sock.on("error", reject);
-    sock.on("listening", () => sock.close(resolve));
-    await promise;
+      // The 'listening' event still fires on the next tick.
+      sock.on("error", reject);
+      sock.on("listening", resolve);
+      await promise;
+    } finally {
+      sock.close();
+    }
   });
 
   it("closing synchronously after bindSync() suppresses the deferred 'listening'", async () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     const sock = dgram.createSocket("udp4");
-    sock.bindSync({ port: 0 });
-    sock.on("listening", () => reject(new Error("'listening' should not fire after close()")));
-    sock.close(resolve);
+    try {
+      sock.bindSync({ port: 0 });
+      sock.on("listening", () => reject(new Error("'listening' should not fire after close()")));
+    } finally {
+      sock.close(resolve);
+    }
     await promise;
   });
 
@@ -101,23 +108,23 @@ describe("Socket.prototype.bindSync", () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     const receiver = dgram.createSocket("udp4");
     const sender = dgram.createSocket("udp4");
-    receiver.on("error", reject);
-    sender.on("error", reject);
-
-    const addr = receiver.bindSync({ address: "127.0.0.1", port: 0 });
-
-    receiver.on("message", msg => {
-      try {
-        expect(msg.toString()).toBe("hello");
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-
-    sender.send("hello", addr.port, "127.0.0.1");
-
     try {
+      receiver.on("error", reject);
+      sender.on("error", reject);
+
+      const addr = receiver.bindSync({ address: "127.0.0.1", port: 0 });
+
+      receiver.on("message", msg => {
+        try {
+          expect(msg.toString()).toBe("hello");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      sender.send("hello", addr.port, "127.0.0.1");
+
       await promise;
     } finally {
       receiver.close();
@@ -128,10 +135,9 @@ describe("Socket.prototype.bindSync", () => {
   // Windows binds the same UDP port twice without error for non-SO_EXCLUSIVEADDRUSE sockets.
   it.skipIf(isWindows)("throws synchronously on EADDRINUSE", () => {
     const first = dgram.createSocket("udp4");
-    const addr = first.bindSync({ address: "127.0.0.1", port: 0 });
-
     const second = dgram.createSocket("udp4");
     try {
+      const addr = first.bindSync({ address: "127.0.0.1", port: 0 });
       expect(() => second.bindSync({ address: "127.0.0.1", port: addr.port })).toThrow(
         expect.objectContaining({ code: "EADDRINUSE", syscall: "bind" }),
       );
@@ -209,27 +215,27 @@ describe("Socket.prototype.bindSync", () => {
     const { promise, resolve, reject } = Promise.withResolvers();
     const receiver = dgram.createSocket("udp6");
     const sender = dgram.createSocket("udp6");
-    receiver.on("error", reject);
-    sender.on("error", reject);
-
-    const addr = receiver.bindSync({ address: "::1", port: 0 });
-    expect(addr.address).toBe("::1");
-    expect(addr.family).toBe("IPv6");
-    expect(addr.port).toBeGreaterThan(0);
-    expect(receiver.address()).toEqual(addr);
-
-    receiver.on("message", msg => {
-      try {
-        expect(msg.toString()).toBe("hello");
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    });
-
-    sender.send("hello", addr.port, "::1");
-
     try {
+      receiver.on("error", reject);
+      sender.on("error", reject);
+
+      const addr = receiver.bindSync({ address: "::1", port: 0 });
+      expect(addr.address).toBe("::1");
+      expect(addr.family).toBe("IPv6");
+      expect(addr.port).toBeGreaterThan(0);
+      expect(receiver.address()).toEqual(addr);
+
+      receiver.on("message", msg => {
+        try {
+          expect(msg.toString()).toBe("hello");
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      });
+
+      sender.send("hello", addr.port, "::1");
+
       await promise;
     } finally {
       receiver.close();

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -249,13 +249,20 @@ describe("Socket.prototype.bindSync", () => {
     }
   });
 
-  it.skipIf(!isIPv6())("honors the ipv6Only flag", () => {
-    const sock = dgram.createSocket({ type: "udp6", ipv6Only: true });
+  // With IPV6_V6ONLY set, the v6 socket does not claim the v4 port, so a
+  // separate udp4 bind on the same port succeeds. Skipped on Windows where
+  // UDP port reuse semantics differ.
+  it.skipIf(!isIPv6() || isWindows)("honors the ipv6Only flag", () => {
+    const v6 = dgram.createSocket({ type: "udp6", ipv6Only: true });
+    const v4 = dgram.createSocket("udp4");
     try {
-      const addr = sock.bindSync({ address: "::", port: 0 });
-      expect(addr.family).toBe("IPv6");
+      const addr6 = v6.bindSync({ address: "::", port: 0 });
+      expect(addr6.family).toBe("IPv6");
+      const addr4 = v4.bindSync({ address: "127.0.0.1", port: addr6.port });
+      expect(addr4.port).toBe(addr6.port);
     } finally {
-      sock.close();
+      v6.close();
+      v4.close();
     }
   });
 });

--- a/test/js/node/dgram/node-dgram.test.js
+++ b/test/js/node/dgram/node-dgram.test.js
@@ -56,6 +56,200 @@ test("node:dgram close() inside 'message' handler stops remaining batch datagram
   expect(exitCode).toBe(0);
 });
 
+// https://github.com/nodejs/node/commit/723dd38882584f95b80f53a0baf1b9562bcee28c
+describe("Socket.prototype.bindSync", () => {
+  it("binds synchronously and returns the resolved address", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const sock = dgram.createSocket("udp4");
+    const addr = sock.bindSync({ address: "127.0.0.1", port: 0 });
+
+    expect(addr.address).toBe("127.0.0.1");
+    expect(addr.family).toBe("IPv4");
+    expect(typeof addr.port).toBe("number");
+    expect(addr.port).toBeGreaterThan(0);
+
+    // address() is valid synchronously and matches the returned address.
+    expect(sock.address()).toEqual(addr);
+
+    // The 'listening' event still fires on the next tick.
+    sock.on("error", reject);
+    sock.on("listening", () => sock.close(resolve));
+    await promise;
+  });
+
+  it("closing synchronously after bindSync() suppresses the deferred 'listening'", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const sock = dgram.createSocket("udp4");
+    sock.bindSync({ port: 0 });
+    sock.on("listening", () => reject(new Error("'listening' should not fire after close()")));
+    sock.close(resolve);
+    await promise;
+  });
+
+  it("defaults the address to the udp4 wildcard when omitted", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      const addr = sock.bindSync();
+      expect(addr.address).toBe("0.0.0.0");
+      expect(addr.port).toBeGreaterThan(0);
+    } finally {
+      sock.close();
+    }
+  });
+
+  it("'message' events still flow asynchronously after a synchronous bind", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const receiver = dgram.createSocket("udp4");
+    const sender = dgram.createSocket("udp4");
+    receiver.on("error", reject);
+    sender.on("error", reject);
+
+    const addr = receiver.bindSync({ address: "127.0.0.1", port: 0 });
+
+    receiver.on("message", msg => {
+      try {
+        expect(msg.toString()).toBe("hello");
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    sender.send("hello", addr.port, "127.0.0.1");
+
+    try {
+      await promise;
+    } finally {
+      receiver.close();
+      sender.close();
+    }
+  });
+
+  // Windows binds the same UDP port twice without error for non-SO_EXCLUSIVEADDRUSE sockets.
+  it.skipIf(isWindows)("throws synchronously on EADDRINUSE", () => {
+    const first = dgram.createSocket("udp4");
+    const addr = first.bindSync({ address: "127.0.0.1", port: 0 });
+
+    const second = dgram.createSocket("udp4");
+    try {
+      expect(() => second.bindSync({ address: "127.0.0.1", port: addr.port })).toThrow(
+        expect.objectContaining({ code: "EADDRINUSE", syscall: "bind" }),
+      );
+    } finally {
+      first.close();
+      second.close();
+    }
+  });
+
+  it("throws synchronously on a non-numeric address (no DNS resolution)", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      expect(() => sock.bindSync({ address: "localhost", port: 0 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE", name: "TypeError" }),
+      );
+    } finally {
+      sock.close();
+    }
+  });
+
+  it("rejects a non-string address", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      expect(() => sock.bindSync({ address: 12345 })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    } finally {
+      sock.close();
+    }
+  });
+
+  it("a rejected argument leaves the socket unbound and reusable", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      expect(() => sock.bindSync({ port: -1 })).toThrow(expect.objectContaining({ code: "ERR_SOCKET_BAD_PORT" }));
+      const addr = sock.bindSync({ port: 0 });
+      expect(addr.port).toBeGreaterThan(0);
+    } finally {
+      sock.close();
+    }
+  });
+
+  it("throws when already bound", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      sock.bindSync({ port: 0 });
+      expect(() => sock.bindSync({ port: 0 })).toThrow(
+        expect.objectContaining({ code: "ERR_SOCKET_ALREADY_BOUND" }),
+      );
+    } finally {
+      sock.close();
+    }
+  });
+
+  it("rejects a non-object options argument", () => {
+    const sock = dgram.createSocket("udp4");
+    try {
+      expect(() => sock.bindSync(0)).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+    } finally {
+      sock.close();
+    }
+  });
+
+  it.skipIf(!isIPv6())("udp6 wildcard default", () => {
+    const sock = dgram.createSocket("udp6");
+    try {
+      const addr = sock.bindSync();
+      expect(addr.address).toBe("::");
+      expect(addr.family).toBe("IPv6");
+      expect(addr.port).toBeGreaterThan(0);
+    } finally {
+      sock.close();
+    }
+  });
+
+  it.skipIf(!isIPv6())("udp6 loopback with an OS-assigned ephemeral port, and async 'message' flow", async () => {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const receiver = dgram.createSocket("udp6");
+    const sender = dgram.createSocket("udp6");
+    receiver.on("error", reject);
+    sender.on("error", reject);
+
+    const addr = receiver.bindSync({ address: "::1", port: 0 });
+    expect(addr.address).toBe("::1");
+    expect(addr.family).toBe("IPv6");
+    expect(addr.port).toBeGreaterThan(0);
+    expect(receiver.address()).toEqual(addr);
+
+    receiver.on("message", msg => {
+      try {
+        expect(msg.toString()).toBe("hello");
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    });
+
+    sender.send("hello", addr.port, "::1");
+
+    try {
+      await promise;
+    } finally {
+      receiver.close();
+      sender.close();
+    }
+  });
+
+  it.skipIf(!isIPv6())("honors the ipv6Only flag", () => {
+    const sock = dgram.createSocket({ type: "udp6", ipv6Only: true });
+    try {
+      const addr = sock.bindSync({ address: "::", port: 0 });
+      expect(addr.family).toBe("IPv6");
+    } finally {
+      sock.close();
+    }
+  });
+});
+
 describe.skipIf(!isIPv6())("node:dgram", () => {
   it("adds membership successfully (IPv6)", () => {
     const socket = makeSocket6();


### PR DESCRIPTION
Ports nodejs/node@723dd38882584f95b80f53a0baf1b9562bcee28c (nodejs/node#63838).

## What

Adds `dgram.Socket.prototype.bindSync([options])`, the synchronous counterpart of `bind()`.

```js
const dgram = require('node:dgram');

const socket = dgram.createSocket('udp4');
const address = socket.bindSync({ address: '0.0.0.0', port: 0 });
console.log(address); // e.g. { address: '0.0.0.0', family: 'IPv4', port: 53124 }
```

`bind(2)` is a local, non-blocking system call, so the bind is performed inline and the resolved address is returned immediately (including the OS-assigned ephemeral port when `port` is 0). A bind failure such as `EADDRINUSE` is thrown synchronously rather than emitted as an `'error'` event. After `bindSync()` returns, `socket.address()` is valid synchronously and the `'listening'` event is emitted on the next tick.

`address` must be a numeric IP literal; `bindSync()` never performs DNS resolution (asynchronous name resolution being the only genuinely blocking part of binding). Message delivery stays asynchronous via `'message'` events.

## How

`Bun.udpSocket()` already performs the bind synchronously and only wraps the result in an already-resolved Promise. This adds an internal `sync: true` option that skips the Promise wrap and returns the bound socket directly, so `bindSync()` can consume it without awaiting.

The native bind-error path now also attaches `syscall` and `port` to the thrown error so it matches Node's `ExceptionWithHostPort` shape (e.g. `{ code: 'EADDRINUSE', syscall: 'bind', address, port }`).

## Tests

13 new tests in `test/js/node/dgram/node-dgram.test.js` covering the cases from Node's `test-dgram-bind-sync.js`: basic sync bind + returned address, `address()` valid synchronously, deferred `'listening'`, close-before-next-tick suppressing `'listening'`, wildcard defaults (udp4/udp6), async message flow after sync bind (udp4/udp6), synchronous `EADDRINUSE` throw, `ERR_INVALID_ARG_VALUE` on non-numeric address, `ERR_INVALID_ARG_TYPE` on non-string address and non-object options, `ERR_SOCKET_BAD_PORT` leaving the socket reusable, `ERR_SOCKET_ALREADY_BOUND` on double bind, and `ipv6Only` honored.