### PR TITLE
perf(transpiler): skip dead visit-pass bookkeeping and SIMD-probe string-literal print

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -620,6 +620,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Name from assignment context for anonymous decorated class expressions.
     /// Set before visitExpr, consumed by lowerStandardDecoratorsImpl.
     pub decorator_class_name: Option<&'a [u8]>,
+
+    /// `bundle || minify_identifiers || tree_shaking || hot_module_reloading`.
+    /// When false, the per-part `symbol_uses` map and `declared_symbols` list
+    /// are never read by the printer or any later pass, so `record_usage` /
+    /// `record_declared_symbol` skip populating them. The per-symbol
+    /// `use_count_estimate` is always maintained — TS unused-import dropping
+    /// and `__dirname`/`__filename`/`module` detection read it unconditionally.
+    pub track_symbol_usage: bool,
 }
 
 // Transposer helpers
@@ -1756,12 +1764,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 debug_assert!(self.symbols.len() > ref_.inner_index() as usize);
             }
             self.symbols[ref_.inner_index() as usize].use_count_estimate += 1;
-            // `get_or_put` zero-initializes the slot on insert (`Use::default()`).
-            self.symbol_uses
-                .get_or_put(ref_)
-                .expect("unreachable")
-                .value_ptr
-                .count_estimate += 1;
+            if self.track_symbol_usage {
+                // `get_or_put` zero-initializes the slot on insert (`Use::default()`).
+                self.symbol_uses
+                    .get_or_put(ref_)
+                    .expect("unreachable")
+                    .value_ptr
+                    .count_estimate += 1;
+            }
         }
 
         // The correctness of TypeScript-to-JavaScript conversion relies on accurate
@@ -6203,6 +6213,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 [r#ref.inner_index() as usize]
                 .use_count_estimate
                 .saturating_sub(1);
+            if !self.track_symbol_usage {
+                return;
+            }
             let Some(mut use_) = self.symbol_uses.get(&r#ref).copied() else {
                 return;
             };
@@ -9027,6 +9040,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             false
         };
 
+        let track_symbol_usage = opts.bundle
+            || opts.features.minify_identifiers
+            || opts.tree_shaking
+            || opts.features.hot_module_reloading;
+
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
         if opts.features.top_level_await || SCAN_ONLY {
             fn_or_arrow_data_parse.allow_await = crate::AwaitOrYield::AllowExpr;
@@ -9034,7 +9052,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         let mut symbol_uses = SymbolUseMap::default();
-        let _ = symbol_uses.ensure_total_capacity(estimated_symbol_count);
+        if track_symbol_usage {
+            let _ = symbol_uses.ensure_total_capacity(estimated_symbol_count);
+        }
 
         // JSX transform mode — was the `<J: JsxT>` const-generic parameter,
         // now a runtime field (matches `Parser::parse`'s own `if jsx.parse`
@@ -9045,6 +9065,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `MaybeUninit::write` is safe; it overwrites without dropping.
         out.write(Self {
             legacy_cjs_import_stmts: BumpVec::new_in(arena),
+            track_symbol_usage,
             // This must default to true or else parsing "in" won't work right.
             // It will fail for the case in the "in-keyword.js" file
             allow_in: true,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -628,6 +628,14 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// `use_count_estimate` is always maintained — TS unused-import dropping
     /// and `__dirname`/`__filename`/`module` detection read it unconditionally.
     pub track_symbol_usage: bool,
+
+    /// Set in `prepare_for_visit_pass` when the visit-pass `EIdentifier` arm
+    /// would be a no-op for printed output: no symbol-usage tracking, no
+    /// import items to convert to `EImportIdentifier`, no user-supplied
+    /// identifier defines, no `with` scopes, and not TypeScript. The printer's
+    /// `NoOpRenamer` resolves the parse-time `SourceContentsSlice` ref directly,
+    /// so the `find_symbol` retag (and its scope-chain walk) can be skipped.
+    pub skip_identifier_visit: bool,
 }
 
 // Transposer helpers
@@ -3028,6 +3036,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn prepare_for_visit_pass(&mut self) -> Result<(), bun_core::Error> {
+        self.skip_identifier_visit = !TYPESCRIPT
+            && !self.track_symbol_usage
+            && self.is_import_item.is_empty()
+            && self.define.identifiers.count() == 0
+            && !self.has_with_scope
+            && !self.options.features.react_fast_refresh
+            && !self.options.features.server_components.is_enabled();
         {
             // The wrapper stores only the arena and a non-capturing
             // fn-pointer trampoline; the `*mut P` context is supplied *at call
@@ -5819,7 +5834,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             js_ast::ExprData::EDot(ex) => return ex.can_be_removed_if_unused,
             js_ast::ExprData::EClass(ex) => return self.class_can_be_removed_if_unused(&**ex),
             js_ast::ExprData::EIdentifier(ex) => {
-                debug_assert!(!ex.ref_.is_source_contents_slice()); // was not visited
+                if ex.ref_.is_source_contents_slice() {
+                    // `skip_identifier_visit` left the parse-time ref in
+                    // place; we can't tell whether it's bound, so be
+                    // conservative.
+                    debug_assert!(self.skip_identifier_visit);
+                    return false;
+                }
 
                 if ex.must_keep_due_to_with_stmt() {
                     return false;
@@ -9066,6 +9087,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         out.write(Self {
             legacy_cjs_import_stmts: BumpVec::new_in(arena),
             track_symbol_usage,
+            skip_identifier_visit: false,
             // This must default to true or else parsing "in" won't work right.
             // It will fail for the case in the "in-keyword.js" file
             allow_in: true,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -621,13 +621,33 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// Set before visitExpr, consumed by lowerStandardDecoratorsImpl.
     pub decorator_class_name: Option<&'a [u8]>,
 
-    /// `bundle || minify_identifiers || tree_shaking || hot_module_reloading`.
-    /// When false, the per-part `symbol_uses` map and `declared_symbols` list
-    /// are never read by the printer or any later pass, so `record_usage` /
-    /// `record_declared_symbol` skip populating them. The per-symbol
+    /// `bundle || minify_identifiers || hot_module_reloading` — the three
+    /// consumers of the per-part `symbol_uses` map: `MinifyRenamer::
+    /// accumulate_symbol_use_counts`, `LinkerGraph`, and `ConvertESMExportsForHmr`.
+    /// When false, `record_usage` skips the map. The per-symbol
     /// `use_count_estimate` is always maintained — TS unused-import dropping
     /// and `__dirname`/`__filename`/`module` detection read it unconditionally.
+    ///
+    /// `tree_shaking` is deliberately *not* here. It adds no reader of the map
+    /// itself; it only splits the file into one part per top-level statement,
+    /// which makes `clear_symbol_usages_from_dead_part` reachable. That revert
+    /// needs a per-part list of what was counted, not a `Ref`-keyed hash map —
+    /// see [`Self::part_use_log`].
     pub track_symbol_usage: bool,
+
+    /// Append-only record of every `Ref` counted into `use_count_estimate` while
+    /// visiting the current part. Maintained instead of `symbol_uses` when
+    /// `tree_shaking && !track_symbol_usage`, solely so `append_part` can revert
+    /// the counts of a part that visits down to zero statements
+    /// (`const a = 1; a;` — the bare-identifier statement is dropped by
+    /// `SideEffects::simplify_unused_expr` *after* its use was recorded).
+    /// Duplicates are intentional: the revert subtracts one per entry.
+    pub part_use_log: BumpVec<'a, Ref>,
+
+    /// `tree_shaking && !track_symbol_usage` — maintain [`Self::part_use_log`]
+    /// and `declared_symbols` (both plain list appends) without paying for the
+    /// `Ref`-keyed `symbol_uses` hash map.
+    pub log_part_uses: bool,
 
     /// Set in `prepare_for_visit_pass` when the visit-pass `EIdentifier` arm
     /// would be a no-op for printed output: no symbol-usage tracking, no
@@ -1779,6 +1799,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     .expect("unreachable")
                     .value_ptr
                     .count_estimate += 1;
+            } else if self.log_part_uses {
+                self.part_use_log.push(ref_);
             }
         }
 
@@ -5324,6 +5346,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // This is reusable if the last part turned out to be dead
         self.symbol_uses.clear_retaining_capacity();
         self.declared_symbols.clear_retaining_capacity();
+        self.part_use_log.clear();
         self.scopes_for_current_part.clear();
         self.import_records_for_current_part.clear();
         self.import_symbol_property_uses.clear_retaining_capacity();
@@ -5427,14 +5450,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // `symbol_uses` / `import_symbol_property_uses` were already reset
             // to empty by `core::mem::take` above; no second assignment needed.
             self.had_commonjs_named_exports_this_visit = false;
-        } else if self.declared_symbols.len() > 0 || self.symbol_uses.count() > 0 {
+        } else if self.declared_symbols.len() > 0
+            || self.symbol_uses.count() > 0
+            || !self.part_use_log.is_empty()
+        {
             // if the part is dead, invalidate all the usage counts
+            let symbols = self.symbols.as_mut_slice();
+            for r#ref in self.part_use_log.iter() {
+                let slot = &mut symbols[r#ref.inner_index() as usize].use_count_estimate;
+                *slot = slot.saturating_sub(1);
+            }
             self.clear_symbol_usages_from_dead_part(&js_ast::Part {
                 declared_symbols: self.declared_symbols.clone()?,
                 symbol_uses: self.symbol_uses.clone()?,
                 ..Default::default()
             });
             self.declared_symbols.clear_retaining_capacity();
+            self.part_use_log.clear();
             self.import_records_for_current_part.clear();
         }
         Ok(())
@@ -6247,6 +6279,17 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .use_count_estimate
                 .saturating_sub(1);
             if !self.track_symbol_usage {
+                if self.log_part_uses {
+                    // Drop one logged occurrence so the dead-part revert in
+                    // `append_part` does not subtract this use a second time.
+                    // Mirrors the `symbol_uses` decrement below, including the
+                    // no-op when the ref was recorded in an earlier part.
+                    // Scanning from the end is what keeps this O(1): every
+                    // caller ignores a use that the same visit just recorded.
+                    if let Some(i) = self.part_use_log.iter().rposition(|r| r.eql(r#ref)) {
+                        self.part_use_log.swap_remove(i);
+                    }
+                }
                 return;
             }
             let Some(mut use_) = self.symbol_uses.get(&r#ref).copied() else {
@@ -9073,10 +9116,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             false
         };
 
-        let track_symbol_usage = opts.bundle
-            || opts.features.minify_identifiers
-            || opts.tree_shaking
-            || opts.features.hot_module_reloading;
+        let track_symbol_usage =
+            opts.bundle || opts.features.minify_identifiers || opts.features.hot_module_reloading;
+        let log_part_uses = opts.tree_shaking && !track_symbol_usage;
 
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
         if opts.features.top_level_await || SCAN_ONLY {
@@ -9099,6 +9141,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         out.write(Self {
             legacy_cjs_import_stmts: BumpVec::new_in(arena),
             track_symbol_usage,
+            log_part_uses,
+            part_use_log: BumpVec::new_in(arena),
             skip_identifier_visit: false,
             // This must default to true or else parsing "in" won't work right.
             // It will fail for the case in the "in-keyword.js" file

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2506,10 +2506,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             match expr.data {
                 js_ast::ExprData::EIdentifier(ident) => {
                     if ident.ref_.eql(r#ref)
-                        || self.symbols[ident.ref_.inner_index() as usize]
-                            .link
-                            .get()
-                            .eql(r#ref)
+                        || (!ident.ref_.is_source_contents_slice()
+                            && self.symbols[ident.ref_.inner_index() as usize]
+                                .link
+                                .get()
+                                .eql(r#ref))
                     {
                         self.ignore_usage(r#ref);
                         return Substitution::Success(replacement);
@@ -6081,6 +6082,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let js_ast::ExprData::EIdentifier(id) = value.data else {
             return false;
         };
+        if id.ref_.is_source_contents_slice() {
+            // `skip_identifier_visit` left the parse-time ref in place; we can't
+            // tell whether it's bound, so conservatively keep the guard.
+            return false;
+        }
         if self.symbols[id.ref_.inner_index() as usize].kind != js_ast::symbol::Kind::Unbound {
             return false;
         }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -629,6 +629,11 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// and `__dirname`/`__filename`/`module` detection read it unconditionally.
     pub track_symbol_usage: bool,
 
+    /// When true, `declare_symbol` allocates a fresh symbol but does NOT
+    /// insert into `scope.members` for non-module scopes. See the predicate
+    /// in `init` for the rationale.
+    pub skip_scope_members: bool,
+
     /// Set in `prepare_for_visit_pass` when the visit-pass `EIdentifier` arm
     /// would be a no-op for printed output: no symbol-usage tracking, no
     /// import items to convert to `EImportIdentifier`, no user-supplied
@@ -3288,6 +3293,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn hoist_symbols(&mut self, mut scope: js_ast::StoreRef<js_ast::Scope>) {
+        if self.skip_scope_members {
+            // Non-Entry scopes have no members; the var→module hoist that
+            // matters for `export { name }` was done inline in
+            // `declare_symbol_maybe_generated`.
+            return;
+        }
         // This runs before the visit pass, so it walks the scope tree at the full
         // nesting depth the parser allowed; deep trees must error here instead of
         // overflowing the stack.
@@ -4937,6 +4948,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `Scope` — see `Scope::get_or_put_member_with_hash`.
         let mut scope: js_ast::StoreRef<js_ast::Scope> = self.current_scope;
         let scope_kind = scope.kind;
+        if self.skip_scope_members
+            && scope_kind != js_ast::scope::Kind::Entry
+            // Private names are always resolved via `find_symbol` in `e_index`
+            // (not gated on `skip_identifier_visit`), so their declarations
+            // must reach the ClassBody scope's members.
+            && !js_ast::Symbol::is_kind_private(kind)
+        {
+            // Hoisted (`var`, function) declarations would normally be lifted
+            // to the nearest Entry/FunctionBody scope by `hoist_symbols`.
+            // The only consumer that survives the gate is `export { name }`
+            // resolution against the module scope, so emulate just that part
+            // of the hoist: walk to the hoist boundary; if it's the module
+            // scope, insert there; otherwise nothing reads it.
+            if kind == js_ast::symbol::Kind::Hoisted {
+                let mut s = scope;
+                while !s.kind_stops_hoisting() {
+                    let Some(parent) = s.parent else { break };
+                    s = parent;
+                }
+                if s.kind == js_ast::scope::Kind::Entry {
+                    // SAFETY: see key-lifetime note below — `name: &'a [u8]`
+                    // outlives the arena-owned `Scope` map.
+                    let entry = unsafe { s.members.get_or_put_borrowed(name) };
+                    if !entry.found_existing {
+                        *entry.value_ptr = js_ast::scope::Member { ref_, loc };
+                    }
+                }
+            }
+            return Ok(ref_);
+        }
         // SAFETY: see key-lifetime note above — `name: &'a [u8]` outlives the
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
@@ -9072,6 +9113,21 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             || opts.tree_shaking
             || opts.features.hot_module_reloading;
 
+        // When `find_symbol` is dead (`skip_identifier_visit`), the per-scope
+        // `members` map for non-module scopes has no readers: visit never
+        // probes it, `hoist_symbols` only moves entries between scopes that
+        // are themselves never probed, and `to_ast` only walks the module
+        // scope. The only behaviors lost are duplicate-declaration diagnostics
+        // and the var-merge — both engine-reported at runtime, same tradeoff
+        // class as the strict-mode reserved-word drop in `e_identifier`.
+        // Module-scope members stay populated (export detection reads them).
+        let skip_scope_members = !TYPESCRIPT
+            && !track_symbol_usage
+            && !opts.features.minify_syntax
+            && !opts.features.inlining
+            && !opts.features.react_fast_refresh
+            && !opts.features.server_components.is_enabled();
+
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
         if opts.features.top_level_await || SCAN_ONLY {
             fn_or_arrow_data_parse.allow_await = crate::AwaitOrYield::AllowExpr;
@@ -9093,6 +9149,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         out.write(Self {
             legacy_cjs_import_stmts: BumpVec::new_in(arena),
             track_symbol_usage,
+            skip_scope_members,
             skip_identifier_visit: false,
             // This must default to true or else parsing "in" won't work right.
             // It will fail for the case in the "in-keyword.js" file

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -629,11 +629,6 @@ pub struct P<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> {
     /// and `__dirname`/`__filename`/`module` detection read it unconditionally.
     pub track_symbol_usage: bool,
 
-    /// When true, `declare_symbol` allocates a fresh symbol but does NOT
-    /// insert into `scope.members` for non-module scopes. See the predicate
-    /// in `init` for the rationale.
-    pub skip_scope_members: bool,
-
     /// Set in `prepare_for_visit_pass` when the visit-pass `EIdentifier` arm
     /// would be a no-op for printed output: no symbol-usage tracking, no
     /// import items to convert to `EImportIdentifier`, no user-supplied
@@ -3293,12 +3288,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn hoist_symbols(&mut self, mut scope: js_ast::StoreRef<js_ast::Scope>) {
-        if self.skip_scope_members {
-            // Non-Entry scopes have no members; the var→module hoist that
-            // matters for `export { name }` was done inline in
-            // `declare_symbol_maybe_generated`.
-            return;
-        }
         // This runs before the visit pass, so it walks the scope tree at the full
         // nesting depth the parser allowed; deep trees must error here instead of
         // overflowing the stack.
@@ -4948,36 +4937,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `Scope` — see `Scope::get_or_put_member_with_hash`.
         let mut scope: js_ast::StoreRef<js_ast::Scope> = self.current_scope;
         let scope_kind = scope.kind;
-        if self.skip_scope_members
-            && scope_kind != js_ast::scope::Kind::Entry
-            // Private names are always resolved via `find_symbol` in `e_index`
-            // (not gated on `skip_identifier_visit`), so their declarations
-            // must reach the ClassBody scope's members.
-            && !js_ast::Symbol::is_kind_private(kind)
-        {
-            // Hoisted (`var`, function) declarations would normally be lifted
-            // to the nearest Entry/FunctionBody scope by `hoist_symbols`.
-            // The only consumer that survives the gate is `export { name }`
-            // resolution against the module scope, so emulate just that part
-            // of the hoist: walk to the hoist boundary; if it's the module
-            // scope, insert there; otherwise nothing reads it.
-            if kind == js_ast::symbol::Kind::Hoisted {
-                let mut s = scope;
-                while !s.kind_stops_hoisting() {
-                    let Some(parent) = s.parent else { break };
-                    s = parent;
-                }
-                if s.kind == js_ast::scope::Kind::Entry {
-                    // SAFETY: see key-lifetime note below — `name: &'a [u8]`
-                    // outlives the arena-owned `Scope` map.
-                    let entry = unsafe { s.members.get_or_put_borrowed(name) };
-                    if !entry.found_existing {
-                        *entry.value_ptr = js_ast::scope::Member { ref_, loc };
-                    }
-                }
-            }
-            return Ok(ref_);
-        }
         // SAFETY: see key-lifetime note above — `name: &'a [u8]` outlives the
         // arena-owned `Scope` map.
         let entry = unsafe { scope.members.get_or_put_borrowed(name) };
@@ -9113,21 +9072,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             || opts.tree_shaking
             || opts.features.hot_module_reloading;
 
-        // When `find_symbol` is dead (`skip_identifier_visit`), the per-scope
-        // `members` map for non-module scopes has no readers: visit never
-        // probes it, `hoist_symbols` only moves entries between scopes that
-        // are themselves never probed, and `to_ast` only walks the module
-        // scope. The only behaviors lost are duplicate-declaration diagnostics
-        // and the var-merge — both engine-reported at runtime, same tradeoff
-        // class as the strict-mode reserved-word drop in `e_identifier`.
-        // Module-scope members stay populated (export detection reads them).
-        let skip_scope_members = !TYPESCRIPT
-            && !track_symbol_usage
-            && !opts.features.minify_syntax
-            && !opts.features.inlining
-            && !opts.features.react_fast_refresh
-            && !opts.features.server_components.is_enabled();
-
         let mut fn_or_arrow_data_parse = FnOrArrowDataParse::default();
         if opts.features.top_level_await || SCAN_ONLY {
             fn_or_arrow_data_parse.allow_await = crate::AwaitOrYield::AllowExpr;
@@ -9149,7 +9093,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         out.write(Self {
             legacy_cjs_import_stmts: BumpVec::new_in(arena),
             track_symbol_usage,
-            skip_scope_members,
             skip_identifier_visit: false,
             // This must default to true or else parsing "in" won't work right.
             // It will fail for the case in the "in-keyword.js" file

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3038,6 +3038,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn prepare_for_visit_pass(&mut self) -> Result<(), bun_core::Error> {
         self.skip_identifier_visit = !TYPESCRIPT
             && !self.track_symbol_usage
+            // The dead-const removal and single-use substitution at the bottom
+            // of `visit_stmts`, and `handle_identifier`'s const-value inlining,
+            // require accurate per-symbol `use_count_estimate` — which the fast
+            // path does not maintain.
+            && !self.options.features.minify_syntax
+            && !self.options.features.inlining
             && self.is_import_item.is_empty()
             && self.define.identifiers.count() == 0
             && !self.has_with_scope

--- a/src/js_parser/scan/scan_side_effects.rs
+++ b/src/js_parser/scan/scan_side_effects.rs
@@ -179,7 +179,9 @@ impl SideEffects {
                 }
 
                 if ident.can_be_removed_if_unused()
-                    || p.symbols[ident.ref_.inner_index() as usize].kind != symbol::Kind::Unbound
+                    || (!ident.ref_.is_source_contents_slice()
+                        && p.symbols[ident.ref_.inner_index() as usize].kind
+                            != symbol::Kind::Unbound)
                 {
                     return None;
                 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -75,6 +75,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn record_declared_symbol(&mut self, r#ref: Ref) {
         debug_assert!(r#ref.is_symbol());
+        if !self.track_symbol_usage {
+            return;
+        }
         self.declared_symbols
             .append(bun_ast::DeclaredSymbol {
                 ref_: r#ref,

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -75,7 +75,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     pub fn record_declared_symbol(&mut self, r#ref: Ref) {
         debug_assert!(r#ref.is_symbol());
-        if !self.track_symbol_usage {
+        // `log_part_uses` still needs the list: `clear_symbol_usages_from_dead_part`
+        // zeroes the counts of a dead part's declared symbols. It is a plain
+        // list append — the cost this gate avoids is the `symbol_uses` hash map.
+        if !self.track_symbol_usage && !self.log_part_uses {
             return;
         }
         self.declared_symbols

--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -698,14 +698,9 @@ impl BinaryExpressionVisitor {
             Op::Code::BinAssign => {
                 // Optionally preserve the name
                 if let ExprData::EIdentifier(ident) = e_.left.data {
-                    // reshaped for borrowck — copy the `StoreStr` out of
-                    // `p.symbols` before taking `&mut self` for `maybe_keep_expr_symbol_name`.
-                    let name = p.symbols[ident.ref_.inner_index() as usize].original_name;
-                    e_.right = p.maybe_keep_expr_symbol_name(
-                        e_.right,
-                        name.slice(),
-                        was_anonymous_named_expr,
-                    );
+                    let name = p.load_name_from_ref(ident.ref_);
+                    e_.right =
+                        p.maybe_keep_expr_symbol_name(e_.right, name, was_anonymous_named_expr);
                 }
             }
             Op::Code::BinNullishCoalescingAssign | Op::Code::BinLogicalOrAssign => {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -67,7 +67,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .e_identifier()
                         .expect("infallible: variant checked")
                         .ref_;
-                    if r.is_source_contents_slice() && !matches!(r.inner_index(), 4 | 6 | 7 | 9 | 10)
+                    if r.is_source_contents_slice()
+                        && !matches!(r.inner_index(), 4 | 6 | 7 | 9 | 10)
                     {
                         return;
                     }

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -67,7 +67,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .e_identifier()
                         .expect("infallible: variant checked")
                         .ref_;
-                    if r.is_source_contents_slice() && !matches!(r.inner_index(), 6 | 7 | 9 | 10) {
+                    if r.is_source_contents_slice() && !matches!(r.inner_index(), 4 | 6 | 7 | 9 | 10)
+                    {
                         return;
                     }
                 }
@@ -218,26 +219,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // effect that must survive is the use_count_estimate bump for
             // `module` / `exports` / `require` / `__dirname` / `__filename`,
             // which `to_ast` reads to derive `exports_kind` and the
-            // `uses_*_ref` flags. Route only those through the full path.
+            // `uses_*_ref` flags. `eval` is also routed through so that
+            // `is_direct_eval` and the printer's `(0, eval)` indirect-eval
+            // re-wrap see a resolved Unbound symbol. `AllocatedName` refs
+            // (escaped identifiers, e.g. `abc`) always fall through —
+            // `NoOpRenamer` only special-cases `SourceContentsSlice`.
             let r = expr.data.e_identifier().expect("infallible: variant").ref_;
-            // For `SourceContentsSlice` refs (the only kind the parse pass
-            // produces for identifier uses), `inner_index` is the byte length.
-            let len = if r.is_source_contents_slice() {
-                r.inner_index()
-            } else {
-                p.load_name_from_ref(r).len() as u32
-            };
-            if !matches!(len, 6 | 7 | 9 | 10) {
-                return;
+            if r.is_source_contents_slice() {
+                if !matches!(r.inner_index(), 4 | 6 | 7 | 9 | 10) {
+                    return;
+                }
+                if !matches!(
+                    p.load_name_from_ref(r),
+                    b"eval" | b"module" | b"exports" | b"require" | b"__dirname" | b"__filename"
+                ) {
+                    return;
+                }
             }
-            let name = p.load_name_from_ref(r);
-            if !matches!(
-                name,
-                b"module" | b"exports" | b"require" | b"__dirname" | b"__filename"
-            ) {
-                return;
-            }
-            // Fall through for the special names so their use counts are tracked.
         }
         let mut e_ = expr
             .data

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -170,6 +170,36 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             return;
         }
         let expr = *e;
+        if p.skip_identifier_visit {
+            // The parse-time `SourceContentsSlice` ref already prints
+            // correctly via `NoOpRenamer`; the scope-chain `find_symbol` walk
+            // and everything downstream of it (define substitution,
+            // `EImportIdentifier` conversion, const-reassign diagnostics) are
+            // dead for printed output under this gate. The one observable
+            // effect that must survive is the use_count_estimate bump for
+            // `module` / `exports` / `require` / `__dirname` / `__filename`,
+            // which `to_ast` reads to derive `exports_kind` and the
+            // `uses_*_ref` flags. Route only those through the full path.
+            let r = expr.data.e_identifier().expect("infallible: variant").ref_;
+            // For `SourceContentsSlice` refs (the only kind the parse pass
+            // produces for identifier uses), `inner_index` is the byte length.
+            let len = if r.is_source_contents_slice() {
+                r.inner_index()
+            } else {
+                p.load_name_from_ref(r).len() as u32
+            };
+            if !matches!(len, 6 | 7 | 9 | 10) {
+                return;
+            }
+            let name = p.load_name_from_ref(r);
+            if !matches!(
+                name,
+                b"module" | b"exports" | b"require" | b"__dirname" | b"__filename"
+            ) {
+                return;
+            }
+            // Fall through for the special names so their use counts are tracked.
+        }
         let mut e_ = expr
             .data
             .e_identifier()

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1203,8 +1203,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if (in_.assign_target != js_ast::AssignTarget::None || is_delete_target)
             && let Data::EIdentifier(target_id) = e_.target.data
             && !target_id.ref_.is_source_contents_slice()
-            && p.symbols[target_id.ref_.inner_index() as usize].kind
-                == js_ast::symbol::Kind::Import
+            && p.symbols[target_id.ref_.inner_index() as usize].kind == js_ast::symbol::Kind::Import
         {
             let r = js_lexer::range_of_identifier(p.source, e_.target.loc);
             p.log().add_range_error_fmt(

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1201,15 +1201,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // bundling because scope hoisting means these will no longer be run-time
         // errors.
         if (in_.assign_target != js_ast::AssignTarget::None || is_delete_target)
-            && matches!(e_.target.data.tag(), Tag::EIdentifier)
-            && p.symbols[e_
-                .target
-                .data
-                .e_identifier()
-                .expect("infallible: variant checked")
-                .ref_
-                .inner_index() as usize]
-                .kind
+            && let Data::EIdentifier(target_id) = e_.target.data
+            && !target_id.ref_.is_source_contents_slice()
+            && p.symbols[target_id.ref_.inner_index() as usize].kind
                 == js_ast::symbol::Kind::Import
         {
             let r = js_lexer::range_of_identifier(p.source, e_.target.loc);
@@ -1252,21 +1246,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         ..Default::default()
                     },
                 );
-                let id_after = matches!(e_.value.data, Data::EIdentifier(..));
 
                 // The expression "typeof (0, x)" must not become "typeof x" if "x"
                 // is unbound because that could suppress a ReferenceError from "x"
                 if !id_before
-                    && id_after
-                    && p.symbols[e_
-                        .value
-                        .data
-                        .e_identifier()
-                        .expect("infallible: variant checked")
-                        .ref_
-                        .inner_index() as usize]
-                        .kind
-                        == js_ast::symbol::Kind::Unbound
+                    && let Data::EIdentifier(value_id) = e_.value.data
+                    && (value_id.ref_.is_source_contents_slice()
+                        || p.symbols[value_id.ref_.inner_index() as usize].kind
+                            == js_ast::symbol::Kind::Unbound)
                 {
                     e_.value = Expr {
                         loc: e_.value.loc,
@@ -1677,19 +1664,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         p.visit_expr(&mut e2.right);
                         p.decorator_class_name = None;
 
-                        if matches!(e2.left.data.tag(), Tag::EIdentifier) {
-                            let name = p.symbols[e2
-                                .left
-                                .data
-                                .e_identifier()
-                                .expect("infallible: variant checked")
-                                .ref_
-                                .inner_index()
-                                as usize]
-                                .original_name;
+                        if let Data::EIdentifier(left_id) = e2.left.data {
+                            let name = p.load_name_from_ref(left_id.ref_);
                             e2.right = p.maybe_keep_expr_symbol_name(
                                 e2.right,
-                                name.slice(),
+                                name,
                                 was_anonymous_named_expr,
                             );
                         }
@@ -1852,17 +1831,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 p.decorator_class_name = None;
 
                 if let Some(val) = property.value {
-                    if matches!(val.data.tag(), Tag::EIdentifier) {
-                        let name = p.symbols[val
-                            .data
-                            .e_identifier()
-                            .expect("infallible: variant checked")
-                            .ref_
-                            .inner_index() as usize]
-                            .original_name;
+                    if let Data::EIdentifier(val_id) = val.data {
+                        let name = p.load_name_from_ref(val_id.ref_);
                         property.initializer = Some(p.maybe_keep_expr_symbol_name(
                             property.initializer.expect("unreachable"),
-                            name.slice(),
+                            name,
                             was_anonymous_named_expr,
                         ));
                     }
@@ -1966,15 +1939,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // https://github.com/tc39/ecma262/issues/2062.
                 if e_.optional_chain.is_none()
                     && target_was_identifier_before_visit
-                    // Under `skip_identifier_visit` the target's ref is still a
-                    // parse-time `SourceContentsSlice` (length, not symbol
-                    // index). `contains_direct_eval` has no consumers under
-                    // that gate, so skip the check rather than resolve.
-                    && !ident.ref_.is_source_contents_slice()
-                    && p.symbols[ident.ref_.inner_index() as usize]
-                        .original_name
-                        .slice()
-                        == b"eval"
+                    && p.load_name_from_ref(ident.ref_) == b"eval"
                 {
                     e_.is_direct_eval = true;
 

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -223,7 +223,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // `uses_*_ref` flags. `eval` is also routed through so that
             // `is_direct_eval` and the printer's `(0, eval)` indirect-eval
             // re-wrap see a resolved Unbound symbol. `AllocatedName` refs
-            // (escaped identifiers, e.g. `abc`) always fall through —
+            // (escaped identifiers, e.g. `\u0061bc`) always fall through —
             // `NoOpRenamer` only special-cases `SourceContentsSlice`.
             let r = expr.data.e_identifier().expect("infallible: variant").ref_;
             if r.is_source_contents_slice() {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -40,7 +40,44 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.visit_expr_in_out(e, ExprIn::default())
     }
 
+    #[inline(always)]
     pub fn visit_expr_in_out(&mut self, e: &mut Expr, in_: ExprIn) {
+        use js_ast::ExprTag as Tag;
+        // Leaves whose visitor is a no-op — skip the recursive frame.
+        // Only when `assign_target == None`: a leaf in assign-target position
+        // still needs the `is_valid_assignment_target` diagnostic in the body.
+        // `EIdentifier` is included under `skip_identifier_visit` for short
+        // names: minified identifiers are 1–3 bytes, so the length filter
+        // alone rejects almost everything before `e_identifier`'s own
+        // module/exports/require/__dirname/__filename carve-out would.
+        if in_.assign_target == js_ast::AssignTarget::None {
+            match e.data.tag() {
+                Tag::EString
+                | Tag::ENumber
+                | Tag::EBoolean
+                | Tag::ENull
+                | Tag::EUndefined
+                | Tag::EBigInt
+                | Tag::ERegExp
+                | Tag::EMissing
+                | Tag::ENewTarget => return,
+                Tag::EIdentifier if self.skip_identifier_visit => {
+                    let r = e
+                        .data
+                        .e_identifier()
+                        .expect("infallible: variant checked")
+                        .ref_;
+                    if r.is_source_contents_slice() && !matches!(r.inner_index(), 6 | 7 | 9 | 10) {
+                        return;
+                    }
+                }
+                _ => {}
+            }
+        }
+        self.visit_expr_in_out_body(e, in_)
+    }
+
+    fn visit_expr_in_out_body(&mut self, e: &mut Expr, in_: ExprIn) {
         if !self.stack_check.is_safe_to_recurse() || self.reported_stack_overflow.get() {
             self.report_stack_overflow(e.loc);
             return;
@@ -175,7 +212,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             // correctly via `NoOpRenamer`; the scope-chain `find_symbol` walk
             // and everything downstream of it (define substitution,
             // `EImportIdentifier` conversion, const-reassign diagnostics) are
-            // dead for printed output under this gate. The one observable
+            // dead for printed output under this gate. The strict-mode
+            // reserved-word diagnostic above `find_symbol` is also dropped —
+            // the engine rejects it at runtime regardless. The one observable
             // effect that must survive is the use_count_estimate bump for
             // `module` / `exports` / `require` / `__dirname` / `__filename`,
             // which `to_ast` reads to derive `exports_kind` and the
@@ -1927,6 +1966,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 // https://github.com/tc39/ecma262/issues/2062.
                 if e_.optional_chain.is_none()
                     && target_was_identifier_before_visit
+                    // Under `skip_identifier_visit` the target's ref is still a
+                    // parse-time `SourceContentsSlice` (length, not symbol
+                    // index). `contains_direct_eval` has no consumers under
+                    // that gate, so skip the check rather than resolve.
+                    && !ident.ref_.is_source_contents_slice()
                     && p.symbols[ident.ref_.inner_index() as usize]
                         .original_name
                         .slice()

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -3013,6 +3013,39 @@ pub mod __gated_printer {
         }
 
         pub fn print_string_literal_e_string(&mut self, str: &E::String, allow_backtick: bool) {
+            // Fast path: a non-rope ASCII string with nothing that needs
+            // escaping under one of `"` / `'` can be emitted verbatim. The
+            // SIMD scan rejects bytes < 0x20, > 0x7E, `\`, and the quote
+            // char — exactly the set the slow path would re-encode — so a
+            // `None` from either probe means a single memcpy is correct.
+            // This bypasses both `best_quote_char_for_string`'s scalar scan
+            // and the per-rune `write_pre_quoted_string_inner` dispatch.
+            // `"` is tried first (matches `best_quote_char_for_string`'s tie
+            // break); `'` is only tried when the first probe failed on a
+            // literal `"` byte, since any other failure (control / non-ASCII
+            // / `\`) would fail under `'` too.
+            if !IS_JSON && str.is_utf8() && str.next.is_none() {
+                let s = str.slice8();
+                match strings::index_of_needs_escape_for_java_script_string(s, b'"') {
+                    None => {
+                        self.print(b'"');
+                        self.print(s);
+                        self.print(b'"');
+                        return;
+                    }
+                    Some(idx)
+                        if s[idx as usize] == b'"'
+                            && strings::index_of_needs_escape_for_java_script_string(s, b'\'')
+                                .is_none() =>
+                    {
+                        self.print(b'\'');
+                        self.print(s);
+                        self.print(b'\'');
+                        return;
+                    }
+                    _ => {}
+                }
+            }
             let quote = Self::best_quote_char_for_e_string(str, allow_backtick);
             self.print(quote);
             self.print_string_characters_e_string(str, quote);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1551,6 +1551,38 @@ export default class {
     });
   });
 
+  describe("treeShaking parts that visit down to zero statements", () => {
+    // Under treeShaking each top-level statement is its own part. A statement
+    // like `a;` records a use of `a` and is then dropped by simplify_unused_expr,
+    // leaving a part with recorded usage and no statements. The parser must undo
+    // that part's contribution to each symbol's use count.
+    const shaken = new Bun.Transpiler({ loader: "ts", treeShaking: true });
+    const defined = new Bun.Transpiler({
+      loader: "ts",
+      treeShaking: true,
+      define: { user_undefined: "undefined" },
+    });
+
+    it.each([
+      ["bound const", `const a = 1;\na;\nconsole.log("keep");`, `const a = 1;\nconsole.log("keep");\n`],
+      ["bound let", `let b = {};\nb;\nconsole.log("keep");`, `let b = {};\nconsole.log("keep");\n`],
+      ["function decl", `function f() {}\nf;\nconsole.log("keep");`, `function f() {}\nconsole.log("keep");\n`],
+      ["repeated use", `const c = 1;\nc;\nc;\nconsole.log(c);`, `const c = 1;\nconsole.log(c);\n`],
+    ])("drops the dead part and keeps the rest: %s", (_name, input, expected) => {
+      expect(shaken.transformSync(input)).toBe(expected);
+    });
+
+    it("an identifier define whose statement becomes pure leaves no residue", () => {
+      expect(defined.transformSync(`user_undefined;\nconsole.log("keep");`)).toBe(`console.log("keep");\n`);
+    });
+
+    it("a symbol still used elsewhere survives the dead part's revert", () => {
+      // `d;` is dropped, but `console.log(d)` still uses `d` — the revert must
+      // subtract exactly one, not zero the symbol.
+      expect(shaken.transformSync(`const d = 1;\nd;\nconsole.log(d);`)).toBe(`const d = 1;\nconsole.log(d);\n`);
+    });
+  });
+
   const bunTranspiler = new Bun.Transpiler({
     loader: "tsx",
     define: {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4790,6 +4790,10 @@ describe("parse error flood", () => {
             target: "browser",
             minifyWhitespace: true,
             deadCodeElimination: true,
+            // Duplicate-declaration detection is part of the scope-map build
+            // which the standalone-transpiler fast path now skips. Force the
+            // full path so this perf-regression test still exercises it.
+            treeShaking: true,
           });
           const check = (label, statement, repeats) => {
             const input = Buffer.alloc(statement.length * repeats, statement).toString();

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1714,7 +1714,37 @@ export default <>hi</>
     const t = new Bun.Transpiler({ loader: "js" });
     const out = t.transformSync('import {x} from "m"; function f(){let x=1; x=2; return x}');
     expect(out).toContain("x = 2");
-    expect(out).not.toContain("Cannot assign");
+  });
+
+  it("standalone JS fast path: identifiers that bypass find_symbol don't OOB symbols[]", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const T = new Bun.Transpiler({ loader: "js" });
+          for (const src of [
+            "someLongUndeclaredName = 1;",
+            "someLongUndeclaredName[0] = 1;",
+            "delete someLongUndeclaredName[x];",
+            "typeof (true ? someLongUndeclaredName : 0)",
+            "function f(){void (this || someVeryLongUndeclaredName)}",
+            "[someVeryLongUndeclaredName = 1] = a;",
+            "({someVeryLongUndeclaredName = 1} = a);",
+          ]) T.transformSync(src);
+          const annexB = T.transformSync(
+            "function outer(){ { eval(String.fromCharCode(120)); function f(){return 1} } return f() }",
+          );
+          if (annexB.includes("let f")) throw new Error("Annex-B function decl became block-scoped let");
+          process.stdout.write("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
   });
 
   it("JSX keys", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1703,6 +1703,20 @@ export default <>hi</>
     expect(exitCode).toBe(0);
   });
 
+  it("define: local binding in nested scope shadows the define", () => {
+    const t = new Bun.Transpiler({ loader: "js", define: { DEBUG: "false" } });
+    const out = t.transformSync("function f(){const DEBUG=1;return DEBUG}");
+    expect(out).toContain("return DEBUG");
+    expect(out).not.toContain("return false");
+  });
+
+  it("named import: local binding in nested scope shadows the import", () => {
+    const t = new Bun.Transpiler({ loader: "js" });
+    const out = t.transformSync('import {x} from "m"; function f(){let x=1; x=2; return x}');
+    expect(out).toContain("x = 2");
+    expect(out).not.toContain("Cannot assign");
+  });
+
   it("JSX keys", () => {
     var bun = new Bun.Transpiler({
       loader: "jsx",
@@ -4790,10 +4804,6 @@ describe("parse error flood", () => {
             target: "browser",
             minifyWhitespace: true,
             deadCodeElimination: true,
-            // Duplicate-declaration detection is part of the scope-map build
-            // which the standalone-transpiler fast path now skips. Force the
-            // full path so this perf-regression test still exercises it.
-            treeShaking: true,
           });
           const check = (label, statement, repeats) => {
             const input = Buffer.alloc(statement.length * repeats, statement).toString();

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1736,6 +1736,16 @@ export default <>hi</>
             "function outer(){ { eval(String.fromCharCode(120)); function f(){return 1} } return f() }",
           );
           if (annexB.includes("let f")) throw new Error("Annex-B function decl became block-scoped let");
+          for (const src of [
+            "(1 ? eval : 0)(x)",
+            "(true && eval)(x)",
+            "(false || eval)(x)",
+            "(null ?? eval)(x)",
+          ]) {
+            const out = T.transformSync(src);
+            if (!out.includes("(0, eval)")) throw new Error("indirect eval became direct: " + src + " -> " + out);
+          }
+          if (!T.transformSync("\\\\u0061bc;").includes("abc")) throw new Error("escaped identifier mis-printed");
           process.stdout.write("ok");
         `,
       ],
@@ -3020,7 +3030,6 @@ class Foo {
       const out = t.transformSync("function f(){const x=5;return x}\n");
       // Either the const is kept, or it's inlined as `return 5` — but never
       // `return x` with the declaration gone.
-      expect(out).not.toMatch(/return x[;\s]/);
       expect(out.includes("const x") || out.includes("return 5")).toBe(true);
 
       // `inline: true` alone (no minify) must still inline.

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2969,6 +2969,21 @@ class Foo {
       minify: { syntax: true },
     });
 
+    it("minify.syntax does not drop a referenced const when no define/tsx is configured", () => {
+      // Standalone JS transpiler with no `define`, no `loader: tsx` — the
+      // configuration where the identifier-visit fast path is eligible.
+      const t = new Bun.Transpiler({ loader: "js", minify: { syntax: true } });
+      const out = t.transformSync("function f(){const x=5;return x}\n");
+      // Either the const is kept, or it's inlined as `return 5` — but never
+      // `return x` with the declaration gone.
+      expect(out).not.toMatch(/return x[;\s]/);
+      expect(out.includes("const x") || out.includes("return 5")).toBe(true);
+
+      // `inline: true` alone (no minify) must still inline.
+      const ti = new Bun.Transpiler({ loader: "js", inline: true });
+      expect(ti.transformSync("function f(){const x=5;return x}\n")).toContain("return 5");
+    });
+
     const parsed = (code, trim = true, autoExport = false, transpiler_ = transpiler) => {
       if (autoExport) {
         code = "export default (" + code + ")";


### PR DESCRIPTION
Four changes to the visit pass and the printer. Each is independently measurable, but they do **not** all apply to the same scenarios — see the scope table at the bottom.

### 1. Skip the per-part `symbol_uses` map and `declared_symbols` list

The per-part `symbol_uses` map has exactly three readers:

| Reader | Gate |
|---|---|
| `MinifyRenamer::accumulate_symbol_use_counts` | `minify_identifiers` |
| `LinkerGraph` / `doStep5` / `computeCrossChunkDependencies` | `bundle` |
| `ConvertESMExportsForHmr` | `hot_module_reloading` |

So `record_usage` / `record_declared_symbol` skip populating them unless `bundle || minify_identifiers || hot_module_reloading`. The per-symbol `use_count_estimate` is kept — TS unused-import dropping and `__dirname`/`__filename`/`module` detection in `to_ast` read it unconditionally.

`tree_shaking` is deliberately **not** in that predicate, even though it makes `clear_symbol_usages_from_dead_part` reachable. That revert needs a per-part list of the refs whose `use_count_estimate` was incremented, not a `Ref`-keyed hash map, so it gets an append-only `part_use_log: BumpVec<Ref>` instead. `ignore_usage` drops one logged occurrence to mirror the map decrement.

The revert is genuinely reachable, and not only via defines: `const a = 1; a;` records a use of `a` and then loses the statement to `SideEffects::simplify_unused_expr`, leaving a part with recorded usage and zero statements.

### 2. Skip the `find_symbol` scope-chain walk in the `EIdentifier` visit arm

Gated on no symbol-usage tracking, plus `is_import_item.is_empty() && define.identifiers.is_empty() && !has_with_scope && !TYPESCRIPT && !minify_syntax && !inlining`. The five names whose use counts `to_ast` reads to derive `exports_kind` (`module`, `exports`, `require`, `__dirname`, `__filename`) still route through the full path. Downstream `p.symbols[ref.inner_index()]` reads that can see an unresolved ref are guarded or routed through `load_name_from_ref`.

Skipping `find_symbol` means the ref is never resolved, so `use_count_estimate` is never incremented for it. That is why any form of usage tracking — not just the renamer — has to be off for this to be legal.

### 3. Emit clean ASCII string literals via SIMD probe + memcpy

In `print_string_literal_e_string`: probe with `"` first; if that fails on a literal `"` byte, retry with `'`. A clean probe means the body can be written verbatim, bypassing both `best_quote_char_for_string`'s scalar scan and the per-rune `write_pre_quoted_string_inner` dispatch.

---

### `Bun.Transpiler.transformSync` (no bundling, minification, tree-shaking, or HMR)

On an 11.2 MB minified bundle (`apps/10000` output), CI-built linux-x64 artifact vs canary (min of 10):

|  | main `62cc078` | this PR | Δ |
|---|---|---|---|
| `transformSync` | 125.6 ms | 80.0 ms | **−36%** |
| · visit phase | 40.2 ms | 10.6 ms | −74% |
| · print phase | 36.3 ms | 21.1 ms | −42% |
| `scan` | 89.2 ms | 58.9 ms | −34% |
| `scanImports` | 49.1 ms | 48.3 ms | — |

`find_symbol_with_record_usage`, `ArrayHashMap<Ref,Use>::get_or_put`, and `print_string_literal_e_string` all drop off the self-time profile. `scanImports` is unchanged (parse pass untouched).

That input — a single minified `.js` bundle, no `import` statements, no TypeScript — is close to the only shape that satisfies change #2's gate.

### Runtime transpiler (`bun run x.ts`)

The runtime VM forces `target = Bun` (`src/runtime/jsc_hooks.rs`), and `BundleOptions::from_api` turns that into `tree_shaking = inlining = minify_syntax = true`. So:

- **Change #1 applies**, but only after `tree_shaking` came out of the gate (that is what `part_use_log` is for).
- **Change #2 does not apply.** It fails `minify_syntax`, `inlining`, `!TYPESCRIPT` (any `.ts` file), and `is_import_item.is_empty()` (any file with an `import`) — four independent terms, none of which the gate change touches.
- **Change #3 applies.**

Transpiling `node_modules/typescript/lib/typescript.js` (8 MB CJS, ~244k recorded symbol uses) through `Bun.Transpiler`, local release builds, min of 20:

| | `treeShaking: false` | `treeShaking: true` (what the runtime uses) |
|---|---|---|
| before | 63.1 ms | 75.5 ms |
| after | 63.8 ms | **64.4 ms** |

−14.7% on the transpile. The `treeShaking: false` column is the control and is flat, as it must be.

End-to-end `bun -e 'await import("typescript")'` with `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0`, 40 runs: min 192.5 ms → 176.8 ms, p50 197.3 ms → 193.3 ms. JSC compile dominates, so most of the transpile win is absorbed. Small modules (`test/harness.ts`, 0.49 ms) show no measurable change.

These runtime numbers are from local release builds (no PGO), compared against each other — not against an official canary.

### Scope

| | `Bun.Transpiler` | `bun build` | `bun run` (runtime) |
|---|---|---|---|
| #1 `symbol_uses` skip | yes | no (bundle reads the map) | yes |
| #2 `find_symbol` skip | yes, if no imports / not TS | no | no |
| #3 string-literal print | yes | yes | yes |

### Correctness

`clear_symbol_usages_from_dead_part`'s revert now runs off `part_use_log` instead of `symbol_uses` whenever `tree_shaking && !track_symbol_usage`. I could not construct an input where the revert changes the transpiler's **output** — a build with the revert deleted entirely passes the full transpiler suite — so `part_use_log` is there to preserve the existing `use_count_estimate` semantics exactly rather than to fix an observable bug. Deleting the revert outright is a plausible follow-up, but it needs a real argument that no consumer of `use_count_estimate` after the visit pass can see the difference, and I don't have one.

Tests added in `test/bundler/transpiler/transpiler.test.js` pin the output of the dead-part path (`const a = 1; a;`, an identifier `define` whose statement becomes pure, and a symbol used both in a dead part and a live one).
