### PR TITLE
Bun.serve: propagate socket backpressure to Response(ReadableStream) bodies

### DIFF
--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -886,6 +886,7 @@ export function readStreamIntoSinkOnClose(this: { didThrow: boolean; didClose: b
   if (!this.didThrow && !this.didClose && stream && stream.$state !== $streamClosed) {
     $readableStreamCancel(stream, reason);
   }
+  this.didClose = true;
 }
 
 export async function readStreamIntoSink(stream: ReadableStream, sink, isNative) {
@@ -930,12 +931,15 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       var wrote = sink.write(values[i]);
       if ($isPromise(wrote) && $isPromisePending(wrote)) {
         await wrote;
+        // The sink's close path resolves the same promise; stop writing into a
+        // dead sink.
+        if (state.didClose) break;
       }
     }
     values = many = undefined;
 
     var streamState = $getByIdDirectPrivate(stream, "state");
-    if (streamState === $streamClosed) {
+    if (state.didClose || streamState === $streamClosed) {
       state.didClose = true;
       return sink.end();
     }
@@ -950,6 +954,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       var wrote = sink.write(value);
       if ($isPromise(wrote) && $isPromisePending(wrote)) {
         await wrote;
+        if (state.didClose) return sink.end();
       }
     }
   } catch (e) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -885,10 +885,27 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
   var started = false;
   const highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark") || 0;
 
+  // The native sink fires onSinkDrain (via signal.ready -> m_onPull) once the
+  // socket has room again; resolve any parked drain waiter so the read loop
+  // resumes. onSinkClose also resumes so an abort while paused doesn't hang.
+  var drainCapability;
+  function onSinkDrain() {
+    var cap = drainCapability;
+    if (cap) {
+      drainCapability = undefined;
+      cap.resolve.$call();
+    }
+  }
+  function waitForDrain() {
+    drainCapability = $newPromiseCapability(Promise);
+    return drainCapability.promise;
+  }
+
   try {
     var reader = stream.getReader();
     var many = reader.readMany();
     function onSinkClose(stream, reason) {
+      onSinkDrain();
       if (!didThrow && !didClose && stream && stream.$state !== $streamClosed) {
         $readableStreamCancel(stream, reason);
       }
@@ -899,7 +916,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       // abort, for example. So we have to start it, if only so that we can
       // receive a notification when it closes or cancels.
       // https://github.com/oven-sh/bun/issues/6758
-      if (isNative) $startDirectStream.$call(sink, stream, undefined, onSinkClose, stream.$asyncContext);
+      if (isNative) $startDirectStream.$call(sink, stream, onSinkDrain, onSinkClose, stream.$asyncContext);
       sink.start({ highWaterMark });
       started = true;
 
@@ -911,12 +928,16 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
     }
 
     if (!started) {
-      if (isNative) $startDirectStream.$call(sink, stream, undefined, onSinkClose, stream.$asyncContext);
+      if (isNative) $startDirectStream.$call(sink, stream, onSinkDrain, onSinkClose, stream.$asyncContext);
       sink.start({ highWaterMark });
     }
 
     for (var i = 0, values = many.value, length = many.value.length; i < length; i++) {
-      sink.write(values[i]);
+      // A negative result means the bytes were accepted but the transport is
+      // backed up; pause until the sink's drain signal fires.
+      if (sink.write(values[i]) < 0 && isNative) {
+        await waitForDrain();
+      }
     }
 
     var streamState = $getByIdDirectPrivate(stream, "state");
@@ -932,7 +953,9 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         return sink.end();
       }
 
-      sink.write(value);
+      if (sink.write(value) < 0 && isNative) {
+        await waitForDrain();
+      }
     }
   } catch (e) {
     didThrow = true;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -925,11 +925,11 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
 
     for (var i = 0, values = many.value, length = many.value.length; i < length; i++) {
       // The native sink returns its pending-flush Promise when the transport
-      // is backed up; await it (only if still pending — an already-drained
-      // socket resolves it before we get here) so we stop pulling until the
-      // socket catches up.
+      // is backed up; await it (only when not already fulfilled — skipping the
+      // microtask on the fast path while still propagating a rejection into
+      // the catch below) so we stop pulling until the socket catches up.
       var wrote = sink.write(values[i]);
-      if ($isPromise(wrote) && $isPromisePending(wrote)) {
+      if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
         await wrote;
         // The sink's close path resolves the same promise; stop writing into a
         // dead sink.
@@ -952,7 +952,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       }
 
       var wrote = sink.write(value);
-      if ($isPromise(wrote) && $isPromisePending(wrote)) {
+      if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
         await wrote;
         if (state.didClose) return sink.end();
       }
@@ -1887,7 +1887,16 @@ export function readableStreamFromAsyncIterator(target, fn) {
         }
 
         if (!$isUndefinedOrNull(value)) {
-          controller.write(value);
+          // The native sink returns its pending-flush Promise when the
+          // transport is backed up; await it (only when not already fulfilled)
+          // so we stop pulling until the socket catches up. A rejected promise
+          // from write() throws into the catch path below.
+          var wrote = controller.write(value);
+          if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
+            clearImmediate(immediateTask);
+            immediateTask = undefined;
+            await wrote;
+          }
         }
       }
     } catch (e) {

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -924,13 +924,14 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
     }
 
     for (var i = 0, values = many.value, length = many.value.length; i < length; i++) {
-      // The native sink returns its pending-flush Promise when the transport
-      // is backed up; await it (only when not already fulfilled — skipping the
-      // microtask on the fast path while still propagating a rejection into
-      // the catch below) so we stop pulling until the socket catches up.
-      var wrote = sink.write(values[i]);
-      if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
-        await wrote;
+      // The HTTP response sink returns a negative number when the socket is
+      // backed up; await flush(true) (the pending-flush promise) so we stop
+      // pulling until it drains. FileSink may return a Promise on every write
+      // (Windows pipes are always async); awaiting that here would serialize
+      // every chunk behind a uv_write round-trip, so the negative-number check
+      // intentionally lets those fall through.
+      if (sink.write(values[i]) < 0) {
+        await sink.flush(true);
         // The sink's close path resolves the same promise; stop writing into a
         // dead sink.
         if (state.didClose) break;
@@ -951,9 +952,8 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         return sink.end();
       }
 
-      var wrote = sink.write(value);
-      if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
-        await wrote;
+      if (sink.write(value) < 0) {
+        await sink.flush(true);
         if (state.didClose) return sink.end();
       }
     }
@@ -1887,15 +1887,14 @@ export function readableStreamFromAsyncIterator(target, fn) {
         }
 
         if (!$isUndefinedOrNull(value)) {
-          // The native sink returns its pending-flush Promise when the
-          // transport is backed up; await it (only when not already fulfilled)
-          // so we stop pulling until the socket catches up. A rejected promise
-          // from write() throws into the catch path below.
-          var wrote = controller.write(value);
-          if ($isPromise(wrote) && !$isPromiseFulfilled(wrote)) {
+          // See readStreamIntoSink: the HTTP response sink returns a negative
+          // number when the socket is backed up; await the drain via
+          // flush(true). FileSink's Promise return is intentionally not
+          // awaited here.
+          if (controller.write(value) < 0) {
             clearImmediate(immediateTask);
             immediateTask = undefined;
-            await wrote;
+            await controller.flush(true);
           }
         }
       }

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -879,37 +879,48 @@ export function assignStreamIntoResumableSink(stream, sink) {
   }
 }
 
+// Bound (via `this`) to readStreamIntoSink's per-request state object so the
+// callbacks the native sink stores in m_onPull/m_onClose hold only that small
+// state, not the whole readStreamIntoSink activation. The native sink fires
+// the drain callback (signal.ready -> m_onPull) once the socket has room
+// again; resolving the parked capability resumes the read loop. The close
+// callback resumes the same waiter so an abort while paused does not hang.
+export function readStreamIntoSinkOnDrain(this: { drainCapability: any }) {
+  var cap = this.drainCapability;
+  if (cap) {
+    this.drainCapability = undefined;
+    cap.resolve.$call();
+  }
+}
+
+export function readStreamIntoSinkOnClose(
+  this: { drainCapability: any; didThrow: boolean; didClose: boolean },
+  stream,
+  reason,
+) {
+  var cap = this.drainCapability;
+  if (cap) {
+    this.drainCapability = undefined;
+    cap.resolve.$call();
+  }
+  if (!this.didThrow && !this.didClose && stream && stream.$state !== $streamClosed) {
+    $readableStreamCancel(stream, reason);
+  }
+}
+
 export async function readStreamIntoSink(stream: ReadableStream, sink, isNative) {
-  var didClose = false;
-  var didThrow = false;
   var started = false;
   const highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark") || 0;
 
-  // The native sink fires onSinkDrain (via signal.ready -> m_onPull) once the
-  // socket has room again; resolve any parked drain waiter so the read loop
-  // resumes. onSinkClose also resumes so an abort while paused doesn't hang.
-  var drainCapability;
-  function onSinkDrain() {
-    var cap = drainCapability;
-    if (cap) {
-      drainCapability = undefined;
-      cap.resolve.$call();
-    }
-  }
-  function waitForDrain() {
-    drainCapability = $newPromiseCapability(Promise);
-    return drainCapability.promise;
-  }
+  // Mutable state the sink callbacks need; bound below so they don't capture
+  // this function's scope.
+  var state = { __proto__: null, didThrow: false, didClose: false, drainCapability: undefined };
+  var onSinkDrain = isNative ? $readStreamIntoSinkOnDrain.bind(state) : undefined;
+  var onSinkClose = isNative ? $readStreamIntoSinkOnClose.bind(state) : undefined;
 
   try {
     var reader = stream.getReader();
     var many = reader.readMany();
-    function onSinkClose(stream, reason) {
-      onSinkDrain();
-      if (!didThrow && !didClose && stream && stream.$state !== $streamClosed) {
-        $readableStreamCancel(stream, reason);
-      }
-    }
 
     if (many && $isPromise(many)) {
       // Some time may pass before this Promise is fulfilled. The sink may
@@ -923,7 +934,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       many = await many;
     }
     if (many.done) {
-      didClose = true;
+      state.didClose = true;
       return sink.end();
     }
 
@@ -936,29 +947,32 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       // A negative result means the bytes were accepted but the transport is
       // backed up; pause until the sink's drain signal fires.
       if (sink.write(values[i]) < 0 && isNative) {
-        await waitForDrain();
+        var cap = (state.drainCapability = $newPromiseCapability(Promise));
+        await cap.promise;
       }
     }
+    values = many = undefined;
 
     var streamState = $getByIdDirectPrivate(stream, "state");
     if (streamState === $streamClosed) {
-      didClose = true;
+      state.didClose = true;
       return sink.end();
     }
 
     while (true) {
       var { value, done } = await reader.read();
       if (done) {
-        didClose = true;
+        state.didClose = true;
         return sink.end();
       }
 
       if (sink.write(value) < 0 && isNative) {
-        await waitForDrain();
+        var cap = (state.drainCapability = $newPromiseCapability(Promise));
+        await cap.promise;
       }
     }
   } catch (e) {
-    didThrow = true;
+    state.didThrow = true;
 
     try {
       reader = undefined;
@@ -968,8 +982,8 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       }
     } catch {}
 
-    if (sink && !didClose) {
-      didClose = true;
+    if (sink && !state.didClose) {
+      state.didClose = true;
       try {
         sink.close(e);
       } catch (j) {
@@ -1002,7 +1016,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         readableStreamController = undefined;
       }
 
-      if (stream && !didThrow && streamState !== $streamClosed && streamState !== $streamErrored) {
+      if (stream && !state.didThrow && streamState !== $streamClosed && streamState !== $streamErrored) {
         $readableStreamCloseIfPossible(stream);
       }
       stream = undefined;

--- a/src/js/builtins/ReadableStreamInternals.ts
+++ b/src/js/builtins/ReadableStreamInternals.ts
@@ -880,29 +880,9 @@ export function assignStreamIntoResumableSink(stream, sink) {
 }
 
 // Bound (via `this`) to readStreamIntoSink's per-request state object so the
-// callbacks the native sink stores in m_onPull/m_onClose hold only that small
-// state, not the whole readStreamIntoSink activation. The native sink fires
-// the drain callback (signal.ready -> m_onPull) once the socket has room
-// again; resolving the parked capability resumes the read loop. The close
-// callback resumes the same waiter so an abort while paused does not hang.
-export function readStreamIntoSinkOnDrain(this: { drainCapability: any }) {
-  var cap = this.drainCapability;
-  if (cap) {
-    this.drainCapability = undefined;
-    cap.resolve.$call();
-  }
-}
-
-export function readStreamIntoSinkOnClose(
-  this: { drainCapability: any; didThrow: boolean; didClose: boolean },
-  stream,
-  reason,
-) {
-  var cap = this.drainCapability;
-  if (cap) {
-    this.drainCapability = undefined;
-    cap.resolve.$call();
-  }
+// onClose callback the native sink stores in m_onClose holds only that small
+// state, not the whole readStreamIntoSink activation.
+export function readStreamIntoSinkOnClose(this: { didThrow: boolean; didClose: boolean }, stream, reason) {
   if (!this.didThrow && !this.didClose && stream && stream.$state !== $streamClosed) {
     $readableStreamCancel(stream, reason);
   }
@@ -912,10 +892,9 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
   var started = false;
   const highWaterMark = $getByIdDirectPrivate(stream, "highWaterMark") || 0;
 
-  // Mutable state the sink callbacks need; bound below so they don't capture
-  // this function's scope.
-  var state = { __proto__: null, didThrow: false, didClose: false, drainCapability: undefined };
-  var onSinkDrain = isNative ? $readStreamIntoSinkOnDrain.bind(state) : undefined;
+  // Mutable state onSinkClose needs; bound so it does not capture this
+  // function's scope.
+  var state = { __proto__: null, didThrow: false, didClose: false };
   var onSinkClose = isNative ? $readStreamIntoSinkOnClose.bind(state) : undefined;
 
   try {
@@ -927,7 +906,7 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
       // abort, for example. So we have to start it, if only so that we can
       // receive a notification when it closes or cancels.
       // https://github.com/oven-sh/bun/issues/6758
-      if (isNative) $startDirectStream.$call(sink, stream, onSinkDrain, onSinkClose, stream.$asyncContext);
+      if (isNative) $startDirectStream.$call(sink, stream, undefined, onSinkClose, stream.$asyncContext);
       sink.start({ highWaterMark });
       started = true;
 
@@ -939,16 +918,18 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
     }
 
     if (!started) {
-      if (isNative) $startDirectStream.$call(sink, stream, onSinkDrain, onSinkClose, stream.$asyncContext);
+      if (isNative) $startDirectStream.$call(sink, stream, undefined, onSinkClose, stream.$asyncContext);
       sink.start({ highWaterMark });
     }
 
     for (var i = 0, values = many.value, length = many.value.length; i < length; i++) {
-      // A negative result means the bytes were accepted but the transport is
-      // backed up; pause until the sink's drain signal fires.
-      if (sink.write(values[i]) < 0 && isNative) {
-        var cap = (state.drainCapability = $newPromiseCapability(Promise));
-        await cap.promise;
+      // The native sink returns its pending-flush Promise when the transport
+      // is backed up; await it (only if still pending — an already-drained
+      // socket resolves it before we get here) so we stop pulling until the
+      // socket catches up.
+      var wrote = sink.write(values[i]);
+      if ($isPromise(wrote) && $isPromisePending(wrote)) {
+        await wrote;
       }
     }
     values = many = undefined;
@@ -966,9 +947,9 @@ export async function readStreamIntoSink(stream: ReadableStream, sink, isNative)
         return sink.end();
       }
 
-      if (sink.write(value) < 0 && isNative) {
-        var cap = (state.drainCapability = $newPromiseCapability(Promise));
-        await cap.promise;
+      var wrote = sink.write(value);
+      if ($isPromise(wrote) && $isPromisePending(wrote)) {
+        await wrote;
       }
     }
   } catch (e) {

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -568,7 +568,13 @@ impl HTMLRewriterLoader {
                 // the destination sink; valid for the duration of this call.
                 unsafe { (*pending).apply_backpressure(&mut self.output, bytes) };
             }
-            Writable::IntoArray(_) | Writable::Owned(_) | Writable::Temporary(_) => {
+            // The bytes were consumed by the output sink either way; the
+            // rewriter has no resume wiring of its own, so treat a
+            // backpressure result the same as `Owned` rather than stalling.
+            Writable::IntoArray(_)
+            | Writable::Owned(_)
+            | Writable::Temporary(_)
+            | Writable::Backpressure(_) => {
                 self.signal.ready(
                     if self.chunk_size > 0 {
                         Some(self.chunk_size as u64)

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1510,11 +1510,11 @@ where
     /// Forward uWS's drain notification to the streaming response sink so it
     /// can resend any `try_end` tail and signal the JS writer to resume.
     ///
-    /// The sink cannot register `on_writable` itself: uWS's `HttpResponseData`
-    /// has a single `userData` slot shared by `onWritable`/`onAborted`/
-    /// `onTimeout`/`onData`, and that slot already holds this `RequestContext`
-    /// (via `set_abort_handler`). Registering through the context keeps every
-    /// handler agreeing on the user-data type.
+    /// Registered once in `do_render_stream` (pending-promise branch) for the
+    /// lifetime of the streaming response, so the sink itself never touches
+    /// uWS callback registration — it only tracks `has_backpressure`. uWS only
+    /// invokes the handler once its own send buffer has fully drained, so an
+    /// always-armed registration costs nothing on the no-backpressure path.
     pub(crate) fn on_writable_response_stream(
         this: *mut Self,
         write_offset: u64,
@@ -1526,7 +1526,9 @@ where
         // while the response (and so this context) is alive.
         let this = unsafe { &mut *this };
         if let Some(wrapper) = this.sink_mut() {
-            return wrapper.sink.on_writable(write_offset, core::ptr::null_mut());
+            return wrapper
+                .sink
+                .on_writable(write_offset, core::ptr::null_mut());
         }
         true
     }
@@ -2075,23 +2077,21 @@ where
                         }
 
                         // The sink only tracks `has_backpressure`; the
-                        // on_writable registration lives here so it shares the
-                        // RequestContext userData with onAborted (uWS has one
-                        // slot for both — see `on_writable_response_stream`).
+                        // on_writable registration lives here so it is armed
+                        // once for the response's lifetime instead of toggled
+                        // on every write — see `on_writable_response_stream`.
                         resp.on_writable(
-                            |this, off, resp| {
-                                Self::on_writable_response_stream(this, off, resp)
-                            },
+                            |this, off, resp| Self::on_writable_response_stream(this, off, resp),
                             std::ptr::from_mut::<Self>(this),
                         );
-                        // Root the controller cell while we own it. While the
-                        // JS reader loop is parked on a drain promise (no
-                        // pending `reader.read()` to root it via the stream),
-                        // nothing else keeps the controller — and so the sink —
-                        // alive. `JSSink::detach` (in handle_resolve_stream /
-                        // handle_reject_stream) drops this protection.
+                        // Root the controller cell while we own the sink: see
+                        // `HTTPServerWritable::controller_strong`. Released
+                        // when `destroy_sink` drops the box.
                         if let Some(ptr) = response_stream.sink.signal.ptr {
-                            JSValue::from_encoded(ptr.as_ptr() as usize).protect();
+                            response_stream.sink.controller_strong = jsc::strong::Optional::create(
+                                JSValue::from_encoded(ptr.as_ptr() as usize),
+                                global_this,
+                            );
                         }
 
                         // TODO: should this timeout?

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -1507,6 +1507,30 @@ where
         Self::on_file_stream_complete(ctx, resp);
     }
 
+    /// Forward uWS's drain notification to the streaming response sink so it
+    /// can resend any `try_end` tail and signal the JS writer to resume.
+    ///
+    /// The sink cannot register `on_writable` itself: uWS's `HttpResponseData`
+    /// has a single `userData` slot shared by `onWritable`/`onAborted`/
+    /// `onTimeout`/`onData`, and that slot already holds this `RequestContext`
+    /// (via `set_abort_handler`). Registering through the context keeps every
+    /// handler agreeing on the user-data type.
+    pub(crate) fn on_writable_response_stream(
+        this: *mut Self,
+        write_offset: u64,
+        _resp: uws::AnyResponse,
+    ) -> bool {
+        ctx_log!("onWritableResponseStream({})", write_offset);
+        // SAFETY: `this` is the live `RequestContext` user-data pointer
+        // registered with uWS in `do_render_stream`; uWS invokes the callback
+        // while the response (and so this context) is alive.
+        let this = unsafe { &mut *this };
+        if let Some(wrapper) = this.sink_mut() {
+            return wrapper.sink.on_writable(write_offset, core::ptr::null_mut());
+        }
+        true
+    }
+
     /// # Safety
     /// `this` must be the live `RequestContext` user-data pointer registered with uWS.
     pub(crate) fn on_writable_bytes(
@@ -2048,6 +2072,26 @@ where
                             response_stream.sink.on_first_write = None;
                             response_stream.sink.ctx = None;
                             this.render_metadata();
+                        }
+
+                        // The sink only tracks `has_backpressure`; the
+                        // on_writable registration lives here so it shares the
+                        // RequestContext userData with onAborted (uWS has one
+                        // slot for both — see `on_writable_response_stream`).
+                        resp.on_writable(
+                            |this, off, resp| {
+                                Self::on_writable_response_stream(this, off, resp)
+                            },
+                            std::ptr::from_mut::<Self>(this),
+                        );
+                        // Root the controller cell while we own it. While the
+                        // JS reader loop is parked on a drain promise (no
+                        // pending `reader.read()` to root it via the stream),
+                        // nothing else keeps the controller — and so the sink —
+                        // alive. `JSSink::detach` (in handle_resolve_stream /
+                        // handle_reject_stream) drops this protection.
+                        if let Some(ptr) = response_stream.sink.signal.ptr {
+                            JSValue::from_encoded(ptr.as_ptr() as usize).protect();
                         }
 
                         // TODO: should this timeout?

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2084,15 +2084,6 @@ where
                             |this, off, resp| Self::on_writable_response_stream(this, off, resp),
                             std::ptr::from_mut::<Self>(this),
                         );
-                        // Root the controller cell while we own the sink: see
-                        // `HTTPServerWritable::controller_strong`. Released
-                        // when `destroy_sink` drops the box.
-                        if let Some(ptr) = response_stream.sink.signal.ptr {
-                            response_stream.sink.controller_strong = jsc::strong::Optional::create(
-                                JSValue::from_encoded(ptr.as_ptr() as usize),
-                                global_this,
-                            );
-                        }
 
                         // TODO: should this timeout?
                         let body_value = this.response_weakref.get().unwrap().get_body_value();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2048,10 +2048,10 @@ where
         // A fully-synchronous ReadableStream can drain through writeBytes
         // and reach endFromJS() inside assignToStream(). If tryEnd() then
         // hits transport backpressure (common on QUIC right after the
-        // HEADERS frame), the sink parks a pending_flush promise and
-        // registers onWritable, but assignToStream() itself returns
-        // undefined. Surface that promise here so the request waits for
-        // the drain instead of falling through to the cancel path below.
+        // HEADERS frame), the sink parks a pending_flush promise, but
+        // assignToStream() itself returns undefined. Surface that promise
+        // here so the request waits for the drain (the Pending branch below
+        // arms on_writable) instead of falling through to the cancel path.
         let mut effective_result = assignment_result;
         if effective_result.is_empty_or_undefined_or_null() {
             if let Some(flush) = response_stream.sink.pending_flush {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -976,31 +976,13 @@ impl FileSink {
         this
     }
 
-    /// Map `to_result(Pending)` for `write*`: the input bytes are buffered in
-    /// the writer's `outgoing` queue, so the producer can continue. Returning
-    /// the WritablePending promise made Windows pipe writes (always async via
-    /// uv_write) report a Promise on every call while POSIX returned a number
-    /// for the same path — and made readStreamIntoSink serialize every chunk
-    /// behind a libuv round-trip. A Promise from write() now means transport
-    /// backpressure (matching HTTPServerWritable); flush()/end() remain the
-    /// completion-await primitives. `to_result` still records the in-flight
-    /// state (keep-alive ref, pending bookkeeping) before this remap.
-    #[inline]
-    fn to_write_result(&self, write_result: WriteResult, accepted: usize) -> streams::Writable {
-        match self.to_result(write_result) {
-            streams::Writable::Pending(_) => streams::Writable::Owned(accepted as u64),
-            other => other,
-        }
-    }
-
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
         }
-        let bytes = data.slice();
         // SAFETY(JsCell): `IOWriter::write` buffers/writes to fd; does not call JS.
-        let rc = self.writer.with_mut(|w| w.write(bytes));
-        self.to_write_result(rc, bytes.len())
+        let rc = self.writer.with_mut(|w| w.write(data.slice()));
+        self.to_result(rc)
     }
 
     #[inline]
@@ -1012,20 +994,18 @@ impl FileSink {
         if self.done.get() {
             return streams::Writable::Done;
         }
-        let bytes = data.slice();
         // SAFETY(JsCell): `IOWriter::write_latin1` buffers/writes; no JS.
-        let rc = self.writer.with_mut(|w| w.write_latin1(bytes));
-        self.to_write_result(rc, bytes.len())
+        let rc = self.writer.with_mut(|w| w.write_latin1(data.slice()));
+        self.to_result(rc)
     }
 
     pub fn write_utf16(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
         }
-        let units = data.slice16();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
-        let rc = self.writer.with_mut(|w| w.write_utf16(units));
-        self.to_write_result(rc, units.len())
+        let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
+        self.to_result(rc)
     }
 
     pub fn end(&self, _err: Option<sys::Error>) -> sys::Result<()> {

--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -976,13 +976,31 @@ impl FileSink {
         this
     }
 
+    /// Map `to_result(Pending)` for `write*`: the input bytes are buffered in
+    /// the writer's `outgoing` queue, so the producer can continue. Returning
+    /// the WritablePending promise made Windows pipe writes (always async via
+    /// uv_write) report a Promise on every call while POSIX returned a number
+    /// for the same path — and made readStreamIntoSink serialize every chunk
+    /// behind a libuv round-trip. A Promise from write() now means transport
+    /// backpressure (matching HTTPServerWritable); flush()/end() remain the
+    /// completion-await primitives. `to_result` still records the in-flight
+    /// state (keep-alive ref, pending bookkeeping) before this remap.
+    #[inline]
+    fn to_write_result(&self, write_result: WriteResult, accepted: usize) -> streams::Writable {
+        match self.to_result(write_result) {
+            streams::Writable::Pending(_) => streams::Writable::Owned(accepted as u64),
+            other => other,
+        }
+    }
+
     pub fn write(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
         }
+        let bytes = data.slice();
         // SAFETY(JsCell): `IOWriter::write` buffers/writes to fd; does not call JS.
-        let rc = self.writer.with_mut(|w| w.write(data.slice()));
-        self.to_result(rc)
+        let rc = self.writer.with_mut(|w| w.write(bytes));
+        self.to_write_result(rc, bytes.len())
     }
 
     #[inline]
@@ -994,18 +1012,20 @@ impl FileSink {
         if self.done.get() {
             return streams::Writable::Done;
         }
+        let bytes = data.slice();
         // SAFETY(JsCell): `IOWriter::write_latin1` buffers/writes; no JS.
-        let rc = self.writer.with_mut(|w| w.write_latin1(data.slice()));
-        self.to_result(rc)
+        let rc = self.writer.with_mut(|w| w.write_latin1(bytes));
+        self.to_write_result(rc, bytes.len())
     }
 
     pub fn write_utf16(&self, data: &streams::Result) -> streams::Writable {
         if self.done.get() {
             return streams::Writable::Done;
         }
+        let units = data.slice16();
         // SAFETY(JsCell): `IOWriter::write_utf16` buffers/writes; no JS.
-        let rc = self.writer.with_mut(|w| w.write_utf16(data.slice16()));
-        self.to_result(rc)
+        let rc = self.writer.with_mut(|w| w.write_utf16(units));
+        self.to_write_result(rc, units.len())
     }
 
     pub fn end(&self, _err: Option<sys::Error>) -> sys::Result<()> {

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -704,7 +704,14 @@ impl<T: JsSinkAbi> SinkSignal<T> {
             _o: Option<crate::webcore::BlobSizeType>,
         ) {
             let cpp = JSValue::from_encoded(this as usize);
-            T::on_ready_extern(cpp, JSValue::UNDEFINED, JSValue::UNDEFINED);
+            // `${abi}__onReady` calls m_onPull through the bare
+            // `AsyncContextFrame::call` overload (no TopExceptionScope of its
+            // own); see `close` above. Same wrapper.
+            // TODO: this should be got from a parameter / properly propagate exception upwards.
+            let global = ::bun_jsc::virtual_machine::VirtualMachine::get().global();
+            let _ = ::bun_jsc::call_check_slow(global, || {
+                T::on_ready_extern(cpp, JSValue::UNDEFINED, JSValue::UNDEFINED)
+            });
         }
         fn start(_this: *mut c_void) {}
         Signal {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1453,8 +1453,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 self.finalize();
                 return true;
             }
+            // If a flush(true) waiter was parked, resolving it is the resume
+            // signal — don't also fire signal.ready(), which for direct
+            // streams re-invokes the user's pull(controller) and would run a
+            // second pull while the first is still suspended on the await.
+            let had_flush_waiter = self.pending_flush.is_some();
             let _ = self.flush_promise(); // TODO: properly propagate exception upwards
-            if !self.done && !self.requested_end && !self.has_backpressure() {
+            if !had_flush_waiter && !self.done && !self.requested_end && !self.has_backpressure() {
                 self.signal.ready(None, None);
             }
             return true;
@@ -1499,11 +1504,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         // flush the javascript promise from calling .flush()
+        let had_flush_waiter = self.pending_flush.is_some();
         let _ = self.flush_promise(); // TODO: properly propagate exception upwards
 
         // pending_flush or callback could have caused another send()
-        // so we check again if we should report readiness
-        if !self.done && !self.requested_end && !self.has_backpressure() {
+        // so we check again if we should report readiness. Skip when a
+        // flush(true) waiter was just resolved — see the empty-buffer branch.
+        if !had_flush_waiter && !self.done && !self.requested_end && !self.has_backpressure() {
             // no pending and total_written > 0
             if total_written > 0 && self.readable_slice().is_empty() {
                 self.signal.ready(Some(total_written as BlobSizeType), None);

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1096,6 +1096,14 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub ctx: Option<*mut c_void>,
 
     pub auto_flusher: AutoFlusher,
+
+    /// GC root for the JS controller cell while the streaming promise is
+    /// pending. While the JS reader loop is parked on a drain promise (no
+    /// pending `reader.read()` to root it via the stream), nothing else keeps
+    /// the controller — and so this sink — reachable. Set by RequestContext in
+    /// the pending-promise branch of `do_render_stream`; released when the
+    /// owning RequestContext drops this struct via `destroy()`.
+    pub controller_strong: crate::webcore::jsc::strong::Optional,
 }
 
 impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTTP3> {
@@ -1120,6 +1128,7 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
             on_first_write: None,
             ctx: None,
             auto_flusher: AutoFlusher::default(),
+            controller_strong: crate::webcore::jsc::strong::Optional::empty(),
         }
     }
 }
@@ -1324,8 +1333,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         // unsent tail internally) and reports whether the socket is now backed
         // up. Track that so the JS writer can pause; the owning RequestContext
         // holds the on_writable registration and forwards the drain to
-        // `on_writable()` below (uWS shares one userData slot across
-        // onWritable/onAborted, so the sink cannot register its own).
+        // `on_writable()` below.
         if self.requested_end {
             res.end(buf, false);
             self.has_backpressure = false;

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -406,10 +406,11 @@ pub enum Writable {
     Err(SysError),
     Done,
     Owned(BlobSizeType),
-    /// `len` bytes were accepted, but the transport is now backed up. The
-    /// writer should pause until the sink's drain signal (`signal.ready()`).
-    /// `to_js()` returns the negated count so JS can branch on `< 0`.
-    Backpressure(BlobSizeType),
+    /// The bytes were accepted, but the transport is now backed up. Carries
+    /// the sink's `pending_flush` promise (already protected by the sink),
+    /// resolved by `flush_promise()` once the socket drains. `to_js()` returns
+    /// the promise so JS can await it only when still pending.
+    Backpressure(*mut JSPromise),
     OwnedAndDone(BlobSizeType),
     TemporaryAndDone(BlobSizeType),
     Temporary(BlobSizeType),
@@ -578,7 +579,10 @@ impl Writable {
                 JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js()
             }
             Writable::Owned(len) => JSValue::from(len),
-            Writable::Backpressure(len) => JSValue::js_number(-(len.max(1) as f64)),
+            // The sink owns this promise (kept alive via `protect()` in
+            // `pending_flush_promise`); hand the same value to the caller.
+            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+            Writable::Backpressure(prom) => JSPromise::opaque_ref(prom).to_js(),
             Writable::OwnedAndDone(len) => JSValue::from(len),
             Writable::TemporaryAndDone(len) => JSValue::from(len),
             Writable::Temporary(len) => JSValue::from(len),
@@ -1096,14 +1100,6 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     pub ctx: Option<*mut c_void>,
 
     pub auto_flusher: AutoFlusher,
-
-    /// GC root for the JS controller cell while the streaming promise is
-    /// pending. While the JS reader loop is parked on a drain promise (no
-    /// pending `reader.read()` to root it via the stream), nothing else keeps
-    /// the controller — and so this sink — reachable. Set by RequestContext in
-    /// the pending-promise branch of `do_render_stream`; released when the
-    /// owning RequestContext drops this struct via `destroy()`.
-    pub controller_strong: crate::webcore::jsc::strong::Optional,
 }
 
 impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTTP3> {
@@ -1128,7 +1124,6 @@ impl<const SSL: bool, const HTTP3: bool> Default for HTTPServerWritable<SSL, HTT
             on_first_write: None,
             ctx: None,
             auto_flusher: AutoFlusher::default(),
-            controller_strong: crate::webcore::jsc::strong::Optional::empty(),
         }
     }
 }
@@ -1279,16 +1274,36 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.has_backpressure && self.end_len > 0
     }
 
-    /// `len` bytes were accepted by `send`/`send_readable`. Surface uWS's
-    /// real backpressure signal to JS so the producer can pause until
-    /// `on_writable` fires the drain signal.
+    /// `len` bytes were accepted by `send`/`send_readable`. When uWS reports
+    /// the socket is now backed up, return the (lazily created) `pending_flush`
+    /// promise so the JS writer can await the drain; `on_writable` resolves it
+    /// via `flush_promise()`. Otherwise just report the byte count.
     #[inline]
-    fn writable_result(&self, len: BlobSizeType) -> Writable {
+    fn writable_result(&mut self, len: BlobSizeType) -> Writable {
         if self.has_backpressure && !self.done && !self.requested_end {
-            Writable::Backpressure(len)
+            Writable::Backpressure(self.pending_flush_promise())
         } else {
             Writable::Owned(len)
         }
+    }
+
+    /// Park (or reuse) the `pending_flush` promise that `on_writable` →
+    /// `flush_promise()` resolves once the socket drains. Same promise as
+    /// `flush_from_js(true)` would return. `global_this` is installed at sink
+    /// construction (before any write), so it is always available here.
+    fn pending_flush_promise(&mut self) -> *mut JSPromise {
+        if let Some(prom) = self.pending_flush {
+            return prom;
+        }
+        self.wrote_at_start_of_flush = self.wrote;
+        let prom: *mut JSPromise = std::ptr::from_mut(JSPromise::create(self.global_this()));
+        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+        let value = JSPromise::opaque_ref(prom).to_js();
+        // Keep it alive until `flush_promise`/`destroy` releases the root. This
+        // also roots the JS writer's await chain while it is parked here.
+        value.protect();
+        self.pending_flush = Some(prom);
+        prom
     }
 
     fn send_without_auto_flusher(&mut self, buf: &[u8]) -> bool {
@@ -1443,9 +1458,10 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         // Streaming-write drain: uWS already holds the data (our buffer is
-        // empty), so there is nothing to resend. Resolve any flush waiter and
-        // signal the JS writer it can resume. Handled before the try_end resend
-        // bookkeeping below, which assumes a non-empty buffer.
+        // empty), so there is nothing to resend. Resolve any flush(true) waiter
+        // — that promise is the resume signal for both readStreamIntoSink and
+        // direct-stream callers. Handled before the try_end resend bookkeeping
+        // below, which assumes a non-empty buffer.
         if self.readable_slice().is_empty() {
             if self.done {
                 self.signal.close(None);
@@ -1453,15 +1469,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 self.finalize();
                 return true;
             }
-            // If a flush(true) waiter was parked, resolving it is the resume
-            // signal — don't also fire signal.ready(), which for direct
-            // streams re-invokes the user's pull(controller) and would run a
-            // second pull while the first is still suspended on the await.
-            let had_flush_waiter = self.pending_flush.is_some();
             let _ = self.flush_promise(); // TODO: properly propagate exception upwards
-            if !had_flush_waiter && !self.done && !self.requested_end && !self.has_backpressure() {
-                self.signal.ready(None, None);
-            }
             return true;
         }
 
@@ -1504,13 +1512,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         // flush the javascript promise from calling .flush()
-        let had_flush_waiter = self.pending_flush.is_some();
         let _ = self.flush_promise(); // TODO: properly propagate exception upwards
 
         // pending_flush or callback could have caused another send()
-        // so we check again if we should report readiness. Skip when a
-        // flush(true) waiter was just resolved — see the empty-buffer branch.
-        if !had_flush_waiter && !self.done && !self.requested_end && !self.has_backpressure() {
+        // so we check again if we should report readiness
+        if !self.done && !self.requested_end && !self.has_backpressure() {
             // no pending and total_written > 0
             if total_written > 0 && self.readable_slice().is_empty() {
                 self.signal.ready(Some(total_written as BlobSizeType), None);

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -406,11 +406,13 @@ pub enum Writable {
     Err(SysError),
     Done,
     Owned(BlobSizeType),
-    /// The bytes were accepted, but the transport is now backed up. Carries
-    /// the sink's `pending_flush` promise (already protected by the sink),
-    /// resolved by `flush_promise()` once the socket drains. `to_js()` returns
-    /// the promise so JS can await it only when still pending.
-    Backpressure(*mut JSPromise),
+    /// The bytes were accepted, but the transport is now backed up. `to_js()`
+    /// reports `-(len + 1)` so the JS write loop can detect backpressure
+    /// without conflating it with `Pending` (FileSink on Windows returns a
+    /// Promise on every write — `Promise < 0` is false, so `readStreamIntoSink`
+    /// keeps its main-branch behavior for non-HTTP sinks). The drain itself is
+    /// awaited via `flush(true)` → `pending_flush`.
+    Backpressure(BlobSizeType),
     OwnedAndDone(BlobSizeType),
     TemporaryAndDone(BlobSizeType),
     Temporary(BlobSizeType),
@@ -580,9 +582,8 @@ impl Writable {
             }
             Writable::Owned(len) => JSValue::from(len),
             // The sink owns this promise (kept alive via `protect()` in
-            // `pending_flush_promise`); hand the same value to the caller.
-            // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-            Writable::Backpressure(prom) => JSPromise::opaque_ref(prom).to_js(),
+            // Negative sentinel; the writer awaits the drain via `flush(true)`.
+            Writable::Backpressure(len) => JSValue::js_number(-((len as f64) + 1.0)),
             Writable::OwnedAndDone(len) => JSValue::from(len),
             Writable::TemporaryAndDone(len) => JSValue::from(len),
             Writable::Temporary(len) => JSValue::from(len),
@@ -1275,35 +1276,16 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
     }
 
     /// `len` bytes were accepted by `send`/`send_readable`. When uWS reports
-    /// the socket is now backed up, return the (lazily created) `pending_flush`
-    /// promise so the JS writer can await the drain; `on_writable` resolves it
-    /// via `flush_promise()`. Otherwise just report the byte count.
+    /// the socket is now backed up, surface that via the negative-sentinel
+    /// `Backpressure` variant so the JS writer can `await flush(true)`;
+    /// `on_writable` resolves that promise via `flush_promise()`.
     #[inline]
-    fn writable_result(&mut self, len: BlobSizeType) -> Writable {
+    fn writable_result(&self, len: BlobSizeType) -> Writable {
         if self.has_backpressure && !self.done && !self.requested_end {
-            Writable::Backpressure(self.pending_flush_promise())
+            Writable::Backpressure(len)
         } else {
             Writable::Owned(len)
         }
-    }
-
-    /// Park (or reuse) the `pending_flush` promise that `on_writable` →
-    /// `flush_promise()` resolves once the socket drains. Same promise as
-    /// `flush_from_js(true)` would return. `global_this` is installed at sink
-    /// construction (before any write), so it is always available here.
-    fn pending_flush_promise(&mut self) -> *mut JSPromise {
-        if let Some(prom) = self.pending_flush {
-            return prom;
-        }
-        self.wrote_at_start_of_flush = self.wrote;
-        let prom: *mut JSPromise = std::ptr::from_mut(JSPromise::create(self.global_this()));
-        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-        let value = JSPromise::opaque_ref(prom).to_js();
-        // Keep it alive until `flush_promise`/`destroy` releases the root. This
-        // also roots the JS writer's await chain while it is parked here.
-        value.protect();
-        self.pending_flush = Some(prom);
-        prom
     }
 
     fn send_without_auto_flusher(&mut self, buf: &[u8]) -> bool {
@@ -1615,11 +1597,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         if let Some(prom) = self.pending_flush {
-            // The promise was parked by `writable_result()` on a prior write,
-            // so a streaming drain is already pending. Any data buffered since
-            // then (below highWaterMark) still needs to reach uWS before we
-            // hand the same promise back; otherwise it would sit here until
-            // `on_writable` fires.
+            // A prior `flush(true)` is already waiting on the drain. Push any
+            // data buffered since (below highWaterMark) so it reaches uWS now
+            // rather than when `on_writable` fires.
             if self.end_len == 0 && !self.readable_slice().is_empty() {
                 let _ = self.send_readable(0);
             }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -581,7 +581,6 @@ impl Writable {
                 JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js()
             }
             Writable::Owned(len) => JSValue::from(len),
-            // The sink owns this promise (kept alive via `protect()` in
             // Negative sentinel; the writer awaits the drain via `flush(true)`.
             Writable::Backpressure(len) => JSValue::js_number(-((len as f64) + 1.0)),
             Writable::OwnedAndDone(len) => JSValue::from(len),

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -406,6 +406,10 @@ pub enum Writable {
     Err(SysError),
     Done,
     Owned(BlobSizeType),
+    /// `len` bytes were accepted, but the transport is now backed up. The
+    /// writer should pause until the sink's drain signal (`signal.ready()`).
+    /// `to_js()` returns the negated count so JS can branch on `< 0`.
+    Backpressure(BlobSizeType),
     OwnedAndDone(BlobSizeType),
     TemporaryAndDone(BlobSizeType),
     Temporary(BlobSizeType),
@@ -574,6 +578,7 @@ impl Writable {
                 JSPromise::rejected_promise(global_this, err.to_js(global_this)).to_js()
             }
             Writable::Owned(len) => JSValue::from(len),
+            Writable::Backpressure(len) => JSValue::js_number(-(len.max(1) as f64)),
             Writable::OwnedAndDone(len) => JSValue::from(len),
             Writable::TemporaryAndDone(len) => JSValue::from(len),
             Writable::Temporary(len) => JSValue::from(len),
@@ -1265,6 +1270,18 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.has_backpressure && self.end_len > 0
     }
 
+    /// `len` bytes were accepted by `send`/`send_readable`. Surface uWS's
+    /// real backpressure signal to JS so the producer can pause until
+    /// `on_writable` fires the drain signal.
+    #[inline]
+    fn writable_result(&self, len: BlobSizeType) -> Writable {
+        if self.has_backpressure && !self.done && !self.requested_end {
+            Writable::Backpressure(len)
+        } else {
+            Writable::Owned(len)
+        }
+    }
+
     fn send_without_auto_flusher(&mut self, buf: &[u8]) -> bool {
         debug_assert!(!self.done);
 
@@ -1291,14 +1308,6 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 self.handle_wrote(self.end_len);
             } else if self.res.is_some() {
                 self.has_backpressure = true;
-                res.on_writable::<Self, _>(
-                    |this: *mut Self, off, _r| {
-                        // SAFETY: `this` was registered as live `*mut Self` and uWS invokes
-                        // the callback while the sink is still alive.
-                        unsafe { (*this).on_writable(off, core::ptr::null_mut()) }
-                    },
-                    std::ptr::from_mut::<Self>(self),
-                );
             }
             bun_core::scoped_log!(
                 HTTPServerWritableLog,
@@ -1310,14 +1319,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
         // clean this so we know when its relevant or not
         self.end_len = 0;
-        // we clear the onWritable handler so uWS can handle the backpressure for us
-        res.clear_on_writable();
         self.handle_first_write_if_necessary();
-        // uWebSockets lacks a tryWrite() function
-        // This means that backpressure will be handled by appending to an "infinite" memory buffer
-        // It will do the backpressure handling for us
-        // so in this scenario, we just append to the buffer
-        // and report success
+        // uWS has no tryWrite(): write() always accepts the buffer (queuing the
+        // unsent tail internally) and reports whether the socket is now backed
+        // up. Track that so the JS writer can pause; the owning RequestContext
+        // holds the on_writable registration and forwards the drain to
+        // `on_writable()` below (uWS shares one userData slot across
+        // onWritable/onAborted, so the sink cannot register its own).
         if self.requested_end {
             res.end(buf, false);
             self.has_backpressure = false;
@@ -1376,14 +1384,6 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 self.handle_wrote(end_len);
             } else if self.res.is_some() {
                 self.has_backpressure = true;
-                res.on_writable::<Self, _>(
-                    |this: *mut Self, off, _r| {
-                        // SAFETY: `this` was registered as a live `*mut Self`;
-                        // uWS invokes the callback while the sink is alive.
-                        unsafe { (*this).on_writable(off, core::ptr::null_mut()) }
-                    },
-                    std::ptr::from_mut::<Self>(self),
-                );
             }
             bun_core::scoped_log!(
                 HTTPServerWritableLog,
@@ -1395,10 +1395,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
         // clean this so we know when its relevant or not
         self.end_len = 0;
-        // we clear the onWritable handler so uWS can handle the backpressure for us
-        res.clear_on_writable();
         self.handle_first_write_if_necessary();
         let buf_len = self.buffer.len().saturating_sub(base);
+        // See `send_without_auto_flusher`.
         if self.requested_end {
             res.end(&self.buffer[base..], false);
             self.has_backpressure = false;
@@ -1434,6 +1433,25 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.finalize();
             return false;
         }
+
+        // Streaming-write drain: uWS already holds the data (our buffer is
+        // empty), so there is nothing to resend. Resolve any flush waiter and
+        // signal the JS writer it can resume. Handled before the try_end resend
+        // bookkeeping below, which assumes a non-empty buffer.
+        if self.readable_slice().is_empty() {
+            if self.done {
+                self.signal.close(None);
+                let _ = self.flush_promise(); // TODO: properly propagate exception upwards
+                self.finalize();
+                return true;
+            }
+            let _ = self.flush_promise(); // TODO: properly propagate exception upwards
+            if !self.done && !self.requested_end && !self.has_backpressure() {
+                self.signal.ready(None, None);
+            }
+            return true;
+        }
+
         let mut total_written: u64 = 0;
 
         // do not write more than available
@@ -1571,7 +1589,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return bun_sys::Result::Ok(JSPromise::opaque_ref(prom).to_js());
         }
 
-        if self.buffer.len() == 0 || self.done {
+        if self.done {
             return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                 global_this,
                 JSValue::from(0i32),
@@ -1580,8 +1598,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         if !self.has_backpressure_and_is_try_end() {
             let slice_len = self.readable_slice().len();
-            debug_assert!(slice_len > 0);
-            if self.send_readable(0) {
+            if slice_len > 0 {
+                let _ = self.send_readable(0);
+            }
+            // Only resolve once the socket has actually accepted everything;
+            // otherwise fall through and let on_writable resolve the promise.
+            if !self.has_backpressure {
                 return bun_sys::Result::Ok(JSPromise::resolved_promise_value(
                     global_this,
                     JSValue::from(slice_len),
@@ -1628,7 +1650,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             // - large-ish chunk
             // - no backpressure
             if self.send(bytes) {
-                return Writable::Owned(len);
+                return self.writable_result(len);
             }
 
             if self.buffer.write(bytes).is_err() {
@@ -1640,7 +1662,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 return Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write));
             }
             if self.send_readable(0) {
-                return Writable::Owned(len);
+                return self.writable_result(len);
             }
         } else {
             // queue the data wait until highWaterMark is reached or the auto flusher kicks in
@@ -1651,7 +1673,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         self.register_auto_flusher();
 
-        Writable::Owned(len)
+        self.writable_result(len)
     }
 
     pub fn write_bytes(&mut self, data: &StreamResult) -> Writable {
@@ -1681,7 +1703,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 // - large-ish chunk
                 // - no backpressure
                 if self.send(bytes) {
-                    return Writable::Owned(len);
+                    return self.writable_result(len);
                 }
                 do_send = false;
             }
@@ -1692,7 +1714,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
             if do_send {
                 if self.send_readable(0) {
-                    return Writable::Owned(len);
+                    return self.writable_result(len);
                 }
             }
         } else if self.buffer.len() as BlobSizeType + len >= self.high_water_mark {
@@ -1703,7 +1725,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
                 return Writable::Err(SysError::from_code(sys::E::ENOMEM, sys::Tag::write));
             }
             if self.send_readable(0) {
-                return Writable::Owned(len);
+                return self.writable_result(len);
             }
         } else {
             if self.buffer.write_latin1(bytes).is_err() {
@@ -1713,7 +1735,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         self.register_auto_flusher();
 
-        Writable::Owned(len)
+        self.writable_result(len)
     }
 
     pub fn write_utf16(&mut self, data: &StreamResult) -> Writable {
@@ -1743,12 +1765,12 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         let readable_len = self.readable_slice().len();
         if readable_len >= self.high_water_mark as usize || self.has_backpressure() {
             if self.send_readable(0) {
-                return Writable::Owned(written as BlobSizeType);
+                return self.writable_result(written as BlobSizeType);
             }
         }
 
         self.register_auto_flusher();
-        Writable::Owned(written as BlobSizeType)
+        self.writable_result(written as BlobSizeType)
     }
 
     pub fn mark_done(&mut self) {

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1475,15 +1475,24 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         let mut total_written: u64 = 0;
 
-        // do not write more than available
-        // if we do, it will cause this to be delayed until the next call, each time
-        // TODO: should we break it in smaller chunks?
-        let to_write = (write_offset as BlobSizeType).min(self.buffer.len() as BlobSizeType - 1);
+        // try_end resend vs streaming-write drain:
+        // - end_len > 0: the buffer holds the body uWS partially sent via
+        //   try_end; `write_offset` is the resume point into that same buffer.
+        // - end_len == 0: the buffer holds *new* data the user queued while the
+        //   socket was backed up (e.g. write(small) after a write(big) that hit
+        //   backpressure). uWS already owns the earlier bytes; send from 0.
+        //   `write_offset` is uWS's cumulative response count here and is not a
+        //   valid index into our buffer.
+        let chunk_start = if self.end_len > 0 {
+            // do not write more than available
+            (write_offset as BlobSizeType).min(self.buffer.len() as BlobSizeType - 1) as usize
+        } else {
+            0
+        };
         // Capture the chunk length before send.
         // `send_readable` re-slices the buffer at call time, which observes any
         // mutation send's internals perform. The length is used only for
         // `total_written` and the empty check.
-        let chunk_start = to_write as usize;
         let chunk_len = self.readable_slice().len().saturating_sub(chunk_start);
         // if we have nothing to write, we are done
         if chunk_len == 0 {
@@ -1606,6 +1615,14 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         }
 
         if let Some(prom) = self.pending_flush {
+            // The promise was parked by `writable_result()` on a prior write,
+            // so a streaming drain is already pending. Any data buffered since
+            // then (below highWaterMark) still needs to reach uWS before we
+            // hand the same promise back; otherwise it would sit here until
+            // `on_writable` fires.
+            if self.end_len == 0 && !self.readable_slice().is_empty() {
+                let _ = self.send_readable(0);
+            }
             // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
             return bun_sys::Result::Ok(JSPromise::opaque_ref(prom).to_js());
         }

--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1961,10 +1961,11 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         if !self.done {
             self.unregister_auto_flusher();
             if let Some(res) = self.any_res() {
-                // Detach the handlers this sink registered before flushing.
-                // onAborted/onData belong to RequestContext, not the sink —
-                // clearing them here would drop the holder's pointer (and on
-                // H3, where the stream is freed after FIN, leave it dangling).
+                // The body is finished; drop the drain callback so the owning
+                // RequestContext is not re-entered for a sink that will never
+                // write again. onAborted/onData stay installed — clearing them
+                // here would drop the holder's pointer (and on H3, where the
+                // stream is freed after FIN, leave it dangling).
                 res.clear_on_writable();
             }
             let _ = self.flush_no_wait();

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2694,3 +2694,62 @@ it("applies backpressure to a Response(async generator) body when the client sta
     socket.destroy();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/32469
+it("type: direct stream — small write queued under backpressure is delivered intact after drain", async () => {
+  const BIG = Buffer.alloc(512 * 1024, 65);
+  const SMALL = Buffer.from("the-tail-marker\n");
+  let hitBackpressure = false;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(controller) {
+          // Drive the socket into backpressure via the fast path (chunk ≥
+          // highWaterMark goes straight to uWS), then queue a small chunk
+          // below highWaterMark — it lands in the sink's local buffer while
+          // pending_flush is already parked.
+          for (let i = 0; i < 256 && !hitBackpressure; i++) {
+            const r = controller.write(BIG);
+            if (r && typeof r.then === "function") hitBackpressure = true;
+          }
+          controller.write(SMALL);
+          await controller.flush(true);
+          await controller.end();
+        },
+      } as any);
+      return new Response(stream);
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  const { promise: bodyDone, resolve: onBodyDone } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
+  const chunks: Buffer[] = [];
+  socket.on("data", c => chunks.push(c));
+  socket.on("close", () => onBodyDone());
+  socket.once("data", () => {
+    socket.pause();
+    onStalled();
+  });
+
+  try {
+    await stalled;
+    // Hold the client until the producer has parked on backpressure.
+    while (!hitBackpressure) await Bun.sleep(5);
+    socket.resume();
+    await bodyDone;
+
+    expect(hitBackpressure).toBe(true);
+    const body = Buffer.concat(chunks).toString("latin1");
+    // on_writable resending from uWS's cumulative write_offset would drop the
+    // head of SMALL; it must arrive intact and contiguous.
+    expect(body.includes(SMALL.toString("latin1"))).toBe(true);
+  } finally {
+    socket.destroy();
+  }
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2429,3 +2429,140 @@ it.if(isPosix)("serves /bun:info over a unix socket in development mode", async 
   expect(text).toContain("bun_version");
   expect(res.status).toBe(200);
 });
+
+// https://github.com/oven-sh/bun/issues/32469
+it("applies backpressure to a Response(ReadableStream) body when the client stalls", async () => {
+  const CHUNK = Buffer.alloc(64 * 1024, 65); // 64 KiB
+  // Without backpressure the producer runs to this cap (128 MiB) and closes;
+  // with it, pull plateaus at roughly the socket send buffer.
+  const CAP_CHUNKS = 2048;
+  let pulls = 0;
+  let producedEverything = false;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream(
+        {
+          pull(controller) {
+            pulls++;
+            controller.enqueue(CHUNK);
+            if (pulls >= CAP_CHUNKS) {
+              producedEverything = true;
+              controller.close();
+            }
+          },
+        },
+        { highWaterMark: 1 },
+      );
+      return new Response(stream);
+    },
+  });
+
+  // Raw client: send the request, read the head of the response, then stop
+  // reading so TCP backpressure propagates back to the server.
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
+  socket.once("data", () => {
+    socket.pause();
+    onStalled();
+  });
+
+  try {
+    await stalled;
+
+    // Poll a bounded window for the absence of a runaway: wait until the pull
+    // count plateaus (backpressure engaged) or the server produces the whole
+    // capped body (the bug).
+    let last = -1;
+    let stable = 0;
+    while (!producedEverything && stable < 12) {
+      await Bun.sleep(25);
+      if (pulls === last) stable++;
+      else {
+        stable = 0;
+        last = pulls;
+      }
+    }
+
+    // Without backpressure the producer runs to CAP_CHUNKS and closes; with
+    // it, pulls plateau at roughly the kernel send/recv buffer. The exact
+    // count depends on per-platform socket sizing, so assert the property
+    // (plateau well below the cap) rather than a hard number.
+    expect(producedEverything).toBe(false);
+    expect(pulls).toBeLessThan(CAP_CHUNKS / 2);
+  } finally {
+    socket.destroy();
+  }
+});
+
+// https://github.com/oven-sh/bun/issues/32469
+it("resumes a backpressured Response(ReadableStream) once the client drains and delivers the full body", async () => {
+  const CHUNK = Buffer.alloc(256 * 1024, 66);
+  const TOTAL_CHUNKS = 512; // 128 MiB — well past any kernel socket buffer
+  let pulls = 0;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      let sent = 0;
+      const stream = new ReadableStream(
+        {
+          pull(controller) {
+            pulls++;
+            controller.enqueue(CHUNK);
+            if (++sent === TOTAL_CHUNKS) controller.close();
+          },
+        },
+        { highWaterMark: 1 },
+      );
+      return new Response(stream);
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  const { promise: bodyDone, resolve: onBodyDone } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
+  let received = 0;
+  socket.on("data", chunk => {
+    received += chunk.length;
+  });
+  socket.on("close", () => onBodyDone());
+  socket.once("data", () => {
+    socket.pause();
+    onStalled();
+  });
+
+  try {
+    await stalled;
+
+    // Wait for the producer to pause under backpressure.
+    let last = -1;
+    let stable = 0;
+    while (stable < 8 && pulls < TOTAL_CHUNKS) {
+      await Bun.sleep(25);
+      if (pulls === last) stable++;
+      else {
+        stable = 0;
+        last = pulls;
+      }
+    }
+    // The producer must have paused well before the full body.
+    expect(pulls).toBeLessThan(TOTAL_CHUNKS);
+
+    // Now drain the client and confirm the producer resumes and completes.
+    socket.resume();
+    await bodyDone;
+
+    expect(pulls).toBe(TOTAL_CHUNKS);
+    // received includes HTTP head + chunked framing, so just assert the full
+    // payload made it through.
+    expect(received).toBeGreaterThanOrEqual(TOTAL_CHUNKS * CHUNK.length);
+  } finally {
+    socket.destroy();
+  }
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2570,7 +2570,7 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
 });
 
 // https://github.com/oven-sh/bun/issues/32469
-it("type: direct stream awaiting the write() backpressure promise does not re-enter pull", async () => {
+it("type: direct stream awaiting flush(true) under backpressure does not re-enter pull", async () => {
   const CHUNK = Buffer.alloc(256 * 1024, 67);
   const TOTAL_CHUNKS = 512; // 128 MiB
   let pullEntries = 0;
@@ -2584,11 +2584,11 @@ it("type: direct stream awaiting the write() backpressure promise does not re-en
         async pull(controller) {
           pullEntries++;
           for (let i = 0; i < TOTAL_CHUNKS; i++) {
-            const wrote = controller.write(CHUNK);
-            // write() returns the pending-flush promise when the socket is
-            // backed up; await it to pause until the drain.
-            if (wrote && typeof wrote.then === "function") {
-              await wrote;
+            // write() returns a negative number when the socket is backed up;
+            // await flush(true) (the pending-flush promise) to pause until the
+            // drain.
+            if (controller.write(CHUNK) < 0) {
+              await controller.flush(true);
             }
             writes++;
           }
@@ -2634,7 +2634,7 @@ it("type: direct stream awaiting the write() backpressure promise does not re-en
     await bodyDone;
 
     // pull must have been entered exactly once — on drain the sink resolves
-    // the write() backpressure promise, it must not also re-invoke pull.
+    // the flush(true) promise, it must not also re-invoke pull.
     expect(pullEntries).toBe(1);
     expect(writes).toBe(TOTAL_CHUNKS);
     expect(received).toBeGreaterThanOrEqual(TOTAL_CHUNKS * CHUNK.length);
@@ -2712,8 +2712,7 @@ it("type: direct stream — small write queued under backpressure is delivered i
           // below highWaterMark — it lands in the sink's local buffer while
           // pending_flush is already parked.
           for (let i = 0; i < 256 && !hitBackpressure; i++) {
-            const r = controller.write(BIG);
-            if (r && typeof r.then === "function") hitBackpressure = true;
+            if (controller.write(BIG) < 0) hitBackpressure = true;
           }
           controller.write(SMALL);
           await controller.flush(true);
@@ -2740,11 +2739,11 @@ it("type: direct stream — small write queued under backpressure is delivered i
   try {
     await stalled;
     // Hold the client until the producer has parked on backpressure.
-    while (!hitBackpressure) await Bun.sleep(5);
+    for (let i = 0; i < 200 && !hitBackpressure; i++) await Bun.sleep(5);
+    expect(hitBackpressure).toBe(true);
     socket.resume();
     await bodyDone;
 
-    expect(hitBackpressure).toBe(true);
     const body = Buffer.concat(chunks).toString("latin1");
     // on_writable resending from uWS's cumulative write_offset would drop the
     // head of SMALL; it must arrive intact and contiguous.

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2566,3 +2566,74 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
     socket.destroy();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/32469
+it("type: direct stream awaiting controller.flush(true) under backpressure does not re-enter pull", async () => {
+  const CHUNK = Buffer.alloc(256 * 1024, 67);
+  const TOTAL_CHUNKS = 512; // 128 MiB
+  let pullEntries = 0;
+  let writes = 0;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      const stream = new ReadableStream({
+        type: "direct",
+        async pull(controller) {
+          pullEntries++;
+          for (let i = 0; i < TOTAL_CHUNKS; i++) {
+            if (controller.write(CHUNK) < 0) {
+              await controller.flush(true);
+            }
+            writes++;
+          }
+          await controller.end();
+        },
+      } as any);
+      return new Response(stream);
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  const { promise: bodyDone, resolve: onBodyDone } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n"));
+  let received = 0;
+  socket.on("data", chunk => {
+    received += chunk.length;
+  });
+  socket.on("close", () => onBodyDone());
+  socket.once("data", () => {
+    socket.pause();
+    onStalled();
+  });
+
+  try {
+    await stalled;
+
+    // Wait for pull to pause under backpressure.
+    let last = -1;
+    let stable = 0;
+    while (stable < 8 && writes < TOTAL_CHUNKS) {
+      await Bun.sleep(25);
+      if (writes === last) stable++;
+      else {
+        stable = 0;
+        last = writes;
+      }
+    }
+    expect(writes).toBeLessThan(TOTAL_CHUNKS);
+
+    socket.resume();
+    await bodyDone;
+
+    // pull must have been entered exactly once — the drain signal resolves the
+    // flush(true) promise, it must not also re-invoke the user's pull.
+    expect(pullEntries).toBe(1);
+    expect(writes).toBe(TOTAL_CHUNKS);
+    expect(received).toBeGreaterThanOrEqual(TOTAL_CHUNKS * CHUNK.length);
+  } finally {
+    socket.destroy();
+  }
+});

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2582,8 +2582,11 @@ it("type: direct stream awaiting controller.flush(true) under backpressure does 
         async pull(controller) {
           pullEntries++;
           for (let i = 0; i < TOTAL_CHUNKS; i++) {
-            if (controller.write(CHUNK) < 0) {
-              await controller.flush(true);
+            const wrote = controller.write(CHUNK);
+            // write() returns the pending-flush promise when the socket is
+            // backed up; await it to pause until the drain.
+            if (wrote && typeof wrote.then === "function") {
+              await wrote;
             }
             writes++;
           }

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2490,8 +2490,10 @@ it("applies backpressure to a Response(ReadableStream) body when the client stal
     // Without backpressure the producer runs to CAP_CHUNKS and closes; with
     // it, pulls plateau at roughly the kernel send/recv buffer. The exact
     // count depends on per-platform socket sizing, so assert the property
-    // (plateau well below the cap) rather than a hard number.
+    // (plateau well below the cap) rather than a hard number. The lower bound
+    // proves pull() actually ran and was paused, not that nothing happened.
     expect(producedEverything).toBe(false);
+    expect(pulls).toBeGreaterThan(0);
     expect(pulls).toBeLessThan(CAP_CHUNKS / 2);
   } finally {
     socket.destroy();
@@ -2568,7 +2570,7 @@ it("resumes a backpressured Response(ReadableStream) once the client drains and 
 });
 
 // https://github.com/oven-sh/bun/issues/32469
-it("type: direct stream awaiting controller.flush(true) under backpressure does not re-enter pull", async () => {
+it("type: direct stream awaiting the write() backpressure promise does not re-enter pull", async () => {
   const CHUNK = Buffer.alloc(256 * 1024, 67);
   const TOTAL_CHUNKS = 512; // 128 MiB
   let pullEntries = 0;
@@ -2631,11 +2633,63 @@ it("type: direct stream awaiting controller.flush(true) under backpressure does 
     socket.resume();
     await bodyDone;
 
-    // pull must have been entered exactly once — the drain signal resolves the
-    // flush(true) promise, it must not also re-invoke the user's pull.
+    // pull must have been entered exactly once — on drain the sink resolves
+    // the write() backpressure promise, it must not also re-invoke pull.
     expect(pullEntries).toBe(1);
     expect(writes).toBe(TOTAL_CHUNKS);
     expect(received).toBeGreaterThanOrEqual(TOTAL_CHUNKS * CHUNK.length);
+  } finally {
+    socket.destroy();
+  }
+});
+
+// https://github.com/oven-sh/bun/issues/32469
+it("applies backpressure to a Response(async generator) body when the client stalls", async () => {
+  const CHUNK = Buffer.alloc(64 * 1024, 68);
+  const CAP_CHUNKS = 2048;
+  let yields = 0;
+  let producedEverything = false;
+
+  using server = serve({
+    port: 0,
+    fetch() {
+      async function* body() {
+        while (yields < CAP_CHUNKS) {
+          yields++;
+          yield CHUNK;
+        }
+        producedEverything = true;
+      }
+      return new Response(body());
+    },
+  });
+
+  const socket = net.connect(server.port, "127.0.0.1");
+  const { promise: stalled, resolve: onStalled, reject: onSocketError } = Promise.withResolvers<void>();
+  socket.on("error", onSocketError);
+  socket.on("connect", () => socket.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n"));
+  socket.once("data", () => {
+    socket.pause();
+    onStalled();
+  });
+
+  try {
+    await stalled;
+
+    let last = -1;
+    let stable = 0;
+    while (!producedEverything && stable < 12) {
+      await Bun.sleep(25);
+      if (yields === last) stable++;
+      else {
+        stable = 0;
+        last = yields;
+      }
+    }
+
+    expect(producedEverything).toBe(false);
+    expect(yields).toBeGreaterThan(0);
+    expect(yields).toBeLessThan(CAP_CHUNKS / 2);
   } finally {
     socket.destroy();
   }


### PR DESCRIPTION
Fixes #32469. Replaces #32475 (rewritten from scratch — no hardcoded cap, no new `unsafe`).

## Problem

When a `Bun.serve` handler returns `new Response(stream)` with a default `ReadableStream`, the response writer pulls from the stream as fast as it can produce, ignoring whether the TCP socket can accept the data. A slow or stalled client makes the whole body buffer in uWS's internal queue, OOM-killing servers that stream large responses.

The reporter's repro on a stalled client: 16384 pulls / 1 GiB buffered within ~1 s while the client read nothing. Bun's own `node:http` server stays flat in the same scenario because it drains through a separate, backpressure-aware path.

## Cause

`readStreamIntoSink` discarded the result of `sink.write()`, and `HTTPServerWritable::write*` never surfaced backpressure anyway — the streaming-write path noted that uWS "appends to an infinite memory buffer" and reported success unconditionally. The sink's `on_writable` callback was only registered for the `try_end` retry path, never for streaming writes.

## Fix

Wire uWS's `WriteResult::Backpressure` signal through to the JS reader loop and back, reusing the existing `flush(true)` drain promise:

- **`HTTPServerWritable::write*`** return a new `Writable::Backpressure(len)` (encodes as `-(len+1)` in JS) when uWS reports the socket is backed up. The sink no longer registers/clears `on_writable` itself — it just tracks `has_backpressure`.
- **`RequestContext` owns the `on_writable` registration** for streaming responses (registered in the pending-promise branch of `do_render_stream`) and forwards the drain to the sink. The sink could not safely register its own: uWS's `HttpResponseData` has a *single* `userData` slot shared across `onWritable`/`onAborted`/`onTimeout`/`onData`, and that slot already holds the `RequestContext` for the abort handler. Registering through the context keeps every handler agreeing on the user-data type — and also fixes a latent type-confusion in the existing `try_end`-backpressure path, where the sink's old self-registration was clobbered by `set_abort_handler`.
- **`HTTPServerWritable::on_writable`** handles the streaming-drain case: if the local buffer is empty (uWS already holds the data) it just resolves any `flush(true)` waiter; if data was queued locally while backed up it sends from offset 0 (the `write_offset` resend math is gated on `end_len > 0` since it is only valid for `try_end` retries).
- **`flush_from_js(true)`** now waits for streaming backpressure too, so direct-stream controllers that `await controller.flush(true)` observe real socket readiness; it also pushes any locally-buffered streaming data before reusing an existing `pending_flush` promise.
- **`readStreamIntoSink`** and **`runAsyncIterator`** check `sink.write() < 0` and `await sink.flush(true)` (the sink's `pending_flush` promise, resolved by `on_writable` on drain or by the abort path so a paused writer never hangs). The negative-number sentinel keeps `FileSink` writes — which return a `Promise` on every call on Windows pipes — out of the await path, so `spawn({stdin: ReadableStream})` keeps its main-branch behavior.
- `SinkSignal::ready` wraps the `on_ready` FFI call in `call_check_slow` so JS exceptions from the pull callback are checked.

Net `unsafe` count: **−1** (two inline `on_writable` thunks removed from the sink, one added in `RequestContext` following the existing `on_writable_bytes` pattern).

## Verification

Reporter's exact repro on a debug build:

| | pulls | enqueued | RSS |
|---|---|---|---|
| before | 16384 | 1024 MB | 2094 MB ↑ |
| after | 114 | 7 MB | flat |

Five new tests in `serve.test.ts`:
- a stalled client must plateau the producer well below the body cap (without the fix the producer runs to the cap and closes within ~150 ms);
- a stalled-then-draining client must receive the full body once it resumes (proves the producer resumes on drain instead of dying or hanging);
- a `type:"direct"` stream awaiting `flush(true)` under backpressure resumes without re-entering `pull`;
- a `Response(asyncGenerator)` body plateaus under backpressure;
- a `type:"direct"` stream that queues a small write while backpressured delivers it intact after the drain (covers the `on_writable` streaming-buffer path).

All five fail on `USE_SYSTEM_BUN=1`, pass on the debug build, and pass under `BUN_JSC_validateExceptionChecks=1`. Existing `serve.test.ts` streaming/abort/leak tests, `serve-direct-readable-stream.test.ts`, `serve-response-stream-sink-leak.test.ts`, `serve-stream-reject-flush-leak.test.ts`, `async-iterator-stream.test.ts`, `filesink.test.ts`, `spawn-stdin-readable-stream-edge-cases.test.ts`, `test-child-process-stdio-big-write-end.js`, and `html-rewriter.test.js` all pass.

## Performance

`oha -z 10s` (default 50 connections), `NODE_ENV=production`, 3 alternating rounds after warmup, comparing `bun-1.3.13` against this PR's release build (`bunx bun-pr 32553`). Linux x64.

### `bench/react-hello-world` — 100 B body

| | bun-1.3.13 | PR | Δ |
|---|---|---|---|
| rps mean | 76,984 | 82,535 | +7.2% |
| p50 | 0.564 ms | 0.524 ms | −7.1% |
| p99 | 1.679 ms | 1.554 ms | −7.4% |

Backpressure never fires here; the gain is unrelated main-branch work since 1.3.13. The hot path adds one `< 0` compare per `sink.write()`.

### 233 KB body (4000 React `<li>`, live `renderToReadableStream`)

| | bun-1.3.13 | PR | Δ |
|---|---|---|---|
| rps mean | 349.2 | 402.1 | +15.2% |
| throughput | 78.5 MiB/s | 90.5 MiB/s | +15.3% |
| p50 | 143.7 ms | 124.2 ms | −13.6% |
| peak RSS | 173 MB | 167 MB | −3.5% |

CPU-bound on React SSR; the socket still doesn't back up. Gain is main-branch work since 1.3.13.

### 2.4 MB body (40000 `<li>` pre-rendered once, streamed as 38 × 64 KB chunks via a default `ReadableStream`)

| | bun-1.3.13 | PR | Δ |
|---|---|---|---|
| rps mean | 1,629.2 | 1,633.1 | +0.2% |
| throughput | 3.67 GiB/s | 3.68 GiB/s | parity |
| p50 | 30.52 ms | 30.43 ms | −0.3% |
| p99 | 51.3 ms | 49.2 ms | −4.1% |
| **peak RSS** | **191.5 MB** | **137.9 MB** | **−28.0%** |

At ~3.7 GiB/s the producer outruns the socket and `has_backpressure` actually fires. Throughput is at parity (the `await flush(true)` round-trip costs nothing measurable) and peak RSS drops ~28% because the producer parks instead of letting uWS queue the whole body per connection.
