### PR TITLE
parser: don't alias automatic JSX runtime import to a user's local binding

### DIFF
--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -2067,7 +2067,7 @@ impl<V: Default, A: Allocator + HashbrownAllocator + Clone + Default> StringHash
     /// uses to turn the lifetime-erased slice into a `Static` key.
     ///
     /// This is the hot path for `Scope::members` (one call per declared
-    /// identifier in `declare_symbol_maybe_generated` / scope hoisting), where
+    /// identifier in `declare_symbol` / scope hoisting), where
     /// the previous owning shape was the parser's single largest
     /// `mi_heap_malloc` source.
     ///

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3214,12 +3214,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
 
             // Server-side components:
-            // Declare upfront the symbols for "Response" and "bun:app"
+            // Declare upfront the symbols for "Response" and "bun:app".
+            // Unlike the other generated symbols above, this one is looked up
+            // by name during visit (user `new Response(...)` resolves via
+            // `find_symbol`), so it must live in `module_scope.members`.
             match self.options.features.server_components {
                 options::ServerComponents::None | options::ServerComponents::ClientSide => {}
                 _ => {
                     self.response_ref =
-                        self.declare_generated_symbol(js_ast::symbol::Kind::Import, b"Response")?;
+                        self.declare_common_js_symbol(js_ast::symbol::Kind::Import, b"Response")?;
                     self.bun_app_namespace_ref =
                         self.new_symbol(js_ast::symbol::Kind::Other, b"import_bun_app")?;
                     let symbol = &mut self.symbols[self.response_ref.inner_index() as usize];

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4912,8 +4912,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
                     // If these are both functions, remove the overwritten declaration
                     if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
-                        self.symbols[symbol_idx]
-                            .set_remove_overwritten_function_declaration(true);
+                        self.symbols[symbol_idx].set_remove_overwritten_function_declaration(true);
                     }
                 }
                 MR::BecomePrivateGetSetPair => {
@@ -4922,8 +4921,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 }
                 MR::BecomePrivateStaticGetSetPair => {
                     ref_ = existing.ref_;
-                    self.symbols[symbol_idx].kind =
-                        js_ast::symbol::Kind::PrivateStaticGetSetPair;
+                    self.symbols[symbol_idx].kind = js_ast::symbol::Kind::PrivateStaticGetSetPair;
                 }
                 MR::OverwriteWithNew => {}
             }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -5639,7 +5639,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.options.features.auto_polyfill_require {
             debug_assert!(self.options.features.allow_runtime);
             self.ensure_require_symbol();
-            let r = self.runtime_identifier_ref(bun_ast::Loc::EMPTY, b"__require");
+            let r = self.runtime_identifier_ref(b"__require");
             self.record_usage(r);
         }
     }
@@ -5647,7 +5647,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     pub fn ignore_usage_of_runtime_require(&mut self) {
         if self.options.features.auto_polyfill_require {
             debug_assert!(!self.runtime_imports.__require.is_empty());
-            let r = self.runtime_identifier_ref(bun_ast::Loc::EMPTY, b"__require");
+            let r = self.runtime_identifier_ref(b"__require");
             self.ignore_usage(r);
             self.symbols[self.require_ref.inner_index() as usize].use_count_estimate = self.symbols
                 [self.require_ref.inner_index() as usize]
@@ -6587,7 +6587,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         )
     }
 
-    pub fn runtime_identifier_ref(&mut self, _loc: bun_ast::Loc, name: &'static [u8]) -> Ref {
+    pub fn runtime_identifier_ref(&mut self, name: &'static [u8]) -> Ref {
         self.has_called_runtime = true;
 
         if !self.runtime_imports.contains(name) {
@@ -6602,7 +6602,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     }
 
     pub fn runtime_identifier(&mut self, loc: bun_ast::Loc, name: &'static [u8]) -> Expr {
-        let ref_ = self.runtime_identifier_ref(loc, name);
+        let ref_ = self.runtime_identifier_ref(name);
         self.record_usage(ref_);
         self.new_expr(E::ImportIdentifier::new(ref_, false), loc)
     }

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4837,6 +4837,29 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.declare_symbol_maybe_generated::<true>(kind, bun_ast::Loc::EMPTY, hashed)
     }
 
+    /// Like [`Self::declare_generated_symbol`] but never touches
+    /// `current_scope.members`. Use for module-level auto-imports created
+    /// during the visit pass, where `current_scope` may be a nested scope
+    /// containing a user binding of the same name; `declare_generated_symbol`
+    /// would link the generated symbol to that binding via the
+    /// `IS_GENERATED` merge path.
+    pub fn new_generated_symbol(
+        &mut self,
+        kind: js_ast::symbol::Kind,
+        name: &'static [u8],
+    ) -> Result<Ref, bun_core::Error> {
+        // The bundler runs the renamer, so it is ok to not append a hash
+        let ref_ = if self.options.bundle {
+            self.new_symbol(kind, name)?
+        } else {
+            let hash = bun_wyhash::hash(name);
+            let hashed: &'a [u8] = bun_alloc::arena_format!(in self.arena, "{}_{}", bstr::BStr::new(name), bun_core::fmt::truncated_hash32(hash)).into_bump_str().as_bytes();
+            self.new_symbol(kind, hashed)?
+        };
+        VecExt::append(&mut self.module_scope_mut().generated, ref_);
+        Ok(ref_)
+    }
+
     pub fn declare_symbol(
         &mut self,
         kind: js_ast::symbol::Kind,
@@ -6145,10 +6168,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             None => {
                 let symbol_name = kind.tag_name();
                 let new_ref = self
-                    .declare_generated_symbol(js_ast::symbol::Kind::Other, symbol_name)
+                    .new_generated_symbol(js_ast::symbol::Kind::Other, symbol_name)
                     .expect("unreachable");
                 let loc_ref = LocRef { loc, ref_: new_ref };
-                VecExt::append(&mut self.module_scope_mut().generated, new_ref);
                 self.is_import_item.insert(new_ref, ());
                 self.jsx_imports.set(kind, loc_ref);
                 new_ref

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -2309,8 +2309,6 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     ref_: entry.r#ref,
                     is_top_level: true,
                 });
-                // SAFETY: arena-owned Scope pointer valid for parser 'a lifetime; no aliasing &mut outstanding
-                VecExt::append(&mut self.module_scope_mut().generated, entry.r#ref);
                 self.is_import_item.insert(entry.r#ref, ());
                 self.named_imports.put(
                     entry.r#ref,
@@ -3144,13 +3142,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             }
         }
 
-        let module_scope = self.module_scope_mut();
-        module_scope
+        self.module_scope_mut()
             .generated
             .ensure_unused_capacity(generated_symbols_count as usize * 3);
-        module_scope.members.ensure_unused_capacity(
-            generated_symbols_count as usize * 3 + module_scope.members.count(),
-        )?;
 
         self.exports_ref =
             self.declare_common_js_symbol(js_ast::symbol::Kind::Hoisted, b"exports")?;
@@ -4819,18 +4813,28 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     /// pass where `current_scope` is nested.
     ///
     /// Name selection:
-    /// - Bundle mode: keep `name` as-is. `NumberRenamer` assigns a unique
-    ///   printed name from `module_scope.generated`.
-    /// - Non-bundle: `printAst` uses `NoOpRenamer`, which prints
-    ///   `symbol.original_name` verbatim with no collision handling and never
-    ///   reads `module_scope.generated`. The `generatedSymbolName` hash suffix
-    ///   appended here is the sole collision guard on that path.
+    /// - [`Self::will_use_renamer`] (bundle or `minify_identifiers`): keep
+    ///   `name` as-is. Collision-free printing additionally requires the ref
+    ///   to land in some live `Part.declared_symbols` with `is_top_level =
+    ///   true` (or the file to be CJS-wrapped); callers do this via their
+    ///   import-stmt emitters (`generate_import_stmt` etc.).
+    ///   `module_scope.generated` alone is not read by `NumberRenamer`'s
+    ///   top-level pass for wrap=none/ESM.
+    /// - Otherwise: `printAst` uses `NoOpRenamer`, which prints
+    ///   `symbol.original_name` verbatim with no collision handling. The
+    ///   `generatedSymbolName` hash suffix appended here is the sole
+    ///   collision guard on that path.
+    ///
+    /// The `'static` bound is the line: generated symbols whose name is
+    /// computed at runtime (react-compiler temps, namespace refs from import
+    /// paths, `${name}` CJS-export shims) hand-roll `new_symbol` +
+    /// `module_scope.generated.append` instead.
     pub fn declare_generated_symbol(
         &mut self,
         kind: js_ast::symbol::Kind,
         name: &'static [u8],
     ) -> Result<Ref, bun_core::Error> {
-        let ref_ = if self.options.bundle {
+        let ref_ = if self.will_use_renamer() {
             self.new_symbol(kind, name)?
         } else {
             let hashed = self.hash_generated_name(name);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3250,16 +3250,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // `options.bundle == true`, which would let a user-level
         // `var __require` collide in `current_scope.members` and link the
         // runtime require to the user symbol via the IS_GENERATED merge path.
-        // Runtime equivalent of `generated_symbol_name!("__require")`:
-        let hash = bun_wyhash::hash(b"__require");
-        let hashed: &'a [u8] = bun_alloc::arena_format!(
-            in self.arena,
-            "{}_{}",
-            bstr::BStr::new(b"__require".as_slice()),
-            bun_core::fmt::truncated_hash32(hash)
-        )
-        .into_bump_str()
-        .as_bytes();
+        let hashed = self.hash_generated_name(b"__require");
         let ref_ = self
             .declare_symbol_maybe_generated::<true>(
                 js_ast::symbol::Kind::Other,
@@ -4819,6 +4810,15 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(ref_)
     }
 
+    /// Runtime equivalent of `generated_symbol_name!`. Same bytes as the
+    /// macro produces; arena-owned for symbol lifetime.
+    fn hash_generated_name(&self, name: &'static [u8]) -> &'a [u8] {
+        let hash = bun_wyhash::hash(name);
+        bun_alloc::arena_format!(in self.arena, "{}_{}", bstr::BStr::new(name), bun_core::fmt::truncated_hash32(hash))
+            .into_bump_str()
+            .as_bytes()
+    }
+
     /// Callers must pre-hash via `generated_symbol_name!`
     /// and pass the result, OR (non-bundle) we runtime-hash into the bump arena.
     pub fn declare_generated_symbol(
@@ -4830,10 +4830,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if self.options.bundle {
             return self.declare_symbol_maybe_generated::<true>(kind, bun_ast::Loc::EMPTY, name);
         }
-        // Runtime equivalent of `generated_symbol_name!`.
-        // Same bytes as the macro produces; arena-owned for symbol lifetime.
-        let hash = bun_wyhash::hash(name);
-        let hashed: &'a [u8] = bun_alloc::arena_format!(in self.arena, "{}_{}", bstr::BStr::new(name), bun_core::fmt::truncated_hash32(hash)).into_bump_str().as_bytes();
+        let hashed = self.hash_generated_name(name);
         self.declare_symbol_maybe_generated::<true>(kind, bun_ast::Loc::EMPTY, hashed)
     }
 
@@ -4852,8 +4849,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         let ref_ = if self.options.bundle {
             self.new_symbol(kind, name)?
         } else {
-            let hash = bun_wyhash::hash(name);
-            let hashed: &'a [u8] = bun_alloc::arena_format!(in self.arena, "{}_{}", bstr::BStr::new(name), bun_core::fmt::truncated_hash32(hash)).into_bump_str().as_bytes();
+            let hashed = self.hash_generated_name(name);
             self.new_symbol(kind, hashed)?
         };
         VecExt::append(&mut self.module_scope_mut().generated, ref_);

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3244,19 +3244,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         if !self.runtime_imports.__require.is_empty() {
             return;
         }
-        // Call declare_symbol_maybe_generated with the hashed
-        // "__require" name directly, regardless of bundle mode. Do NOT route through
-        // declare_generated_symbol — that helper skips the hash when
-        // `options.bundle == true`, which would let a user-level
-        // `var __require` collide in `current_scope.members` and link the
-        // runtime require to the user symbol via the IS_GENERATED merge path.
-        let hashed = self.hash_generated_name(b"__require");
         let ref_ = self
-            .declare_symbol_maybe_generated::<true>(
-                js_ast::symbol::Kind::Other,
-                bun_ast::Loc::EMPTY,
-                hashed,
-            )
+            .declare_generated_symbol(js_ast::symbol::Kind::Other, b"__require")
             .expect("oom");
         self.runtime_imports.__require = ref_;
         self.runtime_imports.put(b"__require", ref_);
@@ -4819,33 +4808,25 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             .as_bytes()
     }
 
-    /// Callers must pre-hash via `generated_symbol_name!`
-    /// and pass the result, OR (non-bundle) we runtime-hash into the bump arena.
+    /// Create a parser-generated symbol (runtime/JSX auto-imports, fast-refresh
+    /// hooks, etc.) and register it on `module_scope.generated` only.
+    ///
+    /// Never inserts into `current_scope.members`, so a user binding of the
+    /// same name in any scope cannot capture it. Safe to call from the visit
+    /// pass where `current_scope` is nested.
+    ///
+    /// Name selection:
+    /// - Bundle mode: keep `name` as-is. `NumberRenamer` assigns a unique
+    ///   printed name from `module_scope.generated`.
+    /// - Non-bundle: `printAst` uses `NoOpRenamer`, which prints
+    ///   `symbol.original_name` verbatim with no collision handling and never
+    ///   reads `module_scope.generated`. The `generatedSymbolName` hash suffix
+    ///   appended here is the sole collision guard on that path.
     pub fn declare_generated_symbol(
         &mut self,
         kind: js_ast::symbol::Kind,
         name: &'static [u8],
     ) -> Result<Ref, bun_core::Error> {
-        // The bundler runs the renamer, so it is ok to not append a hash
-        if self.options.bundle {
-            return self.declare_symbol_maybe_generated::<true>(kind, bun_ast::Loc::EMPTY, name);
-        }
-        let hashed = self.hash_generated_name(name);
-        self.declare_symbol_maybe_generated::<true>(kind, bun_ast::Loc::EMPTY, hashed)
-    }
-
-    /// Like [`Self::declare_generated_symbol`] but never touches
-    /// `current_scope.members`. Use for module-level auto-imports created
-    /// during the visit pass, where `current_scope` may be a nested scope
-    /// containing a user binding of the same name; `declare_generated_symbol`
-    /// would link the generated symbol to that binding via the
-    /// `IS_GENERATED` merge path.
-    pub fn new_generated_symbol(
-        &mut self,
-        kind: js_ast::symbol::Kind,
-        name: &'static [u8],
-    ) -> Result<Ref, bun_core::Error> {
-        // The bundler runs the renamer, so it is ok to not append a hash
         let ref_ = if self.options.bundle {
             self.new_symbol(kind, name)?
         } else {
@@ -4862,28 +4843,18 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         loc: bun_ast::Loc,
         name: &'a [u8],
     ) -> Result<Ref, bun_core::Error> {
-        self.declare_symbol_maybe_generated::<false>(kind, loc, name)
-    }
-
-    pub fn declare_symbol_maybe_generated<const IS_GENERATED: bool>(
-        &mut self,
-        kind: js_ast::symbol::Kind,
-        loc: bun_ast::Loc,
-        name: &'a [u8],
-    ) -> Result<Ref, bun_core::Error> {
         // p.checkForNonBMPCodePoint(loc, name)
-        if !IS_GENERATED {
-            // Forbid declaring a symbol with a reserved word in strict mode
-            if self.is_strict_mode()
-                && name.as_ptr() != arguments_str.as_ptr()
-                && bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
-            {
-                self.mark_strict_mode_feature(
-                    StrictModeFeature::ReservedWord,
-                    js_lexer::range_of_identifier(self.source, loc),
-                    name,
-                )?;
-            }
+
+        // Forbid declaring a symbol with a reserved word in strict mode
+        if self.is_strict_mode()
+            && name.as_ptr() != arguments_str.as_ptr()
+            && bun_ast::lexer_tables::is_strict_mode_reserved_word(name)
+        {
+            self.mark_strict_mode_feature(
+                StrictModeFeature::ReservedWord,
+                js_lexer::range_of_identifier(self.source, loc),
+                name,
+            )?;
         }
 
         // Allocate a new symbol
@@ -4914,59 +4885,50 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             let existing: js_ast::scope::Member = *entry.value_ptr;
             let symbol_idx = existing.ref_.inner_index() as usize;
 
-            if !IS_GENERATED {
-                use js_ast::scope::SymbolMergeResult as MR;
-                let merge = js_ast::Scope::can_merge_symbol_kinds::<TYPESCRIPT>(
-                    scope_kind,
-                    self.symbols[symbol_idx].kind,
-                    kind,
-                );
-                match merge {
-                    MR::Forbidden => {
-                        // Entry already holds `existing`; leave it untouched.
-                        // SAFETY: original_name is an arena-owned slice valid for 'a.
-                        let orig = self.symbols[symbol_idx].original_name.slice();
-                        self.log().add_symbol_already_declared_error(
-                            self.source,
-                            orig,
-                            loc,
-                            existing.loc,
-                        );
-                        return Ok(existing.ref_);
-                    }
-                    MR::KeepExisting => {
-                        ref_ = existing.ref_;
-                    }
-                    MR::ReplaceWithNew => {
-                        self.symbols[symbol_idx].link.set(ref_);
-
-                        // If these are both functions, remove the overwritten declaration
-                        if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
-                            self.symbols[symbol_idx]
-                                .set_remove_overwritten_function_declaration(true);
-                        }
-                    }
-                    MR::BecomePrivateGetSetPair => {
-                        ref_ = existing.ref_;
-                        self.symbols[symbol_idx].kind = js_ast::symbol::Kind::PrivateGetSetPair;
-                    }
-                    MR::BecomePrivateStaticGetSetPair => {
-                        ref_ = existing.ref_;
-                        self.symbols[symbol_idx].kind =
-                            js_ast::symbol::Kind::PrivateStaticGetSetPair;
-                    }
-                    MR::OverwriteWithNew => {}
+            use js_ast::scope::SymbolMergeResult as MR;
+            let merge = js_ast::Scope::can_merge_symbol_kinds::<TYPESCRIPT>(
+                scope_kind,
+                self.symbols[symbol_idx].kind,
+                kind,
+            );
+            match merge {
+                MR::Forbidden => {
+                    // Entry already holds `existing`; leave it untouched.
+                    // SAFETY: original_name is an arena-owned slice valid for 'a.
+                    let orig = self.symbols[symbol_idx].original_name.slice();
+                    self.log().add_symbol_already_declared_error(
+                        self.source,
+                        orig,
+                        loc,
+                        existing.loc,
+                    );
+                    return Ok(existing.ref_);
                 }
-            } else {
-                self.symbols[ref_.inner_index() as usize]
-                    .link
-                    .set(existing.ref_);
+                MR::KeepExisting => {
+                    ref_ = existing.ref_;
+                }
+                MR::ReplaceWithNew => {
+                    self.symbols[symbol_idx].link.set(ref_);
+
+                    // If these are both functions, remove the overwritten declaration
+                    if kind.is_function() && self.symbols[symbol_idx].kind.is_function() {
+                        self.symbols[symbol_idx]
+                            .set_remove_overwritten_function_declaration(true);
+                    }
+                }
+                MR::BecomePrivateGetSetPair => {
+                    ref_ = existing.ref_;
+                    self.symbols[symbol_idx].kind = js_ast::symbol::Kind::PrivateGetSetPair;
+                }
+                MR::BecomePrivateStaticGetSetPair => {
+                    ref_ = existing.ref_;
+                    self.symbols[symbol_idx].kind =
+                        js_ast::symbol::Kind::PrivateStaticGetSetPair;
+                }
+                MR::OverwriteWithNew => {}
             }
         }
         *entry.value_ptr = js_ast::scope::Member { ref_, loc };
-        if IS_GENERATED {
-            VecExt::append(&mut self.module_scope_mut().generated, ref_);
-        }
         Ok(ref_)
     }
 
@@ -6164,7 +6126,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             None => {
                 let symbol_name = kind.tag_name();
                 let new_ref = self
-                    .new_generated_symbol(js_ast::symbol::Kind::Other, symbol_name)
+                    .declare_generated_symbol(js_ast::symbol::Kind::Other, symbol_name)
                     .expect("unreachable");
                 let loc_ref = LocRef { loc, ref_: new_ref };
                 self.is_import_item.insert(new_ref, ());
@@ -6624,20 +6586,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.has_called_runtime = true;
 
         if !self.runtime_imports.contains(name) {
-            if !self.options.bundle {
-                let generated_symbol = self
-                    .declare_generated_symbol(js_ast::symbol::Kind::Other, name)
-                    .expect("unreachable");
-                self.runtime_imports.put(name, generated_symbol);
-                generated_symbol
-            } else {
-                let ref_ = self
-                    .new_symbol(js_ast::symbol::Kind::Other, name)
-                    .expect("unreachable");
-                self.runtime_imports.put(name, ref_);
-                VecExt::append(&mut self.module_scope_mut().generated, ref_);
-                ref_
-            }
+            let ref_ = self
+                .declare_generated_symbol(js_ast::symbol::Kind::Other, name)
+                .expect("unreachable");
+            self.runtime_imports.put(name, ref_);
+            ref_
         } else {
             self.runtime_imports.at(name).unwrap()
         }

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -4575,9 +4575,22 @@ pub fn NewParser_(
                         if (p.jsx_imports.getWithTag(kind) == null) {
                             const symbol_name = @tagName(field);
 
+                            // This runs during visit, so `p.current_scope` may be a
+                            // nested scope containing a user binding named "jsx" /
+                            // "jsxDEV" / "Fragment" etc. Do not route through
+                            // `declareGeneratedSymbol` (which inserts into
+                            // `p.current_scope.members` and would link the runtime
+                            // symbol to the user's local). Create the symbol
+                            // directly and register it on `module_scope.generated`
+                            // only; the renamer handles uniqueness.
+                            const new_ref = if (p.options.bundle)
+                                p.newSymbol(.other, symbol_name) catch unreachable
+                            else
+                                p.newSymbol(.other, generatedSymbolName(symbol_name)) catch unreachable;
+
                             const loc_ref = LocRef{
                                 .loc = loc,
-                                .ref = (p.declareGeneratedSymbol(.other, symbol_name) catch unreachable),
+                                .ref = new_ref,
                             };
 
                             bun.handleOom(p.module_scope.generated.append(p.allocator, loc_ref.ref.?));

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -3936,14 +3936,14 @@ pub fn NewParser_(
                 bun.assert(p.options.features.allow_runtime);
 
                 p.ensureRequireSymbol();
-                p.recordUsage(p.runtimeIdentifierRef(logger.Loc.Empty, "__require"));
+                p.recordUsage(p.runtimeIdentifierRef("__require"));
             }
         }
 
         pub fn ignoreUsageOfRuntimeRequire(p: *P) void {
             if (p.options.features.auto_polyfill_require) {
                 bun.assert(p.runtime_imports.__require != null);
-                p.ignoreUsage(p.runtimeIdentifierRef(logger.Loc.Empty, "__require"));
+                p.ignoreUsage(p.runtimeIdentifierRef("__require"));
                 p.symbols.items[p.require_ref.innerIndex()].use_count_estimate -|= 1;
             }
         }
@@ -5647,8 +5647,7 @@ pub fn NewParser_(
             @compileError("not implemented");
         }
 
-        fn runtimeIdentifierRef(p: *P, loc: logger.Loc, comptime name: string) Ref {
-            _ = loc;
+        fn runtimeIdentifierRef(p: *P, comptime name: string) Ref {
             p.has_called_runtime = true;
 
             if (!p.runtime_imports.contains(name)) {
@@ -5661,7 +5660,7 @@ pub fn NewParser_(
         }
 
         fn runtimeIdentifier(p: *P, loc: logger.Loc, comptime name: string) Expr {
-            const ref = p.runtimeIdentifierRef(loc, name);
+            const ref = p.runtimeIdentifierRef(name);
             p.recordUsage(ref);
             return p.newExpr(
                 E.ImportIdentifier{

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -2198,11 +2198,14 @@ pub fn NewParser_(
             }
 
             // Server-side components:
-            // Declare upfront the symbols for "Response" and "bun:app"
+            // Declare upfront the symbols for "Response" and "bun:app".
+            // Unlike the other generated symbols above, this one is looked up
+            // by name during visit (user `new Response(...)` resolves via
+            // `findSymbol`), so it must live in `module_scope.members`.
             switch (p.options.features.server_components) {
                 .none, .client_side => {},
                 else => {
-                    p.response_ref = try p.declareGeneratedSymbol(.import, "Response");
+                    p.response_ref = try p.declareCommonJSSymbol(.import, "Response");
                     p.bun_app_namespace_ref = try p.newSymbol(
                         .other,
                         "import_bun_app",

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -2223,8 +2223,7 @@ pub fn NewParser_(
 
         fn ensureRequireSymbol(p: *P) void {
             if (p.runtime_imports.__require != null) return;
-            const static_symbol = generatedSymbolName("__require");
-            p.runtime_imports.__require = bun.handleOom(declareSymbolMaybeGenerated(p, .other, logger.Loc.Empty, static_symbol, true));
+            p.runtime_imports.__require = bun.handleOom(p.declareGeneratedSymbol(.other, "__require"));
             p.runtime_imports.put("__require", p.runtime_imports.__require.?);
         }
 
@@ -3301,26 +3300,31 @@ pub fn NewParser_(
             return ref;
         }
 
+        /// Create a parser-generated symbol and register it on
+        /// `module_scope.generated` only. Never inserts into
+        /// `current_scope.members`, so a user binding of the same name in any
+        /// scope cannot capture it.
+        ///
+        /// Bundle mode: `NumberRenamer` assigns a unique printed name from
+        /// `module_scope.generated`. Non-bundle: `printAst` uses `NoOpRenamer`,
+        /// which prints `symbol.original_name` verbatim and never reads
+        /// `module_scope.generated`; the `generatedSymbolName` hash suffix
+        /// appended here is the sole collision guard on that path.
         pub fn declareGeneratedSymbol(p: *P, kind: Symbol.Kind, comptime name: string) !Ref {
-            // The bundler runs the renamer, so it is ok to not append a hash
-            if (p.options.bundle) {
-                return try declareSymbolMaybeGenerated(p, kind, logger.Loc.Empty, name, true);
-            }
-
-            return try declareSymbolMaybeGenerated(p, kind, logger.Loc.Empty, generatedSymbolName(name), true);
+            const ref = if (p.options.bundle)
+                try p.newSymbol(kind, name)
+            else
+                try p.newSymbol(kind, generatedSymbolName(name));
+            try p.module_scope.generated.append(p.allocator, ref);
+            return ref;
         }
 
         pub fn declareSymbol(p: *P, kind: Symbol.Kind, loc: logger.Loc, name: string) !Ref {
-            return try @call(bun.callmod_inline, declareSymbolMaybeGenerated, .{ p, kind, loc, name, false });
-        }
-
-        pub fn declareSymbolMaybeGenerated(p: *P, kind: Symbol.Kind, loc: logger.Loc, name: string, comptime is_generated: bool) !Ref {
             // p.checkForNonBMPCodePoint(loc, name)
-            if (comptime !is_generated) {
-                // Forbid declaring a symbol with a reserved word in strict mode
-                if (p.isStrictMode() and name.ptr != arguments_str.ptr and js_lexer.StrictModeReservedWords.has(name)) {
-                    try p.markStrictModeFeature(.reserved_word, js_lexer.rangeOfIdentifier(p.source, loc), name);
-                }
+
+            // Forbid declaring a symbol with a reserved word in strict mode
+            if (p.isStrictMode() and name.ptr != arguments_str.ptr and js_lexer.StrictModeReservedWords.has(name)) {
+                try p.markStrictModeFeature(.reserved_word, js_lexer.rangeOfIdentifier(p.source, loc), name);
             }
 
             // Allocate a new symbol
@@ -3332,47 +3336,40 @@ pub fn NewParser_(
                 const existing = entry.value_ptr.*;
                 var symbol: *Symbol = &p.symbols.items[existing.ref.innerIndex()];
 
-                if (comptime !is_generated) {
-                    switch (scope.canMergeSymbols(symbol.kind, kind, is_typescript_enabled)) {
-                        .forbidden => {
-                            try p.log.addSymbolAlreadyDeclaredError(p.allocator, p.source, symbol.original_name, loc, existing.loc);
-                            return existing.ref;
-                        },
+                switch (scope.canMergeSymbols(symbol.kind, kind, is_typescript_enabled)) {
+                    .forbidden => {
+                        try p.log.addSymbolAlreadyDeclaredError(p.allocator, p.source, symbol.original_name, loc, existing.loc);
+                        return existing.ref;
+                    },
 
-                        .keep_existing => {
-                            ref = existing.ref;
-                        },
+                    .keep_existing => {
+                        ref = existing.ref;
+                    },
 
-                        .replace_with_new => {
-                            symbol.link = ref;
+                    .replace_with_new => {
+                        symbol.link = ref;
 
-                            // If these are both functions, remove the overwritten declaration
-                            if (kind.isFunction() and symbol.kind.isFunction()) {
-                                symbol.remove_overwritten_function_declaration = true;
-                            }
-                        },
+                        // If these are both functions, remove the overwritten declaration
+                        if (kind.isFunction() and symbol.kind.isFunction()) {
+                            symbol.remove_overwritten_function_declaration = true;
+                        }
+                    },
 
-                        .become_private_get_set_pair => {
-                            ref = existing.ref;
-                            symbol.kind = .private_get_set_pair;
-                        },
+                    .become_private_get_set_pair => {
+                        ref = existing.ref;
+                        symbol.kind = .private_get_set_pair;
+                    },
 
-                        .become_private_static_get_set_pair => {
-                            ref = existing.ref;
-                            symbol.kind = .private_static_get_set_pair;
-                        },
+                    .become_private_static_get_set_pair => {
+                        ref = existing.ref;
+                        symbol.kind = .private_static_get_set_pair;
+                    },
 
-                        .overwrite_with_new => {},
-                    }
-                } else {
-                    p.symbols.items[ref.innerIndex()].link = existing.ref;
+                    .overwrite_with_new => {},
                 }
             }
             entry.key_ptr.* = name;
             entry.value_ptr.* = js_ast.Scope.Member{ .ref = ref, .loc = loc };
-            if (comptime is_generated) {
-                try p.module_scope.generated.append(p.allocator, ref);
-            }
             return ref;
         }
 
@@ -4575,25 +4572,11 @@ pub fn NewParser_(
                         if (p.jsx_imports.getWithTag(kind) == null) {
                             const symbol_name = @tagName(field);
 
-                            // This runs during visit, so `p.current_scope` may be a
-                            // nested scope containing a user binding named "jsx" /
-                            // "jsxDEV" / "Fragment" etc. Do not route through
-                            // `declareGeneratedSymbol` (which inserts into
-                            // `p.current_scope.members` and would link the runtime
-                            // symbol to the user's local). Create the symbol
-                            // directly and register it on `module_scope.generated`
-                            // only; the renamer handles uniqueness.
-                            const new_ref = if (p.options.bundle)
-                                p.newSymbol(.other, symbol_name) catch unreachable
-                            else
-                                p.newSymbol(.other, generatedSymbolName(symbol_name)) catch unreachable;
-
                             const loc_ref = LocRef{
                                 .loc = loc,
-                                .ref = new_ref,
+                                .ref = (p.declareGeneratedSymbol(.other, symbol_name) catch unreachable),
                             };
 
-                            bun.handleOom(p.module_scope.generated.append(p.allocator, loc_ref.ref.?));
                             p.is_import_item.put(p.allocator, loc_ref.ref.?, {}) catch unreachable;
                             @field(p.jsx_imports, @tagName(field)) = loc_ref;
                             break :brk loc_ref.ref.?;
@@ -5653,25 +5636,13 @@ pub fn NewParser_(
         }
 
         fn runtimeIdentifierRef(p: *P, loc: logger.Loc, comptime name: string) Ref {
+            _ = loc;
             p.has_called_runtime = true;
 
             if (!p.runtime_imports.contains(name)) {
-                if (!p.options.bundle) {
-                    const generated_symbol = p.declareGeneratedSymbol(.other, name) catch unreachable;
-                    p.runtime_imports.put(name, generated_symbol);
-                    return generated_symbol;
-                } else {
-                    const loc_ref = js_ast.LocRef{
-                        .loc = loc,
-                        .ref = p.newSymbol(.other, name) catch unreachable,
-                    };
-                    p.runtime_imports.put(
-                        name,
-                        loc_ref.ref.?,
-                    );
-                    bun.handleOom(p.module_scope.generated.append(p.allocator, loc_ref.ref.?));
-                    return loc_ref.ref.?;
-                }
+                const ref = p.declareGeneratedSymbol(.other, name) catch unreachable;
+                p.runtime_imports.put(name, ref);
+                return ref;
             } else {
                 return p.runtime_imports.at(name).?;
             }

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -1556,7 +1556,6 @@ pub fn NewParser_(
                         .name = LocRef{ .ref = entry.ref, .loc = logger.Loc{} },
                     });
                     declared_symbols.appendAssumeCapacity(.{ .ref = entry.ref, .is_top_level = true });
-                    try p.module_scope.generated.append(allocator, entry.ref);
                     try p.is_import_item.put(allocator, entry.ref, {});
                     try p.named_imports.put(allocator, entry.ref, .{
                         .alias = entry.name,
@@ -2156,7 +2155,6 @@ pub fn NewParser_(
             }
 
             try p.module_scope.generated.ensureUnusedCapacity(p.allocator, generated_symbols_count * 3);
-            try p.module_scope.members.ensureUnusedCapacity(p.allocator, generated_symbols_count * 3 + p.module_scope.members.count());
 
             p.exports_ref = try p.declareCommonJSSymbol(.hoisted, "exports");
             p.module_ref = try p.declareCommonJSSymbol(.hoisted, "module");
@@ -3308,13 +3306,24 @@ pub fn NewParser_(
         /// `current_scope.members`, so a user binding of the same name in any
         /// scope cannot capture it.
         ///
-        /// Bundle mode: `NumberRenamer` assigns a unique printed name from
-        /// `module_scope.generated`. Non-bundle: `printAst` uses `NoOpRenamer`,
-        /// which prints `symbol.original_name` verbatim and never reads
-        /// `module_scope.generated`; the `generatedSymbolName` hash suffix
-        /// appended here is the sole collision guard on that path.
+        /// `willUseRenamer()` (bundle or `minify_identifiers`): keep `name`
+        /// as-is. Collision-free printing additionally requires the ref to
+        /// land in some live `Part.declared_symbols` with `is_top_level =
+        /// true` (or the file to be CJS-wrapped); callers do this via their
+        /// import-stmt emitters (`generateImportStmt` etc.).
+        /// `module_scope.generated` alone is not read by `NumberRenamer`'s
+        /// top-level pass for wrap=none/ESM.
+        ///
+        /// Otherwise: `printAst` uses `NoOpRenamer`, which prints
+        /// `symbol.original_name` verbatim with no collision handling. The
+        /// `generatedSymbolName` hash suffix appended here is the sole
+        /// collision guard on that path.
+        ///
+        /// The `comptime` bound is the line: generated symbols whose name is
+        /// computed at runtime hand-roll `newSymbol` +
+        /// `module_scope.generated.append` instead.
         pub fn declareGeneratedSymbol(p: *P, kind: Symbol.Kind, comptime name: string) !Ref {
-            const ref = if (p.options.bundle)
+            const ref = if (p.willUseRenamer())
                 try p.newSymbol(kind, name)
             else
                 try p.newSymbol(kind, generatedSymbolName(name));

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -19,7 +19,7 @@ use crate::parser::{
 };
 use bun_ast as js_ast;
 use bun_ast::DeclaredSymbol;
-use bun_ast::{B, E, Expr, G, S, Stmt, Symbol};
+use bun_ast::{B, E, Expr, G, S, Stmt};
 
 // Named instantiations of `P<'_, TS, SCAN>`.
 pub type JavaScriptParser<'a> = P<'a, false, false>;
@@ -2248,12 +2248,9 @@ impl<'a> Parser<'a> {
 
         // Bake: transform global `Response` to use `import { Response } from 'bun:app'`
         #[allow(deprecated)]
-        if !p.response_ref.is_null() && {
-            // We only want to do this if the symbol is used and didn't get
-            // bound to some other value
-            let symbol: &Symbol = &p.symbols.as_slice()[p.response_ref.inner_index() as usize];
-            !symbol.has_link() && symbol.use_count_estimate > 0
-        } {
+        if !p.response_ref.is_null()
+            && p.symbols.as_slice()[p.response_ref.inner_index() as usize].use_count_estimate > 0
+        {
             p.generate_import_stmt_for_bake_response(&mut before)?;
         }
 

--- a/src/js_parser/parse/parse_entry.zig
+++ b/src/js_parser/parse/parse_entry.zig
@@ -1447,12 +1447,9 @@ pub const Parser = struct {
         }
 
         // Bake: transform global `Response` to use `import { Response } from 'bun:app'`
-        if (!p.response_ref.isNull() and is_used_and_has_no_links: {
-            // We only want to do this if the symbol is used and didn't get
-            // bound to some other value
-            const symbol: *const Symbol = &p.symbols.items[p.response_ref.innerIndex()];
-            break :is_used_and_has_no_links !symbol.hasLink() and symbol.use_count_estimate > 0;
-        }) {
+        if (!p.response_ref.isNull() and
+            p.symbols.items[p.response_ref.innerIndex()].use_count_estimate > 0)
+        {
             try p.generateImportStmtForBakeResponse(&before);
         }
 

--- a/src/js_parser/parse/parse_fn.rs
+++ b/src/js_parser/parse/parse_fn.rs
@@ -358,7 +358,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // be called "arguments", in which case the real "arguments" is inaccessible.
         if !p.current_scope().members.contains_key(arguments_str) {
             func.arguments_ref = p
-                .declare_symbol_maybe_generated::<false>(
+                .declare_symbol(
                     js_ast::symbol::Kind::Arguments,
                     func.open_parens_loc,
                     arguments_str,

--- a/src/js_parser/parse/parse_fn.zig
+++ b/src/js_parser/parse/parse_fn.zig
@@ -309,7 +309,7 @@ pub fn ParseFn(
             // this if it wasn't already declared above because arguments are allowed to
             // be called "arguments", in which case the real "arguments" is inaccessible.
             if (!p.current_scope.members.contains("arguments")) {
-                func.arguments_ref = p.declareSymbolMaybeGenerated(.arguments, func.open_parens_loc, arguments_str, false) catch unreachable;
+                func.arguments_ref = p.declareSymbol(.arguments, func.open_parens_loc, arguments_str) catch unreachable;
                 p.symbols.items[func.arguments_ref.?.innerIndex()].must_not_be_renamed = true;
             }
 

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -68,13 +68,12 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
             Some(existing) => existing,
             None => {
                 let new_ref = p
-                    .declare_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name())
+                    .new_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name())
                     .expect("oom");
                 let loc_ref = js_ast::LocRef {
                     loc: bun_ast::Loc::EMPTY,
                     ref_: new_ref,
                 };
-                VecExt::append(&mut p.module_scope_mut().generated, new_ref);
                 p.is_import_item.insert(new_ref, ());
                 p.jsx_imports.set(kind, loc_ref);
                 new_ref

--- a/src/js_parser/react_compiler_host.rs
+++ b/src/js_parser/react_compiler_host.rs
@@ -68,7 +68,7 @@ impl<'a, const TS: bool, const SCAN_ONLY: bool> bun_react_compiler::Host
             Some(existing) => existing,
             None => {
                 let new_ref = p
-                    .new_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name())
+                    .declare_generated_symbol(js_ast::symbol::Kind::Other, kind.tag_name())
                     .expect("oom");
                 let loc_ref = js_ast::LocRef {
                     loc: bun_ast::Loc::EMPTY,

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -201,6 +201,36 @@ describe("bundler", () => {
     devStdout: `["symbol","object"]`,
     prodStdout: `["symbol","object"]`,
   });
+  // A user's local `jsx` / `jsxDEV` / `Fragment` binding in the scope
+  // containing the first JSX element must not capture the automatic JSX
+  // runtime import. Before the fix, the runtime symbol was declared in
+  // `p.current_scope` (the nested function scope) and linked to the user's
+  // local, so the bundled output called the user's uninitialized local
+  // instead of the runtime helper.
+  itBundledDevAndProd("jsx/AutomaticLocalShadow", {
+    files: {
+      "/index.tsx": /* tsx */ `
+        import { print } from 'bun-test-helpers'
+        function f() {
+          let jsx: any
+          let jsxDEV: any
+          let Fragment: any
+          const el = <><div /></>
+          return [el, jsx, jsxDEV, Fragment]
+        }
+        const [el, a, b, c] = f()
+        print([el, a, b, c])
+      `,
+      ...helpers,
+    },
+    target: "bun",
+    devStdout: `
+      [{"$$typeof":"Symbol(jsxdev)","type":"Symbol(jsxdev.fragment)","props":{"children":{"$$typeof":"Symbol(jsxdev)","type":"div","props":{},"key":"undefined","source":false,"self":"undefined"}},"key":"undefined","source":false,"self":"undefined"},"undefined","undefined","undefined"]
+    `,
+    prodStdout: `
+      [{"$$typeof":"Symbol(jsx)","type":"Symbol(jsx.fragment)","props":{"children":{"$$typeof":"Symbol(jsx)","type":"div","props":{},"key":"undefined"}},"key":"undefined"},"undefined","undefined","undefined"]
+    `,
+  });
   itBundledDevAndProd("jsx/ImportSource", {
     prodTodo: true,
     files: {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -273,12 +273,7 @@ describe("bundler", () => {
       "/index.tsx": ['"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.'],
     },
     onAfterBundle(api) {
-      expectMinifiedRuntimeImportsNotShadowed(api.readFile("out.js"), [
-        "jsx",
-        "jsxs",
-        "Fragment",
-        "createElement",
-      ]);
+      expectMinifiedRuntimeImportsNotShadowed(api.readFile("out.js"), ["jsx", "jsxs", "Fragment", "createElement"]);
     },
   });
   itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersDev", {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -231,6 +231,98 @@ describe("bundler", () => {
       [{"$$typeof":"Symbol(jsx)","type":"Symbol(jsx.fragment)","props":{"children":{"$$typeof":"Symbol(jsx)","type":"div","props":{},"key":"undefined"}},"key":"undefined"},"undefined","undefined","undefined"]
     `,
   });
+  // Same as above but with `--minify-identifiers`. Before the fix the renamer
+  // assigned the same minified name to both the runtime import and the user's
+  // local. Covers jsx / jsxs / Fragment / createElement (prod) and
+  // jsxDEV / Fragment (dev).
+  itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersProd", {
+    files: {
+      "/index.tsx": /* tsx */ `
+        export function f() {
+          let jsx: any
+          let jsxs: any
+          let Fragment: any
+          let createElement: any
+          const props = {}
+          const els = [<div />, <div><a/><b/></div>, <><div /></>, <div {...props} key="k" />]
+          return [els, jsx, jsxs, Fragment, createElement]
+        }
+      `,
+    },
+    external: ["react", "react/*"],
+    minifyIdentifiers: true,
+    env: {
+      NODE_ENV: "production",
+    },
+    bundleWarnings: {
+      "/index.tsx": ['"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.'],
+    },
+    onAfterBundle(api) {
+      const file = api.readFile("out.js");
+      expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
+        "// index.tsx
+        import { jsx as e, jsxs as i, Fragment as o } from "react/jsx-runtime";
+        import { createElement as v } from "react";
+        function y() {
+          let n;
+          let t;
+          let l;
+          let s;
+          const a = {};
+          const d = [/* @__PURE__ */ e("div", {}), /* @__PURE__ */ i("div", {
+            children: [
+              /* @__PURE__ */ e("a", {}),
+              /* @__PURE__ */ e("b", {})
+            ]
+          }), /* @__PURE__ */ e(o, {
+            children: /* @__PURE__ */ e("div", {})
+          }), /* @__PURE__ */ v("div", {
+            ...a,
+            key: "k"
+          })];
+          return [d, n, t, l, s];
+        }
+        export {
+          y as f
+        };"
+      `);
+    },
+  });
+  itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersDev", {
+    files: {
+      "/index.tsx": /* tsx */ `
+        export function f() {
+          let jsxDEV: any
+          let Fragment: any
+          const els = [<div />, <><div /></>]
+          return [els, jsxDEV, Fragment]
+        }
+      `,
+    },
+    external: ["react", "react/*"],
+    minifyIdentifiers: true,
+    env: {
+      NODE_ENV: "development",
+    },
+    onAfterBundle(api) {
+      const file = api.readFile("out.js");
+      expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
+        "// index.tsx
+        import { jsxDEV as n, Fragment as o } from "react/jsx-dev-runtime";
+        function a() {
+          let t;
+          let e;
+          const l = [/* @__PURE__ */ n("div", {}, undefined, false, undefined, this), /* @__PURE__ */ n(o, {
+            children: /* @__PURE__ */ n("div", {}, undefined, false, undefined, this)
+          }, undefined, false, undefined, this)];
+          return [l, t, e];
+        }
+        export {
+          a as f
+        };"
+      `);
+    },
+  });
   itBundledDevAndProd("jsx/ImportSource", {
     prodTodo: true,
     files: {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -230,6 +230,26 @@ describe("bundler", () => {
   });
   // Same as above but with `--minify-identifiers`. Covers jsx / jsxs /
   // Fragment / createElement (prod) and jsxDEV / Fragment (dev).
+  // The property under test is that the minified names assigned to the
+  // auto-imported runtime helpers and the user's local `let` bindings are
+  // pairwise distinct; literal minified slot names are not pinned.
+  function expectMinifiedRuntimeImportsNotShadowed(out: string, runtimeKinds: string[]) {
+    const importClauses = [...out.matchAll(/^import \{([^}]+)\} from /gm)].map(m => m[1]).join(",");
+    const importAliases: Record<string, string> = {};
+    for (const [, orig, alias] of importClauses.matchAll(/\b(\w+) as (\w+)\b/g)) {
+      importAliases[orig] = alias;
+    }
+    const locals = [...out.matchAll(/\blet (\w+);/g)].map(m => m[1]);
+    expect(Object.keys(importAliases).sort()).toEqual([...runtimeKinds].sort());
+    expect(locals).toHaveLength(runtimeKinds.length);
+    for (const kind of runtimeKinds) {
+      expect({ kind, alias: importAliases[kind], locals }).toEqual({
+        kind,
+        alias: expect.not.stringMatching(new RegExp(`^(${locals.join("|")})$`)),
+        locals,
+      });
+    }
+  }
   itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersProd", {
     files: {
       "/index.tsx": /* tsx */ `
@@ -253,34 +273,12 @@ describe("bundler", () => {
       "/index.tsx": ['"key" prop after a {...spread} is deprecated in JSX. Falling back to classic runtime.'],
     },
     onAfterBundle(api) {
-      const file = api.readFile("out.js");
-      expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
-        "// index.tsx
-        import { jsx as e, jsxs as i, Fragment as o } from "react/jsx-runtime";
-        import { createElement as v } from "react";
-        function y() {
-          let n;
-          let t;
-          let l;
-          let s;
-          const a = {};
-          const d = [/* @__PURE__ */ e("div", {}), /* @__PURE__ */ i("div", {
-            children: [
-              /* @__PURE__ */ e("a", {}),
-              /* @__PURE__ */ e("b", {})
-            ]
-          }), /* @__PURE__ */ e(o, {
-            children: /* @__PURE__ */ e("div", {})
-          }), /* @__PURE__ */ v("div", {
-            ...a,
-            key: "k"
-          })];
-          return [d, n, t, l, s];
-        }
-        export {
-          y as f
-        };"
-      `);
+      expectMinifiedRuntimeImportsNotShadowed(api.readFile("out.js"), [
+        "jsx",
+        "jsxs",
+        "Fragment",
+        "createElement",
+      ]);
     },
   });
   itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersDev", {
@@ -300,22 +298,7 @@ describe("bundler", () => {
       NODE_ENV: "development",
     },
     onAfterBundle(api) {
-      const file = api.readFile("out.js");
-      expect(normalizeBunSnapshot(file)).toMatchInlineSnapshot(`
-        "// index.tsx
-        import { jsxDEV as n, Fragment as o } from "react/jsx-dev-runtime";
-        function a() {
-          let t;
-          let e;
-          const l = [/* @__PURE__ */ n("div", {}, undefined, false, undefined, this), /* @__PURE__ */ n(o, {
-            children: /* @__PURE__ */ n("div", {}, undefined, false, undefined, this)
-          }, undefined, false, undefined, this)];
-          return [l, t, e];
-        }
-        export {
-          a as f
-        };"
-      `);
+      expectMinifiedRuntimeImportsNotShadowed(api.readFile("out.js"), ["jsxDEV", "Fragment"]);
     },
   });
   itBundledDevAndProd("jsx/ImportSource", {

--- a/test/bundler/bundler_jsx.test.ts
+++ b/test/bundler/bundler_jsx.test.ts
@@ -203,10 +203,7 @@ describe("bundler", () => {
   });
   // A user's local `jsx` / `jsxDEV` / `Fragment` binding in the scope
   // containing the first JSX element must not capture the automatic JSX
-  // runtime import. Before the fix, the runtime symbol was declared in
-  // `p.current_scope` (the nested function scope) and linked to the user's
-  // local, so the bundled output called the user's uninitialized local
-  // instead of the runtime helper.
+  // runtime import.
   itBundledDevAndProd("jsx/AutomaticLocalShadow", {
     files: {
       "/index.tsx": /* tsx */ `
@@ -231,10 +228,8 @@ describe("bundler", () => {
       [{"$$typeof":"Symbol(jsx)","type":"Symbol(jsx.fragment)","props":{"children":{"$$typeof":"Symbol(jsx)","type":"div","props":{},"key":"undefined"}},"key":"undefined"},"undefined","undefined","undefined"]
     `,
   });
-  // Same as above but with `--minify-identifiers`. Before the fix the renamer
-  // assigned the same minified name to both the runtime import and the user's
-  // local. Covers jsx / jsxs / Fragment / createElement (prod) and
-  // jsxDEV / Fragment (dev).
+  // Same as above but with `--minify-identifiers`. Covers jsx / jsxs /
+  // Fragment / createElement (prod) and jsxDEV / Fragment (dev).
   itBundled("jsx/AutomaticLocalShadowMinifyIdentifiersProd", {
     files: {
       "/index.tsx": /* tsx */ `

--- a/test/bundler/transpiler/react-compiler.test.ts
+++ b/test/bundler/transpiler/react-compiler.test.ts
@@ -451,6 +451,45 @@ describe("bundler", () => {
     });
   }
 
+  // A user's local `jsx` / `jsxs` / `jsxDEV` / `Fragment` binding in the
+  // component body scope must not capture the automatic JSX runtime import
+  // when the React Compiler rewrites the component.
+  itBundled("react-compiler/AutomaticLocalShadow", {
+    files: {
+      "/entry.jsx": /* jsx */ `
+        export function Comp({ a, b }) {
+          let jsx = a
+          let jsxs = b
+          let jsxDEV = a
+          let Fragment = b
+          return <><span>{jsx}</span><span>{jsxs}{jsxDEV}{Fragment}</span></>
+        }
+        console.log(JSON.stringify(Comp({ a: "A", b: "B" })))
+      `,
+      "/node_modules/react/compiler-runtime.js": `
+        exports.c = function (n) { return new Array(n).fill(Symbol.for("react.memo_cache_sentinel")); };
+      `,
+      "/node_modules/react/index.js": `exports.createElement = () => null;`,
+      "/node_modules/react/jsx-runtime.js": `
+        exports.jsx = (type, props) => ({ $: "jsx", type: typeof type === "symbol" ? "Fragment" : type, props });
+        exports.jsxs = (type, props) => ({ $: "jsxs", type: typeof type === "symbol" ? "Fragment" : type, props });
+        exports.Fragment = Symbol.for("fragment");
+      `,
+      "/node_modules/react/jsx-dev-runtime.js": `
+        exports.jsxDEV = (type, props) => ({ $: "jsxDEV", type: typeof type === "symbol" ? "Fragment" : type, props });
+        exports.Fragment = Symbol.for("fragment");
+      `,
+      "/node_modules/react/package.json": `{"name":"react","main":"./index.js"}`,
+    },
+    reactCompiler: true,
+    target: "browser",
+    backend: "api",
+    run: {
+      stdout:
+        '{"$":"jsxDEV","type":"Fragment","props":{"children":[{"$":"jsxDEV","type":"span","props":{"children":"A"}},{"$":"jsxDEV","type":"span","props":{"children":["B","A","B"]}}]}}',
+    },
+  });
+
   itBundled("react-compiler/NonComponentUntouched", {
     files: {
       "/entry.jsx": /* jsx */ `

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1705,6 +1705,27 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
+  // Non-bundle transpile uses NoOpRenamer (prints symbol.original_name
+  // verbatim), so the `generatedSymbolName` hash suffix on the automatic JSX
+  // runtime import is the sole collision guard against a user local of the
+  // same name in the first JSX element's scope.
+  it("JSX automatic runtime import is not shadowed by a user local", () => {
+    var bun = new Bun.Transpiler({
+      loader: "tsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+    });
+
+    const out = bun.transformSync(
+      "export function f() { let jsx: any; let jsxDEV: any; let Fragment: any; return [<><div /></>, jsx, jsxDEV, Fragment] }",
+    );
+    expect(out).toContain("jsxDEV_7x81h0kn(");
+    expect(out).toContain("Fragment_8vg9x3sq,");
+    expect(out).toContain("let jsx;");
+    expect(out).toContain("let jsxDEV;");
+    expect(out).toContain("let Fragment;");
+    expect(out).not.toMatch(/\bjsxDEV\(/);
+  });
+
   it("JSX bare key prop followed by key with a value does not crash", async () => {
     await using proc = Bun.spawn({
       cmd: [

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -1705,25 +1705,43 @@ console.log(<div {...obj} key="after" />);`),
     );
   });
 
-  // Non-bundle transpile uses NoOpRenamer (prints symbol.original_name
-  // verbatim), so the `generatedSymbolName` hash suffix on the automatic JSX
-  // runtime import is the sole collision guard against a user local of the
-  // same name in the first JSX element's scope.
+  // Non-bundle transpile without `minify.identifiers` uses NoOpRenamer
+  // (prints symbol.original_name verbatim), so the `generatedSymbolName`
+  // hash suffix on the automatic JSX runtime import is the sole collision
+  // guard against a user local of the same name in the first JSX element's
+  // scope. With `minify.identifiers`, MinifyRenamer assigns distinct slots
+  // and the hash suffix is not emitted.
   it("JSX automatic runtime import is not shadowed by a user local", () => {
-    var bun = new Bun.Transpiler({
+    const input =
+      "export function f() { let jsx: any; let jsxDEV: any; let Fragment: any; return [<><div /></>, jsx, jsxDEV, Fragment] }";
+
+    const noop = new Bun.Transpiler({
       loader: "tsx",
       define: { "process.env.NODE_ENV": JSON.stringify("development") },
-    });
+    }).transformSync(input);
+    expect(noop).toContain("jsxDEV_7x81h0kn(");
+    expect(noop).toContain("Fragment_8vg9x3sq,");
+    expect(noop).toContain("let jsx;");
+    expect(noop).toContain("let jsxDEV;");
+    expect(noop).toContain("let Fragment;");
+    expect(noop).not.toMatch(/\bjsxDEV\(/);
 
-    const out = bun.transformSync(
-      "export function f() { let jsx: any; let jsxDEV: any; let Fragment: any; return [<><div /></>, jsx, jsxDEV, Fragment] }",
-    );
-    expect(out).toContain("jsxDEV_7x81h0kn(");
-    expect(out).toContain("Fragment_8vg9x3sq,");
-    expect(out).toContain("let jsx;");
-    expect(out).toContain("let jsxDEV;");
-    expect(out).toContain("let Fragment;");
-    expect(out).not.toMatch(/\bjsxDEV\(/);
+    const minified = new Bun.Transpiler({
+      loader: "tsx",
+      define: { "process.env.NODE_ENV": JSON.stringify("development") },
+      minify: { identifiers: true },
+      autoImportJSX: true,
+    }).transformSync(input);
+    expect(minified).not.toContain("_7x81h0kn");
+    expect(minified).not.toContain("_8vg9x3sq");
+    // Import aliases must not collide with the user's `let` bindings.
+    const aliases = [...minified.matchAll(/\b\w+ as (\w+)\b/g)].map(m => m[1]);
+    const locals = [...minified.matchAll(/\blet (\w+);/g)].map(m => m[1]);
+    expect(aliases).toHaveLength(2);
+    expect(locals).toHaveLength(3);
+    for (const alias of aliases) {
+      expect(locals).not.toContain(alias);
+    }
   });
 
   it("JSX bare key prop followed by key with a value does not crash", async () => {


### PR DESCRIPTION
## Repro

```tsx
// input.tsx
export function f() { let jsx: any; return [<div />, jsx] }
```

```sh
bun build ./input.tsx --external 'react/*' --production
```

Before:

```js
import{jsx as n}from"react/jsx-runtime";function f(){let n;return[n("div",{}),n]}export{f};
```

Both the runtime import and the user's local print as `n`; the JSX call invokes the user's uninitialized local and throws `TypeError: jsx is not a function` at runtime. The same happens for a local `jsxDEV` / `jsxs` / `Fragment` / `createElement` in the scope of the first JSX element.

## Cause

`jsx_import()` (`src/js_parser/p.rs`, and its twin in `react_compiler_host.rs`) runs during the visit pass while lowering `<Foo/>`, so `p.current_scope` is whatever nested scope the first JSX element lives in. It calls `declare_generated_symbol(.other, "jsx")`, which inserts into `p.current_scope.members`. If the user already has a `let jsx` in that scope, `declare_symbol_maybe_generated` hits `found_existing` and, in the `IS_GENERATED` else-branch, sets `.link = existing.ref`, aliasing the JSX runtime symbol to the user's local. The renamer follows `.link`, so both print as the same identifier.

## Fix

Add `P::new_generated_symbol()`, which mirrors `declare_generated_symbol`'s bundle/non-bundle name selection (bare `"jsx"` when bundling, hashed `"jsx_7x81h0kn"` otherwise) but only creates the symbol via `new_symbol` and registers it on `module_scope.generated`. The automatic JSX import is semantically a module-scope auto-import, and the renamer handles uniqueness from there. Also drops the redundant second append to `module_scope.generated` in both callers.

Applied in three places: `p.rs::jsx_import`, `react_compiler_host.rs::jsx_import`, and the `p.zig::jsxImport` reference.

After:

```js
import{jsx as f}from"react/jsx-runtime";function o(){let n;return[f("div",{}),n]}export{o as f};
```

Non-bundle transpile output is unchanged (still uses the hashed name).

## Verification

New `jsx/AutomaticLocalShadow{Dev,Prod}` in `test/bundler/bundler_jsx.test.ts` bundles and runs code with local `jsx`/`jsxDEV`/`Fragment` bindings in the same scope as `<><div /></>`.

- `USE_SYSTEM_BUN=1 bun test bundler_jsx.test.ts -t AutomaticLocalShadow`: 2 fail (`TypeError: jsxDEV is not a function`, `TypeError: jsx is not a function`)
- `bun bd test bundler_jsx.test.ts -t AutomaticLocalShadow`: 2 pass
- `bun bd test bundler_jsx.test.ts`: 31 pass, 4 todo, 0 fail
- `bun bd test transpiler/react-compiler.test.ts`: 18 pass
- `bun bd test transpiler/jsx-production.test.ts`: 32 pass