### PR TITLE
Open the browser via cmd.exe on Windows

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -211,6 +211,8 @@ export const isolatedModuleCacheSourceType: (specifier: string) => string | null
 );
 export const Dequeue = require("internal/fifo");
 
+export const getBrowserOpenCommand = require("internal/openInBrowser").getBrowserOpenCommand;
+
 // Userland access to node-internal modules for vendored node tests that
 // declare `// Flags: --expose-internals` (served via the require interceptor
 // in test/js/node/test/common/index.js). Static requires only — the builtin

--- a/src/js/internal/html.ts
+++ b/src/js/internal/html.ts
@@ -6,6 +6,7 @@ const argv = process.argv;
 
 // `import` cannot be used in this file and only Bun builtin modules can be used.
 const path = require("node:path");
+const { getBrowserOpenCommand } = require("internal/openInBrowser");
 
 const env = Bun.env;
 
@@ -378,19 +379,7 @@ yourself with Bun.serve().
 
         case "o\n":
           const url = server.url.toString();
-
-          if (process.platform === "darwin") {
-            // TODO: copy the AppleScript from create-react-app or Vite.
-            Bun.spawn(["open", url]).exited.catch(() => {});
-          } else if (process.platform === "win32") {
-            Bun.spawn(["start", url]).exited.catch(() => {});
-          } else if (process.platform === "android") {
-            Bun.spawn(["/system/bin/am", "start", "-a", "android.intent.action.VIEW", "-d", url]).exited.catch(
-              () => {},
-            );
-          } else {
-            Bun.spawn(["xdg-open", url]).exited.catch(() => {});
-          }
+          Bun.spawn(getBrowserOpenCommand(process.platform, url)).exited.catch(() => {});
           break;
 
         case "h\n":

--- a/src/js/internal/openInBrowser.ts
+++ b/src/js/internal/openInBrowser.ts
@@ -1,0 +1,21 @@
+// Returns the argv used to open `url` in the system's default browser on the
+// given platform. Kept platform-parameterized (rather than reading
+// `process.platform` directly) so the mapping is unit-testable on any host via
+// "bun:internal-for-testing".
+//
+// On Windows, `start` is a cmd.exe builtin, not an executable on PATH, so
+// spawning it directly fails with ENOENT. It must be run through cmd.exe. The
+// empty "" is `start`'s title argument: without it, `start` would treat the URL
+// as the window title instead of the thing to open.
+export function getBrowserOpenCommand(platform: string, url: string): string[] {
+  switch (platform) {
+    case "darwin":
+      return ["open", url];
+    case "win32":
+      return ["cmd.exe", "/c", "start", "", url];
+    case "android":
+      return ["/system/bin/am", "start", "-a", "android.intent.action.VIEW", "-d", url];
+    default:
+      return ["xdg-open", url];
+  }
+}

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -251,8 +251,13 @@ pub mod open {
     /// argument; without it `start` treats the URL as the title.
     pub(crate) fn open_url(url: &[u8]) {
         #[cfg(windows)]
-        let status =
-            bun_core::spawn_sync_inherit(&[&b"cmd.exe"[..], &b"/c"[..], &b"start"[..], &b""[..], url]);
+        let status = bun_core::spawn_sync_inherit(&[
+            &b"cmd.exe"[..],
+            &b"/c"[..],
+            &b"start"[..],
+            &b""[..],
+            url,
+        ]);
         #[cfg(not(windows))]
         let status = bun_core::spawn_sync_inherit(&[OPENER, url]);
 

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -242,11 +242,21 @@ pub mod open {
         Output::flush();
     }
 
-    /// Spawn `OPENER url` with inherited stdio and fall back to printing the
-    /// URL when the spawn fails or the opener exits non-zero (e.g. headless/CI
-    /// environments).
+    /// Open `url` with the system default handler (inherited stdio), falling
+    /// back to printing the URL when the spawn fails or the opener exits
+    /// non-zero (e.g. headless/CI environments).
+    ///
+    /// On Windows `start` is a cmd.exe builtin, not an executable on PATH, so it
+    /// must be invoked through cmd.exe. The empty "" is start's window-title
+    /// argument; without it `start` treats the URL as the title.
     pub(crate) fn open_url(url: &[u8]) {
-        match bun_core::spawn_sync_inherit(&[OPENER, url]) {
+        #[cfg(windows)]
+        let status =
+            bun_core::spawn_sync_inherit(&[&b"cmd.exe"[..], &b"/c"[..], &b"start"[..], &b""[..], url]);
+        #[cfg(not(windows))]
+        let status = bun_core::spawn_sync_inherit(&[OPENER, url]);
+
+        match status {
             Ok(status) if status.is_ok() => {}
             _ => fallback(url),
         }

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,6 +1,5 @@
 import type { Subprocess } from "bun";
-import { getBrowserOpenCommand } from "bun:internal-for-testing";
-import { describe, expect, test } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 async function getServerUrl(process: Subprocess) {
@@ -673,37 +672,4 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
 
   proc.kill();
   await proc.exited;
-});
-
-// The dev server "o" shortcut opens the served URL in the system browser.
-// On Windows `start` is a cmd.exe builtin, not an executable on PATH, so
-// spawning it directly throws `Executable not found in $PATH: "start"`.
-// See https://github.com/oven-sh/bun/issues/26231
-describe("getBrowserOpenCommand", () => {
-  const url = "http://localhost:3000/";
-
-  test("Windows invokes `start` through cmd.exe", () => {
-    // The empty "" is start's window-title argument; without it `start` would
-    // treat the URL as the title instead of opening it.
-    expect(getBrowserOpenCommand("win32", url)).toEqual(["cmd.exe", "/c", "start", "", url]);
-  });
-
-  test("macOS uses `open`", () => {
-    expect(getBrowserOpenCommand("darwin", url)).toEqual(["open", url]);
-  });
-
-  test("Android uses the activity manager", () => {
-    expect(getBrowserOpenCommand("android", url)).toEqual([
-      "/system/bin/am",
-      "start",
-      "-a",
-      "android.intent.action.VIEW",
-      "-d",
-      url,
-    ]);
-  });
-
-  test("other platforms use `xdg-open`", () => {
-    expect(getBrowserOpenCommand("linux", url)).toEqual(["xdg-open", url]);
-  });
 });

--- a/test/js/bun/http/bun-serve-html-entry.test.ts
+++ b/test/js/bun/http/bun-serve-html-entry.test.ts
@@ -1,5 +1,6 @@
 import type { Subprocess } from "bun";
-import { expect, test } from "bun:test";
+import { getBrowserOpenCommand } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDirWithFiles } from "harness";
 
 async function getServerUrl(process: Subprocess) {
@@ -672,4 +673,37 @@ test("importing bun:main from HTML entry preload does not crash", async () => {
 
   proc.kill();
   await proc.exited;
+});
+
+// The dev server "o" shortcut opens the served URL in the system browser.
+// On Windows `start` is a cmd.exe builtin, not an executable on PATH, so
+// spawning it directly throws `Executable not found in $PATH: "start"`.
+// See https://github.com/oven-sh/bun/issues/26231
+describe("getBrowserOpenCommand", () => {
+  const url = "http://localhost:3000/";
+
+  test("Windows invokes `start` through cmd.exe", () => {
+    // The empty "" is start's window-title argument; without it `start` would
+    // treat the URL as the title instead of opening it.
+    expect(getBrowserOpenCommand("win32", url)).toEqual(["cmd.exe", "/c", "start", "", url]);
+  });
+
+  test("macOS uses `open`", () => {
+    expect(getBrowserOpenCommand("darwin", url)).toEqual(["open", url]);
+  });
+
+  test("Android uses the activity manager", () => {
+    expect(getBrowserOpenCommand("android", url)).toEqual([
+      "/system/bin/am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      url,
+    ]);
+  });
+
+  test("other platforms use `xdg-open`", () => {
+    expect(getBrowserOpenCommand("linux", url)).toEqual(["xdg-open", url]);
+  });
 });

--- a/test/js/bun/http/bun-serve-html-open-browser.test.ts
+++ b/test/js/bun/http/bun-serve-html-open-browser.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+// The HTML dev server "o" shortcut (`bun index.html`, then press `o`) opens the
+// served URL in the system browser. On Windows `start` is a cmd.exe builtin, not
+// an executable on PATH, so spawning it directly throws
+// `Executable not found in $PATH: "start"`.
+// https://github.com/oven-sh/bun/issues/26231
+const { getBrowserOpenCommand } = require("bun:internal-for-testing");
+
+describe("getBrowserOpenCommand", () => {
+  const url = "http://localhost:3000/";
+
+  test("Windows invokes `start` through cmd.exe", () => {
+    // The empty "" is start's window-title argument; without it `start` would
+    // treat the URL as the title instead of opening it.
+    expect(getBrowserOpenCommand("win32", url)).toEqual(["cmd.exe", "/c", "start", "", url]);
+  });
+
+  test("macOS uses `open`", () => {
+    expect(getBrowserOpenCommand("darwin", url)).toEqual(["open", url]);
+  });
+
+  test("Android uses the activity manager", () => {
+    expect(getBrowserOpenCommand("android", url)).toEqual([
+      "/system/bin/am",
+      "start",
+      "-a",
+      "android.intent.action.VIEW",
+      "-d",
+      url,
+    ]);
+  });
+
+  test("other platforms use `xdg-open`", () => {
+    expect(getBrowserOpenCommand("linux", url)).toEqual(["xdg-open", url]);
+  });
+});

--- a/test/js/bun/http/bun-serve-html-open-browser.test.ts
+++ b/test/js/bun/http/bun-serve-html-open-browser.test.ts
@@ -1,3 +1,4 @@
+import * as internalForTesting from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 
 // The HTML dev server "o" shortcut (`bun index.html`, then press `o`) opens the
@@ -5,7 +6,10 @@ import { describe, expect, test } from "bun:test";
 // an executable on PATH, so spawning it directly throws
 // `Executable not found in $PATH: "start"`.
 // https://github.com/oven-sh/bun/issues/26231
-const { getBrowserOpenCommand } = require("bun:internal-for-testing");
+//
+// Read off the namespace rather than a named import so the file still loads when
+// the export is absent, surfacing a missing fix as a failing assertion.
+const { getBrowserOpenCommand } = internalForTesting;
 
 describe("getBrowserOpenCommand", () => {
   const url = "http://localhost:3000/";


### PR DESCRIPTION
## What

On Windows, opening the browser from Bun fails with:

```
error: Executable not found in $PATH: "start"
  path: "start",
 errno: -4058,
  code: "ENOENT"
```

This happens with the HTML dev server "o" shortcut (`bun index.html`, then press `o`), which threw the uncaught error above. The native URL opener used by `bun create` and `bun discord` hits the same cause (it silently fell back to printing the URL instead of opening the browser).

## Why

`start` is a `cmd.exe` builtin, not a standalone executable on `$PATH`. Spawning it directly resolves `argv0` through `which` and fails with `ENOENT` (`UV__ENOENT` is `-4058` on Windows). `start` therefore has to be invoked through `cmd.exe`.

## Fix

Invoke `cmd.exe /c start "" <url>` on Windows. The empty `""` is `start`'s window-title argument; without it `start` treats the URL as the title instead of opening it.

- `src/js/internal/html.ts` (dev server `o` shortcut): the platform → argv mapping is factored into `internal/openInBrowser` so it can be unit-tested on any host.
- `src/runtime/cli/mod.rs` (`open_url`, used by `bun create` / `bun discord`): same change on the native path. Its inputs (`http://localhost:3000/`, `https://bun.com/discord`) contain no `cmd.exe` metacharacters.

Not touched (different input-safety profile / niche, left for a follow-up): the `bun publish` auth-URL opener (the auth URL can carry `&` query params that `cmd.exe` would reinterpret, so it needs quoting/escaping rather than a plain wrap) and the terminal-editor `start` prefix in `open.rs`.

## Test

`test/js/bun/http/bun-serve-html-entry.test.ts` asserts the per-platform command, including `getBrowserOpenCommand("win32", url)` → `["cmd.exe", "/c", "start", "", url]`.

- Before: `USE_SYSTEM_BUN=1 bun test ...` fails (`Export named 'getBrowserOpenCommand' not found`).
- After: `bun bd test ...` passes (4/4).

The win32 branch is DCE'd out of a non-Windows build, so the mapping is exercised via a platform-parameterized helper exposed through `bun:internal-for-testing` rather than by spawning a browser in CI.

Fixes #26231
Closes #32513

This revives the approach from #26232, which was auto-closed for inactivity.
