### PR TITLE
Detect Build Tools-only Visual Studio installs in vs-shell.ps1

### DIFF
--- a/scripts/vs-shell.ps1
+++ b/scripts/vs-shell.ps1
@@ -15,7 +15,10 @@ if($env:VSINSTALLDIR -eq $null) {
     throw "Command not found: vswhere (did you install Visual Studio?)"
   }
 
-  $vsDir = (& $vswhere -prerelease -latest -property installationPath)
+  # -products * includes Build Tools (product id Microsoft.VisualStudio.Product.BuildTools);
+  # without it vswhere only returns Community/Professional/Enterprise and a Build Tools-only
+  # machine reports no install. See https://github.com/oven-sh/bun/issues/32374
+  $vsDir = (& $vswhere -prerelease -latest -products * -property installationPath)
   if ($vsDir -eq $null) {
     # Check common VS installation paths
     $searchPaths = @(

--- a/scripts/vs-shell.ps1
+++ b/scripts/vs-shell.ps1
@@ -15,10 +15,12 @@ if($env:VSINSTALLDIR -eq $null) {
     throw "Command not found: vswhere (did you install Visual Studio?)"
   }
 
-  # -products * includes Build Tools (product id Microsoft.VisualStudio.Product.BuildTools);
-  # without it vswhere only returns Community/Professional/Enterprise and a Build Tools-only
-  # machine reports no install. See https://github.com/oven-sh/bun/issues/32374
-  $vsDir = (& $vswhere -prerelease -latest -products * -property installationPath)
+  # vswhere defaults to the Community/Professional/Enterprise SKUs, so a Build Tools-only
+  # machine reports no install. -products * adds Build Tools (and every other SKU); -requires
+  # narrows back to installs that actually carry the MSVC toolchain, so a non-compiler SKU
+  # (TestAgent, TeamExplorer, ...) can't win -latest. See https://github.com/oven-sh/bun/issues/32374
+  $vcComponent = if ($script:IsARM64) { "Microsoft.VisualStudio.Component.VC.Tools.ARM64" } else { "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" }
+  $vsDir = (& $vswhere -prerelease -latest -products * -requires $vcComponent -property installationPath)
   if ($vsDir -eq $null) {
     # Check common VS installation paths
     $searchPaths = @(


### PR DESCRIPTION
## Summary

On Windows a fresh `bun bd` re-execs the build inside the VS dev shell via `scripts/vs-shell.ps1`, which locates the toolchain with `vswhere`. That query omitted `-products *`, so on a machine where Visual Studio is installed **as Build Tools only** (no IDE, e.g. `C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools`) it returned nothing and the build aborted:

```
Loading Visual Studio environment, this may take a second...
Exception: ...\scripts\vs-shell.ps1:32
throw "Visual Studio directory not found."
```

Reported in #32374.

## Cause

`vswhere`'s `-products` option defaults to Community, Professional, and Enterprise. The Build Tools SKU has product id `Microsoft.VisualStudio.Product.BuildTools`, which is not in that default set, so it must be requested explicitly with `-products *` (all products). The reporter's own comparison shows it exactly:

```
> vswhere -prerelease -latest -property installationPath
(empty)

> vswhere -prerelease -latest -products * -property installationPath
C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools
```

Without the flag the query returned empty, control fell into the fallback block, which only probes hardcoded `...\2022` paths and so misses both a Build Tools install and any non-2022 version (e.g. VS 18). With nothing found it threw `Visual Studio directory not found.`

## Fix

Query `vswhere` with `-products *` so Build Tools installs are candidates, paired with `-requires <VC tools component>` (the canonical [Find VC](https://github.com/microsoft/vswhere/wiki/Find-VC) invocation) so only installs that carry the MSVC toolchain qualify:

```diff
-  $vsDir = (& $vswhere -prerelease -latest -property installationPath)
+  $vcComponent = if ($script:IsARM64) { "Microsoft.VisualStudio.Component.VC.Tools.ARM64" } else { "Microsoft.VisualStudio.Component.VC.Tools.x86.x64" }
+  $vsDir = (& $vswhere -prerelease -latest -products * -requires $vcComponent -property installationPath)
```

`-products *` on its own would also match non-compiler SKUs (TestAgent, TeamExplorer, ...), and with `-latest` one of those could outrank the real toolchain install, making `Launch-VsDevShell.ps1` fail less clearly than the previous throw. `-requires` excludes them; the component is chosen per host arch, matching the script's existing arm64/amd64 handling. Any machine that can compile Bun already has the arch-matching component, so this cannot regress a working build. `vswhere` now returns the Build Tools install directly, so the hardcoded 2022-only fallback is no longer reached for these setups.

## Testing

This is a Windows-only build script: it depends on `vswhere.exe` (a Windows-only tool that queries the VS Installer state) and only misbehaves on a Build Tools-only machine, so it can't be reproduced on the Linux CI lanes or by an automated test, and full-VS CI machines don't hit it regardless of the flag. Build-script changes under `scripts/` ship without `test/` changes by convention here; there is no harness that runs `vs-shell.ps1`. The change matches the reporter's verified `vswhere` invocation above.

The same missing-`-products *` pattern exists in `vendor/WebKit/build-icu.ps1` (`& $vswhere -latest -property installationPath`), but that file lives in the `oven-sh/WebKit` fork (gitignored here), so a fix for it belongs in that repo.