### PR TITLE
Bun.serve: close TCP listener when H3 UDP bind fails

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2773,13 +2773,15 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                             // Re-derive: `h3_listener` was just written by `on_h3_listen`.
                             if this_ref.h3_listener.is_none() {
-                                if attempt < max_attempts {
-                                    // UDP:N is taken — release TCP:N so the next
-                                    // attempt gets a fresh kernel-chosen port.
+                                // UDP:N is taken — release TCP:N so the next
+                                // attempt gets a fresh kernel-chosen port, or
+                                // so the post-match `Self::deinit` can tear
+                                // down the group without a live listener.
+                                // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
+                                if let Some(ls) = unsafe { (*this).listener.take() } {
+                                    bun_opaque::opaque_deref_mut(ls).close();
                                     // Only retry if TCP actually succeeded.
-                                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
-                                    if let Some(ls) = unsafe { (*this).listener.take() } {
-                                        bun_opaque::opaque_deref_mut(ls).close();
+                                    if attempt < max_attempts {
                                         continue;
                                     }
                                 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -468,7 +468,8 @@ describe("Bun.serve HTTP/3", () => {
       udp.bind(0, "0.0.0.0", () => {
         const port = udp.address().port;
         try {
-          Bun.serve({ port, tls: ${JSON.stringify(tls)}, http3: true, fetch: () => new Response("x") });
+          const s = Bun.serve({ port, tls: ${JSON.stringify(tls)}, http3: true, fetch: () => new Response("x") });
+          s.stop(true);
           console.log("unexpected-success");
         } catch (e) {
           console.log("caught", e.message);

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -461,6 +461,35 @@ describe("Bun.serve HTTP/3", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  test("UDP bind failure with live TCP listener throws cleanly", async () => {
+    const src = `
+      const dgram = require("dgram");
+      const udp = dgram.createSocket("udp4");
+      udp.bind(0, "0.0.0.0", () => {
+        const port = udp.address().port;
+        try {
+          Bun.serve({ port, tls: ${JSON.stringify(tls)}, http3: true, fetch: () => new Response("x") });
+          console.log("unexpected-success");
+        } catch (e) {
+          console.log("caught", e.message);
+        }
+        udp.close();
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringContaining("caught Failed to listen on UDP port"),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
+
   test("validation: http3 with unix socket warns and skips H3 listener", async () => {
     using dir = tempDir("serve-http3-unix", {});
     const sock = join(String(dir), "h3.sock");


### PR DESCRIPTION
Fuzzilli found a debug assertion failure in `us_socket_group_deinit`:

```
context.c:67: void us_socket_group_deinit(struct us_socket_group_t *): Assertion `group->head_listen_sockets == ((void*)0)' failed.
```

### Cause

With `Bun.serve({ port, http3: true, tls: ... })`, the listen path binds TCP first and then binds UDP on the same port for QUIC. If the UDP bind fails and `port` is 0 the TCP listener is closed and a new port is tried. On the final attempt, however, the TCP listener was left open before throwing. The post-throw `Self::deinit(this)` then destroys the uws app without calling `close()`, so `us_socket_group_deinit` fires with the TCP listener still linked into `head_listen_sockets`.

### Fix

Close the TCP listener on the final attempt as well, not just on retry. The retry gate (`attempt < max_attempts`) moves inside the close block so the listener is always released before the error path runs `deinit`.

### Repro

```js
const dgram = require("dgram");
const udp = dgram.createSocket("udp4");
udp.bind(0, "0.0.0.0", () => {
  const port = udp.address().port;
  Bun.serve({ port, tls, http3: true, fetch: () => new Response("x") });
  udp.close();
});
```

Before: aborts in a debug build.
After: throws `Failed to listen on UDP port N for HTTP/3`.