### PR TITLE
Give File its own prototype with Symbol.toStringTag "File"

### DIFF
--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -166,6 +166,9 @@ extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlob
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
+    // Ensure File.prototype.constructor is wired even when this path (e.g.
+    // structuredClone in a fresh Worker) runs before globalThis.File is accessed.
+    globalObject->JSDOMFileConstructor();
     auto* structure = globalObject->JSDOMFileStructure();
     return JSC::JSValue::encode(WebCore::JSBlob::create(vm, globalObject, structure, ptr));
 }

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -1,4 +1,5 @@
 #include "root.h"
+#include "ZigGlobalObject.h"
 #include "ZigGeneratedClasses.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/InternalFunction.h>
@@ -10,8 +11,50 @@ using namespace JSC;
 extern "C" SYSV_ABI void* JSDOMFile__construct(JSC::JSGlobalObject*, JSC::CallFrame* callframe);
 extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObject*, EncodedJSValue);
 
-// TODO: make this inehrit from JSBlob instead of InternalFunction
-// That will let us remove this hack for [Symbol.hasInstance] and fix the prototype chain.
+class JSDOMFilePrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSDOMFilePrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSDOMFilePrototype* prototype = new (NotNull, JSC::allocateCell<JSDOMFilePrototype>(vm)) JSDOMFilePrototype(vm, structure);
+        prototype->finishCreation(vm);
+        return prototype;
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        auto* structure = JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+        structure->setMayBePrototype(true);
+        return structure;
+    }
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSDOMFilePrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+private:
+    JSDOMFilePrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm);
+        ASSERT(inherits(info()));
+        JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    }
+};
+
+const JSC::ClassInfo JSDOMFilePrototype::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFilePrototype) };
+
 class JSDOMFile : public JSC::InternalFunction {
     using Base = JSC::InternalFunction;
 
@@ -43,12 +86,14 @@ public:
     static JSDOMFile* create(JSC::VM& vm, JSGlobalObject* globalObject)
     {
         auto* zigGlobal = defaultGlobalObject(globalObject);
-        auto structure = createStructure(vm, globalObject, zigGlobal->functionPrototype());
+        auto* structure = createStructure(vm, globalObject, zigGlobal->JSBlobConstructor());
         auto* object = new (NotNull, JSC::allocateCell<JSDOMFile>(vm)) JSDOMFile(vm, structure);
         object->finishCreation(vm);
 
-        // This is not quite right. But we'll fix it if someone files an issue about it.
-        object->putDirect(vm, vm.propertyNames->prototype, zigGlobal->JSBlobPrototype(), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);
+        auto* fileStructure = zigGlobal->JSDOMFileStructure();
+        auto* prototype = fileStructure->storedPrototypeObject();
+        object->putDirect(vm, vm.propertyNames->prototype, prototype, JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);
+        prototype->putDirect(vm, vm.propertyNames->constructor, object, JSC::PropertyAttribute::DontEnum | 0);
 
         return object;
     }
@@ -69,7 +114,7 @@ public:
         auto& vm = JSC::getVM(globalObject);
         JSObject* newTarget = asObject(callFrame->newTarget());
         auto* constructor = globalObject->JSDOMFileConstructor();
-        Structure* structure = globalObject->JSBlobStructure();
+        Structure* structure = globalObject->JSDOMFileStructure();
         if (constructor != newTarget) {
             auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -77,7 +122,7 @@ public:
                 // ShadowRealm functions belong to a different global object.
                 getFunctionRealm(lexicalGlobalObject, newTarget));
             RETURN_IF_EXCEPTION(scope, {});
-            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSBlobStructure());
+            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSDOMFileStructure());
             RETURN_IF_EXCEPTION(scope, {});
         }
 
@@ -106,6 +151,23 @@ namespace Bun {
 JSC::JSObject* createJSDOMFileConstructor(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     return JSDOMFile::create(vm, globalObject);
+}
+
+JSC::Structure* createJSDOMFileStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+{
+    auto* zigGlobal = defaultGlobalObject(globalObject);
+    auto* blobPrototype = zigGlobal->JSBlobPrototype();
+    auto* prototypeStructure = JSDOMFilePrototype::createStructure(vm, globalObject, blobPrototype);
+    auto* prototype = JSDOMFilePrototype::create(vm, globalObject, prototypeStructure);
+    return WebCore::JSBlob::createStructure(vm, globalObject, prototype);
+}
+
+extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlobalObject* lexicalGlobalObject, void* ptr)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto* structure = globalObject->JSDOMFileStructure();
+    return JSC::JSValue::encode(WebCore::JSBlob::create(vm, globalObject, structure, ptr));
 }
 
 }

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -10,6 +10,7 @@ using namespace JSC;
 
 extern "C" SYSV_ABI void* JSDOMFile__construct(JSC::JSGlobalObject*, JSC::CallFrame* callframe);
 extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObject*, EncodedJSValue);
+extern "C" SYSV_ABI size_t Blob__estimatedSize(void* ptr);
 
 class JSDOMFilePrototype final : public JSC::JSNonFinalObject {
 public:
@@ -132,8 +133,9 @@ public:
             return JSValue::encode(JSC::jsUndefined());
         }
 
-        return JSValue::encode(
-            WebCore::JSBlob::create(vm, globalObject, structure, ptr));
+        auto* instance = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+        vm.heap.reportExtraMemoryAllocated(instance, Blob__estimatedSize(ptr));
+        return JSValue::encode(instance);
     }
 
     static JSC_HOST_CALL_ATTRIBUTES EncodedJSValue call(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
@@ -170,7 +172,9 @@ extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlob
     // structuredClone in a fresh Worker) runs before globalThis.File is accessed.
     globalObject->JSDOMFileConstructor();
     auto* structure = globalObject->JSDOMFileStructure();
-    return JSC::JSValue::encode(WebCore::JSBlob::create(vm, globalObject, structure, ptr));
+    auto* instance = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+    vm.heap.reportExtraMemoryAllocated(instance, Blob__estimatedSize(ptr));
+    return JSC::JSValue::encode(instance);
 }
 
 }

--- a/src/jsc/bindings/JSDOMFile.h
+++ b/src/jsc/bindings/JSDOMFile.h
@@ -4,4 +4,5 @@
 
 namespace Bun {
 JSC::JSObject* createJSDOMFileConstructor(JSC::VM&, JSC::JSGlobalObject*);
+JSC::Structure* createJSDOMFileStructure(JSC::VM&, JSC::JSGlobalObject*);
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2098,6 +2098,11 @@ void GlobalObject::finishCreation(VM& vm)
             init.set(Bun::createJSS3FileStructure(init.vm, init.owner));
         });
 
+    m_JSDOMFileStructure.initLater(
+        [](const Initializer<Structure>& init) {
+            init.set(Bun::createJSDOMFileStructure(init.vm, init.owner));
+        });
+
     m_S3ErrorStructure.initLater(
         [](const Initializer<Structure>& init) {
             init.set(Bun::createS3ErrorStructure(init.vm, init.owner));

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -533,6 +533,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<JSObject>, m_processEnvObject)                                      \
                                                                                                              \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSS3FileStructure)                                    \
+    V(public, LazyPropertyOfGlobalObject<Structure>, m_JSDOMFileStructure)                                   \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_S3ErrorStructure)                                     \
                                                                                                              \
     V(public, JSC::LazyClassStructure, m_JSStatsClassStructure)                                              \
@@ -738,6 +739,7 @@ public:
 
     JSObject* cryptoObject() const { return m_cryptoObject.getInitializedOnMainThread(this); }
     JSObject* JSDOMFileConstructor() const { return m_JSDOMFileConstructor.getInitializedOnMainThread(this); }
+    Structure* JSDOMFileStructure() const { return m_JSDOMFileStructure.getInitializedOnMainThread(this); }
 
     JSMap* nodeWorkerEnvironmentData() { return m_nodeWorkerEnvironmentData.get(); }
     void setNodeWorkerEnvironmentData(JSMap* data);

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -1,8 +1,11 @@
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
 
-extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, BunString* filename);
+
+namespace Bun {
+extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlobalObject* globalObject, void* impl);
+}
 
 namespace WebCore {
 
@@ -11,7 +14,7 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     BunString filename = Bun::toString(impl.fileName());
     Blob__setAsFile(impl.impl(), &filename);
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    return JSC::JSValue::decode(Bun::BUN__createJSDOMFileUnsafely(lexicalGlobalObject, Blob__dupe(impl.impl())));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)
@@ -19,7 +22,7 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
     auto fileNameStr = impl->fileName();
     BunString filename = Bun::toString(fileNameStr);
 
-    JSC::EncodedJSValue encoded = Blob__create(lexicalGlobalObject, impl->impl());
+    JSC::EncodedJSValue encoded = Bun::BUN__createJSDOMFileUnsafely(lexicalGlobalObject, impl->impl());
     JSBlob* blob = uncheckedDowncast<JSBlob>(JSC::JSValue::decode(encoded));
     Blob__setAsFile(blob->wrapped(), &filename);
 

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -1,11 +1,8 @@
 #include "blob.h"
 #include "ZigGeneratedClasses.h"
 
+extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, BunString* filename);
-
-namespace Bun {
-extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlobalObject* globalObject, void* impl);
-}
 
 namespace WebCore {
 
@@ -14,7 +11,7 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     BunString filename = Bun::toString(impl.fileName());
     Blob__setAsFile(impl.impl(), &filename);
 
-    return JSC::JSValue::decode(Bun::BUN__createJSDOMFileUnsafely(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)
@@ -22,7 +19,7 @@ JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlo
     auto fileNameStr = impl->fileName();
     BunString filename = Bun::toString(fileNameStr);
 
-    JSC::EncodedJSValue encoded = Bun::BUN__createJSDOMFileUnsafely(lexicalGlobalObject, impl->impl());
+    JSC::EncodedJSValue encoded = Blob__create(lexicalGlobalObject, impl->impl());
     JSBlob* blob = uncheckedDowncast<JSBlob>(JSC::JSValue::decode(encoded));
     Blob__setAsFile(blob->wrapped(), &filename);
 

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -9,9 +9,10 @@ namespace WebCore {
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
     BunString filename = Bun::toString(impl.fileName());
-    Blob__setAsFile(impl.impl(), &filename);
+    void* dupe = Blob__dupe(impl.impl());
+    Blob__setAsFile(dupe, &filename);
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, dupe));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -378,7 +378,10 @@ impl Blob {
             content_type: JsCell::new(self.content_type.get().clone()),
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
-            is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
+            // A dupe is a new Blob over the same bytes; File-ness belongs to
+            // the original wrapper and is set explicitly by the paths that
+            // need it (new File(), Blob__setAsFile, structured-clone deserialize).
+            is_jsdom_file: Cell::new(false),
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2008,6 +2008,9 @@ impl BlobExt for Blob {
         let blob = self.dupe();
         blob.offset.set(offset);
         blob.size.set(len);
+        // Per the File API spec, slice() always returns a plain Blob even when
+        // the receiver is a File.
+        blob.is_jsdom_file.set(false);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3707,6 +3707,10 @@ impl BlobExt for Blob {
             return crate::webcore::s3_file::to_js_unchecked(global_object, this);
         }
 
+        if self.is_jsdom_file.get() {
+            return BUN__createJSDOMFileUnsafely(global_object, this.cast::<core::ffi::c_void>());
+        }
+
         js::to_js_unchecked(global_object, this)
     }
 
@@ -7055,6 +7059,17 @@ bun_jsc::jsc_host_abi! {
         let Some(blob) = value.as_class_ref::<Blob>() else { return false };
         blob.is_jsdom_file.get()
     }
+}
+
+// C++ side defines `SYSV_ABI EncodedJSValue` (JSDOMFile.cpp).
+bun_jsc::jsc_abi_extern! {
+    // `&JSGlobalObject` discharges the only deref'd-param precondition; `blob`
+    // is stored opaquely as `void* m_ctx` (sole caller is `BlobExt::to_js`,
+    // whose signature carries the ownership-transfer contract).
+    safe fn BUN__createJSDOMFileUnsafely(
+        global: &JSGlobalObject,
+        blob: *mut core::ffi::c_void,
+    ) -> JSValue;
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -3390,7 +3390,7 @@ impl BlobExt for Blob {
                                         blob.content_type_was_set.get(),
                                     ),
                                     charset: Cell::new(blob.charset.get()),
-                                    is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
+                                    is_jsdom_file: Cell::new(false),
                                     ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
                                     global_this: Cell::new(blob.global_this.get()),
                                     last_modified: Cell::new(blob.last_modified.get()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2008,9 +2008,6 @@ impl BlobExt for Blob {
         let blob = self.dupe();
         blob.offset.set(offset);
         blob.size.set(len);
-        // Per the File API spec, slice() always returns a plain Blob even when
-        // the receiver is a File.
-        blob.is_jsdom_file.set(false);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
@@ -5725,7 +5722,10 @@ pub fn jsdom_file_construct_(
 
     let blob_ = Blob::new(blob);
     // SAFETY: ptr was just produced by heap::alloc in Blob::new.
-    unsafe { (*blob_).is_jsdom_file.set(true) };
+    unsafe {
+        (*blob_).is_jsdom_file.set(true);
+        (*blob_).calculate_estimated_byte_size();
+    };
     Ok(blob_)
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1150,6 +1150,9 @@ impl Value {
                         let blob_ptr = Blob::new(new.use_());
                         // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
                         let blob = unsafe { &mut *blob_ptr };
+                        // Per the Fetch spec, Body.blob() returns a plain Blob
+                        // even when the body source was a File.
+                        blob.is_jsdom_file.set(false);
                         if let Some(fetch_headers) = headers {
                             // `headers` is a live C++ FetchHeaders handle;
                             // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
@@ -2178,6 +2181,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let blob_ptr = Blob::new(value.use_());
         // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
         let blob = unsafe { &mut *blob_ptr };
+        // Per the Fetch spec, Body.blob() returns a plain Blob even when the
+        // body source was a File.
+        blob.is_jsdom_file.set(false);
         if blob.content_type().is_empty() {
             if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
                 // `fetch_headers` is a live C++ FetchHeaders handle;

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1150,9 +1150,6 @@ impl Value {
                         let blob_ptr = Blob::new(new.use_());
                         // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
                         let blob = unsafe { &mut *blob_ptr };
-                        // Per the Fetch spec, Body.blob() returns a plain Blob
-                        // even when the body source was a File.
-                        blob.is_jsdom_file.set(false);
                         if let Some(fetch_headers) = headers {
                             // `headers` is a live C++ FetchHeaders handle;
                             // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
@@ -2181,9 +2178,6 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let blob_ptr = Blob::new(value.use_());
         // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
         let blob = unsafe { &mut *blob_ptr };
-        // Per the Fetch spec, Body.blob() returns a plain Blob even when the
-        // body source was a File.
-        blob.is_jsdom_file.set(false);
         if blob.content_type().is_empty() {
             if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
                 // `fetch_headers` is a live C++ FetchHeaders handle;

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -315,6 +315,14 @@ describe("File prototype chain", () => {
     expect(Object.getPrototypeOf(req)).toBe(Blob.prototype);
     expect(req instanceof File).toBe(false);
     expect(await req.text()).toBe("Hello");
+
+    // Array body-init (Bun-specific extension) routes through the MOVE=true
+    // struct-literal in from_js_without_defer_gc.
+    const arr = await new Response([file]).blob();
+    expect(arr[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(arr)).toBe(Blob.prototype);
+    expect(arr instanceof File).toBe(false);
+    expect(await arr.text()).toBe("Hello");
   });
 
   test("new Blob([file]) and resolveObjectURL(createObjectURL(file)) return plain Blobs", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -244,6 +244,86 @@ describe("new File() lastModified option", () => {
   });
 });
 
+// https://github.com/oven-sh/bun/issues/14102
+describe("File prototype chain", () => {
+  test("File has its own prototype distinct from Blob.prototype", () => {
+    expect(File.prototype).not.toBe(Blob.prototype);
+    expect(Object.getPrototypeOf(File.prototype)).toBe(Blob.prototype);
+    expect(Object.getPrototypeOf(File)).toBe(Blob);
+    expect(File.prototype.constructor).toBe(File);
+  });
+
+  test("File Symbol.toStringTag is 'File'", () => {
+    const file = new File(["Hello"], "file.txt", { type: "text/plain" });
+    expect(file[Symbol.toStringTag]).toBe("File");
+    expect(Object.prototype.toString.call(file)).toBe("[object File]");
+    expect(Object.getOwnPropertyDescriptor(File.prototype, Symbol.toStringTag)).toEqual({
+      value: "File",
+      writable: false,
+      enumerable: false,
+      configurable: true,
+    });
+  });
+
+  test("Blob Symbol.toStringTag is still 'Blob'", () => {
+    const blob = new Blob(["Hello"]);
+    expect(blob[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.prototype.toString.call(blob)).toBe("[object Blob]");
+  });
+
+  test("File inherits Blob methods via prototype chain", async () => {
+    const file = new File(["Hello"], "file.txt", { type: "text/plain" });
+    expect(file instanceof File).toBe(true);
+    expect(file instanceof Blob).toBe(true);
+    expect(new Blob([]) instanceof File).toBe(false);
+    expect(await file.text()).toBe("Hello");
+    expect(file.name).toBe("file.txt");
+    expect(File.prototype.text).toBe(Blob.prototype.text);
+  });
+
+  test("subclass of File has correct prototype chain", () => {
+    class MyFile extends File {}
+    const mf = new MyFile(["x"], "a.txt");
+    expect(mf[Symbol.toStringTag]).toBe("File");
+    expect(mf instanceof MyFile).toBe(true);
+    expect(mf instanceof File).toBe(true);
+    expect(mf instanceof Blob).toBe(true);
+    expect(Object.getPrototypeOf(Object.getPrototypeOf(mf))).toBe(File.prototype);
+  });
+
+  test("structuredClone of File preserves File prototype", async () => {
+    const file = new File(["Hello"], "file.txt", { type: "text/plain" });
+    const clone = structuredClone(file);
+    expect(clone[Symbol.toStringTag]).toBe("File");
+    expect(Object.prototype.toString.call(clone)).toBe("[object File]");
+    expect(clone instanceof File).toBe(true);
+    expect(clone instanceof Blob).toBe(true);
+    expect(clone.name).toBe("file.txt");
+    expect(await clone.text()).toBe("Hello");
+
+    const blob = new Blob(["Hello"]);
+    const blobClone = structuredClone(blob);
+    expect(blobClone[Symbol.toStringTag]).toBe("Blob");
+    expect(blobClone instanceof File).toBe(false);
+  });
+
+  test("FormData file entries have File prototype", async () => {
+    const fd = new FormData();
+    fd.append("file", new File(["Hello"], "a.txt"));
+    fd.append("blob", new Blob(["World"]));
+    const file = fd.get("file") as File;
+    const blob = fd.get("blob") as File;
+    expect(file[Symbol.toStringTag]).toBe("File");
+    expect(file instanceof File).toBe(true);
+    expect(file.name).toBe("a.txt");
+    expect(await file.text()).toBe("Hello");
+    // Per the FormData spec, Blob values are normalized to File.
+    expect(blob[Symbol.toStringTag]).toBe("File");
+    expect(blob instanceof File).toBe(true);
+    expect(await blob.text()).toBe("World");
+  });
+});
+
 test("new Blob('123') is NOT supported", async () => {
   expect(() => new Blob("123")).toThrow();
 });

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -291,6 +291,16 @@ describe("File prototype chain", () => {
     expect(Object.getPrototypeOf(Object.getPrototypeOf(mf))).toBe(File.prototype);
   });
 
+  test("File.slice() returns a plain Blob", async () => {
+    const file = new File(["Hello"], "a.txt");
+    const sliced = file.slice(0, 3);
+    expect(sliced[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(sliced)).toBe(Blob.prototype);
+    expect(sliced instanceof File).toBe(false);
+    expect(sliced instanceof Blob).toBe(true);
+    expect(await sliced.text()).toBe("Hel");
+  });
+
   test("structuredClone of File preserves File prototype", async () => {
     const file = new File(["Hello"], "file.txt", { type: "text/plain" });
     const clone = structuredClone(file);
@@ -307,20 +317,38 @@ describe("File prototype chain", () => {
     expect(blobClone instanceof File).toBe(false);
   });
 
-  test("FormData file entries have File prototype", async () => {
-    const fd = new FormData();
-    fd.append("file", new File(["Hello"], "a.txt"));
-    fd.append("blob", new Blob(["World"]));
-    const file = fd.get("file") as File;
-    const blob = fd.get("blob") as File;
-    expect(file[Symbol.toStringTag]).toBe("File");
-    expect(file instanceof File).toBe(true);
-    expect(file.name).toBe("a.txt");
-    expect(await file.text()).toBe("Hello");
-    // Per the FormData spec, Blob values are normalized to File.
-    expect(blob[Symbol.toStringTag]).toBe("File");
-    expect(blob instanceof File).toBe(true);
-    expect(await blob.text()).toBe("World");
+  test("File received before File constructor is accessed has correct constructor", async () => {
+    // structuredClone deserialization can materialize a File in a realm before
+    // globalThis.File is ever touched; File.prototype.constructor must still
+    // resolve to File rather than falling through to Blob.prototype.constructor.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { Worker } = require("worker_threads");
+          const w = new Worker(\`
+            const { parentPort } = require("worker_threads");
+            parentPort.once("message", (f) => {
+              parentPort.postMessage({
+                tag: f[Symbol.toStringTag],
+                ctorName: f.constructor.name,
+                ctorIsFile: f.constructor === File,
+              });
+            });
+          \`, { eval: true });
+          w.on("message", (m) => { console.log(JSON.stringify(m)); process.exit(0); });
+          w.postMessage(new File(["hi"], "a.txt"));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout.trim())).toEqual({ tag: "File", ctorName: "File", ctorIsFile: true });
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
+import { resolveObjectURL } from "node:buffer";
 import type { BlobOptions } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
 import path from "node:path";
@@ -328,7 +329,6 @@ describe("File prototype chain", () => {
     expect(wrappedClone instanceof File).toBe(false);
     expect(await wrappedClone.text()).toBe("Hello");
 
-    const { resolveObjectURL } = require("node:buffer");
     const url = URL.createObjectURL(file);
     const resolved = resolveObjectURL(url);
     URL.revokeObjectURL(url);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -301,6 +301,21 @@ describe("File prototype chain", () => {
     expect(await sliced.text()).toBe("Hel");
   });
 
+  test("Response(file).blob() and Request(..., {body: file}).blob() return plain Blobs", async () => {
+    const file = new File(["Hello"], "a.txt");
+    const res = await new Response(file).blob();
+    expect(res[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(res)).toBe(Blob.prototype);
+    expect(res instanceof File).toBe(false);
+    expect(await res.text()).toBe("Hello");
+
+    const req = await new Request("http://x", { method: "POST", body: file }).blob();
+    expect(req[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(req)).toBe(Blob.prototype);
+    expect(req instanceof File).toBe(false);
+    expect(await req.text()).toBe("Hello");
+  });
+
   test("structuredClone of File preserves File prototype", async () => {
     const file = new File(["Hello"], "file.txt", { type: "text/plain" });
     const clone = structuredClone(file);

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, tempDir } from "harness";
-import { resolveObjectURL } from "node:buffer";
 import type { BlobOptions } from "node:buffer";
+import { resolveObjectURL } from "node:buffer";
 import type { BinaryLike } from "node:crypto";
 import path from "node:path";
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -316,6 +316,28 @@ describe("File prototype chain", () => {
     expect(await req.text()).toBe("Hello");
   });
 
+  test("new Blob([file]) and resolveObjectURL(createObjectURL(file)) return plain Blobs", async () => {
+    const file = new File(["Hello"], "a.txt");
+
+    const wrapped = new Blob([file]);
+    expect(wrapped[Symbol.toStringTag]).toBe("Blob");
+    expect(wrapped instanceof File).toBe(false);
+    const wrappedClone = structuredClone(wrapped);
+    expect(wrappedClone[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(wrappedClone)).toBe(Blob.prototype);
+    expect(wrappedClone instanceof File).toBe(false);
+    expect(await wrappedClone.text()).toBe("Hello");
+
+    const { resolveObjectURL } = require("node:buffer");
+    const url = URL.createObjectURL(file);
+    const resolved = resolveObjectURL(url);
+    URL.revokeObjectURL(url);
+    expect(resolved[Symbol.toStringTag]).toBe("Blob");
+    expect(Object.getPrototypeOf(resolved)).toBe(Blob.prototype);
+    expect(resolved instanceof File).toBe(false);
+    expect(await resolved.text()).toBe("Hello");
+  });
+
   test("structuredClone of File preserves File prototype", async () => {
     const file = new File(["Hello"], "file.txt", { type: "text/plain" });
     const clone = structuredClone(file);


### PR DESCRIPTION
## Repro

```js
const file = new File(["Hello"], "file.txt", { type: "text/plain" });
file[Symbol.toStringTag]              // "Blob"   (expected "File")
Object.prototype.toString.call(file)  // "[object Blob]"
File.prototype === Blob.prototype     // true    (expected false)
```

Node and browsers return `"File"` / `"[object File]"`. Packages that branch on the string tag (e.g. some `fetch`/form-data libraries) misclassify File instances as plain Blobs.

## Cause

`JSDOMFile.cpp` set `File.prototype` directly to the `Blob.prototype` object and allocated `new File()` instances with `JSBlobStructure()`:

```cpp
// This is not quite right. But we'll fix it if someone files an issue about it.
object->putDirect(vm, vm.propertyNames->prototype, zigGlobal->JSBlobPrototype(), ...);
...
Structure* structure = globalObject->JSBlobStructure();
```

There was no distinct `File.prototype`, so instances inherited `Symbol.toStringTag = "Blob"` from `JSBlobPrototype`.

## Fix

Add `JSDOMFilePrototype` (a plain object whose `[[Prototype]]` is `Blob.prototype`) with `Symbol.toStringTag = "File"`, and a cached `m_JSDOMFileStructure` on `ZigGlobalObject` that points instances at it. The File constructor's own `[[Prototype]]` is now the Blob constructor and `File.prototype.constructor` is `File`, matching Node and Web IDL.

Paths routed through the new structure:
- `new File()` and its subclasses (`JSDOMFile::construct`)
- `BlobExt::to_js` when `is_jsdom_file` is set (structuredClone, postMessage)

`BUN__createJSDOMFileUnsafely` touches `JSDOMFileConstructor()` so `File.prototype.constructor` is wired even when a File is materialized (e.g. structuredClone in a fresh Worker) before `globalThis.File` is accessed.

Related: `Blob.prototype.slice` on a File previously returned an object with `is_jsdom_file = true` (so `instanceof File === true`). That flag is now cleared on the slice so `file.slice()` is a plain Blob as the File API spec and Node/browsers require.

Instances remain `WebCore::JSBlob` cells; only the structure/prototype differs. `jsDynamicCast<JSBlob*>` and the `is_jsdom_file`-based `instanceof File` check are unchanged.

## Verification

New tests in `test/js/web/fetch/blob.test.ts` cover `new File()`, File subclasses, `file.slice()`, `structuredClone(file)`, a Worker receiving a File before touching `globalThis.File`, and regression guards for `new Blob()`. All existing `blob.test.ts`, `FormData.test.ts`, and structured-clone tests pass with the debug build; the new tests fail with `USE_SYSTEM_BUN=1`.

Fixes #14102

Note: #31656 addresses the same issue by putting `Symbol.toStringTag` on each File instance. This PR instead gives File its own prototype so `File.prototype !== Blob.prototype`, `Object.getPrototypeOf(File.prototype) === Blob.prototype`, and `File.prototype.constructor === File` all hold as they do in Node and browsers.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 3 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (84c40f0f0)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.78ms]
(pass) Blob.slice [44.42ms]
(pass) Bun.file().slice [51.93ms]
(pass) new Blob [4.24ms]
(pass) new Blob stringifies non-Blob object parts in order [12.12ms]
(pass) blob: can be fetched [13.26ms]
(pass) blob: URL has Content-Type [10.97ms]
(pass) blob: can be imported [15.36ms]
(pass) blob: can reliable get type from fetch #10072 [253.73ms]
(pass) new Blob(new Uint8Array()) is supported [5.06ms]
(pass) new File(new Uint8Array()) is supported [4.63ms]
(pass) new File('123', '123') is NOT supported [3.03ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.25ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release without fix: 1 failed, 2 skipped
bun test v1.4.0-canary.1 (02de7dc01)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [0.59ms]
(pass) Blob.slice [0.59ms]
(pass) Bun.file().slice [0.56ms]
(pass) new Blob [0.06ms]
(pass) new Blob stringifies non-Blob object parts in order [0.17ms]
(pass) blob: can be fetched [0.27ms]
(pass) blob: URL has Content-Type [0.18ms]
(pass) blob: can be imported [0.26ms]
(pass) blob: can reliable get type from fetch #10072 [204.20ms]
(pass) new Blob(new Uint8Array()) is supported [0.25ms]
(pass) new File(new Uint8Array()) is supported [0.09ms]
(pass) new File('123', '123') is NOT supported [0.06ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [0.05ms]
(pass) new File() lastModified option > lastModified: "not a number" -> 0
(pass) new File() lastModified option > lastModified: {} -> 0
(pass) new File() lastModified option > lastModified: {
  valueOf: [Function: valueOf],
} -> 0 [0.02ms]
(pass) new File() lastModified option > lastModified: null -> 0
(pass) new File() lastModified option > lastModified: "" -> 0
(pass) new File() lastModified option > lastModified: false -> 0
(pass) new File() lastModified option > lastModi
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/fetch/blob.test.ts
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (84c40f0f0)

test/js/web/fetch/blob.test.ts:
(pass) blob: imports have sourcemapped stacktraces [20.44ms]
(pass) Blob.slice [45.04ms]
(pass) Bun.file().slice [51.07ms]
(pass) new Blob [4.17ms]
(pass) new Blob stringifies non-Blob object parts in order [11.45ms]
(pass) blob: can be fetched [13.78ms]
(pass) blob: URL has Content-Type [10.86ms]
(pass) blob: can be imported [15.39ms]
(pass) blob: can reliable get type from fetch #10072 [256.77ms]
(pass) new Blob(new Uint8Array()) is supported [4.90ms]
(pass) new File(new Uint8Array()) is supported [4.79ms]
(pass) new File('123', '123') is NOT supported [3.04ms]
(pass) new File() lastModified option > lastModified: NaN -> 0 [3.19ms]
(pass) new File() lastModified option > lastModified: "not 
... (truncated)

release with fix: 2 skipped
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 687ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/119] gen generated_host_exports.rs
generated_host_exports.rs: 91 exports (host=3, lazy=10, generic=78, rust=0); 243 extern-C blocks audited
[2/119] gen cpp.rs (cppbind)
[2/119] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

info: checking for self-update (current version: 1.29.0)
  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/JSDOMFile.cpp       |  87 +++++++++++++++++---
 src/jsc/bindings/JSDOMFile.h         |   1 +
 src/jsc/bindings/ZigGlobalObject.cpp |   5 ++
 src/jsc/bindings/ZigGlobalObject.h   |   2 +
 src/jsc/bindings/blob.cpp            |   5 +-
 src/jsc/webcore_types.rs             |   5 +-
 src/runtime/webcore/Blob.rs          |  22 ++++-
 test/js/web/fetch/blob.test.ts       | 153 +++++++++++++++++++++++++++++++++++
 8 files changed, 266 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 3

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/jsc/bindings/JSDOMFile.cpp            4      6     25
src/jsc/bindings/JSDOMFile.h              1      1     25
src/jsc/bindings/ZigGlobalObject.cpp      3      1     25
src/jsc/bindings/ZigGlobalObject.h        2      2     25
src/jsc/bindings/blob.cpp                 4      4     25
src/jsc/webcore_types.rs                  2      1     25
src/runtime/webcore/Blob.rs              13      6     25
test/js/web/fetch/blob.test.ts           11     16     25
```

</details>

<!-- robobun:evidence:end -->