### PR TITLE
fix(ws): pass ServerWebSocket to cork() callback

### DIFF
--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -1032,7 +1032,7 @@ impl ServerWebSocket {
         }
 
         let mut corker = Corker {
-            args: &[],
+            args: &[this_value],
             global_object: global_this,
             this_value,
             callback,

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -941,6 +941,41 @@ describe("ServerWebSocket", () => {
       },
     };
   });
+  // https://github.com/oven-sh/bun/issues/21588
+  test("cork() passes ws to callback", done => {
+    let count = 0;
+    return {
+      open(ws) {
+        try {
+          let thisInside;
+          const ret = ws.cork(function (ctx) {
+            thisInside = this;
+            ctx.send("1");
+            ctx.sendText("2");
+            ctx.sendBinary(new TextEncoder().encode("3"));
+            return ctx;
+          });
+          expect(ret).toBe(ws);
+          expect(thisInside).toBe(ws);
+          ws.cork(ctx => {
+            expect(ctx).toBe(ws);
+          });
+        } catch (err) {
+          done(err);
+        }
+      },
+      message(_, message) {
+        if (typeof message === "string") {
+          expect(+message).toBe(++count);
+        } else {
+          expect(+new TextDecoder().decode(message)).toBe(++count);
+        }
+        if (count === 3) {
+          done();
+        }
+      },
+    };
+  });
   describe("close()", () => {
     test("(no arguments)", done => ({
       open(ws) {


### PR DESCRIPTION
## What does this PR do?

Fixes #21588

`ServerWebSocket.prototype.cork(callback)` is [documented](https://bun.com/docs/api/websockets#reference) and [typed](https://github.com/oven-sh/bun/blob/main/packages/bun-types/serve.d.ts#L224-L230) to invoke `callback` with the `ServerWebSocket` instance as its first argument:

```ts
ws.cork((ctx) => {
  ctx.send("These messages");
  ctx.sendText("are sent");
  ctx.sendBinary(new TextEncoder().encode("together!"));
});
```

However the implementation passed no arguments to the callback (only the `this` binding was set), so the arrow-function usage from the docs threw `TypeError: undefined is not an object (evaluating 'ctx.send')`.

## How did you verify your code works?

Added a test in `test/js/bun/websocket/websocket-server.test.ts` that asserts the callback's first argument and `this` are both `=== ws`, and that sends via `ctx` reach the client.

- Fails on released bun: `TypeError: undefined is not an object (evaluating 'ctx.send')`
- Passes with this change.