### PR TITLE
Don't abort the process on a nested uncaught exception in a worker

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1422,8 +1422,10 @@ impl VirtualMachine {
         if !handled {
             // `beforeExit` has already been dispatched, so the run is winding
             // down and there is no loop turn left to defer to: print the error
-            // and exit, like node's fatal-exception path.
-            if self.exit_on_uncaught_exception {
+            // and exit, like node's fatal-exception path. A worker falls
+            // through to `on_unhandled_rejection` below so the parent Worker
+            // receives the `error` event before `exit` (matching Node).
+            if self.exit_on_uncaught_exception && self.worker.is_none() {
                 self.run_error_handler(err, None);
                 // `process_exit` emits `exit`, re-entering here if a listener
                 // throws. No handler is running, so drop the recursion guard or
@@ -1431,12 +1433,6 @@ impl VirtualMachine {
                 self.is_handling_uncaught_exception = false;
                 // SAFETY: see above.
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
-                if self.worker.is_some() {
-                    // Worker: `process_exit` armed termination and RETURNED
-                    // (main thread diverges). Return handled; `spin()`
-                    // observes the terminate flag and reaches `shutdown()`.
-                    return true;
-                }
                 panic!("made it past process.exit()");
             }
             // TODO maybe we want a separate code path for uncaught exceptions

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1394,6 +1394,20 @@ impl VirtualMachine {
         let hooks = runtime_hooks().expect("RuntimeHooks not installed");
         if self.is_handling_uncaught_exception {
             self.run_error_handler(err, None);
+            if self.worker.is_some() {
+                // Worker: `process_exit` only sets flags and RETURNS, and its
+                // `notify_need_termination` → `JSC__VM__notifyNeedTermination`
+                // drops the JSLock and drains microtasks — one of the paths
+                // that re-enters here. Dispatch the error to the parent and
+                // arm termination via `on_unhandled_rejection` (on the first
+                // call this swaps itself for the quiet handler, so a second
+                // re-entry reaching here only bumps a counter), then let the
+                // stack unwind to `spin()` which reaches `shutdown()`.
+                self.unhandled_error_counter += 1;
+                self.exit_handler.exit_code = 1;
+                (self.on_unhandled_rejection)(self, global_object, err);
+                return true;
+            }
             // SAFETY: `global_object` is the live VM global; `process_exit` is
             // `bun_runtime::node::process::exit` (main-thread `noreturn`).
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
@@ -1417,6 +1431,12 @@ impl VirtualMachine {
                 self.is_handling_uncaught_exception = false;
                 // SAFETY: see above.
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
+                if self.worker.is_some() {
+                    // Worker: `process_exit` armed termination and RETURNED
+                    // (main thread diverges). Return handled; `spin()`
+                    // observes the terminate flag and reaches `shutdown()`.
+                    return true;
+                }
                 panic!("made it past process.exit()");
             }
             // TODO maybe we want a separate code path for uncaught exceptions
@@ -1427,10 +1447,9 @@ impl VirtualMachine {
         // Note: this reset must cover BOTH the FFI call and the
         // `onUnhandledRejection` callback above. The flag must stay raised
         // while that callback runs so a re-entrant `uncaught_exception` from
-        // a user handler trips the recursion guard and hard-exits with code 7
-        // instead of recursing. Neither the FFI call nor the fn-pointer
-        // callback unwind past this frame (re-entry hits `process_exit` →
-        // `panic!`, which never returns), so a linear reset here suffices.
+        // a user handler trips the recursion guard above (main thread:
+        // hard-exit code 7; worker: return handled). Neither call unwinds
+        // past this frame, so a linear reset here suffices.
         self.is_handling_uncaught_exception = false;
         handled
     }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1395,14 +1395,9 @@ impl VirtualMachine {
         if self.is_handling_uncaught_exception {
             self.run_error_handler(err, None);
             if self.worker.is_some() {
-                // Worker: `process_exit` only sets flags and RETURNS, and its
-                // `notify_need_termination` → `JSC__VM__notifyNeedTermination`
-                // drops the JSLock and drains microtasks — one of the paths
-                // that re-enters here. Dispatch the error to the parent and
-                // arm termination via `on_unhandled_rejection` (on the first
-                // call this swaps itself for the quiet handler, so a second
-                // re-entry reaching here only bumps a counter), then let the
-                // stack unwind to `spin()` which reaches `shutdown()`.
+                // Worker `process_exit` returns (only main-thread diverges), so
+                // dispatch to the parent and return. `on_unhandled_rejection`
+                // swaps to the quiet handler on first call, bounding re-entry.
                 self.unhandled_error_counter += 1;
                 self.exit_handler.exit_code = 1;
                 (self.on_unhandled_rejection)(self, global_object, err);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -53,50 +53,33 @@ describe.concurrent("uncaught exceptions in worker don't abort the process", () 
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
+  const expected = {
+    stdout: "worker-exit:1\n",
+    stderr: expect.any(String),
+    exitCode: 0,
+    signalCode: null,
+  };
+
   test("queueMicrotask throws while a setTimeout throw is being handled", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 0)`,
-    );
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "worker-exit:1\n",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    expect(await run(`setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 0)`)).toEqual(expected);
   });
 
   test("two throwing queueMicrotask callbacks", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `queueMicrotask(() => { throw 1 }); queueMicrotask(() => { throw 2 })`,
-    );
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "worker-exit:1\n",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    expect(await run(`queueMicrotask(() => { throw 1 }); queueMicrotask(() => { throw 2 })`)).toEqual(expected);
   });
 
   test("worker beforeExit handler throws", async () => {
-    const { stdout, stderr, exitCode } = await run(`process.on("beforeExit", () => { throw 99 })`);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "worker-exit:1\n",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    expect(await run(`process.on("beforeExit", () => { throw 99 })`)).toEqual(expected);
   });
 
   // https://github.com/oven-sh/bun/issues/28648
   test("worker uncaughtException handler throws", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `process.on("uncaughtException", () => { throw new Error("nested") }); throw new Error("oopsie")`,
-    );
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "worker-exit:1\n",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
+    expect(
+      await run(`process.on("uncaughtException", () => { throw new Error("nested") }); throw new Error("oopsie")`),
+    ).toEqual(expected);
   });
 });
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -52,11 +52,7 @@ describe.concurrent("uncaught exceptions in worker don't abort the process", () 
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     return { stdout, stderr, exitCode };
   }
 
@@ -83,9 +79,7 @@ describe.concurrent("uncaught exceptions in worker don't abort the process", () 
   });
 
   test("worker beforeExit handler throws", async () => {
-    const { stdout, stderr, exitCode } = await run(
-      `process.on("beforeExit", () => { throw 99 })`,
-    );
+    const { stdout, stderr, exitCode } = await run(`process.on("beforeExit", () => { throw 99 })`);
     expect({ stdout, stderr, exitCode }).toEqual({
       stdout: "worker-exit:1\n",
       stderr: expect.any(String),

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -32,6 +32,80 @@ test("support eval in worker", async () => {
   await worker.terminate();
 });
 
+// A nested uncaught exception inside a worker (while the first is still being
+// reported to the parent) used to abort the whole process with
+// `panic: Uncaught exception while handling uncaught exception` because the
+// re-entry guard assumed `process_exit` never returns, which is only true on
+// the main thread. On a worker it returns after arming termination, so the
+// guard must return instead of panicking.
+describe.concurrent("uncaught exceptions in worker don't abort the process", () => {
+  async function run(workerBody: string) {
+    const script = /* js */ `
+      const { Worker } = require("node:worker_threads");
+      new Worker(${JSON.stringify(workerBody)}, { eval: true })
+        .on("error", () => {})
+        .on("exit", c => console.log("worker-exit:" + c));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("queueMicrotask throws while a setTimeout throw is being handled", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 0)`,
+    );
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "worker-exit:1\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+
+  test("two throwing queueMicrotask callbacks", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `queueMicrotask(() => { throw 1 }); queueMicrotask(() => { throw 2 })`,
+    );
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "worker-exit:1\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+
+  test("worker beforeExit handler throws", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `process.on("beforeExit", () => { throw 99 })`,
+    );
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "worker-exit:1\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+
+  // https://github.com/oven-sh/bun/issues/28648
+  test("worker uncaughtException handler throws", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `process.on("uncaughtException", () => { throw new Error("nested") }); throw new Error("oopsie")`,
+    );
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "worker-exit:1\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+});
+
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -32,57 +32,6 @@ test("support eval in worker", async () => {
   await worker.terminate();
 });
 
-// A nested uncaught exception inside a worker (while the first is still being
-// reported to the parent) used to abort the whole process with
-// `panic: Uncaught exception while handling uncaught exception` because the
-// re-entry guard assumed `process_exit` never returns, which is only true on
-// the main thread. On a worker it returns after arming termination, so the
-// guard must return instead of panicking.
-describe.concurrent("uncaught exceptions in worker don't abort the process", () => {
-  async function run(workerBody: string) {
-    const script = /* js */ `
-      const { Worker } = require("node:worker_threads");
-      new Worker(${JSON.stringify(workerBody)}, { eval: true })
-        .on("error", () => {})
-        .on("exit", c => console.log("worker-exit:" + c));
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
-  }
-
-  const expected = {
-    stdout: "worker-exit:1\n",
-    stderr: expect.any(String),
-    exitCode: 0,
-    signalCode: null,
-  };
-
-  test("queueMicrotask throws while a setTimeout throw is being handled", async () => {
-    expect(await run(`setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 0)`)).toEqual(expected);
-  });
-
-  test("two throwing queueMicrotask callbacks", async () => {
-    expect(await run(`queueMicrotask(() => { throw 1 }); queueMicrotask(() => { throw 2 })`)).toEqual(expected);
-  });
-
-  test("worker beforeExit handler throws", async () => {
-    expect(await run(`process.on("beforeExit", () => { throw 99 })`)).toEqual(expected);
-  });
-
-  // https://github.com/oven-sh/bun/issues/28648
-  test("worker uncaughtException handler throws", async () => {
-    expect(
-      await run(`process.on("uncaughtException", () => { throw new Error("nested") }); throw new Error("oopsie")`),
-    ).toEqual(expected);
-  });
-});
-
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");

--- a/test/regression/issue/28648.test.ts
+++ b/test/regression/issue/28648.test.ts
@@ -15,7 +15,7 @@ describe.concurrent("nested uncaught exceptions in a worker don't abort the proc
     const script = /* js */ `
       const { Worker } = require("node:worker_threads");
       new Worker(${JSON.stringify(workerBody)}, { eval: true })
-        .on("error", () => {})
+        .on("error", () => console.log("worker-error"))
         .on("exit", c => console.log("worker-exit:" + c));
     `;
     await using proc = Bun.spawn({
@@ -28,8 +28,10 @@ describe.concurrent("nested uncaught exceptions in a worker don't abort the proc
     return { stdout, stderr, exitCode, signalCode: proc.signalCode };
   }
 
+  // The parent Worker must receive `error` then `exit:1` (Node's behaviour),
+  // and the process must not crash.
   const expected = {
-    stdout: "worker-exit:1\n",
+    stdout: "worker-error\nworker-exit:1\n",
     stderr: expect.any(String),
     exitCode: 0,
     signalCode: null,

--- a/test/regression/issue/28648.test.ts
+++ b/test/regression/issue/28648.test.ts
@@ -1,12 +1,5 @@
 // https://github.com/oven-sh/bun/issues/28648
 // https://github.com/oven-sh/bun/issues/24069
-//
-// A nested uncaught exception inside a worker (while the first is still being
-// reported to the parent) used to abort the whole process with
-// `panic: Uncaught exception while handling uncaught exception` because the
-// re-entry guard in `VirtualMachine::uncaught_exception` assumed `process_exit`
-// never returns, which is only true on the main thread. On a worker it returns
-// after arming termination, so the guard must return instead of panicking.
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 

--- a/test/regression/issue/28648.test.ts
+++ b/test/regression/issue/28648.test.ts
@@ -1,0 +1,55 @@
+// https://github.com/oven-sh/bun/issues/28648
+// https://github.com/oven-sh/bun/issues/24069
+//
+// A nested uncaught exception inside a worker (while the first is still being
+// reported to the parent) used to abort the whole process with
+// `panic: Uncaught exception while handling uncaught exception` because the
+// re-entry guard in `VirtualMachine::uncaught_exception` assumed `process_exit`
+// never returns, which is only true on the main thread. On a worker it returns
+// after arming termination, so the guard must return instead of panicking.
+import { describe, test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+describe.concurrent("nested uncaught exceptions in a worker don't abort the process", () => {
+  async function run(workerBody: string) {
+    const script = /* js */ `
+      const { Worker } = require("node:worker_threads");
+      new Worker(${JSON.stringify(workerBody)}, { eval: true })
+        .on("error", () => {})
+        .on("exit", c => console.log("worker-exit:" + c));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode, signalCode: proc.signalCode };
+  }
+
+  const expected = {
+    stdout: "worker-exit:1\n",
+    stderr: expect.any(String),
+    exitCode: 0,
+    signalCode: null,
+  };
+
+  test("queueMicrotask throws while a setTimeout throw is being handled", async () => {
+    expect(await run(`setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 0)`)).toEqual(expected);
+  });
+
+  test("two throwing queueMicrotask callbacks", async () => {
+    expect(await run(`queueMicrotask(() => { throw 1 }); queueMicrotask(() => { throw 2 })`)).toEqual(expected);
+  });
+
+  test("worker beforeExit handler throws", async () => {
+    expect(await run(`process.on("beforeExit", () => { throw 99 })`)).toEqual(expected);
+  });
+
+  test("worker uncaughtException handler throws", async () => {
+    expect(
+      await run(`process.on("uncaughtException", () => { throw new Error("nested") }); throw new Error("oopsie")`),
+    ).toEqual(expected);
+  });
+});

--- a/test/regression/issue/28648.test.ts
+++ b/test/regression/issue/28648.test.ts
@@ -7,7 +7,7 @@
 // re-entry guard in `VirtualMachine::uncaught_exception` assumed `process_exit`
 // never returns, which is only true on the main thread. On a worker it returns
 // after arming termination, so the guard must return instead of panicking.
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 describe.concurrent("nested uncaught exceptions in a worker don't abort the process", () => {


### PR DESCRIPTION
## Repro

```js
const { Worker } = require("node:worker_threads");
new Worker(
  `setTimeout(() => { queueMicrotask(() => { throw 1 }); throw 2 }, 5)`,
  { eval: true },
)
  .on("error", () => {})
  .on("exit", c => console.log("worker-exit", c));
setTimeout(() => console.log("MAIN-SURVIVED"), 200);
```

Before: the whole process aborts with
```
panic: Uncaught exception while handling uncaught exception
```

Node.js (and Zig-era Bun) print `worker-exit 1` / `MAIN-SURVIVED` and exit 0.

Also crashes (`panic: made it past process.exit()`) when a worker's `beforeExit` handler throws, and when a worker's `process.on("uncaughtException", ...)` handler throws (#28648).

## Cause

`VirtualMachine::uncaught_exception` follows `(hooks.process_exit)(...)` with a `panic!`. On the main thread `process_exit` reaches `global_exit()` which is `-> !`, so the panic is unreachable. On a worker, `process_exit` only calls `worker.exit()` (which arms terminate flags) and *returns*, so the panic executes and with `panic = "abort"` the process dies.

The Zig version never reached this on a worker because `WebWorker.onUnhandledRejection` ended in `shutdown()` (`pthread_exit`, noreturn), so C++ frames above it were abandoned before any re-entry could happen. The Rust `on_unhandled_rejection` intentionally returns instead (calling `shutdown()` with live C++ frames above is a UAF), and its trailing `vm.jsc_vm().notify_need_termination()` goes through `JSC__VM__notifyNeedTermination`, which explicitly drops the API lock:

```cpp
bool didEnter = vm.currentThreadIsHoldingAPILock();
if (didEnter)
    vm.apiLock().unlock();
vm.notifyNeedTermination();
```

That `unlock()` triggers `JSLock::willReleaseLock` → `VM::drainMicrotasks`, which runs any remaining throwing microtask while the outer `uncaught_exception` frame still has `is_handling_uncaught_exception = true`, so the re-entry guard fires and panics.

<details>
<summary>gdb backtrace at the panic</summary>

```
#8  VirtualMachine::uncaught_exception         VirtualMachine.rs:1400
#9  report_unhandled_error
#10 Bun__reportUnhandledError
#11 JSC::runInternalMicrotask                  JSMicrotask.cpp:2167
#12 JSC::runMicrotask
...
#17 JSC::VM::drainMicrotasks
#18 JSC::JSLock::willReleaseLock               JSLock.cpp:313
#19 JSC::JSLock::unlock
#20 JSC::JSLock::unlock()
#21 JSC__VM__notifyNeedTermination             bindings.cpp:5037
#22 VM::notify_need_termination
#23 web_worker::on_unhandled_rejection
#24 VirtualMachine::uncaught_exception         (outer, flag raised)
```
</details>

The other re-entry route is a worker's `process.on("uncaughtException", ...)` handler throwing: `EventEmitter::emit` catches that and calls `Bun__reportUnhandledError` while the outer frame's flag is still raised. In that case `on_unhandled_rejection` has not yet been called, so nothing has armed termination.

## Fix

In `uncaught_exception`, when `self.worker.is_some()`:

- **re-entry guard** (`is_handling_uncaught_exception`): set exit code 1, call `(self.on_unhandled_rejection)` to dispatch the error to the parent and arm termination (the worker handler swaps itself for the quiet one on first call, so a subsequent re-entry here only bumps a counter), and return `true`. `spin()` unwinds to `shutdown()` with no live JSC frames above it.
- **`exit_on_uncaught_exception`**: `process_exit(1)` has already armed termination and returned; return `true` instead of panicking.

Main-thread behaviour is unchanged (exit 7 on re-entry, exit 1 on `exit_on_uncaught_exception`).

Supersedes #28650 (targets the since-removed `src/bun.js/VirtualMachine.zig`).

Fixes #28648
Fixes #24069


---

*Rebased onto #33466, which moved the `exit_on_uncaught_exception` check inside the `!handled` block. The worker guard for that branch moved with it; the `is_handling_uncaught_exception` hunk was unaffected.*
