### PR TITLE
spawn: report cwd in error path when it does not exist

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1247,17 +1247,24 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                         };
                         // posix_spawn collapses chdir(cwd) and execve(argv[0]) failures
                         // into a single errno. When the user passed an explicit cwd and
-                        // it is not an existing directory, blame the cwd so the error
-                        // points at the actual problem instead of argv[0].
-                        let display_path: &[u8] = if user_specified_cwd
+                        // a stat positively confirms it is not a usable directory, blame
+                        // the cwd so the error points at the actual problem. Any other
+                        // stat result (including EUNKNOWN/EACCES) falls through to
+                        // argv[0] so ambiguous cases keep the previous behaviour.
+                        let cwd_confirmed_bad = user_specified_cwd
                             && matches!(errno, sys::Errno::ENOENT | sys::Errno::ENOTDIR)
-                            && !matches!(
-                                sys::exists_at_type(
-                                    sys::Fd::cwd(),
-                                    ZBox::from_bytes(cwd).as_zstr(),
-                                ),
-                                Ok(sys::ExistsAtType::Directory)
+                            && match sys::exists_at_type(
+                                sys::Fd::cwd(),
+                                ZBox::from_bytes(cwd).as_zstr(),
                             ) {
+                                Ok(sys::ExistsAtType::File) => true,
+                                Err(e) => matches!(
+                                    e.get_errno(),
+                                    sys::Errno::ENOENT | sys::Errno::ENOTDIR
+                                ),
+                                Ok(sys::ExistsAtType::Directory) => false,
+                            };
+                        let display_path: &[u8] = if cwd_confirmed_bad {
                             cwd
                         } else {
                             argv0_path.as_bytes()

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1238,14 +1238,31 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                     | sys::Errno::EPERM
                     | sys::Errno::EISDIR
                     | sys::Errno::ENOTDIR) => {
-                        let display_path: &ZStr = if !argv.is_empty() && !argv[0].is_null() {
+                        let argv0_path: &ZStr = if !argv.is_empty() && !argv[0].is_null() {
                             // SAFETY: argv[0] is non-null and points at a NUL-terminated
                             // string we built above (lives in `arg0_backing`/`arg_backing`).
                             ZStr::from_cstr(unsafe { bun_core::ffi::cstr(argv[0]) })
                         } else {
                             ZStr::EMPTY
                         };
-                        if !display_path.as_bytes().is_empty() {
+                        // posix_spawn collapses chdir(cwd) and execve(argv[0]) failures
+                        // into a single errno. When the user passed an explicit cwd and
+                        // it is not an existing directory, blame the cwd so the error
+                        // points at the actual problem instead of argv[0].
+                        let display_path: &[u8] = if user_specified_cwd
+                            && matches!(errno, sys::Errno::ENOENT | sys::Errno::ENOTDIR)
+                            && !matches!(
+                                sys::exists_at_type(
+                                    sys::Fd::cwd(),
+                                    ZBox::from_bytes(cwd).as_zstr(),
+                                ),
+                                Ok(sys::ExistsAtType::Directory)
+                            ) {
+                            cwd
+                        } else {
+                            argv0_path.as_bytes()
+                        };
+                        if !display_path.is_empty() {
                             let mut systemerror = err.with_path(display_path).to_system_error();
                             if errno == sys::Errno::ENOENT {
                                 systemerror.errno = -UV_E::NOENT;

--- a/test/js/bun/spawn/spawn.test.ts
+++ b/test/js/bun/spawn/spawn.test.ts
@@ -85,6 +85,60 @@ for (let [gcTick, label] of [
           });
         }).toThrow("no such file or directory");
       });
+
+      // https://github.com/oven-sh/bun/issues/8024
+      it("error path is the cwd when cwd does not exist", () => {
+        let err: any;
+        try {
+          spawnSync({
+            cmd: [bunExe(), "-e", "1"],
+            env: bunEnv,
+            cwd: "/something/that/doesnt/exist",
+          });
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect({ code: err.code, path: err.path }).toEqual({
+          code: "ENOENT",
+          path: "/something/that/doesnt/exist",
+        });
+        expect(err.message).toContain("/something/that/doesnt/exist");
+      });
+
+      it("error path is argv[0] when binary does not exist but cwd does", () => {
+        let err: any;
+        try {
+          spawnSync({
+            cmd: ["./definitely-not-a-real-binary-xyz"],
+            env: bunEnv,
+            cwd: tmp,
+          });
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect(err.code).toBe("ENOENT");
+        expect(err.path).not.toBe(tmp);
+        expect(err.path).toContain("definitely-not-a-real-binary-xyz");
+      });
+
+      it("error path is the cwd when cwd is a file", () => {
+        const file = path.join(tmp, "i-am-a-file.txt");
+        writeFileSync(file, "hello");
+        let err: any;
+        try {
+          spawnSync({
+            cmd: [bunExe(), "-e", "1"],
+            env: bunEnv,
+            cwd: file,
+          });
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect(err.path).toBe(file);
+      });
     });
 
     describe("spawn", () => {
@@ -601,6 +655,26 @@ for (let [gcTick, label] of [
             cwd: "./this-should-not-exist",
           });
         }).toThrow("no such file or directory");
+      });
+
+      // https://github.com/oven-sh/bun/issues/8024
+      it("error path is the cwd when cwd does not exist", () => {
+        let err: any;
+        try {
+          spawn({
+            cmd: [bunExe(), "-e", "1"],
+            env: bunEnv,
+            cwd: "/something/that/doesnt/exist",
+          });
+        } catch (e) {
+          err = e;
+        }
+        expect(err).toBeDefined();
+        expect({ code: err.code, path: err.path }).toEqual({
+          code: "ENOENT",
+          path: "/something/that/doesnt/exist",
+        });
+        expect(err.message).toContain("/something/that/doesnt/exist");
       });
     });
   });


### PR DESCRIPTION
Fixes #8024
Fixes #14535

## Repro

```js
Bun.spawnSync({
  cmd: ['python3'],
  cwd: '/something/that/doesnt/exist',
});
```

Before:

```
ENOENT: no such file or directory, posix_spawn 'python3'
```

The error blames `python3`, which exists. The thing that doesn't exist is the cwd.

## Cause

`posix_spawn` returns a single errno regardless of whether `chdir(cwd)` or `execve(argv[0])` failed in the child. The error handler in `spawn_maybe_sync` unconditionally attached `argv[0]` as the error path.

## Fix

On the spawn error path, when the user passed an explicit `cwd` and the error is `ENOENT`/`ENOTDIR`, stat the cwd. If it is not an existing directory, set `error.path` to the cwd instead of `argv[0]`. This is one extra syscall on the error path only.

Reuses the `user_specified_cwd` flag that #33829 added.

After:

```
ENOENT: no such file or directory, posix_spawn '/something/that/doesnt/exist'
```

## Verification

New tests in `test/js/bun/spawn/spawn.test.ts`:
- `Bun.spawnSync` with non-existent cwd: `error.path` is the cwd
- `Bun.spawn` (async) with non-existent cwd: `error.path` is the cwd
- `Bun.spawnSync` with cwd pointing at a file: `error.path` is the cwd
- `Bun.spawnSync` with valid cwd but non-existent binary: `error.path` is still `argv[0]` (regression guard)

```
bun bd test spawn.test.ts -t "error path"  -> 4 pass
# without fix                               -> 3 fail, 1 pass
```

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 4 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn.test.ts

<!-- robobun:evidence:end -->