### PR TITLE
MessagePort: don't close a listening peer when its sibling is GC'd

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -445,11 +445,10 @@ bool MessagePort::virtualHasPendingActivity() const
     // it loads our state *afterwards*. Reading our inbox first races: a 0-queued
     // load taken before the send, combined with a Closed load taken after the
     // close, collects the wrapper while a message is in flight.
-    // A merely-collected peer (Closed without ClosedByRequest) counts as open:
-    // a collection does not tear down the channel (see CloseKind), so the
-    // listening wrapper stays pinned and keeps owning its event-loop ref until
-    // a real close or context teardown releases both together.
-    if (!m_pipe->isOtherSideClosedByRequest(m_side))
+    // A merely-collected peer (Closed without ClosedByRequest) pins the wrapper,
+    // but only until our 'close' event fires: a same-context collection never
+    // fires it (see CloseKind); a cross-context one does, releasing the refs.
+    if (!m_closeEventDispatched && !m_pipe->isOtherSideClosedByRequest(m_side))
         return true;
     return MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0;
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -68,8 +68,10 @@ MessagePort::MessagePort(ScriptExecutionContext& context, Ref<MessagePortPipe>&&
 
 MessagePort::~MessagePort()
 {
-    if (!m_isDetached)
-        m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected);
+    if (!m_isDetached) {
+        auto* context = scriptExecutionContext();
+        m_pipe->close(m_side, MessagePortPipe::CloseKind::Collected, context ? context->identifier() : 0);
+    }
 }
 
 ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSValue messageValue, StructuredSerializeOptions&& options)

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -445,7 +445,11 @@ bool MessagePort::virtualHasPendingActivity() const
     // it loads our state *afterwards*. Reading our inbox first races: a 0-queued
     // load taken before the send, combined with a Closed load taken after the
     // close, collects the wrapper while a message is in flight.
-    if (m_pipe->isOtherSideOpen(m_side))
+    // A merely-collected peer (Closed without ClosedByRequest) counts as open:
+    // a collection does not tear down the channel (see CloseKind), so the
+    // listening wrapper stays pinned and keeps owning its event-loop ref until
+    // a real close or context teardown releases both together.
+    if (!m_pipe->isOtherSideClosedByRequest(m_side))
         return true;
     return MessagePortPipe::queuedCount(m_pipe->state(m_side)) > 0;
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -410,8 +410,8 @@ bool MessagePort::virtualHasPendingActivity() const
 {
     // Called from the GC thread concurrently with the mutator; must be
     // lockless. m_pipe is a Ref<> held for the port's whole lifetime, so
-    // the dereference is always safe; state() and isOtherSideOpen() are
-    // atomic loads. The plain bool reads can observe stale values but
+    // the dereference is always safe; state() and isOtherSideClosedByRequest()
+    // are atomic loads. The plain bool reads can observe stale values but
     // cannot crash — at worst the wrapper is collected one cycle early
     // or late, which is the same tolerance as before this refactor.
     if (!scriptExecutionContext() || m_isDetached)

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -306,9 +306,8 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind, ScriptExecutionContext
         Deque<MessageWithMessagePorts> dropped;
         {
             Locker locker { s.lock };
-            // A Collected side keeps its owning context id so a later attach()/
-            // registerCloseContext() on the peer can tell same-context (keep the
-            // hold, node parity) from cross-context (release; nothing else will).
+            // A Collected side keeps its context id so peerRequiresCloseNotification()
+            // can tell a same-context peer (keeps its hold) from a cross-context one.
             s.ctxId = sdKind == CloseKind::Collected ? closingCtx : 0;
             s.port = nullptr;
             // Closed is terminal; queued messages are dropped.
@@ -330,15 +329,9 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind, ScriptExecutionContext
         // outside the lock; they may hold the last ref to pipes whose
         // destructors also take locks.
 
-        // Notify each explicitly-closed pipe's entangled peer so it can fire
-        // 'close' and release its event-loop ref — including nested in-transit
-        // ports drained from the worklist, not just the originally-closed side.
-        // A Collected close notifies only a cross-context peer (the CloseKind
-        // comment in the header has the full rationale): notifying a
-        // same-context peer made the canonical "port1.on('message', ...);
-        // port2.postMessage(...)" pattern exit at GC timing while node stays
-        // alive, but a cross-context peer left unnotified is stranded forever
-        // once the collected port's context dies with nothing to tear down.
+        // Notify the entangled peer so it can fire 'close' and release its
+        // event-loop ref — nested in-transit ports from the worklist too. A
+        // Collected close notifies only a cross-context peer (see CloseKind).
         bool notify = sdKind == CloseKind::Explicit;
         if (!notify && closingCtx) {
             auto& peer = pipe->m_sides[1 - sd];

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -228,10 +228,10 @@ void MessagePortPipe::attach(uint8_t side, ScriptExecutionContext& context, Thre
     }
     if (wakeCtx)
         scheduleDrain(side, wakeCtx, ctxLoopKind);
-    // Peer already closed while this side was in transit (detach() cleared
-    // ContextKnown so notifyPeerClosed() early-returned): re-deliver to the new
-    // owner, or the receiving context's listener loop-ref is never released.
-    if (m_sides[1 - side].state.load(std::memory_order_acquire) & Closed)
+    // Peer already gone while this side was in transit or unregistered (detach()
+    // cleared ContextKnown so notifyPeerClosed() early-returned): re-deliver to
+    // the new owner, or its listener loop-ref is never released.
+    if (peerRequiresCloseNotification(side, ctxId))
         notifyPeerClosed(side);
 }
 
@@ -254,8 +254,18 @@ void MessagePortPipe::registerCloseContext(uint8_t side, ScriptExecutionContext&
     }
     // See attach(): re-deliver a peer-close that fired while this side had no
     // context (in transit or never registered).
-    if (m_sides[1 - side].state.load(std::memory_order_acquire) & Closed)
+    if (peerRequiresCloseNotification(side, ctxId))
         notifyPeerClosed(side);
+}
+
+bool MessagePortPipe::peerRequiresCloseNotification(uint8_t side, ScriptExecutionContextIdentifier ctxId)
+{
+    auto& peer = m_sides[1 - side];
+    Locker locker { peer.lock };
+    uint64_t pst = peer.state.load(std::memory_order_relaxed);
+    if (pst & ClosedByRequest)
+        return true;
+    return (pst & Closed) && peer.ctxId && peer.ctxId != ctxId;
 }
 
 void MessagePortPipe::detach(uint8_t side)
@@ -276,7 +286,7 @@ void MessagePortPipe::detach(uint8_t side)
     s.state.fetch_and(~uint64_t(Attached | ContextKnown | DrainScheduled), std::memory_order_acq_rel);
 }
 
-void MessagePortPipe::close(uint8_t side, CloseKind kind)
+void MessagePortPipe::close(uint8_t side, CloseKind kind, ScriptExecutionContextIdentifier closingCtx)
 {
     ASSERT(side < 2);
 
@@ -296,7 +306,10 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind)
         Deque<MessageWithMessagePorts> dropped;
         {
             Locker locker { s.lock };
-            s.ctxId = 0;
+            // A Collected side keeps its owning context id so a later attach()/
+            // registerCloseContext() on the peer can tell same-context (keep the
+            // hold, node parity) from cross-context (release; nothing else will).
+            s.ctxId = sdKind == CloseKind::Collected ? closingCtx : 0;
             s.port = nullptr;
             // Closed is terminal; queued messages are dropped.
             s.state.store(sdKind == CloseKind::Explicit ? (Closed | ClosedByRequest) : Closed, std::memory_order_release);
@@ -320,15 +333,19 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind)
         // Notify each explicitly-closed pipe's entangled peer so it can fire
         // 'close' and release its event-loop ref — including nested in-transit
         // ports drained from the worklist, not just the originally-closed side.
-        // A Collected close (GC of an unreferenced wrapper) must NOT notify:
-        // node never closes a channel because a port was collected, so a
-        // listening peer keeps the process alive exactly as if the collected
-        // port were still reachable. Notifying here made the canonical
-        // "port1.on('message', ...); port2.postMessage(...)" pattern exit at GC
-        // timing while node stays alive. The resulting "stranded" peer is node
-        // parity, not a leak: node retains even more (it never collects an
-        // entangled port at all).
-        if (sdKind == CloseKind::Explicit)
+        // A Collected close notifies only a cross-context peer (the CloseKind
+        // comment in the header has the full rationale): notifying a
+        // same-context peer made the canonical "port1.on('message', ...);
+        // port2.postMessage(...)" pattern exit at GC timing while node stays
+        // alive, but a cross-context peer left unnotified is stranded forever
+        // once the collected port's context dies with nothing to tear down.
+        bool notify = sdKind == CloseKind::Explicit;
+        if (!notify && closingCtx) {
+            auto& peer = pipe->m_sides[1 - sd];
+            Locker locker { peer.lock };
+            notify = peer.ctxId && peer.ctxId != closingCtx;
+        }
+        if (notify)
             pipe->notifyPeerClosed(1 - sd);
     }
 }

--- a/src/jsc/bindings/webcore/MessagePortPipe.cpp
+++ b/src/jsc/bindings/webcore/MessagePortPipe.cpp
@@ -317,15 +317,19 @@ void MessagePortPipe::close(uint8_t side, CloseKind kind)
         // outside the lock; they may hold the last ref to pipes whose
         // destructors also take locks.
 
-        // Notify each closed pipe's entangled peer so it can fire 'close' and
-        // release its event-loop ref — including nested in-transit ports drained
-        // from the worklist, not just the originally-closed side.
-        // Always notify, even for a collected wrapper. Node never collects an entangled
-        // port so it never faces this; bun does, and a peer that is never told is
-        // stranded -- its loop ref is never released and the process hangs. A 'close'
-        // fired at GC timing is the lesser evil. (jsRef() still ignores a collected
-        // peer: it keys on ClosedByRequest, not on Closed.)
-        pipe->notifyPeerClosed(1 - sd);
+        // Notify each explicitly-closed pipe's entangled peer so it can fire
+        // 'close' and release its event-loop ref — including nested in-transit
+        // ports drained from the worklist, not just the originally-closed side.
+        // A Collected close (GC of an unreferenced wrapper) must NOT notify:
+        // node never closes a channel because a port was collected, so a
+        // listening peer keeps the process alive exactly as if the collected
+        // port were still reachable. Notifying here made the canonical
+        // "port1.on('message', ...); port2.postMessage(...)" pattern exit at GC
+        // timing while node stays alive. The resulting "stranded" peer is node
+        // parity, not a leak: node retains even more (it never collects an
+        // entangled port at all).
+        if (sdKind == CloseKind::Explicit)
+            pipe->notifyPeerClosed(1 - sd);
     }
 }
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -73,10 +73,18 @@ public:
     // transferred endpoint. Collected == the owning MessagePort's wrapper was garbage
     // collected while still entangled. Only Explicit sets ClosedByRequest, so jsRef()
     // can tell a real close from a collection (node never collects an entangled port,
-    // so reading Closed alone made .ref() GC-dependent). Both notify the peer.
+    // so reading Closed alone made .ref() GC-dependent). An Explicit close always
+    // notifies the peer. A Collected close notifies only a peer on a *different*
+    // context (closingCtx is the collected port's context): node never tears a
+    // channel down because a wrapper was collected, so a same-context listening
+    // peer must keep the loop alive exactly as if the port were still reachable;
+    // but a cross-context peer would otherwise be stranded forever, because once
+    // the collected port is gone its context's teardown has nothing left to
+    // notify (node delivers that close at worker exit; collection time is the
+    // closest equivalent we have).
     enum class CloseKind : uint8_t { Explicit,
         Collected };
-    void close(uint8_t side, CloseKind = CloseKind::Collected);
+    void close(uint8_t side, CloseKind = CloseKind::Collected, ScriptExecutionContextIdentifier closingCtx = 0);
 
     // Lockless snapshot for the GC visitor / hasPendingActivity.
     uint64_t state(uint8_t side) const { return m_sides[side].state.load(std::memory_order_acquire); }
@@ -90,6 +98,10 @@ private:
     MessagePortPipe() = default;
 
     void scheduleDrain(uint8_t side, ScriptExecutionContextIdentifier, BunLoopKind);
+    // True if `side` (attaching/registering on ctxId) must be told its peer is
+    // gone: the peer was explicitly closed, or was collected on a different
+    // context (see CloseKind above).
+    bool peerRequiresCloseNotification(uint8_t side, ScriptExecutionContextIdentifier ctxId);
     void notifyPeerClosed(uint8_t peerSide);
     void drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx);
 

--- a/src/jsc/bindings/webcore/MessagePortPipe.h
+++ b/src/jsc/bindings/webcore/MessagePortPipe.h
@@ -70,18 +70,11 @@ public:
     void registerCloseContext(uint8_t side, ScriptExecutionContext&, ThreadSafeWeakPtr<MessagePort>);
     void detach(uint8_t side);
     // Explicit == a real, permanent close: close(), context teardown, or an orphaned
-    // transferred endpoint. Collected == the owning MessagePort's wrapper was garbage
-    // collected while still entangled. Only Explicit sets ClosedByRequest, so jsRef()
-    // can tell a real close from a collection (node never collects an entangled port,
-    // so reading Closed alone made .ref() GC-dependent). An Explicit close always
-    // notifies the peer. A Collected close notifies only a peer on a *different*
-    // context (closingCtx is the collected port's context): node never tears a
-    // channel down because a wrapper was collected, so a same-context listening
-    // peer must keep the loop alive exactly as if the port were still reachable;
-    // but a cross-context peer would otherwise be stranded forever, because once
-    // the collected port is gone its context's teardown has nothing left to
-    // notify (node delivers that close at worker exit; collection time is the
-    // closest equivalent we have).
+    // transferred endpoint; sets ClosedByRequest and always notifies the peer.
+    // Collected == the wrapper was GC'd while entangled (node never collects an
+    // entangled port); notifies only a peer on a different context than closingCtx,
+    // matching node: a collection never closes a channel, and a worker-side close
+    // node fires at worker exit has no later trigger here once the port is gone.
     enum class CloseKind : uint8_t { Explicit,
         Collected };
     void close(uint8_t side, CloseKind = CloseKind::Collected, ScriptExecutionContextIdentifier closingCtx = 0);
@@ -98,9 +91,8 @@ private:
     MessagePortPipe() = default;
 
     void scheduleDrain(uint8_t side, ScriptExecutionContextIdentifier, BunLoopKind);
-    // True if `side` (attaching/registering on ctxId) must be told its peer is
-    // gone: the peer was explicitly closed, or was collected on a different
-    // context (see CloseKind above).
+    // True if `side` (attaching/registering on ctxId) must be told its peer is gone:
+    // explicitly closed, or collected on a different context (see CloseKind above).
     bool peerRequiresCloseNotification(uint8_t side, ScriptExecutionContextIdentifier ctxId);
     void notifyPeerClosed(uint8_t peerSide);
     void drainAndDispatch(uint8_t side, ScriptExecutionContextIdentifier expectedCtx);

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -1,3 +1,5 @@
+import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+
 test("simple usage", done => {
   const channel = new MessageChannel();
   const port1 = channel.port1;
@@ -456,4 +458,151 @@ test("transferring a port from inside peerClosed()'s flush preserves the remaini
   await done.promise;
   // m1 delivered to the old owner; m2/m3 buffered for the new owner.
   expect(seen).toEqual(["old:m1", "new:m2", "new:m3"]);
+});
+
+// https://github.com/oven-sh/bun/issues/32562
+// A local MessageChannel port with a message listener must keep the event loop
+// alive like Node, even when the unreferenced peer is garbage-collected: node
+// never closes a channel because a wrapper was collected. The forced Bun.gc
+// makes the collected-peer path deterministic. ref()/unref(), listener
+// removal, and messageerror-only modulate the hold.
+describe("keeps the event loop alive while a message listener is attached", () => {
+  async function streamHasMarker(stream: ReadableStream<Uint8Array>, marker: string) {
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    try {
+      while (!buf.includes(marker)) {
+        const { done, value } = await reader.read();
+        if (done) return false;
+        buf += decoder.decode(value, { stream: true });
+      }
+      return true;
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  async function expectStaysAlive(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Drain stderr in the background so debug/ASAN warnings can't fill the OS
+    // pipe buffer and deadlock the child while it is expected to stay alive.
+    const stderrDrained = proc.stderr.text();
+    // Synchronize on delivery (condition, not time) so slow ASAN/debug startup
+    // does not race the decision below.
+    const gotMarker = await streamHasMarker(proc.stdout, "RECEIVED");
+    // After delivery the buggy build exits within milliseconds; a real keep
+    // alive hangs. A short window cleanly separates the two.
+    const outcome = await Promise.race([
+      proc.exited.then(() => "exited" as const),
+      Bun.sleep(isDebug || isASAN ? 2000 : 750).then(() => "alive" as const),
+    ]);
+    proc.kill();
+    await Promise.all([stderrDrained, proc.exited]);
+    return { gotMarker, outcome };
+  }
+
+  async function expectExitsOnItsOwn(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Generous upper bound: a process that exits resolves this fast; the full
+    // window only elapses if it wrongly hangs (the failure we are guarding).
+    const outcome = await Promise.race([
+      proc.exited.then(exitCode => ({ kind: "exited" as const, exitCode, signalCode: proc.signalCode })),
+      Bun.sleep(isDebug || isASAN ? 6000 : 2500).then(() => ({
+        kind: "alive" as const,
+        exitCode: -1,
+        signalCode: null,
+      })),
+    ]);
+    if (outcome.kind === "alive") proc.kill();
+    await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return outcome;
+  }
+
+  test.concurrent(".on('message') stays alive after the unreferenced peer is GC'd", async () => {
+    expect(
+      await expectStaysAlive(`
+        const { MessageChannel } = require("node:worker_threads");
+        const { port1 } = (() => {
+          const { port1, port2 } = new MessageChannel();
+          port1.on("message", () => console.log("RECEIVED"));
+          port2.postMessage({ foo: "bar" });
+          return { port1 };
+        })(); // port2 is now unreferenced
+        for (let i = 0; i < 10; i++) Bun.gc(true); // collecting port2 must not close port1
+      `),
+    ).toEqual({ gotMarker: true, outcome: "alive" });
+  });
+
+  test.concurrent("addEventListener('message') (web API) stays alive under GC", async () => {
+    expect(
+      await expectStaysAlive(`
+        const { port1 } = (() => {
+          const { port1, port2 } = new MessageChannel();
+          port1.addEventListener("message", () => console.log("RECEIVED"));
+          port1.start();
+          port2.postMessage({ foo: "bar" });
+          return { port1 };
+        })();
+        for (let i = 0; i < 10; i++) Bun.gc(true);
+      `),
+    ).toEqual({ gotMarker: true, outcome: "alive" });
+  });
+
+  test.concurrent(".onmessage setter stays alive under GC", async () => {
+    expect(
+      await expectStaysAlive(`
+        const { port1 } = (() => {
+          const { port1, port2 } = new MessageChannel();
+          port1.onmessage = () => console.log("RECEIVED");
+          port2.postMessage({ foo: "bar" });
+          return { port1 };
+        })();
+        for (let i = 0; i < 10; i++) Bun.gc(true);
+      `),
+    ).toEqual({ gotMarker: true, outcome: "alive" });
+  });
+
+  test.concurrent("unref() releases the hold so the process exits", async () => {
+    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+      const { MessageChannel } = require("node:worker_threads");
+      const { port1, port2 } = new MessageChannel();
+      port1.on("message", () => {});
+      port1.unref();
+      port2.postMessage({ foo: "bar" });
+    `);
+    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+  });
+
+  test.concurrent("removing the last message listener lets the process exit", async () => {
+    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+      const { MessageChannel } = require("node:worker_threads");
+      const { port1, port2 } = new MessageChannel();
+      const listener = () => {};
+      port1.on("message", listener);
+      port1.off("message", listener);
+      port2.postMessage({ foo: "bar" });
+    `);
+    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+  });
+
+  test.concurrent("onmessageerror alone does not keep the process alive", async () => {
+    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+      const { MessageChannel } = require("node:worker_threads");
+      const { port1, port2 } = new MessageChannel();
+      port1.onmessageerror = () => {};
+      port2.postMessage({ foo: "bar" });
+    `);
+    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+  });
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -686,28 +686,30 @@ describe("keeps the event loop alive while a message listener is attached", () =
     Bun.gc(true);
     const base = count();
     await (async () => {
-      for (let i = 0; i < 3; i++) {
-        const channel = new MessageChannel();
-        const closed = Promise.withResolvers<void>();
-        channel.port1.addEventListener("close", () => closed.resolve());
-        channel.port1.addEventListener("message", () => {});
-        const worker = new Worker(
-          `
-            const { workerData } = require("worker_threads");
-            workerData.messagePort = null;             // drop the only ref
-            for (let i = 0; i < 10; i++) Bun.gc(true); // collect it inside the worker
-            `,
-          { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] },
-        );
-        await closed.promise;
-        await new Promise(r => worker.on("exit", r));
-      }
+      const channels = Array.from({ length: 10 }, () => new MessageChannel());
+      const closes = channels.map(c => new Promise<void>(r => c.port1.addEventListener("close", () => r())));
+      for (const c of channels) c.port1.addEventListener("message", () => {});
+      const worker = new Worker(
+        `
+        const { workerData } = require("worker_threads");
+        workerData.ports = null;                   // drop the only refs
+        for (let i = 0; i < 10; i++) Bun.gc(true); // collect them inside the worker
+        `,
+        {
+          eval: true,
+          workerData: { ports: channels.map(c => c.port2) },
+          transferList: channels.map(c => c.port2),
+        },
+      );
+      await Promise.all(closes);
+      await new Promise(r => worker.on("exit", r));
     })();
-    for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+    for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r));
     Bun.gc(true);
     Bun.gc(true);
-    // All 3 listening ports (and their collected peers) must be swept; allow
-    // small slack for GC nondeterminism.
-    expect(count() - base).toBeLessThanOrEqual(2);
+    // Unfixed, all 10 listening ports stay pinned. Allow generous slack for
+    // wrappers kept by conservative stack scanning, which does not scale with
+    // the channel count.
+    expect(count() - base).toBeLessThanOrEqual(5);
   }, 60_000);
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -675,43 +675,39 @@ describe("keeps the event loop alive while a message listener is attached", () =
     expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
   });
 
-  test(
-    "the listening wrapper is collectable again after a worker-side collection delivers 'close'",
-    async () => {
-      // The merely-collected-peer pin in virtualHasPendingActivity() must release once
-      // 'close' has fired (cross-context collection), or every such port leaks until
-      // context teardown.
-      const { heapStats } = require("bun:jsc");
-      const { Worker } = require("node:worker_threads");
-      const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
-      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
-      Bun.gc(true);
-      const base = count();
-      await (async () => {
-        for (let i = 0; i < 3; i++) {
-          const channel = new MessageChannel();
-          const closed = Promise.withResolvers<void>();
-          channel.port1.addEventListener("close", () => closed.resolve());
-          channel.port1.addEventListener("message", () => {});
-          const worker = new Worker(
-            `
+  test("the listening wrapper is collectable again after a worker-side collection delivers 'close'", async () => {
+    // The merely-collected-peer pin in virtualHasPendingActivity() must release once
+    // 'close' has fired (cross-context collection), or every such port leaks until
+    // context teardown.
+    const { heapStats } = require("bun:jsc");
+    const { Worker } = require("node:worker_threads");
+    const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
+    for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+    Bun.gc(true);
+    const base = count();
+    await (async () => {
+      for (let i = 0; i < 3; i++) {
+        const channel = new MessageChannel();
+        const closed = Promise.withResolvers<void>();
+        channel.port1.addEventListener("close", () => closed.resolve());
+        channel.port1.addEventListener("message", () => {});
+        const worker = new Worker(
+          `
             const { workerData } = require("worker_threads");
             workerData.messagePort = null;             // drop the only ref
             for (let i = 0; i < 10; i++) Bun.gc(true); // collect it inside the worker
             `,
-            { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] },
-          );
-          await closed.promise;
-          await new Promise(r => worker.on("exit", r));
-        }
-      })();
-      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
-      Bun.gc(true);
-      Bun.gc(true);
-      // All 3 listening ports (and their collected peers) must be swept; allow
-      // small slack for GC nondeterminism.
-      expect(count() - base).toBeLessThanOrEqual(2);
-    },
-    60_000,
-  );
+          { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] },
+        );
+        await closed.promise;
+        await new Promise(r => worker.on("exit", r));
+      }
+    })();
+    for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+    Bun.gc(true);
+    Bun.gc(true);
+    // All 3 listening ports (and their collected peers) must be swept; allow
+    // small slack for GC nondeterminism.
+    expect(count() - base).toBeLessThanOrEqual(2);
+  }, 60_000);
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -674,4 +674,44 @@ describe("keeps the event loop alive while a message listener is attached", () =
     `);
     expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
   });
+
+  test(
+    "the listening wrapper is collectable again after a worker-side collection delivers 'close'",
+    async () => {
+      // The merely-collected-peer pin in virtualHasPendingActivity() must release once
+      // 'close' has fired (cross-context collection), or every such port leaks until
+      // context teardown.
+      const { heapStats } = require("bun:jsc");
+      const { Worker } = require("node:worker_threads");
+      const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
+      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+      Bun.gc(true);
+      const base = count();
+      await (async () => {
+        for (let i = 0; i < 3; i++) {
+          const channel = new MessageChannel();
+          const closed = Promise.withResolvers<void>();
+          channel.port1.addEventListener("close", () => closed.resolve());
+          channel.port1.addEventListener("message", () => {});
+          const worker = new Worker(
+            `
+            const { workerData } = require("worker_threads");
+            workerData.messagePort = null;             // drop the only ref
+            for (let i = 0; i < 10; i++) Bun.gc(true); // collect it inside the worker
+            `,
+            { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] },
+          );
+          await closed.promise;
+          await new Promise(r => worker.on("exit", r));
+        }
+      })();
+      for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+      Bun.gc(true);
+      Bun.gc(true);
+      // All 3 listening ports (and their collected peers) must be swept; allow
+      // small slack for GC nondeterminism.
+      expect(count() - base).toBeLessThanOrEqual(2);
+    },
+    60_000,
+  );
 });

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -596,6 +596,63 @@ describe("keeps the event loop alive while a message listener is attached", () =
     expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
   });
 
+  test.concurrent("a second listener added after the peer was GC'd keeps the process alive", async () => {
+    // attach() re-runs on every addEventListener; its retroactive peer-close
+    // check must not treat a same-context collected sibling as a real close.
+    expect(
+      await expectStaysAlive(`
+        const { MessageChannel } = require("node:worker_threads");
+        const { port1 } = (() => {
+          const { port1, port2 } = new MessageChannel();
+          port1.on("message", () => console.log("RECEIVED"));
+          port2.postMessage({ foo: "bar" });
+          return { port1 };
+        })();
+        for (let i = 0; i < 10; i++) Bun.gc(true); // collect port2
+        port1.on("message", () => {});             // re-attach must not release the hold
+      `),
+    ).toEqual({ gotMarker: true, outcome: "alive" });
+  });
+
+  test.concurrent("a listener added after a worker-side port was collected is still released", async () => {
+    // Cross-context late attach: the worker-side port was collected and the
+    // worker is gone, so attaching on main must observe the dead peer and exit.
+    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+      const { Worker, MessageChannel } = require("node:worker_threads");
+      const channel = new MessageChannel();
+      const worker = new Worker(\`
+        const { workerData } = require("worker_threads");
+        workerData.messagePort = null;             // drop the only ref
+        for (let i = 0; i < 10; i++) Bun.gc(true); // collect it inside the worker
+      \`, { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] });
+      worker.on("exit", () => {
+        channel.port1.on("message", () => {});     // attach only after the worker is gone
+      });
+    `);
+    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+    // Worker spawn + full teardown takes seconds under debug/ASAN; the timeout
+    // must outlast expectExitsOnItsOwn's hang window so a real hang fails the
+    // assertion instead of the test timer.
+  }, 15_000);
+
+  test.concurrent("a worker-side port collected before worker exit still releases the main listener", async () => {
+    // Cross-context: once the worker-side port is collected, the worker's
+    // teardown has nothing left to close, so collection itself must release
+    // the listening peer (node delivers this close at worker exit).
+    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+      const { Worker, MessageChannel } = require("node:worker_threads");
+      const channel = new MessageChannel();
+      new Worker(\`
+        const { workerData } = require("worker_threads");
+        workerData.messagePort.postMessage("Meow");
+        workerData.messagePort = null;              // drop the only ref
+        for (let i = 0; i < 10; i++) Bun.gc(true);  // collect it before the worker exits
+      \`, { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] });
+      channel.port1.on("message", () => {});
+    `);
+    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+  }, 15_000); // see the sibling worker test above
+
   test.concurrent("onmessageerror alone does not keep the process alive", async () => {
     const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
       const { MessageChannel } = require("node:worker_threads");

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -514,6 +514,10 @@ describe("keeps the event loop alive while a message listener is attached", () =
       stdout: "pipe",
       stderr: "pipe",
     });
+    // Drain both pipes in the background so output can't fill the OS pipe
+    // buffer and block the child before it reaches exit.
+    const stdoutDrained = proc.stdout.text();
+    const stderrDrained = proc.stderr.text();
     // Generous upper bound: a process that exits resolves this fast; the full
     // window only elapses if it wrongly hangs (the failure we are guarding).
     const outcome = await Promise.race([
@@ -525,7 +529,7 @@ describe("keeps the event loop alive while a message listener is attached", () =
       })),
     ]);
     if (outcome.kind === "alive") proc.kill();
-    await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    await Promise.all([stdoutDrained, stderrDrained, proc.exited]);
     return outcome;
   }
 
@@ -614,10 +618,12 @@ describe("keeps the event loop alive while a message listener is attached", () =
     ).toEqual({ gotMarker: true, outcome: "alive" });
   });
 
-  test.concurrent("a listener added after a worker-side port was collected is still released", async () => {
-    // Cross-context late attach: the worker-side port was collected and the
-    // worker is gone, so attaching on main must observe the dead peer and exit.
-    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+  test.concurrent(
+    "a listener added after a worker-side port was collected is still released",
+    async () => {
+      // Cross-context late attach: the worker-side port was collected and the
+      // worker is gone, so attaching on main must observe the dead peer and exit.
+      const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
       const { Worker, MessageChannel } = require("node:worker_threads");
       const channel = new MessageChannel();
       const worker = new Worker(\`
@@ -629,17 +635,21 @@ describe("keeps the event loop alive while a message listener is attached", () =
         channel.port1.on("message", () => {});     // attach only after the worker is gone
       });
     `);
-    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
-    // Worker spawn + full teardown takes seconds under debug/ASAN; the timeout
-    // must outlast expectExitsOnItsOwn's hang window so a real hang fails the
-    // assertion instead of the test timer.
-  }, 15_000);
+      expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+      // Worker spawn + full teardown takes seconds under debug/ASAN; the timeout
+      // must outlast expectExitsOnItsOwn's hang window so a real hang fails the
+      // assertion instead of the test timer.
+    },
+    15_000,
+  );
 
-  test.concurrent("a worker-side port collected before worker exit still releases the main listener", async () => {
-    // Cross-context: once the worker-side port is collected, the worker's
-    // teardown has nothing left to close, so collection itself must release
-    // the listening peer (node delivers this close at worker exit).
-    const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
+  test.concurrent(
+    "a worker-side port collected before worker exit still releases the main listener",
+    async () => {
+      // Cross-context: once the worker-side port is collected, the worker's
+      // teardown has nothing left to close, so collection itself must release
+      // the listening peer (node delivers this close at worker exit).
+      const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`
       const { Worker, MessageChannel } = require("node:worker_threads");
       const channel = new MessageChannel();
       new Worker(\`
@@ -650,8 +660,10 @@ describe("keeps the event loop alive while a message listener is attached", () =
       \`, { eval: true, workerData: { messagePort: channel.port2 }, transferList: [channel.port2] });
       channel.port1.on("message", () => {});
     `);
-    expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
-  }, 15_000); // see the sibling worker test above
+      expect({ kind, exitCode, signalCode }).toEqual({ kind: "exited", exitCode: 0, signalCode: null });
+    },
+    15_000,
+  ); // see the sibling worker test above
 
   test.concurrent("onmessageerror alone does not keep the process alive", async () => {
     const { kind, exitCode, signalCode } = await expectExitsOnItsOwn(`

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -707,9 +707,8 @@ describe("keeps the event loop alive while a message listener is attached", () =
     for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r));
     Bun.gc(true);
     Bun.gc(true);
-    // Unfixed, all 10 listening ports stay pinned. Allow generous slack for
-    // wrappers kept by conservative stack scanning, which does not scale with
-    // the channel count.
+    // Unfixed, all 10 listening ports stay pinned. Allow small slack for GC
+    // nondeterminism, which does not scale with the channel count.
     expect(count() - base).toBeLessThanOrEqual(5);
   }, 60_000);
 });


### PR DESCRIPTION
Fixes #32562

### Repro

```js
import { MessageChannel } from 'node:worker_threads';
const { port1, port2 } = new MessageChannel();
port1.on('message', (message) => console.log('received', message));
port2.postMessage({ foo: 'bar' });
```

Node prints `received { foo: 'bar' }` and keeps the process alive. Bun delivered the message and then exited.

### History

This PR originally implemented MessagePort listener keep-alive and the peer `'close'` event from scratch. PR #31216 then landed a parallel, more complete implementation on main (close events, `CloseKind`, deferred close tasks), which also fixed #32563, and this branch was rescoped on top of it. PR #37075 (the Worker lifetime rework) later absorbed the `onmessageerror` ref fix that used to be part of this PR, so the remaining delta is the one gap that is exactly the #32562 repro: the exact repro above still exits on current main.

### The remaining gap on main, and the fix

**A GC'd port closed its listening peer.** `~MessagePort` tears down via `MessagePortPipe::close(side, CloseKind::Collected)`, and the close worklist notified the entangled peer for every entry, including Collected ones (with a comment calling a `'close'` at GC timing "the lesser evil"). In the repro, collecting the unreferenced `port2` delivered `peerClosed()` to `port1`, which dropped its listener event-loop ref, so the process exited at GC timing. Node never closes a channel because a wrapper was collected.

The fix makes the Collected notification context-aware rather than suppressing it entirely (suppression strands cross-context peers, see below):

- A Collected close notifies the peer only if the peer lives on a **different** context. A same-context peer keeps its event-loop hold, exactly like Node. Cross-context must still notify: once the worker-side port is collected, the worker's teardown has nothing left to close, so a listening main-thread port would hang forever (Node delivers that close at worker exit; collection time is the closest equivalent). Suppressing unconditionally hung `test-worker-workerdata-messageport`.
- The collected side retains its owning context id, and the retroactive re-notify in `attach()`/`registerCloseContext()` (for listeners added later) applies the same rule via a shared `peerRequiresCloseNotification()`, so a second listener added after a same-context sibling was collected keeps its hold, while a listener added after a worker-side port died is still released.
- Explicit closes (`close()`, context teardown, orphaned in-transit ports) notify unconditionally, as before.
- `virtualHasPendingActivity()` treats a merely-collected peer (`Closed` without `ClosedByRequest`) as still open until this port's `close` event has fired, so the listening wrapper stays pinned while it owns the loop ref (review caught that the wrapper could otherwise be swept with the ref still held), yet is collectable again once a cross-context collection delivers `close` and releases the refs (review also caught that an ungated pin leaked the wrapper until context teardown). A test asserts the wrapper is swept after a worker-side collection delivers `close`.

This also fixes the `.onmessage = fn` variant, which lost its hold the same way.

### Verification

Against Node v26.3.0 (debug+ASAN build, rebased on main at e661130391):

| scenario | Node | main | this PR |
| --- | --- | --- | --- |
| `.on('message')`, sender unreferenced (the repro) | alive | exits at GC timing | alive |
| `.onmessage = fn`, sender unreferenced | alive | exits at GC timing | alive |
| worker-side port collected, main listening | exits at worker exit | exits | exits |
| `.onmessageerror` alone | exits | exits (via #37075) | exits |
| #32563 repro (`close` to peer) | `closed!`, exits | works (via #31216) | works |

New tests force `Bun.gc(true)` after dropping the sender so the collected-peer path is deterministic, plus exit contracts (`unref()`, listener removal, `messageerror`-only, both cross-context worker scenarios). The full `message-channel.test.ts` suite (26 tests), the MessagePort leak/lifetime suites (`message-port-pipe`, `message-port-closed-leak`, `message-port-context-destroy-leak`), and the 22 node `test-worker-message-port*` / `test-messagechannel` / `test-worker-workerdata*` parallel tests pass on the rebased branch.

### Rebase notes

Onto main post-#39905 (loop-kind routing for MessagePort posts):

- `attach()` / `registerCloseContext()` now take `ScriptExecutionContext&` and record `ctxLoopKind`; this PR's `peerRequiresCloseNotification(side, ctxId)` calls were re-based on the `ctxId` local those functions already derive from the context. The `scheduleDrain` signature conflict resolved to main's three-argument form. No behavior change from the merge.
- Re-verified on the rebased debug build: repro hangs like Node (3/3), `message-channel` 27/27, `message-port-pipe` 13/13, the MessagePort leak suites plus `test/regression/issue/39900.test.ts` 17/17, node `test-worker-message-port*` / `test-messagechannel` / `test-worker-workerdata*` 22/22.

Onto main post-#37075:

- The only textual conflict was the comment in the `onmessageerror` setter; main now carries that fix, so this PR no longer touches `JSMessagePort.cpp`.
- The two worker-spawning tests got explicit 15s timeouts: worker spawn plus the full #37075 teardown takes seconds under debug/ASAN, and the timeout must outlast the test's deliberate hang-detection window so a real hang fails the assertion instead of the test timer.

<details>
<summary>Superseded earlier description (pre-#37075 rebase)</summary>

Before the rebase this PR also removed the `jsRef()` call from the `onmessageerror` setter (a `messageerror` handler alone pinned the event loop; Node only refs the loop for `'message'` listeners). #37075 shipped the same change on main, so it dropped out of this diff.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 11 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
bun test v1.4.1 (4448a2e21)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [5.87ms]
(pass) transfer message port [26.64ms]
(pass) transfer array buffer [4.83ms]
(node:19934) Warning: The target port was posted to itself, and the communication channel was lost
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) non-transferable [47.27ms]
(pass) transfer message ports and post messages [14.69ms]
(pass) message channel created on main thread [140.64ms]
(pass) message channel created on other thread [136.76ms]
(node:19934) Warning: The target port was posted to itself, and the communication channel was lost
(pass) many message channels [56.83ms]
(pass) gc [93.38ms]
(pass) cloneable and transferable equals [58.70ms]
(pass) cloneable and non-transferable equals (BunFile) [10.76ms]
(pass) cloneable and non-transferable equals (net.BlockList) [157.12ms]
(pass) a pending close event survives GC after the port becomes unreachable [325.43ms]
(pass) a cl
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [0.11ms]
(pass) transfer message port [0.18ms]
(pass) transfer array buffer [0.07ms]
(node:20012) Warning: The target port was posted to itself, and the communication channel was lost
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) non-transferable [0.72ms]
(pass) transfer message ports and post messages [0.18ms]
(pass) message channel created on main thread [4.20ms]
(pass) message channel created on other thread [2.67ms]
(node:20012) Warning: The target port was posted to itself, and the communication channel was lost
(pass) many message channels [0.76ms]
(pass) gc [0.85ms]
(pass) cloneable and transferable equals [1.66ms]
(pass) cloneable and non-transferable equals (BunFile) [0.26ms]
(pass) cloneable and non-transferable equals (net.BlockList) [2.55ms]
(pass) a pending close event survives GC after the port becomes unreachable [7.24ms]
(pass) a close event from the peer survives GC of the unreachable port [2.60ms]
(pass) explicitly-closed close-listener ports are collected; open ones are pinned like Node [9.30ms]
(pass) on('close') 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/web/workers/message-channel.test.ts
bun test v1.4.1 (4448a2e21)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [18.01ms]
(pass) transfer message port [19.28ms]
(pass) transfer array buffer [5.92ms]
(node:20333) Warning: The target port was posted to itself, and the communication channel was lost
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) non-transferable [47.07ms]
(pass) transfer message ports and post messages [14.56ms]
(pass) message channel created on main thread [128.84ms]
(pass) message channel created on other thread [136.65ms]
(node:20333) Warning: The target port was posted to itself, and the communication channel was lost
(pass) many message channels [55.67ms]
(pass) gc [90.29ms]
(pass) cloneable and transferable equals [59.14ms]
(pass) cloneable and non-transferable equals (BunFile) [11.15ms]
(pass) cloneable and non-transferable equals (net.BlockList) [157.95ms]
(pass) a pending close event survives GC after the port becomes unreachable [447.32ms]
(pass) a c
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 640ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/48] cxx obj/src/jsc/bindings/webcore/streams/BunStreamConsumers.cpp.o
[2/48] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[3/48] cxx obj/src/jsc/bindings/webcore/streams/BunAsyncIterableSource.cpp.o
[4/48] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[5/48] cxx obj/src/jsc/bindings/webcore/JSMessageEventCustom.cpp.o
[6/48] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[7/48] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[8/48] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[9/48] cxx obj/src/jsc/bindings/webcore/streams/CrossRealmTransform.cpp.o
[10/48] cxx obj/src/jsc/bindings/webcore/SerializedScriptValue.cpp.o
[11/48] cxx obj/src/jsc/bindings/webcore/streams/BunStreamSource.cpp.o
[12/48] cxx obj/src/jsc/bindings/webcore/streams/JSByteLengthQueuingStrategy.cpp.o
[13/48] cxx obj/src/jsc/bindings/webcore/streams/JSCompressionStream.cpp.o
[14/48] cxx obj/src/jsc/bindings/webcore/streams/JSDecompressionStream.cpp.o
[15/48] cxx obj/src/jsc/bindings/w
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp     |  15 +-
 src/jsc/bindings/webcore/MessagePortPipe.cpp |  46 +++--
 src/jsc/bindings/webcore/MessagePortPipe.h   |  14 +-
 test/js/web/workers/message-channel.test.ts  | 255 +++++++++++++++++++++++++++
 4 files changed, 304 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 7 passed · 0 rejected · iteration 11

<details><summary>evidence per changed file</summary>

```
file                                          reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp         11     21     32
src/jsc/bindings/webcore/MessagePortPipe.cpp     14     20     32
src/jsc/bindings/webcore/MessagePortPipe.h        7     12     32
test/js/web/workers/message-channel.test.ts      15     21     32
```

</details>

**root cause** · written by the author bot

A MessagePort with an attached message listener never took a reference on the event loop, so Bun's loop saw no pending work and the process exited instead of staying alive like Node.js. The fix centralizes the ref bookkeeping in holdEventLoopRef and releaseEventLoopRef, acquiring an event loop ref and a self-ref when the first message listener is attached and releasing them on close, disentangle, or explicit unref. A new peer-close notification path lets a port whose counterpart has closed dispatch a one-shot close event and then release its ref, so ports keep the process alive exactly whil…

<!-- robobun:evidence:end -->
