### PR TITLE
install: skip non-absolute $BUN_INSTALL when locating global dirs

### DIFF
--- a/src/bunfig/arguments.rs
+++ b/src/bunfig/arguments.rs
@@ -20,13 +20,16 @@ use crate::bunfig::Bunfig;
 fn get_home_config_path(buf: &mut PathBuffer) -> Option<&ZStr> {
     let paths: [&[u8]; 1] = [b".bunfig.toml"];
 
-    if let Some(data_dir) = env_var::XDG_CONFIG_HOME.get() {
+    if let Some(data_dir) = env_var::XDG_CONFIG_HOME
+        .get()
+        .filter(|p| bun_paths::is_absolute(p))
+    {
         return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
             data_dir, &mut **buf, &paths,
         ));
     }
 
-    if let Some(home_dir) = env_var::HOME.get() {
+    if let Some(home_dir) = env_var::HOME.get().filter(|p| bun_paths::is_absolute(p)) {
         return Some(resolve_path::join_abs_string_buf_z::<platform::Auto>(
             home_dir, &mut **buf, &paths,
         ));

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1927,8 +1927,13 @@ pub fn init(
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
         // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
+        // Non-absolute values are skipped: `join_abs_string_buf_z` requires
+        // an absolute base (asserts on Windows, mangles on POSIX).
         let mut global_len: usize = 0;
-        if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+        if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME
+            .get_not_empty()
+            .filter(|p| bun_paths::is_absolute(p))
+        {
             let p =
                 resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf, &parts);
             if bun_sys::exists_z(p) {
@@ -1936,7 +1941,10 @@ pub fn init(
             }
         }
         if global_len == 0 {
-            if let Some(home_dir) = bun_core::env_var::HOME.get_not_empty() {
+            if let Some(home_dir) = bun_core::env_var::HOME
+                .get_not_empty()
+                .filter(|p| bun_paths::is_absolute(p))
+            {
                 global_len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
                     home_dir, &mut buf, &parts,
                 )

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1927,7 +1927,6 @@ pub fn init(
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
         // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
-        // Non-absolute values are skipped (join requires an absolute base).
         let mut global_len: usize = 0;
         if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME
             .get_not_empty()

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1927,8 +1927,7 @@ pub fn init(
 
         // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
         // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
-        // Non-absolute values are skipped: `join_abs_string_buf_z` requires
-        // an absolute base (asserts on Windows, mangles on POSIX).
+        // Non-absolute values are skipped (join requires an absolute base).
         let mut global_len: usize = 0;
         if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME
             .get_not_empty()

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -298,8 +298,7 @@ pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::DependencyGroup;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
-// `join_abs_string_buf` asserts an absolute base. A non-absolute env var
-// falls through to the next candidate.
+// `join_abs_string_buf` asserts an absolute base; skip non-absolute env values (BUN-2V31).
 #[inline]
 fn get_abs(v: Option<&'static [u8]>) -> Option<&'static [u8]> {
     v.filter(|p| bun_paths::is_absolute(p))

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -298,13 +298,10 @@ pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::DependencyGroup;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
-// `join_abs_string_buf` below requires an absolute base: on Windows it
-// asserts, and on POSIX a relative base yields a rooted path with the first
-// byte dropped. These env vars are user input and can be empty or relative
-// (e.g. `BUN_INSTALL=~/.bun` copied to a Windows shell where `~` is not
-// expanded), so skip values that are not absolute and fall through to the
-// next candidate. Resolving against the process cwd is not an option because
-// cwd changes between `open_global_dir` and `open_global_bin_dir`.
+// `join_abs_string_buf` requires an absolute base (asserts on Windows,
+// mangles on POSIX). A non-absolute env var falls through to the next
+// candidate; cwd is not a valid resolve base here because it changes
+// between `open_global_dir` and `open_global_bin_dir`.
 #[inline]
 fn get_abs(v: Option<&'static [u8]>) -> Option<&'static [u8]> {
     v.filter(|p| bun_paths::is_absolute(p))

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -298,12 +298,24 @@ pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::DependencyGroup;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
+// `join_abs_string_buf` below requires an absolute base: on Windows it
+// asserts, and on POSIX a relative base yields a rooted path with the first
+// byte dropped. These env vars are user input and can be empty or relative
+// (e.g. `BUN_INSTALL=~/.bun` copied to a Windows shell where `~` is not
+// expanded), so skip values that are not absolute and fall through to the
+// next candidate. Resolving against the process cwd is not an option because
+// cwd changes between `open_global_dir` and `open_global_bin_dir`.
+#[inline]
+fn get_abs(v: Option<&'static [u8]>) -> Option<&'static [u8]> {
+    v.filter(|p| bun_paths::is_absolute(p))
+}
+
 // mkdir -p + open the dir. Callers store the raw `Fd` (`options.global_bin_dir: Fd`).
 pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd> {
     use bun_paths::{platform, resolve_path::join_abs_string_buf};
     use bun_sys::{Dir, OpenDirOptions};
 
-    if let Some(home_dir) = env_var::BUN_INSTALL_GLOBAL_DIR.get() {
+    if let Some(home_dir) = env_var::BUN_INSTALL_GLOBAL_DIR.get_not_empty() {
         return Dir::cwd()
             .make_open_path(home_dir, OpenDirOptions::default())
             .map(|d| d.into_raw())
@@ -317,7 +329,7 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
             .map_err(Into::into);
     }
 
-    if let Some(home_dir) = env_var::BUN_INSTALL.get() {
+    if let Some(home_dir) = get_abs(env_var::BUN_INSTALL.get()) {
         let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [b"install", b"global"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
@@ -327,9 +339,8 @@ pub fn open_global_dir(explicit_global_dir: &[u8]) -> crate::Result<bun_sys::Fd>
             .map_err(Into::into);
     }
 
-    if let Some(home_dir) = env_var::XDG_CACHE_HOME
-        .get()
-        .or_else(|| env_var::HOME.get())
+    if let Some(home_dir) =
+        get_abs(env_var::XDG_CACHE_HOME.get()).or_else(|| get_abs(env_var::HOME.get()))
     {
         let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 3] = [b".bun", b"install", b"global"];
@@ -347,7 +358,7 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
     use bun_paths::{platform, resolve_path::join_abs_string_buf};
     use bun_sys::{Dir, OpenDirOptions};
 
-    if let Some(home_dir) = env_var::BUN_INSTALL_BIN.get() {
+    if let Some(home_dir) = env_var::BUN_INSTALL_BIN.get_not_empty() {
         return Dir::cwd()
             .make_open_path(home_dir, OpenDirOptions::default())
             .map(|d| d.into_raw())
@@ -365,7 +376,7 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
         }
     }
 
-    if let Some(home_dir) = env_var::BUN_INSTALL.get() {
+    if let Some(home_dir) = get_abs(env_var::BUN_INSTALL.get()) {
         let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 1] = [b"bin"];
         let path = join_abs_string_buf::<platform::Auto>(home_dir, &mut buf.0, &parts);
@@ -375,9 +386,8 @@ pub(crate) fn open_global_bin_dir(opts_: Option<&Api::BunInstall>) -> crate::Res
             .map_err(Into::into);
     }
 
-    if let Some(home_dir) = env_var::XDG_CACHE_HOME
-        .get()
-        .or_else(|| env_var::HOME.get())
+    if let Some(home_dir) =
+        get_abs(env_var::XDG_CACHE_HOME.get()).or_else(|| get_abs(env_var::HOME.get()))
     {
         let mut buf = PathBuffer::uninit();
         let parts: [&[u8]; 2] = [b".bun", b"bin"];

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -298,10 +298,8 @@ pub use crate::config_version::ConfigVersion;
 pub use bun_install_types::DependencyGroup;
 pub use bun_install_types::NodeLinker::NodeLinker;
 
-// `join_abs_string_buf` requires an absolute base (asserts on Windows,
-// mangles on POSIX). A non-absolute env var falls through to the next
-// candidate; cwd is not a valid resolve base here because it changes
-// between `open_global_dir` and `open_global_bin_dir`.
+// `join_abs_string_buf` asserts an absolute base. A non-absolute env var
+// falls through to the next candidate.
 #[inline]
 fn get_abs(v: Option<&'static [u8]>) -> Option<&'static [u8]> {
     v.filter(|p| bun_paths::is_absolute(p))

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -118,7 +118,10 @@ impl SloppyGlobalGitConfig {
     }
 
     fn load_and_parse() -> SloppyGlobalGitConfig {
-        let Some(home_dir) = bun_core::env_var::HOME.get() else {
+        let Some(home_dir) = bun_core::env_var::HOME
+            .get()
+            .filter(|p| Path::is_absolute(p))
+        else {
             return SloppyGlobalGitConfig::default();
         };
 

--- a/src/runtime/cli/pm_diff_command.rs
+++ b/src/runtime/cli/pm_diff_command.rs
@@ -89,7 +89,12 @@ pub(crate) fn exec(
         .iter()
         .map(|&arg| {
             use bun_paths::resolve_path::{join_abs_string, platform};
-            match (arg.strip_prefix(b"~/"), bun_core::env_var::HOME.get()) {
+            match (
+                arg.strip_prefix(b"~/"),
+                bun_core::env_var::HOME
+                    .get()
+                    .filter(|p| bun_paths::is_absolute(p)),
+            ) {
                 (Some(rest), Some(home)) => {
                     join_abs_string::<platform::Auto>(home, &[rest]).to_vec()
                 }

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -965,6 +965,7 @@ for (const [title, bunInstallValue, base] of [
     delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
     delete spawnEnv.BUN_INSTALL_BIN;
     delete spawnEnv.XDG_CACHE_HOME;
+    delete spawnEnv.XDG_CONFIG_HOME;
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "pm", "bin", "-g"],

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -976,10 +976,7 @@ for (const [title, bunInstallValue, base] of [
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stderr, exitCode }).toEqual({
-      stderr: expect.not.stringContaining("error:"),
-      exitCode: 0,
-    });
+    expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
     expect(await exists(binDir)).toBeTrue();
     expect(realpathSync(stdout.trim())).toBe(realpathSync(binDir));
   });

--- a/test/cli/install/bun-pm.test.ts
+++ b/test/cli/install/bun-pm.test.ts
@@ -2,7 +2,7 @@ import { spawn } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, expect, it, test } from "bun:test";
 import { exists, mkdir, writeFile } from "fs/promises";
 import { bunEnv, bunExe, bunEnv as env, readdirSorted, tempDir, tmpdirSync } from "harness";
-import { cpSync } from "node:fs";
+import { cpSync, realpathSync } from "node:fs";
 import { join } from "path";
 import {
   dummyAfterAll,
@@ -936,3 +936,50 @@ test("bun pm cache rm does not create the directory named by a project-local .en
   expect(stderr).not.toContain("error");
   expect(exitCode).toBe(0);
 });
+
+// https://bun-p9.sentry.io/issues/7403306202/
+// Windows panicked in _joinAbsStringBufWindows when $BUN_INSTALL was not an
+// absolute path; POSIX silently opened a mangled path rooted at "/". Now
+// empty and relative values are skipped so the next candidate ($HOME) wins.
+for (const [title, bunInstallValue, base] of [
+  ["empty $BUN_INSTALL falls through to $HOME", "", ["fake-home", ".bun"]],
+  ["relative $BUN_INSTALL falls through to $HOME", "relative-dir", ["fake-home", ".bun"]],
+  ["absolute $BUN_INSTALL", null, ["abs-bun"]],
+] as const) {
+  test(`global dir: ${title}`, async () => {
+    using dir = tempDir("pm-global-dir-env", {
+      "package.json": JSON.stringify({ name: "pm-global-dir-env", version: "1.0.0" }),
+    });
+    const cwd = String(dir);
+    const globalDir = join(cwd, ...base, "install", "global");
+    const binDir = join(cwd, ...base, "bin");
+    await mkdir(globalDir, { recursive: true });
+    await writeFile(join(globalDir, "package.json"), JSON.stringify({ name: "global", version: "1.0.0" }));
+
+    const spawnEnv: NodeJS.Dict<string> = {
+      ...env,
+      BUN_INSTALL: bunInstallValue ?? join(cwd, "abs-bun"),
+      HOME: join(cwd, "fake-home"),
+      USERPROFILE: join(cwd, "fake-home"),
+    };
+    delete spawnEnv.BUN_INSTALL_GLOBAL_DIR;
+    delete spawnEnv.BUN_INSTALL_BIN;
+    delete spawnEnv.XDG_CACHE_HOME;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "pm", "bin", "-g"],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: spawnEnv,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stderr, exitCode }).toEqual({
+      stderr: expect.not.stringContaining("error:"),
+      exitCode: 0,
+    });
+    expect(await exists(binDir)).toBeTrue();
+    expect(realpathSync(stdout.trim())).toBe(realpathSync(binDir));
+  });
+}


### PR DESCRIPTION
## Crash

Sentry BUN-2V31: `Panic: Internal assertion failure` in `_joinAbsStringBufWindows`, ~100+ lifetime events, 100% Windows, all via `PackageManagerCommand` (e.g. `bun why`, `bun add -g`). Present since at least 1.3.11.

```
src/install/PackageManager.zig:572                        init
src/install/PackageManager/PackageManagerOptions.zig:187  openGlobalDir
src/resolver/resolve_path.zig:1329                        joinAbsStringBuf
src/resolver/resolve_path.zig:1539                        _joinAbsStringBufWindows   <- assertion
```

## Repro

Windows (crash):
```
set BUN_INSTALL=
bun add -g cowsay
```

POSIX also affected, just not a crash. Before this change on Linux:
```
$ BUN_INSTALL="" bun pm bin -g
error: No package.json was found for directory "/nstall/global"

$ BUN_INSTALL="relative-dir" bun pm bin -g
error: No package.json was found for directory "/elative-dir/install/global"
```
(note the dropped first byte; the POSIX path through `_join_abs_string_buf` writes a leading `/` over `buf[0]` and then normalizes `temp_buf[1..]`)

## Cause

`open_global_dir` and `open_global_bin_dir` pass the raw value of `$BUN_INSTALL` / `$XDG_CACHE_HOME` / `$HOME` as the `cwd` argument to `join_abs_string_buf`. That function requires an absolute base: on Windows it asserts `is_absolute_windows(cwd)` (Windows release builds are ReleaseSafe so `bun.assert` panics), and on POSIX a relative base yields the mangled rooted path above.

`env_var::BUN_INSTALL.get()` does not filter empty strings, so the assertion fires whenever `$BUN_INSTALL` is empty, relative (`~/.bun` copied to a Windows shell where `~` is not expanded), or a drive-relative path like `C:bun`.

## Fix

Filter the env-var values that feed `join_abs_string_buf` to absolute paths only; anything else falls through to the next candidate in the chain (`$BUN_INSTALL` → `$XDG_CACHE_HOME` → `$HOME`). Resolving a relative `$BUN_INSTALL` against the process cwd was considered but rejected because the process `fchdir`s into the global dir between `open_global_dir` and `open_global_bin_dir`, so a relative value would resolve to two different places.

The same per-candidate filter is applied at the four other sites that hand these env vars to `join_abs_string_buf` as a base:
- `.npmrc` lookup in `PackageManager::init` (`$XDG_CONFIG_HOME` / `$HOME`)
- `.gitconfig` lookup in `repository.rs` (`$HOME`)
- global `.bunfig.toml` lookup in `bunfig/arguments.rs` (`$XDG_CONFIG_HOME` / `$HOME`)
- `~/` expansion in `bun pm diff` arguments (`$HOME`)

`$BUN_INSTALL_GLOBAL_DIR` and `$BUN_INSTALL_BIN` go straight to `Dir::cwd().make_open_path()` without the absolute-join, so those now use `get_not_empty()` (empty falls through, relative still resolves against cwd as before).

## Verification

New tests in `test/cli/install/bun-pm.test.ts` spawn `bun pm bin -g` with `$BUN_INSTALL` set to `""`, a relative path, and an absolute path (regression guard), asserting the printed bin path and that the expected directory is created.

Before:
```
(fail) global dir: empty $BUN_INSTALL falls through to $HOME
  stderr: error: No package.json was found for directory "/nstall/global"
(fail) global dir: relative $BUN_INSTALL falls through to $HOME
  stderr: error: No package.json was found for directory "/elative-dir/install/global"
(pass) global dir: absolute $BUN_INSTALL
```

After: 3/3 pass. Full `bun-pm.test.ts`: 21/21 pass. `cargo check -p bun_install --target x86_64-pc-windows-msvc` clean.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.0 (4199361ed)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [381.05ms]
(pass) should list all dependencies [340.18ms]
(pass) should list top-level aliased dependency [338.93ms]
(pass) should list aliased dependencies [335.61ms]
(pass) should list only trusted dependencies with --trusted [443.85ms]
(pass) should list only trusted dependencies with --all --trusted [320.84ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [331.30ms]
(pass) should list nothing with --trusted when no dependencies are trusted [333.70ms]
(pass) should remove all cache [472.38ms]
(pass) bun pm migrate [1317.78ms]
(pass) bun whoami executes pm whoami [137.72ms]
(pass) bun pm whoami still works [131.18ms]
(pass) bun list executes pm ls [333.80ms]
(pass) bun pm list works as alias for bun pm ls [328.28ms]
(pass) bun pm ls still works [312.46ms]
(pass) bun list --all shows full dependency tree [316.35ms]
(pass) bun pm cache rm resol
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (3d5237e3c)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [13.20ms]
(pass) should list all dependencies [7.85ms]
(pass) should list top-level aliased dependency [7.47ms]
(pass) should list aliased dependencies [6.81ms]
(pass) should list only trusted dependencies with --trusted [9.25ms]
(pass) should list only trusted dependencies with --all --trusted [6.65ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [7.17ms]
(pass) should list nothing with --trusted when no dependencies are trusted [6.53ms]
(pass) should remove all cache [10.20ms]
(pass) bun pm migrate [35.30ms]
(pass) bun whoami executes pm whoami [3.55ms]
(pass) bun pm whoami still works [2.42ms]
(pass) bun list executes pm ls [7.60ms]
(pass) bun pm list works as alias for bun pm ls [7.06ms]
(pass) bun pm ls still works [7.31ms]
(pass) bun list --all shows full dependency tree [7.47ms]
(pass) bun pm cache rm resolves the cache directory from the process environment, ignoring project-local .env overrides [4.00ms]
(pass) bun pm cache rm does not create the directory named by a project-local .env ov
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-pm.test.ts
bun test v1.4.0 (4199361ed)

test/cli/install/bun-pm.test.ts:
(pass) should list top-level dependency [445.78ms]
(pass) should list all dependencies [345.53ms]
(pass) should list top-level aliased dependency [335.10ms]
(pass) should list aliased dependencies [328.31ms]
(pass) should list only trusted dependencies with --trusted [481.51ms]
(pass) should list only trusted dependencies with --all --trusted [365.93ms]
(pass) should list trusted transitive dependencies under untrusted parents with --all --trusted (isolated) [320.25ms]
(pass) should list nothing with --trusted when no dependencies are trusted [329.49ms]
(pass) should remove all cache [464.24ms]
(pass) bun pm migrate [1321.52ms]
(pass) bun whoami executes pm whoami [130.00ms]
(pass) bun pm whoami still works [126.64ms]
(pass) bun list executes pm ls [315.28ms]
(pass) bun pm list works as alias for bun pm ls [311.94ms]
(pass) bun pm ls still works [304.01ms]
(pass) bun list --all shows full dependency tree [313.12ms]
(pass) bun pm cache rm resol
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 610ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 92 exports (host=3, lazy=10, generic=79, rust=0); 241 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bunfig/arguments.rs                            |  7 +++-
 src/install/PackageManager.rs                      | 10 ++++-
 .../PackageManager/PackageManagerOptions.rs        | 24 ++++++-----
 src/install/repository.rs                          |  5 ++-
 src/runtime/cli/pm_diff_command.rs                 |  7 +++-
 test/cli/install/bun-pm.test.ts                    | 47 +++++++++++++++++++++-
 6 files changed, 83 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/bunfig/arguments.rs                                  1      1     14
src/install/PackageManager.rs                            9      8     14
src/install/PackageManager/PackageManagerOptions.rs      8      7     14
src/install/repository.rs                                1      1     14
src/runtime/cli/pm_diff_command.rs                       1      2     14
test/cli/install/bun-pm.test.ts                          4      7     14
```

</details>

**root cause** · written by the author bot

The global directory resolution in the package manager passed raw environment variable values such as BUN_INSTALL, XDG_CACHE_HOME, and HOME directly as the base path for an absolute path join, which on Windows asserts that the base is absolute and panics when the value is empty, relative, or drive-relative. The fix validates each candidate before use, skipping empty or non-absolute values and falling through to the next variable in the chain rather than crashing or silently computing a bogus path. The same validation was applied to sibling sites that load .npmrc, .bunfig.toml, and .gitconfi…

<!-- robobun:evidence:end -->
