### PR TITLE
ci(lint): install dependencies before running oxlint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,5 +17,8 @@ jobs:
         uses: ./.github/actions/setup-bun
         with:
           bun-version: ${{ env.BUN_VERSION }}
+      - name: Setup Dependencies
+        run: |
+          bun install --frozen-lockfile
       - name: Lint
         run: bun lint


### PR DESCRIPTION
The Lint workflow has been failing on every PR with:

```
$ oxlint --config=oxlint.json --format=github src/js
/usr/bin/bash: line 1: oxlint: command not found
error: script "lint" exited with code 127
```

#32522 pinned `oxlint` as a devDependency and changed the `lint` script from `bunx oxlint` to bare `oxlint`, but `lint.yml` never ran `bun install`, so the binary was never on PATH.

This adds a `Setup Dependencies` step (matching `format.yml` / `clippy.yml`) that runs `bun install --frozen-lockfile` before linting.

Verified locally:
```
$ bun install --frozen-lockfile && bun lint
Found 0 warnings and 0 errors.
Finished in 471ms on 199 files with 88 rules using 12 threads.
```