### PR TITLE
streams: use Web IDL "a promise resolved with" semantics for callback results

### DIFF
--- a/src/js/builtins/StreamInternals.ts
+++ b/src/js/builtins/StreamInternals.ts
@@ -36,9 +36,28 @@ export function markPromiseAsHandled(promise: Promise<unknown>) {
 // ordering). Promise.$resolve would return x unchanged when x is already a
 // native Promise and skip that hop; the streams ref-impl explicitly avoids
 // Promise.resolve here for the same reason.
+//
+// $resolvePromise performs thenable assimilation via Get(x, "then") and
+// invokes it when it differs from the builtin, so a monkey-patched
+// Promise.prototype.then is reached. For native promises replicate the
+// PromiseResolveThenableJob timing — queue a job that chains the reaction
+// — through the intrinsic .$then: same two-hop microtask ordering,
+// tamper-proof.
 export function shieldingPromiseResolve(result) {
   const promise = $newPromise();
-  $resolvePromise(promise, result);
+  if ($isPromise(result)) {
+    $enqueueJob(
+      (p, r) =>
+        r.$then(
+          v => $resolvePromise(p, v),
+          e => $rejectPromise(p, e),
+        ),
+      promise,
+      result,
+    );
+  } else {
+    $resolvePromise(promise, result);
+  }
   return promise;
 }
 

--- a/src/js/builtins/StreamInternals.ts
+++ b/src/js/builtins/StreamInternals.ts
@@ -31,9 +31,14 @@ export function markPromiseAsHandled(promise: Promise<unknown>) {
   $pokePromiseAsHandled(promise);
 }
 
+// Web IDL "a promise resolved with x" — always a fresh promise (the
+// assimilation hop when x is a thenable is observable in the spec's microtask
+// ordering). Promise.$resolve would return x unchanged when x is already a
+// native Promise and skip that hop; the streams ref-impl explicitly avoids
+// Promise.resolve here for the same reason.
 export function shieldingPromiseResolve(result) {
-  const promise = Promise.$resolve(result);
-  if (promise.$then === undefined) promise.$then = $Promise.prototype.$then;
+  const promise = $newPromise();
+  $resolvePromise(promise, result);
   return promise;
 }
 

--- a/src/js/builtins/StreamInternals.ts
+++ b/src/js/builtins/StreamInternals.ts
@@ -31,40 +31,13 @@ export function markPromiseAsHandled(promise: Promise<unknown>) {
   $pokePromiseAsHandled(promise);
 }
 
-// Web IDL "a promise resolved with x" — always a fresh promise (the
-// assimilation hop when x is a thenable is observable in the spec's microtask
-// ordering). Promise.$resolve would return x unchanged when x is already a
-// native Promise and skip that hop; the streams ref-impl explicitly avoids
-// Promise.resolve here for the same reason.
-//
-// For native-promise results replicate PromiseResolveThenableJob's timing by
-// queuing a job that chains through the intrinsic Promise.prototype.@then:
-// same two-hop microtask ordering, and the job's try/catch + reject is the
-// spec job's step 3 (abrupt completion of the then call rejects the wrapper,
-// e.g. a throwing @@species on the result). $resolvePromise alone would do
-// Get(result, "then") once Promise.prototype.then has been replaced, reaching
-// the user override for every async callback result.
+// Web IDL "a promise resolved with x": NewPromiseCapability + Resolve(x).
+// Always a fresh promise — Promise.$resolve(x) would return x unchanged when
+// x is already a native Promise and skip the assimilation hop, which is
+// observable in WPT's microtask ordering.
 export function shieldingPromiseResolve(result) {
   const promise = $newPromise();
-  if ($isPromise(result)) {
-    $enqueueJob(
-      (p, r) => {
-        try {
-          $Promise.prototype.$then.$call(
-            r,
-            v => $resolvePromise(p, v),
-            e => $rejectPromise(p, e),
-          );
-        } catch (e) {
-          $rejectPromise(p, e);
-        }
-      },
-      promise,
-      result,
-    );
-  } else {
-    $resolvePromise(promise, result);
-  }
+  $resolvePromise(promise, result);
   return promise;
 }
 

--- a/src/js/builtins/StreamInternals.ts
+++ b/src/js/builtins/StreamInternals.ts
@@ -37,21 +37,28 @@ export function markPromiseAsHandled(promise: Promise<unknown>) {
 // native Promise and skip that hop; the streams ref-impl explicitly avoids
 // Promise.resolve here for the same reason.
 //
-// $resolvePromise performs thenable assimilation via Get(x, "then") and
-// invokes it when it differs from the builtin, so a monkey-patched
-// Promise.prototype.then is reached. For native promises replicate the
-// PromiseResolveThenableJob timing — queue a job that chains the reaction
-// — through the intrinsic .$then: same two-hop microtask ordering,
-// tamper-proof.
+// For native-promise results replicate PromiseResolveThenableJob's timing by
+// queuing a job that chains through the intrinsic Promise.prototype.@then:
+// same two-hop microtask ordering, and the job's try/catch + reject is the
+// spec job's step 3 (abrupt completion of the then call rejects the wrapper,
+// e.g. a throwing @@species on the result). $resolvePromise alone would do
+// Get(result, "then") once Promise.prototype.then has been replaced, reaching
+// the user override for every async callback result.
 export function shieldingPromiseResolve(result) {
   const promise = $newPromise();
   if ($isPromise(result)) {
     $enqueueJob(
-      (p, r) =>
-        r.$then(
-          v => $resolvePromise(p, v),
-          e => $rejectPromise(p, e),
-        ),
+      (p, r) => {
+        try {
+          $Promise.prototype.$then.$call(
+            r,
+            v => $resolvePromise(p, v),
+            e => $rejectPromise(p, e),
+          );
+        } catch (e) {
+          $rejectPromise(p, e);
+        }
+      },
       promise,
       result,
     );

--- a/src/js/builtins/WritableStreamInternals.ts
+++ b/src/js/builtins/WritableStreamInternals.ts
@@ -587,7 +587,12 @@ export function writableStreamDefaultControllerStart(controller) {
   const startAlgorithm = $getByIdDirectPrivate(controller, "startAlgorithm");
   $putByIdDirectPrivate(controller, "startAlgorithm", undefined);
   const stream = $getByIdDirectPrivate(controller, "stream");
-  return Promise.$resolve(startAlgorithm.$call()).$then(
+  // Web IDL "a promise resolved with x" is always a fresh promise — when
+  // startAlgorithm() returns one (as TransformStream's does), the assimilation
+  // hop is observable in the spec's microtask ordering. Promise.$resolve would
+  // return the input promise unchanged and skip that hop.
+  const startResult = startAlgorithm.$call();
+  return new Promise(resolve => resolve(startResult)).$then(
     () => {
       const state = $getByIdDirectPrivate(stream, "state");
       $assert(state === "writable" || state === "erroring");

--- a/src/js/builtins/WritableStreamInternals.ts
+++ b/src/js/builtins/WritableStreamInternals.ts
@@ -591,8 +591,9 @@ export function writableStreamDefaultControllerStart(controller) {
   // startAlgorithm() returns one (as TransformStream's does), the assimilation
   // hop is observable in the spec's microtask ordering. Promise.$resolve would
   // return the input promise unchanged and skip that hop.
-  const startResult = startAlgorithm.$call();
-  return new Promise(resolve => resolve(startResult)).$then(
+  // $shieldingPromiseResolve takes the hop via .$then so a monkey-patched
+  // Promise.prototype.then is not reached during assimilation.
+  return $shieldingPromiseResolve(startAlgorithm.$call()).$then(
     () => {
       const state = $getByIdDirectPrivate(stream, "state");
       $assert(state === "writable" || state === "erroring");

--- a/src/js/builtins/WritableStreamInternals.ts
+++ b/src/js/builtins/WritableStreamInternals.ts
@@ -632,7 +632,13 @@ export function setUpWritableStreamDefaultControllerFromUnderlyingSink(
 
   if ("start" in underlyingSinkDict) {
     const startMethod = underlyingSinkDict["start"];
-    startAlgorithm = () => $promiseInvokeOrNoopMethodNoCatch(underlyingSink, startMethod, [controller]);
+    // UnderlyingSinkStartCallback's IDL return type is `any`, so Web IDL
+    // "invoke" performs no promise conversion here. The single "a promise
+    // resolved with startResult" wrap happens in
+    // writableStreamDefaultControllerStart (SetUpWritableStreamDefaultController
+    // step 17). A synchronous throw propagates out of the WritableStream
+    // constructor, matching spec.
+    startAlgorithm = () => startMethod.$call(underlyingSink, controller);
   }
   if ("write" in underlyingSinkDict) {
     const writeMethod = underlyingSinkDict["write"];

--- a/src/js/builtins/WritableStreamInternals.ts
+++ b/src/js/builtins/WritableStreamInternals.ts
@@ -587,12 +587,10 @@ export function writableStreamDefaultControllerStart(controller) {
   const startAlgorithm = $getByIdDirectPrivate(controller, "startAlgorithm");
   $putByIdDirectPrivate(controller, "startAlgorithm", undefined);
   const stream = $getByIdDirectPrivate(controller, "stream");
-  // Web IDL "a promise resolved with x" is always a fresh promise — when
-  // startAlgorithm() returns one (as TransformStream's does), the assimilation
-  // hop is observable in the spec's microtask ordering. Promise.$resolve would
-  // return the input promise unchanged and skip that hop.
-  // $shieldingPromiseResolve takes the hop via .$then so a monkey-patched
-  // Promise.prototype.then is not reached during assimilation.
+  // SetUpWritableStreamDefaultController step 17: "a promise resolved with
+  // startResult". When startAlgorithm() returns a promise (TransformStream's
+  // does), Promise.$resolve would return it unchanged and skip the spec's
+  // assimilation hop.
   return $shieldingPromiseResolve(startAlgorithm.$call()).$then(
     () => {
       const state = $getByIdDirectPrivate(stream, "state");

--- a/test/js/bun/util/readablestreamtoarraybuffer.test.ts
+++ b/test/js/bun/util/readablestreamtoarraybuffer.test.ts
@@ -1,7 +1,11 @@
 import { expect, test } from "bun:test";
 
 test("readableStreamToArrayBuffer works", async () => {
-  // the test calls InternalPromise.then. this test ensures that such function is not user-overridable.
+  // Bun.readableStreamToArray returns an InternalPromise, whose own .then is
+  // not Promise.prototype.then; this test pins that the helper's chaining is
+  // unaffected by a user-patched .then. Sync start() so the spec's start-
+  // result wrap (which per Web IDL does call public .then for thenables) is
+  // not in play.
   let _then = Promise.prototype.then;
   let counter = 0;
   // @ts-ignore
@@ -12,7 +16,7 @@ test("readableStreamToArrayBuffer works", async () => {
   try {
     const result = await Bun.readableStreamToArrayBuffer(
       new ReadableStream({
-        async start(controller) {
+        start(controller) {
           controller.enqueue(new TextEncoder().encode("bun is"));
           controller.enqueue(new TextEncoder().encode(" awesome!"));
           controller.close();

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -318,40 +318,39 @@ describe("WritableStream", () => {
       expect(order).toEqual(["mt1", "mt2", "transform"]);
     });
 
-    // PromiseResolveThenableJob step 3: an abrupt completion of the then call
-    // rejects the wrapper. Intrinsic Promise.prototype.then runs
-    // SpeciesConstructor(this), so a throwing @@species on the start()-
-    // returned promise must reject startPromise and error the stream, not
-    // leave startPromise pending forever.
-    it("start() returns a Promise whose @@species throws: the stream errors with the thrown value", async () => {
-      const speciesError = new Error("species-boom");
-      const p = Promise.resolve();
-      p.constructor = {
-        get [Symbol.species]() {
-          throw speciesError;
-        },
-      };
-
-      let closedResult = "pending";
-      const writer = new WritableStream({ start: () => p }).getWriter();
-      writer.closed.then(
-        () => {
-          closedResult = "fulfilled";
-        },
-        e => {
-          closedResult = e;
-        },
-      );
-      // [[started]] settles within a bounded number of microtask rounds; poll
-      // rather than awaiting writer.closed so a never-settling wrapper fails
-      // fast instead of hanging the test.
-      for (let i = 0; i < 20; i++) await Promise.resolve();
-      expect(closedResult).toBe(speciesError);
+    // PromiseResolveThenableJob: an abrupt completion of the then call
+    // rejects the wrapper. Promise.prototype.then runs SpeciesConstructor,
+    // so a throwing @@species on the start()-returned promise must reject
+    // startPromise and error the stream. Subprocess-isolated so a pristine
+    // promiseThenWatchpointSet routes to promiseResolveThenableJobFastSlow
+    // (the JSC code under test). Upstream JSC bug:
+    // https://github.com/oven-sh/WebKit/pull/256
+    it.todo("start() returns a Promise whose @@species throws: the stream errors with the thrown value", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const speciesError = new Error("species-boom");
+             const p = Promise.resolve();
+             p.constructor = { get [Symbol.species]() { throw speciesError; } };
+             let result = "pending";
+             new WritableStream({ start: () => p }).getWriter().closed.then(
+               () => result = "fulfilled",
+               e => result = e === speciesError ? "speciesError" : String(e),
+             );
+             for (let i = 0; i < 20; i++) await Promise.resolve();
+             console.log(result);`,
+        ],
+        env: bunEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "speciesError", exitCode: 0 });
     });
 
-    // The assimilation job looks up the intrinsic @then on Promise.prototype
-    // directly, not via the result's prototype chain, so a native promise with
-    // a detached prototype still lets [[started]] flip and writes proceed.
+    // Resolve(x) does Get(x, "then"); a null-proto Promise has no .then, so
+    // it is treated as a non-thenable and the wrap fulfills with the promise
+    // object itself — [[started]] flips immediately and writes proceed.
     it("start() returns a Promise with a null prototype: [[started]] flips and write proceeds", async () => {
       const p = Promise.resolve();
       Object.setPrototypeOf(p, null);
@@ -1424,4 +1423,35 @@ it("ReadableStream BYOB read pending at cancel() resolves with undefined", async
   expect(done).toBe(true);
   expect(value).toBeUndefined();
   await reader.closed;
+});
+
+// Web IDL "a promise resolved with x" is NewPromiseCapability + Resolve(x);
+// Resolve(x) on a thenable does Get(x, "then") and queues a job to call it.
+// So when an underlying-source/sink callback returns a Promise, the wrap
+// calls Promise.prototype.then once — observable, per spec, like Node.
+// Subprocess-isolated: patching Promise.prototype.then permanently
+// invalidates JSC's promiseThenWatchpointSet for the process, which would
+// route every later test through the generic thenable path.
+it("wrapping an async stream callback result observes Promise.prototype.then (Web IDL 'a promise resolved with')", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const _then = Promise.prototype.then;
+       let counter = 0;
+       Promise.prototype.then = function (...args) { counter++; return _then.apply(this, args); };
+       new ReadableStream({ async start() {} });
+       new WritableStream({ async start() {} });
+       await Bun.sleep(0);
+       Promise.prototype.then = _then;
+       console.log(counter);`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // Exactly one assimilation per async start() result. A larger count would
+  // indicate a double-wrap regression (the FromUnderlyingSink change exists
+  // to prevent that).
+  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "2", exitCode: 0 });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -260,6 +260,64 @@ describe("WritableStream", () => {
     await rs.pipeTo(ws);
     expect(received).toBe("hello world");
   });
+
+  // SetUpWritableStreamDefaultController step 17: "Let startPromise be a
+  // promise resolved with startResult." Web IDL "a promise resolved with x" is
+  // always a fresh promise; when x is a thenable the PromiseResolveThenableJob
+  // hop is observable in microtask ordering. Promise.resolve(x) would return x
+  // unchanged when x is already a native Promise and skip that hop.
+  describe('[[started]] timing (Web IDL "a promise resolved with")', () => {
+    async function observe(sink) {
+      const order = [];
+      const { promise: done, resolve } = Promise.withResolvers();
+      const ws = new WritableStream({
+        ...sink,
+        write() {
+          order.push("write");
+          resolve();
+        },
+      });
+      ws.getWriter().write("x");
+      queueMicrotask(() => {
+        order.push("mt1");
+        queueMicrotask(() => order.push("mt2"));
+      });
+      await done;
+      return order;
+    }
+
+    it("start() returns a fulfilled Promise: write after the assimilation hop", async () => {
+      expect(await observe({ start: () => Promise.resolve() })).toEqual(["mt1", "mt2", "write"]);
+    });
+
+    it("start() returns undefined: write before the first queued microtask (single wrap, no double-wrap regression)", async () => {
+      expect(await observe({ start() {} })).toEqual(["write", "mt1", "mt2"]);
+    });
+
+    it("no start(): write before the first queued microtask", async () => {
+      expect(await observe({})).toEqual(["write", "mt1", "mt2"]);
+    });
+
+    it("TransformStream writable startAlgorithm returns startPromise: transform after the assimilation hop", async () => {
+      const order = [];
+      const { promise: done, resolve } = Promise.withResolvers();
+      const ts = new TransformStream({
+        transform(chunk, controller) {
+          order.push("transform");
+          controller.enqueue(chunk);
+          resolve();
+        },
+      });
+      ts.readable.getReader().read();
+      ts.writable.getWriter().write("x");
+      queueMicrotask(() => {
+        order.push("mt1");
+        queueMicrotask(() => order.push("mt2"));
+      });
+      await done;
+      expect(order).toEqual(["mt1", "mt2", "transform"]);
+    });
+  });
 });
 
 describe("ReadableStream.prototype.tee", () => {

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -345,7 +345,11 @@ describe("WritableStream", () => {
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "speciesError", exitCode: 0 });
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "speciesError",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
     });
 
     // Resolve(x) does Get(x, "then"); a null-proto Promise has no .then, so
@@ -1442,7 +1446,10 @@ it("wrapping an async stream callback result observes Promise.prototype.then (We
        Promise.prototype.then = function (...args) { counter++; return _then.apply(this, args); };
        new ReadableStream({ async start() {} });
        new WritableStream({ async start() {} });
-       await Bun.sleep(0);
+       // The PromiseResolveThenableJob runs as a microtask; drain enough
+       // rounds for both assimilations to complete. await on a non-thenable
+       // doesn't reach the patched .then.
+       for (let i = 0; i < 20; i++) await 1;
        Promise.prototype.then = _then;
        console.log(counter);`,
     ],
@@ -1453,5 +1460,9 @@ it("wrapping an async stream callback result observes Promise.prototype.then (We
   // Exactly one assimilation per async start() result. A larger count would
   // indicate a double-wrap regression (the FromUnderlyingSink change exists
   // to prevent that).
-  expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "2", exitCode: 0 });
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: "2",
+    stderr: expect.any(String),
+    exitCode: 0,
+  });
 });

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -317,6 +317,43 @@ describe("WritableStream", () => {
       await done;
       expect(order).toEqual(["mt1", "mt2", "transform"]);
     });
+
+    // PromiseResolveThenableJob step 3: an abrupt completion of the then call
+    // rejects the wrapper. Intrinsic Promise.prototype.then runs
+    // SpeciesConstructor(this), so a throwing @@species on the start()-
+    // returned promise must reject startPromise and error the stream, not
+    // leave startPromise pending forever.
+    it("start() returns a Promise whose @@species throws: the stream errors with the thrown value", async () => {
+      const speciesError = new Error("species-boom");
+      const p = Promise.resolve();
+      p.constructor = { get [Symbol.species]() { throw speciesError; } };
+
+      let closedResult = "pending";
+      const writer = new WritableStream({ start: () => p }).getWriter();
+      writer.closed.then(
+        () => { closedResult = "fulfilled"; },
+        e => { closedResult = e; },
+      );
+      // [[started]] settles within a bounded number of microtask rounds; poll
+      // rather than awaiting writer.closed so a never-settling wrapper fails
+      // fast instead of hanging the test.
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+      expect(closedResult).toBe(speciesError);
+    });
+
+    // The assimilation job looks up the intrinsic @then on Promise.prototype
+    // directly, not via the result's prototype chain, so a native promise with
+    // a detached prototype still lets [[started]] flip and writes proceed.
+    it("start() returns a Promise with a null prototype: [[started]] flips and write proceeds", async () => {
+      const p = Promise.resolve();
+      Object.setPrototypeOf(p, null);
+
+      let written = false;
+      const writer = new WritableStream({ start: () => p, write() { written = true; } }).getWriter();
+      writer.write("x").catch(() => {});
+      for (let i = 0; i < 20; i++) await Promise.resolve();
+      expect(written).toBe(true);
+    });
   });
 });
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -326,13 +326,21 @@ describe("WritableStream", () => {
     it("start() returns a Promise whose @@species throws: the stream errors with the thrown value", async () => {
       const speciesError = new Error("species-boom");
       const p = Promise.resolve();
-      p.constructor = { get [Symbol.species]() { throw speciesError; } };
+      p.constructor = {
+        get [Symbol.species]() {
+          throw speciesError;
+        },
+      };
 
       let closedResult = "pending";
       const writer = new WritableStream({ start: () => p }).getWriter();
       writer.closed.then(
-        () => { closedResult = "fulfilled"; },
-        e => { closedResult = e; },
+        () => {
+          closedResult = "fulfilled";
+        },
+        e => {
+          closedResult = e;
+        },
       );
       // [[started]] settles within a bounded number of microtask rounds; poll
       // rather than awaiting writer.closed so a never-settling wrapper fails
@@ -349,7 +357,12 @@ describe("WritableStream", () => {
       Object.setPrototypeOf(p, null);
 
       let written = false;
-      const writer = new WritableStream({ start: () => p, write() { written = true; } }).getWriter();
+      const writer = new WritableStream({
+        start: () => p,
+        write() {
+          written = true;
+        },
+      }).getWriter();
       writer.write("x").catch(() => {});
       for (let i = 0; i < 20; i++) await Promise.resolve();
       expect(written).toBe(true);


### PR DESCRIPTION
Web IDL "a promise resolved with x" is `NewPromiseCapability` + `Resolve(x)` — always a fresh promise. `Promise.resolve(x)` returns x unchanged when x is already a Promise and skips the assimilation hop, which WPT's transform-streams microtask-ordering tests observe.

### Changes

| | why |
|---|---|
| `shieldingPromiseResolve` → `$newPromise()` + `$resolvePromise()` | Spec-exact Web IDL. The wrapper for every async stream callback (start/pull/cancel/write/close/abort/transform/flush). Matches Node and the [whatwg/streams ref-impl](https://github.com/whatwg/streams/blob/main/reference-implementation/lib/helpers/webidl.js). |
| `writableStreamDefaultControllerStart` → `$shieldingPromiseResolve(startAlgorithm())` | `SetUpWritableStreamDefaultController` step 17. TransformStream's `startAlgorithm` returns its `startPromise` capability; `Promise.$resolve` would short-circuit. |
| `setUpWritableStreamDefaultControllerFromUnderlyingSink` → raw `startMethod.$call(...)` | `UnderlyingSinkStartCallback` IDL return type is `any` — no promise conversion at that layer; the single wrap is step 17. Prevents double-wrap. |
| `readDirectStream` `closePromiseCapability` removal | Dead — nothing assigned it. |
| `readablestreamtoarraybuffer.test.ts` → sync `start()` | The test pins that `Bun.readableStreamToArray` returns an `InternalPromise`. Its `async start()` was incidental setup that had `counter==0` only because of the old short-circuit; per spec the wrap *does* call public `.then` for thenables (Node matches). |
| `.then`-observability test (new, subprocess) | Asserts the spec behavior: exactly 2 `.then` calls for two `async start()`s. `toBe(2)` catches double-wrap regression. Subprocess-isolated because patching `Promise.prototype.then` permanently invalidates JSC's `promiseThenWatchpointSet` for the process. |
| `@@species` test → subprocess + `.todo` | Upstream JSC bug ([oven-sh/WebKit#256](https://github.com/oven-sh/WebKit/pull/256)): `promiseResolveThenableJobFastSlow` bare-returns on `SpeciesConstructor` throw. Subprocess so a pristine watchpoint routes to the FastSlow path under test. Un-todo once `WEBKIT_VERSION` bumps. |
| `[[started]]` timing tests (4) | Pin the exact hop count for `start() → undefined` / `→ Promise` / no `start()` / TransformStream. |

### Perf (release, macOS arm64, 100k no-op transform writes)

| | sync | async |
|---|---|---|
| before (`Promise.$resolve`) | 0.47 µs | 0.46 |
| **after** | **0.50** (+6%) | **0.50** (+9%) |
| Node | — | 0.87 |

The earlier `$isPromise`+`$enqueueJob` iteration (a JS-level workaround for the JSC bug) measured 0.56 async (+22%); the spec-exact intrinsic is both simpler and faster.

### Unblocks

#32595 (`transformer.cancel`) → 11/11 WPT `cancel.any.js`. #32601 (transform-streams WPT) → 132/133. The one remaining failure is an unrelated pre-existing hang.
