### PR TITLE
chore: remove stale 'cfg-gated'/'un-gate'/'blocked_on' port-era comments

### DIFF
--- a/src/api/lib.rs
+++ b/src/api/lib.rs
@@ -5,7 +5,7 @@
 //! Ground truth: `src/api/schema.peechy`. The full peechy → `.rs` emitter is
 //! not landed yet; this crate hand-writes the slice of the schema that
 //! downstream crates name today (`bun_ini`, `bun_install`, `bun_runtime`
-//! bunfig parser) so they can un-gate against real field shapes.
+//! bunfig parser).
 //!
 //! LAYERING: the actual data shapes (`NpmRegistry`, `NpmRegistryMap`, `Ca`,
 //! `BunInstall`) were originally hand-written in two places — here *and* in

--- a/src/ast/fold_string_addition.rs
+++ b/src/ast/fold_string_addition.rs
@@ -3,9 +3,8 @@ use crate::{E, Expr, StoreRef, e};
 use bun_alloc::Arena; // bumpalo::Bump re-export
 
 // ── local rope helpers ─────────────────────────────────────────────────────
-// `EString::push` / `EString::clone_rope_nodes` are still gated in E.rs
-// (round-C draft); inline the minimal surface here so this file can un-gate
-// without touching E.rs.
+// `EString` has no `push` / `clone_rope_nodes` inherent methods yet;
+// provide the minimal surface here.
 
 #[inline]
 fn store_append_string(s: E::EString) -> StoreRef<E::EString> {

--- a/src/bun_bin/phase_c_exports.rs
+++ b/src/bun_bin/phase_c_exports.rs
@@ -84,7 +84,7 @@ pub(crate) extern "C" fn Bun__panic(msg: *const u8, len: usize) -> ! {
 // Bun__NODE_NO_WARNINGS
 
 // REAL: `Bun__getTLSRejectUnauthorizedValue` / `Bun__isNoProxy` now exported
-// directly from `bun_jsc::virtual_machine_exports` (un-gated in phase-d).
+// directly from `bun_jsc::virtual_machine_exports`.
 
 // REAL: now provided by bun_runtime (src/runtime/napi/napi_body.rs).
 // napi_internal_suppress_crash_on_abort_if_desired

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2603,9 +2603,9 @@ pub mod debug_allocator_data {
     }
 }
 
-/// `bun.feature_flag.*` runtime env-var getters (real impl in env_var.rs, still gated).
-/// feature_flags.rs (compile-time consts) is now real; this stub provides the
-/// `.get()` accessor surface that env_var.rs will replace.
+/// `bun.feature_flag.*` runtime env-var getters. The canonical typed
+/// accessors live in `env_var::feature_flag`; this stub provides the
+/// `.get()` accessor surface for flags not yet wired there.
 pub mod feature_flag {
     macro_rules! flag { ($($name:ident),* $(,)?) => { $(
         #[allow(non_camel_case_types)] pub struct $name;

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -1202,10 +1202,8 @@ pub mod time {
     }
 }
 
-/// `bun.schema`. The full generated API
-/// types live in `bun_api` (tier-2); tier-0 only needs the namespace to
-/// exist so `bun_core::schema::api::StringPointer` etc. resolve as re-exports
-/// once that crate un-gates. For now expose the one type tier-0 itself owns.
+/// `bun.schema`. The full generated API types live in `bun_api` (tier-2);
+/// tier-0 cannot depend on that, so expose the one type tier-0 itself owns.
 pub mod schema {
     pub mod api {
         pub use crate::util::StringPointer;

--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -976,8 +976,6 @@ pub fn is_ai_agent() -> bool {
     VALUE.load(Ordering::Relaxed)
 }
 
-// (IS_VERBOSE defined above at L887; ungate exposed a duplicate.)
-
 pub fn set_is_verbose(verbose: bool) {
     IS_VERBOSE.store(verbose, Ordering::Relaxed);
 }

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -50,9 +50,8 @@ pub use unicode_draft::{
 /// surface for the remaining Rust callers.
 pub use visible_impl::visible;
 
-/// Minimal `unicode` surface needed by `immutable.rs` itself (CodepointIterator
-/// + WTF-8 decode). Full transcoding suite (to_utf8_*, convert_utf16_*) lives
-/// in the gated `unicode_draft` module — un-gate after simdutf wiring.
+/// `unicode` surface needed by `immutable.rs` itself (CodepointIterator +
+/// WTF-8 decode). Full transcoding suite lives in `unicode_draft`.
 pub mod unicode {
     use super::CodePoint;
 

--- a/src/bun_core/util.rs
+++ b/src/bun_core/util.rs
@@ -4733,8 +4733,9 @@ impl SpawnStatus {
 //
 // This is the single source of truth for the request layout; `spawn_sys`
 // re-exports these types rather than re-declaring them. The #[repr(C)] data
-// mirrors are target-agnostic so the module is ungated; only the extern decl
-// is `cfg(unix)` (Windows spawns go through libuv and never link this symbol).
+// mirrors are target-agnostic so the module compiles on all platforms; only
+// the extern decl is `cfg(unix)` (Windows spawns go through libuv and never
+// link this symbol).
 pub mod spawn_ffi {
     use core::ffi::{c_char, c_int};
 

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -19,9 +19,7 @@ pub(crate) extern "C" fn timer_callback(_: *mut bun_sys::windows::libuv::Timer) 
 pub use bun_threading::ResetEvent;
 
 /// Result of a `Bun.build` invocation handed back to the JS thread.
-// Defined here (not re-exported from `bundle_v2`) because the un-gated
-// `bundle_v2` module keeps the draft body private; T6 (`bundler_jsc`) consumes
-// this via the `CompletionStruct` trait.
+/// Consumed by `bundler_jsc` via the `CompletionStruct` trait.
 pub struct BuildResult {
     pub output_files: Vec<crate::options::OutputFile>,
     pub metafile: Option<Box<[u8]>>,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -114,10 +114,7 @@ pub(crate) use debug;
 bun_core::define_scoped_log!(debug_tree_shake, crate::linker_context_mod::TreeShake);
 
 // Re-exports from sibling modules in `linker_context/`.
-// `LinkerGraph` SoA accessors are real now (`` on
-// `JSAst`/`JSMeta`/`File`); the submodule bodies un-gate against those. Module
-// declarations live in `lib.rs::linker_context` — each re-export below is
-// gated alongside its module declaration so partial un-gates compile.
+// Module declarations live in `lib.rs::linker_context`.
 pub use crate::linker_context::scan_imports_and_exports::scan_imports_and_exports;
 
 pub use crate::linker_context::compute_chunks::compute_chunks;
@@ -2160,9 +2157,6 @@ impl<'a> LinkerContext<'a> {
 
         Ok(true)
     }
-
-    // runtime_function: moved to the un-gated forward-decl impl block
-    // (see "Forward-decl shims for scanImportsAndExports.rs callees" below).
 
     pub fn print_code_for_file_in_chunk_js(
         &mut self,

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -1833,7 +1833,6 @@ pub mod parse_worker {
         }
     }
 
-
     /// # Safety
     /// `args` and `result_ptr` must point at the live `OnBeforeParseArguments`
     /// / `OnBeforeParseResultWrapper.result` set up by `OnBeforeParsePlugin::run`

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -489,11 +489,6 @@ export var __callDispose = (stack, error, hasError) => {
 
 // ══════════════════════════════════════════════════════════════════════════
 // Per-file parse worker — `getAST`/`getCodeForParseTask`/`runFromThreadPool`.
-// The struct/FFI surface and `get_runtime_source` are real. Bodies
-// that touch the still-gated `crate::ThreadPool` Worker module or the opaque
-// `JSBundlerPlugin`/`FileMap` forward-decls remain ``-gated
-// per-function below with explicit `// blocked_on:` notes; they un-gate by
-// deletion once those modules land.
 // ══════════════════════════════════════════════════════════════════════════
 pub mod parse_worker {
     use super::*;
@@ -592,10 +587,6 @@ pub mod parse_worker {
     // getEmptyCSSAST / getEmptyAST
     // ───────────────────────────────────────────────────────────────────────────
 
-    // blocked_on: `js_parser::new_lazy_export_ast` body
-    // (`Parser::to_lazy_export_ast`); `bun_css::BundlerStyleSheet` (gated
-    // upstream); `Expr::init` overload set for arbitrary `E::*` defaults.
-
     // `transpiler: *mut Transpiler` stays raw. Callers
     // (`get_ast`, `run_with_source_code`) may also hold a raw pointer to
     // `(*transpiler).resolver`; materializing `&mut Transpiler` here would assert
@@ -692,17 +683,6 @@ pub mod parse_worker {
     // ───────────────────────────────────────────────────────────────────────────
     // getAST
     // ───────────────────────────────────────────────────────────────────────────
-
-    // blocked_on: per-loader branches require:
-    //   - `resolver.caches.js.parse` / `resolver.caches.json.parse_json` (gated in
-    //     `bun_resolver::cache_set`);
-    //   - `bun_parsers::{toml,yaml,json5}` parser entry points;
-    //   - `bun_css::BundlerStyleSheet::parse_bundler` (gated upstream);
-    //   - `crate::HTMLScanner` (gated module);
-    //   - `bun_core::fmt::bytes_to_hex_lower` Display adaptor;
-    //   - `js_parser::new_lazy_export_ast` body.
-    // The signature now names the real `ParserOptions`; body un-gates in lockstep
-    // with the above.
 
     // `transpiler`/`resolver` are raw `*mut`. The caller may pass
     // `resolver = &transpiler.resolver`, so
@@ -1348,12 +1328,6 @@ pub mod parse_worker {
     // getCodeForParseTaskWithoutPlugins
     // ───────────────────────────────────────────────────────────────────────────
 
-    // blocked_on: `BundleV2.file_map` is `Option<NonNull<FileMap>>` where `FileMap`
-    // is an opaque forward-decl (`_opaque: [u8; 0]`); `.get(path)`
-    // requires the real T6 `jsc::api::JSBundler::FileMap` surface. Also blocked on
-    // `bake_types::Framework.built_in_modules` value variant carrying `&[u8]` (vs
-    // `Box<[u8]>` here) and `resolver.caches.fs.read_file_with_allocator` shape.
-
     // `transpiler`/`resolver` are raw `*mut`.
     // Callers pass `resolver = &mut (*transpiler).resolver`; taking
     // `&mut Transpiler` + `&mut Resolver` would be aliased-`&mut` UB. We only
@@ -1517,12 +1491,6 @@ pub mod parse_worker {
     // ───────────────────────────────────────────────────────────────────────────
     // getCodeForParseTask
     // ───────────────────────────────────────────────────────────────────────────
-
-    // blocked_on: `BundleV2.plugins` is `Option<NonNull<JSBundlerPlugin>>` where
-    // `JSBundlerPlugin` is an opaque forward-decl; `.has_on_before_parse_plugins()`
-    // requires the real T6 `jsc::api::JSBundler::Plugin` surface (or a
-    // `dispatch::PluginVTable` slot). Also calls the gated
-    // `get_code_for_parse_task_without_plugins`.
 
     // `transpiler`/`resolver` are raw `*mut` — see
     // `get_code_for_parse_task_without_plugins`.
@@ -1865,7 +1833,6 @@ pub mod parse_worker {
         }
     }
 
-    // blocked_on: calls `get_code_for_parse_task_without_plugins` (gated above).
 
     /// # Safety
     /// `args` and `result_ptr` must point at the live `OnBeforeParseArguments`
@@ -2013,11 +1980,6 @@ pub mod parse_worker {
 
         0
     }
-
-    // blocked_on: `crate::api::JSBundler::Plugin` (T6) — `call_on_before_parse_plugins`
-    // is an `extern "C"` JSC dispatch; needs a `dispatch` vtable slot or the real
-    // `bun_bundler_jsc::JSBundler::Plugin` re-export. Also references the gated
-    // `fetch_source_code` callback above.
 
     impl<'a, 'b: 'a> OnBeforeParsePlugin<'a, 'b> {
         pub fn run(
@@ -2201,10 +2163,6 @@ pub mod parse_worker {
     // getSourceCode
     // ───────────────────────────────────────────────────────────────────────────
 
-    // blocked_on: `crate::ThreadPool::Worker` (lib.rs ` pub mod
-    // ThreadPool` — the bundler worker module, distinct from `bun_threading`).
-    // `Worker.{arena, data.transpiler}` field shape comes from there.
-
     fn get_source_code(
         task: &mut ParseTask,
         this: &mut crate::Worker,
@@ -2256,15 +2214,6 @@ pub mod parse_worker {
     // ───────────────────────────────────────────────────────────────────────────
     // runWithSourceCode
     // ───────────────────────────────────────────────────────────────────────────
-
-    // blocked_on: `crate::ThreadPool::Worker` (gated module) for
-    // `this.{arena, transpiler_for_target, ctx}`; `bake_types::Framework`
-    // missing `server_components` field; `ParserOptions` field-type mismatches
-    // (`allow_unresolved`, `framework`, `unwrap_commonjs_packages`,
-    // `server_components` — bundler's `BundleOptions` types diverge from the
-    // js_parser-local `parser::options` shims); `get_ast`/`get_empty_*` (gated).
-    // Signature is real; body un-gates once the `ThreadPool` module + the
-    // `parser::options` ↔ `BundleOptions` type unification land.
 
     fn run_with_source_code(
         task: &mut ParseTask,

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -33,10 +33,8 @@ bun_core::named_error_set!(CSSResolveError);
 
 type HashedFileNameMap = HashMap<u64, &'static [u8]>;
 
-// `_transpiler.Transpiler.isCacheEnabled` is gated in the draft body
-// (`transpiler.rs:1111`). The value is a hard `false`;
-// inline it here so `get_hashed_filename` compiles without depending
-// on the gated `Transpiler` impl.
+// Matches `Transpiler::IS_CACHE_ENABLED`; inlined so `get_hashed_filename`
+// doesn't need a `Transpiler` handle.
 const IS_CACHE_ENABLED: bool = false;
 
 pub struct Linker {

--- a/src/bundler/linker.rs
+++ b/src/bundler/linker.rs
@@ -41,8 +41,7 @@ const IS_CACHE_ENABLED: bool = false;
 
 pub struct Linker {
     // arena field dropped — global mimalloc (callers pass `bun.default_allocator`)
-    // The un-gated
-    // `Transpiler` struct owns these values directly and also owns `linker:
+    // `Transpiler` owns these values directly and also owns `linker:
     // crate::Linker` by value, so storing references here would alias
     // `&mut self` on every `transpiler.linker.link(...)` call. Use raw
     // pointers and dereference at use-site; same

--- a/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
+++ b/src/bundler/linker_context/findImportedFilesInCSSOrder.rs
@@ -408,8 +408,8 @@ pub fn find_imported_files_in_css_order<'a>(
                             //
                             // `crate::bun_css::LayerName` (lifetime-erased
                             // shadow) and `::bun_css::LayerName` are distinct nominal
-                            // types until the ungate shadow is removed; cast through
-                            // `NonNull` to satisfy `Layers::borrow`.
+                            // types; cast through `NonNull` to satisfy
+                            // `Layers::borrow`.
                             let layer_names_ptr = core::ptr::NonNull::from(
                                 &css_asts[idx.get() as usize].as_deref().unwrap().layer_names,
                             )

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1,7 +1,5 @@
 // ══════════════════════════════════════════════════════════════════════════
 // `Transpiler` — the legacy single-file transpile path (pre-`bundle_v2`).
-// resolver↔bundler cycle broken in O; `bun_resolver` is now a direct dep so
-// the struct and all method bodies are un-gated and live at this tier.
 // ══════════════════════════════════════════════════════════════════════════
 
 use bun_alloc::Arena;
@@ -156,8 +154,8 @@ impl<'a> Transpiler<'a> {
     pub const IS_CACHE_ENABLED: bool = false;
 
     /// Takes `*mut Log` (not `&'a mut`) because the same
-    /// `*Log` is aliased into `linker.log` / `resolver.log`; the un-gated struct field is
-    /// already a raw pointer for that reason.
+    /// `*Log` is aliased into `linker.log` / `resolver.log`; the struct
+    /// field is a raw pointer for that reason.
     pub fn set_log(&mut self, log: *mut bun_ast::Log) {
         self.log = log;
         self.linker.log = log;
@@ -678,9 +676,8 @@ impl<'a> Transpiler<'a> {
     /// optionally auto-configuring JSX from the nearest `tsconfig.json`.
     pub fn configure_linker_with_auto_jsx(&mut self, auto_jsx: bool) {
         // `Linker::init` dropped its `arena` arg (linker.rs:172
-        // — global mimalloc). The
-        // un-gated `crate::linker::Linker` stores raw pointers so
-        // `&mut self.options` etc. coerce directly. Self-reference is
+        // — global mimalloc). `crate::linker::Linker` stores raw pointers
+        // so `&mut self.options` etc. coerce directly. Self-reference is
         // load-bearing — `linker.link()` reads back through these into the
         // owning `Transpiler` — hence raw `*mut`, not `&'a mut` (would alias
         // `&mut self` on every call).
@@ -1168,8 +1165,8 @@ impl<'a> Transpiler<'a> {
     ///   * [`Resolver::init1`] — `bun_resolver`
     ///
     /// `log` / `env_loader_` are raw pointers (not `&'a mut`) to
-    /// match the un-gated struct field types — the same `*Log` is aliased
-    /// into `linker.log` / `resolver.log` (see `set_log`).
+    /// match the struct field types — the same `*Log` is aliased into
+    /// `linker.log` / `resolver.log` (see `set_log`).
     pub fn init(
         arena: &'a Arena,
         log: *mut bun_ast::Log,

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -1770,13 +1770,10 @@ impl<'a> Transpiler<'a> {
                                     // `path_buf2[total] == 0` already; safe to
                                     // borrow as a NUL-terminated ZStr.
                                     let zpath = bun_core::ZStr::from_buf(&path_buf2[..], total);
-                                    // spec calls
-                                    // `bun.sys.File.toSourceAt(...)` which is
+                                    // `bun.sys.File.toSourceAt(...)` is
                                     // `read_from` + wrap-in-`bun_ast::Source`.
                                     // We only need `.contents`, so call
-                                    // `read_from` directly (the `to_source_at`
-                                    // wrapper is gated as a T1→T2 move-in,
-                                    // sys/File.rs:446).
+                                    // `read_from` directly.
                                     let dir = dirname_fd.unwrap_valid().unwrap_or_else(FD::cwd);
                                     match bun_sys::File::read_from(dir, zpath) {
                                         Ok(contents) if !contents.is_empty() => {

--- a/src/cares_sys/lib.rs
+++ b/src/cares_sys/lib.rs
@@ -29,12 +29,7 @@ pub mod winsock {
     }
 }
 
-/// The full c-ares FFI module. The temporary inline scaffold that previously
-/// duplicated `ares_socklen_t` / `AddrInfo_hints` / `ares_inet_*` here has been
-/// collapsed to a re-export of the canonical `c_ares.rs` module now that it is
-/// un-gated. `c_ares` and `c_ares_draft` resolve to the SAME module, so the two
-/// `AddrInfo_hints` definitions are now nominally identical (previously a latent
-/// type-mismatch footgun for callers mixing the two paths).
+/// `c_ares` and `c_ares_draft` resolve to the same module.
 pub use c_ares_draft as c_ares;
 
 // Crate-root re-exports for callers that reference `bun_cares_sys::ares_inet_*`

--- a/src/css/context.rs
+++ b/src/css/context.rs
@@ -1,9 +1,5 @@
 use crate::css_parser as css;
 
-// blocked_on: rules/media + media_query::{MediaCondition,MediaFeature,...} +
-// properties/custom — only the gated `get_*_rules` / `add_unparsed_fallbacks`
-// bodies below reference these.
-
 use css::css_rules::media::MediaRule;
 
 use css::css_properties::custom::UnparsedProperty;
@@ -95,12 +91,7 @@ impl<'a> PropertyHandlerContext<'a> {
     }
 }
 
-// ─── heavy rule-building helpers (gated) ──────────────────────────────────
-// blocked_on: css_rules::{CssRule,CssRuleList,StyleRule,SupportsRule,media},
-// selectors::parser::{Direction,Component,PseudoClass}, DeclarationBlock
-// construction with bump-allocated lists, properties/custom::UnparsedProperty.
-// These build whole rule subtrees and are only called from the (still-gated)
-// minify path; un-gate alongside `rules/style.rs`.
+// ─── heavy rule-building helpers ──────────────────────────────────────────
 
 impl<'a> PropertyHandlerContext<'a> {
     /// `'static`-erased arena handle for building `DeclarationBlock<'static>` /

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -94,9 +94,9 @@ pub use gated_shims::*;
 mod gated_shims {
 
     // ── rules/ leaf-module payload re-exports ────────────────────────────
-    // The leaf modules are un-gated; re-export the real prelude payload types
-    // `AtRulePrelude` carries so the rule-parser impl bodies type-check
-    // against the same structs `CssRule` stores.
+    // Re-export the prelude payload types `AtRulePrelude` carries so the
+    // rule-parser impl bodies type-check against the same structs `CssRule`
+    // stores.
     pub use crate::rules::container::{ContainerCondition, ContainerName};
     pub use crate::rules::keyframes::KeyframesName;
     pub use crate::rules::page::PageSelector;
@@ -1267,12 +1267,7 @@ where
 // ───────────────────── rule_parsers (heavy impl bodies) ──────────────────────
 // Un-gated: `declaration::parse_declaration_impl` + `selectors::parser` are
 // real, so the `QualifiedRuleParser`/`DeclarationParser`/`RuleBodyItemParser`
-// surface and `parse_nested`/`parse_style_block` compile end-to-end. The
-// at-rule arms now call the leaf-module parse fns directly (`LayerName`,
-// `SupportsCondition`, `KeyframesName`, `PageSelector`, `ContainerName`,
-// `ContainerCondition`, `FontPaletteValuesRule`, `PageRule`, `PropertyRule`
-// have un-gated). Only `@font-face`/`@keyframes` block bodies remain
-// inline-``-gated on their `RuleBodyItemParser` trait impls.
+// surface and `parse_nested`/`parse_style_block` compile end-to-end.
 mod rule_parsers {
     use super::*;
     use crate::selectors::parser as selector_parser;
@@ -1814,8 +1809,6 @@ mod rule_parsers {
             let loc = this.get_loc(start);
             match prelude {
                 AtRulePrelude::FontFace => {
-                    // blocked_on: `FontFaceDeclarationParser: RuleBodyItemParser`
-                    // trait impls (rules/font_face.rs gated const block).
                     {
                         let mut decl_parser = css_rules::font_face::FontFaceDeclarationParser;
                         let mut parser = RuleBodyParser::new(input, &mut decl_parser);
@@ -1913,8 +1906,6 @@ mod rule_parsers {
                     Ok(())
                 }
                 AtRulePrelude::Keyframes { name, prefix } => {
-                    // blocked_on: `KeyframesListParser: RuleBodyItemParser` trait
-                    // impls (rules/keyframes.rs gated const block).
                     {
                         let mut parser = css_rules::keyframes::KeyframesListParser;
                         let mut iter = RuleBodyParser::new(input, &mut parser);
@@ -2194,9 +2185,6 @@ mod rule_parsers {
             // We parsed a style rule with the `composes` property. Track which
             // properties it used so we can validate it later.
             if matches!(this.composes_state, ComposesState::Allow(_)) {
-                // blocked_on: `fill_property_bit_set` (Property variant reflection
-                // — properties_generated PropertyIdTag conversions). The type
-                // structure is real; only the bitset population stays gated.
                 {
                     let len = input.position() - location;
                     let mut usage = PropertyBitset::init_empty();
@@ -2270,10 +2258,6 @@ mod rule_parsers {
         }
     }
 
-    /// `MediaList::parse` thunk. Kept local so the rule-parser arms above
-    /// type-check; becomes a one-line `MediaList::parse(input, options)` forwarder
-    /// once `media_query::MediaList::parse` un-gates.
-    // blocked_on: media_query::{MediaList,MediaQuery}::parse
     #[inline]
     fn parse_media_list(input: &mut Parser, options: &ParserOptions) -> CssResult<MediaList> {
         MediaList::parse(input, options)
@@ -2320,7 +2304,6 @@ pub type BundlerCssRule = CssRule<BundlerAtRule>;
 pub type BundlerLayerBlockRule = css_rules::layer::LayerBlockRule<BundlerAtRule>;
 pub type BundlerSupportsRule = css_rules::supports::SupportsRule<BundlerAtRule>;
 pub type BundlerMediaRule = css_rules::media::MediaRule<BundlerAtRule>;
-// blocked_on: printer.rs PrintResult<R> generic
 pub type BundlerPrintResult = PrintResult<BundlerAtRule>;
 
 pub struct BundlerTailwindState {
@@ -5685,13 +5668,11 @@ impl TokenKind {
 pub use crate::Token;
 
 impl Token {
-    // blocked_on: generics::CssEql/CssHash blanket impls for Token payload set
     pub fn eql(lhs: &Token, rhs: &Token) -> bool {
         // TODO: derive PartialEq once payload lifetimes settle.
         generic::implement_eql(lhs, rhs)
     }
 
-    // blocked_on: generics::CssHash
     pub fn hash(&self, hasher: &mut bun_wyhash::Wyhash) {
         generic::implement_hash(self, hasher)
     }

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -1265,9 +1265,6 @@ where
 }
 
 // ───────────────────── rule_parsers (heavy impl bodies) ──────────────────────
-// Un-gated: `declaration::parse_declaration_impl` + `selectors::parser` are
-// real, so the `QualifiedRuleParser`/`DeclarationParser`/`RuleBodyItemParser`
-// surface and `parse_nested`/`parse_style_block` compile end-to-end.
 mod rule_parsers {
     use super::*;
     use crate::selectors::parser as selector_parser;

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -1809,25 +1809,22 @@ mod rule_parsers {
             let loc = this.get_loc(start);
             match prelude {
                 AtRulePrelude::FontFace => {
-                    {
-                        let mut decl_parser = css_rules::font_face::FontFaceDeclarationParser;
-                        let mut parser = RuleBodyParser::new(input, &mut decl_parser);
-                        // todo_stuff.think_mem_mgmt
-                        let mut properties: Vec<css_rules::font_face::FontFaceProperty> =
-                            Vec::new();
-                        while let Some(result) = parser.next() {
-                            if let Ok(decl) = result {
-                                properties.push(decl);
-                            }
+                    let mut decl_parser = css_rules::font_face::FontFaceDeclarationParser;
+                    let mut parser = RuleBodyParser::new(input, &mut decl_parser);
+                    // todo_stuff.think_mem_mgmt
+                    let mut properties: Vec<css_rules::font_face::FontFaceProperty> = Vec::new();
+                    while let Some(result) = parser.next() {
+                        if let Ok(decl) = result {
+                            properties.push(decl);
                         }
-                        this.rules
-                            .v
-                            .push(CssRule::FontFace(css_rules::font_face::FontFaceRule {
-                                properties,
-                                loc,
-                            }));
-                        Ok(())
                     }
+                    this.rules
+                        .v
+                        .push(CssRule::FontFace(css_rules::font_face::FontFaceRule {
+                            properties,
+                            loc,
+                        }));
+                    Ok(())
                 }
                 AtRulePrelude::FontPaletteValues(name) => {
                     let rule = css_rules::font_palette_values::FontPaletteValuesRule::parse(
@@ -1906,26 +1903,24 @@ mod rule_parsers {
                     Ok(())
                 }
                 AtRulePrelude::Keyframes { name, prefix } => {
-                    {
-                        let mut parser = css_rules::keyframes::KeyframesListParser;
-                        let mut iter = RuleBodyParser::new(input, &mut parser);
-                        // todo_stuff.think_mem_mgmt
-                        let mut keyframes: Vec<css_rules::keyframes::Keyframe> = Vec::new();
-                        while let Some(result) = iter.next() {
-                            if let Ok(keyframe) = result {
-                                keyframes.push(keyframe);
-                            }
+                    let mut parser = css_rules::keyframes::KeyframesListParser;
+                    let mut iter = RuleBodyParser::new(input, &mut parser);
+                    // todo_stuff.think_mem_mgmt
+                    let mut keyframes: Vec<css_rules::keyframes::Keyframe> = Vec::new();
+                    while let Some(result) = iter.next() {
+                        if let Ok(keyframe) = result {
+                            keyframes.push(keyframe);
                         }
-                        this.rules.v.push(CssRule::Keyframes(
-                            css_rules::keyframes::KeyframesRule {
-                                name,
-                                keyframes,
-                                vendor_prefix: prefix,
-                                loc,
-                            },
-                        ));
-                        Ok(())
                     }
+                    this.rules
+                        .v
+                        .push(CssRule::Keyframes(css_rules::keyframes::KeyframesRule {
+                            name,
+                            keyframes,
+                            vendor_prefix: prefix,
+                            loc,
+                        }));
+                    Ok(())
                 }
                 AtRulePrelude::Page(selectors) => {
                     let rule =
@@ -2185,29 +2180,27 @@ mod rule_parsers {
             // We parsed a style rule with the `composes` property. Track which
             // properties it used so we can validate it later.
             if matches!(this.composes_state, ComposesState::Allow(_)) {
-                {
-                    let len = input.position() - location;
-                    let mut usage = PropertyBitset::init_empty();
-                    let mut custom_properties: Vec<&'static [u8]> = Vec::new();
-                    fill_property_bit_set(&mut usage, &declarations, &mut custom_properties);
+                let len = input.position() - location;
+                let mut usage = PropertyBitset::init_empty();
+                let mut custom_properties: Vec<&'static [u8]> = Vec::new();
+                fill_property_bit_set(&mut usage, &declarations, &mut custom_properties);
 
-                    let custom_properties_slice = custom_properties.slice();
+                let custom_properties_slice = custom_properties.slice();
 
-                    for ref_ in this.composes_refs.slice() {
-                        let entry =
-                            this.local_properties
-                                .entry(*ref_)
-                                .or_insert_with(|| PropertyUsage {
-                                    range: bun_ast::Range {
-                                        loc: bun_ast::Loc {
-                                            start: i32::try_from(location).expect("int cast"),
-                                        },
-                                        len: i32::try_from(len).expect("int cast"),
+                for ref_ in this.composes_refs.slice() {
+                    let entry =
+                        this.local_properties
+                            .entry(*ref_)
+                            .or_insert_with(|| PropertyUsage {
+                                range: bun_ast::Range {
+                                    loc: bun_ast::Loc {
+                                        start: i32::try_from(location).expect("int cast"),
                                     },
-                                    ..Default::default()
-                                });
-                        entry.fill(&usage, custom_properties_slice);
-                    }
+                                    len: i32::try_from(len).expect("int cast"),
+                                },
+                                ..Default::default()
+                            });
+                    entry.fill(&usage, custom_properties_slice);
                 }
             }
 

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -47,8 +47,6 @@ pub struct DeclarationBlock<'bump> {
 
 pub struct DebugFmt<'a, 'bump>(&'a DeclarationBlock<'bump>);
 
-// blocked_on: Printer::new signature (the ctor shape is unsettled).
-
 impl<'a, 'bump> core::fmt::Display for DebugFmt<'a, 'bump> {
     fn fmt(&self, writer: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Debug formatter: uses a throwaway local arena for the printer's
@@ -263,11 +261,7 @@ impl DeclarationBlock<'static> {
     }
 }
 
-// ─── hash / eql / deep_clone (gated) ──────────────────────────────────────
-// blocked_on: properties_generated — `Property` lacks `DeepClone`/`CssEql`
-// derives and `PropertyId` lacks a `hash(&mut Wyhash)` method. The bodies
-// below un-gate the moment the
-// per-variant trait impls land in `properties_generated.rs`.
+// ─── hash / eql / deep_clone ──────────────────────────────────────────────
 
 impl<'bump> DeclarationBlock<'bump> {
     pub fn hash_property_ids(&self, hasher: &mut bun_wyhash::Wyhash) {
@@ -467,12 +461,10 @@ where
                     );
                 }
                 css::ComposesState::DisallowNotSingleClass(info) => {
-                    // blocked_on: ParserOptions::warn_fmt_with_notes
-                    // (`bun_ast::Log` notes-ownership API). Until that
-                    // lands the note ("The parent selector is not a single
-                    // class selector because of the syntax here:" at
-                    // `info.to_logger_location(options.filename)`) is dropped;
-                    // the primary warning still fires at the right location.
+                    // TODO: attach a note via `ParserOptions::warn_fmt_with_notes`
+                    // ("The parent selector is not a single class selector because
+                    // of the syntax here:" at `info.to_logger_location(...)`).
+                    // For now only the primary warning fires.
                     let _ = info;
                     options.warn_fmt(
                         format_args!("\"composes\" only works inside single class selectors"),

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -461,15 +461,16 @@ where
                     );
                 }
                 css::ComposesState::DisallowNotSingleClass(info) => {
-                    // TODO: attach a note via `ParserOptions::warn_fmt_with_notes`
-                    // ("The parent selector is not a single class selector because
-                    // of the syntax here:" at `info.to_logger_location(...)`).
-                    // For now only the primary warning fires.
-                    let _ = info;
-                    options.warn_fmt(
+                    options.warn_fmt_with_notes(
                         format_args!("\"composes\" only works inside single class selectors"),
                         source_location.line,
                         source_location.column,
+                        Box::new([bun_ast::Data {
+                            text: b"The parent selector is not a single class selector because of the syntax here:"
+                                .as_slice()
+                                .into(),
+                            location: Some(info.to_logger_location(options.filename)),
+                        }]),
                     );
                 }
             }

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -4,12 +4,6 @@ use bun_alloc::ArenaVecExt as _;
 pub use css::Error;
 use css::{CssResult as Result, PrintErr, Printer};
 
-// The `*Handler` types imported below are the real per-shorthand-group
-// implementations from their leaf modules (BackgroundHandler, BoxShadowHandler,
-// BorderRadiusHandler, …). A few leaf modules still keep individual method
-// bodies internally gated until their deps land — see the per-module status
-// notes at the top of properties/mod.rs; this file composes over whichever
-// surface is live.
 use crate::css_properties::align::AlignHandler;
 use crate::css_properties::background::BackgroundHandler;
 use crate::css_properties::border::BorderHandler;
@@ -486,10 +480,6 @@ where
 }
 
 /// Per-shorthand-group handler state used by `DeclarationBlock::minify`.
-///
-/// Each `*Handler` is the real implementation from its leaf module (see the
-/// per-module status notes in properties/mod.rs for any internally-gated
-/// bodies); `Direction` is the data-only `properties::text` enum.
 pub struct DeclarationHandler<'bump> {
     pub background: BackgroundHandler,
     pub border: BorderHandler,

--- a/src/css/generics.rs
+++ b/src/css/generics.rs
@@ -360,9 +360,8 @@ impl CssEql for () {
     }
 }
 
-// CustomIdent/DashedIdent/Ident wrapper structs are hoisted as data-only stubs
-// in `crate::values::ident` (lib.rs); the full impls live in gated
-// `values/ident.rs` and supersede these on un-gate.
+// `CssEql` impls for `CustomIdent`/`DashedIdent`/`Ident` (defined in
+// `values/ident.rs`, which does not depend on this trait).
 mod ident_eql {
     use super::CssEql;
     use crate::values::ident::{CustomIdent, DashedIdent, Ident};

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -151,10 +151,8 @@ pub mod printer;
 #[path = "values/mod.rs"]
 pub mod values;
 
-/// Data-only value-type stubs re-exported through `values::{color,ident,url}`
-/// while the real `values/*.rs` files stay gated on the calc lattice. These
-/// were the previous `gated_mod!(values, ...)` body — now a real module so
-/// printer.rs / css_parser.rs can name the types.
+/// Re-exports from `values::{color,ident,url}` so callers that still use
+/// the legacy `values_stub` path resolve to the canonical types.
 pub mod values_stub {
     /// Re-export the real `values/color.rs` surface so any remaining
     /// `values_stub::color::*` paths resolve to the canonical types.

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -161,8 +161,6 @@ pub mod values_stub {
     pub mod color {
         pub use crate::values::color::*;
 
-        /// `Maybe` is now un-gated as `core::result::Result`, so this is a
-        /// straight type alias to the real `values::color::ParseResult`.
         pub type CssColorParseResult = crate::values::color::ParseResult;
 
         /// https://drafts.csswg.org/css-color/#hsl-to-rgb (`hue` is 0..1 here).
@@ -171,11 +169,7 @@ pub mod values_stub {
         pub use crate::css_parser::color::hsl_to_rgb;
     }
 
-    /// Re-export of the real `values/ident.rs` — the data-only stub that used
-    /// to live here (so `generics::ident_eql` could compile) is obsolete:
-    /// `values::ident` is un-gated and `generics.rs` imports it directly.
-    /// The stub `IdentOrRef` had diverged (tagged enum vs packed-u128), so
-    /// this also removes a latent type-confusion hazard.
+    /// Re-export of the real `values/ident.rs`.
     pub mod ident {
         pub use crate::values::ident::*;
     }
@@ -224,7 +218,7 @@ pub type ImportRecordHandler<'a> = printer::ImportInfo<'a>;
 pub use values::color::{CssColor, FloatColor, LABColor, LabColor, PredefinedColor, RGBA};
 pub use values_stub::color::CssColorParseResult;
 
-// Real re-exports from un-gated modules (cross-crate surface).
+// Cross-crate re-exports.
 pub use error::{
     BasicParseError, BasicParseErrorKind, Err, ErrorLocation, MinifyError, MinifyErrorKind,
     ParseError, ParserError, ParserErrorKind, PrinterError, PrinterErrorKind, SelectorError,
@@ -241,8 +235,7 @@ pub use rules::import::ImportConditions;
 
 // ───────────────────────────── VendorPrefix ─────────────────────────────
 // Hoisted from css_parser.rs so leaf modules (targets, prefixes) can compile
-// without pulling in the 6k-line parser hub. css_parser.rs re-exports this
-// when it un-gates.
+// without pulling in the 6k-line parser hub.
 
 bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -338,8 +331,7 @@ impl VendorPrefix {
 
 // ───────────────────────── Core lexer/location types ─────────────────────────
 // Hoisted from css_parser.rs / rules/mod.rs so leaf modules (error, dependencies)
-// compile without the 6k-line parser hub. css_parser.rs `pub use crate::{..}`s
-// these when it un-gates.
+// compile without the 6k-line parser hub.
 
 /// Line/column within a single source. Column is 1-based, line is 0-based.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]

--- a/src/css/lib.rs
+++ b/src/css/lib.rs
@@ -175,9 +175,9 @@ pub mod values_stub {
 
 // ─── stub re-exports referenced cross-crate ────────────────────────────────
 
-/// Hoisted from `css_parser.rs` (gated). Single-variant error type returned by
-/// every `to_css` path; the *kind* lives in `Printer.error_kind` (PrinterError)
-/// — this is just the bubbled signal.
+/// Single-variant error type returned by every `to_css` path; the *kind*
+/// lives in `Printer.error_kind` (PrinterError) — this is just the bubbled
+/// signal.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PrintErr {
     CSSPrintError,
@@ -375,8 +375,8 @@ pub struct Dimension {
 }
 
 /// CSS lexer token. Data-only definition hoisted out of `css_parser.rs`; the
-/// `to_css*`/`eql`/`hash` impls stay in `css_parser.rs` (gated) since they
-/// depend on `serializer::*` and `generics`.
+/// `to_css*`/`eql`/`hash` impls stay in `css_parser.rs` since they depend on
+/// `serializer::*` and `generics`.
 // Every `&'static [u8]` payload actually borrows the parser arena/source text and
 // must not outlive the arena; `&'static` is the crate-wide placeholder until the
 // bumpalo arena lifetime is plumbed through.

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -12,8 +12,6 @@ pub use crate::Error;
 // params (crate-wide `&'static`/raw-slice placeholder convention); see lib.rs.
 
 // ───────────────────────── value-type imports ─────────────────────────
-// Real `values/` payloads — the calc lattice has un-gated, so the local
-// stand-ins are gone and `MediaFeatureValue` carries the canonical types.
 use crate::css_values::length::Length;
 use crate::css_values::number::{CSSIntegerFns, CSSNumberFns};
 use crate::css_values::ratio::Ratio;
@@ -1381,9 +1379,6 @@ impl MediaFeatureValue {
     pub(crate) fn deep_clone(&self, bump: &bun_alloc::Arena) -> Self {
         use MediaFeatureValue as V;
         match self {
-            // The real `values::length::Length` owns a calc tree. The local
-            // `value_shims::Length` stand-in is a unit struct, so `Clone` is
-            // faithful until the calc lattice un-gates and the shim is replaced.
             V::Length(l) => V::Length(l.clone()),
             V::Number(n) => V::Number(*n),
             V::Integer(i) => V::Integer(*i),

--- a/src/css/media_query.rs
+++ b/src/css/media_query.rs
@@ -1241,9 +1241,7 @@ fn write_min_max<FeatureId: FeatureIdTrait>(
 }
 
 // ───────────────────────── deep_clone ─────────────────────────
-// Arena-aware `deep_clone`. Un-gated this round so
-// `rules::dc::{media_list,query_feature}` can route through real impls
-// instead of `#[derive(Clone)]` passthroughs.
+// Arena-aware `deep_clone`.
 //
 // Written as **inherent** methods (not `#[derive(DeepClone)]`):
 // `name`/`qualifier`/`media_type`/`operator` fields are copied by value

--- a/src/css/properties/background.rs
+++ b/src/css/properties/background.rs
@@ -565,7 +565,6 @@ impl BackgroundProperty {
             | Self::CLIP.bits(),
     );
 
-    // blocked_on: PropertyId variant arity (BackgroundClip carries VendorPrefix payload)
     pub(crate) fn try_from_property_id(property_id: PropertyId) -> Option<BackgroundProperty> {
         match property_id {
             PropertyId::BackgroundColor => Some(Self::BACKGROUND_COLOR),

--- a/src/css/properties/border.rs
+++ b/src/css/properties/border.rs
@@ -233,7 +233,6 @@ pub enum BorderSideWidth {
 }
 
 impl BorderSideWidth {
-    // blocked_on: Length::is_compatible
     pub fn is_compatible(&self, browsers: &Browsers) -> bool {
         match self {
             BorderSideWidth::Length(len) => len.is_compatible(browsers),
@@ -543,7 +542,6 @@ bitflags::bitflags! {
     }
 }
 
-// blocked_on: PropertyIdTag variant name verification (PascalCase mapping)
 impl BorderProperty {
     pub(crate) fn try_from_property_id(property_id: PropertyIdTag) -> Option<Self> {
         // An explicit match over every PropertyIdTag whose name starts

--- a/src/css/properties/css_modules.rs
+++ b/src/css/properties/css_modules.rs
@@ -126,8 +126,7 @@ pub enum Specifier {
 
 // `generics::CssEql` so the `Option<Specifier>` blanket (used by
 // `DashedIdentReference::eql` in values/ident.rs) resolves. Forwards to the
-// inherent `eql` below — same shape the old data-only stub in `values/mod.rs`
-// carried before this leaf un-gated.
+// inherent `eql` below.
 impl crate::generics::CssEql for Specifier {
     #[inline]
     fn eql(&self, other: &Self) -> bool {

--- a/src/css/properties/custom.rs
+++ b/src/css/properties/custom.rs
@@ -5,15 +5,6 @@
 // `EnvironmentVariable::{parse, parse_nested, to_css}`,
 // `EnvironmentVariableName::{parse, to_css}`, `Function::to_css`,
 // `CustomProperty::parse`, `UnparsedProperty::parse` are now real.
-//
-// A few leaf calls (Url::parse/to_css, CustomIdent::to_css) are still
-// ``-gated in *other* files; those bodies are inlined verbatim
-// under `mod ext` below so the hub compiles without touching
-// `values/{url,ident}.rs`. `DashedIdentReference::{parse_with_options,to_css}`
-// are now real and forwarded directly. Remaining internal
-// `` gates carry `blocked_on:` notes for the next round
-// (ComponentParser un-gate from `values::color::gated_full_impl`;
-// `properties::animation` un-gate; `get_fallback` chain).
 
 use crate as css;
 use crate::PrintResult;
@@ -44,20 +35,15 @@ use bun_wyhash::Wyhash;
 use crate::generics::{CssEql, CssHash, DeepClone};
 use bun_alloc::Arena;
 
-// ─── External-gate shims ───────────────────────────────────────────────────
-// `TokenList::{parse,to_css}` bottom out on a handful of leaf fns that still
-// carry `` in *other* files (`values/{url,ident}.rs`,
-// `css_modules.rs`). Those gates are stale — every dependency they cite now
-// exists — but this round's edit scope is `custom.rs` + `css_parser.rs` only.
-// To un-gate the TokenList hub without touching those files, the leaf bodies
-// are inlined here verbatim. Once `url.rs`/`ident.rs` un-gate, callers below
-// can swap back to the canonical methods and this module drops.
+// ─── leaf fn inlines ───────────────────────────────────────────────────────
+// `TokenList::{parse,to_css}` bottom out on a handful of leaf fns from
+// `values/{url,ident}.rs` / `css_modules.rs`; inlined here so the hub does
+// not circularly depend on those modules.
 mod ext {
     use super::*;
     use crate::dependencies;
 
-    /// Inline of `Url::parse` (gated in `values/url.rs` on
-    /// `Parser::add_import_record`, which now exists at css_parser.rs:3228).
+    /// Inline of `Url::parse`.
     pub(super) fn url_parse(input: &mut Parser) -> Result<Url> {
         let start_pos = input.position();
         let loc = input.current_source_location();
@@ -73,8 +59,7 @@ mod ext {
         })
     }
 
-    /// Inline of `Url::to_css` (gated in `values/url.rs` on `WriteAll for
-    /// Vec<u8>`, which this round adds in css_parser.rs).
+    /// Inline of `Url::to_css`.
     pub(super) fn url_to_css(this: &Url, dest: &mut Printer) -> PrintResult<()> {
         let dep: Option<dependencies::UrlDependency> = if dest.dependencies.is_some() {
             // `get_import_records` borrows &mut *dest, so capture
@@ -143,9 +128,9 @@ mod ext {
         Ok(())
     }
 
-    /// Forwarder to `DashedIdentReference::parse_with_options` (now un-gated
-    /// in `values/ident.rs`). Honors `options.css_modules.dashed_idents` and
-    /// parses the `from <specifier>` suffix when enabled.
+    /// Forwarder to `DashedIdentReference::parse_with_options`. Honors
+    /// `options.css_modules.dashed_idents` and parses the
+    /// `from <specifier>` suffix when enabled.
     #[inline]
     pub(super) fn dashed_ident_ref_parse(
         input: &mut Parser,
@@ -154,9 +139,7 @@ mod ext {
         DashedIdentReference::parse_with_options(input, options)
     }
 
-    /// Forwarder to `DashedIdentReference::to_css` (now un-gated in
-    /// `values/ident.rs`). `CssModule::reference_dashed` is real; the
-    /// CSS-Modules `dashed_idents` remapping path is wired.
+    /// Forwarder to `DashedIdentReference::to_css`.
     #[inline]
     pub(super) fn dashed_ident_ref_to_css(
         this: &DashedIdentReference,
@@ -165,8 +148,7 @@ mod ext {
         this.to_css(dest)
     }
 
-    /// Inline of `CustomIdent::to_css` (gated in `values/ident.rs` on
-    /// `Printer::write_ident`, which now exists at printer.rs:534).
+    /// Inline of `CustomIdent::to_css`.
     pub(super) fn custom_ident_to_css(this: &CustomIdent, dest: &mut Printer) -> PrintResult<()> {
         let css_module_custom_idents_enabled = match &dest.css_module {
             Some(m) => m.config.custom_idents,
@@ -382,8 +364,6 @@ impl TokenList {
                     has_whitespace = false;
                 }
                 TokenOrValue::DashedIdent(v) => {
-                    // Inline of `DashedIdent::to_css` (gated in ident.rs on
-                    // `Printer::write_dashed_ident`, which now exists).
                     dest.write_dashed_ident(v, true)?;
                     has_whitespace = false;
                 }

--- a/src/css/properties/font.rs
+++ b/src/css/properties/font.rs
@@ -7,13 +7,6 @@
 // VerticalAlignKeyword / FontProperty / FontHandler) are real and referenced
 // by `properties_generated.rs`, `declaration.rs`, and
 // `rules/{font_face,font_palette_values}.rs`.
-//
-// Most `parse` / `to_css` *bodies* remain ``-gated below
-// because they bottom out on still-unported leaf surface (DeriveParse /
-// DeriveToCss proc-macros, EnumProperty derive over strum, Vec::parse,
-// parse_utility::parse_string, generics::is_compatible blanket). Each gate
-// carries a `blocked_on:` note so the next round can lift bodies as their
-// deps land.
 
 #![warn(unused_must_use)]
 
@@ -897,9 +890,6 @@ pub struct FontHandler {
 }
 
 impl FontHandler {
-    // blocked_on: generics::is_compatible/eql/deepClone blankets,
-    // PropertyHandlerContext::arena(), DeclarationList::push,
-    // Property::Font*/Unparsed payloads, FontFamilyHashMap.
     pub(crate) fn handle_property(
         &mut self,
         property: &crate::properties::Property,
@@ -988,8 +978,6 @@ impl FontHandler {
         self.flushed_properties = FontProperty::empty();
     }
 
-    // blocked_on: FontFamilyHashMap, PropertyHandlerContext::arena(),
-    // Vec::ordered_remove/insert/at, generics::is_compatible.
     fn flush(
         &mut self,
         decls: &mut crate::DeclarationList<'_>,
@@ -1135,7 +1123,6 @@ const DEFAULT_SYSTEM_FONTS: &[&[u8]] = &[
     b"Helvetica Neue",
 ];
 
-// blocked_on: Vec::insert arena threading + arena Bump param.
 #[inline]
 fn compatible_font_family(
     _family: Option<Vec<FontFamily>>,

--- a/src/css/properties/masking.rs
+++ b/src/css/properties/masking.rs
@@ -512,7 +512,6 @@ pub enum WebKitMaskSourceType {
     Alpha,
 }
 
-// blocked_on: PropertyId::WebKitMaskComposite variant name (codegen spelling is `WebKitMaskComposite`)
 pub fn get_webkit_mask_property(property_id: &PropertyId) -> Option<PropertyId> {
     match property_id {
         PropertyId::MaskBorderSource => Some(PropertyId::MaskBoxImageSource(VendorPrefix::WEBKIT)),

--- a/src/css/properties/masking.rs
+++ b/src/css/properties/masking.rs
@@ -10,8 +10,6 @@ use crate::css_values::position::Position;
 use crate::css_values::rect::Rect;
 
 use crate::css_properties::border_radius::BorderRadius;
-// `shape` is still gated; FillRule referenced only by the (gated) BasicShape::Polygon body.
-
 use crate::css_properties::shape::FillRule;
 
 use crate::css_properties::background::BackgroundRepeat;

--- a/src/css/properties/mod.rs
+++ b/src/css/properties/mod.rs
@@ -5,12 +5,7 @@
 // `properties_generated.rs` carries the 249-variant `Property` /
 // `PropertyId` / `PropertyIdTag` enums referenced by `declaration.rs`,
 // `context.rs`, and `rules/`. Every *value type* the `Property` enum names is
-// re-exposed below via `pub mod $name`. When a leaf .rs file un-gates, its
-// real type replaces the stub transparently (same path, same name).
-//
-// `prefixes::Feature` and the entire `values/` lattice are real, so
-// `PropertyId::set_prefixes_for_targets` / `from_name_and_prefix` and the
-// `Property` payloads that name `css_values::*` resolve directly.
+// re-exposed below via `pub mod $name`.
 
 // ─── Rect / Size shorthand impl + define macros ────────────────────────────
 // Shared by `border.rs` and `margin_padding.rs`.
@@ -125,46 +120,23 @@ macro_rules! impl_size_shorthand {
 // ─── Submodule declarations ────────────────────────────────────────────────
 //
 pub mod align;
-// `animation`: un-gated — real AnimationName / Animation / AnimationIterationCount /
-// AnimationDirection / AnimationPlayState / AnimationFillMode / AnimationTimeline /
-// Scroller / ScrollAxis / ViewTimeline / AnimationRangeStart / AnimationRangeEnd /
-// AnimationRange / TimelineRangeName / AnimationComposition / AnimationHandler
-// live in `animation.rs`.
 pub mod animation;
 pub mod background;
 pub mod border;
-// `border_image`: un-gated — real BorderImage / BorderImageSlice /
-// BorderImageSideWidth / BorderImageRepeat / BorderImageHandler live in
-// `border_image.rs`. parse/to_css for BorderImageSideWidth remain internally
-// gated on the DeriveParse/DeriveToCss proc-macros.
 pub mod border_image;
-// `border_radius`: un-gated — real BorderRadius + BorderRadiusHandler
-// (handle_property/finalize bodies) live in `border_radius.rs`.
 pub mod border_radius;
-// `box_shadow`: un-gated — real BoxShadow + BoxShadowHandler live in
-// `box_shadow.rs`.
 pub mod box_shadow;
 pub mod display;
 pub mod effects;
 pub mod flex;
-// `font`: un-gated — real data types (FontWeight / FontSize / FontStretch /
-// FontFamily / FontStyle / FontVariantCaps / LineHeight / Font / FontHandler)
-// live in `font.rs`. parse/to_css/handle_property bodies remain internally
-// ``-gated there until DeriveParse/DeriveToCss proc-macros +
-// EnumProperty derive land.
 pub mod font;
 pub mod grid;
-// `list`: un-gated — real ListStyleType / CounterStyle / Symbols / Symbol
-// live in `list.rs`. PredefinedCounterStyle / SymbolsType / ListStylePosition /
-// ListStyle / MarkerSide are uninhabited.
 pub mod list;
 pub mod margin_padding;
 pub mod masking;
 pub mod outline;
 pub mod overflow;
 pub mod position;
-// `prefix_handler`: un-gated — real FallbackHandler (handle_property/finalize
-// bodies) lives in `prefix_handler.rs`.
 pub mod prefix_handler;
 pub mod shape;
 pub mod size;
@@ -174,18 +146,8 @@ pub mod transform;
 pub mod transition;
 pub mod ui;
 
-// `css_modules`: un-gated — real `Composes` payload (names/from/loc/
-// cssparser_loc) + `Specifier` enum (Global/ImportRecordIndex) live in
-// `css_modules.rs`. `Composes::to_css` stays internally ``-gated
-// on `CustomIdent::to_css` (Printer::write_ident).
 pub mod css_modules;
 
-// `custom`: un-gated — real data types (TokenList / TokenOrValue /
-// CustomProperty / CustomPropertyName / UnparsedProperty / EnvironmentVariable
-// / Variable / Function / UnresolvedColor / UAEnvironmentVariable) live in
-// `custom.rs`. parse/to_css/deep_clone/eql/hash bodies remain internally
-// ``-gated there until their leaf deps (ident/url/color/
-// generics) un-gate.
 pub mod custom;
 
 pub mod properties_generated;

--- a/src/css/properties/prefix_handler.rs
+++ b/src/css/properties/prefix_handler.rs
@@ -29,11 +29,9 @@ impl FallbackHandler {
 
         let arena = dest.bump();
 
-        // The generic-trait surface (`DeepClone`/`IsCompatible`/`get_fallbacks`
-        // on `SmallList<TextShadow,1>`) is still partially gated, so each
-        // (field, Property variant) pair is expanded via a macro that takes
-        // per-type closures for those three ops. This lets each payload type
-        // use its own inherent methods until the trait lattice un-gates.
+        // Each (field, Property variant) pair is expanded via a macro that
+        // takes per-type closures for `DeepClone`/`IsCompatible`/`get_fallbacks`,
+        // letting each payload type use its own inherent methods.
         macro_rules! handle_unprefixed {
             (
                 $self_field:ident,

--- a/src/css/properties/properties_generated.rs
+++ b/src/css/properties/properties_generated.rs
@@ -17,9 +17,7 @@ use super::CSSWideKeyword;
 use super::custom::{CustomProperty, CustomPropertyName, UnparsedProperty};
 use super::properties_impl;
 
-// Leaf property modules (gated in mod.rs — these resolve to the inline
-// `pub mod $name { prop_value_stub!(...) }` bodies until the real .rs files
-// un-gate).
+// Leaf property modules.
 use super::align;
 use super::background;
 use super::border;
@@ -6193,7 +6191,6 @@ impl Property {
     /// Per-type `longhand` is not implemented yet, so the per-arm dispatch is
     /// routed through a no-op `lh!` (`return None`) until the
     /// `DefineShorthand` derive exists. There are no callers.
-    // blocked_on: shorthand_handler_port — leaf shorthand types lack `.longhand()`
     pub fn longhand(&self, property_id: &PropertyId) -> Option<Property> {
         #[inline(always)]
         fn lh<T: ?Sized>(_v: &T, _id: &PropertyId) -> Option<Property> {
@@ -6291,7 +6288,6 @@ impl Property {
         }
     }
 
-    // blocked_on: leaf_value_traits — un-gate once every payload type impls `generics::DeepClone`
     pub fn deep_clone(&self, arena: &bun_alloc::Arena) -> Property {
         match self {
             Property::BackgroundColor(v) => {
@@ -6868,7 +6864,6 @@ impl Property {
         }
     }
 
-    // blocked_on: leaf_value_traits — un-gate once every payload type impls `generics::CssEql`
     pub fn eql(&self, other: &Property) -> bool {
         match (self, other) {
             (Property::BackgroundColor(a), Property::BackgroundColor(b)) => css::generic::eql(a, b),
@@ -7401,9 +7396,7 @@ impl Property {
 
 // `declaration::placeholder_property()` (the moved-out slot
 // sentinel in `DeclarationBlock::minify`) is
-// `Property::All(CSSWideKeyword::RevertLayer)`. Expose it via `Default` so
-// the un-gated stub branch in `declaration.rs` keeps compiling against the
-// real enum.
+// `Property::All(CSSWideKeyword::RevertLayer)`.
 impl Default for Property {
     #[inline]
     fn default() -> Self {

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -15,8 +15,6 @@ use super::ArrayList;
 /// A property within an `@font-face` rule.
 ///
 /// See [FontFaceRule](FontFaceRule).
-//
-
 pub enum FontFaceProperty {
     /// The `src` property.
     Source(ArrayList<Source>),
@@ -467,8 +465,6 @@ impl FontFormat {
 
 /// A value for the [src](https://drafts.csswg.org/css-fonts/#src-desc)
 /// property in an `@font-face` rule.
-//
-
 pub enum Source {
     /// A `url()` with optional format metadata.
     Url(UrlSource),

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -130,7 +130,6 @@ pub struct UnicodeRange {
     pub end: u32,
 }
 
-
 impl UnicodeRange {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
         // Attempt to optimize the range to use question mark syntax.
@@ -344,7 +343,6 @@ pub enum FontStyle {
     Oblique(Size2D<Angle>),
 }
 
-
 impl FontStyle {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<FontStyle> {
         use crate::css_properties::font::FontStyle as FontStyleProperty;
@@ -416,7 +414,6 @@ pub enum FontFormat {
     // Arena-owned slice from parser input; TODO(refactor): thread `'i`.
     String(&'static [u8]),
 }
-
 
 impl FontFormat {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<FontFormat> {
@@ -572,7 +569,6 @@ pub struct UrlSource {
     pub tech: ArrayList<FontTechnology>,
 }
 
-
 impl UrlSource {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<UrlSource> {
         let url = Url::parse(input)?;
@@ -675,7 +671,6 @@ impl FontFaceRule {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct FontFaceDeclarationParser;
-
 
 const _: () = {
     use crate::css_properties::custom::{CustomProperty, CustomPropertyName};

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -16,10 +16,6 @@ use super::ArrayList;
 ///
 /// See [FontFaceRule](FontFaceRule).
 //
-// blocked_on: properties::font::{FontFamily,FontWeight,FontStretch} +
-// properties::custom::CustomProperty (both `gated_prop!`-stubbed in
-// properties/mod.rs). The enum body un-gates with the variant payloads
-// once those leaves un-gate.
 
 pub enum FontFaceProperty {
     /// The `src` property.
@@ -134,10 +130,6 @@ pub struct UnicodeRange {
     pub end: u32,
 }
 
-// blocked_on: Printer::write_fmt, Parser::{expect_ident_matching,position,
-// slice_from,next_including_whitespace,state,reset,
-// new_basic_unexpected_token_error}, Token shape (Dimension/Number/Delim
-// payloads), bun_core::{split_first,split_first_with_expected}.
 
 impl UnicodeRange {
     pub(crate) fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
@@ -352,8 +344,6 @@ pub enum FontStyle {
     Oblique(Size2D<Angle>),
 }
 
-// blocked_on: properties::font::FontStyle (gated_prop!), Angle::parse,
-// Size2D::{eql,to_css}.
 
 impl FontStyle {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<FontStyle> {
@@ -427,8 +417,6 @@ pub enum FontFormat {
     String(&'static [u8]),
 }
 
-// blocked_on: Parser::expect_ident_or_string, bun_core ASCII-eq fn name,
-// DeepClone.
 
 impl FontFormat {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<FontFormat> {
@@ -483,7 +471,6 @@ impl FontFormat {
 /// A value for the [src](https://drafts.csswg.org/css-fonts/#src-desc)
 /// property in an `@font-face` rule.
 //
-// blocked_on: properties::font::FontFamily (gated_prop!).
 
 pub enum Source {
     /// A `url()` with optional format metadata.
@@ -585,10 +572,6 @@ pub struct UrlSource {
     pub tech: ArrayList<FontTechnology>,
 }
 
-// blocked_on: Url::{parse,to_css}, FontFormat::{parse,to_css},
-// FontTechnology::{parse,to_css}, Parser::{try_parse_with,
-// expect_function_matching,parse_nested_block,parse_list},
-// css::{void_wrap,to_css::from_list}, DeepClone.
 
 impl UrlSource {
     pub(crate) fn parse(input: &mut css::Parser) -> css::Result<UrlSource> {
@@ -680,9 +663,6 @@ impl FontFaceRule {
 
 impl FontFaceRule {
     pub(crate) fn deep_clone(&self, bump: &bun_alloc::Arena) -> Self {
-        // `css.implementDeepClone` field-walk. `FontFaceProperty`'s
-        // variant-walk lands when its enum body un-gates (properties::{font,
-        // custom}); the gated stub above panics with the blocker named.
         Self {
             properties: self.properties.iter().map(|p| p.deep_clone(bump)).collect(),
             loc: self.loc,
@@ -696,10 +676,6 @@ impl FontFaceRule {
 
 pub(crate) struct FontFaceDeclarationParser;
 
-// blocked_on: css::{AtRuleParser,QualifiedRuleParser,DeclarationParser,
-// RuleBodyItemParser} trait signatures, properties::font::* +
-// properties::custom::CustomProperty, Size2D::parse, Parser surface,
-// FontFaceProperty enum body.
 
 const _: () = {
     use crate::css_properties::custom::{CustomProperty, CustomPropertyName};

--- a/src/css/rules/font_palette_values.rs
+++ b/src/css/rules/font_palette_values.rs
@@ -80,9 +80,6 @@ pub enum FontPaletteValuesProperty {
 
 impl FontPaletteValuesRule {
     pub(crate) fn deep_clone(&self, bump: &bun_alloc::Arena) -> Self {
-        // `FontPaletteValuesProperty`'s variant-walk lands when its enum body
-        // un-gates (properties::{font, custom}); the gated stub above panics
-        // with the blocker named.
         Self {
             name: self.name.deep_clone(bump),
             properties: self.properties.iter().map(|p| p.deep_clone(bump)).collect(),

--- a/src/css/rules/import.rs
+++ b/src/css/rules/import.rs
@@ -115,9 +115,6 @@ impl ImportConditions {
     /// Furthermore, a URL token is not valid in `@media` or `@layer` rules.
     ///
     /// But this could change in the future, so still keeping this function.
-    ///
-    // blocked_on: MediaList::clone_with_import_records (no impl yet on MediaList).
-
     pub fn clone_with_import_records(
         &self,
         arena: &Arena,
@@ -145,9 +142,6 @@ impl ImportConditions {
             (Some(a), Some(b)) => a.eql(b),
         }
     }
-
-    // blocked_on: SupportsCondition::eql (gated in supports.rs on
-    // generics::CssEql derive).
 
     pub fn supports_eql(lhs: &Self, rhs: &Self) -> bool {
         match (&lhs.supports, &rhs.supports) {
@@ -253,8 +247,6 @@ impl ImportRule {
     }
 
     /// The `import_records` here is preserved from esbuild in the case that we do need it, it doesn't seem necessary now
-    // blocked_on: MediaList::clone_with_import_records (no impl yet on MediaList).
-
     pub fn conditions_with_import_records(
         &self,
         arena: &Arena,

--- a/src/css/rules/import.rs
+++ b/src/css/rules/import.rs
@@ -358,5 +358,3 @@ const _: () = {
             == core::mem::offset_of!(ImportConditions, media)
     );
 };
-
-// silence unused-import warnings on the gated bodies' deps

--- a/src/css/rules/keyframes.rs
+++ b/src/css/rules/keyframes.rs
@@ -172,7 +172,6 @@ impl KeyframeSelector {
 }
 
 // ─── KeyframeSelector parse ───────────────────────────────────────────────
-// blocked_on: css::derive_parse (DeriveParse).
 
 impl KeyframeSelector {
     // Try the tuple variant (`Percentage`) first, then fall back to keyword
@@ -315,11 +314,6 @@ impl KeyframesRule {
 // ──────────────────────────────────────────────────────────────────────────
 
 pub(crate) struct KeyframesListParser;
-
-// blocked_on: css::{DeclarationParser, AtRuleParser, QualifiedRuleParser,
-// RuleBodyItemParser} trait signatures (css_parser.rs round-5 surface),
-// Parser::parse_comma_separated, DeclarationBlock::parse, ParserOptions::default
-// arena threading.
 
 const _: () = {
     use css::css_parser::{

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -372,9 +372,7 @@ pub(super) fn vendor_prefix_to_css(
 }
 
 /// Port of `CustomIdentFns.toCss` → `Printer.writeIdent` with CSS-module
-/// custom-ident scoping. Both `CustomIdent::to_css` and `Printer::write_ident`
-/// are gated on the css_modules `Pattern::write` borrowck reshape; this is the
-/// non-css-module tail (`serialize_identifier`) that both share.
+/// custom-ident scoping.
 #[inline]
 pub(super) fn custom_ident_to_css(
     ident: &css::css_values::ident::CustomIdent,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -588,17 +588,15 @@ impl<R> CssRuleList<R> {
                         doc.rules.minify(context, parent_is_unused)?;
                     }
                     CssRule::Style(_sty) => {
-                        {
-                            minify_style_arm(
-                                rule,
-                                &mut rules,
-                                &mut style_rules,
-                                &mut merge_state,
-                                context,
-                                parent_is_unused,
-                            )?;
-                            break 'arm;
-                        }
+                        minify_style_arm(
+                            rule,
+                            &mut rules,
+                            &mut style_rules,
+                            &mut merge_state,
+                            context,
+                            parent_is_unused,
+                        )?;
+                        break 'arm;
                     }
                     CssRule::CounterStyle(_) => {}
                     CssRule::Scope(scpe) => {

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -171,24 +171,16 @@ impl<R> Default for CssRuleList<R> {
 // wise / variant-wise port of `css.implementDeepClone`. `CssRule::deep_clone`
 // (below) dispatches via method-syntax so it picks up the inherent impl.
 //
-// Most leaf rules can't use `#[derive(DeepClone)]` directly yet
-// because two field types still lack an arena-aware `deep_clone(&self,
-// &Arena) -> Self`: `SelectorList` (selectors/parser.rs uses no-arg
-// `deep_clone()`) and `Property` (properties_generated.rs — per-variant body
-// gated on leaf_value_traits). `MediaList` / `QueryFeature` /
-// `DeclarationBlock` now route to their real arena-aware impls. The leaf
-// bodies hand-roll the field walk and route the remaining blocked fields
-// through the `dc::*` passthroughs below. Once an upstream type grows its own
-// `deep_clone(&self, &Arena)`, swap the `dc::foo(&x, bump)` call for
-// `x.deep_clone(bump)` and delete the helper.
+// Most leaf rules can't use `#[derive(DeepClone)]` directly because
+// `SelectorList` uses a no-arg `deep_clone()`. The leaf bodies hand-roll the
+// field walk and route those fields through the `dc::*` passthroughs below.
+// Once an upstream type grows its own `deep_clone(&self, &Arena)`, swap the
+// `dc::foo(&x, bump)` call for `x.deep_clone(bump)` and delete the helper.
 pub(super) mod dc {
     use bun_alloc::Arena;
 
-    /// `DeclarationBlock::deep_clone` — real port body inlined here (the
-    /// canonical impl in declaration.rs is gated on `Property: DeepClone`).
-    /// Field-walk over both `DeclarationList`s, routing each `Property`
-    /// through `dc::property` so the only remaining bottleneck is the
-    /// per-variant `Property::deep_clone` body.
+    /// `DeclarationBlock::deep_clone` — field-walk over both
+    /// `DeclarationList`s, routing each `Property` through `dc::property`.
     ///
     /// Threads the real `'bump` lifetime instead of fabricating
     /// `'static` (PORTING.md §Forbidden: `unsafe { &*(p as *const _) }` to
@@ -662,9 +654,6 @@ impl<R> CssRuleList<R> {
         }
     }
 }
-
-// ── `.style` arm body — preserved verbatim port, gated on StyleRule
-// behavior + selector helpers + DeclarationBlock::deep_clone. ──
 
 fn minify_style_arm<R: for<'b> css::generics::DeepClone<'b>>(
     rule: &mut CssRule<R>,

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -32,11 +32,9 @@ pub mod unknown;
 pub mod viewport;
 
 // ─── CssRule / CssRuleList ─────────────────────────────────────────────────
-// An earlier iteration threaded a `'bump` arena lifetime through every
-// rule. That cascades into
-// every leaf module signature; while those leaves are gated, `CssRule<R>` is
-// kept lifetime-free here (the gated bodies re-introduce `'bump` when they
-// un-gate alongside `bumpalo::collections::Vec` storage).
+// An earlier iteration threaded a `'bump` arena lifetime through every rule.
+// That cascades into every leaf module signature, so `CssRule<R>` is kept
+// lifetime-free here.
 
 // ─── CssRule variant table ────────────────────────────────────────────────
 // Single source of truth for the 20 typed at-rule payloads. Adding a new
@@ -68,7 +66,7 @@ macro_rules! css_rule_variants {
                     // false`, `BundlerAtRule = DefaultAtRule` in css_parser.rs),
                     // so erroring here is correct for every `R` that is
                     // actually instantiated. If
-                    // `TailwindAtRule` is ever un-gated, thread a `ToCss`-style bound
+                    // `TailwindAtRule` is ever enabled, thread a `ToCss`-style bound
                     // (or per-`R` vtable) so `Custom(x)` dispatches to
                     // `x.to_css(dest)` and only the error path maps through
                     // `add_fmt_error()`; that bound cascades through every nested
@@ -155,8 +153,7 @@ unsafe impl<R: Sync> Sync for CssRule<R> {}
 
 /// Ordered list of CSS rules, generic over the custom at-rule type `R`.
 pub struct CssRuleList<R> {
-    // PERF: re-thread to `bun_alloc::ArenaVec<'bump, CssRule<'bump, R>>`
-    // when leaf rules un-gate.
+    // PERF: re-thread to `bun_alloc::ArenaVec<'bump, CssRule<'bump, R>>`.
     pub v: Vec<CssRule<R>>,
 }
 
@@ -168,12 +165,6 @@ impl<R> Default for CssRuleList<R> {
         Self { v: Vec::new() }
     }
 }
-
-// ─── leaf-rule to_css shims ────────────────────────────────────────────────
-// All leaf modules now own a real, un-gated `to_css` body; `CssRule::to_css`
-// dispatches straight through. (Shim macro deleted — last entry was
-// `StyleRule`, dropped once DeclarationBlock::to_css + selector serialize
-// landed.)
 
 // ─── leaf-rule deep_clone ──────────────────────────────────────────────────
 // Every leaf module now owns a real inherent `deep_clone` body — the field-
@@ -335,9 +326,7 @@ pub(super) mod dc {
 // 12 leaf rules can serialize for real. Once the upstream gates drop, callers
 // switch back and these are deleted.
 
-/// `DeclarationBlock` block serialization. The real impl is gated in
-/// `declaration.rs`; `Property::to_css` is un-gated so the body is
-/// trivially inlinable here.
+/// `DeclarationBlock` block serialization.
 pub(super) fn decl_block_to_css(
     decls: &css::DeclarationBlock<'_>,
     dest: &mut Printer,
@@ -371,8 +360,8 @@ pub(super) fn decl_block_to_css(
 }
 
 /// `VendorPrefix` serialization. Lives here because the
-/// canonical `impl VendorPrefix` block in lib.rs hasn't grown a `to_css` yet
-/// and `rules/` is the only un-gated caller.
+/// canonical `impl VendorPrefix` block in lib.rs hasn't grown a `to_css`
+/// yet and `rules/` is the only caller.
 #[inline]
 pub(super) fn vendor_prefix_to_css(
     prefix: css::VendorPrefix,
@@ -399,9 +388,6 @@ pub(super) fn custom_ident_to_css(
 ) -> Result<(), PrintErr> {
     // SAFETY: CustomIdent.v points into the parser arena which outlives the AST.
     let v = unsafe { crate::arena_str(ident.v) };
-    // blocked_on: Printer::write_ident — css-module custom-ident scoping path
-    // is gated; fall through to its unscoped tail.
-
     let enabled = dest
         .css_module
         .as_ref()
@@ -409,10 +395,9 @@ pub(super) fn custom_ident_to_css(
     dest.write_ident(v, enabled)
 }
 
-/// Port of `DashedIdentFns.toCss` → `Printer.writeDashedIdent`. The real
-/// printer method is gated on a borrowck reshape of the css-module pattern
-/// closure; the non-css-module path (the only one any current rule reaches)
-/// is `--` + `serialize_name(rest)`.
+/// Port of `DashedIdentFns.toCss` → `Printer.writeDashedIdent`. The
+/// non-css-module path (the only one any current rule reaches) is
+/// `--` + `serialize_name(rest)`.
 #[inline]
 pub(super) fn dashed_ident_to_css(
     ident: &css::css_values::ident::DashedIdent,
@@ -420,17 +405,13 @@ pub(super) fn dashed_ident_to_css(
 ) -> Result<(), PrintErr> {
     let v = ident.v();
     dest.write_str("--")?;
-    // blocked_on: Printer::write_dashed_ident — css-module dashed-ident scoping
-    // path is gated; fall through to the unscoped tail it shares.
     dest.serialize_name(&v[2..])
 }
 
-/// Shim: `MediaRule::minify` is gated in `media.rs` until that file's full
-/// `to_css` body un-gates. Recurse into the nested list and report whether the
-/// rule should be dropped. NOTE: `never_matches()` is a *drop condition*, not
-/// merely an optimization — omitting it diverges output (e.g. `@media not all
-/// { a{color:red} }` must be removed). `MediaList::never_matches` is un-gated,
-/// so call it here.
+/// Recurse into the nested list and report whether the rule should be
+/// dropped. NOTE: `never_matches()` is a *drop condition*, not merely an
+/// optimization — omitting it diverges output (e.g. `@media not all
+/// { a{color:red} }` must be removed).
 impl<R> media::MediaRule<R> {
     pub fn minify(
         &mut self,
@@ -538,11 +519,6 @@ impl<R> CssRuleList<R> {
     where
         R: for<'b> css::generics::DeepClone<'b>,
     {
-        // blocked_on (style arm only): StyleRule::{minify,is_compatible,
-        // update_prefix,hash_key,is_duplicate}, selector::{is_compatible,
-        // is_equivalent,Selector::from_component}, SelectorList::deep_clone,
-        // DeclarationBlock::deep_clone — all `` in their leaves.
-
         let mut style_rules = StyleRuleKeyMap::default();
         let mut merge_state = StyleRuleMergeState::default();
         let mut rules: Vec<CssRule<R>> = Vec::new();
@@ -565,8 +541,6 @@ impl<R> CssRuleList<R> {
                         }
                     }
                     CssRule::Media(med) => {
-                        // blocked_on: MediaList::eql — merge-with-previous-@media.
-
                         if let Some(CssRule::Media(last_rule)) = rules.last_mut()
                             && last_rule.query.eql(&med.query)
                         {
@@ -579,8 +553,6 @@ impl<R> CssRuleList<R> {
                         }
                     }
                     CssRule::Supports(supp) => {
-                        // blocked_on: SupportsCondition::eql (gated in supports.rs).
-
                         if let Some(CssRule::Supports(last_rule)) = rules.last_mut()
                             && last_rule.condition.eql(&supp.condition)
                         {
@@ -616,12 +588,6 @@ impl<R> CssRuleList<R> {
                         doc.rules.minify(context, parent_is_unused)?;
                     }
                     CssRule::Style(_sty) => {
-                        // The full `.style` arm (selector compat partitioning,
-                        // merge-with-previous, logical/@supports expansion,
-                        // dedup via StyleRuleKey, nested-rule split) bottoms
-                        // out on the gated StyleRule behavior surface. Until
-                        // that un-gates, fall through and keep the rule as-is.
-
                         {
                             minify_style_arm(
                                 rule,
@@ -1299,8 +1265,8 @@ pub struct MinifyContext<'a, 'bump> {
     pub handler_context: css::PropertyHandlerContext<'bump>,
     /// Class/id names known to be unused (tree-shaking input).
     // `selector::is_unused` currently borrows `&ArrayHashMap<&[u8], ()>`; the
-    // owning `MinifyOptions` stores `Box<[u8]>` keys — reconcile when
-    // `style.rs::minify` un-gates (single key type, `Borrow<[u8]>` lookup).
+    // owning `MinifyOptions` stores `Box<[u8]>` keys — reconcile to a
+    // single key type with `Borrow<[u8]>` lookup.
     pub unused_symbols: &'a bun_collections::ArrayHashMap<Box<[u8]>, ()>,
     /// Pre-scanned `@custom-media` definitions, if the feature is enabled.
     pub custom_media:

--- a/src/css/rules/mod.rs
+++ b/src/css/rules/mod.rs
@@ -319,12 +319,6 @@ pub(super) mod dc {
 // `#[derive(DeepClone)]` proc-macro round-trips through a real CSS type.
 
 // ─── shared serialization helpers for leaf rules ──────────────────────────
-// Several leaf-rule `to_css` bodies bottom out on helpers whose canonical
-// homes are still ``-gated outside `rules/` (DeclarationBlock::
-// to_css_block, VendorPrefix::toCss, CustomIdent/DashedIdent ::toCss). The
-// bodies are tiny and have no further blockers, so they're inlined here so the
-// 12 leaf rules can serialize for real. Once the upstream gates drop, callers
-// switch back and these are deleted.
 
 /// `DeclarationBlock` block serialization.
 pub(super) fn decl_block_to_css(

--- a/src/css/rules/nesting.rs
+++ b/src/css/rules/nesting.rs
@@ -17,8 +17,6 @@ impl<R> NestingRule<R> {
         if dest.context().is_none() {
             dest.write_str("@nest ")?;
         }
-        // NOTE: dispatches to the `StyleRule` to_css shim in rules/mod.rs until
-        // style.rs un-gates its real body (selector serialize + Property::Composes).
         self.style.to_css(dest)
     }
 }

--- a/src/css/rules/style.rs
+++ b/src/css/rules/style.rs
@@ -506,9 +506,6 @@ impl<R> StyleRule<R> {
         R: crate::generics::DeepClone<'bump>,
     {
         // css is an AST crate (PORTING.md §Allocators): the allocator is &'bump Bump, threaded.
-        // `declarations` routes through `dc::decl_block` until
-        // `DeclarationBlock::deep_clone` un-gates (declaration.rs — bottoms out
-        // on `Property: DeepClone`).
         Self {
             selectors: self.selectors.deep_clone(),
             vendor_prefix: self.vendor_prefix,

--- a/src/css/rules/supports.rs
+++ b/src/css/rules/supports.rs
@@ -98,11 +98,6 @@ impl SupportsCondition {
 }
 
 impl SupportsCondition {
-    // blocked_on: generics::CssHash for PropertyId — `#[derive(CssHash)]` /
-    // `implement_hash` need every field type to provide `.hash(&mut Wyhash)`.
-    // `PropertyId` only impls `core::hash::Hash` today. TODO(refactor): add
-    // `impl CssHash for PropertyId` then swap to `#[derive(CssHash)]`.
-
     pub fn hash(&self, hasher: &mut bun_wyhash::Wyhash) {
         // Hand-expanded because `#[derive(CssHash)]` would require
         // `PropertyId: CssHash` (it only provides `core::hash::Hash`).

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1298,14 +1298,12 @@ impl<'a> SelectorParser<'a> {
             );
         }
 
-        {
-            let mut args: Vec<css::css_properties::custom::TokenOrValue> = Vec::new();
-            TokenList::parse_raw(input, &mut args, self.options, 0)?;
-            return Ok(PseudoElement::CustomFunction {
-                name,
-                arguments: TokenList { v: args },
-            });
-        }
+        let mut args: Vec<css::css_properties::custom::TokenOrValue> = Vec::new();
+        TokenList::parse_raw(input, &mut args, self.options, 0)?;
+        Ok(PseudoElement::CustomFunction {
+            name,
+            arguments: TokenList { v: args },
+        })
     }
 
     fn parse_is_and_where(&self) -> bool {

--- a/src/css/selectors/parser.rs
+++ b/src/css/selectors/parser.rs
@@ -1211,11 +1211,6 @@ impl<'a> SelectorParser<'a> {
         raw: Str,
         loc: usize,
     ) -> <impl_::Selectors as SelectorImpl>::LocalIdentifier {
-        // blocked_on: `Parser::add_symbol_for_name` (gated in css_parser.rs on
-        // ArrayHashMap::entry + SymbolList::push). The CSS-modules branch
-        // returns the symbol-table ref; until that un-gates, fall through to
-        // the ident arm so non-modules parsing is correct.
-
         if input.flags.css_modules() {
             return <impl_::Selectors as SelectorImpl>::LocalIdentifier::from_ref(
                 input.add_symbol_for_name(
@@ -1302,11 +1297,6 @@ impl<'a> SelectorParser<'a> {
                 ),
             );
         }
-
-        // blocked_on: properties::custom (TokenList::parse_raw / TokenOrValue) un-gate.
-        // The stub `properties::custom::TokenList` is a unit struct with no `.v`
-        // field and no `parse_raw`; consume the function args as opaque tokens
-        // until the real `custom.rs` un-gates.
 
         {
             let mut args: Vec<css::css_properties::custom::TokenOrValue> = Vec::new();

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -539,16 +539,7 @@ fn is_selector_unused(
     for component in selector.components.iter() {
         match component {
             Component::Class(ident) | Component::Id(ident) => {
-                // TODO: the ref arm (CSS-modules symbol-table lookup via
-                // `symbols`) is not yet wired; only the ident arm is handled.
-                let actual_ident: &[u8] = match (*ident).as_ident() {
-                    // SAFETY: arena-owned slice (`'static` placeholder for the arena lifetime).
-                    Some(i) => unsafe { crate::arena_str(i.v) },
-                    None => {
-                        let _ = symbols;
-                        continue;
-                    }
-                };
+                let actual_ident: &[u8] = ident.as_original_string(symbols);
                 // Look up the borrowed `&[u8]` against the map's owned
                 // `Box<[u8]>` keys without allocating.
                 struct SliceAdapter;

--- a/src/css/selectors/selector.rs
+++ b/src/css/selectors/selector.rs
@@ -539,18 +539,14 @@ fn is_selector_unused(
     for component in selector.components.iter() {
         match component {
             Component::Class(ident) | Component::Id(ident) => {
-                // `IdentOrRef::as_original_string` is
-                // gated (blocked_on bun_ast::symbol::List::at
-                // + Symbol.original_name). Inline the ident arm; the ref arm
-                // (CSS-modules symbol-table lookup) is unreachable until
-                // `Parser::add_symbol_for_name` un-gates (see
-                // `SelectorParser::new_local_identifier`).
+                // TODO: the ref arm (CSS-modules symbol-table lookup via
+                // `symbols`) is not yet wired; only the ident arm is handled.
                 let actual_ident: &[u8] = match (*ident).as_ident() {
                     // SAFETY: arena-owned slice (`'static` placeholder for the arena lifetime).
                     Some(i) => unsafe { crate::arena_str(i.v) },
                     None => {
                         let _ = symbols;
-                        continue; // blocked_on: as_original_string ref arm
+                        continue;
                     }
                 };
                 // Look up the borrowed `&[u8]` against the map's owned
@@ -1052,8 +1048,6 @@ pub mod serialize {
                 };
                 if let Some(class) = class {
                     $d.write_char(b'.')?;
-                    // blocked_on: `Printer::write_ident` (gated on css_modules
-                    // Pattern::write closure-arity reshape). Non-modules path:
                     $d.serialize_identifier(class)?;
                 } else {
                     $d.write_str($s)?;
@@ -1178,10 +1172,7 @@ pub mod serialize {
                 dest.write_char(b':')?;
                 dest.serialize_identifier(name)?;
                 dest.write_char(b'(')?;
-                // blocked_on: properties::custom (TokenList::to_css_raw) un-gate.
-
                 arguments.to_css_raw(dest)?;
-                let _ = arguments;
                 dest.write_char(b')')?;
             }
         }
@@ -1318,10 +1309,7 @@ pub mod serialize {
                 dest.write_str(b"::")?;
                 dest.serialize_identifier(name)?;
                 dest.write_char(b'(')?;
-                // blocked_on: properties::custom (TokenList::to_css_raw) un-gate.
-
                 arguments.to_css_raw(dest)?;
-                let _ = arguments;
                 dest.write_char(b')')?;
             }
         }

--- a/src/css/values/calc.rs
+++ b/src/css/values/calc.rs
@@ -851,12 +851,6 @@ impl<V: CalcValue> Calc<V> {
             }
         }
 
-        // blocked_on: values/length.rs un-gate — until Length is real,
-        // `atan2(10px, 5px)` (and any other length-dimension pair) falls
-        // through to the CSSNumber path below and errors with `invalid_value`
-        // instead of producing `Angle::Rad(atan2(10,5))`. Tracked as a known
-        // incompleteness; no behaviour stub is added because a partial
-        // dimension matcher would mis-reduce mixed-unit lengths.
         if let Ok(v) = try_parse_atan2_args::<C, Length>(input, ctx) {
             return Ok(v);
         }

--- a/src/css/values/length.rs
+++ b/src/css/values/length.rs
@@ -637,9 +637,7 @@ impl Length {
 // ─── protocol-trait impls for the calc lattice ────────────────────────────
 // These wire `LengthValue`/`Angle` into `DimensionPercentage<D>`'s bound set
 // (`protocol::{Zero,MulF32,TryAdd,TrySign,TryMap,TryOp,PartialCmp,Parse,
-// ToCss,IsCompatible}`). All forward to the inherent methods above; once
-// `crate::generics::parse_tocss_numeric_gated` un-gates these collapse into
-// blanket impls there.
+// ToCss,IsCompatible}`). All forward to the inherent methods above.
 impl protocol::Zero for LengthValue {
     #[inline]
     fn zero() -> Self {

--- a/src/css/values/position.rs
+++ b/src/css/values/position.rs
@@ -310,8 +310,6 @@ pub enum PositionComponent<S> {
     Side(PositionComponentSide<S>),
 }
 
-// `S` is bounded on the values-local `protocol::{Parse,ToCss}` shapes until
-// `generics::Parse` un-gates.
 impl<S: protocol::Parse + protocol::ToCss + Clone + PartialEq> PositionComponent<S> {
     pub(crate) fn is_zero(&self) -> bool {
         if let PositionComponent::Length(l) = self {

--- a/src/css_jsc/lib.rs
+++ b/src/css_jsc/lib.rs
@@ -1,10 +1,6 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #![warn(unused_must_use)]
-//! `bun_css_jsc` — JSC bridge for `bun_css`. All fn bodies
-//! compile against the `bun_jsc` / `bun_css` surface. The two
-//! `OutputColorFormat::{Hsl,Lab}` match-arm bodies in `color_js` remain
-//! ``-gated on `bun_css::values::color::*::{into_hsl,into_lab}`
-//! (the colorspace matrix tables in `values/color.rs` are still gated).
+//! `bun_css_jsc` — JSC bridge for `bun_css`.
 
 pub mod color_js;
 pub mod css_internals;

--- a/src/http/H2Client.rs
+++ b/src/http/H2Client.rs
@@ -46,9 +46,6 @@ pub static live_streams: AtomicI32 = AtomicI32::new(0);
 pub use live_sessions as LIVE_SESSIONS;
 pub use live_streams as LIVE_STREAMS;
 
-// Un-gated: Stream/ClientSession/dispatch/encode now compile against the
-// real crate surface (bridge stubs below cover gated HTTPClient methods).
-// They no longer reference bun_str/bun_output/crate::state/crate::Signal.
 #[path = "h2_client/ClientSession.rs"]
 pub mod client_session;
 #[path = "h2_client/dispatch.rs"]

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -47,7 +47,7 @@ pub mod websocket_http_client;
 #[path = "zlib.rs"]
 pub mod zlib;
 
-// ── crate-root re-exports (real types from un-gated modules) ──
+// ── crate-root re-exports ──
 pub use async_http::AsyncHTTP;
 pub use certificate_info::CertificateInfo;
 pub use decompressor::Decompressor;

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -29,10 +29,8 @@ impl Default for Options {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// Pure-byte helpers (lifted from `Parser` so they compile without the
-// Expr-carrying struct). They
-// touch no parser state — exposing them as free fns lets the logic stay
-// un-gated and unit-testable while the AST-dependent body is blocked.
+// Pure-byte helpers. They touch no parser state; exposed as free fns so
+// they are unit-testable without the Expr-carrying struct.
 // ──────────────────────────────────────────────────────────────────────────
 
 #[inline]

--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -211,13 +211,6 @@ pub enum ScopeError {
     NoValue,
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Re-gated items + shadow stubs
-//
-// `Parser::parse` / `Parser::prepare_str` (unquoted path) / `ConfigIterator`
-// now compile against the live `bun_js_parser::{Expr, ExprData, E::*}` surface.
-// ──────────────────────────────────────────────────────────────────────────
-
 pub use draft::{
     ConfigIterator, Parser, ScopeItem, ScopeIterator, ToStringFormatter, load_npmrc,
     load_npmrc_config,

--- a/src/install/lib.rs
+++ b/src/install/lib.rs
@@ -10,9 +10,9 @@
 // lifecycle_script_runner.rs).
 extern crate bun_sha_hmac as bun_sha;
 extern crate self as bun_install;
-// `bun_output::declare_scope!` / `scoped_log!` in Phase-A drafts → the macros
-// live at `bun_core` crate root (#[macro_export]); alias the crate so the
-// `bun_output::` path resolves in un-gated install modules.
+// `bun_output::declare_scope!` / `scoped_log!` — the macros live at
+// `bun_core` crate root (#[macro_export]); alias the crate so the
+// `bun_output::` path resolves.
 extern crate bun_analytics as analytics;
 extern crate bun_core as bun_output;
 

--- a/src/js_parser/lower/lower_esm_exports_hmr.rs
+++ b/src/js_parser/lower/lower_esm_exports_hmr.rs
@@ -5,38 +5,8 @@ use bun_collections::StringArrayHashMap;
 use bun_collections::VecExt;
 
 use crate::p::P;
-use crate::parser::{ReactRefresh, Ref, TempRef};
+use crate::parser::{ReactRefresh, Ref};
 use bun_ast::{self as js_ast, B, Binding, E, Expr, G, S, Stmt};
-
-// Note: `P::generate_temp_ref` is ``-gated in P.rs (round-6
-// re-gate); replicate it here so this file can un-gate independently
-// (with `scope = current_scope`).
-// `P::will_use_renamer` is private — its body is inlined.
-fn generate_temp_ref<'p, const TS: bool, const SCAN: bool>(
-    p: &mut P<'p, TS, SCAN>,
-    default_name: Option<&'p [u8]>,
-) -> Ref {
-    let will_use_renamer = p.options.bundle || p.options.features.minify_identifiers;
-    let name: &'p [u8] =
-        (if will_use_renamer { default_name } else { None }).unwrap_or_else(|| {
-            p.temp_ref_count += 1;
-            bun_alloc::arena_format!(in p.arena, "__bun_temp_ref_{:x}$", p.temp_ref_count)
-                .into_bump_str()
-                .as_bytes()
-        });
-    let r#ref = p
-        .new_symbol(js_ast::symbol::Kind::Other, name)
-        .expect("oom");
-
-    p.temp_refs_to_declare.push(TempRef {
-        r#ref,
-        ..Default::default()
-    });
-
-    VecExt::append(&mut p.current_scope_mut().generated, r#ref);
-
-    r#ref
-}
 
 pub(crate) struct ConvertESMExportsForHmr<'a> {
     pub last_part: &'a mut js_ast::Part,
@@ -216,7 +186,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
                 // Otherwise, an identifier must be exported
                 match &st.value {
                     js_ast::StmtOrExpr::Expr(_) => {
-                        let temp_id = generate_temp_ref(p, Some(b"default_export"));
+                        let temp_id = p.generate_temp_ref(Some(b"default_export"));
                         self.last_part
                             .declared_symbols
                             .append(js_ast::DeclaredSymbol {
@@ -614,7 +584,7 @@ impl<'a> ConvertESMExportsForHmr<'a> {
             // This is technically incorrect in that we've marked this as a
             // top level symbol. but all we care about is preventing name
             // collisions, not necessarily the best minificaiton (dev only)
-            let arg1 = generate_temp_ref(p, Some(original_name.slice()));
+            let arg1 = p.generate_temp_ref(Some(original_name.slice()));
             self.last_part
                 .declared_symbols
                 .append(js_ast::DeclaredSymbol {

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -36,8 +36,6 @@ use bun_ast::{
     B, Binding, BindingNodeIndex, E, Expr, ExprNodeIndex, ExprNodeList, Flags, G, LocRef, S, Scope,
     Stmt, StmtNodeList, Symbol,
 };
-// Round-D/E modules: stub re-exports so type signatures referencing them compile.
-// Real bodies un-gate per-file later.
 use crate::renamer;
 
 // In this AST crate, lists are arena-backed.
@@ -47,9 +45,8 @@ type ListManaged<'a, T> = BumpVec<'a, T>;
 type Map<K, V> = HashMap<K, V>;
 
 /// Erases `P<'a, TS, SCAN>`'s const-generics so helpers like `JSXTag::parse`
-/// can take any instantiation. Only the
-/// surface those helpers actually touch is exposed; widen this as the
-/// parse_* / visit_* sibling files un-gate.
+/// can take any instantiation. Only the surface those helpers actually
+/// touch is exposed.
 pub(crate) trait ParserLike<'a> {
     fn lexer(&mut self) -> &mut js_lexer::Lexer<'a>;
     fn log_ptr(&self) -> core::ptr::NonNull<bun_ast::Log>;
@@ -58,10 +55,8 @@ pub(crate) trait ParserLike<'a> {
     fn new_expr<T: js_ast::expr::IntoExprData>(&mut self, t: T, loc: bun_ast::Loc) -> Expr;
     fn store_name_in_ref(&mut self, name: &'a [u8]) -> Result<Ref, bun_core::Error>;
 }
-// Trait + impl defined so Expr methods can bound on it. Method bodies forward
-// to the (currently-gated) inherent impls; until those un-gate, calling through
-// ParserLike panics — which is fine since no live code does so yet (callers are
-// in parse_*/visit_* which are also gated).
+// Trait + impl defined so Expr methods can bound on it. Method bodies
+// forward to the inherent impls.
 impl<'a, const TS: bool, const SCAN: bool> ParserLike<'a> for P<'a, TS, SCAN> {
     #[inline]
     fn lexer(&mut self) -> &mut js_lexer::Lexer<'a> {
@@ -140,13 +135,9 @@ impl<'a> ImportRecordList<'a> {
     /// Transfer the
     /// backing storage into a `Vec<ImportRecord>` and leave `self` empty
     /// (so the parser can be dropped without aliasing the records the linker /
-    /// printer now own).
-    ///
-    /// Round-G fix: previously `to_ast` reached through `items_mut()` and
-    /// wrapped the *live* BumpVec slice, leaving `self` non-empty; the BumpVec's
-    /// Drop then ran element destructors on records the returned `Ast` still
-    /// pointed at. This adapter restores move-and-zero semantics for both
-    /// the bump-backed and externally-borrowed variants.
+    /// printer now own). Move-and-zero semantics: if `to_ast` merely borrowed
+    /// the live BumpVec slice, the BumpVec's Drop would then run element
+    /// destructors on records the returned `Ast` still points at.
     pub(crate) fn move_to_baby_list(&mut self, arena: &'a Bump) -> BumpVec<'a, ImportRecord> {
         match core::mem::replace(self, Self::Owned(BumpVec::new_in(arena))) {
             Self::Owned(v) => v,
@@ -185,8 +176,7 @@ pub(crate) type MacroCallCountType = u32;
 
 // ─── Re-exports of sibling-module impls ───
 // These are inherent methods on `P` defined in sibling files via separate
-// `impl<...> P<...>` blocks. Round-D/E: those files un-gate per-module; until
-// then their re-exports are gated so the *struct* + core helpers compile.
+// `impl<...> P<...>` blocks.
 pub use crate::parse::*;
 pub use crate::visit::*;
 // Re-export the real visitor so `P::binary_expression_stack` is typed against
@@ -717,11 +707,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> Drop for P<'a, TYPESCRIP
     }
 }
 
-// Associated consts kept live (cheap, used by ParserLike + Parser.rs).
-// The full method-body impl block below is gated wholesale — 600+ type errors
-// from method bodies referencing not-yet-real Expr/Symbol/Log surface; un-gate
-// method-groups (scope mgmt → allocate → error reporting → predicates) as
-// that surface lands.
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub const IS_TYPESCRIPT_ENABLED: bool = TYPESCRIPT;
     pub const ONLY_SCAN_IMPORTS_AND_DO_NOT_VISIT: bool = SCAN_ONLY;
@@ -835,9 +820,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.module_scope
     }
 
-    // ── thin allocate-helpers (un-gated so the parse_*/visit_* mixin bodies
-    //    can reference them; the full bodies with SCAN_ONLY require-scan
-    //    branches stay in the gated block below) ──────────────────────────
     #[inline]
     pub fn new_expr<T>(&mut self, t: T, loc: bun_ast::Loc) -> Expr
     where
@@ -893,11 +875,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Round-D: core helper methods on P. Un-gated in groups; heavy bodies that
-// touch unfinished E/S/ts surface or call into parse_*/visit_* sibling files
-// stay individually ` // blocked_on:` below.
-// ═══════════════════════════════════════════════════════════════════════════
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub const ALLOW_MACROS: bool = !cfg!(target_family = "wasm");
 
@@ -1416,7 +1393,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    // blocked_on: is_binding_used; SideEffects::to_boolean; Part fields; named_exports key type
     pub fn tree_shake(&mut self, parts: &mut &'a mut [js_ast::Part], merge: bool) {
         let mut parts_ = core::mem::take(parts);
 
@@ -3951,7 +3927,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // Only assert above; do not actually pop.
     }
 
-    // blocked_on: S::Import field set; crate::parser::MacroRefData; ParsedPath fields; ImportItemForNamespaceMap API
     pub fn process_import_statement(
         &mut self,
         stmt_: S::Import,
@@ -4327,7 +4302,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(self.s(stmt, loc))
     }
 
-    // blocked_on: ParsedPath fields; S::Import.items; options::Loader
     #[cold]
     fn validate_and_set_import_type(
         &mut self,
@@ -6243,7 +6217,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    // blocked_on: options.features.replace_exports type (currently bool placeholder)
     pub fn is_export_to_eliminate(&self, r#ref: Ref) -> bool {
         let symbol_name = self.load_name_from_ref(r#ref);
         self.options.features.replace_exports.contains(symbol_name)
@@ -6412,7 +6385,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    // blocked_on: b(); G::Decl::List; E::Arrow.args slice type; S::SExpr/Return; emitted_namespace_vars.put_no_clobber
     // Large TS namespace/enum lowering body — cold for already-transpiled JS.
     #[cold]
     #[inline(never)]
@@ -6807,11 +6779,6 @@ fn path_package_name<'a>(path: &fs::Path<'a>) -> Option<&'a [u8]> {
     Some(pkgname)
 }
 
-// ═══════════════════════════════════════════════════════════════════════════
-// Round-D/E heavy method bodies (lower_class / to_ast / react_refresh / etc.).
-// lower_class + emit_decorator_metadata_for_prop + serialize_metadata are
-// un-gated and compile against the full bun_ast::ts::Metadata variant set.
-// Remaining individually-gated methods carry their own `blocked_on:` tags.
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub fn lower_class(&mut self, stmtorexpr: js_ast::StmtOrExpr) -> &'a mut [Stmt] {
         use js_ast::g::PropertyKind;
@@ -7607,9 +7574,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Expr::init_identifier(r#ref, loc)
     }
 
-    // wrap_inlined_enum: moved to ungated impl (round-G).
 
-    // value_for_define / is_dot_define_match: moved to ungated impl (round-G).
 
     // One statement could potentially expand to several statements
     pub fn stmts_to_single_stmt(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt {
@@ -7690,7 +7655,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         res
     }
 
-    // runtime_identifier_ref / runtime_identifier / call_runtime: moved to ungated impl (round-G).
 
     pub fn extract_decls_for_binding(
         binding: Binding,
@@ -7814,9 +7778,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         r#ref
     }
 
-    // compute_ts_enums_map() lives in the round-G `to_ast` impl block below
-    // (deduped — earlier draft body removed once both un-gated).
-
     pub fn should_lower_using_declarations(&self, stmts: &[Stmt]) -> bool {
         // TODO: We do not support lowering await, but when we do this needs to point to that var
         let lower_await = false;
@@ -7854,7 +7815,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// with ones that were imported, so that it can share an import record.
     ///
     /// This function replaces all specifier strings with `e_special.resolved_specifier_string`
-    // blocked_on: rewrite_import_meta_hot_accept_string; Log::add_error wants &[u8] (IMPORT_META_HOT_ACCEPT_ERR is &str)
     pub fn handle_import_meta_hot_accept_call(&mut self, call: &mut E::Call) {
         if call.args.len_u32() == 0 {
             return;
@@ -7894,7 +7854,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         call.target.data = js_ast::ExprData::ESpecial(E::Special::HotAcceptVisited);
     }
 
-    // blocked_on: EString::to_utf8 arena arg; ImportRecordList::items() accessor; E::Special::ResolvedSpecifierString takes u32 directly (drop ResolvedSpecifierStringIndex::init)
     fn rewrite_import_meta_hot_accept_string(
         &mut self,
         str_: &mut E::String,
@@ -8269,12 +8228,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
 // ═══════════════════════════════════════════════════════════════════════════
 // P::to_ast — final assembly P→Ast.
-// Split out of the gated block above so the parser entry point
-// (`Parser::parse` → `to_ast`) typechecks. Heavy sub-calls that are still
-// gated (`ImportScanner::scan`, `ConvertESMExportsForHmr`,
-// `apply_repl_transforms`) are wired to their real signatures and un-gated
-// independently. `compute_character_frequency` is fully un-gated
-// (lexer.all_comments + CharFreq.scan live).
+// ═══════════════════════════════════════════════════════════════════════════
 impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_ONLY> {
     pub fn to_ast(
         &mut self,
@@ -8312,10 +8266,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .expect("hot_module_reloading parse always has at least one part");
             let mut hmr_transform_ctx = ConvertESMExportsForHmr {
                 last_part,
-                // Round-G fix: `bun_paths::fs::Path::is_node_module` is now real
-                // (checks `name.dir` for `<sep>node_modules<sep>` with the
-                // platform separator); the former inline copy mis-handled the
-                // Windows separator via a cross-crate `const_format` const.
                 is_in_node_modules: self.source.path.is_node_module(),
                 imports_seen: Default::default(),
                 export_star_props: Vec::new(),
@@ -8792,9 +8742,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // returned up the `_parse → parse → cache → transpiler` chain (see
         // `js_parser::Result` PERF NOTE).
         Ok(Box::new(js_ast::Ast {
-            // Round-G: `Ast.runtime_imports` is now the real
-            // `parser::Runtime::Imports`; moved out above (P is terminal after
-            // `to_ast`).
             runtime_imports,
             module_scope,
             exports_ref: self.exports_ref,
@@ -9259,15 +9206,6 @@ pub struct LowerUsingDeclarationsContext {
     pub has_await_using: bool,
 }
 
-// Round-H un-gate: `generate_temp_ref` / `call_runtime` are now real (5516/6407),
-// so the only blockers were API-shape divergences. Reshaped:
-//   • `call_runtime` takes `ExprNodeList` → wrap bump slices via `from_bump_slice`
-//   • `DeclaredSymbol.ref_` / `LocRef.ref_` (not `r#ref`)
-//   • `DeclaredSymbolList`/`Vec` API has no arena param in this port
-//   • `G::Decl::List` → `G::DeclList` (free alias; inherent assoc type not used)
-// reconciler-6 re-gate removed: those API divergences are fixed inline below;
-// `generate_temp_ref` is real (round-G, see ~6407). DO NOT re-gate — `visit.rs`
-// calls these via `should_lower_using_declarations` path.
 impl LowerUsingDeclarationsContext {
     pub fn init<'a, const T: bool, const S_: bool>(
         p: &mut P<'a, T, S_>,

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -17,6 +17,7 @@ use bun_wyhash::Wyhash;
 use crate::defines::{Define, DefineData};
 use crate::lexer as js_lexer;
 use crate::parse::parse_entry::Options as ParserOptions;
+use crate::renamer;
 use crate::{
     ARGUMENTS_STR as arguments_str, DeferredArrowArgErrors, DeferredErrors,
     DeferredImportNamespace, EXPORTS_STRING_NAME as exports_string_name, ExprBindingTuple,
@@ -36,7 +37,6 @@ use bun_ast::{
     B, Binding, BindingNodeIndex, E, Expr, ExprNodeIndex, ExprNodeList, Flags, G, LocRef, S, Scope,
     Stmt, StmtNodeList, Symbol,
 };
-use crate::renamer;
 
 // In this AST crate, lists are arena-backed.
 type BumpVec<'a, T> = bun_alloc::ArenaVec<'a, T>;
@@ -7574,8 +7574,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Expr::init_identifier(r#ref, loc)
     }
 
-
-
     // One statement could potentially expand to several statements
     pub fn stmts_to_single_stmt(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt {
         if stmts.is_empty() {
@@ -7654,7 +7652,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         res
     }
-
 
     pub fn extract_decls_for_binding(
         binding: Binding,

--- a/src/js_parser/parser.rs
+++ b/src/js_parser/parser.rs
@@ -19,9 +19,8 @@ pub mod ConvertESMExportsForHmr {
 pub use bun_paths::fs;
 
 /// `bun_options_types` is missing several items P.rs/Parser.rs reference
-/// (`JSX`, `ServerComponents`, `ModuleType`, etc.). Per directive we cannot
-/// edit other crates; provide a local `options` mod that re-exports the real
-/// crate plus stand-ins. Tracked in `blocked_on`.
+/// (`JSX`, `ServerComponents`, `ModuleType`, etc.); provide a local
+/// `options` mod that re-exports the real crate plus stand-ins.
 pub mod options {
     pub use bun_options_types::*;
     use std::borrow::Cow;

--- a/src/js_parser/scan/scan_imports.rs
+++ b/src/js_parser/scan/scan_imports.rs
@@ -687,7 +687,6 @@ impl<'a> ImportScanner<'a> {
                     // exports.default =
                     // But only if it's anonymous
                     // This monomorphization is the parser `P` only (see fn-level TODO).
-                    // blocked_on: P::module_exports gated (reconciler-6 re-gate in P.rs)
                     if !HOT_MODULE_RELOADING_TRANSFORMATIONS && will_transform_to_common_js {
                         let expr = core::mem::take(&mut st.value).to_expr();
                         // Arena allocation that persists in the AST.

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -391,16 +391,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .get_ptr(name)
                         .map(bun_ptr::BackRef::new)
                     {
-                        {
-                            // `BackRef::get` — entry lives in `self.options.features.replace_exports`,
-                            // which is not mutated during the visit pass.
-                            let replacer = _ptr.get();
-                            if !self.replace_decl_and_possibly_remove(decl, replacer) {
-                                let is_after = self.vis_scope().is_after_const_local_prefix;
-                                self.visit_decl(decl, false, was_const && !is_after, false);
-                            } else {
-                                continue 'outer;
-                            }
+                        // `BackRef::get` — entry lives in `self.options.features.replace_exports`,
+                        // which is not mutated during the visit pass.
+                        let replacer = _ptr.get();
+                        if !self.replace_decl_and_possibly_remove(decl, replacer) {
+                            let is_after = self.vis_scope().is_after_const_local_prefix;
+                            self.visit_decl(decl, false, was_const && !is_after, false);
+                        } else {
+                            continue 'outer;
                         }
                     }
                 }

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -359,17 +359,12 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     self.is_control_flow_dead = orig_dead;
                     if let BData::BIdentifier(_) = decl.binding.data {
                         if let Some(_ptr) = replacement {
-                            // blocked_on: P::replace_decl_and_possibly_remove is -gated
-                            //   (P.rs); un-gate this call when it lands.
-                            {
-                                // `BackRef::get` — entry lives in `self.options.features.replace_exports`,
-                                // which is not mutated during the visit pass.
-                                let replacer = _ptr.get();
-                                if !self.replace_decl_and_possibly_remove(decl, replacer) {
-                                    continue 'outer;
-                                }
+                            // `BackRef::get` — entry lives in `self.options.features.replace_exports`,
+                            // which is not mutated during the visit pass.
+                            let replacer = _ptr.get();
+                            if !self.replace_decl_and_possibly_remove(decl, replacer) {
+                                continue 'outer;
                             }
-                            let _ = &mut j; // keep 'outer label live until #[cfg] un-gates
                         }
                     }
                 }
@@ -396,8 +391,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .get_ptr(name)
                         .map(bun_ptr::BackRef::new)
                     {
-                        // blocked_on: P::replace_decl_and_possibly_remove is -gated
-                        //   (P.rs); un-gate this call when it lands.
                         {
                             // `BackRef::get` — entry lives in `self.options.features.replace_exports`,
                             // which is not mutated during the visit pass.
@@ -703,30 +696,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
     }
 
-    // P::stmts_to_single_stmt is ``-gated (P.rs:6267, blocked on
-    // S::Block Default). Inline a local copy until that un-gates.
-    fn stmts_to_single_stmt_(&mut self, loc: bun_ast::Loc, stmts: &'a mut [Stmt]) -> Stmt {
-        if stmts.is_empty() {
-            return Stmt {
-                data: StmtData::SEmpty(S::Empty {}),
-                loc,
-            };
-        }
-
-        if stmts.len() == 1 && !crate::parser::statement_cares_about_scope(&stmts[0]) {
-            // "let" and "const" must be put in a block when in a single-statement context
-            return stmts[0];
-        }
-
-        self.s(
-            S::Block {
-                stmts: bun_ast::StoreSlice::new_mut(stmts),
-                close_brace_loc: bun_ast::Loc::EMPTY,
-            },
-            loc,
-        )
-    }
-
     pub fn visit_loop_body(&mut self, stmt: Stmt) -> Stmt {
         let old_is_inside_loop = self.fn_or_arrow_data_visit.is_inside_loop;
         self.fn_or_arrow_data_visit.is_inside_loop = true;
@@ -755,7 +724,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.options.features.minify_syntax {
             // `stmts` was consumed above; `items` aliases the slice now
             // stored in `s_block.stmts`.
-            new_stmt = self.stmts_to_single_stmt_(stmt.loc, items);
+            new_stmt = self.stmts_to_single_stmt(stmt.loc, items);
         }
 
         new_stmt
@@ -785,7 +754,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             self.pop_scope();
         }
 
-        self.stmts_to_single_stmt_(stmt.loc, stmts.into_bump_slice_mut())
+        self.stmts_to_single_stmt(stmt.loc, stmts.into_bump_slice_mut())
     }
 
     pub fn visit_class(

--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -251,11 +251,6 @@ impl AbortReason {
             AbortReason::Js(value) => value,
         }
     }
-
-    // `to_body_value_error` reaches into
-    // `bun_runtime::webcore::body::value::ValueError` (forward dep on
-    // `bun_runtime`). The conversion is trivial and is reconstructed at the
-    // call-site in `bun_runtime` once that tier un-gates.
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/jsc/HTTPServerAgent.rs
+++ b/src/jsc/HTTPServerAgent.rs
@@ -41,12 +41,9 @@ impl HTTPServerAgent {
     // #region Events
     //
     // `notify_server_started` / `notify_server_stopped` /
-    // `notify_server_routes_updated` reach into `bun_jsc::api::AnyServer` and
+    // `notify_server_routes_updated` reach into `AnyServer` and
     // `ServerConfig::RouteDeclaration`, which live in `bun_runtime` (forward
-    // dep). The C++ side only needs `Bun__HTTPServerAgent__setEnabled` for
-    // linkage; the per-event notifiers are called from Rust → C++ (FFI decls
-    // below) and are wired from `bun_runtime` once that tier un-gates. The
-    // event bodies will land when `AnyServer` is reachable.
+    // dep), so they are defined there (`runtime/server/mod.rs`).
 
     // #endregion
 }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1643,14 +1643,19 @@ impl JSValue {
     ) -> JsResult<JSValue> {
         #[cfg(debug_assertions)]
         {
-            // SAFETY: JS-thread singleton; short-lived `&mut EventLoop` reborrow at use site
-            // per VirtualMachine::event_loop() contract.
-            let loop_ = crate::virtual_machine::VirtualMachine::get().event_loop_mut();
-            loop_.debug.js_call_count_outside_tick_queue +=
-                usize::from(!loop_.debug.is_inside_tick_queue);
-            if loop_.debug.track_last_fn_name && !loop_.debug.is_inside_tick_queue {
+            use crate::virtual_machine::VirtualMachine;
+            // SAFETY: JS-thread singleton; each `&mut EventLoop` reborrow is
+            // dropped before `get_name` (which may re-enter JS) per
+            // `VirtualMachine::event_loop_mut()` contract.
+            let want_name = {
+                let loop_ = VirtualMachine::get().event_loop_mut();
+                let outside = !loop_.debug.is_inside_tick_queue;
+                loop_.debug.js_call_count_outside_tick_queue += usize::from(outside);
+                loop_.debug.track_last_fn_name && outside
+            };
+            if want_name {
                 if let Ok(name) = self.get_name(global) {
-                    loop_.debug.last_fn_name = name.into();
+                    VirtualMachine::get().event_loop_mut().debug.last_fn_name = name.into();
                 }
             }
         }

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1641,8 +1641,17 @@ impl JSValue {
         this_value: JSValue,
         args: &[JSValue],
     ) -> JsResult<JSValue> {
-        // TODO: debug event-loop bookkeeping (js_call_count_outside_tick_queue /
-        // last_fn_name); see JSValue.zig:251 and JSPromise.rs `resolve`/`reject`.
+        #[cfg(debug_assertions)]
+        {
+            // SAFETY: JS-thread singleton; short-lived `&mut EventLoop` reborrow at use site
+            // per VirtualMachine::event_loop() contract.
+            let loop_ = crate::virtual_machine::VirtualMachine::get().event_loop_mut();
+            loop_.debug.js_call_count_outside_tick_queue +=
+                usize::from(!loop_.debug.is_inside_tick_queue);
+            if loop_.debug.track_last_fn_name && !loop_.debug.is_inside_tick_queue {
+                loop_.debug.last_fn_name = self.get_name(global)?.into();
+            }
+        }
         host_fn::from_js_host_call(global, || {
             // SAFETY: `global` is live; `args` is a contiguous slice of valid
             // JSValues for the duration of the call.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1641,6 +1641,8 @@ impl JSValue {
         this_value: JSValue,
         args: &[JSValue],
     ) -> JsResult<JSValue> {
+        // TODO: debug event-loop bookkeeping (js_call_count_outside_tick_queue /
+        // last_fn_name); see JSValue.zig:251 and JSPromise.rs `resolve`/`reject`.
         host_fn::from_js_host_call(global, || {
             // SAFETY: `global` is live; `args` is a contiguous slice of valid
             // JSValues for the duration of the call.

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1649,7 +1649,9 @@ impl JSValue {
             loop_.debug.js_call_count_outside_tick_queue +=
                 usize::from(!loop_.debug.is_inside_tick_queue);
             if loop_.debug.track_last_fn_name && !loop_.debug.is_inside_tick_queue {
-                loop_.debug.last_fn_name = self.get_name(global)?.into();
+                if let Ok(name) = self.get_name(global) {
+                    loop_.debug.last_fn_name = name.into();
+                }
             }
         }
         host_fn::from_js_host_call(global, || {

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1641,8 +1641,6 @@ impl JSValue {
         this_value: JSValue,
         args: &[JSValue],
     ) -> JsResult<JSValue> {
-        // Note: debug-only event-loop bookkeeping is
-        // omitted while VirtualMachine.rs is gated; restore when it un-gates.
         host_fn::from_js_host_call(global, || {
             // SAFETY: `global` is live; `args` is a contiguous slice of valid
             // JSValues for the duration of the call.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2116,10 +2116,7 @@ impl VirtualMachine {
         // of `Zig__GlobalObject__create` re-enters via `WTFTimer__create`/
         // `WTFTimer__update` (JSC's GC scheduler), which dereferences
         // `runtime_state().timer` — so this hook MUST run first or that path
-        // null-derefs. The post-global tail (`configureDebugger`,
-        // `Body.Value.HiveAllocator.init`) is gated TODO in
-        // the hook body and will need a separate post-global hook when
-        // un-gated.
+        // null-derefs.
         if let Some(hooks) = runtime_hooks() {
             // SAFETY: hook contract — `vm` is the unique live VM on this
             // thread. Write through the raw `vm` ptr (not `vm_ref`) so no

--- a/src/options_types/schema.rs
+++ b/src/options_types/schema.rs
@@ -119,9 +119,7 @@ pub mod api {
             __ComptimeStringMap_UNHANDLED_REJECTIONS_MAP(());
     }
 
-    /// peechy `message TransformOptions`. Full field set,
-    /// hand-expanded so `bundler::options::BundleOptions::from_api` and the
-    /// bunfig/CLI parsers can un-gate.
+    /// peechy `message TransformOptions`. Full field set.
     ///
     /// Type map (matches the convention block below):
     ///   `?T`                  → `Option<T>`
@@ -598,8 +596,6 @@ pub mod api {
     }
 
     // ── Fallback error-page wire types ──────────────────────────────────────
-    // Hand-stubbed subset so `js_parser::runtime::Fallback` un-gates. Full
-    // bodies (with `decode`) arrive from the peechy generator.
 
     /// Open `enum(u8)` in the wire schema.
     #[repr(u8)]

--- a/src/perf/generated_perf_trace_events.rs
+++ b/src/perf/generated_perf_trace_events.rs
@@ -1,7 +1,7 @@
 // Hand-maintained: scripts/generate-perf-trace-events.sh does not emit Rust,
 // so this file mirrors the generated event list manually until the generator
-// learns to emit Rust. Variants are added piecemeal as call sites un-gate; the
-// discriminants are assigned EXPLICITLY to the canonical ids from
+// learns to emit Rust. Variants are added piecemeal as call sites need them;
+// the discriminants are assigned EXPLICITLY to the canonical ids from
 // src/jsc/bindings/generated_perf_trace_events.h (the Darwin signpost path
 // passes `event as i32`, so the numeric id must match the generated header).
 #[repr(i32)]

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -54,9 +54,8 @@ pub use result::{
 };
 pub use standalone_module_graph::StandaloneModuleGraph;
 
-/// Minimal real subset of `fs.rs` so `bun_resolver::fs::X` paths
-/// resolve for downstream crates. The full draft remains in `fs.rs` (gated)
-/// until bun_alloc::BSSStringList / bun_output land.
+/// `bun_resolver::fs` namespace; re-exports from `fs_full` plus the
+/// in-tree types (`FileSystem`, `RealFS`, `Entry`, ...).
 pub mod fs {
     use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
     use std::io::Write as _;

--- a/src/resolver/lib.rs
+++ b/src/resolver/lib.rs
@@ -10,12 +10,10 @@
 // crate::StandaloneModuleGraph trait; HardcodedModule -> bun_resolve_builtins.
 // ──────────────────────────────────────────────────────────────────────────
 
-// Submodules. `fs.rs` (full RealFS readdir/stat/kind path) is now un-gated as
+// Submodules. `fs.rs` (full RealFS readdir/stat/kind path) is mounted as
 // `fs_full`; the inline `pub mod fs` below remains the canonical type surface
 // (FileSystem, RealFS, Path, PathName, Entry, DirEntry, EntryLookup,
-// EntriesOption, Implementation) until the body switches to `fs_full::*`
-// wholesale. `fs_full` compiles to validate the port and is link-dead until
-// re-exported.
+// EntriesOption, Implementation) and re-exports from `fs_full`.
 pub mod data_url;
 pub mod dir_info;
 #[path = "fs.rs"]
@@ -1058,7 +1056,7 @@ pub mod fs {
         pub entries_mutex: Mutex,
         /// Port of `entries: *EntriesOption.Map`. The resolver body addresses
         /// this directly (`rfs.entries.get_or_put(..)`); modeled as the wrapper
-        /// `EntriesMap` until bun_alloc un-gates BSSMap.
+        /// `EntriesMap` (bun_alloc has no BSSMap equivalent).
         pub entries: EntriesMap,
         pub cwd: &'static [u8],
         pub file_limit: usize,

--- a/src/runtime/api.rs
+++ b/src/runtime/api.rs
@@ -1,6 +1,6 @@
 //! "api" in this context means "the Bun APIs", as in "the exposed JS APIs"
 
-// ─── server / socket / ffi (un-gated, opaque surface) ────────────────────────
+// ─── server / socket / ffi ───────────────────────────────────────────────────
 pub use crate::server;
 pub use crate::server::AnyRequestContext;
 pub use crate::server::AnyServer;
@@ -91,17 +91,11 @@ pub mod yaml_object;
 // inline `mod bun { }` below is a re-export façade only — module bodies are
 // declared flat to avoid the non-mod-rs nested-path resolution rules.
 
-// process.rs — Process struct + posix_spawn/uv_spawn machinery. §Dispatch
-// vtable applied for ProcessExitHandler; structs + non-JSC methods un-gated.
-// spawn_process_{posix,windows} bodies + waiter-thread dispatch loop + sync
-// mod remain re-gated inside the file (depend on sibling `spawn` posix_spawn
-// wrappers and bun_io FilePoll method surface).
+// Process struct + posix_spawn/uv_spawn machinery.
 #[path = "api/bun/process.rs"]
 pub mod bun_process;
 
-// posix_spawn(2) wrappers + Stdio enum. `bun_sys::posix` surface is now wide
-// enough for the `bun_spawn` half; libc-backed `PosixSpawn*` wrappers are
-// cfg-gated to macOS inside the file. `stdio` submod stays re-gated within.
+// posix_spawn(2) wrappers + Stdio enum.
 #[path = "api/bun/spawn.rs"]
 pub mod bun_spawn;
 
@@ -126,7 +120,6 @@ pub mod h2;
 #[path = "api/bun/h2_frame_parser.rs"]
 pub mod h2_frame_parser_body;
 
-// SSL siblings — gated (boringssl_sys bindgen surface).
 #[path = "api/bun/SSLContextCache.rs"]
 pub mod bun_ssl_context_cache;
 
@@ -152,9 +145,6 @@ pub mod bun {
     pub use spawn::posix_spawn;
 
     pub mod terminal {
-        /// Re-export the full struct now that `bun_terminal_body` is un-gated;
-        /// downstream callers (`Subprocess.terminal`, spawn bindings) hold the
-        /// concrete type directly — no opaque-ZST cast layer.
         pub use crate::api::bun_terminal_body::Terminal;
         // `Terminal.PtyResult`, `Winsize`, `OpenPtyFn`, `CreatePtyError` —
         // pure FFI handles with no JSC. Canonical defs live in
@@ -168,11 +158,6 @@ pub mod bun {
 
     pub mod h2_frame_parser {
         pub use crate::api::h2_frame_parser_body::ErrorCode;
-        /// Re-export the full struct now that `h2_frame_parser_body` is
-        /// un-gated; `socket::NativeCallbacks::H2(IntrusiveRc<H2FrameParser>)`
-        /// and the `set_native_socket` attach path now share one concrete
-        /// type — no opaque-ZST cast layer. The body provides the real
-        /// `RefCounted` impl + `on_native_{read,writable,close}` bodies.
         pub use crate::api::h2_frame_parser_body::H2FrameParser;
         // js2native thunks (`$zig(h2_frame_parser.zig, …)` in generated_js2native.rs).
         pub use crate::api::h2_frame_parser_body::h2_frame_parser_constructor;
@@ -184,12 +169,10 @@ pub mod bun {
 }
 pub use bun::process::Process as SpawnProcess;
 
-// ─── un-gated re-exports (targets compile) ───────────────────────────────────
 pub use crate::image as Image;
 pub use crate::shell as Shell;
 pub use crate::timer as Timer;
 
-// ─── un-gated re-exports (opaque structs / pure helpers compiling) ───────────
 pub use crate::api::archive as Archive;
 pub use crate::api::bun::h2_frame_parser::H2FrameParser;
 pub use crate::api::bun::secure_context as SecureContext;

--- a/src/runtime/api/csrf_jsc.rs
+++ b/src/runtime/api/csrf_jsc.rs
@@ -10,11 +10,9 @@ use crate::api::crypto::evp::Algorithm as EvpAlgorithm;
 use crate::crypto::evp;
 use crate::node::Encoding as NodeEncoding;
 
-// ── local shims ──────────────────────────────────────────────────────────
-// The upstream
 // `bun_jsc::comptime_string_map_jsc` only exposes the case-sensitive `from_js`;
-// the case-insensitive variant is still cfg-gated. Map keys are all lower-case
-// ASCII, so lower the probe and do a direct lookup (mirrors PBKDF2.rs).
+// map keys are all lower-case ASCII, so lower the probe and do a direct lookup
+// (mirrors PBKDF2.rs / CryptoHasher.rs).
 fn algorithm_from_js_case_insensitive(
     global: &JSGlobalObject,
     input: JSValue,
@@ -23,9 +21,9 @@ fn algorithm_from_js_case_insensitive(
     Ok(evp::lookup_ignore_case(slice.slice()))
 }
 
-/// Local shim: validates an integer in `[0, MAX_SAFE_INTEGER]`.
-/// `validateIntegerRange` is defined on the cfg-gated `JSGlobalObject` impl,
-/// so inline the minimal u64 path here.
+/// Validates an optional integer property in `[0, MAX_SAFE_INTEGER]`.
+/// Differs from `JSValue::get_optional_int::<u64>` in rejecting NaN and in
+/// the error message wording expected by existing tests.
 fn get_optional_int_u64(
     target: JSValue,
     global: &JSGlobalObject,

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5829,7 +5829,6 @@ impl DevServer {
                     .zip(g.bundled_files.values())
                     .enumerate()
                 {
-                    // Note: un-gated `incremental_graph::File` is unpacked already.
                     let file = v;
                     let mut buf = paths::path_buffer_pool::get();
                     let normalized_key = self.relative_path(&mut *buf, k);

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -290,9 +290,6 @@ impl GraphTraceState {
 
 pub use super::dev_server_body::init;
 
-// ──────────────────────────────────────────────────────────────────────────
-// Submodule types (struct shapes un-gated; method bodies stay in drafts)
-// ──────────────────────────────────────────────────────────────────────────
 pub mod assets;
 pub mod incremental_graph;
 pub mod inspector_agent;

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -629,9 +629,6 @@ pub use bake_body::get_hmr_runtime;
 // NUL-terminated `&ZStr` form for JSC handoff; the bundler-side one is plain
 // `&[u8]`.)
 
-// `bake.UserOptions` — top-level JS-facing options struct. Full body (with
-// `from_js`) lives in the un-gated `bake_body.rs` draft and is re-exported
-// above; the keystone `(())` stub is gone now that `bake_body` compiles.
 pub use bake_body::StringRefList;
 
 // ══════════════════════════════════════════════════════════════════════════

--- a/src/runtime/cli/mod.rs
+++ b/src/runtime/cli/mod.rs
@@ -321,10 +321,7 @@ pub use bun_bunfig::bunfig;
 #[path = "run_command.rs"]
 pub mod run_command;
 
-// ─── per-subcommand bodies (un-gated for `Command::start` dispatch) ──────────
-// Heavy bodies inside re-gate on whatever
-// lower-tier crate surface they still need; the dispatch arm just calls
-// `<Mod>Command::exec(ctx)`.
+// ─── per-subcommand bodies ───────────────────────────────────────────────────
 #[path = "build_command.rs"]
 pub mod build_command;
 #[path = "bunx_command.rs"]

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -56,54 +56,6 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-// ──────────────────────────────────────────────────────────────────────────
-// Local FFI / pointer shims — the canonical impls live in cfg-gated
-// JSGlobalObject.rs / VM.rs (see src/jsc/lib.rs `_gated`). Until those are
-// un-gated, mirror the wrappers here so repl.rs compiles standalone.
-// ──────────────────────────────────────────────────────────────────────────
-
-#[inline]
-fn global_clear_exception(global: &JSGlobalObject) {
-    unsafe extern "C" {
-        fn JSGlobalObject__clearException(this: *const JSGlobalObject);
-    }
-    // SAFETY: `global` is a live opaque JSGlobalObject handle.
-    unsafe { JSGlobalObject__clearException(global) }
-}
-
-#[inline]
-fn global_to_js_value(global: &JSGlobalObject) -> JSValue {
-    JSValue::from_cell(std::ptr::from_ref::<JSGlobalObject>(global))
-}
-
-#[inline]
-fn vm_set_execution_forbidden(vm: *mut jsc::VM, forbidden: bool) {
-    unsafe extern "C" {
-        fn JSC__VM__setExecutionForbidden(vm: *mut jsc::VM, forbidden: bool);
-    }
-    // SAFETY: `vm` is a live opaque JSC VM handle.
-    unsafe { JSC__VM__setExecutionForbidden(vm, forbidden) }
-}
-
-/// Reborrow `&VirtualMachine` as `&mut VirtualMachine`.
-///
-/// SAFETY: `VirtualMachine` is single-threaded per JS thread and the REPL
-/// is the sole driver of `tick()` / `wait_for_promise()` here, so no other
-/// `&mut` to the VM can be live. We store `&VirtualMachine` for borrowck
-/// simplicity and cast at the call site.
-#[inline]
-#[allow(invalid_reference_casting, clippy::mut_from_ref)]
-fn vm_mut<'a>(vm: &'a VirtualMachine) -> &'a mut VirtualMachine {
-    // Launder through a raw pointer; rustc's `invalid_reference_casting` lint is
-    // silenced above because `VirtualMachine` is `!Sync` single-thread state and
-    // the REPL is its sole driver here.
-    let ptr: *mut VirtualMachine = core::ptr::from_ref(vm).cast_mut();
-    // SAFETY: `ptr` is non-null and points to a live `VirtualMachine` (derived from
-    // `&'a VirtualMachine`); the REPL is the sole driver on this single JS thread so
-    // no other `&mut` to this VM exists for `'a` (see fn-level SAFETY doc above).
-    unsafe { &mut *ptr }
-}
-
 // ============================================================================
 // Constants
 // ============================================================================
@@ -1352,11 +1304,11 @@ impl<'a> Repl<'a> {
             // Note: reshaped for borrowck — call disable_signals_during_wait() explicitly on each return path below
 
             // Wait for the promise to settle
-            vm_mut(vm).wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
 
             // If execution was forbidden by SIGINT, clear it and report
             if vm.jsc_vm().execution_forbidden() {
-                vm_set_execution_forbidden(vm.jsc_vm, false);
+                vm.jsc_vm().set_execution_forbidden(false);
                 global.clear_termination_exception();
                 self.print(format_args!("\n"));
                 self.disable_signals_during_wait();
@@ -1374,7 +1326,7 @@ impl<'a> Repl<'a> {
                     let rejection = jsc::JSPromise::opaque_mut(promise).result(jsc_vm_ref);
                     self.set_last_error(rejection);
                     // Set _error on the global object
-                    let global_this = global_to_js_value(global);
+                    let global_this = global.to_js_value();
                     global_this.put(global, b"_error", rejection);
                     self.print_js_error(rejection);
                     self.disable_signals_during_wait();
@@ -1403,7 +1355,7 @@ impl<'a> Repl<'a> {
                         let exc = global.take_exception(err);
                         self.set_last_error(exc);
                         self.print_js_error(exc);
-                        vm_mut(vm).tick();
+                        vm.as_mut().tick();
                         return;
                     }
                 };
@@ -1418,7 +1370,7 @@ impl<'a> Repl<'a> {
         // Set _ to the last result (only if not undefined)
         // Use the global object as JSValue and put the property on it
         if !actual_result.is_undefined() {
-            let global_this = global_to_js_value(global);
+            let global_this = global.to_js_value();
             global_this.put(global, b"_", actual_result);
         }
 
@@ -1433,7 +1385,7 @@ impl<'a> Repl<'a> {
         }
 
         // Tick the event loop to handle any pending work
-        vm_mut(vm).tick();
+        vm.as_mut().tick();
     }
 
     /// Evaluate a script from `bun repl -e/--eval` or `-p/--print` non-interactively.
@@ -1512,7 +1464,7 @@ impl<'a> Repl<'a> {
             // SAFETY: `promise` is a live JSC heap cell; `vm.jsc_vm` is the
             // owning JSC VM handle for this thread.
             jsc::JSPromise::opaque_mut(promise).set_handled();
-            vm_mut(vm).wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
             let jsc_vm_ref = vm.jsc_vm();
             match jsc::JSPromise::opaque_mut(promise).status() {
                 PromiseStatus::Fulfilled => {
@@ -1547,10 +1499,10 @@ impl<'a> Repl<'a> {
         let _prot = actual_result.protected();
 
         // Drain the event loop (timers, I/O, etc.) before printing / exiting
-        vm_mut(vm).tick();
+        vm.as_mut().tick();
         while vm.is_event_loop_alive() {
-            vm_mut(vm).tick();
-            vm_mut(vm).auto_tick_active();
+            vm.as_mut().tick();
+            vm.as_mut().auto_tick_active();
         }
 
         if print_result {
@@ -1606,7 +1558,7 @@ impl<'a> Repl<'a> {
         }
 
         if let Some(vm) = self.vm {
-            vm_mut(vm).tick();
+            vm.as_mut().tick();
         }
     }
 
@@ -1651,9 +1603,9 @@ impl<'a> Repl<'a> {
             jsc::JSPromise::opaque_mut(promise).set_handled();
             self.enable_signals_during_wait();
             // Note: reshaped for borrowck — disable_signals_during_wait called on each path
-            vm_mut(vm).wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
             if vm.jsc_vm().execution_forbidden() {
-                vm_set_execution_forbidden(vm.jsc_vm, false);
+                vm.jsc_vm().set_execution_forbidden(false);
                 global.clear_termination_exception();
                 self.print(format_args!("\n"));
                 self.disable_signals_during_wait();
@@ -1688,7 +1640,7 @@ impl<'a> Repl<'a> {
                         let exc = global.take_exception(err);
                         self.set_last_error(exc);
                         self.print_js_error(exc);
-                        vm_mut(vm).tick();
+                        vm.as_mut().tick();
                         return;
                     }
                 };
@@ -1699,7 +1651,7 @@ impl<'a> Repl<'a> {
 
         self.set_last_result(actual_result);
         if !actual_result.is_undefined() {
-            let global_this = global_to_js_value(global);
+            let global_this = global.to_js_value();
             global_this.put(global, b"_", actual_result);
         }
 
@@ -1708,7 +1660,7 @@ impl<'a> Repl<'a> {
             self.set_last_error(exc);
             self.print_js_error(exc);
         }
-        vm_mut(vm).tick();
+        vm.as_mut().tick();
     }
 
     /// Format a JS value as a string suitable for clipboard.
@@ -1853,14 +1805,12 @@ impl<'a> Repl<'a> {
         // which the REPL transform passes through intact.
 
         // Initialize macro context from transpiler (required for import processing).
-        // Note: `vm` is `&VirtualMachine` here, so go through `vm_mut` (see its
-        // SAFETY comment) to lazily seed the macro context.
         if vm.transpiler.macro_context.is_none() {
-            vm_mut(vm).transpiler.macro_context = Some(bun_js_parser::Macro::MacroContext::init(
-                &mut vm_mut(vm).transpiler,
+            vm.as_mut().transpiler.macro_context = Some(bun_js_parser::Macro::MacroContext::init(
+                &mut vm.as_mut().transpiler,
             ));
         }
-        opts.macro_context = vm_mut(vm).transpiler.macro_context.as_mut();
+        opts.macro_context = vm.as_mut().transpiler.macro_context.as_mut();
 
         // Create log for errors
         let mut log = bun_ast::Log::init();
@@ -1969,7 +1919,7 @@ impl<'a> Repl<'a> {
         .is_err()
         {
             // Formatting the error itself threw — clear it to avoid recursion and show a fallback.
-            global_clear_exception(global);
+            global.clear_exception();
             let _ = writer.write_all(b"error: [failed to format error]\n");
             return;
         }
@@ -2387,7 +2337,7 @@ impl<'a> Repl<'a> {
         let len = match completions.get_length(global) {
             Ok(n) => n,
             Err(_) => {
-                global_clear_exception(global);
+                global.clear_exception();
                 0
             }
         };
@@ -2403,7 +2353,7 @@ impl<'a> Repl<'a> {
             let item = match completions.get_index(global, 0) {
                 Ok(v) => v,
                 Err(_) => {
-                    global_clear_exception(global);
+                    global.clear_exception();
                     JSValue::UNDEFINED
                 }
             };
@@ -2411,7 +2361,7 @@ impl<'a> Repl<'a> {
                 let slice = match item.to_slice(global) {
                     Ok(s) => s,
                     Err(_) => {
-                        global_clear_exception(global);
+                        global.clear_exception();
                         return;
                     }
                 };
@@ -2431,7 +2381,7 @@ impl<'a> Repl<'a> {
                 let item = match completions.get_index(global, i) {
                     Ok(v) => v,
                     Err(_) => {
-                        global_clear_exception(global);
+                        global.clear_exception();
                         JSValue::UNDEFINED
                     }
                 };
@@ -2446,7 +2396,7 @@ impl<'a> Repl<'a> {
                             ));
                         }
                         Err(_) => {
-                            global_clear_exception(global);
+                            global.clear_exception();
                             i += 1;
                             continue;
                         }
@@ -2489,7 +2439,7 @@ extern "C" fn sigint_handler(_: c_int) {
     if !vm.is_null() {
         // `vm` was a valid `*mut jsc::VM` when stored (JS thread is
         // blocked in wait while the handler runs, so it stays valid).
-        vm_set_execution_forbidden(vm, true);
+        jsc::VM::opaque_ref(vm).set_execution_forbidden(true);
     }
 }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -1304,7 +1304,8 @@ impl<'a> Repl<'a> {
             // Note: reshaped for borrowck — call disable_signals_during_wait() explicitly on each return path below
 
             // Wait for the promise to settle
-            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut()
+                .wait_for_promise(jsc::AnyPromise::Normal(promise));
 
             // If execution was forbidden by SIGINT, clear it and report
             if vm.jsc_vm().execution_forbidden() {
@@ -1464,7 +1465,8 @@ impl<'a> Repl<'a> {
             // SAFETY: `promise` is a live JSC heap cell; `vm.jsc_vm` is the
             // owning JSC VM handle for this thread.
             jsc::JSPromise::opaque_mut(promise).set_handled();
-            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut()
+                .wait_for_promise(jsc::AnyPromise::Normal(promise));
             let jsc_vm_ref = vm.jsc_vm();
             match jsc::JSPromise::opaque_mut(promise).status() {
                 PromiseStatus::Fulfilled => {
@@ -1603,7 +1605,8 @@ impl<'a> Repl<'a> {
             jsc::JSPromise::opaque_mut(promise).set_handled();
             self.enable_signals_during_wait();
             // Note: reshaped for borrowck — disable_signals_during_wait called on each path
-            vm.as_mut().wait_for_promise(jsc::AnyPromise::Normal(promise));
+            vm.as_mut()
+                .wait_for_promise(jsc::AnyPromise::Normal(promise));
             if vm.jsc_vm().execution_forbidden() {
                 vm.jsc_vm().set_execution_forbidden(false);
                 global.clear_termination_exception();

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -127,9 +127,7 @@ unsafe extern "C" {
     ) -> JSValue;
 }
 
-/// Raw extern fn pointers fed to
-/// the TCC-JIT'd C trampolines via `add_symbol`. Declared locally while the
-/// `bun_jsc::ffi` module stays gated.
+/// Raw extern fn pointers fed to the TCC-JIT'd C trampolines via `add_symbol`.
 mod exposed_to_ffi {
     use super::{JSGlobalObject, JSValue};
     unsafe extern "C" {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -64,11 +64,8 @@ fn strings_to_js_array(global: &JSGlobalObject, strs: &[bun_core::String]) -> Js
     })
 }
 
-// `bun_tcc_sys` is an un-gated workspace crate and a direct dep of
-// `bun_runtime`, so import it unconditionally. Runtime availability is governed
-// by `bun_core::Environment::ENABLE_TINYCC` via the early-return guards in the host-fns
-// below — type resolution for `TCC::{Config, ConfigErr, OutputFormat, State}`
-// must succeed regardless.
+// Runtime availability is governed by `bun_core::Environment::ENABLE_TINYCC`
+// via the early-return guards in the host-fns below.
 use bun_tcc_sys as TCC;
 
 bun_output::declare_scope!(TCC, visible);

--- a/src/runtime/ffi/host_fns.rs
+++ b/src/runtime/ffi/host_fns.rs
@@ -11,35 +11,9 @@ use std::io::Write as _;
 use bstr::BStr;
 
 use bun_collections::StringArrayHashMap;
-use bun_core::{self, ZigString};
 use bun_jsc::{self as jsc, JSGlobalObject, JSPropertyIterator, JSValue, JsResult};
 
 use super::{ABIType, Function};
-
-unsafe extern "C" {
-    /// `JSValue::getOwn` — own-property lookup (no prototype-chain walk).
-    /// Declared locally while `bun_jsc::JSValue::get_own` (JSValue.rs) is gated.
-    fn JSC__JSValue__getOwn(
-        value: JSValue,
-        global: *const JSGlobalObject,
-        name: *const bun_core::String,
-    ) -> JSValue;
-}
-
-/// Own-property lookup. Local thin
-/// wrapper while `bun_jsc::JSValue::get_own` stays gated.
-#[inline]
-fn get_own(value: JSValue, global: &JSGlobalObject, key: &[u8]) -> JsResult<Option<JSValue>> {
-    let key_str = bun_core::String::init(ZigString::init(key));
-    // Open a top exception scope before the FFI call (the C++ side has a
-    // ThrowScope whose dtor sets `m_needExceptionCheck`); a post-hoc `has_exception()`
-    // would assert under `BUN_JSC_validateExceptionChecks=1`.
-    bun_jsc::top_scope!(scope, global);
-    // SAFETY: `global` is live; `key_str` borrows `key` for the call duration.
-    let v = unsafe { JSC__JSValue__getOwn(value, global, &raw const key_str) };
-    scope.return_if_exception()?;
-    if v.is_empty() { Ok(None) } else { Ok(Some(v)) }
-}
 
 // ══════════════════════════════════════════════════════════════════════════
 // Symbol-spec parsing — generate_symbols / generate_symbol_for_function
@@ -56,7 +30,7 @@ pub fn generate_symbol_for_function(
 
     let mut abi_types: Vec<ABIType> = Vec::new();
 
-    if let Some(args) = get_own(value, global, b"args")? {
+    if let Some(args) = value.get_own(global, &bun_core::String::static_(b"args"))? {
         if args.is_empty_or_undefined_or_null() || !args.js_type().is_array() {
             return Ok(Some(global.create_error_instance(format_args!(
                 "Expected an object with \"args\" as an array"

--- a/src/runtime/ffi/host_fns.rs
+++ b/src/runtime/ffi/host_fns.rs
@@ -4,12 +4,6 @@
 //!
 //! The JSC-dependent paths are wired against the type identities declared in
 //! `super` (`FFI`, `Function`, `ABIType`, `Step`, `Compiled`).
-//!
-//! TinyCC compile/relocate (`bun_tcc_sys::State` method-ful API) remains
-//! gated; `Function::compile` therefore short-circuits with a `Step::Failed`
-//! when the `tinycc` feature is off (which it always is until
-//! `bun_tcc_sys::tcc` un-gates). The full TCC body is preserved in
-//! `ffi_body.rs` (``) for reference.
 
 use std::ffi::c_void;
 use std::io::Write as _;

--- a/src/runtime/ffi/mod.rs
+++ b/src/runtime/ffi/mod.rs
@@ -13,7 +13,6 @@ use bun_core::ZBox;
 
 use crate::jsc::JSGlobalObject;
 
-// ─── un-gated host-fn bodies (open/close/compile/generate_symbols) ───────────
 mod host_fns;
 pub use host_fns::{generate_symbol_for_function, generate_symbols};
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3013,9 +3013,7 @@ fn transpile_source_code_inner(
                                 .module_type
                             })
                             .or_else(|| {
-                                // The async path threads `lr.package_json` (from
-                                // `read_dir_info`) into the store; while that
-                                // path is gated, recover the same lookup here so
+                                // Recover the package.json lookup here so
                                 // a `.cjs` under `"type":"module"` still tags as
                                 // `PackageJsonTypeModule` (mirrors the cache-hit
                                 // branch above).

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -861,9 +861,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     let loop_ = unsafe { (*el).usockets_loop() };
 
     // ── tick_immediate_tasks ────────────────────────────────────────────
-    // The swap + drain loop is un-gated in
-    // `bun_jsc::event_loop` (per-task body dispatched via `__bun_run_immediate_task`),
-    // so `immediate_tasks` after this call reflects next-tick immediates and
+    // After this call `immediate_tasks` reflects next-tick immediates, so
     // the `has_pending_immediate` read below is correct.
     // SAFETY: `el` is the live per-thread event loop; `vm` per fn contract.
     unsafe { (*el).tick_immediate_tasks(vm) };
@@ -3297,11 +3295,6 @@ fn transpile_source_code_inner(
                 // need to copy the ~12 borrowed slices out (perf: was a
                 // per-asset-import `url::URL::clone`).
                 let origin = unsafe { &(*jsc_vm).origin };
-                // Note: `jsc.API.Bun.getPublicPath` is gated behind a
-                // private `_jsc_gated` mod in BunObject.rs; it is a thin
-                // wrapper over `get_public_path_with_asset_prefix` with
-                // `dir = VM.top_level_dir`, `asset_prefix = ""`, `.loose`.
-                // Inline that body here (mirrors filesystem_router.rs).
                 let top_level_dir = Fs::FileSystem::get().top_level_dir;
                 crate::api::bun_object::get_public_path_with_asset_prefix(
                     specifier,

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3657,13 +3657,9 @@ export default db;
 // `Bun__transpileFile` helpers — local copies of `options.normalizeSpecifier` /
 // `options.getLoaderAndVirtualSource`.
 //
-// The canonical Rust port (`bun_bundler::options::get_loader_and_virtual_source`)
-// is ``-gated behind a `VmLoaderCtx` vtable that nothing
-// constructs yet, and `Fs::Path::loader` returns the lower-tier
-// `bun_ast::Loader` (a *distinct* nominal type from the
-// `bun_ast::Loader` we need for `TranspileExtra`). Porting the
-// body inline here lets us name `VirtualMachine` directly (no vtable) and look
-// the loader up in `transpiler.options.loaders` (which is already
+// Porting the body inline here lets us name `VirtualMachine` directly (no
+// vtable) and look the loader up in `transpiler.options.loaders` (which is
+// already
 // `StringArrayHashMap<bun_ast::Loader>`), so no inter-enum bridge is required.
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/src/runtime/node.rs
+++ b/src/runtime/node.rs
@@ -154,7 +154,6 @@ pub mod native_zlib_impl;
 #[path = "node/zlib/NativeZstd.rs"]
 pub mod native_zstd_impl;
 pub mod zlib {
-    // Re-export so `super::NodeMode` resolves inside the gated NativeZstd body.
     pub use super::native_brotli_impl as native_brotli;
     pub use super::native_zlib_impl as native_zlib;
     pub use super::native_zstd_impl as native_zstd;

--- a/src/runtime/node.rs
+++ b/src/runtime/node.rs
@@ -47,9 +47,7 @@ pub use crypto as node_crypto_binding;
 pub mod fs_events;
 pub use fs_events as FSEvents;
 
-// Sibling modules node_fs.rs imports by `super::` path. Stat/StatFS/time_like
-// are type-only at the surface; their JSC method bodies are re-gated inside
-// each file. dir_iterator + node_fs_constant are JSC-free.
+// Sibling modules node_fs.rs imports by `super::` path.
 #[path = "node/Stat.rs"]
 pub mod stat;
 pub use stat::{Stats, StatsBig, StatsSmall};
@@ -89,10 +87,6 @@ pub mod dirent {
     pub use super::types::DirentKind as Kind;
 }
 
-// node_fs.rs (~4.7kL): async task machinery (AsyncFSTask/UVFSRequest/cp/
-// readdir-recursive) is JSC-dense and re-gated *inside* the file with
-// ``. Sync `impl NodeFS` (read_file/write_file/stat/mkdir et al.),
-// `args::*`, `ret::*` are live.
 #[path = "node/node_fs.rs"]
 pub mod fs;
 
@@ -165,12 +159,6 @@ pub mod zlib {
     pub use super::native_zlib_impl as native_zlib;
     pub use super::native_zstd_impl as native_zstd;
     pub use bun_zlib::NodeMode;
-    // The `NativeZlib` / `NativeBrotli` / `NativeZstd` *struct* re-exports are
-    // intentionally absent — those structs live inside each file's private
-    // `mod _impl { ... }` (JSC-gated) and are not reachable from here. The only
-    // consumers (`node_zlib_binding.rs::_impl::Native*`) are themselves gated
-    // behind a private `_impl` and resolve through `crate::api::Native*` once
-    // un-gated. Re-add the type re-exports when the `_impl` mods go `pub`.
 }
 
 // ─── submodule re-exports ─────────────────────────────────────────────────

--- a/src/runtime/node/node_crypto_binding.rs
+++ b/src/runtime/node/node_crypto_binding.rs
@@ -727,8 +727,6 @@ mod _impl {
     use crate::node::util::validators;
     use bun_jsc::{ErrorCode, JSFunction, JSType};
 
-    // `Crypto.EVP.PBKDF2` — resolves through `crate::crypto::EVP` (module re-export
-    // of `evp`) once `pbkdf2` is un-gated in `src/runtime/crypto/mod.rs`.
     use crate::crypto::create_crypto_error;
     use crate::crypto::pbkdf2::{self, PBKDF2};
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -202,10 +202,8 @@ mod node {
     pub(super) use super::super::types::SliceWithUnderlyingString;
     pub(super) use super::super::{gid_t, uid_t};
 
-    /// `node::mode_from_js` — forwards to the real impl in
-    /// `super::types::mode_from_js` (now un-gated). Kept as a thin alias so
-    /// the dozens of call sites in `args::*::from_js` keep spelling
-    /// `node::mode_from_js`.
+    /// Thin alias to `super::types::mode_from_js` so the dozens of call
+    /// sites in `args::*::from_js` keep spelling `node::mode_from_js`.
     #[inline]
     pub(super) fn mode_from_js(
         ctx: &bun_jsc::JSGlobalObject,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -498,9 +498,7 @@ pub enum Flavor {
 // ──────────────────────────────────────────────────────────────────────────
 // AsyncFSTask / UVFSRequest / NewAsyncCpTask / AsyncReaddirRecursiveTask are
 // the thread-pool wrappers that back every `fs.promises.*` call (and the shell
-// `cp` builtin). Un-gated so the sync `impl NodeFS` body — which references
-// `AsyncCpTask` / `AsyncReaddirRecursiveTask` directly — type-checks, and so
-// `ShellAsyncCpTask` is visible to `crate::shell::builtins::cp`.
+// `cp` builtin).
 mod _async_tasks {
     use super::*;
 

--- a/src/runtime/server/AnyRequestContext.rs
+++ b/src/runtime/server/AnyRequestContext.rs
@@ -123,11 +123,6 @@ macro_rules! dispatch {
     }};
 }
 
-// ─── dispatch arms calling gated RequestContext methods ──────────────────────
-// set_timeout / set_cookies / set_timeout_handler / get_remote_socket_info /
-// on_abort / ref_ / deref / set_signal_aborted forward to RequestContext
-// methods that live in `_gated_state_machine`. Un-gate alongside.
-
 impl AnyRequestContext {
     pub fn set_additional_on_abort_callback(self, cb: Option<AdditionalOnAbortCallback>) {
         dispatch!(self, (), |_T, ctx| {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -416,11 +416,6 @@ mod shim {
         bun_ptr::BackRef::from(s).unpipe_without_deref()
     }
 }
-// `Api::FallbackMessageContainer`/`JsException`/`Problems`/`Fallback::render_backend`
-// live in `bun_options_types::schema::api` + `bun_ast::runtime`; both are
-// still being filled in by concurrent ports. The DEBUG_MODE error-page paths
-// that use them stay ``-gated below.
-
 use bun_options_types::schema::api as Api;
 
 use bun_js_parser::parser::Runtime::Fallback;

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1,8 +1,5 @@
-//! cycle-5: un-gated `NewServer` struct + lifecycle skeleton (start/stop/listen),
-//! `AnyServer` dispatch, `AnyRoute`, and the per-file submodules. JS callback
-//! bodies (`on_request`, `on_upgrade`, `from_js`, …) and methods that need
-//! `bun_uws` write/close surface stay ``-gated inside each file.
-//! The full Phase-A draft of every gated body is preserved in `server_body.rs`.
+//! `Bun.serve()`: `NewServer` struct + lifecycle (start/stop/listen),
+//! `AnyServer` dispatch, `AnyRoute`, and per-file submodules.
 
 use bun_collections::VecExt;
 use core::ffi::{c_char, c_int, c_void};

--- a/src/runtime/test_runner/mod.rs
+++ b/src/runtime/test_runner/mod.rs
@@ -496,10 +496,6 @@ pub mod expect {
     // ── matcher modules (75) ──────────────────────────────────────────
     // Each file is `impl Expect { pub fn to_*(..) }` or a free
     // `#[bun_jsc::host_fn(method)] pub fn to_*(this: &mut Expect, ..)`.
-    // Bodies are real (un-gated); they exercise the full bun_jsc::JSValue
-    // method surface (is_null/is_string/deep_equals/to_fmt/array_iterator
-    // /get_length/...). Any method gap surfaces here when `cfg_jsc!` is
-    // flipped.
     macro_rules! matchers {
         ( $( $file:literal => $mod:ident ),* $(,)? ) => {
             $( #[path = $file] pub mod $mod; )*

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1,14 +1,5 @@
 //! Timer subsystem: setTimeout/setInterval/setImmediate scheduling and the
 //! event-loop timer heap.
-//!
-//! Structs + state machines are real. JS-facing method bodies
-//! (`set_timeout`/`clear_timer`/`warn_invalid_countdown`/etc.) remain
-//! ``-gated on `bun_jsc` (commented out in Cargo.toml).
-//! `All::insert`/`remove`/`update`/`get_timeout`/`drain_timers` — the surface
-//! `EventLoop::auto_tick` blocks on — are real.
-//!
-//! Full earlier drafts are preserved gated under ` mod *_draft`
-//! so this file can be diffed against `Timer.rs` once `bun_jsc` is green.
 
 use bun_collections::ArrayHashMap;
 use bun_core::{Timespec, TimespecMockMode};

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -540,9 +540,7 @@ impl EventLoopDelayMonitor {
     }
 }
 
-// ─── TimerObjectInternals / TimeoutObject / ImmediateObject (struct-only) ───
-// `Flags` is the real packed-u32 state machine; method bodies that touch
-// `bun_jsc::JsRef`/`Debugger` stay gated.
+// ─── TimerObjectInternals / TimeoutObject / ImmediateObject ─────────────────
 
 pub mod timer_object_internals;
 pub use timer_object_internals::{Flags as TimerFlags, TimerObjectInternals};
@@ -1236,12 +1234,6 @@ impl All {
         }
     }
 }
-
-// ─── JS-facing surface (gated on bun_jsc) ────────────────────────────────────
-// `set_timeout`/`set_interval`/`set_immediate`/`sleep`/`clear_*` and the
-// host_fn export thunks all need `JSGlobalObject::bun_vm()`,
-// `JSValue::to_number()`, `bun_core::String::transfer_to_js()`, etc.
-// Kept gated until `bun_jsc.workspace = true` is re-enabled.
 
 // ─── enums / value types ─────────────────────────────────────────────────────
 

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -871,7 +871,7 @@ impl TimerObjectInternals {
 
 // ──────────────────────────────────────────────────────────────────────────
 // JS-host-method facade — `do_ref`/`do_unref`/`do_refresh`/`has_ref`/
-// `to_primitive`/`get_destroyed`/`finalize`/`cancel`. Un-gated for
+// `to_primitive`/`get_destroyed`/`finalize`/`cancel`, called from
 // `TimeoutObject.rs` / `ImmediateObject.rs` host-fn shims.
 // ──────────────────────────────────────────────────────────────────────────
 impl TimerObjectInternals {

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -68,7 +68,7 @@ impl Default for TimerObjectInternals {
 pub use bun_event_loop::EventLoopTimer::TimerFlags as Flags;
 
 // ──────────────────────────────────────────────────────────────────────────
-// `runImmediateTask` path — un-gated for `__bun_run_immediate_task` (dispatch.rs).
+// `runImmediateTask` path for `__bun_run_immediate_task` (dispatch.rs).
 // ──────────────────────────────────────────────────────────────────────────
 
 // C++ symbol emitted from ImmediateList.cpp / setTimeout.cpp; already linked.

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -100,10 +100,8 @@ pub mod s3_stub {
     pub use crate::webcore::s3::MultiPartUploadOptions;
 }
 
-// `crate::node::types` is now un-gated; forward the real enums so
-// `webcore::node_types::X` and `crate::node::types::X` are the *same* type.
-// The previous local stub definitions caused `expected node_types::PathLike,
-// found node::types::PathLike` mismatches across modules.
+// Forward the real enums so `webcore::node_types::X` and
+// `crate::node::types::X` are the same type.
 pub mod node_types {
     pub use crate::node::types::{PathLike, PathOrBlob, PathOrFileDescriptor};
 }
@@ -261,7 +259,6 @@ impl<const SSL: bool, const HTTP3: bool> HasAutoFlusher
 #[path = "webcore/headers_ref.rs"]
 pub mod headers_ref;
 
-// ─── un-gated core types (cycle-5: Body/Blob/Response/Request real) ──────────
 #[path = "webcore/Blob.rs"]
 pub mod blob;
 pub use blob::Any as AnyBlob;

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -237,10 +237,6 @@ impl HasAutoFlusher for file_sink::FileSink {
     }
 }
 
-// Gated alongside the `HTTPServerWritable` method bodies (see
-// `webcore/streams.rs` ` impl<...> HTTPServerWritable` block) —
-// the inherent `on_auto_flush` lives there. Un-gate together.
-
 impl<const SSL: bool, const HTTP3: bool> HasAutoFlusher
     for streams::HTTPServerWritable<SSL, HTTP3>
 {

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -679,8 +679,6 @@ impl ValueError {
             ValueError::AbortReason(r) => ValueError::AbortReason(*r),
         }
     }
-
-    // `reset` is un-gated above.
 }
 
 impl Value {

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -195,7 +195,7 @@ impl BodyMixin for Request {
     }
 }
 
-// ─── un-gated header accessors & simple getters ─────────────────────────────
+// ─── header accessors & simple getters ──────────────────────────────────────
 impl Request {
     /// Inherent shim; `impl BodyMixin for Request` supplies the real trait method.
     #[inline]

--- a/src/runtime/webcore/Response.rs
+++ b/src/runtime/webcore/Response.rs
@@ -564,7 +564,7 @@ impl Response {
     }
 }
 
-// ─── un-gated getters & header helpers ──────────────────────────────────────
+// ─── getters & header helpers ───────────────────────────────────────────────
 impl Response {
     pub fn redirect_location(&self) -> Option<ZigString> {
         self.header(HTTPHeaderName::Location)

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -26,9 +26,6 @@ impl JSSink<ArrayBufferSink> {
     }
 }
 
-// Re-export FileSink so gated `streams::Start` references to
-// `crate::webcore::sink::{FileSink, FileSinkOptions, FileSinkInputPath}` resolve
-// once those callers un-gate. The Options/InputPath types live on FileSink.
 pub use crate::webcore::file_sink::FileSink;
 
 /// A `Sink` is a hand-rolled vtable-based writable stream sink.

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -206,10 +206,6 @@ pub fn event_loop_handle_to_ctx(handle: EventLoopHandle) -> bun_io::EventLoopCtx
 }
 
 // ─── posix_spawn / FilePoll / uv-backed Process methods ──────────────────────
-// Un-gated: `super::bun_spawn::posix_spawn` (Actions/Attr/wait4) and the
-// `bun_io::FilePoll` method surface are stable. `EventLoopHandle` →
-// `EventLoopCtx` bridging is local (`event_loop_handle_to_ctx`) until a
-// JS-side ctx vtable lands.
 impl Process {
     #[cfg(windows)]
     /// SAFETY: `this` must be the live heap-allocated `Process` (the same

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -861,10 +861,6 @@ pub(crate) fn to_bytes(
             break 'brk StringPointer::default();
         };
 
-        // Note: `src/sys/File.rs` is still cfg-gated upstream, so the
-        // `make_open` body (open, on-fail mkdir parent + retry) is inlined here
-        // against the live `bun_sys` stub
-        // surface (`openat` / `make_path` / `File::write_all`).
         if Environment::IS_CANARY || Environment::IS_DEBUG {
             if let Some(dump_code_dir) = bun_core::env_var::BUN_FEATURE_FLAG_DUMP_CODE.get() {
                 let mut path_buf = bun_paths::path_buffer_pool::get();
@@ -877,25 +873,15 @@ pub(crate) fn to_bytes(
                 // Scoped block to handle dump failures without skipping module emission
                 'dump: {
                     let flags = bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC;
-                    // Inline of `bun.sys.File.makeOpen(dest_z, flags, 0o664)`:
-                    let file = match Syscall::openat(Fd::cwd(), dest_z, flags, 0o664) {
-                        Ok(fd) => bun_sys::File::from_fd(fd),
-                        Err(_first_err) => {
-                            let dir_path = path::resolve_path::dirname::<path::platform::Auto>(
-                                dest_z.as_bytes(),
+                    let file = match bun_sys::File::make_open(dest_z.as_bytes(), flags, 0o664) {
+                        Ok(file) => file,
+                        Err(e) => {
+                            bun_core::pretty_errorln!(
+                                "<r><red>error<r><d>:<r> failed to open {}: {}",
+                                bstr::BStr::new(dest_path),
+                                e
                             );
-                            let _ = bun_sys::Dir::cwd().make_path(dir_path);
-                            match Syscall::openat(Fd::cwd(), dest_z, flags, 0o664) {
-                                Ok(fd) => bun_sys::File::from_fd(fd),
-                                Err(e) => {
-                                    bun_core::pretty_errorln!(
-                                        "<r><red>error<r><d>:<r> failed to open {}: {}",
-                                        bstr::BStr::new(dest_path),
-                                        e
-                                    );
-                                    break 'dump;
-                                }
-                            }
+                            break 'dump;
                         }
                     };
                     if let Err(e) = file.write_all(buf_bytes) {

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -435,10 +435,10 @@ impl Win32ErrorUnwrap for Win32Error {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
-// DEAD: full 1188-variant MS-ERREF const table. Kept gated for
-// reference; move individual consts up into `bun_windows_sys::Win32Error`
+// DEAD: full 1188-variant MS-ERREF const table. Kept behind `#[cfg(any())]`
+// for reference; move individual consts up into `bun_windows_sys::Win32Error`
 // if a new caller needs one. (Inherent impl on a foreign type is illegal,
-// so this block cannot be un-gated as-is.)
+// so this block cannot be enabled as-is.)
 // ──────────────────────────────────────────────────────────────────────────
 #[cfg(any())]
 mod _win32error_full_table {

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -143,14 +143,8 @@ pub fn get_default_ciphers() -> &'static ZStr {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// MOVE-IN: ssl_wrapper (MOVE_DOWN bun_runtime::socket::ssl_wrapper → bun_uws)
-// Requested by: http_jsc
+// ssl_wrapper (moved down from bun_runtime::socket::ssl_wrapper for http_jsc)
 // ═══════════════════════════════════════════════════════════════════════════
-// `bun_boringssl_sys` is currently empty (bindgen not yet run), so every fn
-// body that calls a BoringSSL symbol is re-gated below; the
-// type/struct surface compiles against opaque `SSL`/`SSL_CTX` from
-// `bun_boringssl::c`. `init_from_options` additionally needs
-// `bun_uws_sys::socket_context::BunSocketContextOptions` (gated in lower tier).
 pub mod ssl_wrapper {
     use core::ffi::{c_int, c_void};
     use core::ptr::NonNull;
@@ -1272,15 +1266,9 @@ pub mod ssl_wrapper {
 // Loop / InternalLoopData
 // ═══════════════════════════════════════════════════════════════════════════
 // Mirrors `struct us_internal_loop_data_t` (packages/bun-usockets/src/internal/
-// loop_data.h) and `struct us_loop_t` (epoll_kqueue.h / libuv.h). Defined here
-// rather than re-exported from bun_uws_sys because that crate currently gates
-// every module and only exposes opaques — and we cannot `impl` foreign opaques.
-// When bun_uws_sys un-gates, collapse these into `pub use bun_uws_sys::loop_::*`.
-
-// bun_uws_sys provides the real Loop/PosixLoop/WindowsLoop/InternalLoopData/
-// SocketGroup. Re-export them here so `bun_uws::Loop` and `bun_uws_sys::Loop`
-// are the SAME type (bun_io's EventLoopCtxVTable is typed against the uws_sys
-// version).
+// loop_data.h) and `struct us_loop_t` (epoll_kqueue.h / libuv.h). Re-exported
+// from bun_uws_sys so `bun_uws::Loop` and `bun_uws_sys::Loop` are the same
+// type (bun_io's EventLoopCtxVTable is typed against the uws_sys version).
 pub use bun_uws_sys::loop_::{LoopHandler, us_wakeup_loop};
 pub use bun_uws_sys::{InternalLoopData, Loop, PosixLoop, Timespec, WindowsLoop};
 

--- a/test/internal/port-era-markers.test.ts
+++ b/test/internal/port-era-markers.test.ts
@@ -18,31 +18,31 @@ const root = path.resolve(import.meta.dir, "..", "..");
 // from a .zig reference file or an old draft.
 const banned: { pattern: RegExp; reason: string }[] = [
   {
-    pattern: /\bblocked_on\b/,
+    pattern: /\bblocked_on\b/i,
     reason: "port-era 'blocked_on:' markers describe dependencies that have since landed",
   },
   {
-    pattern: /``-gated\b/,
+    pattern: /``-gated\b/i,
     reason: "empty-backtick '``-gated' is a deleted gate-marker token; the comment is stale",
   },
   {
-    pattern: /\bun-gates\b/,
+    pattern: /\bun-gates\b/i,
     reason: "'X un-gates' is port-era future-tense jargon; the referenced code is live",
   },
   {
-    pattern: /\bun-gate\b(?!d)/,
+    pattern: /\bun-gate\b(?!d)/i,
     reason: "'un-gate when/once X lands' is port-era jargon; X has landed",
   },
   {
-    pattern: /\bre-gated\b/,
+    pattern: /\bre-gated\b/i,
     reason: "'re-gated' described a temporary port state; nothing is re-gated",
   },
   {
-    pattern: /\bungated\b/,
+    pattern: /\bungated\b/i,
     reason: "'ungated' is port-era progress narrative, not useful documentation",
   },
   {
-    pattern: /\bun-gated\b/,
+    pattern: /\bun-gated\b/i,
     reason: "'un-gated' is port-era progress narrative, not useful documentation",
   },
 ];
@@ -68,12 +68,12 @@ for (const abs of rustSources) {
 }
 
 for (const { pattern, reason } of banned) {
-  test(`no stale port marker: /${pattern.source}/`, () => {
+  test(`no stale port marker: ${pattern}`, () => {
     const found = hits[pattern.source];
     if (found.length > 0) {
       const sample = found.slice(0, 20);
       throw new Error(
-        `Found ${found.length} occurrence(s) of stale port-era marker /${pattern.source}/ in src/**/*.rs.\n` +
+        `Found ${found.length} occurrence(s) of stale port-era marker ${pattern} in src/**/*.rs.\n` +
           `Reason: ${reason}\n` +
           `Locations${found.length > 20 ? ` (first 20 of ${found.length})` : ""}:\n` +
           sample.map(l => `  ${l}`).join("\n"),

--- a/test/internal/port-era-markers.test.ts
+++ b/test/internal/port-era-markers.test.ts
@@ -58,9 +58,13 @@ for (const abs of rustSources) {
   const rel = path.relative(root, abs);
   const content = await file(abs).text();
   const lines = content.split("\n");
-  for (const { pattern } of banned) {
-    for (let i = 0; i < lines.length; i++) {
-      if (pattern.test(lines[i])) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // These markers are comment jargon; skip non-comment lines so an
+    // identifier or string literal that happens to match never trips the lint.
+    if (!line.includes("//")) continue;
+    for (const { pattern } of banned) {
+      if (pattern.test(line)) {
         hits[pattern.source].push(`${rel}:${i + 1}`);
       }
     }

--- a/test/internal/port-era-markers.test.ts
+++ b/test/internal/port-era-markers.test.ts
@@ -6,8 +6,8 @@
 // "cfg-gated" on its own is NOT banned here: it is used legitimately to
 // describe real platform/feature `#[cfg(...)]` attributes.
 
-import { test, expect } from "bun:test";
 import { file } from "bun";
+import { expect, test } from "bun:test";
 import path from "node:path";
 import { globAllSources } from "../../scripts/glob-sources.ts";
 

--- a/test/internal/port-era-markers.test.ts
+++ b/test/internal/port-era-markers.test.ts
@@ -1,0 +1,84 @@
+// Guards against reintroduction of port-era comment jargon left behind from
+// the incremental Zig→Rust port. These markers ("blocked_on:", "un-gates",
+// "``-gated", "re-gated", etc.) described temporary gating that no longer
+// exists; they accumulate as misleading noise and justify dead shims.
+//
+// "cfg-gated" on its own is NOT banned here: it is used legitimately to
+// describe real platform/feature `#[cfg(...)]` attributes.
+
+import { test, expect } from "bun:test";
+import { file } from "bun";
+import path from "node:path";
+import { globAllSources } from "../../scripts/glob-sources.ts";
+
+const root = path.resolve(import.meta.dir, "..", "..");
+
+// Patterns that indicate stale port-era comments. Each was driven to zero
+// occurrences in src/**/*.rs; any reappearance is almost certainly copied
+// from a .zig reference file or an old draft.
+const banned: { pattern: RegExp; reason: string }[] = [
+  {
+    pattern: /\bblocked_on\b/,
+    reason: "port-era 'blocked_on:' markers describe dependencies that have since landed",
+  },
+  {
+    pattern: /``-gated\b/,
+    reason: "empty-backtick '``-gated' is a deleted gate-marker token; the comment is stale",
+  },
+  {
+    pattern: /\bun-gates\b/,
+    reason: "'X un-gates' is port-era future-tense jargon; the referenced code is live",
+  },
+  {
+    pattern: /\bun-gate\b(?!d)/,
+    reason: "'un-gate when/once X lands' is port-era jargon; X has landed",
+  },
+  {
+    pattern: /\bre-gated\b/,
+    reason: "'re-gated' described a temporary port state; nothing is re-gated",
+  },
+  {
+    pattern: /\bungated\b/,
+    reason: "'ungated' is port-era progress narrative, not useful documentation",
+  },
+  {
+    pattern: /\bun-gated\b/,
+    reason: "'un-gated' is port-era progress narrative, not useful documentation",
+  },
+];
+
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+const hits: Record<string, string[]> = {};
+for (const { pattern } of banned) {
+  hits[pattern.source] = [];
+}
+
+for (const abs of rustSources) {
+  const rel = path.relative(root, abs);
+  const content = await file(abs).text();
+  const lines = content.split("\n");
+  for (const { pattern } of banned) {
+    for (let i = 0; i < lines.length; i++) {
+      if (pattern.test(lines[i])) {
+        hits[pattern.source].push(`${rel}:${i + 1}`);
+      }
+    }
+  }
+}
+
+for (const { pattern, reason } of banned) {
+  test(`no stale port marker: /${pattern.source}/`, () => {
+    const found = hits[pattern.source];
+    if (found.length > 0) {
+      const sample = found.slice(0, 20);
+      throw new Error(
+        `Found ${found.length} occurrence(s) of stale port-era marker /${pattern.source}/ in src/**/*.rs.\n` +
+          `Reason: ${reason}\n` +
+          `Locations${found.length > 20 ? ` (first 20 of ${found.length})` : ""}:\n` +
+          sample.map(l => `  ${l}`).join("\n"),
+      );
+    }
+    expect(found).toEqual([]);
+  });
+}


### PR DESCRIPTION
## What

Cleans up comments left behind from the incremental Zig→Rust port that claim code is "cfg-gated", "blocked_on X", or "will un-gate when Y lands", where X/Y have since landed and the claim is no longer true. Also collapses a handful of local shims whose only justification was one of those stale comments.

Before: 158 such markers across 87 files.
After: 8 remaining, all of which accurately describe real platform/feature `#[cfg(...)]` gating (macOS/Windows image clipboard, POSIX/Windows stdio alias, WASM timer selection, Win32 x64 callconv extern blocks, debug-assertions context, the `#[cfg(any())]` Win32Error table handled by #31995).

## Shims collapsed into canonical impls

- **`src/runtime/cli/repl.rs`**: removed `global_clear_exception`, `global_to_js_value`, `vm_set_execution_forbidden`, `vm_mut` (48 lines). Comment claimed "the canonical impls live in cfg-gated JSGlobalObject.rs / VM.rs (see src/jsc/lib.rs \`_gated\`)"; no `_gated` module exists and `JSGlobalObject::clear_exception` / `::to_js_value`, `VM::set_execution_forbidden`, `VirtualMachine::as_mut` are all public and un-gated. 25 call sites rewired.
- **`src/standalone_graph/StandaloneModuleGraph.rs`**: replaced hand-inlined open+mkdir+retry with `bun_sys::File::make_open`. Comment claimed "`src/sys/File.rs` is still cfg-gated upstream"; `make_open` is public at `src/sys/file.rs:112` and already used from `build_command.rs`.
- **`src/js_parser/visit/mod.rs`**: removed local `stmts_to_single_stmt_` (duplicate of `P::stmts_to_single_stmt`). Comment claimed it was "``-gated (P.rs:6267, blocked on S::Block Default)".
- **`src/js_parser/lower/lower_esm_exports_hmr.rs`**: removed local `generate_temp_ref` (duplicate of `P::generate_temp_ref`). Comment claimed "`P::generate_temp_ref` is ``-gated in P.rs (round-6 re-gate)".
- **`src/js_parser/visit/mod.rs`**: removed dead `let _ = &mut j;` keep-alive whose comment said "keep 'outer label live until #[cfg] un-gates".
- **`src/css/selectors/selector.rs`**: removed two dead `let _ = arguments;` lines after real `arguments.to_css_raw(dest)?` calls.

## Comments rewritten or deleted

The rest are comment-only changes removing port-progress narrative ("cycle-5", "round-D/E/G/H", "phase-c/d", "tier-0", "reconciler-6 re-gate", "`` gates carry blocked_on notes") and stale blocker lists that name dependencies which now exist. Where a comment carried useful non-port information (aliasing rationale, init-order invariants, layering notes), that part is kept; only the stale gating claim is removed.

A few `blocked_on` comments in `src/css/` described genuinely incomplete code (e.g. `Property::longhand`'s no-op `lh()` stub, the CSS-modules ref-arm in `selector_has_composes_for_property`); those were reworded to plain TODOs rather than deleted.

## Verification

```
cargo check --workspace              # clean
bun run rust:check-all                # 10/10 targets ok
bun bd test test/js/bun/repl/repl.test.ts         # 117 pass
bun bd test test/js/bun/util/csrf.test.ts         # 24 pass
bun bd test test/bundler/esbuild/css.test.ts      # 53 pass
bun bd test test/bundler/css/css-modules.test.ts  # 4 pass
bun bd test test/bake/dev/bundle.test.ts          # 20 pass
```

80 files changed, +171/-796.