### PR TITLE
webcore/Blob: default FormData Blob entries to filename "blob"

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -5642,6 +5642,11 @@ pub fn jsdom_file_construct_(
         let name_value_str = OwnedString::new(BunString::from_js(args[1], global_this)?);
 
         blob = Blob::get::<false, true>(global_this, args[0])?;
+        // `get::<_, true>` on a single-Blob sequence returns `dupe()`, which
+        // copies the source blob's per-Blob `name`; override it so
+        // `get_name_string` / `Blob__getFileNameString` reflect this
+        // constructor's argument rather than the inherited value.
+        blob.name.set(name_value_str.dupe_ref());
         if let Some(store_) = blob.store.get() {
             match store_.data_mut() {
                 store::Data::Bytes(bytes) => {
@@ -5651,9 +5656,7 @@ pub fn jsdom_file_construct_(
                     // assignment drops (frees) the previous `Box<[u8]>`.
                     bytes.stored_name = name_value_str.to_owned_slice().into_boxed_slice();
                 }
-                store::Data::S3(_) | store::Data::File(_) => {
-                    blob.name.set(name_value_str.dupe_ref());
-                }
+                store::Data::S3(_) | store::Data::File(_) => {}
             }
         } else if !name_value_str.is_empty() {
             // not store but we have a name so we need a store

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4380,6 +4380,12 @@ pub extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
 
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
+    // Mirror `get_name_string`: per-Blob `name` (set by `Blob__setAsFile` for
+    // entries retrieved from FormData) takes precedence over the store's
+    // `stored_name` / file path.
+    if this.name.get().tag() != bun_core::Tag::Dead {
+        return this.name.get();
+    }
     if let Some(filename) = this.get_file_name() {
         return BunString::from_bytes(filename);
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4366,17 +4366,11 @@ pub extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob>> {
 #[unsafe(no_mangle)]
 pub extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunString) {
     this.is_jsdom_file.set(true);
-
-    // This is not 100% correct...
-    if let Some(store) = this.store() {
-        if let store::Data::Bytes(bytes) = &mut store.data_mut() {
-            if bytes.stored_name.is_empty() {
-                // Owned heap slice
-                // owned by `stored_name` (`Box<[u8]>`) and freed by `Bytes::Drop`.
-                bytes.stored_name = path_str.to_owned_slice().into_boxed_slice();
-            }
-        }
-    }
+    // Store on the per-Blob `name` rather than the (possibly shared) store's
+    // `stored_name`, so the filename assigned by `FormData` does not leak
+    // into the user's original Blob and can be overridden by a later
+    // `FormData.set(name, blob, filename)`.
+    this.name.set(path_str.dupe_ref());
 }
 
 #[unsafe(no_mangle)]
@@ -4389,7 +4383,14 @@ pub extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     if let Some(filename) = this.get_file_name() {
         return BunString::from_bytes(filename);
     }
-    BunString::empty()
+    // https://xhr.spec.whatwg.org/#create-an-entry step 3: if the value is a
+    // Blob that is not a File, it becomes a File named "blob". Only called
+    // from `FormData.append`/`set` when no filename argument was provided.
+    if this.is_jsdom_file.get() {
+        BunString::empty()
+    } else {
+        BunString::static_(b"blob")
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -41,7 +41,7 @@ describe("multipart serialization (new Response(formData))", () => {
         `--${boundary}\r\n`,
         `Content-Disposition: form-data; name="crlf%0D%0Aname"\r\n\r\nv2\r\n`,
         `--${boundary}\r\n`,
-        `Content-Disposition: form-data; name="untyped-blob"; filename=""\r\n`,
+        `Content-Disposition: form-data; name="untyped-blob"; filename="blob"\r\n`,
         `Content-Type: application/octet-stream\r\n\r\nblob-bytes\r\n`,
         `--${boundary}\r\n`,
         `Content-Disposition: form-data; name="named-blob"; filename="file.bin"\r\n`,
@@ -80,7 +80,7 @@ describe("multipart serialization (new Response(formData))", () => {
       ["dup", "first"],
       ["dup", "second"],
       ["unicode name ☺", "ünïcode välue 😊"],
-      ["blob", { file: true, name: undefined, type: "", text: "blob-bytes" }],
+      ["blob", { file: true, name: "blob", type: "", text: "blob-bytes" }],
       ["file", { file: true, name: "日本語ファイル名.html", type: "text/html;charset=utf-8", text: "<p>hi</p>" }],
     ]);
   });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -38,7 +38,7 @@ describe("FormData", () => {
     const formData = new FormData();
     formData.append("foo", blob);
     // @ts-expect-error
-    expect(formData.get("foo").name).toBeUndefined();
+    expect(formData.get("foo").name).toBe("blob");
     formData.append("foo2", new File([blob], "foo.txt"));
     // @ts-expect-error
     expect(formData.get("foo2").name).toBe("foo.txt");
@@ -52,15 +52,64 @@ describe("FormData", () => {
 
     let b1 = form.get("foo") as any;
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBe("blob");
 
     form.set("foo", b1, "foo.txt");
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBe("blob");
 
     b1 = form.get("foo") as Blob;
     expect(blob.name).toBeUndefined();
     expect(b1.name).toBe("foo.txt");
+  });
+
+  // https://github.com/oven-sh/bun/issues/14725
+  it("defaults the filename to 'blob' when appending/setting a Blob without a filename", async () => {
+    const formData = new FormData();
+    formData.set("via-set", new Blob(["hello"], { type: "text/plain" }));
+    formData.append("via-append", new Blob(["world"]));
+    formData.set("file", new File(["x"], "explicit.txt"));
+    formData.set("override", new Blob(["y"]), "override.bin");
+
+    const viaSet = formData.get("via-set") as File;
+    const viaAppend = formData.get("via-append") as File;
+    const file = formData.get("file") as File;
+    const override = formData.get("override") as File;
+
+    expect({
+      viaSet: { isFile: viaSet instanceof File, name: viaSet.name },
+      viaAppend: { isFile: viaAppend instanceof File, name: viaAppend.name },
+      file: { isFile: file instanceof File, name: file.name },
+      override: { isFile: override instanceof File, name: override.name },
+    }).toEqual({
+      viaSet: { isFile: true, name: "blob" },
+      viaAppend: { isFile: true, name: "blob" },
+      file: { isFile: true, name: "explicit.txt" },
+      override: { isFile: true, name: "override.bin" },
+    });
+
+    const body = await new Response(formData).text();
+    expect(body).toContain('Content-Disposition: form-data; name="via-set"; filename="blob"\r\n');
+    expect(body).toContain('Content-Disposition: form-data; name="via-append"; filename="blob"\r\n');
+    expect(body).toContain('Content-Disposition: form-data; name="file"; filename="explicit.txt"\r\n');
+    expect(body).toContain('Content-Disposition: form-data; name="override"; filename="override.bin"\r\n');
+  });
+
+  // https://github.com/oven-sh/bun/issues/14725
+  it("sends filename='blob' over fetch for a Blob without a filename", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        return new Response(await req.text());
+      },
+    });
+
+    const formData = new FormData();
+    formData.set("fname", new Blob(["hello, world"], { type: "text/plain" }));
+
+    const res = await fetch(server.url, { method: "POST", body: formData });
+    const body = await res.text();
+    expect(body).toContain('Content-Disposition: form-data; name="fname"; filename="blob"\r\n');
   });
 
   const multipartFormDataFixturesRawBody = [

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -93,6 +93,18 @@ describe("FormData", () => {
     expect(body).toContain('Content-Disposition: form-data; name="via-append"; filename="blob"\r\n');
     expect(body).toContain('Content-Disposition: form-data; name="file"; filename="explicit.txt"\r\n');
     expect(body).toContain('Content-Disposition: form-data; name="override"; filename="override.bin"\r\n');
+
+    // Re-appending a File retrieved from FormData without a filename argument
+    // keeps the File's existing name (spec "create an entry" step 3 only
+    // applies the "blob" default when the value is not already a File).
+    const formData2 = new FormData();
+    formData2.set("a", viaSet);
+    formData2.set("b", override);
+    expect((formData2.get("a") as File).name).toBe("blob");
+    expect((formData2.get("b") as File).name).toBe("override.bin");
+    const body2 = await new Response(formData2).text();
+    expect(body2).toContain('Content-Disposition: form-data; name="a"; filename="blob"\r\n');
+    expect(body2).toContain('Content-Disposition: form-data; name="b"; filename="override.bin"\r\n');
   });
 
   // https://github.com/oven-sh/bun/issues/14725

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -105,6 +105,16 @@ describe("FormData", () => {
     const body2 = await new Response(formData2).text();
     expect(body2).toContain('Content-Disposition: form-data; name="a"; filename="blob"\r\n');
     expect(body2).toContain('Content-Disposition: form-data; name="b"; filename="override.bin"\r\n');
+
+    // Wrapping a File retrieved from FormData in `new File([f], name)` uses
+    // the constructor's name argument, not the inherited one.
+    const renamed = new File([override], "renamed.txt");
+    expect(renamed.name).toBe("renamed.txt");
+    const formData3 = new FormData();
+    formData3.set("r", renamed);
+    expect((formData3.get("r") as File).name).toBe("renamed.txt");
+    const body3 = await new Response(formData3).text();
+    expect(body3).toContain('Content-Disposition: form-data; name="r"; filename="renamed.txt"\r\n');
   });
 
   // https://github.com/oven-sh/bun/issues/14725


### PR DESCRIPTION
Fixes #14725.
Fixes #22762.
Fixes #21788.

## Repro

```js
const formData = new FormData();
formData.set("fname", new Blob(["hello, world"], { type: "text/plain" }));
console.log(await new Response(formData).text());
```

Before:
```
Content-Disposition: form-data; name="fname"; filename=""
```

Node, Chrome, Firefox, Safari:
```
Content-Disposition: form-data; name="fname"; filename="blob"
```

And `formData.get("fname").name` was `undefined` instead of `"blob"`.

## Cause

[XHR spec "create an entry"](https://xhr.spec.whatwg.org/#create-an-entry) step 3 says that when the value is a `Blob` that is not a `File`, it becomes a `File` whose name is `"blob"`. `Blob__getFileNameString` (called from `FormData.append`/`set` when no filename argument is given) returned an empty string for plain Blobs, so both the multipart `filename` attribute and the retrieved entry's `.name` were empty.

Additionally, `Blob__setAsFile` stored the FormData-assigned filename on the Blob store's `stored_name`, which is shared with the user's original Blob. With a non-empty default this would have leaked the name into the original Blob, and the `stored_name.is_empty()` guard prevented overriding the name via a later `set(name, blob, filename)`.

## Fix

- `Blob__getFileNameString` now returns `"blob"` when the value is a plain Blob (not a File) with no existing name.
- `Blob__setAsFile` now stores the filename on the per-Blob `name` field instead of the shared store, so it applies to the FormData entry (and the File returned from `get()`) without affecting the original Blob, and can be overridden by a later `set`/`append` with an explicit filename.

This also makes `formData.set("k", Bun.file(path), "custom.bin")` return `.name === "custom.bin"` from `get()`, which previously returned the path.

## Verification

```sh
bun bd test test/js/web/html/FormData.test.ts
bun bd test test/js/web/html/FormData-multipart-serialization.test.ts
```
