### PR TITLE
node:http: expose Server#_connections and validate getConnections callback

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -361,12 +361,21 @@ Server.prototype.closeAllConnections = function () {
 Server.prototype.getConnections = function (callback) {
   // Connections are tracked from the first parsed request on each socket
   // (the native server does not surface raw accepts to JS yet).
-  const count = this[kTrackedConnections]?.size ?? 0;
-  if (typeof callback === "function") {
-    process.nextTick(callback, null, count);
-  }
+  // Node passes the callback straight to process.nextTick, which throws
+  // ERR_INVALID_ARG_TYPE for non-functions.
+  process.nextTick(callback, null, this[kTrackedConnections]?.size ?? 0);
   return this;
 };
+
+// Node's http.Server inherits `_connections` from net.Server; surface the
+// same count here for code that reads the property directly.
+Object.defineProperty(Server.prototype, "_connections", {
+  __proto__: null,
+  configurable: true,
+  get() {
+    return this[kTrackedConnections]?.size ?? 0;
+  },
+});
 
 Server.prototype.closeIdleConnections = function () {
   const server = this[serverSymbol];

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -375,6 +375,7 @@ Object.defineProperty(Server.prototype, "_connections", {
   get() {
     return this[kTrackedConnections]?.size ?? 0;
   },
+  set(_value) {},
 });
 
 Server.prototype.closeIdleConnections = function () {

--- a/test/regression/issue/04459.test.ts
+++ b/test/regression/issue/04459.test.ts
@@ -1,0 +1,146 @@
+// https://github.com/oven-sh/bun/issues/4459
+// http.Server#getConnections was not implemented.
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
+
+describe("http.Server getConnections", () => {
+  test("exists and reports the number of open connections", async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    });
+
+    expect(typeof server.getConnections).toBe("function");
+
+    await once(server.listen(0), "listening");
+    const { port } = server.address() as net.AddressInfo;
+
+    try {
+      const getConnections = () =>
+        new Promise<number>((resolve, reject) => {
+          server.getConnections((err, count) => {
+            if (err) reject(err);
+            else resolve(count);
+          });
+        });
+
+      expect(await getConnections()).toBe(0);
+
+      const sockets: net.Socket[] = [];
+      let seen = 0;
+      const sawAll = new Promise<void>(resolve => {
+        server.on("connection", () => {
+          if (++seen === 3) resolve();
+        });
+      });
+      for (let i = 0; i < 3; i++) {
+        const sock = net.connect({ port, host: "127.0.0.1" });
+        await once(sock, "connect");
+        // Send a request so the server observes the new connection.
+        sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
+        sockets.push(sock);
+      }
+      await sawAll;
+
+      expect(await getConnections()).toBe(3);
+      expect(server._connections).toBe(3);
+
+      // Close one connection and ensure the count drops.
+      const closing = sockets.pop()!;
+      const closed = once(closing, "close");
+      closing.destroy();
+      await closed;
+      while ((await getConnections()) > 2) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      expect(await getConnections()).toBe(2);
+
+      for (const sock of sockets) sock.destroy();
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  test("callback receives (null, count) and returns this", async () => {
+    const server = http.createServer(() => {});
+    await once(server.listen(0), "listening");
+    try {
+      let sync = true;
+      const { promise, resolve } = Promise.withResolvers<void>();
+      const ret = server.getConnections((err, count) => {
+        expect(sync).toBe(false);
+        expect(err).toBeNull();
+        expect(count).toBe(0);
+        resolve();
+      });
+      sync = false;
+      expect(ret).toBe(server);
+      await promise;
+
+      // Node passes the callback straight to process.nextTick, which validates
+      // it and throws ERR_INVALID_ARG_TYPE for non-functions.
+      expect(() => server.getConnections()).toThrow(expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }));
+      expect(() => server.getConnections("not a function" as any)).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+
+  test("still reports open connections after close() is called", async () => {
+    const server = http.createServer(() => {});
+    const connected = new Promise<void>(resolve => server.once("connection", () => resolve()));
+    await once(server.listen(0), "listening");
+    const { port } = server.address() as net.AddressInfo;
+
+    const sock = net.connect({ port, host: "127.0.0.1" });
+    try {
+      await once(sock, "connect");
+      sock.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n");
+      await connected;
+
+      const getConnections = () =>
+        new Promise<number>((resolve, reject) => {
+          server.getConnections((err, n) => (err ? reject(err) : resolve(n)));
+        });
+
+      // close() stops accepting new connections but the existing one is still open.
+      server.close();
+      expect(await getConnections()).toBe(1);
+      expect(server._connections).toBe(1);
+
+      sock.destroy();
+      while ((await getConnections()) > 0) {
+        await new Promise(resolve => setImmediate(resolve));
+      }
+      expect(await getConnections()).toBe(0);
+      expect(server._connections).toBe(0);
+    } finally {
+      sock.destroy();
+      server.closeAllConnections();
+    }
+  });
+
+  test("is usable inside a request handler (original report)", async () => {
+    const server = http.createServer((req, res) => {
+      server.getConnections((err, conns) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ err: err ?? null, count: conns }));
+      });
+    });
+    await once(server.listen(0), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      const body = await res.json();
+      expect(body).toEqual({ err: null, count: 1 });
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
## What

`http.Server#getConnections` itself landed on `main` via the `kTrackedConnections` set in #31587 after this PR was opened. Rebased onto that, this now adds the two remaining Node-compat gaps plus a regression test for #4459:

- **`Server#_connections`**: Node's `http.Server` inherits this from `net.Server`. Expose it as a getter over the tracked-connections set so code that reads `server._connections` directly gets the right count.
- **`getConnections(callback)` validation**: Node hands the callback straight to `process.nextTick`, which throws `ERR_INVALID_ARG_TYPE` for non-functions. Match that instead of silently no-oping.

## Why

Before #31587 landed on main, `server.getConnections` was undefined on `http.Server` and calling it threw:

```
TypeError: server.getConnections is not a function
```

## Verification

`test/regression/issue/04459.test.ts` covers:
- `getConnections` reports 0 → N → N-1 as connections open and close, and `_connections` mirrors it
- the callback is invoked asynchronously with `(null, count)`, the method returns `this`, and a non-function callback throws `ERR_INVALID_ARG_TYPE`
- the count stays accurate after `server.close()` while connections remain open
- the original report's request-handler usage returns `{"count":1}`

All four fail on the released binary with `server.getConnections is not a function`; on current `main` without this diff, three of four fail on the `_connections` and callback-validation assertions; with the diff all pass.

Fixes #4459
