### PR TITLE
types(streams): make documented backpressure idiom typecheck

### DIFF
--- a/docs/runtime/streams.mdx
+++ b/docs/runtime/streams.mdx
@@ -81,7 +81,8 @@ const stream = new ReadableStream({
   type: "direct",
   async pull(controller) {
     for (const chunk of chunks) {
-      if (controller.write(chunk) < 0) {
+      const n = controller.write(chunk);
+      if (typeof n === "number" && n < 0) {
         // destination is backed up; wait for it to drain before writing more
         await controller.flush(true);
       }

--- a/packages/bun-types/globals.d.ts
+++ b/packages/bun-types/globals.d.ts
@@ -735,13 +735,16 @@ interface ReadableStreamDirectController {
    * which resolves once the destination has drained:
    *
    * ```ts
-   * if (controller.write(chunk) < 0) {
+   * const n = controller.write(chunk);
+   * if (typeof n === "number" && n < 0) {
    *   await controller.flush(true);
    * }
    * ```
    *
    * For some destinations (e.g. {@link Bun.FileSink} on Windows pipes) the
-   * write itself is asynchronous and a `Promise<number>` is returned instead.
+   * write itself is asynchronous and a `Promise<number>` is returned instead;
+   * the `typeof` check above skips the backpressure wait for those — the
+   * promise carries its own flow control.
    */
   write(data: Bun.BufferSource | ArrayBuffer | string): number | Promise<number>;
   end(): number | Promise<number>;

--- a/test/js/bun/http/serve.test.ts
+++ b/test/js/bun/http/serve.test.ts
@@ -2587,14 +2587,15 @@ it("type: direct stream awaiting flush(true) under backpressure does not re-ente
             // write() returns a negative number when the socket is backed up;
             // await flush(true) (the pending-flush promise) to pause until the
             // drain.
-            if (controller.write(CHUNK) < 0) {
+            const n = controller.write(CHUNK);
+            if (typeof n === "number" && n < 0) {
               await controller.flush(true);
             }
             writes++;
           }
           await controller.end();
         },
-      } as any);
+      });
       return new Response(stream);
     },
   });
@@ -2712,13 +2713,14 @@ it("type: direct stream — small write queued under backpressure is delivered i
           // below highWaterMark — it lands in the sink's local buffer while
           // pending_flush is already parked.
           for (let i = 0; i < 256 && !hitBackpressure; i++) {
-            if (controller.write(BIG) < 0) hitBackpressure = true;
+            const n = controller.write(BIG);
+            if (typeof n === "number" && n < 0) hitBackpressure = true;
           }
           controller.write(SMALL);
           await controller.flush(true);
           await controller.end();
         },
-      } as any);
+      });
       return new Response(stream);
     },
   });


### PR DESCRIPTION
Follow-up to #32640 (review comment https://github.com/oven-sh/bun/pull/32640#discussion_r3459276757).

The example shipped in #32640 was:
```ts
if (controller.write(chunk) < 0) { await controller.flush(true); }
```
which is **TS2365** against `write(): number | Promise<number>` — `<` doesn't apply to that union.

Now uses the typeof-narrow form in both the JSDoc and `docs/runtime/streams.mdx`:
```ts
const n = controller.write(chunk);
if (typeof n === "number" && n < 0) {
  await controller.flush(true);
}
```
which is type-safe and matches what `readStreamIntoSink` does internally (it deliberately doesn't await the `Promise<number>` variant per-write — that's the FileSink-on-Windows-pipes path where the promise itself is the flow control).

Also drops the `as any` casts from the two `serve.test.ts` backpressure tests; with `flush(wait?)` typed (#32640) and the comparison narrowed, those literals now typecheck against `DirectUnderlyingSource` directly.

`bun-types.test.ts` 12/12, the 5 `serve.test.ts -t backpressure` tests pass on the debug build, and `bunx tsc --noEmit -p test/tsconfig.json` reports no new errors.