### PR TITLE
fs: accept integer-valued double for numeric open() flags

### DIFF
--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -1711,19 +1711,13 @@ impl FileSystemFlags {
 impl FileSystemFlags {
     pub fn from_js(ctx: &JSGlobalObject, val: JSValue) -> JsResult<Option<FileSystemFlags>> {
         if val.is_number() {
-            if !val.is_int32() {
-                return Err(ctx.throw_value(
-                    ctx.err(
-                        jsc::ErrorCode::OUT_OF_RANGE,
-                        format_args!(
-                            "The value of \"flags\" is out of range. It must be an integer. Received {}",
-                            val.as_number()
-                        ),
-                    )
-                    .to_js(),
-                ));
-            }
-            let number = val.coerce_to_i32(ctx)?;
+            // Match Node's stringToFlags, which runs validateInt32 on a numeric
+            // `flags`: accept any integer-valued number in the int32 range,
+            // regardless of whether JSC boxed it as an int32 or a double. Go's
+            // `syscall/js` bridge reads arguments out of wasm memory with
+            // getFloat64, so valid flags like 578 (O_RDWR|O_CREAT|O_TRUNC)
+            // arrive double-boxed and must not be rejected.
+            let number = validators::validate_int32(ctx, val, "flags", None, None)?;
             let flags = number.max(0);
             // On Windows, numeric flags from fs.constants (e.g. O_CREAT=0x100)
             // use the platform's native MSVC/libuv values which differ from the

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1617,7 +1617,7 @@ describe("open with a numeric flag boxed as a double", () => {
   it("still rejects a non-integer numeric flag", () => {
     using dir = tempDir("fs-flags-double-reject", {});
     const file = join(String(dir), "bad.txt");
-    expect.toThrowWithCode(() => openSync(file, asDouble(578.5), 0o666), "ERR_OUT_OF_RANGE");
+    expect(() => openSync(file, asDouble(578.5), 0o666)).toThrowWithCode(RangeError, "ERR_OUT_OF_RANGE");
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1561,6 +1561,66 @@ describe("readFile", () => {
   });
 });
 
+describe("open with a numeric flag boxed as a double", () => {
+  // https://github.com/oven-sh/bun/issues/32505
+  // Go's `syscall/js` (GOOS=js GOARCH=wasm) reads every argument out of wasm
+  // linear memory with DataView.getFloat64, so a valid integer flag such as
+  // 578 (O_RDWR|O_CREAT|O_TRUNC) reaches fs.open boxed as a double instead of
+  // an int32. Node accepts any integer-valued number; Bun must too.
+  const asDouble = (n: number) => new Float64Array([n])[0];
+
+  it("openSync accepts a double-boxed flag and honors it", () => {
+    using dir = tempDir("fs-flags-double", {});
+    const file = join(String(dir), "sync.txt");
+    const flags = asDouble(constants.O_RDWR | constants.O_CREAT | constants.O_TRUNC);
+    expect(Number.isInteger(flags)).toBe(true);
+
+    const fd = openSync(file, flags, 0o666);
+    try {
+      writeSync(fd, "hello\n");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(file, "utf8")).toBe("hello\n");
+  });
+
+  it("async open accepts a double-boxed flag and honors it", async () => {
+    using dir = tempDir("fs-flags-double-async", {});
+    const file = join(String(dir), "async.txt");
+    const flags = asDouble(constants.O_RDWR | constants.O_CREAT | constants.O_TRUNC);
+
+    const { promise, resolve, reject } = Promise.withResolvers<number>();
+    fs.open(file, flags, 0o666, (err, fd) => (err ? reject(err) : resolve(fd)));
+    const fd = await promise;
+    try {
+      writeSync(fd, "world\n");
+    } finally {
+      closeSync(fd);
+    }
+    expect(readFileSync(file, "utf8")).toBe("world\n");
+  });
+
+  it("promises.open accepts a double-boxed flag and honors it", async () => {
+    using dir = tempDir("fs-flags-double-promise", {});
+    const file = join(String(dir), "promise.txt");
+    const flags = asDouble(constants.O_RDWR | constants.O_CREAT | constants.O_TRUNC);
+
+    const handle = await promises.open(file, flags, 0o666);
+    try {
+      await handle.write("promise\n");
+    } finally {
+      await handle.close();
+    }
+    expect(readFileSync(file, "utf8")).toBe("promise\n");
+  });
+
+  it("still rejects a non-integer numeric flag", () => {
+    using dir = tempDir("fs-flags-double-reject", {});
+    const file = join(String(dir), "bad.txt");
+    expect.toThrowWithCode(() => openSync(file, asDouble(578.5), 0o666), "ERR_OUT_OF_RANGE");
+  });
+});
+
 describe("writeFileSync", () => {
   it("works", () => {
     const path = `${tmpdirSync()}/writeFileSync.txt`;


### PR DESCRIPTION
## Summary

`fs.open` / `openSync` reject a numeric `flags` argument whenever JSC has the number boxed as a **double** rather than an int32, even though the value is a perfectly valid integer:

```
The value of "flags" is out of range. It must be an integer. Received 578
```

`578` is `O_RDWR|O_CREAT|O_TRUNC`. Written as a literal it is int32-boxed and works; the same value read back through `DataView.getFloat64` / `Float64Array` is double-boxed and was rejected.

This breaks Go programs compiled with `GOOS=js GOARCH=wasm` (#32505): Go's `syscall/js` bridge reads every argument out of wasm linear memory with `getFloat64`, so `fs.open` receives a double-boxed integer flag and fails. Node and Deno accept the same module.

```js
const fs = require("fs");
// 578 = O_RDWR|O_CREAT|O_TRUNC, double-boxed the way syscall/js delivers it
const flags = new Float64Array([578])[0];
fs.openSync("/tmp/out.txt", flags, 0o666); // throws ERR_OUT_OF_RANGE on bun, OK on node
```

## Cause

`FileSystemFlags::from_js` (`src/runtime/node/types.rs`) gated on the JSC **tag** (`is_int32()`) rather than the numeric value. Node's `stringToFlags` runs `validateInt32` on a numeric flag, which uses `NumberIsInteger` (value-based) plus the int32 range, not an engine tag.

## Fix

Use the existing `validators::validate_int32` helper (the port of Node's `validateInt32`) in `FileSystemFlags::from_js`. Any integer-valued number in the int32 range is accepted regardless of whether JSC boxed it as an int32 or a double; non-integers and out-of-range values still throw `ERR_OUT_OF_RANGE`. This covers `open`, `openSync`, `readFile` and `writeFile`, which all parse flags through this function.

## Verification

New tests in `test/js/node/fs/fs.test.ts` open a file with a double-boxed `O_RDWR|O_CREAT|O_TRUNC` flag via `openSync`, async `fs.open`, and `fs.promises.open`, then round-trip the contents; a non-integer numeric flag still throws `ERR_OUT_OF_RANGE`.

```
(pass) open with a numeric flag boxed as a double > openSync accepts a double-boxed flag and honors it
(pass) open with a numeric flag boxed as a double > async open accepts a double-boxed flag and honors it
(pass) open with a numeric flag boxed as a double > promises.open accepts a double-boxed flag and honors it
(pass) open with a numeric flag boxed as a double > still rejects a non-integer numeric flag
```

Fails before the change (`The value of "flags" is out of range. It must be an integer. Received 578`), passes after.

Closes #32505

The unmodified Go repro from the issue (`os.Create` -> `fs.open(path, 578, 438, cb)`) now succeeds end to end with this change, matching Node/Deno:

```
$ bun run run.cjs
OK: wrote file via os.Create
$ cat /tmp/bun-wasm-repro-out.txt
hello
```

This also addresses the issue's "secondary finding": the reported `syscall.mapJSError` panic and `worker_threads` hang only showed up under the author's workarounds (coercing `flags` to a string, or routing through `openSync`), which change the call. With the real async `fs.open` path accepting the double-boxed flag, Go's `syscall/js` callback handling works normally, so there is no separate marshaling bug here.
