### PR TITLE
fix(console): send console.trace to stderr with a "Trace:" prefix

### DIFF
--- a/docs/runtime/nodejs-compat.mdx
+++ b/docs/runtime/nodejs-compat.mdx
@@ -21,7 +21,7 @@ We update this page regularly. It reflects the latest version of Bun's compatibi
 
 ### [`node:console`](https://nodejs.org/api/console.html)
 
-🟢 Fully implemented. Bun writes console output directly to the stdout/stderr file descriptors and formats it with its own inspector. As a result, replacing `process.stdout.write` does not capture the output, and object layout differs from `util.inspect`. `console.trace()` writes to stdout and `console.time*()` to stderr.
+🟢 Fully implemented. Bun writes console output directly to the stdout/stderr file descriptors and formats it with its own inspector. As a result, replacing `process.stdout.write` does not capture the output, and object layout differs from `util.inspect`. `console.trace()` and `console.time*()` write to stderr.
 
 ### [`node:dgram`](https://nodejs.org/api/dgram.html)
 

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -536,9 +536,16 @@ fn message_with_type_and_level_(
     }
 
     // console.trace prints "Trace: <message>" (or just "Trace" with no args),
-    // matching Node, with the stack trace appended below.
+    // matching Node, with the stack trace appended below. The label goes through
+    // FormatOptions so it lands after the console.group indent rather than
+    // before it.
     if message_type == MessageType::Trace {
-        let _ = writer.write_all(if print_length > 0 { b"Trace: " } else { b"Trace\n" });
+        if print_length > 0 {
+            print_options.prefix = b"Trace: ";
+        } else {
+            let _ = formatter::write_indent_n(u32::from(default_indent), writer);
+            let _ = writer.write_all(b"Trace\n");
+        }
     }
 
     if print_length > 0 {
@@ -1179,6 +1186,9 @@ pub struct FormatOptions {
     pub single_line: bool,
     pub default_indent: u16,
     pub error_display_level: ErrorDisplayLevel,
+    /// Label emitted immediately after the indent, before the formatted values
+    /// (used by `console.trace` for its "Trace: " prefix).
+    pub prefix: &'static [u8],
 }
 
 impl Default for FormatOptions {
@@ -1193,6 +1203,7 @@ impl Default for FormatOptions {
             single_line: false,
             default_indent: 0,
             error_display_level: ErrorDisplayLevel::Full,
+            prefix: b"",
         }
     }
 }
@@ -1354,6 +1365,7 @@ pub fn format2(
         if fmt.write_indent(writer).is_err() {
             return Ok(());
         }
+        let _ = writer.write_all(options.prefix);
 
         if matches!(tag.tag, TagPayload::String) {
             if options.enable_colors {
@@ -1418,6 +1430,7 @@ pub fn format2(
     if fmt.write_indent(writer).is_err() {
         return Ok(());
     }
+    let _ = writer.write_all(options.prefix);
 
     let mut any = false;
     if options.enable_colors {
@@ -2731,7 +2744,7 @@ pub mod formatter {
     /// conflict with the `&self` borrow `Formatter::write_indent` takes.
     /// `self.indent` is a disjoint field read, so passing it by value here
     /// keeps the borrow checker happy.
-    fn write_indent_n(indent: u32, writer: &mut dyn bun_io::Write) -> bun_io::Result<()> {
+    pub(crate) fn write_indent_n(indent: u32, writer: &mut dyn bun_io::Write) -> bun_io::Result<()> {
         let mut total_remain: u32 = indent;
         while total_remain > 0 {
             let written: u8 = total_remain.min(32) as u8;

--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -408,7 +408,8 @@ fn message_with_type_and_level_(
     // Lock/unlock a mutex incase two JS threads are console.log'ing at the same
     // time. We do this the slightly annoying way to avoid assigning a pointer.
     let use_stderr = matches!(level, MessageLevel::Warning | MessageLevel::Error)
-        || message_type == MessageType::Assert;
+        || message_type == MessageType::Assert
+        || message_type == MessageType::Trace;
     let _stream_lock = ConsoleStreamLock::acquire(use_stderr);
 
     if message_type == MessageType::Clear {
@@ -431,7 +432,9 @@ fn message_with_type_and_level_(
         return Ok(());
     }
 
-    let enable_colors = if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+    let enable_colors = if matches!(level, MessageLevel::Warning | MessageLevel::Error)
+        || message_type == MessageType::Trace
+    {
         Output::enable_ansi_colors_stderr()
     } else {
         Output::enable_ansi_colors_stdout()
@@ -450,7 +453,7 @@ fn message_with_type_and_level_(
     // long-lived `&mut ConsoleObject` across the re-derive in the empty-`Log`
     // arm below.
     let raw_writer: &mut bun_core::io::Writer = unsafe {
-        if matches!(level, MessageLevel::Warning | MessageLevel::Error) {
+        if matches!(level, MessageLevel::Warning | MessageLevel::Error) || message_type == MessageType::Trace {
             (*console).error_writer()
         } else {
             (*console).writer()
@@ -530,6 +533,12 @@ fn message_with_type_and_level_(
                 }
             }
         }
+    }
+
+    // console.trace prints "Trace: <message>" (or just "Trace" with no args),
+    // matching Node, with the stack trace appended below.
+    if message_type == MessageType::Trace {
+        let _ = writer.write_all(if print_length > 0 { b"Trace: " } else { b"Trace\n" });
     }
 
     if print_length > 0 {

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -126,4 +126,16 @@ describe("console.trace", () => {
     expect(stderr).toStartWith("Trace: x=5\n");
     expect(exitCode).toBe(0);
   });
+
+  test("label goes after the console.group indent", async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `console.group("G"); console.trace("x"); console.trace(); console.groupEnd(); console.trace("top");`,
+    );
+    // The group indent precedes the label, and the bare header is indented too.
+    expect(stderr).toStartWith("  Trace: x\n");
+    expect(stderr).toContain("\n  Trace\n");
+    expect(stderr).toContain("\nTrace: top\n");
+    expect(stdout).toBe("G\n");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -113,14 +113,17 @@ describe("console.trace", () => {
   });
 
   test("no arguments prints bare 'Trace'", async () => {
-    const { stdout, stderr } = await run(`console.trace()`);
+    const { stdout, stderr, exitCode } = await run(`console.trace()`);
     expect(stdout).toBe("");
     expect(stderr).toStartWith("Trace\n");
     expect(stderr).toContain("at ");
+    expect(exitCode).toBe(0);
   });
 
   test("applies format specifiers", async () => {
-    const { stderr } = await run(`console.trace("x=%d", 5)`);
+    const { stdout, stderr, exitCode } = await run(`console.trace("x=%d", 5)`);
+    expect(stdout).toBe("");
     expect(stderr).toStartWith("Trace: x=5\n");
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { Console } from "node:console";
+import { bunEnv, bunExe } from "harness";
 
 import { Writable } from "node:stream";
 
@@ -86,5 +87,40 @@ test("console._stderr", () => {
     writable: true,
     enumerable: false,
     configurable: true,
+  });
+});
+
+// console.trace writes to stderr with a "Trace:" prefix, matching Node.
+// https://github.com/oven-sh/bun/issues/19952
+describe("console.trace", () => {
+  async function run(code: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("goes to stderr, not stdout", async () => {
+    const { stdout, stderr, exitCode } = await run(`console.trace("hi")`);
+    expect(stdout).toBe("");
+    expect(stderr).toStartWith("Trace: hi\n");
+    expect(stderr).toContain("at ");
+    expect(exitCode).toBe(0);
+  });
+
+  test("no arguments prints bare 'Trace'", async () => {
+    const { stdout, stderr } = await run(`console.trace()`);
+    expect(stdout).toBe("");
+    expect(stderr).toStartWith("Trace\n");
+    expect(stderr).toContain("at ");
+  });
+
+  test("applies format specifiers", async () => {
+    const { stderr } = await run(`console.trace("x=%d", 5)`);
+    expect(stderr).toStartWith("Trace: x=5\n");
   });
 });

--- a/test/js/node/console/console.test.ts
+++ b/test/js/node/console/console.test.ts
@@ -132,9 +132,8 @@ describe("console.trace", () => {
       `console.group("G"); console.trace("x"); console.trace(); console.groupEnd(); console.trace("top");`,
     );
     // The group indent precedes the label, and the bare header is indented too.
-    expect(stderr).toStartWith("  Trace: x\n");
-    expect(stderr).toContain("\n  Trace\n");
-    expect(stderr).toContain("\nTrace: top\n");
+    const headers = stderr.match(/^(?:  Trace: x|  Trace|Trace: top)$/gm);
+    expect(headers).toEqual(["  Trace: x", "  Trace", "Trace: top"]);
     expect(stdout).toBe("G\n");
     expect(exitCode).toBe(0);
   });


### PR DESCRIPTION
### What does this PR do?

Fixes #19952. `console.trace()` wrote its output to **stdout** with no prefix; Node writes to **stderr** prefixed with `Trace:`.

```
$ bun  -e 'console.trace("hi")'   # before
hi                                # ← stdout, no prefix
      at [eval]:1:9

$ node -e 'console.trace("hi")'
Trace: hi                         # ← stderr, "Trace:" prefix
    at [eval]:1:9
```

The native console handler (`src/jsc/ConsoleObject.rs`) only routed `Warning`/`Error`/`Assert` messages to the stderr writer, and never emitted a label for the `Trace` message type. This change routes `Trace` to the stderr writer (stream selection + color mode) and prints `Trace: ` before the formatted arguments, or a bare `Trace` when called with no arguments — matching Node:

```
console.trace("hi")      -> Trace: hi
console.trace("x=%d", 5) -> Trace: x=5
console.trace({a:1})     -> Trace: { a: 1 }
console.trace()          -> Trace
```

The `.zig` reference sibling has the same gap; left untouched since it is not compiled.

### How did you verify your code works?

Added `console.trace` tests in `test/js/node/console/console.test.ts` that spawn a subprocess and assert stdout is empty, stderr starts with `Trace: hi\n` / bare `Trace\n` (no-args) and contains the stack frames, plus format-specifier handling. Tests pass on the debug build and fail on the released `bun` (`USE_SYSTEM_BUN=1`). Existing console suites (`console.test.ts`, `console-log.test.ts`) still pass: 14 / 14.