### PR TITLE
worker_threads: add isInternalThread export

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -658,6 +658,9 @@ export default {
   parentPort,
   resourceLimits,
   isMainThread,
+  // Bun does not expose Node's internal worker threads (e.g. the module
+  // loader thread) to user code, so this is always false for reachable code.
+  isInternalThread: false,
   MessageChannel,
   BroadcastChannel,
   MessagePort,

--- a/test/js/node/worker_threads/is-internal-thread.test.ts
+++ b/test/js/node/worker_threads/is-internal-thread.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe } from "harness";
 import wt, { Worker } from "worker_threads";
 
 // https://github.com/oven-sh/bun/issues/32532
-describe("isInternalThread", () => {
+describe.concurrent("isInternalThread", () => {
   test("is exported as false on the module object", () => {
     expect(wt).toHaveProperty("isInternalThread");
     expect(wt.isInternalThread).toBe(false);

--- a/test/js/node/worker_threads/is-internal-thread.test.ts
+++ b/test/js/node/worker_threads/is-internal-thread.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import wt, { Worker } from "worker_threads";
+
+// https://github.com/oven-sh/bun/issues/32532
+describe("isInternalThread", () => {
+  test("is exported as false on the module object", () => {
+    expect(wt).toHaveProperty("isInternalThread");
+    expect(wt.isInternalThread).toBe(false);
+  });
+
+  test("named import resolves to false", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "import { isInternalThread } from 'node:worker_threads'; console.log(isInternalThread);"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false", stderr: "", exitCode: 0 });
+  });
+
+  test("require exposes isInternalThread as false", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);",
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false boolean", stderr: "", exitCode: 0 });
+  });
+
+  test("is false inside a user worker", async () => {
+    const worker = new Worker(
+      `const { parentPort, isInternalThread } = require("node:worker_threads"); parentPort.postMessage(isInternalThread);`,
+      { eval: true },
+    );
+    try {
+      const result = await new Promise<boolean>((resolve, reject) => {
+        worker.once("message", value => resolve(value as boolean));
+        worker.once("error", reject);
+        worker.once("exit", code => reject(new Error(`worker exited before posting a message (code ${code})`)));
+      });
+      expect(result).toBe(false);
+    } finally {
+      await worker.terminate();
+    }
+  });
+});

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -111,9 +111,18 @@ describe("isInternalThread", () => {
       `const { parentPort, isInternalThread } = require("node:worker_threads"); parentPort.postMessage(isInternalThread);`,
       { eval: true },
     );
-    const result = await new Promise(resolve => worker.on("message", resolve));
-    expect(result).toBe(false);
-    await worker.terminate();
+    try {
+      const result = await new Promise<boolean>((resolve, reject) => {
+        worker.once("message", value => resolve(value as boolean));
+        worker.once("error", reject);
+        worker.once("exit", code => {
+          if (code !== 0) reject(new Error(`worker exited before posting a message (code ${code})`));
+        });
+      });
+      expect(result).toBe(false);
+    } finally {
+      await worker.terminate();
+    }
   });
 });
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -115,9 +115,7 @@ describe("isInternalThread", () => {
       const result = await new Promise<boolean>((resolve, reject) => {
         worker.once("message", value => resolve(value as boolean));
         worker.once("error", reject);
-        worker.once("exit", code => {
-          if (code !== 0) reject(new Error(`worker exited before posting a message (code ${code})`));
-        });
+        worker.once("exit", code => reject(new Error(`worker exited before posting a message (code ${code})`)));
       });
       expect(result).toBe(false);
     } finally {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -93,7 +93,11 @@ describe("isInternalThread", () => {
 
   test("require exposes isInternalThread as false", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);"],
+      cmd: [
+        bunExe(),
+        "-e",
+        "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);",
+      ],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -35,6 +35,7 @@ test("support eval in worker", async () => {
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");
+  expect(wt).toHaveProperty("isInternalThread");
   expect(wt).toHaveProperty("markAsUntransferable");
   expect(wt).toHaveProperty("moveMessagePortToContext");
   expect(wt).toHaveProperty("parentPort");
@@ -51,6 +52,7 @@ test("all worker_threads module properties are present", () => {
 
   expect(getEnvironmentData).toBeFunction();
   expect(isMainThread).toBeBoolean();
+  expect(wt.isInternalThread).toBe(false);
   expect(markAsUntransferable).toBeFunction();
   expect(moveMessagePortToContext).toBeFunction();
   expect(parentPort).toBeNull();
@@ -74,6 +76,41 @@ test("all worker_threads module properties are present", () => {
     // @ts-expect-error no args
     wt.moveMessagePortToContext();
   }).toThrow("not yet implemented");
+});
+
+describe("isInternalThread", () => {
+  // https://github.com/oven-sh/bun/issues/32532
+  test("named import resolves to false", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "import { isInternalThread } from 'node:worker_threads'; console.log(isInternalThread);"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "false", exitCode: 0 });
+  });
+
+  test("require exposes isInternalThread as false", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);"],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "false boolean", exitCode: 0 });
+  });
+
+  test("is false inside a user worker", async () => {
+    const worker = new Worker(
+      `const { parentPort, isInternalThread } = require("node:worker_threads"); parentPort.postMessage(isInternalThread);`,
+      { eval: true },
+    );
+    const result = await new Promise(resolve => worker.on("message", resolve));
+    expect(result).toBe(false);
+    await worker.terminate();
+  });
 });
 
 test("all worker_threads worker instance properties are present", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -35,7 +35,6 @@ test("support eval in worker", async () => {
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");
-  expect(wt).toHaveProperty("isInternalThread");
   expect(wt).toHaveProperty("markAsUntransferable");
   expect(wt).toHaveProperty("moveMessagePortToContext");
   expect(wt).toHaveProperty("parentPort");
@@ -52,7 +51,6 @@ test("all worker_threads module properties are present", () => {
 
   expect(getEnvironmentData).toBeFunction();
   expect(isMainThread).toBeBoolean();
-  expect(wt.isInternalThread).toBe(false);
   expect(markAsUntransferable).toBeFunction();
   expect(moveMessagePortToContext).toBeFunction();
   expect(parentPort).toBeNull();
@@ -76,52 +74,6 @@ test("all worker_threads module properties are present", () => {
     // @ts-expect-error no args
     wt.moveMessagePortToContext();
   }).toThrow("not yet implemented");
-});
-
-describe("isInternalThread", () => {
-  // https://github.com/oven-sh/bun/issues/32532
-  test("named import resolves to false", async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", "import { isInternalThread } from 'node:worker_threads'; console.log(isInternalThread);"],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false", stderr: "", exitCode: 0 });
-  });
-
-  test("require exposes isInternalThread as false", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);",
-      ],
-      env: bunEnv,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false boolean", stderr: "", exitCode: 0 });
-  });
-
-  test("is false inside a user worker", async () => {
-    const worker = new Worker(
-      `const { parentPort, isInternalThread } = require("node:worker_threads"); parentPort.postMessage(isInternalThread);`,
-      { eval: true },
-    );
-    try {
-      const result = await new Promise<boolean>((resolve, reject) => {
-        worker.once("message", value => resolve(value as boolean));
-        worker.once("error", reject);
-        worker.once("exit", code => reject(new Error(`worker exited before posting a message (code ${code})`)));
-      });
-      expect(result).toBe(false);
-    } finally {
-      await worker.terminate();
-    }
-  });
 });
 
 test("all worker_threads worker instance properties are present", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -88,7 +88,7 @@ describe("isInternalThread", () => {
       stdout: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "false", exitCode: 0 });
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false", stderr: "", exitCode: 0 });
   });
 
   test("require exposes isInternalThread as false", async () => {
@@ -103,7 +103,7 @@ describe("isInternalThread", () => {
       stdout: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "false boolean", exitCode: 0 });
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "false boolean", stderr: "", exitCode: 0 });
   });
 
   test("is false inside a user worker", async () => {


### PR DESCRIPTION
Fixes #32532

### Repro

```js
import { isInternalThread } from "node:worker_threads";
console.log(isInternalThread);
```

Before this change:

```console
$ bun -e "import { isInternalThread } from 'node:worker_threads'; console.log(isInternalThread);"
SyntaxError: Export named 'isInternalThread' not found in module 'node:worker_threads'.

$ bun -e "console.log(require('node:worker_threads').isInternalThread);"
undefined
```

Node prints `false` in both cases.

### Cause

`node:worker_threads` never exported `isInternalThread`. Named exports for these builtin modules are synthesized at runtime from the keys of the `export default { ... }` object, so a missing key makes the named import throw and the property read as `undefined`.

### Fix

Add `isInternalThread: false` to the module's default export object (`src/js/node/worker_threads.ts`). In Node this value is `false` for all user-reachable code (the main thread and user-created workers) and only `true` inside Node's internal worker threads, which Bun does not expose to user code. A constant `false` matches Node for every thread user code can run on.

### Verification

```console
$ bun -e "import { isInternalThread } from 'node:worker_threads'; console.log(isInternalThread);"
false
$ bun -e "const wt = require('node:worker_threads'); console.log(wt.isInternalThread, typeof wt.isInternalThread);"
false boolean
```

Tests added to `test/js/node/worker_threads/worker_threads.test.ts` cover the named import, `require`, the default-import property, and a user worker, each asserting `false`. They fail before this change and pass after.