### PR TITLE
css: bound compiled-nesting selector-prelude bytes and widen indent counter

### DIFF
--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -126,7 +126,9 @@ pub struct Printer<'a> {
     pub sources: Option<&'a Vec<Box<[u8]>>>,
     pub dest: &'a mut dyn Write,
     pub loc: Location,
-    pub indent_amt: u8,
+    // Wide enough for 2 × MAX_NESTING_DEPTH (css_parser.rs) so nesting at the
+    // full permitted depth never overflows it.
+    pub indent_amt: u16,
     pub line: u32,
     pub col: u32,
     pub minify: bool,
@@ -158,6 +160,19 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
+    /// Running total of selector-prelude bytes written for style rules that
+    /// are serialized under a compiled-nesting `StyleContext` (i.e. a parent
+    /// selector chain is being inlined into the prelude). When the targets
+    /// don't support CSS nesting, every nested rule's prelude prints the
+    /// whole ancestor chain, so the output grows with (rule count × nesting
+    /// depth). Minify's `MAX_SELECTOR_EXPANSION` bounds the rule count but
+    /// not the per-rule prelude length (bounded only by the 512-level parser
+    /// depth cap), so deeply nested rules whose selectors are partitioned
+    /// for compatibility can still expand a few KB of input into hundreds of
+    /// megabytes of output. Accumulated across the whole stylesheet (never
+    /// reset) and bounded in `StyleRule::to_css_base`. Complements
+    /// `prefix_expansion_bytes`.
+    pub nesting_expansion_bytes: usize,
     /// Running total of bytes emitted by duplicate vendor-prefix passes. A rule
     /// whose selector list carries more than one vendor prefix (e.g. a list
     /// mixing `:-webkit-autofill` with an unprefixed pseudo-class, or a single
@@ -347,6 +362,7 @@ impl<'a> Printer<'a> {
             css_module: None,
             ctx: None,
             nesting_expansions: 0,
+            nesting_expansion_bytes: 0,
             prefix_expansion_bytes: 0,
             error_kind: None,
         }

--- a/src/css/printer.rs
+++ b/src/css/printer.rs
@@ -160,18 +160,18 @@ pub struct Printer<'a> {
     /// `serialize::serialize_nesting` so deeply nested rules with multiple
     /// `&` references per level cannot expand exponentially.
     pub nesting_expansions: u32,
-    /// Running total of selector-prelude bytes written for style rules that
-    /// are serialized under a compiled-nesting `StyleContext` (i.e. a parent
-    /// selector chain is being inlined into the prelude). When the targets
-    /// don't support CSS nesting, every nested rule's prelude prints the
-    /// whole ancestor chain, so the output grows with (rule count × nesting
-    /// depth). Minify's `MAX_SELECTOR_EXPANSION` bounds the rule count but
-    /// not the per-rule prelude length (bounded only by the 512-level parser
-    /// depth cap), so deeply nested rules whose selectors are partitioned
-    /// for compatibility can still expand a few KB of input into hundreds of
-    /// megabytes of output. Accumulated across the whole stylesheet (never
-    /// reset) and bounded in `StyleRule::to_css_base`. Complements
-    /// `prefix_expansion_bytes`.
+    /// Running total of selector-prelude bytes written for rule preludes
+    /// that are serialized under a compiled-nesting `StyleContext` (i.e. a
+    /// parent selector chain is being inlined into the prelude). When the
+    /// targets don't support CSS nesting, every nested rule's prelude prints
+    /// the whole ancestor chain, so the output grows with (rule count ×
+    /// nesting depth). Minify's `MAX_SELECTOR_EXPANSION` bounds the rule
+    /// count but not the per-rule prelude length (bounded only by the
+    /// 512-level parser depth cap), so deeply nested rules whose selectors
+    /// are partitioned for compatibility can still expand a few KB of input
+    /// into hundreds of megabytes of output. Accumulated across the whole
+    /// stylesheet (never reset) and bounded in `StyleRule::to_css_base` and
+    /// `ScopeRule::to_css`. Complements `prefix_expansion_bytes`.
     pub nesting_expansion_bytes: usize,
     /// Running total of bytes emitted by duplicate vendor-prefix passes. A rule
     /// whose selector list carries more than one vendor prefix (e.g. a list

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -30,6 +30,14 @@ impl<R> ScopeRule<R> {
         // compiling nesting, like style rule preludes do (see
         // `serialize::serialize_nesting`).
         dest.nesting_expansions = 0;
+        // Meter the prelude against the nesting-expansion byte budget (see
+        // `StyleRule::to_css_base`). `&` can expand when an outer parent
+        // context is set, or when `<scope-end>` serializes with
+        // `<scope-start>` as a temporary parent below; without either the
+        // prelude serializes verbatim and is not charged.
+        let has_expanding_context =
+            dest.ctx.is_some() || (self.scope_start.is_some() && self.scope_end.is_some());
+        let prelude_before = has_expanding_context.then(|| dest.bytes_written());
         if let Some(scope_start) = &self.scope_start {
             dest.write_char(b'(')?;
             // scope_start.to_css(dest)?;
@@ -64,6 +72,16 @@ impl<R> ScopeRule<R> {
             }
             dest.write_char(b')')?;
             dest.whitespace()?;
+        }
+        if let Some(before) = prelude_before {
+            let emitted = dest.bytes_written().saturating_sub(before);
+            dest.nesting_expansion_bytes = dest.nesting_expansion_bytes.saturating_add(emitted);
+            if dest.nesting_expansion_bytes > super::style::MAX_NESTING_EXPANSION_BYTES {
+                return dest.new_error(
+                    crate::error::PrinterErrorKind::maximum_nesting_expansion,
+                    None,
+                );
+            }
         }
         dest.write_char(b'{')?;
         dest.indent();

--- a/src/css/rules/scope.rs
+++ b/src/css/rules/scope.rs
@@ -68,7 +68,7 @@ impl<R> ScopeRule<R> {
                 )?;
             } else {
                 let ctx = dest.ctx;
-                return serialize_selector_list(scope_end.v.slice(), dest, ctx, false);
+                serialize_selector_list(scope_end.v.slice(), dest, ctx, false)?;
             }
             dest.write_char(b')')?;
             dest.whitespace()?;

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -91,6 +91,25 @@ impl<R> StyleRule<R> {
 /// (`selectors/selector.rs`) and `MAX_SELECTOR_EXPANSION` (`rules/mod.rs`).
 const MAX_PREFIX_EXPANSION_BYTES: usize = 64 << 20;
 
+/// Maximum number of selector-prelude bytes compiled nesting may emit
+/// across a whole stylesheet.
+///
+/// When the targets don't support CSS nesting, every nested rule's prelude
+/// inlines the full parent selector chain (`serialize::serialize_nesting`
+/// walks the `StyleContext` up to the root). Minify's
+/// [`MAX_SELECTOR_EXPANSION`](super::MAX_SELECTOR_EXPANSION) bounds how many
+/// rules that expansion produces, but each of those rules still writes a
+/// prelude whose length grows with nesting depth — and the parser permits
+/// up to 512 levels. The product of the two (tens of thousands of rules ×
+/// hundreds of ancestor selectors each) lets a few kilobytes of input print
+/// hundreds of megabytes of output without tripping any existing limit. The
+/// bytes written for each such prelude are measured and accumulated (see
+/// `Printer::nesting_expansion_bytes`); exceeding this limit is a runaway
+/// expansion, so bail out with an error instead of allocating without
+/// bound. Real stylesheets stay far below this — even very large nested
+/// sheets expand to a few megabytes of selector preludes.
+const MAX_NESTING_EXPANSION_BYTES: usize = 64 << 20;
+
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         if self.vendor_prefix.is_empty() {
@@ -179,12 +198,34 @@ impl<R> StyleRule<R> {
             // Each rule prelude gets its own budget for `&` substitutions when
             // compiling nesting (see `serialize::serialize_nesting`).
             dest.nesting_expansions = 0;
+            // When a parent-selector chain is being inlined into this
+            // prelude (compiled nesting), measure how many bytes the
+            // prelude emits and charge them against the expansion-byte
+            // budget so the (rule count × nesting depth) blow-up stays
+            // bounded. Rules at the top level (`ctx == None`) are the
+            // original output and are not charged.
+            let prelude_before = if ctx.is_some() {
+                Some(dest.bytes_written())
+            } else {
+                None
+            };
             selector::serialize::serialize_selector_list(
                 self.selectors.v.slice(),
                 dest,
                 ctx,
                 false,
             )?;
+            if let Some(before) = prelude_before {
+                let emitted = dest.bytes_written().saturating_sub(before);
+                dest.nesting_expansion_bytes =
+                    dest.nesting_expansion_bytes.saturating_add(emitted);
+                if dest.nesting_expansion_bytes > MAX_NESTING_EXPANSION_BYTES {
+                    return dest.new_error(
+                        css::error::PrinterErrorKind::maximum_nesting_expansion,
+                        None,
+                    );
+                }
+            }
             dest.whitespace()?;
             dest.write_char(b'{')?;
             dest.indent();

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -217,8 +217,7 @@ impl<R> StyleRule<R> {
             )?;
             if let Some(before) = prelude_before {
                 let emitted = dest.bytes_written().saturating_sub(before);
-                dest.nesting_expansion_bytes =
-                    dest.nesting_expansion_bytes.saturating_add(emitted);
+                dest.nesting_expansion_bytes = dest.nesting_expansion_bytes.saturating_add(emitted);
                 if dest.nesting_expansion_bytes > MAX_NESTING_EXPANSION_BYTES {
                     return dest.new_error(
                         css::error::PrinterErrorKind::maximum_nesting_expansion,

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -108,7 +108,7 @@ const MAX_PREFIX_EXPANSION_BYTES: usize = 64 << 20;
 /// expansion, so bail out with an error instead of allocating without
 /// bound. Real stylesheets stay far below this — even very large nested
 /// sheets expand to a few megabytes of selector preludes.
-const MAX_NESTING_EXPANSION_BYTES: usize = 64 << 20;
+pub(super) const MAX_NESTING_EXPANSION_BYTES: usize = 64 << 20;
 
 impl<R> StyleRule<R> {
     pub fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -327,6 +327,66 @@ test("shallow padded-then-forked nesting still compiles for old targets", () => 
   expect(out.length).toBeLessThan(100_000);
 });
 
+test.concurrent(
+  "deep padding before an @scope prelude errors instead of emitting huge output",
+  async () => {
+    // Same shape as the style-rule case above, but the leaf is an `@scope`
+    // rule whose prelude contains `&`: `ScopeRule::to_css` serializes its
+    // prelude with the enclosing `StyleContext`, so the `&` inlines the
+    // full ~414-level ancestor chain per cloned `@scope` (2^14 clones from
+    // the fork levels). The `@scope` prelude is charged against the same
+    // byte budget as style-rule preludes.
+    const css =
+      ".padding-selector {\n".repeat(400) +
+      ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(14) +
+      "@scope (& .x) { .y { color: red } }";
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { cssInternals } = require("bun:internal-for-testing");
+        const css = ${JSON.stringify(css)};
+        try {
+          const r = cssInternals._test(css, "", { safari: (13 << 16) | (2 << 8) });
+          console.log("OK " + r.length);
+        } catch (e) {
+          console.log("ERR " + e.message);
+        }
+      `,
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stdout: stdout.trim(),
+      exitCode,
+      signalCode: proc.signalCode,
+      panicked: stderr.includes("panic"),
+    }).toEqual({
+      stdout: "ERR " + NESTING_LIMIT_ERROR + " when compiling CSS nesting for the configured targets",
+      exitCode: 0,
+      signalCode: null,
+      panicked: false,
+    });
+  },
+  90_000,
+);
+
+test("shallow @scope preludes under compiled nesting still serialize", () => {
+  // A `&` in a `@scope` prelude under a few levels of compiled nesting
+  // inlines the parent chain but stays well under the byte budget.
+  const src = ".a { .b { @scope (& .x) to (& .y) { .z { color: red } } } }";
+  const out = cssInternals._test(src, "", { safari: (13 << 16) | (2 << 8) });
+  expect(out).toContain("@scope");
+  expect(out).toContain(".a .b .x");
+  expect(out).toContain("color: red");
+});
+
 test("a large realistic nested stylesheet does not trip the nesting byte bound", () => {
   // Many top-level rules, each with a few levels of single-selector nesting:
   // the total prelude bytes under a compiled-nesting context are linear in

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -327,9 +327,17 @@ test("shallow padded-then-forked nesting still compiles for old targets", () => 
   expect(out.length).toBeLessThan(100_000);
 });
 
-test.concurrent(
-  "deep padding before an @scope prelude errors instead of emitting huge output",
-  async () => {
+test.concurrent.each([
+  // Both `<scope-start>` and `<scope-end>` serialize with the enclosing
+  // `StyleContext`, so a `&` in either inlines the full ancestor chain.
+  // The `to`-only form exercises the `scope_start.is_none()` branch in
+  // `ScopeRule::to_css`, which previously early-returned past both the
+  // byte metering and the closing `)`/body/`}`.
+  ["<scope-start>", "@scope (& .x) { .y { color: red } }"],
+  ["<scope-end> without <scope-start>", "@scope to (& .x) { .y { color: red } }"],
+])(
+  "deep padding before an @scope %s prelude errors instead of emitting huge output",
+  async (_label, leaf) => {
     // Same shape as the style-rule case above, but the leaf is an `@scope`
     // rule whose prelude contains `&`: `ScopeRule::to_css` serializes its
     // prelude with the enclosing `StyleContext`, so the `&` inlines the
@@ -337,9 +345,7 @@ test.concurrent(
     // the fork levels). The `@scope` prelude is charged against the same
     // byte budget as style-rule preludes.
     const css =
-      ".padding-selector {\n".repeat(400) +
-      ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(14) +
-      "@scope (& .x) { .y { color: red } }";
+      ".padding-selector {\n".repeat(400) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(14) + leaf;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -385,6 +391,14 @@ test("shallow @scope preludes under compiled nesting still serialize", () => {
   expect(out).toContain("@scope");
   expect(out).toContain(".a .b .x");
   expect(out).toContain("color: red");
+});
+
+test("@scope with <scope-end> but no <scope-start> serializes its whole body", () => {
+  // The `scope_start.is_none()` branch in `ScopeRule::to_css` used to
+  // `return` after writing `<scope-end>`, skipping the closing paren, the
+  // body, and the closing brace. Falling through serializes the full rule.
+  const out = cssInternals._test("@scope to (.x) { .y { color: red } }", "", undefined);
+  expect(out).toBe("@scope to (.x) {\n  .y {\n    color: red;\n  }\n}\n");
 });
 
 test("a large realistic nested stylesheet does not trip the nesting byte bound", () => {

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -262,25 +262,25 @@ const NESTING_LIMIT_ERROR = "Maximum nesting expansion exceeded";
  * multiplier stays 1 across them, so they contribute nothing to the
  * rule-count cap while still lengthening every printed prelude. */
 function deepPadThenFork(pad: number, fork: number): string {
-  return (
-    ".padding-selector {\n".repeat(pad) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(fork) + "color: red;"
-  );
+  return ".padding-selector {\n".repeat(pad) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(fork) + "color: red;";
 }
 
-test.concurrent("deep padding before the multi-selector split errors instead of emitting huge output", async () => {
-  // 15 fork levels × 2 selectors = under 65,536 rules, so the rule-count cap
-  // never fires; but each rule prints a ~7 KB prelude (400 single-selector
-  // levels × ~17 bytes, plus the fork levels) — 32768 × ~7 KB ≈ 230 MB of
-  // output before the fix.
-  //
-  // Runs in a subprocess: before the fix the printer emits the full ~230 MB
-  // (tens of seconds in a debug build), so a regression is SIGKILL'd by the
-  // kill switch below instead of hanging the runner.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+test.concurrent(
+  "deep padding before the multi-selector split errors instead of emitting huge output",
+  async () => {
+    // 15 fork levels × 2 selectors = under 65,536 rules, so the rule-count cap
+    // never fires; but each rule prints a ~7 KB prelude (400 single-selector
+    // levels × ~17 bytes, plus the fork levels) — 32768 × ~7 KB ≈ 230 MB of
+    // output before the fix.
+    //
+    // Runs in a subprocess: before the fix the printer emits the full ~230 MB
+    // (tens of seconds in a debug build), so a regression is SIGKILL'd by the
+    // kill switch below instead of hanging the runner.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         const { cssInternals } = require("bun:internal-for-testing");
         const css = ${JSON.stringify(deepPadThenFork(400, 15))};
         try {
@@ -290,19 +290,21 @@ test.concurrent("deep padding before the multi-selector split errors instead of 
           console.log("ERR " + e.message);
         }
       `,
-    ],
-    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
-    stdout: "pipe",
-    stderr: "pipe",
-    timeout: 60_000,
-    killSignal: "SIGKILL",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(proc.signalCode).toBeNull();
-  expect(stdout).toContain("ERR " + NESTING_LIMIT_ERROR);
-  expect(exitCode).toBe(0);
-}, 90_000);
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+      killSignal: "SIGKILL",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(proc.signalCode).toBeNull();
+    expect(stdout).toContain("ERR " + NESTING_LIMIT_ERROR);
+    expect(exitCode).toBe(0);
+  },
+  90_000,
+);
 
 test("the padded-then-forked reproduction still minifies with no targets", () => {
   // Without targets nesting is preserved, so the output stays linear.
@@ -336,15 +338,17 @@ test("a large realistic nested stylesheet does not trip the nesting byte bound",
 // 512 levels of nesting, so the indentation counter overflowed its 8-bit
 // storage at depth 128 — a panic in debug builds and wrong indentation in
 // release builds.
-test.concurrent("indentation at the full permitted nesting depth does not overflow", async () => {
-  // Runs in a subprocess: before the fix this panics the process in debug
-  // builds ("attempt to add with overflow").
-  const depth = 500;
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `
+test.concurrent(
+  "indentation at the full permitted nesting depth does not overflow",
+  async () => {
+    // Runs in a subprocess: before the fix this panics the process in debug
+    // builds ("attempt to add with overflow").
+    const depth = 500;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
         const { cssInternals } = require("bun:internal-for-testing");
         const depth = ${depth};
         const src = ".a {\\n".repeat(depth) + "color: red;\\n" + "}".repeat(depth);
@@ -353,18 +357,20 @@ test.concurrent("indentation at the full permitted nesting depth does not overfl
         const needle = "\\n" + Buffer.alloc(2 * depth, " ").toString() + "color: red";
         console.log(out.includes(needle) ? "OK" : "BAD-INDENT " + out.length);
       `,
-    ],
-    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout: stdout.trim(), exitCode, panicked: stderr.includes("overflow") }).toEqual({
-    stdout: "OK",
-    exitCode: 0,
-    panicked: false,
-  });
-}, 30_000);
+      ],
+      env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode, panicked: stderr.includes("overflow") }).toEqual({
+      stdout: "OK",
+      exitCode: 0,
+      panicked: false,
+    });
+  },
+  30_000,
+);
 
 test("bun build does not hang on deeply nested multi-selector css spanning @starting-style", async () => {
   using dir = tempDir("css-starting-style-expansion", {

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -344,8 +344,7 @@ test.concurrent.each([
     // full ~414-level ancestor chain per cloned `@scope` (2^14 clones from
     // the fork levels). The `@scope` prelude is charged against the same
     // byte budget as style-rule preludes.
-    const css =
-      ".padding-selector {\n".repeat(400) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(14) + leaf;
+    const css = ".padding-selector {\n".repeat(400) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(14) + leaf;
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -238,6 +238,134 @@ test("shallow nesting spanning @scope still compiles for old targets", () => {
   expect(out).toContain("@scope");
 });
 
+// Regression for a CSS-minifier output bomb found by fuzzing: a ~10 KB input
+// drove the CSS printer to ~200 MB of output (peak ~1.6 GB RSS including the
+// returned JS string and intermediate buffers) when compiling nesting for
+// Safari 13, without tripping any existing limit.
+//
+// When the targets don't support nesting, every nested rule's selector
+// prelude inlines the full parent chain (one ancestor's selector per nesting
+// level). Minify's selector-expansion cap bounds how many rules the nesting
+// expands into, but each of those rules still prints a prelude proportional
+// to the nesting depth (the parser permits up to 512 levels). By stacking the
+// multi-selector rules at the *bottom* of a long single-selector chain, the
+// selector-expansion total stays under 65,536 rules while each of those rules
+// prints a hundreds-of-levels-long prelude. The printer now bounds the total
+// selector-prelude bytes emitted under a compiled-nesting context and errors
+// out instead.
+
+const NESTING_LIMIT_ERROR = "Maximum nesting expansion exceeded";
+
+/** `pad` single-selector levels followed by `fork` levels of two incompatible
+ * (custom-pseudo) selectors that must be partitioned into separate rules when
+ * compiled for old targets. With the pad levels first the selector-expansion
+ * multiplier stays 1 across them, so they contribute nothing to the
+ * rule-count cap while still lengthening every printed prelude. */
+function deepPadThenFork(pad: number, fork: number): string {
+  return (
+    ".padding-selector {\n".repeat(pad) + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(fork) + "color: red;"
+  );
+}
+
+test.concurrent("deep padding before the multi-selector split errors instead of emitting huge output", async () => {
+  // 15 fork levels × 2 selectors = under 65,536 rules, so the rule-count cap
+  // never fires; but each rule prints a ~7 KB prelude (400 single-selector
+  // levels × ~17 bytes, plus the fork levels) — 32768 × ~7 KB ≈ 230 MB of
+  // output before the fix.
+  //
+  // Runs in a subprocess: before the fix the printer emits the full ~230 MB
+  // (tens of seconds in a debug build), so a regression is SIGKILL'd by the
+  // kill switch below instead of hanging the runner.
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { cssInternals } = require("bun:internal-for-testing");
+        const css = ${JSON.stringify(deepPadThenFork(400, 15))};
+        try {
+          const r = cssInternals._test(css, "", { safari: (13 << 16) | (2 << 8) });
+          console.log("OK " + r.length);
+        } catch (e) {
+          console.log("ERR " + e.message);
+        }
+      `,
+    ],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 60_000,
+    killSignal: "SIGKILL",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(proc.signalCode).toBeNull();
+  expect(stdout).toContain("ERR " + NESTING_LIMIT_ERROR);
+  expect(exitCode).toBe(0);
+}, 90_000);
+
+test("the padded-then-forked reproduction still minifies with no targets", () => {
+  // Without targets nesting is preserved, so the output stays linear.
+  const out = minifyTest(deepPadThenFork(100, 15), "");
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(20_000);
+});
+
+test("shallow padded-then-forked nesting still compiles for old targets", () => {
+  // Well under the byte budget.
+  const out = minifyTest(deepPadThenFork(20, 5), "", { safari: (13 << 16) | (2 << 8) });
+  expect(out).toContain("color:red");
+  expect(out.length).toBeLessThan(100_000);
+});
+
+test("a large realistic nested stylesheet does not trip the nesting byte bound", () => {
+  // Many top-level rules, each with a few levels of single-selector nesting:
+  // the total prelude bytes under a compiled-nesting context are linear in
+  // the input size. This must not throw.
+  let src = "";
+  for (let i = 0; i < 4000; i++) {
+    src += `.a${i} { .b${i} { .c${i} { --v${i}: 1 } } }\n`;
+  }
+  const out = minifyTest(src, "", OLD_TARGETS);
+  expect(out.length).toBeGreaterThan(0);
+  expect(out).toContain(".a3999 .b3999 .c3999");
+});
+
+// With no browser targets (or targets that support CSS nesting), nesting is
+// preserved and the printer indents by 2 per level. The parser permits up to
+// 512 levels of nesting, so the indentation counter overflowed its 8-bit
+// storage at depth 128 — a panic in debug builds and wrong indentation in
+// release builds.
+test.concurrent("indentation at the full permitted nesting depth does not overflow", async () => {
+  // Runs in a subprocess: before the fix this panics the process in debug
+  // builds ("attempt to add with overflow").
+  const depth = 500;
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `
+        const { cssInternals } = require("bun:internal-for-testing");
+        const depth = ${depth};
+        const src = ".a {\\n".repeat(depth) + "color: red;\\n" + "}".repeat(depth);
+        const out = cssInternals._test(src, "", undefined);
+        // The innermost declaration is indented at 2 * depth spaces.
+        const needle = "\\n" + Buffer.alloc(2 * depth, " ").toString() + "color: red";
+        console.log(out.includes(needle) ? "OK" : "BAD-INDENT " + out.length);
+      `,
+    ],
+    env: { ...bunEnv, BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode, panicked: stderr.includes("overflow") }).toEqual({
+    stdout: "OK",
+    exitCode: 0,
+    panicked: false,
+  });
+}, 30_000);
+
 test("bun build does not hang on deeply nested multi-selector css spanning @starting-style", async () => {
   using dir = tempDir("css-starting-style-expansion", {
     // The fuzzer's depth (14 outer + 11 inner): without the fix this hangs for

--- a/test/js/bun/css/nested-selector-list-expansion.test.ts
+++ b/test/js/bun/css/nested-selector-list-expansion.test.ts
@@ -298,10 +298,17 @@ test.concurrent(
       killSignal: "SIGKILL",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(proc.signalCode).toBeNull();
-    expect(stdout).toContain("ERR " + NESTING_LIMIT_ERROR);
-    expect(exitCode).toBe(0);
+    expect({
+      stdout: stdout.trim(),
+      exitCode,
+      signalCode: proc.signalCode,
+      panicked: stderr.includes("panic"),
+    }).toEqual({
+      stdout: "ERR " + NESTING_LIMIT_ERROR + " when compiling CSS nesting for the configured targets",
+      exitCode: 0,
+      signalCode: null,
+      panicked: false,
+    });
   },
   90_000,
 );


### PR DESCRIPTION
### What does this PR do?

Fixes a CSS minifier OOM found by fuzzing (signature `oom:css:_RNvC7___rustc12___rust_alloc|_RNvXs_NtNtC5alloc3vec21spec_from_iter_nestedINtB6_3VecINtNtC7bun_css5rules7C10css`, on 1.4.0-canary.1+55f6c899f): a ~10 KB input drove the CSS printer to ~200 MB of output and ~1.6 GB peak RSS when compiling nesting for Safari 13, without tripping any existing limit.

#### Root cause

When the browser targets don't support CSS nesting, every nested rule's selector prelude inlines the full parent-selector chain (`serialize_nesting` walks the `StyleContext` up to the root). The existing `MAX_SELECTOR_EXPANSION` cap (65,536) bounds how many **rules** that expansion produces, but not how long each rule's **prelude** is; the per-prelude `MAX_NESTING_EXPANSIONS` cap resets at every rule. Nesting depth is bounded only by the parser's 512-level `MAX_NESTING_DEPTH`.

By placing many single-selector levels **above** a handful of two-selector levels whose selectors are incompatible with the targets (so they are partitioned into one rule per selector instead of collapsed into `:is()`), the selector-expansion total stays well under 65,536 while each of the tens of thousands of resulting rules prints a prelude hundreds of ancestors long. On current main (all existing caps intact, release build):

```js
// ~8.5 KB in -> ~230 MB out, no error
const c = require("bun:internal-for-testing").cssInternals;
let css = ".padding-selector {\n".repeat(400)
  + ".a:-webkitx .a, .b:-webkitx .b {\n".repeat(15) + "color: red;";
c._test(css, "", { safari: (13 << 16) | (2 << 8) });
```

The minimized 10 KB fuzzer input (283 nesting levels, ~14 of which are two-selector with custom/vendor-prefixed pseudo-classes) reaches the same path: `selector_expansion_total` tops out at 50,320 (under 65,536), output is ~200 MB, RSS peaks at ~1.6 GB including the returned JS string.

Reachable via `bun build --minify` with default browser targets.

#### Fix

1. Track the selector-prelude bytes written while a `StyleContext` parent chain is being inlined (i.e. the rule is being de-nested) and cap them at `MAX_NESTING_EXPANSION_BYTES = 64 MB` across the whole stylesheet, mirroring the existing `MAX_PREFIX_EXPANSION_BYTES`. Past the cap the printer reports the existing `maximum_nesting_expansion` error. Top-level rules (no parent context) are not charged, so large flat stylesheets are unaffected.

2. Widen `Printer.indent_amt` from `u8` to `u16`. The parser accepts up to 512 nesting levels and each level indents by 2, so preserving nesting past depth 128 overflowed the counter: a panic (`attempt to add with overflow`) in debug builds and wrong indentation in release builds.

#### Relationship to open PRs

- #32451 (different fuzz signature, `hang:css:...write_fmt...`) adds the same `Printer::nesting_expansion_bytes` mechanism measured per-prelude in `to_css_base`, and also meters `@scope` preludes. That PR does not widen `indent_amt`, so this fuzzer input's `minifyTest` pass (no targets, nesting preserved at depth 283) still panics there in debug builds. This PR now includes the same `@scope` metering.
- #31916 adds a printer-side byte budget in `serialize_nesting` plus a minify-side selector-weight estimate; its minify-side estimate also catches this input. That PR does not widen `indent_amt` either.
- #31913 widens `indent_amt` (to `u32`) and bounds the deep-clone payload weight, but does not catch this input: the clone-weight walk totals ~48 MB here, under its 64 MB cap, and the ~200 MB output is emitted.

This PR is the minimal standalone fix that handles every pass of this specific fuzzer reproduction; textual conflicts in `printer.rs`/`style.rs`/`scope.rs` are expected with whichever of the above lands first.

#### Verification

- The exact fuzzer repro (all four passes: `minifyTest`, `_test`, `prefixTest`, round-trip `minifyTest`) now either completes or throws `Maximum nesting expansion exceeded` instead of allocating >1 GB.
- New tests in `test/js/bun/css/nested-selector-list-expansion.test.ts`. On an unfixed build: the padded-then-forked test returns the ~230 MB output instead of throwing, and the depth-500 indentation test panics with the overflow in debug builds. On this branch all 29 tests in the file pass.
- A 4,000-rule × 3-level realistic nested stylesheet and shallow padded-then-forked nesting stay well under the budget and compile unchanged.
- `test/js/bun/css/css.test.ts` (1093 pass), `nested-selector-expansion.test.ts`, `nested-vendor-prefix-duplication.test.ts`, `test/bundler/css/` (167 pass). The `css-fuzz.test.ts` debug-build timeouts are pre-existing on main.
