### PR TITLE
parser: declare_common_js_symbol docstring + __require bundle-mode shadow test

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -4734,16 +4734,23 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
     /// Declare an ambient symbol resolvable BY NAME via [`Self::find_symbol`]
     /// during visit (writes `module_scope.members[name]`). Use for parser-minted
-    /// symbols that user code references as a bare identifier — CJS wrapper vars
+    /// symbols that user code references as a bare identifier: CJS wrapper vars
     /// (`exports`, `module`, `require`, `__dirname`, `__filename`), jest globals,
     /// `hmr`, server-components `Response`.
     ///
-    /// If a user binding already owns `name` in `module_scope.members`, returns a
-    /// fresh ref appended to `module_scope.generated` instead (so generated code
-    /// referencing it still gets a renamer-unique name) and leaves the user's
-    /// member entry untouched. Callers that gate on whether the user shadowed
-    /// (e.g. the `Response` → `bun:app` import) can check
-    /// `symbols[ref].use_count_estimate > 0`.
+    /// Collision contract when a user binding already owns `name` in
+    /// `module_scope.members`:
+    /// - Both sides `Hoisted` and the file has no ESM syntax: not a collision
+    ///   (`var exports` inside the CJS wrapper merges with the `exports`
+    ///   argument). Returns the user's existing ref.
+    /// - Otherwise: returns a fresh ref appended to `module_scope.generated`
+    ///   (so generated code referencing it still gets a renamer-unique name)
+    ///   and leaves the user's member entry untouched.
+    ///
+    /// Callers that only want to emit when the ambient was actually reached
+    /// (e.g. the `Response` → `bun:app` import) check
+    /// `symbols[ref].use_count_estimate > 0` after visit: a fresh shadowed ref
+    /// is never recorded by `find_symbol`, so the count stays 0.
     ///
     /// Named for its original CJS-wrapper callers. For parser-generated symbols
     /// consumed BY REF (never via `find_symbol`), use

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3207,11 +3207,8 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 options::ServerComponents::WrapExportsForServerReference => {}
             }
 
-            // Server-side components:
-            // Declare upfront the symbols for "Response" and "bun:app".
-            // Unlike the other generated symbols above, this one is looked up
-            // by name during visit (user `new Response(...)` resolves via
-            // `find_symbol`), so it must live in `module_scope.members`.
+            // Server-side components: declare "Response" / "bun:app" upfront.
+            // By-name ambient — see `declare_common_js_symbol`.
             match self.options.features.server_components {
                 options::ServerComponents::None | options::ServerComponents::ClientSide => {}
                 _ => {
@@ -4735,6 +4732,22 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         self.options.bundle && self.options.output_format.is_esm()
     }
 
+    /// Declare an ambient symbol resolvable BY NAME via [`Self::find_symbol`]
+    /// during visit (writes `module_scope.members[name]`). Use for parser-minted
+    /// symbols that user code references as a bare identifier — CJS wrapper vars
+    /// (`exports`, `module`, `require`, `__dirname`, `__filename`), jest globals,
+    /// `hmr`, server-components `Response`.
+    ///
+    /// If a user binding already owns `name` in `module_scope.members`, returns a
+    /// fresh ref appended to `module_scope.generated` instead (so generated code
+    /// referencing it still gets a renamer-unique name) and leaves the user's
+    /// member entry untouched. Callers that gate on whether the user shadowed
+    /// (e.g. the `Response` → `bun:app` import) can check
+    /// `symbols[ref].use_count_estimate > 0`.
+    ///
+    /// Named for its original CJS-wrapper callers. For parser-generated symbols
+    /// consumed BY REF (never via `find_symbol`), use
+    /// [`Self::declare_generated_symbol`].
     pub fn declare_common_js_symbol(
         &mut self,
         kind: js_ast::symbol::Kind,

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -2195,11 +2195,8 @@ pub fn NewParser_(
                 .wrap_exports_for_server_reference => {},
             }
 
-            // Server-side components:
-            // Declare upfront the symbols for "Response" and "bun:app".
-            // Unlike the other generated symbols above, this one is looked up
-            // by name during visit (user `new Response(...)` resolves via
-            // `findSymbol`), so it must live in `module_scope.members`.
+            // Server-side components: declare "Response" / "bun:app" upfront.
+            // By-name ambient — see `declareCommonJSSymbol`.
             switch (p.options.features.server_components) {
                 .none, .client_side => {},
                 else => {
@@ -3257,6 +3254,22 @@ pub fn NewParser_(
             return p.options.bundle and p.options.output_format.isESM();
         }
 
+        /// Declare an ambient symbol resolvable BY NAME via `findSymbol` during
+        /// visit (writes `module_scope.members[name]`). Use for parser-minted
+        /// symbols that user code references as a bare identifier — CJS wrapper
+        /// vars (`exports`, `module`, `require`, `__dirname`, `__filename`),
+        /// jest globals, `hmr`, server-components `Response`.
+        ///
+        /// If a user binding already owns `name` in `module_scope.members`,
+        /// returns a fresh ref appended to `module_scope.generated` instead (so
+        /// generated code referencing it still gets a renamer-unique name) and
+        /// leaves the user's member entry untouched. Callers that gate on
+        /// whether the user shadowed (e.g. the `Response` → `bun:app` import)
+        /// can check `symbols[ref].use_count_estimate > 0`.
+        ///
+        /// Named for its original CJS-wrapper callers. For parser-generated
+        /// symbols consumed BY REF (never via `findSymbol`), use
+        /// `declareGeneratedSymbol`.
         pub fn declareCommonJSSymbol(p: *P, comptime kind: Symbol.Kind, comptime name: string) !Ref {
             const name_hash = comptime Scope.getMemberHash(name);
             const member = p.module_scope.getMemberWithHash(name, name_hash);

--- a/src/js_parser/p.zig
+++ b/src/js_parser/p.zig
@@ -3256,16 +3256,23 @@ pub fn NewParser_(
 
         /// Declare an ambient symbol resolvable BY NAME via `findSymbol` during
         /// visit (writes `module_scope.members[name]`). Use for parser-minted
-        /// symbols that user code references as a bare identifier — CJS wrapper
+        /// symbols that user code references as a bare identifier: CJS wrapper
         /// vars (`exports`, `module`, `require`, `__dirname`, `__filename`),
         /// jest globals, `hmr`, server-components `Response`.
         ///
-        /// If a user binding already owns `name` in `module_scope.members`,
-        /// returns a fresh ref appended to `module_scope.generated` instead (so
-        /// generated code referencing it still gets a renamer-unique name) and
-        /// leaves the user's member entry untouched. Callers that gate on
-        /// whether the user shadowed (e.g. the `Response` → `bun:app` import)
-        /// can check `symbols[ref].use_count_estimate > 0`.
+        /// Collision contract when a user binding already owns `name` in
+        /// `module_scope.members`:
+        /// - Both sides `.hoisted` and the file has no ESM syntax: not a
+        ///   collision (`var exports` inside the CJS wrapper merges with the
+        ///   `exports` argument). Returns the user's existing ref.
+        /// - Otherwise: returns a fresh ref appended to `module_scope.generated`
+        ///   (so generated code referencing it still gets a renamer-unique
+        ///   name) and leaves the user's member entry untouched.
+        ///
+        /// Callers that only want to emit when the ambient was actually reached
+        /// (e.g. the `Response` → `bun:app` import) check
+        /// `symbols[ref].use_count_estimate > 0` after visit: a fresh shadowed
+        /// ref is never recorded by `findSymbol`, so the count stays 0.
         ///
         /// Named for its original CJS-wrapper callers. For parser-generated
         /// symbols consumed BY REF (never via `findSymbol`), use

--- a/test/bundler/esbuild/default.test.ts
+++ b/test/bundler/esbuild/default.test.ts
@@ -1531,6 +1531,19 @@ describe.concurrent("bundler", () => {
       stdout: "123 object",
     },
   });
+  itBundled("default/RuntimeNameCollisionBundle", {
+    files: {
+      "/entry.js": /* js */ `
+        function __require() { return 123 }
+        console.log(__require(), typeof (require('fs')))
+      `,
+    },
+    target: "node",
+    external: ["fs"],
+    run: {
+      stdout: "123 object",
+    },
+  });
   itBundled("default/TopLevelReturnForbiddenImport", {
     todo: true,
     files: {


### PR DESCRIPTION
Stacked on #32593. Two follow-ups from review on that PR — both tidying, neither is a correctness fix.

### `default/RuntimeNameCollisionBundle` test

#32593 dropped the `__require` force-hash workaround whose comment named `options.bundle == true` as the collision case. The only existing `__require` collision test (`default/RuntimeNameCollisionNoBundle`) is `bundling: false`, so it only exercises the NoOpRenamer hash path. This adds a bundling sibling (`target: "node"` + `external: ["fs"]`) that runs the output and fails if the runtime `__require` alias is linked to or printed as the user's `__require`.

### `declare_common_js_symbol` / `declareCommonJSSymbol` docstring

#32593 made this the canonical "by-name ambient" primitive (now serves `Response` alongside the CJS five, jest globals, and `hmr` — most callers aren't CJS) but left the contract written only at the new `Response` callsite. Adds a docstring on the function in both `p.rs` and `p.zig` matching the one `declare_generated_symbol` got, and trims the callsite comment to point at it.

Not renaming the function here.