### PR TITLE
jsc: drain rejected-promise list in O(n) instead of O(n^2)

### DIFF
--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -667,7 +667,7 @@ extern "C" void JSBundlerPlugin__drainDeferred(Bun::JSBundlerPlugin* pluginObjec
 {
     auto* globalObject = pluginObject->globalObject();
     MarkedArgumentBuffer arguments;
-    pluginObject->plugin.deferredPromises.moveTo(pluginObject, arguments);
+    pluginObject->plugin.deferredPromises.drainTo(pluginObject, arguments);
     ASSERT(!arguments.hasOverflowed());
 
     auto& vm = pluginObject->vm();

--- a/src/jsc/bindings/WriteBarrierList.h
+++ b/src/jsc/bindings/WriteBarrierList.h
@@ -41,20 +41,8 @@ public:
         return m_list.mutableSpan();
     }
 
-    void moveTo(JSC::JSCell* owner, JSC::MarkedArgumentBuffer& arguments)
-    {
-        WTF::Locker locker { owner->cellLock() };
-        for (JSC::WriteBarrier<T>& value : m_list) {
-            if (auto* cell = value.get()) {
-                arguments.append(cell);
-                value.clear();
-            }
-        }
-    }
-
     // Move every element into `arguments` and clear the backing vector in one
-    // pass under a single cellLock. Prefer this over a takeFirst() loop, which
-    // is O(n^2) (Vector::removeAt(0) memmove + per-element lock acquire).
+    // linear pass under a single cellLock.
     void drainTo(JSC::JSCell* owner, JSC::MarkedArgumentBuffer& arguments)
     {
         WTF::Locker locker { owner->cellLock() };

--- a/src/jsc/bindings/WriteBarrierList.h
+++ b/src/jsc/bindings/WriteBarrierList.h
@@ -52,6 +52,20 @@ public:
         }
     }
 
+    // Move every element into `arguments` and clear the backing vector in one
+    // pass under a single cellLock. Prefer this over a takeFirst() loop, which
+    // is O(n^2) (Vector::removeAt(0) memmove + per-element lock acquire).
+    void drainTo(JSC::JSCell* owner, JSC::MarkedArgumentBuffer& arguments)
+    {
+        WTF::Locker locker { owner->cellLock() };
+        arguments.ensureCapacity(arguments.size() + m_list.size());
+        for (JSC::WriteBarrier<T>& value : m_list) {
+            if (auto* cell = value.get())
+                arguments.append(cell);
+        }
+        m_list.clear();
+    }
+
     template<typename Visitor>
     void visit(JSC::JSCell* owner, Visitor& visitor)
     {
@@ -64,18 +78,6 @@ public:
     bool isEmpty() const
     {
         return m_list.isEmpty();
-    }
-
-    T* takeFirst(JSC::JSCell* owner)
-    {
-        WTF::Locker locker { owner->cellLock() };
-        if (m_list.isEmpty()) {
-            return nullptr;
-        }
-
-        T* value = m_list.first().get();
-        m_list.removeAt(0);
-        return value;
     }
 
     template<typename MatchFunction>

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1057,10 +1057,11 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* 
         // running any handler. A handler may .catch() a later still-queued
         // promise; that promise is no longer in m_aboutToBeNotifiedRejectedPromises
         // but has not yet had 'unhandledRejection' fired, so it must not get
-        // 'rejectionHandled'. Check the in-flight tail.
-        if (auto* inflight = globalObj->m_rejectedPromisesBeingProcessed) {
-            for (size_t i = globalObj->m_rejectedPromisesBeingProcessedIndex, n = inflight->size(); i < n; ++i) {
-                if (inflight->at(i).asCell() == promise)
+        // 'rejectionHandled'. Check every in-flight tail (handlers can re-enter
+        // handleRejectedPromises(), so there may be more than one).
+        for (auto* inflight = globalObj->m_rejectedPromisesBeingProcessed; inflight; inflight = inflight->outer) {
+            for (size_t i = inflight->index, n = inflight->buffer->size(); i < n; ++i) {
+                if (inflight->buffer->at(i).asCell() == promise)
                     return;
             }
         }
@@ -3302,13 +3303,16 @@ void GlobalObject::handleRejectedPromises()
         m_aboutToBeNotifiedRejectedPromises.drainTo(this, promises);
         RELEASE_ASSERT(!promises.hasOverflowed());
         // Expose the not-yet-processed tail so promiseRejectionTracker(Handle)
-        // can tell "still pending" apart from "already notified".
-        m_rejectedPromisesBeingProcessed = &promises;
+        // can tell "still pending" apart from "already notified". Linked as a
+        // stack so a re-entrant handleRejectedPromises() (a handler that ticks
+        // the event loop) restores the outer frame instead of nulling it.
+        InFlightRejections inflight { &promises, 0, m_rejectedPromisesBeingProcessed };
+        WTF::SetForScope inflightScope(m_rejectedPromisesBeingProcessed, &inflight);
         for (size_t i = 0, size = promises.size(); i < size; ++i) {
             auto* promise = static_cast<JSC::JSPromise*>(promises.at(i).asCell());
             if (promise->isHandled())
                 continue;
-            m_rejectedPromisesBeingProcessedIndex = i + 1;
+            inflight.index = i + 1;
 
             Bun__handleRejectedPromise(this, promise);
             if (auto ex = scope.exception()) {
@@ -3316,8 +3320,6 @@ void GlobalObject::handleRejectedPromises()
                 this->reportUncaughtExceptionAtEventLoop(this, ex);
             }
         }
-        m_rejectedPromisesBeingProcessed = nullptr;
-        m_rejectedPromisesBeingProcessedIndex = 0;
         // An unhandledRejection handler may itself reject a promise; loop
         // until the list stays empty.
     } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3316,6 +3316,8 @@ void GlobalObject::handleRejectedPromises()
 
             Bun__handleRejectedPromise(this, promise);
             if (auto ex = scope.exception()) {
+                if (virtual_machine.isTerminationException(ex)) [[unlikely]]
+                    return;
                 (void)scope.tryClearException();
                 this->reportUncaughtExceptionAtEventLoop(this, ex);
             }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3278,18 +3278,35 @@ extern "C" void Bun__handleRejectedPromise(Zig::GlobalObject* JSGlobalObject, JS
 
 void GlobalObject::handleRejectedPromises()
 {
+    if (m_aboutToBeNotifiedRejectedPromises.isEmpty()) [[likely]]
+        return;
+
     JSC::VM& virtual_machine = vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(virtual_machine);
-    while (auto* promise = m_aboutToBeNotifiedRejectedPromises.takeFirst(this)) {
-        if (promise->isHandled())
-            continue;
+    do {
+        // Move the whole list out under one cellLock, then iterate linearly.
+        // The previous takeFirst() loop did Vector::removeAt(0) + cellLock per
+        // element, which is O(n^2) for n queued rejections. JSC's
+        // VM::didExhaustMicrotaskQueue and WebCore's RejectedPromiseTracker
+        // both use the same move-out-then-iterate pattern.
+        JSC::MarkedArgumentBuffer promises;
+        m_aboutToBeNotifiedRejectedPromises.drainTo(this, promises);
+        RELEASE_ASSERT(!promises.hasOverflowed());
+        for (size_t i = 0, size = promises.size(); i < size; ++i) {
+            auto* promise = static_cast<JSC::JSPromise*>(promises.at(i).asCell());
+            if (promise->isHandled())
+                continue;
 
-        Bun__handleRejectedPromise(this, promise);
-        if (auto ex = scope.exception()) {
-            (void)scope.tryClearException();
-            this->reportUncaughtExceptionAtEventLoop(this, ex);
+            Bun__handleRejectedPromise(this, promise);
+            if (auto ex = scope.exception()) {
+                (void)scope.tryClearException();
+                this->reportUncaughtExceptionAtEventLoop(this, ex);
+            }
         }
-    }
+        // An unhandledRejection handler may itself reject a promise; loop
+        // until the list stays empty (matches the original takeFirst loop's
+        // semantics, which re-read m_list each iteration).
+    } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());
 }
 
 DEFINE_VISIT_CHILDREN(GlobalObject);

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -1053,6 +1053,17 @@ void GlobalObject::promiseRejectionTracker(JSGlobalObject* obj, JSC::JSPromise* 
             return unhandledPromise.get() == promise;
         });
         if (removed) break;
+        // handleRejectedPromises() drains the list into a local buffer before
+        // running any handler. A handler may .catch() a later still-queued
+        // promise; that promise is no longer in m_aboutToBeNotifiedRejectedPromises
+        // but has not yet had 'unhandledRejection' fired, so it must not get
+        // 'rejectionHandled'. Check the in-flight tail.
+        if (auto* inflight = globalObj->m_rejectedPromisesBeingProcessed) {
+            for (size_t i = globalObj->m_rejectedPromisesBeingProcessedIndex, n = inflight->size(); i < n; ++i) {
+                if (inflight->at(i).asCell() == promise)
+                    return;
+            }
+        }
         // The promise rejection has already been notified, now we need to queue it for the rejectionHandled event
         Bun__handleHandledPromise(globalObj, promise);
         break;
@@ -3284,18 +3295,20 @@ void GlobalObject::handleRejectedPromises()
     JSC::VM& virtual_machine = vm();
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(virtual_machine);
     do {
-        // Move the whole list out under one cellLock, then iterate linearly.
-        // The previous takeFirst() loop did Vector::removeAt(0) + cellLock per
-        // element, which is O(n^2) for n queued rejections. JSC's
-        // VM::didExhaustMicrotaskQueue and WebCore's RejectedPromiseTracker
-        // both use the same move-out-then-iterate pattern.
+        // Move the whole list out under one cellLock, then iterate linearly —
+        // the same pattern JSC's VM::didExhaustMicrotaskQueue and WebCore's
+        // RejectedPromiseTracker use.
         JSC::MarkedArgumentBuffer promises;
         m_aboutToBeNotifiedRejectedPromises.drainTo(this, promises);
         RELEASE_ASSERT(!promises.hasOverflowed());
+        // Expose the not-yet-processed tail so promiseRejectionTracker(Handle)
+        // can tell "still pending" apart from "already notified".
+        m_rejectedPromisesBeingProcessed = &promises;
         for (size_t i = 0, size = promises.size(); i < size; ++i) {
             auto* promise = static_cast<JSC::JSPromise*>(promises.at(i).asCell());
             if (promise->isHandled())
                 continue;
+            m_rejectedPromisesBeingProcessedIndex = i + 1;
 
             Bun__handleRejectedPromise(this, promise);
             if (auto ex = scope.exception()) {
@@ -3303,9 +3316,10 @@ void GlobalObject::handleRejectedPromises()
                 this->reportUncaughtExceptionAtEventLoop(this, ex);
             }
         }
+        m_rejectedPromisesBeingProcessed = nullptr;
+        m_rejectedPromisesBeingProcessedIndex = 0;
         // An unhandledRejection handler may itself reject a promise; loop
-        // until the list stays empty (matches the original takeFirst loop's
-        // semantics, which re-read m_list each iteration).
+        // until the list stays empty.
     } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());
 }
 

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -786,6 +786,12 @@ private:
     WebCore::SubtleCrypto* m_subtleCrypto = nullptr;
 
     Bun::WriteBarrierList<JSC::JSPromise> m_aboutToBeNotifiedRejectedPromises;
+    // While handleRejectedPromises() is iterating its drained snapshot, this
+    // points at the not-yet-processed tail so promiseRejectionTracker(Handle)
+    // can suppress a spurious 'rejectionHandled' for a promise whose
+    // 'unhandledRejection' has not fired yet.
+    JSC::MarkedArgumentBuffer* m_rejectedPromisesBeingProcessed { nullptr };
+    size_t m_rejectedPromisesBeingProcessedIndex { 0 };
 };
 
 class EvalGlobalObject : public GlobalObject {

--- a/src/jsc/bindings/ZigGlobalObject.h
+++ b/src/jsc/bindings/ZigGlobalObject.h
@@ -786,12 +786,21 @@ private:
     WebCore::SubtleCrypto* m_subtleCrypto = nullptr;
 
     Bun::WriteBarrierList<JSC::JSPromise> m_aboutToBeNotifiedRejectedPromises;
+
+public:
     // While handleRejectedPromises() is iterating its drained snapshot, this
     // points at the not-yet-processed tail so promiseRejectionTracker(Handle)
     // can suppress a spurious 'rejectionHandled' for a promise whose
-    // 'unhandledRejection' has not fired yet.
-    JSC::MarkedArgumentBuffer* m_rejectedPromisesBeingProcessed { nullptr };
-    size_t m_rejectedPromisesBeingProcessedIndex { 0 };
+    // 'unhandledRejection' has not fired yet. Linked through `outer` to handle
+    // re-entrant handleRejectedPromises() calls.
+    struct InFlightRejections {
+        JSC::MarkedArgumentBuffer* buffer;
+        size_t index;
+        InFlightRejections* outer;
+    };
+
+private:
+    InFlightRejections* m_rejectedPromisesBeingProcessed { nullptr };
 };
 
 class EvalGlobalObject : public GlobalObject {

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -806,6 +806,44 @@ describe.concurrent(() => {
     expect(await proc.exited).toBe(42);
   });
 
+  it("delivers many unhandledRejections in order, including ones queued from the handler", async () => {
+    // handleRejectedPromises drains the pending-rejection list in one O(n) pass
+    // (instead of takeFirst() per element). This test pins the observable
+    // behaviour: order is preserved, late .catch() suppresses delivery, and a
+    // rejection raised from inside the handler is also delivered.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const N = 1000;
+          const seen = [];
+          let nestedSeen = false;
+          process.on("unhandledRejection", reason => {
+            if (reason === "nested") { nestedSeen = true; return; }
+            seen.push(reason);
+            if (reason === 0) Promise.reject("nested");
+          });
+          for (let i = 0; i < N; i++) Promise.reject(i);
+          // This one is handled before the checkpoint runs — must NOT be delivered.
+          Promise.reject("handled").catch(() => {});
+          await new Promise(r => setImmediate(r));
+          await new Promise(r => setImmediate(r));
+          if (seen.length !== N) throw new Error("count " + seen.length);
+          for (let i = 0; i < N; i++) if (seen[i] !== i) throw new Error("order at " + i + " got " + seen[i]);
+          if (seen.includes("handled")) throw new Error("handled promise was delivered");
+          if (!nestedSeen) throw new Error("rejection from inside handler was dropped");
+          console.log("ok");
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "ok", stderr: "", exitCode: 0 });
+  });
+
   it("aborts when the uncaughtException handler throws", async () => {
     const proc = Bun.spawn([bunExe(), join(import.meta.dir, "process-onUncaughtExceptionAbort.js")], {
       stderr: "pipe",

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -807,10 +807,9 @@ describe.concurrent(() => {
   });
 
   it("delivers many unhandledRejections in order, including ones queued from the handler", async () => {
-    // handleRejectedPromises drains the pending-rejection list in one O(n) pass
-    // (instead of takeFirst() per element). This test pins the observable
-    // behaviour: order is preserved, late .catch() suppresses delivery, and a
-    // rejection raised from inside the handler is also delivered.
+    // Pins the observable behaviour: order is preserved, late .catch()
+    // suppresses delivery, and a rejection raised from inside the handler is
+    // also delivered.
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -833,6 +833,25 @@ describe.concurrent(() => {
           for (let i = 0; i < N; i++) if (seen[i] !== i) throw new Error("order at " + i + " got " + seen[i]);
           if (seen.includes("handled")) throw new Error("handled promise was delivered");
           if (!nestedSeen) throw new Error("rejection from inside handler was dropped");
+
+          // A handler that .catch()es a *later* still-pending rejection must
+          // suppress both 'unhandledRejection' AND 'rejectionHandled' for it.
+          let spuriousRejectionHandled = 0;
+          let lateUnhandled = false;
+          process.on("rejectionHandled", () => spuriousRejectionHandled++);
+          let pLate;
+          process.removeAllListeners("unhandledRejection");
+          process.on("unhandledRejection", reason => {
+            if (reason === "early") pLate.catch(() => {});
+            if (reason === "late") lateUnhandled = true;
+          });
+          Promise.reject("early");
+          pLate = Promise.reject("late");
+          await new Promise(r => setImmediate(r));
+          await new Promise(r => setImmediate(r));
+          if (lateUnhandled) throw new Error("late promise got unhandledRejection");
+          if (spuriousRejectionHandled !== 0)
+            throw new Error("spurious rejectionHandled fired " + spuriousRejectionHandled + "x");
           console.log("ok");
         `,
       ],


### PR DESCRIPTION
## What

`GlobalObject::handleRejectedPromises()` looped on `WriteBarrierList::takeFirst()`, which does `cellLock()` + `Vector::removeAt(0)` (memmove) per element — **O(n²)** for n queued rejections.

This replaces it with `drainTo()` (move the whole list into a `MarkedArgumentBuffer` under one lock) + linear iteration. An outer `do-while` keeps the original behaviour for rejections raised from inside an `unhandledRejection` handler. Also adds an `isEmpty()` early return for the common no-rejections-pending tick. `takeFirst()` is now dead and removed.

This is the same move-out-then-iterate pattern JSC's `VM::didExhaustMicrotaskQueue` and WebCore's `RejectedPromiseTracker` already use.

## Benchmark

Release build, aarch64-darwin. `for (i<N) Promise.reject(i)` then drive one macrotask:

| N      | before   | after   | speedup |
|-------:|---------:|--------:|--------:|
|  1,000 |  0.09 ms | 0.06 ms |   1.5×  |
|  5,000 |  1.17 ms | 0.25 ms |   4.7×  |
| 10,000 |  4.35 ms | 0.45 ms |   9.7×  |
| 20,000 | 19.13 ms | 0.88 ms |  21.7×  |

Before scales ~quadratically (×2 → ×4), after scales linearly (×2 → ×2). Normal microtask throughput (`await`/`.then`/`queueMicrotask`) and memory usage are unchanged.

## Test

Added a subprocess test in `test/js/node/process/process.test.js` that rejects 1000 promises in one tick and asserts:
- all are delivered, in order
- a promise `.catch()`ed before the checkpoint is not delivered
- a rejection raised from inside the handler is also delivered