### PR TITLE
Move `name` and `lastModified` from `Blob.prototype` to `File.prototype`

### DIFF
--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -2673,9 +2673,9 @@ declare module "bun" {
      *
      * @param begin - start offset in bytes
      * @param end - absolute offset in bytes (relative to 0)
-     * @param contentType - MIME type for the new BunFile
+     * @param contentType - MIME type for the new Blob
      */
-    slice(begin?: number, end?: number, contentType?: string): BunFile;
+    slice(begin?: number, end?: number, contentType?: string): Blob;
 
     /**
      * Offset any operation on the file starting at `begin`
@@ -2685,16 +2685,16 @@ declare module "bun" {
      * If `begin` > 0, {@link Bun.write}() is slower on macOS
      *
      * @param begin - start offset in bytes
-     * @param contentType - MIME type for the new BunFile
+     * @param contentType - MIME type for the new Blob
      */
-    slice(begin?: number, contentType?: string): BunFile;
+    slice(begin?: number, contentType?: string): Blob;
 
     /**
      * Slice the file from the beginning to the end, optionally with a new MIME type.
      *
-     * @param contentType - MIME type for the new BunFile
+     * @param contentType - MIME type for the new Blob
      */
-    slice(contentType?: string): BunFile;
+    slice(contentType?: string): Blob;
 
     /**
      * Incremental writer for files and pipes.

--- a/src/jsc/bindings/DOMFormData.cpp
+++ b/src/jsc/bindings/DOMFormData.cpp
@@ -99,7 +99,8 @@ void DOMFormData::append(const String& name, const String& value)
 
 void DOMFormData::append(const String& name, RefPtr<Blob> blob, const String& filename)
 {
-    blob->setFileName(replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
+    // A non-null fileName is what makes toJS(Blob&) wrap this entry as a File.
+    blob->setFileName(filename.isNull() ? emptyString() : replaceUnpairedSurrogatesWithReplacementCharacter(String(filename)));
     m_items.append({ replaceUnpairedSurrogatesWithReplacementCharacter(String(name)), blob });
 }
 void DOMFormData::remove(const StringView name)
@@ -148,7 +149,7 @@ void DOMFormData::set(const String& name, const String& value)
 
 void DOMFormData::set(const String& name, RefPtr<Blob> blob, const String& filename)
 {
-    blob->setFileName(filename);
+    blob->setFileName(filename.isNull() ? emptyString() : filename);
     set(name, { name, blob });
 }
 

--- a/src/jsc/bindings/JSDOMFile.cpp
+++ b/src/jsc/bindings/JSDOMFile.cpp
@@ -1,29 +1,131 @@
 #include "root.h"
 #include "ZigGeneratedClasses.h"
+#include "ZigGlobalObject.h"
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/FunctionPrototype.h>
+#include <JavaScriptCore/LazyClassStructure.h>
+#include <JavaScriptCore/LazyClassStructureInlines.h>
 #include "JSDOMFile.h"
 
 using namespace JSC;
 
 extern "C" SYSV_ABI void* JSDOMFile__construct(JSC::JSGlobalObject*, JSC::CallFrame* callframe);
-extern "C" SYSV_ABI bool JSDOMFile__hasInstance(EncodedJSValue, JSC::JSGlobalObject*, EncodedJSValue);
 
-// TODO: make this inehrit from JSBlob instead of InternalFunction
-// That will let us remove this hack for [Symbol.hasInstance] and fix the prototype chain.
-class JSDOMFile : public JSC::InternalFunction {
+extern "C" SYSV_ABI JSC::EncodedJSValue JSDOMFile__getName(void* ptr, JSC::EncodedJSValue thisValue, JSC::JSGlobalObject* globalObject);
+extern "C" SYSV_ABI bool JSDOMFile__setName(void* ptr, JSC::EncodedJSValue thisValue, JSC::JSGlobalObject* globalObject, JSC::EncodedJSValue value);
+extern "C" SYSV_ABI JSC::EncodedJSValue JSDOMFile__getLastModified(void* ptr, JSC::JSGlobalObject* globalObject);
+
+namespace Bun {
+
+JSC_DEFINE_CUSTOM_GETTER(domFilePrototype_nameGetter, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue encodedThisValue, PropertyName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* thisObject = dynamicDowncast<WebCore::JSBlob>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(jsUndefined());
+    }
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+
+    if (JSValue cachedValue = thisObject->m_name.get())
+        return JSValue::encode(cachedValue);
+
+    JSC::JSValue result = JSC::JSValue::decode(
+        JSDOMFile__getName(thisObject->wrapped(), encodedThisValue, lexicalGlobalObject));
+    RETURN_IF_EXCEPTION(throwScope, {});
+    thisObject->m_name.set(vm, thisObject, result);
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(result));
+}
+
+JSC_DEFINE_CUSTOM_SETTER(domFilePrototype_nameSetter, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue encodedThisValue, EncodedJSValue encodedValue, PropertyName attributeName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* thisObject = dynamicDowncast<WebCore::JSBlob>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        return false;
+    }
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+    bool result = JSDOMFile__setName(thisObject->wrapped(), encodedThisValue, lexicalGlobalObject, encodedValue);
+    RELEASE_AND_RETURN(throwScope, result);
+}
+
+JSC_DEFINE_CUSTOM_GETTER(domFilePrototype_lastModifiedGetter, (JSGlobalObject * lexicalGlobalObject, EncodedJSValue encodedThisValue, PropertyName))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+    auto* thisObject = dynamicDowncast<WebCore::JSBlob>(JSValue::decode(encodedThisValue));
+    if (!thisObject) [[unlikely]] {
+        return JSValue::encode(jsUndefined());
+    }
+    JSC::EnsureStillAliveScope thisArg = JSC::EnsureStillAliveScope(thisObject);
+    JSC::EncodedJSValue result = JSDOMFile__getLastModified(thisObject->wrapped(), lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(throwScope, {});
+    RELEASE_AND_RETURN(throwScope, result);
+}
+
+static const HashTableValue JSDOMFilePrototypeTableValues[] = {
+    { "name"_s, static_cast<unsigned>(PropertyAttribute::CustomAccessor | PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, domFilePrototype_nameGetter, domFilePrototype_nameSetter } },
+    { "lastModified"_s, static_cast<unsigned>(PropertyAttribute::ReadOnly | PropertyAttribute::CustomAccessor | PropertyAttribute::DOMAttribute | PropertyAttribute::DontDelete), NoIntrinsic, { HashTableValue::GetterSetterType, domFilePrototype_lastModifiedGetter, 0 } },
+};
+
+class JSDOMFilePrototype final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
+
+    static JSDOMFilePrototype* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure)
+    {
+        JSDOMFilePrototype* prototype = new (NotNull, JSC::allocateCell<JSDOMFilePrototype>(vm)) JSDOMFilePrototype(vm, structure);
+        prototype->finishCreation(vm, globalObject);
+        return prototype;
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        auto* structure = Bun::createClassStructure(vm, globalObject, prototype, TypeInfo(JSC::ObjectType, StructureFlags), info());
+        structure->setMayBePrototype(true);
+        return structure;
+    }
+
+    DECLARE_INFO;
+
+    template<typename CellType, JSC::SubspaceAccess>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(JSDOMFilePrototype, Base);
+        return &vm.plainObjectSpace();
+    }
+
+private:
+    JSDOMFilePrototype(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+    {
+        Base::finishCreation(vm);
+        Bun::reifyStaticPropertyTable(vm, WebCore::JSBlob::info(), JSDOMFilePrototypeTableValues, *this);
+        Bun::putToStringTagWithoutTransition(vm, this, info());
+    }
+};
+
+const JSC::ClassInfo JSDOMFilePrototype::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFilePrototype) };
+
+class JSDOMFileConstructor final : public JSC::InternalFunction {
     using Base = JSC::InternalFunction;
 
 public:
-    JSDOMFile(JSC::VM& vm, JSC::Structure* structure)
+    JSDOMFileConstructor(JSC::VM& vm, JSC::Structure* structure)
         : Base(vm, structure, call, construct)
     {
     }
 
     DECLARE_INFO;
 
-    static constexpr unsigned StructureFlags = (Base::StructureFlags & ~ImplementsDefaultHasInstance) | ImplementsHasInstance;
+    static constexpr unsigned StructureFlags = Base::StructureFlags;
 
     template<typename CellType, JSC::SubspaceAccess>
     static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
@@ -35,32 +137,13 @@ public:
         return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(InternalFunctionType, StructureFlags), info());
     }
 
-    void finishCreation(JSC::VM& vm)
-    {
-        Base::finishCreation(vm, 2, "File"_s);
-    }
-
-    static JSDOMFile* create(JSC::VM& vm, JSGlobalObject* globalObject)
+    static JSDOMFileConstructor* create(JSC::VM& vm, JSGlobalObject* globalObject, JSObject* prototype)
     {
         auto* zigGlobal = defaultGlobalObject(globalObject);
-        auto structure = createStructure(vm, globalObject, zigGlobal->functionPrototype());
-        auto* object = new (NotNull, JSC::allocateCell<JSDOMFile>(vm)) JSDOMFile(vm, structure);
-        object->finishCreation(vm);
-
-        // This is not quite right. But we'll fix it if someone files an issue about it.
-        object->putDirect(vm, vm.propertyNames->prototype, zigGlobal->JSBlobPrototype(), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);
-
+        auto* structure = createStructure(vm, globalObject, zigGlobal->JSBlobConstructor());
+        auto* object = new (NotNull, JSC::allocateCell<JSDOMFileConstructor>(vm)) JSDOMFileConstructor(vm, structure);
+        object->finishCreation(vm, prototype);
         return object;
-    }
-
-    static bool customHasInstance(JSObject* object, JSGlobalObject* globalObject, JSValue value)
-    {
-        if (!value.isObject())
-            return false;
-
-        // Note: this breaks [Symbol.hasInstance]
-        // We must do this for now until we update the code generator to export classes
-        return JSDOMFile__hasInstance(JSValue::encode(object), globalObject, JSValue::encode(value));
     }
 
     static JSC_HOST_CALL_ATTRIBUTES JSC::EncodedJSValue construct(JSGlobalObject* lexicalGlobalObject, CallFrame* callFrame)
@@ -70,13 +153,13 @@ public:
         auto scope = DECLARE_THROW_SCOPE(vm);
         JSObject* newTarget = asObject(callFrame->newTarget());
         auto* constructor = globalObject->JSDOMFileConstructor();
-        Structure* structure = globalObject->JSBlobStructure();
+        Structure* structure = globalObject->JSDOMFileStructure();
         if (constructor != newTarget) {
-            auto* functionGlobalObject = static_cast<Zig::GlobalObject*>(
+            auto* functionGlobalObject = defaultGlobalObject(
                 // ShadowRealm functions belong to a different global object.
                 getFunctionRealm(lexicalGlobalObject, newTarget));
             RETURN_IF_EXCEPTION(scope, {});
-            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSBlobStructure());
+            structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->JSDOMFileStructure());
             RETURN_IF_EXCEPTION(scope, {});
         }
 
@@ -97,15 +180,40 @@ public:
         throwTypeError(lexicalGlobalObject, scope, "Class constructor File cannot be invoked without 'new'"_s);
         return {};
     }
+
+private:
+    void finishCreation(JSC::VM& vm, JSObject* prototype)
+    {
+        Base::finishCreation(vm, 2, "File"_s);
+        putDirect(vm, vm.propertyNames->prototype, prototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly | 0);
+    }
 };
 
-const JSC::ClassInfo JSDOMFile::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFile) };
+const JSC::ClassInfo JSDOMFileConstructor::s_info = { "File"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSDOMFileConstructor) };
 
-namespace Bun {
-
-JSC::JSObject* createJSDOMFileConstructor(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
+void initJSDOMFileClassStructure(JSC::LazyClassStructure::Initializer& init)
 {
-    return JSDOMFile::create(vm, globalObject);
+    auto* zigGlobal = defaultGlobalObject(init.global);
+    auto* superPrototype = zigGlobal->JSBlobPrototype();
+    auto* protoStructure = JSDOMFilePrototype::createStructure(init.vm, init.global, superPrototype);
+    auto* prototype = JSDOMFilePrototype::create(init.vm, init.global, protoStructure);
+    auto* structure = WebCore::JSBlob::createStructure(init.vm, init.global, prototype);
+    auto* constructor = JSDOMFileConstructor::create(init.vm, init.global, prototype);
+    init.setPrototype(prototype);
+    init.setStructure(structure);
+    init.setConstructor(constructor);
 }
 
+extern "C" SYSV_ABI size_t Blob__estimatedSize(void* ptr);
+
+extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlobalObject* lexicalGlobalObject, void* ptr)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto& vm = JSC::getVM(globalObject);
+    auto* structure = globalObject->JSDOMFileStructure();
+    auto* instance = WebCore::JSBlob::create(vm, globalObject, structure, ptr);
+    vm.heap.reportExtraMemoryAllocated(instance, Blob__estimatedSize(ptr));
+    return JSValue::encode(instance);
 }
+
+} // namespace Bun

--- a/src/jsc/bindings/JSDOMFile.h
+++ b/src/jsc/bindings/JSDOMFile.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "root.h"
+#include <JavaScriptCore/LazyClassStructure.h>
 
 namespace Bun {
-JSC::JSObject* createJSDOMFileConstructor(JSC::VM&, JSC::JSGlobalObject*);
+void initJSDOMFileClassStructure(JSC::LazyClassStructure::Initializer&);
 }

--- a/src/jsc/bindings/JSS3File.cpp
+++ b/src/jsc/bindings/JSS3File.cpp
@@ -131,7 +131,7 @@ JSC::Structure* JSS3File::createStructure(JSC::JSGlobalObject* globalObject)
 {
     auto& vm = JSC::getVM(globalObject);
 
-    JSC::JSObject* superPrototype = defaultGlobalObject(globalObject)->JSBlobPrototype();
+    JSC::JSObject* superPrototype = defaultGlobalObject(globalObject)->JSDOMFileStructure()->storedPrototypeObject();
     auto* protoStructure = JSS3FilePrototype::createStructure(vm, globalObject, superPrototype);
     auto* prototype = JSS3FilePrototype::create(vm, globalObject, protoStructure);
     return Bun::createClassStructure(vm, globalObject, prototype, JSC::TypeInfo(static_cast<JSC::JSType>(0b11101110), StructureFlags), info(), NonArray);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1993,6 +1993,9 @@ void GlobalObject::finishCreation(VM& vm)
         { OBJECT_OFFSETOF(GlobalObject, m_JSDirentClassStructure), [](LazyClassStructure::Initializer& init) {
              Bun::initJSDirentClassStructure(init);
          } },
+        { OBJECT_OFFSETOF(GlobalObject, m_JSDOMFileClassStructure), [](LazyClassStructure::Initializer& init) {
+             Bun::initJSDOMFileClassStructure(init);
+         } },
         { OBJECT_OFFSETOF(GlobalObject, m_JSX509CertificateClassStructure), [](LazyClassStructure::Initializer& init) {
              setupX509CertificateClassStructure(init);
          } },
@@ -2362,10 +2365,6 @@ void GlobalObject::finishCreation(VM& vm)
     static const LazyPropertyInit<JSObject> lazyObjectInits[] = {
         { OBJECT_OFFSETOF(GlobalObject, m_JSAsymmetricKeyObjectPrototype), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
              setupAsymmetricKeyObjectPrototype(init);
-         } },
-        { OBJECT_OFFSETOF(GlobalObject, m_JSDOMFileConstructor), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
-             JSObject* fileConstructor = Bun::createJSDOMFileConstructor(init.vm, init.owner);
-             init.set(fileConstructor);
          } },
         { OBJECT_OFFSETOF(GlobalObject, m_cryptoObject), [](const LazyProperty<JSGlobalObject, JSObject>::Initializer& init) {
              JSC::JSGlobalObject* globalObject = init.owner;

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -540,6 +540,7 @@ public:
     V(public, LazyPropertyOfGlobalObject<Structure>, m_JSS3FileStructure)                                    \
     V(public, LazyPropertyOfGlobalObject<Structure>, m_S3ErrorStructure)                                     \
                                                                                                              \
+    V(public, JSC::LazyClassStructure, m_JSDOMFileClassStructure)                                            \
     V(public, JSC::LazyClassStructure, m_JSStatsClassStructure)                                              \
     V(public, JSC::LazyClassStructure, m_JSStatsBigIntClassStructure)                                        \
     V(public, JSC::LazyClassStructure, m_JSStatFSClassStructure)                                             \
@@ -643,7 +644,6 @@ public:
     V(private, LazyPropertyOfGlobalObject<Structure>, m_importMetaObjectStructure)                           \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_importMetaBakeObjectStructure)                       \
     V(private, LazyPropertyOfGlobalObject<Structure>, m_asyncBoundFunctionStructure)                         \
-    V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSDOMFileConstructor)                             \
     V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSMIMEParamsConstructor)                          \
     V(public, LazyPropertyOfGlobalObject<JSC::JSObject>, m_JSMIMETypeConstructor)                            \
                                                                                                              \
@@ -744,7 +744,8 @@ public:
     JSC::JSWeakMap* napiTypeTags() const { return m_napiTypeTags.getInitializedOnMainThread(this); }
 
     JSObject* cryptoObject() const { return m_cryptoObject.getInitializedOnMainThread(this); }
-    JSObject* JSDOMFileConstructor() const { return m_JSDOMFileConstructor.getInitializedOnMainThread(this); }
+    JSObject* JSDOMFileConstructor() const { return m_JSDOMFileClassStructure.constructorInitializedOnMainThread(this); }
+    Structure* JSDOMFileStructure() const { return m_JSDOMFileClassStructure.getInitializedOnMainThread(this); }
 
     JSMap* nodeWorkerEnvironmentData() { return m_nodeWorkerEnvironmentData.get(); }
     JSObject* nodeWorkerStdioPorts() { return m_nodeWorkerStdioPorts.get(); }

--- a/src/jsc/bindings/ZigGlobalObject.lut.txt
+++ b/src/jsc/bindings/ZigGlobalObject.lut.txt
@@ -25,7 +25,6 @@
   global                          GlobalObject_getGlobalThis                           PropertyCallback
 
   Bun                             GlobalObject::m_bunObject                            CellProperty|DontDelete|ReadOnly
-  File                            GlobalObject::m_JSDOMFileConstructor                 CellProperty
   crypto                          GlobalObject::m_cryptoObject                         CellProperty
   navigator                       GlobalObject::m_navigatorObject                      CellProperty
   performance                     GlobalObject::m_performanceObject                    CellProperty
@@ -36,6 +35,7 @@
   BuildError                      GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSBuildMessage]                       ClassStructure
   BuildMessage                    GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSBuildMessage]                       ClassStructure
   Crypto                          GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSCrypto]                             ClassStructure
+  File                            GlobalObject::m_JSDOMFileClassStructure              ClassStructure
   HTMLRewriter                    GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSHTMLRewriter]                       ClassStructure
   Request                         GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSRequest]                            ClassStructure
   ResolveError                    GlobalObject::m_generatedLazyClasses[Zig::GlobalObject::GeneratedLazyClassJSResolveMessage]                     ClassStructure

--- a/src/jsc/bindings/blob.cpp
+++ b/src/jsc/bindings/blob.cpp
@@ -2,24 +2,33 @@
 #include "ZigGeneratedClasses.h"
 
 extern "C" JSC::EncodedJSValue SYSV_ABI Blob__create(JSC::JSGlobalObject* globalObject, void* impl);
+extern "C" SYSV_ABI JSC::EncodedJSValue BUN__createJSDOMFileUnsafely(JSC::JSGlobalObject* globalObject, void* impl);
 extern "C" void Blob__setAsFile(void* impl, const BunString* filename);
 
 namespace WebCore {
 
 JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, WebCore::Blob& impl)
 {
-    BunString filename = Bun::toString(impl.fileName());
+    auto fileNameStr = impl.fileName();
+    // Null fileName (WebSocket blob payloads) stays a Blob; DOMFormData sets it.
+    if (fileNameStr.isNull()) {
+        return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    }
+    BunString filename = Bun::toString(fileNameStr);
     Blob__setAsFile(impl.impl(), &filename);
 
-    return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, Blob__dupe(impl.impl())));
+    return JSC::JSValue::decode(BUN__createJSDOMFileUnsafely(lexicalGlobalObject, Blob__dupe(impl.impl())));
 }
 
 JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<WebCore::Blob>&& impl)
 {
     auto fileNameStr = impl->fileName();
+    if (fileNameStr.isNull()) {
+        return JSC::JSValue::decode(Blob__create(lexicalGlobalObject, impl->impl()));
+    }
     BunString filename = Bun::toString(fileNameStr);
 
-    JSC::EncodedJSValue encoded = Blob__create(lexicalGlobalObject, impl->impl());
+    JSC::EncodedJSValue encoded = BUN__createJSDOMFileUnsafely(lexicalGlobalObject, impl->impl());
     JSBlob* blob = uncheckedDowncast<JSBlob>(JSC::JSValue::decode(encoded));
     Blob__setAsFile(blob->wrapped(), &filename);
 

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -2915,7 +2915,10 @@ mod stdio_stores {
         });
         let blob = Blob::new(Blob::init_with_store(store, global_this));
         // SAFETY: `Blob::new` heap-allocates; the JS wrapper takes ownership.
-        unsafe { (&*blob).to_js(global_this) }
+        let blob_ref = unsafe { &*blob };
+        // Bun.stdin/stdout/stderr are BunFile, so they get File.prototype.
+        blob_ref.is_jsdom_file.set(true);
+        blob_ref.to_js(global_this)
     }
 
     pub(super) fn stdin(global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/api/standalone_graph_jsc.rs
+++ b/src/runtime/api/standalone_graph_jsc.rs
@@ -43,6 +43,8 @@ fn template_blob(file: &File) -> NonNull<bun_standalone_graph::StandaloneModuleG
             is_all_ascii: IsAllAscii::default(),
         };
         let blob = Blob::default();
+        // Every dupe of the template is an embedded File.
+        blob.is_jsdom_file.set(true);
         if let Some(mime) = MimeType::by_extension_no_default(strings::trim_leading_char(
             bun_paths::extension(file.name),
             b'.',

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -129,7 +129,8 @@ pub use bun_jsc::webcore_types::{Blob, BlobContentType, ClosingState, MAX_SIZE, 
 /// 3: Added File name serialization for File objects (when is_jsdom_file is true)
 /// 4: Added the blob's `size` to file-backed stores so a sliced Bun.file()
 ///    keeps its window's end across structuredClone/postMessage
-const SERIALIZATION_VERSION: u8 = 4;
+/// 5: Bun.file() now writes is_jsdom_file=1; older file-backed payloads are promoted on read.
+const SERIALIZATION_VERSION: u8 = 5;
 
 pub use bun_jsc::generated::JSBlob as js;
 
@@ -1091,13 +1092,21 @@ impl BlobExt for Blob {
             }
         }
 
-        let show_name = (self.is_jsdom_file.get() && self.get_name_string().is_some())
-            || (!self.name.get().is_empty()
-                && self.store.get().is_some()
-                && matches!(
-                    self.store().expect("infallible: store present").data,
-                    store::Data::Bytes(_)
-                ));
+        let show_name = if self.is_s3() {
+            false
+        } else if self.needs_to_read_file() {
+            // Skip when it would just repeat the path in the FileRef header.
+            let name = self.name.get();
+            !name.is_empty() && !self.store_path().is_some_and(|path| name.eql_utf8(path))
+        } else {
+            (self.is_jsdom_file.get() && self.get_name_string().is_some())
+                || (!self.name.get().is_empty()
+                    && self.store.get().is_some()
+                    && matches!(
+                        self.store().expect("infallible: store present").data,
+                        store::Data::Bytes(_)
+                    ))
+        };
         if !self.is_s3()
             && (!self.content_type_slice().is_empty()
                 || self.offset.get() > 0
@@ -1941,6 +1950,9 @@ impl BlobExt for Blob {
         // This copies over the charset field
         // which is okay because this will only be a <= slice
         let blob = self.dupe();
+        // slice() returns a Blob even on a File.
+        blob.is_jsdom_file.set(false);
+        blob.last_modified.set(0.0);
         blob.offset.set(offset);
         blob.size.set(len);
 
@@ -2070,10 +2082,11 @@ impl BlobExt for Blob {
         None
     }
 
-    // TODO: Move this to a separate `File` object or BunFile
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match self.get_name_string() {
             Some(name) => name.to_js(global_this)?,
+            // File.name is a USVString, never undefined (e.g. Bun.file(fd)).
+            None if self.is_jsdom_file.get() => JSValue::js_empty_string(global_this),
             None => JSValue::UNDEFINED,
         })
     }
@@ -2114,7 +2127,6 @@ impl BlobExt for Blob {
         }
     }
 
-    // TODO: Move this to a separate `File` object or BunFile
     fn get_last_modified(&self, _: &JSGlobalObject) -> JSValue {
         if let Some(store) = self.store.get() {
             if matches!(store.data, store::Data::File(_)) {
@@ -2345,6 +2357,9 @@ impl BlobExt for Blob {
             }
             _ => {
                 blob = Blob::get::<false, true>(global_this, args[0])?;
+                // `Blob::get` may dupe() a single File part; this is still a Blob.
+                blob.is_jsdom_file.set(false);
+                blob.last_modified.set(0.0);
 
                 if args.len() > 1 {
                     let options = args[1];
@@ -3512,6 +3527,11 @@ impl BlobExt for Blob {
             return crate::webcore::s3_file::to_js_unchecked(global_object, this);
         }
 
+        // `is_jsdom_file` alone decides File.prototype vs Blob.prototype.
+        if self.is_jsdom_file.get() {
+            return dom_file_to_js_unchecked(global_object, this);
+        }
+
         js::to_js_unchecked(global_object, this)
     }
 
@@ -4105,6 +4125,11 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.content_type
             .set(BlobContentType::Owned(std::sync::Arc::from(content_type)));
         blob.content_type_was_set.set(content_type_was_set);
+    }
+
+    // Before v5 a file-backed store was always a Bun.file(); see SERIALIZATION_VERSION.
+    if version < 5 && blob.needs_to_read_file() {
+        blob.is_jsdom_file.set(true);
     }
 
     let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
@@ -5489,6 +5514,40 @@ fn write_bytes_to_file_fast<const NEEDS_OPEN: bool>(
 // JSDOMFile constructor
 // ──────────────────────────────────────────────────────────────────────────
 
+bun_jsc::jsc_abi_extern! {
+    // JSDOMFile.cpp. Like `Blob__create` but with the File structure; takes ownership of `blob`.
+    safe fn BUN__createJSDOMFileUnsafely(
+        global: &JSGlobalObject,
+        blob: *mut core::ffi::c_void,
+    ) -> JSValue;
+}
+
+pub fn dom_file_to_js_unchecked(global: &JSGlobalObject, this: *mut Blob) -> JSValue {
+    BUN__createJSDOMFileUnsafely(global, this.cast::<core::ffi::c_void>())
+}
+
+// C++ side declares these in JSDOMFile.cpp (File.prototype.name / .lastModified).
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn JSDOMFile__getName(this: &Blob, this_value: JSValue, global: &JSGlobalObject) -> JSValue {
+        bun_jsc::host_fn::host_fn_getter_this_shared(this, this_value, global, Blob::get_name)
+    }
+}
+
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn JSDOMFile__setName(this: &Blob, this_value: JSValue, global: &JSGlobalObject, value: JSValue) -> bool {
+        bun_jsc::host_fn::host_fn_setter_this_shared(this, this_value, global, value, Blob::set_name)
+    }
+}
+
+bun_jsc::jsc_host_abi! {
+    #[unsafe(no_mangle)]
+    pub unsafe fn JSDOMFile__getLastModified(this: &Blob, global: &JSGlobalObject) -> JSValue {
+        bun_jsc::host_fn::host_fn_getter_shared(this, global, Blob::get_last_modified)
+    }
+}
+
 // C++ side declares `extern "C" SYSV_ABI void* JSDOMFile__construct(...)` (JSDOMFile.cpp).
 bun_jsc::jsc_host_abi! {
     #[unsafe(no_mangle)]
@@ -5650,6 +5709,8 @@ pub(crate) fn construct_bun_file(
         }
     }
 
+    // BunFile exposes .name / .lastModified, which live on File.prototype.
+    blob.is_jsdom_file.set(true);
     let ptr = Blob::new(blob);
     // SAFETY: ptr was just produced by heap::alloc in Blob::new. Spelled
     // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the by-value
@@ -6692,24 +6753,6 @@ impl Internal {
             return b"text/plain;charset=utf-8"; // MimeType::TEXT
         }
         b"application/octet-stream" // MimeType::OTHER
-    }
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// JSDOMFile__hasInstance / FileOpener / FileCloser
-// ──────────────────────────────────────────────────────────────────────────
-
-// C++ side declares `extern "C" SYSV_ABI bool JSDOMFile__hasInstance(...)` (JSDOMFile.cpp).
-bun_jsc::jsc_host_abi! {
-    #[unsafe(no_mangle)]
-    pub unsafe fn JSDOMFile__hasInstance(
-        _a: JSValue,
-        _b: &JSGlobalObject,
-        value: JSValue,
-    ) -> bool {
-        jsc::mark_binding();
-        let Some(blob) = value.as_class_ref::<Blob>() else { return false };
-        blob.is_jsdom_file.get()
     }
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -1138,6 +1138,9 @@ impl Value {
                         let blob_ptr = Blob::new(new.use_());
                         // SAFETY: `Blob::new` returns a freshly heap-allocated *mut Blob.
                         let blob = unsafe { &mut *blob_ptr };
+                        // body.blob() returns a Blob even when the body was a File.
+                        blob.is_jsdom_file.set(false);
+                        blob.last_modified.set(0.0);
                         if let Some(fetch_headers) = headers {
                             // `headers` is a live C++ FetchHeaders handle;
                             // `FetchHeaders` is an opaque ZST FFI handle (S008) — safe deref.
@@ -2136,6 +2139,9 @@ pub(crate) trait BodyMixin: BodyOwnerJs + Sized {
         let blob_ptr = Blob::new(value.use_());
         // SAFETY: `Blob::new` returns a freshly heap-allocated, ref-counted Blob.
         let blob = unsafe { &mut *blob_ptr };
+        // body.blob() returns a Blob even when the body was a File.
+        blob.is_jsdom_file.set(false);
+        blob.last_modified.set(0.0);
         if blob.content_type().is_empty() {
             if let Some(fetch_headers) = BodyMixin::get_fetch_headers(self) {
                 // `fetch_headers` is a live C++ FetchHeaders handle;

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -88,7 +88,7 @@ impl ObjectURLRegistry {
     ) -> Option<JSValue> {
         let blob = Blob::new(self.resolve_and_dupe(pathname, global_object)?);
         // SAFETY: `Blob::new` returns a freshly-boxed heap pointer.
-        Some(unsafe { (*blob).to_js(global_object) })
+        Some(unsafe { &*blob }.to_js(global_object))
     }
 
     pub(crate) fn revoke(&self, pathname: &[u8]) {

--- a/src/runtime/webcore/response.classes.ts
+++ b/src/runtime/webcore/response.classes.ts
@@ -155,7 +155,8 @@ export default [
       storable: true,
     },
     estimatedSize: true,
-    values: ["stream"],
+    // `name` backs the File.prototype.name accessor in JSDOMFile.cpp.
+    values: ["stream", "name"],
     overridesToJS: true,
     proto: {
       text: { fn: "getText", async: true },
@@ -176,21 +177,6 @@ export default [
 
       type: {
         getter: "getType",
-      },
-
-      // TODO: Move this to a separate `File` object or BunFile
-      // This is *not* spec-compliant.
-      name: {
-        this: true,
-        cache: true,
-        getter: "getName",
-        setter: "setName",
-      },
-
-      // TODO: Move this to a separate `File` object or BunFile
-      // This is *not* spec-compliant.
-      lastModified: {
-        getter: "getLastModified",
       },
 
       // Non-standard, s3 + BunFile support

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -515,6 +515,14 @@ describe("bundler", () => {
         }
 
         if (Bun.embeddedFiles.length !== 3) throw "fail";
+        {
+          const f = Bun.file(createRequire(import.meta.url).resolve('./1.embed'));
+          if (!(f instanceof File)) throw "Bun.file() of embedded asset is not a File";
+          const cloned = structuredClone(f);
+          if (!(cloned instanceof File)) throw "structuredClone of embedded Bun.file() lost File.prototype";
+          if (typeof cloned.name !== "string") throw "structuredClone of embedded Bun.file() lost .name";
+          if (!Bun.inspect(f).startsWith("File")) throw "Bun.inspect of embedded Bun.file() does not start with File";
+        }
         if ((await Bun.file(createRequire(import.meta.url).resolve('./1.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(createRequire(import.meta.url).resolve('./2.embed')).text()).trim() !== "abcd") throw "fail";
         if ((await Bun.file(createRequire(import.meta.url).resolve('./foo.file')).text()).trim() !== "abcd") throw "fail";

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -110,6 +110,20 @@ it("Blob inspect", () => {
   expect(Bun.inspect(Bun.file(123))).toBe(`FileRef (fd: 123) {
   type: "application/octet-stream"
 }`);
+  // A cloned fd-backed file deserializes with an empty name; don't print it.
+  expect(Bun.inspect(structuredClone(Bun.file(123)))).toBe(Bun.inspect(Bun.file(123)));
+  // Reading .name caches it; the header already shows the path, so no name line.
+  const bunFile = Bun.file(tmpFile);
+  void bunFile.name;
+  expect(Bun.inspect(bunFile)).toBe(`FileRef ("${tmpFile}") {
+  type: "text/plain;charset=utf-8"
+}`);
+  // A File over a BunFile keeps the FileRef header but has its own name.
+  expect(
+    Bun.inspect(new File([bunFile], "custom.txt"))
+      .split("\n")
+      .slice(0, 3),
+  ).toEqual([`FileRef ("${tmpFile}") {`, `  name: "custom.txt",`, `  type: "text/plain;charset=utf-8",`]);
   expect(Bun.inspect(new Response(new Blob()))).toBe(`Response (0 KB) {
   ok: true,
   url: "",
@@ -734,10 +748,6 @@ describe("console.logging class displays names and extends", async () => {
 it("console.log on a Blob shows name", () => {
   const blob = new Blob(["foo"], { type: "text/plain" });
   expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  type: "text/plain;charset=utf-8"\n}');
-  blob.name = "bar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "bar",\n  type: "text/plain;charset=utf-8"\n}');
-  blob.name = "foobar";
-  expect(Bun.inspect(blob)).toBe('Blob (3 bytes) {\n  name: "foobar",\n  type: "text/plain;charset=utf-8"\n}');
 
   const file = new File(["foo"], "bar.txt", { type: "text/plain" });
   expect(Bun.inspect(file)).toBe(

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -249,6 +249,8 @@ test("new Blob('123') is NOT supported", async () => {
 });
 
 test("blob: can set name property #10178", () => {
+  // `name` is not an accessor on Blob.prototype (it lives on File.prototype),
+  // so assigning to it creates a plain own property, matching Node and browsers.
   const blob = new Blob([Buffer.from("Hello, World")]);
   // @ts-expect-error
   expect(blob.name).toBeUndefined();
@@ -259,7 +261,7 @@ test("blob: can set name property #10178", () => {
   // @ts-expect-error
   blob.name = 10;
   // @ts-expect-error
-  expect(blob.name).toBe("logo.svg");
+  expect(blob.name).toBe(10);
   Object.defineProperty(blob, "name", {
     value: 42,
     writable: false,
@@ -281,7 +283,7 @@ test("blob: can set name property #10178", () => {
   // @ts-expect-error
   myBlob.name = 10;
   // @ts-expect-error
-  expect(myBlob.name).toBe("logo.svg");
+  expect(myBlob.name).toBe(10);
   Object.defineProperty(myBlob, "name", {
     value: 42,
     writable: false,
@@ -300,6 +302,163 @@ test("blob: can set name property #10178", () => {
   expect(myOtherBlob.name).toBe("logo.svg");
   myOtherBlob.name = 10;
   expect(myOtherBlob.name).toBe(10);
+});
+
+// https://github.com/oven-sh/bun/issues/14257
+test("blob: can set lastModified property", () => {
+  // Like `name`, `lastModified` is not an accessor on Blob.prototype, so
+  // assigning to it creates an ordinary own data property, as in Node.
+  const blob = new Blob(["Hello, World"]);
+  // @ts-expect-error
+  expect(blob.lastModified).toBeUndefined();
+  // @ts-expect-error
+  blob.lastModified = 123;
+  expect(Object.getOwnPropertyDescriptor(blob, "lastModified")).toEqual({
+    value: 123,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+
+  // The exact shape reported in #14257: a Blob subclass assigning in its constructor.
+  class MyBlob extends Blob {
+    constructor(sources: Array<BinaryLike | Blob>, options?: BlobOptions) {
+      super(sources, options);
+      // @ts-expect-error
+      this.lastModified = 456;
+    }
+  }
+  const myBlob = new MyBlob(["foo"]);
+  // @ts-expect-error
+  expect(myBlob.lastModified).toBe(456);
+  // @ts-expect-error
+  myBlob.lastModified = 789;
+  // @ts-expect-error
+  expect(myBlob.lastModified).toBe(789);
+
+  // File.prototype.lastModified is a read-only accessor, so the same
+  // assignment on a File still throws in strict mode and changes nothing.
+  const file = new File(["foo"], "bar.txt", { lastModified: 100 });
+  expect(() => {
+    // @ts-expect-error
+    file.lastModified = 200;
+  }).toThrow(TypeError);
+  expect(file.lastModified).toBe(100);
+  expect(Object.getOwnPropertyDescriptor(File.prototype, "lastModified")!.set).toBeUndefined();
+});
+
+// https://github.com/oven-sh/bun/issues/20700
+// https://github.com/oven-sh/bun/issues/14257
+test("name and lastModified live on File.prototype, not Blob.prototype", () => {
+  expect("name" in new Blob()).toBe(false);
+  expect("lastModified" in new Blob()).toBe(false);
+  expect(Object.getOwnPropertyNames(Blob.prototype).sort()).not.toContain("name");
+  expect(Object.getOwnPropertyNames(Blob.prototype).sort()).not.toContain("lastModified");
+
+  expect(File.prototype).not.toBe(Blob.prototype);
+  expect(Object.getPrototypeOf(File.prototype)).toBe(Blob.prototype);
+  expect(Object.getOwnPropertyNames(File.prototype)).toContain("name");
+  expect(Object.getOwnPropertyNames(File.prototype)).toContain("lastModified");
+  expect(File.prototype.constructor).toBe(File);
+  expect(Object.getPrototypeOf(File)).toBe(Blob);
+
+  const file = new File(["foo"], "bar.txt");
+  expect("name" in file).toBe(true);
+  expect("lastModified" in file).toBe(true);
+  expect(file.name).toBe("bar.txt");
+  expect(typeof file.lastModified).toBe("number");
+  expect(Object.getPrototypeOf(file)).toBe(File.prototype);
+  expect(file.constructor).toBe(File);
+  expect(file instanceof File).toBe(true);
+  expect(file instanceof Blob).toBe(true);
+  expect(file[Symbol.toStringTag]).toBe("File");
+  expect(Object.prototype.toString.call(file)).toBe("[object File]");
+
+  expect(new Blob() instanceof File).toBe(false);
+
+  // Patching File.prototype must not leak onto plain Blobs.
+  try {
+    (File.prototype as any).__filePrototypePatch = 7;
+    expect((new Blob(["b"]) as any).__filePrototypePatch).toBeUndefined();
+    expect((new File(["x"], "n") as any).__filePrototypePatch).toBe(7);
+  } finally {
+    delete (File.prototype as any).__filePrototypePatch;
+  }
+
+  // File.prototype.slice() returns a plain Blob, not a File.
+  const slice = file.slice(0, 2);
+  expect(Object.getPrototypeOf(slice)).toBe(Blob.prototype);
+  expect(slice instanceof File).toBe(false);
+  expect("name" in slice).toBe(false);
+  expect(slice[Symbol.toStringTag]).toBe("Blob");
+
+  // structuredClone preserves File-ness.
+  const cloned = structuredClone(file);
+  expect(Object.getPrototypeOf(cloned)).toBe(File.prototype);
+  expect(cloned.constructor).toBe(File);
+  expect(cloned.name).toBe("bar.txt");
+  expect(Object.getPrototypeOf(structuredClone(new Blob(["x"])))).toBe(Blob.prototype);
+
+  // Bun.file() keeps its documented .name / .lastModified via File.prototype.
+  const bunFile = Bun.file(import.meta.path);
+  expect("name" in bunFile).toBe(true);
+  expect(bunFile.name).toBe(import.meta.path);
+  expect(typeof bunFile.lastModified).toBe("number");
+  expect(bunFile instanceof Blob).toBe(true);
+
+  // WebIDL: attribute getters throw TypeError on incompatible receivers.
+  const nameGet = Object.getOwnPropertyDescriptor(File.prototype, "name").get;
+  const lmGet = Object.getOwnPropertyDescriptor(File.prototype, "lastModified").get;
+  expect(() => nameGet.call({})).toThrow(TypeError);
+  expect(() => lmGet.call({})).toThrow(TypeError);
+  expect(nameGet.call(file)).toBe("bar.txt");
+});
+
+test("Body.blob() returns a plain Blob even when the body is a File", async () => {
+  const bodies = [new File(["hello"], "x.txt"), Bun.file(import.meta.path)];
+  for (const body of bodies) {
+    const result = await new Response(body).blob();
+    expect(Object.getPrototypeOf(result)).toBe(Blob.prototype);
+    expect(result instanceof File).toBe(false);
+    expect("name" in result).toBe(false);
+    expect(result[Symbol.toStringTag]).toBe("Blob");
+  }
+
+  // structuredClone of that result must also be a plain Blob.
+  const b = await new Response(new File(["hello"], "x.txt")).blob();
+  const cloned = structuredClone(b);
+  expect(Object.getPrototypeOf(cloned)).toBe(Blob.prototype);
+  expect(cloned instanceof File).toBe(false);
+  expect(Bun.inspect(b).startsWith("Blob")).toBe(true);
+});
+
+test("structuredClone of a file-backed plain Blob stays a Blob", async () => {
+  // These inputs share a Data::File store but have is_jsdom_file=false;
+  // the structured-clone round-trip must not promote them to File.prototype.
+  const bunFile = Bun.file(import.meta.path);
+  const inputs = [bunFile.slice(0, 5), new Blob([bunFile]), await new Response(bunFile).blob()];
+  for (const input of inputs) {
+    expect(Object.getPrototypeOf(input)).toBe(Blob.prototype);
+    const clone = structuredClone(input);
+    expect({
+      proto: Object.getPrototypeOf(clone) === Blob.prototype,
+      isFile: clone instanceof File,
+      hasName: "name" in clone,
+    }).toEqual({ proto: true, isFile: false, hasName: false });
+  }
+});
+
+test("File.prototype.constructor is set before the File global is touched", async () => {
+  // Bun.file() creates an instance with File.prototype before anything reads
+  // globalThis.File; .constructor must still resolve to File, not Blob.
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", `const c = Bun.file("/tmp/x").constructor; console.log(c.name, c === File);`],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "File true", exitCode: 0 });
 });
 
 test("#12894", () => {

--- a/test/js/web/html/FormData-multipart-serialization.test.ts
+++ b/test/js/web/html/FormData-multipart-serialization.test.ts
@@ -136,7 +136,7 @@ describe("multipart serialization (new Response(formData))", () => {
       ["dup", "first"],
       ["dup", "second"],
       ["unicode name ☺", "ünïcode välue 😊"],
-      ["blob", { file: true, name: undefined, type: "", text: "blob-bytes" }],
+      ["blob", { file: true, name: "", type: "", text: "blob-bytes" }],
       ["file", { file: true, name: "日本語ファイル名.html", type: "text/html;charset=utf-8", text: "<p>hi</p>" }],
     ]);
   });

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -37,8 +37,10 @@ describe("FormData", () => {
     const blob = new Blob(["bar"]);
     const formData = new FormData();
     formData.append("foo", blob);
+    // File.name is a USVString; a Blob appended without an explicit
+    // filename is wrapped in a File and currently reports the empty string.
     // @ts-expect-error
-    expect(formData.get("foo").name).toBeUndefined();
+    expect(formData.get("foo").name).toBe("");
     formData.append("foo2", new File([blob], "foo.txt"));
     // @ts-expect-error
     expect(formData.get("foo2").name).toBe("foo.txt");
@@ -52,11 +54,11 @@ describe("FormData", () => {
 
     let b1 = form.get("foo") as any;
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBe("");
 
     form.set("foo", b1, "foo.txt");
     expect(blob.name).toBeUndefined();
-    expect(b1.name).toBeUndefined();
+    expect(b1.name).toBe("");
 
     b1 = form.get("foo") as Blob;
     expect(blob.name).toBeUndefined();

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -778,4 +778,43 @@ describe("structuredClone with Blob and File", () => {
       expect(deltaMiB).toBeLessThan(isASAN ? 128 : 32);
     }, 30_000);
   });
+
+  describe("file-backed payloads written before serialization v5", () => {
+    // Before v5, Bun.file() serialized is_jsdom_file as 0 because the flag was
+    // only set by `new File()`; a 0 on a file-backed store therefore meant
+    // "Bun.file()" and must still come back as a File. From v5 on the byte is
+    // authoritative, so a slice() of a Bun.file() stays a Blob.
+    //
+    // The version byte immediately precedes the u64 offset field; locate the
+    // offset field the same way the crafted-payload tests above do.
+    const baseline = new Uint8Array(serialize(new Blob(["x"])));
+    const current = new Uint8Array(serialize(Bun.file(import.meta.path).slice(4)));
+    let versionIndex = -1;
+    for (let i = 1; i + 8 <= current.length; i++) {
+      if (current[i] === 4 && current.subarray(i + 1, i + 8).every(b => b === 0) && baseline[i] === 0) {
+        versionIndex = i - 1;
+        break;
+      }
+    }
+    if (versionIndex < 0) throw new Error("could not locate version byte in serialized blob");
+    if (current[versionIndex] !== 5) throw new Error(`expected serialization v5, found v${current[versionIndex]}`);
+
+    test("current payload of a Bun.file() slice stays a Blob", () => {
+      const blob = deserialize(current);
+      expect({ proto: Object.getPrototypeOf(blob), hasName: "name" in blob }).toEqual({
+        proto: Blob.prototype,
+        hasName: false,
+      });
+    });
+
+    test("v4 file-backed payload is promoted to a File", () => {
+      const legacy = current.slice();
+      legacy[versionIndex] = 4;
+      const file = deserialize(legacy);
+      expect({ proto: Object.getPrototypeOf(file), name: file.name }).toEqual({
+        proto: File.prototype,
+        name: import.meta.path,
+      });
+    });
+  });
 });

--- a/test/js/web/workers/worker_blob.test.ts
+++ b/test/js/web/workers/worker_blob.test.ts
@@ -129,6 +129,7 @@ test("Worker on a revoked blob still works", async () => {
 test("object URL created in one worker is usable and revocable across threads", async () => {
   using dir = tempDir("worker-object-url", {
     "main.mjs": `import { Worker, isMainThread, parentPort, workerData } from "node:worker_threads";
+      import { resolveObjectURL } from "node:buffer";
       if (isMainThread) {
         const a = new Worker(new URL(import.meta.url), { workerData: "a" });
         const b = new Worker(new URL(import.meta.url), { workerData: "b" });
@@ -156,7 +157,9 @@ test("object URL created in one worker is usable and revocable across threads", 
         parentPort.on("message", async urls => {
           let count = 0, ok = true;
           for (const url of urls) {
-            const blob = await (await fetch(url)).blob();
+            // Body.blob() returns a plain Blob; resolveObjectURL hands back the registered File.
+            const blob = resolveObjectURL(url);
+            ok &&= (await (await fetch(url)).text()) === "x";
             const o = {};
             o[blob.name] = 1; // use the name as a property key on this thread
             ok &&= blob.name.startsWith("nm");


### PR DESCRIPTION
## Repro

```js
"name" in new Blob()                                    // true   (expected false)
"lastModified" in new Blob()                            // true   (expected false)
File.prototype === Blob.prototype                       // true   (expected false)
Object.getPrototypeOf(File.prototype) === Blob.prototype // false  (expected true)
```

Per the [W3C File API](https://www.w3.org/TR/FileAPI/), `name` and `lastModified` belong on `File.prototype`, not `Blob.prototype`. Node, Deno, Firefox and Chrome all return `false` for `"name" in new Blob()`.

## Cause

`File` did not have its own prototype. `JSDOMFile.cpp` pointed `File.prototype` directly at the `JSBlobPrototype` object and used `JSBlobStructure()` for `new File()`:

```cpp
// This is not quite right. But we'll fix it if someone files an issue about it.
object->putDirect(vm, vm.propertyNames->prototype, zigGlobal->JSBlobPrototype(), ...);
```

Because there was no separate `File.prototype`, the `name` and `lastModified` accessors were placed on `Blob.prototype` in `response.classes.ts`.

## Fix

Add `JSDOMFilePrototype` (`[[Prototype]]` = `Blob.prototype`) carrying the `name`/`lastModified` accessors plus `Symbol.toStringTag = "File"`, and a cached `m_JSDOMFileStructure` on `ZigGlobalObject` that points instances at it. The File constructor's own `[[Prototype]]` is now the Blob constructor and `File.prototype.constructor === File`. The `Symbol.hasInstance` override on `File` is removed since the prototype chain now makes default `instanceof` work.

All File-producing paths route through the new structure: `new File()` and subclasses, `Bun.file()`, structuredClone of Files, FormData file entries (`WebCore::toJS`/`toJSNewlyCreated`). `S3File.prototype` now chains through `File.prototype` so `name`/`lastModified` remain reachable there. Instances remain `WebCore::JSBlob` cells; only the structure/prototype differs.

The `m_name` cached `WriteBarrier` stays on `JSBlob` (via the `values` list in the class definition) so the Rust-side name cache continues to work.

## Verification

```console
$ bun bd test test/js/web/fetch/blob.test.ts -t "name and lastModified"
(pass) name and lastModified live on File.prototype, not Blob.prototype
$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/blob.test.ts -t "name and lastModified"
(fail) name and lastModified live on File.prototype, not Blob.prototype
$ bun bd test test/js/web/fetch/blob.test.ts -t "can set lastModified"
(pass) blob: can set lastModified property
$ USE_SYSTEM_BUN=1 bun test test/js/web/fetch/blob.test.ts -t "can set lastModified"
(fail) blob: can set lastModified property
```

`blob: can set lastModified property` is the exact scenario from #14257 (assigning `lastModified` on a `Blob` and in a `Blob` subclass constructor now creates an own data property, as in Node; `File.prototype.lastModified` stays read-only).

Existing tests in `blob.test.ts`, `globals.test.js`, `FormData.test.ts`, `structured-clone.test.ts`, `blob-file-name-ownership.test.ts` pass.

Fixes #20700
Fixes #14257

## Relationship to #30328

#30328 is the PR landing the prototype split itself (`File.prototype` distinct from and inheriting `Blob.prototype`, `Symbol.toStringTag`, `constructor`, ordinary `instanceof`; it resolves #14102 and #25422). #32430 and #31656 were closed in its favor. #30328 keeps `name` and `lastModified` on `Blob.prototype` (while also defining them on `File.prototype`), so this PR stays open for removing them from `Blob.prototype` (#20700, #14257). The prototype plumbing here duplicates #30328 and will be dropped once that lands; what remains is the `response.classes.ts` change plus the question below. #32425 (a setter on `Blob.prototype.lastModified`) was closed as the narrower alternative to this.

Point for maintainers: once the accessors leave `Blob.prototype`, something has to keep the documented `Bun.file().name` / `.lastModified` working. This PR does that by having `Bun.file()`, `Bun.stdin`/`stdout`/`stderr`, embedded files and `S3File` inherit from `File.prototype`, which also makes `Bun.file(path) instanceof File` true (it is false today, and #30328 leaves it false). An alternative would be a separate BunFile prototype carrying those two accessors.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 16 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/web/structured-clone-blob-file.test.ts, test/js/web/html/FormData-multipart-serialization.test.ts, test/js/web/fetch/blob.test.ts, test/js/bun/util/inspect.test.js, test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->
