### PR TITLE
install: trust file: paths from root package.json overrides/resolutions

### DIFF
--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1377,8 +1377,17 @@ impl<'a> PackageInstaller<'a> {
                     installer.cache_dir = Fd::cwd();
                 } else {
                     // transitive folder dependencies are relative to their parent. they are not hoisted
+
+                    // overrides/resolutions are only ever parsed from the root package.json,
+                    // so a folder path that reached here via an override was written by the
+                    // user and is trusted the same as a direct dependency of the root.
+                    let dep_name_hash = self.lockfile().buffers.dependencies.as_slice()
+                        [dependency_id as usize]
+                        .name_hash;
+                    let from_override = self.lockfile().overrides.get(dep_name_hash).is_some();
+
                     if folder.len() >= self.folder_path_buf.len()
-                        || bin::bin_target_escapes_package_dir(folder)
+                        || (!from_override && bin::bin_target_escapes_package_dir(folder))
                     {
                         if log_level != Options::LogLevel::Silent {
                             bun_core::pretty_errorln!(

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1377,17 +1377,20 @@ impl<'a> PackageInstaller<'a> {
                     installer.cache_dir = Fd::cwd();
                 } else {
                     // transitive folder dependencies are relative to their parent. they are not hoisted
-
-                    // overrides/resolutions are only ever parsed from the root package.json,
-                    // so a folder path that reached here via an override was written by the
-                    // user and is trusted the same as a direct dependency of the root.
-                    let dep_name_hash = self.lockfile().buffers.dependencies.as_slice()
-                        [dependency_id as usize]
-                        .name_hash;
-                    let from_override = self.lockfile().overrides.get(dep_name_hash).is_some();
-
                     if folder.len() >= self.folder_path_buf.len()
-                        || (!from_override && bin::bin_target_escapes_package_dir(folder))
+                        || (bin::bin_target_escapes_package_dir(folder) && {
+                            // overrides/resolutions are only ever parsed from the root
+                            // package.json, so a folder path that reached here via an
+                            // override was written by the user and is trusted the same
+                            // as a direct dependency of the root.
+                            let dep = &self.lockfile().buffers.dependencies.as_slice()
+                                [dependency_id as usize];
+                            !self.lockfile().overrides.contains_name(
+                                dep.name_hash,
+                                dep.name.slice(string_buf!()),
+                                string_buf!(),
+                            )
+                        })
                     {
                         if log_level != Options::LogLevel::Silent {
                             bun_core::pretty_errorln!(

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2589,15 +2589,21 @@ fn get_or_put_resolved_package(
                 }
 
                 // transitive folder dependencies do not have their dependencies resolved
-
-                // overrides/resolutions are only ever parsed from the root package.json,
-                // so a folder path that reached here via an override was written by the
-                // user and is trusted the same as a direct dependency of the root.
-                let from_override = this.lockfile.overrides.get(dependency.name_hash).is_some();
-                if !from_override
-                    && crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder))
-                {
-                    break 'res FolderResolutionValue::Err(bun_core::err!("MissingPackageJSON"));
+                if crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder)) {
+                    // overrides/resolutions are only ever parsed from the root
+                    // package.json, so a folder path that reached here via an
+                    // override was written by the user and is trusted the same
+                    // as a direct dependency of the root.
+                    let buf = this.lockfile.buffers.string_bytes.as_slice();
+                    if !this.lockfile.overrides.contains_name(
+                        dependency.name_hash,
+                        dependency.name.slice(buf),
+                        buf,
+                    ) {
+                        break 'res FolderResolutionValue::Err(bun_core::err!(
+                            "MissingPackageJSON"
+                        ));
+                    }
                 }
 
                 let mut package = Package::default();

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -2589,7 +2589,14 @@ fn get_or_put_resolved_package(
                 }
 
                 // transitive folder dependencies do not have their dependencies resolved
-                if crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder)) {
+
+                // overrides/resolutions are only ever parsed from the root package.json,
+                // so a folder path that reached here via an override was written by the
+                // user and is trusted the same as a direct dependency of the root.
+                let from_override = this.lockfile.overrides.get(dependency.name_hash).is_some();
+                if !from_override
+                    && crate::bin::bin_target_escapes_package_dir(this.lockfile.str(&folder))
+                {
                     break 'res FolderResolutionValue::Err(bun_core::err!("MissingPackageJSON"));
                 }
 

--- a/src/install/lockfile/OverrideMap.rs
+++ b/src/install/lockfile/OverrideMap.rs
@@ -40,6 +40,22 @@ impl OverrideMap {
         self.map.get(&name_hash).map(|dep| dep.version.clone())
     }
 
+    /// Like `get().is_some()` but also compares the stored name so a hash
+    /// collision cannot produce a false positive.
+    pub(crate) fn contains_name(
+        &self,
+        name_hash: PackageNameHash,
+        name: &[u8],
+        buf: &[u8],
+    ) -> bool {
+        if self.map.count() == 0 {
+            return false;
+        }
+        self.map
+            .get(&name_hash)
+            .is_some_and(|dep| dep.name.slice(buf) == name)
+    }
+
     // Every caller already holds `&mut self` on `lockfile.overrides`, so
     // accept just the string buffer (the only lockfile field `sort` reads)
     // rather than the whole `Lockfile`.

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9423,11 +9423,7 @@ for (const field of ["resolutions", "overrides"]) {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [runOut, runErr, runExit] = await Promise.all([
-      runProc.stdout.text(),
-      runProc.stderr.text(),
-      runProc.exited,
-    ]);
+    const [runOut, runErr, runExit] = await Promise.all([runProc.stdout.text(), runProc.stderr.text(), runProc.exited]);
     expect(runErr).toBe("");
     expect(runOut.trim()).toBe("shared");
     expect(runExit).toBe(0);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -9354,6 +9354,201 @@ it("does not install transitive file: dependencies with overlong folder targets"
   expect(exitCode).toBe(1);
 });
 
+for (const field of ["resolutions", "overrides"]) {
+  it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}"`, async () => {
+    // `overrides` / `resolutions` can only be declared in the root package.json,
+    // so a file: path written there is user-specified and should be trusted
+    // even when it is applied to a transitive dependency in a nested tree.
+    using dir = tempDir("override-file-dep", {
+      "shared/package.json": JSON.stringify({
+        name: "shared",
+        version: "1.0.0",
+      }),
+      "shared/index.js": "module.exports = 'shared';",
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          "pkg-a": "file:./pkg-a",
+          "shared": "file:../shared",
+        },
+        [field]: {
+          shared: "file:../shared",
+        },
+      }),
+      "project/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          shared: "1.0.0",
+        },
+      }),
+      "project/pkg-a/index.js": "module.exports = require('shared');",
+    });
+    const projectDir = join(String(dir), "project");
+
+    // Run install twice: the first pass exercises the resolve/enqueue path
+    // (no lockfile yet), then node_modules is wiped so the second pass
+    // exercises the install-from-lockfile path.
+    for (let i = 0; i < 2; i++) {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: projectDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+      expect(err).not.toContain("unsafe folder path");
+      expect(err).not.toContain("refusing to install");
+      expect(err).not.toContain("Could not find package.json");
+      expect(err).not.toContain("failed to resolve");
+      expect(exitCode).toBe(0);
+      expect(out).toContain("shared");
+
+      if (i === 0) {
+        await rm(join(projectDir, "node_modules"), { recursive: true, force: true });
+      }
+    }
+
+    expect(await exists(join(projectDir, "node_modules", "shared", "package.json"))).toBe(true);
+
+    // pkg-a must be able to resolve `shared` at runtime.
+    await using runProc = spawn({
+      cmd: [bunExe(), "-e", "console.log(require('pkg-a'))"],
+      cwd: projectDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [runOut, runErr, runExit] = await Promise.all([
+      runProc.stdout.text(),
+      runProc.stderr.text(),
+      runProc.exited,
+    ]);
+    expect(runErr).toBe("");
+    expect(runOut.trim()).toBe("shared");
+    expect(runExit).toBe(0);
+  });
+
+  it(`installs a file: dependency pointing outside the project when it came from root package.json "${field}" (existing lockfile)`, async () => {
+    // Same as above but starting from a lockfile that already contains the
+    // nested folder resolution, so the package installer (not the enqueue
+    // path) is what sees the escaping folder path.
+    using dir = tempDir("override-file-dep-lock", {
+      "shared/package.json": JSON.stringify({
+        name: "shared",
+        version: "1.0.0",
+      }),
+      "shared/index.js": "module.exports = 'shared';",
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          "pkg-a": "file:./pkg-a",
+          "shared": "file:../shared",
+        },
+        [field]: {
+          shared: "file:../shared",
+        },
+      }),
+      "project/pkg-a/package.json": JSON.stringify({
+        name: "pkg-a",
+        version: "1.0.0",
+        dependencies: {
+          shared: "1.0.0",
+        },
+      }),
+      "project/pkg-a/index.js": "module.exports = require('shared');",
+      "project/bun.lock": JSON.stringify({
+        lockfileVersion: 1,
+        workspaces: {
+          "": {
+            name: "my-app",
+            dependencies: {
+              "pkg-a": "file:./pkg-a",
+              "shared": "file:../shared",
+            },
+          },
+        },
+        overrides: {
+          shared: "file:../shared",
+        },
+        packages: {
+          "pkg-a": ["pkg-a@file:pkg-a", { dependencies: { shared: "1.0.0" } }],
+          "shared": ["shared@file:../shared", {}],
+          "pkg-a/shared": ["shared@file:../shared", {}],
+        },
+      }),
+    });
+    const projectDir = join(String(dir), "project");
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(err).not.toContain("unsafe folder path");
+    expect(err).not.toContain("refusing to install");
+    expect(err).not.toContain("Could not find package.json");
+    expect(err).not.toContain("failed to resolve");
+    expect(exitCode).toBe(0);
+    expect(out).toContain("shared");
+    expect(await exists(join(projectDir, "node_modules", "shared", "package.json"))).toBe(true);
+  });
+
+  it(`still rejects transitive file: dependencies that escape their package when a different name is in "${field}"`, async () => {
+    // An override for a different name must not whitelist an unrelated
+    // transitive file: dependency that points outside its package.
+    using dir = tempDir("override-file-dep-unrelated", {
+      "secret/credentials.txt": "do-not-link-me",
+      "shared/package.json": JSON.stringify({ name: "shared", version: "1.0.0" }),
+      "project/package.json": JSON.stringify({
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          "evil-folder-dep": "file:./evil-folder-dep",
+        },
+        [field]: {
+          shared: "file:../shared",
+        },
+      }),
+      "project/evil-folder-dep/index.js": "module.exports = 1;",
+      "project/evil-folder-dep/package.json": JSON.stringify({
+        name: "evil-folder-dep",
+        version: "1.0.0",
+        dependencies: {
+          loot: "file:../../secret",
+        },
+      }),
+    });
+    const projectDir = join(String(dir), "project");
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [err, out, exitCode] = await Promise.all([stderr.text(), stdout.text(), exited]);
+
+    expect(await exists(join(projectDir, "node_modules", "loot"))).toBe(false);
+    expect(await exists(join(projectDir, "node_modules", "evil-folder-dep", "node_modules", "loot"))).toBe(false);
+    expect(err).toContain("Could not find package.json");
+    expect(out).not.toContain("2 packages installed");
+    expect(exitCode).toBe(1);
+  });
+}
+
 it("does not extract a local file: tarball outside the temp dir for a dependency alias containing '..' path segments", async () => {
   // For `file:` tarball dependencies, the dependency alias (the key in
   // `dependencies`) is used to derive the temporary extraction folder name.


### PR DESCRIPTION
## Repro

In `test/`:
```
❯ bun install
error: refusing to install dependency react with unsafe folder path "../node_modules/react"
error: refusing to install dependency react with unsafe folder path "../node_modules/react"
...
```

Minimal case: a root package.json with
```json
{
  "dependencies": { "pkg-a": "file:./pkg-a", "shared": "file:../shared" },
  "resolutions": { "shared": "file:../shared" }
}
```
where `pkg-a` depends on `shared`. The `resolutions` entry applies the `../shared` path to pkg-a's transitive `shared` dep, and the escape check added in #31417 rejects it in both the enqueue path (`Could not find package.json for "file:../shared"`) and, when a lockfile already exists, the install path (`refusing to install dependency shared with unsafe folder path "../shared"`).

## Cause

`PackageManagerEnqueue.rs` and `PackageInstaller.rs` gate the escape check on `is_workspace_dependency(id)` / `is_workspace_tree_id(tree)`. A `resolutions`/`overrides` entry is declared in the root package.json but is applied to dependencies owned by transitive packages and installed into nested trees, so both predicates are false and the user's own path is rejected.

## Fix

`lockfile.overrides` is only ever populated from the root package.json (`Package.rs` guards `parse_append` behind `FEATURES.is_main`). Skip the escape check at both sites when the dependency name has an entry in the override map; the path it resolved to came from the root package.json and is trusted the same as a direct dependency. The overlong path check is kept unconditionally.

## Tests

Six new cases in `test/cli/install/bun-install.test.ts`:
- fresh install + install from existing lockfile, for both `resolutions` and `overrides`
- two guard tests: a transitive package's own escaping `file:` dep is still rejected when a different name is in `overrides`/`resolutions`

```
bun bd test test/cli/install/bun-install.test.ts -t "pointing outside the project when it came from root"
  4 pass, 0 fail
bun bd test test/cli/install/bun-install.test.ts -t "still rejects transitive file"
  2 pass, 0 fail
bun bd test test/cli/install/bun-install.test.ts -t "does not install transitive file: dependencies"
  2 pass, 0 fail
bun bd test test/cli/install/overrides.test.ts
  7 pass, 0 fail
```

The four positive tests fail on the released build with the exact errors above.