### PR TITLE
react-compiler: follow-up fixes from #32504 review

### DIFF
--- a/.claude/skills/sync-react-compiler.md
+++ b/.claude/skills/sync-react-compiler.md
@@ -16,10 +16,14 @@ There are two kinds of port:
   `typeinference/`, `optimization/`, `validation/`, `reactive_scopes/`,
   `utils/`) — byte-for-byte copies of the upstream crate's `src/`, modulo
   crate-name/import rewrites. Upstream diffs apply mechanically.
-- **AST-boundary ports** (`lowering/*.rs`, `codegen.rs`, `pipeline.rs`,
-  `program.rs`, `imports.rs`, `gating.rs`, `suppression.rs`,
-  `compile_result.rs`) — re-typed onto `bun_ast` using the mapping in
-  `src/react_compiler/DESIGN.md`. Upstream diffs are re-ported by hand.
+- **AST-boundary ports** (`lowering/build_hir/`, `lowering/*.rs`, `codegen.rs`,
+  `pipeline.rs`, `program.rs`, `imports.rs`, `compile_result.rs`) — re-typed
+  onto `bun_ast` using the mapping in `src/react_compiler/DESIGN.md`. Upstream
+  diffs are re-ported by hand. Upstream's `gating.rs` is folded into
+  `program.rs`; `suppression.rs` is handled by the lexer
+  (`js_parser/lexer.rs`) and consumed in `program.rs`;
+  `identifier_loc_index.rs` is not needed because Bun's `Ref` already
+  provides binding identity.
 
 `react_compiler_ast`, `react_compiler_lowering`, and the `react_compiler`
 umbrella crate are **not** in Bun's tree at all — they exist upstream only as

--- a/scripts/sync-react-compiler.sh
+++ b/scripts/sync-react-compiler.sh
@@ -82,21 +82,22 @@ declare -a pristine=(
 # Upstream diffs here must be re-ported by hand using the type-mapping table
 # in src/react_compiler/DESIGN.md.
 declare -a boundary=(
-  react_compiler_lowering/src/build_hir.rs:lowering/build_hir.rs
+  react_compiler_lowering/src/build_hir.rs:lowering/build_hir/
   react_compiler_lowering/src/hir_builder.rs:lowering/hir_builder.rs
   react_compiler_lowering/src/find_context_identifiers.rs:lowering/find_context_identifiers.rs
-  react_compiler_lowering/src/identifier_loc_index.rs:lowering/identifier_loc_index.rs
+  "react_compiler_lowering/src/identifier_loc_index.rs:(not ported; binding identity is Ref, see lowering/hir_builder.rs)"
   react_compiler_reactive_scopes/src/codegen_reactive_function.rs:codegen.rs
   react_compiler/src/entrypoint/pipeline.rs:pipeline.rs
   react_compiler/src/entrypoint/program.rs:program.rs
   react_compiler/src/entrypoint/imports.rs:imports.rs
-  react_compiler/src/entrypoint/gating.rs:gating.rs
-  react_compiler/src/entrypoint/suppression.rs:suppression.rs
+  "react_compiler/src/entrypoint/gating.rs:(folded into program.rs)"
+  "react_compiler/src/entrypoint/suppression.rs:(detected in js_parser/lexer.rs, consumed in program.rs)"
   react_compiler/src/entrypoint/compile_result.rs:compile_result.rs
 )
 
 diff_one() {
-  local upstream="compiler/crates/$1" port="src/react_compiler/$2"
+  local upstream="compiler/crates/$1" port="$2"
+  case "$port" in '('*) ;; *) port="src/react_compiler/$port" ;; esac
   local out
   out=$(git -C "$tmp" diff --stat=120 --patch "$old" "$new" -- "$upstream")
   if [ -n "$out" ]; then

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -2185,9 +2185,12 @@ impl<'a> Parser<'a> {
             }
             if !rc_stmts.is_empty() {
                 let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
+                let mut import_record_indices: js_ast::PartImportRecordIndices =
+                    bun_alloc::AstAlloc::vec();
                 for stmt in &rc_stmts {
                     match &stmt.data {
                         js_ast::StmtData::SImport(import) => {
+                            import_record_indices.push(import.import_record_index);
                             declared_symbols.append(DeclaredSymbol {
                                 ref_: import.namespace_ref,
                                 is_top_level: true,
@@ -2214,6 +2217,7 @@ impl<'a> Parser<'a> {
                     stmts: p.arena.alloc_slice_copy(&rc_stmts).into(),
                     tag: js_ast::PartTag::ReactCompiler,
                     declared_symbols,
+                    import_record_indices,
                     can_be_removed_if_unused: true,
                     ..Default::default()
                 });

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -43,14 +43,16 @@ rewritten) or an **AST-boundary port** (re-typed onto `bun_ast`).
 | `react_compiler_validation/src/`                                                | `validation/`                          | whole-crate                                                                            |
 | `react_compiler_reactive_scopes/src/`                                           | `reactive_scopes/`                     | whole-crate (all passes EXCEPT `codegen_reactive_function.rs`)                         |
 | `react_compiler_utils/src/`                                                     | `utils/`                               | whole-crate                                                                            |
-| `react_compiler_lowering/build_hir.rs`                                          | `lowering/build_hir.rs`                | AST-boundary — reads `bun_ast::{Expr,Stmt,Binding}` instead of `react_compiler_ast::*` |
+| `react_compiler_lowering/build_hir.rs`                                          | `lowering/build_hir/`                  | AST-boundary — reads `bun_ast::{Expr,Stmt,Binding}` instead of `react_compiler_ast::*` |
 | `react_compiler_lowering/hir_builder.rs`                                        | `lowering/hir_builder.rs`              | AST-boundary — `Builder` holds `&[Symbol]`/`&Scope` instead of `&ScopeInfo`            |
 | `react_compiler_lowering/find_context_identifiers.rs`                           | `lowering/find_context_identifiers.rs` | AST-boundary — walks `bun_ast`                                                         |
-| `react_compiler_lowering/identifier_loc_index.rs`                               | `lowering/identifier_loc_index.rs`     | AST-boundary — keyed by `Ref` not `(u32, String)`                                      |
+| `react_compiler_lowering/identifier_loc_index.rs`                               | — (not ported)                         | Ref already provides binding identity; lookup is by `Ref`, not `(u32, String)`        |
 | `react_compiler_reactive_scopes/codegen_reactive_function.rs`                   | `codegen.rs`                           | AST-boundary — emits `bun_ast::{Expr,Stmt,Binding}`                                    |
 | `react_compiler/entrypoint/pipeline.rs`                                         | `pipeline.rs`                          | AST-boundary — calls our `lower` + HIR passes + our `codegen`                          |
 | `react_compiler/entrypoint/program.rs`                                          | `program.rs`                           | AST-boundary — walks `&[Stmt]`, finds candidate components/hooks                       |
-| `react_compiler/entrypoint/{imports,gating,suppression,compile_result}.rs`      | same names                             | AST-boundary — small; emit/read `bun_ast`                                              |
+| `react_compiler/entrypoint/{imports,compile_result}.rs`                         | same names                             | AST-boundary — small; emit/read `bun_ast`                                              |
+| `react_compiler/entrypoint/gating.rs`                                           | — (folded into `program.rs`)           | dynamic-gating directive parsing lives alongside candidate selection                  |
+| `react_compiler/entrypoint/suppression.rs`                                      | — (not ported)                         | eslint-disable detected in `js_parser/lexer.rs`, consumed in `program.rs`             |
 | `react_compiler_ast`, `react_compiler_lowering` (rest), `react_compiler` (rest) | —                                      | **not in tree** — upstream-only porting reference                                      |
 
 `validate_source_locations.rs` and `fixture_utils.rs` are upstream test/debug

--- a/src/react_compiler/DESIGN.md
+++ b/src/react_compiler/DESIGN.md
@@ -46,13 +46,13 @@ rewritten) or an **AST-boundary port** (re-typed onto `bun_ast`).
 | `react_compiler_lowering/build_hir.rs`                                          | `lowering/build_hir/`                  | AST-boundary — reads `bun_ast::{Expr,Stmt,Binding}` instead of `react_compiler_ast::*` |
 | `react_compiler_lowering/hir_builder.rs`                                        | `lowering/hir_builder.rs`              | AST-boundary — `Builder` holds `&[Symbol]`/`&Scope` instead of `&ScopeInfo`            |
 | `react_compiler_lowering/find_context_identifiers.rs`                           | `lowering/find_context_identifiers.rs` | AST-boundary — walks `bun_ast`                                                         |
-| `react_compiler_lowering/identifier_loc_index.rs`                               | — (not ported)                         | Ref already provides binding identity; lookup is by `Ref`, not `(u32, String)`        |
+| `react_compiler_lowering/identifier_loc_index.rs`                               | — (not ported)                         | Ref already provides binding identity; lookup is by `Ref`, not `(u32, String)`         |
 | `react_compiler_reactive_scopes/codegen_reactive_function.rs`                   | `codegen.rs`                           | AST-boundary — emits `bun_ast::{Expr,Stmt,Binding}`                                    |
 | `react_compiler/entrypoint/pipeline.rs`                                         | `pipeline.rs`                          | AST-boundary — calls our `lower` + HIR passes + our `codegen`                          |
 | `react_compiler/entrypoint/program.rs`                                          | `program.rs`                           | AST-boundary — walks `&[Stmt]`, finds candidate components/hooks                       |
 | `react_compiler/entrypoint/{imports,compile_result}.rs`                         | same names                             | AST-boundary — small; emit/read `bun_ast`                                              |
-| `react_compiler/entrypoint/gating.rs`                                           | — (folded into `program.rs`)           | dynamic-gating directive parsing lives alongside candidate selection                  |
-| `react_compiler/entrypoint/suppression.rs`                                      | — (not ported)                         | eslint-disable detected in `js_parser/lexer.rs`, consumed in `program.rs`             |
+| `react_compiler/entrypoint/gating.rs`                                           | — (folded into `program.rs`)           | dynamic-gating directive parsing lives alongside candidate selection                   |
+| `react_compiler/entrypoint/suppression.rs`                                      | — (not ported)                         | eslint-disable detected in `js_parser/lexer.rs`, consumed in `program.rs`              |
 | `react_compiler_ast`, `react_compiler_lowering` (rest), `react_compiler` (rest) | —                                      | **not in tree** — upstream-only porting reference                                      |
 
 `validate_source_locations.rs` and `fixture_utils.rs` are upstream test/debug

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -122,7 +122,7 @@ pub mod js_bundler {
         pub react_fast_refresh: bool,
         pub react_compiler: bun_ast::runtime::ReactCompilerMode,
         pub react_compiler_parse_test_pragmas: bool,
-        pub react_compiler_output_mode_explicit: bool,
+        pub react_compiler_output_mode: Option<bun_ast::runtime::ReactCompilerMode>,
         pub define: StringMap,
         pub loaders: Option<api::LoaderMap>,
         pub dir: OwnedString,
@@ -181,7 +181,7 @@ pub mod js_bundler {
                 react_fast_refresh: false,
                 react_compiler: bun_ast::runtime::ReactCompilerMode::Disabled,
                 react_compiler_parse_test_pragmas: false,
-                react_compiler_output_mode_explicit: false,
+                react_compiler_output_mode: None,
                 define: StringMap::init(false),
                 loaders: None,
                 dir: OwnedString::default(),
@@ -617,7 +617,7 @@ pub mod js_bundler {
             if let Some(slice) =
                 config.get_optional_slice(global_this, b"reactCompilerOutputMode")?
             {
-                this.react_compiler = match slice.slice() {
+                this.react_compiler_output_mode = Some(match slice.slice() {
                     b"ssr" => bun_ast::runtime::ReactCompilerMode::Ssr,
                     b"client" => bun_ast::runtime::ReactCompilerMode::Client,
                     other => {
@@ -626,8 +626,7 @@ pub mod js_bundler {
                             bstr::BStr::new(other)
                         )));
                     }
-                };
-                this.react_compiler_output_mode_explicit = true;
+                });
                 drop(slice);
             }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -953,16 +953,17 @@ impl CompletionStruct for JSBundleCompletionTask {
         transpiler.options.banner = std::borrow::Cow::Owned(config.banner.list.clone());
         transpiler.options.footer = std::borrow::Cow::Owned(config.footer.list.clone());
         transpiler.options.react_fast_refresh = config.react_fast_refresh;
-        transpiler.options.react_compiler =
-            if config.react_compiler.is_enabled() && !config.react_compiler_output_mode_explicit {
+        transpiler.options.react_compiler = if config.react_compiler.is_enabled() {
+            config.react_compiler_output_mode.unwrap_or_else(|| {
                 if config.target.is_server_side() {
                     bun_ast::runtime::ReactCompilerMode::Ssr
                 } else {
                     bun_ast::runtime::ReactCompilerMode::Client
                 }
-            } else {
-                config.react_compiler
-            };
+            })
+        } else {
+            bun_ast::runtime::ReactCompilerMode::Disabled
+        };
         transpiler.options.react_compiler_parse_test_pragmas =
             config.react_compiler_parse_test_pragmas;
         transpiler.options.metafile = config.metafile;

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -233,6 +233,7 @@ export interface BundlerTestInput {
   splitting?: boolean;
   serverComponents?: boolean;
   reactCompiler?: boolean;
+  reactCompilerOutputMode?: "client" | "ssr";
   treeShaking?: boolean;
   unsupportedCSSFeatures?: string[];
   unsupportedJSFeatures?: string[];
@@ -498,6 +499,7 @@ function expectBundled(
     runtimeFiles,
     serverComponents = false,
     reactCompiler = false,
+    reactCompilerOutputMode,
     skipOnEsbuild,
     snapshotSourceMap,
     sourceMap,
@@ -1155,6 +1157,7 @@ function expectBundled(
           splitting,
           target,
           reactCompiler,
+          reactCompilerOutputMode,
           bytecode,
           publicPath,
           emitDCEAnnotations,

--- a/test/bundler/expectBundled.ts
+++ b/test/bundler/expectBundled.ts
@@ -737,6 +737,9 @@ function expectBundled(
       if (optimizeImports) {
         throw new Error("optimizeImports not possible in backend=CLI (API-only option)");
       }
+      if (reactCompilerOutputMode) {
+        throw new Error("reactCompilerOutputMode not possible in backend=CLI (API-only option)");
+      }
       const cmd = (
         !ESBUILD
           ? [

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -131,6 +131,78 @@ describe("bundler", () => {
     },
   });
 
+  itBundled("react-compiler/OutputModeExplicitSsrOverridesTarget", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useState } from "react";
+        export function Counter() {
+          const [n] = useState(0);
+          return <div>{n}</div>;
+        }
+      `,
+    },
+    reactCompiler: true,
+    reactCompilerOutputMode: "ssr",
+    target: "browser",
+    backend: "api",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // reactCompilerOutputMode: "ssr" with reactCompiler: true overrides the
+      // target-derived default (browser → client) and skips memoization.
+      expect(out).not.toContain("react/compiler-runtime");
+      expect(out).not.toMatch(/\b_c\(\d+\)/);
+      // useState is still lowered by the SSR pass (the named import may
+      // survive, but no call remains).
+      expect(out).not.toContain("useState(");
+    },
+  });
+
+  // https://github.com/oven-sh/bun/pull/32504#discussion_r3447488111
+  itBundled("react-compiler/OutputModeIgnoredWhenCompilerDisabled-Client", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Hello({ name }) {
+          return <div>Hello {name}</div>;
+        }
+      `,
+    },
+    reactCompiler: false,
+    reactCompilerOutputMode: "client",
+    backend: "api",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // reactCompilerOutputMode must not enable the pass on its own.
+      expect(out).not.toContain("react/compiler-runtime");
+      expect(out).not.toMatch(/\b_c\(\d+\)/);
+    },
+  });
+
+  itBundled("react-compiler/OutputModeIgnoredWhenCompilerDisabled-Ssr", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        import { useState } from "react";
+        export function Counter() {
+          const [n] = useState(0);
+          return <div>{n}</div>;
+        }
+      `,
+    },
+    reactCompiler: false,
+    reactCompilerOutputMode: "ssr",
+    backend: "api",
+    external: ["react", "react/compiler-runtime", "react/jsx-runtime", "react/jsx-dev-runtime"],
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // reactCompilerOutputMode: "ssr" with reactCompiler: false must not run
+      // the SSR pass either: useState stays as a runtime call.
+      expect(out).not.toContain("react/compiler-runtime");
+      expect(out).not.toMatch(/\b_c\(\d+\)/);
+      expect(out).toContain("useState(");
+    },
+  });
+
   itBundled("react-compiler/BundledReactPreservesImportRefs", {
     files: {
       "/entry.tsx": /* tsx */ `
@@ -178,6 +250,42 @@ describe("bundler", () => {
         /(?<![.\w])useSyncExternalStore\(|(?<![.\w])useContext\(|(?<![.\w])React\.createElement\b/,
       );
       // Output must round-trip through Bun's own parser.
+      new Bun.Transpiler({ loader: "js" }).transformSync(out);
+    },
+  });
+
+  // https://github.com/oven-sh/bun/pull/32504#discussion_r3447488114
+  itBundled("react-compiler/BundledCjsCompilerRuntimeSurvivesTreeShaking", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Hello({ name }) {
+          return <div>Hello {name}</div>;
+        }
+        console.log(typeof Hello({ name: "world" }));
+      `,
+      // CJS compiler-runtime so the linker must wire a wrapper dependency
+      // from the ReactCompiler part to this module via import_record_indices.
+      "/node_modules/react/compiler-runtime.js": `
+        exports.c = function (n) { return new Array(n).fill(Symbol.for("RC_RUNTIME_SENTINEL")); };
+      `,
+      "/node_modules/react/index.js": `exports.createElement = () => null;`,
+      "/node_modules/react/jsx-runtime.js": `exports.jsx = () => "jsx"; exports.jsxs = () => "jsx";`,
+      "/node_modules/react/jsx-dev-runtime.js": `exports.jsxDEV = () => "jsx";`,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "api",
+    run: { stdout: "string" },
+    onAfterBundle(api) {
+      const out = api.readFile("/out.js");
+      // The ReactCompiler part must declare its import record so the linker
+      // keeps react/compiler-runtime live, orders it before the entry, and
+      // wires the CJS wrapper dependency. Without import_record_indices the
+      // module body can be dropped or left uninitialized, and _c is undefined
+      // at runtime. (The linker may rename `_c`, so assert on the runtime
+      // body's sentinel string instead.)
+      expect(out).toContain("RC_RUNTIME_SENTINEL");
       new Bun.Transpiler({ loader: "js" }).transformSync(out);
     },
   });


### PR DESCRIPTION
Follow-up to #32504, addressing the three review comments left on the merged PR.

## `reactCompilerOutputMode` no longer enables the compiler on its own

`Bun.build({ reactCompiler: false, reactCompilerOutputMode: 'client' })` (or the equivalent with `'ssr'`, or with `reactCompiler` unset) previously ran the React Compiler pass anyway, because the `reactCompilerOutputMode` handler in `JSBundler.rs` unconditionally overwrote `this.react_compiler` with `Client`/`Ssr`. The output mode is now stored in a separate `Option<ReactCompilerMode>` field and only applied in `js_bundle_completion_task.rs` when `reactCompiler` is enabled, matching the documented behavior in `bun.d.ts`. The `react_compiler_output_mode_explicit` bool is no longer needed.

Verified by `OutputModeIgnoredWhenCompilerDisabled-{Client,Ssr}`, which fail on `main` and pass here. `OutputModeExplicitSsrOverridesTarget` guards that an explicit `reactCompilerOutputMode` still overrides the target-derived default when the compiler is on.

## `import_record_indices` on the ReactCompiler part

The `Part` pushed for the `react/compiler-runtime` import in `parse_entry.rs` left `import_record_indices` empty via `..Default::default()`, unlike every sibling synthetic-import part (JSX runtime, react-refresh, BunTest). It now collects each `SImport`'s `import_record_index` and sets the field.

This turns out not to be observable today: `P::to_ast` runs `ImportScanner::scan` over every part and back-fills `import_record_indices` from the `SImport` statements (`p.rs:8392`), so the linker already sees the right edges. The change is kept for consistency with the other synthetic parts and as a guard should that back-fill ever change. `BundledCjsCompilerRuntimeSurvivesTreeShaking` covers the bundled-CJS-runtime + tree-shaking case end to end.

## Stale port paths in the sync tooling

`scripts/sync-react-compiler.sh`, `src/react_compiler/DESIGN.md`, and `.claude/skills/sync-react-compiler.md` referenced `lowering/build_hir.rs` (now the `lowering/build_hir/` directory), plus `lowering/identifier_loc_index.rs`, `gating.rs`, and `suppression.rs`, none of which exist. The script's `port:` hints and the DESIGN.md layout table now point at where that logic actually lives (gating folded into `program.rs`; suppression detected in `js_parser/lexer.rs` and consumed in `program.rs`; identifier-loc index not needed because `Ref` provides binding identity).

## Tests

```
bun bd test test/bundler/transpiler/react-compiler.test.ts           # 15 pass
bun bd test test/bundler/transpiler/react-compiler-fixtures.test.ts  # 1647 pass / 160 skip
```

Closes the review threads on #32504: r3447488111, r3447488114, r3447488115.