### PR TITLE
parser: keep resolved Ref on e_identifier during substitution revisit

### DIFF
--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -161,6 +161,14 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     fn e_identifier(p: &mut Self, e: &mut Expr, in_: ExprIn) {
+        // The substitution revisit re-enters with an already-resolved `Ref`.
+        // `find_symbol` below only looks in `scope.members`, so a symbol that
+        // lives only in `scope.generated` (e.g. a React Compiler outlined
+        // function) would be re-bound to a fresh `Unbound` and the renamer
+        // would lose the link to its declaration.
+        if p.is_revisit_for_substitution {
+            return;
+        }
         let expr = *e;
         let mut e_ = expr
             .data

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -436,7 +436,11 @@ describe("bundler", () => {
         const decl = out.match(/function\s+([A-Za-z_$][\w$]*)\s*\(\s*[A-Za-z_$][\w$]*\s*\)\s*\{\s*return\b/);
         expect(decl).not.toBeNull();
         const name = decl![1];
-        expect(out).toMatch(new RegExp(String.raw`\(\s*${name}\s*\)`));
+        // minifyWhitespace is off, so the call argument is printed as
+        // `(<name>)` with no surrounding whitespace. Use a literal
+        // substring so a `$` in the minified name cannot be misread as a
+        // regex metacharacter.
+        expect(out).toContain(`(${name})`);
         if (minifyIdentifiers) {
           // With identifier minification every react-compiler-generated
           // `_temp*` name must be renamed; a surviving literal is an

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -398,6 +398,58 @@ describe("bundler", () => {
     },
   });
 
+  // Function outlining hoists the anonymous callback to a module-level
+  // `function _temp(s) { ... }` and rewrites the call site to reference it.
+  // With minify.syntax on, the single-use `v` is substituted into the `if`
+  // test and the mangle pass re-visits the resulting `!useBar(_temp)`. That
+  // re-visit must keep the generated `_temp` `Ref` instead of resolving the
+  // name through `find_symbol`, which only walks `scope.members` and would
+  // mint a fresh unbound symbol that the identifier renamer never sees.
+  for (const [minifySyntax, minifyIdentifiers] of [
+    [false, true],
+    [true, false],
+    [true, true],
+  ] as const) {
+    itBundled(
+      `react-compiler/OutlinedFunctionMinify-syntax=${minifySyntax}-identifiers=${minifyIdentifiers}`,
+      {
+        files: {
+          "/entry.tsx": /* tsx */ `
+            import { useFoo, useBar } from "ext";
+            export function C() {
+              useFoo();
+              const v = useBar(s => s.x > 0);
+              if (!v) return null;
+              return <div />;
+            }
+          `,
+        },
+        reactCompiler: true,
+        target: "browser",
+        backend: "cli",
+        minifySyntax,
+        minifyIdentifiers,
+        external: ["*"],
+        onAfterBundle(api) {
+          const out = api.readFile("/out.js");
+          // The outlined function's declaration and its call site must share
+          // the same printed name. Match the decl name, then require that
+          // same name to appear as a bare identifier argument in a call.
+          const decl = out.match(/function\s+([A-Za-z_$][\w$]*)\s*\(\s*[A-Za-z_$][\w$]*\s*\)\s*\{\s*return\b/);
+          expect(decl).not.toBeNull();
+          const name = decl![1];
+          expect(out).toMatch(new RegExp(String.raw`\(\s*${name}\s*\)`));
+          if (minifyIdentifiers) {
+            // With identifier minification every react-compiler-generated
+            // `_temp*` name must be renamed; a surviving literal is an
+            // orphaned reference.
+            expect(out).not.toMatch(/\b_temp\d*\b/);
+          }
+        },
+      },
+    );
+  }
+
   itBundled("react-compiler/NonComponentUntouched", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -410,11 +410,9 @@ describe("bundler", () => {
     [true, false],
     [true, true],
   ] as const) {
-    itBundled(
-      `react-compiler/OutlinedFunctionMinify-syntax=${minifySyntax}-identifiers=${minifyIdentifiers}`,
-      {
-        files: {
-          "/entry.tsx": /* tsx */ `
+    itBundled(`react-compiler/OutlinedFunctionMinify-syntax=${minifySyntax}-identifiers=${minifyIdentifiers}`, {
+      files: {
+        "/entry.tsx": /* tsx */ `
             import { useFoo, useBar } from "ext";
             export function C() {
               useFoo();
@@ -423,31 +421,30 @@ describe("bundler", () => {
               return <div />;
             }
           `,
-        },
-        reactCompiler: true,
-        target: "browser",
-        backend: "cli",
-        minifySyntax,
-        minifyIdentifiers,
-        external: ["*"],
-        onAfterBundle(api) {
-          const out = api.readFile("/out.js");
-          // The outlined function's declaration and its call site must share
-          // the same printed name. Match the decl name, then require that
-          // same name to appear as a bare identifier argument in a call.
-          const decl = out.match(/function\s+([A-Za-z_$][\w$]*)\s*\(\s*[A-Za-z_$][\w$]*\s*\)\s*\{\s*return\b/);
-          expect(decl).not.toBeNull();
-          const name = decl![1];
-          expect(out).toMatch(new RegExp(String.raw`\(\s*${name}\s*\)`));
-          if (minifyIdentifiers) {
-            // With identifier minification every react-compiler-generated
-            // `_temp*` name must be renamed; a surviving literal is an
-            // orphaned reference.
-            expect(out).not.toMatch(/\b_temp\d*\b/);
-          }
-        },
       },
-    );
+      reactCompiler: true,
+      target: "browser",
+      backend: "cli",
+      minifySyntax,
+      minifyIdentifiers,
+      external: ["*"],
+      onAfterBundle(api) {
+        const out = api.readFile("/out.js");
+        // The outlined function's declaration and its call site must share
+        // the same printed name. Match the decl name, then require that
+        // same name to appear as a bare identifier argument in a call.
+        const decl = out.match(/function\s+([A-Za-z_$][\w$]*)\s*\(\s*[A-Za-z_$][\w$]*\s*\)\s*\{\s*return\b/);
+        expect(decl).not.toBeNull();
+        const name = decl![1];
+        expect(out).toMatch(new RegExp(String.raw`\(\s*${name}\s*\)`));
+        if (minifyIdentifiers) {
+          // With identifier minification every react-compiler-generated
+          // `_temp*` name must be renamed; a surviving literal is an
+          // orphaned reference.
+          expect(out).not.toMatch(/\b_temp\d*\b/);
+        }
+      },
+    });
   }
 
   itBundled("react-compiler/NonComponentUntouched", {


### PR DESCRIPTION
## Repro

```tsx
// entry.tsx
import { useFoo, useBar } from "ext";
export function C() {
  useFoo();
  const v = useBar(s => s.x > 0);
  if (!v) return null;
  return <div />;
}
```

```console
$ bun build entry.tsx --react-compiler --minify-syntax --external '*'
function _temp2(s) {
  return s.x > 0;
}
function C() {
  const $ = _c(1);
  if (useFoo(), !useBar(_temp)) {   // ReferenceError: _temp is not defined
  ...
```

The React Compiler outlines the callback to a module-level `function _temp(s)` and rewrites the call site to `useBar(_temp)`, both pointing at the same generated `Ref`. With `--minify-syntax` the single-use `v` is substituted into the `if` test and the mangle pass re-visits the resulting `!useBar(_temp)`. Adding `--minify-identifiers` renames the decl to a short name while the call site still prints `_temp`.

## Cause

`substitute_single_use_symbol_in_stmt` re-enters `visit_expr` with `is_revisit_for_substitution = true` when the substituted result is a unary/binary/conditional. `e_arrow`, `e_function` and `e_class` already early-return under that flag, but `e_identifier` did not: it ran `load_name_from_ref(ref)` followed by `find_symbol(name)` and wrote the result back to `e_.ref_`.

`find_symbol` walks `scope.members` only. Symbols registered via `scope.generated` (which is what `generate_temp_ref` and the React Compiler host's `new_generated` produce) are not found there, so a fresh `Unbound` symbol was allocated and the correct `Ref` was overwritten. The outlined function's declaration kept the original generated `Ref` while the call site got the new `Unbound`, so the number-renamer bumped the decl to `_temp2` (or the minify-renamer shortened it) and the call site was left referencing a name with no declaration.

## Fix

`e_identifier` now early-returns under `is_revisit_for_substitution`, matching `e_arrow`/`e_function`/`e_class`. An already-visited identifier carries a resolved `Symbol` `Ref`; for a declared symbol `find_symbol` was idempotent, and for a `scope.generated`-only symbol it was destructive. `record_usage`/`ignore_usage` already no-op under this flag, so skipping the whole handler keeps use-count accounting unchanged.

## Verification

New `react-compiler/OutlinedFunctionMinify-*` cases in `test/bundler/transpiler/react-compiler.test.ts` cover `{syntax,identifiers} ∈ {false,true}` and assert the outlined decl name matches the call-site argument. Without the fix `syntax=true` fails for both `identifiers=false` (decl becomes `_temp2`, call stays `_temp`) and `identifiers=true` (decl renamed, call stays `_temp`).

`bundler_minify`, `bundler_string`, `bundler_edgecase`, `bundler_regressions` and `esbuild/dce` suites pass unchanged.