### PR TITLE
node:inspector: implement inspector.open() with a Chrome DevTools Protocol server (draft)

### DIFF
--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -95,6 +95,12 @@ type CreateBackendFn = (
   receive: (...messages: string[]) => void,
 ) => unknown;
 
+// CDP translation is only needed for node:inspector servers, so load it lazily.
+let lazyInspectorCDPAdapter: any;
+function cdpAdapterConstructor() {
+  return (lazyInspectorCDPAdapter ??= require("internal/inspector/cdp").InspectorCDPAdapter);
+}
+
 export default function (
   executionContextId: number,
   url: string,
@@ -103,9 +109,72 @@ export default function (
   close: () => void,
   isAutomatic: boolean,
   urlIsServer: boolean,
+  isNodeInspector: boolean,
+  reportNodeInspectorServerStarted: (url: string, controlCallback?: (message: string) => void, error?: string) => void,
 ): void {
   if (urlIsServer) {
     connectToUnixServer(executionContextId, url, createBackend, send, close);
+    return;
+  }
+
+  if (isNodeInspector) {
+    // node:inspector's inspector.open(): connections speak the V8 Chrome
+    // DevTools Protocol, the listening URL is reported back to the inspected
+    // thread (which prints Node's "Debugger listening on ..." line), and a
+    // control callback lets the inspected thread close the server or forward
+    // commands from the in-process inspector.Session.
+    let debug: Debugger;
+    try {
+      debug = new Debugger(executionContextId, url, createBackend, send, close, true);
+    } catch (error) {
+      reportNodeInspectorServerStarted("", undefined, `${(error as Error)?.message ?? error}`);
+      return;
+    }
+
+    let sessionBackend: Backend | undefined;
+    let sessionAdapter: any;
+    const control = (message: string) => {
+      let parsed: any;
+      try {
+        parsed = JSON.parse(message);
+      } catch {
+        return;
+      }
+      switch (parsed?.type) {
+        case "close":
+          sessionBackend?.close();
+          sessionBackend = undefined;
+          sessionAdapter = undefined;
+          debug.stop();
+          return;
+        case "command": {
+          // A CDP command forwarded from the inspected thread's in-process
+          // inspector.Session (e.g. Debugger.setBreakpointByUrl from vitest
+          // --inspect-brk). Responses stay on this thread; the in-process
+          // Session treats these as fire-and-forget.
+          if (!sessionAdapter) {
+            let adapter: any;
+            sessionBackend = debug.createSessionBackend((...messages: string[]) => {
+              for (const backendMessage of messages) {
+                adapter.handleBackendMessage(backendMessage);
+              }
+            });
+            adapter = new (cdpAdapterConstructor())(
+              (backendMessage: string) => void sessionBackend?.write(backendMessage),
+              () => {},
+            );
+            sessionAdapter = adapter;
+            sessionAdapter.handleClientMessage(JSON.stringify({ id: 0, method: "Debugger.enable", params: {} }));
+          }
+          sessionAdapter.handleClientMessage(
+            JSON.stringify({ id: parsed.id ?? 0, method: parsed.method, params: parsed.params ?? {} }),
+          );
+          return;
+        }
+      }
+    };
+
+    reportNodeInspectorServerStarted(debug.url!.href, control, undefined);
     return;
   }
 
@@ -168,6 +237,10 @@ function unescapeUnixSocketUrl(href: string) {
 class Debugger {
   #url?: URL;
   #createBackend: (refEventLoop: boolean, receive: (...messages: string[]) => void) => Backend;
+  // node:inspector mode: connections speak the V8 Chrome DevTools Protocol and
+  // /json discovery endpoints are served.
+  #nodeInspector = false;
+  #server?: WebSocketServer;
 
   constructor(
     executionContextId: number,
@@ -175,7 +248,9 @@ class Debugger {
     createBackend: CreateBackendFn,
     send: (message: string | string[]) => void,
     close: () => void,
+    isNodeInspector: boolean = false,
   ) {
+    this.#nodeInspector = isNodeInspector;
     try {
       this.#createBackend = (refEventLoop, receive) => {
         const backend = createBackend(executionContextId, refEventLoop, receive);
@@ -229,6 +304,19 @@ class Debugger {
     return this.#url;
   }
 
+  // Stops the node:inspector server and terminates its connections
+  // (inspector.close() on the inspected thread).
+  stop(): void {
+    this.#server?.stop(true);
+    this.#server = undefined;
+  }
+
+  // A backend connection that is not tied to a WebSocket client, used for
+  // commands forwarded from the in-process inspector.Session.
+  createSessionBackend(receive: (...messages: string[]) => void): Backend {
+    return this.#createBackend(true, receive);
+  }
+
   #listen(): void {
     const { protocol, hostname, port, pathname } = this.#url!;
 
@@ -241,6 +329,7 @@ class Debugger {
         websocket: this.#websocket,
       });
 
+      this.#server = server;
       this.#url!.hostname = server.hostname;
       this.#url!.port = `${server.port}`;
       return;
@@ -325,6 +414,26 @@ class Debugger {
     };
   }
 
+  // Node-shaped /json/list payload describing the single debuggable target.
+  #nodeInspectorTargets(): unknown[] {
+    const { hostname, port, pathname } = this.#url!;
+    const id = pathname.slice(1);
+    const wsAddress = `${hostname}:${port}${pathname}`;
+    return [
+      {
+        description: "bun instance",
+        devtoolsFrontendUrl: `devtools://devtools/bundled/js_app.html?experiments=true&v8only=true&ws=${wsAddress}`,
+        devtoolsFrontendUrlCompat: `devtools://devtools/bundled/inspector.html?experiments=true&v8only=true&ws=${wsAddress}`,
+        faviconUrl: "https://bun.com/favicon.ico",
+        id,
+        title: `bun[${process.pid}]`,
+        type: "node",
+        url: "file://",
+        webSocketDebuggerUrl: `ws://${wsAddress}`,
+      },
+    ];
+  }
+
   #fetch(request: Request, server: WebSocketServer): Response | undefined {
     const { method, url, headers } = request;
     const { pathname } = new URL(url);
@@ -337,10 +446,16 @@ class Debugger {
 
     switch (pathname) {
       case "/json/version":
-        return Response.json(versionInfo());
+        return Response.json(this.#nodeInspector ? nodeVersionInfo() : versionInfo());
       case "/json":
       case "/json/list":
-      // TODO?
+        // Discovery endpoint used by CDP clients (chrome://inspect, vscode-js-debug)
+        // to find the WebSocket URL. Only served for node:inspector servers; the
+        // Bun-protocol inspector has no CDP-speaking clients to discover it.
+        if (this.#nodeInspector) {
+          return Response.json(this.#nodeInspectorTargets());
+        }
+        break;
     }
 
     if (!this.#url!.protocol.includes("unix") && this.#url!.pathname !== pathname) {
@@ -374,6 +489,27 @@ class Debugger {
     const { refEventLoop } = data;
 
     const client = bufferedWriter(writer);
+
+    if (this.#nodeInspector) {
+      // node:inspector clients speak CDP; the adapter sits between the
+      // WebSocket and the JSC-protocol backend connection.
+      let adapter: any;
+      const backend = this.#createBackend(refEventLoop, (...messages: string[]) => {
+        for (const message of messages) {
+          adapter.handleBackendMessage(message);
+        }
+      });
+      adapter = new (cdpAdapterConstructor())(
+        (message: string) => void backend.write(message),
+        (message: string) => void client.write(message),
+      );
+
+      data.client = client;
+      data.backend = backend;
+      data.adapter = adapter;
+      return;
+    }
+
     const backend = this.#createBackend(refEventLoop, (...messages: string[]) => {
       for (const message of messages) {
         client.write(message);
@@ -386,8 +522,12 @@ class Debugger {
 
   #message(connection: ConnectionOwner, message: string): void {
     const { data } = connection;
-    const { backend } = data;
+    const { backend, adapter } = data;
     $debug("remote:", message);
+    if (adapter) {
+      adapter.handleClientMessage(message);
+      return;
+    }
     backend?.write(message);
   }
 
@@ -522,6 +662,15 @@ function versionInfo(): unknown {
     "WebKit-Version": process.versions.webkit,
     "Bun-Version": Bun.version,
     "Bun-Revision": Bun.revision,
+  };
+}
+
+// Node-shaped /json/version payload, served for node:inspector servers so CDP
+// clients recognize the target the same way they recognize a Node process.
+function nodeVersionInfo(): unknown {
+  return {
+    "Browser": `Bun/${Bun.version}`,
+    "Protocol-Version": "1.1",
   };
 }
 
@@ -679,6 +828,8 @@ type Connection = {
   refEventLoop: boolean;
   client?: Writer;
   backend?: Backend;
+  // Present for node:inspector connections, which speak the V8 protocol.
+  adapter?: any;
 };
 
 type Writer = {

--- a/src/js/internal/debugger.ts
+++ b/src/js/internal/debugger.ts
@@ -492,9 +492,12 @@ class Debugger {
 
     if (this.#nodeInspector) {
       // node:inspector clients speak CDP; the adapter sits between the
-      // WebSocket and the JSC-protocol backend connection.
+      // WebSocket and the JSC-protocol backend connection. Unlike Bun's own
+      // --inspect connections, an attached client must not keep the process
+      // alive — Node exits with a debugger attached — so never ref the event
+      // loop for these connections (the `true` argument means "do not ref").
       let adapter: any;
-      const backend = this.#createBackend(refEventLoop, (...messages: string[]) => {
+      const backend = this.#createBackend(true, (...messages: string[]) => {
         for (const message of messages) {
           adapter.handleBackendMessage(message);
         }

--- a/src/js/internal/inspector/cdp.ts
+++ b/src/js/internal/inspector/cdp.ts
@@ -1,0 +1,607 @@
+// Translates between the V8 Chrome DevTools Protocol (CDP) spoken by clients
+// of node:inspector (Chrome DevTools, vscode-js-debug, vitest --inspect, ...)
+// and the JSC/WebKit inspector protocol spoken by Bun's inspector backend.
+//
+// One adapter instance serves one frontend connection. `handleClientMessage`
+// receives raw CDP JSON from the client, `handleBackendMessage` receives raw
+// JSC-protocol JSON from the backend connection. Command ids from the client
+// are preserved by giving backend commands their own id space and correlating
+// the responses.
+const { pathToFileURL, fileURLToPath } = require("node:url");
+const { isAbsolute } = require("node:path");
+
+const EXECUTION_CONTEXT_ID = 1;
+
+type AnyObject = Record<string, any>;
+
+function toCdpUrl(url: string): string {
+  // V8 reports filesystem-backed scripts with file:// URLs; JSC script URLs
+  // are usually plain absolute paths.
+  if (url && isAbsolute(url)) {
+    try {
+      return pathToFileURL(url).href;
+    } catch {
+      return url;
+    }
+  }
+  return url;
+}
+
+// Written without a regex literal: the builtin-module bundler's scanner cannot
+// parse a character class that escapes both `]` and `\`.
+const REGEX_SPECIAL_CHARACTERS = "\\^$.*+?()[]{}|";
+function escapeRegex(text: string): string {
+  let escaped = "";
+  for (const character of text) {
+    escaped += REGEX_SPECIAL_CHARACTERS.includes(character) ? "\\" + character : character;
+  }
+  return escaped;
+}
+
+// CDP clients address scripts by file:// URL while JSC usually knows them by
+// plain path, so match a breakpoint URL against every spelling.
+function breakpointUrlRegex(url: string): string {
+  const candidates = new Set([url]);
+  if (url.startsWith("file://")) {
+    try {
+      candidates.add(fileURLToPath(url));
+    } catch {}
+  } else if (isAbsolute(url)) {
+    try {
+      candidates.add(pathToFileURL(url).href);
+    } catch {}
+  }
+  return Array.from(candidates, candidate => `^${escapeRegex(candidate)}$`).join("|");
+}
+
+const SCOPE_TYPE_MAP: Record<string, string> = {
+  global: "global",
+  with: "with",
+  closure: "closure",
+  catch: "catch",
+  functionName: "local",
+  globalLexicalEnvironment: "script",
+  nestedLexical: "block",
+};
+
+const CONSOLE_TYPE_MAP: Record<string, string> = {
+  log: "log",
+  dir: "dir",
+  dirxml: "dirxml",
+  table: "table",
+  trace: "trace",
+  clear: "clear",
+  startGroup: "startGroup",
+  startGroupCollapsed: "startGroupCollapsed",
+  endGroup: "endGroup",
+  assert: "assert",
+  timing: "timeEnd",
+  profile: "profile",
+  profileEnd: "profileEnd",
+};
+
+const CONSOLE_LEVEL_MAP: Record<string, string> = {
+  log: "log",
+  info: "info",
+  warning: "warning",
+  error: "error",
+  debug: "debug",
+};
+
+class InspectorCDPAdapter {
+  #writeToBackend: (message: string) => void;
+  #writeToClient: (message: string) => void;
+  #nextBackendId = 1;
+  #nextExceptionId = 1;
+  #pending = new Map<number, { clientId: number | string | null; method: string }>();
+  #scripts = new Map<string, { cdpUrl: string; endLine: number; endColumn: number }>();
+
+  constructor(writeToBackend: (message: string) => void, writeToClient: (message: string) => void) {
+    this.#writeToBackend = writeToBackend;
+    this.#writeToClient = writeToClient;
+  }
+
+  handleClientMessage(message: string): void {
+    let parsed: AnyObject;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      return;
+    }
+    const { id, method, params } = parsed;
+    if (typeof method !== "string") return;
+    try {
+      this.#dispatchClientCommand(id, method, params || {});
+    } catch (error) {
+      this.#replyErrorToClient(id, -32000, `${error}`);
+    }
+  }
+
+  handleBackendMessage(message: string): void {
+    let parsed: AnyObject;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      return;
+    }
+    if (parsed.id !== undefined) {
+      const pending = this.#pending.get(parsed.id);
+      if (!pending) return;
+      this.#pending.delete(parsed.id);
+      if (pending.clientId === null || pending.clientId === undefined) return;
+      if (parsed.error) {
+        this.#replyErrorToClient(
+          pending.clientId,
+          parsed.error.code ?? -32000,
+          parsed.error.message ?? "Unknown error",
+        );
+        return;
+      }
+      this.#replyToClient(pending.clientId, this.#translateResult(pending.method, parsed.result || {}));
+      return;
+    }
+    if (typeof parsed.method === "string") {
+      this.#translateBackendEvent(parsed.method, parsed.params || {});
+    }
+  }
+
+  #replyToClient(id: number | string, result: AnyObject): void {
+    this.#writeToClient(JSON.stringify({ id, result }));
+  }
+
+  #replyErrorToClient(id: number | string, code: number, message: string): void {
+    this.#writeToClient(JSON.stringify({ id, error: { code, message } }));
+  }
+
+  #emitToClient(method: string, params: AnyObject): void {
+    this.#writeToClient(JSON.stringify({ method, params }));
+  }
+
+  // `clientId` undefined/null marks an adapter-internal command whose response
+  // is dropped instead of being forwarded to the client.
+  #sendToBackend(
+    method: string,
+    params?: AnyObject,
+    clientId: number | string | null = null,
+    clientMethod = method,
+  ): void {
+    const id = this.#nextBackendId++;
+    this.#pending.set(id, { clientId, method: clientMethod });
+    this.#writeToBackend(JSON.stringify(params === undefined ? { id, method } : { id, method, params }));
+  }
+
+  #dispatchClientCommand(id: number | string, method: string, params: AnyObject): void {
+    switch (method) {
+      // ── Runtime ──────────────────────────────────────────────────────────
+      case "Runtime.enable":
+        // JSGlobalObject inspection has a single execution context; CDP clients
+        // need at least one announced for the console and evaluation to work.
+        this.#emitToClient("Runtime.executionContextCreated", {
+          context: {
+            id: EXECUTION_CONTEXT_ID,
+            origin: "",
+            name: "Bun",
+            uniqueId: String(EXECUTION_CONTEXT_ID),
+          },
+        });
+        this.#sendToBackend("Runtime.enable", undefined, id, method);
+        // Console output arrives as Console.messageAdded and is re-emitted as
+        // Runtime.consoleAPICalled.
+        this.#sendToBackend("Console.enable");
+        return;
+
+      case "Runtime.disable":
+        this.#sendToBackend("Runtime.disable", undefined, id, method);
+        return;
+
+      case "Runtime.runIfWaitingForDebugger":
+        // Inspector.initialized resolves Bun's wait-for-debugger state, which
+        // unblocks inspector.open(port, host, true) on the inspected thread.
+        this.#sendToBackend("Inspector.initialized");
+        this.#replyToClient(id, {});
+        return;
+
+      case "Runtime.evaluate":
+        this.#sendToBackend(
+          "Runtime.evaluate",
+          {
+            expression: params.expression,
+            objectGroup: params.objectGroup,
+            includeCommandLineAPI: params.includeCommandLineAPI,
+            doNotPauseOnExceptionsAndMuteConsole: params.silent,
+            returnByValue: params.returnByValue,
+            generatePreview: params.generatePreview,
+          },
+          id,
+          method,
+        );
+        return;
+
+      case "Runtime.getProperties":
+        if (params.accessorPropertiesOnly) {
+          // JSC has no accessor-only query; DevTools issues this in addition to
+          // the regular request, so an empty list keeps the merged view correct.
+          this.#replyToClient(id, { result: [] });
+          return;
+        }
+        this.#sendToBackend(
+          "Runtime.getProperties",
+          {
+            objectId: params.objectId,
+            ownProperties: params.ownProperties,
+            generatePreview: params.generatePreview,
+          },
+          id,
+          method,
+        );
+        return;
+
+      case "Runtime.callFunctionOn":
+        if (!params.objectId) {
+          this.#replyErrorToClient(id, -32602, "Runtime.callFunctionOn requires objectId");
+          return;
+        }
+        this.#sendToBackend(
+          "Runtime.callFunctionOn",
+          {
+            objectId: params.objectId,
+            functionDeclaration: params.functionDeclaration,
+            arguments: params.arguments,
+            returnByValue: params.returnByValue,
+            generatePreview: params.generatePreview,
+            awaitPromise: params.awaitPromise,
+          },
+          id,
+          method,
+        );
+        return;
+
+      case "Runtime.releaseObject":
+      case "Runtime.releaseObjectGroup":
+        this.#sendToBackend(method, params, id, method);
+        return;
+
+      case "Runtime.getIsolateId":
+        this.#replyToClient(id, { id: "bun" });
+        return;
+
+      case "Runtime.getHeapUsage":
+        this.#replyToClient(id, { usedSize: 0, totalSize: 0 });
+        return;
+
+      case "Runtime.compileScript":
+        this.#replyToClient(id, {});
+        return;
+
+      case "Runtime.globalLexicalScopeNames":
+        this.#replyToClient(id, { names: [] });
+        return;
+
+      // ── Debugger ─────────────────────────────────────────────────────────
+      case "Debugger.enable":
+        // Note: breakpoints are not activated (Debugger.setBreakpointsActive)
+        // and `debugger;` statements do not pause yet: pausing with a debugger
+        // that was attached at runtime currently crashes inside JSC's module
+        // evaluation (llint_slow_path_put_to_scope reads an empty scope), so
+        // the Debugger domain is limited to inspection (scriptParsed,
+        // getScriptSource, evaluate) until that is fixed.
+        this.#sendToBackend("Debugger.enable", undefined, id, method);
+        return;
+
+      case "Debugger.disable":
+      case "Debugger.pause":
+      case "Debugger.resume":
+      case "Debugger.stepInto":
+      case "Debugger.stepOut":
+      case "Debugger.stepOver":
+      case "Debugger.setBreakpointsActive":
+      case "Debugger.removeBreakpoint":
+      case "Debugger.continueToLocation":
+      case "Debugger.getScriptSource":
+        this.#sendToBackend(method, params, id, method);
+        return;
+
+      case "Debugger.setPauseOnExceptions":
+        this.#sendToBackend(
+          "Debugger.setPauseOnExceptions",
+          { state: params.state === "caught" ? "all" : params.state },
+          id,
+          method,
+        );
+        return;
+
+      case "Debugger.setAsyncCallStackDepth":
+        this.#sendToBackend("Debugger.setAsyncStackTraceDepth", { depth: params.maxDepth ?? 0 }, id, method);
+        return;
+
+      case "Debugger.setBreakpointByUrl": {
+        const options: AnyObject = {};
+        if (params.condition) options.condition = params.condition;
+        const jscParams: AnyObject = {
+          lineNumber: params.lineNumber,
+          columnNumber: params.columnNumber,
+          options,
+        };
+        if (params.urlRegex) {
+          jscParams.urlRegex = params.urlRegex;
+        } else if (params.url) {
+          jscParams.urlRegex = breakpointUrlRegex(params.url);
+        } else {
+          this.#replyErrorToClient(id, -32602, "Either url or urlRegex must be specified.");
+          return;
+        }
+        this.#sendToBackend("Debugger.setBreakpointByUrl", jscParams, id, method);
+        return;
+      }
+
+      case "Debugger.setBreakpoint":
+        this.#sendToBackend(
+          "Debugger.setBreakpoint",
+          {
+            location: params.location,
+            options: params.condition ? { condition: params.condition } : undefined,
+          },
+          id,
+          method,
+        );
+        return;
+
+      case "Debugger.getPossibleBreakpoints": {
+        const start = params.start;
+        let end = params.end;
+        if (!end) {
+          const script = this.#scripts.get(start?.scriptId);
+          end = {
+            scriptId: start?.scriptId,
+            lineNumber: script ? script.endLine : (start?.lineNumber ?? 0) + 1,
+            columnNumber: script ? script.endColumn : 0,
+          };
+        }
+        this.#sendToBackend("Debugger.getBreakpointLocations", { start, end }, id, method);
+        return;
+      }
+
+      case "Debugger.evaluateOnCallFrame":
+        this.#sendToBackend(
+          "Debugger.evaluateOnCallFrame",
+          {
+            callFrameId: params.callFrameId,
+            expression: params.expression,
+            objectGroup: params.objectGroup,
+            includeCommandLineAPI: params.includeCommandLineAPI,
+            doNotPauseOnExceptionsAndMuteConsole: params.silent,
+            returnByValue: params.returnByValue,
+            generatePreview: params.generatePreview,
+          },
+          id,
+          method,
+        );
+        return;
+
+      case "HeapProfiler.collectGarbage":
+        this.#sendToBackend("Heap.gc", undefined, id, method);
+        return;
+
+      case "Console.enable":
+      case "Console.disable":
+      case "Console.clearMessages":
+      case "Inspector.enable":
+        this.#sendToBackend(method, undefined, id, method);
+        return;
+
+      // Accepted but inert: CDP features JSC's inspector does not implement and
+      // that do not affect core debugging.
+      case "Debugger.setSkipAllPauses":
+      case "Debugger.setBlackboxPatterns":
+      case "Debugger.setBlackboxExecutionContexts":
+      case "Debugger.setInstrumentationBreakpoint":
+      case "Debugger.removeInstrumentationBreakpoint":
+      case "Runtime.addBinding":
+      case "Runtime.removeBinding":
+      case "Runtime.setMaxCallStackSizeToCapture":
+      case "Runtime.discardConsoleEntries":
+      case "Runtime.setCustomObjectFormatterEnabled":
+      case "Runtime.setAsyncCallStackDepth":
+      case "Profiler.enable":
+      case "Profiler.disable":
+      case "HeapProfiler.enable":
+      case "HeapProfiler.disable":
+      case "Network.enable":
+      case "Network.disable":
+      case "Log.enable":
+      case "Log.disable":
+      case "Log.clear":
+      case "Page.enable":
+      case "Target.setAutoAttach":
+      case "Target.setDiscoverTargets":
+      case "Target.setRemoteLocations":
+      case "NodeWorker.enable":
+      case "NodeWorker.disable":
+      case "NodeRuntime.enable":
+      case "NodeRuntime.disable":
+      case "NodeRuntime.notifyWhenWaitingForDisconnect":
+        this.#replyToClient(id, {});
+        return;
+
+      default:
+        this.#replyErrorToClient(id, -32601, `'${method}' wasn't found`);
+    }
+  }
+
+  #translateResult(method: string, result: AnyObject): AnyObject {
+    switch (method) {
+      case "Debugger.enable":
+        return { debuggerId: "(bun)", ...result };
+
+      case "Runtime.evaluate":
+      case "Runtime.callFunctionOn":
+      case "Debugger.evaluateOnCallFrame": {
+        const out: AnyObject = { result: result.result ?? { type: "undefined" } };
+        if (result.wasThrown) {
+          out.exceptionDetails = {
+            exceptionId: this.#nextExceptionId++,
+            text: result.result?.description ?? "Uncaught",
+            lineNumber: 0,
+            columnNumber: 0,
+            exception: result.result,
+          };
+        }
+        return out;
+      }
+
+      case "Runtime.getProperties": {
+        const properties = (result.properties ?? []).map((property: AnyObject) => ({
+          configurable: false,
+          enumerable: false,
+          ...property,
+        }));
+        const out: AnyObject = { result: properties };
+        if (result.internalProperties) out.internalProperties = result.internalProperties;
+        return out;
+      }
+
+      case "Debugger.getPossibleBreakpoints":
+        return { locations: result.locations ?? [] };
+
+      default:
+        return result;
+    }
+  }
+
+  #translateBackendEvent(method: string, params: AnyObject): void {
+    switch (method) {
+      case "Debugger.scriptParsed": {
+        const url = params.sourceURL || params.url || "";
+        const cdpUrl = toCdpUrl(url);
+        this.#scripts.set(params.scriptId, {
+          cdpUrl,
+          endLine: params.endLine ?? 0,
+          endColumn: params.endColumn ?? 0,
+        });
+        this.#emitToClient("Debugger.scriptParsed", {
+          scriptId: params.scriptId,
+          url: cdpUrl,
+          startLine: params.startLine ?? 0,
+          startColumn: params.startColumn ?? 0,
+          endLine: params.endLine ?? 0,
+          endColumn: params.endColumn ?? 0,
+          executionContextId: EXECUTION_CONTEXT_ID,
+          hash: "",
+          isModule: !!params.module,
+          sourceMapURL: params.sourceMapURL,
+          embedderName: cdpUrl,
+          scriptLanguage: "JavaScript",
+        });
+        return;
+      }
+
+      case "Debugger.paused": {
+        const callFrames = (params.callFrames ?? []).map((frame: AnyObject) => ({
+          callFrameId: frame.callFrameId,
+          functionName: frame.functionName ?? "",
+          location: frame.location,
+          url: this.#scripts.get(frame.location?.scriptId)?.cdpUrl ?? "",
+          scopeChain: (frame.scopeChain ?? []).map((scope: AnyObject) => ({
+            type: SCOPE_TYPE_MAP[scope.type] ?? "closure",
+            object: scope.object,
+            name: scope.name,
+          })),
+          this: frame.this,
+          canBeRestarted: false,
+        }));
+        const cdpParams: AnyObject = { callFrames, reason: "other", data: params.data };
+        switch (params.reason) {
+          case "exception":
+            cdpParams.reason = "exception";
+            break;
+          case "assert":
+            cdpParams.reason = "assert";
+            break;
+          case "Breakpoint":
+            if (params.data?.breakpointId) cdpParams.hitBreakpoints = [params.data.breakpointId];
+            break;
+        }
+        if (params.asyncStackTrace) cdpParams.asyncStackTrace = this.#translateStackTrace(params.asyncStackTrace);
+        this.#emitToClient("Debugger.paused", cdpParams);
+        return;
+      }
+
+      case "Debugger.resumed":
+        this.#emitToClient("Debugger.resumed", {});
+        return;
+
+      case "Debugger.breakpointResolved":
+        this.#emitToClient("Debugger.breakpointResolved", {
+          breakpointId: params.breakpointId,
+          location: params.location,
+        });
+        return;
+
+      case "Debugger.globalObjectCleared":
+        this.#emitToClient("Runtime.executionContextsCleared", {});
+        return;
+
+      case "Console.messageAdded":
+        this.#translateConsoleMessage(params.message || {});
+        return;
+
+      default:
+        // JSC- and Bun-specific events have no CDP equivalent.
+        return;
+    }
+  }
+
+  #translateStackTrace(stackTrace: AnyObject | undefined): AnyObject | undefined {
+    if (!stackTrace) return undefined;
+    const translated: AnyObject = {
+      callFrames: (stackTrace.callFrames ?? []).map((frame: AnyObject) => ({
+        functionName: frame.functionName ?? "",
+        scriptId: frame.scriptId ?? "",
+        url: toCdpUrl(frame.url ?? ""),
+        lineNumber: frame.lineNumber ?? 0,
+        columnNumber: frame.columnNumber ?? 0,
+      })),
+    };
+    if (stackTrace.parentStackTrace) {
+      translated.parent = this.#translateStackTrace(stackTrace.parentStackTrace);
+    }
+    return translated;
+  }
+
+  #translateConsoleMessage(message: AnyObject): void {
+    const level = message.level ?? "log";
+    const args = message.parameters?.length ? message.parameters : [{ type: "string", value: message.text ?? "" }];
+
+    if (message.source !== "console-api" && level === "error") {
+      this.#emitToClient("Runtime.exceptionThrown", {
+        timestamp: message.timestamp ?? Date.now(),
+        exceptionDetails: {
+          exceptionId: this.#nextExceptionId++,
+          text: message.text ?? "Uncaught",
+          lineNumber: Math.max((message.line ?? 1) - 1, 0),
+          columnNumber: Math.max((message.column ?? 1) - 1, 0),
+          url: toCdpUrl(message.url ?? ""),
+          stackTrace: this.#translateStackTrace(message.stackTrace),
+        },
+      });
+      return;
+    }
+
+    const type =
+      message.type && CONSOLE_TYPE_MAP[message.type]
+        ? CONSOLE_TYPE_MAP[message.type]
+        : (CONSOLE_LEVEL_MAP[level] ?? "log");
+    this.#emitToClient("Runtime.consoleAPICalled", {
+      type,
+      args,
+      executionContextId: EXECUTION_CONTEXT_ID,
+      timestamp: message.timestamp ?? Date.now(),
+      stackTrace: this.#translateStackTrace(message.stackTrace),
+    });
+  }
+}
+
+export default {
+  InspectorCDPAdapter,
+  EXECUTION_CONTEXT_ID,
+};

--- a/src/js/node/inspector.ts
+++ b/src/js/node/inspector.ts
@@ -1,6 +1,6 @@
 // Hardcoded module "node:inspector" and "node:inspector/promises"
 // Profiler APIs are implemented; other inspector APIs are stubs.
-const { hideFromStack, throwNotImplemented } = require("internal/shared");
+const { hideFromStack } = require("internal/shared");
 const EventEmitter = require("node:events");
 const { pathToFileURL } = require("node:url");
 const { isAbsolute } = require("node:path");
@@ -14,22 +14,78 @@ const startPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunct
 const stopPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_stopPreciseCoverage", 0);
 const collectPreciseCoverage = $newCppFunction("JSInspectorProfiler.cpp", "jsFunction_collectPreciseCoverage", 0);
 
-function open() {
-  throwNotImplemented("node:inspector", 2445);
+// Native bindings for inspector.open(): they start Bun's debugger thread with a
+// WebSocket server that speaks the V8 Chrome DevTools Protocol (see
+// internal/debugger.ts and internal/inspector/cdp.ts).
+const openNodeInspector = $newCppFunction("BunDebugger.cpp", "jsFunction_openNodeInspector", 2);
+const waitForNodeInspectorConnection = $newCppFunction(
+  "BunDebugger.cpp",
+  "jsFunction_waitForNodeInspectorConnection",
+  0,
+);
+const postNodeInspectorControl = $newCppFunction("BunDebugger.cpp", "jsFunction_postNodeInspectorControl", 1);
+const markNodeInspectorClosed = $newCppFunction("BunDebugger.cpp", "jsFunction_markNodeInspectorClosed", 0);
+
+let activeInspectorUrl: string | undefined;
+
+function open(port?: number, host?: string, wait?: boolean) {
+  if (activeInspectorUrl !== undefined) {
+    throw new Error("Inspector is already activated. Close it with inspector.close() before activating it again.");
+  }
+  if (!Bun.isMainThread) {
+    throw new Error("inspector.open() is not supported in worker threads");
+  }
+
+  if (port !== undefined && port !== null) {
+    if (typeof port !== "number" || !Number.isInteger(port) || port < 0 || port > 65535) {
+      throw $ERR_OUT_OF_RANGE("port", ">= 0 and <= 65535", port);
+    }
+  }
+  const portNumber = port === undefined || port === null ? 9229 : port;
+  const hostname = typeof host === "string" && host.length > 0 ? host : "127.0.0.1";
+  // Bracket bare IPv6 hosts so they survive URL parsing.
+  const hostPart = hostname.includes(":") && !hostname.startsWith("[") ? `[${hostname}]` : hostname;
+  const requestedUrl = `ws://${hostPart}:${portNumber}/${globalThis.crypto.randomUUID()}`;
+
+  const resolvedUrl = openNodeInspector(requestedUrl, !!wait);
+  if (resolvedUrl === null) {
+    throw new Error("Inspector is already activated. Close it with inspector.close() before activating it again.");
+  }
+
+  activeInspectorUrl = resolvedUrl;
+  process.stderr.write(`Debugger listening on ${resolvedUrl}\nFor help, see: https://nodejs.org/en/docs/inspector\n`);
+
+  if (wait) {
+    waitForNodeInspectorConnection();
+  }
+
+  return {
+    __proto__: null,
+    [Symbol.dispose]() {
+      close();
+    },
+  };
 }
 
 function close() {
-  throwNotImplemented("node:inspector", 2445);
+  if (activeInspectorUrl === undefined) {
+    return;
+  }
+  postNodeInspectorControl(JSON.stringify({ type: "close" }));
+  markNodeInspectorClosed();
+  activeInspectorUrl = undefined;
 }
 
 function url() {
-  // Return undefined since that is allowed by the Node.js API
   // https://nodejs.org/api/inspector.html#inspectorurl
-  return undefined;
+  return activeInspectorUrl;
 }
 
 function waitForDebugger() {
-  throwNotImplemented("node:inspector", 2445);
+  if (activeInspectorUrl === undefined) {
+    throw new Error("Inspector was not activated");
+  }
+  waitForNodeInspectorConnection();
 }
 
 // Sessions with the Runtime domain enabled receive Runtime.consoleAPICalled
@@ -458,6 +514,27 @@ class Session extends EventEmitter {
         const scripts = collectCoverageScripts();
         if (scripts instanceof Error) return scripts;
         return { result: buildScriptCoverageList(scripts, false, false) };
+      }
+
+      // Configuration-only Debugger commands are forwarded to the inspector
+      // server started by inspector.open() (vitest --inspect-brk uses
+      // Debugger.enable + Debugger.setBreakpointByUrl to stop at the first
+      // test file). The forwarding is fire-and-forget: results such as
+      // breakpointId are not available in-process.
+      case "Debugger.enable":
+      case "Debugger.disable":
+      case "Debugger.setBreakpointByUrl":
+      case "Debugger.removeBreakpoint":
+      case "Debugger.setBreakpointsActive":
+      case "Debugger.setPauseOnExceptions":
+      case "Debugger.setSkipAllPauses":
+      case "Debugger.setAsyncCallStackDepth":
+      case "Debugger.setBlackboxPatterns": {
+        if (activeInspectorUrl === undefined) {
+          return new Error(`Inspector method "${method}" requires an active inspector (call inspector.open() first)`);
+        }
+        postNodeInspectorControl(JSON.stringify({ type: "command", method, params }));
+        return {};
       }
 
       default:

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -301,6 +301,16 @@ pub enum Mode {
     Connect,
 }
 
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub enum Protocol {
+    /// WebKit inspector protocol, spoken by debug.bun.sh and the VSCode extension.
+    Jsc,
+    /// V8 Chrome DevTools Protocol, spoken by clients of `node:inspector`'s
+    /// `inspector.open()` (Chrome DevTools, vscode-js-debug, ...). The
+    /// debugger-thread server translates CDP to the JSC protocol.
+    NodeInspector,
+}
+
 pub struct Debugger {
     // `'static` is genuine: set from `cli::cli_dupe` (process-lifetime CLI
     // arena) — see jsc_hooks.rs. Never freed.
@@ -315,6 +325,7 @@ pub struct Debugger {
     // wait_for_connection: bool = false,
     pub set_breakpoint_on_first_line: bool,
     pub mode: Mode,
+    pub protocol: Protocol,
 
     pub test_reporter_agent: TestReporterAgent,
     pub lifecycle_reporter_agent: LifecycleAgent,
@@ -337,6 +348,7 @@ impl Default for Debugger {
             wait_for_connection: Wait::Off,
             set_breakpoint_on_first_line: false,
             mode: Mode::Listen,
+            protocol: Protocol::Jsc,
             test_reporter_agent: TestReporterAgent::default(),
             lifecycle_reporter_agent: LifecycleAgent::default(),
             frontend_dev_server_agent: UnsafeCell::new(BunFrontendDevServerAgent::default()),
@@ -358,6 +370,7 @@ unsafe extern "C" {
         url: &mut BunString,
         from_env: c_int,
         is_connect: bool,
+        is_node_inspector: bool,
     );
 }
 
@@ -691,11 +704,12 @@ impl Debugger {
         // practice; `create()` always populates `debugger` before spawning).
         // SAFETY: `other_vm` live; short-lived shared borrow of `debugger`
         // ends before any other access to `*other_vm`.
-        let (ctx_id, is_connect, from_env, path_or_port) =
+        let (ctx_id, is_connect, is_node_inspector, from_env, path_or_port) =
             match unsafe { (*other_vm).debugger.as_deref() } {
                 Some(d) => (
                     d.script_execution_context_id,
                     d.mode == Mode::Connect,
+                    d.protocol == Protocol::NodeInspector,
                     d.from_environment_variable,
                     d.path_or_port,
                 ),
@@ -709,13 +723,13 @@ impl Debugger {
         if !from_env.is_empty() {
             let mut url = BunString::clone_utf8(from_env);
             let _scope = this.enter_event_loop_scope();
-            Bun__startJSDebuggerThread(global, ctx_id, &mut url, 1, is_connect);
+            Bun__startJSDebuggerThread(global, ctx_id, &mut url, 1, is_connect, false);
         }
 
         if let Some(path_or_port) = path_or_port {
             let mut url = BunString::clone_utf8(path_or_port);
             let _scope = this.enter_event_loop_scope();
-            Bun__startJSDebuggerThread(global, ctx_id, &mut url, 0, is_connect);
+            Bun__startJSDebuggerThread(global, ctx_id, &mut url, 0, is_connect, is_node_inspector);
         }
 
         this.global().handle_rejected_promises();
@@ -756,6 +770,87 @@ impl Debugger {
             this.event_loop_mut().tick_possibly_forever();
         }
     }
+}
+
+/// `inspector.open()` from `node:inspector` — start the debugger thread and
+/// its WebSocket server at runtime, speaking the V8 Chrome DevTools Protocol.
+/// Returns false when an inspector is already configured (CLI `--inspect`,
+/// `BUN_INSPECT`, or a previous `inspector.open()`), when called off the main
+/// thread, or when the debugger thread could not be started.
+// HOST_EXPORT(Debugger__startNodeInspectorServer, c)
+pub fn start_node_inspector_server(url: &mut BunString, wait_for_connection: bool) -> bool {
+    // Short-lived borrows only — `Debugger::create` re-enters JS and forms its
+    // own `&mut VirtualMachine` (see the aliasing note on
+    // `wait_for_debugger_if_necessary`).
+    let this: &VirtualMachine = VirtualMachine::get();
+    if !this.is_main_thread {
+        return false;
+    }
+    if this.debugger.is_some() || HAS_CREATED_DEBUGGER.load(Ordering::Relaxed) {
+        return false;
+    }
+
+    // The URL outlives the process: the debugger struct stores `'static` slices
+    // (CLI-arena lifetimes), so leak the runtime-provided URL the same way.
+    let url_bytes: &'static [u8] = Box::leak(url.to_utf8_bytes().into_boxed_slice());
+    this.as_mut().debugger = Some(Box::new(Debugger {
+        path_or_port: Some(url_bytes),
+        wait_for_connection: if wait_for_connection {
+            Wait::Forever
+        } else {
+            Wait::Off
+        },
+        protocol: Protocol::NodeInspector,
+        ..Default::default()
+    }));
+
+    // Frontends need positions that map back to the original source, so stop
+    // minifying and caching transpiled output for code loaded from now on,
+    // mirroring `configure_debugger` in jsc_hooks.rs.
+    crate::runtime_transpiler_cache::IS_DISABLED.store(true, Ordering::Relaxed);
+    {
+        let opts = &mut this.as_mut().transpiler.options;
+        opts.minify_identifiers = false;
+        opts.minify_syntax = false;
+        opts.minify_whitespace = false;
+        opts.debugger = true;
+    }
+
+    let global = this.global;
+    // SAFETY: `global` is set during `VirtualMachine::init` and outlives the VM.
+    if Debugger::create(VirtualMachine::get_mut_ptr(), unsafe { &*global }).is_err() {
+        this.as_mut().debugger = None;
+        return false;
+    }
+
+    if !wait_for_connection {
+        // The waiting path calls this from `wait_for_debugger_if_necessary`;
+        // without it the inspected global never gets its inspector controller.
+        let ctx_id = match this.debugger.as_deref() {
+            Some(d) => d.script_execution_context_id,
+            None => return false,
+        };
+        Bun__ensureDebugger(ctx_id, false);
+    }
+
+    true
+}
+
+/// `inspector.open(port, host, true)` / `inspector.waitForDebugger()` — block,
+/// ticking the event loop, until a frontend connects to the inspector.
+// HOST_EXPORT(Debugger__waitForNodeInspectorConnection, c)
+pub fn wait_for_node_inspector_connection() {
+    let this = VirtualMachine::get();
+    {
+        let Some(dbg) = this.debugger_mut() else {
+            return;
+        };
+        if dbg.wait_for_connection == Wait::Off {
+            return;
+        }
+        dbg.must_block_until_connected = true;
+    }
+    Debugger::wait_for_debugger_if_necessary(VirtualMachine::get_mut_ptr());
 }
 
 // HOST_EXPORT(Debugger__didConnect, c)

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -1,5 +1,6 @@
 #include "root.h"
 
+#include "BunDebugger.h"
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/InspectorFrontendChannel.h>
@@ -618,7 +619,160 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCreateConnection, (JSGlobalObject * globalObj
     return JSValue::encode(JSBunInspectorConnection::create(vm, JSBunInspectorConnection::createStructure(vm, globalObject, globalObject->objectPrototype()), connection));
 }
 
-extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObject, ScriptExecutionContextIdentifier scriptId, BunString* portOrPathString, int isAutomatic, bool isUrlServer)
+// State shared between the main thread (node:inspector's open()/close()) and
+// the debugger thread, which reports the listening WebSocket URL (or a startup
+// error) and registers a callback that shuts the server down again.
+struct NodeInspectorState {
+    WTF::Lock lock;
+    WTF::Condition condition;
+    WTF::String url;
+    WTF::String error;
+    bool serverStarted { false };
+    // Owned by the debugger thread's VM; only created and cleared there.
+    JSC::Strong<JSC::Unknown> controlCallback {};
+};
+
+static NodeInspectorState& nodeInspectorState()
+{
+    static NodeInspectorState instance;
+    return instance;
+}
+
+// Called by internal/debugger.ts on the debugger thread once the node:inspector
+// server is listening (url, controlCallback) or failed to start ("", undefined, error).
+JSC_DECLARE_HOST_FUNCTION(jsFunctionReportNodeInspectorServerStarted);
+JSC_DEFINE_HOST_FUNCTION(jsFunctionReportNodeInspectorServerStarted, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String url = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    JSValue controlCallbackValue = callFrame->argument(1);
+    String error = callFrame->argument(2).isUndefined() ? String() : callFrame->argument(2).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto& state = nodeInspectorState();
+    {
+        Locker<Lock> locker(state.lock);
+        state.url = url.isolatedCopy();
+        state.error = error.isolatedCopy();
+        if (controlCallbackValue.isCallable()) {
+            state.controlCallback = { vm, controlCallbackValue };
+        }
+        state.serverStarted = true;
+        state.condition.notifyAll();
+    }
+
+    return JSValue::encode(jsUndefined());
+}
+
+extern "C" bool Debugger__startNodeInspectorServer(BunString* url, bool waitForConnection);
+extern "C" void Debugger__waitForNodeInspectorConnection();
+
+// node:inspector's inspector.open(): starts the debugger thread (if possible),
+// waits for its WebSocket server to come up, and returns the resolved ws://
+// URL. Returns null when an inspector is already active; throws when the
+// server failed to start.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_openNodeInspector, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String requestedUrl = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    bool waitForConnection = callFrame->argument(1).toBoolean(globalObject);
+
+    BunString urlString = Bun::toString(requestedUrl);
+    if (!Debugger__startNodeInspectorServer(&urlString, waitForConnection)) {
+        return JSValue::encode(jsNull());
+    }
+
+    auto& state = nodeInspectorState();
+    String resolvedUrl;
+    String error;
+    {
+        Locker<Lock> locker(state.lock);
+        // The debugger thread reports back as soon as Bun.serve is listening;
+        // the timeout is only a safety net so a debugger-thread crash cannot
+        // hang the caller forever.
+        while (!state.serverStarted) {
+            if (!state.condition.waitFor(state.lock, Seconds(30)))
+                break;
+        }
+        resolvedUrl = state.url.isolatedCopy();
+        error = state.error.isolatedCopy();
+    }
+
+    if (!error.isEmpty()) {
+        throwException(globalObject, scope, createError(globalObject, makeString("Failed to start inspector: "_s, error)));
+        return {};
+    }
+    if (resolvedUrl.isEmpty()) {
+        throwException(globalObject, scope, createError(globalObject, "Failed to start inspector: the inspector server did not start"_s));
+        return {};
+    }
+
+    return JSValue::encode(jsString(vm, resolvedUrl));
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsFunction_waitForNodeInspectorConnection, (JSGlobalObject*, CallFrame*))
+{
+    Debugger__waitForNodeInspectorConnection();
+    return JSValue::encode(jsUndefined());
+}
+
+// Forwards a control message (close, breakpoint forwarded from the in-process
+// Session, ...) from the main thread to the node-inspector server running on
+// the debugger thread. Returns false when no server is active.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_postNodeInspectorControl, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String message = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    auto& state = nodeInspectorState();
+    {
+        Locker<Lock> locker(state.lock);
+        if (!state.serverStarted || state.url.isEmpty())
+            return JSValue::encode(jsBoolean(false));
+    }
+
+    if (!debuggerScriptExecutionContext)
+        return JSValue::encode(jsBoolean(false));
+
+    debuggerScriptExecutionContext->postTaskConcurrently([message = message.isolatedCopy()](ScriptExecutionContext& context) {
+        auto& state = nodeInspectorState();
+        JSC::JSValue controlCallback;
+        {
+            Locker<Lock> locker(state.lock);
+            controlCallback = state.controlCallback.get();
+        }
+        if (!controlCallback || !controlCallback.isCallable())
+            return;
+        auto* globalObject = context.jsGlobalObject();
+        MarkedArgumentBuffer arguments;
+        arguments.append(jsString(globalObject->vm(), message));
+        JSC::call(globalObject, controlCallback.getObject(), arguments, "jsFunction_postNodeInspectorControl - controlCallback"_s);
+    });
+
+    return JSValue::encode(jsBoolean(true));
+}
+
+// Marks the node:inspector server closed so url() reports undefined and
+// further control messages are dropped. The server itself is shut down by a
+// "close" control message sent before this.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_markNodeInspectorClosed, (JSGlobalObject*, CallFrame*))
+{
+    auto& state = nodeInspectorState();
+    Locker<Lock> locker(state.lock);
+    state.url = String();
+    return JSValue::encode(jsUndefined());
+}
+
+extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObject, ScriptExecutionContextIdentifier scriptId, BunString* portOrPathString, int isAutomatic, bool isUrlServer, bool isNodeInspector)
 {
     if (!debuggerScriptExecutionContext)
         debuggerScriptExecutionContext = debuggerGlobalObject->scriptExecutionContext();
@@ -642,6 +796,8 @@ extern "C" void Bun__startJSDebuggerThread(Zig::GlobalObject* debuggerGlobalObje
     arguments.append(JSFunction::create(vm, debuggerGlobalObject, 0, String("disconnect"_s), jsFunctionDisconnect, ImplementationVisibility::Public));
     arguments.append(jsBoolean(isAutomatic));
     arguments.append(jsBoolean(isUrlServer));
+    arguments.append(jsBoolean(isNodeInspector));
+    arguments.append(JSFunction::create(vm, debuggerGlobalObject, 3, String("reportNodeInspectorServerStarted"_s), jsFunctionReportNodeInspectorServerStarted, ImplementationVisibility::Public));
 
     JSC::call(debuggerGlobalObject, debuggerDefaultFn, arguments, "Bun__initJSDebuggerThread - debuggerDefaultFn"_s);
     scope.assertNoException();

--- a/src/jsc/bindings/BunDebugger.cpp
+++ b/src/jsc/bindings/BunDebugger.cpp
@@ -870,6 +870,7 @@ extern "C" void Bun__InspectorConnection__disconnectAllOnExit(Zig::GlobalObject*
     // Snapshot under the lock, release before calling into the inspector —
     // `willDestroyFrontendAndBackend` must not run with `inspectorConnectionsLock` held.
     Vector<BunInspectorConnection*, 8> toDisconnect;
+    bool hasEverConnected = false;
     {
         Locker<Lock> locker(inspectorConnectionsLock);
         if (!inspectorConnections)
@@ -881,6 +882,7 @@ extern "C" void Bun__InspectorConnection__disconnectAllOnExit(Zig::GlobalObject*
         if (it == inspectorConnections->end())
             return;
         for (auto* connection : it->value) {
+            hasEverConnected |= connection->hasEverConnected;
             if (connection->status == ConnectionStatus::Disconnected)
                 continue;
             connection->status = ConnectionStatus::Disconnected;
@@ -891,7 +893,11 @@ extern "C" void Bun__InspectorConnection__disconnectAllOnExit(Zig::GlobalObject*
         }
     }
 
-    if (toDisconnect.isEmpty())
+    // A controller that never had a frontend connect has no agents and is safe
+    // to destroy normally. One that did needs the leak workaround below even
+    // if every connection has already disconnected (e.g. inspector.close()
+    // before exit) — its destructor still trips the CheckedPtr ordering bug.
+    if (!hasEverConnected)
         return;
 
     for (auto* connection : toDisconnect)

--- a/src/jsc/bindings/BunDebugger.h
+++ b/src/jsc/bindings/BunDebugger.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/JSCJSValue.h>
+
+namespace Bun {
+
+// node:inspector's inspector.open() / close() / waitForDebugger(), backed by
+// the debugger-thread WebSocket server in src/js/internal/debugger.ts.
+JSC_DECLARE_HOST_FUNCTION(jsFunction_openNodeInspector);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_waitForNodeInspectorConnection);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_postNodeInspectorControl);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_markNodeInspectorClosed);
+
+} // namespace Bun

--- a/test/js/node/inspector/inspector-profiler.test.ts
+++ b/test/js/node/inspector/inspector-profiler.test.ts
@@ -564,16 +564,16 @@ describe("node:inspector", () => {
       expect(inspector.console.log).toBe(globalThis.console.log);
     });
 
-    test("open() throws not implemented", () => {
-      expect(() => inspector.open()).toThrow();
+    // open()/close()/waitForDebugger() behavior is covered in inspector.test.ts;
+    // opening a server is process-global state, so it is not exercised here.
+    test("open(), close() and waitForDebugger() are functions", () => {
+      expect(inspector.open).toBeInstanceOf(Function);
+      expect(inspector.close).toBeInstanceOf(Function);
+      expect(inspector.waitForDebugger).toBeInstanceOf(Function);
     });
 
-    test("close() throws not implemented", () => {
-      expect(() => inspector.close()).toThrow();
-    });
-
-    test("waitForDebugger() throws not implemented", () => {
-      expect(() => inspector.waitForDebugger()).toThrow();
+    test("waitForDebugger() throws when the inspector is not active", () => {
+      expect(() => inspector.waitForDebugger()).toThrow("Inspector was not activated");
     });
   });
 });

--- a/test/js/node/inspector/inspector.test.ts
+++ b/test/js/node/inspector/inspector.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import inspector from "node:inspector";
 
 test("inspector.url()", () => {
@@ -9,16 +10,125 @@ test("inspector.console", () => {
   expect(inspector.console).toBeObject();
 });
 
-test("inspector.open()", () => {
-  expect(() => inspector.open()).toThrow(/not yet implemented/);
+test("inspector.close() is a no-op when the inspector is not open", () => {
+  expect(() => inspector.close()).not.toThrow();
 });
 
-test("inspector.close()", () => {
-  expect(() => inspector.close()).toThrow(/not yet implemented/);
+test("inspector.waitForDebugger() throws when the inspector is not active", () => {
+  expect(() => inspector.waitForDebugger()).toThrow("Inspector was not activated");
 });
 
-test("inspector.waitForDebugger()", () => {
-  expect(() => inspector.waitForDebugger()).toThrow(/not yet implemented/);
+// inspector.open() starts a WebSocket server speaking the V8 Chrome DevTools
+// Protocol (translated to JSC's inspector protocol on the debugger thread).
+// The fixture opens the inspector, talks to its own server as a CDP client,
+// and prints one JSON summary line for the assertions below.
+const openInspectorFixture = `
+import inspector from "node:inspector";
+import assert from "node:assert";
+
+assert.strictEqual(inspector.url(), undefined);
+inspector.open(0, "127.0.0.1", false);
+const url = inspector.url();
+
+let alreadyActivatedError = null;
+try {
+  inspector.open(0, "127.0.0.1", false);
+} catch (error) {
+  alreadyActivatedError = error.message;
+}
+
+const httpBase = "http://" + new URL(url).host;
+const version = await (await fetch(httpBase + "/json/version")).json();
+const list = await (await fetch(httpBase + "/json/list")).json();
+
+const ws = new WebSocket(url);
+const pending = new Map();
+const events = [];
+let nextId = 1;
+let consoleEventResolve;
+const consoleEventPromise = new Promise(resolve => (consoleEventResolve = resolve));
+ws.onmessage = event => {
+  const message = JSON.parse(event.data);
+  if (message.id) {
+    pending.get(message.id)?.(message);
+    pending.delete(message.id);
+  } else {
+    events.push(message);
+    if (message.method === "Runtime.consoleAPICalled" && message.params.args?.[0]?.value === "tagged-console-call") {
+      consoleEventResolve(message.params);
+    }
+  }
+};
+const send = (method, params) =>
+  new Promise(resolve => {
+    const id = nextId++;
+    pending.set(id, resolve);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+await new Promise(resolve => (ws.onopen = resolve));
+
+await send("Runtime.enable", {});
+const debuggerEnable = await send("Debugger.enable", {});
+const evaluate = await send("Runtime.evaluate", { expression: "6 * 7" });
+console.log("tagged-console-call", { tagged: true });
+const consoleEvent = await consoleEventPromise;
+const unknown = await send("Totally.bogus", {});
+inspector.close();
+
+console.log(
+  JSON.stringify({
+    url,
+    alreadyActivatedError,
+    version,
+    list,
+    executionContextCreated: events.some(event => event.method === "Runtime.executionContextCreated"),
+    scriptParsedCount: events.filter(event => event.method === "Debugger.scriptParsed").length,
+    debuggerEnable: debuggerEnable.result,
+    evaluateValue: evaluate.result?.result?.value,
+    consoleEventType: consoleEvent.type,
+    unknownError: unknown.error,
+    urlAfterClose: inspector.url() ?? null,
+  }),
+);
+`;
+
+test("inspector.open() serves the DevTools protocol and /json discovery endpoints", async () => {
+  using dir = tempDir("inspector-open", {
+    "fixture.mjs": openInspectorFixture,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "fixture.mjs"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stderrIfFailed: exitCode === 0 ? "" : stderr, exitCode }).toEqual({ stderrIfFailed: "", exitCode: 0 });
+
+  // Node prints this exact line so debugger frontends can discover the server.
+  expect(stderr).toMatch(/Debugger listening on ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f-]{36}/);
+
+  const lastLine = stdout.trim().split("\n").at(-1)!;
+  const summary = JSON.parse(lastLine);
+
+  expect(summary.url).toStartWith("ws://127.0.0.1:");
+  expect(summary.alreadyActivatedError).toContain("already activated");
+  expect(summary.version).toEqual({ "Browser": expect.stringContaining("Bun/"), "Protocol-Version": "1.1" });
+  expect(summary.list).toEqual([
+    expect.objectContaining({
+      type: "node",
+      webSocketDebuggerUrl: summary.url,
+      devtoolsFrontendUrl: expect.stringContaining("devtools://"),
+    }),
+  ]);
+  expect(summary.executionContextCreated).toBe(true);
+  expect(summary.scriptParsedCount).toBeGreaterThan(0);
+  expect(summary.debuggerEnable).toEqual({ debuggerId: expect.any(String) });
+  expect(summary.evaluateValue).toBe(42);
+  expect(summary.consoleEventType).toBe("log");
+  expect(summary.unknownError).toEqual({ code: -32601, message: "'Totally.bogus' wasn't found" });
+  expect(summary.urlAfterClose).toBeNull();
 });
 
 test("Runtime.consoleAPICalled is emitted while the Runtime domain is enabled", () => {

--- a/test/js/node/test/parallel/test-inspector-has-inspector-false.js
+++ b/test/js/node/test/parallel/test-inspector-has-inspector-false.js
@@ -7,12 +7,17 @@ if (process.features.inspector) {
   common.skip('V8 inspector is enabled');
 }
 
-// Bun: `internal/util/inspector` is not exposed, so assert the public
-// no-inspector surface instead: feature detection reports no inspector and
-// inspector.open() is unavailable.
+// Bun: `internal/util/inspector` is not exposed, so assert the public surface
+// instead. Unlike a Node build without the V8 inspector, inspector.open()
+// works in Bun (it serves the DevTools protocol); only feature detection still
+// reports no inspector.
 const assert = require('assert');
 const inspector = require('inspector');
 
 assert.strictEqual(process.features.inspector, false);
 assert.strictEqual(inspector.url(), undefined);
-assert.throws(() => inspector.open(), { code: 'ERR_NOT_IMPLEMENTED' });
+
+inspector.open(0);
+assert.ok(inspector.url().startsWith('ws://'));
+inspector.close();
+assert.strictEqual(inspector.url(), undefined);

--- a/test/leaksan.supp
+++ b/test/leaksan.supp
@@ -121,3 +121,8 @@ leak:WebCore::jsSQLStatementOpenStatementFunction
 # is called before firing (WaiterListManager::clearTimer on notify/unregister),
 # the DispatchTimer and its Bun-side WTFTimer Box leak. JSC-owned ref-cycle.
 leak:WTF::RunLoop::dispatchAfter
+# test/js/node/inspector/inspector.test.ts — BunInspectorConnection objects are
+# deliberately never freed (cross-thread message queues may still reference
+# them); a node:inspector client that connects and disconnects before exit
+# leaves its connection behind.
+leak:Bun::BunInspectorConnection::create

--- a/test/no-validate-exceptions.txt
+++ b/test/no-validate-exceptions.txt
@@ -167,3 +167,8 @@ test/regression/issue/isArray-proxy-crash.test.ts
 
 # Third-party SDK with unchecked exception path in JSArray pushInline
 test/js/third_party/@azure/service-bus/azure-service-bus.test.ts
+
+# JSC's injected script (Inspector::JSInjectedScriptHost::evaluateWithScopeExtension,
+# reached via Runtime.evaluate on a DevTools protocol connection) is missing an
+# exception check upstream; the inspector.open() fixture exercises that path.
+test/js/node/inspector/inspector.test.ts


### PR DESCRIPTION
**Stacked on #32476** (which is stacked on #31823); only the last two commits are new. **Draft**: the attach/inspection surface works and is tested, but breakpoint pausing is blocked on a pre-existing runtime-attach bug in the JSC debugger described below — this should not merge until that is resolved.

### What this does

`inspector.open(port, host, wait)`, `inspector.url()`, `inspector.close()` and `inspector.waitForDebugger()` now work instead of throwing `ERR_NOT_IMPLEMENTED`:

- `open()` starts Bun's existing debugger thread at runtime (new `Debugger__startNodeInspectorServer` export in `Debugger.rs` + host functions in `BunDebugger.cpp`) and serves a WebSocket endpoint that speaks the **V8 Chrome DevTools Protocol**. A new translation layer (`src/js/internal/inspector/cdp.ts`) maps CDP commands/events onto the JSC inspector protocol spoken by the existing backend (`internal/debugger.ts` runs it on the debugger thread).
- `/json/list` and `/json/version` are served in Node's shape so chrome://inspect and vscode-js-debug can discover the target, and Node's exact `Debugger listening on ws://...` stderr line is printed.
- `open(port, host, true)` blocks until a client sends `Runtime.runIfWaitingForDebugger` (mapped to JSC's `Inspector.initialized`), matching Node.
- The in-process `inspector.Session` forwards configuration-only Debugger commands (`Debugger.enable`, `Debugger.setBreakpointByUrl`, ...) to the server, so vitest `--inspect-brk`'s setup code runs instead of throwing.
- Working over the socket today: `Runtime.enable`/`executionContextCreated`, `Runtime.evaluate`, `Runtime.consoleAPICalled` (from `Console.messageAdded`), `Runtime.exceptionThrown`, `Debugger.scriptParsed` (file:// URL mapping), `Debugger.getScriptSource`, `Debugger.getPossibleBreakpoints`, breakpoint registration/resolution, `Runtime.getProperties`, `Debugger.evaluateOnCallFrame`, plus stubs for the long tail of CDP methods clients send.
- node:inspector connections do not keep the event loop alive (Node exits with a debugger attached), unlike Bun's own `--inspect` connections.

### Known blocker (why this is a draft) — pre-existing bug, not introduced here

Breakpoints are registered but **not activated**, and `debugger;` statements do not pause. Activating them exposes a crash that exists in Bun today, with no involvement of this PR's code:

> Connect an inspector frontend to a running process (`bun --inspect`, plain JSC protocol), enable the Debugger domain **after the program has started executing** (`Debugger.enable`, `Debugger.setBreakpointsActive {active:true}`, `Debugger.setPauseOnDebuggerStatements {enabled:true}`), then let the program `import()` a module containing a `debugger;` statement. The module's top-level evaluation crashes: debug builds assert `isValidScopeOffset(offset)` in `JSLexicalEnvironment::variableAt` (or `isCell()` in `JSValue::asCell`; one variant produces an ASan SEGV on a scribbled value). A conservative stack capture places the failure in `llint_slow_path_put_to_scope` under `Interpreter::executeModuleProgram` — the scope operand register reads back empty. The same sequence works when the debugger is enabled before any user code runs (`--inspect-wait`). Deterministic; not GC-timing dependent (`BUN_JSC_useConcurrentGC=0` / `BUN_JSC_collectContinuously=1` reproduce it).

`inspector.open()` is by definition a runtime attach, so it cannot offer pausing until that is fixed (most likely in the JSC debugger attach/recompile path, i.e. a WebKit-side change). Until then the adapter deliberately does not send `Debugger.setBreakpointsActive`, keeping the Debugger domain inspection-only. This bug also means today's debug.bun.sh / VS Code "attach to running process" flows can crash the inspected process when it imports another module with breakpoints set.

### vitest status

- `vitest --run` and `vitest --run --coverage` (with #32476): work.
- `vitest --inspect-brk`: works end-to-end in the run-to-completion sense, verified on a release build of this branch: each test-file fork opens its own inspector, prints `Debugger listening on ws://...`, and waits; once a debugger client attaches to each worker and sends `Runtime.runIfWaitingForDebugger` (the normal DevTools / vscode-js-debug behavior), the workers resume and the whole run finishes — 2 test files, 6/6 tests passing, exit code 0. (An earlier draft of this description blamed a "resume hang" in the wait path; that turned out to be the verification harness only attaching to the first of vitest's per-file worker forks, not a product bug.) The remaining gap is the one above: breakpoints are registered but inert and `debugger;` does not pause, pending the pre-existing JSC runtime-attach bug, so vitest does not stop at the first test file yet.

### Tests

`test/js/node/inspector/inspector.test.ts`: a spawned fixture opens the inspector, talks to its own server as a CDP client, and asserts the listening line, `/json/version` + `/json/list` shapes, `executionContextCreated`, `scriptParsed`, `Runtime.evaluate`, console events, unknown-method errors, double-open rejection, and `close()`. Error-path tests for `waitForDebugger()`/`close()` without an active inspector. The previous "not yet implemented" tests were replaced by these. 54/54 inspector tests pass on the debug build; the new ones fail under `USE_SYSTEM_BUN=1`.

