### PR TITLE
fix(node:util): correct numericSeparator for negative fractional numbers

### DIFF
--- a/src/js/internal/util/inspect.js
+++ b/src/js/internal/util/inspect.js
@@ -1959,28 +1959,33 @@ function addNumericSeparatorEnd(integerString) {
 const remainingText = remaining => `... ${remaining} more item${remaining > 1 ? "s" : ""}`;
 
 function formatNumber(fn, number, numericSeparator) {
+  // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
+  // String(-0) === '0', so this must be checked before any String() conversion.
+  if (ObjectIs(number, -0)) {
+    return fn("-0", "number");
+  }
   if (!numericSeparator) {
-    // Format -0 as '-0'. Checking `number === -0` won't distinguish 0 from -0.
-    if (ObjectIs(number, -0)) {
-      return fn("-0", "number");
-    }
     return fn(`${number}`, "number");
   }
+
+  const numberString = String(number);
   const integer = MathTrunc(number);
-  const string = String(integer);
+
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(string, "e")) {
-      return fn(string, "number");
+    if (!NumberIsFinite(number) || StringPrototypeIncludes(numberString, "e")) {
+      return fn(numberString, "number");
     }
-    return fn(`${addNumericSeparator(string)}`, "number");
+    return fn(addNumericSeparator(numberString), "number");
   }
-  if (NumberIsNaN(number)) {
-    return fn(string, "number");
+  if (NumberIsNaN(number) || StringPrototypeIncludes(numberString, "e")) {
+    return fn(numberString, "number");
   }
-  return fn(
-    `${addNumericSeparator(string)}.${addNumericSeparatorEnd(StringPrototypeSlice(String(number), string.length + 1))}`,
-    "number",
-  );
+
+  const decimalIndex = StringPrototypeIndexOf(numberString, ".");
+  const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
+  const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);
+
+  return fn(`${addNumericSeparator(integerPart)}.${addNumericSeparatorEnd(fractionalPart)}`, "number");
 }
 
 function formatBigInt(fn, bigint, numericSeparator) {

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -457,5 +457,23 @@ describe("util", () => {
       expect(sep(123456.789)).toBe("123_456.789");
       expect(sep(0.1234)).toBe("0.123_4");
     });
+
+    it("leaves exponent-form numbers intact", () => {
+      // The old integer-length split corrupted these: 1e-7 became "0.-7",
+      // -1e-7 lost its sign as "0.e-7", and 1.23456e-7 became "0.234_56e_-7".
+      expect(sep(1e-7)).toBe("1e-7");
+      expect(sep(-1e-7)).toBe("-1e-7");
+      expect(sep(2e-7)).toBe("2e-7");
+      expect(sep(1.23456e-7)).toBe("1.23456e-7");
+      expect(sep(-0.5)).toBe("-0.5");
+      // Integers large enough to stringify in exponent form take the same path.
+      expect(sep(1234567891234567891234)).toBe("1.234567891234568e+21");
+    });
+
+    it("handles non-finite values", () => {
+      expect(sep(NaN)).toBe("NaN");
+      expect(sep(Infinity)).toBe("Infinity");
+      expect(sep(-Infinity)).toBe("-Infinity");
+    });
   });
 });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -429,4 +429,33 @@ describe("util", () => {
       });
     }
   });
+
+  describe("inspect numericSeparator", () => {
+    const sep = v => util.inspect(v, { numericSeparator: true });
+
+    it("formats negative fractional numbers (#23098)", () => {
+      // Previously produced "0..12" and dropped the sign.
+      expect(sep([0.1234, -0.12, -0.123, -0.1234, -1.234])).toBe("[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]");
+    });
+
+    it("matches Node for each negative fraction", () => {
+      expect(sep(-0.12)).toBe("-0.12");
+      expect(sep(-0.123)).toBe("-0.123");
+      expect(sep(-0.1234)).toBe("-0.123_4");
+      expect(sep(-1.234)).toBe("-1.234");
+      expect(sep(-12345.6789)).toBe("-12_345.678_9");
+    });
+
+    it("keeps the sign on -0", () => {
+      expect(sep(-0)).toBe("-0");
+      expect(sep(0)).toBe("0");
+    });
+
+    it("groups large integers and fractions", () => {
+      expect(sep(1234567)).toBe("1_234_567");
+      expect(sep(-1234567)).toBe("-1_234_567");
+      expect(sep(123456.789)).toBe("123_456.789");
+      expect(sep(0.1234)).toBe("0.123_4");
+    });
+  });
 });

--- a/test/js/node/util/util.test.js
+++ b/test/js/node/util/util.test.js
@@ -459,14 +459,12 @@ describe("util", () => {
     });
 
     it("leaves exponent-form numbers intact", () => {
-      // The old integer-length split corrupted these: 1e-7 became "0.-7",
-      // -1e-7 lost its sign as "0.e-7", and 1.23456e-7 became "0.234_56e_-7".
+      // https://github.com/oven-sh/bun/issues/23098
       expect(sep(1e-7)).toBe("1e-7");
       expect(sep(-1e-7)).toBe("-1e-7");
       expect(sep(2e-7)).toBe("2e-7");
       expect(sep(1.23456e-7)).toBe("1.23456e-7");
       expect(sep(-0.5)).toBe("-0.5");
-      // Integers large enough to stringify in exponent form take the same path.
       expect(sep(1234567891234567891234)).toBe("1.234567891234568e+21");
     });
 


### PR DESCRIPTION
### What does this PR do?

Fixes `util.inspect(value, { numericSeparator: true })` for negative fractional numbers. Fixes #23098.

Before:
```js
util.inspect([0.1234, -0.12, -0.123, -0.1234, -1.234], { numericSeparator: true })
// [ 0.123_4, 0..12, 0..12_3, 0..12_34, -1.234 ]   ← lost sign, doubled "."
```
After (matches Node):
```js
// [ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]
```

`formatNumber` derived the integer part from `String(Math.trunc(n))`. For `-1 < n < 0`, `Math.trunc(-0.12)` is `-0` and `String(-0)` is `"0"`, so the sign was dropped and the offset used to slice the fractional digits was off by one — producing `0..12`. The fix splits the number's own string representation on the decimal point (matching Node's current `formatNumber`) and moves the `-0` check ahead of the separator branch so `-0` keeps its sign there too.

### How did you verify your code works?

Added a `numericSeparator` describe block to `test/js/node/util/util.test.js`:
- the issue repro array (`[ 0.123_4, -0.12, -0.123, -0.123_4, -1.234 ]`)
- each negative fraction individually, including a grouped one (`-12345.6789` → `-12_345.678_9`)
- `-0` keeps its sign with the separator enabled
- large-integer and fraction grouping

The new tests pass on the debug build and fail against the release `bun` (proving they exercise the change). Full `util.test.js` (196) and the Node inspect suite pass with no regressions.
