### PR TITLE
Implement worker_threads.isMarkedAsUntransferable and markAsUntransferable

### DIFF
--- a/src/js/builtins/BunBuiltinNames.h
+++ b/src/js/builtins/BunBuiltinNames.h
@@ -212,6 +212,7 @@ using namespace JSC;
     macro(underlyingByteSource) \
     macro(underlyingSink) \
     macro(underlyingSource) \
+    macro(untransferable) \
     macro(url) \
     macro(view) \
     macro(warning) \

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -451,9 +451,8 @@ function setEnvironmentData(key: unknown, value: unknown): void {
   }
 }
 
-function markAsUntransferable() {
-  throwNotImplemented("worker_threads.markAsUntransferable");
-}
+const markAsUntransferable = $newCppFunction("Worker.cpp", "jsFunction_markAsUntransferable", 1);
+const isMarkedAsUntransferable = $newCppFunction("Worker.cpp", "jsFunction_isMarkedAsUntransferable", 1);
 
 function moveMessagePortToContext() {
   throwNotImplemented("worker_threads.moveMessagePortToContext");
@@ -667,6 +666,7 @@ export default {
     return {};
   },
   markAsUntransferable,
+  isMarkedAsUntransferable,
   moveMessagePortToContext,
   receiveMessageOnPort,
   SHARE_ENV,

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -6217,7 +6217,14 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     Vector<Ref<WebCodecsVideoFrame>> transferredVideoFrames;
 #endif
     HashSet<JSC::JSObject*> uniqueTransferables;
+    const auto& untransferablePrivateName = builtinNames(vm).untransferablePrivateName();
     for (auto& transferable : transferList) {
+        // node:worker_threads.markAsUntransferable(): a marked object is ignored
+        // in the transfer list, so it is cloned in the graph below rather than
+        // transferred (its backing store is left intact).
+        if (!transferable->getDirect(vm, untransferablePrivateName).isEmpty())
+            continue;
+
         if (!uniqueTransferables.add(transferable.get()).isNewEntry) {
             if (toPossiblySharedArrayBuffer(vm, transferable.get())) {
                 return Exception { DataCloneError, "Transfer list contains duplicate ArrayBuffer"_s };

--- a/src/jsc/bindings/webcore/Worker.cpp
+++ b/src/jsc/bindings/webcore/Worker.cpp
@@ -45,6 +45,7 @@
 #include "CloseEvent.h"
 #include "JSMessagePort.h"
 #include "JSBroadcastChannel.h"
+#include "BunClientData.h"
 
 namespace WebCore {
 
@@ -662,6 +663,28 @@ JSC_DEFINE_HOST_FUNCTION(jsReceiveMessageOnPort, (JSGlobalObject * lexicalGlobal
     }
 
     return Bun::throwError(lexicalGlobalObject, scope, Bun::ErrorCode::ERR_INVALID_ARG_TYPE, "The \"port\" argument must be a MessagePort instance"_s);
+}
+
+// node:worker_threads.markAsUntransferable(object): tag an object with a hidden
+// private symbol so the structured-clone transfer list ignores it (the object is
+// cloned instead of transferred). A no-op for primitives, matching Node.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_markAsUntransferable, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    if (auto* object = callFrame->argument(0).getObject())
+        object->putDirect(vm, builtinNames(vm).untransferablePrivateName(), jsBoolean(true), JSC::PropertyAttribute::DontEnum | JSC::PropertyAttribute::DontDelete);
+    return JSC::JSValue::encode(jsUndefined());
+}
+
+// node:worker_threads.isMarkedAsUntransferable(object): report whether the object
+// carries the mark set by markAsUntransferable(). false for primitives.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_isMarkedAsUntransferable, (JSGlobalObject * globalObject, CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    bool marked = false;
+    if (auto* object = callFrame->argument(0).getObject())
+        marked = !object->getDirect(vm, builtinNames(vm).untransferablePrivateName()).isEmpty();
+    return JSC::JSValue::encode(jsBoolean(marked));
 }
 
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject)

--- a/src/jsc/bindings/webcore/Worker.h
+++ b/src/jsc/bindings/webcore/Worker.h
@@ -194,5 +194,7 @@ private:
 JSValue createNodeWorkerThreadsBinding(Zig::GlobalObject* globalObject);
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionPostMessage);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_markAsUntransferable);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_isMarkedAsUntransferable);
 
 } // namespace WebCore

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -7,6 +7,7 @@ import wt, {
   BroadcastChannel,
   getEnvironmentData,
   isMainThread,
+  isMarkedAsUntransferable,
   markAsUntransferable,
   MessageChannel,
   MessagePort,
@@ -35,6 +36,7 @@ test("support eval in worker", async () => {
 test("all worker_threads module properties are present", () => {
   expect(wt).toHaveProperty("getEnvironmentData");
   expect(wt).toHaveProperty("isMainThread");
+  expect(wt).toHaveProperty("isMarkedAsUntransferable");
   expect(wt).toHaveProperty("markAsUntransferable");
   expect(wt).toHaveProperty("moveMessagePortToContext");
   expect(wt).toHaveProperty("parentPort");
@@ -51,6 +53,7 @@ test("all worker_threads module properties are present", () => {
 
   expect(getEnvironmentData).toBeFunction();
   expect(isMainThread).toBeBoolean();
+  expect(isMarkedAsUntransferable).toBeFunction();
   expect(markAsUntransferable).toBeFunction();
   expect(moveMessagePortToContext).toBeFunction();
   expect(parentPort).toBeNull();
@@ -64,11 +67,6 @@ test("all worker_threads module properties are present", () => {
   expect(MessageChannel).toBeDefined();
   expect(MessagePort).toBeDefined();
   expect(Worker).toBeDefined();
-
-  expect(() => {
-    // @ts-expect-error no args
-    wt.markAsUntransferable();
-  }).toThrow("not yet implemented");
 
   expect(() => {
     // @ts-expect-error no args
@@ -627,4 +625,93 @@ test("FileHandles nested in Map and Set workerData are transferred", async () =>
   // and Set entries deserialized to the same single instance
   expect(fh.fd).toBe(-1);
   expect(message).toEqual({ sameInstance: true, text: "hello" });
+});
+
+describe("markAsUntransferable / isMarkedAsUntransferable", () => {
+  test("isMarkedAsUntransferable reflects the mark set by markAsUntransferable", () => {
+    const buf = new ArrayBuffer(8);
+    expect(isMarkedAsUntransferable(buf)).toBe(false);
+    expect(markAsUntransferable(buf)).toBeUndefined();
+    expect(isMarkedAsUntransferable(buf)).toBe(true);
+
+    // Works for ordinary objects too, not just ArrayBuffers.
+    const obj = {};
+    markAsUntransferable(obj);
+    expect(isMarkedAsUntransferable(obj)).toBe(true);
+  });
+
+  test("primitives are never marked and marking them is a no-op", () => {
+    for (const value of [0, 1, "", "x", true, null, undefined, Symbol("s")]) {
+      expect(isMarkedAsUntransferable(value)).toBe(false);
+      expect(() => markAsUntransferable(value)).not.toThrow();
+      expect(isMarkedAsUntransferable(value)).toBe(false);
+    }
+  });
+
+  test("marking is idempotent", () => {
+    const buf = new ArrayBuffer(8);
+    markAsUntransferable(buf);
+    markAsUntransferable(buf);
+    expect(isMarkedAsUntransferable(buf)).toBe(true);
+  });
+
+  test("the mark is hidden from property enumeration", () => {
+    const buf = new ArrayBuffer(8);
+    markAsUntransferable(buf);
+    expect(Object.getOwnPropertySymbols(buf)).toHaveLength(0);
+    expect(Object.getOwnPropertyNames(buf)).not.toContain("untransferable");
+    // An unmarked clone carries no mark, and cloning a marked buffer still works.
+    expect(structuredClone(buf).byteLength).toBe(8);
+  });
+
+  test("a marked ArrayBuffer in a transfer list is cloned, not detached", () => {
+    const view = new Uint8Array([1, 2, 3, 4]);
+    markAsUntransferable(view.buffer);
+    const clone = structuredClone(view, { transfer: [view.buffer] }) as Uint8Array;
+    // Source buffer is intact: it was cloned, not transferred.
+    expect(view.buffer.byteLength).toBe(4);
+    expect(Array.from(view)).toEqual([1, 2, 3, 4]);
+    expect(Array.from(clone)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("an unmarked ArrayBuffer in a transfer list is still detached", () => {
+    const view = new Uint8Array([1, 2, 3, 4]);
+    const clone = structuredClone(view, { transfer: [view.buffer] }) as Uint8Array;
+    expect(view.buffer.byteLength).toBe(0); // detached
+    expect(Array.from(clone)).toEqual([1, 2, 3, 4]);
+  });
+
+  test("the documented pooled-buffer example clones instead of transferring", () => {
+    const pooledBuffer = new ArrayBuffer(8);
+    const typedArray1 = new Uint8Array(pooledBuffer);
+    typedArray1[0] = 42;
+    markAsUntransferable(pooledBuffer);
+
+    const { port1, port2 } = new MessageChannel();
+    port1.postMessage(typedArray1, [typedArray1.buffer]);
+    // Still owns its memory -- cloned, not transferred.
+    expect(pooledBuffer.byteLength).toBe(8);
+    expect(typedArray1[0]).toBe(42);
+
+    const received = receiveMessageOnPort(port2);
+    expect(received).toBeDefined();
+    expect((received!.message as Uint8Array)[0]).toBe(42);
+    port1.close();
+    port2.close();
+  });
+
+  test("a marked ArrayBuffer in a Worker transferList is cloned", async () => {
+    const view = new Uint8Array([9, 8, 7, 6]);
+    markAsUntransferable(view.buffer);
+    const worker = new Worker(
+      `const { parentPort, workerData } = require("worker_threads");
+       parentPort.postMessage(Array.from(new Uint8Array(workerData)));`,
+      { eval: true, workerData: view.buffer, transferList: [view.buffer] } as any,
+    );
+    const [message] = await once(worker, "message");
+    await worker.terminate();
+    expect(message).toEqual([9, 8, 7, 6]);
+    // Parent side is intact: cloned, not transferred.
+    expect(view.buffer.byteLength).toBe(4);
+  });
 });


### PR DESCRIPTION
## Problem

`node:worker_threads` is missing `isMarkedAsUntransferable`, and `markAsUntransferable` is a stub that throws. Closes #32535. Fixes #22405 (the standing request to implement `markAsUntransferable`, which `node-web-audio-api` depends on).

```console
$ bun -e "import { isMarkedAsUntransferable } from 'node:worker_threads'"
SyntaxError: Export named 'isMarkedAsUntransferable' not found in module 'node:worker_threads'.

$ bun -e "import wt from 'node:worker_threads'; wt.markAsUntransferable(new ArrayBuffer(8))"
error: worker_threads.markAsUntransferable is not yet implemented in Bun.
```

The named import fails at module evaluation because `isMarkedAsUntransferable` was never defined or added to the module's export object. `markAsUntransferable` existed but only called `throwNotImplemented`.

## Fix

Both are now native host functions in `Worker.cpp`:

- `markAsUntransferable(object)` tags the object with a hidden private symbol (`untransferablePrivateName`, added to `BunBuiltinNames.h`). No-op for primitives, like Node.
- `isMarkedAsUntransferable(object)` reports whether that symbol is present. `false` for primitives.

The mark is honored in `SerializedScriptValue::create`, the single chokepoint every transfer path funnels through (`worker.postMessage`, `port.postMessage`, the `Worker` constructor `transferList`, and `structuredClone`). A marked object is skipped in the transfer-list loop, so a marked `ArrayBuffer` is cloned rather than transferred and its backing store is left intact. This matches the documented behavior Node relies on to keep its internal `Buffer` pool from being detached when a pooled buffer is listed for transfer.

The symbol uses `PrivateSymbol`, so it is not visible to `Object.getOwnPropertySymbols` and does not survive structured clone, matching Node.

## Verification

New tests in `test/js/node/worker_threads/worker_threads.test.ts` cover: the mark round-trip, primitive no-ops, idempotency, symbol hiding, the documented pooled-buffer example, and the mark being honored across `structuredClone`, a `MessageChannel`, and a `Worker` `transferList` (with an unmarked-buffer negative control that still detaches). The prior assertion that `markAsUntransferable` throws "not yet implemented" is removed.

```console
$ bun bd test test/js/node/worker_threads/worker_threads.test.ts -t "markAsUntransferable"
 8 pass
 0 fail
```

The 215 existing structured-clone tests and `test-messagechannel.js` still pass, confirming the shared serializer change does not regress the normal transfer path.

## Note on Node v26

Node's current `markAsUntransferable` documentation and the feature's original purpose (protecting its `Buffer` pool) specify clone-instead-of-transfer. Node v26 instead throws `DataCloneError` when any marked buffer appears in a transfer list, which also breaks transferring pooled `Buffer`s. This PR implements the documented clone behavior rather than the v26 regression.