### PR TITLE
install: explain unsupported bun.lock version and suggest 'bun upgrade'

### DIFF
--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -1626,10 +1626,23 @@ pub fn parse_into_binary_lockfile(
     };
 
     let Some(lockfile_version) = Version::from_int(lockfile_version_num) else {
-        log.add_error(
+        log.add_range_error_fmt_with_notes(
             Some(source),
-            lockfile_version_expr.loc,
-            b"Unknown lockfile version",
+            bun_ast::Range {
+                loc: lockfile_version_expr.loc,
+                ..Default::default()
+            },
+            Box::new([bun_ast::range_data(
+                None,
+                bun_ast::Range::NONE,
+                b"Run 'bun upgrade' to update to the latest version of Bun",
+            )]),
+            format_args!(
+                "Unsupported lockfile version {}. This lockfile was likely created by a newer version of Bun. (This is Bun v{}, which supports lockfile versions up to {}.)",
+                lockfile_version_num,
+                bun_core::Global::package_json_version,
+                Version::CURRENT as u32,
+            ),
         );
         return Err(ParseError::UnknownLockfileVersion);
     };

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -825,3 +825,45 @@ it("escapes quotes and newlines in requested version literals when writing yarn.
   // No yarn.lock line is forged from the version literal's contents.
   expect(lines.filter(line => line.trimStart().startsWith('resolved "http://injected.example'))).toEqual([]);
 });
+
+it("prints an actionable error for a lockfile version newer than this build supports", async () => {
+  const { packageDir, packageJson } = await registry.createTestDir();
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "future-lockfile",
+      dependencies: {},
+    }),
+  );
+
+  await write(
+    join(packageDir, "bun.lock"),
+    JSON.stringify({
+      lockfileVersion: 99,
+      workspaces: {
+        "": {
+          name: "future-lockfile",
+        },
+      },
+      packages: {},
+    }),
+  );
+
+  const { exited, stdout, stderr } = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [out, err] = await Promise.all([stdout.text(), stderr.text()]);
+
+  expect(err).toContain("Unsupported lockfile version 99");
+  expect(err).toContain("newer version of Bun");
+  expect(err).toContain("Run 'bun upgrade'");
+  // the old message gave no hint at all
+  expect(err).not.toContain("Unknown lockfile version");
+  expect(await exited).toBe(0);
+});

--- a/test/cli/install/bun-lock.test.ts
+++ b/test/cli/install/bun-lock.test.ts
@@ -862,6 +862,8 @@ it("prints an actionable error for a lockfile version newer than this build supp
 
   expect(err).toContain("Unsupported lockfile version 99");
   expect(err).toContain("newer version of Bun");
+  expect(err).toMatch(/This is Bun v\d+\.\d+\.\d+/);
+  expect(err).toMatch(/supports lockfile versions up to \d+/);
   expect(err).toContain("Run 'bun upgrade'");
   // the old message gave no hint at all
   expect(err).not.toContain("Unknown lockfile version");


### PR DESCRIPTION
### What

When `bun install` encounters a `bun.lock` written by a newer release, the error now tells the user what happened and what to do about it.

### Before

```
2 |   "lockfileVersion": 2,
                         ^
error: Unknown lockfile version
    at bun.lock:2:22
UnknownLockfileVersion: failed to parse lockfile: 'bun.lock'
```

### After

```
2 |   "lockfileVersion": 99,
                         ^
error: Unsupported lockfile version 99. This lockfile was likely created by a newer version of Bun. (This is Bun v1.4.0, which supports lockfile versions up to 2.)
    at bun.lock:2:22

note: Run 'bun upgrade' to update to the latest version of Bun
UnknownLockfileVersion: failed to parse lockfile: 'bun.lock'
```

The only way `Version::from_int` returns `None` is when the number is a valid non-negative integer above `Version::CURRENT`, so "created by a newer version" is always the right diagnosis here. The earlier branch that rejects negative / non-integer / non-numeric values ("Invalid lockfile version") is unchanged.

### Verification

New test in `test/cli/install/bun-lock.test.ts` writes a `bun.lock` with `lockfileVersion: 99`, runs `bun install`, and asserts the message includes the found version, the "newer version of Bun" explanation, and the `bun upgrade` note.

```
bun bd test test/cli/install/bun-lock.test.ts -t "actionable error"   # pass
USE_SYSTEM_BUN=1 bun test test/cli/install/bun-lock.test.ts -t "actionable error"   # fail (old message)
```