### PR TITLE
process: include detail in default emitWarning output

### DIFF
--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -86,6 +86,7 @@
 // Using the same typedef and define for `mode_t` and `umask` as node on windows.
 // https://github.com/nodejs/node/blob/ad5e2dab4c8306183685973387829c2f69e793da/src/node_process_methods.cc#L29
 #define umask _umask
+#define getpid _getpid
 typedef int mode_t;
 #endif
 #include "JSNextTickQueue.h"
@@ -1588,7 +1589,80 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitWarning, (JSC::JSGlobalObject * lexicalG
         process->wrapped().emit(ident, args);
         return JSValue::encode(jsUndefined());
     } else if (!Bun__NODE_NO_WARNINGS()) {
-        auto jsArgs = JSValue::encode(value);
+        // Match Node.js default warning format:
+        //   (bun:<pid>) [<code>] <name>: <message>
+        //   <detail>
+        WTF::StringBuilder builder;
+        builder.append("(bun:"_s);
+        builder.append(getpid());
+        builder.append(") "_s);
+
+        if (value.isObject()) {
+            auto* warning = value.getObject();
+
+            JSValue code = warning->getIfPropertyExists(globalObject, builtinNames(vm).codePublicName());
+            RETURN_IF_EXCEPTION(scope, {});
+            if (code && code.toBoolean(globalObject)) {
+                auto codeStr = code.toWTFString(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                builder.append('[');
+                builder.append(codeStr);
+                builder.append("] "_s);
+            }
+
+            JSValue toStringFn = warning->get(globalObject, vm.propertyNames->toString);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (toStringFn.isCallable()) {
+                JSC::MarkedArgumentBuffer noArgs;
+                auto callData = JSC::getCallData(toStringFn);
+                JSValue result = JSC::call(globalObject, toStringFn, callData, warning, noArgs);
+                RETURN_IF_EXCEPTION(scope, {});
+                auto str = result.toWTFString(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                builder.append(str);
+            } else {
+                JSValue name = warning->get(globalObject, vm.propertyNames->name);
+                RETURN_IF_EXCEPTION(scope, {});
+                String nameStr;
+                if (name.isUndefined()) {
+                    nameStr = "Error"_s;
+                } else {
+                    nameStr = name.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+                JSValue message = warning->get(globalObject, vm.propertyNames->message);
+                RETURN_IF_EXCEPTION(scope, {});
+                String messageStr;
+                if (!message.isUndefined()) {
+                    messageStr = message.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+                if (nameStr.isEmpty()) {
+                    builder.append(messageStr);
+                } else if (messageStr.isEmpty()) {
+                    builder.append(nameStr);
+                } else {
+                    builder.append(nameStr);
+                    builder.append(": "_s);
+                    builder.append(messageStr);
+                }
+            }
+
+            JSValue detail = warning->getIfPropertyExists(globalObject, vm.propertyNames->detail);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (detail && detail.isString()) {
+                auto detailStr = detail.toWTFString(globalObject);
+                RETURN_IF_EXCEPTION(scope, {});
+                builder.append('\n');
+                builder.append(detailStr);
+            }
+        } else {
+            auto str = value.toWTFString(globalObject);
+            RETURN_IF_EXCEPTION(scope, {});
+            builder.append(str);
+        }
+
+        auto jsArgs = JSValue::encode(jsString(vm, builder.toString()));
         Bun__ConsoleObject__messageWithTypeAndLevel(reinterpret_cast<Bun::ConsoleObject*>(globalObject->consoleClient().get())->m_client, static_cast<uint32_t>(MessageType::Log), static_cast<uint32_t>(MessageLevel::Warning), globalObject, &jsArgs, 1);
         RETURN_IF_EXCEPTION(scope, {});
     }
@@ -2754,10 +2828,6 @@ static JSValue constructProcessChannel(VM& vm, JSObject* processObject)
         return jsUndefined();
     }
 }
-
-#if OS(WINDOWS)
-#define getpid _getpid
-#endif
 
 static JSValue constructPid(VM& vm, JSObject* processObject)
 {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1610,9 +1610,38 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitWarning, (JSC::JSGlobalObject * lexicalG
                 builder.append("] "_s);
             }
 
+            JSValue traceProcessWarnings = process->getIfPropertyExists(globalObject, Identifier::fromString(vm, "traceProcessWarnings"_s));
+            RETURN_IF_EXCEPTION(scope, {});
+            bool trace = traceProcessWarnings && traceProcessWarnings.toBoolean(globalObject);
+            if (!trace) {
+                JSValue warningName = warning->getIfPropertyExists(globalObject, vm.propertyNames->name);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (warningName && warningName.isString()) {
+                    auto warningNameStr = warningName.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                    if (warningNameStr == "DeprecationWarning"_s) {
+                        JSValue traceDeprecation = process->getIfPropertyExists(globalObject, Identifier::fromString(vm, "traceDeprecation"_s));
+                        RETURN_IF_EXCEPTION(scope, {});
+                        trace = traceDeprecation && traceDeprecation.toBoolean(globalObject);
+                    }
+                }
+            }
+
+            String stackStr;
+            if (trace) {
+                JSValue stack = warning->getIfPropertyExists(globalObject, vm.propertyNames->stack);
+                RETURN_IF_EXCEPTION(scope, {});
+                if (stack && stack.toBoolean(globalObject)) {
+                    stackStr = stack.toWTFString(globalObject);
+                    RETURN_IF_EXCEPTION(scope, {});
+                }
+            }
+
             JSValue toStringFn = warning->get(globalObject, vm.propertyNames->toString);
             RETURN_IF_EXCEPTION(scope, {});
-            if (toStringFn.isCallable()) {
+            if (!stackStr.isNull()) {
+                builder.append(stackStr);
+            } else if (toStringFn.isCallable()) {
                 JSC::MarkedArgumentBuffer noArgs;
                 auto callData = JSC::getCallData(toStringFn);
                 JSValue result = JSC::call(globalObject, toStringFn, callData, warning, noArgs);

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1244,7 +1244,7 @@ it("proxy env vars assigned at runtime propagate to spawned children via {...pro
   expect(got).toEqual({ HTTP_PROXY: "http://x:8080", HTTPS_PROXY: "http://y:8080", NO_PROXY: "z" });
 });
 
-describe("process.emitWarning default output", () => {
+describe.concurrent("process.emitWarning default output", () => {
   // https://github.com/oven-sh/bun/issues/9867
   it("includes detail on its own line", async () => {
     await using proc = Bun.spawn({
@@ -1340,6 +1340,56 @@ describe("process.emitWarning default output", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stdout).toBe("");
     expect(stderr.trim()).toMatch(/^\(bun:\d+\) Error: tostring test$/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("includes stack when process.traceProcessWarnings is truthy", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.traceProcessWarnings = true;
+        process.emitWarning("trace me", { code: "TRC", detail: "extra" });
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    const lines = stderr.trim().split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lines[0]).toMatch(/^\(bun:\d+\) \[TRC\] Warning: trace me$/);
+    expect(lines.at(-1)).toBe("extra");
+    // at least one stack frame between the header and the detail line
+    expect(lines.slice(1, -1).some(l => /^\s+at /.test(l))).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
+  it("includes stack for DeprecationWarning when process.traceDeprecation is truthy", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.traceDeprecation = true;
+        process.emitWarning("dep", "DeprecationWarning");
+        process.emitWarning("other", "OtherWarning");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    const lines = stderr.trim().split("\n");
+    expect(lines[0]).toMatch(/^\(bun:\d+\) DeprecationWarning: dep$/);
+    expect(lines.some(l => /^\s+at /.test(l))).toBe(true);
+    // traceDeprecation only affects DeprecationWarning
+    expect(lines.at(-1)).toMatch(/^\(bun:\d+\) OtherWarning: other$/);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1243,3 +1243,103 @@ it("proxy env vars assigned at runtime propagate to spawned children via {...pro
   const got = JSON.parse(child.stdout.toString().trim());
   expect(got).toEqual({ HTTP_PROXY: "http://x:8080", HTTPS_PROXY: "http://y:8080", NO_PROXY: "z" });
 });
+
+describe("process.emitWarning default output", () => {
+  // https://github.com/oven-sh/bun/issues/9867
+  it("includes detail on its own line", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `process.emitWarning("Warning!", { code: "CODE", detail: "Should do this..." });`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    const lines = stderr.trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toMatch(/^\(bun:\d+\) \[CODE\] Warning: Warning!$/);
+    expect(lines[1]).toBe("Should do this...");
+    expect(exitCode).toBe(0);
+  });
+
+  it("formats as (bun:<pid>) [<code>] <name>: <message>", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        process.emitWarning("msg only");
+        process.emitWarning("msg with type", "MyType");
+        process.emitWarning("msg with type and code", "MyType", "MY_CODE");
+        process.emitWarning("msg with options", { type: "MyType2", code: "C2", detail: "D2" });
+        const e = new Error("err with fields");
+        e.name = "CustomName";
+        e.code = "ECODE";
+        e.detail = "EDetail";
+        process.emitWarning(e);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    const normalized = stderr
+      .trim()
+      .split("\n")
+      .map(line => line.replace(/^\(bun:\d+\) /, "(bun:<pid>) "));
+    expect(normalized).toEqual([
+      "(bun:<pid>) Warning: msg only",
+      "(bun:<pid>) MyType: msg with type",
+      "(bun:<pid>) [MY_CODE] MyType: msg with type and code",
+      "(bun:<pid>) [C2] MyType2: msg with options",
+      "D2",
+      "(bun:<pid>) [ECODE] CustomName: err with fields",
+      "EDetail",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
+  it("omits detail when it is not a string", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const e = new Error("msg");
+        e.detail = 123;
+        process.emitWarning(e);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr.trim()).toMatch(/^\(bun:\d+\) Error: msg$/);
+    expect(exitCode).toBe(0);
+  });
+
+  it("falls back to Error.prototype.toString when toString is not a function", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const e = new Error("tostring test");
+        e.toString = 1;
+        process.emitWarning(e);
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout).toBe("");
+    expect(stderr.trim()).toMatch(/^\(bun:\d+\) Error: tostring test$/);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #9867.

```js
process.emitWarning("Warning!", {
    code: "CODE",
    detail: "Should do this..."
});
```

Before, Bun passed the warning `Error` instance straight to `console.warn`, which printed a generic inspected error with a stack trace and dropped the `detail`:

```
Warning: Warning!
 code: "CODE"

      at /tmp/emitwarn.js:1:9
```

Node.js prints:

```
(node:1126) [CODE] Warning: Warning!
Should do this...
```

### Cause

`jsFunction_emitWarning` in `BunProcess.cpp` (the nextTick callback that prints the warning when no user `'warning'` listener is installed) called `Bun__ConsoleObject__messageWithTypeAndLevel` with the error instance itself, relying on the generic error formatter which doesn't know about `detail`.

### Fix

Build the same formatted string Node's `onWarning` handler uses and print that instead:

```
(bun:<pid>) [<code>] <name>: <message>
<detail>
```

* `[<code>]` is only included when the warning's `code` is truthy.
* `<name>: <message>` comes from `warning.toString()`, falling back to `Error.prototype.toString` semantics when `toString` is not callable (Node's `test-process-warning.js` covers this case).
* `<detail>` is appended on its own line only when it is a string.

The `#define getpid _getpid` for Windows was moved up next to the existing `umask` define so the formatter can use `getpid()` regardless of platform.

## How did you verify your code works?

New tests in `test/js/node/process/process.test.js` spawn subprocesses and assert on stderr for:
* the reported `{ code, detail }` case
* every positional/options overload of `emitWarning` plus an `Error` instance with own `name`/`code`/`detail`
* `detail` being omitted when not a string
* the `Error.prototype.toString` fallback when `toString` is not a function

All four fail on main and pass with this change. The existing Node compat tests `test-process-warning.js` and `test-process-emitwarning.js` continue to pass.