### PR TITLE
cli(test): --coverage-reporter and --coverage-dir imply --coverage

### DIFF
--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -71,11 +71,11 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--coverage-reporter" type="string" default="text">
-  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>
+  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>. Implies <code>--coverage</code>
 </ParamField>
 
 <ParamField path="--coverage-dir" type="string" default="coverage">
-  Directory for coverage files. Defaults to <code>coverage</code>
+  Directory for coverage files. Defaults to <code>coverage</code>. Implies <code>--coverage</code>
 </ParamField>
 
 ### Snapshots

--- a/docs/snippets/cli/test.mdx
+++ b/docs/snippets/cli/test.mdx
@@ -71,7 +71,8 @@ bun test <patterns>
 </ParamField>
 
 <ParamField path="--coverage-reporter" type="string" default="text">
-  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>. Implies <code>--coverage</code>
+  Report coverage in <code>text</code> and/or <code>lcov</code>. Defaults to <code>text</code>. Implies{" "}
+  <code>--coverage</code>
 </ParamField>
 
 <ParamField path="--coverage-dir" type="string" default="coverage">

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -556,10 +556,10 @@ pub(crate) const TEST_ONLY_PARAMS: &[ParamType] = &[
     parse_param!("--seed <INT>                     Set the random seed for test randomization"),
     parse_param!("--coverage                       Generate a coverage profile"),
     parse_param!(
-        "--coverage-reporter <STR>...     Report coverage in 'text' and/or 'lcov'. Defaults to 'text'."
+        "--coverage-reporter <STR>...     Report coverage in 'text' and/or 'lcov'. Defaults to 'text'. Implies --coverage."
     ),
     parse_param!(
-        "--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'."
+        "--coverage-dir <STR>             Directory for coverage files. Defaults to 'coverage'. Implies --coverage."
     ),
     parse_param!(
         "--bail <NUMBER>?                 Exit the test suite after <NUMBER> failures. If you do not specify a number, it defaults to 1."

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -1563,6 +1563,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     }
 
     if !args.options(b"--coverage-reporter").is_empty() {
+        ctx.test_options.coverage.enabled = true;
         ctx.test_options.coverage.reporters = CoverageReporters {
             text: false,
             lcov: false,
@@ -1618,6 +1619,7 @@ fn parse_test_command_options(args: &clap::Args<clap::Help>, ctx: Context<'_>) {
     }
 
     if let Some(dir) = args.option(b"--coverage-dir") {
+        ctx.test_options.coverage.enabled = true;
         ctx.test_options.coverage.reports_directory = Box::<[u8]>::from(dir);
     }
 

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDirWithFiles } from "harness";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "path";
 
 test("coverage crash", () => {
@@ -55,6 +55,77 @@ export class Y {
   expect(normalizeBunSnapshot(readFileSync(path.join(dir, "coverage", "lcov.info"), "utf-8"), dir)).toMatchSnapshot(
     "lcov-coverage-reporter-output",
   );
+});
+
+// https://github.com/oven-sh/bun/issues/17502
+test.each([
+  ["--coverage-reporter=lcov"],
+  ["--coverage-reporter", "lcov"],
+])("%s implies --coverage", (...flags) => {
+  const dir = tempDirWithFiles("cov", {
+    "add.ts": `export function add(a: number, b: number) { return a + b; }`,
+    "add.test.ts": `
+import { test, expect } from "bun:test";
+import { add } from "./add";
+test("add", () => { expect(add(1, 2)).toBe(3); });
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", ...flags], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, "pipe", "pipe"],
+  });
+  const lcovPath = path.join(dir, "coverage", "lcov.info");
+  expect({
+    "coverage/lcov.info exists": existsSync(lcovPath),
+    exitCode: result.exitCode,
+  }).toEqual({
+    "coverage/lcov.info exists": true,
+    exitCode: 0,
+  });
+  expect(readFileSync(lcovPath, "utf-8")).toContain("SF:add.ts");
+});
+
+test("--coverage-reporter=text implies --coverage", () => {
+  const dir = tempDirWithFiles("cov", {
+    "add.ts": `export function add(a: number, b: number) { return a + b; }`,
+    "add.test.ts": `
+import { test, expect } from "bun:test";
+import { add } from "./add";
+test("add", () => { expect(add(1, 2)).toBe(3); });
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage-reporter=text"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, "pipe", "pipe"],
+  });
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("% Funcs");
+  expect(stderr).toContain("% Lines");
+  expect(stderr).toContain("add.ts");
+  expect(result.exitCode).toBe(0);
+});
+
+test("--coverage-dir implies --coverage", () => {
+  const dir = tempDirWithFiles("cov", {
+    "add.ts": `export function add(a: number, b: number) { return a + b; }`,
+    "add.test.ts": `
+import { test, expect } from "bun:test";
+import { add } from "./add";
+test("add", () => { expect(add(1, 2)).toBe(3); });
+`,
+  });
+  const result = Bun.spawnSync([bunExe(), "test", "--coverage-dir=out"], {
+    cwd: dir,
+    env: bunEnv,
+    stdio: [null, "pipe", "pipe"],
+  });
+  const stderr = result.stderr.toString("utf-8");
+  expect(stderr).toContain("% Funcs");
+  expect(stderr).toContain("% Lines");
+  expect(stderr).toContain("add.ts");
+  expect(result.exitCode).toBe(0);
 });
 
 test("coverage excludes node_modules directory", () => {

--- a/test/cli/test/coverage.test.ts
+++ b/test/cli/test/coverage.test.ts
@@ -58,10 +58,7 @@ export class Y {
 });
 
 // https://github.com/oven-sh/bun/issues/17502
-test.each([
-  ["--coverage-reporter=lcov"],
-  ["--coverage-reporter", "lcov"],
-])("%s implies --coverage", (...flags) => {
+test.each([["--coverage-reporter=lcov"], ["--coverage-reporter", "lcov"]])("%s implies --coverage", (...flags) => {
   const dir = tempDirWithFiles("cov", {
     "add.ts": `export function add(a: number, b: number) { return a + b; }`,
     "add.test.ts": `


### PR DESCRIPTION
Fixes #17502.

## Repro

```console
$ bun test --coverage-reporter=lcov
bun test v1.4.0
(pass) add
 1 pass
$ ls coverage/
ls: cannot access 'coverage/': No such file or directory
```

No coverage output is produced unless `--coverage` is also passed.

## Cause

`src/runtime/cli/Arguments.rs` parses `--coverage-reporter` and `--coverage-dir` into `ctx.test_options.coverage.{reporters,reports_directory}` but never sets `coverage.enabled`, so the test runner skips coverage collection entirely.

## Fix

Set `ctx.test_options.coverage.enabled = true` when either `--coverage-reporter` or `--coverage-dir` is passed on the CLI.

The bunfig keys (`coverageReporter`, `coverageDir`) are intentionally left as-is: a preconfigured reporter in bunfig.toml shouldn't force coverage on every `bun test` run. Users who want that already have `coverage = true`.

## Verification

New tests in `test/cli/test/coverage.test.ts`:
- `--coverage-reporter=lcov` / `--coverage-reporter lcov` alone writes `coverage/lcov.info`
- `--coverage-reporter=text` alone prints the coverage table
- `--coverage-dir=out` alone prints the coverage table (default text reporter)

All four fail on main and pass with this change. Full `coverage.test.ts` suite (16 tests) passes.