### PR TITLE
vm: populate Script#sourceMapURL before the script is run

### DIFF
--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -6,6 +6,7 @@
 #include "JavaScriptCore/JIT.h"
 #include "JavaScriptCore/JSWeakMap.h"
 #include "JavaScriptCore/JSWeakMapInlines.h"
+#include "JavaScriptCore/ParserError.h"
 #include "JavaScriptCore/ProgramCodeBlock.h"
 #include "JavaScriptCore/SourceCodeKey.h"
 
@@ -155,6 +156,15 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         if (!unlinkedBlock) {
             script->cachedDataRejected(TriState::True);
         } else {
+            // Restore the directives recorded in the cached bytecode so
+            // Script#sourceMapURL works without re-parsing the source.
+            auto* provider = script->source().provider();
+            if (StringImpl* directive = unlinkedBlock->sourceURLDirective())
+                provider->setSourceURLDirective(directive);
+            if (StringImpl* directive = unlinkedBlock->sourceMappingURLDirective())
+                provider->setSourceMappingURLDirective(directive);
+            script->directivesResolved(true);
+
             JSC::JSScope* jsScope = globalObject->globalScope();
             JSC::CodeBlock* codeBlock = nullptr;
             {
@@ -175,6 +185,8 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
         script->cacheBytecode();
         // TODO(@heimskr): is there ever a case where bytecode production fails?
         script->cachedDataProduced(true);
+        // cacheBytecode() parsed the source, so the directives are populated.
+        script->directivesResolved(true);
     }
 
     return JSValue::encode(script);
@@ -458,6 +470,16 @@ JSC_DEFINE_CUSTOM_GETTER(scriptGetSourceMapURL, (JSGlobalObject * globalObject, 
     auto* script = dynamicDowncast<NodeVMScript>(thisValue);
     if (!script) [[unlikely]] {
         return ERR::INVALID_ARG_VALUE(scope, globalObject, "this"_s, thisValue, "must be a Script"_s);
+    }
+
+    if (!script->directivesResolved()) {
+        // Node makes sourceMapURL available right after construction by compiling
+        // the script eagerly. Bun compiles lazily (on first run), so parse the
+        // source here, without generating bytecode, the first time the directive
+        // is requested. This populates sourceMappingURLDirective on the provider.
+        JSC::ParserError parserError;
+        JSC::checkSyntax(vm, script->source(), parserError);
+        script->directivesResolved(true);
     }
 
     const String& url = script->source().provider()->sourceMappingURLDirective();

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -77,6 +77,8 @@ public:
     void cachedDataProduced(bool value) { m_cachedDataProduced = value; }
     TriState cachedDataRejected() const { return m_cachedDataRejected; }
     void cachedDataRejected(TriState value) { m_cachedDataRejected = value; }
+    bool directivesResolved() const { return m_directivesResolved; }
+    void directivesResolved(bool value) { m_directivesResolved = value; }
 
     DECLARE_VISIT_CHILDREN;
 
@@ -87,6 +89,7 @@ private:
     JSC::WriteBarrier<JSC::ProgramExecutable> m_cachedExecutable;
     ScriptOptions m_options;
     bool m_cachedDataProduced = false;
+    bool m_directivesResolved = false;
     TriState m_cachedDataRejected = TriState::Indeterminate;
 
     NodeVMScript(JSC::VM& vm, JSC::Structure* structure, JSC::SourceCode source, ScriptOptions options)

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -745,6 +745,48 @@ test("can't use bytecode from a different script", () => {
   expect(secondScript.runInThisContext()).toBe(4);
 });
 
+// https://github.com/oven-sh/bun/issues/32530
+describe("Script#sourceMapURL", () => {
+  const source = `
+function myFunc() {}
+//# sourceMappingURL=sourcemap.json
+`;
+
+  test("is available immediately after construction", () => {
+    const script = new Script(source);
+    expect(script.sourceMapURL).toBe("sourcemap.json");
+  });
+
+  test("is available after running the script", () => {
+    const script = new Script(source);
+    script.runInThisContext();
+    expect(script.sourceMapURL).toBe("sourcemap.json");
+  });
+
+  test("is undefined when the source has no sourceMappingURL", () => {
+    const script = new Script("1 + 1;");
+    expect(script.sourceMapURL).toBeUndefined();
+  });
+
+  test("is available with produceCachedData", () => {
+    const script = new Script(source, { produceCachedData: true });
+    expect(script.sourceMapURL).toBe("sourcemap.json");
+  });
+
+  test("is restored from valid cachedData without running", () => {
+    const cachedData = new Script(source).createCachedData();
+    const script = new Script(source, { cachedData });
+    expect(script.cachedDataRejected).toBeFalse();
+    expect(script.sourceMapURL).toBe("sourcemap.json");
+  });
+
+  test("falls back to parsing when cachedData is rejected", () => {
+    const script = new Script(source, { cachedData: Buffer.from("fhqwhgads") });
+    expect(script.cachedDataRejected).toBeTrue();
+    expect(script.sourceMapURL).toBe("sourcemap.json");
+  });
+});
+
 describe("codeGeneration options", () => {
   test("disabling codeGeneration.strings should block eval and Function constructor", () => {
     const context = createContext(


### PR DESCRIPTION
### What / why

`new vm.Script(code).sourceMapURL` returned `undefined` in Bun until the script was first run. Node reports it right after construction.

```js
import vm from "node:vm";

const script = new vm.Script(`
function myFunc() {}
//# sourceMappingURL=sourcemap.json
`);

console.log(script.sourceMapURL);
// Node:  sourcemap.json
// Bun:   undefined   (before this change)
```

Fixes #32530.

### Cause

The `sourceMapURL` getter reads `script->source().provider()->sourceMappingURLDirective()`. That directive is only set while JSC's parser walks the source. Bun parses a `vm.Script` lazily (at first run), whereas Node compiles eagerly at construction, so the directive was empty until the script ran. Running the script first made the value appear, which pinned the cause.

The `cachedData` path had the same gap: the directive is stored in the serialized bytecode but was never copied back onto the source provider after decoding.

### Fix

- Parse the source the first time `sourceMapURL` is read, using `checkSyntax` (no bytecode generation), and cache the result with a flag so scripts that never read the property keep construction cheap and repeated reads do not re-parse.
- When a script is built from `cachedData`, restore the `sourceURL` / `sourceMappingURL` directives recorded in the decoded bytecode onto the provider (mirrors what `CodeCache` does on a cache hit).

### Verification

New tests in `test/js/node/vm/vm.test.ts` cover construction, post-run, `produceCachedData`, valid `cachedData`, rejected `cachedData`, and the no-directive case.

```
bun bd test test/js/node/vm/vm.test.ts -t sourceMapURL
6 pass, 0 fail
```

Without the fix (`USE_SYSTEM_BUN=1`), the construction, valid-`cachedData`, and rejected-`cachedData` cases fail with `undefined`. The full `vm.test.ts` suite stays green (212 pass).