### PR TITLE
buffer: sync vendored tests to Node v26.3.0 and fix compat gaps (64/69 · 92.8%)

### DIFF
--- a/src/js/builtins/JSBufferPrototype.ts
+++ b/src/js/builtins/JSBufferPrototype.ts
@@ -95,7 +95,9 @@ export function readIntLE(this: BufferExt, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      if (typeof offset !== "number" || (offset | 0) !== offset)
+      // Infinity must fall through to boundsError() so it reports the
+      // ">= 0 and <= N" range like Node, not "an integer".
+      if (typeof offset !== "number" || ((offset | 0) !== offset && offset !== Infinity && offset !== -Infinity))
         require("internal/validators").validateInteger(offset, "offset");
       let thisLength;
       if (!(offset >= 0 && offset <= (thisLength = this.length) - byteLength))
@@ -139,7 +141,9 @@ export function readIntBE(this: BufferExt, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      if (typeof offset !== "number" || (offset | 0) !== offset)
+      // Infinity must fall through to boundsError() so it reports the
+      // ">= 0 and <= N" range like Node, not "an integer".
+      if (typeof offset !== "number" || ((offset | 0) !== offset && offset !== Infinity && offset !== -Infinity))
         require("internal/validators").validateInteger(offset, "offset");
       let thisLength;
       if (!(offset >= 0 && offset <= (thisLength = this.length) - byteLength))
@@ -183,7 +187,9 @@ export function readUIntLE(this: BufferExt, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      if (typeof offset !== "number" || (offset | 0) !== offset)
+      // Infinity must fall through to boundsError() so it reports the
+      // ">= 0 and <= N" range like Node, not "an integer".
+      if (typeof offset !== "number" || ((offset | 0) !== offset && offset !== Infinity && offset !== -Infinity))
         require("internal/validators").validateInteger(offset, "offset");
       let thisLength;
       if (!(offset >= 0 && offset <= (thisLength = this.length) - byteLength))
@@ -224,7 +230,9 @@ export function readUIntBE(this: BufferExt, offset, byteLength) {
     case 4:
     case 5:
     case 6: {
-      if (typeof offset !== "number" || (offset | 0) !== offset)
+      // Infinity must fall through to boundsError() so it reports the
+      // ">= 0 and <= N" range like Node, not "an integer".
+      if (typeof offset !== "number" || ((offset | 0) !== offset && offset !== Infinity && offset !== -Infinity))
         require("internal/validators").validateInteger(offset, "offset");
       let thisLength;
       if (!(offset >= 0 && offset <= (thisLength = this.length) - byteLength))

--- a/src/js/node/assert.ts
+++ b/src/js/node/assert.ts
@@ -744,7 +744,7 @@ async function waitForActual(promiseFn) {
   } else if (checkIsPromise(promiseFn)) {
     resultPromise = promiseFn;
   } else {
-    throw $ERR_INVALID_ARG_TYPE("promiseFn", ["function", "an instance of Promise"], promiseFn);
+    throw $ERR_INVALID_ARG_TYPE("promiseFn", ["Function", "Promise"], promiseFn);
   }
 
   try {

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -936,7 +936,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionHRTime, (JSC::JSGlobalObject * globalOb
     if (callFrame->argumentCount() > 0 && !arg0.isUndefined()) {
         JSArray* relativeArray = dynamicDowncast<JSC::JSArray>(arg0);
         if (!relativeArray) {
-            return Bun::ERR::INVALID_ARG_TYPE(throwScope, globalObject, "time"_s, "Array"_s, arg0);
+            return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, globalObject, "time"_s, "Array"_s, arg0);
         }
         if (relativeArray->length() != 2) return Bun::ERR::OUT_OF_RANGE(throwScope, globalObject_, "time"_s, "2"_s, jsNumber(relativeArray->length()));
 
@@ -3151,7 +3151,7 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionsetgroups, (JSGlobalObject * globalObje
     auto* groupsArray = dynamicDowncast<JSC::JSArray>(groups);
     if (!groupsArray) [[unlikely]] {
         // validateArray uses JSC::isArray() which accepts Proxy->Array, but jsDynamicCast returns null.
-        return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "groups"_s, "Array"_s, groups);
+        return Bun::ERR::INVALID_ARG_INSTANCE(scope, globalObject, "groups"_s, "Array"_s, groups);
     }
     auto count = groupsArray->length();
     gid_t groupsStack[64];

--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -488,6 +488,59 @@ extern "C" BunString Bun__ErrorCode__determineSpecificType(JSC::JSGlobalObject* 
     return Bun::toStringRef(builder.toString());
 }
 
+// Port of Node's addNumericalSeparator: groups digits in threes from the right
+// ("18446744073709551616" -> "18_446_744_073_709_551_616").
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L883
+static WTF::String addNumericalSeparator(const WTF::String& val)
+{
+    WTF::String res = emptyString();
+    unsigned start = (!val.isEmpty() && val[0] == '-') ? 1 : 0;
+    unsigned i = val.length();
+    for (; i >= start + 4; i -= 3) {
+        res = makeString("_"_s, StringView(val).substring(i - 3, 3), res);
+    }
+    return makeString(StringView(val).substring(0, i), res);
+}
+
+// ERR_OUT_OF_RANGE renders the received value with numeric separators for
+// integers and bigints whose magnitude exceeds 2**32, matching Node.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1648-L1663
+static void appendOutOfRangeReceived(JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSValue input)
+{
+    if (input.isNumber()) {
+        double d = input.asNumber();
+        if (std::isfinite(d) && std::trunc(d) == d && std::abs(d) > 4294967296.0) {
+            builder.append(addNumericalSeparator(input.toWTFString(globalObject)));
+            return;
+        }
+    } else if (input.isBigInt()) {
+        auto& vm = JSC::getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        WTF::String digits = input.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, );
+        // Separators apply beyond +-2**32. Compare on the digit string: 2**32
+        // is "4294967296" (10 digits), so longer strings are always larger and
+        // equal-length strings compare lexicographically.
+        StringView magnitude = StringView(digits).substring(digits.startsWith('-') ? 1 : 0);
+        bool beyond32Bits = magnitude.length() > 10;
+        if (magnitude.length() == 10) {
+            constexpr const char limit[] = "4294967296";
+            for (unsigned i = 0; i < 10; i++) {
+                if (magnitude[i] != static_cast<char16_t>(limit[i])) {
+                    beyond32Bits = magnitude[i] > static_cast<char16_t>(limit[i]);
+                    break;
+                }
+            }
+        }
+        if (beyond32Bits)
+            digits = addNumericalSeparator(digits);
+        builder.append(digits);
+        builder.append('n');
+        return;
+    }
+    JSValueToStringSafe(globalObject, builder, input);
+}
+
 namespace Message {
 
 void addList(WTF::StringBuilder& result, WTF::Vector<WTF::String>& types)
@@ -568,6 +621,31 @@ WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* gl
     return result.toString();
 }
 
+// Matches Node's kTypes list: primitive type names accepted by ERR_INVALID_ARG_TYPE.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L72
+static bool isPrimitiveTypeName(const WTF::String& type)
+{
+    return type == "string"_s || type == "function"_s || type == "number"_s
+        || type == "object"_s || type == "Function"_s || type == "Object"_s
+        || type == "boolean"_s || type == "bigint"_s || type == "symbol"_s;
+}
+
+// Matches Node's classRegExp /^[A-Z][a-zA-Z0-9]*$/.
+static bool isClassName(const WTF::String& type)
+{
+    if (type.isEmpty() || !isASCIIUpper(type[0]))
+        return false;
+    for (unsigned i = 1; i < type.length(); i++) {
+        if (!isASCIIAlphanumeric(type[i]))
+            return false;
+    }
+    return true;
+}
+
+// Port of Node's ERR_INVALID_ARG_TYPE list rendering: expected entries are
+// grouped into primitive type names ("of type ..."), class names ("an
+// instance of ..."), and everything else.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/errors.js#L1404
 WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, const StringView& arg_name, ArgList expected_types, JSValue actual_value)
 {
     WTF::StringBuilder result;
@@ -575,38 +653,58 @@ WTF::String ERR_INVALID_ARG_TYPE(JSC::ThrowScope& scope, JSC::JSGlobalObject* gl
     result.append("The "_s);
     addParameter(result, arg_name);
     result.append(" must be "_s);
-    result.append("of type "_s);
 
-    unsigned length = expected_types.size();
-    if (length == 1) {
-        auto* str = expected_types.at(0).toString(globalObject);
+    WTF::Vector<WTF::String> types;
+    WTF::Vector<WTF::String> instances;
+    WTF::Vector<WTF::String> other;
+
+    for (unsigned i = 0, length = expected_types.size(); i < length; i++) {
+        auto* str = expected_types.at(i).toString(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-        result.append(str->view(globalObject));
+        auto view = str->view(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
-    } else if (length == 2) {
-        auto* str1 = expected_types.at(0).toString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        result.append(str1->view(globalObject));
-        RETURN_IF_EXCEPTION(scope, {});
-        result.append(" or "_s);
-        auto* str2 = expected_types.at(1).toString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        result.append(str2->view(globalObject));
-        RETURN_IF_EXCEPTION(scope, {});
-    } else {
-        for (unsigned i = 0, end = length - 1; i < end; i++) {
-            JSValue expected_type = expected_types.at(i);
-            auto* str = expected_type.toString(globalObject);
-            RETURN_IF_EXCEPTION(scope, {});
-            result.append(str->view(globalObject));
-            RETURN_IF_EXCEPTION(scope, {});
-            result.append(", "_s);
+        WTF::String value = view->toString();
+        if (isPrimitiveTypeName(value))
+            types.append(value.convertToASCIILowercase());
+        else if (isClassName(value))
+            instances.append(value);
+        else
+            other.append(value);
+    }
+
+    // Special handle `object` in case other instances are allowed to outline
+    // the differences between each other.
+    if (!instances.isEmpty()) {
+        size_t pos = types.find("object"_s);
+        if (pos != WTF::notFound) {
+            types.removeAt(pos);
+            instances.append("Object"_s);
         }
-        result.append("or "_s);
-        auto* str = expected_types.at(length - 1).toString(globalObject);
-        RETURN_IF_EXCEPTION(scope, {});
-        result.append(str->view(globalObject));
-        RETURN_IF_EXCEPTION(scope, {});
+    }
+
+    if (!types.isEmpty()) {
+        result.append(types.size() > 1 ? "one of type "_s : "of type "_s);
+        addList(result, types);
+        if (!instances.isEmpty() || !other.isEmpty())
+            result.append(" or "_s);
+    }
+
+    if (!instances.isEmpty()) {
+        result.append("an instance of "_s);
+        addList(result, instances);
+        if (!other.isEmpty())
+            result.append(" or "_s);
+    }
+
+    if (!other.isEmpty()) {
+        if (other.size() > 1) {
+            result.append("one of "_s);
+            addList(result, other);
+        } else {
+            if (other.at(0).convertToASCIILowercase() != other.at(0))
+                result.append("an "_s);
+            result.append(other.at(0));
+        }
     }
 
     result.append(". Received "_s);
@@ -660,7 +758,7 @@ WTF::String ERR_OUT_OF_RANGE(JSC::ThrowScope& scope, JSC::JSGlobalObject* global
     builder.append("\" is out of range. It must be "_s);
     builder.append(range);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, val_input);
+    appendOutOfRangeReceived(globalObject, builder, val_input);
     RETURN_IF_EXCEPTION(scope, {});
 
     return builder.toString();
@@ -766,7 +864,7 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     builder.append(" and <= "_s);
     builder.append(upper);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, actual);
+    appendOutOfRangeReceived(globalObject, builder, actual);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, builder.toString()));
@@ -789,7 +887,7 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     builder.append(" and <= "_s);
     builder.append(upper);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, actual);
+    appendOutOfRangeReceived(globalObject, builder, actual);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, builder.toString()));
@@ -811,7 +909,7 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     builder.append(bound == LOWER ? ">= "_s : "<= "_s);
     builder.append(bound_num);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, actual);
+    appendOutOfRangeReceived(globalObject, builder, actual);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, builder.toString()));
@@ -832,7 +930,7 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     builder.append("\" is out of range. It must be "_s);
     builder.append(msg);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, actual);
+    appendOutOfRangeReceived(globalObject, builder, actual);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, builder.toString()));
@@ -848,7 +946,7 @@ JSC::EncodedJSValue OUT_OF_RANGE(JSC::ThrowScope& throwScope, JSC::JSGlobalObjec
     builder.append("\" is out of range. It must be "_s);
     builder.append(msg);
     builder.append(". Received "_s);
-    JSValueToStringSafe(globalObject, builder, actual);
+    appendOutOfRangeReceived(globalObject, builder, actual);
     RELEASE_RETURN_IF_EXCEPTION(throwScope, {});
 
     throwScope.throwException(globalObject, createError(globalObject, ErrorCode::ERR_OUT_OF_RANGE, builder.toString()));

--- a/src/jsc/bindings/ErrorCode.h
+++ b/src/jsc/bindings/ErrorCode.h
@@ -71,6 +71,10 @@ JSObject* createInvalidThisError(JSGlobalObject* globalObject, const String& mes
 
 JSC_DECLARE_HOST_FUNCTION(jsFunctionMakeErrorWithCode);
 
+// Appends Node's `determineSpecificType()` rendering of a value ("type number (5)",
+// "an instance of Foo", ...) — the "Received ..." part of ERR_INVALID_ARG_TYPE messages.
+void determineSpecificType(JSC::VM& vm, JSC::JSGlobalObject* globalObject, WTF::StringBuilder& builder, JSC::JSValue value);
+
 enum Bound {
     LOWER,
     UPPER,

--- a/src/jsc/bindings/JSBuffer.cpp
+++ b/src/jsc/bindings/JSBuffer.cpp
@@ -293,6 +293,9 @@ static WebCore::BufferEncodingType parseEncoding(JSC::ThrowScope& scope, JSC::JS
     return encoded.value();
 }
 
+// Matches Node's validateOffset (lib/buffer.js), which is validateInteger and
+// therefore renders its range as ">= min && <= max", unlike boundsError's
+// ">= min and <= max".
 uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObject, JSC::JSValue value, JSC::JSValue name, uint32_t min, uint32_t max)
 {
     if (!value.isNumber()) [[unlikely]]
@@ -301,7 +304,7 @@ uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObjec
     if (std::fmod(value_num, 1.0) != 0) [[unlikely]]
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, "an integer"_s, value);
     if (value_num < min || value_num > max) [[unlikely]]
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, min, max, value);
+        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, makeString(">= "_s, min, " && <= "_s, max), value);
     uint32_t result = JSC::toInt32(value_num);
     return result;
 }
@@ -313,7 +316,7 @@ uint32_t validateOffset(JSC::ThrowScope& scope, JSC::JSGlobalObject* globalObjec
     if (std::fmod(value_num, 1.0) != 0) [[unlikely]]
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, "an integer"_s, value);
     if (value_num < min || value_num > max) [[unlikely]]
-        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, min, max, value);
+        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, name, makeString(">= "_s, min, " && <= "_s, max), value);
     uint32_t result = JSC::toInt32(value_num);
     return result;
 }
@@ -802,7 +805,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     auto castedThisValue = callFrame->argument(0);
     JSC::JSArrayBufferView* castedThis = dynamicDowncast<JSC::JSArrayBufferView>(castedThisValue);
     if (!castedThis) [[unlikely]] {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf1"_s, "Buffer or Uint8Array"_s, castedThisValue);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf1"_s, "Buffer or Uint8Array"_s, castedThisValue);
     }
     if (castedThis->isDetached()) [[unlikely]] {
         throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array (first argument) is detached"_s);
@@ -812,7 +815,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_compareBody(JSC::JSGlobal
     auto buffer = callFrame->argument(1);
     JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
     if (!view) [[unlikely]] {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "buf2"_s, "Buffer or Uint8Array"_s, buffer);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "buf2"_s, "Buffer or Uint8Array"_s, buffer);
     }
     if (view->isDetached()) [[unlikely]] {
         throwVMTypeError(lexicalGlobalObject, throwScope, "Uint8Array (second argument) is detached"_s);
@@ -852,8 +855,13 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
     }
     auto listValue = callFrame->argument(0);
 
-    Bun::V::validateArray(throwScope, lexicalGlobalObject, listValue, "list"_s, jsUndefined());
-    RETURN_IF_EXCEPTION(throwScope, {});
+    // Node's validateArray(list, 'list') renders this as "an instance of Array".
+    {
+        bool isArray = JSC::isArray(lexicalGlobalObject, listValue);
+        RETURN_IF_EXCEPTION(throwScope, {});
+        if (!isArray) [[unlikely]]
+            return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "list"_s, "Array"_s, listValue);
+    }
 
     JSValue totalLengthValue = callFrame->argument(1);
 
@@ -901,7 +909,7 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
         JSValue element = args.at(i);
         auto* typedArray = dynamicDowncast<JSC::JSUint8Array>(element);
         if (!typedArray) [[unlikely]] {
-            return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, makeString("list["_s, i, "]"_s), "Buffer or Uint8Array"_s, element);
+            return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, makeString("list["_s, i, "]"_s), "Buffer or Uint8Array"_s, element);
         }
         if (typedArray->isDetached()) [[unlikely]] {
             return throwVMTypeError(lexicalGlobalObject, throwScope, "ArrayBufferView is detached"_s);
@@ -911,14 +919,18 @@ static JSC::EncodedJSValue jsBufferConstructorFunction_concatBody(JSC::JSGlobalO
 
     size_t byteLength = availableLength;
     if (!totalLengthValue.isUndefined()) {
+        // Matches Node's `validateOffset(length, 'length')`: an integer in [0, kMaxLength].
         if (!totalLengthValue.isNumber()) [[unlikely]] {
-            throwTypeError(lexicalGlobalObject, throwScope, "totalLength must be a valid number"_s);
-            return {};
+            return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "length"_s, "number"_s, totalLengthValue);
         }
-
-        auto totalLength = totalLengthValue.toTypedArrayIndex(lexicalGlobalObject, "totalLength must be a valid number"_s);
-        RETURN_IF_EXCEPTION(throwScope, {});
-        byteLength = totalLength;
+        double totalLength = totalLengthValue.asNumber();
+        if (!std::isfinite(totalLength) || std::trunc(totalLength) != totalLength) [[unlikely]] {
+            return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "length"_s, "an integer"_s, totalLengthValue);
+        }
+        if (totalLength < 0 || totalLength > static_cast<double>(Bun::Buffer::kMaxLength)) [[unlikely]] {
+            return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "length"_s, makeString(">= 0 && <= "_s, static_cast<uint64_t>(Bun::Buffer::kMaxLength)), totalLengthValue);
+        }
+        byteLength = static_cast<size_t>(totalLength);
     }
 
     if (byteLength == 0) {
@@ -1064,7 +1076,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_compareBody(JSC::JSGlobalOb
     JSC::JSUint8Array* view = dynamicDowncast<JSC::JSUint8Array>(arg0);
 
     if (!view) [[unlikely]] {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "target"_s, "Buffer or Uint8Array"_s, arg0);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "target"_s, "Buffer or Uint8Array"_s, arg0);
     }
 
     if (view->isDetached()) [[unlikely]] {
@@ -1178,7 +1190,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
     auto source = castedThis;
     auto target = dynamicDowncast<JSArrayBufferView>(targetValue);
     if (!target) {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "target"_s, "Buffer or Uint8Array"_s, targetValue);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "target"_s, "Buffer or Uint8Array"_s, targetValue);
     }
 
     // Coerce each argument, then immediately bound-check against the
@@ -1202,7 +1214,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
     if (!targetStartValue.isUndefined()) {
         targetStartD = targetStartValue.isAnyInt() ? targetStartValue.asNumber() : toInteger(throwScope, lexicalGlobalObject, targetStartValue, 0);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (targetStartD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "targetStart"_s, 0, target->byteLength(), targetStartValue);
+        if (targetStartD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "targetStart"_s, ">= 0"_s, targetStartValue);
     }
 
     double sourceStartD = 0;
@@ -1215,7 +1227,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
         // original length must stay valid even if sourceEnd's valueOf
         // resizes mid-call (Node behavior: the call then just copies 0).
         auto sourceLengthAtCheck = source->byteLength();
-        if (sourceStartD < 0 || sourceStartD > sourceLengthAtCheck) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceStart"_s, 0, sourceLengthAtCheck, sourceStartValue);
+        if (sourceStartD < 0 || sourceStartD > sourceLengthAtCheck) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceStart"_s, makeString(">= 0 && <= "_s, sourceLengthAtCheck), sourceStartValue);
     }
 
     bool sourceEndGiven = !sourceEndValue.isUndefined();
@@ -1223,7 +1235,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_copyBody(JSC::JSGlobalObjec
     if (sourceEndGiven) {
         sourceEndD = sourceEndValue.isAnyInt() ? sourceEndValue.asNumber() : toInteger(throwScope, lexicalGlobalObject, sourceEndValue, 0);
         RETURN_IF_EXCEPTION(throwScope, {});
-        if (sourceEndD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceEnd"_s, 0, source->byteLength(), sourceEndValue);
+        if (sourceEndD < 0) return Bun::ERR::OUT_OF_RANGE(throwScope, lexicalGlobalObject, "sourceEnd"_s, ">= 0"_s, sourceEndValue);
     }
 
     // Single post-coercion read for the hot path. byteLength is 0 for a
@@ -1273,7 +1285,7 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_equalsBody(JSC::JSGlobalObj
     auto buffer = callFrame->uncheckedArgument(0);
     JSC::JSArrayBufferView* view = dynamicDowncast<JSC::JSArrayBufferView>(buffer);
     if (!view) [[unlikely]] {
-        return Bun::ERR::INVALID_ARG_TYPE(throwScope, lexicalGlobalObject, "otherBuffer"_s, "Buffer or Uint8Array"_s, buffer);
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "otherBuffer"_s, "Buffer or Uint8Array"_s, buffer);
     }
 
     if (view->isDetached()) [[unlikely]] {
@@ -1556,11 +1568,55 @@ static int64_t lastIndexOf(const uint8_t* thisPtr, int64_t thisLength, const uin
     return -1;
 }
 
-static int64_t indexOfNumber(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, uint8_t byteValue)
+// Port of the search-range handling in Node's src/node_buffer.cc
+// (IndexOfString / IndexOfBuffer / IndexOfNumber): `end` is the exclusive
+// upper bound of the search range. Returns true when a real search should run,
+// with *offsetOut / *searchEndOut set; otherwise *immediateResult holds the
+// value to return (the clamped offset for an empty needle, or -1).
+static bool computeIndexOfRange(size_t haystackLength, double byteOffsetD, double endD, size_t needleLength, bool isForward, size_t* offsetOut, size_t* searchEndOut, int64_t* immediateResult)
 {
-    ssize_t byteOffset = indexOfOffset(byteLength, byteOffsetD, 1, !last);
-    if (byteOffset == -1) return -1;
-    auto span = std::span<const uint8_t>(typedVector, byteLength);
+    size_t searchEnd = static_cast<size_t>(std::min<double>(std::max<double>(endD, 0), static_cast<double>(haystackLength)));
+    ssize_t optOffset = indexOfOffset(haystackLength, static_cast<ssize_t>(byteOffsetD), static_cast<ssize_t>(needleLength), isForward);
+
+    if (needleLength == 0) {
+        // Match String#indexOf()/lastIndexOf() behavior, but clamp to searchEnd.
+        *immediateResult = std::min<int64_t>(optOffset, static_cast<int64_t>(searchEnd));
+        return false;
+    }
+    if (haystackLength == 0 || optOffset <= -1) {
+        *immediateResult = -1;
+        return false;
+    }
+    size_t offset = static_cast<size_t>(optOffset);
+    if (!isForward && offset >= searchEnd) {
+        // For backward search, clamp the start to within the search range.
+        if (searchEnd == 0) {
+            *immediateResult = -1;
+            return false;
+        }
+        offset = searchEnd - 1;
+    } else if (isForward && offset >= searchEnd) {
+        *immediateResult = -1;
+        return false;
+    }
+    if ((isForward && needleLength + offset > searchEnd) || needleLength > searchEnd) {
+        *immediateResult = -1;
+        return false;
+    }
+    *offsetOut = offset;
+    *searchEndOut = searchEnd;
+    return true;
+}
+
+static int64_t indexOfNumber(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, uint8_t byteValue)
+{
+    size_t byteOffset = 0;
+    size_t searchEnd = 0;
+    int64_t immediateResult = -1;
+    if (!computeIndexOfRange(byteLength, byteOffsetD, endD, 1, !last, &byteOffset, &searchEnd, &immediateResult))
+        return immediateResult;
+
+    auto span = std::span<const uint8_t>(typedVector, searchEnd);
     if (last) {
         span = span.subspan(0, byteOffset + 1);
         return WTF::reverseFind(span, byteValue);
@@ -1571,12 +1627,8 @@ static int64_t indexOfNumber(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     return result + byteOffset;
 }
 
-static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, JSString* str, BufferEncodingType encoding)
+static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSString* str, BufferEncodingType encoding)
 {
-    ssize_t byteOffset = indexOfOffset(byteLength, byteOffsetD, str->length(), !last);
-    if (byteOffset == -1) return -1;
-    if (str->length() == 0) return byteOffset;
-
     VM& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -1586,34 +1638,49 @@ static int64_t indexOfString(JSC::JSGlobalObject* lexicalGlobalObject, bool last
     RETURN_IF_EXCEPTION(scope, -1);
 
     auto* arrayValue = uncheckedDowncast<JSC::JSUint8Array>(JSC::JSValue::decode(encodedBuffer));
-    auto lengthValue = static_cast<int64_t>(arrayValue->byteLength());
-    if (lengthValue == 0) return byteOffset;
+    size_t needleLength = arrayValue->byteLength();
+
+    // UCS2 searches operate on whole 16-bit units.
+    size_t haystackLength = encoding == BufferEncodingType::ucs2 ? byteLength & ~static_cast<size_t>(1) : byteLength;
+
+    size_t byteOffset = 0;
+    size_t searchEnd = 0;
+    int64_t immediateResult = -1;
+    if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
+        return immediateResult;
+    if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
 
     const uint8_t* typedVectorValue = arrayValue->typedVector();
     if (last) {
-        return lastIndexOf(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+        return lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
     if (encoding == BufferEncodingType::ucs2) {
-        return indexOf16(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+        return indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
 
-    return indexOf(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+    return indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
 }
 
-static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, JSC::JSGenericTypedArrayView<JSC::Uint8Adaptor>* array, BufferEncodingType encoding)
+static int64_t indexOfBuffer(JSC::JSGlobalObject* lexicalGlobalObject, bool last, const uint8_t* typedVector, size_t byteLength, double byteOffsetD, double endD, JSC::JSGenericTypedArrayView<JSC::Uint8Adaptor>* array, BufferEncodingType encoding)
 {
-    size_t lengthValue = array->byteLength();
-    ssize_t byteOffset = indexOfOffset(byteLength, byteOffsetD, lengthValue, !last);
-    if (byteOffset == -1) return -1;
-    if (lengthValue == 0) return byteOffset;
+    size_t needleLength = array->byteLength();
+    size_t haystackLength = encoding == BufferEncodingType::ucs2 ? byteLength & ~static_cast<size_t>(1) : byteLength;
+
+    size_t byteOffset = 0;
+    size_t searchEnd = 0;
+    int64_t immediateResult = -1;
+    if (!computeIndexOfRange(haystackLength, byteOffsetD, endD, needleLength, !last, &byteOffset, &searchEnd, &immediateResult))
+        return immediateResult;
+    if (encoding == BufferEncodingType::ucs2) searchEnd &= ~static_cast<size_t>(1);
+
     const uint8_t* typedVectorValue = array->typedVector();
     if (last) {
-        return lastIndexOf(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+        return lastIndexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
     if (encoding == BufferEncodingType::ucs2) {
-        return indexOf16(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+        return indexOf16(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
     }
-    return indexOf(typedVector, byteLength, typedVectorValue, lengthValue, byteOffset);
+    return indexOf(typedVector, searchEnd, typedVectorValue, needleLength, byteOffset);
 }
 
 static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& scope, JSC::CallFrame* callFrame, typename IDLOperation<JSArrayBufferView>::ClassParameter buffer, bool last)
@@ -1627,7 +1694,24 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
 
     auto valueValue = callFrame->argument(0);
     auto byteOffsetValue = callFrame->argument(1);
-    auto encodingValue = callFrame->argument(2);
+    auto endValue = callFrame->argument(2);
+    auto encodingValue = callFrame->argument(3);
+
+    // Buffer.prototype.indexOf(value[, byteOffset[, end]][, encoding]):
+    // a string `end` is an encoding (Node's lib/buffer.js wrapper), and a
+    // string `byteOffset` is an encoding that takes precedence over it
+    // (bidirectionalIndexOf).
+    if (endValue.isString()) {
+        encodingValue = endValue;
+        endValue = jsUndefined();
+    }
+
+    double endD = std::numeric_limits<double>::infinity();
+    if (!endValue.isUndefined()) {
+        endD = endValue.toNumber(lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, -1);
+        if (std::isnan(endD)) endD = std::numeric_limits<double>::infinity();
+    }
 
     if (byteOffsetValue.isString()) {
         encodingValue = byteOffsetValue;
@@ -1669,7 +1753,7 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
         if (byteLength == 0) return -1;
-        return indexOfNumber(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, byteValue);
+        return indexOfNumber(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, byteValue);
     }
 
     WTF::String encodingString;
@@ -1690,7 +1774,7 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
         if (byteLength == 0) return -1;
-        return indexOfString(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, str, encoding.value());
+        return indexOfString(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, str, encoding.value());
     }
 
     if (auto* array = dynamicDowncast<JSC::JSUint8Array>(valueValue)) {
@@ -1698,18 +1782,22 @@ static int64_t indexOf(JSC::JSGlobalObject* lexicalGlobalObject, ThrowScope& sco
         const uint8_t* typedVector;
         if (!refetchBufferState(typedVector, byteLength)) return -1;
         if (byteLength == 0) return -1;
-        // The needle's backing buffer may also have been detached by a
-        // valueOf/toPrimitive callback during toNumber/toWTFString above.
-        // Treat a detached needle as an empty buffer (matches Node.js:
-        // returns the computed byteOffset for a zero-length match).
-        if (array->isDetached()) [[unlikely]] {
-            return indexOfOffset(byteLength, byteOffsetD, 0, !last);
-        }
-        return indexOfBuffer(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, array, encoding.value());
+        // A needle whose backing buffer was detached by a valueOf/toPrimitive
+        // callback above reports byteLength()==0; computeIndexOfRange's
+        // empty-needle path handles that (clamped to `end`) without touching
+        // typedVector(), so no explicit isDetached() branch is needed here.
+        return indexOfBuffer(lexicalGlobalObject, last, typedVector, byteLength, byteOffsetD, endD, array, encoding.value());
     }
 
-    Bun::ERR::INVALID_ARG_TYPE(scope, lexicalGlobalObject, "value"_s, "number, string, Buffer, or Uint8Array"_s, valueValue);
-    return -1;
+    {
+        // Matches Node's ERR_INVALID_ARG_TYPE('value', ['number', 'string', 'Buffer', 'Uint8Array'], val).
+        WTF::StringBuilder messageBuilder;
+        messageBuilder.append("The \"value\" argument must be one of type number or string or an instance of Buffer or Uint8Array. Received "_s);
+        Bun::determineSpecificType(JSC::getVM(lexicalGlobalObject), lexicalGlobalObject, messageBuilder, valueValue);
+        RETURN_IF_EXCEPTION(scope, -1);
+        scope.throwException(lexicalGlobalObject, Bun::createError(lexicalGlobalObject, Bun::ErrorCode::ERR_INVALID_ARG_TYPE, messageBuilder.toString()));
+        return -1;
+    }
 }
 
 static JSC::EncodedJSValue jsBufferPrototypeFunction_includesBody(JSC::JSGlobalObject* lexicalGlobalObject, JSC::CallFrame* callFrame, typename IDLOperation<JSArrayBufferView>::ClassParameter castedThis)
@@ -2661,7 +2749,18 @@ JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_compare, (JSGlobalObject * le
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_copy, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))
 {
-    return IDLOperation<JSArrayBufferView>::call<jsBufferPrototypeFunction_copyBody>(*lexicalGlobalObject, *callFrame, "copy");
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    // Node's copyImpl() validates `source` (the receiver) with
+    // ERR_INVALID_ARG_TYPE('source', ['Buffer', 'Uint8Array'], source) rather
+    // than a generic this-type error.
+    auto thisValue = callFrame->thisValue().toThis(lexicalGlobalObject, JSC::ECMAMode::strict());
+    auto* thisObject = dynamicDowncast<JSC::JSUint8Array>(thisValue);
+    if (!thisObject) [[unlikely]]
+        return Bun::ERR::INVALID_ARG_INSTANCE(throwScope, lexicalGlobalObject, "source"_s, "Buffer or Uint8Array"_s, thisValue);
+
+    RELEASE_AND_RETURN(throwScope, jsBufferPrototypeFunction_copyBody(lexicalGlobalObject, callFrame, thisObject));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsBufferPrototypeFunction_equals, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/NodeVM.cpp
+++ b/src/jsc/bindings/NodeVM.cpp
@@ -2061,13 +2061,13 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
 
             if (auto* contextExtensionsObject = asObject(contextExtensionsValue)) {
                 if (!isArray(globalObject, contextExtensionsObject))
-                    return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
+                    return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
 
                 // Validate that all items in the array are objects
                 auto* contextExtensionsArray = dynamicDowncast<JSArray>(contextExtensionsValue);
                 if (!contextExtensionsArray) [[unlikely]] {
                     // isArray() accepts Proxy->Array, but jsDynamicCast returns null.
-                    return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
+                    return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
                 }
                 unsigned length = contextExtensionsArray->length();
                 for (unsigned i = 0; i < length; i++) {
@@ -2077,7 +2077,7 @@ bool CompileFunctionOptions::fromJS(JSC::JSGlobalObject* globalObject, JSC::VM& 
                         return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextExtensions[0]"_s, "object"_s, extension);
                 }
             } else {
-                return ERR::INVALID_ARG_TYPE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
+                return ERR::INVALID_ARG_INSTANCE(scope, globalObject, "options.contextExtensions"_s, "Array"_s, contextExtensionsValue);
             }
 
             this->contextExtensions = contextExtensionsValue;

--- a/src/jsc/bindings/NodeValidator.cpp
+++ b/src/jsc/bindings/NodeValidator.cpp
@@ -365,7 +365,11 @@ JSC::EncodedJSValue V::validateArray(JSC::ThrowScope& scope, JSC::JSGlobalObject
 
     bool isArray = JSC::isArray(globalObject, value);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!isArray) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Array"_s, value);
+    if (!isArray) {
+        auto nameString = name.toWTFString(globalObject);
+        RETURN_IF_EXCEPTION(scope, {});
+        return Bun::ERR::INVALID_ARG_INSTANCE(scope, globalObject, nameString, "Array"_s, value);
+    }
 
     auto length = value.get(globalObject, Identifier::fromString(vm, "length"_s));
     RETURN_IF_EXCEPTION(scope, {});
@@ -386,7 +390,7 @@ JSC::EncodedJSValue V::validateArray(JSC::ThrowScope& scope, JSC::JSGlobalObject
 
     bool isArray = JSC::isArray(globalObject, value);
     RETURN_IF_EXCEPTION(scope, {});
-    if (!isArray) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, name, "Array"_s, value);
+    if (!isArray) return Bun::ERR::INVALID_ARG_INSTANCE(scope, globalObject, name, "Array"_s, value);
 
     auto length = value.get(globalObject, Identifier::fromString(vm, "length"_s));
     RETURN_IF_EXCEPTION(scope, {});

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -2796,9 +2796,12 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCheckBufferRead, (JSC::JSGlobalObject * globa
     auto offsetVal = callFrame->argument(1);
     auto byteLengthVal = callFrame->argument(2);
 
-    ssize_t offset;
-    Bun::V::validateInteger(scope, globalObject, offsetVal, "offset"_s, jsUndefined(), jsUndefined(), &offset);
-    RETURN_IF_EXCEPTION(scope, {});
+    // Mirrors Node's read-path validation (lib/internal/buffer.js): validateNumber
+    // on the offset, then boundsError(). A non-integer offset (NaN, 1.01) reports
+    // "an integer", but a finite-floor value like Infinity or a negative integer
+    // reports the ">= 0 and <= N" range, matching boundsError's MathFloor check.
+    if (!offsetVal.isNumber()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "offset"_s, "number"_s, offsetVal);
+    double offset = offsetVal.asNumber();
 
     if (!bufVal.isCell()) return Bun::ERR::INVALID_ARG_TYPE(scope, globalObject, "buf"_s, "Buffer"_s, bufVal);
     auto* buf = dynamicDowncast<JSC::JSArrayBufferView>(bufVal.asCell());
@@ -2806,12 +2809,13 @@ JSC_DEFINE_HOST_FUNCTION(jsFunctionCheckBufferRead, (JSC::JSGlobalObject * globa
     size_t byteLength = byteLengthVal.asNumber();
     ssize_t type = ((ssize_t)buf->length()) - byteLength;
 
-    if (!(offset >= 0 && offset <= type)) {
-        if (std::floor(offset) != offset) {
-            Bun::V::validateNumber(scope, globalObject, offsetVal, jsUndefined(), jsUndefined(), jsUndefined());
-            RETURN_IF_EXCEPTION(scope, {});
-            return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "offset"_s, "an integer"_s, offsetVal);
-        }
+    // A non-integer offset (NaN, 1.01) is "an integer" even when numerically
+    // within bounds — the caller only reaches here because buf[offset] was
+    // undefined, which for a fractional index happens regardless of bounds.
+    if (std::floor(offset) != offset) {
+        return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "offset"_s, "an integer"_s, offsetVal);
+    }
+    if (!(offset >= 0 && offset <= (double)type)) {
         if (type < 0) return Bun::ERR::BUFFER_OUT_OF_BOUNDS(scope, globalObject, ""_s);
         return Bun::ERR::OUT_OF_RANGE(scope, globalObject, "offset"_s, makeString(">= 0 and <= "_s, type), offsetVal);
     }

--- a/test/js/bun/test/parallel/test-http-host-array-should-throw-in-request.ts
+++ b/test/js/bun/test/parallel/test-http-host-array-should-throw-in-request.ts
@@ -3,5 +3,5 @@ import http from "node:http";
 const { expect } = createTest(import.meta.path);
 
 expect(() => http.request({ host: [1, 2, 3] })).toThrow(
-  'The "options.host" property must be of type string, undefined, or null. Received an instance of Array',
+  'The "options.host" property must be of type string or one of undefined or null. Received an instance of Array',
 );

--- a/test/js/node/child_process/child_process-node.test.js
+++ b/test/js/node/child_process/child_process-node.test.js
@@ -657,7 +657,7 @@ describe("fork", () => {
             code: "ERR_INVALID_ARG_TYPE",
             name: "TypeError",
             message: expect.stringContaining(
-              `The "modulePath" argument must be of type string, Buffer, or URL. Received `,
+              `The "modulePath" argument must be of type string or an instance of Buffer or URL. Received `,
             ),
           }),
         );
@@ -674,7 +674,7 @@ describe("fork", () => {
             expect(() => fork(fixtures.path("child-process-echo-options.js"), arg)).toThrow({
               code: "ERR_INVALID_ARG_TYPE",
               name: "TypeError",
-              message: `The \"args\" argument must be of type Array. Received ${arg?.toString()}`,
+              message: `The \"args\" argument must be an instance of Array. Received ${arg?.toString()}`,
             });
           });
         } catch (e) {

--- a/test/js/node/test/parallel/test-assert.js
+++ b/test/js/node/test/parallel/test-assert.js
@@ -1049,7 +1049,7 @@ test('Additional asserts', () => {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
       // message: 'The "error" argument must be of type Object, Error, Function or RegExp. Received: "Error message"',
-      message: 'The "error" argument must be of type Object, Error, Function, or RegExp.' + invalidArgTypeHelper('Error message'),
+      message: 'The "error" argument must be of type function or an instance of Error, RegExp, or Object.' + invalidArgTypeHelper('Error message'),
     }
   );
 
@@ -1059,7 +1059,7 @@ test('Additional asserts', () => {
       () => assert.throws(() => {}, input),
       {
         code: 'ERR_INVALID_ARG_TYPE',
-        message: 'The "error" argument must be of type Object, Error, Function, or RegExp.' + invalidArgTypeHelper(input)
+        message: 'The "error" argument must be of type function or an instance of Error, RegExp, or Object.' + invalidArgTypeHelper(input)
 
       }
     );
@@ -1140,8 +1140,8 @@ test('Throws accepts objects', () => {
     {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
-      message: 'The "expected" argument must be of type Function or ' +
-        'RegExp.' + invalidArgTypeHelper({foo: 'bar'})
+      message: 'The "expected" argument must be of type function or an ' +
+        'instance of RegExp.' + invalidArgTypeHelper({foo: 'bar'})
     }
   );
 

--- a/test/js/node/test/parallel/test-buffer-alloc.js
+++ b/test/js/node/test/parallel/test-buffer-alloc.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const vm = require('vm');
 
 const {
-  SlowBuffer,
+  Buffer,
   kMaxLength,
 } = require('buffer');
 
@@ -13,6 +13,7 @@ const {
 // internal limits should be updated if this fails.
 assert.throws(
   () => new Uint8Array(kMaxLength + 1),
+  // JSC throws "Out of memory" here instead of V8's "Invalid typed array length: ...".
   { name: 'RangeError', message: `Out of memory` },
 );
 
@@ -1086,25 +1087,24 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "target" argument must be of type Buffer or ' +
+    message: 'The "target" argument must be an instance of Buffer or ' +
              'Uint8Array. Received undefined'
   });
 
 assert.throws(() => Buffer.from(), {
   name: 'TypeError',
-  message: 'The first argument must be of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received undefined'
+  message: 'The first argument must be of type string or an instance of ' +
+  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received undefined'
 });
 assert.throws(() => Buffer.from(null), {
   name: 'TypeError',
-  message: 'The first argument must be of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received null'
+  message: 'The first argument must be of type string or an instance of ' +
+  'Buffer, ArrayBuffer, or Array or an Array-like Object. Received null'
 });
 
 // Test prototype getters don't throw
 assert.strictEqual(Buffer.prototype.parent, undefined);
 assert.strictEqual(Buffer.prototype.offset, undefined);
-assert.strictEqual(SlowBuffer.prototype.parent, undefined);
-assert.strictEqual(SlowBuffer.prototype.offset, undefined);
-
 
 {
   // Test that large negative Buffer length inputs don't affect the pool offset.
@@ -1137,7 +1137,7 @@ assert.throws(() => {
   a.copy(b, 0, 0x100000000, 0x100000001);
 }, outOfRangeError);
 
-// Unpooled buffer (replaces SlowBuffer)
+// Unpooled buffer
 {
   const ubuf = Buffer.allocUnsafeSlow(10);
   assert(ubuf);

--- a/test/js/node/test/parallel/test-buffer-arraybuffer.js
+++ b/test/js/node/test/parallel/test-buffer-arraybuffer.js
@@ -43,8 +43,8 @@ assert.throws(function() {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The first argument must be of type string, ' +
-           'Buffer, ArrayBuffer, Array, or Array-like Object. Received ' +
+  message: 'The first argument must be of type string or an instance of ' +
+           'Buffer, ArrayBuffer, or Array or an Array-like Object. Received ' +
            'an instance of AB'
 });
 

--- a/test/js/node/test/parallel/test-buffer-bigint64.js
+++ b/test/js/node/test/parallel/test-buffer-bigint64.js
@@ -45,7 +45,7 @@ const buf = Buffer.allocUnsafe(9);
   }, {
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "value" is out of range. It must be ' +
-      '>= 0n and < 2n ** 64n. Received 18446744073709551616n'
+      '>= 0n and < 2n ** 64n. Received 18_446_744_073_709_551_616n'
   });
 
   // Should throw a TypeError upon invalid input

--- a/test/js/node/test/parallel/test-buffer-bytelength.js
+++ b/test/js/node/test/parallel/test-buffer-bytelength.js
@@ -105,17 +105,13 @@ assert.strictEqual(Buffer.byteLength('aaaa==', 'base64url'), 3);
 assert.strictEqual(Buffer.byteLength('Il était tué'), 14);
 assert.strictEqual(Buffer.byteLength('Il était tué', 'utf8'), 14);
 
-['ascii', 'latin1', 'binary']
-  .reduce((es, e) => es.concat(e, e.toUpperCase()), [])
-  .forEach((encoding) => {
-    assert.strictEqual(Buffer.byteLength('Il était tué', encoding), 12);
-  });
+for (const encoding of ['ascii', 'latin1', 'binary'].flatMap((e) => [e, e.toUpperCase()])) {
+  assert.strictEqual(Buffer.byteLength('Il était tué', encoding), 12);
+}
 
-['ucs2', 'ucs-2', 'utf16le', 'utf-16le']
-  .reduce((es, e) => es.concat(e, e.toUpperCase()), [])
-  .forEach((encoding) => {
-    assert.strictEqual(Buffer.byteLength('Il était tué', encoding), 24);
-  });
+for (const encoding of ['ucs2', 'ucs-2', 'utf16le', 'utf-16le'].flatMap((e) => [e, e.toUpperCase()])) {
+  assert.strictEqual(Buffer.byteLength('Il était tué', encoding), 24);
+}
 
 // Test that ArrayBuffer from a different context is detected correctly
 const arrayBuf = vm.runInNewContext('new ArrayBuffer()');

--- a/test/js/node/test/parallel/test-buffer-compare-offset.js
+++ b/test/js/node/test/parallel/test-buffer-compare-offset.js
@@ -89,6 +89,6 @@ assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
 assert.throws(() => a.compare(), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "target" argument must be of type ' +
+  message: 'The "target" argument must be an instance of ' +
            'Buffer or Uint8Array. Received undefined'
 });

--- a/test/js/node/test/parallel/test-buffer-compare.js
+++ b/test/js/node/test/parallel/test-buffer-compare.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const b = Buffer.alloc(1, 'a');
@@ -30,18 +30,18 @@ assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
 assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf2" argument must be of type Buffer or Uint8Array.' +
-           common.invalidArgTypeHelper('abc')
+  message: 'The "buf2" argument must be an instance of Buffer or Uint8Array. ' +
+           "Received type string ('abc')"
 });
 assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf1" argument must be of type Buffer or Uint8Array.' +
-           common.invalidArgTypeHelper('abc')
+  message: 'The "buf1" argument must be an instance of Buffer or Uint8Array. ' +
+           "Received type string ('abc')"
 });
 
 assert.throws(() => Buffer.alloc(1).compare('abc'), {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "target" argument must be of type ' +
-           "Buffer or Uint8Array." + common.invalidArgTypeHelper('abc')
+  message: 'The "target" argument must be an instance of ' +
+           "Buffer or Uint8Array. Received type string ('abc')"
 });

--- a/test/js/node/test/parallel/test-buffer-concat.js
+++ b/test/js/node/test/parallel/test-buffer-concat.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const { kMaxLength } = require('buffer');
 
 const zero = [];
 const one = [ Buffer.from('asdf') ];
@@ -49,7 +50,7 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list" argument must be of type Array.' +
+    message: 'The "list" argument must be an instance of Array.' +
              `${common.invalidArgTypeHelper(value)}`
   });
 });
@@ -59,7 +60,7 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list[0]" argument must be of type Buffer ' +
+    message: 'The "list[0]" argument must be an instance of Buffer ' +
              `or Uint8Array.${common.invalidArgTypeHelper(value[0])}`
   });
 });
@@ -68,14 +69,37 @@ assert.throws(() => {
   Buffer.concat([Buffer.from('hello'), 3]);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "list[1]" argument must be of type Buffer ' +
+  message: 'The "list[1]" argument must be an instance of Buffer ' +
            'or Uint8Array. Received type number (3)'
+});
+
+assert.throws(() => {
+  Buffer.concat([Buffer.from('hello')], 3.5);
+}, {
+  code: 'ERR_OUT_OF_RANGE',
+  message: 'The value of "length" is out of range. It must be an integer. ' +
+           'Received 3.5'
+});
+
+assert.throws(() => {
+  Buffer.concat([Buffer.from('hello')], -2);
+}, {
+  code: 'ERR_OUT_OF_RANGE',
+  message: 'The value of "length" is out of range. It must be >= 0 && <= ' +
+    `${kMaxLength}. Received -2`
 });
 
 // eslint-disable-next-line node-core/crypto-check
 const random10 = common.hasCrypto ?
   require('crypto').randomBytes(10) :
   Buffer.alloc(10, 1);
+const derived18 = Buffer.alloc(18);
+for (let i = 0, j = 0; i < 18; i++) {
+  if (i < 10)
+    derived18[i] = random10[i];
+  else
+    derived18[i] = random10[j++];
+}
 const empty = Buffer.alloc(0);
 
 assert.notDeepStrictEqual(random10, empty);
@@ -85,6 +109,7 @@ assert.deepStrictEqual(Buffer.concat([], 100), empty);
 assert.deepStrictEqual(Buffer.concat([random10], 0), empty);
 assert.deepStrictEqual(Buffer.concat([random10], 10), random10);
 assert.deepStrictEqual(Buffer.concat([random10, random10], 10), random10);
+assert.deepStrictEqual(Buffer.concat([random10, random10], 18), derived18);
 assert.deepStrictEqual(Buffer.concat([empty, random10]), random10);
 assert.deepStrictEqual(Buffer.concat([random10, empty, empty]), random10);
 
@@ -98,3 +123,13 @@ assert.deepStrictEqual(
 assert.deepStrictEqual(Buffer.concat([new Uint8Array([0x41, 0x42]),
                                       new Uint8Array([0x43, 0x44])]),
                        Buffer.from('ABCD'));
+
+// Spoofed length getter should not cause uninitialized memory exposure
+{
+  const u8_1 = new Uint8Array([1, 2, 3, 4]);
+  const u8_2 = new Uint8Array([5, 6, 7, 8]);
+  Object.defineProperty(u8_1, 'length', { get() { return 100; } });
+  const buf = Buffer.concat([u8_1, u8_2]);
+  assert.strictEqual(buf.length, 8);
+  assert.deepStrictEqual(buf, Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]));
+}

--- a/test/js/node/test/parallel/test-buffer-constants.js
+++ b/test/js/node/test/parallel/test-buffer-constants.js
@@ -9,6 +9,7 @@ assert.strictEqual(typeof MAX_LENGTH, 'number');
 assert.strictEqual(typeof MAX_STRING_LENGTH, 'number');
 assert(MAX_STRING_LENGTH <= MAX_LENGTH);
 assert.throws(() => ' '.repeat(MAX_STRING_LENGTH + 1),
+              // JSC throws "Out of memory" here instead of V8's "Invalid string length".
               /^RangeError: Out of memory$/);
 
 ' '.repeat(MAX_STRING_LENGTH); // Should not throw.

--- a/test/js/node/test/parallel/test-buffer-copy.js
+++ b/test/js/node/test/parallel/test-buffer-copy.js
@@ -133,8 +133,7 @@ b.copy(c, 0, 100, 10);
 assert.throws(
   () => Buffer.prototype.copy.call(0),
   {
-    // code: 'ERR_INVALID_ARG_TYPE',
-    code: 'ERR_INVALID_THIS',
+    code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
   }
 );
@@ -146,7 +145,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "targetStart" is out of range. ' +
-             'It must be >= 0 and <= 5. Received -1'
+             'It must be >= 0. Received -1'
   }
 );
 
@@ -185,7 +184,7 @@ assert.throws(
     code: 'ERR_OUT_OF_RANGE',
     name: 'RangeError',
     message: 'The value of "sourceEnd" is out of range. ' +
-             'It must be >= 0 and <= 1024. Received -1'
+             'It must be >= 0. Received -1'
   }
 );
 
@@ -226,6 +225,23 @@ c.fill('c');
 b.copy(c, 'not a valid offset');
 // Make sure this acted like a regular copy with `0` offset.
 assert.deepStrictEqual(c, b.slice(0, c.length));
+
+// Copy into a Uint16Array target; bytes are packed into 16-bit elements.
+{
+  const x = new Uint16Array(4);
+  const buf = Buffer.of(1, 2, 3, 4);
+  const copied = buf.copy(x);
+  assert.strictEqual(copied, 4);
+  assert.ok(x instanceof Uint16Array);
+  const bytes = new Uint8Array(x.buffer, x.byteOffset, 4);
+  assert.deepStrictEqual(Array.from(bytes), [1, 2, 3, 4]);
+  const remaining = new Uint8Array(
+    x.buffer,
+    x.byteOffset + 4,
+    x.byteLength - 4
+  );
+  assert.ok(remaining.every((b) => b === 0));
+}
 
 {
   c.fill('C');

--- a/test/js/node/test/parallel/test-buffer-equals.js
+++ b/test/js/node/test/parallel/test-buffer-equals.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const common = require('../common');
+require('../common');
 const assert = require('assert');
 
 const b = Buffer.from('abcdf');
@@ -19,7 +19,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "otherBuffer" argument must be of type ' +
-             "Buffer or Uint8Array." + common.invalidArgTypeHelper('abc')
+    message: 'The "otherBuffer" argument must be an instance of ' +
+             "Buffer or Uint8Array. Received type string ('abc')"
   }
 );

--- a/test/js/node/test/parallel/test-buffer-fill.js
+++ b/test/js/node/test/parallel/test-buffer-fill.js
@@ -2,6 +2,9 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+// Bun does not expose node's internal/errors or internal/test/binding modules.
+// const { codes: { ERR_OUT_OF_RANGE } } = require('internal/errors');
+// const { internalBinding } = require('internal/test/binding');
 const SIZE = 28;
 
 const buf1 = Buffer.allocUnsafe(SIZE);
@@ -339,9 +342,10 @@ Buffer.alloc(8, '');
   assert.strictEqual(buf.toString(), 'էէէէէ');
 }
 
-// Testing process.binding. Make sure "start" is properly checked for range errors.
+// Testing process.binding. Make sure "start" is properly checked for range
+// errors.
 // assert.throws(
-//   () => { process.binding('buffer').fill(Buffer.alloc(1), 1, -1, 0, 1); },
+//   () => { internalBinding('buffer').fill(Buffer.alloc(1), 1, -1, 0, 1); },
 //   { code: 'ERR_OUT_OF_RANGE' }
 // );
 
@@ -362,13 +366,15 @@ Buffer.alloc(8, '');
   });
 }
 
-// Testing process.binding. Make sure "end" is properly checked for range errors.
+// Testing process.binding. Make sure "end" is properly checked for range
+// errors.
 // assert.throws(
-//   () => { process.binding('buffer').fill(Buffer.alloc(1), 1, 1, -2, 1); },
+//   () => { internalBinding('buffer').fill(Buffer.alloc(1), 1, 1, -2, 1); },
 //   { code: 'ERR_OUT_OF_RANGE' }
 // );
 
 // Test that bypassing 'length' won't cause an abort.
+// Bun's fill() reads the real byteLength, not the (spoofable) length property.
 // assert.throws(() => {
 //   const buf = Buffer.from('w00t');
 //   Object.defineProperty(buf, 'length', {

--- a/test/js/node/test/parallel/test-buffer-from.js
+++ b/test/js/node/test/parallel/test-buffer-from.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const common = require('../common');
-const { deepStrictEqual, strictEqual, throws } = require('assert');
+const assert = require('assert');
 const { runInNewContext } = require('vm');
 
 const checkString = 'test';
@@ -26,10 +26,10 @@ class MyBadPrimitive {
   }
 }
 
-deepStrictEqual(Buffer.from(new String(checkString)), check);
-deepStrictEqual(Buffer.from(new MyString()), check);
-deepStrictEqual(Buffer.from(new MyPrimitive()), check);
-deepStrictEqual(
+assert.deepStrictEqual(Buffer.from(new String(checkString)), check);
+assert.deepStrictEqual(Buffer.from(new MyString()), check);
+assert.deepStrictEqual(Buffer.from(new MyPrimitive()), check);
+assert.deepStrictEqual(
   Buffer.from(runInNewContext('new String(checkString)', { checkString })),
   check
 );
@@ -52,11 +52,12 @@ deepStrictEqual(
   const errObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The first argument must be of type string, Buffer, ArrayBuffer, Array, or Array-like Object.' +
+    message: 'The first argument must be of type string or an instance of ' +
+             'Buffer, ArrayBuffer, or Array or an Array-like Object.' +
              common.invalidArgTypeHelper(input)
   };
-  throws(() => Buffer.from(input), errObj);
-  throws(() => Buffer.from(input, 'hex'), errObj);
+  assert.throws(() => Buffer.from(input), errObj);
+  assert.throws(() => Buffer.from(input, 'hex'), errObj);
 });
 
 Buffer.allocUnsafe(10); // Should not throw.
@@ -67,9 +68,9 @@ Buffer.from('deadbeaf', 'hex'); // Should not throw.
   const u16 = new Uint16Array([0xffff]);
   const b16 = Buffer.copyBytesFrom(u16);
   u16[0] = 0;
-  strictEqual(b16.length, 2);
-  strictEqual(b16[0], 255);
-  strictEqual(b16[1], 255);
+  assert.strictEqual(b16.length, 2);
+  assert.strictEqual(b16[0], 255);
+  assert.strictEqual(b16[1], 255);
 }
 
 {
@@ -77,30 +78,30 @@ Buffer.from('deadbeaf', 'hex'); // Should not throw.
   const b16 = Buffer.copyBytesFrom(u16, 1, 5);
   u16[0] = 0xffff;
   u16[1] = 0;
-  strictEqual(b16.length, 2);
-  strictEqual(b16[0], 255);
-  strictEqual(b16[1], 255);
+  assert.strictEqual(b16.length, 2);
+  assert.strictEqual(b16[0], 255);
+  assert.strictEqual(b16[1], 255);
 }
 
 {
   const u32 = new Uint32Array([0xffffffff]);
   const b32 = Buffer.copyBytesFrom(u32);
   u32[0] = 0;
-  strictEqual(b32.length, 4);
-  strictEqual(b32[0], 255);
-  strictEqual(b32[1], 255);
-  strictEqual(b32[2], 255);
-  strictEqual(b32[3], 255);
+  assert.strictEqual(b32.length, 4);
+  assert.strictEqual(b32[0], 255);
+  assert.strictEqual(b32[1], 255);
+  assert.strictEqual(b32[2], 255);
+  assert.strictEqual(b32[3], 255);
 }
 
-throws(() => {
+assert.throws(() => {
   Buffer.copyBytesFrom();
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
 ['', Symbol(), true, false, {}, [], () => {}, 1, 1n, null, undefined].forEach(
-  (notTypedArray) => throws(() => {
+  (notTypedArray) => assert.throws(() => {
     Buffer.copyBytesFrom('nope');
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
@@ -108,7 +109,7 @@ throws(() => {
 );
 
 ['', Symbol(), true, false, {}, [], () => {}, 1n].forEach((notANumber) =>
-  throws(() => {
+  assert.throws(() => {
     Buffer.copyBytesFrom(new Uint8Array(1), notANumber);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
@@ -116,7 +117,7 @@ throws(() => {
 );
 
 [-1, NaN, 1.1, -Infinity].forEach((outOfRange) =>
-  throws(() => {
+  assert.throws(() => {
     Buffer.copyBytesFrom(new Uint8Array(1), outOfRange);
   }, {
     code: 'ERR_OUT_OF_RANGE',
@@ -124,7 +125,7 @@ throws(() => {
 );
 
 ['', Symbol(), true, false, {}, [], () => {}, 1n].forEach((notANumber) =>
-  throws(() => {
+  assert.throws(() => {
     Buffer.copyBytesFrom(new Uint8Array(1), 0, notANumber);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
@@ -132,12 +133,51 @@ throws(() => {
 );
 
 [-1, NaN, 1.1, -Infinity].forEach((outOfRange) =>
-  throws(() => {
+  assert.throws(() => {
     Buffer.copyBytesFrom(new Uint8Array(1), 0, outOfRange);
   }, {
     code: 'ERR_OUT_OF_RANGE',
   })
 );
+
+// copyBytesFrom: length exceeds view (should clamp, not throw)
+{
+  const u8 = new Uint8Array([1, 2, 3, 4, 5]);
+  const b = Buffer.copyBytesFrom(u8, 2, 100);
+  assert.strictEqual(b.length, 3);
+  assert.deepStrictEqual([...b], [3, 4, 5]);
+}
+
+// copyBytesFrom: length 0 returns empty buffer
+{
+  const u8 = new Uint8Array([1, 2, 3]);
+  const b = Buffer.copyBytesFrom(u8, 1, 0);
+  assert.strictEqual(b.length, 0);
+}
+
+// copyBytesFrom: offset past end returns empty buffer
+{
+  const u8 = new Uint8Array([1, 2, 3]);
+  const b = Buffer.copyBytesFrom(u8, 10);
+  assert.strictEqual(b.length, 0);
+}
+
+// copyBytesFrom: Float64Array with offset and length
+{
+  const f64 = new Float64Array([1.0, 2.0, 3.0, 4.0]);
+  const b = Buffer.copyBytesFrom(f64, 1, 2);
+  assert.strictEqual(b.length, 16);
+  const view = new Float64Array(b.buffer, b.byteOffset, 2);
+  assert.strictEqual(view[0], 2.0);
+  assert.strictEqual(view[1], 3.0);
+}
+
+// copyBytesFrom: empty typed array returns empty buffer
+{
+  const empty = new Uint8Array(0);
+  const b = Buffer.copyBytesFrom(empty);
+  assert.strictEqual(b.length, 0);
+}
 
 // Invalid encoding is allowed
 Buffer.from('asd', 1);

--- a/test/js/node/test/parallel/test-buffer-includes.js
+++ b/test/js/node/test/parallel/test-buffer-includes.js
@@ -279,7 +279,8 @@ for (let lengthIndex = 0; lengthIndex < lengths.length; lengthIndex++) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "value" argument must be of type number, string, Buffer, or Uint8Array.' +
+      message: 'The "value" argument must be one of type number or string ' +
+               'or an instance of Buffer or Uint8Array.' +
                common.invalidArgTypeHelper(val)
     }
   );

--- a/test/js/node/test/parallel/test-buffer-indexof.js
+++ b/test/js/node/test/parallel/test-buffer-indexof.js
@@ -369,7 +369,8 @@ assert.strictEqual(Buffer.from('aaaaa').indexOf('b', 'ucs2'), -1);
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "value" argument must be of type number, string, Buffer, or Uint8Array.' +
+      message: 'The "value" argument must be one of type number or string ' +
+               'or an instance of Buffer or Uint8Array.' +
                common.invalidArgTypeHelper(val)
     }
   );
@@ -626,9 +627,104 @@ assert.strictEqual(reallyLong.lastIndexOf(pattern), 0);
     new buffer.Buffer.prototype.lastIndexOf(1, 'str');
   }, {
     name: 'TypeError',
+    // In Bun, native prototype methods are not constructors, so `new` throws
+    // before the argument validation that produces ERR_INVALID_ARG_TYPE in Node.
     // code: 'ERR_INVALID_ARG_TYPE',
     // message: 'The "buffer" argument must be an instance of Buffer, TypedArray, or DataView.' +
     //          ' Received an instance of lastIndexOf'
     message: `function is not a constructor (evaluating 'new (require("buffer")).Buffer.prototype.lastIndexOf(1, "str")')`
   });
+}
+
+{
+  const buf = Buffer.from('abcabc');
+
+  assert.strictEqual(buf.indexOf('c', 0, 3), 2);
+  assert.strictEqual(buf.indexOf('c', 0, 2), -1);
+  assert.strictEqual(buf.indexOf('a', 0, 1), 0);
+  assert.strictEqual(buf.indexOf('a', 0, 0), -1);
+  assert.strictEqual(buf.indexOf('abc', 0, 3), 0);
+  assert.strictEqual(buf.indexOf('abc', 0, 2), -1);
+
+  assert.strictEqual(buf.indexOf('a', 2, 5), 3);
+  assert.strictEqual(buf.indexOf('a', 2, 3), -1);
+  assert.strictEqual(buf.indexOf('bc', 1, 4), 1);
+  assert.strictEqual(buf.indexOf('bc', 1, 3), 1);
+
+  assert.strictEqual(buf.indexOf(Buffer.from('bc'), 0, 3), 1);
+  assert.strictEqual(buf.indexOf(Buffer.from('bc'), 0, 2), -1);
+  assert.strictEqual(buf.indexOf(new Uint8Array([0x61]), 0, 4), 0);
+
+  assert.strictEqual(buf.indexOf(0x61, 0, 3), 0);
+  assert.strictEqual(buf.indexOf(0x61, 0, 1), 0);
+  assert.strictEqual(buf.indexOf(0x61, 1, 4), 3);
+  assert.strictEqual(buf.indexOf(0x61, 1, 3), -1);
+  assert.strictEqual(buf.indexOf(0x63, 0, 2), -1);
+
+  assert.strictEqual(buf.indexOf('a', 0, 'utf8'), 0);
+  assert.strictEqual(buf.indexOf('abc', 0, 'utf8'), 0);
+
+  assert.strictEqual(buf.indexOf('c'), 2);
+  assert.strictEqual(buf.indexOf('c', 3), 5);
+
+  const latin1buf = Buffer.from('abcabc', 'latin1');
+  assert.strictEqual(latin1buf.indexOf('c', 0, 3, 'latin1'), 2);
+  assert.strictEqual(latin1buf.indexOf('c', 0, 2, 'latin1'), -1);
+
+  assert.strictEqual(buf.lastIndexOf('a', 5, 4), 3);
+  assert.strictEqual(buf.lastIndexOf('a', 5, 3), 0);
+  assert.strictEqual(buf.lastIndexOf('c', 5, 3), 2);
+  assert.strictEqual(buf.lastIndexOf('c', 5, buf.length), 5);
+
+  assert.strictEqual(buf.lastIndexOf(0x61, 5, 4), 3);
+  assert.strictEqual(buf.lastIndexOf(0x61, 5, 3), 0);
+
+  assert.strictEqual(buf.lastIndexOf('a', 5, 'utf8'), 3);
+
+  assert.strictEqual(buf.lastIndexOf('a'), 3);
+  assert.strictEqual(buf.lastIndexOf('a', 2), 0);
+
+  assert.strictEqual(buf.includes('c', 0, 3), true);
+  assert.strictEqual(buf.includes('c', 0, 2), false);
+  assert.strictEqual(buf.includes('abc', 0, 3), true);
+  assert.strictEqual(buf.includes('abc', 0, 2), false);
+
+  assert.strictEqual(buf.includes('a', 0, 'utf8'), true);
+
+  assert.strictEqual(buf.includes('c'), true);
+}
+
+{
+  const buf = Buffer.from('abcabc');
+
+  // Negative end should be treated as 0 (no match possible).
+  assert.strictEqual(buf.indexOf('a', 0, -1), -1);
+  assert.strictEqual(buf.indexOf('a', 0, -100), -1);
+  assert.strictEqual(buf.indexOf(0x61, 0, -1), -1);
+  assert.strictEqual(buf.lastIndexOf('a', 5, -1), -1);
+  assert.strictEqual(buf.lastIndexOf(0x61, 5, -1), -1);
+  assert.strictEqual(buf.includes('a', 0, -1), false);
+  assert.strictEqual(buf.indexOf(Buffer.from('a'), 0, -1), -1);
+  assert.strictEqual(buf.lastIndexOf(Buffer.from('a'), 5, -1), -1);
+
+  // End = 0 means empty search range.
+  assert.strictEqual(buf.indexOf('a', 0, 0), -1);
+  assert.strictEqual(buf.indexOf(0x61, 0, 0), -1);
+  assert.strictEqual(buf.lastIndexOf('a', 5, 0), -1);
+  assert.strictEqual(buf.lastIndexOf(0x61, 5, 0), -1);
+
+  // End greater than buffer length should be clamped.
+  assert.strictEqual(buf.indexOf('c', 0, 100), 2);
+  assert.strictEqual(buf.indexOf(0x63, 0, 100), 2);
+  assert.strictEqual(buf.lastIndexOf('c', 5, 100), 5);
+  assert.strictEqual(buf.lastIndexOf(0x63, 5, 100), 5);
+  assert.strictEqual(buf.indexOf(Buffer.from('c'), 0, 100), 2);
+
+  // Empty needle with end parameter should clamp to search_end.
+  assert.strictEqual(buf.indexOf('', 0, 3), 0);
+  assert.strictEqual(buf.indexOf('', 5, 3), 3);
+  assert.strictEqual(buf.indexOf(Buffer.from(''), 5, 3), 3);
+  assert.strictEqual(buf.indexOf('', 0, 0), 0);
+  assert.strictEqual(buf.lastIndexOf('', 5, 3), 3);
+  assert.strictEqual(buf.lastIndexOf(Buffer.from(''), 5, 3), 3);
 }

--- a/test/js/node/test/parallel/test-buffer-pool-untransferable.js
+++ b/test/js/node/test/parallel/test-buffer-pool-untransferable.js
@@ -22,3 +22,9 @@ assert.throws(() => port1.postMessage(a, [ a.buffer ]), {
 // Verify that the pool ArrayBuffer has not actually been transferred:
 assert.strictEqual(a.buffer, b.buffer);
 assert.strictEqual(a.length, length);
+
+// Verify that ArrayBuffer.prototype.transfer() also throws.
+assert.throws(() => a.buffer.transfer(), {
+  name: 'TypeError',
+});
+assert.strictEqual(a.buffer, b.buffer);

--- a/test/js/node/test/parallel/test-buffer-readdouble.js
+++ b/test/js/node/test/parallel/test-buffer-readdouble.js
@@ -112,7 +112,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
     );
   });
 
-  [-1, 1].forEach((offset) => {
+  [Infinity, -1, 1].forEach((offset) => {
     assert.throws(
       () => buffer[fn](offset),
       {
@@ -131,7 +131,7 @@ assert.strictEqual(buffer.readDoubleLE(0), -Infinity);
       message: 'Attempt to access memory outside buffer bounds'
     });
 
-  [Infinity, NaN, 1.01].forEach((offset) => {
+  [NaN, 1.01].forEach((offset) => {
     assert.throws(
       () => buffer[fn](offset),
       {

--- a/test/js/node/test/parallel/test-buffer-readfloat.js
+++ b/test/js/node/test/parallel/test-buffer-readfloat.js
@@ -74,7 +74,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
     );
   });
 
-  [-1, 1].forEach((offset) => {
+  [Infinity, -1, 1].forEach((offset) => {
     assert.throws(
       () => buffer[fn](offset),
       {
@@ -93,7 +93,7 @@ assert.strictEqual(buffer.readFloatLE(0), -Infinity);
       message: 'Attempt to access memory outside buffer bounds'
     });
 
-  [Infinity, NaN, 1.01].forEach((offset) => {
+  [NaN, 1.01].forEach((offset) => {
     assert.throws(
       () => buffer[fn](offset),
       {

--- a/test/js/node/test/parallel/test-buffer-readint.js
+++ b/test/js/node/test/parallel/test-buffer-readint.js
@@ -22,7 +22,7 @@ const assert = require('assert');
         });
     });
 
-    [-1, -4294967295].forEach((offset) => {
+    [Infinity, -1, -4294967295].forEach((offset) => {
       assert.throws(
         () => buffer[`read${fn}`](offset),
         {
@@ -31,7 +31,7 @@ const assert = require('assert');
         });
     });
 
-    [Infinity, NaN, 1.01].forEach((offset) => {
+    [NaN, 1.01].forEach((offset) => {
       assert.throws(
         () => buffer[`read${fn}`](offset),
         {
@@ -171,7 +171,7 @@ const assert = require('assert');
           });
       });
 
-      [-1, -4294967295].forEach((offset) => {
+      [Infinity, -1, -4294967295].forEach((offset) => {
         assert.throws(
           () => buffer[fn](offset, i),
           {
@@ -182,7 +182,7 @@ const assert = require('assert');
           });
       });
 
-      [Infinity, NaN, 1.01].forEach((offset) => {
+      [NaN, 1.01].forEach((offset) => {
         assert.throws(
           () => buffer[fn](offset, i),
           {

--- a/test/js/node/test/parallel/test-buffer-readuint.js
+++ b/test/js/node/test/parallel/test-buffer-readuint.js
@@ -139,7 +139,7 @@ const assert = require('assert');
           });
       });
 
-      [-1, -4294967295].forEach((offset) => {
+      [Infinity, -1, -4294967295].forEach((offset) => {
         assert.throws(
           () => buffer[fn](offset, i),
           {
@@ -150,7 +150,7 @@ const assert = require('assert');
           });
       });
 
-      [Infinity, NaN, 1.01].forEach((offset) => {
+      [NaN, 1.01].forEach((offset) => {
         assert.throws(
           () => buffer[fn](offset, i),
           {

--- a/test/js/node/test/parallel/test-buffer-resizable.js
+++ b/test/js/node/test/parallel/test-buffer-resizable.js
@@ -3,27 +3,27 @@
 
 require('../common');
 const { Buffer } = require('node:buffer');
-const { strictEqual } = require('node:assert');
+const assert = require('node:assert');
 const { describe, it } = require('node:test');
 
 describe('Using resizable ArrayBuffer with Buffer...', () => {
   it('works as expected', () => {
     const ab = new ArrayBuffer(10, { maxByteLength: 20 });
     const buffer = Buffer.from(ab, 1);
-    strictEqual(buffer.byteLength, 9);
+    assert.strictEqual(buffer.byteLength, 9);
     ab.resize(15);
-    strictEqual(buffer.byteLength, 14);
+    assert.strictEqual(buffer.byteLength, 14);
     ab.resize(5);
-    strictEqual(buffer.byteLength, 4);
+    assert.strictEqual(buffer.byteLength, 4);
   });
 
   it('works with the deprecated constructor also', () => {
     const ab = new ArrayBuffer(10, { maxByteLength: 20 });
     const buffer = new Buffer(ab, 1);
-    strictEqual(buffer.byteLength, 9);
+    assert.strictEqual(buffer.byteLength, 9);
     ab.resize(15);
-    strictEqual(buffer.byteLength, 14);
+    assert.strictEqual(buffer.byteLength, 14);
     ab.resize(5);
-    strictEqual(buffer.byteLength, 4);
+    assert.strictEqual(buffer.byteLength, 4);
   });
 });

--- a/test/js/node/test/parallel/test-buffer-tostring-range.js
+++ b/test/js/node/test/parallel/test-buffer-tostring-range.js
@@ -78,6 +78,46 @@ assert.strictEqual(rangeBuffer.toString('ascii', 0, '-1.99'), '');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, 1.99), 'a');
 assert.strictEqual(rangeBuffer.toString('ascii', 0, true), 'a');
 
+// Test hex/base64/base64url partial range encoding (exercises V8 builtin path)
+{
+  const buf = Buffer.from([0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe]);
+  assert.strictEqual(buf.toString('hex'), 'deadbeefcafe');
+  assert.strictEqual(buf.toString('hex', 0, 3), 'deadbe');
+  assert.strictEqual(buf.toString('hex', 2, 5), 'beefca');
+  assert.strictEqual(buf.toString('hex', 4), 'cafe');
+  assert.strictEqual(buf.toString('hex', 6), '');
+  assert.strictEqual(buf.toString('hex', 0, 0), '');
+}
+
+{
+  const buf = Buffer.from('Hello, World!');
+  assert.strictEqual(buf.toString('base64'), 'SGVsbG8sIFdvcmxkIQ==');
+  assert.strictEqual(buf.toString('base64', 0, 5), 'SGVsbG8=');
+  assert.strictEqual(buf.toString('base64', 7), 'V29ybGQh');
+  assert.strictEqual(buf.toString('base64', 0, 0), '');
+}
+
+{
+  const buf = Buffer.from('Hello, World!');
+  assert.strictEqual(buf.toString('base64url'), 'SGVsbG8sIFdvcmxkIQ');
+  assert.strictEqual(buf.toString('base64url', 0, 5), 'SGVsbG8');
+  assert.strictEqual(buf.toString('base64url', 7), 'V29ybGQh');
+  assert.strictEqual(buf.toString('base64url', 0, 0), '');
+}
+
+// Test with pool-allocated buffer (has non-zero byteOffset)
+{
+  const poolBuf = Buffer.from('test data for hex encoding');
+  assert.strictEqual(
+    poolBuf.toString('hex'),
+    Buffer.from('test data for hex encoding').toString('hex')
+  );
+  assert.strictEqual(
+    poolBuf.toString('hex', 5, 9),
+    Buffer.from('data').toString('hex')
+  );
+}
+
 // Try toString() with an object as an encoding
 assert.strictEqual(rangeBuffer.toString({ toString: function() {
   return 'ascii';

--- a/test/js/node/test/parallel/test-buffer-tostring.js
+++ b/test/js/node/test/parallel/test-buffer-tostring.js
@@ -4,14 +4,10 @@ const common = require('../common');
 const assert = require('assert');
 
 // utf8, ucs2, ascii, latin1, utf16le
-const encodings = ['utf8', 'utf-8', 'ucs2', 'ucs-2', 'ascii', 'latin1',
-                   'binary', 'utf16le', 'utf-16le'];
-
-encodings
-  .reduce((es, e) => es.concat(e, e.toUpperCase()), [])
-  .forEach((encoding) => {
-    assert.strictEqual(Buffer.from('foo', encoding).toString(encoding), 'foo');
-  });
+for (const encoding of ['utf8', 'utf-8', 'ucs2', 'ucs-2', 'ascii', 'latin1',
+                        'binary', 'utf16le', 'utf-16le'].flatMap((e) => [e, e.toUpperCase()])) {
+  assert.strictEqual(Buffer.from('foo', encoding).toString(encoding), 'foo');
+}
 
 // base64
 ['base64', 'BASE64'].forEach((encoding) => {

--- a/test/js/node/test/parallel/test-buffer-write-fast.js
+++ b/test/js/node/test/parallel/test-buffer-write-fast.js
@@ -1,9 +1,15 @@
-// Flags: --no-warnings --allow-natives-syntax
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
 'use strict';
 
 const common = require('../common');
 if ('Bun' in globalThis) common.skip('uses internals');
 const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
+
+// eslint-disable-next-line no-unused-vars
+const { utf8Write } = require('internal/buffer');
+
 
 function testFastUtf8Write() {
   {
@@ -33,8 +39,12 @@ function testFastUtf8Write() {
   }
 }
 
-// node --expose-internals --allow-natives-syntax -p "eval('%PrepareFunctionForOptimization(Buffer.prototype.utf8Write)')"
-eval('%PrepareFunctionForOptimization(Buffer.prototype.utf8Write)');
+eval('%PrepareFunctionForOptimization(utf8Write)');
 testFastUtf8Write();
-eval('%OptimizeFunctionOnNextCall(Buffer.prototype.utf8Write)');
+eval('%OptimizeFunctionOnNextCall(utf8Write)');
 testFastUtf8Write();
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('buffer.writeString'), 4);
+}

--- a/test/js/node/test/parallel/test-buffer-write.js
+++ b/test/js/node/test/parallel/test-buffer-write.js
@@ -10,7 +10,7 @@ const assert = require('assert');
       code: 'ERR_OUT_OF_RANGE',
       name: 'RangeError',
       message: 'The value of "offset" is out of range. ' +
-               `It must be >= 0 and <= 9. Received ${offset}`
+               `It must be >= 0 && <= 9. Received ${offset}`
     }
   );
 });
@@ -28,21 +28,14 @@ const resultMap = new Map([
 ]);
 
 // utf8, ucs2, ascii, latin1, utf16le
-const encodings = ['utf8', 'utf-8', 'ucs2', 'ucs-2', 'ascii', 'latin1',
-                   'binary', 'utf16le', 'utf-16le'];
+for (const encoding of ['utf8', 'utf-8', 'ucs2', 'ucs-2', 'ascii', 'latin1',
+                        'binary', 'utf16le', 'utf-16le'].flatMap((e) => [e, e.toUpperCase()])) {
+  const buf = Buffer.alloc(9);
+  const len = Buffer.byteLength('foo', encoding);
+  assert.strictEqual(buf.write('foo', 0, len, encoding), len);
 
-encodings
-  .reduce((es, e) => es.concat(e, e.toUpperCase()), [])
-  .forEach((encoding) => {
-    const buf = Buffer.alloc(9);
-    const len = Buffer.byteLength('foo', encoding);
-    assert.strictEqual(buf.write('foo', 0, len, encoding), len);
-
-    if (encoding.includes('-'))
-      encoding = encoding.replace('-', '');
-
-    assert.deepStrictEqual(buf, resultMap.get(encoding.toLowerCase()));
-  });
+  assert.deepStrictEqual(buf, resultMap.get(encoding.replace('-', '').toLowerCase()));
+}
 
 // base64
 ['base64', 'BASE64', 'base64url', 'BASE64URL'].forEach((encoding) => {

--- a/test/js/node/test/parallel/test-buffer-writeint.js
+++ b/test/js/node/test/parallel/test-buffer-writeint.js
@@ -222,7 +222,9 @@ const errorOutOfBounds = {
         range = `>= -(2 ** ${i * 8 - 1}) and < 2 ** ${i * 8 - 1}`;
       }
       [min - 1, max + 1].forEach((val) => {
-        const received = val;
+        const received = i > 4 ?
+          String(val).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1_') :
+          val;
         assert.throws(() => {
           data[fn](val, 0, i);
         }, {

--- a/test/js/node/test/parallel/test-buffer-writeuint.js
+++ b/test/js/node/test/parallel/test-buffer-writeuint.js
@@ -170,7 +170,9 @@ const assert = require('assert');
   // Test 1 to 6 bytes.
   for (let i = 1; i <= 6; i++) {
     const range = i < 5 ? `= ${val - 1}` : ` 2 ** ${i * 8}`;
-    const received = val;
+    const received = i > 4 ?
+      String(val).replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1_') :
+      val;
     ['writeUIntBE', 'writeUIntLE'].forEach((fn) => {
       assert.throws(() => {
         data[fn](val, 0, i);

--- a/test/js/node/test/parallel/test-buffer-zero-fill-cli.js
+++ b/test/js/node/test/parallel/test-buffer-zero-fill-cli.js
@@ -14,6 +14,13 @@ function isZeroFilled(buf) {
   return true;
 }
 
+// We have to consume the data from the pool as otherwise
+// we would be testing what's in snapshot, which is zero-filled
+// regardless of the flag presence, and we want to test the flag
+for (let i = 0; i < 8; i++) {
+  assert(isZeroFilled(Buffer.allocUnsafe(1024)));
+}
+
 // This can be somewhat unreliable because the
 // allocated memory might just already happen to
 // contain all zeroes. The test is run multiple
@@ -22,7 +29,8 @@ for (let i = 0; i < 50; i++) {
   const bufs = [
     Buffer.alloc(20),
     Buffer.allocUnsafe(20),
-    Buffer.allocUnsafeSlow(20),
+    Buffer.allocUnsafeSlow(20), // Heap
+    Buffer.allocUnsafeSlow(128), // Alloc
     Buffer(20),
   ];
   for (const buf of bufs) {

--- a/test/js/node/test/parallel/test-child-process-constructor.js
+++ b/test/js/node/test/parallel/test-child-process-constructor.js
@@ -47,7 +47,7 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.envPairs" property must be of type Array.' +
+      message: 'The "options.envPairs" property must be an instance of Array.' +
               common.invalidArgTypeHelper(envPairs)
     });
   });
@@ -63,7 +63,7 @@ assert.strictEqual(typeof ChildProcess, 'function');
     }, {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.args" property must be of type Array.' +
+      message: 'The "options.args" property must be an instance of Array.' +
                common.invalidArgTypeHelper(args)
     });
   });

--- a/test/js/node/test/parallel/test-dgram-send-bad-arguments.js
+++ b/test/js/node/test/parallel/test-dgram-send-bad-arguments.js
@@ -35,7 +35,8 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string, Buffer, TypedArray, or DataView. Received undefined'
+      message: 'The "buffer" argument must be of type string or an instance ' +
+      'of Buffer, TypedArray, or DataView. Received undefined'
     }
   );
 
@@ -129,7 +130,8 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer" argument must be of type string, Buffer, TypedArray, or DataView. Received type number (23)'
+      message: 'The "buffer" argument must be of type string or an instance ' +
+      'of Buffer, TypedArray, or DataView. Received type number (23)'
     }
   );
 
@@ -139,7 +141,8 @@ function checkArgs(connected) {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "buffer list arguments" argument must be of type string, Buffer, TypedArray, or DataView. ' +
+      message: 'The "buffer list arguments" argument must be of type string ' +
+      'or an instance of Buffer, TypedArray, or DataView. ' +
       'Received an instance of Array'
     }
   );

--- a/test/js/node/test/parallel/test-dns-setservers-type-check.js
+++ b/test/js/node/test/parallel/test-dns-setservers-type-check.js
@@ -20,7 +20,7 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "servers" argument must be of type Array\./
+      message: /^The "servers" argument must be an instance of Array\./
     };
     assert.throws(
       () => {

--- a/test/js/node/test/parallel/test-file-write-stream3.js
+++ b/test/js/node/test/parallel/test-file-write-stream3.js
@@ -204,7 +204,7 @@ const run_test_5 = common.mustCall(function() {
     code: 'ERR_OUT_OF_RANGE',
     message: 'The value of "start" is out of range. It must be ' +
              `>= 0 and <= ${Number.MAX_SAFE_INTEGER}. ` +
-             'Received 9007199254740992',
+             'Received 9_007_199_254_740_992',
     name: 'RangeError'
   };
   assert.throws(fn, err);

--- a/test/js/node/test/parallel/test-http-client-reject-unexpected-agent.js
+++ b/test/js/node/test/parallel/test-http-client-reject-unexpected-agent.js
@@ -52,7 +52,8 @@ server.listen(0, baseOptions.host, common.mustCall(function() {
       {
         code: 'ERR_INVALID_ARG_TYPE',
         name: 'TypeError',
-        message: 'The "options.agent" property must be of type Agent-like Object, undefined, or false.' +
+        message: 'The "options.agent" property must be one of Agent-like ' +
+                 'Object, undefined, or false.' +
                  common.invalidArgTypeHelper(agent)
       }
     );

--- a/test/js/node/test/parallel/test-http-hostname-typechecking.js
+++ b/test/js/node/test/parallel/test-http-hostname-typechecking.js
@@ -15,7 +15,9 @@ vals.forEach((v) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.hostname" property must be of type string, undefined, or null.' + received
+      message: 'The "options.hostname" property must be of ' +
+               'type string or one of undefined or null.' +
+               received
     }
   );
 
@@ -24,7 +26,9 @@ vals.forEach((v) => {
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "options.host" property must be of type string, undefined, or null.' + received
+      message: 'The "options.host" property must be of ' +
+               'type string or one of undefined or null.' +
+               received
     }
   );
 });

--- a/test/js/node/test/parallel/test-http-outgoing-proto.js
+++ b/test/js/node/test/parallel/test-http-outgoing-proto.js
@@ -80,16 +80,18 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-    message: 'The "chunk" argument must be of type string, Buffer, or Uint8Array. Received undefined'
+  message: 'The "chunk" argument must be of type string or an instance of ' +
+           'Buffer or Uint8Array. Received undefined'
 });
 
 assert.throws(() => {
   const outgoingMessage = new OutgoingMessage();
   outgoingMessage.write.call({ _header: 'test', _hasBody: 'test' }, 1);
 }, {
-  code: "ERR_INVALID_ARG_TYPE",
-  name: "TypeError",
-  message: 'The "chunk" argument must be of type string, Buffer, or Uint8Array. Received type number (1)',
+  code: 'ERR_INVALID_ARG_TYPE',
+  name: 'TypeError',
+  message: 'The "chunk" argument must be of type string or an instance of ' +
+           'Buffer or Uint8Array. Received type number (1)'
 });
 
 assert.throws(() => {

--- a/test/js/node/test/parallel/test-net-write-arguments.js
+++ b/test/js/node/test/parallel/test-net-write-arguments.js
@@ -33,7 +33,7 @@ assert.throws(() => {
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "chunk" argument must be of type string, ' +
-             `Buffer, TypedArray, or DataView.${common.invalidArgTypeHelper(value)}`
+    message: 'The "chunk" argument must be of type string or an instance of ' +
+              `Buffer, TypedArray, or DataView.${common.invalidArgTypeHelper(value)}`
   });
 });

--- a/test/js/node/test/parallel/test-process-hrtime.js
+++ b/test/js/node/test/parallel/test-process-hrtime.js
@@ -38,7 +38,7 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
   name: 'TypeError',
-  message: 'The "time" argument must be of type Array. Received type ' +
+  message: 'The "time" argument must be an instance of Array. Received type ' +
            'number (1)'
 });
 assert.throws(() => {

--- a/test/js/node/test/parallel/test-process-setgroups.js
+++ b/test/js/node/test/parallel/test-process-setgroups.js
@@ -17,7 +17,7 @@ assert.throws(
   {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: 'The "groups" argument must be of type Array. ' +
+    message: 'The "groups" argument must be an instance of Array. ' +
              'Received undefined'
   }
 );

--- a/test/js/node/test/sequential/test-buffer-creation-regression.js
+++ b/test/js/node/test/sequential/test-buffer-creation-regression.js
@@ -18,8 +18,9 @@ function test(arrayBuffer, offset, length) {
 const acceptableOOMErrors = [
   'Array buffer allocation failed',
   'Invalid array buffer length',
+  // JSC's equivalent allocation-failure messages.
   'length too large: 4294968296',
-  'Out of memory'
+  'Out of memory',
 ];
 
 const length = 1000;
@@ -35,5 +36,4 @@ try {
   throw e;
 }
 
-test(200, 50, 100);
 test(arrayBuffer, offset, length);

--- a/test/js/node/tls/node-tls-create-secure-context-args.test.ts
+++ b/test/js/node/tls/node-tls-create-secure-context-args.test.ts
@@ -5,30 +5,30 @@ describe("tls.createSecureContext extra arguments test", () => {
   it("should throw an error if the privateKeyEngine is not a string", () => {
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: "valid", privateKeyEngine: 0 })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: "valid", privateKeyEngine: true })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: "valid", privateKeyEngine: {} })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
   });
 
   it("should throw an error if the privateKeyIdentifier is not a string", () => {
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: 0, privateKeyEngine: "valid" })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: true, privateKeyEngine: "valid" })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
     // @ts-expect-error
     expect(() => tls.createSecureContext({ privateKeyIdentifier: {}, privateKeyEngine: "valid" })).toThrow(
-      "string, null, or undefined",
+      "string or one of null or undefined",
     );
   });
 


### PR DESCRIPTION
## Summary

Syncs the vendored `node:buffer` test suite to Node.js v26.3.0 and fixes the Buffer/validator behavior the verbatim tests cover.

**Buffer suite: 64 / 69 (92.8%)** of Node v26.3.0's `test-buffer*.js` files pass.
- **+0** new test files — the 5 v26.3.0 buffer tests not vendored exercise V8/Node-internal machinery with no JSC equivalent (see below).
- **28** vendored buffer tests re-synced to v26.3.0; verbatim parity goes from **30/64 → 51/64** (21 more tests no longer carry a Bun-specific patch).
- 12 unrelated vendored Node tests and 2 Bun tests updated for the new `ERR_INVALID_ARG_TYPE` / `ERR_OUT_OF_RANGE` wording.

### Runtime changes

Error message/format fixes verified against Node v26.3.0:
- `ERR_INVALID_ARG_TYPE` expected-type lists are grouped like Node ("of type string or an instance of Buffer, ArrayBuffer, …").
- `ERR_OUT_OF_RANGE` renders received integers/bigints beyond 2**32 with numeric separators (`18_446_744_073_709_551_616n`).
- `Buffer.compare/equals/copy/concat` report "must be an instance of Buffer or Uint8Array"; `copy()` on a non-buffer receiver throws `ERR_INVALID_ARG_TYPE` for `source`; `buf.write` range errors use `>= 0 && <= N`.
- `validateArray` and the `process.hrtime`/`process.setgroups`/`vm contextExtensions` checks say "an instance of Array" like Node.
- `assert.rejects/doesNotReject` now pass `['Function', 'Promise']` to `ERR_INVALID_ARG_TYPE` instead of a pre-baked "an instance of Promise" phrase.

Behavior fixes:
- `indexOf`/`lastIndexOf`/`includes` support the `end` parameter (search-range upper bound, ported from `node_buffer.cc`).
- `Buffer.concat` validates `totalLength` like Node's `validateOffset`.
- `copy()` range checks match Node's `copyImpl`.
- `read*/write*` offset validation reports `Infinity` as a range error instead of "an integer".

Tests that asserted the previous Bun-specific wording are updated to Node's actual messages; where that was the only deviation, the vendored copies are restored to verbatim v26.3.0 (`test-dgram-send-bad-arguments`, `test-http-outgoing-proto`, `test-http-client-reject-unexpected-agent`, `test-http-hostname-typechecking`, `test-net-write-arguments`, `test-child-process-constructor`).

### The 5 v26.3.0 buffer tests not vendored

Each exercises engine-internal machinery and cannot pass on JSC by construction, so per the project's vendor-only-what-passes convention they are simply not added:
- `test-buffer-alloc-unsafe-is-uninitialized.js`, `test-buffer-alloc-unsafe-is-initialized-with-zero-fill-flag.js` — require `--expose-internals` debug-build allocator counters (`internalBinding('debug').getGenericUsageCount`).
- `test-buffer-swap-fast.js` — uses V8 natives syntax (`--allow-natives-syntax %OptimizeFunctionOnNextCall`) and `internalBinding('debug')` fast-API call counters.
- `test-buffer-generic-methods.js` — asserts the exact `Buffer.prototype` own-key set; Bun intentionally exposes extra helpers (`readInt32(offset)`-style aliases, `utf16leSlice`/`utf16leWrite`, `Symbol.species`) that Bun's own FFI tests depend on, so removing them is out of scope here.
- `test-buffer-tostring-4gb.js` — needs a 4 GiB + 20 byte buffer; JSC's `MAX_ARRAY_BUFFER_SIZE` is 2**32.

## Test plan

- [x] All 64 vendored `test/js/node/test/{parallel,sequential}/test-buffer-*.js` files pass with a debug build via `bun run --config=bunfig.node-test.toml`.
- [x] `bun bd test test/js/node/buffer.test.js` plus the other `test/js/node/buffer-*.test.ts` suites pass (571 tests).
- [x] Affected non-buffer tests pass locally: assert (`test-assert.js`, `test-assert-async.js`, `assert-promise.test.ts`), tls secure-context args, http host/hostname/agent typechecking, net write arguments, dgram send arguments, child_process constructor/fork, dns setServers, process hrtime/setgroups, fs write-stream range error.
- [ ] Full CI green.
