### PR TITLE
napi: `napi_is_arraybuffer` returns false for SharedArrayBuffer

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1366,7 +1366,13 @@ pub(super) extern "C" fn napi_is_arraybuffer(
     env.check_gc();
     let result = get_out!(env, result_);
     let value = value_.get();
-    *result = !value.is_number() && value.js_type_loose() == jsc::JSType::ArrayBuffer;
+    // A SharedArrayBuffer shares the `ArrayBuffer` cell type with a plain
+    // ArrayBuffer in JSC, so `js_type` alone can't tell them apart. Node's
+    // `napi_is_arraybuffer` maps to V8's `IsArrayBuffer()`, which is false for
+    // SharedArrayBuffer, so exclude shared buffers here too.
+    *result = value
+        .as_array_buffer(env.to_js())
+        .is_some_and(|ab| ab.typed_array_type == jsc::JSType::ArrayBuffer && !ab.shared);
     env.ok()
 }
 

--- a/test/napi/napi-app/standalone_tests.cpp
+++ b/test/napi/napi-app/standalone_tests.cpp
@@ -556,6 +556,29 @@ static napi_value test_is_typedarray(const Napi::CallbackInfo &info) {
   return ok(env);
 }
 
+// https://github.com/oven-sh/bun/issues/32624
+// info[0] is the GC callback; the values to classify start at info[1]. For each
+// one, print napi_is_arraybuffer and the raw napi_get_arraybuffer_info status so
+// the output can be diffed against Node (napi_ok is 0, napi_invalid_arg is 1).
+static napi_value test_is_arraybuffer(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+  for (size_t i = 1; i < info.Length(); i++) {
+    napi_value value = info[i];
+
+    bool is_ab = false;
+    NODE_API_CALL(env, napi_is_arraybuffer(env, value, &is_ab));
+
+    void *data = nullptr;
+    size_t length = 0;
+    napi_status info_status =
+        napi_get_arraybuffer_info(env, value, &data, &length);
+
+    printf("napi_is_arraybuffer=%s napi_get_arraybuffer_info=%d\n",
+           is_ab ? "true" : "false", static_cast<int>(info_status));
+  }
+  return ok(env);
+}
+
 static napi_value test_napi_get_default_values(const Napi::CallbackInfo &info) {
   napi_env env = info.Env();
 
@@ -2386,6 +2409,7 @@ void register_standalone_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, bigint_to_64_null);
   REGISTER_FUNCTION(env, exports, test_is_buffer);
   REGISTER_FUNCTION(env, exports, test_is_typedarray);
+  REGISTER_FUNCTION(env, exports, test_is_arraybuffer);
   REGISTER_FUNCTION(env, exports, test_napi_get_default_values);
   REGISTER_FUNCTION(env, exports, test_napi_numeric_string_keys);
   REGISTER_FUNCTION(env, exports, test_deferred_exceptions);

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -949,6 +949,26 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
     });
   });
 
+  describe("napi_is_arraybuffer", () => {
+    it("distinguishes ArrayBuffer from SharedArrayBuffer and typed arrays", async () => {
+      // https://github.com/oven-sh/bun/issues/32624
+      // napi_is_arraybuffer must report false for a SharedArrayBuffer the way
+      // Node does, even though JSC gives it the same cell type as a plain
+      // ArrayBuffer. napi_get_arraybuffer_info still accepts a SharedArrayBuffer
+      // in Node (napi_ok), so the check below pins that asymmetry too.
+      // napi_ok is 0 and napi_invalid_arg is 1.
+      const output = await checkSameOutput(
+        "test_is_arraybuffer",
+        "[new ArrayBuffer(8), new SharedArrayBuffer(8), new Uint8Array(8)]",
+      );
+      expect(output.split("\n")).toEqual([
+        "napi_is_arraybuffer=true napi_get_arraybuffer_info=0",
+        "napi_is_arraybuffer=false napi_get_arraybuffer_info=0",
+        "napi_is_arraybuffer=false napi_get_arraybuffer_info=1",
+      ]);
+    });
+  });
+
   describe("error handling", () => {
     it("removing non-existent env cleanup hook should not crash", async () => {
       // Test that removing non-existent hooks doesn't crash the process


### PR DESCRIPTION
### Problem

`napi_is_arraybuffer` returns `true` for a `SharedArrayBuffer`. Node returns `false`: in V8 (which N-API maps onto) `napi_is_arraybuffer` is `value->IsArrayBuffer()`, and a `SharedArrayBuffer` is a distinct type.

```c
// addon.c, called from JS as add(new SharedArrayBuffer(1))
bool is;
napi_is_arraybuffer(env, args[0], &is);
printf("%d\n", is); // Node: 0, Bun: 1
```

```
$ node addon.js       $ bun addon.js
1                     1
0                     1   <- should be 0
```

### Cause

In JSC both `ArrayBuffer` and `SharedArrayBuffer` carry the same cell type (`JSType::ArrayBufferType`), so the previous check in `src/runtime/napi/napi_body.rs` could not tell them apart:

```rust
*result = !value.is_number() && value.js_type_loose() == jsc::JSType::ArrayBuffer;
```

The only distinguisher is the backing buffer's `isShared()` flag, already surfaced to Rust as `ArrayBuffer.shared`.

### Fix

Resolve the value as an array buffer and additionally require it to be non-shared, matching V8's `IsArrayBuffer()`:

```rust
*result = value
    .as_array_buffer(env.to_js())
    .is_some_and(|ab| ab.typed_array_type == jsc::JSType::ArrayBuffer && !ab.shared);
```

`napi_get_arraybuffer_info` is left unchanged on purpose. Node's behavior there is asymmetric: it still accepts a `SharedArrayBuffer` and returns `napi_ok`, which Bun already matched. The regression test pins both behaviors.

### Verification

Added `test_is_arraybuffer` to the napi-app fixture and a case in `test/napi/napi.test.ts` that diffs Bun's output against the ABI-matching Node for `ArrayBuffer`, `SharedArrayBuffer`, and a typed array (`napi_ok` is 0, `napi_invalid_arg` is 1):

```
napi_is_arraybuffer=true napi_get_arraybuffer_info=0   # ArrayBuffer
napi_is_arraybuffer=false napi_get_arraybuffer_info=0  # SharedArrayBuffer
napi_is_arraybuffer=false napi_get_arraybuffer_info=1  # Uint8Array
```

Fails before the fix (Bun reports `napi_is_arraybuffer=true` for the `SharedArrayBuffer`), passes after.

Fixes #32624