### PR TITLE
node:fs: stop draining tasks after termination in fs.watchFile initial-stat callbacks

### DIFF
--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -426,7 +426,17 @@ impl EventLoop {
 
     fn tick_with_count(&mut self, virtual_machine: *mut VirtualMachine) -> u32 {
         let mut counter: u32 = 0;
-        let _ = tick_queue_with_count(self, virtual_machine, &mut counter);
+        // On `JsTerminated`, report 0 so the `while tick_with_count() > 0`
+        // drain loops in `tick()` / `tick_tasks_only()` stop immediately. The
+        // termination exception is left on the VM (`tryClearException` never
+        // clears it), so continuing to drain would re-enter
+        // `executeCallImpl` with an exception pending and trip its
+        // `scope.assertNoException()` RELEASE_ASSERT. `tick()` observes the
+        // pending exception via `scope.has_exception()` on the next line and
+        // returns.
+        if tick_queue_with_count(self, virtual_machine, &mut counter).is_err() {
+            return 0;
+        }
         counter
     }
 

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -864,14 +864,13 @@ impl StatWatcher {
         };
         let global_this = this_ref.global_this();
 
-        let jsvalue =
-            match stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint) {
-                Ok(v) => v,
-                Err(err) => {
-                    global_this.report_active_exception_as_unhandled(err);
-                    return Ok(());
-                }
-            };
+        // Propagate to the dispatcher rather than swallowing: a termination
+        // exception is not cleared by `report_active_exception_as_unhandled`,
+        // so swallowing it here leaves the VM with an exception pending and
+        // the next queued task re-enters JS under a
+        // `scope.assertNoException()` RELEASE_ASSERT.
+        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
+            .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
         js::gc::prev_stat::set(js_this, global_this, jsvalue);
 
         // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
@@ -896,14 +895,8 @@ impl StatWatcher {
             return Ok(());
         };
         let global_this = this_ref.global_this();
-        let jsvalue =
-            match stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint) {
-                Ok(v) => v,
-                Err(err) => {
-                    global_this.report_active_exception_as_unhandled(err);
-                    return Ok(());
-                }
-            };
+        let jsvalue = stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
+            .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
         js::gc::prev_stat::set(js_this, global_this, jsvalue);
 
         let result = js::listener_get_cached(js_this).unwrap().call(
@@ -911,16 +904,21 @@ impl StatWatcher {
             JSValue::UNDEFINED,
             &[jsvalue, jsvalue],
         );
-        if let Err(err) = result {
-            global_this.report_active_exception_as_unhandled(err);
+
+        // Append to the scheduler before propagating a listener error so the
+        // watcher keeps running after a throwing listener (Node semantics).
+        // `append` does not enter JS, so it is safe with an exception pending.
+        if !this_ref.closed.load(Ordering::Relaxed) {
+            // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
+            StatWatcherScheduler::append(this_ref.scheduler.as_ptr(), this);
         }
 
-        if this_ref.closed.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-        // SAFETY: scheduler is live (`RefPtr`); `this` is live (ref'd, guard above).
-        StatWatcherScheduler::append(this_ref.scheduler.as_ptr(), this);
-        Ok(())
+        // Propagate to the dispatcher: `report_error_or_terminate` reports a
+        // regular throw as uncaught and stops the tick loop on termination.
+        // Swallowing the error here leaves a termination exception on the VM
+        // and the next queued task re-enters JS under a
+        // `scope.assertNoException()` RELEASE_ASSERT.
+        result.map(drop).map_err(Into::into)
     }
 
     /// Called from any thread
@@ -986,21 +984,24 @@ impl StatWatcher {
         let global_this = this_ref.global_this();
         let prev_jsvalue = js::gc::prev_stat::get(js_this).unwrap_or(JSValue::UNDEFINED);
         let current_jsvalue =
-            match stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint) {
-                Ok(v) => v,
-                Err(_) => return Ok(()), // TODO: properly propagate exception upwards
-            };
+            stat_to_js_stats(global_this, &this_ref.get_last_stat(), this_ref.bigint)
+                .map_err(Into::<bun_event_loop::ErasedJsError>::into)?;
         js::gc::prev_stat::set(js_this, global_this, current_jsvalue);
 
-        let result = js::listener_get_cached(js_this).unwrap().call(
-            global_this,
-            JSValue::UNDEFINED,
-            &[current_jsvalue, prev_jsvalue],
-        );
-        if let Err(err) = result {
-            global_this.report_active_exception_as_unhandled(err);
-        }
-        Ok(())
+        // Propagate to the dispatcher: `report_error_or_terminate` reports a
+        // regular throw as uncaught and stops the tick loop on termination.
+        // Swallowing the error here leaves a termination exception on the VM
+        // and the next queued task re-enters JS under a
+        // `scope.assertNoException()` RELEASE_ASSERT.
+        js::listener_get_cached(js_this)
+            .unwrap()
+            .call(
+                global_this,
+                JSValue::UNDEFINED,
+                &[current_jsvalue, prev_jsvalue],
+            )
+            .map(drop)
+            .map_err(Into::into)
     }
 
     pub(crate) fn init(args: &Arguments) -> Result<*mut StatWatcher, bun_core::Error> {

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -294,4 +294,115 @@ describe("fs.watchFile", () => {
     expect(stdout.trim()).toBe("OK");
     expect(exitCode).toBe(0);
   });
+
+  // Many initial-stat completions for nonexistent paths land in the worker's
+  // concurrent task queue. When terminate() fires the termination exception
+  // mid-drain, one completion's listener.call() throws it; the tick loop must
+  // stop there. The unfixed build kept draining with the termination
+  // exception still on the VM, so the next completion re-entered
+  // executeCallImpl() under scope.assertNoException() and aborted. In the
+  // reported release crash this surfaced through
+  // StatWatcher::initial_stat_error_on_main_thread ->
+  // report_active_exception_as_unhandled -> VM::clearException as a null
+  // dereference.
+  test("terminating a worker while many watchFile initial-stat callbacks are queued does not crash", async () => {
+    const fixture = /* js */ `
+      const { Worker } = require("worker_threads");
+      const os = require("os");
+      const path = require("path");
+
+      const workerCode = \`
+        const fs = require("fs");
+        const os = require("os");
+        const path = require("path");
+        const base = path.join(os.tmpdir(), "bun-watchfile-nx-" + process.pid + "-");
+        for (let i = 0; i < 200; i++) {
+          fs.watchFile(base + i, { interval: 1000000, persistent: false }, () => {});
+        }
+        require("worker_threads").parentPort.postMessage("ready");
+      \`;
+
+      const w = new Worker(workerCode, { eval: true });
+      w.on("message", () => { w.terminate(); });
+      w.on("error", (e) => { console.error("worker error:", e && e.message); process.exit(1); });
+      w.on("exit", () => { console.log("ok"); process.exit(0); });
+    `;
+
+    // Run several iterations concurrently: the race window depends on how
+    // many InitialStatTask completions are queued when terminate() fires.
+    const runOnce = async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode };
+    };
+
+    const results = await Promise.all(Array.from({ length: 4 }, runOnce));
+    for (const result of results) {
+      expect(result).toEqual({
+        stdout: "ok",
+        stderr: expect.not.stringContaining("ASSERTION"),
+        exitCode: 0,
+        signalCode: null,
+      });
+    }
+  }, 30_000);
+
+  // A listener that throws during the initial ENOENT callback must surface as
+  // an uncaught exception but keep the watcher scheduled. Guards the
+  // reordering in initial_stat_error_on_main_thread (append before
+  // propagating the error).
+  test("a throwing listener on the initial ENOENT callback keeps watching", async () => {
+    const fixture = /* js */ `
+      const fs = require("fs");
+      const os = require("os");
+      const path = require("path");
+
+      const target = path.join(os.tmpdir(), "bun-watchfile-throw-" + process.pid);
+      let calls = 0;
+
+      process.on("uncaughtException", (err) => {
+        if (err && err.message === "listener-boom") {
+          console.log("uncaught");
+        } else {
+          console.error("unexpected uncaught:", err && err.message);
+          process.exit(1);
+        }
+      });
+
+      fs.watchFile(target, { interval: 20, persistent: true }, (curr, prev) => {
+        calls++;
+        if (calls === 1) {
+          // Initial ENOENT callback: throw and then create the file so the
+          // watcher (still scheduled) observes a change.
+          process.nextTick(() => fs.writeFileSync(target, "a"));
+          throw new Error("listener-boom");
+        } else {
+          console.log("second");
+          fs.unwatchFile(target);
+          try { fs.unlinkSync(target); } catch {}
+          process.exit(0);
+        }
+      });
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "uncaught\nsecond",
+      stderr: expect.not.stringContaining("error"),
+      exitCode: 0,
+      signalCode: null,
+    });
+  }, 20_000);
 });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -308,8 +308,6 @@ describe("fs.watchFile", () => {
   test("terminating a worker while many watchFile initial-stat callbacks are queued does not crash", async () => {
     const fixture = /* js */ `
       const { Worker } = require("worker_threads");
-      const os = require("os");
-      const path = require("path");
 
       const workerCode = \`
         const fs = require("fs");
@@ -365,12 +363,17 @@ describe("fs.watchFile", () => {
   // reordering in initial_stat_error_on_main_thread (append before
   // propagating the error).
   test("a throwing listener on the initial ENOENT callback keeps watching", async () => {
+    // Fresh per-run directory so the target is guaranteed not to exist and
+    // the initial stat takes the ENOENT path.
+    const dir = tempDirWithFiles("watchfile-throw", {
+      ".keep": "",
+    });
+    const target = path.join(dir, "does-not-exist.txt");
+
     const fixture = /* js */ `
       const fs = require("fs");
-      const os = require("os");
-      const path = require("path");
 
-      const target = path.join(os.tmpdir(), "bun-watchfile-throw-" + process.pid);
+      const target = ${JSON.stringify(target)};
       let calls = 0;
 
       process.on("uncaughtException", (err) => {
@@ -392,7 +395,6 @@ describe("fs.watchFile", () => {
         } else {
           console.log("second");
           fs.unwatchFile(target);
-          try { fs.unlinkSync(target); } catch {}
           process.exit(0);
         }
       });

--- a/test/js/node/watch/fs.watchFile.test.ts
+++ b/test/js/node/watch/fs.watchFile.test.ts
@@ -333,7 +333,15 @@ describe("fs.watchFile", () => {
     const runOnce = async () => {
       await using proc = Bun.spawn({
         cmd: [bunExe(), "-e", fixture],
-        env: bunEnv,
+        env: {
+          ...bunEnv,
+          // detect_leaks=0: ConcurrentTask/ManagedTask nodes left in a
+          // terminated worker's undrained concurrent queue are a known
+          // pre-existing leak (see #32071); this test asserts no crash, not
+          // no leaks. symbolize=0 so a pre-fix ASAN abort exits promptly
+          // instead of spending seconds in llvm-symbolizer.
+          ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "symbolize=0", "detect_leaks=0"].filter(Boolean).join(":"),
+        },
         stdout: "pipe",
         stderr: "pipe",
       });


### PR DESCRIPTION
### What does this PR do?

Fixes a crash when a worker running `fs.watchFile()` is terminated while many initial-stat completions are queued on its event loop.

#### Crash

```
Bun v1.4.0 (324c5f0) on linux x86_64 [StandaloneExecutable]
Segmentation fault at address 0x00000000

VM.h: JSC::VM::clearException
ExceptionScope.h: JSC::ExceptionScope::tryClearException
bindings.cpp: JSGlobalObject__tryTakeException
JSGlobalObject.rs: try_take_exception
JSGlobalObject.rs: take_exception
JSGlobalObject.rs: report_active_exception_as_unhandled
node_fs_stat_watcher.rs: <StatWatcher>::initial_stat_error_on_main_thread
```

#### Cause

Each `fs.watchFile(nonexistent)` schedules an `InitialStatTask` to the work pool, which posts `initial_stat_error_on_main_thread` back to the worker's concurrent task queue. The worker's `tick()` drains those in a batch. When `terminate()` is called from the parent, the termination trap fires the first time one of those callbacks enters JS via `listener.call()`, and the call returns `Err`.

The callback handled that `Err` with `report_active_exception_as_unhandled`, which reads the exception (`JSGlobalObject__tryTakeException` -> `tryClearException`) but does **not** clear it, because `tryClearException` leaves termination exceptions in place. The callback then returned `Ok(())`, and `EventLoop::tick_with_count` discarded the `JsTerminated` result from `tick_queue_with_count` anyway, so `tick()`'s `while tick_with_count() > 0` loop pulled the next queued completion and called `listener.call()` again with `vm.m_exception` still set to the termination exception. `Interpreter::executeCallImpl` begins with `scope.assertNoException()`, which is a `RELEASE_ASSERT`, so the process aborts.

#### Fix

- `EventLoop::tick_with_count`: return `0` when `tick_queue_with_count` reports `JsTerminated`, so the `while tick_with_count() > 0` drain loops in `tick()` / `tick_tasks_only()` stop immediately. `tick()` observes the pending exception via `scope.has_exception()` on the next line and returns.
- `StatWatcher::{initial_stat_success_on_main_thread, initial_stat_error_on_main_thread, swap_and_call_listener_on_main_thread}`: propagate errors to the dispatcher instead of swallowing them with `report_active_exception_as_unhandled`. The dispatcher's `report_error_or_terminate` reports a regular throw as uncaught (same user-visible behavior) and returns `Err(JsTerminated)` for termination, which is now respected by `tick_with_count`. `initial_stat_error_on_main_thread` appends the watcher to the scheduler **before** propagating the error so a throwing listener keeps the watcher running (Node semantics); a second test covers that.

This does not address the separate cross-thread delivery race where `InitialStatTask` dereferences a freed worker VM from the work pool; that is #32071's scope.

### How did you verify your code works?

In a Worker, create many `fs.watchFile()` calls on nonexistent paths, then `terminate()` the worker while the initial-stat completions are still queued. Under a debug+ASAN build this aborts deterministically:

```
ASSERTION FAILED: !exception()
ExceptionScope.h(61): void JSC::ExceptionScope::assertNoException()
```

with the following stack (rbp walk under gdb):

```
JSC::Interpreter::executeCallImpl
  <- JSC::profiledCall
  <- Bun__JSValue__call
  <- JSValue::call
  <- StatWatcher::initial_stat_error_on_main_thread
  <- ManagedTask::run
  <- tick_queue_with_count
  <- EventLoop::tick
  <- EventLoop::wait_for_promise_with_termination
  <- WebWorker::spin
```

Two tests added to `test/js/node/watch/fs.watchFile.test.ts`:

- "terminating a worker while many watchFile initial-stat callbacks are queued does not crash": spawns four concurrent subprocesses, each starting a worker with 200 `fs.watchFile()` calls on nonexistent paths and terminating it as soon as the worker signals ready. Without the fix this aborts 4/4 under `bun bd` with the `!exception()` assertion; with the fix all four exit cleanly.
- "a throwing listener on the initial ENOENT callback keeps watching": the initial ENOENT callback throws; the error surfaces as `uncaughtException` and the next poll observes a file change. Pins the append-before-propagate ordering in `initial_stat_error_on_main_thread`.

Full `fs.watchFile.test.ts` suite: 9 pass / 2 skip / 0 fail. `worker.test.ts` and `worker_threads.test.ts` failures are identical to an unfixed main build in the same container (1s hardcoded timeouts under debug+ASAN; run-as-root artifacts).
