### PR TITLE
console: write timeEnd/timeLog to stdout instead of stderr

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -6003,12 +6003,12 @@ pub extern "C" fn Bun__ConsoleObject__timeEnd(
     };
     let Some(value) = prev else { return };
     // get the duration in microseconds, then display it in milliseconds
-    Output::print_elapsed(
+    Output::print_elapsed_stdout(
         (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
     );
     match len {
-        0 => Output::print_errorln(format_args!("")),
-        _ => Output::print_errorln(format_args!(" {}", bstr::BStr::new(slice))),
+        0 => Output::println(format_args!("")),
+        _ => Output::println(format_args!(" {}", bstr::BStr::new(slice))),
     }
 
     Output::flush();
@@ -6035,12 +6035,12 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
         return;
     };
     // get the duration in microseconds, then display it in milliseconds
-    Output::print_elapsed(
+    Output::print_elapsed_stdout(
         (value.read() / bun_core::time::NS_PER_US) as f64 / bun_core::time::US_PER_MS as f64,
     );
     match len {
         0 => {}
-        _ => Output::print_error(format_args!(" {}", bstr::BStr::new(slice))),
+        _ => Output::print(format_args!(" {}", bstr::BStr::new(slice))),
     }
     Output::flush();
 
@@ -6058,14 +6058,14 @@ pub extern "C" fn Bun__ConsoleObject__timeLog(
     // this VM; JS-thread-only. Kept as a raw deref (not `vm_console_mut`) so the
     // resulting `writer` borrow does not pin a long-lived `&mut ConsoleObject`
     // across the `fmt.format(...)` calls below, which can re-enter JS.
-    let mut writer = unsafe { (*console).error_writer() };
+    let mut writer = unsafe { (*console).writer() };
     // SAFETY: caller passes a valid (args, args_len) pair.
     for &arg in unsafe { bun_core::ffi::slice(args, args_len) } {
         let Ok(tag) = formatter::Tag::get(arg, global) else {
             return;
         };
         let _ = bun_io::Write::write_all(&mut writer, b" ");
-        if Output::enable_ansi_colors_stderr() {
+        if Output::enable_ansi_colors_stdout() {
             let _ = fmt.format::<true>(tag, &mut writer, arg, global);
         } else {
             let _ = fmt.format::<false>(tag, &mut writer, arg, global);

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -11,8 +11,8 @@ it.concurrent("console.timeEnd with empty label emits exactly one trailing newli
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\]\n$/);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\[[\d.]+[mnµ]?s\]\n$/);
   expect(exitCode).toBe(0);
 });
 
@@ -24,25 +24,58 @@ it.concurrent("console.timeEnd with non-empty label emits exactly one trailing n
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stdout).toBe("");
-  expect(stderr).toMatch(/^\[[\d.]+[mnµ]?s\] abc\n$/);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\[[\d.]+[mnµ]?s\] abc\n$/);
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/12031
+it.concurrent("console.timeEnd writes to stdout, not stderr", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time(); console.timeEnd();`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\[[\d.]+[mnµ]?s\] default\n$/);
+  expect(exitCode).toBe(0);
+});
+
+// https://github.com/oven-sh/bun/issues/12031
+it.concurrent("console.timeLog writes to stdout, not stderr", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `console.time(); console.timeLog(); console.timeLog("default", "extra", "args");`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const lines = stdout.split("\n");
+  expect(lines[0]).toMatch(/^\[[\d.]+[mnµ]?s\] default$/);
+  expect(lines[1]).toMatch(/^\[[\d.]+[mnµ]?s\] default extra args$/);
+  expect(lines[2]).toBe("");
+  expect(lines.length).toBe(3);
   expect(exitCode).toBe(0);
 });
 
 it("should log to console correctly", async () => {
-  const { stderr, exited } = spawn({
+  const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), join(import.meta.dir, "console-timeLog.js")],
     stdin: null,
     stdout: "pipe",
     stderr: "pipe",
     env: bunEnv,
   });
-  expect(await exited).toBe(0);
-  const outText = await stderr.text();
+  const [outText, errText, exitCode] = await Promise.all([stdout.text(), stderr.text(), exited]);
+  expect(errText).toBe("");
   const expectedText = (await file(join(import.meta.dir, "console-timeLog.expected.txt")).text()).replaceAll(
     "\r\n",
     "\n",
   );
 
   expect(outText.replace(/^\[.+?s\] /gm, "")).toBe(expectedText.replace(/^\[.+?s\] /gm, ""));
+  expect(exitCode).toBe(0);
 });

--- a/test/js/web/console/console-timeLog.test.ts
+++ b/test/js/web/console/console-timeLog.test.ts
@@ -61,7 +61,7 @@ it.concurrent("console.timeLog writes to stdout, not stderr", async () => {
   expect(exitCode).toBe(0);
 });
 
-it("should log to console correctly", async () => {
+it.concurrent("should log to console correctly", async () => {
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), join(import.meta.dir, "console-timeLog.js")],
     stdin: null,


### PR DESCRIPTION
Fixes #12031.

## Repro

```console
$ bun -e 'console.time(); console.timeEnd()' > /dev/null
[0.00ms] default

$ node -e 'console.time(); console.timeEnd()' > /dev/null
(no output)
```

Node routes `console.timeEnd()` and `console.timeLog()` through `console.log`, so the timing output goes to stdout. Bun wrote it to stderr, which meant redirecting stdout did not capture the timing output and it leaked past pipes.

## Cause

`Bun__ConsoleObject__timeEnd` and `Bun__ConsoleObject__timeLog` in `src/jsc/ConsoleObject.rs` used the stderr helpers: `Output::print_elapsed` (which targets stderr via `pretty_error!`), `Output::print_error`/`print_errorln`, the console's `error_writer()`, and `enable_ansi_colors_stderr()`. `console.count()` in the same file already goes to stdout.

## Fix

Switch to the stdout equivalents: `print_elapsed_stdout`, `print`/`println`, `writer()`, and `enable_ansi_colors_stdout()`. `print_elapsed_stdout` already existed in `bun_core::output`.

## Verification

`test/js/web/console/console-timeLog.test.ts` updated to assert output lands on stdout with stderr empty, covering `timeEnd` (default, empty, and named labels) and `timeLog` (with and without extra args).

- `USE_SYSTEM_BUN=1 bun test test/js/web/console/console-timeLog.test.ts` → 5 fail
- `bun bd test test/js/web/console/console-timeLog.test.ts` → 5 pass

The reporter also noted that Node routes through `console.log` itself (so overriding `console.log` intercepts the output). Bun's global console is native and does not call back into `console.log`; that is a larger design question left out of scope here.