### PR TITLE
test: Bun.isStandaloneExecutable is false under BUN_BE_BUN=1

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -923,17 +923,29 @@ error: Hello World`,
     files: {
       "/entry.ts": /* js */ `
         console.log("This is compiled code");
+        console.log(JSON.stringify({ isStandaloneExecutable: Bun.isStandaloneExecutable }));
       `,
     },
     run: [
       {
-        stdout: "This is compiled code",
+        stdout: `This is compiled code\n{"isStandaloneExecutable":true}`,
       },
       {
         env: { BUN_BE_BUN: "1" },
         validate({ stdout }) {
           expect(stdout).not.toContain("This is compiled code");
         },
+      },
+      {
+        // With BUN_BE_BUN=1 the compiled executable behaves like the plain `bun` CLI:
+        // the embedded standalone module graph is never loaded, so Bun.isStandaloneExecutable
+        // must be false even though the binary itself contains one.
+        env: { BUN_BE_BUN: "1" },
+        args: [
+          "-e",
+          `console.log(JSON.stringify({ isStandaloneExecutable: Bun.isStandaloneExecutable, type: typeof Bun.isStandaloneExecutable }))`,
+        ],
+        stdout: `{"isStandaloneExecutable":false,"type":"boolean"}`,
       },
     ],
   });


### PR DESCRIPTION
Extends the existing `compile/BunBeBunEnvVar` test to lock in how `Bun.isStandaloneExecutable` interacts with `BUN_BE_BUN`.

## What this covers

A compiled (`bun build --compile`) executable:

- run normally: bundled entrypoint executes and `Bun.isStandaloneExecutable === true`
- run with `BUN_BE_BUN=1` and `-e <script>`: the binary behaves like the plain `bun` CLI, the embedded standalone module graph is never loaded, and `Bun.isStandaloneExecutable === false`

## Why

`BUN_BE_BUN=1` short-circuits the `Graph::from_executable()` probe in [`src/runtime/cli/mod.rs`](https://github.com/oven-sh/bun/blob/main/src/runtime/cli/mod.rs#L1210), so the VM is created with no standalone module graph and `Bun.isStandaloneExecutable` (which is just `vm.standalone_module_graph.is_some()`, see [`BunObject.rs`](https://github.com/oven-sh/bun/blob/main/src/runtime/api/BunObject.rs#L1993)) reports `false`. This test pins that behavior so it can't silently change.

## Verification

```
bun bd test test/bundler/bundler_compile.test.ts -t BunBeBunEnvVar
  (pass) bundler > compile/BunBeBunEnvVar
```