### PR TITLE
Remove the js-call-outside-microtask-queue debug check

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -105,7 +105,6 @@ platform_specific_new!(pub C_INCLUDE_PATH: string, posix = "C_INCLUDE_PATH", win
 // Used by bun:ffi's TinyCC integration for systems like NixOS.
 platform_specific_new!(pub LIBRARY_PATH: string, posix = "LIBRARY_PATH", windows = None, {});
 new!(pub BUN_TMPDIR: string, "BUN_TMPDIR", {});
-new!(pub BUN_TRACK_LAST_FN_NAME: boolean, "BUN_TRACK_LAST_FN_NAME", { default: false });
 new!(pub BUN_TRACY_PATH: string, "BUN_TRACY_PATH", {});
 new!(pub BUN_WATCHER_TRACE: string, "BUN_WATCHER_TRACE", {});
 new!(pub CI: boolean, "CI", {});

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -21,7 +21,6 @@
 use core::ffi::c_int;
 
 #[cfg(debug_assertions)]
-use bun_core::env_var;
 use bun_uws as uws;
 
 use crate::VM;
@@ -121,13 +120,6 @@ impl GarbageCollectionController {
             std::ptr::from_mut::<Self>(self),
         ));
         actual.internal_loop_data.jsc_vm = vm.jsc_vm.cast();
-
-        #[cfg(debug_assertions)]
-        {
-            if env_var::BUN_TRACK_LAST_FN_NAME.get().unwrap_or(false) {
-                vm.event_loop_mut().debug.track_last_fn_name = true;
-            }
-        }
 
         // `Transpiler::init` is deferred to the high-tier
         // `init_runtime_state` hook (which runs *after* `ensure_waker` →

--- a/src/jsc/GarbageCollectionController.rs
+++ b/src/jsc/GarbageCollectionController.rs
@@ -20,7 +20,6 @@
 
 use core::ffi::c_int;
 
-#[cfg(debug_assertions)]
 use bun_uws as uws;
 
 use crate::VM;

--- a/src/jsc/JSPromise.rs
+++ b/src/jsc/JSPromise.rs
@@ -1,8 +1,5 @@
 use core::ffi::c_void;
 
-#[cfg(debug_assertions)]
-use bun_core::String as BunString;
-
 use crate::{JSGlobalObject, JSValue, JsError, JsResult, VM};
 // `jsc.Strong.Optional` and `jsc.Weak(T)` collide with this module's own `Strong`/`Weak`,
 // so import them under aliases.
@@ -441,18 +438,6 @@ impl JSPromise {
     /// The value can be another Promise.
     /// If you want to create a new Promise that is already resolved, see `resolved_promise_value`.
     pub fn resolve(&mut self, global: &JSGlobalObject, value: JSValue) -> Result<(), JsTerminated> {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: JS-thread singleton; short-lived `&mut EventLoop` reborrow at use site
-            // per VirtualMachine::event_loop() contract.
-            let loop_ = VirtualMachine::get().event_loop_mut();
-            loop_.debug.js_call_count_outside_tick_queue +=
-                (!loop_.debug.is_inside_tick_queue) as usize;
-            if loop_.debug.track_last_fn_name && !loop_.debug.is_inside_tick_queue {
-                loop_.debug.last_fn_name = BunString::static_(b"resolve").into();
-            }
-        }
-
         // `[[ZIG_EXPORT(check_slow)]]`
         crate::cpp::JSC__JSPromise__resolve(self, global, value)
             .map_err(|_| JsTerminated::JSTerminated)
@@ -463,18 +448,6 @@ impl JSPromise {
         global: &JSGlobalObject,
         value: JsResult<JSValue>,
     ) -> Result<(), JsTerminated> {
-        #[cfg(debug_assertions)]
-        {
-            // SAFETY: JS-thread singleton; short-lived `&mut EventLoop` reborrow at use site
-            // per VirtualMachine::event_loop() contract.
-            let loop_ = VirtualMachine::get().event_loop_mut();
-            loop_.debug.js_call_count_outside_tick_queue +=
-                (!loop_.debug.is_inside_tick_queue) as usize;
-            if loop_.debug.track_last_fn_name && !loop_.debug.is_inside_tick_queue {
-                loop_.debug.last_fn_name = BunString::static_(b"reject").into();
-            }
-        }
-
         let err = match value {
             Ok(v) => v,
             // We can't use `global.take_exception()` because it throws an

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1641,24 +1641,6 @@ impl JSValue {
         this_value: JSValue,
         args: &[JSValue],
     ) -> JsResult<JSValue> {
-        #[cfg(debug_assertions)]
-        {
-            use crate::virtual_machine::VirtualMachine;
-            // SAFETY: JS-thread singleton; each `&mut EventLoop` reborrow is
-            // dropped before `get_name` (which may re-enter JS) per
-            // `VirtualMachine::event_loop_mut()` contract.
-            let want_name = {
-                let loop_ = VirtualMachine::get().event_loop_mut();
-                let outside = !loop_.debug.is_inside_tick_queue;
-                loop_.debug.js_call_count_outside_tick_queue += usize::from(outside);
-                loop_.debug.track_last_fn_name && outside
-            };
-            if want_name {
-                if let Ok(name) = self.get_name(global) {
-                    VirtualMachine::get().event_loop_mut().debug.last_fn_name = name.into();
-                }
-            }
-        }
         host_fn::from_js_host_call(global, || {
             // SAFETY: `global` is live; `args` is a contiguous slice of valid
             // JSValues for the duration of the call.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -84,7 +84,6 @@ pub struct EventLoop {
     #[cfg(not(windows))]
     pub uws_loop: (),
 
-    pub debug: Debug,
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
     /// Atomic nullable pointer to the next-due `WTFTimer`.
@@ -122,7 +121,6 @@ impl Default for EventLoop {
             uws_loop: None,
             #[cfg(not(windows))]
             uws_loop: (),
-            debug: Debug::default(),
             entered_event_loop_count: 0,
             concurrent_ref: AtomicI32::new(0),
             imminent_gc_timer: AtomicPtr::new(core::ptr::null_mut()),
@@ -131,81 +129,6 @@ impl Default for EventLoop {
             #[cfg(not(unix))]
             signal_handler: (),
         }
-    }
-}
-
-#[cfg(debug_assertions)]
-#[derive(Default)]
-pub struct Debug {
-    pub is_inside_tick_queue: bool,
-    pub js_call_count_outside_tick_queue: usize,
-    pub drain_microtasks_count_outside_tick_queue: usize,
-    pub _prev_is_inside_tick_queue: bool,
-    /// RAII: deref-on-drop. `exit()` just `take()`s; if `Debug` is dropped
-    /// without `exit()` running, the +1 from the last `run_callback` no
-    /// longer leaks.
-    pub last_fn_name: bun_core::OwnedString,
-    pub track_last_fn_name: bool,
-}
-
-#[cfg(debug_assertions)]
-impl Debug {
-    pub fn enter(&mut self) {
-        self._prev_is_inside_tick_queue = self.is_inside_tick_queue;
-        self.is_inside_tick_queue = true;
-        self.js_call_count_outside_tick_queue = 0;
-        self.drain_microtasks_count_outside_tick_queue = 0;
-    }
-
-    pub fn exit(&mut self) {
-        self.is_inside_tick_queue = self._prev_is_inside_tick_queue;
-        self._prev_is_inside_tick_queue = false;
-        self.js_call_count_outside_tick_queue = 0;
-        self.drain_microtasks_count_outside_tick_queue = 0;
-        drop(core::mem::take(&mut self.last_fn_name));
-    }
-}
-
-#[cfg(not(debug_assertions))]
-#[derive(Default)]
-pub struct Debug;
-
-#[cfg(not(debug_assertions))]
-impl Debug {
-    #[inline]
-    pub fn enter(&mut self) {}
-    #[inline]
-    pub fn exit(&mut self) {}
-}
-
-/// RAII pairing for [`Debug::enter`] / [`Debug::exit`]. Holds the raw pointer
-/// (not `&mut`) so re-entrant JS callbacks that touch the same loop while the
-/// guard is live don't alias a long-lived mutable borrow.
-#[must_use = "dropping immediately exits the debug scope"]
-pub struct DebugEnterGuard {
-    debug: *mut Debug,
-}
-
-impl Drop for DebugEnterGuard {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: `debug` was live at `enter_scope` and is owned by the
-        // process-lifetime `EventLoop`.
-        unsafe { (*self.debug).exit() };
-    }
-}
-
-impl Debug {
-    /// `enter()` now, `exit()` on drop.
-    ///
-    /// # Safety
-    /// `debug` must point to a live `Debug` (the `event_loop.debug` field) and
-    /// remain valid for the guard's lifetime.
-    #[inline]
-    pub unsafe fn enter_scope(debug: *mut Debug) -> DebugEnterGuard {
-        // SAFETY: caller contract — `debug` is live; short-lived `&mut` only.
-        unsafe { (*debug).enter() };
-        DebugEnterGuard { debug }
     }
 }
 
@@ -317,7 +240,6 @@ impl EventLoop {
     pub fn enter(&mut self) {
         bun_core::scoped_log!(EventLoop, "enter() = {}", self.entered_event_loop_count);
         self.entered_event_loop_count += 1;
-        self.debug.enter();
     }
 
     /// "exit" a microtask context in the event loop. See `enter`.
@@ -330,7 +252,6 @@ impl EventLoop {
         }
 
         self.entered_event_loop_count -= 1;
-        self.debug.exit();
     }
 
     /// `enter()` now, `exit()` on drop. Takes the raw VM-owned pointer so the
@@ -361,11 +282,10 @@ impl EventLoop {
         };
 
         // On the error path, `entered_event_loop_count` is intentionally NOT
-        // decremented; only the debug-scope exit runs.
+        // decremented.
         if result.is_ok() {
             self.entered_event_loop_count -= 1;
         }
-        self.debug.exit();
         result
     }
 
@@ -421,12 +341,6 @@ impl EventLoop {
         // `event_loop_handle` (which is the libuv loop).
         if vm.event_loop_handle.is_some() {
             vm.uws_loop_mut().drain_quic_if_necessary();
-        }
-
-        #[cfg(debug_assertions)]
-        {
-            self.debug.drain_microtasks_count_outside_tick_queue +=
-                (!self.debug.is_inside_tick_queue) as usize;
         }
 
         Ok(())
@@ -671,9 +585,8 @@ impl EventLoop {
         jsc::mark_binding();
         crate::top_scope!(scope, self.global_ref());
         self.entered_event_loop_count += 1;
-        self.debug.enter();
-        // The scope/counter/debug-exit cleanup is inlined at each return site
-        // below (a scopeguard closure would alias `&mut self`).
+        // The scope/counter cleanup is inlined at each return site below (a
+        // scopeguard closure would alias `&mut self`).
 
         let ctx = self.vm();
         self.tick_concurrent();
@@ -695,7 +608,6 @@ impl EventLoop {
                 || scope.has_exception()
             {
                 self.entered_event_loop_count -= 1;
-                self.debug.exit();
                 return;
             }
             self.tick_concurrent();
@@ -712,7 +624,6 @@ impl EventLoop {
         self.global_ref().handle_rejected_promises();
 
         self.entered_event_loop_count -= 1;
-        self.debug.exit();
     }
 
     /// Tick the task queue without draining microtasks afterward.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -597,17 +597,6 @@ pub fn tick_queue_with_count(
     let global: &JSGlobalObject = unsafe { el.global.expect("EventLoop.global unset").as_ref() };
     let global_vm = global.vm();
 
-    #[cfg(debug_assertions)]
-    if el.debug.js_call_count_outside_tick_queue
-        > el.debug.drain_microtasks_count_outside_tick_queue
-    {
-        panic!(
-            "{} JavaScript functions were called outside of the microtask queue without draining microtasks. Use EventLoop.runCallback().",
-            el.debug.js_call_count_outside_tick_queue
-                - el.debug.drain_microtasks_count_outside_tick_queue
-        );
-    }
-
     while let Some(task) = el.tasks.read_item() {
         // Incremented before dispatch so the count includes every task,
         // including the one that takes the HotReloadTask early return.

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -661,18 +661,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
 
         server.on_pending_request();
 
-        // `vm.eventLoop().debug.enter()/exit()` is debug-build
-        // re-entrancy bookkeeping; `Debug::enter_scope` is the RAII pairing
-        // (no-op enter/exit in release builds).
-        let vm_ptr = server.vm_mut();
-        // SAFETY: vm backref is live for the server's lifetime; `event_loop()`
-        // returns the VM-owned `*mut EventLoop` whose `debug` field outlives
-        // this frame.
-        let _dbg_guard = unsafe {
-            bun_jsc::event_loop::Debug::enter_scope(core::ptr::addr_of_mut!(
-                (*(*vm_ptr).event_loop()).debug
-            ))
-        };
         req.set_yield(false);
         resp_ref.timeout(server.config.idle_timeout);
 
@@ -1167,12 +1155,6 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             core::ptr::NonNull::new(this).expect("on_node_http_request: this non-null"),
         );
         let vm = this_ref.vm_mut();
-        // SAFETY: `vm.event_loop()` returns the live VM-owned `*mut EventLoop`.
-        let _dbg = unsafe {
-            jsc::event_loop::Debug::enter_scope(core::ptr::addr_of_mut!(
-                (*(*vm).event_loop()).debug
-            ))
-        };
         req.set_yield(false);
         resp.timeout(this_ref.config.idle_timeout);
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -2978,12 +2978,6 @@ where
 
         self.on_pending_request();
 
-        // SAFETY: vm.event_loop() returns the live VM-owned `*mut EventLoop`.
-        let _dbg_guard = unsafe {
-            jsc::event_loop::Debug::enter_scope(core::ptr::addr_of_mut!(
-                (*self.vm_ref().event_loop()).debug
-            ))
-        };
         ReqLike::set_yield(req, false);
         RespLike::timeout(resp, self.config.idle_timeout);
 


### PR DESCRIPTION
This debug-only assertion in `tick_queue_with_count` tracked whether JS functions were invoked without a matching microtask drain and panicked when the counters disagreed. The bookkeeping produces false positives, so remove it.

### What's removed

- the panic in `src/runtime/dispatch.rs`
- the `Debug` struct on `EventLoop` (both cfg variants), `DebugEnterGuard`, and `Debug::enter_scope`
- counter increments in `JSValue::call`, `JSPromise::resolve`/`reject`, and `drain_microtasks_with_global`
- the `BUN_TRACK_LAST_FN_NAME` env var and its setup in `GarbageCollectionController::init`
- the three `Debug::enter_scope` guards at server request entry points

`EventLoop::enter`/`exit` and `EventLoopEnterGuard` keep their real work (`entered_event_loop_count` + microtask drain on exit); only the debug counter bookkeeping is gone.

8 files, +3/-181.