### PR TITLE
fix(worker): don't keep the main thread alive for a global message listener

### DIFF
--- a/src/jsc/bindings/GlobalEventScope.cpp
+++ b/src/jsc/bindings/GlobalEventScope.cpp
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include "GlobalEventScope.h"
+#include "BunClientData.h"
 #include "MessagePort.h"
 #include "ScriptExecutionContext.h"
 #include "ZigGlobalObject.h"
@@ -14,6 +15,11 @@ void GlobalEventScope::onDidChangeListenerImpl(EventTarget& self, const AtomStri
 {
     if (eventType == eventNames().messageEvent) {
         auto& global = static_cast<GlobalEventScope&>(self);
+        auto* context = global.scriptExecutionContext();
+        // Only a worker has a parent that can post to its global scope; on the main thread this
+        // listener can never fire, so it must not hold the event loop open.
+        if (!context || !clientData(context->vm())->isWorkerVM())
+            return;
         switch (kind) {
         case Add:
             if (global.m_messageEventCount == 0) {

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -331,6 +331,60 @@ describe("web worker", () => {
     });
   });
 
+  // https://github.com/oven-sh/bun/issues/24256
+  // A global "message" listener keeps a Worker alive to receive messages from
+  // its parent, but on the main thread there is no parent, so it must not keep
+  // the process running.
+  test.each([
+    ["globalThis.onmessage = () => {};", "onmessage setter"],
+    [`globalThis.addEventListener("message", () => {});`, "addEventListener"],
+  ])("main thread exits with a global message listener (%s)", async (snippet, _label) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log("ready");\n${snippet}`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode, signalCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+      proc.exited.then(() => proc.signalCode),
+    ]);
+
+    expect({ stdout: stdout.trim(), exitCode, signalCode }).toEqual({
+      stdout: "ready",
+      exitCode: 0,
+      signalCode: null,
+    });
+    expect(stderr).not.toContain("error");
+  });
+
+  // The other half of the same rule: a worker does have a parent, so the
+  // listener is the only thing keeping it alive between messages. With nothing
+  // else on its loop it must still be there once the parent gets around to
+  // posting, rather than closing as soon as its script finishes.
+  test("worker stays alive for a global message listener", async () => {
+    const w = new Worker(
+      URL.createObjectURL(new Blob([`addEventListener("message", e => postMessage("pong:" + e.data)); postMessage("ready");`])),
+    );
+    const ready = Promise.withResolvers<void>();
+    const pong = Promise.withResolvers<string>();
+    const closed = Promise.withResolvers<string>();
+    w.onmessage = e => (e.data === "ready" ? ready.resolve() : pong.resolve(e.data));
+    w.addEventListener("close", () => closed.resolve("closed early"));
+
+    await ready.promise;
+    // An unref'd worker has an empty loop the moment its script returns, so it
+    // exits while the parent is off doing this read.
+    await Bun.file(import.meta.path).text();
+    w.postMessage("one");
+
+    expect(await Promise.race([pong.promise, closed.promise])).toBe("pong:one");
+    w.terminate();
+  });
+
   test("worker with process.exit", done => {
     const worker = new Worker(new URL("worker-fixture-process-exit.js", import.meta.url), {
       smol: true,


### PR DESCRIPTION
### What does this PR do?

Fixes #24256. Setting a global `message` listener on the main thread kept the process running forever instead of exiting:

```js
console.log("hello world");
globalThis.onmessage = () => {};
// Node: prints "hello world" and exits.
// Bun:  prints "hello world" and hangs indefinitely.
```

`WorkerGlobalScope::onDidChangeListenerImpl` refs the event loop whenever a `message` listener is added, so a Worker stays alive to receive messages from its parent. That is correct for worker threads, but on the main thread there is no parent message channel, so the ref is never balanced and the process never exits.

The fix skips the event-loop ref/unref when the global scope is on the main thread (`ScriptExecutionContext::isMainThread()`). Worker threads still get the keepalive, so they continue to receive messages. The same path backs `addEventListener("message", ...)`, so both spellings are covered.

### How did you verify your code works?

Added a parameterized test in `test/js/web/workers/worker.test.ts` that spawns a main-thread process setting a global `message` listener via both `globalThis.onmessage =` and `addEventListener("message", ...)`, and asserts it exits on its own (`exitCode === 0`, `signalCode === null`). The test times out (hangs) on the released `bun` and passes on the debug build.

Also confirmed a Worker that sets `globalThis.onmessage` still receives messages from its parent (existing worker suite passes: 25 pass / 1 todo).