### PR TITLE
node:url: route url.format(URL[,opts]) to the WHATWG serializer

### DIFF
--- a/src/js/node/url.ts
+++ b/src/js/node/url.ts
@@ -28,7 +28,7 @@
 const { URL, URLSearchParams } = globalThis;
 const [domainToASCII, domainToUnicode] = $cpp("NodeURL.cpp", "Bun::createNodeURLBinding");
 const { urlToHttpOptions } = require("internal/url");
-const { validateString } = require("internal/validators");
+const { validateString, validateObject } = require("internal/validators");
 const ObjectSetPrototypeOf = Object.setPrototypeOf;
 
 function Url() {
@@ -465,8 +465,8 @@ function getHostname(self, rest, hostname: string, url) {
 }
 
 // format a parsed object into a url string
-declare function urlFormat(urlObject: string | URL | Url): string;
-function urlFormat(urlObject: unknown) {
+declare function urlFormat(urlObject: string | URL | Url, options?: object): string;
+function urlFormat(urlObject: unknown, options?: unknown) {
   /*
    * ensure it's an object, and not a string url.
    * If it's an obj, this is a no-op.
@@ -478,12 +478,124 @@ function urlFormat(urlObject: unknown) {
     // NOTE: $isObject returns true for functions
   } else if (typeof urlObject !== "object" || urlObject === null) {
     throw $ERR_INVALID_ARG_TYPE("urlObject", ["Object", "string"], urlObject);
+  } else if (urlObject instanceof URL) {
+    let fragment = true;
+    let unicode = false;
+    let search = true;
+    let auth = true;
+
+    if (options) {
+      validateObject(options, "options");
+
+      const { fragment: fragmentOption, unicode: unicodeOption, search: searchOption, auth: authOption } = options;
+      if (fragmentOption != null) {
+        fragment = Boolean(fragmentOption);
+      }
+      if (unicodeOption != null) {
+        unicode = Boolean(unicodeOption);
+      }
+      if (searchOption != null) {
+        search = Boolean(searchOption);
+      }
+      if (authOption != null) {
+        auth = Boolean(authOption);
+      }
+    }
+
+    return formatWHATWG(urlObject, auth, fragment, search, unicode);
   }
 
   if (!(urlObject instanceof Url)) {
     return Url.prototype.format.$call(urlObject);
   }
   return urlObject.format();
+}
+
+function formatWHATWG(urlObject: URL, auth: boolean, fragment: boolean, search: boolean, unicode: boolean) {
+  const href = urlObject.href;
+  const protocol = urlObject.protocol;
+  const pathname = urlObject.pathname;
+
+  let ret = protocol;
+
+  // A URL has an authority component if its serialization has "//" directly
+  // after the scheme. Special-scheme URLs (http, https, ws, wss, ftp, file)
+  // always do; non-special URLs may or may not.
+  if (
+    href.length > protocol.length + 1 &&
+    href.$charCodeAt(protocol.length) === Char.FORWARD_SLASH &&
+    href.$charCodeAt(protocol.length + 1) === Char.FORWARD_SLASH
+  ) {
+    ret += "//";
+
+    const username = urlObject.username;
+    const password = urlObject.password;
+    if (auth && (username || password)) {
+      ret += username;
+      if (password) ret += ":" + password;
+      ret += "@";
+    }
+
+    ret += unicode ? hostnameToUnicode(urlObject.hostname) : urlObject.hostname;
+
+    const port = urlObject.port;
+    if (port) ret += ":" + port;
+  } else if (
+    pathname.length > 1 &&
+    pathname.$charCodeAt(0) === Char.FORWARD_SLASH &&
+    pathname.$charCodeAt(1) === Char.FORWARD_SLASH
+  ) {
+    // https://url.spec.whatwg.org/#url-serializing step 3: when the host is
+    // null and the first path segment is empty, emit "/." so the result does
+    // not re-parse as having an authority.
+    ret += "/.";
+  }
+
+  ret += pathname;
+
+  // The .search and .hash getters collapse "absent" and "empty" to the same
+  // value (""). "?" and "#" only appear in the serialized href as the query
+  // and fragment delimiters, so scan the href to recover the empty case.
+  const hashIdx = href.indexOf("#");
+  if (search) {
+    let s = urlObject.search;
+    if (!s) {
+      const qIdx = href.indexOf("?");
+      if (qIdx !== -1 && (hashIdx === -1 || qIdx < hashIdx)) s = "?";
+    }
+    ret += s;
+  }
+  if (fragment) {
+    ret += urlObject.hash || (hashIdx !== -1 ? "#" : "");
+  }
+
+  return ret;
+}
+
+function hostnameToUnicode(hostname: string) {
+  // Only labels that literally start with "xn--" are decoded; others keep
+  // their original bytes and case (opaque hosts for non-special schemes are
+  // not lowercased by the parser). domainToUnicode is UTS#46 and case-folds,
+  // so a mixed-case "xn--" label in an opaque host can differ from Node's
+  // serializer (raw per-label punycode); it matches Node's own
+  // url.domainToUnicode instead.
+  if (!hostname || hostname.$charCodeAt(0) === Char.LEFT_SQUARE_BRACKET || hostname.indexOf("xn--") === -1) {
+    return hostname;
+  }
+  const labels = hostname.split(".");
+  for (let i = 0; i < labels.length; i++) {
+    const label = labels[i];
+    if (
+      label.length >= 4 &&
+      label.$charCodeAt(0) === 120 /* x */ &&
+      label.$charCodeAt(1) === 110 /* n */ &&
+      label.$charCodeAt(2) === 45 /* - */ &&
+      label.$charCodeAt(3) === 45 /* - */
+    ) {
+      labels[i] = domainToUnicode(label);
+    }
+  }
+  return labels.join(".");
 }
 
 Url.prototype.format = function format() {

--- a/test/js/node/url/url-format-whatwg.test.js
+++ b/test/js/node/url/url-format-whatwg.test.js
@@ -6,22 +6,34 @@ describe("url.format", () => {
   test("WHATWG", () => {
     const myURL = new URL("http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // TODO: Support these.
-    //
-    // assert.strictEqual(url.format(myURL), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, {}), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, {}), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // TODO: Support this kind of assert.throws.
-    // {
-    //   [true, 1, "test", Infinity].forEach(value => {
-    //     assert.throws(() => url.format(myURL, value), {
-    //       code: "ERR_INVALID_ARG_TYPE",
-    //       name: "TypeError",
-    //       message: 'The "options" argument must be of type object.',
-    //     });
-    //   });
-    // }
+    {
+      [true, 1, "test", Infinity].forEach(value => {
+        assert.throws(() => url.format(myURL, value), {
+          code: "ERR_INVALID_ARG_TYPE",
+          name: "TypeError",
+        });
+      });
+    }
+
+    // Node only validates a truthy `options` value; falsy values other than
+    // undefined are ignored and the defaults apply (auth is kept).
+    {
+      [false, 0, "", null].forEach(value => {
+        assert.strictEqual(url.format(myURL, value), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+      });
+    }
+
+    // An explicit `null` option value is treated the same as undefined: the
+    // default applies (Node checks each option with `!= null`).
+    {
+      ["auth", "fragment", "search", "unicode"].forEach(name => {
+        assert.strictEqual(url.format(myURL, { [name]: null }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+      });
+    }
 
     // Any falsy value other than undefined will be treated as false.
     // Any truthy value will be treated as true.
@@ -32,47 +44,121 @@ describe("url.format", () => {
 
     assert.strictEqual(url.format(myURL, { auth: 0 }), "http://xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // TODO: Support these.
-    //
-    // assert.strictEqual(url.format(myURL, { auth: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { auth: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { auth: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { auth: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { fragment: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
+    assert.strictEqual(url.format(myURL, { fragment: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
 
-    // assert.strictEqual(url.format(myURL, { fragment: "" }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
+    assert.strictEqual(url.format(myURL, { fragment: "" }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
 
-    // assert.strictEqual(url.format(myURL, { fragment: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
+    assert.strictEqual(url.format(myURL, { fragment: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b");
 
-    // assert.strictEqual(url.format(myURL, { fragment: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { fragment: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { fragment: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { fragment: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { search: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
+    assert.strictEqual(url.format(myURL, { search: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
 
-    // assert.strictEqual(url.format(myURL, { search: "" }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
+    assert.strictEqual(url.format(myURL, { search: "" }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
 
-    // assert.strictEqual(url.format(myURL, { search: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
+    assert.strictEqual(url.format(myURL, { search: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a#c");
 
-    // assert.strictEqual(url.format(myURL, { search: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { search: 1 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { search: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { search: {} }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { unicode: true }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { unicode: true }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { unicode: 1 }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { unicode: 1 }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { unicode: {} }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { unicode: {} }), "http://user:pass@理容ナカムラ.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { unicode: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { unicode: false }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(url.format(myURL, { unicode: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
+    assert.strictEqual(url.format(myURL, { unicode: 0 }), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
 
-    // assert.strictEqual(
-    //   url.format(new URL("http://user:pass@xn--0zwm56d.com:8080/path"), { unicode: true }),
-    //   "http://user:pass@测试.com:8080/path",
-    // );
+    assert.strictEqual(
+      url.format(new URL("http://user:pass@xn--0zwm56d.com:8080/path"), { unicode: true }),
+      "http://user:pass@测试.com:8080/path",
+    );
 
     assert.strictEqual(url.format(new URL("tel:123")), url.format(new URL("tel:123"), { unicode: true }));
+  });
+
+  // https://github.com/oven-sh/bun/issues/24233
+  test("WHATWG fragment: false strips the hash", () => {
+    const myURL = new URL("https://example.org?abc#foo");
+    assert.strictEqual(url.format(myURL, { fragment: false }), "https://example.org/?abc");
+  });
+
+  // Previously a WHATWG URL fell into the legacy formatter, which only emits
+  // "//" for the slashedProtocol table (http/https/ftp/gopher/file) and reads
+  // `.slashes`/`.auth` (both undefined on URL). The result dropped the
+  // authority marker and userinfo for every other scheme.
+  test("WHATWG non-special schemes keep their authority", () => {
+    for (const href of [
+      "wss://h:99/x?q",
+      "ws://h/x",
+      "git+ssh://git@github.com/x.git",
+      "myapp://open/x",
+      "custom://a.b:8/c",
+      "file:///a/b",
+      "file://host/a/b",
+    ]) {
+      const u = new URL(href);
+      assert.strictEqual(url.format(u), u.href, href);
+      assert.strictEqual(url.format(u, {}), u.href, href);
+    }
+  });
+
+  test("WHATWG edge cases", () => {
+    assert.strictEqual(url.format(new URL("tel:123")), "tel:123");
+    assert.strictEqual(url.format(new URL("tel:123"), { unicode: true }), "tel:123");
+    assert.strictEqual(url.format(new URL("file:///path"), { unicode: true }), "file:///path");
+    assert.strictEqual(url.format(new URL("http://[::1]:8080/path"), { unicode: true }), "http://[::1]:8080/path");
+    assert.strictEqual(url.format(new URL("foo://bar/path"), { unicode: true }), "foo://bar/path");
+    assert.strictEqual(
+      url.format(new URL("http://user@example.com/path"), { auth: true }),
+      "http://user@example.com/path",
+    );
+    assert.strictEqual(
+      url.format(new URL("http://user:pass@example.com/path?q#h"), { auth: false, search: false, fragment: false }),
+      "http://example.com/path",
+    );
+    assert.strictEqual(url.format(new URL("blob:http://a/b")), "blob:http://a/b");
+
+    // No authority, path starting with "//": must emit "/." so the result
+    // round-trips instead of re-parsing with a host.
+    assert.strictEqual(url.format(new URL("web+foo:/.//p")), "web+foo:/.//p");
+    assert.strictEqual(new URL(url.format(new URL("web+foo:/.//p"))).pathname, "//p");
+
+    // .search and .hash return "" for both absent and empty; the serializer
+    // must keep a bare "?" or "#" that is present in the href.
+    assert.strictEqual(url.format(new URL("http://a/?#")), "http://a/?#");
+    assert.strictEqual(url.format(new URL("http://a/?#"), { search: false }), "http://a/#");
+    assert.strictEqual(url.format(new URL("http://a/?#"), { fragment: false }), "http://a/?");
+    assert.strictEqual(url.format(new URL("http://a/?")), "http://a/?");
+    assert.strictEqual(url.format(new URL("http://a/#")), "http://a/#");
+    assert.strictEqual(url.format(new URL("http://a/#?")), "http://a/#?");
+    assert.strictEqual(url.format(new URL("http://a/#?"), { search: false }), "http://a/#?");
+    assert.strictEqual(url.format(new URL("http://a/p?q#"), { fragment: false }), "http://a/p?q");
+
+    // Opaque hosts (non-special schemes) keep their case with unicode: true;
+    // only labels that literally start with "xn--" are decoded.
+    assert.strictEqual(url.format(new URL("foo://EXAMPLE.com/p"), { unicode: true }), "foo://EXAMPLE.com/p");
+    assert.strictEqual(url.format(new URL("foo://xn--0zwm56d.example/p"), { unicode: true }), "foo://测试.example/p");
+    assert.strictEqual(
+      url.format(new URL("foo://XN--0ZWM56D.EXAMPLE/p"), { unicode: true }),
+      "foo://XN--0ZWM56D.EXAMPLE/p",
+    );
+    assert.strictEqual(
+      url.format(new URL("foo://Sub.xn--0zwm56d.Example/p"), { unicode: true }),
+      "foo://Sub.测试.Example/p",
+    );
+
+    // A bare or undecodable "xn--" label becomes an empty label, matching Node.
+    assert.strictEqual(url.format(new URL("foo://xn--.a/"), { unicode: true }), "foo://.a/");
+    assert.strictEqual(url.format(new URL("foo://xn--a.b/"), { unicode: true }), "foo://.b/");
   });
 });


### PR DESCRIPTION
Closes #24233
Fixes #24343
Fixes #18695

### What does this PR do?

`url.format(url, options)` from `node:url` now serializes WHATWG `URL` instances through a WHATWG serializer instead of the legacy `Url.prototype.format` path. This fixes two user-visible bugs:

1. The `//` authority marker and userinfo were dropped for every scheme outside the legacy `slashedProtocol` table (`http`/`https`/`ftp`/`gopher`/`file`). That includes `ws:`, `wss:`, `git+ssh:`, `file:` with an empty host, and any custom scheme.
2. The `fragment`, `search`, `auth`, and `unicode` options were silently ignored.

### Repro

```js
import url from "node:url";

url.format(new URL("wss://h:99/x?q"))
// Before: "wss:h:99/x?q"
// After:  "wss://h:99/x?q"

url.format(new URL("git+ssh://git@github.com/x.git"))
// Before: "git+ssh:github.com/x.git"   (userinfo gone, reparses to a different host)
// After:  "git+ssh://git@github.com/x.git"

url.format(new URL("file:///a/b"))
// Before: "file:/a/b"
// After:  "file:///a/b"

url.format(new URL("https://a:b@example.org/"))
// Before: "https://example.org/"       (auth dropped)
// After:  "https://a:b@example.org/"

url.format(new URL("https://example.org?abc#foo"), { fragment: false })
// Before: "https://example.org/?abc#foo"   (option ignored)
// After:  "https://example.org/?abc"
```

Node returns `u.href` unchanged for `url.format(u)` with no options; Bun now matches.

### Cause

`urlFormat` in `src/js/node/url.ts` had no branch for WHATWG `URL` instances and never accepted a second `options` parameter. A `URL` instance fell through to `Url.prototype.format.$call(urlObject)`, which reads legacy `Url` fields (`.auth`, `.slashes`, `.query`) that do not exist on WHATWG `URL`. With `.slashes` undefined, only the hardcoded `slashedProtocol` table got `//` back, and with `.auth` undefined the userinfo was always stripped.

### Fix

Add an `urlObject instanceof URL` branch mirroring Node's [`lib/url.js`](https://github.com/nodejs/node/blob/main/lib/url.js): read `auth`, `fragment`, `search`, `unicode` from `options` (defaults `true, true, true, false`), validate with `validateObject`, and re-serialize from the URL's components. The authority check reads `//` directly out of `href` so it works for any scheme. `unicode: true` runs the hostname through `domainToUnicode` per label.

### Verification

- `USE_SYSTEM_BUN=1 bun test test/js/node/url/url-format-whatwg.test.js` fails (4/4)
- `bun bd test test/js/node/url/url-format-whatwg.test.js` passes (4/4)

The test file previously had the full set of Node-ported assertions commented out behind `// TODO: Support these.`; they are now enabled and a round-trip test for `ws:`/`wss:`/`git+ssh:`/`file:`/custom schemes has been added.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-format-whatwg.test.js
bun test v1.4.0 (aa13b3ac9)

test/js/node/url/url-format-whatwg.test.js:
4 | 
5 | describe("url.format", () => {
6 |   test("WHATWG", () => {
7 |     const myURL = new URL("http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
8 | 
9 |     assert.strictEqual(url.format(myURL), "http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c");
               ^
AssertionError: Expected values to be strictly equal:
+ actual - expected

+ 'http://xn--lck1c3crb1723bpq4a.com/a?a=b#c'
- 'http://user:pass@xn--lck1c3crb1723bpq4a.com/a?a=b#c'

      at innerFail (node:assert:62:32)
      at strictEqual (node:assert:205:14)
      at <anonymous> (/workspace/bun/test/js/node/url/url-format-whatwg.test.js:9:12)
(fail) url.format > WHATWG [97.16ms]
87 |   });
88 | 
89 |   // https://github.com/oven-sh/bun/issues/24233
90 |   test("WHATWG fragment: false strips the hash", () => {
91 |     const myURL = new URL("https://example.org?abc#foo");
92 |     assert.strictEqual(url.format(myURL, { fragment: false }), "https://e
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (2c3c5876e)

test/js/node/url/url-format-whatwg.test.js:
(pass) url.format > WHATWG [1.74ms]
(pass) url.format > WHATWG fragment: false strips the hash [0.04ms]
(pass) url.format > WHATWG non-special schemes keep their authority [0.13ms]
(pass) url.format > WHATWG edge cases [0.28ms]

 4 pass
 0 fail
Ran 4 tests across 1 file. [261.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/url/url-format-whatwg.test.js
bun test v1.4.0 (aa13b3ac9)

test/js/node/url/url-format-whatwg.test.js:
(pass) url.format > WHATWG [81.13ms]
(pass) url.format > WHATWG fragment: false strips the hash [2.37ms]
(pass) url.format > WHATWG non-special schemes keep their authority [11.67ms]
(pass) url.format > WHATWG edge cases [22.24ms]

 4 pass
 0 fail
Ran 4 tests across 1 file. [2.93s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 794ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (11720ms)
Bundle modules (41ms)
Postprocesss modules (166ms)
Bundle Functions (999ms)
Generate Code (30ms)

[12.97s] Bundled "src/js" for production
  2078 kb
  167 internal modules
  13 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/url.ts                         | 118 ++++++++++++++++++++-
 test/js/node/url/url-format-whatwg.test.js | 164 ++++++++++++++++++++++-------
 2 files changed, 240 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 2 passed · 1 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
src/js/node/url.ts                              6      6      8
test/js/node/url/url-format-whatwg.test.js      6      8      8
```

</details>

<!-- robobun:evidence:end -->