### PR TITLE
zlib: make brotli/zstd native handle close() idempotent

### DIFF
--- a/src/runtime/node/zlib/NativeBrotli.rs
+++ b/src/runtime/node/zlib/NativeBrotli.rs
@@ -521,7 +521,12 @@ mod _impl {
         }
 
         pub fn close(&mut self) {
-            self.deinit_state();
+            // Idempotent: a second close() (or close() before init()) sees
+            // `state == None` and must not reach deinit_state(), whose match
+            // has no arm for `mode == NONE`.
+            if self.state.is_some() {
+                self.deinit_state();
+            }
             self.mode = bun_zlib::NodeMode::NONE;
         }
 

--- a/src/runtime/node/zlib/NativeZstd.rs
+++ b/src/runtime/node/zlib/NativeZstd.rs
@@ -514,24 +514,29 @@ mod _impl {
         }
 
         pub fn close(&mut self) {
-            let _ = match self.mode {
-                // SAFETY: state is a valid CCtx/DCtx for this mode.
-                NodeMode::ZSTD_COMPRESS => unsafe {
-                    c::ZSTD_CCtx_reset(
-                        self.state_ptr().cast(),
-                        c::ZSTD_reset_session_and_parameters,
-                    )
-                },
-                // SAFETY: state is a valid DCtx set by init() for this mode.
-                NodeMode::ZSTD_DECOMPRESS => unsafe {
-                    c::ZSTD_DCtx_reset(
-                        self.state_ptr().cast(),
-                        c::ZSTD_reset_session_and_parameters,
-                    )
-                },
-                _ => unreachable!(),
-            };
-            self.deinit_state();
+            // Idempotent: a second close() (or close() before init()) sees
+            // `state == None` and must not reach the reset/free calls below,
+            // whose match has no arm for `mode == NONE`.
+            if self.state.is_some() {
+                let _ = match self.mode {
+                    // SAFETY: state is a valid CCtx/DCtx for this mode.
+                    NodeMode::ZSTD_COMPRESS => unsafe {
+                        c::ZSTD_CCtx_reset(
+                            self.state_ptr().cast(),
+                            c::ZSTD_reset_session_and_parameters,
+                        )
+                    },
+                    // SAFETY: state is a valid DCtx set by init() for this mode.
+                    NodeMode::ZSTD_DECOMPRESS => unsafe {
+                        c::ZSTD_DCtx_reset(
+                            self.state_ptr().cast(),
+                            c::ZSTD_reset_session_and_parameters,
+                        )
+                    },
+                    _ => unreachable!(),
+                };
+                self.deinit_state();
+            }
             self.mode = NodeMode::NONE;
         }
 

--- a/test/js/node/zlib/zlib-handle-double-close.test.ts
+++ b/test/js/node/zlib/zlib-handle-double-close.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Calling `_handle.close()` twice on a brotli/zstd stream must be a no-op,
+// matching the deflate/gzip handle behavior. The first close() sets
+// `mode = NONE` and frees the native encoder/decoder state; a second close()
+// previously fell through to `unreachable!()` in Context::deinit_state() and
+// aborted the process.
+
+describe.concurrent("zlib native handle double close()", () => {
+  test.each([
+    ["createBrotliCompress"],
+    ["createBrotliDecompress"],
+    ["createZstdCompress"],
+    ["createZstdDecompress"],
+    ["createGzip"],
+    ["createGunzip"],
+  ])("%s", async factory => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const zlib = require("zlib");
+          const stream = zlib.${factory}();
+          const h = stream._handle;
+          h.close();
+          h.close();
+          h.close();
+          console.log("OK");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "OK", stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
## Repro

```js
const zlib = require("zlib");
const h = zlib.createBrotliCompress()._handle;
h.close();
h.close(); // panic: internal error: entered unreachable code
```

Same crash for `createBrotliDecompress`, `createZstdCompress`, `createZstdDecompress`. `createGzip` / `createDeflate` are unaffected.

## Cause

`CompressionStream::close_internal()` does not gate on `closed`, so a second JS `_handle.close()` calls `Context::close()` again. For brotli and zstd, `Context::close()` unconditionally enters a `match self.mode { … _ => unreachable!() }` (directly in zstd, via `deinit_state()` in brotli). After the first close, `mode == NONE`, so the second call hits `unreachable!()` and aborts.

`NativeZlib::Context::close()` already handles this with an explicit `NONE => {}` arm. The Zig brotli sibling has the same `else => unreachable` but shipped in ReleaseFast where Zig `unreachable` compiles to nothing and execution happened to fall through harmlessly; the Rust `unreachable!()` panics in every profile.

## Fix

Guard the native-state teardown in `Context::close()` on `self.state.is_some()`, mirroring how `Context::reset()` already guards `deinit_state()`. This makes `close()` a no-op when already closed (or when `init()` was never called), matching NativeZlib and Node's smart-pointer reset semantics.

## Verification

```
# before (USE_SYSTEM_BUN=1 / bun bd with src stashed)
4 fail: createBrotliCompress, createBrotliDecompress, createZstdCompress, createZstdDecompress
2 pass: createGzip, createGunzip

# after (bun bd)
6 pass
```