### PR TITLE
test(streams): vendor full WPT transform-streams suite into CI

### DIFF
--- a/test/js/third_party/wpt-streams/backpressure.any.js
+++ b/test/js/third_party/wpt-streams/backpressure.any.js
@@ -1,0 +1,195 @@
+// META: global=window,worker
+// META: script=../resources/recording-streams.js
+// META: script=../resources/test-utils.js
+'use strict';
+
+const error1 = new Error('error1 message');
+error1.name = 'error1';
+
+promise_test(() => {
+  const ts = recordingTransformStream();
+  const writer = ts.writable.getWriter();
+  // This call never resolves.
+  writer.write('a');
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(ts.events, [], 'transform should not be called');
+  });
+}, 'backpressure allows no transforms with a default identity transform and no reader');
+
+promise_test(() => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  // This call to write() resolves asynchronously.
+  writer.write('a');
+  // This call to write() waits for backpressure that is never relieved and never calls transform().
+  writer.write('b');
+  return flushAsyncEvents().then(() => {
+    assert_array_equals(ts.events, ['transform', 'a'], 'transform should be called once');
+  });
+}, 'backpressure only allows one transform() with a identity transform with a readable HWM of 1 and no reader');
+
+promise_test(() => {
+  // Without a transform() implementation, recordingTransformStream() never enqueues anything.
+  const ts = recordingTransformStream({
+    transform() {
+      // Discard all chunks. As a result, the readable side is never full enough to exert backpressure and transform()
+      // keeps being called.
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  const writePromises = [];
+  for (let i = 0; i < 4; ++i) {
+    writePromises.push(writer.write(i));
+  }
+  return Promise.all(writePromises).then(() => {
+    assert_array_equals(ts.events, ['transform', 0, 'transform', 1, 'transform', 2, 'transform', 3],
+                        'all 4 events should be transformed');
+  });
+}, 'transform() should keep being called as long as there is no backpressure');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const events = [];
+  const writerPromises = [
+    writer.write('a').then(() => events.push('a')),
+    writer.write('b').then(() => events.push('b')),
+    writer.close().then(() => events.push('closed'))];
+  return delay(0).then(() => {
+    assert_array_equals(events, ['a'], 'the first write should have resolved');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should not be true');
+    assert_equals('a', value, 'value should be "a"');
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(events, ['a', 'b', 'closed'], 'both writes and close() should have resolved');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should still not be true');
+    assert_equals('b', value, 'value should be "b"');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+    return writerPromises;
+  });
+}, 'writes should resolve as soon as transform completes');
+
+promise_test(() => {
+  const ts = new TransformStream(undefined, undefined, { highWaterMark: 0 });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const readPromise = reader.read();
+  writer.write('a');
+  return readPromise.then(({ value, done }) => {
+    assert_false(done, 'not done');
+    assert_equals(value, 'a', 'value should be "a"');
+  });
+}, 'calling pull() before the first write() with backpressure should work');
+
+promise_test(() => {
+  let reader;
+  const ts = recordingTransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      return reader.read();
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  reader = ts.readable.getReader();
+  return writer.write('a');
+}, 'transform() should be able to read the chunk it just enqueued');
+
+promise_test(() => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = recordingTransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, new CountQueuingStrategy({ highWaterMark: Infinity }));
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  return delay(0).then(() => {
+    writer.write('a');
+    assert_array_equals(ts.events, ['transform', 'a']);
+    assert_equals(writer.desiredSize, 0, 'desiredSize should be 0');
+    return flushAsyncEvents();
+  }).then(() => {
+    assert_equals(writer.desiredSize, 0, 'desiredSize should still be 0');
+    resolveTransform();
+    return delay(0);
+  }).then(() => {
+    assert_equals(writer.desiredSize, 1, 'desiredSize should be 1');
+  });
+}, 'blocking transform() should cause backpressure');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  ts.readable.cancel(error1);
+  return promise_rejects_exactly(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+}, 'writer.closed should resolve after readable is canceled during start');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects_exactly(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+  });
+}, 'writer.closed should resolve after readable is canceled with backpressure');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects_exactly(t, error1, ts.writable.getWriter().closed, 'closed should reject');
+  });
+}, 'writer.closed should resolve after readable is canceled with no backpressure');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 1 });
+  const writer = ts.writable.getWriter();
+  return delay(0).then(() => {
+    const writePromise = writer.write('a');
+    ts.readable.cancel(error1);
+    return writePromise;
+  });
+}, 'cancelling the readable should cause a pending write to resolve');
+
+promise_test(t => {
+  const rs = new ReadableStream();
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  ts.readable.cancel(error1);
+  return promise_rejects_exactly(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+}, 'cancelling the readable side of a TransformStream should abort an empty pipe');
+
+promise_test(t => {
+  const rs = new ReadableStream();
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects_exactly(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+  });
+}, 'cancelling the readable side of a TransformStream should abort an empty pipe after startup');
+
+promise_test(t => {
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.enqueue('b');
+      controller.enqueue('c');
+    }
+  });
+  const ts = new TransformStream();
+  const pipePromise = rs.pipeTo(ts.writable);
+  // Allow data to flow into the pipe.
+  return delay(0).then(() => {
+    ts.readable.cancel(error1);
+    return promise_rejects_exactly(t, error1, pipePromise, 'promise returned from pipeTo() should be rejected');
+  });
+}, 'cancelling the readable side of a TransformStream should abort a full pipe');

--- a/test/js/third_party/wpt-streams/errors.any.js
+++ b/test/js/third_party/wpt-streams/errors.any.js
@@ -1,0 +1,360 @@
+// META: global=window,worker
+// META: script=../resources/test-utils.js
+'use strict';
+
+const thrownError = new Error('bad things are happening!');
+thrownError.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+      throw thrownError;
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writer.write('a'),
+                            'writable\'s write should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.read(),
+                            'readable\'s read should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.closed,
+                            'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects_exactly(t, thrownError, writer.closed,
+                            'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in transform put the writable and readable in an errored state');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform() {
+    },
+    flush() {
+      throw thrownError;
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+
+  return Promise.all([
+    writer.write('a'),
+    promise_rejects_exactly(t, thrownError, writer.close(),
+                            'writable\'s close should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.read(),
+                            'readable\'s read should reject with the thrown error'),
+    promise_rejects_exactly(t, thrownError, reader.closed,
+                            'readable\'s closed should be rejected with the thrown error'),
+    promise_rejects_exactly(t, thrownError, writer.closed,
+                            'writable\'s closed should be rejected with the thrown error')
+  ]);
+}, 'TransformStream errors thrown in flush put the writable and readable in an errored state');
+
+test(t => {
+  new TransformStream({
+    start(c) {
+      c.enqueue('a');
+      c.error(new Error('generic error'));
+      assert_throws_js(TypeError, () => c.enqueue('b'), 'enqueue() should throw');
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+}, 'errored TransformStream should not enqueue new chunks');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start() {
+      return flushAsyncEvents().then(() => {
+        throw thrownError;
+      });
+    },
+    transform: t.unreached_func('transform should not be called'),
+    flush: t.unreached_func('flush should not be called'),
+    cancel: t.unreached_func('cancel should not be called')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writer.write('a'), 'writer should reject with thrownError'),
+    promise_rejects_exactly(t, thrownError, writer.close(), 'close() should reject with thrownError'),
+    promise_rejects_exactly(t, thrownError, reader.read(), 'reader should reject with thrownError')
+  ]);
+}, 'TransformStream transformer.start() rejected promise should error the stream');
+
+promise_test(t => {
+  const controllerError = new Error('start failure');
+  controllerError.name = 'controllerError';
+  const ts = new TransformStream({
+    start(c) {
+      return flushAsyncEvents()
+        .then(() => {
+          c.error(controllerError);
+          throw new Error('ignored error');
+        });
+    },
+    transform: t.unreached_func('transform should never be called if start() fails'),
+    flush: t.unreached_func('flush should never be called if start() fails'),
+    cancel: t.unreached_func('cancel should never be called if start() fails')
+  });
+
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  return Promise.all([
+    promise_rejects_exactly(t, controllerError, writer.write('a'), 'writer should reject with controllerError'),
+    promise_rejects_exactly(t, controllerError, writer.close(), 'close should reject with same error'),
+    promise_rejects_exactly(t, controllerError, reader.read(), 'reader should reject with same error')
+  ]);
+}, 'when controller.error is followed by a rejection, the error reason should come from controller.error');
+
+test(() => {
+  assert_throws_js(URIError, () => new TransformStream({
+    start() { throw new URIError('start thrown error'); },
+    transform() {}
+  }), 'constructor should throw');
+}, 'TransformStream constructor should throw when start does');
+
+test(() => {
+  const strategy = {
+    size() { throw new URIError('size thrown error'); }
+  };
+
+  assert_throws_js(URIError, () => new TransformStream({
+    start(c) {
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'constructor should throw the same error strategy.size throws');
+}, 'when strategy.size throws inside start(), the constructor should throw the same error');
+
+test(() => {
+  const controllerError = new URIError('controller.error');
+
+  let controller;
+  const strategy = {
+    size() {
+      controller.error(controllerError);
+      throw new Error('redundant error');
+    }
+  };
+
+  assert_throws_js(URIError, () => new TransformStream({
+    start(c) {
+      controller = c;
+      c.enqueue('a');
+    },
+    transform() {}
+  }, undefined, strategy), 'the first error should be thrown');
+}, 'when strategy.size calls controller.error() then throws, the constructor should throw the first error');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  const closedPromise = writer.closed;
+  return Promise.all([
+    ts.readable.cancel(thrownError),
+    promise_rejects_exactly(t, thrownError, closedPromise, 'closed should throw a TypeError')
+  ]);
+}, 'cancelling the readable side should error the writable');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  const writePromise = writer.write('a');
+  const closePromise = writer.close();
+  controller.error(thrownError);
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, reader.closed, 'reader.closed should reject'),
+    promise_rejects_exactly(t, thrownError, writePromise, 'writePromise should reject'),
+    promise_rejects_exactly(t, thrownError, closePromise, 'closePromise should reject')]);
+}, 'it should be possible to error the readable between close requested and complete');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      controller.enqueue(chunk);
+      controller.terminate();
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: 1 });
+  const writePromise = ts.writable.getWriter().write('a');
+  const closedPromise = ts.readable.getReader().closed;
+  return Promise.all([
+    promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject'),
+    promise_rejects_exactly(t, thrownError, closedPromise, 'reader.closed should reject')
+  ]);
+}, 'an exception from transform() should error the stream if terminate has been requested but not completed');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  // The microtask following transformer.start() hasn't completed yet, so the abort is queued and not notified to the
+  // TransformStream yet.
+  const abortPromise = writer.abort(thrownError);
+  const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+  return Promise.all([
+    abortPromise,
+    cancelPromise,
+    promise_rejects_exactly(t, thrownError, writer.closed, 'writer.closed should reject'),
+  ]);
+}, 'abort should set the close reason for the writable when it happens before cancel during start, and cancel should ' +
+             'reject');
+
+promise_test(t => {
+  let resolveTransform;
+  const transformPromise = new Promise(resolve => {
+    resolveTransform = resolve;
+  });
+  const ts = new TransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, { highWaterMark: 2 });
+  const writer = ts.writable.getWriter();
+  return delay(0).then(() => {
+    const writePromise = writer.write();
+    const abortPromise = writer.abort(thrownError);
+    const cancelPromise = ts.readable.cancel(new Error('cancel reason'));
+    resolveTransform();
+    return Promise.all([
+      writePromise,
+      abortPromise,
+      cancelPromise,
+      promise_rejects_exactly(t, thrownError, writer.closed, 'writer.closed should reject with thrownError')]);
+  });
+}, 'abort should set the close reason for the writable when it happens before cancel during underlying sink write, ' +
+             'but cancel should still succeed');
+
+const ignoredError = new Error('ignoredError');
+ignoredError.name = 'ignoredError';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.error(thrownError);
+      controller.error(ignoredError);
+    }
+  });
+  return promise_rejects_exactly(t, thrownError, ts.writable.abort(), 'abort() should reject with thrownError');
+}, 'controller.error() should do nothing the second time it is called');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelPromise = ts.readable.cancel(ignoredError);
+  controller.error(thrownError);
+  return Promise.all([
+    cancelPromise,
+    promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError')
+  ]);
+}, 'controller.error() should close writable immediately after readable.cancel()');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ts.readable.cancel(thrownError).then(() => {
+    controller.error(ignoredError);
+    return promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after readable.cancel() resolves');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  return ts.writable.abort(thrownError).then(() => {
+    controller.error(ignoredError);
+    return promise_rejects_exactly(t, thrownError, ts.writable.getWriter().closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after writable.abort() has completed');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      throw thrownError;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  const writer = ts.writable.getWriter();
+  return promise_rejects_exactly(t, thrownError, writer.write(), 'write() should reject').then(() => {
+    controller.error();
+    return promise_rejects_exactly(t, thrownError, writer.closed, 'closed should reject with thrownError');
+  });
+}, 'controller.error() should do nothing after a transformer method has thrown an exception');
+
+promise_test(t => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    },
+    transform() {
+      ++calls;
+    }
+  }, undefined, { highWaterMark: 1 });
+  return delay(0).then(() => {
+    // Create backpressure.
+    controller.enqueue('a');
+    const writer = ts.writable.getWriter();
+    // transform() will not be called until backpressure is relieved.
+    const writePromise = writer.write('b');
+    assert_equals(calls, 0, 'transform() should not have been called');
+    controller.error(thrownError);
+    // Now backpressure has been relieved and the write can proceed.
+    return promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject').then(() => {
+      assert_equals(calls, 0, 'transform() should not be called');
+    });
+  });
+}, 'erroring during write with backpressure should result in the write failing');
+
+promise_test(t => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+  return delay(0).then(() => {
+    const writer = ts.writable.getWriter();
+    // write should start synchronously
+    const writePromise = writer.write(0);
+    // The underlying sink's abort() is not called until the write() completes.
+    const abortPromise = writer.abort(thrownError);
+    // Perform a read to relieve backpressure and permit the write() to complete.
+    const readPromise = ts.readable.getReader().read();
+    return Promise.all([
+      promise_rejects_exactly(t, thrownError, readPromise, 'read() should reject'),
+      promise_rejects_exactly(t, thrownError, writePromise, 'write() should reject'),
+      abortPromise
+    ]);
+  });
+}, 'a write() that was waiting for backpressure should reject if the writable is aborted');
+
+promise_test(t => {
+  const ts = new TransformStream();
+  ts.writable.abort(thrownError);
+  const reader = ts.readable.getReader();
+  return promise_rejects_exactly(t, thrownError, reader.read(), 'read() should reject with thrownError');
+}, 'the readable should be errored with the reason passed to the writable abort() method');

--- a/test/js/third_party/wpt-streams/flush.any.js
+++ b/test/js/third_party/wpt-streams/flush.any.js
@@ -1,0 +1,146 @@
+// META: global=window,worker
+// META: script=../resources/test-utils.js
+'use strict';
+
+promise_test(() => {
+  let flushCalled = false;
+  const ts = new TransformStream({
+    transform() { },
+    flush() {
+      flushCalled = true;
+    }
+  });
+
+  return ts.writable.getWriter().close().then(() => {
+    return assert_true(flushCalled, 'closing the writable triggers the transform flush immediately');
+  });
+}, 'TransformStream flush is called immediately when the writable is closed, if no writes are queued');
+
+promise_test(() => {
+  let flushCalled = false;
+  let resolveTransform;
+  const ts = new TransformStream({
+    transform() {
+      return new Promise(resolve => {
+        resolveTransform = resolve;
+      });
+    },
+    flush() {
+      flushCalled = true;
+      return new Promise(() => {}); // never resolves
+    }
+  }, undefined, { highWaterMark: 1 });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+  assert_false(flushCalled, 'closing the writable does not immediately call flush if writes are not finished');
+
+  let rsClosed = false;
+  ts.readable.getReader().closed.then(() => {
+    rsClosed = true;
+  });
+
+  return delay(0).then(() => {
+    assert_false(flushCalled, 'closing the writable does not asynchronously call flush if writes are not finished');
+    resolveTransform();
+    return delay(0);
+  }).then(() => {
+    assert_true(flushCalled, 'flush is eventually called');
+    assert_false(rsClosed, 'if flushPromise does not resolve, the readable does not become closed');
+  });
+}, 'TransformStream flush is called after all queued writes finish, once the writable is closed');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+    },
+    flush() {
+      c.enqueue('x');
+      c.enqueue('y');
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'x', 'the first chunk read is the first one enqueued in flush');
+    assert_equals(result1.done, false, 'the first chunk read is the first one enqueued in flush');
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'y', 'the second chunk read is the second one enqueued in flush');
+      assert_equals(result2.done, false, 'the second chunk read is the second one enqueued in flush');
+    });
+  });
+}, 'TransformStream flush gets a chance to enqueue more into the readable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+    },
+    flush() {
+      c.enqueue('x');
+      c.enqueue('y');
+      return delay(0);
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  return Promise.all([
+    reader.read().then(result1 => {
+      assert_equals(result1.value, 'x', 'the first chunk read is the first one enqueued in flush');
+      assert_equals(result1.done, false, 'the first chunk read is the first one enqueued in flush');
+
+      return reader.read().then(result2 => {
+        assert_equals(result2.value, 'y', 'the second chunk read is the second one enqueued in flush');
+        assert_equals(result2.done, false, 'the second chunk read is the second one enqueued in flush');
+      });
+    }),
+    reader.closed.then(() => {
+      assert_true(true, 'readable reader becomes closed');
+    })
+  ]);
+}, 'TransformStream flush gets a chance to enqueue more into the readable, and can then async close');
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.error(error1);
+    }
+  });
+  return promise_rejects_exactly(t, error1, ts.writable.getWriter().close(), 'close() should reject');
+}, 'error() during flush should cause writer.close() to reject');
+
+promise_test(async t => {
+  let flushed = false;
+  const ts = new TransformStream({
+    flush() {
+      flushed = true;
+    },
+    cancel: t.unreached_func('cancel should not be called')
+  });
+  const closePromise = ts.writable.close();
+  await delay(0);
+  const cancelPromise = ts.readable.cancel(error1);
+  await Promise.all([closePromise, cancelPromise]);
+  assert_equals(flushed, true, 'transformer.flush() should be called');
+}, 'closing the writable side should call transformer.flush() and a parallel readable.cancel() should not reject');

--- a/test/js/third_party/wpt-streams/general.any.js
+++ b/test/js/third_party/wpt-streams/general.any.js
@@ -1,0 +1,452 @@
+// META: global=window,worker
+// META: script=../resources/test-utils.js
+// META: script=../resources/rs-utils.js
+'use strict';
+
+test(() => {
+  new TransformStream({ transform() { } });
+}, 'TransformStream can be constructed with a transform function');
+
+test(() => {
+  new TransformStream();
+  new TransformStream({});
+}, 'TransformStream can be constructed with no transform function');
+
+test(() => {
+  const ts = new TransformStream({ transform() { } });
+
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'writer.desiredSize should be 1');
+}, 'TransformStream writable starts in the writable state');
+
+promise_test(() => {
+  const ts = new TransformStream();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  assert_equals(writer.desiredSize, 0, 'writer.desiredSize should be 0 after write()');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'a',
+      'result from reading the readable is the same as was written to writable');
+    assert_false(result.done, 'stream should not be done');
+
+    return delay(0).then(() => assert_equals(writer.desiredSize, 1, 'desiredSize should be 1 again'));
+  });
+}, 'Identity TransformStream: can read from readable what is put into writable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      c.enqueue(chunk.toUpperCase());
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'A',
+      'result from reading the readable is the transformation of what was written to writable');
+    assert_false(result.done, 'stream should not be done');
+  });
+}, 'Uppercaser sync TransformStream: can read from readable transformed version of what is put into writable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      c.enqueue(chunk.toUpperCase());
+      c.enqueue(chunk.toUpperCase());
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  const reader = ts.readable.getReader();
+
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'A',
+      'the first chunk read is the transformation of the single chunk written');
+    assert_false(result1.done, 'stream should not be done');
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'A',
+        'the second chunk read is also the transformation of the single chunk written');
+      assert_false(result2.done, 'stream should not be done');
+    });
+  });
+}, 'Uppercaser-doubler sync TransformStream: can read both chunks put into the readable');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform(chunk) {
+      return delay(0).then(() => c.enqueue(chunk.toUpperCase()));
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return ts.readable.getReader().read().then(result => {
+    assert_equals(result.value, 'A',
+      'result from reading the readable is the transformation of what was written to writable');
+    assert_false(result.done, 'stream should not be done');
+  });
+}, 'Uppercaser async TransformStream: can read from readable transformed version of what is put into writable');
+
+promise_test(() => {
+  let doSecondEnqueue;
+  let returnFromTransform;
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      delay(0).then(() => controller.enqueue(chunk.toUpperCase()));
+      doSecondEnqueue = () => controller.enqueue(chunk.toUpperCase());
+      return new Promise(resolve => {
+        returnFromTransform = resolve;
+      });
+    }
+  });
+
+  const reader = ts.readable.getReader();
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+
+  return reader.read().then(result1 => {
+    assert_equals(result1.value, 'A',
+      'the first chunk read is the transformation of the single chunk written');
+    assert_false(result1.done, 'stream should not be done');
+    doSecondEnqueue();
+
+    return reader.read().then(result2 => {
+      assert_equals(result2.value, 'A',
+        'the second chunk read is also the transformation of the single chunk written');
+      assert_false(result2.done, 'stream should not be done');
+      returnFromTransform();
+    });
+  });
+}, 'Uppercaser-doubler async TransformStream: can read both chunks put into the readable');
+
+promise_test(() => {
+  const ts = new TransformStream({ transform() { } });
+
+  const writer = ts.writable.getWriter();
+  writer.close();
+
+  return Promise.all([writer.closed, ts.readable.getReader().closed]);
+}, 'TransformStream: by default, closing the writable closes the readable (when there are no queued writes)');
+
+promise_test(() => {
+  let transformResolve;
+  const transformPromise = new Promise(resolve => {
+    transformResolve = resolve;
+  });
+  const ts = new TransformStream({
+    transform() {
+      return transformPromise;
+    }
+  }, undefined, { highWaterMark: 1 });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  let rsClosed = false;
+  ts.readable.getReader().closed.then(() => {
+    rsClosed = true;
+  });
+
+  return delay(0).then(() => {
+    assert_equals(rsClosed, false, 'readable is not closed after a tick');
+    transformResolve();
+
+    return writer.closed.then(() => {
+      // TODO: Is this expectation correct?
+      assert_equals(rsClosed, true, 'readable is closed at that point');
+    });
+  });
+}, 'TransformStream: by default, closing the writable waits for transforms to finish before closing both');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+      c.enqueue('x');
+      c.enqueue('y');
+      return delay(0);
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
+    });
+  });
+}, 'TransformStream: by default, closing the writable closes the readable after sync enqueues and async done');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    start(controller) {
+      c = controller;
+    },
+    transform() {
+      return delay(0)
+          .then(() => c.enqueue('x'))
+          .then(() => c.enqueue('y'))
+          .then(() => delay(0));
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['x', 'y'], 'both enqueued chunks can be read from the readable');
+    });
+  });
+}, 'TransformStream: by default, closing the writable closes the readable after async enqueues and async done');
+
+promise_test(() => {
+  let c;
+  const ts = new TransformStream({
+    suffix: '-suffix',
+
+    start(controller) {
+      c = controller;
+      c.enqueue('start' + this.suffix);
+    },
+
+    transform(chunk) {
+      c.enqueue(chunk + this.suffix);
+    },
+
+    flush() {
+      c.enqueue('flushed' + this.suffix);
+    }
+  });
+
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  const readableChunks = readableStreamToArray(ts.readable);
+
+  return writer.closed.then(() => {
+    return readableChunks.then(chunks => {
+      assert_array_equals(chunks, ['start-suffix', 'a-suffix', 'flushed-suffix'], 'all enqueued chunks have suffixes');
+    });
+  });
+}, 'Transform stream should call transformer methods as methods');
+
+promise_test(() => {
+  function functionWithOverloads() {}
+  functionWithOverloads.apply = () => assert_unreached('apply() should not be called');
+  functionWithOverloads.call = () => assert_unreached('call() should not be called');
+  const ts = new TransformStream({
+    start: functionWithOverloads,
+    transform: functionWithOverloads,
+    flush: functionWithOverloads
+  });
+  const writer = ts.writable.getWriter();
+  writer.write('a');
+  writer.close();
+
+  return readableStreamToArray(ts.readable);
+}, 'methods should not not have .apply() or .call() called');
+
+promise_test(t => {
+  let startCalled = false;
+  let startDone = false;
+  let transformDone = false;
+  let flushDone = false;
+  const ts = new TransformStream({
+    start() {
+      startCalled = true;
+      return flushAsyncEvents().then(() => {
+        startDone = true;
+      });
+    },
+    transform() {
+      return t.step(() => {
+        assert_true(startDone, 'transform() should not be called until the promise returned from start() has resolved');
+        return flushAsyncEvents().then(() => {
+          transformDone = true;
+        });
+      });
+    },
+    flush() {
+      return t.step(() => {
+        assert_true(transformDone,
+                    'flush() should not be called until the promise returned from transform() has resolved');
+        return flushAsyncEvents().then(() => {
+          flushDone = true;
+        });
+      });
+    }
+  }, undefined, { highWaterMark: 1 });
+
+  assert_true(startCalled, 'start() should be called synchronously');
+
+  const writer = ts.writable.getWriter();
+  const writePromise = writer.write('a');
+  return writer.close().then(() => {
+    assert_true(flushDone, 'promise returned from flush() should have resolved');
+    return writePromise;
+  });
+}, 'TransformStream start, transform, and flush should be strictly ordered');
+
+promise_test(() => {
+  let transformCalled = false;
+  const ts = new TransformStream({
+    transform() {
+      transformCalled = true;
+    }
+  }, undefined, { highWaterMark: Infinity });
+  // transform() is only called synchronously when there is no backpressure and all microtasks have run.
+  return delay(0).then(() => {
+    const writePromise = ts.writable.getWriter().write();
+    assert_true(transformCalled, 'transform() should have been called');
+    return writePromise;
+  });
+}, 'it should be possible to call transform() synchronously');
+
+promise_test(() => {
+  const ts = new TransformStream({}, undefined, { highWaterMark: 0 });
+
+  const writer = ts.writable.getWriter();
+  writer.close();
+
+  return Promise.all([writer.closed, ts.readable.getReader().closed]);
+}, 'closing the writable should close the readable when there are no queued chunks, even with backpressure');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.terminate();
+      assert_throws_js(TypeError, () => controller.enqueue(), 'enqueue should throw');
+    }
+  });
+}, 'enqueue() should throw after controller.terminate()');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelPromise = ts.readable.cancel();
+  assert_throws_js(TypeError, () => controller.enqueue(), 'enqueue should throw');
+  return cancelPromise;
+}, 'enqueue() should throw after readable.cancel()');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.terminate();
+      controller.terminate();
+    }
+  });
+}, 'controller.terminate() should do nothing the second time it is called');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelReason = { name: 'cancelReason' };
+  const cancelPromise = ts.readable.cancel(cancelReason);
+  controller.terminate();
+  return Promise.all([
+    cancelPromise,
+    promise_rejects_js(t, TypeError, ts.writable.getWriter().closed, 'closed should reject with TypeError')
+  ]);
+}, 'terminate() should abort writable immediately after readable.cancel()');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  });
+  const cancelReason = { name: 'cancelReason' };
+  return ts.readable.cancel(cancelReason).then(() => {
+    controller.terminate();
+    return promise_rejects_exactly(t, cancelReason, ts.writable.getWriter().closed, 'closed should reject with TypeError');
+  })
+}, 'terminate() should do nothing after readable.cancel() resolves');
+
+
+promise_test(() => {
+  let calls = 0;
+  new TransformStream({
+    start() {
+      ++calls;
+    }
+  });
+  return flushAsyncEvents().then(() => {
+    assert_equals(calls, 1, 'start() should have been called exactly once');
+  });
+}, 'start() should not be called twice');
+
+test(() => {
+  assert_throws_js(RangeError, () => new TransformStream({ readableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined readableType should throw');
+
+test(() => {
+  assert_throws_js(RangeError, () => new TransformStream({ writableType: 'bytes' }), 'constructor should throw');
+}, 'specifying a defined writableType should throw');
+
+test(() => {
+  class Subclass extends TransformStream {
+    extraFunction() {
+      return true;
+    }
+  }
+  assert_equals(
+      Object.getPrototypeOf(Subclass.prototype), TransformStream.prototype,
+      'Subclass.prototype\'s prototype should be TransformStream.prototype');
+  assert_equals(Object.getPrototypeOf(Subclass), TransformStream,
+                'Subclass\'s prototype should be TransformStream');
+  const sub = new Subclass();
+  assert_true(sub instanceof TransformStream,
+              'Subclass object should be an instance of TransformStream');
+  assert_true(sub instanceof Subclass,
+              'Subclass object should be an instance of Subclass');
+  const readableGetter = Object.getOwnPropertyDescriptor(
+      TransformStream.prototype, 'readable').get;
+  assert_equals(readableGetter.call(sub), sub.readable,
+                'Subclass object should pass brand check');
+  assert_true(sub.extraFunction(),
+              'extraFunction() should be present on Subclass object');
+}, 'Subclassing TransformStream should work');

--- a/test/js/third_party/wpt-streams/known-failures.ts
+++ b/test/js/third_party/wpt-streams/known-failures.ts
@@ -1,0 +1,36 @@
+// WPT streams tests Bun does not yet pass. Each entry is the upstream test
+// name → a one-line reason. Registered as test.todo so the gap is visible
+// without turning CI red. Remove entries as the underlying behavior is fixed.
+
+import { knownFailures } from "./testharness-shim";
+
+// Web IDL "a promise resolved with x" is `new Promise(r => r(x))` (always a
+// fresh promise; one extra microtask when x is a thenable), not
+// `Promise.resolve(x)` (returns x when x is already a Promise). Bun's
+// writableStreamDefaultControllerStart uses Promise.$resolve(startAlgorithm()),
+// so when startAlgorithm() returns a promise the [[started]] reaction is
+// queued one microtask earlier than the spec ref-impl. The test below depends
+// on the cancel-fulfill reaction observing the writable mid-"erroring" rather
+// than already "errored".
+knownFailures.set(
+  "readable.cancel() and a parallel writable.close() should reject if a transformer.cancel() calls controller.error()",
+  "Promise.$resolve short-circuit in writableStreamDefaultControllerStart shifts [[started]] one microtask early",
+);
+
+// Pre-existing: writer.write()/reader.read() never settle when start() returns
+// a promise that rejects asynchronously. Reproduces on releases without the
+// transformer.cancel changes.
+knownFailures.set(
+  "TransformStream transformer.start() rejected promise should error the stream",
+  "pre-existing: write()/read() hang when start() rejects asynchronously",
+);
+
+// Pre-existing: with abort queued before [[started]] and readable.cancel()
+// racing it, the source-cancel reaction runs first and resolves the shared
+// finishPromise; the writable's pendingAbortRequest then surfaces as a
+// rejection of writer.abort() instead of fulfilling it. Same Promise.$resolve
+// vs Web IDL "a promise resolved with" hop-count root cause as above.
+knownFailures.set(
+  "abort should set the close reason for the writable when it happens before cancel during start, and cancel should reject",
+  "abort()/cancel() race during start: hop-count divergence vs spec ref-impl",
+);

--- a/test/js/third_party/wpt-streams/known-failures.ts
+++ b/test/js/third_party/wpt-streams/known-failures.ts
@@ -4,33 +4,10 @@
 
 import { knownFailures } from "./testharness-shim";
 
-// Web IDL "a promise resolved with x" is `new Promise(r => r(x))` (always a
-// fresh promise; one extra microtask when x is a thenable), not
-// `Promise.resolve(x)` (returns x when x is already a Promise). Bun's
-// writableStreamDefaultControllerStart uses Promise.$resolve(startAlgorithm()),
-// so when startAlgorithm() returns a promise the [[started]] reaction is
-// queued one microtask earlier than the spec ref-impl. The test below depends
-// on the cancel-fulfill reaction observing the writable mid-"erroring" rather
-// than already "errored".
-knownFailures.set(
-  "readable.cancel() and a parallel writable.close() should reject if a transformer.cancel() calls controller.error()",
-  "Promise.$resolve short-circuit in writableStreamDefaultControllerStart shifts [[started]] one microtask early",
-);
-
 // Pre-existing: writer.write()/reader.read() never settle when start() returns
 // a promise that rejects asynchronously. Reproduces on releases without the
 // transformer.cancel changes.
 knownFailures.set(
   "TransformStream transformer.start() rejected promise should error the stream",
   "pre-existing: write()/read() hang when start() rejects asynchronously",
-);
-
-// Pre-existing: with abort queued before [[started]] and readable.cancel()
-// racing it, the source-cancel reaction runs first and resolves the shared
-// finishPromise; the writable's pendingAbortRequest then surfaces as a
-// rejection of writer.abort() instead of fulfilling it. Same Promise.$resolve
-// vs Web IDL "a promise resolved with" hop-count root cause as above.
-knownFailures.set(
-  "abort should set the close reason for the writable when it happens before cancel during start, and cancel should reject",
-  "abort()/cancel() race during start: hop-count divergence vs spec ref-impl",
 );

--- a/test/js/third_party/wpt-streams/lipfuzz.any.js
+++ b/test/js/third_party/wpt-streams/lipfuzz.any.js
@@ -1,0 +1,163 @@
+// META: global=window,worker
+'use strict';
+
+class LipFuzzTransformer {
+  constructor(substitutions) {
+    this.substitutions = substitutions;
+    this.partialChunk = '';
+    this.lastIndex = undefined;
+  }
+
+  transform(chunk, controller) {
+    chunk = this.partialChunk + chunk;
+    this.partialChunk = '';
+    // lastIndex is the index of the first character after the last substitution.
+    this.lastIndex = 0;
+    chunk = chunk.replace(/\{\{([a-zA-Z0-9_-]+)\}\}/g, this.replaceTag.bind(this));
+    // Regular expression for an incomplete template at the end of a string.
+    const partialAtEndRegexp = /\{(\{([a-zA-Z0-9_-]+(\})?)?)?$/g;
+    // Avoid looking at any characters that have already been substituted.
+    partialAtEndRegexp.lastIndex = this.lastIndex;
+    this.lastIndex = undefined;
+    const match = partialAtEndRegexp.exec(chunk);
+    if (match) {
+      this.partialChunk = chunk.substring(match.index);
+      chunk = chunk.substring(0, match.index);
+    }
+    controller.enqueue(chunk);
+  }
+
+  flush(controller) {
+    if (this.partialChunk.length > 0) {
+      controller.enqueue(this.partialChunk);
+    }
+  }
+
+  replaceTag(match, p1, offset) {
+    let replacement = this.substitutions[p1];
+    if (replacement === undefined) {
+      replacement = '';
+    }
+    this.lastIndex = offset + replacement.length;
+    return replacement;
+  }
+}
+
+const substitutions = {
+  in1: 'out1',
+  in2: 'out2',
+  quine: '{{quine}}',
+  bogusPartial: '{{incompleteResult}'
+};
+
+const cases = [
+  {
+    input: [''],
+    output: ['']
+  },
+  {
+    input: [],
+    output: []
+  },
+  {
+    input: ['{{in1}}'],
+    output: ['out1']
+  },
+  {
+    input: ['z{{in1}}'],
+    output: ['zout1']
+  },
+  {
+    input: ['{{in1}}q'],
+    output: ['out1q']
+  },
+  {
+    input: ['{{in1}}{{in1}'],
+    output: ['out1', '{{in1}']
+  },
+  {
+    input: ['{{in1}}{{in1}', '}'],
+    output: ['out1', 'out1']
+  },
+  {
+    input: ['{{in1', '}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{', '{in1}}'],
+    output: ['', 'out1']
+  },
+  {
+    input: ['{{', 'in1}'],
+    output: ['', '', '{{in1}']
+  },
+  {
+    input: ['{'],
+    output: ['', '{']
+  },
+  {
+    input: ['{', ''],
+    output: ['', '', '{']
+  },
+  {
+    input: ['{', '{', 'i', 'n', '1', '}', '}'],
+    output: ['', '', '', '', '', '', 'out1']
+  },
+  {
+    input: ['{{in1}}{{in2}}{{in1}}'],
+    output: ['out1out2out1']
+  },
+  {
+    input: ['{{wrong}}'],
+    output: ['']
+  },
+  {
+    input: ['{{wron', 'g}}'],
+    output: ['', '']
+  },
+  {
+    input: ['{{quine}}'],
+    output: ['{{quine}}']
+  },
+  {
+    input: ['{{bogusPartial}}'],
+    output: ['{{incompleteResult}']
+  },
+  {
+    input: ['{{bogusPartial}}}'],
+    output: ['{{incompleteResult}}']
+  }
+];
+
+for (const testCase of cases) {
+  const inputChunks = testCase.input;
+  const outputChunks = testCase.output;
+  promise_test(() => {
+    const lft = new TransformStream(new LipFuzzTransformer(substitutions));
+    const writer = lft.writable.getWriter();
+    const promises = [];
+    for (const inputChunk of inputChunks) {
+      promises.push(writer.write(inputChunk));
+    }
+    promises.push(writer.close());
+    const reader = lft.readable.getReader();
+    let readerChain = Promise.resolve();
+    for (const outputChunk of outputChunks) {
+      readerChain = readerChain.then(() => {
+        return reader.read().then(({ value, done }) => {
+          assert_false(done, `done should be false when reading ${outputChunk}`);
+          assert_equals(value, outputChunk, `value should match outputChunk`);
+        });
+      });
+    }
+    readerChain = readerChain.then(() => {
+      return reader.read().then(({ done }) => assert_true(done, `done should be true`));
+    });
+    promises.push(readerChain);
+    return Promise.all(promises);
+  }, `testing "${inputChunks}" (length ${inputChunks.length})`);
+}

--- a/test/js/third_party/wpt-streams/patched-global.any.js
+++ b/test/js/third_party/wpt-streams/patched-global.any.js
@@ -1,0 +1,53 @@
+// META: global=window,worker
+'use strict';
+
+// Tests which patch the global environment are kept separate to avoid
+// interfering with other tests.
+
+test(t => {
+  // eslint-disable-next-line no-extend-native, accessor-pairs
+  Object.defineProperty(Object.prototype, 'highWaterMark', {
+    set() { throw new Error('highWaterMark setter called'); },
+    configurable: true
+  });
+
+  // eslint-disable-next-line no-extend-native, accessor-pairs
+  Object.defineProperty(Object.prototype, 'size', {
+    set() { throw new Error('size setter called'); },
+    configurable: true
+  });
+
+  t.add_cleanup(() => {
+    delete Object.prototype.highWaterMark;
+    delete Object.prototype.size;
+  });
+
+  assert_not_equals(new TransformStream(), null, 'constructor should work');
+}, 'TransformStream constructor should not call setters for highWaterMark or size');
+
+test(t => {
+  const oldReadableStream = ReadableStream;
+  const oldWritableStream = WritableStream;
+  const getReader = ReadableStream.prototype.getReader;
+  const getWriter = WritableStream.prototype.getWriter;
+
+  // Replace ReadableStream and WritableStream with broken versions.
+  ReadableStream = function () {
+    throw new Error('Called the global ReadableStream constructor');
+  };
+  WritableStream = function () {
+    throw new Error('Called the global WritableStream constructor');
+  };
+  t.add_cleanup(() => {
+    ReadableStream = oldReadableStream;
+    WritableStream = oldWritableStream;
+  });
+
+  const ts = new TransformStream();
+
+  // Just to be sure, ensure the readable and writable pass brand checks.
+  assert_not_equals(getReader.call(ts.readable), undefined,
+                    'getReader should work when called on ts.readable');
+  assert_not_equals(getWriter.call(ts.writable), undefined,
+                    'getWriter should work when called on ts.writable');
+}, 'TransformStream should use the original value of ReadableStream and WritableStream');

--- a/test/js/third_party/wpt-streams/properties.any.js
+++ b/test/js/third_party/wpt-streams/properties.any.js
@@ -1,0 +1,49 @@
+// META: global=window,worker
+'use strict';
+
+const transformerMethods = {
+  start: {
+    length: 1,
+    trigger: () => Promise.resolve()
+  },
+  transform: {
+    length: 2,
+    trigger: ts => ts.writable.getWriter().write()
+  },
+  flush: {
+    length: 1,
+    trigger: ts => ts.writable.getWriter().close()
+  }
+};
+
+for (const method in transformerMethods) {
+  const { length, trigger } = transformerMethods[method];
+
+  // Some semantic tests of how transformer methods are called can be found in general.js, as well as in the test files
+  // specific to each method.
+  promise_test(() => {
+    let argCount;
+    const ts = new TransformStream({
+      [method](...args) {
+        argCount = args.length;
+      }
+    }, undefined, { highWaterMark: Infinity });
+    return Promise.resolve(trigger(ts)).then(() => {
+      assert_equals(argCount, length, `${method} should be called with ${length} arguments`);
+    });
+  }, `transformer method ${method} should be called with the right number of arguments`);
+
+  promise_test(() => {
+    let methodWasCalled = false;
+    function Transformer() {}
+    Transformer.prototype = {
+      [method]() {
+        methodWasCalled = true;
+      }
+    };
+    const ts = new TransformStream(new Transformer(), undefined, { highWaterMark: Infinity });
+    return Promise.resolve(trigger(ts)).then(() => {
+      assert_true(methodWasCalled, `${method} should be called`);
+    });
+  }, `transformer method ${method} should be called even when it's located on the prototype chain`);
+}

--- a/test/js/third_party/wpt-streams/recording-streams.js
+++ b/test/js/third_party/wpt-streams/recording-streams.js
@@ -1,0 +1,131 @@
+'use strict';
+
+self.recordingReadableStream = (extras = {}, strategy) => {
+  let controllerToCopyOver;
+  const stream = new ReadableStream({
+    type: extras.type,
+    start(controller) {
+      controllerToCopyOver = controller;
+
+      if (extras.start) {
+        return extras.start(controller);
+      }
+
+      return undefined;
+    },
+    pull(controller) {
+      stream.events.push('pull');
+
+      if (extras.pull) {
+        return extras.pull(controller);
+      }
+
+      return undefined;
+    },
+    cancel(reason) {
+      stream.events.push('cancel', reason);
+      stream.eventsWithoutPulls.push('cancel', reason);
+
+      if (extras.cancel) {
+        return extras.cancel(reason);
+      }
+
+      return undefined;
+    }
+  }, strategy);
+
+  stream.controller = controllerToCopyOver;
+  stream.events = [];
+  stream.eventsWithoutPulls = [];
+
+  return stream;
+};
+
+self.recordingWritableStream = (extras = {}, strategy) => {
+  let controllerToCopyOver;
+  const stream = new WritableStream({
+    start(controller) {
+      controllerToCopyOver = controller;
+
+      if (extras.start) {
+        return extras.start(controller);
+      }
+
+      return undefined;
+    },
+    write(chunk, controller) {
+      stream.events.push('write', chunk);
+
+      if (extras.write) {
+        return extras.write(chunk, controller);
+      }
+
+      return undefined;
+    },
+    close() {
+      stream.events.push('close');
+
+      if (extras.close) {
+        return extras.close();
+      }
+
+      return undefined;
+    },
+    abort(e) {
+      stream.events.push('abort', e);
+
+      if (extras.abort) {
+        return extras.abort(e);
+      }
+
+      return undefined;
+    }
+  }, strategy);
+
+  stream.controller = controllerToCopyOver;
+  stream.events = [];
+
+  return stream;
+};
+
+self.recordingTransformStream = (extras = {}, writableStrategy, readableStrategy) => {
+  let controllerToCopyOver;
+  const stream = new TransformStream({
+    start(controller) {
+      controllerToCopyOver = controller;
+
+      if (extras.start) {
+        return extras.start(controller);
+      }
+
+      return undefined;
+    },
+
+    transform(chunk, controller) {
+      stream.events.push('transform', chunk);
+
+      if (extras.transform) {
+        return extras.transform(chunk, controller);
+      }
+
+      controller.enqueue(chunk);
+
+      return undefined;
+    },
+
+    flush(controller) {
+      stream.events.push('flush');
+
+      if (extras.flush) {
+        return extras.flush(controller);
+      }
+
+      return undefined;
+    }
+  }, writableStrategy, readableStrategy);
+
+  stream.controller = controllerToCopyOver;
+  stream.events = [];
+
+  return stream;
+};

--- a/test/js/third_party/wpt-streams/reentrant-strategies.any.js
+++ b/test/js/third_party/wpt-streams/reentrant-strategies.any.js
@@ -1,0 +1,323 @@
+// META: global=window,worker
+// META: script=../resources/recording-streams.js
+// META: script=../resources/rs-utils.js
+// META: script=../resources/test-utils.js
+'use strict';
+
+// The size() function of readableStrategy can re-entrantly call back into the TransformStream implementation. This
+// makes it risky to cache state across the call to ReadableStreamDefaultControllerEnqueue. These tests attempt to catch
+// such errors. They are separated from the other strategy tests because no real user code should ever do anything like
+// this.
+//
+// There is no such issue with writableStrategy size() because it is never called from within TransformStream
+// algorithms.
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(() => {
+  let controller;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        controller.enqueue('b');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['b', 'a'], 'array should contain two chunks'));
+}, 'enqueue() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // The readable queue is empty.
+      controller.terminate();
+      // The readable state has gone from "readable" to "closed".
+      return 1;
+      // This chunk will be enqueued, but will be impossible to read because the state is already "closed".
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, [], 'array should contain no chunks'));
+  // The chunk 'a' is still in readable's queue. readable is closed so 'a' cannot be read. writable's queue is empty and
+  // it is still writable.
+}, 'terminate() inside size() should work');
+
+promise_test(t => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      controller.error(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => promise_rejects_exactly(t, error1, ts.readable.getReader().read(), 'read() should reject'));
+}, 'error() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      assert_equals(controller.desiredSize, 1, 'desiredSize should be 1');
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([writer.write('a'), writer.close()])
+      .then(() => readableStreamToArray(ts.readable))
+      .then(array => assert_array_equals(array, ['a'], 'array should contain one chunk'));
+}, 'desiredSize inside size() should work');
+
+promise_test(t => {
+  let cancelPromise;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      cancelPromise = ts.readable.cancel(error1);
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  const writer = ts.writable.getWriter();
+  return writer.write('a')
+      .then(() => {
+        promise_rejects_exactly(t, error1, writer.closed, 'writer.closed should reject');
+        return cancelPromise;
+      });
+}, 'readable cancel() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let pipeToPromise;
+  const ws = recordingWritableStream();
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      if (!pipeToPromise) {
+        pipeToPromise = ts.readable.pipeTo(ws);
+      }
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  // Allow promise returned by start() to resolve so that enqueue() will happen synchronously.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    assert_not_equals(pipeToPromise, undefined);
+
+    // Some pipeTo() implementations need an additional chunk enqueued in order for the first one to be processed. See
+    // https://github.com/whatwg/streams/issues/794 for background.
+    controller.enqueue('a');
+
+    // Give pipeTo() a chance to process the queued chunks.
+    return delay(0);
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'a'], 'ws should contain two chunks');
+    controller.terminate();
+    return pipeToPromise;
+  }).then(() => {
+    assert_array_equals(ws.events, ['write', 'a', 'write', 'a', 'close'], 'target should have been closed');
+  });
+}, 'pipeTo() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let readPromise;
+  let calls = 0;
+  let reader;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      // This is triggered by controller.enqueue(). The queue is empty and there are no pending reads. pull() is called
+      // synchronously, allowing transform() to proceed asynchronously. This results in a second call to enqueue(),
+      // which resolves this pending read() without calling size() again.
+      readPromise = reader.read();
+      ++calls;
+      return 1;
+    },
+    highWaterMark: 0
+  });
+  reader = ts.readable.getReader();
+  const writer = ts.writable.getWriter();
+  let writeResolved = false;
+  const writePromise = writer.write('b').then(() => {
+    writeResolved = true;
+  });
+  return flushAsyncEvents().then(() => {
+    assert_false(writeResolved);
+    controller.enqueue('a');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return delay(0);
+  }).then(() => {
+    assert_true(writeResolved);
+    assert_equals(calls, 1, 'size() should only be called once');
+    return readPromise;
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    // See https://github.com/whatwg/streams/issues/794 for why this chunk is not 'a'.
+    assert_equals(value, 'b', 'chunk should have been read');
+    assert_equals(calls, 1, 'calls should still be 1');
+    return writePromise;
+  });
+}, 'read() inside of size() should work');
+
+promise_test(() => {
+  let writer;
+  let writePromise1;
+  let calls = 0;
+  const ts = new TransformStream({}, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise1 = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This write results in a synchronous call to transform(), enqueue(), and size().
+    const writePromise2 = writer.write('b');
+    assert_equals(calls, 1, 'size() should have been called once');
+    return Promise.all([writePromise1, writePromise2, writer.close()]);
+  }).then(() => {
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    assert_array_equals(array, ['b', 'a'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'writer.write() inside size() should work');
+
+promise_test(() => {
+  let controller;
+  let writer;
+  let writePromise;
+  let calls = 0;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      ++calls;
+      if (calls < 2) {
+        writePromise = writer.write('a');
+      }
+      return 1;
+    },
+    highWaterMark: Infinity
+  });
+  writer = ts.writable.getWriter();
+  // Give pull() a chance to be called.
+  return delay(0).then(() => {
+    // This enqueue results in synchronous calls to size(), write(), transform() and enqueue().
+    controller.enqueue('b');
+    assert_equals(calls, 2, 'size() should have been called twice');
+    return Promise.all([writePromise, writer.close()]);
+  }).then(() => {
+    return readableStreamToArray(ts.readable);
+  }).then(array => {
+    // Because one call to enqueue() is nested inside the other, they finish in the opposite order that they were
+    // called, so the chunks end up reverse order.
+    assert_array_equals(array, ['a', 'b'], 'both chunks should have been enqueued');
+    assert_equals(calls, 2, 'calls should still be 2');
+  });
+}, 'synchronous writer.write() inside size() should work');
+
+promise_test(() => {
+  let writer;
+  let closePromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      closePromise = writer.close();
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  writer = ts.writable.getWriter();
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to close() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be correct');
+    return reader.read();
+  }).then(({ done }) => {
+    assert_true(done, 'done should be true');
+    return closePromise;
+  });
+}, 'writer.close() inside size() should work');
+
+promise_test(t => {
+  let abortPromise;
+  let controller;
+  const ts = new TransformStream({
+    start(c) {
+      controller = c;
+    }
+  }, undefined, {
+    size() {
+      abortPromise = ts.writable.abort(error1);
+      return 1;
+    },
+    highWaterMark: 1
+  });
+  const reader = ts.readable.getReader();
+  // Wait for the promise returned by start() to be resolved so that the call to abort() will result in a synchronous
+  // call to TransformStreamDefaultSink.
+  return delay(0).then(() => {
+    controller.enqueue('a');
+    return reader.read();
+  }).then(({ value, done }) => {
+    assert_false(done, 'done should be false');
+    assert_equals(value, 'a', 'value should be correct');
+    return Promise.all([promise_rejects_exactly(t, error1, reader.read(), 'read() should reject'), abortPromise]);
+  });
+}, 'writer.abort() inside size() should work');

--- a/test/js/third_party/wpt-streams/rs-utils.js
+++ b/test/js/third_party/wpt-streams/rs-utils.js
@@ -1,0 +1,226 @@
+'use strict';
+(function () {
+  // Fake setInterval-like functionality in environments that don't have it
+  class IntervalHandle {
+    constructor(callback, delayMs) {
+      this.callback = callback;
+      this.delayMs = delayMs;
+      this.cancelled = false;
+      Promise.resolve().then(() => this.check());
+    }
+
+    async check() {
+      while (true) {
+        await new Promise(resolve => step_timeout(resolve, this.delayMs));
+        if (this.cancelled) {
+          return;
+        }
+        this.callback();
+      }
+    }
+
+    cancel() {
+      this.cancelled = true;
+    }
+  }
+
+  let localSetInterval, localClearInterval;
+  if (typeof globalThis.setInterval !== "undefined" &&
+      typeof globalThis.clearInterval !== "undefined") {
+    localSetInterval = globalThis.setInterval;
+    localClearInterval = globalThis.clearInterval;
+  } else {
+    localSetInterval = function setInterval(callback, delayMs) {
+      return new IntervalHandle(callback, delayMs);
+    }
+    localClearInterval = function clearInterval(handle) {
+      handle.cancel();
+    }
+  }
+
+  class RandomPushSource {
+    constructor(toPush) {
+      this.pushed = 0;
+      this.toPush = toPush;
+      this.started = false;
+      this.paused = false;
+      this.closed = false;
+
+      this._intervalHandle = null;
+    }
+
+    readStart() {
+      if (this.closed) {
+        return;
+      }
+
+      if (!this.started) {
+        this._intervalHandle = localSetInterval(writeChunk, 2);
+        this.started = true;
+      }
+
+      if (this.paused) {
+        this._intervalHandle = localSetInterval(writeChunk, 2);
+        this.paused = false;
+      }
+
+      const source = this;
+      function writeChunk() {
+        if (source.paused) {
+          return;
+        }
+
+        source.pushed++;
+
+        if (source.toPush > 0 && source.pushed > source.toPush) {
+          if (source._intervalHandle) {
+            localClearInterval(source._intervalHandle);
+            source._intervalHandle = undefined;
+          }
+          source.closed = true;
+          source.onend();
+        } else {
+          source.ondata(randomChunk(128));
+        }
+      }
+    }
+
+    readStop() {
+      if (this.paused) {
+        return;
+      }
+
+      if (this.started) {
+        this.paused = true;
+        localClearInterval(this._intervalHandle);
+        this._intervalHandle = undefined;
+      } else {
+        throw new Error('Can\'t pause reading an unstarted source.');
+      }
+    }
+  }
+
+  function randomChunk(size) {
+    let chunk = '';
+
+    for (let i = 0; i < size; ++i) {
+      // Add a random character from the basic printable ASCII set.
+      chunk += String.fromCharCode(Math.round(Math.random() * 84) + 32);
+    }
+
+    return chunk;
+  }
+
+  function readableStreamToArray(readable, reader) {
+    if (reader === undefined) {
+      reader = readable.getReader();
+    }
+
+    const chunks = [];
+
+    return pump();
+
+    function pump() {
+      return reader.read().then(result => {
+        if (result.done) {
+          return chunks;
+        }
+
+        chunks.push(result.value);
+        return pump();
+      });
+    }
+  }
+
+  class SequentialPullSource {
+    constructor(limit, options) {
+      const async = options && options.async;
+
+      this.current = 0;
+      this.limit = limit;
+      this.opened = false;
+      this.closed = false;
+
+      this._exec = f => f();
+      if (async) {
+        this._exec = f => step_timeout(f, 0);
+      }
+    }
+
+    open(cb) {
+      this._exec(() => {
+        this.opened = true;
+        cb();
+      });
+    }
+
+    read(cb) {
+      this._exec(() => {
+        if (++this.current <= this.limit) {
+          cb(null, false, this.current);
+        } else {
+          cb(null, true, null);
+        }
+      });
+    }
+
+    close(cb) {
+      this._exec(() => {
+        this.closed = true;
+        cb();
+      });
+    }
+  }
+
+  function sequentialReadableStream(limit, options) {
+    const sequentialSource = new SequentialPullSource(limit, options);
+
+    const stream = new ReadableStream({
+      start() {
+        return new Promise((resolve, reject) => {
+          sequentialSource.open(err => {
+            if (err) {
+              reject(err);
+            }
+            resolve();
+          });
+        });
+      },
+
+      pull(c) {
+        return new Promise((resolve, reject) => {
+          sequentialSource.read((err, done, chunk) => {
+            if (err) {
+              reject(err);
+            } else if (done) {
+              sequentialSource.close(err2 => {
+                if (err2) {
+                  reject(err2);
+                }
+                c.close();
+                resolve();
+              });
+            } else {
+              c.enqueue(chunk);
+              resolve();
+            }
+          });
+        });
+      }
+    });
+
+    stream.source = sequentialSource;
+
+    return stream;
+  }
+
+  function transferArrayBufferView(view) {
+    return structuredClone(view, { transfer: [view.buffer] });
+  }
+
+  self.RandomPushSource = RandomPushSource;
+  self.readableStreamToArray = readableStreamToArray;
+  self.sequentialReadableStream = sequentialReadableStream;
+  self.transferArrayBufferView = transferArrayBufferView;
+
+}());

--- a/test/js/third_party/wpt-streams/run.test.ts
+++ b/test/js/third_party/wpt-streams/run.test.ts
@@ -13,8 +13,8 @@
 import { describe } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { wptTest } from "./testharness-shim";
 import "./known-failures";
+import { wptTest } from "./testharness-shim";
 
 function load(file: string) {
   return readFileSync(join(import.meta.dir, file), "utf8");

--- a/test/js/third_party/wpt-streams/run.test.ts
+++ b/test/js/third_party/wpt-streams/run.test.ts
@@ -1,45 +1,48 @@
-// Runs vendored WPT streams .any.js tests against Bun's TransformStream.
-// The .any.js files are byte-identical to upstream; this driver supplies the
-// testharness globals they need.
+// Runs the vendored WPT streams/transform-streams .any.js suite against Bun's
+// TransformStream. The .any.js files and resources/ helpers are byte-identical
+// to upstream; this driver supplies the testharness globals.
 //
 // Vendored from web-platform-tests/wpt @ e4a4672e9e607fc2b28e7173b83ce4e38ef53071
-//   streams/transform-streams/cancel.any.js
+//   streams/transform-streams/*.any.js
+//   streams/resources/{test-utils,recording-streams,rs-utils}.js
+//
+// To update: re-download the files above at a newer wpt commit and refresh the
+// SHA. Tests Bun does not yet pass are listed in known-failures.ts and run as
+// test.todo so the suite stays green while documenting each gap.
 
 import { describe } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { wptTest } from "../wpt-h2/testharness-shim";
+import { wptTest } from "./testharness-shim";
+import "./known-failures";
 
-const g = globalThis as any;
-g.self = globalThis;
+function load(file: string) {
+  return readFileSync(join(import.meta.dir, file), "utf8");
+}
 
-g.step_timeout = (fn: () => void, ms: number) => setTimeout(fn, ms);
-g.delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-g.flushAsyncEvents = () =>
-  g
-    .delay(0)
-    .then(() => g.delay(0))
-    .then(() => g.delay(0))
-    .then(() => g.delay(0));
+// Resource scripts the .any.js files reference via META: script= directives.
+// They install helpers on `self`, which the shim aliases to globalThis.
+const resources = ["test-utils.js", "recording-streams.js", "rs-utils.js"].map(load).join("\n;\n");
 
-const wptTestObject = {
-  unreached_func(msg: string) {
-    return () => {
-      throw new Error(`unreached_func: ${msg}`);
-    };
-  },
-};
-
-g.promise_test = (fn: (t: unknown) => Promise<unknown>, name: string) => {
-  wptTest(() => fn(wptTestObject), name);
-};
+const files = [
+  "backpressure.any.js",
+  "cancel.any.js",
+  "errors.any.js",
+  "flush.any.js",
+  "general.any.js",
+  "lipfuzz.any.js",
+  "patched-global.any.js",
+  "properties.any.js",
+  "reentrant-strategies.any.js",
+  "strategies.any.js",
+  "terminate.any.js",
+];
 
 // bun:test injects its own `test` binding into every imported module, which
 // would shadow the WPT-style test(fn, name) global. Load each vendored file
 // as text and run it inside a Function whose `test` parameter is the shim.
-for (const file of ["cancel.any.js"]) {
-  const src = readFileSync(join(import.meta.dir, file), "utf8");
+for (const file of files) {
   describe(file, () => {
-    new Function("test", src)(wptTest);
+    new Function("test", resources + "\n;\n" + load(file))(wptTest);
   });
 }

--- a/test/js/third_party/wpt-streams/strategies.any.js
+++ b/test/js/third_party/wpt-streams/strategies.any.js
@@ -1,0 +1,150 @@
+// META: global=window,worker
+// META: script=../resources/recording-streams.js
+// META: script=../resources/test-utils.js
+'use strict';
+
+// Here we just test that the strategies are correctly passed to the readable and writable sides. We assume that
+// ReadableStream and WritableStream will correctly apply the strategies when they are being used by a TransformStream
+// and so it isn't necessary to repeat their tests here.
+
+test(() => {
+  const ts = new TransformStream({}, { highWaterMark: 17 });
+  assert_equals(ts.writable.getWriter().desiredSize, 17, 'desiredSize should be 17');
+}, 'writableStrategy highWaterMark should work');
+
+promise_test(() => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 9 });
+  const writer = ts.writable.getWriter();
+  for (let i = 0; i < 10; ++i) {
+    writer.write(i);
+  }
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, [
+      'transform', 0, 'transform', 1, 'transform', 2, 'transform', 3, 'transform', 4,
+      'transform', 5, 'transform', 6, 'transform', 7, 'transform', 8],
+                        'transform() should have been called 9 times');
+  });
+}, 'readableStrategy highWaterMark should work');
+
+promise_test(t => {
+  let writableSizeCalled = false;
+  let readableSizeCalled = false;
+  let transformCalled = false;
+  const ts = new TransformStream(
+    {
+      transform(chunk, controller) {
+        t.step(() => {
+          transformCalled = true;
+          assert_true(writableSizeCalled, 'writableStrategy.size() should have been called');
+          assert_false(readableSizeCalled, 'readableStrategy.size() should not have been called');
+          controller.enqueue(chunk);
+          assert_true(readableSizeCalled, 'readableStrategy.size() should have been called');
+        });
+      }
+    },
+    {
+      size() {
+        writableSizeCalled = true;
+        return 1;
+      }
+    },
+    {
+      size() {
+        readableSizeCalled = true;
+        return 1;
+      },
+      highWaterMark: Infinity
+    });
+  return ts.writable.getWriter().write().then(() => {
+    assert_true(transformCalled, 'transform() should be called');
+  });
+}, 'writable should have the correct size() function');
+
+test(() => {
+  const ts = new TransformStream();
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 1, 'default writable HWM is 1');
+  writer.write(undefined);
+  assert_equals(writer.desiredSize, 0, 'default chunk size is 1');
+}, 'default writable strategy should be equivalent to { highWaterMark: 1 }');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      return t.step(() => {
+        assert_equals(controller.desiredSize, 0, 'desiredSize should be 0');
+        controller.enqueue(undefined);
+        // The first chunk enqueued is consumed by the pending read().
+        assert_equals(controller.desiredSize, 0, 'desiredSize should still be 0');
+        controller.enqueue(undefined);
+        assert_equals(controller.desiredSize, -1, 'desiredSize should be -1');
+      });
+    }
+  });
+  const writePromise = ts.writable.getWriter().write();
+  return ts.readable.getReader().read().then(() => writePromise);
+}, 'default readable strategy should be equivalent to { highWaterMark: 0 }');
+
+test(() => {
+  assert_throws_js(RangeError, () => new TransformStream(undefined, { highWaterMark: -1 }),
+                   'should throw RangeError for negative writableHighWaterMark');
+  assert_throws_js(RangeError, () => new TransformStream(undefined, undefined, { highWaterMark: -1 }),
+                   'should throw RangeError for negative readableHighWaterMark');
+  assert_throws_js(RangeError, () => new TransformStream(undefined, { highWaterMark: NaN }),
+                   'should throw RangeError for NaN writableHighWaterMark');
+  assert_throws_js(RangeError, () => new TransformStream(undefined, undefined, { highWaterMark: NaN }),
+                   'should throw RangeError for NaN readableHighWaterMark');
+}, 'a RangeError should be thrown for an invalid highWaterMark');
+
+const objectThatConvertsTo42 = {
+  toString() {
+    return '42';
+  }
+};
+
+test(() => {
+  const ts = new TransformStream(undefined, { highWaterMark: objectThatConvertsTo42 });
+  const writer = ts.writable.getWriter();
+  assert_equals(writer.desiredSize, 42, 'writable HWM is 42');
+}, 'writableStrategy highWaterMark should be converted to a number');
+
+test(() => {
+  const ts = new TransformStream({
+    start(controller) {
+      assert_equals(controller.desiredSize, 42, 'desiredSize should be 42');
+    }
+  }, undefined, { highWaterMark: objectThatConvertsTo42 });
+}, 'readableStrategy highWaterMark should be converted to a number');
+
+promise_test(t => {
+  const ts = new TransformStream(undefined, undefined, {
+    size() { return NaN; },
+    highWaterMark: 1
+  });
+  const writer = ts.writable.getWriter();
+  return promise_rejects_js(t, RangeError, writer.write(), 'write should reject');
+}, 'a bad readableStrategy size function should cause writer.write() to reject on an identity transform');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    transform(chunk, controller) {
+      // This assert has the important side-effect of catching the error, so transform() does not throw.
+      assert_throws_js(RangeError, () => controller.enqueue(chunk), 'enqueue should throw');
+    }
+  }, undefined, {
+    size() {
+      return -1;
+    },
+    highWaterMark: 1
+  });
+
+  const writer = ts.writable.getWriter();
+  return writer.write().then(() => {
+    return Promise.all([
+      promise_rejects_js(t, RangeError, writer.ready, 'ready should reject'),
+      promise_rejects_js(t, RangeError, writer.closed, 'closed should reject'),
+      promise_rejects_js(t, RangeError, ts.readable.getReader().closed, 'readable closed should reject')
+    ]);
+  });
+}, 'a bad readableStrategy size function should error the stream on enqueue even when transformer.transform() ' +
+   'catches the exception');

--- a/test/js/third_party/wpt-streams/terminate.any.js
+++ b/test/js/third_party/wpt-streams/terminate.any.js
@@ -1,0 +1,100 @@
+// META: global=window,worker
+// META: script=../resources/recording-streams.js
+// META: script=../resources/test-utils.js
+'use strict';
+
+promise_test(t => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 0 });
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(0);
+    }
+  });
+  let pipeToRejected = false;
+  const pipeToPromise = promise_rejects_js(t, TypeError, rs.pipeTo(ts.writable), 'pipeTo should reject').then(() => {
+    pipeToRejected = true;
+  });
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, [], 'transform() should have seen no chunks');
+    assert_false(pipeToRejected, 'pipeTo() should not have rejected yet');
+    ts.controller.terminate();
+    return pipeToPromise;
+  }).then(() => {
+    assert_array_equals(ts.events, [], 'transform() should still have seen no chunks');
+    assert_true(pipeToRejected, 'pipeToRejected must be true');
+  });
+}, 'controller.terminate() should error pipeTo()');
+
+promise_test(t => {
+  const ts = recordingTransformStream({}, undefined, { highWaterMark: 1 });
+  const rs = new ReadableStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.enqueue(1);
+    }
+  });
+  const pipeToPromise = rs.pipeTo(ts.writable);
+  return delay(0).then(() => {
+    assert_array_equals(ts.events, ['transform', 0], 'transform() should have seen one chunk');
+    ts.controller.terminate();
+    return promise_rejects_js(t, TypeError, pipeToPromise, 'pipeTo() should reject');
+  }).then(() => {
+    assert_array_equals(ts.events, ['transform', 0], 'transform() should still have seen only one chunk');
+  });
+}, 'controller.terminate() should prevent remaining chunks from being processed');
+
+test(() => {
+  new TransformStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.terminate();
+      assert_throws_js(TypeError, () => controller.enqueue(1), 'enqueue should throw');
+    }
+  });
+}, 'controller.enqueue() should throw after controller.terminate()');
+
+const error1 = new Error('error1');
+error1.name = 'error1';
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.enqueue(0);
+      controller.terminate();
+      controller.error(error1);
+    }
+  });
+  return Promise.all([
+    promise_rejects_js(t, TypeError, ts.writable.abort(), 'abort() should reject with a TypeError'),
+    promise_rejects_exactly(t, error1, ts.readable.cancel(), 'cancel() should reject with error1'),
+    promise_rejects_exactly(t, error1, ts.readable.getReader().closed, 'closed should reject with error1')
+  ]);
+}, 'controller.error() after controller.terminate() with queued chunk should error the readable');
+
+promise_test(t => {
+  const ts = new TransformStream({
+    start(controller) {
+      controller.terminate();
+      controller.error(error1);
+    }
+  });
+  return Promise.all([
+    promise_rejects_js(t, TypeError, ts.writable.abort(), 'abort() should reject with a TypeError'),
+    ts.readable.cancel(),
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.error() after controller.terminate() without queued chunk should do nothing');
+
+promise_test(() => {
+  const ts = new TransformStream({
+    flush(controller) {
+      controller.terminate();
+    }
+  });
+  const writer = ts.writable.getWriter();
+  return Promise.all([
+    writer.close(),
+    writer.closed,
+    ts.readable.getReader().closed
+  ]);
+}, 'controller.terminate() inside flush() should not prevent writer.close() from succeeding');

--- a/test/js/third_party/wpt-streams/test-utils.js
+++ b/test/js/third_party/wpt-streams/test-utils.js
@@ -1,0 +1,27 @@
+'use strict';
+
+self.delay = ms => new Promise(resolve => step_timeout(resolve, ms));
+
+// For tests which verify that the implementation doesn't do something it shouldn't, it's better not to use a
+// timeout. Instead, assume that any reasonable implementation is going to finish work after 2 times around the event
+// loop, and use flushAsyncEvents().then(() => assert_array_equals(...));
+// Some tests include promise resolutions which may mean the test code takes a couple of event loop visits itself. So go
+// around an extra 2 times to avoid complicating those tests.
+self.flushAsyncEvents = () => delay(0).then(() => delay(0)).then(() => delay(0)).then(() => delay(0));
+
+self.assert_typed_array_equals = (actual, expected, message) => {
+  const prefix = message === undefined ? '' : `${message} `;
+  assert_equals(typeof actual, 'object', `${prefix}type is object`);
+  assert_equals(actual.constructor, expected.constructor, `${prefix}constructor`);
+  assert_equals(actual.byteOffset, expected.byteOffset, `${prefix}byteOffset`);
+  assert_equals(actual.byteLength, expected.byteLength, `${prefix}byteLength`);
+  assert_equals(actual.buffer.byteLength, expected.buffer.byteLength, `${prefix}buffer.byteLength`);
+  assert_array_equals([...actual], [...expected], `${prefix}contents`);
+  assert_array_equals([...new Uint8Array(actual.buffer)], [...new Uint8Array(expected.buffer)], `${prefix}buffer contents`);
+};
+
+self.makePromiseAndResolveFunc = () => {
+  let resolve;
+  const promise = new Promise(r => { resolve = r; });
+  return [promise, resolve];
+};

--- a/test/js/third_party/wpt-streams/testharness-shim.ts
+++ b/test/js/third_party/wpt-streams/testharness-shim.ts
@@ -1,0 +1,148 @@
+// WPT testharness.js shim for the vendored streams .any.js files, mapped onto
+// bun:test. Only the surface those files touch is implemented. Tests whose
+// names appear in `knownFailures` are registered via test.todo so the suite
+// stays green while documenting the gap.
+
+import { test as bunTest } from "bun:test";
+
+export const knownFailures = new Map<string, string>();
+
+function register(name: string, body: () => unknown | Promise<unknown>) {
+  if (knownFailures.has(name)) {
+    bunTest.todo(`${name} — ${knownFailures.get(name)}`);
+    return;
+  }
+  bunTest(name, async () => {
+    await body();
+  });
+}
+
+class WPTTest {
+  cleanups: Array<() => unknown> = [];
+  unreached_func(msg: string) {
+    return (..._args: unknown[]) => {
+      throw new Error(`unreached_func: ${msg}`);
+    };
+  }
+  step(fn: (...a: unknown[]) => unknown, ..._args: unknown[]) {
+    return fn();
+  }
+  step_func(fn: (...a: unknown[]) => unknown) {
+    return (...args: unknown[]) => fn(...args);
+  }
+  add_cleanup(fn: () => unknown) {
+    this.cleanups.push(fn);
+  }
+}
+
+const g = globalThis as any;
+g.self = globalThis;
+
+g.promise_test = (fn: (t: WPTTest) => Promise<unknown>, name: string) => {
+  register(name, async () => {
+    const t = new WPTTest();
+    try {
+      await fn(t);
+    } finally {
+      for (const c of t.cleanups.reverse()) await c();
+    }
+  });
+};
+
+// Exported (not on globalThis) — bun:test injects its own `test` per module.
+export const wptTest = (fn: (t: WPTTest) => unknown, name: string) => {
+  register(name, () => {
+    const t = new WPTTest();
+    try {
+      return fn(t);
+    } finally {
+      for (const c of t.cleanups.reverse()) c();
+    }
+  });
+};
+
+g.step_timeout = (fn: () => void, ms: number) => setTimeout(fn, ms);
+
+function fmt(v: unknown) {
+  if (typeof v === "string") return JSON.stringify(v);
+  if (v && typeof v === "object") return Object.prototype.toString.call(v);
+  return String(v);
+}
+
+g.assert_equals = (actual: unknown, expected: unknown, msg?: string) => {
+  if (!Object.is(actual, expected)) {
+    throw new Error(`assert_equals: ${msg ?? ""} expected ${fmt(expected)} got ${fmt(actual)}`);
+  }
+};
+
+g.assert_not_equals = (actual: unknown, expected: unknown, msg?: string) => {
+  if (Object.is(actual, expected)) throw new Error(`assert_not_equals: ${msg ?? ""} got ${fmt(actual)}`);
+};
+
+g.assert_true = (actual: unknown, msg?: string) => {
+  if (actual !== true) throw new Error(`assert_true: ${msg ?? ""} got ${fmt(actual)}`);
+};
+
+g.assert_false = (actual: unknown, msg?: string) => {
+  if (actual !== false) throw new Error(`assert_false: ${msg ?? ""} got ${fmt(actual)}`);
+};
+
+g.assert_unreached = (msg?: string) => {
+  throw new Error(`assert_unreached: ${msg ?? ""}`);
+};
+
+g.assert_array_equals = (actual: ArrayLike<unknown>, expected: ArrayLike<unknown>, msg?: string) => {
+  if (actual.length !== expected.length) {
+    throw new Error(
+      `assert_array_equals: ${msg ?? ""} lengths differ, expected ${expected.length} got ${actual.length}`,
+    );
+  }
+  for (let i = 0; i < actual.length; i++) {
+    if (!Object.is(actual[i], expected[i])) {
+      throw new Error(
+        `assert_array_equals: ${msg ?? ""} index ${i}, expected ${fmt(expected[i])} got ${fmt(actual[i])}`,
+      );
+    }
+  }
+};
+
+g.assert_throws_js = (ctor: new (...a: unknown[]) => Error, fn: () => unknown, msg?: string) => {
+  try {
+    fn();
+  } catch (e) {
+    if (!(e instanceof ctor)) {
+      throw new Error(`assert_throws_js: ${msg ?? ""} expected ${ctor.name}, got ${(e as Error)?.constructor?.name}`);
+    }
+    return;
+  }
+  throw new Error(`assert_throws_js: ${msg ?? ""} expected ${ctor.name}, but did not throw`);
+};
+
+g.promise_rejects_js = async (
+  _t: unknown,
+  ctor: new (...a: unknown[]) => Error,
+  promise: Promise<unknown>,
+  msg?: string,
+) => {
+  try {
+    await promise;
+  } catch (e) {
+    if (!(e instanceof ctor)) {
+      throw new Error(`promise_rejects_js: ${msg ?? ""} expected ${ctor.name}, got ${(e as Error)?.constructor?.name}`);
+    }
+    return;
+  }
+  throw new Error(`promise_rejects_js: ${msg ?? ""} expected rejection with ${ctor.name}, but promise fulfilled`);
+};
+
+g.promise_rejects_exactly = async (_t: unknown, expected: unknown, promise: Promise<unknown>, msg?: string) => {
+  try {
+    await promise;
+  } catch (e) {
+    if (e !== expected) {
+      throw new Error(`promise_rejects_exactly: ${msg ?? ""} expected ${fmt(expected)}, got ${fmt(e)}`);
+    }
+    return;
+  }
+  throw new Error(`promise_rejects_exactly: ${msg ?? ""} expected rejection, but promise fulfilled`);
+};


### PR DESCRIPTION
### What does this PR do?

Stacked on #32595. Vendors the complete `streams/transform-streams/*.any.js` WPT suite (11 files, 133 tests) plus its `streams/resources/` helpers, byte-identical from web-platform-tests/wpt@e4a4672e9e, with a self-contained testharness shim mapped onto `bun:test`.

**132/133 pass.** The 1 remaining known failure run as `test.todo` with a one-line root cause each in `known-failures.ts`:

| test | root cause |
|---|---|
| `errors.any.js` › TransformStream transformer.start() rejected promise should error the stream | pre-existing: `writer.write()`/`reader.read()` never settle when `start()` returns a promise that rejects asynchronously — reproduces on releases without the `transformer.cancel` changes |

The runner replaces #32595's cancel-only driver with a generic loader so adding `readable-streams/` / `writable-streams/` / `piping/` later is just appending file names.

### Why

Directly addresses the review concern on #31728 ("hesitant to make a large change to TransformStream internals without running web platform tests in CI") with the actual upstream tests, not hand-mirrored ones — and surfaced two real spec gaps (the WritableStream `Promise.$resolve` short-circuit, now fixed in #32620; the start-reject hang) that the hand-mirrored tests missed.

### How did you verify your code works?

```sh
bun bd test test/js/third_party/wpt-streams/run.test.ts
```

132 pass / 1 todo / 0 fail. `streams.test.js`, `compression.test.ts`, `wpt-h2/run.test.ts` unaffected.

