### PR TITLE
Bun.serve: close listen socket before destroying app in deinit()

### DIFF
--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1853,10 +1853,21 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
         // config / on_clienterror / h3_alt_svc / dev_server / plugins) is
         // handled by the heap::take drop below — see `impl Drop for NewServer`.
         if Self::HAS_H3 {
+            if let Some(h3l) = this_ref.h3_listener.take() {
+                // S008: `h3::ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+                bun_opaque::opaque_deref_mut(h3l).close();
+            }
             if let Some(h3a) = this_ref.h3_app.take() {
                 // SAFETY: live H3::App handle owned by this server.
                 unsafe { uws_sys::h3::App::destroy(h3a) };
             }
+        }
+        if let Some(listener) = this_ref.listener.take() {
+            // The listen socket is still linked in the app's HttpContext group;
+            // `~TemplatedApp` only deinit()'s the group (asserting the listen
+            // list is empty), so unlink it here before destroying the app.
+            // S012: `app::ListenSocket<SSL>` is a ZST opaque — safe deref.
+            bun_opaque::opaque_deref_mut(listener).close();
         }
         if let Some(app) = this_ref.app.take() {
             // SAFETY: live uws App handle owned by this server.

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -425,6 +425,61 @@ describe("Bun.serve HTTP/3", () => {
     expect(exitCode).not.toBe(0);
   });
 
+  test("http3 UDP bind failure after TCP listen succeeds does not crash", async () => {
+    // Occupy a UDP port, then Bun.serve({ tls, http3: true }) on that port.
+    // The TCP listen succeeds and links a listen socket into the HttpContext
+    // group; the UDP bind fails and the server is torn down. The teardown
+    // must close the TCP listen socket before destroying the uws app: debug
+    // builds abort on the us_socket_group_deinit() head_listen_sockets
+    // assert, release builds leak the bound TCP socket (observed below by
+    // re-binding the port).
+    const script = `
+      const dgram = require("node:dgram");
+      const net = require("node:net");
+      const udp = dgram.createSocket("udp4");
+      udp.bind(0, "127.0.0.1", () => {
+        const port = udp.address().port;
+        let err;
+        try {
+          const s = Bun.serve({
+            port,
+            hostname: "127.0.0.1",
+            tls: ${JSON.stringify(tls)},
+            http3: true,
+            fetch: () => new Response("x"),
+          });
+          s.stop();
+        } catch (e) {
+          err = e;
+        }
+        console.log(err ? "threw: " + err.message : "no error");
+        const tcp = net.createServer();
+        tcp.on("error", e => {
+          console.log("tcp-rebind: " + e.code);
+          udp.close();
+        });
+        tcp.listen({ port, host: "127.0.0.1", exclusive: true }, () => {
+          console.log("tcp-rebind: ok");
+          tcp.close();
+          udp.close();
+        });
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim().split("\n"), stderr, signalCode: proc.signalCode }).toEqual({
+      stdout: [expect.stringContaining("threw: Failed to listen on UDP port"), "tcp-rebind: ok"],
+      stderr: "",
+      signalCode: null,
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("static route (Response value) is mirrored onto H3", async () => {
     await withServer(async port => {
       const res = await fetchH3(port, "/static");


### PR DESCRIPTION
Found by fuzzer (fingerprint `777577b59557fdfd`).

## What

When `Bun.serve({ tls, http3: true })` binds TCP successfully but the UDP bind for QUIC fails on the last retry attempt, `listen()` throws and tears the server down via `NewServer::deinit()`. At that point the TCP listen socket is still linked in the HttpContext socket group, so `~TemplatedApp -> httpContext->free() -> us_socket_group_deinit()`:

- aborts on the `head_listen_sockets != NULL` assertion in debug/ASAN builds
- leaks the bound listen socket and its fd in release builds (the listen fd stays in the epoll set with `ls->accept_group` pointing into freed memory)

The fuzzer hit this via `{ port: 0, http3: <truthy>, serverName: "..." }` (serverName alone promotes to an HTTPS server, so HAS_H3 is true); under REPRL load enough UDP ports get occupied that the 3-attempt retry loop eventually exhausts.

## Fix

Close any remaining TCP/H3 listen socket in `deinit()` before destroying the uws app. This matches what `stop_listening()` would have done and covers every synchronous `Self::deinit(this)` caller in the `listen()` error path.

## Repro

Deterministic: occupy a UDP port, then `Bun.serve({ tls, http3: true, port: <that port> })`. Since the port is non-zero, `max_attempts = 1`; TCP listen succeeds, UDP bind fails, exception is thrown, `deinit()` runs with the listener still linked.

Before:
```
bun-debug: packages/bun-usockets/src/context.c:67: void us_socket_group_deinit(struct us_socket_group_t *): Assertion `group->head_listen_sockets == ((void*)0)' failed.
```

After: clean `Failed to listen on UDP port N for HTTP/3` error, and the TCP port is released (verified by re-binding it in the test).