### PR TITLE
module_loader: generate bun:main wrapper on demand instead of caching it

### DIFF
--- a/src/bundler/entry_points.rs
+++ b/src/bundler/entry_points.rs
@@ -255,26 +255,28 @@ impl ClientEntryPoint {
 
 #[derive(Default)]
 pub struct ServerEntryPoint {
-    /// The generated wrapper source for `bun:main`. Always a valid slice
-    /// (either empty or owned by `bun.default_allocator`) so readers never
-    /// see `undefined` memory regardless of the `generated` flag's state.
-    pub contents: Box<[u8]>,
+    /// Set once `reload_entry_point` has run, i.e. the VM has a `main` path
+    /// that `bun:main` should wrap. The wrapper source itself is not stored;
+    /// it is regenerated on demand by [`generate_source`] each time `bun:main`
+    /// is fetched, so there is no cached buffer that can go stale between the
+    /// call to `generate()` and a later `import("bun:main")`.
     pub generated: bool,
 }
-
-// `deinit` only freed `contents` and reset flags; with `Box<[u8]>` this is the
-// auto-generated `Drop`, so no explicit impl is needed.
 
 impl ServerEntryPoint {
     pub fn generate(
         entry: &mut ServerEntryPoint,
-        is_hot_reload_enabled: bool,
-        path_to_use: &[u8],
+        _is_hot_reload_enabled: bool,
+        _path_to_use: &[u8],
     ) -> Result<(), bun_core::Error> {
-        // Use the global arena so this buffer's lifetime is decoupled
-        // from whichever arena the caller's VM happens to be using; the
-        // slice is read later from `getHardcodedModule` which outlives any
-        // per-transpile arena.
+        entry.generated = true;
+        Ok(())
+    }
+
+    /// Build the synthetic `bun:main` wrapper that imports `path_to_use` and
+    /// auto-starts `Bun.serve` on its default export. Pure function of its
+    /// arguments; called each time `bun:main` is fetched.
+    pub fn generate_source(is_hot_reload_enabled: bool, path_to_use: &[u8]) -> Vec<u8> {
         let code: Vec<u8> = 'brk: {
             if is_hot_reload_enabled {
                 let mut v: Vec<u8> = Vec::new();
@@ -313,7 +315,7 @@ impl ServerEntryPoint {
                      }}\n",
                     strings::format_escapes(path_to_use, strings::QuoteEscapeFormatFlags { quote_char: b'\'', ..Default::default() }),
                 )
-                .map_err(|_| bun_core::err!("FormatError"))?;
+                .expect("write! into Vec<u8> is infallible");
                 break 'brk v;
             }
             let mut v: Vec<u8> = Vec::new();
@@ -338,16 +340,10 @@ impl ServerEntryPoint {
                  }}\n",
                 strings::format_escapes(path_to_use, strings::QuoteEscapeFormatFlags { quote_char: b'"', ..Default::default() }),
             )
-            .map_err(|_| bun_core::err!("FormatError"))?;
+            .expect("write! into Vec<u8> is infallible");
             v
         };
-
-        // Free the previous buffer on regenerate (hot reload) instead of
-        // leaking it. `contents` is either "" or a previously generated buffer.
-        // (Handled implicitly: assigning to `Box<[u8]>` drops the old one.)
-        entry.contents = code.into_boxed_slice();
-        entry.generated = true;
-        Ok(())
+        code
     }
 }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3426,7 +3426,7 @@ fn js_synthetic_module(name: &'static [u8], specifier: &bun_core::String) -> Own
 /// before `ServerEntryPoint::generate` has run, or `bun:internal-for-testing`
 /// without the opt-in flag).
 fn get_hardcoded_module(
-    _jsc_vm: *mut VirtualMachine,
+    jsc_vm: *mut VirtualMachine,
     specifier: &bun_core::String,
     hardcoded: HardcodedModule,
 ) -> Option<OwnedResolvedSource> {
@@ -3437,21 +3437,29 @@ fn get_hardcoded_module(
 
     match hardcoded {
         HardcodedModule::BunMain => {
-            // Synthetic `bun:main` wrapper — pulls source from this thread's
-            // `RuntimeState.entry_point`.
+            // Synthetic `bun:main` wrapper. Regenerate the source on demand
+            // from `vm.main` rather than reading a stored buffer, so there is
+            // no cached slice that can dangle between `reload_entry_point`
+            // and a later `import("bun:main")` (Sentry BUN-36H7).
             let state = runtime_state();
             if state.is_null() {
                 return None;
             }
             // SAFETY: `state` is the live per-thread `RuntimeState` boxed in
             // `init_runtime_state`; no other `&mut` to `entry_point` is held.
-            let ep = unsafe { &(*state).entry_point };
-            if !ep.generated {
+            if !unsafe { &(*state).entry_point }.generated {
                 return None;
             }
+            // SAFETY: `jsc_vm` is the live per-thread VM (fn contract).
+            let vm = unsafe { &*jsc_vm };
+            let main = vm.main();
+            if main.is_empty() {
+                return None;
+            }
+            let code = ServerEntryPoint::generate_source(vm.is_watcher_enabled(), main);
             use bun_jsc::resolved_source::Tag;
             Some(OwnedResolvedSource::from(ResolvedSource {
-                source_code: bun_core::String::clone_utf8(&ep.contents),
+                source_code: bun_core::String::clone_utf8(&code),
                 // +1 each: ~SourceProvider() derefs `specifier` and
                 // `source_url` once all uses are done (see ZigSourceProvider.cpp).
                 specifier: specifier.dupe_ref(),

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -15,9 +15,7 @@ import { join } from "node:path";
 function stripAsanWarning(stderr: string): string[] {
   return stderr
     .split("\n")
-    .filter(
-      l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes") && !l.startsWith("debug warn:"),
-    );
+    .filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes") && !l.startsWith("debug warn:"));
 }
 
 test.concurrent("dynamic import('bun:main') returns the wrapper module", async () => {
@@ -130,11 +128,7 @@ test.concurrent(
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stderr, exitCode }).toEqual({ stderr: expect.not.stringContaining("error:"), exitCode: 0 });
       void stdout;
     }
@@ -145,11 +139,7 @@ test.concurrent(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr: stripAsanWarning(stderr), exitCode, signalCode: proc.signalCode }).toEqual({
       stdout: "OK\n",
       stderr: [],

--- a/test/js/bun/resolve/bun-main-entry-point.test.ts
+++ b/test/js/bun/resolve/bun-main-entry-point.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
 import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -13,7 +13,11 @@ import { join } from "node:path";
 // free-then-reallocate on each reload.
 
 function stripAsanWarning(stderr: string): string[] {
-  return stderr.split("\n").filter(l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes"));
+  return stderr
+    .split("\n")
+    .filter(
+      l => l.length > 0 && !l.startsWith("WARNING: ASAN interferes") && !l.startsWith("debug warn:"),
+    );
 }
 
 test.concurrent("dynamic import('bun:main') returns the wrapper module", async () => {
@@ -82,6 +86,79 @@ test.concurrent("import('bun:main') from a preload (before the module map is pop
     signalCode: null,
   });
 });
+
+// Sentry BUN-36H7 / https://github.com/oven-sh/bun/issues/27192:
+// import("bun:main") inside a compiled standalone executable faulted in
+// getHardcodedModule reading the stored `entry_point.contents` slice
+// (SEGV at a page-aligned high address, i.e. a freed mimalloc segment).
+// The wrapper source is now regenerated on demand from `vm.main` at fetch
+// time, so there is no stored buffer that can go stale between
+// `reload_entry_point` and the fetch. This exercises the exact crash
+// scenario: the bundled entry both (a) is reached via the initial
+// bun:main fetch at boot and (b) explicitly re-imports bun:main after the
+// top-level evaluation has completed.
+test.concurrent(
+  "import('bun:main') in a compiled standalone executable",
+  async () => {
+    using dir = tempDir("bun-main-compile", {
+      "package.json": "{}",
+      "entry.mjs": `
+        // bun:main statically imports this file, so awaiting it at the top
+        // level would be a TLA self-cycle. Defer to a task so bun:main
+        // finishes evaluating first, then re-import it from user code.
+        setImmediate(async () => {
+          try {
+            Bun.gc(true);
+            const m = await import("bun:main");
+            if (m[Symbol.toStringTag] !== "Module") throw new Error("expected module namespace");
+            const keys = Object.keys(m);
+            if (keys.length !== 0) throw new Error("expected empty wrapper namespace, got keys: " + keys.join(","));
+            console.log("OK");
+          } catch (e) {
+            console.error(String(e));
+            process.exit(1);
+          }
+        });
+      `,
+    });
+    const outfile = join(String(dir), isWindows ? "out.exe" : "out");
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build", "--compile", "./entry.mjs", "--outfile", outfile],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stderr, exitCode }).toEqual({ stderr: expect.not.stringContaining("error:"), exitCode: 0 });
+      void stdout;
+    }
+    await using proc = Bun.spawn({
+      cmd: [outfile],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout, stderr: stripAsanWarning(stderr), exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "OK\n",
+      stderr: [],
+      exitCode: 0,
+      signalCode: null,
+    });
+  },
+  isDebug ? 120_000 : 60_000,
+);
 
 test.concurrent(
   "ServerEntryPoint regenerates cleanly across --hot reloads",


### PR DESCRIPTION
## What

Sentry BUN-36H7: 269 events (100% Linux x86_64 baseline, 100% standalone executable) with this stack on 1.3.14:

```
Zig::GlobalObject::moduleLoaderFetch (ZigGlobalObject.cpp:3583)
Bun::fetchESMSourceCodeAsync (ModuleLoader.cpp:1206)
Bun__fetchBuiltinModule (ModuleLoader.zig:861)
getHardcodedModule (ModuleLoader.zig:1150)   <- reads entry_point.contents
String.cloneUTF8 (string.zig:204)
toBunStringComptime (encoding.zig:215)       <- SEGV reading the slice
```

Fault addresses are page-aligned high values (0x2C767000000, 0x5E4E3400000, ...), i.e. freed mimalloc segments. Same signature as #27192, which #29450 was supposed to close.

## Cause

`ServerEntryPoint` stored the generated `bun:main` wrapper source in a buffer (`contents`) that is written once in `reload_entry_point` and read back whenever `bun:main` is fetched. The fetch can happen an arbitrary time later (ShadowRealm, user `import("bun:main")`, module registry clear), and the fault shape says the stored slice had gone stale by then. I audited every writer of the struct and could not construct a deterministic reproduction; #29450 already eliminated the `undefined` default and moved the allocation to `bun.default_allocator`, so whatever is corrupting `contents` is not obvious from the invariants alone.

## Fix

Stop storing the wrapper. It is a pure function of `vm.main()` and `vm.is_watcher_enabled()`, both of which are plain VM fields that are valid at fetch time. `get_hardcoded_module(BunMain)` now regenerates the source on demand from those and `ServerEntryPoint` keeps only the `generated` flag. The generated source is byte-identical to before, so auto-serve / hot-reload behaviour is unchanged; there is just no longer a cached allocation that can dangle between `reload_entry_point` and a later fetch.

## Verification

- `bun bd test test/js/bun/resolve/bun-main-entry-point.test.ts` (4 pass, including the new compiled-standalone case that does `import("bun:main")` from inside the bundled entry)
- `bun bd test test/js/bun/http/bun-serve-html-entry.test.ts -t bun:main`
- `bun bd test test/regression/issue/440.test.ts test/regression/issue/26142.test.ts` (auto-serve wrapper behaviour unchanged)
- manual: `export default { port: 0, fetch: ... }` still prints `Started ... server: http://...`

The crash itself is not deterministically reproducible (same as noted in #29450), so the new standalone-executable test exercises the fetch path and wrapper shape rather than the fault directly; the fix removes the state that was being read at the fault site.
