### PR TITLE
fix(s3): correct typo checksumAlgorithme -> checksumAlgorithm + add test coverage

### DIFF
--- a/src/runtime/webcore/s3/list_objects.rs
+++ b/src/runtime/webcore/s3/list_objects.rs
@@ -38,7 +38,7 @@ pub struct S3ListObjectsContents<'a> {
     // a maybe-owned slice.
     etag: Option<Cow<'a, [u8]>>,
     checksum_type: Option<&'a [u8]>,
-    checksum_algorithme: Option<&'a [u8]>,
+    checksum_algorithm: Option<&'a [u8]>,
     last_modified: Option<&'a [u8]>,
     object_size: Option<i64>,
     storage_class: Option<&'a [u8]>,
@@ -100,8 +100,8 @@ impl<'a> S3ListObjectsV2Result<'a> {
                 object_info.put_optional_utf8(global_object, b"eTag", item.etag.as_deref())?;
                 object_info.put_optional_utf8(
                     global_object,
-                    b"checksumAlgorithme",
-                    item.checksum_algorithme,
+                    b"checksumAlgorithm",
+                    item.checksum_algorithm,
                 )?;
                 object_info.put_optional_utf8(
                     global_object,
@@ -217,7 +217,7 @@ pub fn parse_s3_list_objects_result(xml: &[u8]) -> S3ListObjectsV2Result<'_> {
                     let mut etag: Option<&[u8]> = None;
                     let mut etag_owned: Option<Vec<u8>> = None;
                     let mut checksum_type: Option<&[u8]> = None;
-                    let mut checksum_algorithme: Option<&[u8]> = None;
+                    let mut checksum_algorithm: Option<&[u8]> = None;
                     let mut owner_id: Option<&[u8]> = None;
                     let mut owner_display_name: Option<&[u8]> = None;
 
@@ -284,7 +284,7 @@ pub fn parse_s3_list_objects_result(xml: &[u8]) -> S3ListObjectsV2Result<'_> {
                                     if let Some(__tag_end) =
                                         strings::index_of(&xml[i..], b"</ChecksumAlgorithm>")
                                     {
-                                        checksum_algorithme = Some(&xml[i..i + __tag_end]);
+                                        checksum_algorithm = Some(&xml[i..i + __tag_end]);
                                         i = i + __tag_end + 20;
                                     } else {
                                         i = xml.len();
@@ -380,7 +380,7 @@ pub fn parse_s3_list_objects_result(xml: &[u8]) -> S3ListObjectsV2Result<'_> {
                                 (None, None) => None,
                             },
                             checksum_type,
-                            checksum_algorithme,
+                            checksum_algorithm,
                             last_modified,
                             object_size,
                             storage_class,

--- a/test/js/bun/s3/s3-list-objects.test.ts
+++ b/test/js/bun/s3/s3-list-objects.test.ts
@@ -790,6 +790,7 @@ describe.concurrent("S3 - List Objects", () => {
             <ID>some_id_</ID>
         </Owner>
         <StorageClass>STANDARD_IA</StorageClass>
+        <ChecksumAlgorithm>AbCd1234567890EfGhIjKlMnOpQrStUvWxYz1234567890</ChecksumAlgorithm>
     </Contents>
    
 
@@ -838,6 +839,7 @@ describe.concurrent("S3 - List Objects", () => {
           lastModified: "2025-01-20T23:02:53.000Z",
           size: 922282819299999,
           storageClass: "STANDARD_IA",
+          checksumAlgorithm: "AbCd1234567890EfGhIjKlMnOpQrStUvWxYz1234567890",
           owner: {
             displayName: "some display name",
             id: "some_id_",
@@ -903,6 +905,7 @@ describe.concurrent("S3 - List Objects", () => {
             <ID>some_id_</ID>
         </Owner>
         <StorageClass>STANDARD_IA</StorageClass>
+        <ChecksumAlgorithm>AbCd1234567890EfGhIjKlMnOpQrStUvWxYz1234567890</ChecksumAlgorithm>
     </Contents>`,
         )
         .join("");


### PR DESCRIPTION
## Summary

Fixes #19142 - Typo in property name `S3ListObjectsResponse.contents.checksumAlgorithm`

The S3 `listObjects` response handler was returning the JavaScript property `checksumAlgorithme` (with a trailing 'e') instead of the correct `checksumAlgorithm`. This typo affected both the internal Rust struct field name and the JavaScript property key exposed to users.

## Changes

- `src/runtime/webcore/s3/list_objects.rs`: Renamed all occurrences of `checksum_algorithme` → `checksum_algorithm` and `checksumAlgorithme` → `checksumAlgorithm` (6 occurrences across struct definition, property exposure, and XML parsing)
- `test/js/bun/s3/s3-list-objects.test.ts`: Added `<ChecksumAlgorithm>` XML fixture and `checksumAlgorithm` field assertion in 'Should return parsed response with all fields' test

## Testing

The fix corrects the runtime property name so that `await s3.list().contents[i].checksumAlgorithm` returns the correct value instead of `undefined`. The new test assertion ensures the field is properly parsed and returned in the response object.

Closes #19142