### PR TITLE
Make Bun.SQL resilient to globalThis.Array being overwritten

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1,6 +1,6 @@
 import type { Query as QueryType } from "./query";
 
-const PublicArray = globalThis.Array;
+const PublicArray = Array;
 const {
   Query,
   SQLQueryFlags,

--- a/test/js/sql/sql-array-global-pollution.test.ts
+++ b/test/js/sql/sql-array-global-pollution.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("Bun.SQL loads when globalThis.Array is overwritten", async () => {
+  const src = `
+    const OrigArray = Array;
+    globalThis.Array = () => {};
+    const sql = new Bun.SQL("sqlite://:memory:");
+    const rows = await sql\`SELECT 1 as x\`;
+    globalThis.Array = OrigArray;
+    if (!Array.isArray(rows)) throw new Error("result is not an array");
+    if (!(rows instanceof Array)) throw new Error("result is not instanceof Array");
+    if (rows[0].x !== 1) throw new Error("unexpected row: " + JSON.stringify(rows));
+    const { sql: defaultSql } = Bun;
+    if (typeof defaultSql !== "function") throw new Error("Bun.sql is not a function");
+    await sql.end();
+    console.log("ok");
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), stderr }).toEqual({ stdout: "ok", stderr: "" });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/sql/sql-array-global-pollution.test.ts
+++ b/test/js/sql/sql-array-global-pollution.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
 test("Bun.SQL loads when globalThis.Array is overwritten", async () => {


### PR DESCRIPTION
The internal `sql/shared` module captured `Array` via `globalThis.Array`, so if user code replaced `globalThis.Array` with a non-constructor before `Bun.SQL` or `Bun.sql` was first accessed, evaluating the module threw `TypeError: The superclass is not a constructor.` while defining `SQLResultArray`. In debug builds the lazy `Bun` property loader then crashed on an `assertNoException` / null `JSCell` dereference inside `constructBunSQLObject`.

Capture the bare `Array` identifier instead so the builtin codegen rewrites it to the `@Array` link-time constant, matching how `internal/sql/query` already captures `Promise`.

Found by Fuzzilli (fingerprint `13af6d8fba1f0cc2`). The crash was flaky because it required a prior REPRL iteration to have overwritten `globalThis.Array` before this script touched `Bun.SQL`.

Related: #31346 hardens the lazy property reification path itself; this change removes the specific trigger so the SQL module no longer depends on a user-controllable global.