### PR TITLE
Add Bun.isStandaloneExecutable

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -888,6 +888,20 @@ export default {
 
 This is honestly a workaround, and we expect to improve this in the future with a more direct API.
 
+### Detecting standalone mode at runtime
+
+Use `Bun.isStandaloneExecutable` to check whether the current process is running from a compiled binary:
+
+```ts index.ts icon="/icons/typescript.svg"
+if (Bun.isStandaloneExecutable) {
+  // Running from `bun build --compile` output
+} else {
+  // Running via `bun <file>` or as a library
+}
+```
+
+Unlike `Bun.embeddedFiles.length > 0`, this check does not allocate `Blob` objects for each embedded file, so it is safe to call at startup in binaries that embed large assets.
+
 ### Listing embedded files
 
 `Bun.embeddedFiles` gives you access to all embedded files as `Blob` objects:

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -4149,6 +4149,22 @@ declare module "bun" {
   const embeddedFiles: ReadonlyArray<Blob>;
 
   /**
+   * `true` when the current process is a standalone executable produced by
+   * `bun build --compile`, `false` otherwise.
+   *
+   * Unlike checking `Bun.embeddedFiles.length > 0`, reading this property does
+   * not materialize embedded files as `Blob` objects.
+   *
+   * @example
+   * ```ts
+   * if (Bun.isStandaloneExecutable) {
+   *   console.log("Running from a compiled binary");
+   * }
+   * ```
+   */
+  const isStandaloneExecutable: boolean;
+
+  /**
    * `Blob` that leverages the fastest system calls available to operate on files.
    *
    * This Blob is lazy. It won't do any work until you read from it. Errors propagate as promise rejections.

--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -35,6 +35,7 @@
     macro(enableANSIColors) \
     macro(hash) \
     macro(inspect) \
+    macro(isStandaloneExecutable) \
     macro(origin) \
     macro(s3) \
     macro(semver) \

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -970,6 +970,7 @@ JSC_DEFINE_HOST_FUNCTION(functionFileURLToPath, (JSC::JSGlobalObject * globalObj
     inflateSync                                    BunObject_callback_inflateSync                                      DontDelete|Function 1
     inspect                                        BunObject_lazyPropCb_wrap_inspect                                   DontDelete|PropertyCallback
     isMainThread                                   constructIsMainThread                                               ReadOnly|DontDelete|PropertyCallback
+    isStandaloneExecutable                         BunObject_lazyPropCb_wrap_isStandaloneExecutable                    ReadOnly|DontDelete|PropertyCallback
     jest                                           BunObject_callback_jest                                             DontEnum|DontDelete|Function 1
     listen                                         BunObject_callback_listen                                           DontDelete|Function 1
     udpSocket                                      BunObject_callback_udpSocket                                        DontDelete|Function 1

--- a/src/runtime/api/BunObject.rs
+++ b/src/runtime/api/BunObject.rs
@@ -405,6 +405,7 @@ pub mod bun_object {
         BunObject_lazyPropCb_cwd => super::get_cwd,
         BunObject_lazyPropCb_embeddedFiles => super::get_embedded_files,
         BunObject_lazyPropCb_enableANSIColors => super::enable_ansi_colors,
+        BunObject_lazyPropCb_isStandaloneExecutable => super::get_is_standalone_executable,
         BunObject_lazyPropCb_hash => super::get_hash_object,
         BunObject_lazyPropCb_inspect => super::get_inspect,
         BunObject_lazyPropCb_origin => super::get_origin,
@@ -1987,6 +1988,10 @@ pub(crate) fn get_valkey_client_constructor(global_this: &JSGlobalObject, _: &JS
 
 pub(crate) fn get_terminal_constructor(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
     crate::api::bun_terminal_body::js::get_constructor(global_this)
+}
+
+pub(crate) fn get_is_standalone_executable(global_this: &JSGlobalObject, _: &JSObject) -> JSValue {
+    JSValue::js_boolean(global_this.bun_vm().standalone_module_graph.is_some())
 }
 
 pub(crate) fn get_embedded_files(global_this: &JSGlobalObject, _: &JSObject) -> JsResult<JSValue> {

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -443,6 +443,51 @@ describe("bundler", () => {
     outfile: "dist/out",
     run: { stdout: "Hello, world!", setCwd: true },
   });
+  itBundled("compile/Bun.isStandaloneExecutable", {
+    compile: true,
+    assetNaming: "[name].[ext]",
+    files: {
+      "/entry.ts": /* js */ `
+        import { heapStats } from "bun:jsc";
+        import "./asset.file";
+
+        if (Bun.isStandaloneExecutable !== true) {
+          throw new Error("expected Bun.isStandaloneExecutable === true, got " + Bun.isStandaloneExecutable);
+        }
+
+        // Reading isStandaloneExecutable must not materialize embedded files as Blobs.
+        Bun.gc(true);
+        const before = heapStats().objectTypeCounts.Blob ?? 0;
+
+        // Accessing embeddedFiles allocates a Blob per embedded asset.
+        const files = Bun.embeddedFiles;
+        if (files.length !== 1) throw new Error("expected 1 embedded file, got " + files.length);
+        const after = heapStats().objectTypeCounts.Blob ?? 0;
+
+        if (after <= before) {
+          throw new Error("expected Blob count to increase after reading Bun.embeddedFiles (before=" + before + " after=" + after + ")");
+        }
+        console.log("before=" + before, "after=" + after);
+      `,
+      "/asset.file": "abcd",
+    },
+    outfile: "dist/out",
+    run: { stdout: /^before=0 after=[1-9]\d*$/ },
+  });
+  test("Bun.isStandaloneExecutable is false when not compiled", async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(JSON.stringify({ value: Bun.isStandaloneExecutable, type: typeof Bun.isStandaloneExecutable }))`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: `{"value":false,"type":"boolean"}`,
+      stderr: expect.not.stringContaining("error"),
+      exitCode: 0,
+    });
+  });
   itBundled("compile/ResolveEmbeddedFileOutfile", {
     compile: true,
     // TODO: this shouldn't be necessary, or we should add a map aliasing files.

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -451,28 +451,33 @@ describe("bundler", () => {
         import { heapStats } from "bun:jsc";
         import "./asset.file";
 
-        if (Bun.isStandaloneExecutable !== true) {
-          throw new Error("expected Bun.isStandaloneExecutable === true, got " + Bun.isStandaloneExecutable);
-        }
+        const blobCount = () => heapStats().objectTypeCounts.Blob ?? 0;
 
         // Reading isStandaloneExecutable must not materialize embedded files as Blobs.
         Bun.gc(true);
-        const before = heapStats().objectTypeCounts.Blob ?? 0;
+        const baseline = blobCount();
+        if (Bun.isStandaloneExecutable !== true) {
+          throw new Error("expected Bun.isStandaloneExecutable === true, got " + Bun.isStandaloneExecutable);
+        }
+        const afterRead = blobCount();
+        if (afterRead !== baseline) {
+          throw new Error("reading Bun.isStandaloneExecutable changed Blob count (" + baseline + " -> " + afterRead + ")");
+        }
 
-        // Accessing embeddedFiles allocates a Blob per embedded asset.
+        // Accessing embeddedFiles allocates a Blob per embedded asset; if it did not,
+        // the afterRead === baseline check above would be vacuous.
         const files = Bun.embeddedFiles;
         if (files.length !== 1) throw new Error("expected 1 embedded file, got " + files.length);
-        const after = heapStats().objectTypeCounts.Blob ?? 0;
-
-        if (after <= before) {
-          throw new Error("expected Blob count to increase after reading Bun.embeddedFiles (before=" + before + " after=" + after + ")");
+        const afterEmbedded = blobCount();
+        if (afterEmbedded <= baseline) {
+          throw new Error("expected Blob count to increase after reading Bun.embeddedFiles (" + baseline + " -> " + afterEmbedded + ")");
         }
-        console.log("before=" + before, "after=" + after);
+        console.log("ok", JSON.stringify({ baseline, afterRead, afterEmbedded }));
       `,
       "/asset.file": "abcd",
     },
     outfile: "dist/out",
-    run: { stdout: /^before=0 after=[1-9]\d*$/ },
+    run: { stdout: /^ok \{"baseline":\d+,"afterRead":\d+,"afterEmbedded":\d+\}$/ },
   });
   test("Bun.isStandaloneExecutable is false when not compiled", async () => {
     await using proc = Bun.spawn({

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -476,7 +476,11 @@ describe("bundler", () => {
   });
   test("Bun.isStandaloneExecutable is false when not compiled", async () => {
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", `console.log(JSON.stringify({ value: Bun.isStandaloneExecutable, type: typeof Bun.isStandaloneExecutable }))`],
+      cmd: [
+        bunExe(),
+        "-e",
+        `console.log(JSON.stringify({ value: Bun.isStandaloneExecutable, type: typeof Bun.isStandaloneExecutable }))`,
+      ],
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",


### PR DESCRIPTION
### What does this PR do?

Adds `Bun.isStandaloneExecutable`, a read-only boolean that is `true` when the current process is a `bun build --compile` standalone executable and `false` otherwise.

#### Why

The only public way to detect standalone mode today is `Bun.embeddedFiles.length > 0`, but `Bun.embeddedFiles` materializes every embedded file as a heap-backed `Blob` (via `dupe_with_content_type`). For binaries that embed large native addons this allocates megabytes just to answer a yes/no question.

The other workaround, `Bun.main.startsWith('/$bunfs/')` (plus the Windows variant), couples user code to an internal path prefix that isn't documented as a stable detection signal.

#### Implementation

The getter reads `global_this.bun_vm().standalone_module_graph.is_some()` and returns `jsBoolean`. Wired as a lazy `PropertyCallback` on the Bun object alongside `isMainThread`.

### How did you verify your code works?

Two tests in `test/bundler/bundler_compile.test.ts`:

- `compile/Bun.isStandaloneExecutable`: compiles a binary with one embedded asset, asserts `Bun.isStandaloneExecutable === true`, and verifies via `heapStats().objectTypeCounts.Blob` that reading the property allocates zero `Blob` objects (whereas reading `Bun.embeddedFiles` afterwards does).
- `Bun.isStandaloneExecutable is false when not compiled`: spawns `bun -e` and asserts `{ value: false, type: 'boolean' }`.

Both tests fail on the released bun (`undefined`) and pass with this change.