### PR TITLE
node:http: reset res.url and res.method on client IncomingMessage

### DIFF
--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -148,6 +148,13 @@ function IncomingMessage(req, options = defaultIncomingOpts) {
       if (!assignHeaders(this, req)) {
         this[fakeSocketSymbol] = req;
       }
+      if (type === NodeHTTPIncomingRequestType.FetchResponse) {
+        // message.url and message.method are only populated for requests
+        // obtained from http.Server. assignHeaders derives url from the
+        // underlying fetch Response URL; reset to match Node.js defaults.
+        this.url = "";
+        this.method = null;
+      }
     } else {
       // Node defaults url and method to null.
       this.url = "";

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -610,6 +610,23 @@ describe("node:http", () => {
       });
     });
 
+    // https://github.com/oven-sh/bun/issues/13820
+    it("res.url should be empty and res.method should be null on client responses", done => {
+      runTest(done, (server, serverPort, done) => {
+        const req = request(`http://localhost:${serverPort}/pathTest?a=1#hash`, res => {
+          try {
+            expect({ url: res.url, method: res.method }).toEqual({ url: "", method: null });
+          } catch (err) {
+            return done(err);
+          }
+          res.resume();
+          res.on("end", () => done());
+          res.on("error", err => done(err));
+        });
+        req.end();
+      });
+    });
+
     // NOTE: Node http.request doesn't follow redirects by default
     it("should handle redirects properly", done => {
       runTest(done, (server, serverPort, done) => {


### PR DESCRIPTION
Fixes #13820.

## What

For the `IncomingMessage` passed to the `http.request` / `https.request` response callback, Node.js initializes `url` to `""` and `method` to `null` and never populates them. The docs for [`message.url`](https://nodejs.org/api/http.html#messageurl) and [`message.method`](https://nodejs.org/api/http.html#messagemethod) both state they are only valid for requests obtained from `http.Server`.

Bun was instead setting `res.url` to the request path + query string (and leaving `res.method` as `undefined`).

## Repro

```js
import { createServer, request } from "http";

const server = createServer((req, res) => res.end("ok"));
server.listen(0, () => {
  request(`http://127.0.0.1:${server.address().port}/some/path?a=1`, res => {
    console.log(JSON.stringify({ url: res.url, method: res.method }));
    res.resume();
    res.on("end", () => server.close());
  }).end();
});
```

| Runtime | Output |
| --- | --- |
| Node.js | `{"url":"","method":null}` |
| Bun (before) | `{"url":"/some/path?a=1"}` |
| Bun (after) | `{"url":"","method":null}` |

## Cause

The client-side `IncomingMessage` is constructed with `type === NodeHTTPIncomingRequestType.FetchResponse` and the underlying fetch `Response` as `req`. `assignHeaders` calls into `jsHTTPAssignHeaders` in `NodeHTTP.cpp`, which reads `.url` off the passed object and writes the parsed path+query onto the `IncomingMessage`. That is correct for server-side requests but not for client responses.

## Fix

After `assignHeaders` populates headers for the `FetchResponse` case, reset `url` to `""` and `method` to `null` to match Node's defaults. Server-side request messages (which go through the `kHandle` / `NodeHTTPResponse` path or the `FetchRequest` path) are unaffected.