### PR TITLE
crash_handler: emit baseline platform char from Environment::BASELINE

### DIFF
--- a/src/crash_handler/lib.rs
+++ b/src/crash_handler/lib.rs
@@ -2287,24 +2287,18 @@ mod draft {
 
     impl Platform {
         // Rust cannot concat ident names at const time without a proc-macro; spell out the cfg matrix.
+        // Baseline is `Environment::BASELINE`, not a Cargo feature — `cfg(feature = "baseline")`
+        // was always false because no such feature exists, so baseline builds emitted the
+        // non-baseline char and bun.report symbolicated them against the wrong artifact.
         const CURRENT: u8 = {
             // Android folds into the Linux variants. bun.report decodes the same
             // single-char codes; introducing new ones would break older decoders.
             #[cfg(all(
                 any(target_os = "linux", target_os = "android"),
-                target_arch = "x86_64",
-                not(feature = "baseline")
+                target_arch = "x86_64"
             ))]
             {
-                b'l'
-            }
-            #[cfg(all(
-                any(target_os = "linux", target_os = "android"),
-                target_arch = "x86_64",
-                feature = "baseline"
-            ))]
-            {
-                b'B'
+                if Environment::BASELINE { b'B' } else { b'l' }
             }
             #[cfg(all(
                 any(target_os = "linux", target_os = "android"),
@@ -2313,41 +2307,25 @@ mod draft {
             {
                 b'L'
             }
-            #[cfg(all(target_os = "macos", target_arch = "x86_64", not(feature = "baseline")))]
+            #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
             {
-                b'm'
-            }
-            #[cfg(all(target_os = "macos", target_arch = "x86_64", feature = "baseline"))]
-            {
-                b'b'
+                if Environment::BASELINE { b'b' } else { b'm' }
             }
             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
             {
                 b'M'
             }
-            #[cfg(all(windows, target_arch = "x86_64", not(feature = "baseline")))]
+            #[cfg(all(windows, target_arch = "x86_64"))]
             {
-                b'w'
-            }
-            #[cfg(all(windows, target_arch = "x86_64", feature = "baseline"))]
-            {
-                b'e'
+                if Environment::BASELINE { b'e' } else { b'w' }
             }
             #[cfg(all(windows, target_arch = "aarch64"))]
             {
                 b'W'
             }
-            #[cfg(all(
-                target_os = "freebsd",
-                target_arch = "x86_64",
-                not(feature = "baseline")
-            ))]
+            #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))]
             {
-                b'f'
-            }
-            #[cfg(all(target_os = "freebsd", target_arch = "x86_64", feature = "baseline"))]
-            {
-                b'g'
+                if Environment::BASELINE { b'g' } else { b'f' }
             }
             #[cfg(all(target_os = "freebsd", target_arch = "aarch64"))]
             {


### PR DESCRIPTION
`Platform::CURRENT` in `src/crash_handler/lib.rs` gated the baseline platform character on `cfg(feature = "baseline")`, but no `baseline` Cargo feature exists in this crate — so the predicate was always false and baseline x86_64 builds emitted the non-baseline trace-string char (`l`/`m`/`w`/`f` instead of `B`/`b`/`e`/`g`). bun.report decodes that as the non-baseline arch, fetches the non-baseline debug artifact, and symbolicates addresses against a binary with a different code layout — producing unrelated function names for every crash from a baseline build. macOS arm64 is unaffected (no baseline variant).

Replaces the dead `cfg(feature = "baseline")` gates with `Environment::BASELINE` (already used a few hundred lines up for the " (baseline)" display suffix), matching `crash_handler.zig` which keys on `bun.Environment.baseline`.

Verified: `cargo check -p bun_crash_handler` passes; re-symbolicating a known baseline crash trace against the baseline-profile artifact (the one bun.report would now select) yields the expected call chain instead of unrelated names.
