### PR TITLE
resolver: resolve the entry point by stat instead of reading its directory

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -4534,11 +4534,12 @@ impl VirtualMachine {
             top_level_dir
         };
 
-        // A `loop`
-        // returning the resolver result; `retry_on_not_found` is consumed on
-        // the first miss.
+        if source == MAIN_FILE_NAME && bun_paths::is_absolute(normalized_specifier) {
+            self.transpiler.resolver.entry_point_hint = Some(Box::from(normalized_specifier));
+        }
+
         let mut retry_on_not_found = bun_paths::is_absolute(source_to_use);
-        let result: bun_resolver::Result = loop {
+        let resolved: Result<bun_resolver::Result, crate::CrateError> = loop {
             let import_kind = if is_esm {
                 bun_ast::ImportKind::Stmt
             } else {
@@ -4551,11 +4552,11 @@ impl VirtualMachine {
                 import_kind,
                 global_cache,
             ) {
-                ResultUnion::Success(r) => break r,
-                ResultUnion::Failure(e) => return Err(e.into()),
+                ResultUnion::Success(r) => break Ok(r),
+                ResultUnion::Failure(e) => break Err(e.into()),
                 ResultUnion::Pending(_) | ResultUnion::NotFound => {
                     if !retry_on_not_found {
-                        return Err(crate::CrateError::ModuleNotFound);
+                        break Err(crate::CrateError::ModuleNotFound);
                     }
                     retry_on_not_found = false;
 
@@ -4565,7 +4566,7 @@ impl VirtualMachine {
                     let buster_name: &[u8] = if bun_paths::is_absolute(normalized_specifier) {
                         if let Some(dir) = bun_paths::dirname(normalized_specifier) {
                             if dir.len() > buf.len() {
-                                return Err(crate::CrateError::ModuleNotFound);
+                                break Err(crate::CrateError::ModuleNotFound);
                             }
                             // Normalized without trailing slash.
                             bun_paths::string_paths::normalize_slashes_only(
@@ -4586,7 +4587,7 @@ impl VirtualMachine {
                         // If the specifier is too long to join, it can't name
                         // a real directory — skip the cache bust and fail.
                         if source_to_use.len() + normalized_specifier.len() + 4 >= buf.len() {
-                            return Err(crate::CrateError::ModuleNotFound);
+                            break Err(crate::CrateError::ModuleNotFound);
                         }
                         let parts: [&[u8]; 3] = [
                             source_to_use,
@@ -4605,10 +4606,13 @@ impl VirtualMachine {
                     ) {
                         continue;
                     }
-                    return Err(crate::CrateError::ModuleNotFound);
+                    break Err(crate::CrateError::ModuleNotFound);
                 }
             }
         };
+
+        self.transpiler.resolver.entry_point_hint = None;
+        let result = resolved?;
 
         if !self.macro_mode {
             self.has_any_macro_remappings =

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -385,6 +385,9 @@ pub struct DirEntry {
     pub fd: Fd,
     pub(crate) generation: Generation,
     pub data: dir_entry::EntryMap,
+    /// `false` marks a listing created without a full `readdir` (entry-point
+    /// fast path); consumers that iterate must re-read it first.
+    pub complete: bool,
 }
 
 impl DirEntry {
@@ -394,6 +397,7 @@ impl DirEntry {
             data: dir_entry::EntryMap::default(),
             generation,
             fd: Fd::INVALID,
+            complete: true,
         }
     }
 

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -1250,7 +1250,7 @@ pub mod fs {
                     // scrutinee directly so no second `&mut *cached_ptr` is materialized
                     // while the first is on the borrow stack (Stacked Borrows hygiene).
                     match unsafe { &mut *cached_ptr } {
-                        EntriesOption::Entries(e) if e.generation < generation => {
+                        EntriesOption::Entries(e) if e.generation < generation || !e.complete => {
                             in_place = Some(std::ptr::from_mut::<DirEntry>(*e));
                         }
                         cached => return Ok(cached),
@@ -1608,7 +1608,7 @@ pub mod fs {
             let result_ptr = std::ptr::from_mut::<EntriesOption>(self.entries.at_index(index)?);
             // SAFETY: BSSMap-owned slot; uniquely held under `entries_mutex`.
             if let EntriesOption::Entries(existing) = unsafe { &mut *result_ptr } {
-                if existing.generation < generation {
+                if existing.generation < generation || !existing.complete {
                     let e_ptr: *mut DirEntry = std::ptr::from_mut::<DirEntry>(*existing);
                     // SAFETY: BSSMap-owned `DirEntry` (boxed/leaked into `EntriesOption`); `entries_mutex` held.
                     let dir = unsafe { (*e_ptr).dir };

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -572,6 +572,8 @@ pub struct Resolver<'a> {
     ///
     /// When this is null, it is as if it is set to `&.{ path.dirname(referrer) }`.
     pub custom_dir_paths: Option<&'a [bun_core::String]>,
+
+    pub entry_point_hint: Option<Box<[u8]>>,
 }
 
 /// RAII guard returned by [`Resolver::scoped_log`]. Restores the previous
@@ -644,6 +646,7 @@ impl<'a> Resolver<'a> {
             mutex: from.mutex,
             dir_cache: from.dir_cache,
             prefer_module_field: from.prefer_module_field,
+            entry_point_hint: None,
             // Transient per-resolve scratch (only set for `require(..., {paths})`);
             // never carried across worker init.
             custom_dir_paths: None,
@@ -933,6 +936,7 @@ impl<'a> Resolver<'a> {
             standalone_module_graph: None,
             prefer_module_field: true,
             custom_dir_paths: None,
+            entry_point_hint: None,
         }
     }
 
@@ -4408,7 +4412,18 @@ impl<'a> Resolver<'a> {
             let queue_top_safe_path: &[u8] = qt_safe_path.slice();
             queue_slice_len -= 1;
 
-            let open_dir: FD = if queue_top.fd.is_valid() {
+            let lazy_leaf = queue_slice_len == 0
+                && !self.care_about_bin_folder
+                && self.entry_point_hint.as_deref().is_some_and(|hint| {
+                    strings::eql(
+                        strings::without_trailing_slash_windows_path(queue_top_unsafe_path),
+                        strings::without_trailing_slash_windows_path(Dirname::dirname(hint)),
+                    )
+                });
+
+            let open_dir: FD = if lazy_leaf {
+                FD::INVALID
+            } else if queue_top.fd.is_valid() {
                 queue_top.fd
             } else {
                 'open_dir: {
@@ -4609,15 +4624,18 @@ impl<'a> Resolver<'a> {
                     self.generation,
                 );
 
-                // Pre-size `data` so the per-entry inserts below skip the
-                // 1→2→4→…→N hashbrown rehash cascade from an empty table. 64
-                // covers a typical node_modules package dir; larger dirs
-                // still rehash from there (cheap relative to starting at 0).
-                new_entry.data.reserve(64);
+                if lazy_leaf {
+                    new_entry.complete = false;
+                }
 
-                // A permission-denied ancestor has no fd to enumerate; its
-                // entry set stays empty.
+                // A permission-denied ancestor (or the lazy entry-point leaf)
+                // has no fd to enumerate; its entry set stays empty.
                 if open_dir.is_valid() {
+                    // Pre-size `data` so the per-entry inserts below skip the
+                    // 1→2→4→…→N hashbrown rehash cascade from an empty table. 64
+                    // covers a typical node_modules package dir; larger dirs
+                    // still rehash from there (cheap relative to starting at 0).
+                    new_entry.data.reserve(64);
                     let mut dir_iterator = bun_sys::iterate_dir(open_dir);
                     // NOTE: `WrappedIterator::next` returns
                     // `Result<Option<IteratorResult>>`, so use `?`-style break-on-error.
@@ -5770,6 +5788,31 @@ impl<'a> Resolver<'a> {
 
         let dir_path = strings::without_trailing_slash_windows_path(Dirname::dirname(path));
 
+        if self.entry_point_hint.as_deref() == Some(path) && !self.care_about_bin_folder {
+            let base = bun_paths::basename(path);
+            // SAFETY: `rfs` points at the process-global RealFS singleton.
+            if let Ok(cache) = unsafe { &mut *rfs }.kind(dir_path, base, FD::INVALID, false) {
+                if cache.kind == Fs::file_system::EntryKind::File && cache.symlink.is_empty() {
+                    let abs_path: &'static [u8] = self
+                        .fs_ref()
+                        .dirname_store
+                        .append_slice(path)
+                        .expect("unreachable");
+                    if let Some(debug) = self.debug_logs.as_mut() {
+                        debug.add_note_fmt(format_args!(
+                            "Found entry-point file \"{}\" ",
+                            bstr::BStr::new(base)
+                        ));
+                    }
+                    dec_ret!(Some(LoadResult {
+                        path: abs_path,
+                        dirname_fd: FD::INVALID,
+                        file_fd: FD::INVALID,
+                    }));
+                }
+            }
+        }
+
         // PORT — `dir_entry` is a slot in the BSSMap singleton (ARENA, see
         // LIFETIMES.tsv); wrap in `BackRef` so later `&mut self` calls
         // (debug_logs / load_extension / dirname_store) don't trip borrowck
@@ -6071,6 +6114,24 @@ impl<'a> Resolver<'a> {
             };
         }
 
+        let entries_complete = entries!().complete;
+        macro_rules! marker_kind {
+            ($name:expr) => {
+                if entries_complete {
+                    entries!().get_comptime_query($name).map(|lookup| {
+                        // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
+                        unsafe { lookup.entry().kind(rfs_ptr, self.store_fd) }
+                    })
+                } else {
+                    // SAFETY: `rfs_ptr` points at the process-global RealFS singleton.
+                    unsafe { &mut *rfs_ptr }
+                        .kind(path, $name, FD::INVALID, false)
+                        .ok()
+                        .map(|cache| cache.kind)
+                }
+            };
+        }
+
         if cfg!(debug_assertions) {
             // `path` is stored in the permanent `dir_cache` as `DirInfo.abs_path`. It must not
             // point into a reused threadlocal scratch buffer, or a later resolution will
@@ -6105,19 +6166,14 @@ impl<'a> Resolver<'a> {
 
         // if (entries != null) {
         if !info.is_node_modules() {
-            if let Some(entry) = entries!().get_comptime_query(b"node_modules") {
-                info.flags.set_present(
-                    DirInfo::Flag::HasNodeModules,
-                    // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
-                    unsafe { entry.entry().kind(rfs_ptr, self.store_fd) }
-                        == Fs::file_system::EntryKind::Dir,
-                );
+            if marker_kind!(b"node_modules") == Some(Fs::file_system::EntryKind::Dir) {
+                info.flags.set_present(DirInfo::Flag::HasNodeModules, true);
             }
         }
 
         if self.care_about_bin_folder {
             'append_bin_dir: {
-                if info.has_node_modules() {
+                if info.has_node_modules() && entries_complete {
                     if entries!().has_comptime_query(b"node_modules") {
                         // SAFETY: BIN_FOLDERS guarded by BIN_FOLDERS_LOCK below
                         if !BIN_FOLDERS_LOADED.load(core::sync::atomic::Ordering::Acquire) {
@@ -6158,7 +6214,7 @@ impl<'a> Resolver<'a> {
                     }
                 }
 
-                if info.is_node_modules() {
+                if info.is_node_modules() && entries_complete {
                     if let Some(q) = entries!().get_comptime_query(b".bin") {
                         // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
                         if unsafe { q.entry().kind(rfs_ptr, self.store_fd) }
@@ -6315,67 +6371,60 @@ impl<'a> Resolver<'a> {
 
         // Record if this directory has a package.json file
         if self.opts.load_package_json {
-            if let Some(lookup) = entries!().get_comptime_query(b"package.json") {
-                // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
-                // dies (NLL) before any later `&mut` to this slot.
-                let entry = lookup.entry();
-                // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
-                if unsafe { entry.kind(rfs_ptr, self.store_fd) } == Fs::file_system::EntryKind::File
+            if marker_kind!(b"package.json") == Some(Fs::file_system::EntryKind::File) {
+                info.package_json = if self.use_package_manager()
+                    && !info.has_node_modules()
+                    && !info.is_node_modules()
                 {
-                    info.package_json = if self.use_package_manager()
-                        && !info.has_node_modules()
-                        && !info.is_node_modules()
+                    self.parse_package_json::<true>(
+                        path,
+                        if FeatureFlags::STORE_FILE_DESCRIPTORS {
+                            fd
+                        } else {
+                            FD::INVALID
+                        },
+                        package_id,
+                    )
+                    .ok()
+                    .flatten()
+                } else {
+                    self.parse_package_json::<false>(
+                        path,
+                        if FeatureFlags::STORE_FILE_DESCRIPTORS {
+                            fd
+                        } else {
+                            FD::INVALID
+                        },
+                        None,
+                    )
+                    .ok()
+                    .flatten()
+                };
+
+                if let Some(pkg) = info.package_json() {
+                    if pkg.browser_map.count() > 0 {
+                        info.enclosing_browser_scope = result.index;
+                        info.package_json_for_browser_field = Some(pkg);
+                    }
+
+                    if !pkg.name.is_empty() || self.care_about_bin_folder {
+                        info.enclosing_package_json = Some(pkg);
+                    }
+
+                    if pkg.dependencies.map.count() > 0
+                        || pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
                     {
-                        self.parse_package_json::<true>(
-                            path,
-                            if FeatureFlags::STORE_FILE_DESCRIPTORS {
-                                fd
-                            } else {
-                                FD::INVALID
-                            },
-                            package_id,
-                        )
-                        .ok()
-                        .flatten()
-                    } else {
-                        self.parse_package_json::<false>(
-                            path,
-                            if FeatureFlags::STORE_FILE_DESCRIPTORS {
-                                fd
-                            } else {
-                                FD::INVALID
-                            },
-                            None,
-                        )
-                        .ok()
-                        .flatten()
-                    };
+                        // NOTE: store the raw `NonNull` field (not the
+                        // `&'static` accessor result) so mut-provenance flows
+                        // through to `enqueue_dependency_to_resolve`.
+                        info.package_json_for_dependencies = info.package_json;
+                    }
 
-                    if let Some(pkg) = info.package_json() {
-                        if pkg.browser_map.count() > 0 {
-                            info.enclosing_browser_scope = result.index;
-                            info.package_json_for_browser_field = Some(pkg);
-                        }
-
-                        if !pkg.name.is_empty() || self.care_about_bin_folder {
-                            info.enclosing_package_json = Some(pkg);
-                        }
-
-                        if pkg.dependencies.map.count() > 0
-                            || pkg.package_manager_package_id != Install::INVALID_PACKAGE_ID
-                        {
-                            // NOTE: store the raw `NonNull` field (not the
-                            // `&'static` accessor result) so mut-provenance flows
-                            // through to `enqueue_dependency_to_resolve`.
-                            info.package_json_for_dependencies = info.package_json;
-                        }
-
-                        if let Some(logs) = self.debug_logs.as_mut() {
-                            logs.add_note_fmt(format_args!(
-                                "Resolved package.json in \"{}\"",
-                                bstr::BStr::new(path)
-                            ));
-                        }
+                    if let Some(logs) = self.debug_logs.as_mut() {
+                        logs.add_note_fmt(format_args!(
+                            "Resolved package.json in \"{}\"",
+                            bstr::BStr::new(path)
+                        ));
                     }
                 }
             }
@@ -6389,37 +6438,21 @@ impl<'a> Resolver<'a> {
         if self.opts.load_tsconfig_json {
             let mut tsconfig_path: Option<&[u8]> = None;
             if self.opts.tsconfig_override.is_none() {
-                if let Some(lookup) = entries!().get_comptime_query(b"tsconfig.json") {
-                    // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
-                    // dies (NLL) before any later `&mut` to this slot.
-                    let entry = lookup.entry();
-                    // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
-                    if unsafe { entry.kind(rfs_ptr, self.store_fd) }
-                        == Fs::file_system::EntryKind::File
-                    {
-                        let parts = [path, b"tsconfig.json".as_slice()];
-                        tsconfig_path = Some(
-                            self.fs_ref()
-                                .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
-                        );
-                    }
+                if marker_kind!(b"tsconfig.json") == Some(Fs::file_system::EntryKind::File) {
+                    let parts = [path, b"tsconfig.json".as_slice()];
+                    tsconfig_path = Some(
+                        self.fs_ref()
+                            .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
+                    );
                 }
-                if tsconfig_path.is_none() {
-                    if let Some(lookup) = entries!().get_comptime_query(b"jsconfig.json") {
-                        // SAFETY: EntryStore-owned slot; `entries_mutex` held — read-only borrow,
-                        // dies (NLL) before any later `&mut` to this slot.
-                        let entry = lookup.entry();
-                        // SAFETY: entries_mutex held; `rfs_ptr` points at the process-global RealFS.
-                        if unsafe { entry.kind(rfs_ptr, self.store_fd) }
-                            == Fs::file_system::EntryKind::File
-                        {
-                            let parts = [path, b"jsconfig.json".as_slice()];
-                            tsconfig_path = Some(
-                                self.fs_ref()
-                                    .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
-                            );
-                        }
-                    }
+                if tsconfig_path.is_none()
+                    && marker_kind!(b"jsconfig.json") == Some(Fs::file_system::EntryKind::File)
+                {
+                    let parts = [path, b"jsconfig.json".as_slice()];
+                    tsconfig_path = Some(
+                        self.fs_ref()
+                            .abs_buf(&parts, bufs!(dir_info_uncached_filename)),
+                    );
                 }
             } else if parent.is_none() {
                 // NOTE: re-borrow as 'static so the `&self.opts` borrow ends before

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
-import { writeFileSync } from "node:fs";
+import { bunEnv, bunExe, isDebug, isLinux, isWindows, tempDir } from "harness";
+import { chmodSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // `bun:main` is backed by ServerEntryPoint.contents — a slice that is
@@ -15,6 +15,98 @@ import { join } from "node:path";
 function stripAsanWarning(stderr: string): string[] {
   return stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
 }
+
+const NOBODY = "65534";
+const canDropPrivs =
+  isLinux && typeof process.getuid === "function" && process.getuid() === 0 && Bun.which("setpriv") != null;
+
+async function runAsNobody(scriptPath: string) {
+  using childHome = tempDir("bun-main-nobody-home", {});
+  chmodSync(String(childHome), 0o777);
+  await using proc = Bun.spawn({
+    cmd: ["setpriv", `--reuid=${NOBODY}`, `--regid=${NOBODY}`, "--clear-groups", bunExe(), scriptPath],
+    cwd: String(childHome),
+    env: { ...bunEnv, HOME: String(childHome) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+}
+
+test.skipIf(!canDropPrivs).concurrent("runs an entry point in a searchable-but-not-listable directory", async () => {
+  using dir = tempDir("bun-main-nolist", {
+    "sub/entry.js": `console.log("RAN_OK");`,
+  });
+  const root = String(dir);
+  chmodSync(root, 0o755);
+  // 0711: nobody can traverse sub and open entry.js by name, but not readdir it.
+  chmodSync(join(root, "sub"), 0o711);
+  chmodSync(join(root, "sub", "entry.js"), 0o644);
+
+  const [stdout, _stderr, exitCode] = await runAsNobody(join(root, "sub", "entry.js"));
+  expect(stdout).toBe("RAN_OK\n");
+  if (exitCode !== 0) expect(_stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(!canDropPrivs).concurrent("control: runs an entry point in a listable directory as nobody", async () => {
+  using dir = tempDir("bun-main-list", {
+    "sub/entry.js": `console.log("RAN_OK");`,
+  });
+  const root = String(dir);
+  chmodSync(root, 0o755);
+  chmodSync(join(root, "sub"), 0o755);
+  chmodSync(join(root, "sub", "entry.js"), 0o644);
+
+  const [stdout, _stderr, exitCode] = await runAsNobody(join(root, "sub", "entry.js"));
+  expect(stdout).toBe("RAN_OK\n");
+  if (exitCode !== 0) expect(_stderr).toBe("");
+  expect(exitCode).toBe(0);
+});
+
+test.skipIf(isWindows).concurrent("resolves a symlinked entry point relative to its real directory", async () => {
+  using dir = tempDir("bun-main-symlink", {
+    "real/main.js": `import { dep } from "./dep.js";\nconsole.log("SYM_OK", dep);`,
+    "real/dep.js": `export const dep = "from-real";`,
+  });
+  const root = String(dir);
+  symlinkSync(join(root, "real", "main.js"), join(root, "link.js"));
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(root, "link.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: stripAsanWarning(stderr), exitCode }).toEqual({
+    stdout: "SYM_OK from-real\n",
+    stderr: [],
+    exitCode: 0,
+  });
+});
+
+test.concurrent("imports the entry point's own directory (incomplete-cache upgrade)", async () => {
+  using dir = tempDir("bun-main-dirimport", {
+    "pkg/package.json": `{"type":"commonjs"}`,
+    "pkg/index.js": `module.exports = "PKG_INDEX";`,
+    "pkg/entry.js": `require("../consumer/consume.js");`,
+    "consumer/consume.js": `console.log("RESOLVED:", require("../pkg"));`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), join(String(dir), "pkg", "entry.js")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr: stripAsanWarning(stderr), exitCode }).toEqual({
+    stdout: "RESOLVED: PKG_INDEX\n",
+    stderr: [],
+    exitCode: 0,
+  });
+});
 
 test.concurrent("dynamic import('bun:main') returns the wrapper module", async () => {
   using dir = tempDir("bun-main-dyn", {


### PR DESCRIPTION
### What

Running `bun <script>` resolves the entry point by reading its parent directory's **entire** listing to (1) confirm the file exists and (2) locate the enclosing `package.json`/`tsconfig.json`. That work is O(entries in the directory), so startup scales with the number of siblings.

Fixes #32389: a script under a large immutable tree such as `/nix/store` starts 10-16x slower than the same script in a small directory. The same directory read also makes `bun` fail on a directory that is searchable but not listable (mode `0711`), even though the file itself is readable and Node runs it fine.

### Repro

```console
$ echo 'console.log("test")' > pkgs.js
$ time bun ./pkgs.js                         # small dir
real    0m0.039s
$ nix store add-file ./pkgs.js
/nix/store/ffy4qxjb9cd8sjl44736mibyxw99bmzx-pkgs.js
$ time bun /nix/store/ffy4qxjb9cd8sjl44736mibyxw99bmzx-pkgs.js
real    0m0.626s                             # ~16x slower, same file
```

Synthetic confirmation: startup grows linearly with the sibling count (60k entries ≈ 3x a 1-entry dir on a release build), independent of script content.

### Cause

Entry-point resolution goes `VirtualMachine::_resolve` → `resolve_and_auto_install` → `load_as_file` (`read_directory` on the parent) → `finalize_result` → `dir_info_cached_miss` (builds the parent `DirInfo`). Both steps only need a handful of named lookups (the entry file, `package.json`, `tsconfig.json`, `jsconfig.json`, `node_modules`), but the esbuild-derived cache reads and interns the whole directory to answer them.

### Fix

The entry point's specifier is a canonicalized absolute path (from `get_fd_path`), so its exact basename is the correct on-disk name. When resolving it:

- `load_as_file` stats `dir/base` once and returns if it is a regular file (anything else falls through to the normal directory read).
- `dir_info_uncached` resolves the four config markers by direct `stat` instead of a map lookup.

A new `DirEntry.complete` flag marks an entry created without a `readdir`; `read_directory_with_iterator` and `entries_at` re-read it to a full listing before any consumer iterates it (shell completions, routers, the glob walker, the test scanner), so the cache's completeness invariant is preserved. The fast path is gated to the main entry via `Resolver.entry_point_hint`, so ordinary relative/package imports and the bundler are unchanged, and case-insensitive filesystems are unaffected (the canonical entry path already carries the on-disk case).

### Verification

`test/js/bun/resolve/bun-main-entry-point.test.ts` runs an entry point under a `0711` (searchable, non-listable) directory. As root the directory read is bypassed by the kernel, so the child is dropped to `nobody` via `setpriv` (Linux-only, skipped otherwise):

- before: `error: Module not found` (the resolver tries to `readdir` the directory)
- after: the script runs

A listable-directory control under the same privilege drop isolates the assertion from setup failures. With the fix, a 60k-entry directory starts in the same time as a 1-entry directory.

Existing resolver suites (`resolve`, `resolve-ts`, `require`, `resolve-error`, tsconfig/long-path overflow) pass, and entry points whose directory carries a `tsconfig.json` (path aliases) or `package.json` (`#imports`) still pick up that config via the stat path.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/resolve/bun-main-entry-point.test.ts

<!-- robobun:evidence:end -->