### PR TITLE
test(sql): cover both adapters in the synchronous-tls-rejection test

### DIFF
--- a/test/js/sql/sql.test.ts
+++ b/test/js/sql/sql.test.ts
@@ -12804,16 +12804,21 @@ describe("shared createInstance validation (no server)", () => {
     expect(err?.code).toBe("ERR_BORINGSSL");
   });
 
-  test.concurrent("rejects tls that is neither a boolean nor an object", async () => {
-    // A truthy non-boolean/non-object upgrades sslMode to `require` in JS and
-    // reaches the native parser as-is.
-    await using sql = new SQL({ ...base, username: "u", tls: 1 as any });
-    const err: any = await sql`select 1`.then(
-      () => null,
-      e => e,
-    );
-    expect(err?.message).toBe("tls must be a boolean or an object");
-  });
+  test.concurrent.each(["postgres", "mysql"] as const)(
+    "%s: rejects tls that is neither a boolean nor an object",
+    async adapter => {
+      // A truthy non-boolean/non-object upgrades sslMode to `require` in JS and
+      // reaches the native parser as-is. The constructor throws synchronously,
+      // and createPooledConnectionHandle defers onClose via process.nextTick so
+      // the pending query rejects cleanly instead of hanging (see #32145).
+      await using sql = new SQL({ ...base, adapter, username: "u", tls: 1 as any });
+      const err: any = await sql`select 1`.then(
+        () => null,
+        e => e,
+      );
+      expect(err?.message).toBe("tls must be a boolean or an object");
+    },
+  );
 
   test.concurrent("rejects simple queries with parameters", async () => {
     await using sql = new SQL({ ...base, username: "u" });


### PR DESCRIPTION
Extends the existing postgres-only `rejects tls that is neither a boolean nor an object` test (added in #32352) to mysql via `test.each`.

The native constructor throws synchronously on a non-boolean/non-object `tls`, and `createPooledConnectionHandle` defers `onClose` via `process.nextTick` (since #32145) so the pending query rejects cleanly instead of hanging. This locks that in for both adapters.

No code change; 2/2 pass on `bun bd test`.