### PR TITLE
ci(machine): note Azure delete-before-recreate cancel hazard

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -847,7 +847,8 @@ function getTestBunStep(platform, options, testOptions = {}) {
       EXPECTED_PLATFORM_ARCH: platform.arch,
       ...(platform.abi ? { EXPECTED_PLATFORM_ABI: platform.abi } : {}),
       ...(platform.os === "linux" && platform.distro ? { EXPECTED_PLATFORM_DISTRO: platform.distro } : {}),
-      ...(platform.os === "linux" || (platform.os === "darwin" && platform.arch === "aarch64" && platform.tier === "latest")
+      ...(platform.os === "linux" ||
+      (platform.os === "darwin" && platform.arch === "aarch64" && platform.tier === "latest")
         ? { EXPECTED_PLATFORM_RELEASE: platform.release }
         : {}),
     },
@@ -1360,6 +1361,8 @@ async function getPipelineOptions() {
     };
   }
 
+  // BUILDKITE_MESSAGE is the commit subject line only — option tags like
+  // [publish images] must appear in the subject, not the commit body.
   const commitMessage = getCommitMessage();
 
   /**

--- a/scripts/machine.mjs
+++ b/scripts/machine.mjs
@@ -1209,6 +1209,10 @@ async function buildWindowsImageWithPacker({ os, arch, release, command, ci, age
   // image_version 1.0.0 and 409s if it already exists, so a re-run of
   // [publish images] would fail on every Windows variant that already
   // succeeded. Match the AWS path's deregister-then-recreate.
+  // CAUTION: unlike the AWS path (which only deregisters after the new
+  // create-image collides), this deletes the live version BEFORE Packer
+  // has produced a replacement. If this job is canceled or dies mid-bake,
+  // CI is left with no Windows image until a publish run completes.
   const versionPath = `${galleryPath}/versions/1.0.0`;
   const existing = await fetch(`https://management.azure.com${versionPath}?api-version=2024-03-03`, {
     headers: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
Comment-only change to `scripts/machine.mjs` documenting that the Windows image publish path deletes the existing gallery version before Packer has produced its replacement, so a canceled run leaves CI without a Windows image until another publish completes.

The commit message on this branch carries the tag that triggers a Windows image republish; the title and this description intentionally do not, so the squash-merge to main will not re-trigger a publish.