### PR TITLE
fix(types): add jest.now() to jest namespace in bun:test

### DIFF
--- a/packages/bun-types/test.d.ts
+++ b/packages/bun-types/test.d.ts
@@ -94,6 +94,23 @@ declare module "bun:test" {
     function resetAllMocks(): void;
     function fn<T extends (...args: any[]) => any>(func?: T): Mock<T>;
     function setSystemTime(now?: number | Date): void;
+    /**
+     * Returns the current clock time in milliseconds since the Unix epoch.
+     * When fake timers are active (via {@link useFakeTimers} or {@link setSystemTime}),
+     * this returns the fake clock value; otherwise it returns the real `Date.now()`.
+     *
+     * @example
+     * ```ts
+     * import { jest } from "bun:test";
+     *
+     * jest.setSystemTime(new Date("2020-01-01"));
+     * console.log(jest.now()); // 1577836800000
+     *
+     * jest.useRealTimers();
+     * console.log(jest.now()); // current real timestamp
+     * ```
+     */
+    function now(): number;
     function setTimeout(milliseconds: number): void;
     function useFakeTimers(options?: { now?: number | Date }): typeof vi;
     function useRealTimers(): typeof vi;

--- a/test/integration/bun-types/fixture/mocks.ts
+++ b/test/integration/bun-types/fixture/mocks.ts
@@ -29,3 +29,6 @@ jest.fn<() => string>().mockResolvedValue("24");
 jest.fn().mockClear();
 jest.fn().mockReset();
 jest.fn().mockRejectedValueOnce(new Error());
+
+// jest.now() returns a number (current clock time, fake-timer-aware)
+expectType<number>(jest.now());


### PR DESCRIPTION
`jest.now()` exists on the `jest` object at runtime but was missing from the `jest` namespace in `bun:test` types.

**Runtime:**
```ts
import { jest } from "bun:test";
jest.now(); // works — returns number
```

**Before this fix:**
```ts
jest.now(); // TS error: Property 'now' does not exist on type 'typeof jest'
```

**After this fix:** compiles without error and is typed as `() => number`.

`jest.now()` returns the current clock time in milliseconds (like `Date.now()`), but respects fake timers — when `jest.useFakeTimers()` or `jest.setSystemTime()` is active, it returns the fake clock value.

Fixture: added type-check to `test/integration/bun-types/fixture/mocks.ts`.