### PR TITLE
process.exit: don't crash when a native addon's global destructor throws

### DIFF
--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals, non_snake_case)]
 
 use core::ffi::{c_char, c_int};
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 
 use const_format::{concatcp, formatcp};
 
@@ -610,14 +610,25 @@ pub(crate) fn run_exit_callbacks() {
 }
 
 static IS_EXITING: AtomicBool = AtomicBool::new(false);
+static EXIT_CODE: AtomicI32 = AtomicI32::new(0);
 
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn bun_is_exiting() -> c_int {
     is_exiting() as c_int
 }
 
-pub(crate) fn is_exiting() -> bool {
+pub fn is_exiting() -> bool {
     IS_EXITING.load(Ordering::Relaxed)
+}
+
+/// The code passed to [`exit`]. Only meaningful when [`is_exiting`] is true.
+pub fn exit_code() -> c_int {
+    EXIT_CODE.load(Ordering::Relaxed)
+}
+
+#[unsafe(no_mangle)]
+pub(crate) extern "C" fn bun_exit_code() -> c_int {
+    exit_code()
 }
 
 // libc process-termination entry points used by `exit` /
@@ -633,12 +644,19 @@ unsafe extern "C" {
     #[cfg(unix)]
     #[link_name = "exit"]
     safe fn libc_exit(code: c_int) -> !;
+    #[cfg(target_os = "macos")]
+    #[link_name = "_exit"]
+    safe fn libc__exit(code: c_int) -> !;
     #[cfg(all(unix, not(target_os = "macos")))]
     safe fn quick_exit(code: c_int) -> !;
 }
 
 /// Flushes stdout and stderr (in exit/quick_exit callback) and exits with the given code.
 pub fn exit(code: u32) -> ! {
+    // Store the code before setting IS_EXITING so any observer that sees
+    // IS_EXITING also sees the correct code (the std::terminate handler
+    // reads both to decide whether to _Exit cleanly).
+    EXIT_CODE.store(code as i32, Ordering::Relaxed);
     IS_EXITING.store(true, Ordering::Relaxed);
     // MOVE_DOWN: bun_analytics::features → bun_core (move-in pass).
     crate::features::EXITED.fetch_add(1, Ordering::Relaxed);
@@ -657,7 +675,17 @@ pub fn exit(code: u32) -> ! {
 
     #[cfg(target_os = "macos")]
     {
-        libc_exit(code as i32)
+        // ASAN's leak detector runs from an atexit handler, so use full
+        // exit() there. Otherwise match Linux (quick_exit) / Windows
+        // (ExitProcess) and skip global destructors: a native addon's
+        // throwing static destructor would otherwise reach std::terminate
+        // and turn a clean process.exit() into a crash report. macOS libc
+        // has no quick_exit, so run our own at-exit callbacks and _exit.
+        if env::ENABLE_ASAN {
+            libc_exit(code as i32);
+        }
+        Bun__onExit();
+        libc__exit(code as i32);
     }
     #[cfg(windows)]
     {

--- a/src/bun_core/Global.rs
+++ b/src/bun_core/Global.rs
@@ -618,10 +618,15 @@ pub(crate) extern "C" fn bun_is_exiting() -> c_int {
 }
 
 pub fn is_exiting() -> bool {
-    IS_EXITING.load(Ordering::Relaxed)
+    // Acquire pairs with the Release store in `exit()` so a thread that
+    // observes `true` here also observes the `EXIT_CODE` written just
+    // before it. The std::set_terminate handler is process-wide and can
+    // fire on any thread.
+    IS_EXITING.load(Ordering::Acquire)
 }
 
-/// The code passed to [`exit`]. Only meaningful when [`is_exiting`] is true.
+/// The code passed to [`exit`]. Only meaningful after [`is_exiting`] has
+/// returned true (which provides the Acquire edge that makes this visible).
 pub fn exit_code() -> c_int {
     EXIT_CODE.load(Ordering::Relaxed)
 }
@@ -653,11 +658,12 @@ unsafe extern "C" {
 
 /// Flushes stdout and stderr (in exit/quick_exit callback) and exits with the given code.
 pub fn exit(code: u32) -> ! {
-    // Store the code before setting IS_EXITING so any observer that sees
-    // IS_EXITING also sees the correct code (the std::terminate handler
-    // reads both to decide whether to _Exit cleanly).
+    // Publish the code before flipping IS_EXITING. The Release here pairs
+    // with the Acquire load in `is_exiting()`, so a cross-thread observer
+    // (the process-wide std::set_terminate handler may run on any thread)
+    // that sees IS_EXITING == true also sees EXIT_CODE.
     EXIT_CODE.store(code as i32, Ordering::Relaxed);
-    IS_EXITING.store(true, Ordering::Relaxed);
+    IS_EXITING.store(true, Ordering::Release);
     // MOVE_DOWN: bun_analytics::features → bun_core (move-in pass).
     crate::features::EXITED.fetch_add(1, Ordering::Relaxed);
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -278,6 +278,12 @@ export const lsanDoLeakCheck = $newCppFunction("InternalForTesting.cpp", "jsFunc
 
 export const isASANEnabled: () => boolean = $newCppFunction("InternalForTesting.cpp", "jsFunction_isASANEnabled", 0);
 
+export const terminateAtExitForTesting: () => void = $newCppFunction(
+  "InternalForTesting.cpp",
+  "jsFunction_terminateAtExitForTesting",
+  0,
+);
+
 export const BunString_toThreadSafeRefCountDelta: () => number = $newCppFunction(
   "InternalForTesting.cpp",
   "jsFunction_BunString_toThreadSafeRefCountDelta",

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -8,6 +8,8 @@
 #include "webcore/HTTPHeaderMap.h"
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
+#include <cstdlib>
+#include <exception>
 
 #if ASAN_ENABLED
 #include <sanitizer/lsan_interface.h>
@@ -122,6 +124,20 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+// Registers an atexit handler that calls std::terminate(), simulating a native
+// addon whose global destructor throws during libc exit(). This binary is
+// built with -fno-exceptions, so we call std::terminate() directly rather than
+// throwing; the observable behavior (the std::set_terminate handler runs while
+// bun_is_exiting() is true) is the same. Lets the Linux/ASAN lane exercise the
+// terminate handler's is-exiting short-circuit, which a real addon cannot: on
+// Linux an addon links the system libstdc++ and so reaches that runtime's
+// terminate handler, not the one Bun installed in its statically-linked copy.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_terminateAtExitForTesting, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    std::atexit([] { std::terminate(); });
+    return encodedJSUndefined();
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_terminateAtExitForTesting);
 
 }

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -271,6 +271,9 @@ extern "C" unsigned getJSCBytecodeCacheVersion()
 extern "C" void Bun__REPRL__registerFuzzilliFunctions(Zig::GlobalObject*);
 #endif
 
+extern "C" int bun_is_exiting();
+extern "C" int bun_exit_code();
+
 extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(const char* ptr, size_t length), bool evalMode, bool oneShotStartup)
 {
     static std::once_flag jsc_init_flag;
@@ -278,7 +281,18 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
     std::call_once(jsc_init_flag, [evalMode, oneShotStartup, envp, envc, onCrash]() {
         JSC::Config::enableRestrictedOptions();
 
-        std::set_terminate([]() { Zig__GlobalObject__onCrash(); });
+        std::set_terminate([]() {
+            // A global destructor or atexit handler (typically from a native
+            // addon) can throw while libc exit() is tearing the process down.
+            // By that point process.exit() has already committed to a code;
+            // honor it instead of reporting a crash.
+            if (bun_is_exiting()) {
+                fflush(stdout);
+                fflush(stderr);
+                ::_Exit(bun_exit_code());
+            }
+            Zig__GlobalObject__onCrash();
+        });
         WTF::initializeMainThread();
 
         // Use JSC::initialize with a callback to set Options during initialization.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -1,7 +1,7 @@
 import { spawnSync, which } from "bun";
 import { describe, expect, it } from "bun:test";
 import { familySync } from "detect-libc";
-import { bunEnv, bunExe, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isMacOS, isWindows, tempDir, tmpdirSync } from "harness";
 import { basename, join, resolve } from "path";
 
 const process_sleep = resolve(import.meta.dir, "process-sleep.js");
@@ -396,6 +396,38 @@ describe("process.exitCode", () => {
     expect(stdout.toString().trim()).toBe("PASS");
   });
 });
+
+// Sentry BUN-390H: a native addon's global destructor threw during libc exit()
+// after process.exit(), and the std::set_terminate handler turned that into a
+// crash report instead of honoring the requested exit code. On POSIX the atexit
+// callback registered here only runs when the process uses full libc exit(),
+// which after the fix is only the ASAN configuration; release builds skip
+// global destructors via _exit / quick_exit / ExitProcess, making this
+// assertion vacuous there.
+it.skipIf(!isASAN)(
+  "process.exit honors the requested code when std::terminate fires from an atexit handler",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `require("bun:internal-for-testing").terminateAtExitForTesting();` +
+          `console.log("armed");` +
+          `process.exit(42);`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "armed\n", stderr: "", exitCode: 42 });
+    expect(proc.signalCode).toBeNull();
+  },
+);
 
 it("process exitCode range (#6284)", () => {
   const { exitCode, stdout } = spawnSync({

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -419,11 +419,7 @@ it.skipIf(!isASAN)(
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({ stdout: "armed\n", stderr: "", exitCode: 42 });
     expect(proc.signalCode).toBeNull();
   },

--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -132,6 +132,17 @@
             ],
         },
         {
+            "target_name": "throwing_dtor_addon",
+            "sources": ["throwing_dtor_addon.cpp"],
+            "cflags!": ["-fno-exceptions"],
+            "cflags_cc!": ["-fno-exceptions"],
+            "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES" },
+            "msvs_settings": { "VCCLCompilerTool": { "ExceptionHandling": "1" } },
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+        },
+        {
             "target_name": "reentrant_register_addon",
             "sources": ["reentrant_register_addon.cpp"],
             "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],

--- a/test/napi/napi-app/throwing_dtor_addon.cpp
+++ b/test/napi/napi-app/throwing_dtor_addon.cpp
@@ -1,0 +1,17 @@
+// A native addon whose file-scope object throws from its destructor. The
+// destructor runs from __cxa_finalize when libc exit() is used (macOS, and
+// ASAN builds on other POSIX platforms). It models a real-world addon whose
+// teardown fails after the VM has been torn down. Bun should honor the
+// process.exit() code rather than reporting a crash from std::terminate.
+#include <node_api.h>
+
+struct ThrowsOnDestruct {
+  ~ThrowsOnDestruct() noexcept(false) { throw 1; }
+};
+
+static ThrowsOnDestruct instance;
+
+NAPI_MODULE_INIT(/* napi_env env, napi_value exports */) {
+  (void)env;
+  return exports;
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -631,29 +631,18 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
   // instead (which aborts), so this assertion cannot hold there; the
   // terminate-handler guard is exercised separately via bun:internal-for-testing
   // in test/js/node/process/process.test.js.
-  it.skipIf(!isMacOS)(
-    "honors process.exit() code when a native addon's global destructor throws",
-    async () => {
-      const addonPath = join(__dirname, "napi-app", "build", "Debug", "throwing_dtor_addon.node");
-      await using proc = spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `require(${JSON.stringify(addonPath)}); console.log("loaded"); process.exit(42);`,
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "loaded\n", stderr: "", exitCode: 42 });
-      expect(proc.signalCode).toBeNull();
-    },
-  );
+  it.skipIf(!isMacOS)("honors process.exit() code when a native addon's global destructor throws", async () => {
+    const addonPath = join(__dirname, "napi-app", "build", "Debug", "throwing_dtor_addon.node");
+    await using proc = spawn({
+      cmd: [bunExe(), "-e", `require(${JSON.stringify(addonPath)}); console.log("loaded"); process.exit(42);`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: "loaded\n", stderr: "", exitCode: 42 });
+    expect(proc.signalCode).toBeNull();
+  });
 
   it("behaves as expected when performing operations with an exception pending", async () => {
     await checkSameOutput("test_deferred_exceptions", []);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -624,6 +624,37 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     expect(exitCode).toBe(0);
   });
 
+  // Sentry BUN-390H. On macOS, Bun and native addons share the system libc++,
+  // so an exception thrown from an addon's global destructor during libc
+  // exit() reaches Bun's std::set_terminate handler. On Linux, Bun statically
+  // links its C++ runtime and an addon's throw reaches the system libstdc++
+  // instead (which aborts), so this assertion cannot hold there; the
+  // terminate-handler guard is exercised separately via bun:internal-for-testing
+  // in test/js/node/process/process.test.js.
+  it.skipIf(!isMacOS)(
+    "honors process.exit() code when a native addon's global destructor throws",
+    async () => {
+      const addonPath = join(__dirname, "napi-app", "build", "Debug", "throwing_dtor_addon.node");
+      await using proc = spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `require(${JSON.stringify(addonPath)}); console.log("loaded"); process.exit(42);`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "loaded\n", stderr: "", exitCode: 42 });
+      expect(proc.signalCode).toBeNull();
+    },
+  );
+
   it("behaves as expected when performing operations with an exception pending", async () => {
     await checkSameOutput("test_deferred_exceptions", []);
   });


### PR DESCRIPTION
## Crash signature

`panic: A C++ exception occurred` during `process.exit()` on macOS. 92/92 Sentry events are macOS, always with `napi_module_register` + `process_dlopen` in the feature tags. Sentry BUN-390H.

```
Process_functionReallyExit            BunProcess.cpp:3257
Bun__Process__exit                    node_process.zig:308
jsc.VirtualMachine.globalExit         VirtualMachine.zig:995
bun_core.Global.exit                  Global.zig:128
  libc exit -> __cxa_finalize -> addon global dtor -> __cxa_throw
JSCInitialize::$_0                    ZigGlobalObject.cpp:281  (std::set_terminate handler)
Zig__GlobalObject__onCrash            JSGlobalObject.zig:919
```

## Cause

`Global::exit` on macOS called libc `exit()`, which runs atexit handlers and C++ global destructors. Linux uses `quick_exit` and Windows uses `ExitProcess`, both of which skip them; macOS was the only platform running third-party teardown after `process.exit()` had already committed to an exit code. A native addon whose global destructor throws (or calls into a torn-down runtime) reaches `std::terminate`, and the handler installed at `JSCInitialize` turned that into a crash report.

## Fix

- `bun_core::Global::exit` on macOS now runs `Bun__onExit()` and calls `_exit()`, matching the Windows shape. ASAN builds keep full `exit()` so LSan still runs, same as the existing Linux behavior.
- The `std::set_terminate` handler in `ZigGlobalObject.cpp` now checks `bun_is_exiting()` and `_Exit(bun_exit_code())` instead of crashing. This covers the remaining `exit()` users (ASAN builds, or an addon calling `exit()` directly).
- New `EXIT_CODE` atomic alongside `IS_EXITING`, exported as `bun_exit_code()` for the handler.

## Verification

Two tests:

- `test/napi/napi-app/throwing_dtor_addon.cpp` is a native addon with a file-scope object whose destructor throws. `napi.test.ts` loads it and calls `process.exit(42)`, asserting exit code 42. macOS-only: on macOS, Bun and addons share the system libc++ so the addon's throw reaches Bun's terminate handler. On Linux, Bun statically links its C++ runtime while the addon links system libstdc++, so the addon's throw reaches libstdc++'s handler instead and the assertion cannot hold.
- `test/js/node/process/process.test.js` uses a new `bun:internal-for-testing` helper that registers a `std::terminate()` atexit handler inside Bun's own C++ runtime and asserts `process.exit(42)` exits 42. Runs on ASAN builds (the only configuration that still uses full `exit()` after this change) so the Linux gate exercises the terminate-handler short-circuit.

```
$ bun bd test test/js/node/process/process.test.js -t "std::terminate"
(pass) process.exit honors the requested code when std::terminate fires from an atexit handler
```

#30291 addresses a different source of the same panic message (JS exceptions leaking out of napi finalizers during `VirtualMachine.onExit`, before `Global::exit` is reached); this PR addresses C++ exceptions from global destructors during libc `exit()` after `Global::exit`.

## Related

- #30431: the macOS half of that report is this bug (onnxruntime-node's global destructor reaching `std::terminate` after `bun test` finishes). The Linux segfault in the same issue is a separate crash during execution, not addressed here.
- #28557: same panic signature on macOS with a napi addon loaded. #30291 attributes it to a napi finalizer leaking a JSC exception into `VirtualMachine.onExit`; if the throw instead originates from a global destructor after `Global::exit`, this PR covers it. The two fixes are complementary.
