### PR TITLE
css: fix exponential backtracking in atan2() dimension fallbacks

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -857,14 +857,40 @@ impl<V: CalcValue> Calc<V> {
         // instead of producing `Angle::Rad(atan2(10,5))`. Tracked as a known
         // incompleteness; no behaviour stub is added because a partial
         // dimension matcher would mis-reduce mixed-unit lengths.
-        if let Ok(v) = try_parse_atan2_args::<C, Length>(input, ctx) {
-            return Ok(v);
+        //
+        // The `hit_unrecoverable` check after each attempt prevents exponential
+        // re-descent: the <angle> attempt above can fail at `Calc::add` (e.g.
+        // `Product + Number`, which `Angle::from_calc` rejects) *before* ever
+        // reaching a nested type-independent math function, so that attempt
+        // would not have bumped the failure counter yet. The dimension attempts
+        // below (`Length`/`Percentage`, whose `from_calc` wrap anything) then
+        // descend the full nested expression and do hit such a function, so the
+        // counter is bumped by the time they return. Without re-checking it
+        // here every nesting level would re-descend once per permissive type,
+        // turning a depth-N chain into 2^N work.
+        match try_parse_atan2_args::<C, Length>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Percentage>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Percentage>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Time>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Time>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
 
         let parse_ident_fn = move |c: C, ident: &[u8]| -> Option<Calc<CSSNumber>> {

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -8,10 +8,32 @@ function nestedAtan2Chain(depth: number): string {
   return `hsl(sin(2\n${body}` + Buffer.alloc(depth + 3, ")").toString();
 }
 
+// Nesting atan2() via an argument that the <angle> attempt rejects at the
+// add() step (Product + Number) but the <length>/<percentage> attempts accept
+// and descend into. Without the unrecoverable-failure guard on the dimension
+// fallbacks each level re-descends twice, so depth N takes 2^N.
+function productSumAtan2Chain(depth: number): string {
+  let s = "hsl(sin(1 + atan2(";
+  for (let i = 0; i < depth; i++) s += "2 * min(1,2) + 1 + atan2(";
+  return s + "1" + Buffer.alloc(depth + 3, ")").toString();
+}
+
+// The fuzzer-minimized reproduction (2074 bytes) that first exposed the
+// Product + Number variant of this backtracking.
+const fuzzProductSumInput = Bun.gunzipSync(
+  Buffer.from(
+    "H4sIAAAAAAACA8soztEozsyDY13LUUAG4NLm0jW0MDExMzcxMTA3NjewNDU1NDM0HUDxxJLEPCMNoBhtlcPFwEArF5iGLLm0DCx1zE1hlOaQNGco6iXkd3oZRIwF1HDkqBmjZpBrBm3zzSAqCDXJgwBGtHpjGggAAA==",
+    "base64",
+  ),
+).toString("latin1");
+
 const cases: [css: string, expected: string | null][] = [
   [nestedAtan2Chain(40), null],
   [nestedAtan2Chain(64), null],
   ["hsl(" + Buffer.alloc(6 * 64, "atan2(").toString() + "9, 1" + Buffer.alloc(64, ")").toString() + " 50% 50%)", null],
+  [productSumAtan2Chain(40), null],
+  [productSumAtan2Chain(64), null],
+  [fuzzProductSumInput, null],
   ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
   ["hsl(atan2(1deg, 2deg) 50% 50%)", "#bf7840"],
@@ -27,6 +49,11 @@ const cases: [css: string, expected: string | null][] = [
   ["hsl(atan2(sin(1), sign(1px)) 50% 50%)", "#bf9540"],
   ["hsl(atan2(1, sign(1s)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(1, calc(sign(1px))) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(min(1px, 2px), 1px) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(2 * min(1px, 2px), 1px) 50% 50%)", "#b8bf40"],
+  ["hsl(atan2(1px + min(1px,2px), 1px) 50% 50%)", "#b8bf40"],
+  ["hsl(atan2(min(10%, 20%), 5%) 50% 50%)", "#b8bf40"],
+  ["hsl(atan2(min(1s, 2s), 1s) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(atan2(9,1), 1) 50% 50%)", null],
 ];
 


### PR DESCRIPTION
## What

Fixes a fuzzer-reported hang in `Bun.color()` on deeply nested `atan2()` expressions where each argument contains a product of a number and a `min()`/`max()` result.

## Repro

```js
// 2 KB, hangs well past 10s
Bun.color(Buffer.from(Bun.gunzipSync(Buffer.from("H4sIAAAAAAACA8soztEozsyDY13LUUAG4NLm0jW0MDExMzcxMTA3NjewNDU1NDM0HUDxxJLEPCMNoBhtlcPFwEArF5iGLLm0DCx1zE1hlOaQNGco6iXkd3oZRIwF1HDkqBmjZpBrBm3zzSAqCDXJgwBGtHpjGggAAA==", "base64"))).toString("latin1"), "css");
```

Reduced to a generator (each level doubles parse time; depth 20 is ~9s):

```js
let s = "hsl(sin(1 + atan2(";
for (let i = 0; i < 30; i++) s += "2 * min(1,2) + 1 + atan2(";
Bun.color(s + "1" + ")".repeat(33), "css");  // hang
```

## Cause

`Calc::parse_atan2` (`src/css/values/calc.rs`) tries the argument as `<angle>` first, then falls back to `<length>`, `<percentage>`, `<time>`, `<number>`. #31558 added a `hit_unrecoverable` guard that bails when a nested type-independent math function has already failed during an attempt, but that guard was only applied to the `<angle>` attempt.

In this input each `atan2()` argument starts with `N * min(...) + ...`. The `<angle>` attempt parses that as a `Calc::Product` and then fails inside `Calc::add` (adding `Product + Number`, which `Angle::from_calc` rejects) before it reaches the nested `atan2()`. So the failure counter has not moved, the `<angle>` guard is not tripped, and the dimension fallbacks run.

`Length::from_calc` and `Percentage::from_calc` accept any `Calc` variant, so both attempts parse past the `Product + Number` sum and descend into the nested `atan2()`, which repeats the same 5-way probe. Two full re-descents per level gives `2^depth` work.

## Fix

Check `hit_unrecoverable` after each dimension fallback as well. Once the first full descent records a nested type-independent failure (which it does, via the existing `note_math_fn_parse_failure` in `parse_value`), the remaining fallbacks are skipped at every level. Dimension-only mismatches (`atan2(1s, 2s)` failing the `<length>` probe, for example) do not bump the counter, so valid inputs still fall through to the right type.

Fuzzer input: >10s to 17ms (debug). Depth scales roughly linearly afterwards.

## Verification

`test/js/bun/css/atan2-backtracking-hang.test.ts` gains the synthetic `productSumAtan2Chain` cases at depth 40/64, the original fuzzer input, and five new behavior-preservation cases covering `min()` arguments at each of the `<length>`/`<percentage>`/`<time>` fallbacks. Fails before (subprocess killed at 20s), passes after in ~1s. `css.test.ts`, `nested-function-backtracking.test.ts`, `angle-serialization-hang.test.ts`, `token-list-backtracking.test.ts`, `doesnt_crash.test.ts` and `wpt/color-computed.test.ts` all pass unchanged. The pre-existing debug-build `fuzz ansi256` timeout in `color.test.ts` (16.7M-iteration integer loop, unrelated to the CSS parser) reproduces identically on `main`.

Fuzz signature: `hang:color:_RNvMsn_NtC7bun_css10css_parserNtB5_9Tokenizer12consume_name|_RNvMsn_NtC7bun_css10css_parserNtB5_9Tokenizer18`