### PR TITLE
ci(runner): ignore local console logins in wait-for-user loop

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3032,14 +3032,12 @@ export function getLoggedInUserCountOrDetails() {
       // job — waiting for it would hang the runner forever.
       .filter(line => /\([^)]+\)\s*$/.test(line))
       .map(line => {
-        // who output format: username terminal date/time (ip)
-        const [username, terminal, datetime, ip] = line.split(/\s+/);
-        return {
-          username,
-          terminal,
-          datetime,
-          ip: (ip || "").replace(/[()]/g, ""), // Remove parentheses from IP
-        };
+        // `who` output: `username terminal date time (host)`. The date/time
+        // field has spaces, so a plain split() can't slice it cleanly — take
+        // the first two tokens and pull the host from the trailing `(...)`.
+        const [username, terminal] = line.split(/\s+/);
+        const ip = line.match(/\(([^)]+)\)\s*$/)?.[1] || "";
+        return { username, terminal, ip };
       });
 
     if (users.length === 0) {
@@ -3049,7 +3047,7 @@ export function getLoggedInUserCountOrDetails() {
     let message = `${users.length} currently logged in users:`;
 
     for (const user of users) {
-      message += `\n- ${user.username} on ${user.terminal} since ${user.datetime}${user.ip ? ` from ${user.ip}` : ""}`;
+      message += `\n- ${user.username} on ${user.terminal}${user.ip ? ` from ${user.ip}` : ""}`;
     }
 
     return message;

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3026,6 +3026,11 @@ export function getLoggedInUserCountOrDetails() {
     const users = stdout
       .split("\n")
       .filter(line => /tty|pts/i.test(line))
+      // Only count REMOTE logins (have an `(ip)` suffix from sshd). A local
+      // console/auto-login (e.g. cirruslabs CI VM images log the admin user in
+      // on ttys000 at boot) has no source host and isn't a human debugging the
+      // job — waiting for it would hang the runner forever.
+      .filter(line => /\([^)]+\)\s*$/.test(line))
       .map(line => {
         // who output format: username terminal date/time (ip)
         const [username, terminal, datetime, ip] = line.split(/\s+/);


### PR DESCRIPTION
## What
The runner's post-test `waitForUser` loop now only counts **remote** logins (sessions whose `who` line ends with a `(host)` suffix from sshd). Local console/auto-login sessions are ignored.

## Why
The loop is meant to keep the runner alive if a human is SSH'd in debugging. But it currently counts *any* tty/pts session — including the console auto-login that some CI VM images do at boot (e.g. the cirruslabs macOS runner images log `admin` in on `ttys000`). With one of those present, the runner prints `--- End` then waits forever.

We hit this on Tart-hosted macOS 26 guests: the suite finishes in ~14 min, then the job sits for 30+ minutes until the step timeout kills it. The sequoia (15) base image happens not to auto-login, so only the tahoe lane was affected.

## Change
One filter line: keep only `who` lines matching `/(host)\s*$/` (sshd-originated). Console logins have no source host and are skipped.