### PR TITLE
watch: exit on SIGINT when a custom signal handler drains the event loop

### DIFF
--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicU8, AtomicU16, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU16, Ordering};
 
 use crate::event_loop::EventLoop;
 use crate::{JSGlobalObject, Task, VirtualMachineRef as VirtualMachine};
@@ -17,6 +17,12 @@ pub struct PosixSignalHandle {
     tail: AtomicU16,
     /// Consumer index (main thread reads).
     head: AtomicU16,
+
+    /// Set when a termination-class signal (SIGHUP/SIGINT/SIGQUIT/SIGTERM) has
+    /// been delivered to a user handler. The `--watch`/`--hot` run-loop reads
+    /// this to exit once the event loop drains instead of blocking in the
+    /// watcher keep-alive forever; a plain `bun run` already exits on drain.
+    termination_requested: AtomicBool,
 }
 
 impl Default for PosixSignalHandle {
@@ -25,8 +31,22 @@ impl Default for PosixSignalHandle {
             signals: [const { AtomicU8::new(0) }; BUFFER_SIZE as usize],
             tail: AtomicU16::new(0),
             head: AtomicU16::new(0),
+            termination_requested: AtomicBool::new(false),
         }
     }
+}
+
+/// Termination-class signals convey "shut down" (the default disposition of
+/// each is to terminate the process). A `--watch`/`--hot` session exits once
+/// the event loop drains after one of these is routed to a user handler,
+/// matching a plain `bun run`. Signals like SIGWINCH or SIGUSR1/2 do not imply
+/// shutdown and are deliberately excluded.
+fn is_termination_signal(signal: u8) -> bool {
+    use bun_core::SignalCode;
+    signal == SignalCode::SIGHUP as u8
+        || signal == SignalCode::SIGINT as u8
+        || signal == SignalCode::SIGQUIT as u8
+        || signal == SignalCode::SIGTERM as u8
 }
 
 impl PosixSignalHandle {
@@ -40,6 +60,12 @@ impl PosixSignalHandle {
     /// Returns `true` if enqueued successfully, or `false` if the ring is full.
     #[allow(dead_code)]
     pub(crate) fn enqueue(&self, signal: u8) -> bool {
+        // Record a shutdown request before anything can short-circuit (a full
+        // ring drops the signal but the intent to terminate still stands).
+        if is_termination_signal(signal) {
+            self.termination_requested.store(true, Ordering::Release);
+        }
+
         // Read the current tail and head (Acquire to ensure we have up-to-date values).
         let old_tail = self.tail.load(Ordering::Acquire);
         let head_val = self.head.load(Ordering::Acquire);
@@ -91,6 +117,13 @@ impl PosixSignalHandle {
         self.head.store(old_head.wrapping_add(1), Ordering::Release);
 
         Some(signal)
+    }
+
+    /// True once a termination-class signal has been delivered to a user
+    /// handler (see [`is_termination_signal`]).
+    #[allow(dead_code)]
+    pub(crate) fn termination_requested(&self) -> bool {
+        self.termination_requested.load(Ordering::Acquire)
     }
 
     /// Drain as many signals as possible and enqueue them as tasks in the event loop.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1056,6 +1056,14 @@ impl VirtualMachine {
             || !el.next_immediate_tasks.is_empty()
     }
 
+    /// True once a termination-class signal (SIGHUP/SIGINT/SIGQUIT/SIGTERM) has
+    /// been delivered to a user handler. The `--watch`/`--hot` run-loop exits
+    /// once the event loop drains after such a signal, matching a plain
+    /// `bun run`.
+    pub fn termination_signal_requested(&self) -> bool {
+        self.event_loop_shared().termination_signal_requested()
+    }
+
     pub fn wakeup(&mut self) {
         self.event_loop_mut().wakeup();
     }

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -526,6 +526,22 @@ impl EventLoop {
         self.concurrent_ref.load(Ordering::SeqCst) > 0
     }
 
+    /// True once a termination-class signal (SIGHUP/SIGINT/SIGQUIT/SIGTERM) has
+    /// been delivered to a user handler via the POSIX signal ring. The
+    /// `--watch`/`--hot` run-loop reads this to exit once the event loop drains.
+    pub fn termination_signal_requested(&self) -> bool {
+        #[cfg(unix)]
+        {
+            self.signal_handler
+                .map(|h| h.termination_requested())
+                .unwrap_or(false)
+        }
+        #[cfg(not(unix))]
+        {
+            false
+        }
+    }
+
     pub fn run_imminent_gc_timer(&mut self) {
         // The real `WTFTimer` lives in `bun_runtime` (cycle), so the body
         // dispatches through `__bun_run_wtf_timer` (link-time extern).

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1571,6 +1571,16 @@ impl Run {
                 }
                 vm.on_before_exit();
                 vm.report_exception_in_hot_reloaded_module_if_needed();
+                // A termination signal (SIGINT/SIGTERM/SIGHUP/SIGQUIT) was
+                // routed to a user handler and the event loop has since drained
+                // (the `while` above only exits when nothing keeps it alive).
+                // Exit like a plain `bun run` instead of blocking in the watcher
+                // keep-alive below. Otherwise a handler that cleans up (e.g.
+                // `server.stop()`) could never let the process exit under
+                // --watch/--hot.
+                if vm.termination_signal_requested() && !vm.is_event_loop_alive() {
+                    break;
+                }
                 // SAFETY: `event_loop` is a self-pointer into this VM; uniquely
                 // accessed here. Watcher arm keeps the process alive across
                 // reloads.

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2971,6 +2971,14 @@ impl TestCommand {
                 vm.event_loop_ref().auto_tick_active();
             }
 
+            // A termination signal (SIGINT/SIGTERM/SIGHUP/SIGQUIT) was routed to
+            // a user handler (e.g. from a preload) and the event loop has since
+            // drained. Exit through the normal post-watch path instead of
+            // blocking in the watcher keep-alive again.
+            if vm.termination_signal_requested() && !vm.is_event_loop_alive() {
+                return;
+            }
+
             vm.event_loop_ref().tick_possibly_forever();
         }
     }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -2963,8 +2963,6 @@ impl TestCommand {
     }
 
     fn run_event_loop_for_watch(vm: &mut VirtualMachine) {
-        vm.event_loop_ref().tick_possibly_forever();
-
         loop {
             while vm.is_event_loop_alive() {
                 vm.tick();
@@ -2974,7 +2972,9 @@ impl TestCommand {
             // A termination signal (SIGINT/SIGTERM/SIGHUP/SIGQUIT) was routed to
             // a user handler (e.g. from a preload) and the event loop has since
             // drained. Exit through the normal post-watch path instead of
-            // blocking in the watcher keep-alive again.
+            // blocking in the watcher keep-alive again. The guard precedes the
+            // only blocking call so a signal delivered mid-run (before this
+            // function is entered) can't park on the keep-alive timer.
             if vm.termination_signal_requested() && !vm.is_event_loop_alive() {
                 return;
             }

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -201,13 +201,18 @@ it.skipIf(isWindows)("bun test --watch exits on a SIGINT delivered during the ru
 
   // On the buggy build the leading keep-alive call parks here: the signal was
   // already handled and the loop already drained, so nothing wakes it. A clean
-  // exit is code 0 with no signalCode.
-  const exitCode = await proc.exited;
-  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+  // exit is code 0 with no signalCode. Drain both pipes alongside `exited` so a
+  // full pipe can't stall the child.
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
 
   if (exitCode !== 0) {
     expect(stderr).toBe("");
   }
+  expect(stdout).toContain("GOT_SIGINT");
   expect(proc.signalCode).toBe(null);
   expect(exitCode).toBe(0);
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,7 +1,7 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isBroken, isWindows, tempDir, tmpdirSync } from "harness";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -53,58 +53,54 @@ afterEach(() => {
 // the watcher kept the process alive. It should exit like a plain `bun run`
 // (and like `node --watch`) once the loop drains after the signal.
 describe.each(["--watch", "--hot"])("%s exits on SIGINT after the handler cleans up", flag => {
-  it.skipIf(isWindows)(
-    "issue #32400",
-    async () => {
-      using dir = tempDir("watch-sigint", {
-        "serve.ts": `
-          const server = Bun.serve({ port: 0, fetch() { return new Response("OK"); } });
-          process.on("SIGINT", async () => {
-            await server.stop();
-            console.log("CLEANED_UP");
-          });
-          console.log("READY");
-        `,
-      });
+  it.skipIf(isWindows)("issue #32400", async () => {
+    using dir = tempDir("watch-sigint", {
+      "serve.ts": `
+        const server = Bun.serve({ port: 0, fetch() { return new Response("OK"); } });
+        process.on("SIGINT", async () => {
+          await server.stop();
+          console.log("CLEANED_UP");
+        });
+        console.log("READY");
+      `,
+    });
 
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "run", flag, "serve.ts"],
-        cwd: String(dir),
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", flag, "serve.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-      // Drain stderr concurrently so the watch banner can't fill the pipe.
-      const stderrDone = proc.stderr.text();
+    // Drain stderr concurrently so the watch banner can't fill the pipe.
+    const stderrDone = proc.stderr.text();
 
-      // Wait until the server is up and the SIGINT handler is installed.
-      const reader = proc.stdout.getReader();
-      const decoder = new TextDecoder();
-      let stdout = "";
-      let ready = false;
-      while (!ready) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        stdout += decoder.decode(value, { stream: true });
-        if (stdout.includes("READY")) ready = true;
-      }
-      reader.releaseLock();
-      expect(ready).toBe(true);
+    // Wait until the server is up and the SIGINT handler is installed.
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let stdout = "";
+    let ready = false;
+    while (!ready) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      stdout += decoder.decode(value, { stream: true });
+      if (stdout.includes("READY")) ready = true;
+    }
+    reader.releaseLock();
+    expect(ready).toBe(true);
 
-      process.kill(proc.pid, "SIGINT");
+    process.kill(proc.pid, "SIGINT");
 
-      // On the fixed build the handler stops the server, the loop drains and
-      // the process exits. On the buggy build the --watch/--hot loop blocks
-      // forever, so this await hangs and the test times out (the fail-before
-      // state). The handler caught SIGINT, so the exit is clean (code 0, no
-      // signalCode), not a signal kill.
-      const exitCode = await proc.exited;
+    // On the fixed build the handler stops the server, the loop drains and the
+    // process exits. On the buggy build the --watch/--hot loop blocks forever,
+    // so this await hangs and the test times out (the fail-before state). The
+    // handler caught SIGINT, so the exit is clean (code 0, no signalCode), not
+    // a signal kill.
+    const exitCode = await proc.exited;
 
-      expect(exitCode).toBe(0);
-      expect(proc.signalCode).toBe(null);
-      await stderrDone.catch(() => {});
-    },
-    isDebug ? 30_000 : 15_000,
-  );
+    expect(exitCode).toBe(0);
+    expect(proc.signalCode).toBe(null);
+    await stderrDone.catch(() => {});
+  });
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -175,3 +175,39 @@ it.skipIf(isWindows)("bun test --watch exits on SIGINT after the handler cleans 
   expect(proc.signalCode).toBe(null);
   expect(exitCode).toBe(0);
 });
+
+// Same class, but for a SIGINT delivered *during* the test run (before the
+// watcher loop is entered): the handler runs and the loop drains first, so the
+// loop must not park on the keep-alive timer when it is finally entered.
+// Sending the signal from inside a test makes the timing deterministic.
+it.skipIf(isWindows)("bun test --watch exits on a SIGINT delivered during the run", async () => {
+  using dir = tempDir("test-watch-sigint-midrun", {
+    "setup.ts": `process.on("SIGINT", () => { console.log("GOT_SIGINT"); });`,
+    "sigint.test.ts": `
+      import { test } from "bun:test";
+      test("sends SIGINT to itself mid-run", () => {
+        process.kill(process.pid, "SIGINT");
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--watch", "--preload", "./setup.ts", "./sigint.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // On the buggy build the leading keep-alive call parks here: the signal was
+  // already handled and the loop already drained, so nothing wakes it. A clean
+  // exit is code 0 with no signalCode.
+  const exitCode = await proc.exited;
+  const [stdout, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text()]);
+
+  if (exitCode !== 0) {
+    expect(stderr).toBe("");
+  }
+  expect(proc.signalCode).toBe(null);
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -203,11 +203,7 @@ it.skipIf(isWindows)("bun test --watch exits on a SIGINT delivered during the ru
   // already handled and the loop already drained, so nothing wakes it. A clean
   // exit is code 0 with no signalCode. Drain both pipes alongside `exited` so a
   // full pipe can't stall the child.
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   if (exitCode !== 0) {
     expect(stderr).toBe("");

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -109,3 +109,69 @@ describe.each(["--watch", "--hot"])("%s exits on SIGINT after the handler cleans
     expect(exitCode).toBe(0);
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32400 (same class, `bun test --watch`)
+// A preload that installs a custom SIGINT handler and cleans up a ref'd
+// resource used to hang the test-watch keep-alive loop after Ctrl+C, the same
+// way `bun run --watch` did. It should exit once the loop drains.
+it.skipIf(isWindows)("bun test --watch exits on SIGINT after the handler cleans up", async () => {
+  using dir = tempDir("test-watch-sigint", {
+    "setup.ts": `
+      const server = Bun.serve({ port: 0, fetch() { return new Response("ok"); } });
+      process.on("SIGINT", async () => {
+        await server.stop();
+        console.log("CLEANED_UP");
+      });
+    `,
+    "noop.test.ts": `
+      import { test, expect } from "bun:test";
+      test("noop", () => { expect(1).toBe(1); });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--watch", "--preload", "./setup.ts", "./noop.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // `bun test` prints results to stderr; the first run finishing ("Ran ...")
+  // means the watcher is now idle. Drain both streams so neither pipe blocks,
+  // and resolve readiness when the marker appears (or the stream ends early).
+  const stdoutDone = proc.stdout.text();
+  const decoder = new TextDecoder();
+  let stderr = "";
+  const { promise: ranReady, resolve: onRan } = Promise.withResolvers<void>();
+  const stderrDone = (async () => {
+    const reader = proc.stderr.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stderr += decoder.decode(value, { stream: true });
+        if (stderr.includes("Ran ")) onRan();
+      }
+    } finally {
+      reader.releaseLock();
+      onRan();
+    }
+  })();
+
+  await ranReady;
+  expect(stderr).toContain("Ran ");
+
+  process.kill(proc.pid, "SIGINT");
+
+  // On the buggy build the test-watch loop blocks forever here; the handler
+  // caught SIGINT, so a clean exit is code 0 with no signalCode.
+  const exitCode = await proc.exited;
+  await Promise.all([stdoutDone, stderrDone]);
+
+  if (exitCode !== 0) {
+    expect(stderr).toBe("");
+  }
+  expect(proc.signalCode).toBe(null);
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,7 +1,7 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBroken, isWindows, tmpdirSync } from "harness";
+import { afterEach, describe, expect, it } from "bun:test";
+import { bunEnv, bunExe, isBroken, isDebug, isWindows, tempDir, tmpdirSync } from "harness";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 
@@ -45,4 +45,66 @@ for (const dir of ["dir", "©️"]) {
 
 afterEach(() => {
   watchee?.kill();
+});
+
+// https://github.com/oven-sh/bun/issues/32400
+// A custom SIGINT handler that cleans up a ref'd resource used to hang the
+// --watch/--hot run-loop forever: the handler ran, the event loop drained, but
+// the watcher kept the process alive. It should exit like a plain `bun run`
+// (and like `node --watch`) once the loop drains after the signal.
+describe.each(["--watch", "--hot"])("%s exits on SIGINT after the handler cleans up", flag => {
+  it.skipIf(isWindows)(
+    "issue #32400",
+    async () => {
+      using dir = tempDir("watch-sigint", {
+        "serve.ts": `
+          const server = Bun.serve({ port: 0, fetch() { return new Response("OK"); } });
+          process.on("SIGINT", async () => {
+            await server.stop();
+            console.log("CLEANED_UP");
+          });
+          console.log("READY");
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", flag, "serve.ts"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      // Drain stderr concurrently so the watch banner can't fill the pipe.
+      const stderrDone = proc.stderr.text();
+
+      // Wait until the server is up and the SIGINT handler is installed.
+      const reader = proc.stdout.getReader();
+      const decoder = new TextDecoder();
+      let stdout = "";
+      let ready = false;
+      while (!ready) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        stdout += decoder.decode(value, { stream: true });
+        if (stdout.includes("READY")) ready = true;
+      }
+      reader.releaseLock();
+      expect(ready).toBe(true);
+
+      process.kill(proc.pid, "SIGINT");
+
+      // On the fixed build the handler stops the server, the loop drains and
+      // the process exits. On the buggy build the --watch/--hot loop blocks
+      // forever, so this await hangs and the test times out (the fail-before
+      // state). The handler caught SIGINT, so the exit is clean (code 0, no
+      // signalCode), not a signal kill.
+      const exitCode = await proc.exited;
+
+      expect(exitCode).toBe(0);
+      expect(proc.signalCode).toBe(null);
+      await stderrDone.catch(() => {});
+    },
+    isDebug ? 30_000 : 15_000,
+  );
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -98,9 +98,14 @@ describe.each(["--watch", "--hot"])("%s exits on SIGINT after the handler cleans
     // handler caught SIGINT, so the exit is clean (code 0, no signalCode), not
     // a signal kill.
     const exitCode = await proc.exited;
+    const stderr = await stderrDone;
 
-    expect(exitCode).toBe(0);
+    // Surface stderr (watch banner + any crash output) if the process didn't
+    // exit cleanly, so a regression shows the cause rather than just a code.
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
     expect(proc.signalCode).toBe(null);
-    await stderrDone.catch(() => {});
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/internal/dead-code-escape-limits.json
+++ b/test/internal/dead-code-escape-limits.json
@@ -12,7 +12,7 @@
   "src/install/lockfile/Package.rs": 1,
   "src/io/lib.rs": 2,
   "src/io/posix_event_loop.rs": 8,
-  "src/jsc/PosixSignalHandle.rs": 6,
+  "src/jsc/PosixSignalHandle.rs": 7,
   "src/jsc_macros/lib.rs": 2,
   "src/opaque/lib.rs": 5,
   "src/patch/lib.rs": 2,


### PR DESCRIPTION
Fixes #32400.
Fixes #13539.

## Repro

```ts
// serve.ts
const server = Bun.serve({ port: 0, fetch() { return new Response("OK"); } });
process.on("SIGINT", async () => {
  await server.stop();
  console.log("cleaned up");
});
```

```sh
bun run --watch serve.ts
# press Ctrl+C -> handler runs, server stops, but the process never exits
```

## Cause

On POSIX, `bun run --watch`/`--hot` run the script in-process with an infinite run-loop in `src/runtime/cli/run_command.rs` so the watcher can keep the process alive between reloads:

```rust
loop {
    while vm.is_event_loop_alive() { vm.tick(); vm.auto_tick_active(); }
    vm.on_before_exit();
    vm.event_loop_ref().tick_possibly_forever(); // blocks, then loops again
}
```

When a script calls `process.on("SIGINT", ...)`, Bun installs its own `sigaction` that routes the signal to the JS event loop instead of terminating. The handler runs and drains the loop (e.g. `server.stop()`), but the outer `loop` just goes back to `tick_possibly_forever()`. The only escape was an explicit `process.exit()`. Without a custom handler the default disposition terminates the process, so this never came up.

A plain `bun run` exits in the same scenario, and so does `node --watch`, so the watcher hanging is a compatibility gap.

## Fix

Record when a termination-class signal (SIGHUP/SIGINT/SIGQUIT/SIGTERM) has been delivered to a handler (an `AtomicBool` on `PosixSignalHandle`, set in `enqueue`). After the inner event loop drains (so the handler and any async cleanup it started have run), the watch loop checks the flag and breaks to the normal exit path instead of blocking again:

```rust
if vm.termination_signal_requested() && !vm.is_event_loop_alive() {
    break;
}
```

The process then exits via the usual path with `process.exitCode` (0 by default), matching `bun run` and `node --watch`.

`bun test --watch` has the same keep-alive loop (`run_event_loop_for_watch` in `test_command.rs`), so a preload that installs a SIGINT handler and cleans up would hang it the same way. The identical guard is applied there too, returning through the normal post-watch exit path.

The flag is intentionally sticky: once a termination signal has been delivered, the process exits the next time the event loop drains. That matches the intent of the signal and is strictly more conservative than a plain `bun run`, which exits on any drain. A handler that keeps the loop alive (doesn't clean up) is unaffected, since the loop never drains and the break is never taken. Non-termination signals (SIGWINCH, SIGUSR1/2, and so on) are excluded. The flag lives behind `#[cfg(unix)]`; on Windows the accessor returns `false`, so behavior there is unchanged.

## Relation to #30597

#30597 targeted the same root cause (for #13539/#9871) but was opened the day before #30412 ("Rewrite Bun in Rust") landed, so its edits are in the `.zig` files that are now reference-only and no longer compiled. This PR implements the fix on the live Rust path. It also differs on exit code: #30597 exits `128+signal`, whereas a caught-and-cleaned-up signal should exit `0` (what `bun run` and `node --watch` do), which is what this PR produces.

## Verification

New tests in `test/cli/watch/watch.test.ts` cover `bun run --watch`, `bun run --hot`, and `bun test --watch` (preload) with a custom SIGINT handler that stops a server. Each hangs until timeout on the baked bun and exits with code 0 on this change.

```
(pass) should watch files [7385ms]
(pass) should watch files (non-ascii path) [7518ms]
(pass) --watch exits on SIGINT after the handler cleans up > issue #32400 [650ms]
(pass) --hot exits on SIGINT after the handler cleans up > issue #32400 [676ms]
(pass) bun test --watch exits on SIGINT after the handler cleans up [720ms]
(pass) bun test --watch exits on a SIGINT delivered during the run [621ms]
```

I also reproduced #13539 (`Bun.spawn` children + `--watch` + a SIGINT handler that kills them): it hangs on the baked bun and exits cleanly (code 0) on this change, so it is fixed by the same mechanism. #5624 was suggested by the issue bot, but its repro has no custom SIGINT handler, so the default disposition already terminates it (exit 130) both before and after this change; it is a different scenario and is not closed here.


