### PR TITLE
fetch: send streamed request body through CONNECT proxy tunnel

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -3234,14 +3234,12 @@ impl<'a> HTTPClient<'a> {
                         );
                     }
 
-                    let has_sent_body = if matches!(
-                        self.state.original_request_body,
-                        HTTPRequestBody::Bytes(_)
-                    ) {
-                        self.request_body().is_empty()
-                    } else {
-                        false
-                    };
+                    let has_sent_body =
+                        if matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_)) {
+                            self.request_body().is_empty()
+                        } else {
+                            false
+                        };
 
                     if has_sent_headers && has_sent_body {
                         self.state.request_stage = RequestStage::Done;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2811,6 +2811,64 @@ impl<'a> HTTPClient<'a> {
         buffer: &mut bun_io::StreamBuffer,
         data: &[u8],
     ) -> Result<bool, bun_core::Error> {
+        // When tunneling (CONNECT + inner TLS) the chunked body must go through
+        // the inner SSL wrapper; `socket` is the outer proxy connection and
+        // writing plaintext to it would corrupt the encrypted stream. The
+        // wrapper's `write_encrypted` callback pushes the ciphertext onto the
+        // outer socket.
+        if let Some(proxy_ptr) = self.proxy_tunnel.as_ref().map(|p| p.as_ptr()) {
+            // Detached upgrade so `&mut self` can be reborrowed below; the
+            // tunnel is a disjoint heap allocation (see
+            // `proxy_tunnel::raw_as_mut` INVARIANT).
+            let proxy = proxy_tunnel::raw_as_mut(proxy_ptr);
+            let to_send_len = buffer.slice().len();
+            if to_send_len > 0 {
+                match ProxyTunnel::write(proxy, buffer.slice()) {
+                    Ok(amount) => {
+                        self.state.request_sent_len += amount;
+                        buffer.cursor += amount;
+                        if amount < to_send_len {
+                            if !data.is_empty() {
+                                let _ = buffer.write(data);
+                            }
+                            return Ok(true);
+                        }
+                        if buffer.is_empty() {
+                            buffer.reset();
+                        }
+                    }
+                    Err(e) if e == err!(ConnectionClosed) => return Err(e),
+                    Err(_) => {
+                        // WantRead/WantWrite from the inner SSL: treat as
+                        // backpressure — queue any new data and retry on
+                        // the next onWritable.
+                        if !data.is_empty() {
+                            let _ = buffer.write(data);
+                        }
+                        return Ok(true);
+                    }
+                }
+            }
+            if !data.is_empty() {
+                match ProxyTunnel::write(proxy, data) {
+                    Ok(sent) => {
+                        self.state.request_sent_len += sent;
+                        if sent < data.len() {
+                            let _ = buffer.write(&data[sent..]);
+                            return Ok(true);
+                        }
+                        return Ok(false);
+                    }
+                    Err(e) if e == err!(ConnectionClosed) => return Err(e),
+                    Err(_) => {
+                        let _ = buffer.write(data);
+                        return Ok(true);
+                    }
+                }
+            }
+            return Ok(false);
+        }
+
         let to_send_len = buffer.slice().len();
         if to_send_len > 0 {
             let amount = write_to_socket::<IS_SSL>(socket, buffer.slice())?;
@@ -3176,7 +3234,14 @@ impl<'a> HTTPClient<'a> {
                         );
                     }
 
-                    let has_sent_body = self.request_body().is_empty();
+                    let has_sent_body = if matches!(
+                        self.state.original_request_body,
+                        HTTPRequestBody::Bytes(_)
+                    ) {
+                        self.request_body().is_empty()
+                    } else {
+                        false
+                    };
 
                     if has_sent_headers && has_sent_body {
                         self.state.request_stage = RequestStage::Done;
@@ -3190,7 +3255,15 @@ impl<'a> HTTPClient<'a> {
                             let ctx = self.get_ssl_ctx::<IS_SSL>();
                             self.progress_update::<IS_SSL>(ctx, socket);
                         }
-                        debug_assert!(!self.request_body().is_empty());
+                        debug_assert!(
+                            // we should have leftover data OR we use sendfile/stream
+                            (matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
+                                && !self.request_body().is_empty())
+                                || matches!(
+                                    self.state.original_request_body,
+                                    HTTPRequestBody::Sendfile(_) | HTTPRequestBody::Stream(_)
+                                )
+                        );
 
                         // we sent everything, but there's some body leftover
                         if amount == to_send.len() {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -228,6 +228,52 @@ for (const proxy_tls of [false, true]) {
   }
 }
 
+// Streamed request bodies through a CONNECT tunnel: after the inner TLS
+// handshake completes and the request headers are written, the body must be
+// written through the tunnel's inner TLS wrapper (not the outer proxy socket)
+// and the ProxyHeaders stage must not short-circuit to Done just because the
+// synchronous `request_body` slice is empty for the Stream variant. Before
+// the fix both happened, so the origin waited forever for a body that was
+// never sent.
+describe("streamed request body through CONNECT tunnel", () => {
+  const streamedBodies = {
+    ReadableStream: () =>
+      new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode("hello, "));
+          c.enqueue(new TextEncoder().encode("tunneled "));
+          c.enqueue(new TextEncoder().encode("world"));
+          c.close();
+        },
+      }),
+    "async iterator": () =>
+      (async function* () {
+        yield new TextEncoder().encode("hello, ");
+        yield new TextEncoder().encode("tunneled ");
+        yield new TextEncoder().encode("world");
+      })(),
+  } as const;
+
+  for (const proxy_tls of [false, true]) {
+    for (const [kind, makeBody] of Object.entries(streamedBodies)) {
+      test(`${kind} body through ${proxy_tls ? "TLS" : "non-TLS"} proxy -> TLS target`, async () => {
+        const response = await fetch(httpsServer.url, {
+          method: "POST",
+          proxy: proxy_tls ? httpsProxyServer.url : httpProxyServer.url,
+          headers: { "Content-Type": "text/plain" },
+          keepalive: false,
+          body: makeBody() as any,
+          duplex: "half",
+          tls: { ca: tlsCert.cert, rejectUnauthorized: false },
+        });
+        const result = await response.text();
+        expect(result).toBe("hello, tunneled world");
+        expect(response.status).toBe(200);
+      });
+    }
+  }
+});
+
 for (const server_tls of [false, true]) {
   describe.concurrent(`proxy can handle redirects with ${server_tls ? "TLS" : "non-TLS"} server`, () => {
     test("with empty body #12007", async () => {


### PR DESCRIPTION
## Repro

```ts
// run with: NO_PROXY= HTTP_PROXY= HTTPS_PROXY= bun repro.ts
import net from "node:net";
import { once } from "node:events";
import { tls as tlsCert } from "harness";

const origin = Bun.serve({
  port: 0, tls: tlsCert,
  fetch: async req => new Response(await req.text()),
});
const proxy = net.createServer(client => {
  client.on("error", () => {});
  let head = Buffer.alloc(0), upstream: net.Socket | undefined;
  client.on("close", () => upstream?.destroy());
  client.on("data", chunk => {
    if (upstream) { upstream.write(chunk); return; }
    head = Buffer.concat([head, chunk]);
    const end = head.indexOf("\r\n\r\n");
    if (end === -1) return;
    const leftover = head.subarray(end + 4);
    upstream = net.connect(origin.port, "127.0.0.1", () => {
      client.write("HTTP/1.1 200 OK\r\n\r\n");
      if (leftover.length) upstream!.write(leftover);
      upstream!.pipe(client);
    });
    upstream.on("error", () => client.destroy());
    upstream.on("close", () => client.destroy());
  });
});
proxy.listen(0, "127.0.0.1");
await once(proxy, "listening");

const body = new ReadableStream({
  start(c) { c.enqueue(new TextEncoder().encode("hello")); c.close(); },
});
const res = await fetch(`https://localhost:${origin.port}/`, {
  method: "POST", body, duplex: "half",
  proxy: `http://127.0.0.1:${(proxy.address() as net.AddressInfo).port}`,
  keepalive: false, tls: { rejectUnauthorized: false },
  signal: AbortSignal.timeout(3000),
});
console.log(res.status, await res.text()); // expected 200 hello; actual: TimeoutError
```

A `fetch()` to an `https://` origin through any HTTP(S) proxy with a `ReadableStream` or async-iterator request body hangs forever. CONNECT succeeds, the inner TLS handshake completes, the request headers (`Transfer-Encoding: chunked`) are written, then nothing: the body never goes out and the origin waits forever. String / `Uint8Array` / `Blob` / `FormData` bodies are fine; `http://` origins (absolute-form, no tunnel) are fine.

## Cause

Two bugs stacked:

1. In `on_writable`'s `ProxyHeaders` arm, `has_sent_body = self.request_body().is_empty()`. For `HTTPRequestBody::Stream` the synchronous bytes cursor is always empty, so `has_sent_headers && has_sent_body` is true and the stage jumps straight to `Done`; the `is_streaming_request_body` signal to start pulling chunks from JS never fires. The non-proxy `send_initial_request_payload` path already computes `has_sent_body` only for `HTTPRequestBody::Bytes`.

2. Even once the stage reaches `ProxyBody`, that arm's `Stream` case calls `flush_stream` → `write_to_stream_using_buffer` → `write_to_socket(socket, …)`, i.e. the outer proxy socket, writing plaintext chunked bytes into the encrypted tunnel. The `Bytes` case right above it correctly goes through `ProxyTunnel::write`.

## Fix

1. In `ProxyHeaders`, compute `has_sent_body` the same way as `send_initial_request_payload` (only true for `HTTPRequestBody::Bytes` with an empty buffer). Relax the `debug_assert!(!self.request_body().is_empty())` below it to also allow `Stream`/`Sendfile`, matching the non-proxy `Body` arm.

2. In `write_to_stream_using_buffer`, when `self.proxy_tunnel.is_some()`, route both the buffered flush and new data through `ProxyTunnel::write` instead of `write_to_socket`. `WantRead`/`WantWrite` from the inner SSL are treated as backpressure (queue into `buffer`, return `Ok(true)`); `ConnectionClosed` is propagated so the caller's `close_and_fail` runs. The encrypted output reaches the outer socket via the existing `write_encrypted` callback, same as the `Bytes` path. This also covers `HTTPThread::drain_queued_writes`, which reaches the same helper.

## Verification

Before:
```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/http/proxy.test.ts -t "streamed request body"
(fail) streamed request body through CONNECT tunnel > ReadableStream body through non-TLS proxy -> TLS target [5001ms]  (timed out)
(fail) streamed request body through CONNECT tunnel > async iterator body through non-TLS proxy -> TLS target [5001ms]  (timed out)
(fail) streamed request body through CONNECT tunnel > ReadableStream body through TLS proxy -> TLS target [5001ms]  (timed out)
(fail) streamed request body through CONNECT tunnel > async iterator body through TLS proxy -> TLS target [5001ms]  (timed out)
```

After:
```
$ bun bd test test/js/bun/http/proxy.test.ts -t "streamed request body"
(pass) streamed request body through CONNECT tunnel > ReadableStream body through non-TLS proxy -> TLS target
(pass) streamed request body through CONNECT tunnel > async iterator body through non-TLS proxy -> TLS target
(pass) streamed request body through CONNECT tunnel > ReadableStream body through TLS proxy -> TLS target
(pass) streamed request body through CONNECT tunnel > async iterator body through TLS proxy -> TLS target
```

The full `proxy.test.ts` (52 tests) and the non-proxy streamed-body suites (`async-iterator-stream.test.ts`, `body-stream.test.ts`) still pass.