### PR TITLE
GarbageCollectionController: use EventLoopTimer instead of raw uws::Timer

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -203,6 +203,8 @@ pub enum Tag {
     BunTest,
     EventLoopDelayMonitor,
     CronJob,
+    GcOneShot,
+    GcRepeating,
 }
 
 impl Tag {
@@ -213,6 +215,7 @@ impl Tag {
             | Tag::EventLoopDelayMonitor // probably important
             | Tag::StatWatcherScheduler
             | Tag::CronJob // calendar-anchored to real wall clock
+            | Tag::GcOneShot | Tag::GcRepeating // internal GC pacing
             => false,
             _ => true,
         }

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -22,36 +22,43 @@ use core::ffi::c_int;
 
 #[cfg(debug_assertions)]
 use bun_core::env_var;
+use bun_event_loop::EventLoopTimer::{EventLoopTimer, State as TimerState, Tag as TimerTag};
 use bun_uws as uws;
 
 use crate::VM;
 use crate::virtual_machine::VirtualMachine;
 
 pub struct GarbageCollectionController {
-    // Raw FFI handle created by `uws::Timer::create_fallthrough` in `init`,
-    // freed in Drop. Stored as `Option<NonNull<Timer>>` (None = uninit).
-    pub gc_timer: Option<core::ptr::NonNull<uws::Timer>>,
+    /// 16ms one-shot: when it fires, the next `process_gc_timer()` will
+    /// `collect_async()`. Embedded intrusive node — re-armed via the in-process
+    /// timer heap (no `timerfd_settime`/`epoll_ctl` per re-arm).
+    pub gc_timer: EventLoopTimer,
+    /// 1s/30s repeating: drives `perform_gc()` and the fast↔slow backoff.
+    pub gc_repeating_timer: EventLoopTimer,
     pub gc_last_heap_size: usize,
     pub gc_last_heap_size_on_repeating_timer: usize,
     pub heap_size_didnt_change_for_repeating_timer_ticks_count: u8,
     pub gc_timer_state: GCTimerState,
-    // Raw FFI handle created by `uws::Timer::create_fallthrough` in `init`,
-    // freed in Drop.
-    pub gc_repeating_timer: Option<core::ptr::NonNull<uws::Timer>>,
     pub gc_timer_interval: i32,
     pub gc_repeating_timer_fast: bool,
     pub disabled: bool,
 }
 
+bun_event_loop::impl_timer_owner!(
+    GarbageCollectionController;
+    from_gc_timer_ptr => gc_timer,
+    from_gc_repeating_timer_ptr => gc_repeating_timer,
+);
+
 impl Default for GarbageCollectionController {
     fn default() -> Self {
         Self {
-            gc_timer: None,
+            gc_timer: EventLoopTimer::init_paused(TimerTag::GcOneShot),
+            gc_repeating_timer: EventLoopTimer::init_paused(TimerTag::GcRepeating),
             gc_last_heap_size: 0,
             gc_last_heap_size_on_repeating_timer: 0,
             heap_size_didnt_change_for_repeating_timer_ticks_count: 0,
             gc_timer_state: GCTimerState::Pending,
-            gc_repeating_timer: None,
             gc_timer_interval: 0,
             gc_repeating_timer_fast: true,
             disabled: false,
@@ -66,60 +73,9 @@ pub enum GcRepeatSetting {
 }
 
 impl GarbageCollectionController {
-    /// Recover `&mut Self` from a uws timer's ext slot. Single audited deref
-    /// for the two `extern "C"` callbacks below so they stay safe-bodied.
-    ///
-    /// `timer` is the live uws timer whose ext data was set to
-    /// `*mut GarbageCollectionController` in [`Self::init`]; the controller is
-    /// a BACKREF that strictly outlives the timer (`deinit()` closes the timer
-    /// before `self` is dropped). `Timer` is an `opaque_ffi!` ZST handle, so
-    /// [`uws::Timer::opaque_mut`] is the centralised non-null deref proof for
-    /// the handle itself; only the recovered `*mut Self` needs the audited
-    /// deref below.
-    #[inline]
-    fn from_timer_ext<'a>(timer: *mut uws::Timer) -> &'a mut Self {
-        let ptr = uws::Timer::opaque_mut(timer).as_::<*mut Self>();
-        // SAFETY: BACKREF — see doc comment above.
-        unsafe { &mut *ptr }
-    }
-
-    /// Accessor for the init-once `gc_timer` handle. Consolidates the four
-    /// open-coded `(*self.<field>.unwrap().as_ptr())` deref sites into one
-    /// SAFETY block so call sites are safe.
-    #[inline]
-    fn gc_timer_mut(&mut self) -> &mut uws::Timer {
-        // SAFETY: `gc_timer` is set in `init()` (via `Timer::create_fallthrough`)
-        // before any code path reaches a deref site, and remains a live FFI
-        // handle until `deinit()` closes it. The Timer lives on the uws heap,
-        // not inside `self`, so the returned `&mut` cannot alias `self`.
-        unsafe { &mut *self.gc_timer.expect("gc_timer set in init()").as_ptr() }
-    }
-
-    /// Accessor for the init-once `gc_repeating_timer` handle (see
-    /// [`gc_timer_mut`] for the invariant).
-    #[inline]
-    fn gc_repeating_timer_mut(&mut self) -> &mut uws::Timer {
-        // SAFETY: same invariant as `gc_timer_mut` — set in `init()`, live
-        // until `deinit()`, FFI-heap-owned.
-        unsafe {
-            &mut *self
-                .gc_repeating_timer
-                .expect("gc_repeating_timer set in init()")
-                .as_ptr()
-        }
-    }
-
     pub fn init(&mut self, vm: &mut VirtualMachine) {
         // SAFETY: uws::Loop::get() returns the live process-global loop.
         let actual = unsafe { &mut *uws::Loop::get() };
-        self.gc_timer = Some(uws::Timer::create_fallthrough(
-            actual,
-            std::ptr::from_mut::<Self>(self),
-        ));
-        self.gc_repeating_timer = Some(uws::Timer::create_fallthrough(
-            actual,
-            std::ptr::from_mut::<Self>(self),
-        ));
         actual.internal_loop_data.jsc_vm = vm.jsc_vm.cast();
 
         #[cfg(debug_assertions)]
@@ -160,20 +116,31 @@ impl GarbageCollectionController {
         self.disabled = env.is_some_and(|e| e.has(b"BUN_GC_TIMER_DISABLE"));
 
         if !self.disabled {
-            let ext = std::ptr::from_mut::<Self>(self);
-            self.gc_repeating_timer_mut().set(
-                ext,
-                Some(on_gc_repeating_timer),
-                gc_timer_interval,
-                gc_timer_interval,
+            Self::arm(
+                core::ptr::from_mut(vm),
+                &raw mut self.gc_repeating_timer,
+                i64::from(gc_timer_interval),
             );
+        }
+    }
+
+    /// Remove `t` from the heap if linked, set its deadline to `now + ms`, and
+    /// insert. JS-thread only.
+    fn arm(vm: *mut VirtualMachine, t: *mut EventLoopTimer, ms: i64) {
+        // SAFETY: `t` is one of the two embedded nodes of the per-VM controller,
+        // address-stable for the VM lifetime; JS-thread only.
+        unsafe {
+            if (*t).state == TimerState::ACTIVE {
+                VirtualMachine::timer_remove(vm, t);
+            }
+            (*t).next = bun_core::Timespec::now_allow_mocked_time().add_ms(ms);
+            VirtualMachine::timer_insert(vm, t);
         }
     }
 
     pub fn schedule_gc_timer(&mut self) {
         self.gc_timer_state = GCTimerState::Scheduled;
-        let ext = std::ptr::from_mut::<Self>(self);
-        self.gc_timer_mut().set(ext, Some(on_gc_timer), 16, 0);
+        Self::arm(VirtualMachine::get_mut_ptr(), &raw mut self.gc_timer, 16);
     }
 
     pub fn bun_vm(&mut self) -> &mut VirtualMachine {
@@ -187,16 +154,15 @@ impl GarbageCollectionController {
 
     /// Explicit teardown. Idempotent — `Drop` forwards here.
     /// Kept as an inherent method because callers (web_worker, VM exit path)
-    /// need to release the uws timers before the owning VM storage is freed.
+    /// must unlink the timers from the per-VM heap before that heap is dropped
+    /// in `deinit_runtime_state`.
     pub fn deinit(&mut self) {
-        // SAFETY: timers were created via uws::Timer::create_fallthrough; close::<true>
-        // frees the fallthrough timer. `take()` ensures we close at most once.
-        unsafe {
-            if let Some(t) = self.gc_timer.take() {
-                uws::Timer::close::<true>(t.as_ptr());
-            }
-            if let Some(t) = self.gc_repeating_timer.take() {
-                uws::Timer::close::<true>(t.as_ptr());
+        for t in [&raw mut self.gc_timer, &raw mut self.gc_repeating_timer] {
+            // SAFETY: JS-thread; nodes are linked iff state == ACTIVE.
+            unsafe {
+                if (*t).state == TimerState::ACTIVE {
+                    VirtualMachine::timer_remove(VirtualMachine::get_mut_ptr(), t);
+                }
             }
         }
     }
@@ -213,19 +179,24 @@ impl GarbageCollectionController {
     // When the heap size is increasing, we always switch to fast mode
     // When the heap size has been the same or less for 30 seconds, we switch to slow mode
     pub fn update_gc_repeat_timer(&mut self, setting: GcRepeatSetting) {
-        if setting == GcRepeatSetting::Fast && !self.gc_repeating_timer_fast {
-            self.gc_repeating_timer_fast = true;
-            let ext = std::ptr::from_mut::<Self>(self);
-            let interval = self.gc_timer_interval;
-            self.gc_repeating_timer_mut()
-                .set(ext, Some(on_gc_repeating_timer), interval, interval);
-            self.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
-        } else if setting == GcRepeatSetting::Slow && self.gc_repeating_timer_fast {
-            self.gc_repeating_timer_fast = false;
-            let ext = std::ptr::from_mut::<Self>(self);
-            self.gc_repeating_timer_mut()
-                .set(ext, Some(on_gc_repeating_timer), 30_000, 30_000);
-            self.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
+        let (interval, want_fast) = match setting {
+            GcRepeatSetting::Fast if !self.gc_repeating_timer_fast => {
+                (i64::from(self.gc_timer_interval), true)
+            }
+            GcRepeatSetting::Slow if self.gc_repeating_timer_fast => (30_000, false),
+            _ => return,
+        };
+        self.gc_repeating_timer_fast = want_fast;
+        self.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
+        // When called from inside `on_gc_repeating_timer` the node has just
+        // been popped (state set to FIRED at the top of the callback) — skip
+        // the re-arm; the callback's tail re-inserts at the new interval.
+        if self.gc_repeating_timer.state == TimerState::ACTIVE {
+            Self::arm(
+                VirtualMachine::get_mut_ptr(),
+                &raw mut self.gc_repeating_timer,
+                interval,
+            );
         }
     }
 
@@ -281,38 +252,58 @@ impl GarbageCollectionController {
         vm.collect_async();
         self.gc_last_heap_size = vm.block_bytes_allocated();
     }
+
+    /// `Tag::GcOneShot` fire body.
+    ///
+    /// # Safety
+    /// `this` is the live per-VM controller; JS-thread only.
+    pub unsafe fn on_gc_timer(this: *mut Self) {
+        // SAFETY: per fn contract.
+        let this = unsafe { &mut *this };
+        this.gc_timer.state = TimerState::FIRED;
+        if this.disabled {
+            return;
+        }
+        this.gc_timer_state = GCTimerState::RunOnNextTick;
+    }
+
+    /// `Tag::GcRepeating` fire body.
+    ///
+    /// # Safety
+    /// `this` is the live per-VM controller; `vm` is the per-thread VM.
+    pub unsafe fn on_gc_repeating_timer(this: *mut Self, vm: *mut VirtualMachine) {
+        // SAFETY: per fn contract.
+        let this = unsafe { &mut *this };
+        this.gc_repeating_timer.state = TimerState::FIRED;
+
+        let prev_heap_size = this.gc_last_heap_size_on_repeating_timer;
+        this.perform_gc();
+        this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
+        if prev_heap_size == this.gc_last_heap_size_on_repeating_timer {
+            this.heap_size_didnt_change_for_repeating_timer_ticks_count = this
+                .heap_size_didnt_change_for_repeating_timer_ticks_count
+                .saturating_add(1);
+            if this.heap_size_didnt_change_for_repeating_timer_ticks_count >= 30 {
+                // make the timer interval longer
+                this.update_gc_repeat_timer(GcRepeatSetting::Slow);
+            }
+        } else {
+            this.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
+            this.update_gc_repeat_timer(GcRepeatSetting::Fast);
+        }
+
+        let interval = if this.gc_repeating_timer_fast {
+            i64::from(this.gc_timer_interval)
+        } else {
+            30_000
+        };
+        Self::arm(vm, &raw mut this.gc_repeating_timer, interval);
+    }
 }
 
 impl Drop for GarbageCollectionController {
     fn drop(&mut self) {
         self.deinit();
-    }
-}
-
-pub(crate) extern "C" fn on_gc_timer(timer: *mut uws::Timer) {
-    let this = GarbageCollectionController::from_timer_ext(timer);
-    if this.disabled {
-        return;
-    }
-    this.gc_timer_state = GCTimerState::RunOnNextTick;
-}
-
-pub(crate) extern "C" fn on_gc_repeating_timer(timer: *mut uws::Timer) {
-    let this = GarbageCollectionController::from_timer_ext(timer);
-    let prev_heap_size = this.gc_last_heap_size_on_repeating_timer;
-    this.perform_gc();
-    this.gc_last_heap_size_on_repeating_timer = this.gc_last_heap_size;
-    if prev_heap_size == this.gc_last_heap_size_on_repeating_timer {
-        this.heap_size_didnt_change_for_repeating_timer_ticks_count = this
-            .heap_size_didnt_change_for_repeating_timer_ticks_count
-            .saturating_add(1);
-        if this.heap_size_didnt_change_for_repeating_timer_ticks_count >= 30 {
-            // make the timer interval longer
-            this.update_gc_repeat_timer(GcRepeatSetting::Slow);
-        }
-    } else {
-        this.heap_size_didnt_change_for_repeating_timer_ticks_count = 0;
-        this.update_gc_repeat_timer(GcRepeatSetting::Fast);
     }
 }
 

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -114,14 +114,6 @@ impl GarbageCollectionController {
         }
 
         self.disabled = env.is_some_and(|e| e.has(b"BUN_GC_TIMER_DISABLE"));
-
-        if !self.disabled {
-            Self::arm(
-                core::ptr::from_mut(vm),
-                &raw mut self.gc_repeating_timer,
-                i64::from(gc_timer_interval),
-            );
-        }
     }
 
     /// Remove `t` from the heap if linked, set its deadline to `now + ms`, and
@@ -204,6 +196,16 @@ impl GarbageCollectionController {
     pub fn process_gc_timer(&mut self) {
         if self.disabled {
             return;
+        }
+        // Lazy-arm the repeating timer on the first event-loop tick instead of
+        // in `init()`, so the timer heap is never touched before the event loop
+        // is fully wired (matters for Windows' `ensure_uv_timer`).
+        if self.gc_repeating_timer.state == TimerState::PENDING {
+            Self::arm(
+                VirtualMachine::get_mut_ptr(),
+                &raw mut self.gc_repeating_timer,
+                i64::from(self.gc_timer_interval),
+            );
         }
         let vm = VirtualMachine::get().jsc_vm();
         self.process_gc_timer_with_heap_size(vm, vm.block_bytes_allocated());

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -164,6 +164,7 @@ use bun_sql_jsc::postgres::PostgresSQLConnection;
 use crate::test_runner::bun_test::{BunTest, BunTestPtr};
 use crate::timer::{DateHeaderTimer, EventLoopDelayMonitor};
 use bun_jsc::abort_signal::Timeout as AbortSignalTimeout;
+use bun_jsc::garbage_collection_controller::GarbageCollectionController;
 
 #[cfg(not(windows))]
 use bun_io::pipe_writer::PosixPipeWriter; // brings `on_poll` into scope for FileSinkPoll/StaticPipeWriterPoll/etc.
@@ -977,6 +978,18 @@ pub unsafe fn __bun_fire_timer(t: *mut EventLoopTimer, now: *const ElTimespec, v
             timer_arm!(AbortSignalTimeout, event_loop_timer, |c, _now, vm| {
                 AbortSignalTimeout::run(c, vm)
             })
+        }
+        EventLoopTimerTag::GcOneShot => {
+            timer_arm!(GarbageCollectionController, gc_timer, |c, _now, _vm| {
+                GarbageCollectionController::on_gc_timer(c)
+            })
+        }
+        EventLoopTimerTag::GcRepeating => {
+            timer_arm!(
+                GarbageCollectionController,
+                gc_repeating_timer,
+                |c, _now, vm| GarbageCollectionController::on_gc_repeating_timer(c, vm)
+            )
         }
         EventLoopTimerTag::DateHeaderTimer => {
             timer_arm!(DateHeaderTimer, event_loop_timer, |c, _now, vm| (*c)


### PR DESCRIPTION
The GC controller's two timers (16ms one-shot + 1s/30s repeating) were the
only remaining users of raw libusockets fallthrough timers. Every re-arm
issued timerfd_settime() + an epoll_ctl(ADD) that always returned EEXIST,
since us_timer_set's has_added_timer_to_event_loop short-circuit only
covers loop->data.sweep_timer.

Embed two EventLoopTimer nodes directly in the controller and re-arm via
the in-process timer heap (VirtualMachine::timer_insert/remove), same as
DateHeaderTimer / AbortSignal::Timeout / WTFTimer. New Tag::GcOneShot and
Tag::GcRepeating dispatch arms recover the controller via container_of.
Neither refs the event loop and both opt out of fake timers.

strace -c on a 500k-request Bun.serve hello-world:
  timerfd_settime  1,270 -> 2
  epoll_ctl        1,468 (1,268 EEXIST) -> 200 (0 errors)

rps is unchanged within noise (~0.3% of kernel time; below the ~4%
run-to-run variance).