### PR TITLE
ci: document the publish-images requirement in bootstrap.sh version comment

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,8 +8,9 @@
 # https://github.com/oven-sh/bun/issues
 
 # If you need to make a change to this script, such as upgrading a dependency,
-# increment the version comment to indicate that a new image should be built.
-# Otherwise, the existing image will be retroactively updated.
+# increment the version comment to indicate that a new image should be built,
+# and land it with `[publish images]` in the commit message so the new tag is
+# actually baked. Otherwise, the existing image will be retroactively updated.
 
 pid="$$"
 


### PR DESCRIPTION
## What

Re-trigger the publish-images bake for bootstrap v37 (linux) / v21 (windows).

## Why

0fcead62d8df317ca62b15cd2d6ad185f7639d59 bumped `scripts/bootstrap.sh` from `# Version: 34` to `# Version: 37` and was merged to main with the publish-images marker in its commit message. Its Buildkite build ([#62873](https://buildkite.com/bun/bun/builds/62873)) started the ten `build-image` jobs, but the pipeline has `cancel_running_branch_builds: true`, and #32396 merged to main ~4 minutes later, auto-canceling all of them before any image was snapshotted.

Since then every job on every build targets agent query rule `image-name=...-v37`, no such image exists, and the jobs are canceled within seconds with no agent assigned (e.g. main builds [#62876](https://buildkite.com/bun/bun/builds/62876) through [#62934](https://buildkite.com/bun/bun/builds/62934), and all PR builds).

## Fix

Run the publish from a branch build. `machine.mjs publish-image` tags the snapshot as `${imageKey}-v${getBootstrapVersion(os)}` regardless of branch, so once these jobs finish the v37/v21 images exist and main (and every PR) will schedule normally again. Running on a branch also means unrelated main merges cannot auto-cancel it mid-bake.

The only source change is a one-line clarification in the bootstrap.sh version comment so the build has a diff to run against.

## Note

The squash-merge title/body deliberately do not contain the literal bracket marker, so merging this will not re-trigger a second image bake on main.