### PR TITLE
threading: wake all parked workers on pool shutdown

### DIFF
--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1444,9 +1444,21 @@ impl Event {
         // Release barrier to ensure any operations before this are this to happen before the wait() in the other threads.
         let state = self.state.swap(release_with, Ordering::Release);
 
-        // Only wake threads sleeping in futex if the state is WAITING.
-        // Avoids unnecessary wake ups.
-        if state == Self::WAITING {
+        // Normally we only wake futex sleepers when the prior state was WAITING,
+        // which avoids a syscall when there is definitely nobody parked.
+        //
+        // That optimization is unsound for the one-shot "wake everyone" paths
+        // (`shutdown`, `wake_for_idle_events`, both `wake_threads == u32::MAX`).
+        // A worker can be genuinely parked in `Futex::wait(WAITING)` while
+        // `state` is transiently EMPTY or NOTIFIED: a concurrent consumer that
+        // took a notification without ever parking clears `state` back to EMPTY
+        // via the `acquire_with == EMPTY` path (see `wait`). For a normal
+        // single `notify()` that is fine, because a later `notify()` re-arms and
+        // wakes the sleeper. A teardown wake happens once, so a skipped wake
+        // here strands the parked worker until its 10s idle timeout, which shows
+        // up as a ~10s stall joining the pool. Always wake in that case; the
+        // extra syscall is negligible because these paths run once at teardown.
+        if state == Self::WAITING || wake_threads == u32::MAX {
             Futex::wake(&self.state, wake_threads);
         }
     }

--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -25,9 +25,11 @@ test("concurrent bun build does not stall on worker-pool shutdown", async () => 
 
   const CONCURRENCY = 24;
   const ROUNDS = 16;
-  // A healthy bundle here is a few hundred ms even under ASAN + contention; the
-  // regression stalls for a fixed ~10s, so this threshold cleanly separates them.
-  const STALL_MS = 5000;
+  // The regression is a fixed 10s idle-futex timeout, so a stalled build always
+  // exceeds 10s regardless of machine speed. A healthy build is well under a
+  // second; keep the threshold high so 24-way oversubscription on a slow ASAN
+  // shard can't trip it, while staying comfortably below the 10s floor.
+  const STALL_MS = 9000;
 
   const buildOnce = async (round: number, i: number) => {
     const entry = entries[i % entries.length];

--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -12,70 +12,64 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
-test(
-  "concurrent bun build does not stall on worker-pool shutdown",
-  async () => {
-    const N_MODULES = 40;
-    const files: Record<string, string> = {
-      "package.json": JSON.stringify({ name: "repro-32492", version: "0.0.0" }),
-    };
-    // A chain of modules so each entry bundles real work and warms the pool.
-    for (let i = 1; i <= N_MODULES; i++) {
-      const next = i + 1;
-      files[`src/m${i}.ts`] =
-        i < N_MODULES
-          ? `import { v${next} } from "./m${next}";\nexport const v${i} = ${i} + v${next};\nexport function f${i}() { return v${i} * 2; }\n`
-          : `export const v${i} = ${i};\nexport function f${i}() { return v${i} * 2; }\n`;
+test("concurrent bun build does not stall on worker-pool shutdown", async () => {
+  const N_MODULES = 40;
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({ name: "repro-32492", version: "0.0.0" }),
+  };
+  // A chain of modules so each entry bundles real work and warms the pool.
+  for (let i = 1; i <= N_MODULES; i++) {
+    const next = i + 1;
+    files[`src/m${i}.ts`] =
+      i < N_MODULES
+        ? `import { v${next} } from "./m${next}";\nexport const v${i} = ${i} + v${next};\nexport function f${i}() { return v${i} * 2; }\n`
+        : `export const v${i} = ${i};\nexport function f${i}() { return v${i} * 2; }\n`;
+  }
+  const entries = ["browser", "node", "bun", "worker", "schema", "graph", "media", "compress"];
+  for (const e of entries) {
+    files[`src/${e}-entry.ts`] = `import { v1, f1 } from "./m1";\nconsole.log("${e}", v1, f1());\n`;
+  }
+
+  using dir = tempDir("bun-build-pool-shutdown", files);
+  const root = String(dir);
+
+  const CONCURRENCY = 24;
+  const ROUNDS = 16;
+  // The stall, when it happens, is the fixed ~10s idle-futex timeout. A normal
+  // bundle here is a few hundred ms even under ASAN + heavy contention, so any
+  // build over this threshold is the regression.
+  const STALL_MS = 5000;
+
+  const buildOnce = async (round: number, i: number) => {
+    const entry = entries[i % entries.length];
+    const started = Date.now();
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "build",
+        "--target=browser",
+        "--sourcemap=external",
+        "--packages=external",
+        "--outdir",
+        `${root}/out/d${round}_${i}`,
+        `./src/${entry}-entry.ts`,
+      ],
+      env: bunEnv,
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { ms: Date.now() - started, exitCode, stdout, stderr };
+  };
+
+  for (let round = 0; round < ROUNDS; round++) {
+    const results = await Promise.all(Array.from({ length: CONCURRENCY }, (_, i) => buildOnce(round, i)));
+    const failed = results.find(r => r.exitCode !== 0);
+    if (failed) {
+      throw new Error(`bun build exited with ${failed.exitCode}\nstdout:\n${failed.stdout}\nstderr:\n${failed.stderr}`);
     }
-    const entries = ["browser", "node", "bun", "worker", "schema", "graph", "media", "compress"];
-    for (const e of entries) {
-      files[`src/${e}-entry.ts`] = `import { v1, f1 } from "./m1";\nconsole.log("${e}", v1, f1());\n`;
-    }
-
-    using dir = tempDir("bun-build-pool-shutdown", files);
-    const root = String(dir);
-
-    const CONCURRENCY = 24;
-    const ROUNDS = 16;
-    // The stall, when it happens, is the fixed ~10s idle-futex timeout. A normal
-    // bundle here is a few hundred ms even under ASAN + heavy contention, so any
-    // build over this threshold is the regression.
-    const STALL_MS = 5000;
-
-    const buildOnce = async (round: number, i: number) => {
-      const entry = entries[i % entries.length];
-      const started = Date.now();
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "build",
-          "--target=browser",
-          "--sourcemap=external",
-          "--packages=external",
-          "--outdir",
-          `${root}/out/d${round}_${i}`,
-          `./src/${entry}-entry.ts`,
-        ],
-        env: bunEnv,
-        cwd: root,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      return { ms: Date.now() - started, exitCode, stdout, stderr };
-    };
-
-    for (let round = 0; round < ROUNDS; round++) {
-      const results = await Promise.all(
-        Array.from({ length: CONCURRENCY }, (_, i) => buildOnce(round, i)),
-      );
-      const failed = results.find(r => r.exitCode !== 0);
-      if (failed) {
-        throw new Error(`bun build exited with ${failed.exitCode}\nstdout:\n${failed.stdout}\nstderr:\n${failed.stderr}`);
-      }
-      const slowestMs = Math.max(...results.map(r => r.ms));
-      expect(slowestMs).toBeLessThan(STALL_MS);
-    }
-  },
-  120_000,
-);
+    const slowestMs = Math.max(...results.map(r => r.ms));
+    expect(slowestMs).toBeLessThan(STALL_MS);
+  }
+}, 120_000);

--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -1,0 +1,81 @@
+// https://github.com/oven-sh/bun/issues/32492
+//
+// Running several `bun build` processes at once (as `concurrently` / `turbo` do)
+// made some of them take ~10,000ms instead of ~10ms. Each CLI `bun build` owns
+// its bundler worker pool and shuts it down when the build finishes. The pool's
+// shutdown woke idle workers only when the wake-event's prior state happened to
+// be WAITING, but a worker can be genuinely parked while that state is
+// transiently cleared by a concurrent consumer. When shutdown raced that window
+// the parked worker was never woken and slept until its 10s idle-futex timeout,
+// stalling the whole build by ~10s. The stall is non-deterministic and only
+// shows up under CPU contention, so this fires many builds concurrently.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+test(
+  "concurrent bun build does not stall on worker-pool shutdown",
+  async () => {
+    const N_MODULES = 40;
+    const files: Record<string, string> = {
+      "package.json": JSON.stringify({ name: "repro-32492", version: "0.0.0" }),
+    };
+    // A chain of modules so each entry bundles real work and warms the pool.
+    for (let i = 1; i <= N_MODULES; i++) {
+      const next = i + 1;
+      files[`src/m${i}.ts`] =
+        i < N_MODULES
+          ? `import { v${next} } from "./m${next}";\nexport const v${i} = ${i} + v${next};\nexport function f${i}() { return v${i} * 2; }\n`
+          : `export const v${i} = ${i};\nexport function f${i}() { return v${i} * 2; }\n`;
+    }
+    const entries = ["browser", "node", "bun", "worker", "schema", "graph", "media", "compress"];
+    for (const e of entries) {
+      files[`src/${e}-entry.ts`] = `import { v1, f1 } from "./m1";\nconsole.log("${e}", v1, f1());\n`;
+    }
+
+    using dir = tempDir("bun-build-pool-shutdown", files);
+    const root = String(dir);
+
+    const CONCURRENCY = 24;
+    const ROUNDS = 16;
+    // The stall, when it happens, is the fixed ~10s idle-futex timeout. A normal
+    // bundle here is a few hundred ms even under ASAN + heavy contention, so any
+    // build over this threshold is the regression.
+    const STALL_MS = 5000;
+
+    const buildOnce = async (round: number, i: number) => {
+      const entry = entries[i % entries.length];
+      const started = Date.now();
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "build",
+          "--target=browser",
+          "--sourcemap=external",
+          "--packages=external",
+          "--outdir",
+          `${root}/out/d${round}_${i}`,
+          `./src/${entry}-entry.ts`,
+        ],
+        env: bunEnv,
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { ms: Date.now() - started, exitCode, stdout, stderr };
+    };
+
+    for (let round = 0; round < ROUNDS; round++) {
+      const results = await Promise.all(
+        Array.from({ length: CONCURRENCY }, (_, i) => buildOnce(round, i)),
+      );
+      const failed = results.find(r => r.exitCode !== 0);
+      if (failed) {
+        throw new Error(`bun build exited with ${failed.exitCode}\nstdout:\n${failed.stdout}\nstderr:\n${failed.stderr}`);
+      }
+      const slowestMs = Math.max(...results.map(r => r.ms));
+      expect(slowestMs).toBeLessThan(STALL_MS);
+    }
+  },
+  120_000,
+);

--- a/test/regression/issue/32492.test.ts
+++ b/test/regression/issue/32492.test.ts
@@ -1,14 +1,4 @@
 // https://github.com/oven-sh/bun/issues/32492
-//
-// Running several `bun build` processes at once (as `concurrently` / `turbo` do)
-// made some of them take ~10,000ms instead of ~10ms. Each CLI `bun build` owns
-// its bundler worker pool and shuts it down when the build finishes. The pool's
-// shutdown woke idle workers only when the wake-event's prior state happened to
-// be WAITING, but a worker can be genuinely parked while that state is
-// transiently cleared by a concurrent consumer. When shutdown raced that window
-// the parked worker was never woken and slept until its 10s idle-futex timeout,
-// stalling the whole build by ~10s. The stall is non-deterministic and only
-// shows up under CPU contention, so this fires many builds concurrently.
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
@@ -35,9 +25,8 @@ test("concurrent bun build does not stall on worker-pool shutdown", async () => 
 
   const CONCURRENCY = 24;
   const ROUNDS = 16;
-  // The stall, when it happens, is the fixed ~10s idle-futex timeout. A normal
-  // bundle here is a few hundred ms even under ASAN + heavy contention, so any
-  // build over this threshold is the regression.
+  // A healthy bundle here is a few hundred ms even under ASAN + contention; the
+  // regression stalls for a fixed ~10s, so this threshold cleanly separates them.
   const STALL_MS = 5000;
 
   const buildOnce = async (round: number, i: number) => {


### PR DESCRIPTION
### What

Concurrent `bun build` invocations (as run by `concurrently` / `turbo`) non-deterministically took ~10,000ms instead of ~10ms. Reported in #32492, where individual sub-builds landed at exactly ~10,013ms while the same build in isolation took ~11ms.

### Reproduction

Fire many `bun build` processes at once over a small multi-module project. Roughly 5% of builds stall at ~10,013ms, which exactly matches the bundler thread pool's 10-second idle-worker futex timeout. In isolation a build never stalls; it needs CPU contention from other concurrent builds.

### Cause

The stall is at pool shutdown, not during the bundle. Each CLI `bun build` creates its own bundler worker pool and joins it on teardown (`ThreadPool::deinit` -> `Drop` -> `shutdown()` -> `join()`).

`shutdown()` wakes idle workers via `idle_event.shutdown()` -> `Event::wake(SHUTDOWN, u32::MAX)`. `wake()` issued the underlying `Futex::wake` only when the state it swapped out was exactly `WAITING`:

```rust
let state = self.state.swap(release_with, Ordering::Release);
if state == Self::WAITING {
    Futex::wake(&self.state, wake_threads);
}
```

But a worker can be parked in `Futex::wait(WAITING)` while the event state is transiently `EMPTY`/`NOTIFIED`: a concurrent consumer that takes a notification without ever parking resets the state to `EMPTY` via the `acquire_with == EMPTY` path in `wait()`. For a normal single `notify()` that is harmless because a later `notify()` re-arms the state and wakes the sleeper. Shutdown is one-shot, so a skipped wake there strands the parked worker until its 10s idle-futex timeout before it observes `SHUTDOWN` and exits.

The build does eventually complete (after 10s), so this is a performance bug rather than a deadlock, which is why the pool's liveness properties still hold.

### Fix

Always issue the futex wake on the one-shot "wake everyone" teardown paths (`shutdown` and `wake_for_idle_events`, both `wake_threads == u32::MAX`). The extra syscall is negligible because these run once at teardown.

### Verification

- Release repro: 0 stalls across 1,280 concurrent builds (was ~5%).
- Regression test `test/regression/issue/32492.test.ts` fires 24x16 concurrent `bun build` processes and asserts none take >= 5s.
  - Without the fix: fails, slowest build 10,798ms.
  - With the fix: passes.

Fixes #32492