### PR TITLE
crypto: accept `shake-128`/`shake-256` aliases in createHash and crypto.hash

### DIFF
--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -93,7 +93,7 @@ impl CryptoHasher {
             return Some(CryptoHasher::new(CryptoHasher::Zig(JsCell::new(inner))));
         }
 
-        let algorithm = evp::lookup(name)?;
+        let algorithm = evp::lookup_ignore_case(name)?;
 
         match algorithm {
             evp::Algorithm::Ripemd160
@@ -506,10 +506,10 @@ impl CryptoHasher {
             if let Some(key) = &hmac_key {
                 // Inlined `JSValue::to_enum_from_map` (the `is_string` guard
                 // already ran above) so the lookup goes through the
-                // length-gated `evp::lookup` directly.
+                // length-gated `evp::lookup_ignore_case` directly.
                 let chosen_algorithm: evp::Algorithm = {
                     let slice = algorithm_name.to_slice(global)?;
-                    match evp::lookup(slice.slice()) {
+                    match evp::lookup_ignore_case(slice.slice()) {
                         Some(v) => v,
                         None => {
                             return Err(global.throw_invalid_arguments(format_args!(
@@ -796,7 +796,6 @@ pub struct CryptoHasherZig {
 /// Trait for the non-BoringSSL hash algorithms used by `CryptoHasherZig`.
 /// Implemented for each algo in `zig_crypto_algos` below.
 pub trait ZigHashAlgo: Default + Clone + 'static {
-    const NAME: &'static [u8];
     const ALGORITHM: evp::Algorithm;
     /// Shake128→16, Shake256→32, else the algorithm's digest length.
     const DIGEST_LENGTH: u8;
@@ -825,9 +824,8 @@ mod zig_crypto_algos {
     /// Fixed-digest Keccak/BLAKE2 — `final_` writes exactly `DIGEST_LENGTH`
     /// bytes via `FixedOutputReset`.
     macro_rules! impl_fixed {
-        ($ty:ty, $name:literal, $variant:ident, $len:expr) => {
+        ($ty:ty, $variant:ident, $len:expr) => {
             impl ZigHashAlgo for $ty {
-                const NAME: &'static [u8] = $name;
                 const ALGORITHM: evp::Algorithm = evp::Algorithm::$variant;
                 const DIGEST_LENGTH: u8 = $len;
                 fn update(&mut self, bytes: &[u8]) {
@@ -847,9 +845,8 @@ mod zig_crypto_algos {
     /// SHAKE XOF — default digest lengths: Shake128 = 16, Shake256 = 32;
     /// `final_` squeezes exactly `out.len` bytes.
     macro_rules! impl_xof {
-        ($ty:ty, $name:literal, $variant:ident, $len:expr) => {
+        ($ty:ty, $variant:ident, $len:expr) => {
             impl ZigHashAlgo for $ty {
-                const NAME: &'static [u8] = $name;
                 const ALGORITHM: evp::Algorithm = evp::Algorithm::$variant;
                 const DIGEST_LENGTH: u8 = $len;
                 fn update(&mut self, bytes: &[u8]) {
@@ -864,25 +861,25 @@ mod zig_crypto_algos {
         };
     }
 
-    impl_fixed!(Sha3_224, b"sha3-224", Sha3_224, 28);
-    impl_fixed!(Sha3_256, b"sha3-256", Sha3_256, 32);
-    impl_fixed!(Sha3_384, b"sha3-384", Sha3_384, 48);
-    impl_fixed!(Sha3_512, b"sha3-512", Sha3_512, 64);
-    impl_xof!(Shake128, b"shake128", Shake128, 16);
-    impl_xof!(Shake256, b"shake256", Shake256, 32);
-    impl_fixed!(Blake2s256, b"blake2s256", Blake2s256, 32);
+    impl_fixed!(Sha3_224, Sha3_224, 28);
+    impl_fixed!(Sha3_256, Sha3_256, 32);
+    impl_fixed!(Sha3_384, Sha3_384, 48);
+    impl_fixed!(Sha3_512, Sha3_512, 64);
+    impl_xof!(Shake128, Shake128, 16);
+    impl_xof!(Shake256, Shake256, 32);
+    impl_fixed!(Blake2s256, Blake2s256, 32);
 }
 
-/// Expands the macro once per supported `(name_literal, Type)` pair.
+/// Expands the macro once per supported `ZigHashAlgo` type.
 macro_rules! for_each_zig_algo {
     ($mac:ident $(, $($args:tt)*)?) => {
-        $mac!(b"sha3-224",   Sha3_224   $(, $($args)*)?);
-        $mac!(b"sha3-256",   Sha3_256   $(, $($args)*)?);
-        $mac!(b"sha3-384",   Sha3_384   $(, $($args)*)?);
-        $mac!(b"sha3-512",   Sha3_512   $(, $($args)*)?);
-        $mac!(b"shake128",   Shake128   $(, $($args)*)?);
-        $mac!(b"shake256",   Shake256   $(, $($args)*)?);
-        $mac!(b"blake2s256", Blake2s256 $(, $($args)*)?);
+        $mac!(Sha3_224   $(, $($args)*)?);
+        $mac!(Sha3_256   $(, $($args)*)?);
+        $mac!(Sha3_384   $(, $($args)*)?);
+        $mac!(Sha3_512   $(, $($args)*)?);
+        $mac!(Shake128   $(, $($args)*)?);
+        $mac!(Shake256   $(, $($args)*)?);
+        $mac!(Blake2s256 $(, $($args)*)?);
     };
 }
 
@@ -898,7 +895,7 @@ impl CryptoHasherZig {
             return Ok(None);
         };
         macro_rules! arm {
-            ($name:literal, $ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
+            ($ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
                 if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
                     return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out)?));
                 }
@@ -1018,7 +1015,7 @@ impl CryptoHasherZig {
     pub fn init(name: &[u8]) -> Option<CryptoHasherZig> {
         let algorithm = evp::lookup_ignore_case(name)?;
         macro_rules! arm {
-            ($name:literal, $ty:ty, $alg:expr) => {
+            ($ty:ty, $alg:expr) => {
                 if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
                     let handle = CryptoHasherZig {
                         algorithm: <$ty as ZigHashAlgo>::ALGORITHM,
@@ -1035,7 +1032,7 @@ impl CryptoHasherZig {
 
     fn update(&mut self, bytes: &[u8]) {
         macro_rules! arm {
-            ($name:literal, $ty:ty, $self:expr, $bytes:expr) => {
+            ($ty:ty, $self:expr, $bytes:expr) => {
                 if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
                     // SAFETY: tag matches type stored in `state` (set in init/constructor).
                     let state = $self.state.downcast_mut::<$ty>().expect("unreachable");
@@ -1049,7 +1046,7 @@ impl CryptoHasherZig {
 
     fn copy(&self) -> CryptoHasherZig {
         macro_rules! arm {
-            ($name:literal, $ty:ty, $self:expr) => {
+            ($ty:ty, $self:expr) => {
                 if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
                     let state = $self.state.downcast_ref::<$ty>().expect("unreachable");
                     return CryptoHasherZig {
@@ -1070,7 +1067,7 @@ impl CryptoHasherZig {
         res_len: usize,
     ) -> &'a mut [u8] {
         macro_rules! arm {
-            ($name:literal, $ty:ty, $self:expr, $out:expr, $len:expr) => {
+            ($ty:ty, $self:expr, $out:expr, $len:expr) => {
                 if $self.algorithm == <$ty as ZigHashAlgo>::ALGORITHM {
                     let state = $self.state.downcast_mut::<$ty>().expect("unreachable");
                     <$ty as ZigHashAlgo>::final_(state, $out);

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -893,14 +893,18 @@ impl CryptoHasherZig {
         input: &BlobOrStringOrBuffer,
         output: Option<StringOrBuffer>,
     ) -> JsResult<Option<JSValue>> {
+        let name = algorithm.to_slice();
+        let Some(algo) = evp::lookup_ignore_case(name.slice()) else {
+            return Ok(None);
+        };
         macro_rules! arm {
             ($name:literal, $ty:ty, $g:expr, $alg:expr, $in:expr, $out:expr) => {
-                if $alg.eql_comptime($name) {
+                if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
                     return Ok(Some(Self::hash_by_name_inner::<$ty>($g, $in, $out)?));
                 }
             };
         }
-        for_each_zig_algo!(arm, global, algorithm, input, output);
+        for_each_zig_algo!(arm, global, algo, input, output);
         Ok(None)
     }
 
@@ -1006,27 +1010,16 @@ impl CryptoHasherZig {
     }
 
     fn constructor(algorithm: &ZigString) -> Option<Box<CryptoHasher>> {
-        macro_rules! arm {
-            ($name:literal, $ty:ty, $alg:expr) => {
-                if $alg.eql_comptime($name) {
-                    return Some(CryptoHasher::new(CryptoHasher::Zig(JsCell::new(
-                        CryptoHasherZig {
-                            algorithm: <$ty as ZigHashAlgo>::ALGORITHM,
-                            state: Box::new(<$ty as ZigHashAlgo>::init()),
-                            digest_length: <$ty as ZigHashAlgo>::DIGEST_LENGTH,
-                        },
-                    ))));
-                }
-            };
-        }
-        for_each_zig_algo!(arm, algorithm);
-        None
+        let name = algorithm.to_slice();
+        Self::init(name.slice())
+            .map(|inner| CryptoHasher::new(CryptoHasher::Zig(JsCell::new(inner))))
     }
 
-    pub fn init(algorithm: &[u8]) -> Option<CryptoHasherZig> {
+    pub fn init(name: &[u8]) -> Option<CryptoHasherZig> {
+        let algorithm = evp::lookup_ignore_case(name)?;
         macro_rules! arm {
             ($name:literal, $ty:ty, $alg:expr) => {
-                if $alg == $name {
+                if $alg == <$ty as ZigHashAlgo>::ALGORITHM {
                     let handle = CryptoHasherZig {
                         algorithm: <$ty as ZigHashAlgo>::ALGORITHM,
                         state: Box::new(<$ty as ZigHashAlgo>::init()),

--- a/src/runtime/crypto/EVP.rs
+++ b/src/runtime/crypto/EVP.rs
@@ -156,12 +156,7 @@ bun_core::comptime_string_map! {
 // b"rsa-sha512" => .@"RSA-SHA512",
 // b"rsa-ripemd160" => .@"RSA-RIPEMD160",
 
-/// Case-sensitive name → `Algorithm`.
-pub(crate) fn lookup(bytes: &[u8]) -> Option<Algorithm> {
-    ALGORITHM_MAP.get(bytes).copied()
-}
-
-/// ASCII-case-insensitive `lookup`.
+/// ASCII-case-insensitive name → `Algorithm`.
 pub(crate) fn lookup_ignore_case(bytes: &[u8]) -> Option<Algorithm> {
     ALGORITHM_MAP.get_ascii_case_insensitive(bytes).copied()
 }

--- a/src/runtime/crypto/EVP.rs
+++ b/src/runtime/crypto/EVP.rs
@@ -126,6 +126,8 @@ bun_core::comptime_string_map! {
         b"sha3-512" => Algorithm::Sha3_512,
         b"shake128" => Algorithm::Shake128,
         b"shake256" => Algorithm::Shake256,
+        b"shake-128" => Algorithm::Shake128,
+        b"shake-256" => Algorithm::Shake256,
         b"ripemd160" => Algorithm::Ripemd160,
         b"blake2b256" => Algorithm::Blake2b256,
         b"blake2b512" => Algorithm::Blake2b512,

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -331,6 +331,32 @@ describe("createHash", () => {
     });
   }
 
+  // https://github.com/oven-sh/bun/issues/18019
+  describe.each([
+    ["shake128", "7f9c2ba4e88f827d616045507605853e"],
+    ["shake-128", "7f9c2ba4e88f827d616045507605853e"],
+    ["SHAKE128", "7f9c2ba4e88f827d616045507605853e"],
+    ["SHAKE-128", "7f9c2ba4e88f827d616045507605853e"],
+    ["Shake-128", "7f9c2ba4e88f827d616045507605853e"],
+    ["shake256", "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f"],
+    ["shake-256", "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f"],
+    ["SHAKE256", "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f"],
+    ["SHAKE-256", "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f"],
+    ["Shake-256", "46b9dd2b0ba88d13233b3feb743eeb243fcd52ea62b81b82b50c27646ed5762f"],
+    ["blake2s256", "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"],
+    ["BLAKE2s256", "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"],
+  ])("accepts alias %s", (alias, expected) => {
+    it("via createHash", () => {
+      expect(crypto.createHash(alias).update("").digest("hex")).toBe(expected);
+    });
+    it("via crypto.hash", () => {
+      expect(crypto.hash(alias, "", "hex")).toBe(expected);
+    });
+    it("via Bun.CryptoHasher", () => {
+      expect(new Bun.CryptoHasher(alias).update("").digest("hex")).toBe(expected);
+    });
+  });
+
   it("update & digest", () => {
     const hash = crypto.createHash("sha256");
     hash.update("some data to hash");

--- a/test/js/node/crypto/node-crypto.test.js
+++ b/test/js/node/crypto/node-crypto.test.js
@@ -357,6 +357,12 @@ describe("createHash", () => {
     });
   });
 
+  it("Bun.CryptoHasher HMAC accepts mixed-case algorithm", () => {
+    const expected = new Bun.CryptoHasher("sha256", "key").update("data").digest("hex");
+    expect(new Bun.CryptoHasher("SHA-256", "key").update("data").digest("hex")).toBe(expected);
+    expect(new Bun.CryptoHasher("SHA256", "key").update("data").digest("hex")).toBe(expected);
+  });
+
   it("update & digest", () => {
     const hash = crypto.createHash("sha256");
     hash.update("some data to hash");


### PR DESCRIPTION
### What does this PR do?

Fixes #18019.

Node.js accepts both `"shake128"` and `"shake-128"` (case-insensitive) as algorithm names for SHAKE hashes, since OpenSSL registers both the short name (`shake128`) and long name (`SHAKE-128`). Bun only accepted the exact lowercase string `"shake128"`/`"shake256"`.

#### Repro

```js
import crypto from "node:crypto";
console.log(crypto.hash("shake-128", "", "base64url"));
```

Before:
```
TypeError: Unsupported algorithm "shake-128"
```

After (matches Node.js):
```
f5wrpOiPgn1hYEVQdgWFPg
```

#### Cause

`CryptoHasherZig::hash_by_name`, `constructor`, and `init` dispatched on the algorithm name via byte-exact comparison against `b"shake128"` etc. instead of going through the `evp::ALGORITHM_MAP` alias table. The alias table also lacked `shake-128`/`shake-256` entries.

#### Fix

- Add `shake-128` → `Shake128` and `shake-256` → `Shake256` to `ALGORITHM_MAP` in `EVP.rs` (alongside the existing `sha-256` etc. aliases).
- Route `CryptoHasherZig`'s name-based lookups through `evp::lookup_ignore_case` and dispatch on the resolved `Algorithm` enum. This makes every alias in the map, and ASCII case-insensitivity, work for the RustCrypto-backed algorithms the same way they already work for the BoringSSL-backed ones.

As a side effect this also fixes case-insensitive lookup for `SHAKE128`, `BLAKE2s256`, etc., which Node.js accepts and Bun previously rejected.

### How did you verify your code works?

Added tests in `test/js/node/crypto/node-crypto.test.js` covering `crypto.createHash`, `crypto.hash`, and `Bun.CryptoHasher` for the hyphenated and mixed-case variants of `shake128`/`shake256`/`blake2s256`. All 36 cases fail on current main and pass with this change. Existing crypto tests (`node-crypto.test.js`, `crypto.test.ts`, `crypto-oneshot.test.ts`, `bun-cryptohasher.test.ts`, `test-crypto-hash.js`) continue to pass.