### PR TITLE
sourcemap: static_assert ParseMappingsState layout matches kSt* indices

### DIFF
--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -570,6 +570,12 @@ pub struct ParseMappingsState {
     pub slow_blocks: i32,
 }
 
+// The C++ kernel indexes this struct as `int32_t state[10]` via the kSt*
+// constants, and `highway_sourcemap.cpp` static_asserts each offsetof against
+// its kSt* index. This pins the size from the Rust side so adding a field
+// here without updating the C++ enum fails the build.
+const _: () = assert!(core::mem::size_of::<ParseMappingsState>() == 10 * core::mem::size_of::<i32>());
+
 /// Count of `,` and `;` bytes in `bytes`. `count + 1` is an upper bound on
 /// the number of segments (and therefore the number of output rows) for a
 /// source-map `mappings` string.

--- a/src/highway/lib.rs
+++ b/src/highway/lib.rs
@@ -574,7 +574,8 @@ pub struct ParseMappingsState {
 // constants, and `highway_sourcemap.cpp` static_asserts each offsetof against
 // its kSt* index. This pins the size from the Rust side so adding a field
 // here without updating the C++ enum fails the build.
-const _: () = assert!(core::mem::size_of::<ParseMappingsState>() == 10 * core::mem::size_of::<i32>());
+const _: () =
+    assert!(core::mem::size_of::<ParseMappingsState>() == 10 * core::mem::size_of::<i32>());
 
 /// Count of `,` and `;` bytes in `bytes`. `count + 1` is an upper bound on
 /// the number of segments (and therefore the number of output rows) for a

--- a/src/jsc/bindings/highway_sourcemap.cpp
+++ b/src/jsc/bindings/highway_sourcemap.cpp
@@ -138,6 +138,34 @@ enum : size_t {
     kStSlowBlocks = 9,
 };
 
+// Layout mirror of bun_highway::ParseMappingsState (#[repr(C)]). The kernel
+// indexes `state` as int32_t[10] via the kSt* constants above; the Rust side
+// reads named fields. These asserts pin the field order so a reorder on either
+// side fails the build instead of silently mis-seeding the scalar resume.
+struct ParseMappingsState {
+    int32_t gen_line;
+    int32_t gen_col;
+    int32_t orig_line;
+    int32_t orig_col;
+    int32_t src_idx;
+    int32_t name_idx;
+    int32_t needs_sort;
+    int32_t has_names;
+    int32_t fast_blocks;
+    int32_t slow_blocks;
+};
+static_assert(sizeof(ParseMappingsState) == 10 * sizeof(int32_t), "ParseMappingsState size changed; update kSt* and the Rust mirror in bun_highway");
+static_assert(offsetof(ParseMappingsState, gen_line) == kStGenLine * sizeof(int32_t), "kStGenLine out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, gen_col) == kStGenCol * sizeof(int32_t), "kStGenCol out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, orig_line) == kStOrigLine * sizeof(int32_t), "kStOrigLine out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, orig_col) == kStOrigCol * sizeof(int32_t), "kStOrigCol out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, src_idx) == kStSrcIdx * sizeof(int32_t), "kStSrcIdx out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, name_idx) == kStNameIdx * sizeof(int32_t), "kStNameIdx out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, needs_sort) == kStNeedsSort * sizeof(int32_t), "kStNeedsSort out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, has_names) == kStHasNames * sizeof(int32_t), "kStHasNames out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, fast_blocks) == kStFastBlocks * sizeof(int32_t), "kStFastBlocks out of sync with bun_highway::ParseMappingsState");
+static_assert(offsetof(ParseMappingsState, slow_blocks) == kStSlowBlocks * sizeof(int32_t), "kStSlowBlocks out of sync with bun_highway::ParseMappingsState");
+
 // VLQ sign recovery. Source-map VLQ is sign-magnitude (NOT zigzag): bit 0 is
 // the sign flag, bits 1.. are the magnitude. Written branch-free as
 // `(mag ^ s) - s` with `s = -(v & 1)`: s is 0 or -1, so XOR+SUB is either


### PR DESCRIPTION
Follow-up to #32556.

The SIMD kernel in `highway_sourcemap.cpp` indexes the in/out accumulator state as `int32_t[10]` via the `kSt*` enum constants; the Rust side (`bun_highway::ParseMappingsState`) reads named fields of a `#[repr(C)]` struct to seed the scalar resume at `Mapping.rs:542`. The mapping between the two was held together by a doc comment.

This adds:
- a C++ mirror struct with `static_assert(offsetof(...) == kSt* * sizeof(int32_t))` for every field plus a `sizeof == 40` assert, matching the `xxhash3.cpp:658` precedent in the same crate (which is *weaker* — that struct is opaque `[u64; 10]` on the Rust side so only size matters; this one needs per-offset);
- a Rust-side `const _: () = assert!(size_of == 40)` so adding a field on either side without updating the other fails the build instead of silently mis-seeding the scalar decoder.

No runtime change. `sourcemap-simd.test.ts` 24/24 pass on the debug build.