### PR TITLE
test scanner: skip paths exceeding MAX_PATH_BYTES instead of panicking

### DIFF
--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -3,12 +3,11 @@ use std::collections::VecDeque;
 use bun_alloc::AllocError;
 use bun_bundler::Transpiler;
 use bun_bundler::options::BundleOptions;
-#[cfg(not(windows))]
 use bun_core::ZStr;
 use bun_core::err;
 use bun_core::{StringOrTinyString, strings};
 use bun_output::{declare_scope, scoped_log};
-use bun_paths::resolve_path::{join_abs_string_buf, platform};
+use bun_paths::resolve_path::{join_abs_string_buf_checked, platform};
 use bun_paths::{self, PathBuffer};
 use bun_ptr::Interned;
 use bun_resolver::fs::{self as fs, DirEntryIterator, EntriesOption, FileSystem};
@@ -121,8 +120,8 @@ impl<'a> Scanner<'a> {
         top_level_dir: &'static [u8],
         parts: &[&[u8]],
         buf: &'b mut [u8],
-    ) -> &'b [u8] {
-        join_abs_string_buf::<platform::Loose>(top_level_dir, buf, parts)
+    ) -> Option<&'b [u8]> {
+        join_abs_string_buf_checked::<platform::Loose>(top_level_dir, buf, parts)
     }
 
     /// Take the list of test files out of this scanner. Caller owns the returned
@@ -136,7 +135,11 @@ impl<'a> Scanner<'a> {
         // reshaped for borrowck — abs_buf's return keeps a &mut borrow
         // of scan_dir_buf alive across the &mut self calls below. Capture only the
         // length, then reconstruct a detached slice from the raw buffer pointer.
-        let path_len = self.fs().abs_buf(&parts, &mut self.scan_dir_buf).len();
+        let path_len = match self.fs().abs_buf_checked(&parts, &mut self.scan_dir_buf) {
+            Some(p) => p.len(),
+            // A path longer than MAX_PATH_BYTES cannot be opened.
+            None => return Err(ScanError::DoesNotExist),
+        };
         // SAFETY: scan_dir_buf is not written again for the remainder of this
         // function — read_dir_with_name/next() only touch open_dir_buf — so the
         // bytes at [0, path_len) remain valid while `path` is live.
@@ -208,7 +211,16 @@ impl<'a> Scanner<'a> {
                 let dir = entry.relative_dir;
 
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = self.fs().abs_buf(&parts2, &mut self.open_dir_buf);
+                // Reserve one byte for the NUL written below. Skip this entry if the
+                // joined path exceeds MAX_PATH_BYTES; openat would fail with
+                // ENAMETOOLONG anyway and the unchecked join panics on overflow.
+                let buf_len = self.open_dir_buf.len();
+                let Some(path2) = self
+                    .fs()
+                    .abs_buf_checked(&parts2, &mut self.open_dir_buf[..buf_len - 1])
+                else {
+                    continue;
+                };
                 let path2_len = path2.len();
                 self.open_dir_buf[path2_len] = 0;
                 let name_len = entry.name.slice().len();
@@ -238,7 +250,17 @@ impl<'a> Scanner<'a> {
             {
                 let fs = self.fs();
                 let parts2: [&[u8]; 2] = [entry.dir_path, entry.name.slice()];
-                let path2 = fs.abs_buf_z(&parts2, &mut self.open_dir_buf);
+                let buf_len = self.open_dir_buf.len();
+                let Some(path2_slice) =
+                    fs.abs_buf_checked(&parts2, &mut self.open_dir_buf[..buf_len - 1])
+                else {
+                    continue;
+                };
+                let path2_len = path2_slice.len();
+                self.open_dir_buf[path2_len] = 0;
+                // SAFETY: NUL written at path2_len above.
+                let path2 =
+                    unsafe { ZStr::from_raw(self.open_dir_buf.as_ptr(), path2_len) };
                 let Ok(child_fd) = bun_sys::open_dir_no_renaming_or_deleting_windows(
                     Fd::INVALID,
                     path2.as_bytes(),
@@ -393,12 +415,14 @@ impl<'a> Scanner<'a> {
                     // reshaped for borrowck — drop the &mut borrow from
                     // abs_buf and reborrow open_dir_buf immutably so &self methods
                     // can be called with the slice.
-                    let dir_path_len = Self::abs_buf_projected(
+                    let Some(dir_path_len) = Self::abs_buf_projected(
                         self.top_level_dir(),
                         &parts,
                         &mut self.open_dir_buf,
                     )
-                    .len();
+                    .map(<[u8]>::len) else {
+                        return;
+                    };
                     let dir_path = &self.open_dir_buf[..dir_path_len];
                     if self.matches_path_ignore_pattern(dir_path) {
                         return;
@@ -430,9 +454,12 @@ impl<'a> Scanner<'a> {
                 // reshaped for borrowck — drop the &mut borrow from
                 // abs_buf and reborrow open_dir_buf immutably so &self methods
                 // below can be called with the slice.
-                let path_len =
+                let Some(path_len) =
                     Self::abs_buf_projected(self.top_level_dir(), &parts, &mut self.open_dir_buf)
-                        .len();
+                        .map(<[u8]>::len)
+                else {
+                    return;
+                };
                 let path = &self.open_dir_buf[..path_len];
 
                 if !self.does_absolute_path_match_filter(path) {

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -259,8 +259,7 @@ impl<'a> Scanner<'a> {
                 let path2_len = path2_slice.len();
                 self.open_dir_buf[path2_len] = 0;
                 // SAFETY: NUL written at path2_len above.
-                let path2 =
-                    unsafe { ZStr::from_raw(self.open_dir_buf.as_ptr(), path2_len) };
+                let path2 = unsafe { ZStr::from_raw(self.open_dir_buf.as_ptr(), path2_len) };
                 let Ok(child_fd) = bun_sys::open_dir_no_renaming_or_deleting_windows(
                     Fd::INVALID,
                     path2.as_bytes(),

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isMusl, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1584,7 +1584,14 @@ describe.concurrent("test file discovery (scanner)", () => {
         stderr: "pipe",
       });
       const [, setupErr, setupExit] = await Promise.all([setup.stdout.text(), setup.stderr.text(), setup.exited]);
-      expect({ setupErr, setupExit }).toEqual({ setupErr: "", setupExit: 0 });
+      // On musl, getcwd(3) fails once the cumulative path exceeds PATH_MAX. bash
+      // prints a cd warning for each subsequent level but mkdir/cd still succeed,
+      // so filter that one known warning out before asserting stderr is clean.
+      const filteredSetupErr = setupErr
+        .split("\n")
+        .filter(line => !(isMusl && line.startsWith("cd: error retrieving current directory: getcwd:")))
+        .join("\n");
+      expect({ setupErr: filteredSetupErr, setupExit }).toEqual({ setupErr: "", setupExit: 0 });
 
       await using proc = Bun.spawn({
         cmd: [bunExe(), "test"],

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1560,41 +1560,44 @@ describe.concurrent("test file discovery (scanner)", () => {
   // https://github.com/oven-sh/bun/issues/sentry-BUN-3JDD
   // On Windows, MAX_PATH_BYTES is ~98 KB (32767 * 3 + 1), which is impractical
   // to exercise here; the POSIX path (1024 macOS / 4096 Linux) is what users hit.
-  test.skipIf(isWindows)("skips directories whose absolute path exceeds MAX_PATH_BYTES instead of panicking", async () => {
-    using dir = tempDir("scanner-deep-tree", {
-      "shallow.test.ts": `import { test } from "bun:test"; test("shallow", () => { console.log("RAN shallow"); });`,
-    });
+  test.skipIf(isWindows)(
+    "skips directories whose absolute path exceeds MAX_PATH_BYTES instead of panicking",
+    async () => {
+      using dir = tempDir("scanner-deep-tree", {
+        "shallow.test.ts": `import { test } from "bun:test"; test("shallow", () => { console.log("RAN shallow"); });`,
+      });
 
-    // Build a directory chain whose absolute path exceeds the platform's
-    // MAX_PATH_BYTES. We cannot pass the full path to mkdir (ENAMETOOLONG),
-    // so create it one segment at a time via cd in a child shell.
-    const seg = Buffer.alloc(200, "a").toString();
-    const maxPathBytes = process.platform === "darwin" ? 1024 : 4096;
-    const depth = Math.ceil((maxPathBytes + 200 - String(dir).length) / (seg.length + 1));
-    let script = `set -e; cd ${JSON.stringify(String(dir))}\n`;
-    for (let i = 0; i < depth; i++) {
-      script += `mkdir -p ${seg} && cd ${seg}\n`;
-    }
-    await using setup = Bun.spawn({
-      cmd: ["bash", "-c", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [, setupErr, setupExit] = await Promise.all([setup.stdout.text(), setup.stderr.text(), setup.exited]);
-    expect({ setupErr, setupExit }).toEqual({ setupErr: "", setupExit: 0 });
+      // Build a directory chain whose absolute path exceeds the platform's
+      // MAX_PATH_BYTES. We cannot pass the full path to mkdir (ENAMETOOLONG),
+      // so create it one segment at a time via cd in a child shell.
+      const seg = Buffer.alloc(200, "a").toString();
+      const maxPathBytes = process.platform === "darwin" ? 1024 : 4096;
+      const depth = Math.ceil((maxPathBytes + 200 - String(dir).length) / (seg.length + 1));
+      let script = `set -e; cd ${JSON.stringify(String(dir))}\n`;
+      for (let i = 0; i < depth; i++) {
+        script += `mkdir -p ${seg} && cd ${seg}\n`;
+      }
+      await using setup = Bun.spawn({
+        cmd: ["bash", "-c", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [, setupErr, setupExit] = await Promise.all([setup.stdout.text(), setup.stderr.text(), setup.exited]);
+      expect({ setupErr, setupExit }).toEqual({ setupErr: "", setupExit: 0 });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stderr).toContain(" 1 pass");
-    expect(stdout).toContain("RAN shallow");
-    expect(exitCode).toBe(0);
-  });
+      expect(stderr).toContain(" 1 pass");
+      expect(stdout).toContain("RAN shallow");
+      expect(exitCode).toBe(0);
+    },
+  );
 });

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1554,6 +1554,47 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stdout).toContain("RAN solo");
     expect(stdout).not.toContain("RAN other");
     expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/sentry-BUN-3JDD
+  // On Windows, MAX_PATH_BYTES is ~98 KB (32767 * 3 + 1), which is impractical
+  // to exercise here; the POSIX path (1024 macOS / 4096 Linux) is what users hit.
+  test.skipIf(isWindows)("skips directories whose absolute path exceeds MAX_PATH_BYTES instead of panicking", async () => {
+    using dir = tempDir("scanner-deep-tree", {
+      "shallow.test.ts": `import { test } from "bun:test"; test("shallow", () => { console.log("RAN shallow"); });`,
+    });
+
+    // Build a directory chain whose absolute path exceeds the platform's
+    // MAX_PATH_BYTES. We cannot pass the full path to mkdir (ENAMETOOLONG),
+    // so create it one segment at a time via cd in a child shell.
+    const seg = Buffer.alloc(200, "a").toString();
+    const maxPathBytes = process.platform === "darwin" ? 1024 : 4096;
+    const depth = Math.ceil((maxPathBytes + 200 - String(dir).length) / (seg.length + 1));
+    let script = `set -e; cd ${JSON.stringify(String(dir))}\n`;
+    for (let i = 0; i < depth; i++) {
+      script += `mkdir -p ${seg} && cd ${seg}\n`;
+    }
+    await using setup = Bun.spawn({
+      cmd: ["bash", "-c", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [, setupErr, setupExit] = await Promise.all([setup.stdout.text(), setup.stderr.text(), setup.exited]);
+    expect({ setupErr, setupExit }).toEqual({ setupErr: "", setupExit: 0 });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(" 1 pass");
+    expect(stdout).toContain("RAN shallow");
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
Fixes Sentry BUN-3JDD (`Panic: range end index 1041 out of range for slice of length 1023`).

## Repro

```sh
d=$(mktemp -d); cd "$d"
seg=$(printf 'a%.0s' {1..200})
# 22 levels → ~4400 byte abs path on Linux; 6 levels → ~1400 on macOS
for i in $(seq 1 22); do mkdir "$seg" && cd "$seg"; done
cd "$d" && bun test
```

```
panic: range end index 4236 out of range for slice of length 4095
```

Stack: `bun test` → `Scanner::scan` → `abs_buf` → `join_abs_string_buf<Loose>` → `_join_abs_string_buf` → `normalize_string_buf` → `normalize_string_generic_tz` → `core::slice::index::slice_index_fail`.

## Cause

The test scanner walks the tree by joining `[parent_abs_path, entry_name]` into a fixed `PathBuffer` (`[u8; MAX_PATH_BYTES]`: 1024 on macOS, 4096 on Linux). `_join_abs_string_buf` concatenates the parts into an unbounded `JoinScratch` (heap-grows past `MAX_PATH_BYTES`), then calls `normalize_string_buf` with the fixed output buffer sliced to `buf[leading_len..]` (1023 / 4095 bytes after the leading `/`). `normalize_string_generic_tz` copies each segment with no bounds check at `resolve_path.rs:1119`, so the first segment that crosses the limit panics.

The Zig reference (`normalizeStringGenericTZ`) used an unchecked `@memcpy` here, so this was pre-existing UB in the Zig build that Rust's bounds checking now catches as a panic.

## Fix

Switch every path join in `Scanner.rs` to the existing `join_abs_string_buf_checked` / `abs_buf_checked` variant, which returns `None` when the normalized result does not fit. On overflow the scanner now skips that entry (directories are not descended into, files are not added) instead of aborting the whole `bun test` run. The OS would reject such paths with `ENAMETOOLONG` anyway.

The initial scan path (`bun test <huge-arg>`) returns `DoesNotExist` on overflow, matching what the user would see from the failed open.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/cli/test/bun-test.test.ts -t "skips directories whose absolute"
(fail) ... panic: range end index 4249 out of range for slice of length 4095

$ bun bd test test/cli/test/bun-test.test.ts -t "skips directories whose absolute"
(pass) test file discovery (scanner) > skips directories whose absolute path exceeds MAX_PATH_BYTES instead of panicking
```

Existing scanner / path-ignore-pattern tests all pass.