### PR TITLE
Coerce process.env assignments to strings like Node.js

### DIFF
--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -1,5 +1,6 @@
 #include "root.h"
 #include "ZigGlobalObject.h"
+#include "JSEnvironmentVariableMap.h"
 
 #include "helpers.h"
 
@@ -344,6 +345,39 @@ JSC_DEFINE_HOST_FUNCTION(jsEditWindowsEnvVar, (JSGlobalObject * global, JSC::Cal
 }
 #endif
 
+const JSC::ClassInfo JSEnvironmentVariableMap::s_info = { "EnvironmentVariableMap"_s, &Base::s_info, nullptr, nullptr, CREATE_METHOD_TABLE(JSEnvironmentVariableMap) };
+
+bool JSEnvironmentVariableMap::put(JSC::JSCell* cell, JSC::JSGlobalObject* globalObject, JSC::PropertyName propertyName, JSC::JSValue value, JSC::PutPropertySlot& slot)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Node coerces keys to strings and throws on Symbol keys.
+    if (propertyName.isSymbol()) [[unlikely]] {
+        throwTypeError(globalObject, scope, "Cannot convert a symbol to a string"_s);
+        return false;
+    }
+
+    // Node's process.env stores only strings: `process.env.X = v` behaves like
+    // `process.env.X = String(v)`. Coercing here keeps reads from ever seeing a
+    // non-string. toString() throws for Symbol values, matching Node.
+    JSString* string = value.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    RELEASE_AND_RETURN(scope, Base::put(cell, globalObject, propertyName, string, slot));
+}
+
+bool JSEnvironmentVariableMap::putByIndex(JSC::JSCell* cell, JSC::JSGlobalObject* globalObject, unsigned propertyName, JSC::JSValue value, bool shouldThrow)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSString* string = value.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, false);
+
+    RELEASE_AND_RETURN(scope, Base::putByIndex(cell, globalObject, propertyName, string, shouldThrow));
+}
+
 JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 {
     VM& vm = globalObject->vm();
@@ -351,12 +385,8 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
 
     void* list;
     size_t count = Bun__getEnvCount(globalObject, &list);
-    JSC::JSObject* object = nullptr;
-    if (count < 63) {
-        object = constructEmptyObject(globalObject, globalObject->objectPrototype(), count);
-    } else {
-        object = constructEmptyObject(globalObject, globalObject->objectPrototype());
-    }
+    auto* structure = JSEnvironmentVariableMap::createStructure(vm, globalObject, globalObject->objectPrototype());
+    JSC::JSObject* object = JSEnvironmentVariableMap::create(vm, structure);
 
 #if OS(WINDOWS)
     JSArray* keyArray = constructEmptyArray(globalObject, nullptr, count);

--- a/src/jsc/bindings/JSEnvironmentVariableMap.h
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.h
@@ -1,4 +1,8 @@
+#pragma once
+
 #include "root.h"
+#include "headers-handwritten.h"
+#include "BunClientData.h"
 
 namespace Zig {
 class GlobalObject;
@@ -11,5 +15,56 @@ class JSValue;
 namespace Bun {
 
 JSC::JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject);
+
+// process.env backing object. Overrides the write paths so that assigning a
+// non-string coerces it to a string, matching Node.js: `process.env.X = 123`
+// stores `"123"`, `process.env.X = undefined` stores `"undefined"`. Reads stay
+// on the fast plain-object path (no getOwnPropertySlot override).
+class JSEnvironmentVariableMap final : public JSC::JSNonFinalObject {
+public:
+    using Base = JSC::JSNonFinalObject;
+    static constexpr unsigned StructureFlags = Base::StructureFlags | JSC::OverridesPut;
+
+    static JSEnvironmentVariableMap* create(JSC::VM& vm, JSC::Structure* structure)
+    {
+        JSEnvironmentVariableMap* ptr = new (NotNull, JSC::allocateCell<JSEnvironmentVariableMap>(vm)) JSEnvironmentVariableMap(vm, structure);
+        ptr->finishCreation(vm);
+        return ptr;
+    }
+
+    DECLARE_INFO;
+
+    template<typename, JSC::SubspaceAccess mode>
+    static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
+    {
+        if constexpr (mode == JSC::SubspaceAccess::Concurrently)
+            return nullptr;
+        return WebCore::subspaceForImpl<JSEnvironmentVariableMap, WebCore::UseCustomHeapCellType::No>(
+            vm,
+            [](auto& spaces) { return spaces.m_clientSubspaceForJSEnvironmentVariableMap.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_clientSubspaceForJSEnvironmentVariableMap = std::forward<decltype(space)>(space); },
+            [](auto& spaces) { return spaces.m_subspaceForJSEnvironmentVariableMap.get(); },
+            [](auto& spaces, auto&& space) { spaces.m_subspaceForJSEnvironmentVariableMap = std::forward<decltype(space)>(space); });
+    }
+
+    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+    {
+        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info());
+    }
+
+    static bool put(JSC::JSCell*, JSC::JSGlobalObject*, JSC::PropertyName, JSC::JSValue, JSC::PutPropertySlot&);
+    static bool putByIndex(JSC::JSCell*, JSC::JSGlobalObject*, unsigned propertyName, JSC::JSValue, bool shouldThrow);
+
+private:
+    JSEnvironmentVariableMap(JSC::VM& vm, JSC::Structure* structure)
+        : Base(vm, structure)
+    {
+    }
+
+    void finishCreation(JSC::VM& vm)
+    {
+        Base::finishCreation(vm);
+    }
+};
 
 }

--- a/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMClientIsoSubspaces.h
@@ -42,6 +42,7 @@ public:
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForNodeVMSyntheticModule;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSCommonJSModule;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSCommonJSExtensions;
+    std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSEnvironmentVariableMap;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSMockImplementation;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSModuleMock;
     std::unique_ptr<GCClient::IsoSubspace> m_clientSubspaceForJSMockFunction;

--- a/src/jsc/bindings/webcore/DOMIsoSubspaces.h
+++ b/src/jsc/bindings/webcore/DOMIsoSubspaces.h
@@ -42,6 +42,7 @@ public:
     std::unique_ptr<IsoSubspace> m_subspaceForNodeVMSyntheticModule;
     std::unique_ptr<IsoSubspace> m_subspaceForJSCommonJSModule;
     std::unique_ptr<IsoSubspace> m_subspaceForJSCommonJSExtensions;
+    std::unique_ptr<IsoSubspace> m_subspaceForJSEnvironmentVariableMap;
     std::unique_ptr<IsoSubspace> m_subspaceForJSMockImplementation;
     std::unique_ptr<IsoSubspace> m_subspaceForJSModuleMock;
     std::unique_ptr<IsoSubspace> m_subspaceForJSMockFunction;

--- a/test/cli/run/env.test.ts
+++ b/test/cli/run/env.test.ts
@@ -794,8 +794,7 @@ for (const shell of ["system", "bun"]) {
   });
 }
 
-const todoOnPosix = process.platform !== "win32" ? test.todo : test;
-todoOnPosix("setting process.env coerces the value to a string", () => {
+test("setting process.env coerces the value to a string", () => {
   // @ts-expect-error
   process.env.SET_TO_TRUE = true;
   let did_call = 0;

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -173,6 +173,79 @@ it("process.env is spreadable and editable", () => {
   expect(eval(`globalThis.process.env.USER = "${orig}"`)).toBe(String(orig));
 });
 
+it("process.env coerces assigned values to strings like Node.js (#32496)", () => {
+  // Node stores only strings in process.env. Assigning a non-string coerces it
+  // via ToString, so code like `if ("X" in env) env.X.length` never sees a
+  // non-string. Bun previously stored the raw value.
+  process.env.BUN_ENV_COERCE_32496 = undefined;
+  expect("BUN_ENV_COERCE_32496" in process.env).toBe(true);
+  expect(process.env.BUN_ENV_COERCE_32496).toBe("undefined");
+
+  process.env.BUN_ENV_COERCE_32496 = null;
+  expect(process.env.BUN_ENV_COERCE_32496).toBe("null");
+
+  process.env.BUN_ENV_COERCE_32496 = 123;
+  expect(process.env.BUN_ENV_COERCE_32496).toBe("123");
+
+  process.env.BUN_ENV_COERCE_32496 = true;
+  expect(process.env.BUN_ENV_COERCE_32496).toBe("true");
+
+  process.env.BUN_ENV_COERCE_32496 = { toString: () => "stringified" };
+  expect(process.env.BUN_ENV_COERCE_32496).toBe("stringified");
+  delete process.env.BUN_ENV_COERCE_32496;
+
+  // Integer-like keys go through the indexed write path.
+  process.env[32496] = 123;
+  expect(process.env[32496]).toBe("123");
+  expect(typeof process.env[32496]).toBe("string");
+  delete process.env[32496];
+
+  // Symbols cannot be coerced to a string; Node throws for both Symbol values
+  // and Symbol keys.
+  expect(() => {
+    process.env.BUN_ENV_SYMBOL_32496 = Symbol("nope");
+  }).toThrow(TypeError);
+  expect("BUN_ENV_SYMBOL_32496" in process.env).toBe(false);
+  expect(() => {
+    process.env[Symbol("nope")] = "value";
+  }).toThrow(TypeError);
+});
+
+it("process.env coerces writes to startup variables (chalk supports-color) (#32496)", async () => {
+  // FORCE_COLOR exists at startup, so it is installed as a cached accessor
+  // rather than a plain property. The write path must still coerce. This mirrors
+  // chalk/supports-color's envForceColor(), the exact code from the bug report.
+  const fixture = `
+    process.env.FORCE_COLOR = undefined;
+    const env = process.env;
+    let forceColor;
+    if ("FORCE_COLOR" in env) {
+      forceColor =
+        env.FORCE_COLOR === "true" ? 1 :
+        env.FORCE_COLOR === "false" ? 0 :
+        env.FORCE_COLOR.length === 0 ? 1 : Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+    }
+    console.log(JSON.stringify({
+      value: process.env.FORCE_COLOR,
+      type: typeof process.env.FORCE_COLOR,
+      present: "FORCE_COLOR" in process.env,
+      forceColor: String(forceColor),
+    }));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, FORCE_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: JSON.parse(stdout || "null"), stderr: stderr.includes("TypeError") }).toEqual({
+    stdout: { value: "undefined", type: "string", present: true, forceColor: "NaN" },
+    stderr: false,
+  });
+  expect(exitCode).toBe(0);
+});
+
 const MIN_ICU_VERSIONS_BY_PLATFORM_ARCH = {
   "darwin-x64": "70.1",
   "darwin-arm64": "72.1",


### PR DESCRIPTION
Fixes #32496

## Repro

```js
process.env.FORCE_COLOR = undefined;
const env = process.env;
// chalk / supports-color envForceColor():
if ("FORCE_COLOR" in env) {
  env.FORCE_COLOR.length; // <-- throws in Bun
}
```

```
TypeError: undefined is not an object (evaluating 'env.FORCE_COLOR.length')
      at envForceColor (.../chalk/source/vendor/supports-color/index.js:43:14)
```

Node stores `"undefined"` (a string), so the same code yields `NaN` and never throws. The crash shows up in CI (GitHub Actions, no TTY) because a test sets `process.env.FORCE_COLOR = undefined` and a later file imports chalk, which reads it back.

## Cause

`process.env` in Bun was a plain object. Writes stored the raw value:

```
bun -e 'process.env.X = undefined; console.log("X" in process.env, typeof process.env.X)'
# Bun before:  true undefined
# Node:         true string   (value is "undefined")
```

Node's `process.env` coerces every assigned value with `ToString`, so `= undefined` stores `"undefined"`, `= 123` stores `"123"`. Bun only coerced the special-cased accessors (TZ, proxy vars, NODE_TLS_REJECT_UNAUTHORIZED, BUN_CONFIG_VERBOSE_FETCH); ordinary keys, brand-new keys, and integer keys stored the raw value.

## Fix

Back `process.env` with a `JSEnvironmentVariableMap` (a `JSNonFinalObject` subclass) whose `put`/`putByIndex` coerce the value via `ToString` before delegating to the base, so the stored value is always a string. This covers all three write paths in one place: keys present at startup (cached accessors), brand-new keys, and integer keys. Reads stay on the fast plain-object path (no `getOwnPropertySlot` override). Symbol keys and Symbol values throw `TypeError`, matching Node and the existing Windows proxy.

```
bun -e 'process.env.X = undefined; console.log(typeof process.env.X, JSON.stringify(process.env.X))'
# now: string "undefined"
```

## Verification

New tests in `test/js/node/process/process.test.js`:
- value coercion for `undefined`/`null`/number/boolean/objects with `toString`, integer keys, and Symbol-key/Symbol-value throwing;
- a subprocess with `FORCE_COLOR=1` at startup that runs the exact supports-color pattern and no longer crashes.

Also un-todo'd the pre-existing `test/cli/run/env.test.ts` "setting process.env coerces the value to a string" test, which was `test.todo` on POSIX and now passes. Both fail on the unfixed build and pass with the fix.