### PR TITLE
server: close TCP listener when H3 UDP bind fails

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2773,13 +2773,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                             // Re-derive: `h3_listener` was just written by `on_h3_listen`.
                             if this_ref.h3_listener.is_none() {
-                                if attempt < max_attempts {
-                                    // UDP:N is taken — release TCP:N so the next
-                                    // attempt gets a fresh kernel-chosen port.
-                                    // Only retry if TCP actually succeeded.
-                                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
-                                    if let Some(ls) = unsafe { (*this).listener.take() } {
-                                        bun_opaque::opaque_deref_mut(ls).close();
+                                // Release TCP:N — either to retry on a fresh
+                                // kernel-chosen port, or so the listen socket
+                                // is unlinked from the group before deinit()
+                                // below destroys the app.
+                                // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
+                                if let Some(ls) = unsafe { (*this).listener.take() } {
+                                    bun_opaque::opaque_deref_mut(ls).close();
+                                    if attempt < max_attempts {
                                         continue;
                                     }
                                 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1077,3 +1077,38 @@ describe("Bun.serve HTTP/3 production", () => {
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
 });
+
+test("H3 UDP bind failure after TCP listen succeeds throws cleanly", async () => {
+  const script = `
+    const dgram = require("node:dgram");
+    const udp = dgram.createSocket("udp4");
+    udp.bind(0, "127.0.0.1", () => {
+      const port = udp.address().port;
+      try {
+        Bun.serve({
+          port,
+          hostname: "127.0.0.1",
+          tls: ${JSON.stringify(tls)},
+          http3: true,
+          fetch() { return new Response("ok"); },
+        });
+        console.log("unexpected success");
+      } catch (e) {
+        console.log("threw: " + e.message);
+      }
+      udp.close();
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: expect.stringContaining("threw: Failed to listen on UDP port"),
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
+});

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1085,7 +1085,7 @@ test("H3 UDP bind failure after TCP listen succeeds throws cleanly", async () =>
     udp.bind(0, "127.0.0.1", () => {
       const port = udp.address().port;
       try {
-        Bun.serve({
+        const server = Bun.serve({
           port,
           hostname: "127.0.0.1",
           tls: ${JSON.stringify(tls)},
@@ -1093,6 +1093,8 @@ test("H3 UDP bind failure after TCP listen succeeds throws cleanly", async () =>
           fetch() { return new Response("ok"); },
         });
         console.log("unexpected success");
+        server.stop(true);
+        process.exitCode = 1;
       } catch (e) {
         console.log("threw: " + e.message);
       }


### PR DESCRIPTION
Fuzzilli found an assertion failure in `us_socket_group_deinit`:

```
bun-debug: packages/bun-usockets/src/context.c:67: void us_socket_group_deinit(struct us_socket_group_t *): Assertion `group->head_listen_sockets == ((void*)0)' failed.
```

## Root cause

When `Bun.serve({ http3: true, tls })` successfully binds the TCP listen socket but the UDP bind for QUIC fails on the same port, the error path throws and then calls `deinit()`, which destroys the uws App (`~TemplatedApp` -> `httpContext->free()` -> `us_socket_group_deinit`). That path never runs `TemplatedApp::close()`, so the TCP listen socket is still linked into `group->head_listen_sockets` when the group is torn down, tripping the assertion in debug/ASAN builds and leaking the fd + listen socket struct in release.

The port-0 retry path already closed the TCP listener; the fix extends that to the final failure path so the socket is unlinked before `deinit()` destroys the app.

## Repro

```js
const dgram = require("node:dgram");
const udp = dgram.createSocket("udp4");
udp.bind(0, "127.0.0.1", () => {
  const port = udp.address().port;
  Bun.serve({ port, hostname: "127.0.0.1", tls, http3: true, fetch() {} });
});
```

Fingerprint: `f384476a45a89910`