### PR TITLE
Fix use-after-free in JSReadable*Controller end()/close() when onClose re-enters the event loop

### DIFF
--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -452,9 +452,19 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
 
+    // Null the native pointer before running any JS. detach() fires the
+    // onClose callback, which can re-enter the event loop and free the
+    // sink (e.g. handle_resolve_stream -> destroy_sink) while ptr is still
+    // live on our stack. Do the native close first, then let detach() run
+    // the JS callback once we no longer need ptr.
+    ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
+    controller->m_sinkPtr = nullptr;
+
+    ${name}__close(lexicalGlobalObject, ptr);
+    RETURN_IF_EXCEPTION(scope, {});
+
     controller->detach();
     RETURN_IF_EXCEPTION(scope, {});
-    ${name}__close(lexicalGlobalObject, ptr);
     return JSC::JSValue::encode(JSC::jsUndefined());
 }
 
@@ -475,9 +485,20 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__end, (JSC::JSGlobalObject * lexicalGloba
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
 
+    // Null the native pointer before running any JS. detach() fires the
+    // onClose callback, which can re-enter the event loop and free the
+    // sink (e.g. handle_resolve_stream -> destroy_sink) while ptr is still
+    // live on our stack. Do the native end first, then let detach() run
+    // the JS callback once we no longer need ptr.
+    ${name}__controllerDetached(ptr, JSC::JSValue::encode(controller));
+    controller->m_sinkPtr = nullptr;
+
+    auto result = ${name}__endWithSink(ptr, lexicalGlobalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
     controller->detach();
     RETURN_IF_EXCEPTION(scope, {});
-    return ${name}__endWithSink(ptr, lexicalGlobalObject);
+    return result;
 }
 
 extern "C" JSC::EncodedJSValue ${name}__getInternalFd(void* sinkPtr);

--- a/src/codegen/generate-jssink.ts
+++ b/src/codegen/generate-jssink.ts
@@ -461,7 +461,21 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__close, (JSC::JSGlobalObject * lexicalGlo
     controller->m_sinkPtr = nullptr;
 
     ${name}__close(lexicalGlobalObject, ptr);
-    RETURN_IF_EXCEPTION(scope, {});
+
+    // detach() must still fire onClose (it transitions the direct
+    // ReadableStream to closed/errored and calls underlyingSource.cancel())
+    // even if the native close threw, matching the pre-reorder behaviour.
+    // Stash and rethrow around it; the sink's error wins over any onClose
+    // error.
+    if (JSC::Exception* pending = scope.exception()) [[unlikely]] {
+        if (!scope.tryClearException()) {
+            return {};
+        }
+        controller->detach();
+        (void)scope.tryClearException();
+        scope.throwException(lexicalGlobalObject, pending);
+        return {};
+    }
 
     controller->detach();
     RETURN_IF_EXCEPTION(scope, {});
@@ -494,7 +508,21 @@ JSC_DEFINE_HOST_FUNCTION(${controller}__end, (JSC::JSGlobalObject * lexicalGloba
     controller->m_sinkPtr = nullptr;
 
     auto result = ${name}__endWithSink(ptr, lexicalGlobalObject);
-    RETURN_IF_EXCEPTION(scope, {});
+
+    // detach() must still fire onClose (it transitions the direct
+    // ReadableStream to closed/errored and calls underlyingSource.cancel())
+    // even if the native end threw, matching the pre-reorder behaviour.
+    // Stash and rethrow around it; the sink's error wins over any onClose
+    // error.
+    if (JSC::Exception* pending = scope.exception()) [[unlikely]] {
+        if (!scope.tryClearException()) {
+            return {};
+        }
+        controller->detach();
+        (void)scope.tryClearException();
+        scope.throwException(lexicalGlobalObject, pending);
+        return {};
+    }
 
     controller->detach();
     RETURN_IF_EXCEPTION(scope, {});

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -39,8 +39,10 @@ test("HTTPResponseSink displays correct message", async () => {
 // callback (which is what detach()'s onClose invokes for a direct stream).
 // Under ASAN this is a heap-use-after-free without the fix; in release it
 // segfaults on the scrubbed buffer pointer.
-test.skipIf(!isASAN)("controller.end() after pull() resolved does not use the sink after free", async () => {
-  const fixture = `
+test.skipIf(!isASAN)(
+  "controller.end() after pull() resolved does not use the sink after free",
+  async () => {
+    const fixture = `
     const { drainMicrotasks } = require("bun:jsc");
 
     const big = Buffer.alloc(128 * 1024, 0x61);
@@ -96,21 +98,19 @@ test.skipIf(!isASAN)("controller.end() after pull() resolved does not use the si
     console.log("ok");
   `;
 
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect({ stdout, stderr, exitCode }).toEqual({
-    stdout: "ok\n",
-    stderr: "",
-    exitCode: 0,
-  });
-}, 30_000);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "ok\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+  30_000,
+);

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -1,5 +1,6 @@
 import { sleep } from "bun";
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN } from "harness";
 
 test("HTTPResponseSink displays correct message", async () => {
   let leakedCtrl: any;
@@ -27,3 +28,89 @@ test("HTTPResponseSink displays correct message", async () => {
   );
   expect(() => leakedCtrl.write.call({}, "c")).toThrow("Expected HTTPResponseSink");
 });
+
+// Sentry BUN-2WJA / BUN-2WKB: JSReadable*Controller.end() ran the onClose
+// callback (via detach()) before calling endWithSink() on the stashed sink
+// pointer. If the stream's pull() promise had already settled, the queued
+// on_resolve_stream reaction frees the sink when microtasks drain during
+// onClose, leaving endWithSink() to dereference a freed HTTPServerWritable.
+//
+// The repro forces the microtask drain from inside the stream's cancel()
+// callback (which is what detach()'s onClose invokes for a direct stream).
+// Under ASAN this is a heap-use-after-free without the fix; in release it
+// segfaults on the scrubbed buffer pointer.
+test.skipIf(!isASAN)("controller.end() after pull() resolved does not use the sink after free", async () => {
+  const fixture = `
+    const { drainMicrotasks } = require("bun:jsc");
+
+    const big = Buffer.alloc(128 * 1024, 0x61);
+    let capturedController;
+    let resolvePull;
+    const pullSettled = Promise.withResolvers();
+
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(
+          new ReadableStream({
+            type: "direct",
+            pull(controller) {
+              capturedController = controller;
+              controller.write(big);
+              const p = new Promise(r => { resolvePull = r; });
+              p.then(() => pullSettled.resolve());
+              return p;
+            },
+            cancel() {
+              // Reached from controller.end() -> detach() -> onClose.
+              // Draining here runs on_resolve_stream, which destroys the
+              // native sink while endWithSink() still holds a pointer to it.
+              drainMicrotasks();
+            },
+          }),
+        );
+      },
+    });
+
+    const res = await fetch(server.url);
+    const reader = res.body.getReader();
+    // Read the body to completion so the client never applies backpressure
+    // and the server-side write drains without parking a pending_flush.
+    const drained = (async () => { while (!(await reader.read()).done); })();
+
+    // Wait until pull() has been invoked and the controller is live.
+    while (!resolvePull) await Bun.sleep(0);
+
+    // Queue on_resolve_stream: pull()'s promise -> .then(() => {}) wrapper
+    // inside readDirectStream -> then_with_value(on_resolve_stream, ...).
+    resolvePull();
+    await pullSettled.promise;
+
+    // controller.end(): stashes ptr, detach() fires onClose -> cancel()
+    // -> drainMicrotasks() -> on_resolve_stream frees the sink, then
+    // endWithSink(ptr) runs on the freed allocation.
+    capturedController.end();
+
+    await drained;
+    server.stop(true);
+    console.log("ok");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout: "ok\n",
+    stderr: "",
+    exitCode: 0,
+  });
+}, 30_000);


### PR DESCRIPTION
Sentry BUN-2WJA / BUN-2WKB (~290 events combined, Windows x86_64, `http_server=True`, bun 1.2.23 through 1.3.14):

```
Segmentation fault at address 0xFFFFFFFFFFFFFFFF
  endWithSink      src/runtime/webcore/Sink.zig:577
  endFromJS        src/runtime/webcore/streams.zig:1200
  finalize         src/runtime/webcore/streams.zig:1301
  clearAndFree     src/collections/baby_list.zig:148
  memset           (fault at 0xFFFFFFFFFFFFFFFF)
```

## Cause

The generated `JSReadable*Controller` `end()` and `close()` host functions (`src/codegen/generate-jssink.ts`) stash `m_sinkPtr` in a local, call `controller->detach()`, and only afterward dereference the stashed pointer via `endWithSink()` / `${name}__close()`:

```cpp
void *ptr = controller->wrapped();
controller->detach();              // runs onClose JS synchronously
return ${name}__endWithSink(ptr, lexicalGlobalObject);  // derefs ptr
```

`detach()` invokes the stored `onClose` callback. For a `type: "direct"` stream this is `readDirectStream`'s `close(stream, reason)`, which calls `underlyingSource.cancel()`. That is arbitrary user code running while `ptr` is still live on the C++ stack.

If the stream's `pull()` promise has already settled, `RequestContext::on_resolve_stream` is sitting in the microtask queue. Any path from `cancel()` that drains microtasks (e.g. the server-side drain points in `on_response` / `do_render_with_body`, or an explicit `drainMicrotasks()`) runs `handle_resolve_stream`, which calls `destroy_sink` and frees the `HTTPServerWritable`. `endWithSink(ptr)` then enters `end_from_js` on the freed allocation; `finalize()` reads garbage for `pooled_buffer` / `buffer.cap` / `buffer.ptr` and faults in the `memset` the allocator's free-scrub path performs.

The same ordering appears in the Rust port (`streams.rs` / `Sink.rs`) unchanged.

## Fix

In `${controller}__end` and `${controller}__close`, finish the native sink operation before any JS runs:

1. Call `${name}__controllerDetached(ptr, controller)` and null `m_sinkPtr` up front (so `end_from_js`'s own `signal.close()` stays a no-op, matching the previous behaviour, and so the later `detach()` won't touch the native side again).
2. Run `endWithSink(ptr)` / `close(ptr)`.
3. Call `controller->detach()` last. With `m_sinkPtr` already null it only clears `m_onPull` and fires `onClose`; by now we hold no reference into the sink, so re-entrant teardown is safe.

## Verification

New ASAN-gated test in `test/js/bun/http/serve-direct-readable-stream.test.ts` reproduces the exact UAF deterministically by draining microtasks from the stream's `cancel()` callback (the test uses `require("bun:jsc").drainMicrotasks()` to force the drain that the production crash hits via the server's own drain points).

<details>
<summary>ASAN output on the unfixed build</summary>

```
==22203==ERROR: AddressSanitizer: heap-use-after-free on address 0x6ee5f87602ca
READ of size 1 at 0x6ee5f87602ca thread T0
    #0 HTTPServerWritable::end_from_js src/runtime/webcore/streams.rs:1831
    #2 JSSink::js_end_with_sink src/runtime/webcore/Sink.rs:1107
    #4 WebCore::JSReadableHTTPResponseSinkController__end JSSink.cpp:620

freed by thread T0 here:
    #10 HTTPServerWritable::destroy src/runtime/webcore/streams.rs:1950
    #11 RequestContext::destroy_sink src/runtime/server/RequestContext.rs:1930
    #12 RequestContext::handle_resolve_stream src/runtime/server/RequestContext.rs:2680
    #13 RequestContext::on_resolve_stream src/runtime/server/RequestContext.rs:2716
    ...
    #24 JSC::VM::drainMicrotasks()
```
</details>

With the fix the fixture completes normally. Existing suites (`serve.test.ts`, `bun-server.test.ts`, `direct-readable-stream.test.tsx`, `streams.test.js`, the sink leak tests) show no new failures against the unfixed build.