### PR TITLE
Bun.serve: apply backpressure when streaming a Response(ReadableStream) to a slow client

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -916,7 +916,12 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
     }
 
     for (var i = 0, values = many.value, length = many.value.length; i < length; i++) {
-      sink.write(values[i]);
+      // The native sink returns a Promise when the transport is backed up;
+      // await it so we stop pulling until the socket drains (backpressure).
+      const writeResult = sink.write(values[i]);
+      if (writeResult && $isPromise(writeResult)) {
+        await writeResult;
+      }
     }
 
     var streamState = $getByIdDirectPrivate(stream, "state");
@@ -932,7 +937,10 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         return sink.end();
       }
 
-      sink.write(value);
+      const writeResult = sink.write(value);
+      if (writeResult && $isPromise(writeResult)) {
+        await writeResult;
+      }
     }
   } catch (e) {
     didThrow = true;

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -568,7 +568,13 @@ impl HTMLRewriterLoader {
                 // the destination sink; valid for the duration of this call.
                 unsafe { (*pending).apply_backpressure(&mut self.output, bytes) };
             }
-            Writable::IntoArray(_) | Writable::Owned(_) | Writable::Temporary(_) => {
+            // `PendingPromise` is only produced by the HTTP server response
+            // sink, which this rewriter output never wraps; treat it as a normal
+            // ready write.
+            Writable::IntoArray(_)
+            | Writable::Owned(_)
+            | Writable::Temporary(_)
+            | Writable::PendingPromise(_) => {
                 self.signal.ready(
                     if self.chunk_size > 0 {
                         Some(self.chunk_size as u64)

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -592,9 +592,9 @@ impl Writable {
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 JSPromise::opaque_ref(prom).to_js()
             }
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-            // The sink owns this promise (kept alive via `protect()`); hand the
-            // same value to the caller.
+            // S008: `JSPromise` is an `opaque_ffi!` ZST, so the `*const` to `&`
+            // deref is safe. The sink owns this promise (kept alive via
+            // `protect()`); hand the same value to the caller.
             Writable::PendingPromise(prom) => JSPromise::opaque_ref(prom).to_js(),
         }
     }
@@ -1519,15 +1519,16 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         // Streaming write() backpressure: the chunk was handed to uWS (so our
-        // own buffer is empty) and the socket has now drained. There is nothing
-        // staged to resend — just resolve the parked drain promise so the JS
-        // writer resumes. The `to_write` bookkeeping below assumes a non-empty
-        // buffer (the tryEnd resend path) and would underflow on `len - 1`.
+        // own buffer is empty) and the socket has now drained. Nothing is
+        // staged to resend, so just resolve the parked drain promise and let
+        // the JS writer resume. The `to_write` bookkeeping below assumes a
+        // non-empty buffer (the tryEnd resend path) and would underflow on
+        // `len - 1`.
         if self.buffer.is_empty() {
             if self.done {
                 self.signal.close(None);
             }
-            let _ = self.flush_promise(); // TODO: properly propagate exception upwards
+            let _ = self.flush_promise();
             if self.done {
                 self.finalize();
             }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -403,6 +403,10 @@ pub enum Writable {
     // Self-referential via WritablePending.result (see StreamResult::Pending above);
     // raw pointer with the BORROW_PARAM contract.
     Pending(*mut WritablePending),
+    // A JSPromise the sink already created and keeps alive; `to_js` hands it to
+    // the caller verbatim. Used to surface transport backpressure through the
+    // flush(true) promise so the JS writer can pause until the socket drains.
+    PendingPromise(*mut JSPromise),
     Err(SysError),
     Done,
     Owned(BlobSizeType),
@@ -588,6 +592,10 @@ impl Writable {
                 // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 JSPromise::opaque_ref(prom).to_js()
             }
+            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+            // The sink owns this promise (kept alive via `protect()`); hand the
+            // same value to the caller.
+            Writable::PendingPromise(prom) => JSPromise::opaque_ref(prom).to_js(),
         }
     }
 }
@@ -1062,6 +1070,13 @@ impl SignalVTable {
 // type level; all dispatch happens at runtime through `any_res()` / `uws::AnyResponse`.
 pub type UwsResponse<const SSL: bool, const HTTP3: bool> = c_void;
 
+/// Outbound buffering cap for streaming HTTP responses. Once uWS has at least
+/// this much unsent data queued, the sink reports backpressure (write returns a
+/// drain promise) so the JS writer pauses until the socket catches up. Bounds
+/// memory for a slow or stalled client while leaving enough headroom that a
+/// healthy client never pauses between chunks.
+const STREAM_BACKPRESSURE_HIGH_WATER_MARK: u64 = 1024 * 1024;
+
 pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub res: Option<*mut UwsResponse<SSL, HTTP3>>,
     pub buffer: Vec<u8>,
@@ -1265,6 +1280,67 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.has_backpressure && self.end_len > 0
     }
 
+    /// Ask uWS to notify us (via `on_writable`) once the socket can accept more
+    /// data. For streaming (non-`tryEnd`) writes, uWS buffers the chunk itself;
+    /// registering this handler lets the JS writer pause until the drain instead
+    /// of handing uWS the whole body at once.
+    fn listen_for_writable(&mut self) {
+        let Some(res) = self.any_res() else { return };
+        res.on_writable::<Self, _>(
+            |this: *mut Self, off, _r| {
+                // SAFETY: `this` was registered as a live `*mut Self`; uWS
+                // invokes the callback while the sink is alive.
+                unsafe { (*this).on_writable(off, core::ptr::null_mut()) }
+            },
+            std::ptr::from_mut::<Self>(self),
+        );
+    }
+
+    /// Park (or reuse) the flush(true) promise so a caller can await the socket
+    /// draining. `on_writable` -> `flush_promise` resolves it. `global_this` is
+    /// installed at sink construction, so it is always available here.
+    fn backpressure_promise(&mut self) -> *mut JSPromise {
+        if let Some(prom) = self.pending_flush {
+            return prom;
+        }
+        // Copy the global pointer so the immutable borrow of `self` ends before
+        // the `self.pending_flush` assignment below. `global_this` is installed
+        // at sink construction and lives for the process.
+        let global: *const JSGlobalObject = self.global_this();
+        self.wrote_at_start_of_flush = self.wrote;
+        // SAFETY: process-lifetime VM global; the BackRef keeps it valid.
+        let prom = JSPromise::create(unsafe { &*global });
+        // Keep it alive until `flush_promise`/`destroy` releases the root.
+        JSPromise::opaque_ref(prom).to_js().protect();
+        self.pending_flush = Some(prom);
+        prom
+    }
+
+    /// Bytes uWS has queued but not yet handed to the socket, plus anything
+    /// still staged in our own buffer.
+    fn buffered_amount(&self) -> u64 {
+        let queued = self.any_res().map_or(0, |r| r.get_buffered_amount());
+        queued + self.readable_slice().len() as u64
+    }
+
+    /// `len` bytes were accepted. Once the outbound queue grows past the cap,
+    /// return a promise resolved on drain so the JS writer pauses; otherwise
+    /// report the byte count as usual. Pausing on the cap (rather than on uWS's
+    /// per-write backpressure hint, which fires whenever a chunk can't be sent
+    /// instantly) keeps a healthy client from stalling between chunks while
+    /// still bounding memory for a slow or stalled one.
+    fn owned_or_backpressure(&mut self, len: BlobSizeType) -> Writable {
+        if !self.done
+            && !self.requested_end
+            && self.buffered_amount() >= STREAM_BACKPRESSURE_HIGH_WATER_MARK
+        {
+            // Make sure uWS will wake us when the socket drains.
+            self.listen_for_writable();
+            return Writable::PendingPromise(self.backpressure_promise());
+        }
+        Writable::Owned(len)
+    }
+
     fn send_without_auto_flusher(&mut self, buf: &[u8]) -> bool {
         debug_assert!(!self.done);
 
@@ -1310,19 +1386,21 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
         // clean this so we know when its relevant or not
         self.end_len = 0;
-        // we clear the onWritable handler so uWS can handle the backpressure for us
-        res.clear_on_writable();
         self.handle_first_write_if_necessary();
-        // uWebSockets lacks a tryWrite() function
-        // This means that backpressure will be handled by appending to an "infinite" memory buffer
-        // It will do the backpressure handling for us
-        // so in this scenario, we just append to the buffer
-        // and report success
+        // uWebSockets lacks a tryWrite() function, so `write()` appends to uWS's
+        // own send buffer and tells us whether the socket is now backed up. When
+        // it is, register `on_writable` and report backpressure so the JS writer
+        // pauses; otherwise uWS would buffer the whole body in memory.
         if self.requested_end {
+            res.clear_on_writable();
             res.end(buf, false);
             self.has_backpressure = false;
+        } else if matches!(res.write(buf), uws::WriteResult::Backpressure(_)) {
+            self.has_backpressure = true;
+            self.listen_for_writable();
         } else {
-            self.has_backpressure = matches!(res.write(buf), uws::WriteResult::Backpressure(_));
+            self.has_backpressure = false;
+            res.clear_on_writable();
         }
         self.handle_wrote(buf.len());
         bun_core::scoped_log!(
@@ -1395,18 +1473,23 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
         // clean this so we know when its relevant or not
         self.end_len = 0;
-        // we clear the onWritable handler so uWS can handle the backpressure for us
-        res.clear_on_writable();
         self.handle_first_write_if_necessary();
         let buf_len = self.buffer.len().saturating_sub(base);
+        // See `send_without_auto_flusher`: register `on_writable` on backpressure
+        // so the JS writer pauses instead of growing uWS's buffer without bound.
         if self.requested_end {
+            res.clear_on_writable();
             res.end(&self.buffer[base..], false);
             self.has_backpressure = false;
+        } else if matches!(
+            res.write(&self.buffer[base..]),
+            uws::WriteResult::Backpressure(_)
+        ) {
+            self.has_backpressure = true;
+            self.listen_for_writable();
         } else {
-            self.has_backpressure = matches!(
-                res.write(&self.buffer[base..]),
-                uws::WriteResult::Backpressure(_)
-            );
+            self.has_backpressure = false;
+            res.clear_on_writable();
         }
         self.handle_wrote(buf_len);
         bun_core::scoped_log!(
@@ -1434,6 +1517,23 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.finalize();
             return false;
         }
+
+        // Streaming write() backpressure: the chunk was handed to uWS (so our
+        // own buffer is empty) and the socket has now drained. There is nothing
+        // staged to resend — just resolve the parked drain promise so the JS
+        // writer resumes. The `to_write` bookkeeping below assumes a non-empty
+        // buffer (the tryEnd resend path) and would underflow on `len - 1`.
+        if self.buffer.is_empty() {
+            if self.done {
+                self.signal.close(None);
+            }
+            let _ = self.flush_promise(); // TODO: properly propagate exception upwards
+            if self.done {
+                self.finalize();
+            }
+            return true;
+        }
+
         let mut total_written: u64 = 0;
 
         // do not write more than available
@@ -1628,7 +1728,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             // - large-ish chunk
             // - no backpressure
             if self.send(bytes) {
-                return Writable::Owned(len);
+                return self.owned_or_backpressure(len);
             }
 
             if self.buffer.write(bytes).is_err() {
@@ -1640,7 +1740,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 return Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write));
             }
             if self.send_readable(0) {
-                return Writable::Owned(len);
+                return self.owned_or_backpressure(len);
             }
         } else {
             // queue the data wait until highWaterMark is reached or the auto flusher kicks in
@@ -1681,7 +1781,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 // - large-ish chunk
                 // - no backpressure
                 if self.send(bytes) {
-                    return Writable::Owned(len);
+                    return self.owned_or_backpressure(len);
                 }
                 do_send = false;
             }
@@ -1692,7 +1792,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
             if do_send {
                 if self.send_readable(0) {
-                    return Writable::Owned(len);
+                    return self.owned_or_backpressure(len);
                 }
             }
         } else if self.buffer.len() as BlobSizeType + len >= self.high_water_mark {
@@ -1703,7 +1803,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 return Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write));
             }
             if self.send_readable(0) {
-                return Writable::Owned(len);
+                return self.owned_or_backpressure(len);
             }
         } else {
             if self.buffer.write_latin1(bytes).is_err() {
@@ -1743,7 +1843,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let readable_len = self.readable_slice().len();
         if readable_len >= self.high_water_mark as usize || self.has_backpressure() {
             if self.send_readable(0) {
-                return Writable::Owned(written as BlobSizeType);
+                return self.owned_or_backpressure(written as BlobSizeType);
             }
         }
 

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2429,3 +2429,74 @@ it.if(isPosix)("serves /bun:info over a unix socket in development mode", async 
   expect(text).toContain("bun_version");
   expect(res.status).toBe(200);
 });
+
+it("applies backpressure to a Response(ReadableStream) body when the client stalls reading (#32469)", async () => {
+  const CHUNK = Buffer.alloc(64 * 1024, 65); // 64 KiB
+  // If the server ever ignores backpressure it runs away to this cap (128 MiB)
+  // and closes the stream; correct backpressure plateaus far below it.
+  const CAP_CHUNKS = 2048;
+  let pulls = 0;
+  let producedEverything = false;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream(
+        {
+          pull(controller) {
+            pulls++;
+            controller.enqueue(CHUNK);
+            if (pulls >= CAP_CHUNKS) {
+              controller.close();
+              producedEverything = true;
+              return;
+            }
+            // Yield to macrotasks periodically so a runaway (no-backpressure)
+            // producer can't starve the event loop and hide from this test.
+            if (pulls % 64 === 0) return Bun.sleep(0);
+          },
+        },
+        { highWaterMark: 1 },
+      );
+      return new Response(stream);
+    },
+  });
+
+  // Raw client: send the request, read the response headers + a little body,
+  // then stop reading so TCP backpressure propagates back to the server.
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
+  socket.once("data", () => {
+    socket.pause(); // got the head of the response; now stall forever
+    onStalled();
+  });
+
+  try {
+    await stalled;
+
+    // Poll a bounded window for the absence of a runaway: wait until the pull
+    // count stops growing (backpressure engaged) or the server produces the
+    // whole capped body (the bug).
+    let lastPulls = -1;
+    let stableTurns = 0;
+    while (!producedEverything && stableTurns < 12) {
+      await Bun.sleep(25);
+      if (pulls === lastPulls) {
+        stableTurns++;
+      } else {
+        stableTurns = 0;
+        lastPulls = pulls;
+      }
+    }
+
+    // A stalled client must not let the server buffer the whole body. Correct
+    // backpressure plateaus at roughly the socket buffer (tens of 64 KiB
+    // chunks); without it the producer runs to CAP_CHUNKS and closes.
+    expect(producedEverything).toBe(false);
+    expect(pulls).toBeLessThan(1024);
+  } finally {
+    socket.destroy();
+  }
+});


### PR DESCRIPTION
Fixes #32469.

## Problem

When a `Bun.serve` handler returns `new Response(stream)` with a non-direct `ReadableStream`, the response writer pulls and enqueues from the stream as fast as it can, ignoring whether the TCP socket can accept the data. A slow or stalled client makes the whole body buffer in memory without bound, OOM-killing servers that stream large responses.

```js
const server = Bun.serve({
  port: 0,
  fetch() {
    let pulls = 0;
    const stream = new ReadableStream({
      pull(c) { pulls++; c.enqueue(new Uint8Array(64 * 1024)); },
    }, { highWaterMark: 1 });
    return new Response(stream);
  },
});
// client connects, reads the headers, then stops reading the body
```

Before: `pull` runs to 16384 and ~1 GiB is buffered within ~1s while the client reads nothing. Remove the reporter's 1 GiB cap and it OOMs outright.

## Cause

The server consumes the stream through `readStreamIntoSink` (`src/js/builtins/ReadableStreamInternals.ts`), which ignored the sink's `write()` result. On the native side, `HTTPServerWritable` (`src/runtime/webcore/streams.rs`) cleared its `onWritable` handler on every streaming write and let uWS buffer the unsent data indefinitely (the old `// "infinite" memory buffer` path), always reporting success.

The `node:http` compat server stays flat in the same scenario because it drains through a different, backpressure-aware path, so the buggy behavior was specific to the native `Bun.serve` `Response(ReadableStream)` writer.

## Fix

- `HTTPServerWritable` now registers `onWritable` when a streaming write backs the socket up, instead of clearing it.
- Once uWS has at least 1 MiB of unsent data queued, `write()` returns a promise that resolves when the socket drains, reusing the existing `pending_flush` / `onWritable` machinery. Pausing on the queued-bytes cap (rather than on uWS's per-write backpressure hint, which fires whenever a chunk can't be sent instantly) keeps a healthy client from stalling between chunks.
- `readStreamIntoSink` awaits that promise, so it stops pulling from the stream until the socket catches up.

Memory is now bounded at roughly the socket send buffer plus the 1 MiB cap. A client that reads slowly still receives the entire body (backpressure resumes on drain); a client that disconnects cancels the stream via the existing abort path.

## Verification

New test in `test/js/bun/http/serve.test.ts`: a server streams 64 KiB chunks (capped so a runaway closes the stream), a raw client reads the headers then stalls, and the test polls a bounded window asserting the producer plateaus far below the cap.

- Without the fix the producer runs to the 128 MiB cap and closes in ~160 ms (test fails).
- With the fix the pull count plateaus at a few dozen chunks and stays flat (test passes).

Manual check with the issue's reproduction on a debug build: `pulls` plateaus at ~58 / ~4 MiB RSS flat (was 16384 / 1 GiB). A slow-but-reading client receives the full body with bounded memory.