### PR TITLE
Add `--trusted` flag to `bun list`

### DIFF
--- a/completions/bun.zsh
+++ b/completions/bun.zsh
@@ -292,6 +292,7 @@ _bun_pm_completion() {
         ls)
             pmargs=(
                 "--all[list the entire dependency tree according to the current lockfile]"
+                "--trusted[list only trusted dependencies]"
             )
 
             _arguments -s -C \

--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -152,6 +152,19 @@ bun list --all
 ├── ...
 ```
 
+To print only trusted dependencies (those allowed to run lifecycle scripts). When `trustedDependencies` is set in `package.json`, packages from that list are shown; otherwise packages from Bun's [default trusted dependencies](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt) list are shown.
+
+```bash terminal icon="terminal"
+bun pm ls --trusted
+# or
+bun list --trusted
+```
+
+```txt
+/path/to/project node_modules (135)
+└── esbuild@0.21.5
+```
+
 ## whoami
 
 Print your npm username. Requires you to be logged in (`bunx npm login`) with credentials in either `bunfig.toml` or `.npmrc`:

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -174,7 +174,8 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder
   <b><green>bun<r> <blue>list<r>                  list the dependency tree according to the current lockfile
-  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
+  <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile
+  <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies
   <b><green>bun pm<r> <blue>why<r> <d>\<pkg\><r>            show dependency tree explaining why a package is installed
   <b><green>bun pm<r> <blue>whoami<r>               print the current npm username
   <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry <d>(use `bun info` instead)<r>

--- a/src/install/PackageManager/CommandLineArguments.rs
+++ b/src/install/PackageManager/CommandLineArguments.rs
@@ -169,6 +169,7 @@ pub static PM_PARAMS: &[ParamType] = concat_params![
     SHARED_PARAMS,
     &[
         clap::param!("-a, --all"),
+        clap::param!("--trusted"),
         clap::param!("--json                              Output in JSON format"),
         // clap::param!("--filter <STR>...                      Pack each matching workspace"),
         clap::param!(

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -156,7 +156,8 @@ impl PackageManagerCommand {
   <b><green>bun pm<r> <blue>bin<r>                  print the path to bin folder\n\
   <d>└<r> <cyan>-g<r>                        print the <b>global<r> path to bin folder\n\
   <b><green>bun<r> <blue>list<r>                  list the dependency tree according to the current lockfile\n\
-  <d>└<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile\n\
+  <d>├<r> <cyan>--all<r>                     list the entire dependency tree according to the current lockfile\n\
+  <d>└<r> <cyan>--trusted<r>                 list only trusted dependencies\n\
   <b><green>bun pm<r> <blue>why<r> <d>\\<pkg\\><r>            show dependency tree explaining why a package is installed\n\
   <b><green>bun pm<r> <blue>whoami<r>               print the current npm username\n\
   <b><green>bun pm<r> <blue>view<r> <d>name[@version]<r>  view package metadata from the registry <d>(use `bun info` instead)<r>\n\
@@ -531,6 +532,8 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 more_packages[0] = true;
             }
 
+            let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
+
             if strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]) {
                 print_node_modules_folder_structure(
                     &first_directory,
@@ -539,6 +542,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                     &mut directories,
                     lockfile,
                     &mut more_packages,
+                    trusted_only,
                 )?;
             } else {
                 let mut cwd_buf = PathBuffer::uninit();
@@ -554,6 +558,7 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 let dependencies = lockfile.buffers.dependencies.as_slice();
                 let slice = lockfile.packages.slice();
                 let resolutions = slice.items_resolution();
+                let pkg_names = slice.items_name();
                 let root_deps = slice.items_dependencies()[0];
 
                 Output::println(format_args!(
@@ -574,6 +579,22 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
                 // `sort_unstable_by` is pdqsort; names are
                 // unique so stability is irrelevant.
                 sorted_dependencies.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
+
+                if trusted_only {
+                    sorted_dependencies.retain(|&dep_id| {
+                        let package_id = lockfile.buffers.resolutions.as_slice()[dep_id as usize];
+                        if package_id as usize >= lockfile.packages.len() {
+                            return false;
+                        }
+                        let alias = dependencies[dep_id as usize].name.slice(string_bytes);
+                        let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
+                        lockfile.has_trusted_dependency(
+                            alias,
+                            pkg_name,
+                            &resolutions[package_id as usize],
+                        )
+                    });
+                }
 
                 for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
                     let package_id =
@@ -700,8 +721,10 @@ fn print_node_modules_folder_structure(
     directories: &mut Vec<NodeModulesFolder>,
     lockfile: &Lockfile,
     more_packages: &mut [bool],
+    trusted_only: bool,
 ) -> Result<(), bun_core::Error> {
     let resolutions = lockfile.packages.items_resolution();
+    let pkg_names = lockfile.packages.items_name();
     let string_bytes = lockfile.buffers.string_bytes.as_slice();
 
     {
@@ -776,6 +799,21 @@ fn print_node_modules_folder_structure(
     // stability is irrelevant.
     sorted_dependencies.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
 
+    if trusted_only {
+        sorted_dependencies.retain(|&dep_id| {
+            let package_id = lockfile.buffers.resolutions[dep_id as usize];
+            if package_id as usize >= lockfile.packages.len() {
+                return false;
+            }
+            let alias = dependencies[dep_id as usize].name.slice(string_bytes);
+            let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
+            lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id as usize])
+        });
+        if depth == 0 {
+            more_packages[0] = sorted_dependencies.len() > 1;
+        }
+    }
+
     let sorted_len = sorted_dependencies.len();
     for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
         let package_name = dependencies[dependency_id as usize]
@@ -833,6 +871,7 @@ fn print_node_modules_folder_structure(
                     directories,
                     lockfile,
                     more_packages,
+                    trusted_only,
                 )?;
             }
             dir_index += 1;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -535,15 +535,22 @@ Learn more about these at <magenta>https://bun.com/docs/cli/pm<r>.\n";
             let trusted_only = strings::left_has_any_in_right(args, &[b"--trusted"]);
 
             if strings::left_has_any_in_right(args, &[b"-A", b"-a", b"--all"]) {
-                print_node_modules_folder_structure(
-                    &first_directory,
-                    None,
-                    0,
-                    &mut directories,
-                    lockfile,
-                    &mut more_packages,
-                    trusted_only,
-                )?;
+                if trusted_only {
+                    // Trust is by package name, not tree position, so a trusted
+                    // package nested under an untrusted parent must still be
+                    // shown. Walk every node_modules folder and print a flat
+                    // list instead of pruning the tree.
+                    print_trusted_dependencies_flat(&first_directory, &directories, lockfile);
+                } else {
+                    print_node_modules_folder_structure(
+                        &first_directory,
+                        None,
+                        0,
+                        &mut directories,
+                        lockfile,
+                        &mut more_packages,
+                    )?;
+                }
             } else {
                 let mut cwd_buf = PathBuffer::uninit();
                 let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
@@ -721,10 +728,8 @@ fn print_node_modules_folder_structure(
     directories: &mut Vec<NodeModulesFolder>,
     lockfile: &Lockfile,
     more_packages: &mut [bool],
-    trusted_only: bool,
 ) -> Result<(), bun_core::Error> {
     let resolutions = lockfile.packages.items_resolution();
-    let pkg_names = lockfile.packages.items_name();
     let string_bytes = lockfile.buffers.string_bytes.as_slice();
 
     {
@@ -799,21 +804,6 @@ fn print_node_modules_folder_structure(
     // stability is irrelevant.
     sorted_dependencies.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
 
-    if trusted_only {
-        sorted_dependencies.retain(|&dep_id| {
-            let package_id = lockfile.buffers.resolutions[dep_id as usize];
-            if package_id as usize >= lockfile.packages.len() {
-                return false;
-            }
-            let alias = dependencies[dep_id as usize].name.slice(string_bytes);
-            let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
-            lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id as usize])
-        });
-        if depth == 0 {
-            more_packages[0] = sorted_dependencies.len() > 1;
-        }
-    }
-
     let sorted_len = sorted_dependencies.len();
     for (index, &dependency_id) in sorted_dependencies.iter().enumerate() {
         let package_name = dependencies[dependency_id as usize]
@@ -871,7 +861,6 @@ fn print_node_modules_folder_structure(
                     directories,
                     lockfile,
                     more_packages,
-                    trusted_only,
                 )?;
             }
             dir_index += 1;
@@ -911,6 +900,74 @@ fn print_node_modules_folder_structure(
     }
 
     Ok(())
+}
+
+fn print_trusted_dependencies_flat(
+    first_directory: &NodeModulesFolder,
+    directories: &[NodeModulesFolder],
+    lockfile: &Lockfile,
+) {
+    let mut cwd_buf = PathBuffer::uninit();
+    let path = match bun_sys::getcwd(&mut cwd_buf[..]) {
+        Ok(len) => &cwd_buf[..len],
+        Err(_) => {
+            bun_core::pretty_errorln!("<r><red>error<r>: Could not get current working directory",);
+            Global::exit(1);
+        }
+    };
+    Output::println(format_args!("{} node_modules", bstr::BStr::new(path)));
+
+    let dependencies = lockfile.buffers.dependencies.as_slice();
+    let resolutions_buf = lockfile.buffers.resolutions.as_slice();
+    let string_bytes = lockfile.buffers.string_bytes.as_slice();
+    let slice = lockfile.packages.slice();
+    let resolutions = slice.items_resolution();
+    let pkg_names = slice.items_name();
+    let pkg_count = lockfile.packages.len();
+
+    let mut seen: Vec<bool> = vec![false; pkg_count];
+    let mut trusted: Vec<DependencyID> = Vec::new();
+
+    let mut visit = |dep_id: DependencyID| {
+        let package_id = resolutions_buf[dep_id as usize];
+        if package_id as usize >= pkg_count {
+            return;
+        }
+        if seen[package_id as usize] {
+            return;
+        }
+        let alias = dependencies[dep_id as usize].name.slice(string_bytes);
+        let pkg_name = pkg_names[package_id as usize].slice(string_bytes);
+        if lockfile.has_trusted_dependency(alias, pkg_name, &resolutions[package_id as usize]) {
+            seen[package_id as usize] = true;
+            trusted.push(dep_id);
+        }
+    };
+    for &dep_id in first_directory.dependencies.iter() {
+        visit(dep_id);
+    }
+    for folder in directories {
+        for &dep_id in folder.dependencies.iter() {
+            visit(dep_id);
+        }
+    }
+
+    let by_name = ByName {
+        dependencies,
+        buf: string_bytes,
+    };
+    trusted.sort_unstable_by(|a, b| by_name.cmp(*a, *b));
+
+    for (index, &dep_id) in trusted.iter().enumerate() {
+        let package_id = resolutions_buf[dep_id as usize];
+        let name = dependencies[dep_id as usize].name.slice(string_bytes);
+        let resolution = resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
+        if index + 1 < trusted.len() {
+            bun_core::prettyln!("<d>├──<r> {}<r><d>@{}<r>\n", bstr::BStr::new(name), resolution,);
+        } else {
+            bun_core::prettyln!("<d>└──<r> {}<r><d>@{}<r>\n", bstr::BStr::new(name), resolution,);
+        }
+    }
 }
 
 use bun_core::fmt::buf_print_infallible as buf_print;

--- a/src/runtime/cli/package_manager_command.rs
+++ b/src/runtime/cli/package_manager_command.rs
@@ -963,9 +963,17 @@ fn print_trusted_dependencies_flat(
         let name = dependencies[dep_id as usize].name.slice(string_bytes);
         let resolution = resolutions[package_id as usize].fmt(string_bytes, PathSep::Auto);
         if index + 1 < trusted.len() {
-            bun_core::prettyln!("<d>├──<r> {}<r><d>@{}<r>\n", bstr::BStr::new(name), resolution,);
+            bun_core::prettyln!(
+                "<d>├──<r> {}<r><d>@{}<r>\n",
+                bstr::BStr::new(name),
+                resolution,
+            );
         } else {
-            bun_core::prettyln!("<d>└──<r> {}<r><d>@{}<r>\n", bstr::BStr::new(name), resolution,);
+            bun_core::prettyln!(
+                "<d>└──<r> {}<r><d>@{}<r>\n",
+                bstr::BStr::new(name),
+                resolution,
+            );
         }
     }
 }

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1715,6 +1715,102 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
       assertManifestsPopulated(join(packageDir, ".bun-cache"), verdaccio.registryUrl());
     });
 
+    test("bun pm ls --trusted uses default trusted list when trustedDependencies is not set", async () => {
+      using ctx = await setupTest();
+      const { packageDir, packageJson, env } = ctx;
+
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.2.3",
+          dependencies: {
+            "electron": "1.0.0",
+            "no-deps": "1.0.0",
+          },
+        }),
+      );
+
+      {
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("error:");
+        expect(err).toContain("Saved lockfile");
+        expect(await exited).toBe(0);
+      }
+
+      // Without `trustedDependencies` in package.json, `--trusted` falls back to
+      // the default trusted list. `electron` is on it, `no-deps` is not.
+      {
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "pm", "ls", "--trusted"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env,
+        });
+        const out = await stdout.text();
+        expect(await stderr.text()).toBe("");
+        expect(out).toBe(`${packageDir} node_modules (2)
+└── electron@1.0.0
+`);
+        expect(await exited).toBe(0);
+      }
+
+      // With `trustedDependencies` set, the default list is ignored.
+      await writeFile(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          version: "1.2.3",
+          dependencies: {
+            "electron": "1.0.0",
+            "no-deps": "1.0.0",
+          },
+          trustedDependencies: ["no-deps"],
+        }),
+      );
+
+      {
+        const { stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env,
+        });
+        const err = await stderr.text();
+        expect(err).not.toContain("error:");
+        expect(await exited).toBe(0);
+      }
+
+      {
+        const { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "pm", "ls", "--trusted"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "ignore",
+          stderr: "pipe",
+          env,
+        });
+        const out = await stdout.text();
+        expect(await stderr.text()).toBe("");
+        expect(out).toBe(`${packageDir} node_modules (2)
+└── no-deps@1.0.0
+`);
+        expect(await exited).toBe(0);
+      }
+    });
+
     test("default trusted dependencies should not be used of trustedDependencies is populated", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -1718,6 +1718,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
     test("bun pm ls --trusted uses default trusted list when trustedDependencies is not set", async () => {
       using ctx = await setupTest();
       const { packageDir, packageJson, env } = ctx;
+      const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
 
       await writeFile(
         packageJson,
@@ -1738,7 +1739,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           stdout: "pipe",
           stdin: "ignore",
           stderr: "pipe",
-          env,
+          env: testEnv,
         });
         const err = await stderr.text();
         expect(err).not.toContain("error:");
@@ -1755,7 +1756,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           stdout: "pipe",
           stdin: "ignore",
           stderr: "pipe",
-          env,
+          env: testEnv,
         });
         const out = await stdout.text();
         expect(await stderr.text()).toBe("");
@@ -1786,7 +1787,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           stdout: "pipe",
           stdin: "ignore",
           stderr: "pipe",
-          env,
+          env: testEnv,
         });
         const err = await stderr.text();
         expect(err).not.toContain("error:");
@@ -1800,7 +1801,7 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
           stdout: "pipe",
           stdin: "ignore",
           stderr: "pipe",
-          env,
+          env: testEnv,
         });
         const out = await stdout.text();
         expect(await stderr.text()).toBe("");

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -257,6 +257,194 @@ it("should list aliased dependencies", async () => {
   expect(requested).toBe(2);
 });
 
+it("should list only trusted dependencies with --trusted", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        moo: "./moo",
+        bar: "latest",
+      },
+      trustedDependencies: ["bar"],
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  urls.length = 0;
+
+  // --trusted shows only bar (in trustedDependencies), not moo
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "ls", "--trusted"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toBe("");
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+└── bar@0.0.2
+`);
+    expect(await exited).toBe(0);
+  }
+
+  // without --trusted still shows both
+  {
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "pm", "ls"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    expect(await stderr.text()).toBe("");
+    expect(await stdout.text()).toBe(`${package_dir} node_modules (2)
+├── bar@0.0.2
+└── moo@moo
+`);
+    expect(await exited).toBe(0);
+  }
+});
+
+it("should list only trusted dependencies with --all --trusted", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        moo: "./moo",
+      },
+      trustedDependencies: ["moo"],
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  urls.length = 0;
+
+  // --all --trusted shows only moo (trusted), not bar (transitive, not trusted)
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--all", "--trusted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).toBe("");
+  expect(await stdout.text()).toBe(`${package_dir} node_modules
+└── moo@moo
+`);
+  expect(await exited).toBe(0);
+});
+
+it("should list nothing with --trusted when no dependencies are trusted", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        bar: "latest",
+      },
+      trustedDependencies: [],
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  urls.length = 0;
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--trusted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).toBe("");
+  expect(await stdout.text()).toBe(`${package_dir} node_modules (1)
+`);
+  expect(await exited).toBe(0);
+});
+
 it("should remove all cache", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -345,7 +345,7 @@ it("should list only trusted dependencies with --all --trusted", async () => {
       dependencies: {
         moo: "./moo",
       },
-      trustedDependencies: ["moo"],
+      trustedDependencies: ["bar"],
     }),
   );
   await mkdir(join(package_dir, "moo"));
@@ -375,7 +375,9 @@ it("should list only trusted dependencies with --all --trusted", async () => {
   }
   urls.length = 0;
 
-  // --all --trusted shows only moo (trusted), not bar (transitive, not trusted)
+  // `bar` is a transitive dependency of `moo` (untrusted). Trust is by
+  // package name, so `--all --trusted` must still find it regardless of
+  // where it sits in the tree.
   const { stdout, stderr, exited } = spawn({
     cmd: [bunExe(), "pm", "ls", "--all", "--trusted"],
     cwd: package_dir,
@@ -386,7 +388,69 @@ it("should list only trusted dependencies with --all --trusted", async () => {
   });
   expect(await stderr.text()).toBe("");
   expect(await stdout.text()).toBe(`${package_dir} node_modules
-└── moo@moo
+└── bar@0.0.2
+`);
+  expect(await exited).toBe(0);
+});
+
+it("should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated)", async () => {
+  const urls: string[] = [];
+  setHandler(dummyRegistry(urls));
+  // Isolated linker gives every package its own nested node_modules, so the
+  // trusted transitive dep lives under an untrusted parent folder.
+  await writeFile(
+    join(package_dir, "bunfig.toml"),
+    `[install]\ncache = false\nregistry = "${root_url}/"\nlinker = "isolated"\n`,
+  );
+  await writeFile(
+    join(package_dir, "package.json"),
+    JSON.stringify({
+      name: "foo",
+      version: "0.0.1",
+      dependencies: {
+        moo: "./moo",
+      },
+      trustedDependencies: ["bar"],
+    }),
+  );
+  await mkdir(join(package_dir, "moo"));
+  await writeFile(
+    join(package_dir, "moo", "package.json"),
+    JSON.stringify({
+      name: "moo",
+      version: "0.1.0",
+      dependencies: {
+        bar: "latest",
+      },
+    }),
+  );
+  {
+    const { stderr, exited } = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: package_dir,
+      stdout: "pipe",
+      stdin: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(err).toContain("Saved lockfile");
+    expect(await exited).toBe(0);
+  }
+  urls.length = 0;
+
+  const { stdout, stderr, exited } = spawn({
+    cmd: [bunExe(), "pm", "ls", "--all", "--trusted"],
+    cwd: package_dir,
+    stdout: "pipe",
+    stdin: "pipe",
+    stderr: "pipe",
+    env,
+  });
+  expect(await stderr.text()).toBe("");
+  expect(await stdout.text()).toBe(`${package_dir} node_modules
+└── bar@0.0.2
 `);
   expect(await exited).toBe(0);
 });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -260,10 +260,7 @@ it("should list aliased dependencies", async () => {
 it("should list only trusted dependencies with --trusted", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeFile(
-    join(package_dir, "bunfig.toml"),
-    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
-  );
+  await writeFile(join(package_dir, "bunfig.toml"), `[install]\ncache = false\nregistry = "${root_url}/"\n`);
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -339,10 +336,7 @@ it("should list only trusted dependencies with --trusted", async () => {
 it("should list only trusted dependencies with --all --trusted", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeFile(
-    join(package_dir, "bunfig.toml"),
-    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
-  );
+  await writeFile(join(package_dir, "bunfig.toml"), `[install]\ncache = false\nregistry = "${root_url}/"\n`);
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({
@@ -400,10 +394,7 @@ it("should list only trusted dependencies with --all --trusted", async () => {
 it("should list nothing with --trusted when no dependencies are trusted", async () => {
   const urls: string[] = [];
   setHandler(dummyRegistry(urls));
-  await writeFile(
-    join(package_dir, "bunfig.toml"),
-    `[install]\ncache = false\nregistry = "${root_url}/"\n`,
-  );
+  await writeFile(join(package_dir, "bunfig.toml"), `[install]\ncache = false\nregistry = "${root_url}/"\n`);
   await writeFile(
     join(package_dir, "package.json"),
     JSON.stringify({


### PR DESCRIPTION
## What

Adds a `--trusted` flag to `bun pm ls` / `bun list` that filters the output to only show dependencies that are trusted (i.e. allowed to run lifecycle scripts).

```sh
$ bun pm ls --trusted
/path/to/project node_modules (135)
└── esbuild@0.21.5
```

The flag filters using `Lockfile::has_trusted_dependency()`, so it honors both:
- an explicit `"trustedDependencies"` array in `package.json` (only packages listed there are shown)
- Bun's [default trusted list](https://github.com/oven-sh/bun/blob/main/src/install/default-trusted-dependencies.txt) when `trustedDependencies` is not set

Works on its own and combined with `--all`.

## Changes

- `src/runtime/cli/package_manager_command.rs`: parse `--trusted` and filter the sorted dependency list in both the top-level and recursive (`--all`) printers before rendering
- `src/install/PackageManager.rs`, `src/install/PackageManager/CommandLineArguments.rs`: register the flag and add it to `bun pm --help`
- `docs/pm/cli/pm.mdx`: document the flag

## Verification

- New tests in `test/cli/install/bun-pm.test.ts` cover `--trusted`, `--all --trusted`, and an empty `trustedDependencies` list; all fail on the released bun and pass with this change.
- New test in `test/cli/install/bun-install-lifecycle-scripts.test.ts` covers the default trusted list fallback (no `trustedDependencies` in `package.json`, `electron` is on the default list, `no-deps` is not) and the switchover when `trustedDependencies` is added.
- `bun bd test test/cli/install/bun-pm.test.ts`: 17 pass, 0 fail.
- Manual check against this repo (which has no `trustedDependencies`): `bun list --trusted` prints only `esbuild`, the one top-level dep on the default list.