### PR TITLE
shell(rm): don't leak ShellRmTask when readdir loop aborts after enqueuing children

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -1092,16 +1092,23 @@ impl ShellRmTask {
             need_to_wait_out: None,
         };
 
+        // The loop may have already enqueued child DirTasks (bumping
+        // `dir_task.subtask_count`) when a readdir/unlink error or an
+        // `error_signal` from another worker aborts it. Returning from
+        // inside the loop would skip the `need_to_wait` hand-off below,
+        // so the last child's `post_run` would never drive
+        // `delete_after_waiting_for_children` on this dir and the owning
+        // `ShellRmTask` would never be freed.
         let mut i: usize = 0;
-        loop {
+        let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
-                Err(e) => return Err(self.error_with_path(&e, path.as_bytes())),
-                Ok(None) => break,
+                Err(e) => break Err(self.error_with_path(&e, path.as_bytes())),
+                Ok(None) => break Ok(()),
                 Ok(Some(ent)) => ent,
             };
             // TODO this seems bad maybe better to listen to kqueue/epoll event
             if (i & 3) == 0 && self.error_signal().load(Ordering::SeqCst) {
-                return Ok(());
+                break Ok(());
             }
             i += 1;
             match current.kind {
@@ -1121,15 +1128,26 @@ impl ShellRmTask {
                         let joined = self.buf_join(buf, &[path.as_bytes(), name]);
                         ZBox::from_bytes(joined.as_bytes())
                     };
-                    self.remove_entry_file(
+                    if let Err(e) = self.remove_entry_file(
                         dir_task,
                         file_path.as_zstr(),
                         is_absolute,
                         buf,
                         &mut child_vtable,
-                    )?;
+                    ) {
+                        break Err(e);
+                    }
                 }
             }
+        };
+
+        // Stash any loop error before the hand-off — once `need_to_wait`
+        // is published `self` may be freed, and `handle_err` takes a
+        // mutex so it must not sit between the `subtask_count` load and
+        // the `need_to_wait` store. The `error_signal` check below covers
+        // the no-children early-out.
+        if let Err(e) = loop_result {
+            self.handle_err(e);
         }
 
         // Need to wait for children to finish.
@@ -1372,9 +1390,9 @@ impl DirTask {
             Ok(waiting) => waiting,
             Err(err) => {
                 tm.handle_err(err);
-                // `need_to_wait` is only stored on the `Ok(())` return path of
-                // `remove_entry_dir`, so an error guarantees ownership of
-                // `this` was not handed off.
+                // `need_to_wait` is only stored on the `Ok(())` return path
+                // of `remove_entry_dir`, so an `Err` return guarantees
+                // ownership of `this` was not handed off.
                 false
             }
         };


### PR DESCRIPTION
## What does this PR do?

Fixes an ASAN-reported leak of `Box<ShellRmTask>` (and its root `DirTask`, `root_path`, and stashed `err.path`) in the shell `rm` builtin, surfaced by `test/js/bun/shell/commands/rm.test.ts` SIGABRT'ing on the Debian 13 x64-asan job.

### Mechanism

`remove_entry_dir`'s readdir loop had three early `return`s — readdir error, `error_signal` observed from another worker, and `remove_entry_file` error — that could fire **after** `enqueue()` had already bumped `dir_task.subtask_count` for one or more child `DirTask`s. Returning skipped the `need_to_wait` hand-off block, so:

- the parent's own `post_run` ran with `subtask_count > 1` and fell through doing nothing;
- each child's `post_run` decremented the parent's count but read `parent.need_to_wait == false` and skipped `delete_after_waiting_for_children`;
- nothing ever drove `finish_concurrently` for the root, so `decr_pending_and_maybe_deinit` never freed the `Box<ShellRmTask>`.

The trigger in CI is the symlink-swap race test: a swapped entry's `O_DIRECTORY|O_NOFOLLOW` open fails, the child's `handle_err` flips the shared `error_signal`, and the root worker — still mid-readdir of the target directory with subdirectory tasks already scheduled — bails out of the loop on its next `(i & 3) == 0` check.

### Fix

The readdir loop now evaluates to a `bun_sys::Maybe<()>` (every exit is a `break`, never a `return`), and any loop error is stashed via `handle_err` **before** the `subtask_count` load — `handle_err` takes a mutex, so it must not sit between the load and the `need_to_wait.store(true)`. After the hand-off block, the existing `error_signal` check covers the no-children-pending early-out (the error was just stashed, so the signal is set).

The caller invariant in `run_from_thread_pool_impl` ("`Err` return ⇒ hand-off never happened") is preserved: `Err` is now only returned from the pre-loop section, before any child can be enqueued.

### Out of scope

There is a separate, pre-existing few-instruction window between `subtask_count.load(SeqCst) > 1` and `need_to_wait.store(true, SeqCst)` where the last child can decrement and read `need_to_wait == false`. That race predates this change, is not what ASAN is reporting, and closing it cleanly requires reworking the `post_run` join (e.g. parent participates in the same `fetch_sub` instead of check-then-publish). This PR keeps that window at its original width and does not put any new work inside it.

## How did you verify your code works?

- `bun bd test test/js/bun/shell/commands/rm.test.ts` — 5/5 pass.
- The symlink-swap race test (`-t 'replaced by a symlink'`) run 10× back-to-back — 10/10 pass, no hangs.
- `bun run rust:check-all` — clean on all 10 targets.
- The leak itself is only observable under ASAN; the existing symlink-swap test in `rm.test.ts` is the ASAN reproducer that this PR is fixing.