### PR TITLE
types(streams): document ReadableStreamDirectController backpressure contract

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -70,6 +70,29 @@ const stream = new ReadableStream({
 
 When using a direct `ReadableStream`, the destination handles all chunk queueing. The consumer of the stream receives exactly what is passed to `controller.write()`, without any encoding or modification.
 
+### Handling backpressure
+
+`controller.write()` returns the number of bytes written. When the destination's internal buffer is full (for example, a slow HTTP client), it returns a **negative number** instead. The chunk is still accepted — the negative return is a signal to pause and wait for the destination to drain.
+
+To wait for the drain, `await controller.flush(true)`:
+
+```ts
+const stream = new ReadableStream({
+  type: "direct",
+  async pull(controller) {
+    for (const chunk of chunks) {
+      if (controller.write(chunk) < 0) {
+        // destination is backed up; wait for it to drain before writing more
+        await controller.flush(true);
+      }
+    }
+    controller.close();
+  },
+});
+```
+
+For default (non-`direct`) `ReadableStream`s and async-generator response bodies, Bun applies this backpressure automatically — the producer is paused while the destination is backed up.
+
 ---
 
 ## Async generator streams

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -726,9 +726,33 @@ interface ReadableStreamDefaultController<R = any> {
 
 interface ReadableStreamDirectController {
   close(error?: Error): void;
+  /**
+   * Write a chunk directly to the destination.
+   *
+   * Returns the number of bytes written, or a **negative number** when the
+   * destination's internal buffer is full (backpressure). When negative, the
+   * chunk *was* accepted; pause writing and `await controller.flush(true)`,
+   * which resolves once the destination has drained:
+   *
+   * ```ts
+   * if (controller.write(chunk) < 0) {
+   *   await controller.flush(true);
+   * }
+   * ```
+   *
+   * For some destinations (e.g. {@link Bun.FileSink} on Windows pipes) the
+   * write itself is asynchronous and a `Promise<number>` is returned instead.
+   */
   write(data: Bun.BufferSource | ArrayBuffer | string): number | Promise<number>;
   end(): number | Promise<number>;
-  flush(): number | Promise<number>;
+  /**
+   * Flush any locally buffered data to the destination.
+   *
+   * @param wait When `true`, the returned promise resolves only once the
+   * destination has drained its own internal buffer (i.e. backpressure has
+   * cleared). Use this after {@link write} returns a negative value.
+   */
+  flush(wait?: boolean): number | Promise<number>;
   start(): void;
 }
 


### PR DESCRIPTION
Follow-up to #32553.

`controller.write()` on a `type: "direct"` stream backed by an HTTP response now returns a **negative number** when the socket's internal buffer is full, and `controller.flush(true)` waits for the drain. Neither was documented — the `< 0` check + `await flush(true)` idiom only appeared in `serve.test.ts`.

This adds:
- JSDoc for `ReadableStreamDirectController.write()` describing the negative-on-backpressure return and the `await flush(true)` recovery
- the missing `wait?: boolean` parameter on `flush()` (the native side has accepted it since `flush_from_js(global, wait: bool)` but the type signature was `flush(): number | Promise<number>`)
- a "Handling backpressure" section under the `type: "direct"` docs in `docs/runtime/streams.mdx`

No runtime change. `test/integration/bun-types/bun-types.test.ts` 12/12 pass.