### PR TITLE
Fix structuredClone crash with large nested ArrayBuffer

### DIFF
--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -796,24 +796,48 @@ static bool unwrapCryptoKey(JSGlobalObject* lexicalGlobalObject, const Vector<ui
 }
 #endif
 
-#if ASSUME_LITTLE_ENDIAN
-template<typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
+// Vector<uint8_t>::append() grows capacity by 1.5x via expandCapacity(). When the buffer is
+// already large (from serializing a big ArrayBuffer), 1.5x can exceed the ~2GB Vector capacity
+// limit and CRASH() even though the exact needed size would fit. This helper grows by 1.5x when
+// possible but clamps to the maximum valid capacity, and reports failure instead of crashing.
+static bool ensureBufferCapacity(Vector<uint8_t>& buffer, size_t needed)
 {
+    if (needed <= buffer.capacity()) [[likely]]
+        return true;
+    constexpr size_t maxCapacity = std::numeric_limits<unsigned>::max() >> 1;
+    if (needed > maxCapacity) [[unlikely]]
+        return false;
+    size_t grown = std::min(std::max(needed, buffer.capacity() + buffer.capacity() / 2), maxCapacity);
+    return buffer.tryReserveCapacity(grown) || buffer.tryReserveCapacity(needed);
+}
+
+#if ASSUME_LITTLE_ENDIAN
+template<typename T> static bool writeLittleEndian(Vector<uint8_t>& buffer, T value)
+{
+    if (!ensureBufferCapacity(buffer, buffer.size() + sizeof(value))) [[unlikely]]
+        return false;
     buffer.append(std::span { reinterpret_cast<uint8_t*>(&value), sizeof(value) });
+    return true;
 }
 #else
-template<typename T> static void writeLittleEndian(Vector<uint8_t>& buffer, T value)
+template<typename T> static bool writeLittleEndian(Vector<uint8_t>& buffer, T value)
 {
+    if (!ensureBufferCapacity(buffer, buffer.size() + sizeof(T))) [[unlikely]]
+        return false;
     for (unsigned i = 0; i < sizeof(T); i++) {
         buffer.append(value & 0xFF);
         value >>= 8;
     }
+    return true;
 }
 #endif
 
-template<> void writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, uint8_t value)
+template<> bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, uint8_t value)
 {
+    if (!ensureBufferCapacity(buffer, buffer.size() + 1)) [[unlikely]]
+        return false;
     buffer.append(value);
+    return true;
 }
 
 template<typename T> static bool writeLittleEndian(Vector<uint8_t>& buffer, const T* values, uint32_t length)
@@ -821,6 +845,8 @@ template<typename T> static bool writeLittleEndian(Vector<uint8_t>& buffer, cons
     if (length > std::numeric_limits<uint32_t>::max() / sizeof(T))
         return false;
 
+    if (!ensureBufferCapacity(buffer, buffer.size() + static_cast<size_t>(length) * sizeof(T))) [[unlikely]]
+        return false;
 #if ASSUME_LITTLE_ENDIAN
     buffer.append(std::span { reinterpret_cast<const uint8_t*>(values), length * sizeof(T) });
 #else
@@ -837,6 +863,8 @@ template<typename T> static bool writeLittleEndian(Vector<uint8_t>& buffer, cons
 
 template<> bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, const uint8_t* values, uint32_t length)
 {
+    if (!ensureBufferCapacity(buffer, buffer.size() + length)) [[unlikely]]
+        return false;
     buffer.append(std::span { values, length });
     return true;
 }
@@ -849,7 +877,8 @@ public:
 
     void write(const uint8_t* data, unsigned length)
     {
-        writeLittleEndian(m_buffer, data, length);
+        if (!writeLittleEndian(m_buffer, data, length)) [[unlikely]]
+            fail();
     }
     //     static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
     // #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -2103,59 +2132,70 @@ private:
 
     void write(SerializationTag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(ArrayBufferViewSubtag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(DestinationColorSpaceTag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
 #if ENABLE(WEB_CRYPTO)
     void write(CryptoKeyClassSubtag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(CryptoKeyAsymmetricTypeSubtag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(CryptoKeyUsageTag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(CryptoAlgorithmIdentifierTag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 
     void write(CryptoKeyOKPOpNameTag tag)
     {
-        writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag));
+        if (!writeLittleEndian<uint8_t>(m_buffer, static_cast<uint8_t>(tag))) [[unlikely]]
+            fail();
     }
 #endif
 
     void write(bool b)
     {
-        writeLittleEndian(m_buffer, static_cast<int32_t>(b));
+        if (!writeLittleEndian(m_buffer, static_cast<int32_t>(b))) [[unlikely]]
+            fail();
     }
 
     void write(uint8_t c)
     {
-        writeLittleEndian(m_buffer, c);
+        if (!writeLittleEndian(m_buffer, c)) [[unlikely]]
+            fail();
     }
 
     void write(uint32_t i)
     {
-        writeLittleEndian(m_buffer, i);
+        if (!writeLittleEndian(m_buffer, i)) [[unlikely]]
+            fail();
     }
 
     void write(double d)
@@ -2165,22 +2205,26 @@ private:
             int64_t i;
         } u;
         u.d = d;
-        writeLittleEndian(m_buffer, u.i);
+        if (!writeLittleEndian(m_buffer, u.i)) [[unlikely]]
+            fail();
     }
 
     void write(int32_t i)
     {
-        writeLittleEndian(m_buffer, i);
+        if (!writeLittleEndian(m_buffer, i)) [[unlikely]]
+            fail();
     }
 
     void write(uint64_t i)
     {
-        writeLittleEndian(m_buffer, i);
+        if (!writeLittleEndian(m_buffer, i)) [[unlikely]]
+            fail();
     }
 
     void write(uint16_t ch)
     {
-        writeLittleEndian(m_buffer, ch);
+        if (!writeLittleEndian(m_buffer, ch)) [[unlikely]]
+            fail();
     }
 
     void writeStringIndex(unsigned i)
@@ -2227,10 +2271,13 @@ private:
             return;
         }
 
-        if (str.is8Bit())
-            writeLittleEndian<uint32_t>(m_buffer, length | StringDataIs8BitFlag);
-        else
-            writeLittleEndian<uint32_t>(m_buffer, length);
+        if (str.is8Bit()) {
+            if (!writeLittleEndian<uint32_t>(m_buffer, length | StringDataIs8BitFlag)) [[unlikely]]
+                fail();
+        } else {
+            if (!writeLittleEndian<uint32_t>(m_buffer, length)) [[unlikely]]
+                fail();
+        }
 
         if (!length)
             return;
@@ -2263,7 +2310,8 @@ private:
     {
         uint32_t size = vector.size();
         write(size);
-        writeLittleEndian(m_buffer, vector.begin(), size);
+        if (!writeLittleEndian(m_buffer, vector.begin(), size)) [[unlikely]]
+            fail();
     }
 
     // void write(const File& file)

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -959,20 +959,22 @@ public:
 
     static bool serialize(StringView string, Vector<uint8_t>& out)
     {
-        writeLittleEndian(out, CurrentVersion);
-        if (string.isEmpty()) {
-            writeLittleEndian<uint8_t>(out, EmptyStringTag);
-            return true;
-        }
-        writeLittleEndian<uint8_t>(out, StringTag);
+        if (!writeLittleEndian(out, CurrentVersion))
+            return false;
+        if (string.isEmpty())
+            return writeLittleEndian<uint8_t>(out, EmptyStringTag);
+        if (!writeLittleEndian<uint8_t>(out, StringTag))
+            return false;
         const auto length = string.length();
         if (string.is8Bit()) {
             const auto span = string.span8();
-            writeLittleEndian(out, length | StringDataIs8BitFlag);
+            if (!writeLittleEndian(out, length | StringDataIs8BitFlag))
+                return false;
             return writeLittleEndian(out, span.data(), length);
         }
         const auto span = string.span16();
-        writeLittleEndian(out, length);
+        if (!writeLittleEndian(out, length))
+            return false;
         return writeLittleEndian(out, span.data(), length);
     }
 

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -367,7 +367,11 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
     ["ArrayBuffer in array", "[new ArrayBuffer(size)]", "r[0].byteLength === size"],
     ["Uint8Array in object", "{ h: new Uint8Array(size) }", "r.h.byteLength === size"],
     ["nested ArrayBuffer", "{ a: { b: new ArrayBuffer(size) } }", "r.a.b.byteLength === size"],
-    ["resizable ArrayBuffer in object", "{ h: new ArrayBuffer(size, { maxByteLength: size }) }", "r.h.byteLength === size"],
+    [
+      "resizable ArrayBuffer in object",
+      "{ h: new ArrayBuffer(size, { maxByteLength: size }) }",
+      "r.h.byteLength === size",
+    ],
   ] as const) {
     test(`${label} under 2GiB clones without crashing`, async () => {
       const script = `

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -357,4 +357,41 @@ describe("structuredClone with ArrayBuffer larger than serialization buffer capa
       expect(exitCode).toBe(0);
     });
   }
+
+  // A large-but-under-2GiB ArrayBuffer nested inside an object/array fills the serialization
+  // buffer to its reserved capacity; the subsequent terminator write then triggers vector
+  // growth. The default 1.5x growth exceeds the 2GiB cap and would crash. These cases must
+  // succeed and round-trip correctly since the total serialized size still fits under 2GiB.
+  for (const [label, expr, check] of [
+    ["ArrayBuffer in object", "{ h: new ArrayBuffer(size) }", "r.h.byteLength === size"],
+    ["ArrayBuffer in array", "[new ArrayBuffer(size)]", "r[0].byteLength === size"],
+    ["Uint8Array in object", "{ h: new Uint8Array(size) }", "r.h.byteLength === size"],
+    ["nested ArrayBuffer", "{ a: { b: new ArrayBuffer(size) } }", "r.a.b.byteLength === size"],
+    ["resizable ArrayBuffer in object", "{ h: new ArrayBuffer(size, { maxByteLength: size }) }", "r.h.byteLength === size"],
+  ] as const) {
+    test(`${label} under 2GiB clones without crashing`, async () => {
+      const script = `
+        const size = 1600000000;
+        let v;
+        try {
+          v = ${expr};
+        } catch {
+          console.log("SKIP");
+          process.exit(0);
+        }
+        const r = structuredClone(v);
+        console.log((${check}) ? "OK" : "BAD_ROUNDTRIP");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "inherit",
+      });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(["OK", "SKIP"]).toContain(stdout.trim());
+      expect(proc.signalCode).toBe(null);
+      expect(exitCode).toBe(0);
+    });
+  }
 });


### PR DESCRIPTION
## What does this PR do?

Fixes a `SIGABRT` crash in `structuredClone` / `postMessage` when serializing an object or array that contains a large `ArrayBuffer` (roughly 1.4GB-2GB).

```js
structuredClone({ h: new ArrayBuffer(1_600_000_000) }); // aborted
```

### Root cause

The serialization buffer is a `WTF::Vector<uint8_t>`, which has a hard capacity cap of `UINT_MAX >> 1` (~2GB).

When a large `ArrayBuffer` is serialized, `CloneSerializer` calls `tryReserveCapacity` for exactly `current + tag + length + payload` bytes, then fills the buffer to that exact capacity. The next write (e.g. the object `TerminatorTag` from `endObject()`) triggers `Vector::append`'s `expandCapacity`, which always requests `max(needed, 1.5 * capacity)`. With the buffer already at ~1.5-1.8GB, `1.5 * capacity` exceeds the 2GB cap and `allocateBuffer<FailureAction::Crash>` hits `CRASH()`, even though the actual needed size (current + 4 bytes) fits comfortably.

Cloning a bare `ArrayBuffer` (not nested) was unaffected because nothing is written after the payload.

### Fix

Add an `ensureBufferCapacity` helper that all `writeLittleEndian` overloads use before appending. It grows by 1.5x when that fits, clamps to the maximum valid capacity otherwise, and falls back to exact growth. On genuine overflow (total > 2GB) it returns `false` instead of crashing; the `write()` helpers propagate that to `m_failed` so `serialize()` returns an error.

With this change:
- `structuredClone({ h: new ArrayBuffer(1.8GB) })` succeeds and round-trips correctly
- `structuredClone({ a: new ArrayBuffer(1.2GB), b: new ArrayBuffer(1.2GB) })` (total > 2GB) throws `DataCloneError` instead of aborting

## How did you verify your code works?

- Reproduced the abort with the minimal repro above on the debug build
- Added subprocess tests in `test/js/web/workers/structured-clone.test.ts` covering ArrayBuffer/Uint8Array/resizable variants nested in objects, arrays, and nested objects
- Verified the new tests fail (process aborts with empty stdout) on the current release and pass with this change
- Ran `structured-clone.test.ts`, `structuredClone-classes.test.ts`, `structured-clone-fastpath.test.ts`, `structured-clone-blob-file.test.ts`: all pass

Found by Fuzzilli (fingerprint `e68e44226230e2d1`).