### PR TITLE
streams: detach ArrayBuffers supplied to byte stream reads and enqueues

### DIFF
--- a/src/js/builtins.d.ts
+++ b/src/js/builtins.d.ts
@@ -386,6 +386,7 @@ declare function $createEmptyReadableStream(): TODO;
 declare function $createFIFO(): TODO;
 declare function $createNativeReadableStream(): TODO;
 declare function $createUninitializedArrayBuffer(size: number): ArrayBuffer;
+declare function $transferArrayBuffer(buffer: ArrayBuffer): ArrayBuffer;
 declare function $createWritableStreamFromInternal(...args: any[]): TODO;
 declare function $data(): TODO;
 declare function $dataView(): TODO;

--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -208,6 +208,7 @@ using namespace JSC;
     macro(textEncoderStreamTransform) \
     macro(toClass) \
     macro(toNamespacedPath) \
+    macro(transferArrayBuffer) \
     macro(transformAlgorithm) \
     macro(underlyingByteSource) \
     macro(underlyingSink) \

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -325,6 +325,14 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
 
     /* BYOB */
     case 2: {
+      // Spec step 8: a pending pull-into's buffer (the one vended through
+      // byobRequest) is transferred too, detaching any view the source kept.
+      const pendingPullIntos = $getByIdDirectPrivate(controller, "pendingPullIntos");
+      if (pendingPullIntos?.isNotEmpty()) {
+        $readableByteStreamControllerInvalidateBYOBRequest(controller);
+        const firstDescriptor = pendingPullIntos.peek();
+        firstDescriptor.buffer = $transferBufferToCurrentRealm(firstDescriptor.buffer);
+      }
       $readableByteStreamControllerEnqueueChunk(
         controller,
         $transferBufferToCurrentRealm(chunk.buffer),
@@ -384,7 +392,10 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
   if (firstDescriptor!.byteOffset + firstDescriptor!.bytesFilled !== view.byteOffset)
     throw new RangeError("Invalid value for view.byteOffset");
 
-  if (firstDescriptor!.byteLength < viewByteLength) throw $ERR_INVALID_ARG_VALUE("view", view);
+  // Account for bytes already filled (spec step 9); an oversized view must be
+  // rejected before the transfer below so it is not detached on failure.
+  if (firstDescriptor!.bytesFilled + viewByteLength > firstDescriptor!.byteLength)
+    throw $ERR_INVALID_ARG_VALUE("view", view);
 
   // Spec: transfer the supplied view's buffer, detaching it.
   firstDescriptor!.buffer = $transferBufferToCurrentRealm(view.buffer);

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -213,6 +213,7 @@ export function readableByteStreamControllerPull(controller) {
     }
     const pullIntoDescriptor: PullIntoDescriptor = {
       buffer,
+      bufferByteLength: buffer.byteLength,
       byteOffset: 0,
       byteLength: $getByIdDirectPrivate(controller, "autoAllocateChunkSize"),
       bytesFilled: 0,
@@ -325,6 +326,10 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
 
     /* BYOB */
     case 2: {
+      // Spec step 7: transfer the chunk's buffer first. This is the fallible
+      // step (a non-transferable chunk throws here), and it must run before the
+      // pending descriptor is touched so a failed enqueue has no side effects.
+      const transferredBuffer = $transferBufferToCurrentRealm(chunk.buffer);
       // Spec step 8: a pending pull-into's buffer (the one vended through
       // byobRequest) is transferred too, detaching any view the source kept.
       const pendingPullIntos = $getByIdDirectPrivate(controller, "pendingPullIntos");
@@ -333,12 +338,7 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
         const firstDescriptor = pendingPullIntos.peek();
         firstDescriptor.buffer = $transferBufferToCurrentRealm(firstDescriptor.buffer);
       }
-      $readableByteStreamControllerEnqueueChunk(
-        controller,
-        $transferBufferToCurrentRealm(chunk.buffer),
-        byteOffset,
-        byteLength,
-      );
+      $readableByteStreamControllerEnqueueChunk(controller, transferredBuffer, byteOffset, byteLength);
       $readableByteStreamControllerProcessPullDescriptors(controller);
       break;
     }
@@ -393,8 +393,10 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
     throw new RangeError("Invalid value for view.byteOffset");
 
   // Spec step 8: the new view must be backed by a buffer the same size as the
-  // descriptor's, otherwise its byteOffset/byteLength geometry would no longer fit.
-  if (firstDescriptor!.buffer.byteLength !== view.buffer.byteLength)
+  // descriptor's, otherwise its byteOffset/byteLength geometry would no longer
+  // fit. Compare against the cached length so this still works when the caller
+  // transferred the descriptor's buffer out before responding.
+  if (firstDescriptor!.bufferByteLength !== view.buffer.byteLength)
     throw new RangeError("Invalid value for view.buffer");
 
   // Account for bytes already filled (spec step 9); an oversized view must be
@@ -671,6 +673,7 @@ export function readableByteStreamControllerPullInto(controller, view) {
 
   const pullIntoDescriptor: PullIntoDescriptor = {
     buffer: transferredBuffer,
+    bufferByteLength: transferredBuffer.byteLength,
     byteOffset,
     byteLength,
     bytesFilled: 0,
@@ -731,6 +734,14 @@ interface PullIntoDescriptor {
    * An {@link ArrayBuffer}
    */
   buffer: ArrayBuffer;
+
+  /**
+   * A positive integer representing the initial byte length of {@link buffer}.
+   * Cached at creation so the buffer-size check in respondWithNewView survives
+   * the caller detaching {@link buffer} (e.g. transferring it out before
+   * responding), matching the spec's "buffer byte length" descriptor field.
+   */
+  bufferByteLength: number;
 
   /**
    * A nonnegative integer byte offset into the {@link buffer} where the

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -381,8 +381,11 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
 
   let firstDescriptor: PullIntoDescriptor | undefined = $getByIdDirectPrivate(controller, "pendingPullIntos").peek();
 
-  // Capture byteLength before any transfer detaches the view (which zeroes it).
+  // Capture byteLength before any transfer detaches the view (which zeroes it),
+  // and the buffer once so the size check and the transfer below operate on the
+  // same object even if the view's buffer getter was tampered with.
   const viewByteLength = view.byteLength;
+  const viewBuffer = view.buffer;
 
   // Validate before transferring so an invalid response does not detach the buffer
   // (matches the spec, which validates before TransferArrayBuffer).
@@ -399,7 +402,7 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
   // descriptor's, otherwise its byteOffset/byteLength geometry would no longer
   // fit. Compare against the cached length so this still works when the caller
   // transferred the descriptor's buffer out before responding.
-  if (firstDescriptor!.bufferByteLength !== view.buffer.byteLength)
+  if (firstDescriptor!.bufferByteLength !== viewBuffer.byteLength)
     throw new RangeError("Invalid value for view.buffer");
 
   // Account for bytes already filled (spec step 9); an oversized view must be
@@ -409,7 +412,7 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
     throw new RangeError("bytesWritten value is too great");
 
   // Spec: transfer the supplied view's buffer, detaching it.
-  firstDescriptor!.buffer = $transferBufferToCurrentRealm(view.buffer);
+  firstDescriptor!.buffer = $transferBufferToCurrentRealm(viewBuffer);
   $readableByteStreamControllerRespondInternal(controller, viewByteLength);
 }
 
@@ -452,8 +455,9 @@ export function readableByteStreamControllerRespondInternal(controller, bytesWri
 }
 
 export function readableByteStreamControllerRespondInReadableState(controller, bytesWritten, pullIntoDescriptor) {
-  if (pullIntoDescriptor.bytesFilled + bytesWritten > pullIntoDescriptor.byteLength)
-    throw new RangeError("bytesWritten value is too great");
+  // Both callers (respond/respondWithNewView) already rejected an over-fill
+  // before transferring, so this is a spec Assert, not a reachable throw.
+  $assert(pullIntoDescriptor.bytesFilled + bytesWritten <= pullIntoDescriptor.byteLength);
 
   $assert(
     $getByIdDirectPrivate(controller, "pendingPullIntos").isEmpty() ||

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -280,11 +280,9 @@ export function readableByteStreamControllerCallPullIfNeeded(controller) {
 }
 
 export function transferBufferToCurrentRealm(buffer) {
-  // FIXME: Determine what should be done here exactly (what is already existing in current
-  // codebase and what has to be added). According to spec, Transfer operation should be
-  // performed in order to transfer buffer to current realm. For the moment, simply return
-  // received buffer.
-  return buffer;
+  // Spec operation TransferArrayBuffer: detach the buffer and return a new one
+  // that owns the same bytes. $transferArrayBuffer is a non-overridable native.
+  return $transferArrayBuffer(buffer);
 }
 
 export function readableStreamReaderKind(reader) {
@@ -300,6 +298,11 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
   $assert(!$getByIdDirectPrivate(controller, "closeRequested"));
   $assert($getByIdDirectPrivate(stream, "state") === $streamReadable);
 
+  // Spec (ReadableByteStreamControllerEnqueue): the chunk's buffer is transferred
+  // (detached) below. Read its geometry first, since detaching zeroes it.
+  const byteOffset = chunk.byteOffset;
+  const byteLength = chunk.byteLength;
+
   switch (
     $getByIdDirectPrivate(stream, "reader") ? $readableStreamReaderKind($getByIdDirectPrivate(stream, "reader")) : 0
   ) {
@@ -309,13 +312,12 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
         $readableByteStreamControllerEnqueueChunk(
           controller,
           $transferBufferToCurrentRealm(chunk.buffer),
-          chunk.byteOffset,
-          chunk.byteLength,
+          byteOffset,
+          byteLength,
         );
       else {
         $assert(!$getByIdDirectPrivate(controller, "queue").content.size());
-        const transferredView =
-          chunk.constructor === Uint8Array ? chunk : new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength);
+        const transferredView = new Uint8Array($transferBufferToCurrentRealm(chunk.buffer), byteOffset, byteLength);
         $readableStreamFulfillReadRequest(stream, transferredView, false);
       }
       break;
@@ -326,8 +328,8 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
       $readableByteStreamControllerEnqueueChunk(
         controller,
         $transferBufferToCurrentRealm(chunk.buffer),
-        chunk.byteOffset,
-        chunk.byteLength,
+        byteOffset,
+        byteLength,
       );
       $readableByteStreamControllerProcessPullDescriptors(controller);
       break;
@@ -345,8 +347,8 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
       $readableByteStreamControllerEnqueueChunk(
         controller,
         $transferBufferToCurrentRealm(chunk.buffer),
-        chunk.byteOffset,
-        chunk.byteLength,
+        byteOffset,
+        byteLength,
       );
       break;
     }
@@ -373,8 +375,11 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
 
   if (firstDescriptor!.byteLength < view.byteLength) throw $ERR_INVALID_ARG_VALUE("view", view);
 
-  firstDescriptor!.buffer = view.buffer;
-  $readableByteStreamControllerRespondInternal(controller, view.byteLength);
+  // Spec: transfer the supplied view's buffer (detaching it). Capture byteLength
+  // first, since detaching zeroes it.
+  const viewByteLength = view.byteLength;
+  firstDescriptor!.buffer = $transferBufferToCurrentRealm(view.buffer);
+  $readableByteStreamControllerRespondInternal(controller, viewByteLength);
 }
 
 export function readableByteStreamControllerRespond(controller, bytesWritten) {
@@ -422,7 +427,6 @@ export function readableByteStreamControllerRespondInReadableState(controller, b
     $readableByteStreamControllerEnqueueChunk(controller, remainder, 0, remainder.byteLength);
   }
 
-  pullIntoDescriptor.buffer = $transferBufferToCurrentRealm(pullIntoDescriptor.buffer);
   pullIntoDescriptor.bytesFilled -= remainderSize;
   $readableByteStreamControllerCommitDescriptor(
     $getByIdDirectPrivate(controller, "controlledReadableStream"),
@@ -432,7 +436,6 @@ export function readableByteStreamControllerRespondInReadableState(controller, b
 }
 
 export function readableByteStreamControllerRespondInClosedState(controller, firstDescriptor) {
-  firstDescriptor.buffer = $transferBufferToCurrentRealm(firstDescriptor.buffer);
   $assert(firstDescriptor.bytesFilled === 0);
 
   if ($readableStreamHasBYOBReader($getByIdDirectPrivate(controller, "controlledReadableStream"))) {
@@ -610,10 +613,16 @@ export function readableByteStreamControllerPullInto(controller, view) {
   // name has already been met before.
   const ctor = view.constructor;
 
+  // Spec (ReadableByteStreamControllerPullInto): transfer the view's buffer up
+  // front so every path below uses the detached buffer and the caller's view is
+  // always detached. Read the geometry first, since detaching zeroes it.
+  const byteOffset = view.byteOffset;
+  const byteLength = view.byteLength;
+
   const pullIntoDescriptor: PullIntoDescriptor = {
-    buffer: view.buffer,
-    byteOffset: view.byteOffset,
-    byteLength: view.byteLength,
+    buffer: $transferBufferToCurrentRealm(view.buffer),
+    byteOffset,
+    byteLength,
     bytesFilled: 0,
     elementSize,
     ctor,
@@ -622,7 +631,6 @@ export function readableByteStreamControllerPullInto(controller, view) {
 
   var pending = $getByIdDirectPrivate(controller, "pendingPullIntos");
   if (pending?.isNotEmpty()) {
-    pullIntoDescriptor.buffer = $transferBufferToCurrentRealm(pullIntoDescriptor.buffer);
     pending.push(pullIntoDescriptor);
     return $readableStreamAddReadIntoRequest(stream);
   }
@@ -645,7 +653,6 @@ export function readableByteStreamControllerPullInto(controller, view) {
     }
   }
 
-  pullIntoDescriptor.buffer = $transferBufferToCurrentRealm(pullIntoDescriptor.buffer);
   $getByIdDirectPrivate(controller, "pendingPullIntos").push(pullIntoDescriptor);
   const promise = $readableStreamAddReadIntoRequest(stream);
   $readableByteStreamControllerCallPullIfNeeded(controller);

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -390,6 +390,19 @@ export function readableByteStreamControllerRespond(controller, bytesWritten) {
 
   $assert($getByIdDirectPrivate(controller, "pendingPullIntos").isNotEmpty());
 
+  const firstDescriptor = $getByIdDirectPrivate(controller, "pendingPullIntos").peek();
+  // Validate before transferring so an out-of-range respond does not detach the
+  // buffer (matches the spec, which checks the range before TransferArrayBuffer).
+  if (
+    $getByIdDirectPrivate($getByIdDirectPrivate(controller, "controlledReadableStream"), "state") === $streamReadable &&
+    firstDescriptor.bytesFilled + bytesWritten > firstDescriptor.byteLength
+  )
+    throw new RangeError("bytesWritten value is too great");
+
+  // Spec (ReadableByteStreamControllerRespond step 6): transfer the descriptor's
+  // buffer, detaching the view that was vended through byobRequest.
+  firstDescriptor.buffer = $transferBufferToCurrentRealm(firstDescriptor.buffer);
+
   $readableByteStreamControllerRespondInternal(controller, bytesWritten);
 }
 
@@ -619,8 +632,18 @@ export function readableByteStreamControllerPullInto(controller, view) {
   const byteOffset = view.byteOffset;
   const byteLength = view.byteLength;
 
+  // TransferArrayBuffer throws for non-transferable buffers (SharedArrayBuffer,
+  // WebAssembly.Memory). read() must surface that as a rejected promise, not a
+  // synchronous throw, so convert the abrupt completion here.
+  let transferredBuffer;
+  try {
+    transferredBuffer = $transferBufferToCurrentRealm(view.buffer);
+  } catch (e) {
+    return Promise.$reject(e);
+  }
+
   const pullIntoDescriptor: PullIntoDescriptor = {
-    buffer: $transferBufferToCurrentRealm(view.buffer),
+    buffer: transferredBuffer,
     byteOffset,
     byteLength,
     bytesFilled: 0,

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -392,6 +392,11 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
   if (firstDescriptor!.byteOffset + firstDescriptor!.bytesFilled !== view.byteOffset)
     throw new RangeError("Invalid value for view.byteOffset");
 
+  // Spec step 8: the new view must be backed by a buffer the same size as the
+  // descriptor's, otherwise its byteOffset/byteLength geometry would no longer fit.
+  if (firstDescriptor!.buffer.byteLength !== view.buffer.byteLength)
+    throw new RangeError("Invalid value for view.buffer");
+
   // Account for bytes already filled (spec step 9); an oversized view must be
   // rejected before the transfer below so it is not detached on failure.
   if (firstDescriptor!.bytesFilled + viewByteLength > firstDescriptor!.byteLength)

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -332,11 +332,14 @@ export function readableByteStreamControllerEnqueue(controller, chunk) {
       const transferredBuffer = $transferBufferToCurrentRealm(chunk.buffer);
       // Spec step 8: a pending pull-into's buffer (the one vended through
       // byobRequest) is transferred too, detaching any view the source kept.
+      // The transfer (step 8.d, which throws on an already-detached buffer per
+      // step 8.b) must run before invalidating the byobRequest (step 8.c), so a
+      // source that detached the buffer itself can still recover via it.
       const pendingPullIntos = $getByIdDirectPrivate(controller, "pendingPullIntos");
       if (pendingPullIntos?.isNotEmpty()) {
-        $readableByteStreamControllerInvalidateBYOBRequest(controller);
         const firstDescriptor = pendingPullIntos.peek();
         firstDescriptor.buffer = $transferBufferToCurrentRealm(firstDescriptor.buffer);
+        $readableByteStreamControllerInvalidateBYOBRequest(controller);
       }
       $readableByteStreamControllerEnqueueChunk(controller, transferredBuffer, byteOffset, byteLength);
       $readableByteStreamControllerProcessPullDescriptors(controller);
@@ -400,9 +403,10 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
     throw new RangeError("Invalid value for view.buffer");
 
   // Account for bytes already filled (spec step 9); an oversized view must be
-  // rejected before the transfer below so it is not detached on failure.
+  // rejected before the transfer below so it is not detached on failure. Spec
+  // and Node throw a RangeError here, matching respond().
   if (firstDescriptor!.bytesFilled + viewByteLength > firstDescriptor!.byteLength)
-    throw $ERR_INVALID_ARG_VALUE("view", view);
+    throw new RangeError("bytesWritten value is too great");
 
   // Spec: transfer the supplied view's buffer, detaching it.
   firstDescriptor!.buffer = $transferBufferToCurrentRealm(view.buffer);

--- a/src/js/builtins/ReadableByteStreamInternals.ts
+++ b/src/js/builtins/ReadableByteStreamInternals.ts
@@ -370,14 +370,23 @@ export function readableByteStreamControllerRespondWithNewView(controller, view)
 
   let firstDescriptor: PullIntoDescriptor | undefined = $getByIdDirectPrivate(controller, "pendingPullIntos").peek();
 
+  // Capture byteLength before any transfer detaches the view (which zeroes it).
+  const viewByteLength = view.byteLength;
+
+  // Validate before transferring so an invalid response does not detach the buffer
+  // (matches the spec, which validates before TransferArrayBuffer).
+  if ($getByIdDirectPrivate($getByIdDirectPrivate(controller, "controlledReadableStream"), "state") === $streamClosed) {
+    if (viewByteLength !== 0) throw new TypeError("view.byteLength must be 0 when the readable byte stream is closed");
+  } else if (viewByteLength === 0) {
+    throw new TypeError("view.byteLength must be greater than 0");
+  }
+
   if (firstDescriptor!.byteOffset + firstDescriptor!.bytesFilled !== view.byteOffset)
     throw new RangeError("Invalid value for view.byteOffset");
 
-  if (firstDescriptor!.byteLength < view.byteLength) throw $ERR_INVALID_ARG_VALUE("view", view);
+  if (firstDescriptor!.byteLength < viewByteLength) throw $ERR_INVALID_ARG_VALUE("view", view);
 
-  // Spec: transfer the supplied view's buffer (detaching it). Capture byteLength
-  // first, since detaching zeroes it.
-  const viewByteLength = view.byteLength;
+  // Spec: transfer the supplied view's buffer, detaching it.
   firstDescriptor!.buffer = $transferBufferToCurrentRealm(view.buffer);
   $readableByteStreamControllerRespondInternal(controller, viewByteLength);
 }
@@ -391,13 +400,15 @@ export function readableByteStreamControllerRespond(controller, bytesWritten) {
   $assert($getByIdDirectPrivate(controller, "pendingPullIntos").isNotEmpty());
 
   const firstDescriptor = $getByIdDirectPrivate(controller, "pendingPullIntos").peek();
-  // Validate before transferring so an out-of-range respond does not detach the
-  // buffer (matches the spec, which checks the range before TransferArrayBuffer).
-  if (
-    $getByIdDirectPrivate($getByIdDirectPrivate(controller, "controlledReadableStream"), "state") === $streamReadable &&
-    firstDescriptor.bytesFilled + bytesWritten > firstDescriptor.byteLength
-  )
-    throw new RangeError("bytesWritten value is too great");
+  // Validate before transferring so an invalid respond does not detach the buffer
+  // (matches the spec, which validates before TransferArrayBuffer).
+  if ($getByIdDirectPrivate($getByIdDirectPrivate(controller, "controlledReadableStream"), "state") === $streamClosed) {
+    if (bytesWritten !== 0) throw new TypeError("bytesWritten must be 0 when the readable byte stream is closed");
+  } else {
+    if (bytesWritten === 0) throw new TypeError("bytesWritten must be greater than 0");
+    if (firstDescriptor.bytesFilled + bytesWritten > firstDescriptor.byteLength)
+      throw new RangeError("bytesWritten value is too great");
+  }
 
   // Spec (ReadableByteStreamControllerRespond step 6): transfer the descriptor's
   // buffer, detaching the view that was vended through byobRequest.

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1532,12 +1532,24 @@ JSC_DEFINE_HOST_FUNCTION(functionTransferArrayBuffer,
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     JSC::JSArrayBuffer* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(callFrame->argument(0));
-    if (!jsBuffer || jsBuffer->impl()->sharingMode() != JSC::ArrayBufferSharingMode::Default) [[unlikely]] {
-        JSC::throwTypeError(globalObject, scope, "Receiver must be an ArrayBuffer"_s);
+    if (!jsBuffer) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "Argument must be an ArrayBuffer"_s);
         return {};
     }
 
     auto* impl = jsBuffer->impl();
+    if (impl->sharingMode() != JSC::ArrayBufferSharingMode::Default) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "Cannot transfer a SharedArrayBuffer"_s);
+        return {};
+    }
+
+    // WebAssembly.Memory buffers cannot be detached; transferring one would be
+    // unsound, so reject it the same way ArrayBuffer.prototype.transfer does.
+    if (impl->isWasmMemory()) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "Cannot transfer a WebAssembly.Memory buffer"_s);
+        return {};
+    }
+
     if (impl->isDetached()) [[unlikely]] {
         JSC::throwTypeError(globalObject, scope, "Cannot transfer a detached ArrayBuffer"_s);
         return {};

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1520,6 +1520,39 @@ JSC_DEFINE_HOST_FUNCTION(functionCreateUninitializedArrayBuffer,
     RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSArrayBuffer::create(globalObject->vm(), globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(arrayBuffer))));
 }
 
+// Implements the spec's TransferArrayBuffer: detaches the supplied ArrayBuffer
+// and returns a new ArrayBuffer that takes ownership of the same data block
+// (zero-copy move). Used by the byte stream internals so that BYOB reads and
+// enqueues detach the caller-supplied buffer as required by the Streams spec.
+JSC_DECLARE_HOST_FUNCTION(functionTransferArrayBuffer);
+JSC_DEFINE_HOST_FUNCTION(functionTransferArrayBuffer,
+    (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSC::JSArrayBuffer* jsBuffer = dynamicDowncast<JSC::JSArrayBuffer>(callFrame->argument(0));
+    if (!jsBuffer || jsBuffer->impl()->sharingMode() != JSC::ArrayBufferSharingMode::Default) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "Receiver must be an ArrayBuffer"_s);
+        return {};
+    }
+
+    auto* impl = jsBuffer->impl();
+    if (impl->isDetached()) [[unlikely]] {
+        JSC::throwTypeError(globalObject, scope, "Cannot transfer a detached ArrayBuffer"_s);
+        return {};
+    }
+
+    JSC::ArrayBufferContents contents;
+    if (!impl->transferTo(vm, contents)) [[unlikely]] {
+        JSC::throwRangeError(globalObject, scope, "ArrayBuffer transfer failed"_s);
+        return {};
+    }
+
+    auto newBuffer = JSC::ArrayBuffer::create(WTF::move(contents));
+    RELEASE_AND_RETURN(scope, JSValue::encode(JSC::JSArrayBuffer::create(vm, globalObject->arrayBufferStructure(JSC::ArrayBufferSharingMode::Default), WTF::move(newBuffer))));
+}
+
 static inline JSC::EncodedJSValue jsFunctionAddEventListenerBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, Zig::GlobalObject* castedThis)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
@@ -2954,6 +2987,7 @@ void GlobalObject::addBuiltinGlobals(JSC::VM& vm)
     putDirectBuiltinFunction(vm, this, builtinNames.overridableRequirePrivateName(), commonJSOverridableRequireCodeGenerator(vm), 0);
 
     putDirectNativeFunction(vm, this, builtinNames.createUninitializedArrayBufferPrivateName(), 1, functionCreateUninitializedArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
+    putDirectNativeFunction(vm, this, builtinNames.transferArrayBufferPrivateName(), 1, functionTransferArrayBuffer, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.resolveSyncPrivateName(), 1, functionImportMeta__resolveSyncPrivate, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNativeFunction(vm, this, builtinNames.createInternalModuleByIdPrivateName(), 1, InternalModuleRegistry::jsCreateInternalModuleById, ImplementationVisibility::Public, NoIntrinsic, PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1430,4 +1430,121 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(value).toBeInstanceOf(Uint8Array);
     expect(Array.from(value)).toEqual([5, 6, 7]);
   });
+
+  it("byobRequest.respond() detaches the view vended through byobRequest", async () => {
+    let vendoredView;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        vendoredView[0] = 42;
+        controller.byobRequest.respond(1);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const { value } = await reader.read(new Uint8Array(1));
+
+    // The buffer the source wrote into is detached and no longer aliases the
+    // buffer the reader receives.
+    expect(vendoredView.byteLength).toBe(0);
+    expect(value.buffer).not.toBe(vendoredView.buffer);
+    expect(value[0]).toBe(42);
+  });
+
+  it("byobRequest.respond() detaches the vended view even on a partial respond", async () => {
+    let vendoredView;
+    let byteLengthAfterPartialRespond;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        // Uint32Array element is 4 bytes; respond(2) is a partial fill.
+        controller.byobRequest.respond(2);
+        // The transfer happens in respond() itself, so the view is already
+        // detached here, before the pull-into is committed.
+        byteLengthAfterPartialRespond = vendoredView.byteLength;
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint32Array(1)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(byteLengthAfterPartialRespond).toBe(0);
+  });
+
+  it("byobRequest.respond() with an out-of-range value throws without detaching", async () => {
+    let threw;
+    let vendoredView;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        try {
+          controller.byobRequest.respond(999);
+        } catch (e) {
+          threw = e;
+        }
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint8Array(4)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(threw).toBeInstanceOf(RangeError);
+    // A rejected respond must not detach the buffer.
+    expect(vendoredView.byteLength).toBe(4);
+  });
+
+  it("read() rejects (does not throw) for a SharedArrayBuffer-backed view", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        controller.byobRequest.respond(1);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const sabView = new Uint8Array(new SharedArrayBuffer(4));
+
+    // Must return a promise and reject, not throw synchronously.
+    const result = reader.read(sabView);
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow(TypeError);
+  });
+
+  it("read() rejects (does not throw) for a WebAssembly.Memory-backed view", async () => {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        controller.byobRequest.respond(1);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const view = new Uint8Array(memory.buffer, 0, 4);
+
+    const result = reader.read(view);
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).rejects.toThrow(TypeError);
+    // The memory must not have been detached by the failed transfer.
+    expect(memory.buffer.byteLength).toBeGreaterThan(0);
+  });
+
+  it("enqueue() throws synchronously for a SharedArrayBuffer-backed chunk", () => {
+    let controller;
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    expect(() => controller.enqueue(new Uint8Array(new SharedArrayBuffer(4)))).toThrow(
+      "Cannot transfer a SharedArrayBuffer",
+    );
+  });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1642,7 +1642,7 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
       () => {},
     );
 
-    expect(threw).toBeInstanceOf(TypeError);
+    expect(threw).toBeInstanceOf(RangeError);
     expect(newBuffer.byteLength).toBe(16);
   });
 
@@ -1780,5 +1780,39 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(threw).toBeInstanceOf(TypeError);
     expect(byteLengthAfter).toBe(4);
     expect(value[0]).toBe(7);
+  });
+
+  it("enqueue after the source detached the vended buffer throws but keeps the byobRequest usable", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    let threw;
+    let recovered;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const byobRequest = controller.byobRequest;
+        // The source detaches the descriptor's buffer itself, then enqueues a
+        // valid chunk. The enqueue must throw (the descriptor buffer is detached)
+        // before invalidating the byobRequest, so the source can still recover.
+        byobRequest.view.buffer.transfer();
+        try {
+          controller.enqueue(new Uint8Array([1]));
+        } catch (e) {
+          threw = e;
+        }
+        try {
+          byobRequest.respondWithNewView(new Uint8Array(4));
+          recovered = true;
+        } catch (e) {
+          recovered = e;
+        }
+        resolve();
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const [{ value }] = await Promise.all([reader.read(new Uint8Array(4)), promise]);
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(recovered).toBe(true);
+    expect(value.byteLength).toBe(4);
   });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1731,4 +1731,54 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(threw).toBeInstanceOf(TypeError);
     expect(newBuffer.byteLength).toBe(4);
   });
+
+  it("respondWithNewView() works after the source transfers the vended buffer out", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        // Canonical pattern: transfer the vended buffer away, fill it, respond
+        // with a view over the transferred buffer. The descriptor's own buffer
+        // is now detached, but the new view is the same size.
+        const view = controller.byobRequest.view;
+        const newBuffer = view.buffer.transfer();
+        new Uint8Array(newBuffer)[0] = 42;
+        controller.byobRequest.respondWithNewView(new Uint8Array(newBuffer));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const { value } = await reader.read(new Uint8Array(4));
+
+    expect(value).toBeInstanceOf(Uint8Array);
+    expect(Array.from(value)).toEqual([42, 0, 0, 0]);
+  });
+
+  it("a failed enqueue while a BYOB pull-into is pending leaves the vended view usable", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    let threw;
+    let byteLengthAfter;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const vendoredView = controller.byobRequest.view;
+        try {
+          // Non-transferable chunk: the enqueue must throw without detaching the
+          // pending descriptor's buffer or invalidating the byobRequest.
+          controller.enqueue(new Uint8Array(new SharedArrayBuffer(4)));
+        } catch (e) {
+          threw = e;
+        }
+        byteLengthAfter = vendoredView.byteLength;
+        // The byobRequest survived the failed enqueue, so a normal respond works.
+        vendoredView[0] = 7;
+        controller.byobRequest.respond(1);
+        resolve();
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const [{ value }] = await Promise.all([reader.read(new Uint8Array(4)), promise]);
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(byteLengthAfter).toBe(4);
+    expect(value[0]).toBe(7);
+  });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1290,3 +1290,144 @@ it("reader.cancel() settles a pending BYOB read with done: true (whatwg Readable
   expect(result.done).toBe(true);
   expect(result.value).toBeUndefined();
 });
+
+// Per the WHATWG Streams spec, a byte stream transfers (detaches) the
+// caller-supplied ArrayBuffer when it is handed to the controller.
+// https://github.com/oven-sh/bun/issues/32402
+describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
+  it("BYOB read() detaches the supplied view and its buffer", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        controller.byobRequest.view[0] = 42;
+        controller.byobRequest.respond(1);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const view = new Uint8Array(1);
+    const originalBuffer = view.buffer;
+
+    const { done, value } = await reader.read(view);
+
+    // The supplied view and its backing buffer are detached.
+    expect(view.byteLength).toBe(0);
+    expect(originalBuffer.byteLength).toBe(0);
+    expect(() => new Uint8Array(originalBuffer)).toThrow(TypeError);
+
+    // The resolved value is a fresh view over the transferred buffer and
+    // carries the byte the source wrote.
+    expect(done).toBe(false);
+    expect(value).toBeInstanceOf(Uint8Array);
+    expect(value.byteLength).toBe(1);
+    expect(value[0]).toBe(42);
+    expect(value.buffer).not.toBe(originalBuffer);
+    expect(value.buffer.byteLength).toBe(1);
+  });
+
+  it("BYOB read() satisfied synchronously from the queue detaches the view", async () => {
+    let controller;
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    controller.enqueue(new Uint8Array([1, 2, 3, 4]));
+
+    const reader = stream.getReader({ mode: "byob" });
+    const view = new Uint8Array(4);
+    const originalBuffer = view.buffer;
+
+    const { value } = await reader.read(view);
+
+    expect(view.byteLength).toBe(0);
+    expect(originalBuffer.byteLength).toBe(0);
+    expect(Array.from(value)).toEqual([1, 2, 3, 4]);
+    expect(value.buffer).not.toBe(originalBuffer);
+  });
+
+  it("BYOB read() on a closed stream detaches the view", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(controller) {
+        controller.close();
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const view = new Uint8Array(4);
+    const originalBuffer = view.buffer;
+
+    const { done, value } = await reader.read(view);
+
+    expect(done).toBe(true);
+    expect(originalBuffer.byteLength).toBe(0);
+    expect(value).toBeInstanceOf(Uint8Array);
+    expect(value.byteLength).toBe(0);
+  });
+
+  it("byobRequest.respondWithNewView() detaches both the read view and the new view", async () => {
+    let newViewBuffer;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const newView = new Uint8Array(controller.byobRequest.view.byteLength);
+        newView[0] = 7;
+        newViewBuffer = newView.buffer;
+        controller.byobRequest.respondWithNewView(newView);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const view = new Uint8Array(4);
+    const originalBuffer = view.buffer;
+
+    const { value } = await reader.read(view);
+
+    expect(originalBuffer.byteLength).toBe(0);
+    expect(newViewBuffer.byteLength).toBe(0);
+    expect(Array.from(value)).toEqual([7, 0, 0, 0]);
+    expect(value.buffer).not.toBe(originalBuffer);
+    expect(value.buffer).not.toBe(newViewBuffer);
+  });
+
+  it("controller.enqueue() detaches the enqueued chunk's buffer", async () => {
+    let controller;
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    const chunk = new Uint8Array([9, 8, 7]);
+    const chunkBuffer = chunk.buffer;
+    controller.enqueue(chunk);
+    controller.close();
+
+    expect(chunk.byteLength).toBe(0);
+    expect(chunkBuffer.byteLength).toBe(0);
+
+    const bytes = await readableStreamToBytes(stream);
+    expect(Array.from(bytes)).toEqual([9, 8, 7]);
+  });
+
+  it("enqueue() with a waiting default reader detaches the chunk and delivers its bytes", async () => {
+    let controller;
+    const stream = new ReadableStream({
+      type: "bytes",
+      start(c) {
+        controller = c;
+      },
+    });
+    const reader = stream.getReader();
+    const readPromise = reader.read();
+
+    const chunk = new Uint8Array([5, 6, 7]);
+    const chunkBuffer = chunk.buffer;
+    controller.enqueue(chunk);
+
+    expect(chunkBuffer.byteLength).toBe(0);
+
+    const { value } = await readPromise;
+    expect(value).toBeInstanceOf(Uint8Array);
+    expect(Array.from(value)).toEqual([5, 6, 7]);
+  });
+});

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1815,4 +1815,34 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(recovered).toBe(true);
     expect(value.byteLength).toBe(4);
   });
+
+  it("respondWithNewView() reads the supplied view's buffer only once", async () => {
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const goodBuffer = new ArrayBuffer(4);
+        new Uint8Array(goodBuffer)[0] = 9;
+        const badBuffer = new ArrayBuffer(64);
+        const view = new Uint8Array(goodBuffer);
+        // A tampered `.buffer` getter must not open a check-vs-use gap: the
+        // buffer whose size is validated must be the buffer that is transferred.
+        let reads = 0;
+        Object.defineProperty(view, "buffer", {
+          configurable: true,
+          get() {
+            return reads++ === 0 ? goodBuffer : badBuffer;
+          },
+        });
+        controller.byobRequest.respondWithNewView(view);
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const { value } = await reader.read(new Uint8Array(4));
+
+    // If the second read (badBuffer, 64 bytes) were transferred, value.buffer
+    // would be 64 bytes; the single read keeps it at the validated 4.
+    expect(value.byteLength).toBe(4);
+    expect(value.buffer.byteLength).toBe(4);
+    expect(value[0]).toBe(9);
+  });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1501,6 +1501,56 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(vendoredView.byteLength).toBe(4);
   });
 
+  it("byobRequest.respond(0) on a readable stream throws without detaching", async () => {
+    let threw;
+    let vendoredView;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        try {
+          controller.byobRequest.respond(0);
+        } catch (e) {
+          threw = e;
+        }
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint8Array(4)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(vendoredView.byteLength).toBe(4);
+  });
+
+  it("byobRequest.respondWithNewView() with a zero-length view throws without detaching", async () => {
+    let threw;
+    let vendoredView;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        try {
+          controller.byobRequest.respondWithNewView(new Uint8Array(vendoredView.buffer, 0, 0));
+        } catch (e) {
+          threw = e;
+        }
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint8Array(4)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(vendoredView.byteLength).toBe(4);
+  });
+
   it("read() rejects (does not throw) for a SharedArrayBuffer-backed view", async () => {
     const stream = new ReadableStream({
       type: "bytes",

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1646,6 +1646,33 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
     expect(newBuffer.byteLength).toBe(16);
   });
 
+  it("respondWithNewView() backed by a differently-sized buffer throws without detaching", async () => {
+    let threw;
+    let newBuffer;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        // The descriptor's buffer is 16 bytes; a view backed by a 6-byte buffer
+        // does not match and must be rejected before the transfer.
+        newBuffer = new ArrayBuffer(6);
+        try {
+          controller.byobRequest.respondWithNewView(new Uint8Array(newBuffer, 4, 2));
+        } catch (e) {
+          threw = e;
+        }
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint32Array(new ArrayBuffer(16), 4, 2)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(threw).toBeInstanceOf(RangeError);
+    expect(newBuffer.byteLength).toBe(6);
+  });
+
   it("respond() with a non-zero value on a closed stream throws without detaching", async () => {
     const { promise, resolve } = Promise.withResolvers();
     let threw;

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1597,4 +1597,111 @@ describe("ReadableStream byte source detaches supplied ArrayBuffers", () => {
       "Cannot transfer a SharedArrayBuffer",
     );
   });
+
+  it("enqueue() while a BYOB pull-into is pending detaches the vended view", async () => {
+    let vendoredView;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        vendoredView = controller.byobRequest.view;
+        controller.enqueue(new Uint8Array([42]));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    const { value } = await reader.read(new Uint8Array(1));
+
+    // The source enqueued instead of responding; the pending descriptor's buffer
+    // (which byobRequest.view was vended over) must still be detached.
+    expect(vendoredView.byteLength).toBe(0);
+    expect(value.buffer).not.toBe(vendoredView.buffer);
+    expect(value[0]).toBe(42);
+  });
+
+  it("respondWithNewView() exceeding the remaining space throws without detaching", async () => {
+    let threw;
+    let newBuffer;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        // Partial fill: elementSize 4, bytesFilled becomes 2.
+        controller.byobRequest.respond(2);
+        newBuffer = new ArrayBuffer(16);
+        // byteOffset 6 matches byteOffset(4) + bytesFilled(2); byteLength 7 makes
+        // bytesFilled(2) + 7 exceed the descriptor's byteLength (8).
+        try {
+          controller.byobRequest.respondWithNewView(new Uint8Array(newBuffer, 6, 7));
+        } catch (e) {
+          threw = e;
+        }
+        controller.error(new Error("stop"));
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    await reader.read(new Uint32Array(new ArrayBuffer(16), 4, 2)).then(
+      () => {},
+      () => {},
+    );
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(newBuffer.byteLength).toBe(16);
+  });
+
+  it("respond() with a non-zero value on a closed stream throws without detaching", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    let threw;
+    let byteLengthAfter;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const byobRequest = controller.byobRequest;
+        const vendoredView = byobRequest.view;
+        controller.close();
+        try {
+          byobRequest.respond(5);
+        } catch (e) {
+          threw = e;
+        }
+        byteLengthAfter = vendoredView.byteLength;
+        resolve();
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    reader.read(new Uint8Array(4)).then(
+      () => {},
+      () => {},
+    );
+    await promise;
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(byteLengthAfter).toBe(4);
+  });
+
+  it("respondWithNewView() with a non-zero view on a closed stream throws without detaching", async () => {
+    const { promise, resolve } = Promise.withResolvers();
+    let threw;
+    let newBuffer;
+    const stream = new ReadableStream({
+      type: "bytes",
+      pull(controller) {
+        const byobRequest = controller.byobRequest;
+        controller.close();
+        newBuffer = new ArrayBuffer(4);
+        try {
+          byobRequest.respondWithNewView(new Uint8Array(newBuffer));
+        } catch (e) {
+          threw = e;
+        }
+        resolve();
+      },
+    });
+    const reader = stream.getReader({ mode: "byob" });
+    reader.read(new Uint8Array(4)).then(
+      () => {},
+      () => {},
+    );
+    await promise;
+
+    expect(threw).toBeInstanceOf(TypeError);
+    expect(newBuffer.byteLength).toBe(4);
+  });
 });


### PR DESCRIPTION
### What

Fixes #32402. A `ReadableStream` byte source (`type: "bytes"`) did not transfer (detach) the caller-supplied `ArrayBuffer`, so after a BYOB `read(view)` the original view and its buffer stayed attached and readable.

```js
const stream = new ReadableStream({
  type: "bytes",
  pull(controller) { controller.byobRequest.respond(1); },
});
const reader = stream.getReader({ mode: "byob" });
const view = new Uint8Array(1);
await reader.read(view);
view.byteLength;          // bun: 1   node: 0
view.buffer.byteLength;   // bun: 1   node: 0
new Uint8Array(view.buffer); // bun: ok   node: throws (detached)
```

### Cause

`transferBufferToCurrentRealm` in `src/js/builtins/ReadableByteStreamInternals.ts` was a no-op stub that returned the buffer unchanged, so the spec operation `TransferArrayBuffer` was never performed. Every call site that should detach (BYOB `read`, `controller.enqueue`, `byobRequest.respondWithNewView`) was affected.

### Fix

- Implement `TransferArrayBuffer` as a non-overridable native `$transferArrayBuffer` (in `ZigGlobalObject.cpp`, modeled on the existing `$createUninitializedArrayBuffer`). It detaches the source buffer and returns a new `ArrayBuffer` owning the same data block via `ArrayBuffer::transferTo` (zero-copy move).
- Transfer the view's buffer up front in `readableByteStreamControllerPullInto` so every path (pending pull-into, closed stream, queue-satisfied, async) detaches the caller's view, and transfer in `respondWithNewView` and the `enqueue` paths. Buffer geometry (`byteOffset`/`byteLength`) is read before the transfer, since detaching zeroes it. The now-redundant transfers in the respond paths are removed.

Internal native/direct streams (`Bun.file().stream()`, `Response.body`, fetch/serve bodies) are unaffected: they use the `ReadableStreamDefaultController` path, which never routed through this helper. The native-reader enqueue case is left as a no-op as before.

### Verification

New tests in `test/js/web/streams/streams.test.js` cover BYOB read, queue-satisfied BYOB read, closed-stream BYOB read, `respondWithNewView`, `controller.enqueue`, and enqueue with a waiting default reader. Each asserts the supplied buffer is detached and the delivered bytes are correct. All fail on the released binary and pass with the fix; the full streams suite (76 tests) and the HTTP body-stream suite (9086 tests) stay green.
