### PR TITLE
Use visitor.vm() in GlobalObject::visitChildren; make HTTPHeaderIdentifiers eager

### DIFF
--- a/src/jsc/bindings/BunClientData.cpp
+++ b/src/jsc/bindings/BunClientData.cpp
@@ -125,11 +125,4 @@ void JSVMClientData::create(VM* vm, void* bunVM)
     clientData->builtinFunctions().exportNames();
 }
 
-WebCore::HTTPHeaderIdentifiers& JSVMClientData::httpHeaderIdentifiers()
-{
-    if (!m_httpHeaderIdentifiers)
-        m_httpHeaderIdentifiers.emplace();
-    return *m_httpHeaderIdentifiers;
-}
-
 } // namespace WebCore

--- a/src/jsc/bindings/BunClientData.h
+++ b/src/jsc/bindings/BunClientData.h
@@ -111,7 +111,12 @@ public:
 
     JSC::GCClient::IsoSubspace& domBuiltinConstructorSpace() { return m_domBuiltinConstructorSpace; }
 
-    WebCore::HTTPHeaderIdentifiers& httpHeaderIdentifiers();
+    // Constructed eagerly so the concurrent GC marker
+    // (Zig::GlobalObject::visitChildrenImpl) never races the mutator on a
+    // lazy std::optional::emplace(). The ctor only calls
+    // LazyProperty::initLater ~90 times (stores a tagged function pointer),
+    // so there is no startup cost worth deferring.
+    WebCore::HTTPHeaderIdentifiers& httpHeaderIdentifiers() { return m_httpHeaderIdentifiers; }
 
     template<typename Func> void forEachOutputConstraintSpace(const Func& func)
     {
@@ -163,7 +168,7 @@ private:
     std::unique_ptr<ExtendedDOMClientIsoSubspaces> m_clientSubspaces;
     Vector<JSC::IsoSubspace*> m_outputConstraintSpaces;
 
-    std::optional<WebCore::HTTPHeaderIdentifiers> m_httpHeaderIdentifiers;
+    WebCore::HTTPHeaderIdentifiers m_httpHeaderIdentifiers;
     WeakHashSet<JSVMClientDataClient> m_clients;
 };
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3165,7 +3165,15 @@ void GlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     FOR_EACH_GLOBALOBJECT_GC_MEMBER(VISIT_GLOBALOBJECT_GC_MEMBER)
 #undef VISIT_GLOBALOBJECT_GC_MEMBER
 
-    WebCore::clientData(thisObject->vm())->httpHeaderIdentifiers().visit<Visitor>(visitor);
+    // This runs on a concurrent GC helper thread. Fetch the VM through the
+    // visitor (AbstractSlotVisitor::vm() returns m_heap.vm(), guaranteed alive
+    // for the duration of marking) rather than thisObject->vm() which
+    // dereferences JSGlobalObject::m_vm and can read stale bytes if the cell
+    // was picked up via conservative scan mid-recycle (see the
+    // visitGlobalObjectMember(unique_ptr) guard above for the same window).
+    // A stale m_vm surfaces as a SEGV in TypeCastTraits<JSVMClientData>::isType
+    // when downcast<> calls the virtual isWebCoreJSClientData() on garbage.
+    WebCore::clientData(visitor.vm())->httpHeaderIdentifiers().template visit<Visitor>(visitor);
 
     thisObject->visitGeneratedLazyClasses<Visitor>(thisObject, visitor);
     thisObject->visitAdditionalChildrenInGCThread<Visitor>(visitor);

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -185,6 +185,100 @@ test(
   timeout,
 );
 
+// SEGV in TypeCastTraits<JSVMClientData>::isType reached from
+// Zig::GlobalObject::visitChildrenImpl on a concurrent GC helper thread. The
+// visit used `clientData(thisObject->vm())` (raw JSGlobalObject::m_vm deref)
+// and `httpHeaderIdentifiers()` did an unsynchronized std::optional::emplace()
+// that both the mutator and parallel marker threads could enter. Observed in
+// production crash reports almost exclusively on Windows x64, strongly
+// correlated with worker spawn+terminate.
+//
+// This stress maximises the race surface:
+//   - extra ShadowRealm globals so multiple parallel marker helpers each visit
+//     a distinct Zig::GlobalObject and all dereference vm.clientData
+//   - continuous allocation so the concurrent collector is always active
+//   - worker spawn/terminate churn for the reported correlation
+//
+// The race window is too narrow to trip deterministically on Linux even under
+// ASAN + Malloc=1 + collectContinuously, so this test is a guard rather than
+// a fail-before proof; it is the Windows CI lane that intermittently crashed
+// with this signature on the unfixed build.
+test(
+  "GlobalObject::visitChildren does not dereference stale vm.clientData under parallel marking",
+  async () => {
+    const script = /* js */ `
+    const workerCode = \`
+      // Extra Zig::GlobalObject cells in this VM so parallel GC helper
+      // threads each get one to visit and all call clientData(vm).
+      const realms = [];
+      for (let i = 0; i < 6; i++) { try { realms.push(new ShadowRealm()); } catch {} }
+
+      const bc = new BroadcastChannel("clientdata-visit");
+      bc.onmessage = () => {};
+
+      // Keep the concurrent marker busy so visitChildrenImpl fires
+      // repeatedly on helper threads while the mutator runs.
+      const junk = [];
+      for (let i = 0; i < 2000; i++) junk.push({ i, a: [i, i] });
+      Bun.gc(true);
+      postMessage("ready");
+      for (let i = 0; i < 2000; i++) junk.push({ i });
+    \`;
+    const blobUrl = URL.createObjectURL(new Blob([workerCode], { type: "application/javascript" }));
+
+    const mainChannel = new BroadcastChannel("clientdata-visit");
+    mainChannel.onmessage = () => {};
+
+    // Extra globals on the main VM too.
+    const realms = [];
+    for (let i = 0; i < 6; i++) { try { realms.push(new ShadowRealm()); } catch {} }
+
+    for (let round = 0; round < 6; round++) {
+      const workers = [];
+      const ready = [];
+      for (let i = 0; i < 4; i++) {
+        const w = new Worker(blobUrl);
+        const { promise, resolve, reject } = Promise.withResolvers();
+        w.onmessage = () => resolve();
+        w.onerror = (e) => reject(e.message ?? String(e));
+        workers.push(w);
+        ready.push(promise);
+      }
+      await Promise.all(ready);
+
+      // Allocation pressure on main so its parallel markers are live while
+      // worker VMs tear down.
+      const junk = [];
+      for (let i = 0; i < 3000; i++) junk.push({ a: i, b: [i] });
+
+      for (const w of workers) {
+        mainChannel.postMessage("x");
+        w.terminate();
+      }
+      for (let i = 0; i < 3; i++) Bun.gc(true);
+      junk.length = 0;
+    }
+
+    mainChannel.close();
+    console.log("OK");
+  `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, BUN_JSC_numberOfGCMarkers: "8", Malloc: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(filterStderr(stderr)).toBe("");
+    expect(stdout.trim()).toBe("OK");
+    expect(exitCode).toBe(0);
+  },
+  timeout,
+);
+
 test(
   "BroadcastChannel: repeated worker create/terminate stress",
   async () => {

--- a/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
+++ b/test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isWindows } from "harness";
 
 // Debug/ASAN builds are much slower at spawning workers.
 const timeout = isDebug || isASAN ? 60_000 : 10_000;
@@ -265,7 +265,15 @@ test(
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", script],
-      env: { ...bunEnv, BUN_JSC_numberOfGCMarkers: "8", Malloc: "1" },
+      env: {
+        ...bunEnv,
+        BUN_JSC_numberOfGCMarkers: "8",
+        // Route bmalloc/libpas to the system allocator so ASAN can see a UAF
+        // on JSVMClientData instead of it being masked by the pool. Not set
+        // on Windows: bmalloc's SystemHeap is unimplemented there and would
+        // RELEASE_BASSERT, and Windows builds have no ASAN lane anyway.
+        ...(isWindows ? {} : { Malloc: "1" }),
+      },
       stderr: "pipe",
       stdout: "pipe",
     });


### PR DESCRIPTION
## Crash

Sentry BUN-2V1E: segfault inside `WTF::TypeCastTraits<JSVMClientData>::isType` reached from `Zig::GlobalObject::visitChildrenImpl` on a concurrent GC helper thread. 695 lifetime events (26 in the last 24h), 100% Windows x64, 1.2.17 through 1.3.14. 31% of events carry both `workers_spawned=True` and `workers_terminated=True` vs a ~3% baseline, pointing at worker-termination churn. Also seen intermittently in CI as the `broadcast-channel-worker-gc` flake (b03f1e6f06 is a rekick for it).

```
WTF::ParallelHelperPool::Thread::work
JSC::Heap::runBeginPhase lambda
JSC::SlotVisitor::drainFromShared
JSC::SlotVisitor::drain
JSC::SlotVisitor::visitChildren
JSC::MethodTable::visitChildren
Zig::GlobalObject::visitChildren
Zig::GlobalObject::visitChildrenImpl
WebCore::clientData(JSC::VM&)
WTF::downcast<JSVMClientData>
WTF::is<JSVMClientData>
TypeCastTraits<JSVMClientData>::isType   <-- SEGV
```

## Cause

`visitChildrenImpl` ran:

```cpp
WebCore::clientData(thisObject->vm())->httpHeaderIdentifiers().visit<Visitor>(visitor);
```

Two problems on this line:

**1. `thisObject->vm()` dereferences cell state on the marker thread.** `JSGlobalObject::vm()` returns `*m_vm` (a raw `VM* const` stored on the cell); `clientData()` then does `downcast<JSVMClientData>(vm.clientData)` whose `RELEASE_ASSERT(!source || is<Target>(*source))` calls the virtual `isWebCoreJSClientData()`. The neighbouring `visitGlobalObjectMember(unique_ptr)` overload already guards a window where the concurrent marker visits a `Zig::GlobalObject` picked up via conservative stack scan while its IsoSubspace slot is being recycled; in that same window `m_vm` can read stale bytes, resolving to a garbage `clientData` whose vtable load faults. `visitor.vm()` (= `m_heap.vm()`) is guaranteed alive for the duration of marking and does not depend on the visited cell at all; this is how JSC's own `visitChildren` implementations (`FunctionExecutable`, `JSWeakObjectRef`, `Structure`) fetch the VM on the marker thread.

**2. `httpHeaderIdentifiers()` was an unlocked lazy `std::optional::emplace()`** called from both the mutator (`NodeHTTP.cpp` header assignment) and concurrent GC helper threads. With more than one `Zig::GlobalObject` in a VM (ShadowRealm, test-isolation swap, bake) distinct parallel marker helpers each visit a different global and all call `httpHeaderIdentifiers()` on the same `JSVMClientData`, so two threads can enter `emplace()` on the same storage. The `HTTPHeaderIdentifiers` constructor only runs ~90 `LazyProperty::initLater()` calls (each a single tagged-pointer store), so there is nothing worth deferring.

## Fix

- `ZigGlobalObject.cpp`: fetch the VM via `visitor.vm()` instead of `thisObject->vm()`.
- `BunClientData.{h,cpp}`: `m_httpHeaderIdentifiers` is now a plain eagerly-constructed member; `httpHeaderIdentifiers()` is an inline accessor.

## Verification

The race window is too narrow to trip deterministically on Linux. An honest probe against the unfixed debug (ASAN) build, with `Malloc=1` + `BUN_JSC_collectContinuously=1` + `BUN_JSC_numberOfGCMarkers=8`:

- 5 iterations of an 8-round × 6-worker BroadcastChannel create/terminate/GC stress: clean.
- 8 iterations of a 100-round × 8-ShadowRealm (parallel-marker emplace) stress: clean.

So there is no fail-before proof to hand the gate; the crash signature is Windows-specific and timing-dependent. The fix is nonetheless clearly correct on inspection:

- `visitor.vm()` is the JSC convention for the marker thread and cannot read through the visited cell.
- An unlocked `std::optional::emplace()` reachable from two threads is a data race in any memory model.

A new stress test in `test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts` hammers the exact path (multiple globals per VM via ShadowRealm, worker churn, forced parallel markers, `Malloc=1` on non-Windows) so a future regression on Windows CI will show up where the signature has already been observed.

```
bun bd test test/js/web/broadcastchannel/broadcast-channel-worker-gc.test.ts   # 4 pass
bun bd test test/js/node/http/node-http.test.ts -t headers                     # 5 pass (HTTPHeaderIdentifiers path)
bun bd test test/js/node/http/numeric-header.test.ts                           # 1 pass
```

## Related

Checked #31990 / #32071 / #32082 (worker event-loop enqueue after terminate, Strong<> releases before VM teardown): none touch `visitChildrenImpl` or `vm.clientData` access from the marker thread. No open PR addresses this crash.

The issue-matcher suggested four candidates; assessment against the actual stack:

- #20641 (BUN-N2D): same `TypeCastTraits<JSVMClientData>::isType` frame but reached from `bunVMConcurrently` on the main event loop during libuv signal processing, not from a GC marker thread. Different code path; this PR does not touch it.
- #20786 (BUN-PD8): same `isType` frame reached from `JSC::subspaceFor` inside `Request__create` on the HTTP server request path (main thread). Different code path; this PR does not touch it.
- #27312: SIGILL (not SEGV) in `SlotVisitor::drain` on Linux during `bun test` cleanup. Adjacent area but a different fault signature; not claimed.
- #31880: generic "multiple threads are crashing" under worker churn, no decoded stack. #32071 already declines to claim it for the same reason; not claimed here either.

None are auto-closed by this PR. #20641 and #20786 suggest there may be other callers of `clientData()` that can see a bad `vm.clientData` on Windows; those are separate paths and out of scope here.
