### PR TITLE
TextEncoder: avoid double Uint8Array allocation on large UTF-16 with lone surrogates

### DIFF
--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1876,7 +1876,7 @@ pub(crate) mod strings_impl {
         copy_utf16_into_utf8_with_utf8_len(buf, utf16, utf8_len)
     }
 
-    pub fn copy_utf16_into_utf8_with_utf8_len(
+    fn copy_utf16_into_utf8_with_utf8_len(
         buf: &mut [u8],
         utf16: &[u16],
         utf8_len: usize,

--- a/src/runtime/webcore/TextEncoder.rs
+++ b/src/runtime/webcore/TextEncoder.rs
@@ -61,8 +61,12 @@ fn replacement_char_uint8_array(global_this: &JSGlobalObject) -> JSValue {
 }
 
 fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
-    const SMALL_BUF_LEN: usize = 192;
-    if slice.len() <= SMALL_BUF_LEN / 3 {
+    const SMALL_BUF_LEN: usize = 2048;
+    // max utf16 -> utf8 expansion is 3 bytes per code unit (BMP) and 4 bytes
+    // per surrogate pair (2 bytes per unit), but an unpaired surrogate becomes
+    // U+FFFD (3 bytes), so worst case per unit is 3. `/ 4` matches the Zig
+    // threshold and leaves slack for the replacement-char case.
+    if slice.len() <= SMALL_BUF_LEN / 4 {
         let mut buf = [0u8; SMALL_BUF_LEN];
         let result = strings::copy_utf16_into_utf8(&mut buf, slice);
         if result.read == 0 || result.written == 0 {
@@ -83,25 +87,12 @@ fn encode16_impl(global_this: &JSGlobalObject, slice: &[u16]) -> JSValue {
         return uint8array;
     }
 
-    let need = strings::element_length_utf16_into_utf8(slice);
-
-    if need == 0 {
-        return replacement_char_uint8_array(global_this);
-    }
-
-    let Ok(uint8array) = create_uninitialized_uint8_array(global_this, need) else {
-        return JSValue::ZERO;
-    };
-    let Some(mut array_buffer) = uint8array.as_array_buffer(global_this) else {
-        return JSValue::ZERO;
-    };
-    debug_assert!(array_buffer.len == need);
-    let result =
-        strings::copy_utf16_into_utf8_with_utf8_len(array_buffer.byte_slice_mut(), slice, need);
-    if result.written as usize == need && result.read as usize == slice.len() {
-        return uint8array;
-    }
-
+    // Large input: allocate once via to_utf8_alloc_with_type and wrap the
+    // resulting Vec as an external Uint8Array. Pre-sizing a JSC Uint8Array via
+    // simdutf's utf16->utf8 length is unsafe here because that length counts
+    // an unpaired surrogate as 2 bytes, but the U+FFFD replacement we emit is
+    // 3 bytes, so the buffer would be undersized and require a second
+    // allocation.
     let bytes = strings::to_utf8_alloc_with_type(slice);
     ArrayBuffer::from_bytes(bytes.leak(), JSType::Uint8Array)
         .to_js_unchecked(global_this)

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { gc as gcTrace, withoutAggressiveGC } from "harness";
+import { bunEnv, bunExe, gc as gcTrace, withoutAggressiveGC } from "harness";
 
 const getByteLength = str => {
   // returns the byte length of an utf8 string
@@ -682,4 +682,48 @@ describe("TextEncoder UTF-16 exact-size path", () => {
       }
     }
   });
+});
+
+// Regression: encode16 on large UTF-16 input with an unpaired surrogate used
+// to allocate a JSC Uint8Array sized by simdutf's utf16->utf8 length (which
+// undercounts a lone surrogate as 2 bytes instead of the 3-byte U+FFFD), fail
+// to fill it, and then allocate a second external Uint8Array, orphaning the
+// first until GC. One encode() call must produce exactly one Uint8Array.
+it("encode() allocates one Uint8Array per call for large UTF-16 with a lone surrogate", async () => {
+  const src = `
+    const { heapStats } = require("bun:jsc");
+    const N = 20;
+    const results = {};
+    for (const [name, units] of [["large", 100000], ["mid", 200]]) {
+      const s = Buffer.alloc(units, "x").toString() + "\\uD800" + Buffer.alloc(units, "y").toString();
+      Bun.gc(true);
+      const before = heapStats().objectTypeCounts.Uint8Array || 0;
+      const keep = [];
+      for (let i = 0; i < N; i++) keep.push(new TextEncoder().encode(s));
+      const after = heapStats().objectTypeCounts.Uint8Array || 0;
+      results[name] = { delta: after - before, len: keep[0].length, expectedLen: units + 3 + units };
+    }
+    process.stdout.write(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  const results = JSON.parse(stdout);
+
+  // Output bytes must be correct regardless of the allocation path taken.
+  expect(results.large.len).toBe(results.large.expectedLen);
+  expect(results.mid.len).toBe(results.mid.expectedLen);
+
+  // Exactly one Uint8Array per encode() call. Allow a couple of slack
+  // objects from unrelated lazy init, but 2x (the regressed behavior) must
+  // fail: 20 calls must yield well under 30 live Uint8Arrays, never 40.
+  expect(results.large.delta).toBeGreaterThanOrEqual(20);
+  expect(results.large.delta).toBeLessThan(30);
+  expect(results.mid.delta).toBeGreaterThanOrEqual(20);
+  expect(results.mid.delta).toBeLessThan(30);
 });

--- a/test/js/web/encoding/text-encoder.test.js
+++ b/test/js/web/encoding/text-encoder.test.js
@@ -712,7 +712,7 @@ it("encode() allocates one Uint8Array per call for large UTF-16 with a lone surr
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
+  expect(stderr).toBe("");
   const results = JSON.parse(stdout);
 
   // Output bytes must be correct regardless of the allocation path taken.
@@ -726,4 +726,5 @@ it("encode() allocates one Uint8Array per call for large UTF-16 with a lone surr
   expect(results.large.delta).toBeLessThan(30);
   expect(results.mid.delta).toBeGreaterThanOrEqual(20);
   expect(results.mid.delta).toBeLessThan(30);
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Reproduction

```js
const { heapStats } = require("bun:jsc");
const s = "x".repeat(100000) + "\uD800" + "y".repeat(100000);
Bun.gc(true);
const before = heapStats().objectTypeCounts.Uint8Array || 0;
const keep = [];
for (let i = 0; i < 20; i++) keep.push(new TextEncoder().encode(s));
console.log(heapStats().objectTypeCounts.Uint8Array - before);
// before: 40
// after:  20
```

### Cause

`encode16_impl` in `src/runtime/webcore/TextEncoder.rs` pre-sized a JSC `Uint8Array` via `simdutf::length::utf8::from::utf16::le()`. That function counts an unpaired surrogate as 2 output bytes (surrogate-pair cost / 2), but the `U+FFFD` replacement we actually emit is 3 bytes. When the input contains a lone surrogate the buffer is undersized, `simdutf__convert_utf16le_to_utf8_with_errors` fails, the scalar fallback runs out of space before consuming the whole input, the `result.read != slice.len()` check fails, and the code falls through to `to_utf8_alloc_with_type(slice).leak()` wrapped in a second external `Uint8Array`. The first JSC `Uint8Array` (potentially MB-sized) is orphaned until GC.

The Rust port had also lowered the stack-buffer fast-path threshold from 512 code units (Zig: `2048 / 4`) to 64 (`192 / 3`), so strings in the 65 to 512 range that previously hit the stack path now hit this slow path too.

Output bytes were always correct; the regression is purely the doubled `Uint8Array` allocation count and the associated GC pressure.

### Fix

Match the Zig `TextEncoder__encode16`: encode inputs up to 512 code units into a 2048-byte stack buffer and copy into a single JSC `Uint8Array`; for anything larger, allocate once via `to_utf8_alloc_with_type` and wrap the result as an external `Uint8Array`. No pre-sized JSC buffer, no fallback allocation.

### Verification

New test in `test/js/web/encoding/text-encoder.test.js` spawns a subprocess that encodes a 200,001-unit string and a 401-unit string (both containing `\uD800`) 20 times each, and asserts `heapStats().objectTypeCounts.Uint8Array` grows by at least 20 and less than 30 (never 40). Also asserts the output byte lengths are correct (`units + 3 + units`).

```
USE_SYSTEM_BUN=1 bun test text-encoder.test.js -t "allocates one"
  -> fail: Received: 40
bun bd test text-encoder.test.js -t "allocates one"
  -> pass
bun bd test text-encoder.test.js
  -> 43 pass, 0 fail
```