### PR TITLE
install: name cache directory when its .tmp fallback fails

### DIFF
--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -212,9 +212,21 @@ const _: fn() = || {
 static GET_TEMPORARY_DIRECTORY_ONCE: std::sync::OnceLock<TemporaryDirectory> =
     std::sync::OnceLock::new();
 
+#[cold]
+fn crash_cache_directory_unwritable(cache_directory_path: &[u8], err: &sys::Error) -> ! {
+    bun_core::pretty_errorln!(
+        "<r><red>error<r>: bun is unable to write to the install cache directory {}: {}",
+        bun_fmt::quote(cache_directory_path),
+        bun_fmt::s(err.name())
+    );
+    bun_core::note!("set <b>$BUN_INSTALL_CACHE_DIR<r> to a writable path");
+    Global::crash();
+}
+
 fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirectory {
     let cache_directory_fd = get_cache_directory(manager);
     let cache_directory = Dir::borrow(&cache_directory_fd);
+    let cache_directory_path = manager.cache_directory_path.as_bytes();
     // The chosen tempdir must be on the same filesystem as the cache directory
     // This makes renameat() work
     let temp_dir_name = FileSystem::get_default_temp_dir();
@@ -231,13 +243,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
                     Default::default(),
                 ) {
                     Ok(d) => d,
-                    Err(err) => {
-                        bun_core::pretty_errorln!(
-                            "<r><red>error<r>: bun is unable to access tempdir: {}",
-                            bun_fmt::s(err.name())
-                        );
-                        Global::crash();
-                    }
+                    Err(err) => crash_cache_directory_unwritable(cache_directory_path, &err),
                 }
             }
         };
@@ -271,13 +277,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
                         Default::default(),
                     ) {
                         Ok(d) => d,
-                        Err(err) => {
-                            bun_core::pretty_errorln!(
-                                "<r><red>error<r>: bun is unable to access tempdir: {}",
-                                bun_fmt::s(err.name())
-                            );
-                            Global::crash();
-                        }
+                        Err(err) => crash_cache_directory_unwritable(cache_directory_path, &err),
                     };
 
                     if verbose_install() {
@@ -289,11 +289,9 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
 
                     continue 'brk;
                 }
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: {} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>",
-                    bun_fmt::s(err2.name())
-                );
-                Global::crash();
+                // `tried_dot_tmp`, so `tempdir` is `<cache>/.tmp`: the cache
+                // directory is what isn't writable, not the system tempdir.
+                crash_cache_directory_unwritable(cache_directory_path, &err2)
             }
         };
         let _ = file.close(); // close error is non-actionable
@@ -305,13 +303,7 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
                     tried_dot_tmp = true;
                     tempdir = match cache_directory.make_open_path(b".tmp", Default::default()) {
                         Ok(d) => d,
-                        Err(err2) => {
-                            bun_core::pretty_errorln!(
-                                "<r><red>error<r>: bun is unable to write files to tempdir: {}",
-                                bun_fmt::s(err2.name())
-                            );
-                            Global::crash();
-                        }
+                        Err(err2) => crash_cache_directory_unwritable(cache_directory_path, &err2),
                     };
 
                     if verbose_install() {
@@ -324,11 +316,9 @@ fn get_temporary_directory_run(manager: &mut PackageManager) -> TemporaryDirecto
                     continue 'brk;
                 }
 
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: {} accessing temporary directory. Please set <b>$BUN_TMPDIR<r> or <b>$BUN_INSTALL<r>",
-                    bun_fmt::s(err.name())
-                );
-                Global::crash();
+                // `tried_dot_tmp`, so the rename source is `<cache>/.tmp` and
+                // the destination is always the cache directory itself.
+                crash_cache_directory_unwritable(cache_directory_path, &err)
             }
         }
         let _ = cache_directory.delete_file_z(tmpname);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,6 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
-import { readlinkSync, realpathSync } from "fs";
+import { existsSync, readlinkSync, realpathSync, statSync, symlinkSync } from "fs";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
@@ -17,6 +17,7 @@ import {
   toBeWorkspaceLink,
   toHaveBins,
 } from "harness";
+import { tmpdir } from "os";
 import { join, resolve, sep } from "path";
 import {
   createTestContext,
@@ -10019,3 +10020,111 @@ it.each([
     expect(exitCode).not.toBe(0);
   });
 });
+
+// Windows openat with O_DIRECTORY on a regular file does not reliably fail
+// with ENOTDIR the way POSIX does, so this repro cannot portably force the
+// `<cache>/.tmp` fallback to fail there. The error-message code path itself
+// is platform-agnostic.
+it.skipIf(isWindows)("names the install cache directory when it cannot be written to", async () => {
+  // The temporary directory probe falls back to `<cache>/.tmp` when the
+  // configured tempdir is unusable. If that fallback also fails, the error
+  // must blame the install cache directory (and suggest
+  // $BUN_INSTALL_CACHE_DIR), not the tempdir.
+  using dir = tempDir("install-cache-unwritable", {
+    "project/package.json": JSON.stringify({
+      name: "cache-unwritable-app",
+      version: "1.0.0",
+      dependencies: { "some-pkg": "1.0.0" },
+    }),
+    // A regular file where the `.tmp` fallback directory would be created,
+    // so `makeOpenPath("<cache>/.tmp")` fails with ENOTDIR.
+    "cache/.tmp": "not a directory",
+    // A regular file that $BUN_TMPDIR will point beneath, so opening the
+    // configured tempdir fails and the `.tmp` fallback is taken.
+    "not-a-dir": "file",
+  });
+  const root = String(dir);
+  const cacheDir = join(root, "cache");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: join(root, "project"),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...env,
+      BUN_INSTALL_CACHE_DIR: cacheDir,
+      BUN_TMPDIR: join(root, "not-a-dir", "sub"),
+      TMPDIR: join(root, "not-a-dir", "sub"),
+    },
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toContain("unable to write to the install cache directory");
+  expect(stderr).toContain(cacheDir);
+  expect(stderr).toContain("$BUN_INSTALL_CACHE_DIR");
+  expect(stderr).not.toContain("tempdir");
+  expect(stderr).not.toContain("$BUN_TMPDIR");
+  expect(stdout).not.toContain("installed");
+  expect(exitCode).not.toBe(0);
+});
+
+// Forcing the `renameat(<cache>/.tmp -> <cache>)` step to fail requires `.tmp`
+// to live on a different filesystem than the cache directory. `/dev/shm` is a
+// tmpfs on Linux, so verify at collection time that it really is a distinct
+// device from where `tempDir()` roots its fixtures; skip otherwise.
+const shmIsSeparateDevice = !isWindows && existsSync("/dev/shm") && statSync("/dev/shm").dev !== statSync(tmpdir()).dev;
+
+it.skipIf(!shmIsSeparateDevice)(
+  "names the install cache directory when the rename out of its .tmp fallback fails",
+  async () => {
+    // An already-used cache has a `.tmp/` subdirectory, so the probe reaches
+    // it, creates the probe file, and only then fails moving it into the cache
+    // directory. That terminal error must also blame the cache directory, not
+    // the tempdir (the rename destination is always the cache directory).
+    const shmTarget = join("/dev/shm", `bun-install-exdev-${crypto.randomUUID()}`);
+    await mkdir(shmTarget, { recursive: true });
+    try {
+      using dir = tempDir("install-cache-exdev", {
+        "project/package.json": JSON.stringify({
+          name: "cache-exdev-app",
+          version: "1.0.0",
+          dependencies: { "some-pkg": "1.0.0" },
+        }),
+        "cache/keep": "",
+        // A regular file that $BUN_TMPDIR will point beneath, so the probe
+        // skips straight to the `<cache>/.tmp` fallback.
+        "not-a-dir": "file",
+      });
+      const root = String(dir);
+      const cacheDir = join(root, "cache");
+      // `.tmp` opens fine and is writable, but renaming out of it into the
+      // cache directory crosses a filesystem boundary and fails with EXDEV.
+      symlinkSync(shmTarget, join(cacheDir, ".tmp"));
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: join(root, "project"),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...env,
+          BUN_INSTALL_CACHE_DIR: cacheDir,
+          BUN_TMPDIR: join(root, "not-a-dir", "sub"),
+          TMPDIR: join(root, "not-a-dir", "sub"),
+        },
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain("unable to write to the install cache directory");
+      expect(stderr).toContain(cacheDir);
+      expect(stderr).toContain("$BUN_INSTALL_CACHE_DIR");
+      expect(stderr).not.toContain("tempdir");
+      expect(stderr).not.toContain("$BUN_TMPDIR");
+      expect(stdout).not.toContain("installed");
+      expect(exitCode).not.toBe(0);
+    } finally {
+      await rm(shmTarget, { recursive: true, force: true });
+    }
+  },
+);


### PR DESCRIPTION
## What

When the install cache directory is not writable (read-only mount, restrictive permissions, sandboxed filesystem), `bun install` prints:

```
error: bun is unable to write files to tempdir: PermissionDenied
```

but the failing operation is `cache_directory.makeOpenPath(".tmp")`, not a write to `$TMPDIR`. The probe file in the actual tempdir succeeded; it was the rename into the cache directory and the `.tmp` fallback inside it that were denied. The message sends users to `$BUN_TMPDIR` / `$TMPDIR` when the real fix is the cache-directory path or permissions.

## Repro

```sh
mkdir -p /tmp/ro-cache && chmod -w /tmp/ro-cache
BUN_INSTALL_CACHE_DIR=/tmp/ro-cache bun install
# before: "error: bun is unable to write files to tempdir: PermissionDenied"
```

An already-used cache has a leftover `.tmp/` subdirectory, which routes the same scenario to a different terminal branch (the `renameat` out of `.tmp`) that printed a third wrong message: `EXDEV accessing temporary directory. Please set $BUN_TMPDIR or $BUN_INSTALL`.

## Fix

All five terminal error sites in `get_temporary_directory_run` (the three `makeOpenPath(".tmp")` failures, plus the `create_file_z` and `renameat_z` failures once the `.tmp` fallback is in use) are only ever reached because the install cache directory rejected a write, so they now share one `crash_cache_directory_unwritable` helper that names that directory and its path:

```
error: bun is unable to write to the install cache directory "/tmp/ro-cache": EACCES
note: set $BUN_INSTALL_CACHE_DIR to a writable path
```

Nothing in the function points at `$BUN_TMPDIR` anymore; it never helps at any of these sites (the rename destination is always the cache directory).

Note: an earlier revision also patched `PackageManagerDirectories.zig`. That file was a porting-reference source removed on `main` by #32621 while this PR was open, so the Zig half of the change was dropped during the rebase; only the `.rs` change remains.

Rebased across #33909 (per-crate `thiserror` enums): the helper now takes `&bun_sys::Error` (what all five `Err(..)` branches bind after that change) and displays `err.name()` via `bun_fmt::s`.

## Verification

Two tests in `test/cli/install/bun-install.test.ts`, both of which fail on `main` with the old messages and pass with this change:

- `names the install cache directory when it cannot be written to`: `$BUN_TMPDIR` points beneath a regular file and `<cache>/.tmp` is a regular file, so the `.tmp` fallback fails to open. Skipped on Windows, where the file-as-directory open does not portably fail this way.
- `names the install cache directory when the rename out of its .tmp fallback fails`: `<cache>/.tmp` already exists (symlinked onto a separate filesystem so the rename back into the cache deterministically fails with `EXDEV`), exercising the `renameat_z` branch. Gated on a runtime device check rather than a platform name.

Both assert the message names the cache directory path and `$BUN_INSTALL_CACHE_DIR`, and that neither "tempdir" nor `$BUN_TMPDIR` appears.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 13 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->