### PR TITLE
css: stop exponential atan2() backtracking when Angle add() rejects

### DIFF
--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -857,14 +857,39 @@ impl<V: CalcValue> Calc<V> {
         // instead of producing `Angle::Rad(atan2(10,5))`. Tracked as a known
         // incompleteness; no behaviour stub is added because a partial
         // dimension matcher would mis-reduce mixed-unit lengths.
-        if let Ok(v) = try_parse_atan2_args::<C, Length>(input, ctx) {
-            return Ok(v);
+        //
+        // The `Calc<Angle>` attempt above can fail before it ever reaches a
+        // nested math function (e.g. `2 * min(1, 2) + 3` errors in `add()`
+        // because `Angle::from_calc` rejects `Calc::Product`), leaving the
+        // failure counter unchanged. `Length`/`Percentage` have an infallible
+        // `from_calc` and so parse past that point into a nested `atan2()`,
+        // which then repeats the same five-way probe. Re-checking the counter
+        // after each fallback keeps this from branching exponentially: once
+        // any attempt has descended into a nested type-independent math
+        // function that failed, the remaining probes cannot succeed either.
+        match try_parse_atan2_args::<C, Length>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Percentage>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Percentage>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
-        if let Ok(v) = try_parse_atan2_args::<C, Time>(input, ctx) {
-            return Ok(v);
+        match try_parse_atan2_args::<C, Time>(input, ctx) {
+            Ok(v) => return Ok(v),
+            Err(e) => {
+                if hit_unrecoverable(input) {
+                    return Err(e);
+                }
+            }
         }
 
         let parse_ident_fn = move |c: C, ident: &[u8]| -> Option<Calc<CSSNumber>> {

--- a/test/js/bun/css/atan2-backtracking-hang.test.ts
+++ b/test/js/bun/css/atan2-backtracking-hang.test.ts
@@ -8,9 +8,23 @@ function nestedAtan2Chain(depth: number): string {
   return `hsl(sin(2\n${body}` + Buffer.alloc(depth + 3, ")").toString();
 }
 
+// A nested atan2() chain whose first argument starts with an unreducible
+// product (`2 * min(1, 2)` stays as `Calc::Product` because numeric `min()`
+// arguments are not folded), so `Calc<Angle>::parse_sum` fails at `add()`
+// rather than at a nested math function. The previous short-circuit only
+// covered the latter, letting the `Length` and `Percentage` fallbacks both
+// recurse, which is 2^depth.
+function nestedAtan2ProductChain(depth: number): string {
+  let body = "atan2(1)";
+  for (let i = 0; i < depth; i++) body = `atan2(2 * min(1, 2) + 3 + ${body})`;
+  return `hsl(calc(${body}) 50% 50%)`;
+}
+
 const cases: [css: string, expected: string | null][] = [
   [nestedAtan2Chain(40), null],
   [nestedAtan2Chain(64), null],
+  [nestedAtan2ProductChain(40), null],
+  [nestedAtan2ProductChain(64), null],
   ["hsl(" + Buffer.alloc(6 * 64, "atan2(").toString() + "9, 1" + Buffer.alloc(64, ")").toString() + " 50% 50%)", null],
   ["hsl(atan2(9, 1) 50% 50%)", "#8dbf40"],
   ["hsl(atan2(atan2(9,1), atan2(2,3)) 50% 50%)", "#aebf40"],
@@ -28,6 +42,11 @@ const cases: [css: string, expected: string | null][] = [
   ["hsl(atan2(1, sign(1s)) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(1, calc(sign(1px))) 50% 50%)", "#bf9f40"],
   ["hsl(atan2(atan2(9,1), 1) 50% 50%)", null],
+  ["hsl(atan2(2 * min(1, 2) + 3, 5) 50% 50%)", null],
+  ["hsl(atan2(2 * min(1deg, 2deg) + 3deg, 5deg) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(2 * min(1px, 2px) + 3px, 5px) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(2 * min(1%, 2%) + 3%, 5%) 50% 50%)", "#bf9f40"],
+  ["hsl(atan2(2 * min(1s, 2s) + 3s, 5s) 50% 50%)", "#bf9f40"],
 ];
 
 test("deeply nested atan2() color values parse in linear time instead of hanging", async () => {


### PR DESCRIPTION
## What

Fixes a hang in `Bun.color()` (and any CSS `calc()` path) on deeply nested `atan2()` where each argument starts with an unreducible product term. Found by fuzzing.

Signature: `hang:color:_RINvMs2_NtNtC7bun_css6values4calcINtB6_4CalcfE11parse_valueuNCINvMs2_B6_IBJ_NtNtB8_10percentage10PercentageE`

## Repro

```js
let body = "atan2(1)";
for (let i = 0; i < 40; i++) body = `atan2(2 * min(1, 2) + 3 + ${body})`;
Bun.color(`hsl(calc(${body}) 50% 50%)`, "css"); // hangs
```

Parse time doubles per nesting level: depth 15 is ~280 ms, depth 18 is ~2.2 s, depth 20 times out.

## Cause

This is a gap in the short-circuit added by #31558. That fix samples the math-fn-failure counter before the initial `Calc<Angle>` probe in `parse_atan2` and bails on the dimension fallbacks if a nested type-independent math function failed during that probe.

The initial probe can also fail *before* it reaches the nested `atan2()`. `2 * min(1, 2)` stays as `Calc::Product` (numeric `min()` arguments are not folded by `reduce_args`, which only compares `Calc::Value`s), and `Calc::Product + Calc::Number` errors in `add()` because `Angle::from_calc` only accepts `Calc::Value`. The counter is unchanged, so all four fallback probes run.

`Length::from_calc` and `Percentage::from_calc` are infallible, so those two probes parse past the product term and descend into the nested `atan2()`, which repeats the same five-way probe. Two recursive branches per level is `2^depth`.

## Fix

Re-check the failure counter after each fallback probe, not just the initial one. Once any probe has descended into a nested type-independent math function that failed, the remaining probes cannot succeed either, so they are skipped. Valid dimension arguments (`atan2(2 * min(1px, 2px) + 3px, 5px)` etc.) still parse through the first probe that accepts them because no nested math function fails on those paths.

## Verification

`test/js/bun/css/atan2-backtracking-hang.test.ts` adds the product-chain repro at depth 40 and 64 alongside behavior-preservation cases for the same expression shape with each dimension type. On an unfixed build the subprocess is killed by the 20 s timeout; with the fix the full case list completes in well under a second (debug) and depth 160 is flat.

`css.test.ts`, `nested-function-backtracking.test.ts`, `token-list-backtracking.test.ts`, `angle-serialization-hang.test.ts`, `doesnt_crash.test.ts`, and `color.test.ts` (aside from the pre-existing `fuzz ansi256` debug-build timeout that reproduces identically on `main`) pass.