### PR TITLE
Support transferring ReadableStream via postMessage

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2540,7 +2540,16 @@ export function structuredCloneTransferReadableStream(readable, port) {
     return Promise.$resolve();
   };
   const abortAlgorithm = reason => {
-    port.postMessage({ type: "error", value: reason });
+    // PackAndPostMessageHandlingError: a non-cloneable reason makes postMessage
+    // throw synchronously; still close the port and surface the failure as a
+    // rejected promise instead of letting it escape through abortSteps.
+    try {
+      port.postMessage({ type: "error", value: reason });
+    } catch (e) {
+      $crossRealmTransformSendError(port, e);
+      port.close();
+      return Promise.$reject(e);
+    }
     port.close();
     return Promise.$resolve();
   };

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2479,10 +2479,15 @@ export function structuredCloneReceiveReadableStream(port) {
       port.postMessage({ type: "pull", value: undefined });
     },
     $cancel: reason => {
+      // PackAndPostMessageHandlingError: mirror abortAlgorithm. A non-cloneable
+      // reason makes postMessage throw; close the port and reject so the
+      // caller's cancel() rejects rather than resolving.
       try {
         port.postMessage({ type: "error", value: reason });
       } catch (e) {
         $crossRealmTransformSendError(port, e);
+        port.close();
+        return Promise.$reject(e);
       }
       port.close();
     },

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -2458,3 +2458,131 @@ export function readableStreamDefineLazyIterators(prototype) {
   $Object.$defineProperty(prototype, "values", { value: createValues });
   return prototype;
 }
+
+// Transferable streams: https://streams.spec.whatwg.org/#transferable-streams
+// The following helpers implement the cross-realm transform used by structured
+// clone to transfer a ReadableStream across a MessagePort. They mirror the
+// abstract operations SetUpCrossRealmTransformReadable/Writable from the spec.
+
+// https://streams.spec.whatwg.org/#abstract-opdef-crossrealmtransformsenderror
+export function crossRealmTransformSendError(port, error) {
+  try {
+    port.postMessage({ type: "error", value: error });
+  } catch {}
+}
+
+// Receives a ReadableStream that was transferred into `port` and returns a new
+// ReadableStream backed by it (SetUpCrossRealmTransformReadable).
+export function structuredCloneReceiveReadableStream(port) {
+  const source = {
+    $pull: () => {
+      port.postMessage({ type: "pull", value: undefined });
+    },
+    $cancel: reason => {
+      try {
+        port.postMessage({ type: "error", value: reason });
+      } catch (e) {
+        $crossRealmTransformSendError(port, e);
+      }
+      port.close();
+    },
+  };
+  const readable = new $ReadableStream(source, { $highWaterMark: 0 });
+  const controller = readable.$readableStreamController;
+
+  port.onmessage = event => {
+    const data = event.data;
+    const type = data.type;
+    if (type === "chunk") {
+      $readableStreamDefaultControllerEnqueue(controller, data.value);
+    } else if (type === "close") {
+      $readableStreamDefaultControllerClose(controller);
+      port.close();
+    } else if (type === "error") {
+      $readableStreamDefaultControllerError(controller, data.value);
+      port.close();
+    }
+  };
+  port.onmessageerror = () => {
+    const error = new TypeError("Failed to deserialize transferred stream chunk");
+    $crossRealmTransformSendError(port, error);
+    $readableStreamDefaultControllerError(controller, error);
+    port.close();
+  };
+  port.start();
+  return readable;
+}
+
+// Transfers `readable` by piping it into a cross-realm writable whose sink posts
+// chunks to `port` (SetUpCrossRealmTransformWritable + rs-transfer steps).
+export function structuredCloneTransferReadableStream(readable, port) {
+  let backpressure = $newPromiseCapability(Promise);
+
+  const writeAlgorithm = chunk => {
+    if (backpressure === undefined) {
+      backpressure = $newPromiseCapability(Promise);
+      backpressure.resolve.$call();
+    }
+    return backpressure.promise.$then(() => {
+      backpressure = $newPromiseCapability(Promise);
+      try {
+        port.postMessage({ type: "chunk", value: chunk });
+      } catch (e) {
+        $crossRealmTransformSendError(port, e);
+        port.close();
+        throw e;
+      }
+    });
+  };
+  const closeAlgorithm = () => {
+    port.postMessage({ type: "close", value: undefined });
+    port.close();
+    return Promise.$resolve();
+  };
+  const abortAlgorithm = reason => {
+    port.postMessage({ type: "error", value: reason });
+    port.close();
+    return Promise.$resolve();
+  };
+
+  const internalWritable = {};
+  $initializeWritableStreamSlots(internalWritable, {});
+  const controller = new WritableStreamDefaultController();
+  $setUpWritableStreamDefaultController(
+    internalWritable,
+    controller,
+    () => {},
+    writeAlgorithm,
+    closeAlgorithm,
+    abortAlgorithm,
+    1,
+    () => 1,
+  );
+
+  const resolveBackpressure = () => {
+    if (backpressure !== undefined) {
+      backpressure.resolve.$call();
+      backpressure = undefined;
+    }
+  };
+  port.onmessage = event => {
+    const data = event.data;
+    const type = data.type;
+    if (type === "pull") {
+      resolveBackpressure();
+    } else if (type === "error") {
+      $writableStreamDefaultControllerErrorIfNeeded(controller, data.value);
+      resolveBackpressure();
+    }
+  };
+  port.onmessageerror = () => {
+    const error = new TypeError("Failed to deserialize transferred stream chunk");
+    $crossRealmTransformSendError(port, error);
+    $writableStreamDefaultControllerErrorIfNeeded(controller, error);
+    port.close();
+  };
+  port.start();
+
+  const promise = $readableStreamPipeToWritableStream(readable, internalWritable, false, false, false, undefined);
+  $markPromiseAsHandled(promise);
+}

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -799,6 +799,7 @@ static RefPtr<MessagePort> runReadableStreamTransferSteps(JSC::JSGlobalObject& l
     Ref<MessagePort> port2 = channel->port2();
 
     auto& vm = lexicalGlobalObject.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
     auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
     auto& name = clientData->builtinFunctions().readableStreamInternalsBuiltins().structuredCloneTransferReadableStreamPrivateName();
 
@@ -807,24 +808,26 @@ static RefPtr<MessagePort> runReadableStreamTransferSteps(JSC::JSGlobalObject& l
     arguments.append(toJS(&lexicalGlobalObject, globalObject, port1.get()));
     ASSERT(!arguments.hasOverflowed());
     invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
     return port2.ptr();
 }
 
 // rs-transfer-receiving steps: wrap a received MessagePort in a new ReadableStream
-// backed by a cross-realm transform readable.
-static JSC::JSValue runReadableStreamTransferReceivingSteps(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSGlobalObject* globalObject, MessagePort* port)
+// backed by a cross-realm transform readable. The stream is constructed in the
+// destination realm (globalObject), not the serializer's lexical realm.
+static JSC::JSValue runReadableStreamTransferReceivingSteps(JSC::JSGlobalObject& globalObject, MessagePort* port)
 {
     if (!port)
         return {};
-    auto& vm = lexicalGlobalObject.vm();
+    auto& vm = globalObject.vm();
     auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
     auto& name = clientData->builtinFunctions().readableStreamInternalsBuiltins().structuredCloneReceiveReadableStreamPrivateName();
 
     MarkedArgumentBuffer arguments;
-    arguments.append(toJS(&lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), port));
+    arguments.append(toJS(&globalObject, uncheckedDowncast<JSDOMGlobalObject>(&globalObject), port));
     ASSERT(!arguments.hasOverflowed());
-    return invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
+    return invokeStreamTransferBuiltin(globalObject, name, arguments);
 }
 
 class CloneBase {
@@ -5150,11 +5153,21 @@ private:
                 fail();
                 return JSValue();
             }
-            JSValue result = runReadableStreamTransferReceivingSteps(*m_lexicalGlobalObject, m_globalObject, m_messagePorts[index].get());
+            // The same transferred stream can appear multiple times in the graph;
+            // every occurrence shares one port, so reconstruct it once and return
+            // the same object to preserve structured-clone identity.
+            if (JSValue cached = m_transferredReadableStreams.get(index))
+                return cached;
+            auto& vm = m_globalObject->vm();
+            auto scope = DECLARE_THROW_SCOPE(vm);
+            JSValue result = runReadableStreamTransferReceivingSteps(*m_globalObject, m_messagePorts[index].get());
+            RETURN_IF_EXCEPTION(scope, JSValue());
             if (!result) {
                 fail();
                 return JSValue();
             }
+            m_transferredReadableStreamRoots.appendWithCrashOnOverflow(result);
+            m_transferredReadableStreams.add(index, result);
             return result;
         }
 #if ENABLE(WEBASSEMBLY)
@@ -5396,6 +5409,12 @@ private:
     Vector<CachedString> m_constantPool;
     // Vector<Ref<ImageData>> m_imageDataPool;
     const Vector<RefPtr<MessagePort>>& m_messagePorts;
+    // Deserialized transferred ReadableStreams, keyed by port index, so repeated
+    // references resolve to the same object. Roots kept alive separately from
+    // m_gcBuffer to avoid perturbing the object-reference pool. The zero-key
+    // traits allow port index 0 (a valid key here).
+    HashMap<uint32_t, JSC::JSValue, WTF::DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_transferredReadableStreams;
+    MarkedArgumentBuffer m_transferredReadableStreamRoots;
     ArrayBufferContentsArray* m_arrayBufferContents;
     Vector<RefPtr<JSC::ArrayBuffer>> m_arrayBuffers;
     Vector<String> m_blobURLs;

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -807,8 +807,12 @@ static RefPtr<MessagePort> runReadableStreamTransferSteps(JSC::JSGlobalObject& l
     arguments.append(readableStream);
     arguments.append(toJS(&lexicalGlobalObject, globalObject, port1.get()));
     ASSERT(!arguments.hasOverflowed());
-    invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
+    JSValue result = invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
     RETURN_IF_EXCEPTION(scope, nullptr);
+    // The builtin is always installed; guard against a missing/non-callable
+    // private name so we never hand back a port whose writable side is unwired.
+    if (!result)
+        return nullptr;
 
     return port2.ptr();
 }
@@ -6483,6 +6487,18 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     if (scope.exception() || code != SerializationReturnCode::SuccessfullyCompleted) [[unlikely]] {
         releaseSerializedBlockListRefs();
         RELEASE_AND_RETURN(scope, exceptionForSerializationFailure(code));
+    }
+
+    // Serialization can run user getters that lock a stream after the
+    // transfer-list check passed (rs-transfer step 1 runs at transfer time, not
+    // serialize time). Re-validate every stream before detaching any of them, so
+    // a later locked stream can't leave earlier ones partially detached, and the
+    // failure surfaces as DataCloneError rather than the pipe's TypeError.
+    for (auto* readableStream : readableStreams) {
+        if (ReadableStream::isLocked(&lexicalGlobalObject, uncheckedDowncast<JSReadableStream>(readableStream))) {
+            releaseSerializedBlockListRefs();
+            return Exception { DataCloneError, "ReadableStream is locked and cannot be transferred"_s };
+        }
     }
 
     // rs-transfer steps run after the message value is serialized. Each transferred

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -56,6 +56,9 @@
 // #include "JSImageBitmap.h"
 // #include "JSImageData.h"
 #include "JSMessagePort.h"
+#include "JSReadableStream.h"
+#include "ReadableStream.h"
+#include "MessageChannel.h"
 // #include "JSNavigator.h"
 // #include "JSRTCCertificate.h"
 // #include "JSRTCDataChannel.h"
@@ -64,6 +67,7 @@
 #include "ScriptExecutionContext.h"
 // #include "WebCodecsEncodedVideoChunk.h"
 #include "WebCoreJSClientData.h"
+#include "WebCoreJSBuiltins.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/BigIntObject.h>
 #include <JavaScriptCore/BooleanObject.h>
@@ -245,6 +249,7 @@ enum SerializationTag {
 #endif
     ResizableArrayBufferTag = 54,
     ErrorInstanceTag = 55,
+    ReadableStreamTag = 56,
 
     Bun__BlobTag = 254,
     // bun types start at 254 and decrease with each addition
@@ -762,6 +767,66 @@ static constexpr unsigned StringDataIs8BitFlag = 0x80000000;
 
 using DeserializationResult = std::pair<JSC::JSValue, SerializationReturnCode>;
 
+// Transferable streams support. These bridge the structured clone layer to the
+// cross-realm transform builtins in ReadableStreamInternals.ts.
+static JSC::JSValue invokeStreamTransferBuiltin(JSC::JSGlobalObject& globalObject, const JSC::Identifier& identifier, const JSC::MarkedArgumentBuffer& arguments)
+{
+    JSC::VM& vm = globalObject.vm();
+    JSC::JSLockHolder lock(vm);
+    auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+    auto function = globalObject.get(&globalObject, identifier);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!function.isCallable())
+        return {};
+    auto callData = JSC::getCallData(function);
+    auto result = JSC::call(&globalObject, function, callData, JSC::jsUndefined(), arguments);
+    RETURN_IF_EXCEPTION(scope, {});
+    return result;
+}
+
+// rs-transfer steps: create an entangled MessagePort pair, pipe the stream into
+// a cross-realm writable backed by one port, and return the other port so it can
+// be serialized alongside the message's transferred ports.
+static RefPtr<MessagePort> runReadableStreamTransferSteps(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSObject* readableStream)
+{
+    auto* context = executionContext(&lexicalGlobalObject);
+    if (!context)
+        return nullptr;
+    auto* globalObject = uncheckedDowncast<JSDOMGlobalObject>(&lexicalGlobalObject);
+
+    Ref channel = MessageChannel::create(*context);
+    Ref<MessagePort> port1 = channel->port1();
+    Ref<MessagePort> port2 = channel->port2();
+
+    auto& vm = lexicalGlobalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
+    auto& name = clientData->builtinFunctions().readableStreamInternalsBuiltins().structuredCloneTransferReadableStreamPrivateName();
+
+    MarkedArgumentBuffer arguments;
+    arguments.append(readableStream);
+    arguments.append(toJS(&lexicalGlobalObject, globalObject, port1.get()));
+    ASSERT(!arguments.hasOverflowed());
+    invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
+
+    return port2.ptr();
+}
+
+// rs-transfer-receiving steps: wrap a received MessagePort in a new ReadableStream
+// backed by a cross-realm transform readable.
+static JSC::JSValue runReadableStreamTransferReceivingSteps(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSGlobalObject* globalObject, MessagePort* port)
+{
+    if (!port)
+        return {};
+    auto& vm = lexicalGlobalObject.vm();
+    auto* clientData = static_cast<JSVMClientData*>(vm.clientData);
+    auto& name = clientData->builtinFunctions().readableStreamInternalsBuiltins().structuredCloneReceiveReadableStreamPrivateName();
+
+    MarkedArgumentBuffer arguments;
+    arguments.append(toJS(&lexicalGlobalObject, uncheckedDowncast<JSDOMGlobalObject>(globalObject), port));
+    ASSERT(!arguments.hasOverflowed());
+    return invokeStreamTransferBuiltin(lexicalGlobalObject, name, arguments);
+}
+
 class CloneBase {
     WTF_FORBID_HEAP_ALLOCATION;
 
@@ -888,7 +953,7 @@ public:
     //         return serializer.serialize(value);
     //     }
 
-    static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers,
+    static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, const Vector<JSC::JSObject*>& readableStreams, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
 #endif
@@ -907,7 +972,7 @@ public:
         Vector<void*>& serializedBlockListRefs,
         SerializationForStorage forStorage, SerializationForCrossProcessTransfer forTransfer)
     {
-        CloneSerializer serializer(lexicalGlobalObject, messagePorts, arrayBuffers,
+        CloneSerializer serializer(lexicalGlobalObject, messagePorts, readableStreams, arrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
             offscreenCanvases,
 #endif
@@ -994,7 +1059,7 @@ private:
     // #endif
     //     }
 
-    CloneSerializer(JSGlobalObject* lexicalGlobalObject, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers,
+    CloneSerializer(JSGlobalObject* lexicalGlobalObject, Vector<RefPtr<MessagePort>>& messagePorts, const Vector<JSC::JSObject*>& readableStreams, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         const Vector<RefPtr<OffscreenCanvas>>& offscreenCanvases,
 #endif
@@ -1028,6 +1093,7 @@ private:
     {
         write(CurrentVersion);
         fillTransferMap(messagePorts, m_transferredMessagePorts);
+        fillTransferMapFromObjects(readableStreams, m_transferredReadableStreams);
         fillTransferMap(arrayBuffers, m_transferredArrayBuffers);
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         fillTransferMap(offscreenCanvases, m_transferredOffscreenCanvases);
@@ -1059,6 +1125,15 @@ private:
         for (size_t i = 0; i < input.size(); i++) {
             JSC::JSValue value = toJS(m_lexicalGlobalObject, globalObject, input[i].get());
             JSC::JSObject* obj = value.getObject();
+            if (obj && !result.contains(obj))
+                result.add(obj, i);
+        }
+    }
+
+    void fillTransferMapFromObjects(const Vector<JSC::JSObject*>& input, ObjectPool& result)
+    {
+        for (size_t i = 0; i < input.size(); i++) {
+            JSC::JSObject* obj = input[i];
             if (obj && !result.contains(obj))
                 result.add(obj, i);
         }
@@ -1751,6 +1826,17 @@ private:
                 code = SerializationReturnCode::ValidationError;
                 return true;
             }
+            if (obj->inherits<JSReadableStream>()) {
+                auto index = m_transferredReadableStreams.find(obj);
+                if (index != m_transferredReadableStreams.end()) {
+                    write(ReadableStreamTag);
+                    write(static_cast<uint32_t>(m_transferredMessagePorts.size() + index->value));
+                    return true;
+                }
+                // A ReadableStream can be transferred but not cloned.
+                code = SerializationReturnCode::DataCloneError;
+                return true;
+            }
             if (auto* arrayBuffer = toPossiblySharedArrayBuffer(vm, obj)) {
                 if (arrayBuffer->isDetached()) {
                     code = SerializationReturnCode::ValidationError;
@@ -1849,7 +1935,8 @@ private:
                 //                     dummyMemoryHandles,
                 // #endif
                 //                     dummyBlobHandles, serializedKey, SerializationContext::Default, dummySharedBuffers, m_forStorage);
-                CloneSerializer rawKeySerializer(m_lexicalGlobalObject, dummyMessagePorts, dummyArrayBuffers,
+                Vector<JSC::JSObject*> dummyReadableStreams;
+                CloneSerializer rawKeySerializer(m_lexicalGlobalObject, dummyMessagePorts, dummyReadableStreams, dummyArrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
                     {},
 #endif
@@ -2579,6 +2666,7 @@ private:
     // Vector<URLKeepingBlobAlive>& m_blobHandles;
     ObjectPool m_objectPool;
     ObjectPool m_transferredMessagePorts;
+    ObjectPool m_transferredReadableStreams;
     ObjectPool m_transferredArrayBuffers;
     ObjectPool m_transferredImageBitmaps;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -5055,6 +5143,20 @@ private:
             }
             return getJSValue(m_messagePorts[index].get());
         }
+        case ReadableStreamTag: {
+            uint32_t index;
+            bool indexSuccessfullyRead = read(index);
+            if (!indexSuccessfullyRead || index >= m_messagePorts.size()) {
+                fail();
+                return JSValue();
+            }
+            JSValue result = runReadableStreamTransferReceivingSteps(*m_lexicalGlobalObject, m_globalObject, m_messagePorts[index].get());
+            if (!result) {
+                fail();
+                return JSValue();
+            }
+            return result;
+        }
 #if ENABLE(WEBASSEMBLY)
         case WasmModuleTag: {
             if (m_version >= 12) {
@@ -6216,6 +6318,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 #if ENABLE(WEB_CODECS)
     Vector<Ref<WebCodecsVideoFrame>> transferredVideoFrames;
 #endif
+    Vector<JSC::JSObject*> readableStreams;
     HashSet<JSC::JSObject*> uniqueTransferables;
     for (auto& transferable : transferList) {
         if (!uniqueTransferables.add(transferable.get()).isNewEntry) {
@@ -6243,6 +6346,12 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
             if (port->isDetached())
                 return Exception { DataCloneError, "MessagePort in transfer list is already detached"_s };
             messagePorts.append(WTF::move(port));
+            continue;
+        }
+        if (auto* readableStream = dynamicDowncast<JSReadableStream>(transferable.get())) {
+            if (ReadableStream::isLocked(&lexicalGlobalObject, readableStream))
+                return Exception { DataCloneError, "ReadableStream is locked and cannot be transferred"_s };
+            readableStreams.append(readableStream);
             continue;
         }
 
@@ -6320,7 +6429,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     //         wasmMemoryHandles,
     // #endif
     //         blobHandles, buffer, context, *sharedBuffers, forStorage);
-    auto code = CloneSerializer::serialize(&lexicalGlobalObject, value, messagePorts, arrayBuffers,
+    auto code = CloneSerializer::serialize(&lexicalGlobalObject, value, messagePorts, readableStreams, arrayBuffers,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         offscreenCanvases,
 #endif
@@ -6355,6 +6464,24 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     if (scope.exception() || code != SerializationReturnCode::SuccessfullyCompleted) [[unlikely]] {
         releaseSerializedBlockListRefs();
         RELEASE_AND_RETURN(scope, exceptionForSerializationFailure(code));
+    }
+
+    // rs-transfer steps run after the message value is serialized. Each transferred
+    // ReadableStream is detached into a cross-realm transform backed by a fresh
+    // MessagePort pair; the remote port is appended to messagePorts so it is
+    // disentangled and delivered alongside the message, matching the index the
+    // serializer wrote (messagePorts.size() at dump time + the stream's index).
+    for (auto* readableStream : readableStreams) {
+        auto port = runReadableStreamTransferSteps(lexicalGlobalObject, readableStream);
+        if (scope.exception()) [[unlikely]] {
+            releaseSerializedBlockListRefs();
+            RELEASE_AND_RETURN(scope, Exception { ExistingExceptionError });
+        }
+        if (!port) {
+            releaseSerializedBlockListRefs();
+            return Exception { DataCloneError, "Failed to transfer ReadableStream"_s };
+        }
+        messagePorts.append(WTF::move(port));
     }
 
     auto arrayBufferContentsArray = transferArrayBuffers(vm, arrayBuffers);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6501,6 +6501,25 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         }
     }
 
+    // Stream transfer steps below irreversibly detach each stream, but
+    // transferArrayBuffers() runs afterward and can still fail (a serialization
+    // getter may have detached an ArrayBuffer from the same transfer list). When
+    // streams are involved, re-validate the ArrayBuffers up front, mirroring
+    // transferTo()'s failure conditions, so no stream is left half-detached.
+    if (!readableStreams.isEmpty()) {
+        for (auto& arrayBuffer : arrayBuffers) {
+            if (!arrayBuffer || arrayBuffer->isDetached() || arrayBuffer->isShared()) {
+                releaseSerializedBlockListRefs();
+                return Exception { DataCloneError };
+            }
+            if (arrayBuffer->isLocked()) {
+                releaseSerializedBlockListRefs();
+                throwVMTypeError(&lexicalGlobalObject, scope, errorMessageForTransfer(arrayBuffer));
+                RELEASE_AND_RETURN(scope, Exception { ExistingExceptionError });
+            }
+        }
+    }
+
     // rs-transfer steps run after the message value is serialized. Each transferred
     // ReadableStream is detached into a cross-realm transform backed by a fresh
     // MessagePort pair; the remote port is appended to messagePorts so it is

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -322,8 +322,11 @@ describe("ReadableStream transfer", () => {
       },
       rs,
     };
-    expect(() => port1.postMessage(message, [rs])).toThrow(expect.objectContaining({ name: "DataCloneError" }));
-    port1.close();
-    port2.close();
+    try {
+      expect(() => port1.postMessage(message, [rs])).toThrow(expect.objectContaining({ name: "DataCloneError" }));
+    } finally {
+      port1.close();
+      port2.close();
+    }
   });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -249,4 +249,63 @@ describe("ReadableStream transfer", () => {
       URL.revokeObjectURL(url);
     }
   });
+
+  test("preserves identity when the same stream is referenced twice", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const rs = new ReadableStream({
+      start(c) {
+        c.enqueue("dup");
+        c.close();
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<unknown[]>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        const { a, b } = e.data;
+        expect(a).toBeInstanceOf(ReadableStream);
+        // One transferred stream shared by two references must deserialize to
+        // the same object, not two streams fighting over one port.
+        expect(a).toBe(b);
+        const chunks: unknown[] = [];
+        for await (const chunk of a) chunks.push(chunk);
+        resolve(chunks);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    port2.start();
+
+    port1.postMessage({ a: rs, b: rs }, [rs]);
+    expect(await promise).toEqual(["dup"]);
+    port1.close();
+    port2.close();
+  });
+
+  test("errors the receiver when the source errors with a non-cloneable reason", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const rs = new ReadableStream({
+      start(c) {
+        // A function is not structured-cloneable: posting it over the port
+        // throws, which must still propagate an error (not hang) to the receiver.
+        c.error(() => {});
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        for await (const _ of e.data);
+        reject(new Error("expected the transferred stream to error"));
+      } catch {
+        resolve("errored");
+      }
+    };
+    port2.start();
+
+    port1.postMessage(rs, [rs]);
+    expect(await promise).toBe("errored");
+    port1.close();
+    port2.close();
+  });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -329,4 +329,36 @@ describe("ReadableStream transfer", () => {
       port2.close();
     }
   });
+
+  test("cancel() with a non-cloneable reason rejects on the transferred stream", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const rs = new ReadableStream({
+      start(c) {
+        c.enqueue("x");
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<boolean>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        // A function is not structured-cloneable, so relaying the cancel reason
+        // over the port throws; cancel() must reject rather than resolve.
+        let rejected = false;
+        try {
+          await e.data.cancel(() => {});
+        } catch {
+          rejected = true;
+        }
+        resolve(rejected);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    port2.start();
+
+    port1.postMessage(rs, [rs]);
+    expect(await promise).toBe(true);
+    port1.close();
+    port2.close();
+  });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -356,9 +356,12 @@ describe("ReadableStream transfer", () => {
     };
     port2.start();
 
-    port1.postMessage(rs, [rs]);
-    expect(await promise).toBe(true);
-    port1.close();
-    port2.close();
+    try {
+      port1.postMessage(rs, [rs]);
+      expect(await promise).toBe(true);
+    } finally {
+      port1.close();
+      port2.close();
+    }
   });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -197,9 +197,7 @@ describe("ReadableStream transfer", () => {
     const rs = new ReadableStream();
     rs.getReader();
     const { port1, port2 } = new MessageChannel();
-    expect(() => port1.postMessage(rs, [rs])).toThrow(
-      expect.objectContaining({ name: "DataCloneError" }),
-    );
+    expect(() => port1.postMessage(rs, [rs])).toThrow(expect.objectContaining({ name: "DataCloneError" }));
     port1.close();
     port2.close();
   });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -308,4 +308,22 @@ describe("ReadableStream transfer", () => {
     port1.close();
     port2.close();
   });
+
+  test("throws DataCloneError when a getter locks the stream during serialization", () => {
+    const rs = new ReadableStream();
+    const { port1, port2 } = new MessageChannel();
+    // The getter runs while the message is being serialized, locking `rs` after
+    // the transfer-list check already passed. The transfer steps must re-check
+    // and reject with DataCloneError, not the cross-realm pipe's TypeError.
+    const message = {
+      get locker() {
+        rs.getReader();
+        return 1;
+      },
+      rs,
+    };
+    expect(() => port1.postMessage(message, [rs])).toThrow(expect.objectContaining({ name: "DataCloneError" }));
+    port1.close();
+    port2.close();
+  });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -98,3 +98,157 @@ describe("self.postMessage transfer list", () => {
     }
   });
 });
+
+// Transferable streams: a ReadableStream listed in the transfer list is detached
+// into a cross-realm transform and reconstructed on the receiving side, so data
+// written to the source is readable through the transferred stream.
+// https://github.com/oven-sh/bun/issues/32397
+describe("ReadableStream transfer", () => {
+  test("carries data across a MessageChannel and detaches the source", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const rs = new ReadableStream({
+      start(c) {
+        c.enqueue("a");
+        c.enqueue("b");
+        c.enqueue("c");
+        c.close();
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<unknown[]>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        const stream = e.data;
+        expect(stream).toBeInstanceOf(ReadableStream);
+        const chunks: unknown[] = [];
+        for await (const chunk of stream) chunks.push(chunk);
+        resolve(chunks);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    port2.start();
+
+    port1.postMessage(rs, [rs]);
+    // The source stream is locked/detached immediately after transfer.
+    expect(rs.locked).toBe(true);
+
+    expect(await promise).toEqual(["a", "b", "c"]);
+    port1.close();
+    port2.close();
+  });
+
+  test("preserves order and backpressure across many chunks", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const N = 1000;
+    const rs = new ReadableStream({
+      start(c) {
+        for (let i = 0; i < N; i++) c.enqueue(i);
+        c.close();
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<number[]>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        const received: number[] = [];
+        for await (const chunk of e.data) received.push(chunk as number);
+        resolve(received);
+      } catch (err) {
+        reject(err);
+      }
+    };
+    port2.start();
+
+    port1.postMessage(rs, [rs]);
+    const received = await promise;
+    expect(received).toHaveLength(N);
+    expect(received).toEqual(Array.from({ length: N }, (_, i) => i));
+    port1.close();
+    port2.close();
+  });
+
+  test("propagates a source error to the receiving stream", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const rs = new ReadableStream({
+      start(c) {
+        c.error(new Error("boom"));
+      },
+    });
+
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    port2.onmessage = async (e: MessageEvent) => {
+      try {
+        for await (const _ of e.data);
+        reject(new Error("expected the transferred stream to error"));
+      } catch (err: any) {
+        resolve(String(err?.message ?? err));
+      }
+    };
+    port2.start();
+
+    port1.postMessage(rs, [rs]);
+    expect(await promise).toBe("boom");
+    port1.close();
+    port2.close();
+  });
+
+  test("throws DataCloneError when the stream is locked", () => {
+    const rs = new ReadableStream();
+    rs.getReader();
+    const { port1, port2 } = new MessageChannel();
+    expect(() => port1.postMessage(rs, [rs])).toThrow(
+      expect.objectContaining({ name: "DataCloneError" }),
+    );
+    port1.close();
+    port2.close();
+  });
+
+  test("throws DataCloneError when transferring a stream that is not cloneable without transfer", () => {
+    const rs = new ReadableStream();
+    const { port1, port2 } = new MessageChannel();
+    expect(() => port1.postMessage(rs)).toThrow(expect.objectContaining({ name: "DataCloneError" }));
+    port1.close();
+    port2.close();
+  });
+
+  test("transfers to a Worker and carries data across threads", async () => {
+    const url = URL.createObjectURL(
+      new Blob([
+        `
+          self.onmessage = async e => {
+            try {
+              const chunks = [];
+              for await (const chunk of e.data.stream) chunks.push(chunk);
+              self.postMessage({ chunks });
+            } catch (err) {
+              self.postMessage({ error: String(err) });
+            }
+          };
+        `,
+      ]),
+    );
+    const worker = new Worker(url);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<any>();
+      worker.onerror = e => reject(e.error ?? e.message ?? e);
+      worker.onmessage = e => resolve(e.data);
+
+      const rs = new ReadableStream({
+        start(c) {
+          c.enqueue("x");
+          c.enqueue("y");
+          c.enqueue("z");
+          c.close();
+        },
+      });
+      worker.postMessage({ stream: rs }, [rs]);
+      expect(rs.locked).toBe(true);
+
+      expect(await promise).toEqual({ chunks: ["x", "y", "z"] });
+    } finally {
+      worker.terminate();
+      URL.revokeObjectURL(url);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Transferring a `ReadableStream` through `postMessage` (directly or via `node:worker_threads`) threw:

```
DataCloneError: The object can not be cloned.
```

```js
const rs = new ReadableStream();
const mc = new MessageChannel();
mc.port1.postMessage(rs, [rs]); // DataCloneError in Bun, succeeds in Node
```

Transferable streams are part of the WHATWG Streams standard and work in Node's `worker_threads`. Bun's structured-clone layer had no support for them: the transfer-list validation recognized only `ArrayBuffer`, `MessagePort`, `OffscreenCanvas`, and WebCodecs frames, so any stream fell through to `DataCloneError`.

## Fix

Implement ReadableStream transfer end to end, following the spec's cross-realm transform design:

- **Serialize** (`SerializedScriptValue.cpp`): a `ReadableStream` in the transfer list is validated (must not be locked) and collected. After the message value is serialized, the stream runs its transfer steps: a fresh `MessageChannel` is created, the stream is piped into a cross-realm writable whose sink posts chunks over `port1`, and `port2` is appended to the message's transferred ports. A new `ReadableStreamTag` records the port index. A `ReadableStream` that appears in the message but not the transfer list still yields `DataCloneError` (streams are transfer-only).
- **Deserialize**: `ReadableStreamTag` takes the corresponding re-entangled port and wraps it in a new `ReadableStream` backed by a cross-realm transform readable.
- **Builtins** (`ReadableStreamInternals.ts`): the cross-realm transform (the `pull`/`chunk`/`close`/`error` protocol with pull-based backpressure) is implemented in JS and reuses the existing `readableStreamPipeToWritableStream` machinery.

The transferred stream is detached (locked) on the sending side, and chunks written to the source become readable through the transferred stream on the receiving side, across threads.

Scope: this covers `ReadableStream`. `WritableStream` and `TransformStream` transfer reuse the same cross-realm primitives and can follow up.

## Verification

New tests in `test/js/web/workers/worker-postmessage-transfer.test.ts` cover: round-trip data + source detachment over a `MessageChannel`, ordering/backpressure across 1000 chunks, source-error propagation, `DataCloneError` on a locked stream and on a non-transferred stream, and a cross-thread `Worker` transfer.

```
$ bun bd test test/js/web/workers/worker-postmessage-transfer.test.ts
 9 pass  0 fail
```

The data-flow tests throw `DataCloneError` on the released binary (bug present) and pass on this build.

## Related

Supersedes #28436, an earlier attempt for the same feature (#28434) that predates the source-tree reorganization and no longer applies (it targets the removed `src/bun.js/bindings/webcore/` path).
