### PR TITLE
docs: explain MIMALLOC_SHOW_STATS output and fix grammar

### DIFF
--- a/docs/project/benchmarking.mdx
+++ b/docs/project/benchmarking.mdx
@@ -189,7 +189,21 @@ Once imported, you should see something like this:
 
 ### Native heap stats
 
-Bun uses mimalloc for the other heap. To report a summary of non-JavaScript memory usage, set the `MIMALLOC_SHOW_STATS=1` environment variable. and stats will print on exit.
+Bun uses mimalloc for the other heap. To report a summary of non-JavaScript memory usage, set the `MIMALLOC_SHOW_STATS=1` environment variable, and stats will print to stderr on exit.
+
+<Note>
+This is only available in builds of Bun compiled with mimalloc. Official release builds for most platforms include mimalloc, but some custom or debug builds may not.
+</Note>
+
+The table has five columns:
+
+| Column | Meaning |
+| --- | --- |
+| `peak` | Highest amount allocated at any point |
+| `total` | Total amount allocated over the lifetime |
+| `freed` | Total amount freed |
+| `current` | Current allocated amount (`total - freed`) |
+| `count` | Number of allocations (where applicable) |
 
 ```sh terminal icon="terminal"
 MIMALLOC_SHOW_STATS=1 bun script.js

--- a/docs/project/benchmarking.mdx
+++ b/docs/project/benchmarking.mdx
@@ -186,6 +186,8 @@ Once imported, you should see something like this:
 </Frame>
 
 > The [web debugger](/runtime/debugger#inspect) also offers the timeline feature which allows you to track and examine the memory usage of the running debug session.
+>
+> For an example of a programmatic memory benchmark that combines `heapStats()` with `process.memoryUsage().rss`, see [`bench/snippets/promise-memory.mjs`](https://github.com/oven-sh/bun/blob/main/bench/snippets/promise-memory.mjs) in the Bun repo.
 
 ### Native heap stats
 


### PR DESCRIPTION
Clarifies the native heap stats section in the benchmarking docs:

- Fixes grammar ("environment variable. and stats" → comma).
- Notes that stats are printed to stderr on exit.
- Adds a short table explaining the meaning of each column (peak, total, freed, current, count).
- Notes that the output is only available in builds of Bun compiled with mimalloc.