### PR TITLE
css: fix exponential atan2() backtracking when argument contains a Calc::Product

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -857,14 +857,28 @@ impl<V: CalcValue> Calc<V> {
         // instead of producing `Angle::Rad(atan2(10,5))`. Tracked as a known
         // incompleteness; no behaviour stub is added because a partial
         // dimension matcher would mis-reduce mixed-unit lengths.
-        if let Ok(v) = try_parse_atan2_args::<C, Length>(input, ctx) {
-            return Ok(v);
+        //
+        // `hit_unrecoverable` is rechecked between each dimension probe: when
+        // the `Calc<Angle>` attempt above fails before reaching a nested math
+        // function (e.g. `Product + Number` is rejected by `Angle::from_calc`),
+        // the failure counter is unchanged and execution falls through here.
+        // `Length` and `Percentage` both accept such sums via `from_calc`,
+        // so without these checks each would independently recurse into the
+        // nested `atan2()`, yielding O(2^depth) parse time.
+        match try_parse_atan2_args::<C, Length>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) if hit_unrecoverable(input) => return Err(e),
+            Err(_) => {}
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Percentage>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Percentage>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) if hit_unrecoverable(input) => return Err(e),
+            Err(_) => {}
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Time>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Time>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) if hit_unrecoverable(input) => return Err(e),
+            Err(_) => {}
         }
 
         let parse_ident_fn = move |c: C, ident: &[u8]| -> Option<Calc<CSSNumber>> {

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -8,10 +8,24 @@ function nestedAtan2Chain(depth: number): string {
   return `hsl(sin(2\n${body}` + Buffer.alloc(depth + 3, ")").toString();
 }
 
+// `5*min(9,7)` parses as `Calc::Product` (not `Calc::Function`), and
+// `Product + Number` is rejected by `Angle::from_calc` before the nested
+// `atan2` is reached, so the failure-counter guard on the angle attempt
+// never fires. `Length::from_calc` / `Percentage::from_calc` both accept
+// `Product`, so without a check between dimension probes each of those
+// fallbacks independently recurses into the nested `atan2()`.
+function nestedAtan2Product(depth: number): string {
+  let s = "1";
+  for (let i = 0; i < depth; i++) s = `atan2(5*min(9,7) + 1 + ${s})`;
+  return `hsl(sin(sin(sin(${s}))))`;
+}
+
 const cases: [css: string, expected: string | null][] = [
   [nestedAtan2Chain(40), null],
   [nestedAtan2Chain(64), null],
   ["hsl(" + Buffer.alloc(6 * 64, "atan2(").toString() + "9, 1" + Buffer.alloc(64, ")").toString() + " 50% 50%)", null],
+  [nestedAtan2Product(40), null],
+  [nestedAtan2Product(64), null],
   ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
   ["hsl(atan2(1deg, 2deg) 50% 50%)", "#bf7840"],
@@ -28,6 +42,13 @@ const cases: [css: string, expected: string | null][] = [
   ["hsl(atan2(1, sign(1s)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(1, calc(sign(1px))) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(atan2(9,1), 1) 50% 50%)", null],
+  ["hsl(atan2(min(1px,2px), 2px) 50% 50%)", "#bf7840"],
+  ["hsl(atan2(5*min(1px,2px) + 1px, 2px) 50% 50%)", "#a7bf40"],
+  ["hsl(atan2(5*min(50%,25%) + 10%, 20%) 50% 50%)", "#91bf40"],
+  ["hsl(atan2(5*min(1s,2s) + 1s, 2s) 50% 50%)", "#a7bf40"],
+  ["hsl(atan2(5*max(1px,2px) + 1px, 2px) 50% 50%)", "#95bf40"],
+  ["hsl(atan2(5*min(9,7) + 1, 2) 50% 50%)", null],
+  ["hsl(atan2(1deg + atan2(1px, 2px), 2deg) 50% 50%)", "#88bf40"],
 ];
 
 test("deeply nested atan2() color values parse in linear time instead of hanging", async () => {


### PR DESCRIPTION
## What

Fixes an exponential-time hang in `Bun.color()` (and any CSS `calc()` path) on deeply nested `atan2()` when the argument sum contains a `Calc::Product` (e.g. `N * min(...)`) followed by another addend before the nested `atan2()`. Found by fuzzing.

Signature: `hang:color:_RNvC9bun_alloc14copy_lowercase|_RNvMNtNtC7bun_css6values4calcNtB2_8CalcUnit12get_any_case`

## Repro

```js
function nest(n) {
  let s = '1';
  for (let i = 0; i < n; i++) s = `atan2(5*min(9,7) + 1 + ${s})`;
  return `hsl(sin(sin(sin(${s}))))`;
}
Bun.color(nest(20), 'css'); // ~8.5s on release; doubles per level
```

| depth | before | after |
| - | - | - |
| 15 | 270ms | <1ms |
| 18 | 2.1s | <1ms |
| 20 | 8.5s | <1ms |

The original 1.9KB fuzzer input (nested `sin`/`atan2`/`min` with `-Infinity` and large integers) goes from ~7s to ~6ms.

## Cause

`min()`/`max()` don't reduce `Calc::Number` arguments (only `Calc::Value`), so `min(9,7)` stays as `Calc::Function(Min(...))` and `5*min(9,7)` becomes `Calc::Product`.

In `Calc::add`, `Product + Number` falls through to `self.into_value(input)?`, which `Angle::from_calc` rejects for anything that isn't `Calc::Value`. So the `Calc<Angle>` attempt in `parse_atan2` errors at `+ 1` **before** reaching the nested `atan2()`, and the math-fn failure counter added in #31558 is never bumped. `hit_unrecoverable` is therefore false after the angle attempt.

Execution then falls through to the `Length` / `Percentage` / `Time` / `CSSNumber` fallbacks, none of which recheck `hit_unrecoverable`. `Length::from_calc` and `Percentage::from_calc` both happily wrap `Calc::Product` (returning `Length::Calc(...)` / `Percentage{v: NAN}`), so their `parse_sum` continues past `+ 1` and recurses into the nested `atan2()`. Two recursions per level gives O(2^depth).

## Fix

Extend the existing `hit_unrecoverable` guard to run between each dimension probe. Once the `Length` attempt has recursed and a nested type-independent math function failed (bumping the counter via `parse_value`'s existing `note_math_fn_parse_failure` hook), the remaining probes are skipped.

This only fires when a type-independent math function (`sin`/`cos`/`atan2`/`pow`/...) failed, which by definition fails regardless of `V`, so skipping the remaining dimension probes never changes the result.

## Verification

- `test/js/bun/css/atan2-backtracking-hang.test.ts` gains two depth-40/64 `Product`-shaped repros plus behavior-preservation cases for `atan2(5*min(...) + ..., ...)` at each dimension type (`px`/`%`/`s`) and for `max()`. Passes under a second on this build; on an unfixed build the subprocess is killed by the 20s timeout and the test fails.
- `test/js/bun/css/css.test.ts` (1093 pass), the three related backtracking/hang suites (12 pass), and `color.test.ts` (916 pass; the pre-existing `fuzz ansi256` debug-build timeout reproduces identically on `main`) all pass.