### PR TITLE
fix(node:perf_hooks): report nodeTiming milestones as offsets from timeOrigin

### DIFF
--- a/src/js/node/perf_hooks.ts
+++ b/src/js/node/perf_hooks.ts
@@ -79,7 +79,8 @@ class PerformanceNodeTiming {
   }
 
   get startTime() {
-    return this.nodeStart;
+    // A "node" entry is the timeOrigin reference, so its startTime is always 0.
+    return 0;
   }
 
   get duration() {
@@ -107,11 +108,26 @@ if (PerformanceEntry) {
   Object.setPrototypeOf(PerformanceNodeTiming, PerformanceEntry);
 }
 
+// Node exposes the entry accessors as own enumerable properties of the
+// nodeTiming object, not only on the prototype. Null-prototype descriptors so
+// prototype pollution before this module loads cannot inject extra keys.
+const performanceNodeTimingEntryDescriptors = {
+  __proto__: null,
+  name: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
+  entryType: { __proto__: null, get: () => "node", configurable: true, enumerable: true },
+  startTime: { __proto__: null, get: () => 0, configurable: true, enumerable: true },
+  duration: { __proto__: null, get: () => performance.now(), configurable: true, enumerable: true },
+};
+
 function createPerformanceNodeTiming() {
   const object = Object.create(PerformanceNodeTiming.prototype);
+  Object.defineProperties(object, performanceNodeTimingEntryDescriptors);
 
-  object.bootstrapComplete = object.environment = object.nodeStart = object.v8Start = performance.timeOrigin;
-  object.loopStart = object.idleTime = 1;
+  // Milestones are offsets in milliseconds from performance.timeOrigin, not
+  // absolute epoch timestamps. Bun does not record the individual startup
+  // milestones, so report them relative to the process start (0).
+  object.nodeStart = object.v8Start = object.environment = object.bootstrapComplete = 0;
+  object.loopStart = object.idleTime = 0;
   object.loopExit = -1;
   return object;
 }

--- a/test/js/node/perf_hooks/perf_hooks.test.ts
+++ b/test/js/node/perf_hooks/perf_hooks.test.ts
@@ -11,6 +11,46 @@ test("stubs", () => {
   expect(perf.performance.eventLoopUtilization()).toBeObject();
 });
 
+// https://github.com/oven-sh/bun/issues/23041
+test("nodeTiming reports offsets from timeOrigin, not epoch timestamps", () => {
+  const nt = perf.performance.nodeTiming;
+
+  expect(nt.name).toBe("node");
+  expect(nt.entryType).toBe("node");
+  // A "node" entry is the timeOrigin reference, so startTime is 0 in Node.
+  expect(nt.startTime).toBe(0);
+  expect(nt.duration).toBeNumber();
+
+  // timeOrigin is epoch-scale; the milestones are offsets from it, so they must
+  // not themselves be epoch timestamps.
+  expect(perf.performance.timeOrigin).toBeGreaterThan(1e12);
+  for (const key of ["nodeStart", "v8Start", "environment", "bootstrapComplete", "loopStart", "idleTime"] as const) {
+    expect(nt[key]).toBeNumber();
+    expect(nt[key]).toBeLessThan(1e12);
+  }
+  expect(nt.loopExit).toBe(-1);
+
+  // Node exposes the entry accessors as own enumerable properties.
+  expect(Object.keys(nt)).toEqual(expect.arrayContaining(["name", "entryType", "startTime", "duration"]));
+
+  const json = nt.toJSON();
+  // duration is a live reading, so assert its type and drop it before comparing.
+  expect(json.duration).toBeNumber();
+  delete json.duration;
+  expect(json).toEqual({
+    name: "node",
+    entryType: "node",
+    startTime: 0,
+    nodeStart: nt.nodeStart,
+    v8Start: nt.v8Start,
+    bootstrapComplete: nt.bootstrapComplete,
+    environment: nt.environment,
+    loopStart: nt.loopStart,
+    loopExit: nt.loopExit,
+    idleTime: nt.idleTime,
+  });
+});
+
 test("doesn't throw", () => {
   expect(() => performance.mark("test")).not.toThrow();
   expect(() => performance.measure("test", "test")).not.toThrow();


### PR DESCRIPTION
### What does this PR do?

Fixes #23041. `performance.nodeTiming` reports absolute epoch timestamps instead of offsets from `performance.timeOrigin`:

```js
const nt = require("node:perf_hooks").performance.nodeTiming;
nt.nodeStart;   // before: 1.7715e12 (epoch ms)   node: 0.72
nt.startTime;   // before: 1.7715e12 (epoch ms)   node: 0
```

Node measures every startup milestone in milliseconds from `timeOrigin`, and a `"node"` entry *is* the timeOrigin reference, so its `startTime` is `0`.

- `createPerformanceNodeTiming()` set `bootstrapComplete`/`environment`/`nodeStart`/`v8Start` to `performance.timeOrigin`; they are now offsets (`0`), with `loopExit` staying `-1`. Bun does not record the individual startup milestones, so they are reported relative to process start.
- `startTime` returned `this.nodeStart` (an epoch value); it now returns `0`.
- `name`/`entryType`/`startTime`/`duration` are now own enumerable properties of the `nodeTiming` object, not only prototype accessors, so `Object.keys(performance.nodeTiming)` matches Node. They use null-prototype descriptors so prototype pollution before the module loads cannot inject extra descriptor keys (`value`/`writable`/`get`/`set`).

The `startTime`/`duration` getters throwing `The PerformanceEntry.startTime getter can only be used on instances of PerformanceEntry` — the other half of #23041 — is already fixed on main by the switch to `Object.setPrototypeOf`, which preserves the class-body accessors. This PR was rebased onto that and reduced to the remaining gap.

### How did you verify your code works?

Added a `nodeTiming` test in `test/js/node/perf_hooks/perf_hooks.test.ts` asserting `startTime === 0`, `name`/`entryType`, a numeric `duration`, that the entry accessors are own enumerable properties, and that every milestone is an offset (`< 1e12`) while `timeOrigin` is epoch-scale — plus the exact `toJSON()` shape. Values were checked against `node -e` on v22 and the documented Node behaviour (`startTime: 0`, small millisecond milestones).