### PR TITLE
server: close TCP listener before App::destroy in deinit

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1858,6 +1858,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 unsafe { uws_sys::h3::App::destroy(h3a) };
             }
         }
+        // listen()'s post-listen error path (h3 UDP bind failed) can reach
+        // here with the TCP listener still linked into the app's group —
+        // unlink it before App::destroy so us_socket_group_deinit doesn't
+        // assert head_listen_sockets == NULL.
+        if let Some(listener) = this_ref.listener.take() {
+            // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
+            bun_opaque::opaque_deref_mut(listener).close();
+        }
         if let Some(app) = this_ref.app.take() {
             // SAFETY: live uws App handle owned by this server.
             unsafe { uws_sys::NewApp::<SSL>::destroy(app) };

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -480,6 +480,52 @@ describe("Bun.serve HTTP/3", () => {
     expect(stdout).toContain("listening");
     expect(exitCode).toBe(0);
   });
+
+  test("H3 UDP bind failure after TCP listen succeeded throws cleanly", async () => {
+    // Previously the TCP listen socket was still linked to the app's socket
+    // group when deinit ran on this error path, tripping the
+    // head_listen_sockets == NULL assert in us_socket_group_deinit.
+    const script = `
+      const dgram = require("dgram");
+      const net = require("net");
+      const tcp = net.createServer();
+      await new Promise(r => tcp.listen(0, "127.0.0.1", r));
+      const port = tcp.address().port;
+      tcp.close();
+      await new Promise(r => tcp.on("close", r));
+      const udp = dgram.createSocket("udp4");
+      await new Promise((resolve, reject) => {
+        udp.on("error", reject);
+        udp.bind(port, "127.0.0.1", resolve);
+      });
+      try {
+        Bun.serve({
+          port,
+          hostname: "127.0.0.1",
+          tls: ${JSON.stringify(tls)},
+          http3: true,
+          fetch: () => new Response("x"),
+        });
+        console.log("unexpected-success");
+      } catch (e) {
+        console.log("threw:" + e.message);
+      }
+      udp.close();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: expect.stringContaining("threw:Failed to listen on UDP port"),
+      stderr: expect.not.stringContaining("head_listen_sockets"),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
 });
 
 // Cases ported from h2o t/40http3 and aioquic interop. Each test gets its own


### PR DESCRIPTION
When `Bun.serve` with `http3: true` fails the QUIC UDP bind after the TCP listen has already succeeded, `listen()` throws and calls `Self::deinit(this)` directly. At that point the TCP listen socket is still linked into the uWS app's socket group, so `App::destroy` -> `~TemplatedApp` -> `httpContext->free()` -> `us_socket_group_deinit` trips the `head_listen_sockets == NULL` assert.

Close the listener in `deinit` before destroying the app. In the normal teardown paths `self.listener` has already been taken by `stop_listening` (and `deinit_if_we_can` gates on `!has_listener()`), so this only fires on the listen-failure error path. `us_listen_socket_close` is idempotent on already-closed sockets.

Repro: hold the UDP port before `Bun.serve({ port, http3: true, tls })` so the TCP bind succeeds but the H3 bind fails. Added as a regression test in `serve-http3.test.ts`.

Found by Fuzzilli (fingerprint 897bba1f930ab927).