### PR TITLE
Deliver buffered IPC messages on the forked child's startup turn

### DIFF
--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -146,6 +146,9 @@ extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_re
 
 /* Loop related */
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events);
+/* Non-zero while a socket on_data dispatch still holds unconsumed bytes in the
+ * shared recv_buf; callers that would recv into recv_buf re-entrantly must defer. */
+int us_internal_recv_buf_is_busy(void);
 void us_internal_timer_sweep(us_loop_r loop);
 void us_internal_enable_sweep_timer(struct us_loop_t *loop);
 void us_internal_disable_sweep_timer(struct us_loop_t *loop);

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -624,6 +624,9 @@ int us_socket_set_tos(us_socket_r s, int tos);
 int us_socket_get_tos(us_socket_r s);
 void us_socket_resume(us_socket_r s);
 void us_socket_pause(us_socket_r s);
+/* Dispatch a readable event now for bytes already buffered on the socket.
+ * No-op when nothing is buffered (MSG_DONTWAIT) or under libuv/Windows. */
+void us_socket_ipc_recv_pending(us_socket_r s);
 
 #ifdef __cplusplus
 }

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -369,6 +369,18 @@ void us_internal_loop_post(struct us_loop_t *loop) {
 #define us_ioctl ioctl
 #endif
 
+/* Re-entrancy guard for the shared per-loop recv_buf. Set while a POSIX socket
+ * on_data dispatch still holds unconsumed bytes in recv_buf: a handler can drain
+ * microtasks (e.g. Bun's HTTP/WS request path), and an IPC eager-drain
+ * (us_socket_ipc_recv_pending) scheduled as a microtask would then recv into the
+ * same recv_buf and clobber the outer frame's bytes. Bun runs one uws loop per
+ * thread, so thread-local tracks per-loop state. */
+static __thread int us_internal_recv_buf_in_use = 0;
+
+int us_internal_recv_buf_is_busy(void) {
+    return us_internal_recv_buf_in_use;
+}
+
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events) {
     switch (us_internal_poll_type(p)) {
     case POLL_TYPE_CALLBACK: {
@@ -622,8 +634,15 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     #endif
 
                     if (length > 0) {
+                        /* recv_buf holds this frame's bytes across the handler,
+                         * which may drain microtasks; block a re-entrant
+                         * recv into recv_buf until we return. Save/restore to
+                         * stay correct under any nesting. */
+                        int prev_recv_buf_in_use = us_internal_recv_buf_in_use;
+                        us_internal_recv_buf_in_use = 1;
                         s = s->ssl ? us_internal_ssl_on_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length)
                                    : us_dispatch_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length);
+                        us_internal_recv_buf_in_use = prev_recv_buf_in_use;
                         /* After socket adoption, track the new socket; the old one becomes invalid */
                         if(s && s->flags.adopted && s->prev) {
                             s = s->prev;
@@ -791,7 +810,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     bsd_udp_setup_recvbuf(&recvbuf, u->loop->data.recv_buf, LIBUS_RECV_BUFFER_LENGTH);
                     int npackets = bsd_recvmmsg(us_poll_fd(p), &recvbuf, MSG_DONTWAIT);
                     if (npackets > 0) {
+                        /* recvbuf aliases the shared recv_buf; guard it against a
+                         * re-entrant recv while on_data may drain microtasks. */
+                        int prev_recv_buf_in_use = us_internal_recv_buf_in_use;
+                        us_internal_recv_buf_in_use = 1;
                         u->on_data(u, &recvbuf, npackets);
+                        us_internal_recv_buf_in_use = prev_recv_buf_in_use;
                     } else {
                         if (npackets == LIBUS_SOCKET_ERROR) {
                             if (!bsd_would_block()) {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -369,16 +369,25 @@ void us_internal_loop_post(struct us_loop_t *loop) {
 #define us_ioctl ioctl
 #endif
 
-/* Re-entrancy guard for the shared per-loop recv_buf. Set while a POSIX socket
- * on_data dispatch still holds unconsumed bytes in recv_buf: a handler can drain
- * microtasks (e.g. Bun's HTTP/WS request path), and an IPC eager-drain
- * (us_socket_ipc_recv_pending) scheduled as a microtask would then recv into the
- * same recv_buf and clobber the outer frame's bytes. Bun runs one uws loop per
- * thread, so thread-local tracks per-loop state. */
+/* Set while a socket/UDP on_data dispatch still holds bytes in the shared
+ * per-loop recv_buf, so a re-entrant IPC drain does not clobber them. One uws
+ * loop per thread, so thread-local tracks per-loop state. */
 static __thread int us_internal_recv_buf_in_use = 0;
 
 int us_internal_recv_buf_is_busy(void) {
     return us_internal_recv_buf_in_use;
+}
+
+/* Bracket an on_data dispatch that reads into recv_buf; save/restore to stay
+ * correct under nesting. */
+static inline int us_internal_recv_buf_guard_enter(void) {
+    int prev = us_internal_recv_buf_in_use;
+    us_internal_recv_buf_in_use = 1;
+    return prev;
+}
+
+static inline void us_internal_recv_buf_guard_leave(int prev) {
+    us_internal_recv_buf_in_use = prev;
 }
 
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events) {
@@ -634,15 +643,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     #endif
 
                     if (length > 0) {
-                        /* recv_buf holds this frame's bytes across the handler,
-                         * which may drain microtasks; block a re-entrant
-                         * recv into recv_buf until we return. Save/restore to
-                         * stay correct under any nesting. */
-                        int prev_recv_buf_in_use = us_internal_recv_buf_in_use;
-                        us_internal_recv_buf_in_use = 1;
+                        int prev_recv_buf_in_use = us_internal_recv_buf_guard_enter();
                         s = s->ssl ? us_internal_ssl_on_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length)
                                    : us_dispatch_data(s, loop->data.recv_buf + LIBUS_RECV_BUFFER_PADDING, length);
-                        us_internal_recv_buf_in_use = prev_recv_buf_in_use;
+                        us_internal_recv_buf_guard_leave(prev_recv_buf_in_use);
                         /* After socket adoption, track the new socket; the old one becomes invalid */
                         if(s && s->flags.adopted && s->prev) {
                             s = s->prev;
@@ -810,12 +814,9 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     bsd_udp_setup_recvbuf(&recvbuf, u->loop->data.recv_buf, LIBUS_RECV_BUFFER_LENGTH);
                     int npackets = bsd_recvmmsg(us_poll_fd(p), &recvbuf, MSG_DONTWAIT);
                     if (npackets > 0) {
-                        /* recvbuf aliases the shared recv_buf; guard it against a
-                         * re-entrant recv while on_data may drain microtasks. */
-                        int prev_recv_buf_in_use = us_internal_recv_buf_in_use;
-                        us_internal_recv_buf_in_use = 1;
+                        int prev_recv_buf_in_use = us_internal_recv_buf_guard_enter();
                         u->on_data(u, &recvbuf, npackets);
-                        us_internal_recv_buf_in_use = prev_recv_buf_in_use;
+                        us_internal_recv_buf_guard_leave(prev_recv_buf_in_use);
                     } else {
                         if (npackets == LIBUS_SOCKET_ERROR) {
                             if (!bsd_would_block()) {

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -453,6 +453,25 @@ struct us_socket_t *us_socket_from_fd(struct us_socket_group_t *group, unsigned 
 #endif
 }
 
+/* Eagerly dispatch any bytes already sitting in the socket's receive buffer by
+ * running the readable handler now, instead of waiting for the next epoll
+ * iteration. The POLL_TYPE_SOCKET handler reads with MSG_DONTWAIT and tolerates
+ * EWOULDBLOCK, so this is a no-op when nothing is buffered.
+ *
+ * Used for inherited IPC channels on child startup: a message the parent queued
+ * before the child attached its listener is delivered on the first tick rather
+ * than one event-loop iteration later, matching Node. */
+void us_socket_ipc_recv_pending(struct us_socket_t *s) {
+#if defined(LIBUS_USE_LIBUV) || defined(WIN32)
+    (void) s;
+#else
+    if (us_socket_is_closed(s) || us_socket_is_shut_down(s)) {
+        return;
+    }
+    us_internal_dispatch_ready_poll((struct us_poll_t *) s, 0, 0, LIBUS_SOCKET_READABLE);
+#endif
+}
+
 void *us_socket_get_native_handle(struct us_socket_t *s) {
     if (s->ssl) {
         return us_internal_ssl_get_native_handle(s);

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -453,14 +453,9 @@ struct us_socket_t *us_socket_from_fd(struct us_socket_group_t *group, unsigned 
 #endif
 }
 
-/* Eagerly dispatch any bytes already sitting in the socket's receive buffer by
- * running the readable handler now, instead of waiting for the next epoll
- * iteration. The POLL_TYPE_SOCKET handler reads with MSG_DONTWAIT and tolerates
- * EWOULDBLOCK, so this is a no-op when nothing is buffered.
- *
- * Used for inherited IPC channels on child startup: a message the parent queued
- * before the child attached its listener is delivered on the first tick rather
- * than one event-loop iteration later, matching Node. */
+/* Dispatch a readable event now for bytes already buffered, so an inherited IPC
+ * channel delivers a pre-startup message on the first tick. No-op when nothing
+ * is buffered (the read uses MSG_DONTWAIT). */
 void us_socket_ipc_recv_pending(struct us_socket_t *s) {
 #if defined(LIBUS_USE_LIBUV) || defined(WIN32)
     (void) s;
@@ -468,10 +463,8 @@ void us_socket_ipc_recv_pending(struct us_socket_t *s) {
     if (us_socket_is_closed(s) || us_socket_is_shut_down(s)) {
         return;
     }
-    /* This recv would reuse the shared recv_buf. If another socket's on_data is
-     * still on the stack (it drained microtasks, which ran us here), recv'ing now
-     * would clobber the bytes that frame has not consumed yet. Leave them for the
-     * next poll in that case; delivery is just deferred, not lost. */
+    /* Skip if a socket on_data is still on the stack (it drained microtasks into
+     * us): recv'ing would clobber recv_buf. The bytes wait for the next poll. */
     if (us_internal_recv_buf_is_busy()) {
         return;
     }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -468,6 +468,13 @@ void us_socket_ipc_recv_pending(struct us_socket_t *s) {
     if (us_socket_is_closed(s) || us_socket_is_shut_down(s)) {
         return;
     }
+    /* This recv would reuse the shared recv_buf. If another socket's on_data is
+     * still on the stack (it drained microtasks, which ran us here), recv'ing now
+     * would clobber the bytes that frame has not consumed yet. Leave them for the
+     * next poll in that case; delivery is just deferred, not lost. */
+    if (us_internal_recv_buf_is_busy()) {
+        return;
+    }
     us_internal_dispatch_ready_poll((struct us_poll_t *) s, 0, 0, LIBUS_SOCKET_READABLE);
 #endif
 }

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2798,6 +2798,10 @@ pub enum IPCInstanceUnion {
     Waiting {
         fd: bun_sys::Fd,
         mode: crate::ipc::Mode,
+        /// Set when `NODE_UNIQUE_ID` was inherited, i.e. this is a
+        /// `node:cluster` worker. Captured at env-parse time because the
+        /// cluster module deletes the variable during its own setup.
+        cluster_worker: bool,
     },
     Initialized(*mut IPCInstance),
 }
@@ -2894,6 +2898,8 @@ impl IPCInstance {
 unsafe extern "C" {
     safe fn Process__emitMessageEvent(global: &JSGlobalObject, value: JSValue, handle: JSValue);
     safe fn Process__emitDisconnectEvent(global: &JSGlobalObject);
+    #[cfg(not(windows))]
+    safe fn Process__hasMessageListeners(global: &JSGlobalObject) -> bool;
 }
 
 /// `IPC.SendQueue` owner dispatch for the child-side `IPCInstance`. Mirrors
@@ -3238,6 +3244,11 @@ impl VirtualMachine {
                 .map(|i| map.map.swap_remove_at(i).1)
                 .and_then(|v| crate::ipc::Mode::from_string(&v.value))
                 .unwrap_or(crate::ipc::Mode::Json);
+            // `node:cluster` workers inherit `NODE_UNIQUE_ID`. Capture it here:
+            // the cluster module deletes the variable during its own setup, and
+            // its internal handshake must not be disturbed by the startup drain.
+            // Check presence only (cluster reads it from `process.env` in JS).
+            let cluster_worker = map.map.get_index(b"NODE_UNIQUE_ID").is_some();
             // Accept only
             // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
             // Parsing as `u32` then `as i32` would silently wrap values in
@@ -3246,7 +3257,7 @@ impl VirtualMachine {
                 .ok()
                 .filter(|&n| n >= 0)
             {
-                Some(fd) => self.init_ipc_instance(bun_sys::Fd::from_uv(fd), mode),
+                Some(fd) => self.init_ipc_instance(bun_sys::Fd::from_uv(fd), mode, cluster_worker),
                 None => bun_core::warn!(
                     "Failed to parse IPC channel number '{}'",
                     bstr::BStr::new(&fd_s[..])
@@ -6401,17 +6412,28 @@ impl VirtualMachine {
     }
 
     /// Records the inherited IPC fd/mode in the waiting state until JS attaches a listener.
-    pub fn init_ipc_instance(&mut self, fd: bun_sys::Fd, mode: crate::ipc::Mode) {
+    pub fn init_ipc_instance(&mut self, fd: bun_sys::Fd, mode: crate::ipc::Mode, cluster_worker: bool) {
         bun_core::scoped_log!(IPC, "initIPCInstance {:?}", fd);
-        self.ipc = Some(IPCInstanceUnion::Waiting { fd, mode });
+        self.ipc = Some(IPCInstanceUnion::Waiting {
+            fd,
+            mode,
+            cluster_worker,
+        });
     }
 
     /// Returns the initialized IPC instance, lazily creating it from the waiting fd/mode.
     pub fn get_ipc_instance(&mut self) -> Option<*mut IPCInstance> {
-        let (fd, mode) = match self.ipc.as_ref()? {
+        let (fd, mode, cluster_worker) = match self.ipc.as_ref()? {
             IPCInstanceUnion::Initialized(inst) => return Some(*inst),
-            IPCInstanceUnion::Waiting { fd, mode } => (*fd, *mode),
+            IPCInstanceUnion::Waiting {
+                fd,
+                mode,
+                cluster_worker,
+            } => (*fd, *mode, *cluster_worker),
         };
+        // Only the non-Windows startup-drain path reads this.
+        #[cfg(windows)]
+        let _ = cluster_worker;
 
         bun_core::scoped_log!(IPC, "getIPCInstance {:?}", fd);
 
@@ -6542,9 +6564,14 @@ impl VirtualMachine {
         // like Node, instead of one event-loop iteration later. Deferred rather
         // than read inline so the `message` handler never fires synchronously
         // from inside `process.on(...)` / `process.send(...)`.
+        //
+        // Skip cluster workers: their internal handshake runs on its own message
+        // protocol during bootstrap and must not be reordered by an early drain.
         #[cfg(not(windows))]
-        self.global()
-            .queue_microtask_callback(instance, ipc_drain_pending_microtask);
+        if !cluster_worker {
+            self.global()
+                .queue_microtask_callback(instance, ipc_drain_pending_microtask);
+        }
 
         Some(instance)
     }
@@ -6570,6 +6597,16 @@ unsafe extern "C" fn ipc_drain_pending_microtask(ctx: *mut core::ffi::c_void) {
     // SAFETY: scheduled during the same synchronous turn that created
     // `instance`; the microtask checkpoint runs at the end of that turn, before
     // the event loop could close the channel and free the instance.
+    // Reading a message with no `message` listener attached would decode and
+    // then drop it (`Process__emitMessageEvent` no-ops without a listener). The
+    // channel is also adopted lazily from `process.send()`, so a child that
+    // sends first and attaches its listener after an async gap would have the
+    // buffered message consumed here before the listener exists. Only drain
+    // when a listener is present; otherwise leave the bytes for the normal poll.
+    if !Process__hasMessageListeners(JSGlobalObject::opaque_ref(unsafe { (*instance).global_this }))
+    {
+        return;
+    }
     let socket = match unsafe { &(*instance).data.socket } {
         crate::ipc::SocketUnion::Open(s) => *s,
         _ => return,

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6535,6 +6535,17 @@ impl VirtualMachine {
         // SAFETY: `instance` is the live boxed IPCInstance.
         unsafe { (*instance).data.write_version_packet(self.global()) };
 
+        // A message the parent queued before this child attached its listener
+        // is already sitting in the socket's receive buffer. Drain it on the
+        // first microtask checkpoint (before the event loop's first poll, hence
+        // before `setImmediate`) so it is observed on the child's startup turn
+        // like Node, instead of one event-loop iteration later. Deferred rather
+        // than read inline so the `message` handler never fires synchronously
+        // from inside `process.on(...)` / `process.send(...)`.
+        #[cfg(not(windows))]
+        self.global()
+            .queue_microtask_callback(instance, ipc_drain_pending_microtask);
+
         Some(instance)
     }
 
@@ -6547,6 +6558,23 @@ impl VirtualMachine {
     pub fn bust_dir_cache(&mut self, path: &[u8]) -> bool {
         self.transpiler.resolver.bust_dir_cache(path)
     }
+}
+
+/// Microtask thunk for [`VirtualMachine::get_ipc_instance`]: drain any IPC
+/// bytes the parent buffered before this child attached, delivering them on the
+/// startup turn. `ctx` is the `*mut IPCInstance` stored in `vm.ipc`; it is owned
+/// by the VM and must not be freed here.
+#[cfg(not(windows))]
+unsafe extern "C" fn ipc_drain_pending_microtask(ctx: *mut core::ffi::c_void) {
+    let instance = ctx.cast::<IPCInstance>();
+    // SAFETY: scheduled during the same synchronous turn that created
+    // `instance`; the microtask checkpoint runs at the end of that turn, before
+    // the event loop could close the channel and free the instance.
+    let socket = match unsafe { &(*instance).data.socket } {
+        crate::ipc::SocketUnion::Open(s) => *s,
+        _ => return,
+    };
+    socket.ipc_recv_pending();
 }
 
 fn is_error_like(global_object: &JSGlobalObject, reason: JSValue) -> JsResult<bool> {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6412,7 +6412,12 @@ impl VirtualMachine {
     }
 
     /// Records the inherited IPC fd/mode in the waiting state until JS attaches a listener.
-    pub fn init_ipc_instance(&mut self, fd: bun_sys::Fd, mode: crate::ipc::Mode, cluster_worker: bool) {
+    pub fn init_ipc_instance(
+        &mut self,
+        fd: bun_sys::Fd,
+        mode: crate::ipc::Mode,
+        cluster_worker: bool,
+    ) {
         bun_core::scoped_log!(IPC, "initIPCInstance {:?}", fd);
         self.ipc = Some(IPCInstanceUnion::Waiting {
             fd,
@@ -6603,8 +6608,9 @@ unsafe extern "C" fn ipc_drain_pending_microtask(ctx: *mut core::ffi::c_void) {
     // sends first and attaches its listener after an async gap would have the
     // buffered message consumed here before the listener exists. Only drain
     // when a listener is present; otherwise leave the bytes for the normal poll.
-    if !Process__hasMessageListeners(JSGlobalObject::opaque_ref(unsafe { (*instance).global_this }))
-    {
+    if !Process__hasMessageListeners(JSGlobalObject::opaque_ref(unsafe {
+        (*instance).global_this
+    })) {
         return;
     }
     let socket = match unsafe { &(*instance).data.socket } {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3244,12 +3244,9 @@ impl VirtualMachine {
                 .map(|i| map.map.swap_remove_at(i).1)
                 .and_then(|v| crate::ipc::Mode::from_string(&v.value))
                 .unwrap_or(crate::ipc::Mode::Json);
-            // `node:cluster` workers inherit `NODE_UNIQUE_ID`. Capture it here:
-            // the cluster module deletes the variable during its own setup, and
-            // its internal handshake must not be disturbed by the startup drain.
-            // Match the module's own truthiness check (`if (NODE_UNIQUE_ID)`): an
-            // empty value does not start the worker handshake, so do not treat it
-            // as a cluster worker.
+            // `node:cluster` workers inherit `NODE_UNIQUE_ID` (captured here; the
+            // module deletes it during setup). Match its truthy check so an empty
+            // value is not treated as a worker (see the drain skip below).
             let cluster_worker = map.get(b"NODE_UNIQUE_ID").is_some_and(|v| !v.is_empty());
             // Accept only
             // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
@@ -6564,16 +6561,9 @@ impl VirtualMachine {
         // SAFETY: `instance` is the live boxed IPCInstance.
         unsafe { (*instance).data.write_version_packet(self.global()) };
 
-        // A message the parent queued before this child attached its listener
-        // is already sitting in the socket's receive buffer. Drain it on the
-        // first microtask checkpoint (before the event loop's first poll, hence
-        // before `setImmediate`) so it is observed on the child's startup turn
-        // like Node, instead of one event-loop iteration later. Deferred rather
-        // than read inline so the `message` handler never fires synchronously
-        // from inside `process.on(...)` / `process.send(...)`.
-        //
-        // Skip cluster workers: their internal handshake runs on its own message
-        // protocol during bootstrap and must not be reordered by an early drain.
+        // Deliver a pre-startup message on the first microtask checkpoint (before
+        // `setImmediate`) like Node; deferred so `message` never fires inline from
+        // process.on/send. Cluster workers skip it (their handshake must not reorder).
         #[cfg(not(windows))]
         if !cluster_worker {
             self.global()
@@ -6594,22 +6584,17 @@ impl VirtualMachine {
     }
 }
 
-/// Microtask thunk for [`VirtualMachine::get_ipc_instance`]: drain any IPC
-/// bytes the parent buffered before this child attached, delivering them on the
-/// startup turn. `ctx` is the `*mut IPCInstance` stored in `vm.ipc`; it is owned
-/// by the VM and must not be freed here.
+/// Microtask thunk for [`VirtualMachine::get_ipc_instance`]: drain IPC bytes the
+/// parent buffered before this child attached. `ctx` is the VM-owned
+/// `*mut IPCInstance` from `vm.ipc`; do not free it here.
 #[cfg(not(windows))]
 unsafe extern "C" fn ipc_drain_pending_microtask(ctx: *mut core::ffi::c_void) {
     let instance = ctx.cast::<IPCInstance>();
-    // SAFETY: scheduled during the same synchronous turn that created
-    // `instance`; the microtask checkpoint runs at the end of that turn, before
-    // the event loop could close the channel and free the instance.
-    // Reading a message with no `message` listener attached would decode and
-    // then drop it (`Process__emitMessageEvent` no-ops without a listener). The
-    // channel is also adopted lazily from `process.send()`, so a child that
-    // sends first and attaches its listener after an async gap would have the
-    // buffered message consumed here before the listener exists. Only drain
-    // when a listener is present; otherwise leave the bytes for the normal poll.
+    // Only drain with a `message` listener present: otherwise the decoded message
+    // is dropped (emit no-ops), and on the lazy `process.send()` adopt path we
+    // would consume it before a listener attaches. Leave it for the poll instead.
+    // SAFETY: scheduled in the turn that created `instance`; the microtask runs
+    // before the loop can close the channel and free it.
     if !Process__hasMessageListeners(JSGlobalObject::opaque_ref(unsafe {
         (*instance).global_this
     })) {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3247,8 +3247,10 @@ impl VirtualMachine {
             // `node:cluster` workers inherit `NODE_UNIQUE_ID`. Capture it here:
             // the cluster module deletes the variable during its own setup, and
             // its internal handshake must not be disturbed by the startup drain.
-            // Check presence only (cluster reads it from `process.env` in JS).
-            let cluster_worker = map.map.get_index(b"NODE_UNIQUE_ID").is_some();
+            // Match the module's own truthiness check (`if (NODE_UNIQUE_ID)`): an
+            // empty value does not start the worker handshake, so do not treat it
+            // as a cluster worker.
+            let cluster_worker = map.get(b"NODE_UNIQUE_ID").is_some_and(|v| !v.is_empty());
             // Accept only
             // non-negative values that fit in i31 (i.e. `0..=i32::MAX`).
             // Parsing as `u32` then `as i32` would silently wrap values in

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -4366,6 +4366,13 @@ extern "C" void Process__emitMessageEvent(Zig::GlobalObject* global, EncodedJSVa
     }
 }
 
+extern "C" bool Process__hasMessageListeners(Zig::GlobalObject* global)
+{
+    auto* process = global->processObject();
+    auto& vm = JSC::getVM(global);
+    return process->wrapped().hasEventListeners(vm.propertyNames->message);
+}
+
 extern "C" void Process__emitDisconnectEvent(Zig::GlobalObject* global)
 {
     auto* process = global->processObject();

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -514,6 +514,17 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
+    /// Dispatch a readable event now for bytes already buffered on the socket.
+    /// No-op when nothing is buffered or under libuv/Windows.
+    pub fn ipc_recv_pending(&self) {
+        on_socket!(self.socket;
+            connected s => s.ipc_recv_pending(),
+            duplex _d => {},
+            pipe _p => {},
+            else => {},
+        )
+    }
+
     pub fn set_no_delay(&self, enabled: bool) -> bool {
         match self.socket {
             InternalSocket::Connected(s) => {

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -72,6 +72,14 @@ impl us_socket_t {
         c::us_socket_resume(self);
     }
 
+    /// Dispatch a readable event now for bytes already buffered on the socket,
+    /// instead of waiting for the next event-loop poll. No-op when nothing is
+    /// buffered (the read path uses `MSG_DONTWAIT`).
+    pub fn ipc_recv_pending(&mut self) {
+        bun_core::scoped_log!(uws, "us_socket_ipc_recv_pending({:p})", self);
+        c::us_socket_ipc_recv_pending(self);
+    }
+
     pub fn close(&mut self, code: CloseCode) {
         bun_core::scoped_log!(
             uws,
@@ -549,6 +557,7 @@ mod c {
         ) -> *mut us_socket_t;
         pub(super) safe fn us_socket_pause(s: &mut us_socket_t);
         pub(super) safe fn us_socket_resume(s: &mut us_socket_t);
+        pub(super) safe fn us_socket_ipc_recv_pending(s: &mut us_socket_t);
         pub(super) fn us_socket_close(
             s: *mut us_socket_t,
             code: CloseCode,

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -1,7 +1,7 @@
 import { semver, write } from "bun";
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, nodeExe, runBunInstall, shellExe, tempDir, tmpdirSync } from "harness";
 import { ChildProcess, exec, execFile, execFileSync, execSync, fork, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { promisify } from "node:util";
@@ -857,4 +857,40 @@ console.log(JSON.stringify({ uid: process.getuid(), threwCode: thrown?.code, thr
     const r = spawnSync("cmd.exe", ["/c", "exit 0"], { gid: 0 });
     expect(r.error?.code).toBe("ENOTSUP");
   });
+});
+
+// https://github.com/oven-sh/bun/issues/32567
+// A message the parent sends before the forked child has attached its listener
+// sits in the IPC pipe buffer until the child adopts the channel. It must be
+// delivered on the child's startup turn (before the first setImmediate runs),
+// matching Node, rather than one event-loop iteration later.
+it.skipIf(isWindows)("fork: a message queued before the child is ready is delivered before setImmediate", async () => {
+  using dir = tempDir("fork-ipc-startup-order", {
+    "child.js": `
+      let immediateFired = false;
+      setImmediate(() => {
+        immediateFired = true;
+      });
+      process.on("message", message => {
+        process.send({ immediateFired, received: message });
+      });
+    `,
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<any>();
+  const child = fork(path.join(String(dir), "child.js"), { env: bunEnv });
+  child.once("message", resolve);
+  child.once("error", reject);
+  child.once("exit", code => reject(new Error(`child exited before replying (code ${code})`)));
+
+  // Sent before the child has booted and attached its listener.
+  child.send({ hello: "world" });
+
+  try {
+    const message = await promise;
+    expect(message).toEqual({ immediateFired: false, received: { hello: "world" } });
+  } finally {
+    if (child.connected) child.disconnect();
+    child.kill();
+  }
 });

--- a/test/js/node/child_process/child_process.test.ts
+++ b/test/js/node/child_process/child_process.test.ts
@@ -894,3 +894,50 @@ it.skipIf(isWindows)("fork: a message queued before the child is ready is delive
     child.kill();
   }
 });
+
+// https://github.com/oven-sh/bun/issues/32567
+// The IPC channel is adopted lazily from process.send() too, so a child that
+// sends first and attaches its 'message' listener after an async gap must not
+// have the parent's buffered message consumed (and dropped) before the listener
+// exists. The message must survive until the listener attaches, matching Node.
+it.skipIf(isWindows)("fork: a buffered message survives when the child sends before it listens", async () => {
+  using dir = tempDir("fork-ipc-send-first", {
+    "child.js": `
+      // Adopt the channel via send() before any 'message' listener exists.
+      process.send({ stage: "booting" });
+      setImmediate(() => {
+        process.on("message", message => {
+          process.send({ echo: message.seq });
+        });
+        process.send({ stage: "listening" });
+      });
+    `,
+  });
+
+  const { promise, resolve, reject } = Promise.withResolvers<number[]>();
+  const child = fork(path.join(String(dir), "child.js"), { env: bunEnv });
+  const echoes: number[] = [];
+  child.on("message", (m: any) => {
+    if (m.stage === "listening") {
+      // Sentinel sent only after the child is listening, so it is never subject
+      // to the startup drain.
+      child.send({ seq: 2 });
+    } else if (m.echo !== undefined) {
+      echoes.push(m.echo);
+      if (m.echo === 2) resolve(echoes);
+    }
+  });
+  child.once("error", reject);
+  child.once("exit", code => reject(new Error(`child exited before replying (code ${code})`)));
+
+  // Queued before the child attaches its listener.
+  child.send({ seq: 1 });
+
+  try {
+    const received = await promise;
+    expect(received).toEqual([1, 2]);
+  } finally {
+    if (child.connected) child.disconnect();
+    child.kill();
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #32567. A message the parent sends to a forked child before the child has attached its listener is delivered one event-loop iteration later than Node, so the parent observes the child's reply before the child observes the parent's message.

```js
// test.js
import { fork } from "node:child_process";
const child = fork(`${import.meta.dirname}/helpers/script.js`);
child.on("message", m => console.log("PARENT got message:", m));
child.send({ hello: "world" });

// helpers/script.js
process.on("message", m => console.log("CHILD got message:", m));
process.send({ foo: "bar", baz: NaN });
```

Node prints `CHILD` first, then `PARENT`. Bun printed them reversed.

## Cause

The child's inherited IPC socket is adopted lazily, on the first `process.on("message")` / `process.send()`. Its first read only happened on the first event-loop poll, which in Bun runs *after* `setImmediate` (the check phase). So a message already sitting in the pipe buffer when the child adopted the channel was drained a tick late.

This is deterministic and observable without relying on cross-process stdout interleaving: when the child receives the buffered message, a `setImmediate` scheduled during startup has already fired in Bun but not in Node.

| | `immediateFired` when the child receives the buffered message |
| --- | --- |
| Node | `false` (8/8) |
| Bun (before) | `true` (8/8) |
| Bun (after) | `false` (8/8) |

## Fix

When the child adopts the inherited IPC fd, schedule a microtask that drains any already-buffered bytes from the socket. The microtask runs at the end-of-turn checkpoint, before the event loop's first poll (hence before `setImmediate`), so a pre-buffered message is observed on the child's startup turn like Node.

The drain is deferred rather than read inline so the `message` handler never fires synchronously from inside `process.on()` / `process.send()`.

`us_socket_ipc_recv_pending()` (new, in usockets) dispatches a readable event for already-buffered bytes using the same path the event loop uses, so SCM_RIGHTS fd passing and partial-message buffering keep working. It reads with `MSG_DONTWAIT`, so it is a no-op when nothing is buffered. POSIX only; the Windows named-pipe (libuv) path is unaffected.

## Verification

New test in `test/js/node/child_process/child_process.test.ts` asserts the buffered message is delivered before the first `setImmediate`:
- fails on the unfixed build (`immediateFired: true`), passes after (`immediateFired: false`), 5/5 each.

Existing IPC suites pass: `spawn.ipc*`, `bun-ipc-inherit`, `spawn-ipc-gc`, `child_process_ipc`, `child_process_send_cb`, `child_process_ipc_large_disconnect`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 7 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process.test.ts

<!-- robobun:evidence:end -->