### PR TITLE
Fix SubtleCrypto.wrapKey with AES-KW and jwk format

### DIFF
--- a/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
+++ b/src/jsc/bindings/webcrypto/SubtleCrypto.cpp
@@ -1197,6 +1197,14 @@ void SubtleCrypto::wrapKey(JSC::JSGlobalObject& state, KeyFormat format, CryptoK
                     String jwkString = JSONStringify(promise->globalObject(), jwk, 0);
                     CString jwkUTF8String = jwkString.utf8(StrictConversion);
                     bytes.append(jwkUTF8String.span());
+
+                    // AES-KW (RFC 3394) can only wrap plaintext whose length is a multiple of
+                    // 8 bytes. A serialized JWK usually isn't, so pad it with trailing spaces,
+                    // which JSON.parse ignores when the key is unwrapped. This matches Node.js.
+                    if (wrappingKey->algorithmIdentifier() == CryptoAlgorithmIdentifier::AES_KW) {
+                        while (bytes.size() % 8)
+                            bytes.append(' ');
+                    }
                 }
                 }
 

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -364,15 +364,31 @@ describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
     expect(roundTrippedJwk.k).toBe(originalJwk.k);
   });
 
-  it("does not pad raw-format key material", async () => {
-    const keyToWrap = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+  it("does not apply jwk padding to raw-format keys", async () => {
     const wrappingKey = await crypto.subtle.generateKey({ name: "AES-KW", length: 256 }, true, [
       "wrapKey",
       "unwrapKey",
     ]);
-    // 32-byte key is already a multiple of 8; wrapped output is key + 8 bytes, no padding.
-    const wrapped = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, "AES-KW");
+
+    // A 32-byte key is already a multiple of 8; wrapped output is key + 8 bytes.
+    const alignedKey = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+    const wrapped = await crypto.subtle.wrapKey("raw", alignedKey, wrappingKey, "AES-KW");
     expect(wrapped.byteLength).toBe(40);
+
+    // A raw key whose length is not a multiple of 8 must still be rejected: the
+    // jwk whitespace padding must not leak into the raw branch. A 56-bit HMAC
+    // key exports to 7 raw bytes, which AES-KW cannot wrap.
+    const unalignedKey = await crypto.subtle.generateKey({ name: "HMAC", hash: "SHA-256", length: 56 }, true, [
+      "sign",
+      "verify",
+    ]);
+    expect((await crypto.subtle.exportKey("raw", unalignedKey)).byteLength).toBe(7);
+    const err = await crypto.subtle.wrapKey("raw", unalignedKey, wrappingKey, "AES-KW").then(
+      () => null,
+      e => e,
+    );
+    expect(err).toBeInstanceOf(DOMException);
+    expect(err.name).toBe("OperationError");
   });
 
   it("unwraps an AES-KW jwk blob produced by Node.js", async () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -334,3 +334,72 @@ describe("Ed25519", () => {
     });
   });
 });
+
+// https://github.com/oven-sh/bun/issues/32613
+describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
+  // The serialized JWK is rarely a multiple of 8 bytes, which AES-KW (RFC 3394)
+  // requires. Bun used to reject these with OperationError; it now pads the JWK
+  // JSON with trailing spaces, matching Node.js.
+  it.each(["SHA-256", "SHA-384", "SHA-512"])("round-trips an HMAC %s key", async hash => {
+    const hmacKey = await crypto.subtle.generateKey({ name: "HMAC", hash }, true, ["sign", "verify"]);
+    const wrappingKey = await crypto.subtle.generateKey({ name: "AES-KW", length: 256 }, true, [
+      "wrapKey",
+      "unwrapKey",
+    ]);
+    const originalJwk = (await crypto.subtle.exportKey("jwk", hmacKey)) as JsonWebKey;
+
+    const wrapped = await crypto.subtle.wrapKey("jwk", hmacKey, wrappingKey, "AES-KW");
+    expect(wrapped.byteLength % 8).toBe(0);
+
+    const unwrapped = await crypto.subtle.unwrapKey(
+      "jwk",
+      wrapped,
+      wrappingKey,
+      "AES-KW",
+      { name: "HMAC", hash },
+      true,
+      ["sign", "verify"],
+    );
+    const roundTrippedJwk = (await crypto.subtle.exportKey("jwk", unwrapped)) as JsonWebKey;
+    expect(roundTrippedJwk.kty).toBe("oct");
+    expect(roundTrippedJwk.k).toBe(originalJwk.k);
+  });
+
+  it("does not pad raw-format key material", async () => {
+    const keyToWrap = await crypto.subtle.generateKey({ name: "AES-GCM", length: 256 }, true, ["encrypt", "decrypt"]);
+    const wrappingKey = await crypto.subtle.generateKey({ name: "AES-KW", length: 256 }, true, [
+      "wrapKey",
+      "unwrapKey",
+    ]);
+    // 32-byte key is already a multiple of 8; wrapped output is key + 8 bytes, no padding.
+    const wrapped = await crypto.subtle.wrapKey("raw", keyToWrap, wrappingKey, "AES-KW");
+    expect(wrapped.byteLength).toBe(40);
+  });
+
+  it("unwraps an AES-KW jwk blob produced by Node.js", async () => {
+    // Fixed wrapping key + HMAC SHA-512 key wrapped by Node.js, proving interop.
+    const wrappingKey = await crypto.subtle.importKey(
+      "raw",
+      Buffer.from("000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f", "hex"),
+      "AES-KW",
+      false,
+      ["unwrapKey"],
+    );
+    const wrapped = Buffer.from(
+      "8bb2ba91c19d8e05a8c07a4634bacc1fb3eac4725a5c206452865a3d034cc8d1cad992b8d6e45cea1369d2a3073306ab8f2fe826e71da572dc404a9662a05fdd759dcfd4fea26f8b980d87d4871ed12b3b681bb090f29ee19d0def9c708a462ab29789f59c1b68861877667fd39a3e20bae77eb0f6581ad758cd4a70b1659dd5005db7405b88cd1a15aa1397c3dbde2b11a61a84d467881375cb5a779cdcab00e4faabba1121e450",
+      "hex",
+    );
+    const unwrapped = await crypto.subtle.unwrapKey(
+      "jwk",
+      wrapped,
+      wrappingKey,
+      "AES-KW",
+      { name: "HMAC", hash: "SHA-512" },
+      true,
+      ["sign", "verify"],
+    );
+    const jwk = (await crypto.subtle.exportKey("jwk", unwrapped)) as JsonWebKey;
+    expect(jwk.kty).toBe("oct");
+    expect(jwk.k).toBe("AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkqKywtLi8wMTIzNDU2Nzg5Ojs8PT4_QA");
+  });
+});

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -349,7 +349,6 @@ describe("AES-KW wrapKey/unwrapKey with jwk format", () => {
     const originalJwk = (await crypto.subtle.exportKey("jwk", hmacKey)) as JsonWebKey;
 
     const wrapped = await crypto.subtle.wrapKey("jwk", hmacKey, wrappingKey, "AES-KW");
-    expect(wrapped.byteLength % 8).toBe(0);
 
     const unwrapped = await crypto.subtle.unwrapKey(
       "jwk",


### PR DESCRIPTION
Fixes #32613.

### Repro

```js
const { subtle } = globalThis.crypto;
const key = await subtle.generateKey({ name: "HMAC", hash: "SHA-512" }, true, ["sign", "verify"]);
const wrappingKey = await subtle.generateKey({ name: "AES-KW", length: 256 }, true, ["wrapKey", "unwrapKey"]);
await subtle.wrapKey("jwk", key, wrappingKey, "AES-KW"); // throws OperationError
```

```
OperationError: The operation failed for an operation-specific reason
  at wrapKey@[native code]
```

Node.js returns a 256-byte `ArrayBuffer` and round-trips the key through `unwrapKey`.

### Cause

`SubtleCrypto::wrapKey` serializes the JWK to UTF-8 JSON and hands the bytes straight to the wrapping algorithm. AES-KW (RFC 3394) can only wrap plaintext whose length is a multiple of 8 bytes, so any JWK that is not a multiple of 8 is rejected with `OperationError`. An HMAC SHA-512 key serializes to 244 bytes (244 % 8 == 4), so it always fails.

### Fix

In the `jwk` branch of `SubtleCrypto::wrapKey`, pad the serialized JWK with trailing ASCII spaces up to the next multiple of 8 bytes, but only when the wrapping algorithm is AES-KW. `JSON.parse` ignores the trailing whitespace on unwrap, so keys round-trip, and the output matches Node.js byte-for-byte (Node uses the same whitespace-pad + RFC 3394 scheme, sanctioned by the [W3C WebCrypto wrapKey note](https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey)). `raw`/`spki`/`pkcs8` key material is never padded.

### Verification

- The issue repro now wraps to 256 bytes and unwraps back to an HMAC SHA-512 key, matching Node.
- Added tests to `test/js/web/crypto/web-crypto.test.ts`: HMAC SHA-256/384/512 round-trips through AES-KW jwk wrap/unwrap, a check that raw-format material is not padded, and unwrapping a fixed AES-KW jwk blob produced by Node.js (interop).
- Confirmed the round-trip tests fail on the released build (`OperationError`) and pass with this change; verified manually that a blob Bun wraps decrypts under Node's `id-aes256-wrap` (RFC 3394) to the original JSON plus trailing spaces.