### PR TITLE
node:v8: return false from startupSnapshot.isBuildingSnapshot()

### DIFF
--- a/src/js/node/v8.ts
+++ b/src/js/node/v8.ts
@@ -170,7 +170,9 @@ const promiseHooks = {
     addDeserializeCallback: () => notimpl("addDeserializeCallback"),
     addSerializeCallback: () => notimpl("addSerializeCallback"),
     setDeserializeMainFunction: () => notimpl("setDeserializeMainFunction"),
-    isBuildingSnapshot: () => notimpl("isBuildingSnapshot"),
+    // Bun never builds a V8 startup snapshot, so this is always false, matching
+    // Node's behavior during normal execution.
+    isBuildingSnapshot: () => false,
   };
 
 export default {

--- a/test/js/node/stubs.test.js
+++ b/test/js/node/stubs.test.js
@@ -115,9 +115,7 @@ describe("v8.getHeapStatistics", () => {
 });
 
 describe("v8.startupSnapshot", () => {
-  // Bun never builds a V8 startup snapshot, so isBuildingSnapshot() must return
-  // false instead of throwing. bson (via mongodb / @keyv/mongo) calls it at
-  // import time and expects a boolean. https://github.com/oven-sh/bun/issues/32501
+  // https://github.com/oven-sh/bun/issues/32501
   test("isBuildingSnapshot() returns false", () => {
     const { startupSnapshot } = require("node:v8");
     expect(startupSnapshot.isBuildingSnapshot()).toBe(false);

--- a/test/js/node/stubs.test.js
+++ b/test/js/node/stubs.test.js
@@ -113,3 +113,18 @@ describe("v8.getHeapStatistics", () => {
     });
   }
 });
+
+describe("v8.startupSnapshot", () => {
+  // Bun never builds a V8 startup snapshot, so isBuildingSnapshot() must return
+  // false instead of throwing. bson (via mongodb / @keyv/mongo) calls it at
+  // import time and expects a boolean. https://github.com/oven-sh/bun/issues/32501
+  test("isBuildingSnapshot() returns false", () => {
+    const { startupSnapshot } = require("node:v8");
+    expect(startupSnapshot.isBuildingSnapshot()).toBe(false);
+  });
+
+  test("isBuildingSnapshot() returns false via process.getBuiltinModule", () => {
+    const { startupSnapshot } = process.getBuiltinModule("v8");
+    expect(startupSnapshot.isBuildingSnapshot()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #32501

### Repro

```js
// what bson (via mongodb / @keyv/mongo) runs in a class static initializer at import time
const { startupSnapshot } = process.getBuiltinModule("v8");
startupSnapshot.isBuildingSnapshot();
```

```
NotImplementedError: node:v8 isBuildingSnapshot is not yet implemented in Bun.
 code: "ERR_NOT_IMPLEMENTED"
    at <anonymous> (.../node_modules/bson/lib/bson.cjs:2610:30)
```

A recent `bson` release started probing `startupSnapshot.isBuildingSnapshot()` at module load time. Bun's stub threw `ERR_NOT_IMPLEMENTED`, so the whole `bson` module failed to load, which took down `mongodb` and anything importing it. This is why the reporter saw it "start a few hours ago" without changing their own code.

### Cause

`src/js/node/v8.ts` stubbed `isBuildingSnapshot` to always throw:

```ts
isBuildingSnapshot: () => notimpl("isBuildingSnapshot"),
```

Node returns a boolean here: `false` during normal execution, `true` only while actually building a startup snapshot via `--build-snapshot`.

### Fix

Bun never builds a V8 startup snapshot, so `isBuildingSnapshot()` now returns `false`. The sibling methods (`addSerializeCallback`, `addDeserializeCallback`, `setDeserializeMainFunction`) are only reachable while a snapshot is being built, so they keep throwing.

### Verification

`test/js/node/stubs.test.js` gains a `v8.startupSnapshot` block. Without the fix both assertions throw `NotImplementedError`; with it they return `false`.

```
bun bd test test/js/node/stubs.test.js
377 pass, 0 fail
```