### PR TITLE
fix(types): ArrayBuffer.prototype.resize returns void

### DIFF
--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -1060,7 +1060,7 @@ interface ArrayBuffer {
   /**
    * Resize an ArrayBuffer in-place.
    */
-  resize(byteLength: number): ArrayBuffer;
+  resize(byteLength: number): void;
 
   /**
    * Returns a section of an ArrayBuffer.

--- a/test/integration/bun-types/fixture/array-buffer.ts
+++ b/test/integration/bun-types/fixture/array-buffer.ts
@@ -7,6 +7,11 @@ const buffer = new ArrayBuffer(1024, {
 console.log(buffer.byteLength); // 1024
 buffer.resize(2048);
 console.log(buffer.byteLength); // 2048
+
+// resize() mutates the buffer in place and returns undefined (void) per the
+// ECMAScript spec, not the ArrayBuffer.
+const resizeResult: void = buffer.resize(1024);
+void resizeResult;
 TextDecoder;
 
 const buf = new SharedArrayBuffer(1024);


### PR DESCRIPTION
### What does this PR do?

`ArrayBuffer.prototype.resize()` resizes the buffer in place and returns `undefined` per the [ECMAScript spec](https://tc39.es/ecma262/#sec-arraybuffer.prototype.resize), but `bun-types` declared it as returning `ArrayBuffer`:

```ts
resize(byteLength: number): ArrayBuffer; // wrong
```

This both gives the wrong type at runtime (the return is `undefined`) and conflicts with TypeScript's own lib and `core-js-types`, which type the return as `void` (reported in #26868). Corrected to `void`.

Part of #26868. #39608 covers the whole issue and includes this change.

### How did you verify your code works?

Added an assertion in `test/integration/bun-types/fixture/array-buffer.ts` that the result of `resize()` is `void`. Verified with `tsc` against the packed `bun-types` declarations: the fixture type-checks with this change and fails on the previous declaration (`Type 'ArrayBuffer' is not assignable to type 'void'`).
