### PR TITLE
Allow assigning to Blob#lastModified

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -260,6 +260,7 @@ pub trait BlobExt {
     ) -> JsResult<()>;
     fn get_loader(&self, jsc_vm: &VirtualMachine) -> Option<bun_ast::Loader>;
     fn get_last_modified(&self, _: &JSGlobalObject) -> JSValue;
+    fn set_last_modified(&self, global_this: &JSGlobalObject, value: JSValue) -> JsResult<()>;
     fn get_size_for_bindings(&self) -> u64;
     fn get_stat(&self, global_this: &JSGlobalObject, callback: &CallFrame) -> JsResult<JSValue>;
     fn get_size(&self, _: &JSGlobalObject) -> JSValue;
@@ -2238,11 +2239,19 @@ impl BlobExt for Blob {
             }
         }
 
-        if self.is_jsdom_file.get() {
-            return JSValue::js_number(self.last_modified.get());
-        }
+        JSValue::js_number(self.last_modified.get())
+    }
 
-        JSValue::js_number(jsc::INIT_TIMESTAMP as f64)
+    fn set_last_modified(&self, global_this: &JSGlobalObject, value: JSValue) -> JsResult<()> {
+        let number = value.to_number(global_this)?;
+        if let Some(store) = self.store.get() {
+            if matches!(store.data, store::Data::File(_)) {
+                store.data_mut().as_file_mut().last_modified = number as jsc::JSTimeType;
+                return Ok(());
+            }
+        }
+        self.last_modified.set(number);
+        Ok(())
     }
 
     fn get_size_for_bindings(&self) -> u64 {

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2243,14 +2243,7 @@ impl BlobExt for Blob {
     }
 
     fn set_last_modified(&self, global_this: &JSGlobalObject, value: JSValue) -> JsResult<()> {
-        let number = value.to_number(global_this)?;
-        if let Some(store) = self.store.get() {
-            if matches!(store.data, store::Data::File(_)) {
-                store.data_mut().as_file_mut().last_modified = number as jsc::JSTimeType;
-                return Ok(());
-            }
-        }
-        self.last_modified.set(number);
+        self.last_modified.set(value.to_number(global_this)?);
         Ok(())
     }
 

--- a/src/runtime/webcore/response.classes.ts
+++ b/src/runtime/webcore/response.classes.ts
@@ -189,6 +189,7 @@ export default [
       // This is *not* spec-compliant.
       lastModified: {
         getter: "getLastModified",
+        setter: "setLastModified",
       },
 
       // Non-standard, s3 + BunFile support

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -260,6 +260,46 @@ test("blob: can set name property #10178", () => {
   expect(myOtherBlob.name).toBe(10);
 });
 
+// https://github.com/oven-sh/bun/issues/14257
+test("blob: can set lastModified property", () => {
+  const blob = new Blob(["Hello, World"]);
+  // @ts-expect-error
+  blob.lastModified = 123;
+  // @ts-expect-error
+  expect(blob.lastModified).toBe(123);
+
+  class MyBlob extends Blob {
+    constructor(sources: Array<BinaryLike | Blob>, options?: BlobOptions) {
+      super(sources, options);
+      // @ts-expect-error
+      this.lastModified = 456;
+    }
+  }
+
+  const myBlob = new MyBlob(["foo"]);
+  // @ts-expect-error
+  expect(myBlob.lastModified).toBe(456);
+  // @ts-expect-error
+  myBlob.lastModified = 789;
+  // @ts-expect-error
+  expect(myBlob.lastModified).toBe(789);
+
+  const file = new File(["foo"], "bar.txt", { lastModified: 100 });
+  expect(file.lastModified).toBe(100);
+  // @ts-expect-error
+  file.lastModified = 200;
+  expect(file.lastModified).toBe(200);
+
+  class MyFile extends File {
+    constructor() {
+      super(["foo"], "bar.txt");
+      // @ts-expect-error
+      this.lastModified = 999;
+    }
+  }
+  expect(new MyFile().lastModified).toBe(999);
+});
+
 test("#12894", () => {
   const bunFile = Bun.file("foo.txt");
   expect(new File([bunFile], "bar.txt").name).toBe("bar.txt");


### PR DESCRIPTION
## Repro

```js
class MyBlob extends Blob {
  constructor(parts) {
    super(parts);
    this.lastModified = 123;
  }
}
new MyBlob(["foo"]);
```

```
TypeError: Attempted to assign to readonly property.
      at new MyBlob (repro.js:4:5)
```

## Cause

`Blob.prototype.lastModified` was defined as a getter-only accessor in `response.classes.ts`. Class bodies are strict mode, so assigning to it on a subclass instance hits the prototype accessor and throws.

Node and browsers don't put `lastModified` on `Blob.prototype` at all (only `File.prototype`), so the same assignment just creates an own data property there. Bun keeps it on `Blob` for `Bun.file()` / BunFile support.

## Fix

Add a `setLastModified` setter alongside the existing getter, mirroring the pattern already used for `name` directly above it. The setter coerces the value to a number and stores it in the blob's `last_modified` field (or the file store's field for file-backed blobs).

The getter now returns the stored `last_modified` value for non-file-backed Blobs instead of the `INIT_TIMESTAMP` sentinel so set-then-get round-trips correctly. This changes the default `lastModified` of a plain `new Blob([...])` from `4503599627370495` to `0`.

## Verification

Added a test in `test/js/web/fetch/blob.test.ts` covering direct assignment on `Blob`, assignment in a `Blob` subclass constructor, assignment on `File`, and assignment in a `File` subclass constructor.

Fixes #14257