### PR TITLE
websocket: only cap header bytes, not pipelined frames, during upgrade

### DIFF
--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -925,11 +925,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let me = unsafe { &mut *this.as_ptr() };
         let mut body = data;
         if !me.body.is_empty() {
-            if me.body.len().saturating_add(data.len()) > bun_http::max_http_header_size() {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
-                return;
-            }
             me.body.extend_from_slice(data);
             body = &me.body;
         }
@@ -954,12 +949,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
             Err(picohttp::ParseResponseError::ShortRead) => {
                 if me.body.is_empty() {
-                    if data.len() > bun_http::max_http_header_size() {
-                        // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                        unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
-                        return;
-                    }
                     me.body.extend_from_slice(data);
+                }
+                // ShortRead means no \r\n\r\n was found, so every byte in
+                // `body` is part of an incomplete header — cap that, not
+                // total bytes received (which may include pipelined
+                // WebSocket frames once the header does complete).
+                if me.body.len() > bun_http::max_http_header_size() {
+                    // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                    unsafe { Self::terminate(this.as_ptr(), ErrorCode::InvalidResponse) };
                 }
                 return;
             }
@@ -985,11 +983,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let me = unsafe { &mut *this };
         let mut body = data;
         if !me.body.is_empty() {
-            if me.body.len().saturating_add(data.len()) > bun_http::max_http_header_size() {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                return;
-            }
             me.body.extend_from_slice(data);
             body = &me.body;
         }
@@ -1017,12 +1010,14 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
             Err(picohttp::ParseResponseError::ShortRead) => {
                 if me.body.is_empty() {
-                    if data.len() > bun_http::max_http_header_size() {
-                        // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                        unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                        return;
-                    }
                     me.body.extend_from_slice(data);
+                }
+                // ShortRead means no \r\n\r\n was found, so every byte in
+                // `body` is part of an incomplete header — cap that, not
+                // total bytes received.
+                if me.body.len() > bun_http::max_http_header_size() {
+                    // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                    unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
                 }
                 return;
             }
@@ -1233,11 +1228,6 @@ impl<const SSL: bool> HTTPClient<SSL> {
         // Process as if it came directly from the socket
         let mut body = data;
         if !me.body.is_empty() {
-            if me.body.len().saturating_add(data.len()) > bun_http::max_http_header_size() {
-                // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                return;
-            }
             me.body.extend_from_slice(data);
             body = &me.body;
         }
@@ -1262,12 +1252,15 @@ impl<const SSL: bool> HTTPClient<SSL> {
             }
             Err(picohttp::ParseResponseError::ShortRead) => {
                 if me.body.is_empty() {
-                    if data.len() > bun_http::max_http_header_size() {
-                        // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
-                        unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
-                        return;
-                    }
                     me.body.extend_from_slice(data);
+                }
+                // ShortRead means no \r\n\r\n was found, so every byte in
+                // `body` is part of an incomplete header — cap that, not
+                // total bytes received (which may include pipelined
+                // WebSocket frames once the header does complete).
+                if me.body.len() > bun_http::max_http_header_size() {
+                    // SAFETY: `me`'s last use is above; no `&mut Self` spans this call.
+                    unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
                 }
                 return;
             }

--- a/test/js/web/websocket/websocket-client-short-read.test.ts
+++ b/test/js/web/websocket/websocket-client-short-read.test.ts
@@ -100,6 +100,148 @@ describe("WebSocket", () => {
   });
 });
 
+describe("WebSocket upgrade split across reads", () => {
+  function makeAccept(key: string): string {
+    const hasher = new Bun.CryptoHasher("sha1");
+    hasher.update(key);
+    hasher.update("258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    return hasher.digest("base64");
+  }
+
+  // Unmasked binary frame with a 64-bit length header and `n` zero bytes of payload.
+  function bigBinaryFrame(n: number): Uint8Array {
+    const header = new Uint8Array(10);
+    header[0] = 0x82; // FIN + binary
+    header[1] = 127; // 64-bit length follows
+    header[6] = (n >>> 24) & 0xff;
+    header[7] = (n >>> 16) & 0xff;
+    header[8] = (n >>> 8) & 0xff;
+    header[9] = n & 0xff;
+    const out = new Uint8Array(10 + n);
+    out.set(header, 0);
+    return out;
+  }
+
+  test("large frame pipelined after split 101 header is not counted against the header-size cap", async () => {
+    // First read delivers a partial status line (ShortRead -> buffered); second
+    // read delivers the rest of the 101 header plus a >16KB binary frame in one
+    // segment. The header-size cap must only apply to bytes that are provably
+    // header (the ShortRead accumulator), not to pipelined frame bytes.
+    const PAYLOAD = 20000; // > default max_http_header_size (16384)
+
+    using server = Bun.listen<{ buf: string; done: boolean }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { buf: "", done: false };
+        },
+        data(socket, chunk) {
+          const st = socket.data;
+          if (st.done) return;
+          st.buf += chunk.toString("latin1");
+          if (!st.buf.includes("\r\n\r\n")) return;
+          st.done = true;
+          const m = /Sec-WebSocket-Key:\s*(\S+)/i.exec(st.buf);
+          if (!m) {
+            socket.end();
+            return;
+          }
+          const accept = makeAccept(m[1]);
+
+          // First segment: partial status line -> client buffers via ShortRead.
+          socket.write("HTTP/1.1 101 ");
+          socket.flush();
+
+          // Second segment: header tail + a >16KB frame, written together so
+          // they arrive in the same read on the client.
+          setTimeout(() => {
+            const tail =
+              "Switching Protocols\r\n" +
+              "Upgrade: websocket\r\n" +
+              "Connection: Upgrade\r\n" +
+              `Sec-WebSocket-Accept: ${accept}\r\n` +
+              "\r\n";
+            const tailBytes = new TextEncoder().encode(tail);
+            const frame = bigBinaryFrame(PAYLOAD);
+            const packet = new Uint8Array(tailBytes.length + frame.length);
+            packet.set(tailBytes, 0);
+            packet.set(frame, tailBytes.length);
+            socket.write(packet);
+            socket.flush();
+          }, 50);
+        },
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<{ open: boolean; bytes: number }>();
+    let opened = false;
+    const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
+    ws.binaryType = "arraybuffer";
+    ws.onopen = () => {
+      opened = true;
+    };
+    ws.onmessage = ev => {
+      const data = ev.data as ArrayBuffer;
+      resolve({ open: opened, bytes: data.byteLength });
+    };
+    ws.onerror = ev => reject(new Error("ws error: " + (ev as ErrorEvent).message));
+    ws.onclose = ev => {
+      if (!ev.wasClean) reject(new Error(`unclean close: ${ev.code} ${ev.reason}`));
+    };
+
+    try {
+      expect(await promise).toEqual({ open: true, bytes: PAYLOAD });
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("incomplete header larger than the cap is still rejected", async () => {
+    // >16KB of header bytes with no terminating blank line must still fail.
+    using server = Bun.listen<{ buf: string; done: boolean }>({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open(socket) {
+          socket.data = { buf: "", done: false };
+        },
+        data(socket, chunk) {
+          const st = socket.data;
+          if (st.done) return;
+          st.buf += chunk.toString("latin1");
+          if (!st.buf.includes("\r\n\r\n")) return;
+          st.done = true;
+
+          socket.write("HTTP/1.1 101 Switching Protocols\r\n");
+          socket.flush();
+          setTimeout(() => {
+            // 20KB of header field bytes, no \r\n\r\n terminator.
+            const pad = Buffer.alloc(20000, "a");
+            socket.write(Buffer.concat([Buffer.from("X-Pad: "), pad]));
+            socket.flush();
+          }, 50);
+        },
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const ws = new globalThis.WebSocket(`ws://127.0.0.1:${server.port}`);
+    ws.onopen = () => reject(new Error("unexpected open"));
+    ws.onerror = ev => resolve((ev as ErrorEvent).message ?? "error");
+    ws.onclose = ev => {
+      if (ev.wasClean) reject(new Error("unexpected clean close"));
+    };
+
+    try {
+      const msg = await promise;
+      expect(msg).toContain("Invalid response");
+    } finally {
+      ws.close();
+    }
+  });
+});
+
 describe("WebSocket buffered handshake data", () => {
   test("terminating the client from its open handler while handshake bytes are buffered shuts down cleanly", async () => {
     // A raw TCP "websocket server" that appends a complete text frame to the 101


### PR DESCRIPTION
## Problem

The hardening pass in #31175 added a `max_http_header_size` cap (default 16384) to the WebSocket upgrade client's response accumulator at all three entry points (`handle_data`, `handle_proxy_response`, `handle_decrypted_data`). The cap was applied to **total bytes received** before parsing:

```rust
if !me.body.is_empty() {
    if me.body.len().saturating_add(data.len()) > bun_http::max_http_header_size() {
        Self::terminate(this, ErrorCode::InvalidResponse);
        return;
    }
    me.body.extend_from_slice(data);
}
```

This counts any WebSocket frame bytes the server pipelines after the 101 response in the same TCP segment as the header tail. Failing sequence:

1. First read delivers a partial 101 status line → picohttp `ShortRead` → buffered to `self.body`
2. Second read delivers rest-of-header plus a >16KB initial WS frame → `body.len() + data.len() > 16384` → `terminate(InvalidResponse)`

The Zig reference (`WebSocketUpgradeClient.zig` lines 594-598 / 616-620 / 631-634 / 656-658 / 802-805 / 824-826) has no size cap; it appends and continues, parses the header, and hands the trailing bytes to `processResponse` as `remain_buf`.

## Reproduction

```
error: ws error: WebSocket connection to 'ws://127.0.0.1:.../' failed: Invalid response
```

Raw TCP server that writes `"HTTP/1.1 101 "`, flushes, then after a short delay writes the header tail plus a 20000-byte binary frame in one packet. 10/10 failures on the released build.

## Fix

Move the cap to the `ShortRead` arm, where picohttp has confirmed no `\r\n\r\n` exists and therefore every byte in the accumulator is provably header:

```rust
Err(picohttp::ParseResponseError::ShortRead) => {
    if me.body.is_empty() {
        me.body.extend_from_slice(data);
    }
    if me.body.len() > bun_http::max_http_header_size() {
        Self::terminate(this, ErrorCode::InvalidResponse);
    }
    return;
}
```

Applied identically to `handle_data`, `handle_proxy_response`, and `handle_decrypted_data`. This keeps the DoS protection from #31175 (a server that never sends `\r\n\r\n` is still rejected once the accumulator exceeds 16KB) while matching the Zig reference for well-formed responses that pipeline large frames. Worst-case allocation before rejection is `max_http_header_size + one socket read`, bounded by the kernel recv buffer.

## Tests

Added to `test/js/web/websocket/websocket-client-short-read.test.ts`:

- `large frame pipelined after split 101 header is not counted against the header-size cap`: fails with `Invalid response` on the unfixed build, passes with the fix (verified 5x stable).
- `incomplete header larger than the cap is still rejected`: confirms the retained DoS guard still fires when 20KB of header bytes arrive with no terminator.