### PR TITLE
Reject runtime URL imports instead of returning a stub namespace

### DIFF
--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4028,17 +4028,22 @@ unsafe fn transpile_file(
     // Bun has no URL-fetching module loader. The resolver marks `http(s)://`
     // and `//protocol-relative` specifiers external (so `Bun.resolveSync` /
     // `import.meta.resolve` echo them back, matching Node), but actually
-    // importing one can't work: the file loader handed back a bogus
-    // `{ __esModule, default: "<url>" }` namespace (every named export
-    // `undefined`) and `.js` URLs ENOENT'd reading the URL as a path. Surface a
-    // clean module-not-found error instead. See #32398 / #29076.
+    // importing one can't work: reject it here at load time with a clean
+    // module-not-found error instead of letting it fall through to the file
+    // loader. `require()` uses `MODULE_NOT_FOUND`, ESM uses `ERR_MODULE_NOT_FOUND`,
+    // mirroring `ResolveMessage`.
     {
         let spec = _specifier.slice();
         if spec.starts_with(b"http://") || spec.starts_with(b"https://") || spec.starts_with(b"//")
         {
+            let code = if is_commonjs_require {
+                bun_jsc::ErrCode::MODULE_NOT_FOUND
+            } else {
+                bun_jsc::ErrCode::ERR_MODULE_NOT_FOUND
+            };
             let js = global_ref
                 .err(
-                    bun_jsc::ErrCode::ERR_MODULE_NOT_FOUND,
+                    code,
                     format_args!(
                         "Cannot find module '{}'. Bun does not support importing from URLs.",
                         bstr::BStr::new(spec),

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4025,6 +4025,34 @@ unsafe fn transpile_file(
     // SAFETY: per fn contract — `referrer` is valid for the call.
     let referrer_slice = unsafe { &*referrer }.to_utf8();
 
+    // Bun has no URL-fetching module loader. The resolver marks `http(s)://`
+    // and `//protocol-relative` specifiers external (so `Bun.resolveSync` /
+    // `import.meta.resolve` echo them back, matching Node), but actually
+    // importing one can't work: the file loader handed back a bogus
+    // `{ __esModule, default: "<url>" }` namespace (every named export
+    // `undefined`) and `.js` URLs ENOENT'd reading the URL as a path. Surface a
+    // clean module-not-found error instead. See #32398 / #29076.
+    {
+        let spec = _specifier.slice();
+        if spec.starts_with(b"http://") || spec.starts_with(b"https://") || spec.starts_with(b"//")
+        {
+            let js = global_ref
+                .err(
+                    bun_jsc::ErrCode::ERR_MODULE_NOT_FOUND,
+                    format_args!(
+                        "Cannot find module '{}'. Bun does not support importing from URLs.",
+                        bstr::BStr::new(spec),
+                    ),
+                )
+                .to_js();
+            // SAFETY: per fn contract — `ret` is a valid out-param.
+            unsafe {
+                *ret = ErrorableResolvedSource::err(bun_core::err!("JSErrorObject"), js);
+            }
+            return ptr::null_mut();
+        }
+    }
+
     // `type_attribute` may be null (no `with { type }`).
     // SAFETY: per fn contract — null or a live `bun.String*`.
     let type_attribute_str: Option<&[u8]> =

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -191,6 +191,8 @@ describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The error is caught and printed to stdout, so stderr stays empty.
+    expect(stderr).toBe("");
     expect(stdout.trim()).toBe(
       "MODULE_NOT_FOUND Cannot find module 'https://cdn.pika.dev/vtils@3.0.1-beta.2'. Bun does not support importing from URLs.",
     );

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -171,7 +171,28 @@ describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
     // Post-fix: the import fails at load time, so the program never runs.
     expect(stdout).toBe("");
     expect(stderr).toContain("vtils@3.0.1-beta.2");
+    expect(stderr).toContain("ERR_MODULE_NOT_FOUND");
     expect(exitCode).not.toBe(0);
+  });
+
+  // require() is CommonJS, so it gets MODULE_NOT_FOUND (no ERR_ prefix),
+  // matching ResolveMessage and Node. Pre-fix require(url) threw an ENOENT
+  // with no `.code`. Run in a subprocess so it doesn't share the module
+  // registry entry for `url` with the concurrent import() cases above.
+  it("require() of a URL rejects with MODULE_NOT_FOUND", async () => {
+    using dir = tempDir("issue-32398-require", {
+      "entry.cjs": `try { require(${JSON.stringify(url)}); } catch (e) { console.log(e.code + " " + e.message); }`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.cjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim()).toBe("MODULE_NOT_FOUND Cannot find module 'https://cdn.pika.dev/vtils@3.0.1-beta.2'. Bun does not support importing from URLs.");
+    expect(exitCode).toBe(0);
   });
 
   // Resolution still succeeds and echoes the URL (matching Node's

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -191,7 +191,9 @@ describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stdout.trim()).toBe("MODULE_NOT_FOUND Cannot find module 'https://cdn.pika.dev/vtils@3.0.1-beta.2'. Bun does not support importing from URLs.");
+    expect(stdout.trim()).toBe(
+      "MODULE_NOT_FOUND Cannot find module 'https://cdn.pika.dev/vtils@3.0.1-beta.2'. Bun does not support importing from URLs.",
+    );
     expect(exitCode).toBe(0);
   });
 

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -111,6 +111,71 @@ describe("ResolveMessage", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/32398 (and #29076)
+//
+// Bun has no URL-fetching module loader. The resolver marks `http(s)://` /
+// `//protocol-relative` specifiers external (so `Bun.resolveSync` and
+// `import.meta.resolve` echo them back, like Node), but the runtime loader
+// then handed back a synthetic `{ __esModule, default: "<url>" }` namespace,
+// so `import * as x from "https://cdn.pika.dev/..."; x.isNumber` was silently
+// `undefined` instead of failing. Importing a URL now fails at load time with
+// a clean module-not-found error. No network is touched.
+//
+// The `@3.0.1-beta.2` tail is load-bearing: it has no recognized file
+// extension, so pre-fix the loader took the `.file` path and produced the stub
+// (rather than the `.js` path, which ENOENTs and would look the same as the
+// fixed behavior).
+describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
+  const url = "https://cdn.pika.dev/vtils@3.0.1-beta.2";
+
+  // All three externalized schemes, each with the unrecognized `.2` extension
+  // tail so pre-fix they hit the `.file` stub path (not a `.js` ENOENT).
+  it.each([
+    "https://cdn.pika.dev/vtils@3.0.1-beta.2",
+    "http://cdn.pika.dev/vtils@3.0.1-beta.2",
+    "//cdn.pika.dev/vtils@3.0.1-beta.2",
+  ])("dynamic import() of %p rejects with ERR_MODULE_NOT_FOUND", async specifier => {
+    let err: any;
+    try {
+      await import(specifier);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeDefined();
+    expect(err.code).toBe("ERR_MODULE_NOT_FOUND");
+    expect(err.message).toContain("vtils@3.0.1-beta.2");
+  });
+
+  it("namespace import of a URL errors at load time (no { default: <url> } stub)", async () => {
+    using dir = tempDir("issue-32398", {
+      "entry.mjs": `
+        import * as vtils from ${JSON.stringify(url)};
+        console.log("isNumber=" + typeof vtils.isNumber);
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "entry.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Pre-fix: prints "isNumber=undefined" and exits 0 (the bogus stub).
+    // Post-fix: the import fails at load time, so the program never runs.
+    expect(stdout).toBe("");
+    expect(stderr).toContain("vtils@3.0.1-beta.2");
+    expect(exitCode).not.toBe(0);
+  });
+
+  // Resolution still succeeds and echoes the URL (matching Node's
+  // import.meta.resolve); only loading it fails. Guards against a future
+  // "fix" that rejects at resolve time and breaks Bun.resolveSync.
+  it("Bun.resolveSync echoes the URL (resolution is not the failure point)", () => {
+    expect(Bun.resolveSync(url, import.meta.dir)).toBe(url);
+  });
+});
+
 // These tests reproduce panics where the module resolver wrote past fixed-size
 // PathBuffers when given very long import specifiers. The bug triggers when
 // `import_path < PATH_MAX` but `baseUrl + import_path > PATH_MAX` (otherwise a

--- a/test/js/bun/resolve/resolve-error.test.ts
+++ b/test/js/bun/resolve/resolve-error.test.ts
@@ -111,15 +111,16 @@ describe("ResolveMessage", () => {
   });
 });
 
-// https://github.com/oven-sh/bun/issues/32398 (and #29076)
+// https://github.com/oven-sh/bun/issues/32398 (and #32399, #29076)
 //
 // Bun has no URL-fetching module loader. The resolver marks `http(s)://` /
 // `//protocol-relative` specifiers external (so `Bun.resolveSync` and
 // `import.meta.resolve` echo them back, like Node), but the runtime loader
 // then handed back a synthetic `{ __esModule, default: "<url>" }` namespace,
-// so `import * as x from "https://cdn.pika.dev/..."; x.isNumber` was silently
-// `undefined` instead of failing. Importing a URL now fails at load time with
-// a clean module-not-found error. No network is touched.
+// so `import * as x from "https://cdn.pika.dev/..."; x.isNumber` (and the
+// `import x from "https://cdn.skypack.dev/..."; x.tag` default-import variant)
+// was silently `undefined` instead of failing. Importing a URL now fails at
+// load time with a clean module-not-found error. No network is touched.
 //
 // The `@3.0.1-beta.2` tail is load-bearing: it has no recognized file
 // extension, so pre-fix the loader took the `.file` path and produced the stub
@@ -146,12 +147,17 @@ describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
     expect(err.message).toContain("vtils@3.0.1-beta.2");
   });
 
-  it("namespace import of a URL errors at load time (no { default: <url> } stub)", async () => {
+  // Static imports of a URL fail at load time, for both namespace (#32398) and
+  // default (#32399) bindings, rather than binding to a bogus stub. Pre-fix the
+  // program ran and printed the undefined member access; post-fix it never runs.
+  it.each([
+    // #32398: `import * as x from "<url>"; x.isNumber` was undefined.
+    { label: "namespace (#32398)", src: `import * as x from %URL%;\nconsole.log("member=" + typeof x.isNumber);` },
+    // #32399: `import X from "<url>"; X.tag(...)` threw "X.tag is not a function".
+    { label: "default (#32399)", src: `import x from %URL%;\nconsole.log("member=" + typeof x.tag);` },
+  ])("static $label import of a URL errors at load time", async ({ src }) => {
     using dir = tempDir("issue-32398", {
-      "entry.mjs": `
-        import * as vtils from ${JSON.stringify(url)};
-        console.log("isNumber=" + typeof vtils.isNumber);
-      `,
+      "entry.mjs": src.replace("%URL%", JSON.stringify(url)),
     });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "run", "entry.mjs"],
@@ -161,7 +167,7 @@ describe.concurrent("URL imports at runtime are rejected, not stubbed", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    // Pre-fix: prints "isNumber=undefined" and exits 0 (the bogus stub).
+    // Pre-fix: prints "member=undefined" and exits 0 (the bogus stub).
     // Post-fix: the import fails at load time, so the program never runs.
     expect(stdout).toBe("");
     expect(stderr).toContain("vtils@3.0.1-beta.2");


### PR DESCRIPTION
### What

At runtime, `import * as vtils from "https://cdn.pika.dev/vtils@3.0.1-beta.2"` silently returned a stub namespace, so every named export was `undefined`:

```js
import * as vtils from 'https://cdn.pika.dev/vtils@3.0.1-beta.2';
console.log('direct import isNumber type:', typeof vtils.isNumber);
// before: direct import isNumber type: undefined   (exit 0)
```

### Cause

The resolver marks `http(s)://` and `//protocol-relative` specifiers external (so `Bun.resolveSync` / `import.meta.resolve` echo them back, matching Node). But Bun has no URL-fetching module loader, so when one was actually imported the file loader handed back a synthetic `{ __esModule, default: "<url>" }` namespace. A specifier whose trailing segment has no recognized extension (common for CDN URLs that embed a version like `@3.0.1-beta.2`) hit this `.file` path and produced the stub; `.js` URLs instead failed with a confusing `ENOENT`.

### Fix

Reject these specifiers at the module-load step (`transpile_file`, the single runtime fetch bridge for ESM and CJS) with a clear error that names the URL:

```
error: Cannot find module 'https://cdn.pika.dev/vtils@3.0.1-beta.2'. Bun does not support importing from URLs.
 code: "ERR_MODULE_NOT_FOUND"
```

Resolution is left unchanged, so `Bun.resolveSync`/`import.meta.resolve` still echo the URL (Node parity) and `bun build` still externalizes URL imports. `data:` URLs are unaffected.

### Verification

`test/js/bun/resolve/resolve-error.test.ts` (new `describe`): dynamic `import()` of `http(s)://` and `//` URLs rejects with `ERR_MODULE_NOT_FOUND`, static namespace (#32398) and default (#32399) imports exit non-zero with the URL in stderr, and `Bun.resolveSync` still echoes the URL. Fails before the change (prints `isNumber=undefined`, exit 0), passes after. The existing `bun build` AutoExternal and non-ASCII URL `resolveSync` tests still pass.

Fixes #32398
Fixes #29076
Fixes #32399