### PR TITLE
server: close TCP listener when HTTP/3 UDP bind fails

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -2773,13 +2773,14 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                             );
                             // Re-derive: `h3_listener` was just written by `on_h3_listen`.
                             if this_ref.h3_listener.is_none() {
-                                if attempt < max_attempts {
-                                    // UDP:N is taken — release TCP:N so the next
-                                    // attempt gets a fresh kernel-chosen port.
-                                    // Only retry if TCP actually succeeded.
-                                    // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
-                                    if let Some(ls) = unsafe { (*this).listener.take() } {
-                                        bun_opaque::opaque_deref_mut(ls).close();
+                                // UDP:N is taken — release TCP:N so it isn't still
+                                // linked into the app's socket group when we deinit
+                                // on the throw path below. If we have attempts left,
+                                // retry so the kernel picks a fresh N.
+                                // SAFETY: `this` is the live boxed server; no other borrow is live across this take.
+                                if let Some(ls) = unsafe { (*this).listener.take() } {
+                                    bun_opaque::opaque_deref_mut(ls).close();
+                                    if attempt < max_attempts {
                                         continue;
                                     }
                                 }

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1077,3 +1077,53 @@ describe("Bun.serve HTTP/3 production", () => {
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
 });
+
+test("Bun.serve closes the TCP listener when the HTTP/3 UDP bind fails", async () => {
+  // TCP listen succeeds, then the QUIC bind on the same port fails; the
+  // error path must close the TCP listener before tearing down the app or
+  // the listen socket stays registered against a freed socket group.
+  const script = `
+    const dgram = require("dgram");
+    const net = require("net");
+    const sock = dgram.createSocket("udp4");
+    await new Promise((resolve, reject) => {
+      sock.on("error", reject);
+      sock.bind(0, "127.0.0.1", resolve);
+    });
+    const port = sock.address().port;
+    let err;
+    try {
+      Bun.serve({
+        port,
+        hostname: "127.0.0.1",
+        tls: ${JSON.stringify(tls)},
+        http3: true,
+        fetch: () => new Response("ok"),
+      });
+    } catch (e) {
+      err = e;
+    }
+    sock.close();
+    if (!err) throw new Error("expected Bun.serve to throw");
+    if (!String(err.message).includes("HTTP/3")) throw new Error("wrong error: " + err.message);
+    const status = await new Promise(resolve => {
+      const c = net.connect(port, "127.0.0.1");
+      c.on("connect", () => { c.destroy(); resolve("LEAKED"); });
+      c.on("error", () => resolve("CLOSED"));
+    });
+    console.log(status);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "CLOSED",
+    stderr: expect.any(String),
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1105,7 +1105,8 @@ test("Bun.serve closes the TCP listener when the HTTP/3 UDP bind fails", async (
     }
     sock.close();
     if (!err) throw new Error("expected Bun.serve to throw");
-    if (!String(err.message).includes("HTTP/3")) throw new Error("wrong error: " + err.message);
+    const expected = "Failed to listen on UDP port " + port + " for HTTP/3";
+    if (String(err.message) !== expected) throw new Error("wrong error: " + err.message);
     const status = await new Promise(resolve => {
       const c = net.connect(port, "127.0.0.1");
       c.on("connect", () => { c.destroy(); resolve("LEAKED"); });


### PR DESCRIPTION
When `Bun.serve` with `http3: true` successfully binds the TCP port but the QUIC listener cannot bind the matching UDP port on the final attempt, the error path threw and called `deinit()` while the TCP listen socket was still linked into the uWS socket group. `~TemplatedApp` then hit the `head_listen_sockets == NULL` assertion in debug builds; in release builds the listen socket kept polling into a freed `HttpContext` and segfaulted on the next accept.

### What changed

Close the TCP listener unconditionally when the H3 bind fails, then either retry (`port: 0` with attempts remaining) or throw. Previously the close only ran on the retry branch.

### How to reproduce

```js
const dgram = require('dgram');
const sock = dgram.createSocket('udp4');
sock.bind(0, '127.0.0.1', () => {
  const port = sock.address().port;
  Bun.serve({ port, hostname: '127.0.0.1', tls, http3: true, fetch: () => new Response('ok') });
});
```

Before: debug assertion `group->head_listen_sockets == NULL` failed; release build segfaults if anything connects to the leaked TCP port.
After: throws `Failed to listen on UDP port N for HTTP/3` and the TCP port is released.

Found by Fuzzilli (fingerprint 23068b3612b07851).