### PR TITLE
fix(install): preserve path-based registry when joining manifests

### DIFF
--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -1,6 +1,7 @@
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::{self, NonNull};
 use core::sync::atomic::Ordering;
+use std::borrow::Cow;
 
 use bstr::ByteSlice;
 
@@ -415,6 +416,53 @@ impl bun_core::output::ErrName for ForManifestError {
 }
 
 impl NetworkTask {
+    fn registry_href_has_http_scheme(registry_href: &[u8]) -> bool {
+        registry_href
+            .get(..b"http://".len())
+            .is_some_and(|scheme| scheme.eq_ignore_ascii_case(b"http://"))
+            || registry_href
+                .get(..b"https://".len())
+                .is_some_and(|scheme| scheme.eq_ignore_ascii_case(b"https://"))
+    }
+
+    fn registry_url_suffix_start(registry_href: &[u8]) -> usize {
+        let query_start = strings::index_of_char(registry_href, b'?').map(|i| i as usize);
+        let hash_start = strings::index_of_char(registry_href, b'#').map(|i| i as usize);
+        match (query_start, hash_start) {
+            (Some(query), Some(hash)) => query.min(hash),
+            (Some(query), None) => query,
+            (None, Some(hash)) => hash,
+            (None, None) => registry_href.len(),
+        }
+    }
+
+    fn registry_base_for_manifest_join(
+        registry_href: &[u8],
+    ) -> Result<Cow<'_, [u8]>, ForManifestError> {
+        if !Self::registry_href_has_http_scheme(registry_href) {
+            return Ok(Cow::Borrowed(registry_href));
+        }
+
+        let suffix_start = Self::registry_url_suffix_start(registry_href);
+
+        if suffix_start > 0 && registry_href[suffix_start - 1] == b'/' {
+            return Ok(Cow::Borrowed(registry_href));
+        }
+
+        let mut base = Vec::new();
+        let capacity = registry_href
+            .len()
+            .checked_add(1)
+            .ok_or(ForManifestError::OutOfMemory)?;
+        base.try_reserve_exact(capacity)
+            .map_err(|_| ForManifestError::OutOfMemory)?;
+        base.extend_from_slice(&registry_href[..suffix_start]);
+        base.push(b'/');
+        base.extend_from_slice(&registry_href[suffix_start..]);
+
+        Ok(Cow::Owned(base))
+    }
+
     pub fn for_manifest(
         &mut self,
         name: &[u8],
@@ -444,8 +492,9 @@ impl NetworkTask {
             // `OwnedString` derefs the WTF-backed result on scope exit —
             // covers both the
             // success path and the InvalidURL early returns below.
+            let registry_base = Self::registry_base_for_manifest_join(scope.url.href())?;
             let tmp = bun_core::OwnedString::new(bun_url::join(
-                &bun_core::String::borrow_utf8(scope.url.href()),
+                &bun_core::String::borrow_utf8(registry_base.as_ref()),
                 &bun_core::String::borrow_utf8(encoded_name),
             ));
 
@@ -502,7 +551,10 @@ impl NetworkTask {
 
             {
                 let joined = URL::parse(&url_bytes);
-                let registry = scope.url.url();
+                let registry_base_href = registry_base.as_ref();
+                let registry_base_path =
+                    &registry_base_href[..Self::registry_url_suffix_start(registry_base_href)];
+                let registry = URL::parse(registry_base_path);
                 let registry_dir_end =
                     strings::last_index_of_char(registry.pathname, b'/').map_or(0, |i| i + 1);
                 let registry_dir = &registry.pathname[..registry_dir_end];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -711,8 +711,8 @@ describe.concurrent("bun-install", () => {
 
       setContextHandler(ctx, async request => {
         expect(request.method).toBe("GET");
-        const { pathname } = new URL(request.url);
-        requestPaths.push(`${request.method} ${pathname}`);
+        const { pathname, search } = new URL(request.url);
+        requestPaths.push(`${request.method} ${pathname}${search}`);
 
         if (pathname === manifestPath) {
           expect(request.headers.get("accept")).toBe(

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -695,6 +695,219 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  async function testPathBasedRegistryWithoutTrailingSlash(
+    source: "cli" | "bunfig" | "npmrc",
+    dependency: { name: string; version: string; tarballPath: string; tgz: string },
+    registrySuffix = "",
+    registryTransform: (registry: string) => string = registry => registry,
+  ) {
+    await withContext(defaultOpts, async ctx => {
+      const registry = registryTransform(`${ctx.registry_url}api/npm${registrySuffix}`);
+      const registryPath = `/${ctx.id}/api/npm`;
+      const encodedName = dependency.name.replace("/", "%2f");
+      const manifestPath = `${registryPath}/${encodedName}`;
+      const tarballPath = `${registryPath}/${dependency.tarballPath}`;
+      const requestPaths: string[] = [];
+
+      setContextHandler(ctx, async request => {
+        expect(request.method).toBe("GET");
+        const { pathname } = new URL(request.url);
+        requestPaths.push(`${request.method} ${pathname}`);
+
+        if (pathname === manifestPath) {
+          expect(request.headers.get("accept")).toBe(
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+          );
+          expect(await request.text()).toBe("");
+          return Response.json({
+            name: dependency.name,
+            versions: {
+              [dependency.version]: {
+                name: dependency.name,
+                version: dependency.version,
+                dist: {
+                  tarball: `${ctx.registry_url}api/npm/${dependency.tarballPath}`,
+                },
+              },
+            },
+            "dist-tags": {
+              latest: dependency.version,
+            },
+          });
+        }
+
+        if (pathname === tarballPath) {
+          return new Response(file(join(import.meta.dir, dependency.tgz)));
+        }
+
+        return new Response("not found", { status: 404 });
+      });
+
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            [dependency.name]: dependency.version,
+          },
+        }),
+      );
+
+      const args = ["install", "--no-cache"];
+      if (source === "cli") {
+        await writeFile(
+          join(ctx.package_dir, "bunfig.toml"),
+          `
+[install]
+cache = false
+saveTextLockfile = false
+linker = "hoisted"
+`,
+        );
+        args.push("--registry", registry);
+      } else if (source === "bunfig") {
+        await writeFile(
+          join(ctx.package_dir, "bunfig.toml"),
+          `
+[install]
+cache = false
+registry = "${registry}"
+saveTextLockfile = false
+linker = "hoisted"
+`,
+        );
+      } else {
+        await writeFile(
+          join(ctx.package_dir, "bunfig.toml"),
+          `
+[install]
+cache = false
+saveTextLockfile = false
+linker = "hoisted"
+`,
+        );
+        await writeFile(join(ctx.package_dir, ".npmrc"), `registry=${registry}\n`);
+      }
+
+      const proc = spawn({
+        cmd: [bunExe(), ...args],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain("Saved lockfile");
+      expect(stdout).toContain(`+ ${dependency.name}@${dependency.version}`);
+      expect(exitCode).toBe(0);
+      expect(requestPaths).toEqual([`GET ${manifestPath}`, `GET ${tarballPath}`]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ...dependency.name.split("/")))).toContain(
+        "package.json",
+      );
+    });
+  }
+
+  it.each([
+    ["--registry", "cli"],
+    ["bunfig.toml", "bunfig"],
+    [".npmrc", "npmrc"],
+  ] as const)("should preserve a path-based registry without trailing slash from %s", async (_, source) => {
+    await testPathBasedRegistryWithoutTrailingSlash(source, {
+      name: "bar",
+      version: "0.0.2",
+      tarballPath: "bar-0.0.2.tgz",
+      tgz: "bar-0.0.2.tgz",
+    });
+  });
+
+  it("should preserve a path-based registry without trailing slash for scoped packages", async () => {
+    await testPathBasedRegistryWithoutTrailingSlash("cli", {
+      name: "@barn/moo",
+      version: "0.1.0",
+      tarballPath: "@barn/moo-0.1.0.tgz",
+      tgz: "moo-0.1.0.tgz",
+    });
+  });
+
+  it("should preserve a path-based registry without trailing slash when query contains slashes", async () => {
+    await testPathBasedRegistryWithoutTrailingSlash(
+      "bunfig",
+      {
+        name: "bar",
+        version: "0.0.2",
+        tarballPath: "bar-0.0.2.tgz",
+        tgz: "bar-0.0.2.tgz",
+      },
+      "?path=a/b",
+    );
+  });
+
+  it("should preserve a path-based registry without trailing slash when scheme is uppercase", async () => {
+    await testPathBasedRegistryWithoutTrailingSlash(
+      "bunfig",
+      {
+        name: "bar",
+        version: "0.0.2",
+        tarballPath: "bar-0.0.2.tgz",
+        tgz: "bar-0.0.2.tgz",
+      },
+      "",
+      registry => registry.replace("http://", "HTTP://"),
+    );
+  });
+
+  it("should reject manifest URLs that escape a path-based registry without trailing slash", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const registry = `${ctx.registry_url}api/npm`;
+      const requestPaths: string[] = [];
+
+      setContextHandler(ctx, request => {
+        const { pathname } = new URL(request.url);
+        requestPaths.push(`${request.method} ${pathname}`);
+        return new Response("not found", { status: 404 });
+      });
+
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            "..\\escape": "0.0.1",
+          },
+        }),
+      );
+      await writeFile(
+        join(ctx.package_dir, "bunfig.toml"),
+        `
+[install]
+cache = false
+registry = "${registry}"
+saveTextLockfile = false
+linker = "hoisted"
+`,
+      );
+
+      const proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("manifest URL");
+      expect(stderr).toContain("is not on registry");
+      expect(stdout).not.toContain("1 package installed");
+      expect(exitCode).not.toBe(0);
+      expect(requestPaths).toEqual([]);
+    });
+  });
+
   // The Rust port adds a same-origin guard in `NetworkTask::for_tarball` so a
   // malicious registry can't point `dist.tarball` at a third-party host and
   // harvest the scope's `Authorization` header. The guard must compare


### PR DESCRIPTION
close https://github.com/oven-sh/bun/issues/14017
close https://github.com/oven-sh/bun/issues/20373

### What does this PR do?

Fixes manifest URL resolution for npm registries configured with a path and no trailing slash. This can happen with private npm registries or registry proxies, which are common in corporate environments.

Previously, a registry such as:

```txt
http://localhost:1234/api/npm
```

could resolve a package manifest request for `bar` as:

```txt
http://localhost:1234/api/bar
```

because URL joining treated `npm` as the final path segment instead of a directory. This PR treats HTTP(S) registry URLs without a trailing slash as directory bases when joining package manifest paths, so the request stays under the configured registry path:

```txt
http://localhost:1234/api/npm/bar
```

This matches the behavior of npm, Yarn, and pnpm.

### How did you verify your code works?

Added install tests for path-based registries without trailing slashes, covering `--registry`, `bunfig.toml`, `.npmrc`, scoped packages, query strings, uppercase schemes, and path-escape rejection.

Verified key regression tests fail with `USE_SYSTEM_BUN=1 bun test ...` and pass with the debug build:

```sh
bun bd test test/cli/install/bun-install.test.ts -t "should preserve a path-based registry without trailing slash"
bun bd test test/cli/install/bun-install.test.ts -t "should reject manifest URLs that escape a path-based registry without trailing slash"
```
