### PR TITLE
Keep escaped newlines in string literals without --minify-syntax

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -809,7 +809,7 @@ pub fn can_print_without_escape(c: i32, ascii_only: bool) -> bool {
 const INDENTATION_SPACE_BUF: [u8; 128] = [b' '; 128];
 const INDENTATION_TAB_BUF: [u8; 128] = [b'\t'; 128];
 
-pub fn best_quote_char_for_string<T>(str: &[T], allow_backtick: bool) -> u8
+pub fn best_quote_char_for_string<T>(str: &[T], allow_backtick: bool, minify_syntax: bool) -> u8
 where
     T: Copy + Into<u32>,
 {
@@ -825,8 +825,15 @@ where
             0x22 /* " */ => double_cost += 1,
             0x60 /* ` */ => backtick_cost += 1,
             0x0A /* \n */ => {
-                single_cost += 1;
-                double_cost += 1;
+                // A newline can be written literally only inside a template
+                // literal, so counting it against the quoted forms biases the
+                // choice toward a backtick. That rewrite only pays off when
+                // minifying syntax; otherwise keep the newline escaped in a
+                // quoted string (matches esbuild's non-minified output).
+                if minify_syntax {
+                    single_cost += 1;
+                    double_cost += 1;
+                }
             }
             0x5C /* \\ */ => {
                 i += 1;
@@ -2592,14 +2599,18 @@ pub mod __gated_printer {
             self.print(b"}");
         }
 
-        pub fn best_quote_char_for_e_string(str: &E::String, allow_backtick: bool) -> u8 {
+        pub fn best_quote_char_for_e_string(
+            str: &E::String,
+            allow_backtick: bool,
+            minify_syntax: bool,
+        ) -> u8 {
             if IS_JSON {
                 return b'"';
             }
             if str.is_utf8() {
-                best_quote_char_for_string(str.slice8(), allow_backtick)
+                best_quote_char_for_string(str.slice8(), allow_backtick, minify_syntax)
             } else {
-                best_quote_char_for_string(str.slice16(), allow_backtick)
+                best_quote_char_for_string(str.slice16(), allow_backtick, minify_syntax)
             }
         }
 
@@ -3015,7 +3026,8 @@ pub mod __gated_printer {
         }
 
         pub fn print_string_literal_e_string(&mut self, str: &E::String, allow_backtick: bool) {
-            let quote = Self::best_quote_char_for_e_string(str, allow_backtick);
+            let quote =
+                Self::best_quote_char_for_e_string(str, allow_backtick, self.options.minify_syntax);
             self.print(quote);
             self.print_string_characters_e_string(str, quote);
             self.print(quote);
@@ -3054,7 +3066,7 @@ pub mod __gated_printer {
             debug_assert!(is_valid_wtf8(str));
 
             let quote = if !IS_JSON {
-                best_quote_char_for_string(str, allow_backtick)
+                best_quote_char_for_string(str, allow_backtick, self.options.minify_syntax)
             } else {
                 b'"'
             };
@@ -4884,7 +4896,11 @@ pub mod __gated_printer {
                             }
                         }
                     } else {
-                        let c = best_quote_char_for_string(key_str.slice16(), false);
+                        let c = best_quote_char_for_string(
+                            key_str.slice16(),
+                            false,
+                            self.options.minify_syntax,
+                        );
                         self.print(c);
                         self.print_string_characters_utf16(key_str.slice16(), c);
                         self.print(c);
@@ -6390,7 +6406,11 @@ pub mod __gated_printer {
                 unreachable!();
             }
 
-            let quote = best_quote_char_for_string(import_record.path.text, false);
+            let quote = best_quote_char_for_string(
+                import_record.path.text,
+                false,
+                self.options.minify_syntax,
+            );
             if import_record
                 .flags
                 .contains(ImportRecordFlags::PRINT_NAMESPACE_IN_PATH)

--- a/test/bundler/bundler_string.test.ts
+++ b/test/bundler/bundler_string.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "bun:test";
+import { describe, expect } from "bun:test";
 import { dedent, itBundled } from "./expectBundled";
 
 interface TemplateStringTest {
@@ -216,6 +216,64 @@ describe("bundler", () => {
       dOOPSl
       CONST_VALUE
       true`,
+    },
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/32576
+// A `\n` escape in a string literal must stay escaped inside a quoted string
+// unless syntax is being minified. Only --minify-syntax (the documented
+// template-literal conversion) may rewrite it to a backtick with a literal
+// newline. This matches esbuild across --minify-whitespace and friends.
+describe("bundler", () => {
+  itBundled("string/NewlineEscapeStaysQuotedWithoutMinify", {
+    files: {
+      "index.ts": `console.log("Hello\\nWorld");`,
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain('"Hello\\nWorld"');
+      expect(code).not.toContain("`Hello");
+    },
+  });
+  itBundled("string/NewlineEscapeStaysQuotedWithMinifyWhitespace", {
+    files: {
+      "index.ts": `console.log("Hello\\nWorld");`,
+    },
+    minifyWhitespace: true,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain('"Hello\\nWorld"');
+      expect(code).not.toContain("`Hello");
+    },
+  });
+  itBundled("string/NewlineEscapeBecomesTemplateWithMinifySyntax", {
+    files: {
+      "index.ts": `console.log("Hello\\nWorld");`,
+    },
+    minifySyntax: true,
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("`Hello\nWorld`");
+    },
+  });
+  itBundled("string/BothQuotesUseBacktickWithoutMinify", {
+    files: {
+      "index.ts": `console.log("a'b\\"c");`,
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("`a'b\"c`");
+    },
+  });
+  itBundled("string/DoubleQuoteWithNewlineUsesSingleQuoteWithoutMinify", {
+    files: {
+      "index.ts": `console.log("x\\"y\\nz");`,
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("'x\"y\\nz'");
+      expect(code).not.toContain("`x");
     },
   });
 });

--- a/test/bundler/bundler_string.test.ts
+++ b/test/bundler/bundler_string.test.ts
@@ -266,6 +266,18 @@ describe("bundler", () => {
       expect(code).toContain("`a'b\"c`");
     },
   });
+  // A string containing both ' and " picks a backtick to avoid escaping either
+  // quote, even without minify and even with a newline present: the two quote
+  // chars drive the choice, not the newline. esbuild emits the same backtick.
+  itBundled("string/BothQuotesWithNewlineUseBacktickWithoutMinify", {
+    files: {
+      "index.ts": `console.log("a'b\\"c\\nd");`,
+    },
+    onAfterBundle(api) {
+      const code = api.readFile("/out.js");
+      expect(code).toContain("`a'b\"c\nd`");
+    },
+  });
   itBundled("string/DoubleQuoteWithNewlineUsesSingleQuoteWithoutMinify", {
     files: {
       "index.ts": `console.log("x\\"y\\nz");`,

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2166,7 +2166,7 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("string quote selection", () => {
-      expectPrinted_(`console.log("\\n")`, "console.log(`\n`)");
+      expectPrinted_(`console.log("\\n")`, 'console.log("\\n")');
       expectPrinted_(`console.log("\\"")`, `console.log('"')`);
       expectPrinted_(`console.log('\\'')`, `console.log("'")`);
       expectPrinted_("console.log(`\\`hi\\``)", "console.log(`\\`hi\\``)");


### PR DESCRIPTION
Fixes #32576

### Problem

`bun build` converts any string literal containing a `\n` escape into a backtick template literal with a literal newline, even with no minify flag:

```ts
// test.ts
const greeting = "Hello\nWorld";
console.log(greeting);
```

```console
$ bun build test.ts
var greeting = `Hello
World`;
console.log(greeting);
```

The template-literal conversion is documented as a minifier feature, so it should not happen unless syntax is being minified.

### Cause

`best_quote_char_for_string` in `src/js_printer/lib.rs` counts a newline as a cost against single and double quotes but not against backticks. With `backtick_cost` left at 0, any newline-containing string satisfies `backtick_cost < single_cost.min(double_cost)` and the quote choice becomes a backtick. This ran unconditionally, independent of the minify options.

### Fix

Gate the newline cost on `minify_syntax` (threaded through `best_quote_char_for_string` / `best_quote_char_for_e_string` and their callers). Without `--minify-syntax` a newline no longer biases toward a backtick, so it stays escaped inside a quoted string. `--minify-syntax` (and full `--minify`) keep the existing template-literal output.

This matches esbuild, the reference implementation:

| input `"Hello\nWorld"` | esbuild | Bun after fix |
| --- | --- | --- |
| no flags | `"Hello\nWorld"` | `"Hello\nWorld"` |
| `--minify-whitespace` | `"Hello\nWorld"` | `"Hello\nWorld"` |
| `--minify-syntax` | template (literal newline) | template (literal newline) |

The newline cost only affected the backtick decision, so strings with both `'` and `"` (no newline) still choose a backtick to avoid escaping, matching esbuild; a string with a `"` and a newline now picks a single quote with an escaped `\n`, also matching esbuild.

### Verification

```console
$ bun build test.ts
var greeting = "Hello\nWorld";
$ bun build test.ts --minify-whitespace
var greeting="Hello\nWorld";
$ bun build test.ts --minify-syntax
console.log(`Hello
World`);
```

Tests in `test/bundler/bundler_string.test.ts` cover the no-minify, `--minify-whitespace`, and `--minify-syntax` paths plus the both-quotes and double-quote-with-newline variants. The existing quote-selection assertion in `test/bundler/transpiler/transpiler.test.js` is updated to the escaped form. New tests fail on the current build and pass with the fix.