### PR TITLE
docs: clarify the example security scanner package name is a placeholder

### DIFF
--- a/docs/pm/security-scanner-api.mdx
+++ b/docs/pm/security-scanner-api.mdx
@@ -56,8 +56,9 @@ bun add -d @acme/bun-security-scanner
 ```
 
 <Note>
-  Consult your security scanner's documentation for their specific package name and installation instructions. Most
-  scanners will be installed with `bun add`.
+  `@acme/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
+  use, and consult that scanner's documentation for the exact package name and installation instructions. Most scanners
+  are installed with `bun add`.
 </Note>
 
 ### Configuring the Scanner

--- a/docs/pm/security-scanner-api.mdx
+++ b/docs/pm/security-scanner-api.mdx
@@ -13,7 +13,7 @@ Configure a security scanner in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@oven/bun-security-scanner"
+scanner = "@oven/bun-security-scanner" # example name, replace with your scanner's package
 ```
 
 When configured, Bun will:
@@ -67,7 +67,7 @@ After installation, configure it in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@oven/bun-security-scanner"
+scanner = "@oven/bun-security-scanner" # example name, replace with your scanner's package
 ```
 
 ### Enterprise Configuration

--- a/docs/pm/security-scanner-api.mdx
+++ b/docs/pm/security-scanner-api.mdx
@@ -13,7 +13,7 @@ Configure a security scanner in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@acme/bun-security-scanner"
+scanner = "@oven/bun-security-scanner"
 ```
 
 When configured, Bun will:
@@ -52,11 +52,11 @@ Many security companies publish Bun security scanners as npm packages that you c
 Install a security scanner from npm:
 
 ```bash terminal icon="terminal"
-bun add -d @acme/bun-security-scanner
+bun add -d @oven/bun-security-scanner
 ```
 
 <Note>
-  `@acme/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
+  `@oven/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
   use, and consult that scanner's documentation for the exact package name and installation instructions. Most scanners
   are installed with `bun add`.
 </Note>
@@ -67,7 +67,7 @@ After installation, configure it in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@acme/bun-security-scanner"
+scanner = "@oven/bun-security-scanner"
 ```
 
 ### Enterprise Configuration

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -717,6 +717,12 @@ First, install a security scanner from npm:
 bun add -d @acme/bun-security-scanner
 ```
 
+<Note>
+  `@acme/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
+  use, and consult that scanner's documentation for the exact package name and installation instructions. Most scanners
+  are installed with `bun add`.
+</Note>
+
 Then configure it in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -714,11 +714,11 @@ Configure a security scanner to scan packages for vulnerabilities before install
 First, install a security scanner from npm:
 
 ```bash terminal icon="terminal"
-bun add -d @acme/bun-security-scanner
+bun add -d @oven/bun-security-scanner
 ```
 
 <Note>
-  `@acme/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
+  `@oven/bun-security-scanner` is an example package name, not a real package. Replace it with the scanner you want to
   use, and consult that scanner's documentation for the exact package name and installation instructions. Most scanners
   are installed with `bun add`.
 </Note>
@@ -727,7 +727,7 @@ Then configure it in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@acme/bun-security-scanner"
+scanner = "@oven/bun-security-scanner"
 ```
 
 When a security scanner is configured:

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -727,7 +727,7 @@ Then configure it in your `bunfig.toml`:
 
 ```toml bunfig.toml icon="settings"
 [install.security]
-scanner = "@oven/bun-security-scanner"
+scanner = "@oven/bun-security-scanner" # example name, replace with your scanner's package
 ```
 
 When a security scanner is configured:


### PR DESCRIPTION
## What

The `install.security.scanner` docs read as a literal call to action:

```bash
bun add -d @acme/bun-security-scanner
```

`@acme/bun-security-scanner` was a placeholder that does not exist on npm, so a reader who copy-pasted the command hit a 404:

```
$ bun add -d @acme/bun-security-scanner
bun add v1.3.14 (0d9b296a)
error: GET https://registry.npmjs.org/@acme%2fbun-security-scanner - 404
```

## Fix

- Add a `<Note>` after the `bun add` snippet in `docs/runtime/bunfig.mdx`, and align the existing note in `docs/pm/security-scanner-api.mdx`, making clear the name is an example to replace with a real scanner.
- Rename the example from `@acme/bun-security-scanner` to `@oven/bun-security-scanner` (per review feedback). `@oven` is the npm scope Bun already owns (it publishes the platform binaries there, e.g. `@oven/bun-linux-x64`), so the advertised name cannot be squatted by a third party.
- Add an inline `# example name, replace with your scanner's package` comment to each `scanner = ...` config snippet, since the Quick Start snippet sits above the note.

Docs-only change, no code paths affected.

Closes #32588
