### PR TITLE
Fix crash expanding nested `${...}` defaults in .env files

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1220,7 +1220,9 @@ impl<'a> Parser<'a> {
                     let default_start = j;
                     if braced {
                         // Stop at the `}` that closes this substitution,
-                        // balancing the braces of any nested `${...}`.
+                        // balancing the braces of any nested `${...}`. A `\$`
+                        // escape inside the default is resolved when the
+                        // default is expanded, so it is not special here.
                         let mut depth = 0usize;
                         while j < n {
                             match value[j] {
@@ -1231,7 +1233,6 @@ impl<'a> Parser<'a> {
                                     }
                                     depth -= 1;
                                 }
-                                b'\\' => break,
                                 _ => {}
                             }
                             j += 1;

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1223,15 +1223,15 @@ impl<'a> Parser<'a> {
                         // balancing the braces of any nested `${...}`. A `\$`
                         // escape inside the default is resolved when the
                         // default is expanded, so it is not special here.
-                        let mut depth = 0usize;
+                        let mut brace_depth = 0usize;
                         while j < n {
                             match value[j] {
-                                b'{' => depth += 1,
+                                b'{' => brace_depth += 1,
                                 b'}' => {
-                                    if depth == 0 {
+                                    if brace_depth == 0 {
                                         break;
                                     }
-                                    depth -= 1;
+                                    brace_depth -= 1;
                                 }
                                 _ => {}
                             }

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1172,77 +1172,99 @@ impl<'a> Parser<'a> {
     }
 
     fn expand_value(&mut self, map: &Map, value: &[u8]) -> Result<Option<&[u8]>, AllocError> {
-        if value.len() < 2 {
+        if value.len() < 2 || !strings::contains(value, b"$") {
             return Ok(None);
         }
 
         self.value_buffer.clear();
-
-        let mut pos = value.len() - 2;
-        let mut last = value.len();
-        loop {
-            if value[pos] == b'$' {
-                if pos > 0 && value[pos - 1] == b'\\' {
-                    // PERF: splice at the front is O(n)
-                    self.value_buffer
-                        .splice(0..0, value[pos..last].iter().copied());
-                    pos -= 1;
-                } else {
-                    let mut end = if value[pos + 1] == b'{' {
-                        pos + 2
-                    } else {
-                        pos + 1
-                    };
-                    let key_start = end;
-                    while end < value.len() {
-                        match value[end] {
-                            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => {
-                                end += 1;
-                                continue;
-                            }
-                            _ => break,
-                        }
-                    }
-                    let lookup_value = map.get(&value[key_start..end]);
-                    let default_value: &[u8] = if value[end..].starts_with(b":-") {
-                        end += b":-".len();
-                        let value_start = end;
-                        while end < value.len() {
-                            match value[end] {
-                                b'}' | b'\\' => break,
-                                _ => {
-                                    end += 1;
-                                    continue;
-                                }
-                            }
-                        }
-                        &value[value_start..end]
-                    } else {
-                        b""
-                    };
-                    if end < value.len() && value[end] == b'}' {
-                        end += 1;
-                    }
-                    self.value_buffer
-                        .splice(0..0, value[end..last].iter().copied());
-                    self.value_buffer
-                        .splice(0..0, lookup_value.unwrap_or(default_value).iter().copied());
-                }
-                last = pos;
-            }
-            if pos == 0 {
-                if last == value.len() {
-                    return Ok(None);
-                }
-                break;
-            }
-            pos -= 1;
-        }
-        if last > 0 {
-            self.value_buffer
-                .splice(0..0, value[..last].iter().copied());
+        if !self.expand_into(map, value, 0)? {
+            return Ok(None);
         }
         Ok(Some(self.value_buffer.as_slice()))
+    }
+
+    /// Append the expansion of `value` to `self.value_buffer`, returning
+    /// whether any `$` substitution or `\$` escape was processed. A nested
+    /// `${...}` inside a `:-` default is expanded recursively, so values like
+    /// `${FOO:-${BAR:-baz}}` resolve correctly. `depth` caps recursion so a
+    /// pathologically nested value cannot overflow the stack; past the cap the
+    /// remaining default is emitted verbatim instead of being expanded.
+    fn expand_into(&mut self, map: &Map, value: &[u8], depth: u32) -> Result<bool, AllocError> {
+        const MAX_EXPAND_DEPTH: u32 = 64;
+        let n = value.len();
+        let mut found = false;
+        let mut i = 0;
+        while i < n {
+            let c = value[i];
+            // `\$` escapes the dollar sign: drop the backslash and emit `$`
+            // literally without expanding it. A `$` in the final byte cannot
+            // start a substitution, so it is left untouched.
+            if c == b'\\' && i + 1 < n && value[i + 1] == b'$' && i + 1 != n - 1 {
+                found = true;
+                self.value_buffer.push(b'$');
+                i += 2;
+                continue;
+            }
+            if c == b'$' && i != n - 1 {
+                found = true;
+                let braced = value[i + 1] == b'{';
+                let key_start = if braced { i + 2 } else { i + 1 };
+                let mut j = key_start;
+                while j < n && matches!(value[j], b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_') {
+                    j += 1;
+                }
+                let lookup = map.get(&value[key_start..j]);
+                let mut default_range: Option<(usize, usize)> = None;
+                if value[j..].starts_with(b":-") {
+                    j += b":-".len();
+                    let default_start = j;
+                    if braced {
+                        // Stop at the `}` that closes this substitution,
+                        // balancing the braces of any nested `${...}`.
+                        let mut depth = 0usize;
+                        while j < n {
+                            match value[j] {
+                                b'{' => depth += 1,
+                                b'}' => {
+                                    if depth == 0 {
+                                        break;
+                                    }
+                                    depth -= 1;
+                                }
+                                b'\\' => break,
+                                _ => {}
+                            }
+                            j += 1;
+                        }
+                    } else {
+                        while j < n && value[j] != b'}' && value[j] != b'\\' {
+                            j += 1;
+                        }
+                    }
+                    default_range = Some((default_start, j));
+                }
+                if j < n && value[j] == b'}' {
+                    j += 1;
+                }
+                match lookup {
+                    Some(found_value) => self.value_buffer.extend_from_slice(found_value),
+                    None => {
+                        if let Some((start, end)) = default_range {
+                            if depth < MAX_EXPAND_DEPTH {
+                                self.expand_into(map, &value[start..end], depth + 1)?;
+                            } else {
+                                self.value_buffer.extend_from_slice(&value[start..end]);
+                            }
+                        }
+                    }
+                }
+                i = j;
+                continue;
+            }
+            self.value_buffer.push(c);
+            i += 1;
+        }
+        Ok(found)
     }
 
     fn _parse<const OVERRIDE: bool, const IS_PROCESS: bool, const EXPAND: bool>(

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1219,16 +1219,21 @@ impl<'a> Parser<'a> {
                     j += b":-".len();
                     let default_start = j;
                     if braced {
-                        // Stop at the `}` that closes this substitution. Only a
-                        // nested `${` opens a scope to balance; a bare `{` is a
-                        // literal byte. A `\$` escape in the default is resolved
-                        // when the default is expanded, so it is not special
-                        // here.
+                        // Find the `}` that closes this substitution. A nested
+                        // `${` opens a scope whose own `}` must be balanced; a
+                        // bare `{` is a literal byte, and an escaped `\$` never
+                        // opens a scope (it is a literal `$` once expanded).
                         let mut brace_depth = 0usize;
                         while j < n {
                             match value[j] {
-                                b'{' if j > default_start && value[j - 1] == b'$' => {
-                                    brace_depth += 1
+                                b'\\' if j + 1 < n && value[j + 1] == b'$' => {
+                                    j += 2;
+                                    continue;
+                                }
+                                b'$' if j + 1 < n && value[j + 1] == b'{' => {
+                                    brace_depth += 1;
+                                    j += 2;
+                                    continue;
                                 }
                                 b'}' => {
                                     if brace_depth == 0 {

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1196,15 +1196,15 @@ impl<'a> Parser<'a> {
         let mut i = 0;
         while i < n {
             let c = value[i];
-            // `\$` escapes the dollar sign: drop the backslash and emit `$`
-            // literally without expanding it. A `$` in the final byte cannot
-            // start a substitution, so it is left untouched.
-            if c == b'\\' && i + 1 < n && value[i + 1] == b'$' && i + 1 != n - 1 {
+            // `\$` escapes the dollar sign: drop the backslash and emit a
+            // literal `$` without expanding it.
+            if c == b'\\' && i + 1 < n && value[i + 1] == b'$' {
                 found = true;
                 self.value_buffer.push(b'$');
                 i += 2;
                 continue;
             }
+            // A trailing `$` has no name to expand, so leave it literal.
             if c == b'$' && i != n - 1 {
                 found = true;
                 let braced = value[i + 1] == b'{';

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -1219,14 +1219,17 @@ impl<'a> Parser<'a> {
                     j += b":-".len();
                     let default_start = j;
                     if braced {
-                        // Stop at the `}` that closes this substitution,
-                        // balancing the braces of any nested `${...}`. A `\$`
-                        // escape inside the default is resolved when the
-                        // default is expanded, so it is not special here.
+                        // Stop at the `}` that closes this substitution. Only a
+                        // nested `${` opens a scope to balance; a bare `{` is a
+                        // literal byte. A `\$` escape in the default is resolved
+                        // when the default is expanded, so it is not special
+                        // here.
                         let mut brace_depth = 0usize;
                         while j < n {
                             match value[j] {
-                                b'{' => brace_depth += 1,
+                                b'{' if j > default_start && value[j - 1] == b'$' => {
+                                    brace_depth += 1
+                                }
                                 b'}' => {
                                     if brace_depth == 0 {
                                         break;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -278,11 +278,14 @@ test(".env escaped $ inside a default resolves (#32411)", () => {
       "NE_ESC_FLAT=${NE_EC:-a\\$b}",
       "NE_ESC_TRAIL=${NE_ED:-a\\$}",
       "NE_ESC_TOP=x\\$",
+      // An escaped \$ is not a nested substitution: the first `}` closes
+      // the default, so `${NE_EF:-\${}` resolves to `${` (matches bash).
+      "NE_ESC_EBRACE=${NE_EF:-\\${}",
     ].join("\n"),
-    "index.ts": `console.log([process.env.NE_ESC_NESTED, process.env.NE_ESC_FLAT, process.env.NE_ESC_TRAIL, process.env.NE_ESC_TOP].join("|"));`,
+    "index.ts": `console.log([process.env.NE_ESC_NESTED, process.env.NE_ESC_FLAT, process.env.NE_ESC_TRAIL, process.env.NE_ESC_TOP, process.env.NE_ESC_EBRACE].join("|"));`,
   });
   const { stdout } = bunRun(`${dir}/index.ts`);
-  expect(stdout).toBe("a$b|a$b|a$|x$");
+  expect(stdout).toBe("a$b|a$b|a$|x$|${");
 });
 
 test(".env comments", () => {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -239,6 +239,34 @@ test(".env value expansion", () => {
   expect(stdout).toBe("foo|foo bar|foo foo bar moo");
 });
 
+test(".env nested default substitution does not crash (#32411)", () => {
+  const dir = tempDirWithFiles("dotenv-nested-default", {
+    ".env": `FOO="\${FOO:-\${BAR:-baz}}"\n`,
+    "index.ts": `console.log("hello");`,
+  });
+  const result = Bun.spawnSync([bunExe(), `${dir}/index.ts`], {
+    cwd: dir,
+    env: { ...bunEnv, NODE_ENV: undefined },
+  });
+  expect(result.stdout.toString("utf8").trim()).toBe("hello");
+  expect(result.signalCode).toBeFalsy();
+  expect(result.exitCode).toBe(0);
+});
+
+test(".env nested default substitution resolves (#32411)", () => {
+  const dir = tempDirWithFiles("dotenv-nested-default-resolve", {
+    ".env": [
+      "NE_DEEP=${NE_UA:-${NE_UB:-deep}}",
+      "NE_INNER=innerval",
+      "NE_USEINNER=${NE_UC:-${NE_INNER:-fallback}}",
+      "NE_TRIPLE=${NE_TA:-${NE_TB:-${NE_TC:-z}}}",
+    ].join("\n"),
+    "index.ts": `console.log([process.env.NE_DEEP, process.env.NE_USEINNER, process.env.NE_TRIPLE].join("|"));`,
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe("deep|innerval|z");
+});
+
 test(".env comments", () => {
   const dir = tempDirWithFiles("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -269,11 +269,16 @@ test(".env nested default substitution resolves (#32411)", () => {
 
 test(".env escaped $ inside a default resolves (#32411)", () => {
   const dir = tempDirWithFiles("dotenv-nested-default-escape", {
-    ".env": ["NE_ESC_NESTED=${NE_EA:-${NE_EB:-a\\$b}}", "NE_ESC_FLAT=${NE_EC:-a\\$b}"].join("\n"),
-    "index.ts": `console.log([process.env.NE_ESC_NESTED, process.env.NE_ESC_FLAT].join("|"));`,
+    ".env": [
+      "NE_ESC_NESTED=${NE_EA:-${NE_EB:-a\\$b}}",
+      "NE_ESC_FLAT=${NE_EC:-a\\$b}",
+      "NE_ESC_TRAIL=${NE_ED:-a\\$}",
+      "NE_ESC_TOP=x\\$",
+    ].join("\n"),
+    "index.ts": `console.log([process.env.NE_ESC_NESTED, process.env.NE_ESC_FLAT, process.env.NE_ESC_TRAIL, process.env.NE_ESC_TOP].join("|"));`,
   });
   const { stdout } = bunRun(`${dir}/index.ts`);
-  expect(stdout).toBe("a$b|a$b");
+  expect(stdout).toBe("a$b|a$b|a$|x$");
 });
 
 test(".env comments", () => {

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -267,6 +267,15 @@ test(".env nested default substitution resolves (#32411)", () => {
   expect(stdout).toBe("deep|innerval|z");
 });
 
+test(".env escaped $ inside a default resolves (#32411)", () => {
+  const dir = tempDirWithFiles("dotenv-nested-default-escape", {
+    ".env": ["NE_ESC_NESTED=${NE_EA:-${NE_EB:-a\\$b}}", "NE_ESC_FLAT=${NE_EC:-a\\$b}"].join("\n"),
+    "index.ts": `console.log([process.env.NE_ESC_NESTED, process.env.NE_ESC_FLAT].join("|"));`,
+  });
+  const { stdout } = bunRun(`${dir}/index.ts`);
+  expect(stdout).toBe("a$b|a$b");
+});
+
 test(".env comments", () => {
   const dir = tempDirWithFiles("dotenv-comments", {
     ".env": "#FOZ\nFOO = foo#FAIL\nBAR='bar' #BAZ",

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -260,11 +260,15 @@ test(".env nested default substitution resolves (#32411)", () => {
       "NE_INNER=innerval",
       "NE_USEINNER=${NE_UC:-${NE_INNER:-fallback}}",
       "NE_TRIPLE=${NE_TA:-${NE_TB:-${NE_TC:-z}}}",
+      // A bare `{` in a default is literal: the first `}` closes the
+      // substitution (matches bash), but balanced braces are preserved.
+      "NE_BRACE=${NE_BU:-{}",
+      "NE_URL=${NE_UU:-http://x/{id}}",
     ].join("\n"),
-    "index.ts": `console.log([process.env.NE_DEEP, process.env.NE_USEINNER, process.env.NE_TRIPLE].join("|"));`,
+    "index.ts": `console.log([process.env.NE_DEEP, process.env.NE_USEINNER, process.env.NE_TRIPLE, process.env.NE_BRACE, process.env.NE_URL].join("|"));`,
   });
   const { stdout } = bunRun(`${dir}/index.ts`);
-  expect(stdout).toBe("deep|innerval|z");
+  expect(stdout).toBe("deep|innerval|z|{|http://x/{id}");
 });
 
 test(".env escaped $ inside a default resolves (#32411)", () => {


### PR DESCRIPTION
Fixes #32411

## Repro

```console
$ printf 'FOO="${FOO:-${BAR:-baz}}"\n' > .env
$ printf 'console.log("hello")\n' > hello.ts
$ bun run hello.ts
panic: slice index starts at 18 but ends at 7
```

Expected `hello` / exit 0. A `.env` value that nests one substitution inside another's `:-` default crashes Bun before the script runs. On macOS the same logic error surfaces as `Segmentation fault at address 0x240913FFFEA`.

## Cause

`Parser::expand_value` in `src/dotenv/env_loader.rs` scanned the value **backwards**, splicing each expansion to the front of a buffer and tracking the processed-tail boundary in `last`. For `${FOO:-${BAR:-baz}}` the inner `${BAR:-baz}` is matched first and sets `last` to its own offset. The outer `${FOO:-...}` then scans its default forward, and because the default scan stopped at the first `}` (ignoring the nested braces) its `end` overran `last`. The resulting `value[end..last]` splice had `start > end`, an inverted range: a checked-slice panic in the Rust build, UB/segfault in release.

The backward-scan + splice-at-front design assumes left-to-right-disjoint matches, which nesting violates.

## Fix

Rewrite the expander as a forward scan (`expand_into`) that expands a nested `${...}` inside a `:-` default recursively, matching braces so the outer substitution's extent is computed correctly. Plain `$VAR`, `${VAR}`, `${VAR:-default}`, and unknown-key behavior is preserved. A depth cap keeps a pathologically nested value from overflowing the stack, and a fast path skips values with no `$`.

## Behavior notes

The crash fix aside, escape/brace handling now follows bash consistently. One case is a user-visible change for input that previously did *not* crash:

- A `\$` whose `$` is the final byte of a value or default now resolves to a literal `$`, same as `\$` anywhere else. Before, such a trailing `\$` was left as `\$` (an artifact of the old scanner never visiting the last byte). Example: `FOO=x\$` now yields `x$` (previously `x\$`).

The remaining refinements only affect input that previously crashed or was malformed: `\$` inside a nested default resolves correctly, a bare `{` in a default stays literal (`${FOO:-{}` -> `{`), and an escaped `\${` is not treated as a nested substitution (`${FOO:-\${}` -> `${`). All match bash.

## Verification

```console
$ printf 'FOO="${FOO:-${BAR:-baz}}"\n' > .env && printf 'console.log("hello")\n' > hello.ts
$ bun run hello.ts
hello
```

Tests in `test/cli/run/env.test.ts`:
- `.env nested default substitution does not crash (#32411)` runs the exact report and asserts exit 0.
- `.env nested default substitution resolves (#32411)` asserts `${NE_UA:-${NE_UB:-deep}}` -> `deep`, inner-resolves -> the set value, triple nesting -> `z`, and the bare/balanced brace cases above.
- `.env escaped $ inside a default resolves (#32411)` covers `\$` mid-default, in a nested default, trailing, top-level, and the escaped `\${` case.

The crashing cases fail on the current release binary (the panic above) and pass with this change. Existing `.env value expansion` and special-character (escaped `$`) coverage still passes.
