### PR TITLE
child_process: make child.stdin a Duplex so setEncoding works

### DIFF
--- a/src/js/internal/fs/streams.ts
+++ b/src/js/internal/fs/streams.ts
@@ -790,20 +790,8 @@ function thenIfPromise<T>(maybePromise: Promise<T> | T, cb: any) {
   }
 }
 
-function writableFromFileSink(fileSink: any) {
-  $assert(typeof fileSink === "object", "fileSink is not an object");
-  $assert(typeof fileSink.write === "function", "fileSink.write is not a function");
-  $assert(typeof fileSink.end === "function", "fileSink.end is not a function");
-  const w = new WriteStream("", { $fastPath: true });
-  $assert(w[kWriteStreamFastPath] === true, "fast path not enabled");
-  w[kWriteStreamFastPath] = fileSink;
-  w.path = undefined;
-  return w;
-}
-
 export default {
   ReadStream,
   WriteStream,
   kWriteStreamFastPath,
-  writableFromFileSink,
 };

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1759,7 +1759,7 @@ function stdinStreamWritev(this: any, chunks: any, cb: any) {
     const { chunk, encoding } = chunks[i];
     buffers[i] = typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
   }
-  stdinStreamWrite.$call(this, Buffer.concat(buffers), "buffer", cb);
+  stdinStreamWrite.$call(this, BufferConcat(buffers), "buffer", cb);
 }
 
 function stdinStreamDestroy(this: any, err: any, cb: any) {
@@ -1794,6 +1794,7 @@ function createStdinStream(sink: any) {
   if (StdinStream === undefined) {
     const Duplex = require("internal/streams/duplex");
     StdinStream = class Socket extends Duplex {
+      [kStdinSink] = undefined;
       constructor() {
         super({
           readable: false,

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1785,6 +1785,12 @@ function stdinStreamDestroy(this: any, err: any, cb: any) {
   cb(err);
 }
 
+function stdinStreamDestroySoon(this: any) {
+  if (this.writable) this.end();
+  if (this.writableFinished) this.destroy();
+  else this.once("finish", this.destroy);
+}
+
 let StdinStream;
 function createStdinStream(sink: any) {
   if (StdinStream === undefined) {
@@ -1801,6 +1807,7 @@ function createStdinStream(sink: any) {
     StdinStream.prototype._write = stdinStreamWrite;
     StdinStream.prototype._writev = stdinStreamWritev;
     StdinStream.prototype._destroy = stdinStreamDestroy;
+    StdinStream.prototype.destroySoon = stdinStreamDestroySoon;
   }
   const stream = new StdinStream();
   if (sink) {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1721,11 +1721,9 @@ function fdToStdioName(fd: number) {
   }
 }
 
-// In Node.js, all three stdio pipe streams are `net.Socket` instances (which extend
-// `stream.Duplex`). Packages such as python-shell call Readable methods like
-// `setEncoding()` on `child.stdin`, so stdin must expose the full Duplex surface even
-// though its readable side is ended. Node passes `readable: false` when creating the
-// stdin socket.
+// Node's stdio pipe streams are `net.Socket` (Duplex) instances. stdin must expose the
+// full Duplex surface (setEncoding, pause, resume) even though its readable side is
+// ended; Node passes `readable: false` when creating the stdin socket.
 const kStdinSink = Symbol("kStdinSink");
 
 function stdinStreamWrite(this: any, chunk: any, encoding: any, cb: any) {

--- a/src/js/node/child_process.ts
+++ b/src/js/node/child_process.ts
@@ -1188,40 +1188,13 @@ class ChildProcess extends EventEmitter {
       case 0: {
         switch (io) {
           case "pipe": {
-            const stdin = handle?.stdin;
-
-            if (!stdin) {
-              // This can happen if the process was already killed.
-              const Writable = require("internal/streams/writable");
-              const stream = new Writable({
-                write(chunk, encoding, callback) {
-                  // Gracefully handle writes - stream acts as if it's ended
-                  if (callback) callback();
-                  return false;
-                },
-              });
-              // Mark as destroyed to indicate it's not usable
-              stream.destroy();
-              return stream;
-            }
-            const result = require("internal/fs/streams").writableFromFileSink(stdin);
-            result.readable = false;
-            return result;
+            // This can be undefined if the process was already killed.
+            return createStdinStream(handle?.stdin);
           }
           case "inherit":
             return null;
           case "destroyed": {
-            const Writable = require("internal/streams/writable");
-            const stream = new Writable({
-              write(chunk, encoding, callback) {
-                // Gracefully handle writes - stream acts as if it's ended
-                if (callback) callback();
-                return false;
-              },
-            });
-            // Mark as destroyed to indicate it's not usable
-            stream.destroy();
-            return stream;
+            return createStdinStream(undefined);
           }
           case "undefined":
             return undefined;
@@ -1746,6 +1719,96 @@ function fdToStdioName(fd: number) {
     default:
       return null;
   }
+}
+
+// In Node.js, all three stdio pipe streams are `net.Socket` instances (which extend
+// `stream.Duplex`). Packages such as python-shell call Readable methods like
+// `setEncoding()` on `child.stdin`, so stdin must expose the full Duplex surface even
+// though its readable side is ended. Node passes `readable: false` when creating the
+// stdin socket.
+const kStdinSink = Symbol("kStdinSink");
+
+function stdinStreamWrite(this: any, chunk: any, encoding: any, cb: any) {
+  const sink = this[kStdinSink];
+  try {
+    // The underlying FileSink treats string input as UTF-8. For other
+    // encodings, convert to a Buffer first so the bytes are preserved.
+    if (
+      typeof chunk === "string" &&
+      encoding !== undefined &&
+      encoding !== "utf8" &&
+      encoding !== "utf-8" &&
+      encoding !== "buffer"
+    ) {
+      chunk = Buffer.from(chunk, encoding);
+    }
+    const result = sink.write(chunk);
+    if ($isPromise(result)) {
+      result.then(() => cb(), cb);
+      return false;
+    }
+    cb();
+    return true;
+  } catch (err) {
+    cb(err);
+    return false;
+  }
+}
+
+function stdinStreamWritev(this: any, chunks: any, cb: any) {
+  const buffers = new Array(chunks.length);
+  for (let i = 0; i < chunks.length; i++) {
+    const { chunk, encoding } = chunks[i];
+    buffers[i] = typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk;
+  }
+  stdinStreamWrite.$call(this, Buffer.concat(buffers), "buffer", cb);
+}
+
+function stdinStreamDestroy(this: any, err: any, cb: any) {
+  const sink = this[kStdinSink];
+  if (sink) {
+    this[kStdinSink] = undefined;
+    try {
+      const result = sink.end(err);
+      if ($isPromise(result)) {
+        result.then(
+          () => cb(err),
+          (e: any) => cb(e || err),
+        );
+        return;
+      }
+    } catch (e) {
+      cb(e || err);
+      return;
+    }
+  }
+  cb(err);
+}
+
+let StdinStream;
+function createStdinStream(sink: any) {
+  if (StdinStream === undefined) {
+    const Duplex = require("internal/streams/duplex");
+    StdinStream = class Socket extends Duplex {
+      constructor() {
+        super({
+          readable: false,
+          decodeStrings: false,
+          autoDestroy: true,
+        });
+      }
+    };
+    StdinStream.prototype._write = stdinStreamWrite;
+    StdinStream.prototype._writev = stdinStreamWritev;
+    StdinStream.prototype._destroy = stdinStreamDestroy;
+  }
+  const stream = new StdinStream();
+  if (sink) {
+    stream[kStdinSink] = sink;
+  } else {
+    stream.destroy();
+  }
+  return stream;
 }
 
 function getBunStdioFromOptions(stdio) {

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -256,4 +256,28 @@ describe("ChildProcess stdio streams", () => {
     expect(code).toBe(0);
     expect(signal).toBeNull();
   });
+
+  it("child.stdin.write preserves non-UTF-8 encodings", async () => {
+    const child = spawn(
+      bunExe(),
+      ["-e", `process.stdin.on("data", chunk => process.stdout.write(chunk.toString("hex")))`],
+      { env: bunEnv, stdio: ["pipe", "pipe", "ignore"] },
+    );
+
+    child.stdout.setEncoding("utf8");
+    let data = "";
+    child.stdout.on("data", chunk => {
+      data += chunk;
+    });
+
+    child.stdin.write("\u00e9", "latin1");
+    child.stdin.write("\u00e9", "utf8");
+    child.stdin.write(Buffer.from([0xff]));
+    child.stdin.end();
+
+    const [code] = await once(child, "close");
+    // latin1 "é" -> e9, utf8 "é" -> c3 a9, raw buffer -> ff
+    expect(data).toBe("e9c3a9ff");
+    expect(code).toBe(0);
+  });
 });

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -183,6 +183,7 @@ describe("ChildProcess stdio streams", () => {
         "typeof stdin.resume": typeof child.stdin.resume,
         "typeof stdin.write": typeof child.stdin.write,
         "typeof stdin.end": typeof child.stdin.end,
+        "typeof stdin.destroySoon": typeof child.stdin.destroySoon,
         "stdin instanceof Duplex": child.stdin instanceof Duplex,
         "stdin instanceof Readable": child.stdin instanceof Readable,
         "stdin instanceof Writable": child.stdin instanceof Writable,
@@ -194,6 +195,7 @@ describe("ChildProcess stdio streams", () => {
         "typeof stdin.resume": "function",
         "typeof stdin.write": "function",
         "typeof stdin.end": "function",
+        "typeof stdin.destroySoon": "function",
         "stdin instanceof Duplex": true,
         "stdin instanceof Readable": true,
         "stdin instanceof Writable": true,
@@ -204,6 +206,27 @@ describe("ChildProcess stdio streams", () => {
       child.stdin.end();
       await once(child, "exit");
     }
+  });
+
+  it("child.stdin.destroySoon flushes pending writes then closes", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: "pipe",
+    });
+
+    let data = "";
+    child.stdout.setEncoding("utf8");
+    child.stdout.on("data", chunk => {
+      data += chunk;
+    });
+
+    child.stdin.write("abc\n");
+    child.stdin.destroySoon();
+
+    const [code] = await once(child, "close");
+    expect(data).toBe("data: abc\n");
+    expect(child.stdin.destroyed).toBe(true);
+    expect(code).toBe(0);
   });
 
   // https://github.com/oven-sh/bun/issues/11011

--- a/test/js/node/child_process/child-process-stdio.test.js
+++ b/test/js/node/child_process/child-process-stdio.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 import { execSync, spawn } from "node:child_process";
 import { once } from "node:events";
+import { Duplex, Readable, Writable } from "node:stream";
 
 const CHILD_PROCESS_FILE = import.meta.dir + "/spawned-child.js";
 const OUT_FILE = import.meta.dir + "/stdio-test-out.txt";
@@ -164,5 +165,72 @@ describe("child.stdin", () => {
       ret: false,
       cbCode: "ERR_STREAM_DESTROYED",
     });
+  });
+});
+
+describe("ChildProcess stdio streams", () => {
+  // https://github.com/oven-sh/bun/issues/11011
+  it("child.stdin is a Duplex and supports setEncoding", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: "pipe",
+    });
+
+    try {
+      expect({
+        "typeof stdin.setEncoding": typeof child.stdin.setEncoding,
+        "typeof stdin.pause": typeof child.stdin.pause,
+        "typeof stdin.resume": typeof child.stdin.resume,
+        "typeof stdin.write": typeof child.stdin.write,
+        "typeof stdin.end": typeof child.stdin.end,
+        "stdin instanceof Duplex": child.stdin instanceof Duplex,
+        "stdin instanceof Readable": child.stdin instanceof Readable,
+        "stdin instanceof Writable": child.stdin instanceof Writable,
+        "stdin.readable": child.stdin.readable,
+        "stdin.writable": child.stdin.writable,
+      }).toEqual({
+        "typeof stdin.setEncoding": "function",
+        "typeof stdin.pause": "function",
+        "typeof stdin.resume": "function",
+        "typeof stdin.write": "function",
+        "typeof stdin.end": "function",
+        "stdin instanceof Duplex": true,
+        "stdin instanceof Readable": true,
+        "stdin instanceof Writable": true,
+        "stdin.readable": false,
+        "stdin.writable": true,
+      });
+    } finally {
+      child.stdin.end();
+      await once(child, "exit");
+    }
+  });
+
+  // https://github.com/oven-sh/bun/issues/11011
+  it("setEncoding can be called on stdin, stdout and stderr and writes still reach the child", async () => {
+    const child = spawn(bunExe(), [CHILD_PROCESS_FILE, "STDIN", "FLOWING"], {
+      env: bunEnv,
+      stdio: "pipe",
+    });
+
+    // python-shell calls setEncoding on all three stdio streams unconditionally.
+    for (const name of ["stdout", "stdin", "stderr"]) {
+      expect(child[name].setEncoding("utf8")).toBe(child[name]);
+    }
+
+    let data = "";
+    child.stdout.on("data", chunk => {
+      data += chunk;
+    });
+
+    child.stdin.write("hello");
+    child.stdin.write(" ");
+    child.stdin.write("world\n");
+    child.stdin.end();
+
+    const [code, signal] = await once(child, "close");
+    expect(data).toBe("data: hello world\n");
+    expect(code).toBe(0);
+    expect(signal).toBeNull();
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #11011.

In Node.js, `child_process.spawn()` stdio pipe streams are `net.Socket` instances which extend `stream.Duplex`. Bun was creating `child.stdin` as an `fs.WriteStream` (a plain `Writable`), so `Readable` prototype methods like `setEncoding`, `pause` and `resume` were missing. Packages such as `python-shell` and `say` unconditionally call `setEncoding` on all three stdio streams and threw:

```
TypeError: self[name].setEncoding is not a function
```

### Reproduction

```js
const { spawn } = require("node:child_process");
const child = spawn("cat", [], { stdio: "pipe" });
["stdout", "stdin", "stderr"].forEach(name => {
  child[name].setEncoding("utf8"); // throws on stdin in Bun, works in Node
});
child.stdin.end();
```

### Fix

Replace the `fs.WriteStream` with a `Duplex` subclass constructed with `readable: false`, matching how Node creates the stdin socket (`new net.Socket({ handle, readable: false })`). Writes go to the underlying `FileSink` in `_write`/`_writev` and the sink is ended in `_destroy`, same as before. The now-unused `writableFromFileSink` helper in `internal/fs/streams` is removed.

After:

```
stdin.constructor.name  === "Socket"    (was "WriteStream")
stdin instanceof Duplex === true        (was false)
typeof stdin.setEncoding === "function" (was "undefined")
stdin.readable === false, stdin.writable === true (matches Node)
```

## How did you verify your code works?

Added tests in `test/js/node/child_process/child-process-stdio.test.js` that assert `child.stdin` is a Duplex with the expected surface, and that calling `setEncoding` on stdin/stdout/stderr succeeds while writes still reach the child. The tests fail on the current release and pass with this change.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (042e10fe1)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1298.02ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1527.31ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1511.15ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [4932.65ms]
(pass) process.stdin > should allow us to read from a file [1545.61ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [147.00ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [1497.45ms]
187 |         "st
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (746a35610)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [24.97ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [27.63ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [29.98ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [35.52ms]
(pass) process.stdin > should allow us to read from a file [29.23ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [2.40ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [26.29ms]
(pass) ChildProcess stdio streams > child.stdin is a Duplex and supports setEncoding [28.29ms]
(pass) ChildProcess stdio streams > child.stdin.destroySoon flushes pending writes then closes [27.59ms]
(pass) ChildProcess stdio streams > setEncoding can be called on stdin, stdout and stderr and writes still reach the child [27.43ms]
(pass) ChildProcess stdio streams > child.stdin.write preserves non-UTF-8 encodings [26.02ms]

 11 pass
 0 fail
 20 expect() calls
Ran 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/child_process/child-process-stdio.test.js
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
bun test v1.4.0 (042e10fe1)

test/js/node/child_process/child-process-stdio.test.js:
(pass) process.stdout > should allow us to write to it [1284.37ms]
(pass) process.stdin > should allow us to read from stdin in readable mode [1516.59ms]
(pass) process.stdin > should allow us to read from stdin via flowing mode [1515.78ms]
(pass) process.stdin > should allow us to read > 65kb from stdin [4942.01ms]
(pass) process.stdin > should allow us to read from a file [1517.31ms]
(pass) child.stdin > write() after child 'close' returns false and calls back with ERR_STREAM_DESTROYED [142.44ms]
(pass) child.stdin > write() after child 'exit' (before 'close') returns false and calls back with ERR_STREAM_DESTROYED [1494.60ms]
(pass) ChildProce
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: checking for self-update (current version: 1.29.0)
[configured] bun-profile → bun (stripped) in 724ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/20] gen JS modules (bundle-modules)
Preprocess modules (8531ms)
Bundle modules (50ms)
Postprocesss modules (94ms)
Bundle Functions (817ms)
Generate Code (114ms)

[9.62s] Bundled "src/js" for production
  1912 kb
  162 internal modules
  12 native modules
  90 internal functions across 19 files
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)
info: syncing channel updates for nightly-2026-05-06-x86_64-unknown-linux-gnu
info: latest update on 2026-05-06 for version 1.97.0-nightly (e95e73209 2026-05-05)
info: component rust-src is up to date
info: component rust-std is up to date

  nightly-2026-05-06-x86_64-unknown-linux-gnu unchanged - rustc 1.97.0-nightly (e95e73209 2026-05-05)

info: checking for self-update (current version
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/fs/streams.ts                      |  12 --
 src/js/node/child_process.ts                       | 129 ++++++++++++++++-----
 .../node/child_process/child-process-stdio.test.js | 115 ++++++++++++++++++
 3 files changed, 214 insertions(+), 42 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/js/internal/fs/streams.ts                               4      1     10
src/js/node/child_process.ts                                9     14     10
test/js/node/child_process/child-process-stdio.test.js      6      7     10
```

</details>

<!-- robobun:evidence:end -->