### PR TITLE
node:https: add addContext and other tls.Server methods to https.Server

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1622,6 +1622,16 @@ int us_socket_alpn_is_h2(struct us_socket_t *s) {
   return len == 2 && proto[0] == 'h' && proto[1] == '2';
 }
 
+/* Clears the per-domain userdata (uWS HttpRouter*) stored on a SNI SSL_CTX.
+ * App.h::removeServerName() deletes the router while live keep-alive
+ * connections may still hold a ref on this SSL_CTX via SSL_set_SSL_CTX();
+ * without clearing, the next request on such a connection would read the
+ * freed router through us_socket_server_name_userdata(). After clearing,
+ * HttpContext.h falls back to the default router. */
+void us_internal_ssl_ctx_clear_sni_userdata(struct ssl_ctx_st *p) {
+  if (p && us_sni_ex_idx >= 0) SSL_CTX_set_ex_data(p, us_sni_ex_idx, NULL);
+}
+
 /* ── Per-socket SSL attach/detach ────────────────────────────────────────── */
 
 void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2974,6 +2974,14 @@ int us_socket_server_name_reject_unauthorized(struct us_socket_t *s) {
   return us_ssl_ctx_reject_unauthorized(SSL_get_SSL_CTX(s_ssl(s)));
 }
 
+int us_socket_server_name_request_cert(struct us_socket_t *s) {
+  if (!s->ssl || us_ctx_sni_policy_ex_idx < 0) return 0;
+  SSL_CTX *ctx = SSL_get_SSL_CTX(s_ssl(s));
+  if (!ctx) return 0;
+  uintptr_t packed = (uintptr_t)SSL_CTX_get_ex_data(ctx, us_ctx_sni_policy_ex_idx);
+  return (packed & US_SNI_POLICY_REQUEST_CERT) != 0;
+}
+
 /* Extracts the host_name from the ClientHello's server_name extension.
  * Returns the length written to `out` (NUL-terminated), or 0 if absent /
  * malformed. BoringSSL does document SSL_get_servername as usable inside

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -561,6 +561,7 @@ void us_internal_ssl_ctx_unref(struct ssl_ctx_st *ssl_ctx);
 void us_ssl_ctx_enable_http2_alpn(struct ssl_ctx_st *ssl_ctx, int allow_http1);
 /* 1 iff the completed handshake on `s` negotiated ALPN "h2". */
 int us_socket_alpn_is_h2(us_socket_r s);
+void us_internal_ssl_ctx_clear_sni_userdata(struct ssl_ctx_st *ssl_ctx);
 long us_ssl_ctx_live_count(void);
 /* Appends the certificates in the PEM `content` to `ctx`'s trust store;
  * returns 0 when nothing could be added. */

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -440,6 +440,8 @@ void us_ssl_ctx_set_sni_policy(struct ssl_ctx_st *ctx, int request_cert,
  * client-certificate verification error. */
 int us_socket_server_name_reject_unauthorized(us_socket_r s);
 int us_ssl_ctx_reject_unauthorized(struct ssl_ctx_st *ctx);
+/* 1 iff the SNI-selected context for this connection requests a client certificate. */
+int us_socket_server_name_request_cert(us_socket_r s);
 /* Socket-level SNI resolver, for a server-side socket adopted into TLS with no
  * listen socket behind it. Same contract as the listener resolver: an owned
  * SSL_CTX ref or NULL; *abort_handshake 1 = drop silently, 2 = suspend. */

--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -192,6 +192,14 @@ public:
             });
             for (auto it = pendingServerNames.begin(); it != pendingServerNames.end(); ) {
                 if (it->hostname == hostname_pattern) {
+                    /* Live keep-alive connections accepted under this SNI
+                     * still hold a ref on it->ctx (via SSL_set_SSL_CTX in
+                     * sni_cb) and would read the freed router through
+                     * us_socket_server_name_userdata() on their next
+                     * request. Clear the ex_data slot so those connections
+                     * fall back to the default router instead of
+                     * dereferencing freed memory. */
+                    us_internal_ssl_ctx_clear_sni_userdata(it->ctx);
                     us_internal_ssl_ctx_unref(it->ctx);
                     delete it->router;
                     it = pendingServerNames.erase(it);

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -169,8 +169,11 @@ private:
              * report _secureEstablished = false. Peer-cert authorization is
              * surfaced separately (rejectUnauthorized above / tls.authorized). */
             httpResponseData->isAuthorized = success;
-            httpResponseData->peerCertVerified = success && verify_error.error == 0;
-            httpResponseData->peerCertVerifyErrorCode = verify_error.code;
+            /* Like node, a connection that was not asked for a client certificate
+             * reports authorized = false and no authorizationError. */
+            bool requestCert = httpContextData->flags.requestCert || us_socket_server_name_request_cert(s);
+            httpResponseData->peerCertVerified = requestCert && success && verify_error.error == 0;
+            httpResponseData->peerCertVerifyErrorCode = requestCert ? verify_error.code : nullptr;
 
             /* Any connected socket should timeout until it has a request */
             ((HttpResponse<SSL> *) s)->resetTimeout();
@@ -976,6 +979,7 @@ public:
     static HttpContext *create(Loop *loop, bool requestCert = false, bool rejectUnauthorized = false) {
         HttpContext *httpContext = new HttpContext;
         us_socket_group_init(&httpContext->group, (us_loop_t *) loop, &httpVTable<false>, httpContext);
+        httpContext->data.flags.requestCert = requestCert;
         if (requestCert && rejectUnauthorized) {
             httpContext->data.flags.rejectUnauthorized = true;
         }

--- a/packages/bun-uws/src/HttpContextData.h
+++ b/packages/bun-uws/src/HttpContextData.h
@@ -30,6 +30,7 @@ struct Http2Context;
 
 struct HttpFlags {
     bool isParsingHttp: 1 = false;
+    bool requestCert: 1 = false;
     bool rejectUnauthorized: 1 = false;
     bool usingCustomExpectHandler: 1 = false;
     bool requireHostHeader: 1 = true;

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -40,6 +40,7 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
+const kSNIContexts = Symbol("sniContexts");
 
 export const enum NodeHTTPResponseAbortEvent {
   none = 0,
@@ -514,6 +515,7 @@ export {
   kProxyConfig,
   kRealListen,
   kRequest,
+  kSNIContexts,
   kWaitForProxyTunnel,
   noBodySymbol,
   onDataIncomingMessage,

--- a/src/js/internal/tls.ts
+++ b/src/js/internal/tls.ts
@@ -1,4 +1,5 @@
-const { isTypedArray, isArrayBuffer } = require("node:util/types");
+const { isTypedArray, isArrayBuffer, isArrayBufferView } = require("node:util/types");
+const { validateInt32, validateString } = require("internal/validators");
 
 function isPemObject(obj: unknown): obj is { pem: unknown } {
   return $isObject(obj) && "pem" in obj;
@@ -53,6 +54,202 @@ function isValidTLSArray(obj: unknown) {
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/secure-context.js#L74-L87
 const VALID_TLS_ERROR_MESSAGE_TYPES = "string or an instance of Buffer, TypedArray, or DataView";
 
+const SSL_OP_CIPHER_SERVER_PREFERENCE = 0x00400000;
+
+const StringPrototypeSplit = String.prototype.split;
+const StringPrototypeIncludes = String.prototype.includes;
+const StringPrototypeStartsWith = String.prototype.startsWith;
+const StringPrototypeCharCodeAt = String.prototype.charCodeAt;
+const ArrayPrototypeFilter = Array.prototype.filter;
+const ArrayPrototypeJoin = Array.prototype.join;
+const ArrayPrototypeMap = Array.prototype.map;
+const ArrayPrototypeSome = Array.prototype.some;
+
+let _VALID_CIPHERS_SET: Set<string> | undefined;
+function getValidCiphersSet() {
+  if (!_VALID_CIPHERS_SET) {
+    _VALID_CIPHERS_SET = new Set([
+      "DES-CBC3-SHA",
+      "AES128-SHA",
+      "AES256-SHA",
+      "PSK-AES128-CBC-SHA",
+      "PSK-AES256-CBC-SHA",
+      "AES128-GCM-SHA256",
+      "AES256-GCM-SHA384",
+      "ECDHE-ECDSA-AES128-SHA",
+      "ECDHE-ECDSA-AES256-SHA",
+      "ECDHE-RSA-AES128-SHA",
+      "ECDHE-RSA-AES256-SHA",
+      "ECDHE-ECDSA-AES128-SHA256",
+      "ECDHE-RSA-AES128-SHA256",
+      "ECDHE-ECDSA-AES128-GCM-SHA256",
+      "ECDHE-ECDSA-AES256-GCM-SHA384",
+      "ECDHE-RSA-AES128-GCM-SHA256",
+      "ECDHE-RSA-AES256-GCM-SHA384",
+      "ECDHE-PSK-AES128-CBC-SHA",
+      "ECDHE-PSK-AES256-CBC-SHA",
+      "ECDHE-RSA-CHACHA20-POLY1305",
+      "ECDHE-ECDSA-CHACHA20-POLY1305",
+      "ECDHE-PSK-CHACHA20-POLY1305",
+    ]);
+  }
+  return _VALID_CIPHERS_SET;
+}
+
+// OpenSSL cipher-list selector keywords that are not literal suite names.
+let _CIPHER_LIST_SELECTORS: Set<string> | undefined;
+function getCipherListSelectors() {
+  if (!_CIPHER_LIST_SELECTORS) {
+    _CIPHER_LIST_SELECTORS = new Set([
+      "DEFAULT",
+      "ALL",
+      "COMPLEMENTOFDEFAULT",
+      "COMPLEMENTOFALL",
+      "HIGH",
+      "MEDIUM",
+      "LOW",
+      "PSK",
+      "aNULL",
+      "eNULL",
+      "NULL",
+      "EXPORT",
+      "EXP",
+      "kRSA",
+      "aRSA",
+      "RSA",
+      "kDHE",
+      "kEDH",
+      "DH",
+      "DHE",
+      "EDH",
+      "kECDHE",
+      "kEECDH",
+      "ECDHE",
+      "EECDH",
+      "ECDH",
+      "aECDSA",
+      "ECDSA",
+      "aDSS",
+      "DSS",
+      "kPSK",
+      "aPSK",
+      "AES",
+      "AES128",
+      "AES256",
+      "AESGCM",
+      "AESCCM",
+      "CHACHA20",
+      "3DES",
+      "DES",
+      "RC4",
+      "RC2",
+      "MD5",
+      "SHA",
+      "SHA1",
+      "SHA256",
+      "SHA384",
+      "CAMELLIA",
+      "ARIA",
+      "SRP",
+      "TLSv1",
+      "TLSv1.0",
+      "TLSv1.2",
+      "TLSv1.3",
+      "SSLv3",
+      "FIPS",
+    ]);
+  }
+  return _CIPHER_LIST_SELECTORS;
+}
+
+// The SSL_CTX is only built at listen()/connect() time, so the list is checked up front the way BoringSSL would.
+function validateCiphers(ciphers: string, name: string = "options") {
+  if (ciphers !== undefined && ciphers !== null) {
+    validateString(ciphers, `${name}.ciphers`);
+
+    const ciphersSet = getValidCiphersSet();
+    const requested = StringPrototypeSplit.$call(ciphers, ":");
+    let sawLegacyEntry = false;
+    let sawUsableEntry = false;
+    for (const r of requested) {
+      if (!r) continue;
+      // BoringSSL has no security levels: its cipher parser rejects
+      // @SECLEVEL with INVALID_COMMAND. Report that the way the native
+      // parser would, with Node's decomposed error shape.
+      if (StringPrototypeIncludes.$call(r, "@SECLEVEL")) {
+        const err = new Error("error:0f000076:SSL routines:OPENSSL_internal:INVALID_COMMAND") as Error & {
+          code: string;
+          library: string;
+          function: string;
+          reason: string;
+        };
+        err.code = "ERR_SSL_INVALID_COMMAND";
+        err.library = "SSL routines";
+        err.function = "OPENSSL_internal";
+        err.reason = "INVALID_COMMAND";
+        throw err;
+      }
+      if (StringPrototypeStartsWith.$call(r, "TLS_")) continue;
+      sawLegacyEntry = true;
+      // OpenSSL cipher-list grammar: `!X`/`-X`/`+X` operators, `A+B`
+      // intersections, `@STRENGTH` directives and selector keywords
+      // (HIGH, PSK, aNULL, ...) are not literal cipher names — leave their
+      // evaluation to BoringSSL and assume they can contribute matches.
+      const first = StringPrototypeCharCodeAt.$call(r, 0);
+      if (
+        first === 0x21 /* ! */ ||
+        first === 0x2d /* - */ ||
+        first === 0x2b /* + */ ||
+        first === 0x40 /* @ */ ||
+        StringPrototypeIncludes.$call(r, "+") ||
+        getCipherListSelectors().has(r) ||
+        ciphersSet.has(r)
+      ) {
+        sawUsableEntry = true;
+      }
+    }
+    if (sawLegacyEntry && !sawUsableEntry) {
+      throw $ERR_SSL_NO_CIPHER_MATCH();
+    }
+  }
+}
+
+function tlsCipherFilter(a: string) {
+  return !StringPrototypeStartsWith.$call(a, "TLS_");
+}
+
+// Node's processCiphers splits into cipherList (<=1.2) and cipherSuites (1.3);
+// when only 1.3 suites were given it forces minVersion = TLSv1.3 so the empty
+// 1.2 list does not leave the handshake with nothing to offer:
+// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/internal/tls/secure-context.js#L117
+function stripTls13CipherNames(ciphers: string): { cipherList: string; tls13Only: boolean } {
+  if (!StringPrototypeIncludes.$call(ciphers, "TLS_")) return { cipherList: ciphers, tls13Only: false };
+  const parts = StringPrototypeSplit.$call(ciphers, ":");
+  const kept = ArrayPrototypeFilter.$call(parts, tlsCipherFilter);
+  const cipherList = ArrayPrototypeJoin.$call(kept, ":");
+  return { cipherList, tls13Only: cipherList === "" && kept.length !== parts.length };
+}
+
+// Process-wide fallbacks behind tls.DEFAULT_* and setDefaultCACertificates(); `ca` is undefined until one is installed.
+const tlsDefaults: { minVersion: string; maxVersion: string; ecdhCurve: string; ca: Array<string> | undefined } = {
+  minVersion: "TLSv1.2",
+  maxVersion: "TLSv1.3",
+  ecdhCurve: "auto",
+  ca: undefined,
+};
+
+// Seeded from Node's --tls-{min,max}-vX.Y flags like Node does: the lowest minimum and highest maximum given win.
+{
+  const execArgv = process.execArgv;
+  const hasFlag = (flag: string) => execArgv.includes(flag);
+  if (hasFlag("--tls-min-v1.0")) tlsDefaults.minVersion = "TLSv1";
+  else if (hasFlag("--tls-min-v1.1")) tlsDefaults.minVersion = "TLSv1.1";
+  else if (hasFlag("--tls-min-v1.2")) tlsDefaults.minVersion = "TLSv1.2";
+  else if (hasFlag("--tls-min-v1.3")) tlsDefaults.minVersion = "TLSv1.3";
+  if (hasFlag("--tls-max-v1.3")) tlsDefaults.maxVersion = "TLSv1.3";
+  else if (hasFlag("--tls-max-v1.2")) tlsDefaults.maxVersion = "TLSv1.2";
+}
+
 // BoringSSL TLS1_x_VERSION constants (from openssl/tls1.h). The native TLS
 // config applies these via SSL_CTX_set_min/max_proto_version.
 const TLS1_VERSION = 0x0301;
@@ -72,6 +269,14 @@ function tlsStringToProtocolVersion(v) {
     default:
       return 0;
   }
+}
+
+const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
+function validateProtocolVersions(minVersion, maxVersion) {
+  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
+  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
+    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
 }
 
 // Matches Node: SSLv2/SSLv3 methods are disabled, anything unrecognized is an
@@ -135,6 +340,31 @@ function secureProtocolToVersionRange(secureProtocol) {
   return null;
 }
 
+function hasPemObject(key) {
+  if (!key) return false;
+  if ($isArray(key)) return ArrayPrototypeSome.$call(key, isPemKeyEntry);
+  return isPemKeyEntry(key);
+}
+
+function isPemKeyEntry(k) {
+  return k && typeof k === "object" && !isArrayBufferView(k) && "pem" in k;
+}
+
+function normalizePemKeyOption(key, ctxPassphrase) {
+  if (!key || !hasPemObject(key)) return key;
+  const entries = $isArray(key) ? key : [key];
+  return ArrayPrototypeMap.$call(entries, k => {
+    if (!isPemKeyEntry(k)) return k;
+    // Node: val?.passphrase !== undefined ? val.passphrase : passphrase - an
+    // explicit per-key null means "no passphrase for this key" and does NOT
+    // fall back to the context-level one.
+    const passphrase = k.passphrase !== undefined ? k.passphrase : ctxPassphrase;
+    if (passphrase == null) return k.pem;
+    const { createPrivateKey } = require("node:crypto");
+    return createPrivateKey({ key: k.pem, passphrase }).export({ type: "pkcs8", format: "pem" });
+  });
+}
+
 let NativeSecureContext;
 
 /**
@@ -178,10 +408,127 @@ function processPfxOptions(options) {
   return out;
 }
 
+// Node.js only requests a client certificate when `requestCert: true`.
+// The uSockets SSL context treats `ca` alone as "verify peer", so without
+// these two flags an `https.Server({ ca })` would reject every client that
+// doesn't present a cert. Mirror tls.Server (net.ts): default `requestCert`
+// to false and, when not requesting, force `rejectUnauthorized` to false so
+// the CA is loaded into the trust store without requiring a client cert.
+function normalizeServerTls(tls) {
+  const requestCert = !!tls.requestCert;
+  tls.requestCert = requestCert;
+  tls.rejectUnauthorized = requestCert ? tls.rejectUnauthorized !== false : false;
+  return tls;
+}
+
+/**
+ * Turns the TLS options Node's http.Server / https.Server accept (in the
+ * constructor, `setSecureContext()` and `addContext()`) into the `tls` object
+ * handed to `Bun.serve`. Every option is validated before anything is built,
+ * so a throw leaves the caller's current config untouched.
+ */
+function serverTlsFromOptions(options) {
+  const tlsOptions = options.pfx ? processPfxOptions(options) : options;
+
+  const cert = tlsOptions.cert;
+  if (cert) throwOnInvalidTLSArray("options.cert", cert);
+
+  const key = tlsOptions.key;
+  if (key) throwOnInvalidTLSArray("options.key", key);
+
+  let ca = tlsOptions.ca;
+  if (ca) throwOnInvalidTLSArray("options.ca", ca);
+  else if (ca == null) ca = tlsDefaults.ca;
+  // PKCS#12-embedded CAs extend the trust set; the server path hands raw
+  // {key, cert, ca} to the native config and has no addCACert hook, so fold
+  // them into `ca` (mirrors tls.Server.setSecureContext).
+  const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
+  if (pfxExtraCAs?.length) {
+    ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
+  }
+
+  const passphrase = options.passphrase;
+  if (passphrase && typeof passphrase !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  }
+
+  const serverName = options.servername;
+  if (serverName && typeof serverName !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
+  }
+
+  let secureOptions = options.secureOptions || 0;
+  if (secureOptions && typeof secureOptions !== "number") {
+    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
+  }
+  // Servers prefer their own cipher order unless told otherwise, as in Node.
+  if (options.honorCipherOrder !== false) secureOptions |= SSL_OP_CIPHER_SERVER_PREFERENCE;
+
+  // Same checks as tls.Server#setSecureContext() for the options it shares.
+  const crl = options.crl;
+  if (crl) throwOnInvalidTLSArray("options.crl", crl);
+  const sigalgs = options.sigalgs;
+  if (sigalgs != null) {
+    validateString(sigalgs, "options.sigalgs");
+    if (sigalgs === "") throw $ERR_INVALID_ARG_VALUE("options.sigalgs", sigalgs);
+  }
+  const ecdhCurve = options.ecdhCurve;
+  if (ecdhCurve !== undefined) validateString(ecdhCurve, "options.ecdhCurve");
+  const sessionTimeout = options.sessionTimeout;
+  if (sessionTimeout != null) validateInt32(sessionTimeout, "options.sessionTimeout", 0);
+  let ciphers = options.ciphers || undefined;
+  let tls13CiphersOnly = false;
+  if (ciphers !== undefined) {
+    validateCiphers(ciphers);
+    ({ cipherList: ciphers, tls13Only: tls13CiphersOnly } = stripTls13CipherNames(ciphers));
+  }
+
+  // secureProtocol wins over minVersion/maxVersion, as in Node; the native layer reads integers, 0 = its default.
+  validateSecureProtocol(options.secureProtocol);
+  validateProtocolVersions(options.minVersion, options.maxVersion);
+  let minVersion, maxVersion;
+  const range = secureProtocolToVersionRange(options.secureProtocol);
+  if (range) {
+    minVersion = range[0];
+    maxVersion = range[1];
+  } else {
+    minVersion = tls13CiphersOnly
+      ? TLS1_3_VERSION
+      : tlsStringToProtocolVersion(options.minVersion ?? tlsDefaults.minVersion);
+    maxVersion = tlsStringToProtocolVersion(options.maxVersion ?? tlsDefaults.maxVersion);
+  }
+  return normalizeServerTls({
+    serverName,
+    key: normalizePemKeyOption(key, passphrase),
+    cert,
+    ca,
+    passphrase,
+    secureOptions,
+    minVersion,
+    maxVersion,
+    ciphers,
+    crl,
+    sigalgs,
+    ecdhCurve: ecdhCurve ?? tlsDefaults.ecdhCurve,
+    sessionTimeout: sessionTimeout ?? 0,
+    allowPartialTrustChain: !!options.allowPartialTrustChain,
+    requestCert: options.requestCert,
+    rejectUnauthorized: options.rejectUnauthorized,
+  });
+}
+
 export {
+  SSL_OP_CIPHER_SERVER_PREFERENCE,
+  normalizePemKeyOption,
+  normalizeServerTls,
   processPfxOptions,
   secureProtocolToVersionRange,
+  serverTlsFromOptions,
+  stripTls13CipherNames,
   throwOnInvalidTLSArray,
+  tlsDefaults,
   tlsStringToProtocolVersion,
+  validateCiphers,
+  validateProtocolVersions,
   validateSecureProtocol,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1769,18 +1769,14 @@ function getNodeHTTPServerSocket() {
       return typeof name === "string" && name.length > 0 ? name : false;
     }
 
-    // Like Node's server-side TLSSocket: `authorized` is only ever true when the
-    // server requested a client certificate and its verification succeeded;
-    // `authorizationError` carries the X.509 verification error code otherwise.
+    // Like Node: false / null unless the context this connection was accepted under requested a client certificate.
     get authorized() {
       if (!this.encrypted) return undefined;
-      if (!this.server?.[tlsSymbol]?.requestCert) return false;
       return this[kHandle]?.peerCertVerified === true;
     }
 
     get authorizationError() {
       if (!this.encrypted) return undefined;
-      if (!this.server?.[tlsSymbol]?.requestCert) return null;
       return this[kHandle]?.authorizationError ?? null;
     }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -235,19 +235,6 @@ function emitListenErrorNextTick(self, err) {
   self.emit("error", err);
 }
 
-// Node.js only requests a client certificate when `requestCert: true`.
-// The uSockets SSL context treats `ca` alone as "verify peer", so without
-// these two flags an `https.Server({ ca })` would reject every client that
-// doesn't present a cert. Mirror tls.Server (net.ts): default `requestCert`
-// to false and, when not requesting, force `rejectUnauthorized` to false so
-// the CA is loaded into the trust store without requiring a client cert.
-function normalizeServerTls(tls) {
-  const requestCert = !!tls.requestCert;
-  tls.requestCert = requestCert;
-  tls.rejectUnauthorized = requestCert ? tls.rejectUnauthorized !== false : false;
-  return tls;
-}
-
 // Node registers connectionListener on every http.Server so `server.emit("connection", socket)`
 // works for foreign Duplex sockets. The native listener handles its own sockets end to end;
 // this picks up the rest. https://github.com/nodejs/node/blob/main/lib/_http_server.js
@@ -289,86 +276,12 @@ function Server(options, callback): void {
   } else {
     validateObject(options, "options");
     options = { ...options };
-    const tlsHelpers = options.pfx || options.cert || options.key || options.ca ? require("internal/tls") : undefined;
 
-    // Node's https.Server accepts PKCS#12 bundles (pfx [+ passphrase]); fold
-    // them into plain key/cert/ca so the native TLS config sees PEM material.
-    let tlsOptions = options;
-    if (options.pfx) {
-      tlsOptions = tlsHelpers.processPfxOptions(options);
-      this[isTlsSymbol] = true;
-    }
-
-    let cert = tlsOptions.cert;
-    if (cert) {
-      tlsHelpers.throwOnInvalidTLSArray("options.cert", cert);
-      this[isTlsSymbol] = true;
-    }
-
-    let key = tlsOptions.key;
-    if (key) {
-      tlsHelpers.throwOnInvalidTLSArray("options.key", key);
-      this[isTlsSymbol] = true;
-    }
-
-    let ca = tlsOptions.ca;
-    // PKCS#12-embedded CAs extend the trust set; the server path hands raw
-    // {key, cert, ca} to the native config and has no addCACert hook, so fold
-    // them into `ca` (mirrors tls.Server.setSecureContext).
-    const pfxExtraCAs = tlsOptions._pfxExtraCACerts;
-    if (pfxExtraCAs?.length) {
-      ca = ca == null ? pfxExtraCAs : $isArray(ca) ? [...ca, ...pfxExtraCAs] : [ca, ...pfxExtraCAs];
-    }
-    if (ca) {
-      tlsHelpers.throwOnInvalidTLSArray("options.ca", ca);
-      this[isTlsSymbol] = true;
-    }
-
-    let passphrase = options.passphrase;
-    if (passphrase && typeof passphrase !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
-    }
-
-    let serverName = options.servername;
-    if (serverName && typeof serverName !== "string") {
-      throw $ERR_INVALID_ARG_TYPE("options.servername", "string", serverName);
-    }
-
-    let secureOptions = options.secureOptions || 0;
-    if (secureOptions && typeof secureOptions !== "number") {
-      throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
-    }
-
-    if (this[isTlsSymbol]) {
-      const { validateSecureProtocol, secureProtocolToVersionRange, tlsStringToProtocolVersion } = tlsHelpers;
-      // Translate minVersion/maxVersion/secureProtocol into the integer
-      // protocol range the native layer applies (secureProtocol wins, like
-      // Node's SecureContext::Init); 0 keeps the native defaults.
-      validateSecureProtocol(options.secureProtocol);
-      let minVersion, maxVersion;
-      const range = secureProtocolToVersionRange(options.secureProtocol);
-      if (range) {
-        minVersion = range[0];
-        maxVersion = range[1];
-      } else {
-        minVersion = tlsStringToProtocolVersion(options.minVersion);
-        maxVersion = tlsStringToProtocolVersion(options.maxVersion);
-      }
-      this[tlsSymbol] = normalizeServerTls({
-        serverName,
-        key,
-        cert,
-        ca,
-        passphrase,
-        secureOptions,
-        minVersion,
-        maxVersion,
-        ciphers: typeof options.ciphers === "string" && options.ciphers ? options.ciphers : undefined,
-        requestCert: options.requestCert,
-        rejectUnauthorized: options.rejectUnauthorized,
-      });
-    } else {
-      this[tlsSymbol] = null;
+    // https.Server sets isTlsSymbol before calling: it is a TLS server even
+    // when constructed without key material (certificates can arrive later via
+    // setSecureContext()/addContext()). An http.Server is one only if given some.
+    if (this[isTlsSymbol] === true || options.pfx || options.cert || options.key || options.ca) {
+      this[tlsSymbol] = require("internal/tls").serverTlsFromOptions(options);
     }
   }
 
@@ -552,7 +465,7 @@ Server.prototype.listen = function () {
 
       const otherTLS = arg0.tls;
       if (otherTLS && $isObject(otherTLS)) {
-        tls = normalizeServerTls({ ...otherTLS });
+        tls = require("internal/tls").normalizeServerTls({ ...otherTLS });
       }
     } else if (typeof arg0 === "string" && !(Number(arg0) >= 0)) {
       // (path[...][, cb])

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -28,6 +28,7 @@ const {
   kRealListen,
   tlsSymbol,
   optionsSymbol,
+  kSNIContexts,
   headerStateSymbol,
   NodeHTTPHeaderState,
   kPendingCallbacks,
@@ -629,6 +630,19 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
 
     if (tls) {
       this.serverName = tls.serverName || host || "localhost";
+    }
+    const sniContexts = this[kSNIContexts];
+    const sniContextsLength = sniContexts ? sniContexts.length : 0;
+    if (sniContextsLength > 0) {
+      // Bun.serve accepts an array of TLS configs where the first entry
+      // is the default context and subsequent entries (each with a
+      // serverName) are matched via SNI. Ensure there is a base context
+      // so the SNI contexts are never promoted to the default.
+      const tlsArray = [tls ?? { requestCert: false, rejectUnauthorized: false }];
+      for (let i = 0; i < sniContextsLength; i++) {
+        tlsArray.push(sniContexts[i]);
+      }
+      tls = tlsArray;
     }
     this[serverSymbol] = Bun.serve<any>({
       idleTimeout: 0, // nodejs dont have a idleTimeout by default

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -634,10 +634,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
     const sniContexts = this[kSNIContexts];
     const sniContextsLength = sniContexts ? sniContexts.length : 0;
     if (sniContextsLength > 0) {
-      // Bun.serve accepts an array of TLS configs where the first entry
-      // is the default context and subsequent entries (each with a
-      // serverName) are matched via SNI. Ensure there is a base context
-      // so the SNI contexts are never promoted to the default.
+      // tls array: [default context, ...SNI contexts]. The first entry must be
+      // the default so an SNI context is never promoted to it.
       const tlsArray = [tls ?? { requestCert: false, rejectUnauthorized: false }];
       for (let i = 0; i < sniContextsLength; i++) {
         tlsArray.push(sniContexts[i]);

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -527,12 +527,8 @@ function Server(options, requestListener): void {
   }
   http.Server.$call(this, options, requestListener);
   this[isTlsSymbol] = true;
-  // An https.Server is always TLS. When no cert/key were supplied,
-  // http.Server leaves tlsSymbol null and the server would listen as plain
-  // HTTP. Seed a minimal TLS config so Bun.serve creates an SSL app, which
-  // in turn lets post-listen addContext() register SNI contexts instead of
-  // throwing "addContext requires SSL support". Matches the defaults used
-  // by normalizeServerTls when requestCert is false.
+  // Without key/cert, http.Server leaves this null and would listen as plain HTTP;
+  // an https.Server always listens with TLS (the defaults are normalizeServerTls's).
   this[tlsSymbol] ??= { requestCert: false, rejectUnauthorized: false };
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
@@ -571,14 +567,10 @@ Server.prototype.addContext = function (hostname, context) {
   const contexts = (this[kSNIContexts] ??= []);
   const bunServer = this[serverSymbol];
   if (bunServer) {
-    // Register on the running app first so a failed add (malformed PEM,
-    // key/cert mismatch) throws before we drop the previous JS-side entry.
+    // Throws on bad key material, before the previous entry below is dropped.
     httpServerAddServerName(bunServer, hostname, entry);
   }
-  // Node's addContext() lets the most recently added context for a given
-  // hostname win. uWS rejects a duplicate serverName at register time, so
-  // drop any earlier entry for the same hostname rather than passing both
-  // to Bun.serve.
+  // Last context added for a hostname wins, as in Node; Bun.serve rejects duplicate serverNames.
   for (let i = contexts.length - 1; i >= 0; i--) {
     if (contexts[i].serverName === hostname) {
       contexts.splice(i, 1);
@@ -589,39 +581,35 @@ Server.prototype.addContext = function (hostname, context) {
 
 Server.prototype.setSecureContext = function (options) {
   if (options == null) return;
-  // Seed with the same defaults normalizeServerTls produces so that a
-  // server constructed with no TLS options (tlsSymbol === null) does not
-  // end up with an un-normalized config where the native side defaults
-  // rejectUnauthorized to true and rejects every client that presents no
-  // certificate.
-  const current = this[tlsSymbol] || { requestCert: false, rejectUnauthorized: false };
   const { cert, key, ca, passphrase, servername, secureOptions, requestCert, rejectUnauthorized } = options;
-  // Assign unconditionally so a later setSecureContext() that omits an
-  // option clears the previous call's value (Node resets each omitted
-  // field) instead of silently keeping stale key material. Matches the
-  // tls.Server implementation.
   if (cert) throwOnInvalidTLSArray("options.cert", cert);
-  current.cert = cert;
   if (key) throwOnInvalidTLSArray("options.key", key);
-  current.key = key;
   if (ca) throwOnInvalidTLSArray("options.ca", ca);
-  current.ca = ca;
   if (passphrase && typeof passphrase !== "string") {
     throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
   }
-  current.passphrase = passphrase;
   if (servername && typeof servername !== "string") {
     throw $ERR_INVALID_ARG_TYPE("options.servername", "string", servername);
   }
-  current.serverName = servername;
   if (secureOptions && typeof secureOptions !== "number") {
     throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
   }
-  current.secureOptions = secureOptions;
-  if (requestCert !== undefined) current.requestCert = !!requestCert;
-  if (rejectUnauthorized !== undefined) current.rejectUnauthorized = rejectUnauthorized;
-  if (!current.requestCert) current.rejectUnauthorized = false;
-  this[tlsSymbol] = current;
+  // Validated above; nothing is applied if any option was rejected. Like
+  // tls.Server, an omitted option clears the value from an earlier call.
+  const previous = this[tlsSymbol] || { requestCert: false, rejectUnauthorized: false };
+  const nextRequestCert = requestCert === undefined ? !!previous.requestCert : !!requestCert;
+  const nextRejectUnauthorized = rejectUnauthorized === undefined ? previous.rejectUnauthorized : rejectUnauthorized;
+  this[tlsSymbol] = {
+    ...previous,
+    cert,
+    key,
+    ca,
+    passphrase,
+    serverName: servername,
+    secureOptions,
+    requestCert: nextRequestCert,
+    rejectUnauthorized: nextRequestCert ? nextRejectUnauthorized : false,
+  };
 };
 
 Server.prototype.getTicketKeys = function () {

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -21,6 +21,7 @@ const httpServerAddServerName = $newRustFunction("node_http_binding.rs", "httpSe
 
 const ArrayPrototypeShift = Array.prototype.shift;
 const ArrayPrototypePush = Array.prototype.push;
+const ArrayPrototypeSplice = Array.prototype.splice;
 const ObjectAssign = Object.assign;
 const ArrayPrototypeUnshift = Array.prototype.unshift;
 const JSONStringify = JSON.stringify;
@@ -553,7 +554,7 @@ Server.prototype.addContext = function (hostname, context) {
   // Last context added for a hostname wins, as in Node; Bun.serve rejects duplicate serverNames.
   for (let i = contexts.length - 1; i >= 0; i--) {
     if (contexts[i].serverName === hostname) {
-      contexts.splice(i, 1);
+      ArrayPrototypeSplice.$call(contexts, i, 1);
     }
   }
   ArrayPrototypePush.$call(contexts, entry);

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -6,10 +6,22 @@ const { isIP } = require("internal/net/isIP");
 const { urlToHttpOptions } = require("internal/url");
 const { kEmptyObject, once } = require("internal/shared");
 const { validateObject } = require("internal/validators");
-const { kProxyConfig, checkShouldUseProxy, kWaitForProxyTunnel } = require("internal/http");
+const {
+  kProxyConfig,
+  checkShouldUseProxy,
+  kWaitForProxyTunnel,
+  kSNIContexts,
+  isTlsSymbol,
+  tlsSymbol,
+  serverSymbol,
+} = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
+const { throwOnInvalidTLSArray } = require("internal/tls");
+
+const httpServerAddServerName = $newRustFunction("node_http_binding.rs", "httpServerAddServerName", 3);
 
 const ArrayPrototypeShift = Array.prototype.shift;
+const ArrayPrototypePush = Array.prototype.push;
 const ObjectAssign = Object.assign;
 const ArrayPrototypeUnshift = Array.prototype.unshift;
 const JSONStringify = JSON.stringify;
@@ -492,14 +504,13 @@ Agent.prototype._evictSession = function _evictSession(key) {
   delete this._sessionCache.map[key];
 };
 
-const { shouldUseEnvProxy } = require("node:_http_agent");
-
 // Like Node's https.Server constructor: default ALPNProtocols to ['http/1.1']
 // when neither ALPNProtocols nor ALPNCallback was given, and store the
 // normalized protocol list / callback on the server instance the way
 // tls.Server does (test-https-argument-of-creating.js).
 // https://github.com/nodejs/node/blob/v26.3.0/lib/https.js#L82-L97
-function createServer(options, requestListener) {
+function Server(options, requestListener): void {
+  if (!(this instanceof Server)) return new Server(options, requestListener);
   if (typeof options === "function") {
     requestListener = options;
     options = {};
@@ -514,14 +525,124 @@ function createServer(options, requestListener) {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  const server = http.createServer(options, requestListener);
+  http.Server.$call(this, options, requestListener);
+  this[isTlsSymbol] = true;
+  // An https.Server is always TLS. When no cert/key were supplied,
+  // http.Server leaves tlsSymbol null and the server would listen as plain
+  // HTTP. Seed a minimal TLS config so Bun.serve creates an SSL app, which
+  // in turn lets post-listen addContext() register SNI contexts instead of
+  // throwing "addContext requires SSL support". Matches the defaults used
+  // by normalizeServerTls when requestCert is false.
+  this[tlsSymbol] ??= { requestCert: false, rejectUnauthorized: false };
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
-    require("node:tls").convertALPNProtocols(optionsALPNProtocols, server);
+    require("node:tls").convertALPNProtocols(optionsALPNProtocols, this);
   }
-  server.ALPNCallback = options.ALPNCallback;
-  return server;
+  this.ALPNCallback = options.ALPNCallback;
 }
+$toClass(Server, "Server", http.Server);
+
+function tlsOptionsFromContext(context) {
+  const { key, cert, ca, passphrase, secureOptions, requestCert, rejectUnauthorized } = context || {};
+  if (cert) throwOnInvalidTLSArray("options.cert", cert);
+  if (key) throwOnInvalidTLSArray("options.key", key);
+  if (ca) throwOnInvalidTLSArray("options.ca", ca);
+  if (passphrase && typeof passphrase !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  }
+  const requested = !!requestCert;
+  return {
+    key,
+    cert,
+    ca,
+    passphrase,
+    secureOptions,
+    requestCert: requested,
+    rejectUnauthorized: requested ? rejectUnauthorized !== false : false,
+  };
+}
+
+Server.prototype.addContext = function (hostname, context) {
+  if (typeof hostname !== "string") {
+    throw new TypeError("hostname must be a string");
+  }
+  const entry = tlsOptionsFromContext(context);
+  entry.serverName = hostname;
+  const contexts = (this[kSNIContexts] ??= []);
+  const bunServer = this[serverSymbol];
+  if (bunServer) {
+    // Register on the running app first so a failed add (malformed PEM,
+    // key/cert mismatch) throws before we drop the previous JS-side entry.
+    httpServerAddServerName(bunServer, hostname, entry);
+  }
+  // Node's addContext() lets the most recently added context for a given
+  // hostname win. uWS rejects a duplicate serverName at register time, so
+  // drop any earlier entry for the same hostname rather than passing both
+  // to Bun.serve.
+  for (let i = contexts.length - 1; i >= 0; i--) {
+    if (contexts[i].serverName === hostname) {
+      contexts.splice(i, 1);
+    }
+  }
+  ArrayPrototypePush.$call(contexts, entry);
+};
+
+Server.prototype.setSecureContext = function (options) {
+  if (options == null) return;
+  // Seed with the same defaults normalizeServerTls produces so that a
+  // server constructed with no TLS options (tlsSymbol === null) does not
+  // end up with an un-normalized config where the native side defaults
+  // rejectUnauthorized to true and rejects every client that presents no
+  // certificate.
+  const current = this[tlsSymbol] || { requestCert: false, rejectUnauthorized: false };
+  const { cert, key, ca, passphrase, servername, secureOptions, requestCert, rejectUnauthorized } = options;
+  // Assign unconditionally so a later setSecureContext() that omits an
+  // option clears the previous call's value (Node resets each omitted
+  // field) instead of silently keeping stale key material. Matches the
+  // tls.Server implementation.
+  if (cert) throwOnInvalidTLSArray("options.cert", cert);
+  current.cert = cert;
+  if (key) throwOnInvalidTLSArray("options.key", key);
+  current.key = key;
+  if (ca) throwOnInvalidTLSArray("options.ca", ca);
+  current.ca = ca;
+  if (passphrase && typeof passphrase !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  }
+  current.passphrase = passphrase;
+  if (servername && typeof servername !== "string") {
+    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", servername);
+  }
+  current.serverName = servername;
+  if (secureOptions && typeof secureOptions !== "number") {
+    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
+  }
+  current.secureOptions = secureOptions;
+  if (requestCert !== undefined) current.requestCert = !!requestCert;
+  if (rejectUnauthorized !== undefined) current.rejectUnauthorized = rejectUnauthorized;
+  if (!current.requestCert) current.rejectUnauthorized = false;
+  this[tlsSymbol] = current;
+};
+
+Server.prototype.getTicketKeys = function () {
+  throw Error("Not implemented in Bun yet");
+};
+
+Server.prototype.setTicketKeys = function (keys) {
+  if (!ArrayBuffer.isView(keys)) {
+    throw $ERR_INVALID_ARG_TYPE("buffer", ["Buffer", "TypedArray", "DataView"], keys);
+  }
+  if (keys.byteLength !== 48) {
+    throw $ERR_INVALID_ARG_VALUE("buffer", keys, "Session ticket keys must be a 48-byte buffer");
+  }
+  throw Error("Not implemented in Bun yet");
+};
+
+function createServer(options, requestListener) {
+  return new Server(options, requestListener);
+}
+
+const { shouldUseEnvProxy } = require("node:_http_agent");
 
 var https = {
   Agent,
@@ -531,7 +652,7 @@ var https = {
     timeout: 5000,
     proxyEnv: shouldUseEnvProxy() ? process.env : undefined,
   }),
-  Server: http.Server,
+  Server,
   createServer,
   get,
   request,

--- a/src/js/node/https.ts
+++ b/src/js/node/https.ts
@@ -16,7 +16,6 @@ const {
   serverSymbol,
 } = require("internal/http");
 const { validateHeaderValue } = require("node:_http_common");
-const { throwOnInvalidTLSArray } = require("internal/tls");
 
 const httpServerAddServerName = $newRustFunction("node_http_binding.rs", "httpServerAddServerName", 3);
 
@@ -525,11 +524,9 @@ function Server(options, requestListener): void {
     // ALPN requests are always answered with http/1.1.
     options.ALPNProtocols = ["http/1.1"];
   }
-  http.Server.$call(this, options, requestListener);
+  // Tells http.Server to build a TLS config even when no key material was given.
   this[isTlsSymbol] = true;
-  // Without key/cert, http.Server leaves this null and would listen as plain HTTP;
-  // an https.Server always listens with TLS (the defaults are normalizeServerTls's).
-  this[tlsSymbol] ??= { requestCert: false, rejectUnauthorized: false };
+  http.Server.$call(this, options, requestListener);
   const optionsALPNProtocols = options.ALPNProtocols;
   if (optionsALPNProtocols) {
     require("node:tls").convertALPNProtocols(optionsALPNProtocols, this);
@@ -538,31 +535,14 @@ function Server(options, requestListener): void {
 }
 $toClass(Server, "Server", http.Server);
 
-function tlsOptionsFromContext(context) {
-  const { key, cert, ca, passphrase, secureOptions, requestCert, rejectUnauthorized } = context || {};
-  if (cert) throwOnInvalidTLSArray("options.cert", cert);
-  if (key) throwOnInvalidTLSArray("options.key", key);
-  if (ca) throwOnInvalidTLSArray("options.ca", ca);
-  if (passphrase && typeof passphrase !== "string") {
-    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
-  }
-  const requested = !!requestCert;
-  return {
-    key,
-    cert,
-    ca,
-    passphrase,
-    secureOptions,
-    requestCert: requested,
-    rejectUnauthorized: requested ? rejectUnauthorized !== false : false,
-  };
-}
-
 Server.prototype.addContext = function (hostname, context) {
   if (typeof hostname !== "string") {
     throw new TypeError("hostname must be a string");
   }
-  const entry = tlsOptionsFromContext(context);
+  if (hostname === "") {
+    throw $ERR_TLS_REQUIRED_SERVER_NAME('"servername" is required parameter for Server.addContext');
+  }
+  const entry = require("internal/tls").serverTlsFromOptions(context ?? kEmptyObject);
   entry.serverName = hostname;
   const contexts = (this[kSNIContexts] ??= []);
   const bunServer = this[serverSymbol];
@@ -581,35 +561,18 @@ Server.prototype.addContext = function (hostname, context) {
 
 Server.prototype.setSecureContext = function (options) {
   if (options == null) return;
-  const { cert, key, ca, passphrase, servername, secureOptions, requestCert, rejectUnauthorized } = options;
-  if (cert) throwOnInvalidTLSArray("options.cert", cert);
-  if (key) throwOnInvalidTLSArray("options.key", key);
-  if (ca) throwOnInvalidTLSArray("options.ca", ca);
-  if (passphrase && typeof passphrase !== "string") {
-    throw $ERR_INVALID_ARG_TYPE("options.passphrase", "string", passphrase);
+  validateObject(options, "options");
+  // Built in full from `options` (so anything omitted is cleared, as in Node)
+  // and only assigned once every option has been validated.
+  const next = require("internal/tls").serverTlsFromOptions(options);
+  const previous = this[tlsSymbol];
+  if (previous) {
+    // The client certificate policy belongs to the server, not to the
+    // certificate material: Node's setSecureContext() leaves it alone too.
+    next.requestCert = previous.requestCert;
+    next.rejectUnauthorized = previous.rejectUnauthorized;
   }
-  if (servername && typeof servername !== "string") {
-    throw $ERR_INVALID_ARG_TYPE("options.servername", "string", servername);
-  }
-  if (secureOptions && typeof secureOptions !== "number") {
-    throw $ERR_INVALID_ARG_TYPE("options.secureOptions", "number", secureOptions);
-  }
-  // Validated above; nothing is applied if any option was rejected. Like
-  // tls.Server, an omitted option clears the value from an earlier call.
-  const previous = this[tlsSymbol] || { requestCert: false, rejectUnauthorized: false };
-  const nextRequestCert = requestCert === undefined ? !!previous.requestCert : !!requestCert;
-  const nextRejectUnauthorized = rejectUnauthorized === undefined ? previous.rejectUnauthorized : rejectUnauthorized;
-  this[tlsSymbol] = {
-    ...previous,
-    cert,
-    key,
-    ca,
-    passphrase,
-    serverName: servername,
-    secureOptions,
-    requestCert: nextRequestCert,
-    rejectUnauthorized: nextRequestCert ? nextRejectUnauthorized : false,
-  };
+  this[tlsSymbol] = next;
 };
 
 Server.prototype.getTicketKeys = function () {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1422,7 +1422,7 @@ function Server(options, secureConnectionListener): void {
   Server.prototype[kNativeSecureContextCtor] = NativeSecureContext;
 
   Server.prototype.getTicketKeys = function () {
-    throw Error("Not implented in Bun yet");
+    throw Error("Not implemented in Bun yet");
   };
 
   Server.prototype.setTicketKeys = function (keys) {
@@ -1432,7 +1432,7 @@ function Server(options, secureConnectionListener): void {
     if (keys.byteLength !== 48) {
       throw $ERR_INVALID_ARG_VALUE("buffer", keys, "Session ticket keys must be a 48-byte buffer");
     }
-    throw Error("Not implented in Bun yet");
+    throw Error("Not implemented in Bun yet");
   };
 
   this[buntls] = function (port, host, isClient) {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -6,7 +6,13 @@ const EventEmitter = require("node:events");
 const addServerName = $newRustFunction("Listener.rs", "jsAddServerName", 3);
 const { throwNotImplemented } = require("internal/shared");
 const {
+  SSL_OP_CIPHER_SERVER_PREFERENCE,
+  normalizePemKeyOption,
+  stripTls13CipherNames,
+  tlsDefaults,
   throwOnInvalidTLSArray,
+  validateCiphers,
+  validateProtocolVersions,
   tlsStringToProtocolVersion,
   secureProtocolToVersionRange,
   processPfxOptions,
@@ -32,160 +38,6 @@ const parseCACertificates = $newCppFunction("NodeTLS.cpp", "parseCACertificates"
 
 const getTLSDefaultCiphers = $newCppFunction("NodeTLS.cpp", "getDefaultCiphers", 0);
 const setTLSDefaultCiphers = $newCppFunction("NodeTLS.cpp", "setDefaultCiphers", 1);
-let _VALID_CIPHERS_SET: Set<string> | undefined;
-function getValidCiphersSet() {
-  if (!_VALID_CIPHERS_SET) {
-    _VALID_CIPHERS_SET = new Set([
-      "DES-CBC3-SHA",
-      "AES128-SHA",
-      "AES256-SHA",
-      "PSK-AES128-CBC-SHA",
-      "PSK-AES256-CBC-SHA",
-      "AES128-GCM-SHA256",
-      "AES256-GCM-SHA384",
-      "ECDHE-ECDSA-AES128-SHA",
-      "ECDHE-ECDSA-AES256-SHA",
-      "ECDHE-RSA-AES128-SHA",
-      "ECDHE-RSA-AES256-SHA",
-      "ECDHE-ECDSA-AES128-SHA256",
-      "ECDHE-RSA-AES128-SHA256",
-      "ECDHE-ECDSA-AES128-GCM-SHA256",
-      "ECDHE-ECDSA-AES256-GCM-SHA384",
-      "ECDHE-RSA-AES128-GCM-SHA256",
-      "ECDHE-RSA-AES256-GCM-SHA384",
-      "ECDHE-PSK-AES128-CBC-SHA",
-      "ECDHE-PSK-AES256-CBC-SHA",
-      "ECDHE-RSA-CHACHA20-POLY1305",
-      "ECDHE-ECDSA-CHACHA20-POLY1305",
-      "ECDHE-PSK-CHACHA20-POLY1305",
-    ]);
-  }
-  return _VALID_CIPHERS_SET;
-}
-
-// OpenSSL cipher-list selector keywords that are not literal suite names.
-let _CIPHER_LIST_SELECTORS: Set<string> | undefined;
-function getCipherListSelectors() {
-  if (!_CIPHER_LIST_SELECTORS) {
-    _CIPHER_LIST_SELECTORS = new Set([
-      "DEFAULT",
-      "ALL",
-      "COMPLEMENTOFDEFAULT",
-      "COMPLEMENTOFALL",
-      "HIGH",
-      "MEDIUM",
-      "LOW",
-      "PSK",
-      "aNULL",
-      "eNULL",
-      "NULL",
-      "EXPORT",
-      "EXP",
-      "kRSA",
-      "aRSA",
-      "RSA",
-      "kDHE",
-      "kEDH",
-      "DH",
-      "DHE",
-      "EDH",
-      "kECDHE",
-      "kEECDH",
-      "ECDHE",
-      "EECDH",
-      "ECDH",
-      "aECDSA",
-      "ECDSA",
-      "aDSS",
-      "DSS",
-      "kPSK",
-      "aPSK",
-      "AES",
-      "AES128",
-      "AES256",
-      "AESGCM",
-      "AESCCM",
-      "CHACHA20",
-      "3DES",
-      "DES",
-      "RC4",
-      "RC2",
-      "MD5",
-      "SHA",
-      "SHA1",
-      "SHA256",
-      "SHA384",
-      "CAMELLIA",
-      "ARIA",
-      "SRP",
-      "TLSv1",
-      "TLSv1.0",
-      "TLSv1.2",
-      "TLSv1.3",
-      "SSLv3",
-      "FIPS",
-    ]);
-  }
-  return _CIPHER_LIST_SELECTORS;
-}
-
-function validateCiphers(ciphers: string, name: string = "options") {
-  // Set the cipher list and cipher suite before anything else because
-  // @SECLEVEL=<n> changes the security level and that affects subsequent
-  // operations.
-  if (ciphers !== undefined && ciphers !== null) {
-    validateString(ciphers, `${name}.ciphers`);
-
-    // TODO: right now we need this because we dont create the CTX before listening/connecting
-    // we need to change that in the future and let BoringSSL do the validation
-    const ciphersSet = getValidCiphersSet();
-    const requested = StringPrototypeSplit.$call(ciphers, ":");
-    let sawLegacyEntry = false;
-    let sawUsableEntry = false;
-    for (const r of requested) {
-      if (!r) continue;
-      // BoringSSL has no security levels: its cipher parser rejects
-      // @SECLEVEL with INVALID_COMMAND. Report that the way the native
-      // parser would, with Node's decomposed error shape.
-      if (StringPrototypeIncludes.$call(r, "@SECLEVEL")) {
-        const err = new Error("error:0f000076:SSL routines:OPENSSL_internal:INVALID_COMMAND") as Error & {
-          code: string;
-          library: string;
-          function: string;
-          reason: string;
-        };
-        err.code = "ERR_SSL_INVALID_COMMAND";
-        err.library = "SSL routines";
-        err.function = "OPENSSL_internal";
-        err.reason = "INVALID_COMMAND";
-        throw err;
-      }
-      if (StringPrototypeStartsWith.$call(r, "TLS_")) continue;
-      sawLegacyEntry = true;
-      // OpenSSL cipher-list grammar: `!X`/`-X`/`+X` operators, `A+B`
-      // intersections, `@STRENGTH` directives and selector keywords
-      // (HIGH, PSK, aNULL, ...) are not literal cipher names — leave their
-      // evaluation to BoringSSL and assume they can contribute matches.
-      const first = StringPrototypeCharCodeAt.$call(r, 0);
-      if (
-        first === 0x21 /* ! */ ||
-        first === 0x2d /* - */ ||
-        first === 0x2b /* + */ ||
-        first === 0x40 /* @ */ ||
-        StringPrototypeIncludes.$call(r, "+") ||
-        getCipherListSelectors().has(r) ||
-        ciphersSet.has(r)
-      ) {
-        sawUsableEntry = true;
-      }
-    }
-    if (sawLegacyEntry && !sawUsableEntry) {
-      throw $ERR_SSL_NO_CIPHER_MATCH();
-    }
-  }
-}
-
-const VALID_TLS_VERSIONS = new Set(["TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3"]);
 
 const SUPPORTED_ECDH_GROUPS = new Set([
   "P-256",
@@ -254,10 +106,7 @@ function validateSecureContextOptions(options) {
   if (dhparam === "auto") {
     throw $ERR_CRYPTO_UNSUPPORTED_OPERATION("Automatic DH parameter selection is not supported");
   }
-  if (minVersion != null && !VALID_TLS_VERSIONS.has(minVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(minVersion), "minimum");
-  if (maxVersion != null && !VALID_TLS_VERSIONS.has(maxVersion))
-    throw $ERR_TLS_INVALID_PROTOCOL_VERSION(String(maxVersion), "maximum");
+  validateProtocolVersions(minVersion, maxVersion);
   if (ticketKeys !== undefined && ticketKeys !== null) {
     validateBuffer(ticketKeys, "options.ticketKeys");
     const ticketKeysByteLength = ticketKeys.byteLength;
@@ -306,8 +155,6 @@ const ArrayPrototypeForEach = Array.prototype.forEach;
 const ArrayPrototypePush = Array.prototype.push;
 const ArrayPrototypeSome = Array.prototype.some;
 const ArrayPrototypeReduce = Array.prototype.reduce;
-const ArrayPrototypeFilter = Array.prototype.filter;
-const ArrayPrototypeMap = Array.prototype.map;
 
 const ObjectFreeze = Object.freeze;
 
@@ -511,34 +358,6 @@ const NativeSecureContext = $rust("SecureContext.rs", "js.getConstructor");
 // accepts null|string|ArrayBuffer|Blob|array, so coerce falsy → null before
 // crossing into native so `{ key: false }` etc. doesn't throw
 // ERR_INVALID_ARG_TYPE from the bindgen layer.
-
-function hasPemObject(key) {
-  if (!key) return false;
-  if ($isArray(key)) return ArrayPrototypeSome.$call(key, isPemKeyEntry);
-  return isPemKeyEntry(key);
-}
-
-function isPemKeyEntry(k) {
-  return k && typeof k === "object" && !isArrayBufferView(k) && "pem" in k;
-}
-
-function normalizePemKeyOption(key, ctxPassphrase) {
-  if (!key || !hasPemObject(key)) return key;
-  const entries = $isArray(key) ? key : [key];
-  return ArrayPrototypeMap.$call(entries, k => {
-    if (!isPemKeyEntry(k)) return k;
-    // Node: val?.passphrase !== undefined ? val.passphrase : passphrase - an
-    // explicit per-key null means "no passphrase for this key" and does NOT
-    // fall back to the context-level one.
-    const passphrase = k.passphrase !== undefined ? k.passphrase : ctxPassphrase;
-    if (passphrase == null) return k.pem;
-    const { createPrivateKey } = require("node:crypto");
-    return createPrivateKey({ key: k.pem, passphrase }).export({ type: "pkcs8", format: "pem" });
-  });
-}
-
-const SSL_OP_CIPHER_SERVER_PREFERENCE = 0x00400000;
-
 function newNativeSecureContext(options, cached = false) {
   maybeWarnAboutExtraCACerts();
   // tls.createSecureContext() with no options still goes through the version
@@ -576,7 +395,7 @@ function newNativeSecureContext(options, cached = false) {
       options = { ...options, sessionTimeout: 0 };
     }
     if (options.ecdhCurve === undefined) {
-      options = { ...options, ecdhCurve: DEFAULT_ECDH_CURVE };
+      options = { ...options, ecdhCurve: tlsDefaults.ecdhCurve };
     }
     const rejectUnauthorized = options.rejectUnauthorized;
     if (rejectUnauthorized !== undefined && typeof rejectUnauthorized !== "boolean") {
@@ -604,8 +423,8 @@ function newNativeSecureContext(options, cached = false) {
         minVersion = range[0];
         maxVersion = range[1];
       } else {
-        minVersion = tlsStringToProtocolVersion(optMinVersion ?? DEFAULT_MIN_VERSION);
-        maxVersion = tlsStringToProtocolVersion(optMaxVersion ?? DEFAULT_MAX_VERSION);
+        minVersion = tlsStringToProtocolVersion(optMinVersion ?? tlsDefaults.minVersion);
+        maxVersion = tlsStringToProtocolVersion(optMaxVersion ?? tlsDefaults.maxVersion);
       }
       options = { ...options, minVersion, maxVersion };
     }
@@ -627,8 +446,9 @@ var InternalSecureContext = class SecureContext {
     // process-wide default applies on every construction path (the public
     // createSecureContext(), the connect/TLSSocket path, addContext and
     // setSecureContext), matching Node's secure-context default.
-    if (_defaultCACertificatesOverride !== undefined && (options == null || options.ca == null)) {
-      options = { ...options, ca: _defaultCACertificatesOverride };
+    const defaultCA = tlsDefaults.ca;
+    if (defaultCA !== undefined && (options == null || options.ca == null)) {
+      options = { ...options, ca: defaultCA };
     }
     if (options) {
       validateSecureContextOptions(options);
@@ -1156,7 +976,7 @@ function buildSharedCreds(server) {
       allowPartialTrustChain: server.allowPartialTrustChain,
       sessionTimeout: server.sessionTimeout,
       sigalgs: server.sigalgs,
-      ecdhCurve: server.ecdhCurve ?? DEFAULT_ECDH_CURVE,
+      ecdhCurve: server.ecdhCurve ?? tlsDefaults.ecdhCurve,
       passphrase: server.passphrase,
       secureProtocol: server.secureProtocol,
       minVersion: server.minVersion,
@@ -1225,6 +1045,9 @@ function Server(options, secureConnectionListener): void {
   this.addContext = function (hostname, context) {
     if (typeof hostname !== "string") {
       throw new TypeError("hostname must be a string");
+    }
+    if (hostname === "") {
+      throw $ERR_TLS_REQUIRED_SERVER_NAME('"servername" is required parameter for Server.addContext');
     }
     if (!(context instanceof InternalSecureContext)) {
       context = new InternalSecureContext(context, true);
@@ -1314,8 +1137,9 @@ function Server(options, secureConnectionListener): void {
       // InternalSecureContext, so without this an mTLS server would verify
       // client certificates against the bundled roots instead of the
       // overridden defaults.
-      if (_defaultCACertificatesOverride !== undefined && ca == null) {
-        ca = _defaultCACertificatesOverride;
+      const defaultCA = tlsDefaults.ca;
+      if (defaultCA !== undefined && ca == null) {
+        ca = defaultCA;
       }
       // PKCS#12-embedded CAs are stashed separately so createSecureContext can
       // extend (not replace) the default trust set via addCACert. The server
@@ -1446,7 +1270,7 @@ function Server(options, secureConnectionListener): void {
         allowPartialTrustChain: this.allowPartialTrustChain,
         sessionTimeout: this.sessionTimeout ?? 0,
         sigalgs: this.sigalgs,
-        ecdhCurve: this.ecdhCurve ?? DEFAULT_ECDH_CURVE,
+        ecdhCurve: this.ecdhCurve ?? tlsDefaults.ecdhCurve,
         passphrase: this.passphrase,
         secureOptions: this.secureOptions,
         rejectUnauthorized: this._rejectUnauthorized,
@@ -1467,9 +1291,9 @@ function Server(options, secureConnectionListener): void {
             minVersion = range[0];
             maxVersion = range[1];
           } else {
-            const min = processed && processed.tls13Only ? "TLSv1.3" : (this.minVersion ?? DEFAULT_MIN_VERSION);
+            const min = processed && processed.tls13Only ? "TLSv1.3" : (this.minVersion ?? tlsDefaults.minVersion);
             minVersion = tlsStringToProtocolVersion(min);
-            maxVersion = tlsStringToProtocolVersion(this.maxVersion ?? DEFAULT_MAX_VERSION);
+            maxVersion = tlsStringToProtocolVersion(this.maxVersion ?? tlsDefaults.maxVersion);
           }
           return { ciphers: processed && processed.cipherList, minVersion, maxVersion };
         })(),
@@ -1523,25 +1347,6 @@ Server.prototype[kSharedCreds] = function () {
 
 function createServer(options, connectionListener) {
   return new Server(options, connectionListener);
-}
-let DEFAULT_ECDH_CURVE = "auto";
-// https://github.com/Jarred-Sumner/uSockets/blob/fafc241e8664243fc0c51d69684d5d02b9805134/src/crypto/openssl.c#L519-L523
-let DEFAULT_MIN_VERSION = "TLSv1.2",
-  DEFAULT_MAX_VERSION = "TLSv1.3";
-
-// Node seeds the protocol-version defaults from its --tls-min-vX.Y /
-// --tls-max-vX.Y CLI flags; the equivalent flags reach us through
-// process.execArgv. The lowest requested minimum and the highest requested
-// maximum win when several are passed, matching node_options precedence.
-{
-  const execArgv = process.execArgv;
-  const hasFlag = (flag: string) => execArgv.includes(flag);
-  if (hasFlag("--tls-min-v1.0")) DEFAULT_MIN_VERSION = "TLSv1";
-  else if (hasFlag("--tls-min-v1.1")) DEFAULT_MIN_VERSION = "TLSv1.1";
-  else if (hasFlag("--tls-min-v1.2")) DEFAULT_MIN_VERSION = "TLSv1.2";
-  else if (hasFlag("--tls-min-v1.3")) DEFAULT_MIN_VERSION = "TLSv1.3";
-  if (hasFlag("--tls-max-v1.3")) DEFAULT_MAX_VERSION = "TLSv1.3";
-  else if (hasFlag("--tls-max-v1.2")) DEFAULT_MAX_VERSION = "TLSv1.2";
 }
 
 function normalizeConnectArgs(listArgs) {
@@ -1748,13 +1553,6 @@ function maybeWarnAboutExtraCACerts() {
   }
 }
 
-// Runtime override for the "default" CA certificate set, installed by
-// tls.setDefaultCACertificates(). undefined = no override (use the real
-// bundled/system default). Only affects type "default"/implicit — "bundled",
-// "system" and "extra" are unchanged.
-// https://github.com/nodejs/node/blob/main/lib/internal/tls/secure-context.js
-let _defaultCACertificatesOverride: Array<string> | undefined;
-
 type CACertInput = string | NodeJS.ArrayBufferView;
 // tls.setDefaultCACertificates(certs)
 // https://github.com/nodejs/node/blob/v25.2.1/lib/tls.js#L202
@@ -1789,7 +1587,7 @@ function setDefaultCACertificates(certs: ReadonlyArray<CACertInput>): void {
   if (normalized.length === 0 && snapshot.length > 0) {
     throw $ERR_CRYPTO_OPERATION_FAILED("No valid certificates found in the provided array");
   }
-  _defaultCACertificatesOverride = normalized;
+  tlsDefaults.ca = normalized;
 }
 
 function getCACertificates(type = "default") {
@@ -1797,10 +1595,7 @@ function getCACertificates(type = "default") {
 
   switch (type) {
     case "default":
-      if (_defaultCACertificatesOverride !== undefined) {
-        return _defaultCACertificatesOverride.slice();
-      }
-      return cacheDefaultCACertificates();
+      return tlsDefaults.ca?.slice() ?? cacheDefaultCACertificates();
     case "bundled":
       return cacheBundledRootCertificates();
     case "system":
@@ -1810,22 +1605,6 @@ function getCACertificates(type = "default") {
     default:
       throw $ERR_INVALID_ARG_VALUE("type", type);
   }
-}
-
-function tlsCipherFilter(a: string) {
-  return !StringPrototypeStartsWith.$call(a, "TLS_");
-}
-
-// Node's processCiphers splits into cipherList (<=1.2) and cipherSuites (1.3);
-// when only 1.3 suites were given it forces minVersion = TLSv1.3 so the empty
-// 1.2 list does not leave the handshake with nothing to offer:
-// https://github.com/nodejs/node/blob/843dc5f0d5ad/lib/internal/tls/secure-context.js#L117
-function stripTls13CipherNames(ciphers: string): { cipherList: string; tls13Only: boolean } {
-  if (!StringPrototypeIncludes.$call(ciphers, "TLS_")) return { cipherList: ciphers, tls13Only: false };
-  const parts = StringPrototypeSplit.$call(ciphers, ":");
-  const kept = ArrayPrototypeFilter.$call(parts, tlsCipherFilter);
-  const cipherList = ArrayPrototypeJoin.$call(kept, ":");
-  return { cipherList, tls13Only: cipherList === "" && kept.length !== parts.length };
 }
 
 function getDefaultCiphers() {
@@ -1853,25 +1632,23 @@ export default {
     setTLSDefaultCiphers(value);
   },
   get DEFAULT_ECDH_CURVE() {
-    return DEFAULT_ECDH_CURVE;
+    return tlsDefaults.ecdhCurve;
   },
   set DEFAULT_ECDH_CURVE(value) {
-    DEFAULT_ECDH_CURVE = value;
+    tlsDefaults.ecdhCurve = value;
   },
-  // Accessors so `tls.DEFAULT_MAX_VERSION = 'TLSv1.2'` reaches the
-  // module-level variables that context construction reads (Node mutates the
-  // exports object the same way).
+  // Accessors, so assigning tls.DEFAULT_*_VERSION (as Node allows) updates the shared defaults.
   get DEFAULT_MAX_VERSION() {
-    return DEFAULT_MAX_VERSION;
+    return tlsDefaults.maxVersion;
   },
   set DEFAULT_MAX_VERSION(value) {
-    DEFAULT_MAX_VERSION = value;
+    tlsDefaults.maxVersion = value;
   },
   get DEFAULT_MIN_VERSION() {
-    return DEFAULT_MIN_VERSION;
+    return tlsDefaults.minVersion;
   },
   set DEFAULT_MIN_VERSION(value) {
-    DEFAULT_MIN_VERSION = value;
+    tlsDefaults.minVersion = value;
   },
   getCiphers,
   setDefaultCACertificates,

--- a/src/jsc/bindings/ErrorCode.ts
+++ b/src/jsc/bindings/ErrorCode.ts
@@ -362,5 +362,6 @@ const errors: ErrorCodeMapping = [
   ["ERR_INSPECTOR_COMMAND", Error],
   ["ERR_REDIS_SERVER_ERROR", Error, "RedisError"],
   ["ERR_FFI_CC_DISABLED", Error],
+  ["ERR_TLS_REQUIRED_SERVER_NAME", Error],
 ];
 export default errors;

--- a/src/runtime/node/node_http_binding.rs
+++ b/src/runtime/node/node_http_binding.rs
@@ -1,5 +1,5 @@
 //! `node:http` native binding — `getBunServerAllClosedPromise` /
-//! `{get,set}MaxHTTPHeaderSize`.
+//! `httpServerAddServerName` / `{get,set}MaxHTTPHeaderSize`.
 
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsResult};
 
@@ -37,6 +37,39 @@ pub(crate) fn get_bun_server_all_closed_promise(
     try_server!(DebugHTTPSServer);
 
     Err(global.throw_invalid_argument_type_value("server", "bun.Server", value))
+}
+
+pub(crate) fn http_server_add_server_name(
+    global: &JSGlobalObject,
+    frame: &CallFrame,
+) -> JsResult<JSValue> {
+    let arguments = frame.arguments();
+    if arguments.len() < 3 {
+        return Err(global.throw_not_enough_arguments("addServerName", 3, arguments.len()));
+    }
+
+    let server = arguments[0];
+    let hostname = arguments[1];
+    let options = arguments[2];
+
+    let name = hostname.to_utf8(global)?;
+
+    macro_rules! try_server {
+        ($ty:ty) => {
+            if let Some(this) = server.as_::<$ty>() {
+                // SAFETY: `JSValue::as_` returns a non-null pointer to the live
+                // JS-owned server instance; we hold the JS thread for the
+                // duration of this call so the GC cannot collect it under us.
+                return unsafe { &mut *this }.add_sni_context(global, &name, options);
+            }
+        };
+    }
+    try_server!(HTTPSServer);
+    try_server!(DebugHTTPSServer);
+    try_server!(HTTPServer);
+    try_server!(DebugHTTPServer);
+
+    Err(global.throw_invalid_argument_type_value("server", "bun.Server", server))
 }
 
 pub(crate) fn get_max_http_header_size(

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2494,6 +2494,122 @@ where
         Ok(JSValue::js_number(closed as f64))
     }
 
+    /// `node:https` Server.addContext() post-listen path. Registers a new SNI
+    /// TLS context on the running uWS app and reinstalls routes for that
+    /// domain so it serves the same handlers as the default context.
+    pub(crate) fn add_sni_context(
+        &mut self,
+        global: &JSGlobalObject,
+        hostname: &[u8],
+        options: JSValue,
+    ) -> JsResult<JSValue> {
+        use crate::socket::{SSLConfig, SSLConfigFromJs};
+        if !SSL {
+            return Err(
+                global.throw_invalid_arguments(format_args!("addContext requires SSL support"))
+            );
+        }
+        if self.app.is_none() {
+            return Ok(JSValue::UNDEFINED);
+        }
+        let ssl_config =
+            SSLConfig::from_js(self.vm(), global, options)?.unwrap_or_else(SSLConfig::zero);
+        let ssl_opts = ssl_config.as_usockets();
+
+        let server_name = match std::ffi::CString::new(hostname) {
+            Ok(s) => s,
+            Err(_) => {
+                return Err(global
+                    .throw_invalid_arguments(format_args!("hostname must not contain NUL bytes")));
+            }
+        };
+        // Validate that an SSL_CTX can be built from these options before
+        // touching the existing SNI entry. uWS's addServerName builds the
+        // SSL_CTX internally, so without this probe a malformed cert/key
+        // would fail after remove_server_name() had already stripped the
+        // previous entry, leaving the hostname with no SNI context.
+        {
+            let mut create_err = uws::create_bun_socket_error_t::none;
+            match ssl_opts.create_ssl_context(&mut create_err) {
+                Some(probe) => {
+                    // SAFETY: create_ssl_context returned a +1 ref; release it.
+                    unsafe { bun_boringssl_sys::SSL_CTX_free(probe) };
+                }
+                None => {
+                    if create_err != uws::create_bun_socket_error_t::none {
+                        return Err(global.throw_value(
+                            crate::socket::uws_jsc::create_bun_socket_error_to_js(
+                                create_err, global,
+                            ),
+                        ));
+                    }
+                    if !super::throw_ssl_error_if_necessary(global) {
+                        return Err(global.throw(format_args!(
+                            "Failed to create SSL context for serverName: {}",
+                            bstr::BStr::new(server_name.to_bytes())
+                        )));
+                    }
+                    return Err(JsError::Thrown);
+                }
+            }
+        }
+        // Node's addContext() permits repeated calls with the same hostname
+        // (last one wins). uWS's addServerName rejects a duplicate and its
+        // rollback also removes the existing entry from every listen socket,
+        // so without this a second addContext() would both throw and strip
+        // the previous SNI context. Remove first so the re-add replaces.
+        self.app_mut().remove_server_name(&server_name);
+        // `true`: a context added for one hostname carries its own
+        // requestCert/rejectUnauthorized, the same as a per-serverName entry
+        // of the `tls` array at listen time (see `listen` in mod.rs).
+        if self
+            .app_mut()
+            .add_server_name_with_options(&server_name, &ssl_opts, true)
+            .is_err()
+        {
+            if !global.has_exception() && !super::throw_ssl_error_if_necessary(global) {
+                return Err(global.throw(format_args!(
+                    "Failed to add serverName: {}",
+                    bstr::BStr::new(server_name.to_bytes())
+                )));
+            }
+            return Err(JsError::Thrown);
+        }
+        if super::throw_ssl_error_if_necessary(global) {
+            return Err(JsError::Thrown);
+        }
+        // SAFETY: server_name is a CString with a trailing NUL byte.
+        let z = unsafe {
+            bun_core::ZStr::from_raw(server_name.as_ptr().cast(), server_name.as_bytes().len())
+        };
+        self.app_mut().domain(z);
+        if super::throw_ssl_error_if_necessary(global) {
+            return Err(JsError::Thrown);
+        }
+
+        if Self::HAS_H3 {
+            if let Some(h3_app) = self.h3_app {
+                if bun_opaque::opaque_deref_mut(h3_app)
+                    .add_server_name_with_options(z, &ssl_opts)
+                    .is_err()
+                {
+                    if !global.has_exception() && !super::throw_ssl_error_if_necessary(global) {
+                        return Err(global.throw(format_args!(
+                            "Failed to add serverName \"{}\" for HTTP/3",
+                            bstr::BStr::new(server_name.to_bytes())
+                        )));
+                    }
+                    return Err(JsError::Thrown);
+                }
+                if super::throw_ssl_error_if_necessary(global) {
+                    return Err(JsError::Thrown);
+                }
+            }
+        }
+        let _ = self.set_routes();
+        Ok(JSValue::UNDEFINED)
+    }
+
     pub(crate) fn stop_from_js(&mut self, abruptly: Option<JSValue>) -> JSValue {
         let rc = self.get_all_closed_promise(&self.global());
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2494,9 +2494,8 @@ where
         Ok(JSValue::js_number(closed as f64))
     }
 
-    /// `node:https` Server.addContext() post-listen path. Registers a new SNI
-    /// TLS context on the running uWS app and reinstalls routes for that
-    /// domain so it serves the same handlers as the default context.
+    /// `node:https` `Server#addContext()` after `listen()`: registers the SNI
+    /// context on the running app and installs this server's routes for it.
     pub(crate) fn add_sni_context(
         &mut self,
         global: &JSGlobalObject,
@@ -2523,11 +2522,8 @@ where
                     .throw_invalid_arguments(format_args!("hostname must not contain NUL bytes")));
             }
         };
-        // Validate that an SSL_CTX can be built from these options before
-        // touching the existing SNI entry. uWS's addServerName builds the
-        // SSL_CTX internally, so without this probe a malformed cert/key
-        // would fail after remove_server_name() had already stripped the
-        // previous entry, leaving the hostname with no SNI context.
+        // Build the SSL_CTX once up front: bad key material must fail before
+        // remove_server_name() below drops the hostname's existing context.
         {
             let mut create_err = uws::create_bun_socket_error_t::none;
             match ssl_opts.create_ssl_context(&mut create_err) {
@@ -2553,15 +2549,10 @@ where
                 }
             }
         }
-        // Node's addContext() permits repeated calls with the same hostname
-        // (last one wins). uWS's addServerName rejects a duplicate and its
-        // rollback also removes the existing entry from every listen socket,
-        // so without this a second addContext() would both throw and strip
-        // the previous SNI context. Remove first so the re-add replaces.
+        // Last addContext() for a hostname wins (Node semantics); uWS's
+        // addServerName fails on a duplicate and unregisters the existing one.
         self.app_mut().remove_server_name(&server_name);
-        // `true`: a context added for one hostname carries its own
-        // requestCert/rejectUnauthorized, the same as a per-serverName entry
-        // of the `tls` array at listen time (see `listen` in mod.rs).
+        // apply_client_cert_policy: same as the per-serverName `tls` entries in `listen`.
         if self
             .app_mut()
             .add_server_name_with_options(&server_name, &ssl_opts, true)

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2495,7 +2495,7 @@ where
     }
 
     /// `node:https` `Server#addContext()` after `listen()`: registers the SNI
-    /// context on the running app and installs this server's routes for it.
+    /// context on the running TCP app and installs this server's routes for it.
     pub(crate) fn add_sni_context(
         &mut self,
         global: &JSGlobalObject,
@@ -2511,6 +2511,7 @@ where
         if self.app.is_none() {
             return Ok(JSValue::UNDEFINED);
         }
+        debug_assert!(self.h3_app.is_none());
         // Same guard as `Listener::add_server_name`: the SNI tree would file an
         // empty name on its root, where nothing can ever match it.
         if hostname.is_empty() {
@@ -2572,37 +2573,12 @@ where
             }
             return Err(JsError::Thrown);
         }
-        if super::throw_ssl_error_if_necessary(global) {
-            return Err(JsError::Thrown);
-        }
         // SAFETY: server_name is a CString with a trailing NUL byte.
         let z = unsafe {
             bun_core::ZStr::from_raw(server_name.as_ptr().cast(), server_name.as_bytes().len())
         };
+        // Routes are installed into the router domain() selects.
         self.app_mut().domain(z);
-        if super::throw_ssl_error_if_necessary(global) {
-            return Err(JsError::Thrown);
-        }
-
-        if Self::HAS_H3 {
-            if let Some(h3_app) = self.h3_app {
-                if bun_opaque::opaque_deref_mut(h3_app)
-                    .add_server_name_with_options(z, &ssl_opts)
-                    .is_err()
-                {
-                    if !global.has_exception() && !super::throw_ssl_error_if_necessary(global) {
-                        return Err(global.throw(format_args!(
-                            "Failed to add serverName \"{}\" for HTTP/3",
-                            bstr::BStr::new(server_name.to_bytes())
-                        )));
-                    }
-                    return Err(JsError::Thrown);
-                }
-                if super::throw_ssl_error_if_necessary(global) {
-                    return Err(JsError::Thrown);
-                }
-            }
-        }
         let _ = self.set_routes();
         Ok(JSValue::UNDEFINED)
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2511,10 +2511,13 @@ where
         if self.app.is_none() {
             return Ok(JSValue::UNDEFINED);
         }
-        let ssl_config =
-            SSLConfig::from_js(self.vm(), global, options)?.unwrap_or_else(SSLConfig::zero);
-        let ssl_opts = ssl_config.as_usockets();
-
+        // Same guard as `Listener::add_server_name`: the SNI tree would file an
+        // empty name on its root, where nothing can ever match it.
+        if hostname.is_empty() {
+            return Err(
+                global.throw_invalid_arguments(format_args!("hostname pattern cannot be empty"))
+            );
+        }
         let server_name = match std::ffi::CString::new(hostname) {
             Ok(s) => s,
             Err(_) => {
@@ -2522,6 +2525,9 @@ where
                     .throw_invalid_arguments(format_args!("hostname must not contain NUL bytes")));
             }
         };
+        let ssl_config =
+            SSLConfig::from_js(self.vm(), global, options)?.unwrap_or_else(SSLConfig::zero);
+        let ssl_opts = ssl_config.as_usockets();
         // Build the SSL_CTX once up front: bad key material must fail before
         // remove_server_name() below drops the hostname's existing context.
         {

--- a/src/uws_sys/App.rs
+++ b/src/uws_sys/App.rs
@@ -390,6 +390,17 @@ impl<const SSL: bool> App<SSL> {
         }
     }
 
+    pub fn remove_server_name(&mut self, hostname_pattern: &core::ffi::CStr) {
+        // SAFETY: self is a valid app; hostname_pattern is NUL-terminated.
+        unsafe {
+            c::uws_remove_server_name(
+                Self::SSL_FLAG,
+                std::ptr::from_mut::<Self>(self).cast::<uws_app_t>(),
+                hostname_pattern.as_ptr(),
+            )
+        }
+    }
+
     pub fn add_server_name_with_options(
         &mut self,
         hostname_pattern: &core::ffi::CStr,
@@ -664,6 +675,11 @@ pub mod c {
             opcode: Opcode,
             compress: bool,
         ) -> SendStatus;
+        pub(crate) fn uws_remove_server_name(
+            ssl: i32,
+            app: *mut uws_app_t,
+            hostname_pattern: *const c_char,
+        );
         pub(crate) fn uws_add_server_name_with_options(
             ssl: i32,
             app: *mut uws_app_t,

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -579,6 +579,20 @@ extern "C"
     }
     return !success;
   }
+  void uws_remove_server_name(int ssl, uws_app_t *app,
+                              const char *hostname_pattern)
+  {
+    if (ssl)
+    {
+      uWS::SSLApp *uwsApp = (uWS::SSLApp *)app;
+      uwsApp->removeServerName(hostname_pattern);
+    }
+    else
+    {
+      uWS::App *uwsApp = (uWS::App *)app;
+      uwsApp->removeServerName(hostname_pattern);
+    }
+  }
 
   void uws_filter(int ssl, uws_app_t *app, uws_filter_handler handler,
                   void *user_data)

--- a/test/js/node/http/node-https-server-context.test.ts
+++ b/test/js/node/http/node-https-server-context.test.ts
@@ -1,0 +1,253 @@
+// https://github.com/oven-sh/bun/issues/12157
+// https.Server should expose the same SNI helpers as tls.Server.
+import { describe, expect, test } from "bun:test";
+import { once } from "node:events";
+import { readFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import tls from "node:tls";
+
+const fixtures = join(import.meta.dir, "..", "tls", "fixtures");
+const load = (name: string) => readFileSync(join(fixtures, name), "utf8");
+
+const agent1Cert = load("agent1-cert.pem");
+const agent1Key = load("agent1-key.pem");
+const agent2Cert = load("agent2-cert.pem");
+const agent2Key = load("agent2-key.pem");
+const agent3Cert = load("agent3-cert.pem");
+const agent3Key = load("agent3-key.pem");
+const ca1 = load("ca1-cert.pem");
+
+async function peerCN(port: number, servername?: string) {
+  const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false });
+  const errored = once(socket, "error");
+  await Promise.race([once(socket, "secureConnect"), errored.then(([e]) => Promise.reject(e))]);
+  const cert = socket.getPeerCertificate();
+  socket.destroy();
+  return cert.subject?.CN;
+}
+
+// `agent: false` so every call opens a fresh connection and therefore a fresh
+// SNI lookup; a pooled keep-alive socket would keep serving the cert (and
+// router) selected when it was first opened.
+async function httpsGetViaSNI(port: number, servername: string) {
+  const { promise, resolve, reject } = Promise.withResolvers<{ cn: string | undefined; body: string }>();
+  https
+    .get(
+      { host: "127.0.0.1", port, servername, headers: { Host: servername }, rejectUnauthorized: false, agent: false },
+      res => {
+        const cn = (res.socket as tls.TLSSocket).getPeerCertificate().subject?.CN;
+        res.setEncoding("utf8");
+        let body = "";
+        res.on("data", chunk => (body += chunk));
+        res.on("error", reject);
+        res.on("end", () => resolve({ cn, body }));
+      },
+    )
+    .on("error", reject);
+  return promise;
+}
+
+async function listen(server: https.Server) {
+  const listenErr = once(server, "error");
+  server.listen(0);
+  await Promise.race([once(server, "listening"), listenErr.then(([e]) => Promise.reject(e))]);
+  return (server.address() as AddressInfo).port;
+}
+
+describe("https.Server", () => {
+  test("exposes tls.Server methods and is an http.Server subclass", () => {
+    const server = https.createServer({ key: agent1Key, cert: agent1Cert });
+    expect({
+      addContext: typeof server.addContext,
+      setSecureContext: typeof server.setSecureContext,
+      getTicketKeys: typeof server.getTicketKeys,
+      setTicketKeys: typeof server.setTicketKeys,
+    }).toEqual({
+      addContext: "function",
+      setSecureContext: "function",
+      getTicketKeys: "function",
+      setTicketKeys: "function",
+    });
+    expect(server instanceof https.Server).toBe(true);
+    expect(server instanceof http.Server).toBe(true);
+    expect(() => server.addContext(123 as any, {})).toThrow(TypeError);
+    expect(() => server.addContext(123 as any, {})).toThrow("hostname must be a string");
+  });
+
+  // https://github.com/oven-sh/bun/issues/31125
+  // supertest <= 6.1.6 and @astrojs/node pick the protocol with
+  // `app instanceof https.Server`, so a plain http.Server must not match.
+  test("is a distinct class from http.Server", () => {
+    expect(https.Server).not.toBe(http.Server);
+    const plain = http.createServer();
+    const secure = new https.Server({ key: agent1Key, cert: agent1Cert });
+    expect({
+      plainIsHttp: plain instanceof http.Server,
+      plainIsHttps: plain instanceof https.Server,
+      secureIsHttp: secure instanceof http.Server,
+      secureIsHttps: secure instanceof https.Server,
+      httpServerHasAddContext: "addContext" in plain,
+    }).toEqual({
+      plainIsHttp: true,
+      plainIsHttps: false,
+      secureIsHttp: true,
+      secureIsHttps: true,
+      httpServerHasAddContext: false,
+    });
+  });
+
+  test("addContext registers a SNI context before listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      server.addContext("a.example.com", { key: agent1Key, cert: agent1Cert });
+      server.addContext("b.example.com", { key: agent3Key, cert: agent3Cert });
+
+      const port = await listen(server);
+
+      expect(await peerCN(port, "a.example.com")).toBe("agent1");
+      expect(await peerCN(port, "b.example.com")).toBe("agent3");
+      // A hostname with no SNI match falls through to the default context.
+      expect(await peerCN(port, "unknown.example.com")).toBe("agent2");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("addContext registers a SNI context after listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      const port = await listen(server);
+      expect(await peerCN(port, "a.example.com")).toBe("agent2");
+
+      server.addContext("a.example.com", { key: agent1Key, cert: agent1Cert });
+      server.addContext("b.example.com", { key: agent3Key, cert: agent3Cert });
+
+      expect(await peerCN(port, "a.example.com")).toBe("agent1");
+      expect(await peerCN(port, "b.example.com")).toBe("agent3");
+      expect(await peerCN(port, "unknown.example.com")).toBe("agent2");
+
+      // The SNI-selected domain must also have routes installed (not just
+      // a TLS context), so an HTTP request over that SNI reaches the
+      // request handler.
+      expect(await httpsGetViaSNI(port, "a.example.com")).toEqual({ cn: "agent1", body: "ok" });
+      expect(await httpsGetViaSNI(port, "b.example.com")).toEqual({ cn: "agent3", body: "ok" });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("addContext with a repeated hostname replaces the previous context", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      server.addContext("a.example.com", { key: agent1Key, cert: agent1Cert });
+      server.addContext("a.example.com", { key: agent3Key, cert: agent3Cert });
+
+      const port = await listen(server);
+      // pre-listen: the most recently added context wins
+      expect(await peerCN(port, "a.example.com")).toBe("agent3");
+
+      // post-listen: re-adding the same hostname replaces rather than throws
+      server.addContext("a.example.com", { key: agent1Key, cert: agent1Cert });
+      expect(await peerCN(port, "a.example.com")).toBe("agent1");
+      expect(await httpsGetViaSNI(port, "a.example.com")).toEqual({ cn: "agent1", body: "ok" });
+
+      server.addContext("a.example.com", { key: agent3Key, cert: agent3Cert });
+      expect(await peerCN(port, "a.example.com")).toBe("agent3");
+
+      // A re-add with a malformed cert throws, and must not strip the
+      // previous working SNI entry.
+      expect(() =>
+        server.addContext("a.example.com", { key: agent1Key, cert: "-----BEGIN CERTIFICATE-----\ntruncated" }),
+      ).toThrow();
+      expect(await peerCN(port, "a.example.com")).toBe("agent3");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("addContext re-add does not break keep-alive connections on the previous SNI context", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200, { "Content-Length": "2" });
+      res.end("ok");
+    });
+    try {
+      const port = await listen(server);
+      server.addContext("a.example.com", { key: agent1Key, cert: agent1Cert });
+
+      const socket = tls.connect({ host: "127.0.0.1", port, servername: "a.example.com", rejectUnauthorized: false });
+      const errored = once(socket, "error").then(([e]) => Promise.reject(e));
+      const closed = once(socket, "close").then(() => Promise.reject(new Error("socket closed before response")));
+      try {
+        await Promise.race([once(socket, "secureConnect"), errored, closed]);
+        expect(socket.getPeerCertificate().subject?.CN).toBe("agent1");
+
+        const readResponse = async () => {
+          const chunks: Buffer[] = [];
+          while (true) {
+            const [chunk] = await Promise.race([once(socket, "data"), closed, errored]);
+            chunks.push(chunk);
+            const raw = Buffer.concat(chunks).toString("utf8");
+            const sep = raw.indexOf("\r\n\r\n");
+            if (sep >= 0 && raw.length >= sep + 4 + 2) return raw.slice(sep + 4, sep + 4 + 2);
+          }
+        };
+
+        socket.write("GET / HTTP/1.1\r\nHost: a.example.com\r\n\r\n");
+        expect(await readResponse()).toBe("ok");
+
+        // Replace the SNI context while the keep-alive connection is open;
+        // the per-domain router for the previous SSL_CTX is freed here.
+        server.addContext("a.example.com", { key: agent3Key, cert: agent3Cert });
+
+        // A second request on the same connection must fall back to the
+        // default router rather than dereferencing the freed per-domain one.
+        socket.write("GET / HTTP/1.1\r\nHost: a.example.com\r\n\r\n");
+        expect(await readResponse()).toBe("ok");
+      } finally {
+        socket.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext replaces the default context before listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      server.setSecureContext({ key: agent3Key, cert: agent3Cert });
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent3");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext on a server with no initial TLS options does not require a client certificate", async () => {
+    const server = https.createServer((req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      server.setSecureContext({ key: agent1Key, cert: agent1Cert, ca: ca1 });
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent1");
+    } finally {
+      server.close();
+    }
+  });
+});

--- a/test/js/node/http/node-https-server-context.test.ts
+++ b/test/js/node/http/node-https-server-context.test.ts
@@ -85,11 +85,19 @@ async function requestOutcome(port: number, extra: https.RequestOptions = {}) {
 // `agent: false` so every call opens a fresh connection and therefore a fresh
 // SNI lookup; a pooled keep-alive socket would keep serving the cert (and
 // router) selected when it was first opened.
-async function httpsGetViaSNI(port: number, servername: string) {
+async function httpsGetViaSNI(port: number, servername: string, extra: https.RequestOptions = {}) {
   const { promise, resolve, reject } = Promise.withResolvers<{ cn: string | undefined; body: string }>();
   https
     .get(
-      { host: "127.0.0.1", port, servername, headers: { Host: servername }, rejectUnauthorized: false, agent: false },
+      {
+        host: "127.0.0.1",
+        port,
+        servername,
+        headers: { Host: servername },
+        rejectUnauthorized: false,
+        agent: false,
+        ...extra,
+      },
       res => {
         const cn = (res.socket as tls.TLSSocket).getPeerCertificate().subject?.CN;
         res.setEncoding("utf8");
@@ -641,6 +649,37 @@ describe("https.Server", () => {
     }
   });
 
+  test("socket.authorized follows the SNI context's requestCert, not only the default context's", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) =>
+      res.end(JSON.stringify({ authorized: req.socket.authorized, authorizationError: req.socket.authorizationError })),
+    );
+    try {
+      const port = await listen(server);
+      server.addContext("mtls.example.com", {
+        key: agent1Key,
+        cert: agent1Cert,
+        ca: privateCA,
+        requestCert: true,
+        rejectUnauthorized: false,
+      });
+      const verdict = async (servername: string, extra?: https.RequestOptions) =>
+        JSON.parse((await httpsGetViaSNI(port, servername, extra)).body);
+      expect({
+        mtlsWithCert: await verdict("mtls.example.com", privateCAClient),
+        mtlsWithoutCert: await verdict("mtls.example.com"),
+        // The default context never asked, so a certificate offered anyway is not consulted.
+        defaultWithCert: await verdict("other.example.com", privateCAClient),
+      }).toEqual({
+        mtlsWithCert: { authorized: true, authorizationError: null },
+        mtlsWithoutCert: { authorized: false, authorizationError: "UNABLE_TO_GET_ISSUER_CERT" },
+        defaultWithCert: { authorized: false, authorizationError: null },
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  // Last on purpose: setDefaultCACertificates() can only be replaced, never removed, so later servers would inherit it.
   test("an mTLS server without `ca` verifies clients against tls.setDefaultCACertificates(), like tls.Server", async () => {
     const mtls = { key: agent2Key, cert: agent2Cert, requestCert: true, rejectUnauthorized: true };
     const handler: https.RequestListener = (req, res) => res.end("ok");

--- a/test/js/node/http/node-https-server-context.test.ts
+++ b/test/js/node/http/node-https-server-context.test.ts
@@ -19,14 +19,67 @@ const agent2Key = load("agent2-key.pem");
 const agent3Cert = load("agent3-cert.pem");
 const agent3Key = load("agent3-key.pem");
 const ca1 = load("ca1-cert.pem");
+const nodeKeys = join(import.meta.dir, "..", "test", "fixtures", "keys");
+// agent1's key and certificate as a PKCS#12 bundle (passphrase "sample").
+const agent1Pfx = readFileSync(join(nodeKeys, "agent1.pfx"));
+// This generation of agent3 is issued by this ca2, and the CRL revokes it.
+const revokedClient = {
+  key: readFileSync(join(nodeKeys, "agent3-key.pem"), "utf8"),
+  cert: readFileSync(join(nodeKeys, "agent3-cert.pem"), "utf8"),
+};
+const revokedClientCA = readFileSync(join(nodeKeys, "ca2-cert.pem"), "utf8");
+const revokedClientCRL = readFileSync(join(nodeKeys, "ca2-crl-agent3.pem"), "utf8");
+// This generation of agent1 is issued by this ca1, which is not a bundled root.
+const privateCAClient = {
+  key: readFileSync(join(nodeKeys, "agent1-key.pem"), "utf8"),
+  cert: readFileSync(join(nodeKeys, "agent1-cert.pem"), "utf8"),
+};
+const privateCA = readFileSync(join(nodeKeys, "ca1-cert.pem"), "utf8");
+// A passphrase-protected key (passphrase "password") and its certificate, CN "localhost".
+const encryptedKey = readFileSync(join(nodeKeys, "rsa_private_encrypted.pem"), "utf8");
+const encryptedKeyCert = readFileSync(join(nodeKeys, "rsa_cert.crt"), "utf8");
 
-async function peerCN(port: number, servername?: string) {
-  const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false });
+async function peerCN(port: number, servername?: string, extra: tls.ConnectionOptions = {}) {
+  const socket = tls.connect({ host: "127.0.0.1", port, servername, rejectUnauthorized: false, ...extra });
   const errored = once(socket, "error");
   await Promise.race([once(socket, "secureConnect"), errored.then(([e]) => Promise.reject(e))]);
   const cert = socket.getPeerCertificate();
   socket.destroy();
   return cert.subject?.CN;
+}
+
+// peerCN() that resolves with the error code when the handshake is refused.
+// Deliberately not `expect().rejects`: its nested event loop spin currently segfaults on Windows.
+async function handshakeOutcome(port: number, extra: tls.ConnectionOptions) {
+  try {
+    return { cn: await peerCN(port, undefined, extra) };
+  } catch (err) {
+    return { code: (err as NodeJS.ErrnoException).code };
+  }
+}
+
+// The cipher a TLS 1.2 client offering `ciphers` (in that order) ends up with.
+async function negotiatedCipher(port: number, ciphers: string) {
+  const socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, maxVersion: "TLSv1.2", ciphers });
+  const errored = once(socket, "error").then(([e]) => Promise.reject(e));
+  await Promise.race([once(socket, "secureConnect"), errored]);
+  const { name } = socket.getCipher();
+  socket.destroy();
+  return name;
+}
+
+// Resolves with the server certificate's CN when a request round-trips, or with
+// the error code when the server refuses the client (at the handshake or, for
+// TLS 1.3 client-certificate failures, right after it).
+async function requestOutcome(port: number, extra: https.RequestOptions = {}) {
+  const { promise, resolve } = Promise.withResolvers<{ cn: string | undefined } | { code: string }>();
+  https
+    .get({ host: "127.0.0.1", port, rejectUnauthorized: false, agent: false, ...extra }, res => {
+      res.resume();
+      resolve({ cn: (res.socket as tls.TLSSocket).getPeerCertificate().subject?.CN });
+    })
+    .on("error", (err: NodeJS.ErrnoException) => resolve({ code: err.code ?? err.message }));
+  return promise;
 }
 
 // `agent: false` so every call opens a fresh connection and therefore a fresh
@@ -50,7 +103,7 @@ async function httpsGetViaSNI(port: number, servername: string) {
   return promise;
 }
 
-async function listen(server: https.Server) {
+async function listen(server: http.Server) {
   const listenErr = once(server, "error");
   server.listen(0);
   await Promise.race([once(server, "listening"), listenErr.then(([e]) => Promise.reject(e))]);
@@ -97,6 +150,24 @@ describe("https.Server", () => {
       secureIsHttps: true,
       httpServerHasAddContext: false,
     });
+  });
+
+  test("http.Server is a TLS server only when given key material", async () => {
+    // Like Node, a plain http.Server does not look at TLS-only options (this passphrase would be rejected by a
+    // TLS server), while key material still turns it into one.
+    const plain = http.createServer({ passphrase: 123 } as any, (req, res) => res.end("plain"));
+    const secure = http.createServer({ key: agent1Key, cert: agent1Cert } as any, (req, res) => res.end("secure"));
+    try {
+      const plainPort = await listen(plain);
+      const securePort = await listen(secure);
+      expect({
+        plain: await (await fetch(`http://127.0.0.1:${plainPort}/`)).text(),
+        secure: await peerCN(securePort),
+      }).toEqual({ plain: "plain", secure: "agent1" });
+    } finally {
+      plain.close();
+      secure.close();
+    }
   });
 
   test("addContext registers a SNI context before listen", async () => {
@@ -223,6 +294,37 @@ describe("https.Server", () => {
     }
   });
 
+  test("addContext rejects an empty hostname before and after listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      const requiredServerName = '"servername" is required parameter for Server.addContext';
+      expect(() => server.addContext("", { key: agent1Key, cert: agent1Cert })).toThrow(requiredServerName);
+      // The rejected call must not have queued anything that breaks listen().
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent2");
+      expect(() => server.addContext("", { key: agent1Key, cert: agent1Cert })).toThrow(requiredServerName);
+      expect(await peerCN(port)).toBe("agent2");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("addContext accepts the same options as the constructor (pfx) before and after listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      server.addContext("a.example.com", { pfx: agent1Pfx, passphrase: "sample" });
+      const port = await listen(server);
+      server.addContext("b.example.com", { pfx: agent1Pfx, passphrase: "sample" });
+      expect({
+        a: await peerCN(port, "a.example.com"),
+        b: await peerCN(port, "b.example.com"),
+        other: await peerCN(port, "c.example.com"),
+      }).toEqual({ a: "agent1", b: "agent1", other: "agent2" });
+    } finally {
+      server.close();
+    }
+  });
+
   test("setSecureContext replaces the default context before listen", async () => {
     const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
       res.writeHead(200);
@@ -266,6 +368,308 @@ describe("https.Server", () => {
       expect(await peerCN(port)).toBe("agent1");
     } finally {
       server.close();
+    }
+  });
+
+  test("setSecureContext accepts the same options as the constructor (pfx, minVersion)", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      server.setSecureContext({ pfx: agent1Pfx, passphrase: "sample", minVersion: "TLSv1.3" });
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent1");
+      expect(await handshakeOutcome(port, { maxVersion: "TLSv1.2" })).toEqual({
+        code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext clears options the constructor had set but the new call omits", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert, minVersion: "TLSv1.3" });
+    try {
+      server.setSecureContext({ key: agent3Key, cert: agent3Cert });
+      const port = await listen(server);
+      expect(await peerCN(port, undefined, { maxVersion: "TLSv1.2" })).toBe("agent3");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext rejects an unknown secureProtocol and applies nothing", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      expect(() =>
+        server.setSecureContext({ key: agent3Key, cert: agent3Cert, secureProtocol: "bogus_method" }),
+      ).toThrow(
+        expect.objectContaining({ code: "ERR_TLS_INVALID_PROTOCOL_METHOD", message: "Unknown method: bogus_method" }),
+      );
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent2");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext keeps the client certificate policy the server was created with", async () => {
+    const server = https.createServer(
+      { key: agent2Key, cert: agent2Cert, ca: ca1, requestCert: true, rejectUnauthorized: true },
+      (req, res) => res.end("ok"),
+    );
+    try {
+      // Like Node, requestCert/rejectUnauthorized are server settings; swapping
+      // the certificate (with a call that does not mention them) keeps them.
+      server.setSecureContext({ key: agent3Key, cert: agent3Cert, ca: ca1 });
+      const port = await listen(server);
+      // agent1 is issued by ca1, so it is the one client the server accepts.
+      expect(await requestOutcome(port, { key: agent1Key, cert: agent1Cert })).toEqual({ cn: "agent3" });
+      expect(await requestOutcome(port)).toEqual({ code: expect.stringMatching(/^ERR_SSL_|^ECONNRESET$/) });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext applies ecdhCurve", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      server.setSecureContext({ key: agent2Key, cert: agent2Cert, ecdhCurve: "secp384r1" });
+      const port = await listen(server);
+      expect({
+        p256Only: await handshakeOutcome(port, { ecdhCurve: "prime256v1" }),
+        p384: await handshakeOutcome(port, { ecdhCurve: "secp384r1" }),
+      }).toEqual({
+        p256Only: { code: "ERR_SSL_SSLV3_ALERT_HANDSHAKE_FAILURE" },
+        p384: { cn: "agent2" },
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("addContext applies crl to a context added after listen", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => res.end("ok"));
+    try {
+      const port = await listen(server);
+      const mtls = {
+        key: agent1Key,
+        cert: agent1Cert,
+        ca: revokedClientCA,
+        requestCert: true,
+        rejectUnauthorized: true,
+      };
+      server.addContext("lenient.example.com", mtls);
+      server.addContext("strict.example.com", { ...mtls, crl: revokedClientCRL });
+      expect({
+        lenient: await requestOutcome(port, { ...revokedClient, servername: "lenient.example.com" }),
+        strict: await requestOutcome(port, { ...revokedClient, servername: "strict.example.com" }),
+      }).toEqual({
+        lenient: { cn: "agent1" },
+        strict: { code: expect.stringMatching(/^ERR_SSL_|^ECONNRESET$/) },
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext validates the secure context options tls.Server does, before applying anything", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      const next = { key: agent3Key, cert: agent3Cert };
+      expect(() => server.setSecureContext({ ...next, sigalgs: "" })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_VALUE" }),
+      );
+      expect(() => server.setSecureContext({ ...next, ecdhCurve: 1 as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => server.setSecureContext({ ...next, sessionTimeout: -1 })).toThrow(
+        expect.objectContaining({ code: "ERR_OUT_OF_RANGE" }),
+      );
+      expect(() => server.setSecureContext({ ...next, crl: 42 as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => server.setSecureContext({ ...next, ciphers: "@SECLEVEL=0:ECDHE-RSA-AES128-GCM-SHA256" })).toThrow(
+        expect.objectContaining({ code: "ERR_SSL_INVALID_COMMAND" }),
+      );
+      expect(() => server.setSecureContext({ ...next, ciphers: "NOT-A-CIPHER" })).toThrow(
+        expect.objectContaining({ code: "ERR_SSL_NO_CIPHER_MATCH" }),
+      );
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent2");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("the constructor, setSecureContext and addContext reject an unknown minVersion/maxVersion, like tls.Server", async () => {
+    const invalidMin = expect.objectContaining({
+      code: "ERR_TLS_INVALID_PROTOCOL_VERSION",
+      message: "TLSv1.4 is not a valid minimum TLS protocol version",
+    });
+    const invalidMax = expect.objectContaining({
+      code: "ERR_TLS_INVALID_PROTOCOL_VERSION",
+      message: "tlsv1.3 is not a valid maximum TLS protocol version",
+    });
+    const badMin = { minVersion: "TLSv1.4" as any };
+    const badMax = { maxVersion: "tlsv1.3" as any };
+    expect(() => https.createServer({ key: agent2Key, cert: agent2Cert, ...badMin })).toThrow(invalidMin);
+    expect(() => https.createServer({ key: agent2Key, cert: agent2Cert, ...badMax })).toThrow(invalidMax);
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      const next = { key: agent3Key, cert: agent3Cert };
+      expect(() => server.setSecureContext({ ...next, ...badMin })).toThrow(invalidMin);
+      expect(() => server.setSecureContext({ ...next, ...badMax })).toThrow(invalidMax);
+      expect(() => server.addContext("a.example.com", { ...next, ...badMin })).toThrow(invalidMin);
+      const port = await listen(server);
+      expect(() => server.addContext("a.example.com", { ...next, ...badMax })).toThrow(invalidMax);
+      expect({ default: await peerCN(port), sni: await peerCN(port, "a.example.com") }).toEqual({
+        default: "agent2",
+        sni: "agent2",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("the constructor, setSecureContext and addContext accept key: [{ pem, passphrase }], like tls.Server", async () => {
+    const encrypted = { key: [{ pem: encryptedKey, passphrase: "password" }], cert: encryptedKeyCert };
+    const fromConstructor = https.createServer(encrypted);
+    const replaced = https.createServer({ key: agent2Key, cert: agent2Cert });
+    const withContexts = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      // A key that does not decrypt fails at the call, not later at listen().
+      expect(() =>
+        replaced.setSecureContext({ key: [{ pem: encryptedKey, passphrase: "wrong" }], cert: encryptedKeyCert }),
+      ).toThrow(expect.objectContaining({ code: "ERR_OSSL_BAD_DECRYPT" }));
+      replaced.setSecureContext(encrypted);
+      withContexts.addContext("a.example.com", encrypted);
+      const constructorPort = await listen(fromConstructor);
+      const replacedPort = await listen(replaced);
+      const contextsPort = await listen(withContexts);
+      withContexts.addContext("b.example.com", encrypted);
+      expect({
+        constructor: await peerCN(constructorPort),
+        setSecureContext: await peerCN(replacedPort),
+        addContextBeforeListen: await peerCN(contextsPort, "a.example.com"),
+        addContextAfterListen: await peerCN(contextsPort, "b.example.com"),
+        noMatch: await peerCN(contextsPort, "c.example.com"),
+      }).toEqual({
+        constructor: "localhost",
+        setSecureContext: "localhost",
+        addContextBeforeListen: "localhost",
+        addContextAfterListen: "localhost",
+        noMatch: "agent2",
+      });
+    } finally {
+      fromConstructor.close();
+      replaced.close();
+      withContexts.close();
+    }
+  });
+
+  test("the server's cipher order wins unless honorCipherOrder is false, like tls.Server", async () => {
+    const serverOrder = "ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256";
+    const clientOrder = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384";
+    const tlsOptions = { key: agent2Key, cert: agent2Cert, ciphers: serverOrder };
+    const byDefault = https.createServer(tlsOptions);
+    const clientDecides = https.createServer(tlsOptions);
+    try {
+      clientDecides.setSecureContext({ ...tlsOptions, honorCipherOrder: false });
+      const [defaultPort, clientDecidesPort] = [await listen(byDefault), await listen(clientDecides)];
+      expect({
+        byDefault: await negotiatedCipher(defaultPort, clientOrder),
+        clientDecides: await negotiatedCipher(clientDecidesPort, clientOrder),
+      }).toEqual({
+        byDefault: "ECDHE-RSA-AES256-GCM-SHA384",
+        clientDecides: "ECDHE-RSA-AES128-GCM-SHA256",
+      });
+    } finally {
+      byDefault.close();
+      clientDecides.close();
+    }
+  });
+
+  test("a ciphers list of only TLS 1.3 suites is accepted and pins TLS 1.3, like tls.Server", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert });
+    try {
+      server.setSecureContext({ key: agent2Key, cert: agent2Cert, ciphers: "TLS_AES_256_GCM_SHA384" });
+      const port = await listen(server);
+      expect({
+        tls12Client: await handshakeOutcome(port, { minVersion: "TLSv1.2", maxVersion: "TLSv1.2" }),
+        tls13Client: await handshakeOutcome(port, { minVersion: "TLSv1.3" }),
+      }).toEqual({
+        tls12Client: { code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION" },
+        tls13Client: { cn: "agent2" },
+      });
+    } finally {
+      server.close();
+    }
+  });
+
+  test("the constructor and setSecureContext apply tls.DEFAULT_MIN_VERSION like tls.Server", async () => {
+    // An EC certificate keeps the debug-build handshakes short.
+    const material = { key: load("ec10-key.pem"), cert: load("ec10-cert.pem") };
+    const tls12Client = { minVersion: "TLSv1.2", maxVersion: "TLSv1.2" } as const;
+    const previousDefault = tls.DEFAULT_MIN_VERSION;
+    tls.DEFAULT_MIN_VERSION = "TLSv1.3";
+    let fromConstructor: https.Server | undefined;
+    let fromSetSecureContext: https.Server | undefined;
+    try {
+      fromConstructor = https.createServer(material);
+      fromSetSecureContext = https.createServer(material);
+      fromSetSecureContext.setSecureContext(material);
+      const [constructorPort, setSecureContextPort] = [
+        await listen(fromConstructor),
+        await listen(fromSetSecureContext),
+      ];
+      expect({
+        fromConstructor: {
+          tls12Client: await handshakeOutcome(constructorPort, tls12Client),
+          tls13Client: await handshakeOutcome(constructorPort, { minVersion: "TLSv1.3" }),
+        },
+        fromSetSecureContext: { tls12Client: await handshakeOutcome(setSecureContextPort, tls12Client) },
+      }).toEqual({
+        fromConstructor: {
+          tls12Client: { code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION" },
+          tls13Client: { cn: "agent10.example.com" },
+        },
+        fromSetSecureContext: { tls12Client: { code: "ERR_SSL_TLSV1_ALERT_PROTOCOL_VERSION" } },
+      });
+    } finally {
+      tls.DEFAULT_MIN_VERSION = previousDefault;
+      fromConstructor?.close();
+      fromSetSecureContext?.close();
+    }
+  });
+
+  test("an mTLS server without `ca` verifies clients against tls.setDefaultCACertificates(), like tls.Server", async () => {
+    const mtls = { key: agent2Key, cert: agent2Cert, requestCert: true, rejectUnauthorized: true };
+    const handler: https.RequestListener = (req, res) => res.end("ok");
+    const servers: https.Server[] = [];
+    const previousDefaults = tls.getCACertificates("default");
+    try {
+      const createdBeforeOverride = https.createServer(mtls, handler);
+      servers.push(createdBeforeOverride);
+      tls.setDefaultCACertificates([privateCA]);
+      createdBeforeOverride.setSecureContext(mtls);
+      const createdUnderOverride = https.createServer(mtls, handler);
+      servers.push(createdUnderOverride);
+      tls.setDefaultCACertificates(previousDefaults);
+      const createdAfterRestore = https.createServer(mtls, handler);
+      servers.push(createdAfterRestore);
+
+      const [setSecureContextPort, constructorPort, restoredPort] = await Promise.all(servers.map(listen));
+      expect({
+        setSecureContext: await requestOutcome(setSecureContextPort, privateCAClient),
+        constructor: await requestOutcome(constructorPort, privateCAClient),
+        withoutOverride: await requestOutcome(restoredPort, privateCAClient),
+      }).toEqual({
+        setSecureContext: { cn: "agent2" },
+        constructor: { cn: "agent2" },
+        withoutOverride: { code: expect.stringMatching(/^ERR_SSL_|^ECONNRESET$/) },
+      });
+    } finally {
+      tls.setDefaultCACertificates(previousDefaults);
+      for (const server of servers) server.close();
     }
   });
 });

--- a/test/js/node/http/node-https-server-context.test.ts
+++ b/test/js/node/http/node-https-server-context.test.ts
@@ -170,7 +170,7 @@ describe("https.Server", () => {
       // previous working SNI entry.
       expect(() =>
         server.addContext("a.example.com", { key: agent1Key, cert: "-----BEGIN CERTIFICATE-----\ntruncated" }),
-      ).toThrow();
+      ).toThrow("PEM routines");
       expect(await peerCN(port, "a.example.com")).toBe("agent3");
     } finally {
       server.close();
@@ -232,6 +232,24 @@ describe("https.Server", () => {
       server.setSecureContext({ key: agent3Key, cert: agent3Cert });
       const port = await listen(server);
       expect(await peerCN(port)).toBe("agent3");
+    } finally {
+      server.close();
+    }
+  });
+
+  test("setSecureContext with an invalid option applies nothing", async () => {
+    const server = https.createServer({ key: agent2Key, cert: agent2Cert }, (req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    try {
+      // Rejected on `key`, after `cert` was already read: the new cert must not
+      // be left paired with the old key.
+      expect(() => server.setSecureContext({ cert: agent3Cert, key: 123 as any })).toThrow(
+        'The "options.key" property must be of type string or an instance of Buffer, TypedArray, or DataView.',
+      );
+      const port = await listen(server);
+      expect(await peerCN(port)).toBe("agent2");
     } finally {
       server.close();
     }

--- a/test/js/node/tls/node-tls-context.test.ts
+++ b/test/js/node/tls/node-tls-context.test.ts
@@ -140,6 +140,26 @@ describe("tls.Server", () => {
     }
   });
 
+  it("addContext rejects an empty hostname up front, like Node", async () => {
+    const server = tls.createServer({ key: agent2Key, cert: agent2Cert });
+    const context = { key: agent1Key, cert: agent1Cert };
+    const requiredServerName = expect.objectContaining({
+      code: "ERR_TLS_REQUIRED_SERVER_NAME",
+      message: '"servername" is required parameter for Server.addContext',
+    });
+    try {
+      expect(() => server.addContext("", context)).toThrow(requiredServerName);
+      // Nothing was buffered for the empty name, so listen() still succeeds.
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      server.once("error", reject);
+      server.listen(0, resolve);
+      await promise;
+      expect(() => server.addContext("", context)).toThrow(requiredServerName);
+    } finally {
+      server.close();
+    }
+  });
+
   it("should select the most recently added SecureContext", async () => {
     let listening_server: tls.Server | null = null;
     const { promise, resolve, reject } = Promise.withResolvers();


### PR DESCRIPTION
### What does this PR do?

Fixes #12157.
Fixes #24474.

`https.Server` was a direct alias for `http.Server`, so none of the `tls.Server` methods (`addContext`, `setSecureContext`, `getTicketKeys`, `setTicketKeys`) were available on servers created via `https.createServer()`. In Node.js, `https.Server` extends `tls.Server`, which provides these.

#### Reproduction

```ts
import https from "https";

const server = https.createServer({ ca: "", cert: "", key: "" });
server.addContext("my-domain.com", { ca: "", cert: "", key: "" });
```

```
TypeError: server.addContext is not a function. (In 'server.addContext("my-domain.com", {...})', 'server.addContext' is undefined)
```

#### Fix

- `https.Server` is now its own class extending `http.Server` (so `httpsServer instanceof http.Server` is still `true`, and `http.Server` does not gain these methods).
- `addContext(hostname, context)` accepts the same options as the constructor (key/cert/ca, pfx, minVersion/maxVersion, secureProtocol, ciphers, crl, sigalgs, ecdhCurve, sessionTimeout, allowPartialTrustChain, honorCipherOrder, per-context requestCert/rejectUnauthorized; an empty hostname throws `ERR_TLS_REQUIRED_SERVER_NAME` like Node) and buffers the context. When `listen()` is called, the buffered SNI contexts are passed to `Bun.serve` via the `tls` array so each `serverName` is matched via SNI. When called after `listen()`, a new native binding (`httpServerAddServerName`) registers the SNI context on the running uWS SSL app via `uws_add_server_name_with_options` and reinstalls routes for that domain.
- `setSecureContext(options)` rebuilds the default TLS config used at `listen()` from the options given (an omitted option is cleared, as in Node), keeping the server's `requestCert`/`rejectUnauthorized`; like Node, providing `ca` alone does not start requiring a client certificate. Nothing is applied unless every option validated.
- The constructor, `addContext()` and `setSecureContext()` share one option pipeline (`serverTlsFromOptions` in `internal/tls`, extracted from `http.Server`'s constructor), so the three cannot drift apart again. `https.Server` marks itself TLS before `http.Server` runs, so it gets a real config even when constructed without certificates. The helper also passes `crl`, `sigalgs`, `ecdhCurve`, `sessionTimeout` and `allowPartialTrustChain` to the native config (validated the way `tls.Server#setSecureContext()` validates them), and like `tls.Server` makes the server's cipher order win unless `honorCipherOrder: false` and applies the process-wide `tls.DEFAULT_MIN_VERSION` / `DEFAULT_MAX_VERSION` / `DEFAULT_ECDH_CURVE` and the `tls.setDefaultCACertificates()` override when no `ca` is given, and runs `ciphers` through the same `validateCiphers()` / `stripTls13CipherNames()` as `tls.Server` (those helpers also moved to `internal/tls`), so a list of TLS 1.3 suite names pins TLS 1.3 instead of failing at `listen()` and a bad list throws before anything is applied (that state, including the `--tls-min/max-vX.Y` seeding, now lives in `internal/tls` and `node:tls` reads and writes it there); the `http.Server` constructor used to ignore all of these. The helper also decrypts `key: [{ pem, passphrase }]` entries with the same `normalizePemKeyOption()` as `tls.Server` (they passed validation and were then rejected by the native layer, at `listen()` or, after listen, in `addContext()`), and rejects a `minVersion` / `maxVersion` string that is not a TLS version with `ERR_TLS_INVALID_PROTOCOL_VERSION` the way `tls.Server` does, instead of silently selecting the default. Both helpers moved to `internal/tls` as well.
- `getTicketKeys()` / `setTicketKeys()` are stubbed the same way as on `tls.Server`. Also fixed the existing `"implented"` typo in the `tls.Server` stubs.
- `req.socket.authorized` / `authorizationError` now follow the context the connection was accepted under. They used to consult only the default config's `requestCert`, so a client certificate presented to a hostname that `addContext()` made mTLS-only read as unauthorized. uWS records the default entry's `requestCert` and combines it at handshake time with the SNI-selected context's policy (new `us_socket_server_name_request_cert()`), recording the verification result only when that connection was asked for a certificate (Node's not-requested means false / null), so the getters just read the handle.

#### Verification

New tests at `test/js/node/http/node-https-server-context.test.ts`:

- `https.Server` exposes all four methods and is an `http.Server` subclass
- a plain `http.Server` given only TLS-irrelevant options (a bad `passphrase`) serves HTTP, while one given `key` / `cert` still serves TLS
- `addContext` before `listen()`: connecting with SNI `"a.example.com"` and `"b.example.com"` returns the respective per-hostname certs (CN `agent1` / `agent3`); an unknown SNI falls through to the default cert (CN `agent2`)
- `addContext` after `listen()`: same SNI behavior on a running server, plus an HTTPS request still reaches the request handler
- `setSecureContext` before `listen()` replaces the default cert
- `setSecureContext({key, cert, ca})` on a server created with no initial TLS options does not require a client certificate
- `addContext("")` throws before and after `listen()`, and `pfx` works through `addContext()` (both phases) and `setSecureContext()`
- with a non-mTLS default context and an mTLS `addContext()` hostname: a client with a valid certificate on that hostname reads `authorized: true`, one without reads `false` + `UNABLE_TO_GET_ISSUER_CERT`, and a certificate offered to the default hostname reads `false` + `null` (Node's `test-https-pfx`, `test-https-strict`, `test-tls-server-verify` and the SNI tests still pass)
- `setSecureContext()` applies `ecdhCurve` (a P-256-only client is refused by a secp384r1 context), a post-listen `addContext()` applies `crl` (a revoked client certificate passes the context without the CRL and is refused by the one with it), and the shared validation of these options runs before anything is applied; a TLS 1.2 client offering the reverse cipher order gets the server's first cipher by default and its own with `honorCipherOrder: false`; with `tls.DEFAULT_MIN_VERSION = "TLSv1.3"` set, both a constructor-configured and a `setSecureContext()`-configured server refuse a TLS 1.2 client (Node's `test-tls-cli-{min,max}-version-*` and `test-tls-min-max-version` still pass against the moved state); with `tls.setDefaultCACertificates([privateCA])` installed, an mTLS server without `ca` (constructor or `setSecureContext()`) accepts a client signed by that CA and one configured after the override is removed refuses it (`ssl-ctx-cache.test.ts` and Node's 20 `set-default-ca-certificates` / `get-ca-certificates` tests still pass); `setSecureContext({ ciphers: "TLS_AES_256_GCM_SHA384" })` listens (it used to fail with `ERR_SSL_NO_CIPHER_MATCH` at listen) and refuses a TLS 1.2 client, while `@SECLEVEL=0` and an unknown list throw `ERR_SSL_INVALID_COMMAND` / `ERR_SSL_NO_CIPHER_MATCH` synchronously and apply nothing (Node's tls cipher tests still pass)
- the constructor, `setSecureContext()` and `addContext()` (before and after `listen()`) serve a certificate whose key was given as `[{ pem, passphrase }]`, a wrong passphrase throws `ERR_OSSL_BAD_DECRYPT` at the call, and all three throw `ERR_TLS_INVALID_PROTOCOL_VERSION` for `minVersion: "TLSv1.4"` / `maxVersion: "tlsv1.3"` without applying anything (Node's `test-tls-passphrase`, `test-tls-multi-key` and `test-tls-min-max-version` still pass against the moved helpers)
- `setSecureContext()` applies `minVersion`, clears a `minVersion` the constructor had set, rejects an unknown `secureProtocol` without applying anything, and keeps the constructor's client certificate policy (a client with a certificate from the configured CA is served the new certificate, one without is refused)

All tests fail on `main` (`TypeError: server.addContext is not a function`) and pass with this change. Existing `test/js/node/tls/node-tls-context.test.ts`, `test/js/node/tls/node-tls-server.test.ts`, `test/js/node/http/node-https-checkServerIdentity.test.ts`, and the `test-https-*` Node parallel tests still pass.

Supersedes #31095 by @sam-shridhar1950f, which introduced the same `https.Server` subclass split with method stubs (credited with a `Co-authored-by` trailer on the commit); this PR additionally wires `addContext` to the underlying SNI mechanism, both at listen time and on a running server, so the contexts actually select per-hostname certificates. Making `https.Server` a distinct class also fixes the `instanceof` confusion from #31125 (supertest <= 6.1.6 and `@astrojs/node` treat every `http.Server` as HTTPS on Bun).

#### Known limitations (unchanged from the original review)

- `addContext()` / `setSecureContext()` take plain `{ key, cert, ca, ... }` objects; a `tls.createSecureContext()` result is not accepted, because `Bun.serve`'s TLS config is built from PEM material and cannot adopt an existing `SSL_CTX`. Supporting it needs native plumbing shared with `tls.Server` and is left as a follow-up.
- `setSecureContext()` after `listen()` only affects the next `listen()`, the same as Bun's `tls.Server` today; there is no uWS primitive for swapping a running app's default context. `addContext()` after `listen()` does take effect.

#### Rebase notes (current main)

- `https.createServer()` on main had grown the ALPN defaulting from Node's `https.Server` constructor; that logic now lives in the new `Server` constructor (as in Node), and `createServer()` returns `new Server(...)`, so `new https.Server()` gets the same defaults.
- The post-listen path passes `apply_client_cert_policy = true` to `add_server_name_with_options`, matching what the listen-time `tls` array entries get since #36174, so a context's `requestCert` / `rejectUnauthorized` behave the same whether it was added before or after `listen()`.
- `App::remove_server_name` (the `uws_remove_server_name` binding, removed as unused in #35002) is restored since it now has a caller.
- The test helper reads the response through `https.get` instead of parsing raw bytes, since the server now sends the `writeHead(); end("ok")` body chunked.
- The `instanceof` coverage from #31095 is carried over as a test here (`http.createServer()` is not an `https.Server`, `http.Server` does not gain `addContext`).
- Two review findings after the rebase: `setSecureContext()` used to update the live config in place (a rejected option left a half-applied config; the test for it fails against that version with `KEY_VALUES_MISMATCH` at listen), and both methods still used the option list from before #32488, so `pfx`, `minVersion`/`maxVersion`, `secureProtocol` and `ciphers` were silently dropped (a `pfx` context registered with no certificate). Both are fixed by the shared helper above; `ERR_TLS_REQUIRED_SERVER_NAME` is added to `ErrorCode.ts` for the empty-hostname case, and the native binding rejects an empty name like `Listener::add_server_name` does. `tls.Server#addContext()` gets the same up-front check (it used to accept `""` and fail later at `listen()`), covered in `test/js/node/tls/node-tls-context.test.ts`.
- Later review round: after a successful `add_server_name_with_options` the post-listen path had two dead error-queue checks that returned before `set_routes()` (which would have left the hostname registered with an empty router); they are removed, along with the HTTP/3 branch (unreachable from `node:https`, and the QUIC SNI table has no remove operation, so it could not have given a repeated hostname last-wins semantics); a debug assertion records that this path has no HTTP/3 app. `tls.Server#addContext()` and the `addContext` dedup loop (`ArrayPrototypeSplice`) were tidied in the same rounds.
- Rebased again onto current main (d0f6486). #39628 moved `node:http` / `node:https` / `node:tls` module-init work to first use, so this change follows it: `_http_server.ts` and `https.ts` require `internal/tls` inside `listen()`, `addContext()`, `setSecureContext()` and the constructor (there only behind main's existing gate: an `https.Server`, or `pfx` / `cert` / `key` / `ca` given, so a plain `http.Server` does not load it; with that gate the helper always returns a config, and a plain server no longer type-checks a `passphrase` / `servername` / `secureOptions` it does not use, as in Node) instead of at module load, the `https.Server` constructor requires `node:tls` for `convertALPNProtocols()` the way `createServer()` did on main, and the cipher selector set that #39628 made lazy in `node:tls` stays lazy in its new home in `internal/tls`. The `socket.authorized` / `authorizationError` change was re-applied inside the server socket class, which main now builds on the first connection. Nothing else changed in the resolution. On the rebased debug build: `node-https-server-context.test.ts` 26/26, `node-tls-context.test.ts` 18/18, and `node-http`, `node-https-checkServerIdentity`, `node-tls-server`, `node-tls-create-secure-context-args` and `node-tls-connect` pass apart from the two environment cases below (proxy env vars, `localhost` resolving to `::1`), which fail the same way on an unmodified binary here. Node's tls cipher, passphrase, min/max version and https creation / pfx / strict tests pass.
- Rebased onto current main (c6f335f, 138 commits later). Two conflicts, both in the usockets files that #40137 (HTTP/2 for `Bun.serve`) also extends: `openssl.c` and `libusockets.h` now carry both its ALPN helpers and this PR's `us_internal_ssl_ctx_clear_sni_userdata()`. Two things changed outside conflict markers: `uws_remove_server_name` in `libuwsockets.cpp` is restored (removed as unused in #37181, it has a caller again, the same situation as #35002 before), and the binding reads the hostname with `JSValue::to_utf8()` because #40238 removed `bun_core::OwnedString`. On the rebased debug build: `node-https-server-context.test.ts` 26/26, `node-tls-context.test.ts` 18/18, `node-http`, `node-https-checkServerIdentity`, `node-tls-server` and `bun-serve-ssl` pass apart from the two environment cases below, and main's new `serve-http2` and `serve-http2-lifecycle` suites (97 tests) pass.
- Rebased onto current main (43fad9b). The only conflict was the tail of `ErrorCode.ts`, where #40592 added `ERR_FFI_CC_DISABLED` next to this PR's `ERR_TLS_REQUIRED_SERVER_NAME`; both entries are kept. Nothing else changed. On the rebased debug build: `node-https-server-context.test.ts` 26/26, `node-tls-context.test.ts` 18/18, and `node-http`, `node-https-checkServerIdentity`, `node-tls-server` and `node-tls-connect` pass (278 tests) apart from the two environment cases below.
- Verified: `test/js/node/http/node-https-server-context.test.ts` (26/26, all fail on main), `node-http.test.ts`, `node-https-checkServerIdentity.test.ts`, `node-http-agent-tls-options.test.mts`, `node-tls-context.test.ts`, `node-tls-server.test.ts`, `bun-serve-ssl.test.ts`, and all 76 `test-https-*` Node parallel tests; the only failures seen also fail on main in this environment (proxy env vars, `localhost` resolving to `::1`). Also 15/15 on Windows x64 (debug build). The `minVersion` test reads the refused handshake through a try/catch helper rather than `expect().rejects`: the latter spins a nested event loop, which on Windows hits a pre-existing usockets crash that reproduces on main with a plain `https.createServer({ minVersion })` (the libuv backend never sets `tick_depth`, so a nested tick frees the socket whose callback is still on the stack); reported separately.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 22 · 17 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 27 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-https-server-context.test.ts test/js/node/tls/node-tls-context.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [838.00ms]
146 |     const requiredServerName = expect.objectContaining({
147 |       code: "ERR_TLS_REQUIRED_SERVER_NAME",
148 |       message: '"servername" is required parameter for Server.addContext',
149 |     });
150 |     try {
151 |       expect(() => server.addContext("", context)).toThrow(requiredServerName);
                                                         ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: undefined

      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-context.test.ts:151:52)
      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-context.test.ts:143:66)
(fail) tls.Server > addContext rejects an empty hostname up front, like Node [22.30ms]
(pass) tls.Server > should select the most recently added SecureC
... (truncated)

release without fix: 27 FAILED
bun test v1.4.1-canary.1 (65362b53b)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [42.59ms]
146 |     const requiredServerName = expect.objectContaining({
147 |       code: "ERR_TLS_REQUIRED_SERVER_NAME",
148 |       message: '"servername" is required parameter for Server.addContext',
149 |     });
150 |     try {
151 |       expect(() => server.addContext("", context)).toThrow(requiredServerName);
                                                         ^
error: expect(received).toThrow(expected)

Expected constructor: ExpectObjectContaining

Received function did not throw
Received value: undefined

      at <anonymous> (/workspace/bun/test/js/node/tls/node-tls-context.test.ts:151:52)
(fail) tls.Server > addContext rejects an empty hostname up front, like Node [1.10ms]
(pass) tls.Server > should select the most recently added SecureContext [10.10ms]
(pass) tls.Server > should allow multiple CA [6.45ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [3.59ms]
(pass) tls.Server > SNI tls.Server + tls.connect [15.84ms]
(pass) Bun.serve SNI > single SNI [19.67ms]
(pass) Bun.serve SNI > multiple SNI [10.10ms]
(pas
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-https-server-context.test.ts test/js/node/tls/node-tls-context.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/tls/node-tls-context.test.ts:
(pass) tls.Server > addContext [1225.66ms]
(pass) tls.Server > addContext rejects an empty hostname up front, like Node [34.48ms]
(pass) tls.Server > should select the most recently added SecureContext [175.64ms]
(pass) tls.Server > should allow multiple CA [218.60ms]
(pass) tls.Server > should allow multiple CA in newline-separated strings [86.84ms]
(pass) tls.Server > SNI tls.Server + tls.connect [396.84ms]
(pass) Bun.serve SNI > single SNI [519.07ms]
(pass) Bun.serve SNI > multiple SNI [242.82ms]
(pass) server certificate chain built from `ca` > presents an intermediate known only to the default store (NODE_EXTRA_CA_CERTS) [2440.75ms]
(pass) server certificate chain built from `ca` > does not present `ca` entries unrelated to the leaf's issuer chain [70.93ms]
(pass) server certificate chain built from `ca` > presents the issuer path when the leaf and intermediate are lo
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e2db850e8a
  features     baseline

23 deps, 131 codegen, 1172 objects in 744ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.1-canary.1 (65362b53b)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1244] gen bindgenv2
[3/1244] install /workspace/bun/packages/bun-error
bun install v1.4.1-canary.1 (65362b53b)

Checked 1 install across 2 packages (no changes) [5.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] fetch zlib
[zlib] up to date
[7/1217] install /workspace/bun/src/node-fallbacks
bun install v1.4.1-canary.1 (65362b53b)

Checked 111 installs across 104 packages (no changes) [14.00ms]
[8/1217] gen .bind.ts → GeneratedBindings.cpp
[9/1217] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[10/1217] fetch tinycc
[tinycc] up to date
[11/1216] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/Proc
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/crypto/openssl.c         |  18 +
 packages/bun-usockets/src/libusockets.h            |   3 +
 packages/bun-uws/src/App.h                         |   8 +
 packages/bun-uws/src/HttpContext.h                 |   8 +-
 packages/bun-uws/src/HttpContextData.h             |   1 +
 src/js/internal/http.ts                            |   2 +
 src/js/internal/tls.ts                             | 349 +++++++++-
 src/js/node/_http_server.ts                        | 117 +---
 src/js/node/https.ts                               |  91 ++-
 src/js/node/tls.ts                                 | 291 +--------
 src/jsc/bindings/ErrorCode.ts                      |   1 +
 src/runtime/node/node_http_binding.rs              |  35 +-
 src/runtime/server/server_body.rs                  |  89 +++
 src/uws_sys/App.rs                                 |  16 +
 src/uws_sys/libuwsockets.cpp                       |  14 +
 .../js/node/http/node-https-server-context.test.ts | 714 +++++++++++++++++++++
 test/js/node/tls/node-tls-context.test.ts          |  20 +
 17 files changed, 1409 insertions(+), 368 deletions(-)
```

</details>

**gate history** · 17 passed · 2 rejected · iteration 22

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
packages/bun-usockets/src/crypto/openssl.c               3      2     37
packages/bun-usockets/src/libusockets.h                  3      3     37
packages/bun-uws/src/App.h                               1      1     37
packages/bun-uws/src/HttpContext.h                       2      3     37
packages/bun-uws/src/HttpContextData.h                   1      2     37
src/js/internal/http.ts                                  3      3     37
src/js/internal/tls.ts                                  21     30     37
src/js/node/_http_server.ts                             15     15     37
src/js/node/https.ts                                    20     30     37
src/js/node/tls.ts                                      25     13     37
src/jsc/bindings/ErrorCode.ts                            1      2     37
src/runtime/node/node_http_binding.rs                    4      4     37
src/runtime/server/server_body.rs                       10      9     37
src/uws_sys/App.rs                                       1      0     37
src/uws_sys/libuwsockets.cpp                             1      2     37
test/js/node/http/node-https-server-context.test.ts     19     34     28
(+ 1 more files)
```

</details>

<!-- robobun:evidence:end -->















