### PR TITLE
Upgrade WebKit to b5ba38a21e17

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -7,7 +7,7 @@
 // -lto variants built with ThinLTO (per-module summaries for cross-language
 // importing), and the Windows ICU data table filtered + per-item zstd
 // compressed (lazily decompressed via bun_icu_decompress.cpp).
-export const WEBKIT_VERSION = "9cb85a0716065c461bea14a0de9fe7139e5323aa";
+export const WEBKIT_VERSION = "09f04cd5a489b7c0b44aed255bfafce2a316eada";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -937,7 +937,7 @@ bool NodeVMSpecialSandbox::getOwnPropertySlot(JSObject* cell, JSGlobalObject* gl
     auto* thisObject = uncheckedDowncast<NodeVMSpecialSandbox>(cell);
     NodeVMGlobalObject* parentGlobal = thisObject->parentGlobal();
 
-    if (propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
+    if (propertyName == vm.propertyNames->globalThis) [[unlikely]] {
         slot.disableCaching();
         slot.setThisValue(thisObject);
         slot.setValue(thisObject, slot.attributes(), thisObject);
@@ -963,7 +963,7 @@ bool NodeVMGlobalObject::getOwnPropertySlot(JSObject* cell, JSGlobalObject* glob
 
     bool notContextified = thisObject->isNotContextified();
 
-    if (notContextified && propertyName.uid()->utf8() == "globalThis") [[unlikely]] {
+    if (notContextified && propertyName == vm.propertyNames->globalThis) [[unlikely]] {
         slot.disableCaching();
         slot.setThisValue(thisObject);
         slot.setValue(thisObject, slot.attributes(), thisObject->specialSandbox());


### PR DESCRIPTION
Merges upstream WebKit [b5ba38a21e17](https://github.com/WebKit/WebKit/commit/b5ba38a21e17) into oven-sh/WebKit@[09f04cd5a489](https://github.com/oven-sh/WebKit/commit/09f04cd5a489).

**Bun-side changes**
- `NodeVM.cpp`: compare against `vm.propertyNames->globalThis` (added to `CommonIdentifiers` in the fork) instead of allocating `uid()->utf8()`. Upstream's new `operator==(CString, ASCIILiteral)` overload made the old comparison ambiguous.

> [!NOTE]
> CI will fail until the [`autobuild-09f04cd5a489b7c0b44aed255bfafce2a316eada`](https://github.com/oven-sh/WebKit/releases) release finishes building.

## Notable JSC changes

**Spec compliance / correctness**
- `Promise.resolve` is no longer folded to identity for Promise subclasses [WebKit/WebKit@0f5acb567be0](https://github.com/WebKit/WebKit/commit/0f5acb567be0)
- `Object.freeze` / `Object.seal` now reify lazy/special properties before freezing [WebKit/WebKit@357d3881fd8d](https://github.com/WebKit/WebKit/commit/357d3881fd8d)
- `String#replace` / `replaceAll` / `split` RegExp paths now perform required observable side effects [WebKit/WebKit@eff90f74db57](https://github.com/WebKit/WebKit/commit/eff90f74db57)
- DFG `RegExpSearch` constant folding no longer drops the `TypeError` for non-writable `lastIndex` [WebKit/WebKit@21b46f50939e](https://github.com/WebKit/WebKit/commit/21b46f50939e)
- Iterator helper built-ins updated for tc39/ecma262#3776 [WebKit/WebKit@8310ec8b3200](https://github.com/WebKit/WebKit/commit/8310ec8b3200)
- DFGClobberize: `ToBoolean` / `TypeOfIsUndefined` / `TypeOfIsFunction` / `TypeOf` / `CompareEq` def value no longer keyed on semantic origin (CSE correctness) [WebKit/WebKit@c7fe05eb98f6](https://github.com/WebKit/WebKit/commit/c7fe05eb98f6)

**RegExp / Yarr**
- Fix heap overflow in Yarr `RegularExpression` with duplicate named capture groups [WebKit/WebKit@e5368156542a](https://github.com/WebKit/WebKit/commit/e5368156542a)
- Fix Yarr JIT `\B` + unicode + surrogate producing corrupted `JSString` and crashing [WebKit/WebKit@116394de195b](https://github.com/WebKit/WebKit/commit/116394de195b)
- `RegExp.prototype[Symbol.split]` moved from builtin JS to C++ [WebKit/WebKit@0c18eb164fca](https://github.com/WebKit/WebKit/commit/0c18eb164fca)

**JIT / optimizer**
- Reland global backward-liveness MovHint removal in DFG (replaces single-successor heuristic) [WebKit/WebKit@4401bf8b0133](https://github.com/WebKit/WebKit/commit/4401bf8b0133)
- DFG/FTL `Spread` now uses a runtime structure check for the fast path instead of requiring a proven AbstractValue [WebKit/WebKit@4b8ee8d96bd1](https://github.com/WebKit/WebKit/commit/4b8ee8d96bd1)
- New DFG node for `StringIteratorPrototype.next` [WebKit/WebKit@93518ed198a1](https://github.com/WebKit/WebKit/commit/93518ed198a1)
- `for-of` over a closure-captured `const` binding can now reach DFG/FTL [WebKit/WebKit@85309cfe91e8](https://github.com/WebKit/WebKit/commit/85309cfe91e8)
- Bytecode: emit `??` (nullish coalescing) in condition context [WebKit/WebKit@0dde5cddb126](https://github.com/WebKit/WebKit/commit/0dde5cddb126)
- Faster liveness analysis [WebKit/WebKit@53209b2d1762](https://github.com/WebKit/WebKit/commit/53209b2d1762)

**Temporal**
- Cache ICU `UCalendar` per TimeZoneID, drop `ucal_clone`, use `UCAL_TZ_TRANSITION_PREVIOUS_INCLUSIVE`, and optimize several Temporal date operations [WebKit/WebKit@7830cc6341b5](https://github.com/WebKit/WebKit/commit/7830cc6341b5) [WebKit/WebKit@ba459bae8fa7](https://github.com/WebKit/WebKit/commit/ba459bae8fa7) [WebKit/WebKit@82b8665ef1c3](https://github.com/WebKit/WebKit/commit/82b8665ef1c3) [WebKit/WebKit@33ca7b8504a9](https://github.com/WebKit/WebKit/commit/33ca7b8504a9)

**Wasm**
- BBQ JIT: fix tail-call argument shuffle when stack slots overlap [WebKit/WebKit@a6f42da10166](https://github.com/WebKit/WebKit/commit/a6f42da10166)
- Remove `OMGIRGenerator::RootBlock` [WebKit/WebKit@b29dbe254948](https://github.com/WebKit/WebKit/commit/b29dbe254948)

**Runtime / memory**
- Move non-cell primitive structured-cloning into JavaScriptCore [WebKit/WebKit@177aa8b796d4](https://github.com/WebKit/WebKit/commit/177aa8b796d4)
- Pack `ArrayBuffer` boolean fields to remove padding [WebKit/WebKit@660e785c5128](https://github.com/WebKit/WebKit/commit/660e785c5128)
- Store `usedRegisters` only on `RepatchingPropertyInlineCache` [WebKit/WebKit@3429f34cbda2](https://github.com/WebKit/WebKit/commit/3429f34cbda2)

## WTF / bmalloc

- libpas: new `tagged_bmalloc_heap` [WebKit/WebKit@3f04665f12e8](https://github.com/WebKit/WebKit/commit/3f04665f12e8)
- libpas: enable pleiades on Linux [WebKit/WebKit@a484a181f9e1](https://github.com/WebKit/WebKit/commit/a484a181f9e1)
- `Borrow<T>` constructor is now `lifetimebound` [WebKit/WebKit@44c202a8ebfb](https://github.com/WebKit/WebKit/commit/44c202a8ebfb)
- New `WTF::FormattedLogging` (`std::format`-based logging helpers, requires GCC ≥ 13) [WebKit/WebKit@a2495fb672e2](https://github.com/WebKit/WebKit/commit/a2495fb672e2)

## Other

- Build: Swift support in JSC for non-Production builds; CMake parallelizes LowLevelInterpreterLib; CMake codesigns JSC binaries; `InlineCacheHandler` static_assert fix for Windows ARM64
- Header / include hygiene and build-speed cleanups (centralized `#include`s, IWYU, inlines moved out of headers)
- Minor refactors: drop unnecessary `std::optional` initializers in JSC; libpas xctest timeout bump
- Feature-flag / WebCore-adjacent toggles touching WTF (`object-view-box`, Close Watcher, partitioned cookies, Spatial Backdrop removal, etc.) — not relevant to Bun