### PR TITLE
build: add --remap-path-prefix to cargo RUSTFLAGS for reproducible builds

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -503,6 +503,16 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   if (cfg.release && !cfg.assertions) {
     rustflags.push("-Zlocation-detail=none");
   }
+  // Path remapping (CI reproducibility) — rustc equivalent of the C/C++
+  // `-ffile-prefix-map` entries in flags.ts. Without this, `file!()` /
+  // panic locations and the DWARF compilation-dir from every workspace
+  // crate and vendored Rust dep (lol-html) embed the absolute checkout
+  // path into the release binary (`strings bun | grep $PWD` shows them).
+  // Gated on `cfg.ci` to match the flags.ts entry.
+  if (cfg.ci) {
+    rustflags.push(`--remap-path-prefix=${cfg.cwd}=.`);
+    rustflags.push(`--remap-path-prefix=${cfg.vendorDir}=vendor`);
+  }
   // IR PGO, Rust half — mirrors the C++ `-fprofile-generate`/`-fprofile-use`
   // (flags.ts) so the Rust ~half of bun's `.text` participates too (a port-era
   // `bun` is mostly Rust now; instrumenting only C++ would leave most of the

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -1374,9 +1374,19 @@ function emitCargo(n: Ninja, cfg: Config, name: string, spec: CargoBuild, input:
   // `rust_eh_personality`. RUSTUP_TOOLCHAIN overrides the directory walk.
   if (cfg.rustToolchain !== undefined) env.RUSTUP_TOOLCHAIN = cfg.rustToolchain;
 
-  if (spec.rustflags && spec.rustflags.length > 0) {
+  // Path remapping (CI reproducibility) — mirrors the C/C++
+  // `-ffile-prefix-map` entries in flags.ts and the same block in rust.ts,
+  // so vendored Rust deps built here (lol-html) don't embed the absolute
+  // checkout path in `file!()`/panic locations/debuginfo either.
+  const rustflags: string[] = [...(spec.rustflags ?? [])];
+  if (cfg.ci) {
+    rustflags.push(`--remap-path-prefix=${cfg.cwd}=.`);
+    rustflags.push(`--remap-path-prefix=${cfg.vendorDir}=vendor`);
+  }
+
+  if (rustflags.length > 0) {
     // The \x1f encoding is deliberate — see cargo's docs on CARGO_ENCODED_RUSTFLAGS.
-    env.CARGO_ENCODED_RUSTFLAGS = spec.rustflags.join("\x1f");
+    env.CARGO_ENCODED_RUSTFLAGS = rustflags.join("\x1f");
   }
 
   // Windows: pin the linker to MSVC's link.exe. Without this, if Git Bash
@@ -1404,7 +1414,7 @@ function emitCargo(n: Ninja, cfg: Config, name: string, spec: CargoBuild, input:
       const llvmArch = cfg.arm64 ? "aarch64" : "x86_64";
       linkArgs.push(`-Clink-arg=-L${join(cfg.androidNdkRuntimeDir, llvmArch)}`);
     }
-    env.CARGO_ENCODED_RUSTFLAGS = [...(spec.rustflags ?? []), ...linkArgs].join("\x1f");
+    env.CARGO_ENCODED_RUSTFLAGS = [...rustflags, ...linkArgs].join("\x1f");
   }
 
   // ─── Emit build node ───


### PR DESCRIPTION
## What

`scripts/build/flags.ts` already passes `-ffile-prefix-map=${cwd}=.` (and `vendorDir`/`cacheDir`) to C/C++ on CI so `__FILE__` and debuginfo don't embed the absolute checkout path. Nothing equivalent was passed to cargo, so Rust `file!()`/panic locations and debuginfo from workspace crates and vendored Rust deps (e.g. `vendor/lolhtml`) still embedded the full absolute build path into the release binary:

```sh
strings build/release/bun | grep "$PWD"
```

## Change

Add the rustc equivalent, `--remap-path-prefix`, to the two places that assemble `CARGO_ENCODED_RUSTFLAGS`:

- `scripts/build/rust.ts` (`emitRust`): pushed onto the `rustflags` array right after the existing `-Zlocation-detail=none` block.
- `scripts/build/source.ts` (`emitCargo`, the `kind: "cargo"` dep build path): applied to both the default and cross-compile `CARGO_ENCODED_RUSTFLAGS` assignments by folding `spec.rustflags` and the remap flags into a single `rustflags` array used by both branches.

Gated on `cfg.ci` to match the existing `-ffile-prefix-map` entry in `flags.ts`.

## Verification

```sh
$ bunx tsc --noEmit -p scripts/build/tsconfig.json
# clean

$ bun scripts/build.ts --configure-only --ci=true
$ grep -c remap-path-prefix build/debug/build.ninja
1   # present in CARGO_ENCODED_RUSTFLAGS for the bun_bin cargo edge

$ bun scripts/build.ts --configure-only --ci=false
$ grep -c remap-path-prefix build/debug/build.ninja
0   # absent when not CI
```