### PR TITLE
http: fail with ConnectionClosed instead of asserting when outer proxy socket is dead at ProxyHeaders write

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2644,9 +2644,15 @@ impl<'a> HTTPClient<'a> {
         }
 
         let to_send = &temporary_send_buffer[self.state.request_sent_len..];
-        if cfg!(debug_assertions) {
-            debug_assert!(!socket.is_shutdown());
-            debug_assert!(!socket.is_closed());
+        // The socket can be dead here: on_handshake → on_writable runs while
+        // draining buffered TLS bytes, and a write on the outer connection in
+        // proxy.on_writable (or a close fired from the SSL wrapper's flush)
+        // can mark the socket closed/shut down before we reach this point.
+        // Writing to it would return 0 and the request would hang at
+        // Headers forever. Surface ConnectionClosed so the caller's
+        // close_and_fail runs.
+        if socket.is_closed() || socket.is_shutdown() {
+            return Err(err!(ConnectionClosed));
         }
         let amount = write_to_socket::<IS_SSL>(socket, to_send)?;
         if IS_FIRST_CALL {
@@ -3032,9 +3038,15 @@ impl<'a> HTTPClient<'a> {
                     }
 
                     let to_send = &temporary_send_buffer[self.state.request_sent_len..];
-                    if cfg!(debug_assertions) {
-                        debug_assert!(!socket.is_shutdown());
-                        debug_assert!(!socket.is_closed());
+                    // Same reasoning as send_initial_request_payload: the
+                    // inner TLS handshake can complete from buffered bytes
+                    // after the outer proxy socket is already gone (or
+                    // proxy.on_writable above marked it dead). Writing into
+                    // the tunnel would succeed at the SSL layer and buffer
+                    // forever on a dead outer socket.
+                    if socket.is_closed() || socket.is_shutdown() {
+                        self.close_and_fail::<IS_SSL>(err!(ConnectionClosed), socket);
+                        return;
                     }
                     // just wait and retry when onWritable! if closed internally will call proxy.onClose
                     let Ok(amount) = ProxyTunnel::write(proxy, to_send) else {

--- a/test/js/bun/http/proxy-handshake-closed-socket-fixture.ts
+++ b/test/js/bun/http/proxy-handshake-closed-socket-fixture.ts
@@ -1,0 +1,110 @@
+// Fixture for proxy.test.ts: fetch through a CONNECT proxy to an HTTPS
+// backend where the proxy tears down the outer connection immediately
+// after relaying the inner TLS server-handshake flight. The client's
+// SSLWrapper completes the inner handshake from buffered bytes and reaches
+// on_writable → ProxyHeaders while the outer socket is (or is about to be)
+// dead. Previously a debug_assert!(!socket.is_shutdown()/is_closed()) fired
+// here (Sentry BUN-2V7Z); now the request fails with a connection error.
+//
+// Usage: bun proxy-handshake-closed-socket-fixture.ts <"http"|"https"> [iterations]
+// Prints one line per iteration: "rejected: <code>" on clean failure.
+
+import net from "node:net";
+import tls from "node:tls";
+import { once } from "node:events";
+import { tls as tlsCert } from "harness";
+
+const proxyScheme = process.argv[2] === "https" ? "https" : "http";
+const iterations = Number(process.argv[3] ?? "20");
+
+// HTTPS backend that completes the TLS handshake but never replies at the
+// HTTP layer — the proxy severs the client before any request arrives.
+const backend = tls.createServer({ ...tlsCert }, sock => {
+  sock.on("error", () => {});
+});
+backend.listen(0, "127.0.0.1");
+await once(backend, "listening");
+const backendPort = (backend.address() as net.AddressInfo).port;
+
+function handleClient(client: net.Socket) {
+  client.on("error", () => {});
+  let upstream: net.Socket | null = null;
+  let head = Buffer.alloc(0);
+  let postConnectClientFlights = 0;
+
+  function killClient() {
+    upstream?.destroy();
+    try {
+      // RST the underlying TCP so the client's next write on the outer
+      // socket fails instead of being buffered by the kernel.
+      const raw: net.Socket = (client as any)._parent ?? (client as any).socket ?? client;
+      if (typeof raw.resetAndDestroy === "function") raw.resetAndDestroy();
+      else client.destroy();
+    } catch {
+      client.destroy();
+    }
+  }
+
+  client.on("data", chunk => {
+    if (!upstream) {
+      head = Buffer.concat([head, chunk]);
+      const end = head.indexOf("\r\n\r\n");
+      if (end === -1) return;
+      const leftover = head.subarray(end + 4);
+      upstream = net.connect(backendPort, "127.0.0.1", () => {
+        client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        if (leftover.length) {
+          postConnectClientFlights++;
+          upstream!.write(leftover);
+        }
+      });
+      upstream.on("error", () => {});
+      // When the backend's ServerHello/Cert/Finished flight arrives, relay
+      // it to the client and immediately reset the outer connection. The
+      // client completes the inner handshake from these bytes and tries to
+      // write the HTTP request into a socket whose TCP peer is gone.
+      upstream.on("data", data => {
+        client.write(data, () => killClient());
+      });
+      upstream.on("close", () => client.destroy());
+      return;
+    }
+    postConnectClientFlights++;
+    upstream.write(chunk);
+  });
+  client.on("close", () => upstream?.destroy());
+}
+
+let proxy: net.Server | tls.Server;
+if (proxyScheme === "https") {
+  proxy = tls.createServer({ ...tlsCert }, handleClient);
+} else {
+  proxy = net.createServer(handleClient);
+}
+proxy.listen(0, "127.0.0.1");
+await once(proxy, "listening");
+const proxyPort = (proxy.address() as net.AddressInfo).port;
+
+let hung = 0;
+for (let i = 0; i < iterations; i++) {
+  try {
+    const res = await fetch(`https://localhost:${backendPort}/`, {
+      proxy: `${proxyScheme}://localhost:${proxyPort}`,
+      keepalive: false,
+      tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+      signal: AbortSignal.timeout(5000),
+    });
+    console.log(`resolved: ${res.status}`);
+  } catch (e: any) {
+    const code = typeof e?.code === "string" ? e.code : (e?.name ?? String(e));
+    if (code === "TimeoutError" || e?.name === "TimeoutError") hung++;
+    console.log(`rejected: ${code}`);
+  }
+}
+
+proxy.close();
+backend.close();
+if (hung > 0) {
+  console.error(`${hung} request(s) hung until AbortSignal timeout`);
+}
+process.exit(0);

--- a/test/js/bun/http/proxy-handshake-closed-socket-fixture.ts
+++ b/test/js/bun/http/proxy-handshake-closed-socket-fixture.ts
@@ -30,7 +30,6 @@ function handleClient(client: net.Socket) {
   client.on("error", () => {});
   let upstream: net.Socket | null = null;
   let head = Buffer.alloc(0);
-  let postConnectClientFlights = 0;
 
   function killClient() {
     upstream?.destroy();
@@ -53,10 +52,7 @@ function handleClient(client: net.Socket) {
       const leftover = head.subarray(end + 4);
       upstream = net.connect(backendPort, "127.0.0.1", () => {
         client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
-        if (leftover.length) {
-          postConnectClientFlights++;
-          upstream!.write(leftover);
-        }
+        if (leftover.length) upstream!.write(leftover);
       });
       upstream.on("error", () => {});
       // When the backend's ServerHello/Cert/Finished flight arrives, relay
@@ -69,7 +65,6 @@ function handleClient(client: net.Socket) {
       upstream.on("close", () => client.destroy());
       return;
     }
-    postConnectClientFlights++;
     upstream.write(chunk);
   });
   client.on("close", () => upstream?.destroy());

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -922,12 +922,7 @@ test("HTTPS origin close-delimited body via HTTP proxy does not ECONNRESET", asy
 for (const scheme of ["http", "https"] as const) {
   test(`outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`, async () => {
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        require.resolve("./proxy-handshake-closed-socket-fixture.ts"),
-        scheme,
-        "10",
-      ],
+      cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, "10"],
       env: {
         ...bunEnv,
         // The explicit per-request proxy must not be bypassed or rerouted

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -920,36 +920,39 @@ test("HTTPS origin close-delimited body via HTTP proxy does not ECONNRESET", asy
 // on_writable returns), so this test verifies the fetch rejects cleanly
 // with a connection error rather than asserting or hanging.
 for (const scheme of ["http", "https"] as const) {
-  test(`outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`, async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, "10"],
-      env: {
-        ...bunEnv,
-        // The explicit per-request proxy must not be bypassed or rerouted
-        // by ambient proxy configuration on CI hosts; Bun caches these at
-        // startup so clearing them inside the fixture is too late.
-        NO_PROXY: undefined,
-        no_proxy: undefined,
-        HTTP_PROXY: undefined,
-        http_proxy: undefined,
-        HTTPS_PROXY: undefined,
-        https_proxy: undefined,
-      },
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    if (exitCode !== 0) console.error("stderr:", stderr);
-    const lines = stdout.trim().split("\n");
-    // Every iteration must reject with a connection-flavored error, not
-    // TimeoutError (which would mean the request stalled on a dead socket
-    // and only the AbortSignal freed it) and not "resolved".
-    expect(lines).toHaveLength(10);
-    for (const line of lines) {
-      expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
-    }
-    expect(stderr).not.toContain("hung");
-    expect(exitCode).toBe(0);
-  });
+  test.concurrent(
+    `outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`,
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), require.resolve("./proxy-handshake-closed-socket-fixture.ts"), scheme, "10"],
+        env: {
+          ...bunEnv,
+          // The explicit per-request proxy must not be bypassed or rerouted
+          // by ambient proxy configuration on CI hosts; clear them in the
+          // spawn env so the child starts clean (see PROXY_ENV_KEYS above).
+          NO_PROXY: undefined,
+          no_proxy: undefined,
+          HTTP_PROXY: undefined,
+          http_proxy: undefined,
+          HTTPS_PROXY: undefined,
+          https_proxy: undefined,
+        },
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) console.error("stderr:", stderr);
+      const lines = stdout.trim().split("\n");
+      // Every iteration must reject with a connection-flavored error, not
+      // TimeoutError (which would mean the request stalled on a dead socket
+      // and only the AbortSignal freed it) and not "resolved".
+      expect(lines).toHaveLength(10);
+      for (const line of lines) {
+        expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
+      }
+      expect(stderr).not.toContain("hung");
+      expect(exitCode).toBe(0);
+    },
+  );
 }
 
 describe.concurrent("proxy object format with headers", () => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -908,6 +908,55 @@ test("HTTPS origin close-delimited body via HTTP proxy does not ECONNRESET", asy
   }
 });
 
+// Sentry BUN-2V7Z: debug_assert!(!socket.is_shutdown()/is_closed()) in the
+// ProxyHeaders arm of on_writable (and the matching assert in
+// send_initial_request_payload) fired when the outer proxy socket died
+// between the inner-TLS handshake completing and the first HTTP write.
+// The assertion only fired in builds with debug-assertions on (Windows
+// Zig release builds used ReleaseSafe, hence 100% Windows in Sentry);
+// on other release builds the request would write into a dead outer
+// socket and stall. The race is not deterministically reproducible on
+// Linux loopback (the RST is processed as a separate event after
+// on_writable returns), so this test verifies the fetch rejects cleanly
+// with a connection error rather than asserting or hanging.
+for (const scheme of ["http", "https"] as const) {
+  test(`outer ${scheme.toUpperCase()} proxy socket reset right after inner TLS handshake rejects cleanly`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        require.resolve("./proxy-handshake-closed-socket-fixture.ts"),
+        scheme,
+        "10",
+      ],
+      env: {
+        ...bunEnv,
+        // The explicit per-request proxy must not be bypassed or rerouted
+        // by ambient proxy configuration on CI hosts; Bun caches these at
+        // startup so clearing them inside the fixture is too late.
+        NO_PROXY: undefined,
+        no_proxy: undefined,
+        HTTP_PROXY: undefined,
+        http_proxy: undefined,
+        HTTPS_PROXY: undefined,
+        https_proxy: undefined,
+      },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    if (exitCode !== 0) console.error("stderr:", stderr);
+    const lines = stdout.trim().split("\n");
+    // Every iteration must reject with a connection-flavored error, not
+    // TimeoutError (which would mean the request stalled on a dead socket
+    // and only the AbortSignal freed it) and not "resolved".
+    expect(lines).toHaveLength(10);
+    for (const line of lines) {
+      expect(line).toMatch(/^rejected: (ECONNRESET|ConnectionClosed|ECONNREFUSED|ConnectionRefused)$/);
+    }
+    expect(stderr).not.toContain("hung");
+    expect(exitCode).toBe(0);
+  });
+}
+
 describe.concurrent("proxy object format with headers", () => {
   test("proxy object with url string works same as string proxy", async () => {
     const response = await fetch(httpServer.url, {


### PR DESCRIPTION
## Crash signature

`Panic: Internal assertion failure` inside `on_writable` after the proxy-tunnel inner TLS handshake completes. Sentry BUN-2V7Z (~1080 lifetime, ~28/24h) and BUN-36JT (sibling). 100% Windows; affected 1.3.x back to firstSeen 2026-04-11.

Stack (bun 1.3.14):
```
onData                    src/http/HTTPContext.zig
onData                    src/http/http.zig
receive                   src/http/ProxyTunnel.zig
receiveData / handleTraffic / updateHandshakeState / triggerHandshakeCallback
onHandshake               src/http/ProxyTunnel.zig
onWritable                src/http/http.zig   <- assert(!socket.isShutdown()); assert(!socket.isClosed());
```

## Cause

`on_writable` has two sites that asserted the outer socket was live immediately before writing the initial request:

* `send_initial_request_payload` (Pending/Headers/Opened arm)
* the `ProxyHeaders` arm (proxy tunnel: first HTTP write after the inner TLS handshake)

When `fetch()` goes through a CONNECT proxy to an `https://` target, the inner TLS handshake runs inside an in-process `SSLWrapper`. `ProxyTunnel.on_handshake` fires from `handleTraffic` while draining buffered bytes delivered by a single `onData` call, then synchronously calls `HTTPClient.on_writable`. Between that call and the `ProxyHeaders` write, the outer socket can already be closed or shut down:

* `proxy.on_writable` (run first, line 2849) writes buffered encrypted bytes with `socket.write()` and then `wrapper.flush()` re-enters `handleTraffic`; on an HTTPS proxy, a failing outer `SSL_write` sets `ssl_fatal_error` so `socket.is_shutdown()` flips true, and a buffered inner `close_notify` fires `on_close -> close_and_fail -> terminate_socket` so `socket.is_closed()` flips true.

In release builds without debug assertions, both sites fall through to `write_to_socket` / `ProxyTunnel::write` which return 0 on a dead socket, leaving the request stuck at `Headers` / `ProxyHeaders` until the idle timeout. In builds with debug assertions enabled the assert panicked.

The Sentry cluster is 100% Windows because Windows Zig release builds used `ReleaseSafe` (see `scripts/build/zig.ts` at the affected revisions: "since Bun 1.1, Windows builds use ReleaseSafe"), which enables `Environment.allow_assert`. Other platforms shipped `ReleaseFast` where the assert compiled out. Since the Rust rewrite the assert is `debug_assert!`, so release builds on all platforms now stall instead of panicking; `bun bd` still panics.

## Fix

Convert both assertion sites to real runtime checks that surface `error.ConnectionClosed` through the existing `close_and_fail` path. `send_initial_request_payload` already returns `Result<_, Error>` and its caller already `close_and_fail`s on error; the `ProxyHeaders` arm calls `close_and_fail` directly (matching the adjacent `write_request` error branch).

## Verification

New test in `test/js/bun/http/proxy.test.ts` (fixture at `proxy-handshake-closed-socket-fixture.ts`) runs 10 fetches through an HTTP and HTTPS CONNECT proxy that relays the backend's TLS server-handshake flight and immediately RSTs the outer connection. Every iteration rejects with `ECONNRESET` / `ConnectionClosed` (not `TimeoutError`, not a panic). Full `proxy.test.ts` (47 tests) passes.

### Note on fail-before

This race is not deterministically reproducible on Linux loopback. A 100-iteration probe against an unfixed `bun bd` build (50 HTTP-proxy + 50 HTTPS-proxy) never tripped the assertion: on POSIX the proxy's RST is delivered to the client as a separate event loop iteration after `on_writable` has already returned, so `socket.is_closed()/is_shutdown()` is still false at the assertion site. The Windows-specific timing that lands the dead-socket state inside the synchronous `on_handshake -> on_writable` window (AFD poll semantics plus ReleaseSafe assertions) cannot be reconstructed without instrumenting `src/`. The new test guards the code path and the observable behaviour (clean rejection, no stall) but does not fail-before on Linux.

## Related

* #31959 fixes a UAF on the *response* side of the same tunnel (`handle_reading` after the client is freed); this PR is the *request* side (first write after handshake).
* #23092 is a different crash site in the same function.
