### PR TITLE
Honor absolute paths for heap and CPU profiler --*-dir/--*-name options

### DIFF
--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -115,22 +115,38 @@ fn write_profile_to_file(
     #[cfg(windows)]
     let output_path_os =
         bun_core::strings::convert_utf8_to_utf16_in_buffer_z(&mut path_buf_os, path_buf.slice_z());
-    #[cfg(not(windows))]
-    let output_path_os = path_buf.slice_z();
 
-    // Write the profile to disk using bun.sys.File.writeFile
+    // Write the profile to disk.
+    // `slice_z()` borrows `path_buf` mutably, so on non-Windows we re-derive it
+    // at each call site instead of holding a single binding.
+    #[cfg(windows)]
     let result =
         bun_sys::File::write_file_os_path(Fd::cwd(), output_path_os, profile_slice.slice());
+    #[cfg(not(windows))]
+    let result =
+        bun_sys::File::write_file_os_path(Fd::cwd(), path_buf.slice_z(), profile_slice.slice());
     if let Err(err) = result {
-        // If we got ENOENT, PERM, or ACCES, try creating the directory and retry
+        // If we got ENOENT, PERM, or ACCES, try creating the directory and retry.
         let errno = err.get_errno();
         if errno == Errno::ENOENT || errno == Errno::EPERM || errno == Errno::EACCES {
-            if !config.dir.is_empty() {
-                let _ = Fd::cwd().make_path(config.dir);
+            // Derive the directory from the absolute output path so that a
+            // missing parent of an absolute --cpu-prof-name (not just
+            // --cpu-prof-dir) is created before the retry.
+            let dir_path =
+                bun_paths::resolve_path::dirname::<bun_paths::platform::Auto>(path_buf.slice());
+            if !dir_path.is_empty() {
+                let _ = Fd::cwd().make_path(dir_path);
                 // Retry write
+                #[cfg(windows)]
                 let retry_result = bun_sys::File::write_file_os_path(
                     Fd::cwd(),
                     output_path_os,
+                    profile_slice.slice(),
+                );
+                #[cfg(not(windows))]
+                let retry_result = bun_sys::File::write_file_os_path(
+                    Fd::cwd(),
+                    path_buf.slice_z(),
                     profile_slice.slice(),
                 );
                 if retry_result.is_err() {

--- a/src/jsc/BunCPUProfiler.rs
+++ b/src/jsc/BunCPUProfiler.rs
@@ -178,15 +178,18 @@ fn build_output_path(
         generate_default_filename(&mut filename_buf, is_md_format)?
     };
 
-    // Append directory if specified
+    // Use `join` rather than `append` for both the directory and the filename
+    // so that an absolute `--cpu-prof-dir` or `--cpu-prof-name` is honored:
+    // `append` trims its input as relative to the already-rooted path and
+    // strips the leading separator, whereas `join` resets the accumulated path
+    // when a segment is absolute.
+    // AutoAbsPath uses CheckLength::ASSUME — Err arm is unreachable.
+    // See paths/Path.rs `options::Result` note.
     if !config.dir.is_empty() {
-        // AutoAbsPath uses CheckLength::ASSUME — Err arm is unreachable.
-        // See paths/Path.rs `options::Result` note.
         path.join(&[config.dir]).expect("unreachable");
     }
 
-    // Append filename
-    path.append(filename).expect("unreachable");
+    path.join(&[filename]).expect("unreachable");
 
     Ok(())
 }

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -104,16 +104,17 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
 
-    // Append directory if specified. Use `join` rather than `append` so an
-    // absolute `config.dir` is honored: `append` trims its input as relative
-    // to the already-rooted path and strips the leading separator, whereas
-    // `join` resets the accumulated path when a segment is absolute.
+    // Use `join` rather than `append` for both the directory and the filename
+    // so that an absolute `--heap-prof-dir` or `--heap-prof-name` is honored:
+    // `append` trims its input as relative to the already-rooted path and
+    // strips the leading separator (it also debug-asserts the input is
+    // relative), whereas `join` resets the accumulated path when a segment is
+    // absolute.
     if !config.dir.is_empty() {
         path.join(&[config.dir])?;
     }
 
-    // Append filename
-    path.append(filename)?;
+    path.join(&[filename])?;
     Ok(())
 }
 

--- a/src/jsc/BunHeapProfiler.rs
+++ b/src/jsc/BunHeapProfiler.rs
@@ -104,9 +104,12 @@ fn build_output_path(path: &mut AutoAbsPath, config: &HeapProfilerConfig) -> Res
         generate_default_filename(&mut filename_buf, config.text_format)?
     };
 
-    // Append directory if specified
+    // Append directory if specified. Use `join` rather than `append` so an
+    // absolute `config.dir` is honored: `append` trims its input as relative
+    // to the already-rooted path and strips the leading separator, whereas
+    // `join` resets the accumulated path when a segment is absolute.
     if !config.dir.is_empty() {
-        path.append(config.dir)?;
+        path.join(&[config.dir])?;
     }
 
     // Append filename

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -156,6 +156,35 @@ test("--heap-prof-dir honors an absolute output directory", async () => {
   expect(cwdFiles).toEqual([]);
 });
 
+test("--heap-prof-name honors an absolute path", async () => {
+  // An absolute --heap-prof-name must be written verbatim, not resolved
+  // relative to CWD (which stripped the leading separator).
+  using cwdDir = tempDir("heap-prof-name-abs-cwd", {});
+  using targetDir = tempDir("heap-prof-name-abs-target", {});
+  const target = join(String(targetDir), "custom.heapsnapshot");
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--heap-prof", "--heap-prof-name", target, "-e", `console.log("hello");`],
+    cwd: String(cwdDir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
+  expect(stderr).toContain("Heap profile written to:");
+  expect(exitCode).toBe(0);
+
+  // The snapshot must land at the absolute path.
+  expect(Bun.file(target).size).toBeGreaterThan(0);
+
+  // And nothing should have been written anywhere under CWD.
+  const cwdFiles = Array.from(new Bun.Glob("**/*.heapsnapshot").scanSync({ cwd: String(cwdDir) }));
+  expect(cwdFiles).toEqual([]);
+});
+
 test("--heap-prof-dir specifies output directory for markdown format", async () => {
   using dir = tempDir("heap-prof-md-dir-test", {
     "profiles": {},

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -126,6 +126,36 @@ test("--heap-prof-dir specifies output directory for V8 format", async () => {
   expect(files.length).toBeGreaterThan(0);
 });
 
+test("--heap-prof-dir honors an absolute output directory", async () => {
+  // Two separate directories: one is the CWD, the other is the absolute
+  // target. An absolute --heap-prof-dir must be written to that directory, not
+  // resolved relative to CWD (which stripped the leading separator).
+  using cwdDir = tempDir("heap-prof-abs-cwd", {});
+  using targetDir = tempDir("heap-prof-abs-target", {});
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "--heap-prof", "--heap-prof-dir", String(targetDir), "-e", `console.log("hello");`],
+    cwd: String(cwdDir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe("hello");
+  expect(stderr).toContain("Heap profile written to:");
+  expect(exitCode).toBe(0);
+
+  // The snapshot must land in the absolute target directory.
+  const targetFiles = Array.from(new Bun.Glob("Heap.*.heapsnapshot").scanSync({ cwd: String(targetDir) }));
+  expect(targetFiles.length).toBeGreaterThan(0);
+
+  // And nothing should have been written anywhere under CWD.
+  const cwdFiles = Array.from(new Bun.Glob("**/Heap.*.heapsnapshot").scanSync({ cwd: String(cwdDir) }));
+  expect(cwdFiles).toEqual([]);
+});
+
 test("--heap-prof-dir specifies output directory for markdown format", async () => {
   using dir = tempDir("heap-prof-md-dir-test", {
     "profiles": {},

--- a/test/cli/heap-prof.test.ts
+++ b/test/cli/heap-prof.test.ts
@@ -145,7 +145,6 @@ test("--heap-prof-dir honors an absolute output directory", async () => {
 
   expect(stdout.trim()).toBe("hello");
   expect(stderr).toContain("Heap profile written to:");
-  expect(exitCode).toBe(0);
 
   // The snapshot must land in the absolute target directory.
   const targetFiles = Array.from(new Bun.Glob("Heap.*.heapsnapshot").scanSync({ cwd: String(targetDir) }));
@@ -154,14 +153,18 @@ test("--heap-prof-dir honors an absolute output directory", async () => {
   // And nothing should have been written anywhere under CWD.
   const cwdFiles = Array.from(new Bun.Glob("**/Heap.*.heapsnapshot").scanSync({ cwd: String(cwdDir) }));
   expect(cwdFiles).toEqual([]);
+
+  expect(exitCode).toBe(0);
 });
 
 test("--heap-prof-name honors an absolute path", async () => {
   // An absolute --heap-prof-name must be written verbatim, not resolved
-  // relative to CWD (which stripped the leading separator).
+  // relative to CWD (which stripped the leading separator). The target's
+  // parent directory does not exist yet, so this also covers creating the
+  // parent of an absolute output path.
   using cwdDir = tempDir("heap-prof-name-abs-cwd", {});
   using targetDir = tempDir("heap-prof-name-abs-target", {});
-  const target = join(String(targetDir), "custom.heapsnapshot");
+  const target = join(String(targetDir), "nested", "custom.heapsnapshot");
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "--heap-prof", "--heap-prof-name", target, "-e", `console.log("hello");`],
@@ -175,7 +178,6 @@ test("--heap-prof-name honors an absolute path", async () => {
 
   expect(stdout.trim()).toBe("hello");
   expect(stderr).toContain("Heap profile written to:");
-  expect(exitCode).toBe(0);
 
   // The snapshot must land at the absolute path.
   expect(Bun.file(target).size).toBeGreaterThan(0);
@@ -183,6 +185,8 @@ test("--heap-prof-name honors an absolute path", async () => {
   // And nothing should have been written anywhere under CWD.
   const cwdFiles = Array.from(new Bun.Glob("**/*.heapsnapshot").scanSync({ cwd: String(cwdDir) }));
   expect(cwdFiles).toEqual([]);
+
+  expect(exitCode).toBe(0);
 });
 
 test("--heap-prof-dir specifies output directory for markdown format", async () => {

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -125,6 +125,40 @@ describe.concurrent("--cpu-prof", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("--cpu-prof-name honors an absolute path", async () => {
+    // An absolute --cpu-prof-name must be written verbatim, not resolved
+    // relative to CWD (which stripped the leading separator).
+    using cwdDir = tempDir("cpu-prof-name-abs-cwd", {
+      "test.js": `
+        function loop() {
+          const end = Date.now() + 100;
+          while (Date.now() < end) {}
+        }
+        loop();
+      `,
+    });
+    using targetDir = tempDir("cpu-prof-name-abs-target", {});
+    const target = join(String(targetDir), "custom.cpuprofile");
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "--cpu-prof", "--cpu-prof-name", target, "test.js"],
+      cwd: String(cwdDir),
+      env: bunEnv,
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+
+    const exitCode = await proc.exited;
+
+    // The profile must land at the absolute path.
+    expect(Bun.file(target).size).toBeGreaterThan(0);
+
+    // And nothing should have been written anywhere under CWD.
+    const cwdFiles = Array.from(new Bun.Glob("**/*.cpuprofile").scanSync({ cwd: String(cwdDir) }));
+    expect(cwdFiles).toEqual([]);
+    expect(exitCode).toBe(0);
+  });
+
   test("--cpu-prof-dir sets custom directory", async () => {
     using dir = tempDir("cpu-prof-dir", {
       "test.js": `

--- a/test/cli/run/cpu-prof.test.ts
+++ b/test/cli/run/cpu-prof.test.ts
@@ -127,7 +127,9 @@ describe.concurrent("--cpu-prof", () => {
 
   test("--cpu-prof-name honors an absolute path", async () => {
     // An absolute --cpu-prof-name must be written verbatim, not resolved
-    // relative to CWD (which stripped the leading separator).
+    // relative to CWD (which stripped the leading separator). The target's
+    // parent directory does not exist yet, so this also covers creating the
+    // parent of an absolute output path.
     using cwdDir = tempDir("cpu-prof-name-abs-cwd", {
       "test.js": `
         function loop() {
@@ -138,7 +140,7 @@ describe.concurrent("--cpu-prof", () => {
       `,
     });
     using targetDir = tempDir("cpu-prof-name-abs-target", {});
-    const target = join(String(targetDir), "custom.cpuprofile");
+    const target = join(String(targetDir), "nested", "custom.cpuprofile");
 
     await using proc = Bun.spawn({
       cmd: [bunExe(), "--cpu-prof", "--cpu-prof-name", target, "test.js"],


### PR DESCRIPTION
Fixes #32568

### What

An absolute `--heap-prof-dir` was resolved relative to the current working directory: the leading separator was stripped and the snapshot landed under `$CWD` instead of the given directory. The same bug affected `--heap-prof-name` and the CPU profiler's `--cpu-prof-name` (an absolute name stripped its leading separator in release and tripped a `debug_assert` in debug builds). `--cpu-prof-dir` was already handled correctly.

### Repro

```sh
mkdir -p /tmp/abs-heap-target
cd /some/other/dir
bun --heap-prof --heap-prof-dir=/tmp/abs-heap-target -e 'globalThis.__x = new Array(10000).fill({x:1})'
# Heap profile written to: /some/other/dir/tmp/abs-heap-target/Heap.….heapsnapshot
#                          ^^^^^^^^^^^^^^^ leading "/" stripped, resolved under CWD
```

Expected the file in `/tmp/abs-heap-target`; it was written to `$CWD/tmp/abs-heap-target`.

### Cause

`build_output_path` appended the directory and filename onto a path already rooted at CWD (`AutoAbsPath::init_top_level_dir()`):

```rust
path.append(config.dir)?;
path.append(filename)?;
```

For a rooted absolute `Path`, `Path::append` trims its input as **relative** and strips the leading separator (it even `debug_assert!(!is_input_absolute(input))`s, so an absolute segment here is misuse). `Path::join` resets the accumulated path when a segment is absolute, which is the behavior that was already used for `--cpu-prof-dir`.

### Fix

Use `Path::join` instead of `Path::append` for both the directory and the filename, in both `src/jsc/BunHeapProfiler.rs` and `src/jsc/BunCPUProfiler.rs`. Absolute `--heap-prof-dir` / `--heap-prof-name` / `--cpu-prof-name` are now honored; relative values still resolve under CWD.

### Verification

`test/cli/heap-prof.test.ts` and `test/cli/run/cpu-prof.test.ts` gain cases that run from one directory and write to a separate absolute `--*-dir` / `--*-name`, asserting the profile lands at the absolute target and nothing is written under CWD. They fail before this change (under a debug build the stripped-absolute `append` trips the `debug_assert` at `src/paths/Path.rs:961`) and pass after. The existing relative-path tests still pass.