### PR TITLE
fix(sys/windows): return error for unmapped Win32 codes in symlink_w

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -8713,18 +8713,21 @@ mod win_symlink_impl {
                     WindowsSymlinkOptions::denied();
                     continue;
                 }
-                if let Some(sys_errno) = win_err.to_system_errno() {
-                    let e: E = sys_errno.to_e();
-                    // Only ENOENT/EEXIST keep `has_failed_to_create_symlink`
-                    // unset; every other failure flips the sticky bit so
-                    // `symlinkOrJunction` falls through to junctions next time.
-                    if !matches!(e, E::NOENT | E::EXIST) {
-                        WindowsSymlinkOptions::set_has_failed_to_create_symlink(true);
-                    }
-                    return Err(Error::from_code(e, Tag::symlink));
+                // `to_e()` falls back to `E::UNKNOWN` for Win32 codes not in
+                // the errno table. Filter drivers, network redirectors, and
+                // security software hooking `CreateSymbolicLinkW` can return
+                // codes outside the mapped set; treating those as success
+                // would leave the caller believing a symlink exists when it
+                // does not. Returning an error lets `symlink_or_junction`
+                // fall through to a junction.
+                let e: E = win_err.to_e();
+                // Only ENOENT/EEXIST keep `has_failed_to_create_symlink`
+                // unset; every other failure flips the sticky bit so
+                // `symlinkOrJunction` falls through to junctions next time.
+                if !matches!(e, E::NOENT | E::EXIST) {
+                    WindowsSymlinkOptions::set_has_failed_to_create_symlink(true);
                 }
-                // Win32 error without an errno mapping — treat as success
-                // (the `if let` yields `null`).
+                return Err(Error::from_code(e, Tag::symlink));
             }
             return Ok(());
         }

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -427,10 +427,10 @@ impl Win32ErrorUnwrap for Win32Error {
         if self == Win32Error::SUCCESS {
             return Ok(());
         }
-        if let Some(err) = self.to_system_errno() {
-            return Err(err.to_error());
-        }
-        Ok(())
+        Err(self
+            .to_system_errno()
+            .unwrap_or(SystemErrno::EUNKNOWN)
+            .to_error())
     }
 }
 
@@ -4975,3 +4975,36 @@ pub fn getenv_w(name: &[u16]) -> Option<Vec<u16>> {
 bun_core::declare_scope!(windowsUserUniqueId, visible);
 
 // SetFilePointerEx referenced via the `pub use` at the top of this module.
+
+#[cfg(test)]
+mod tests {
+    use super::{E, SystemErrno, Win32Error, Win32ErrorExt as _, Win32ErrorUnwrap as _};
+
+    /// A Win32 code with no entry in `SystemErrno::init_win32_error`.
+    const UNMAPPED: Win32Error = Win32Error(0xFFFE);
+
+    #[test]
+    fn unwrap_success_is_ok() {
+        assert!(Win32Error::SUCCESS.unwrap().is_ok());
+    }
+
+    #[test]
+    fn unwrap_mapped_is_err() {
+        assert!(Win32Error::FILE_NOT_FOUND.unwrap().is_err());
+    }
+
+    /// `GetLastError()` after a failed Win32 call can return codes not present
+    /// in the errno mapping table (filter drivers, network redirectors, AV
+    /// hooks). Reporting success for those would swallow the failure.
+    #[test]
+    fn unwrap_unmapped_is_err() {
+        assert!(UNMAPPED.to_system_errno().is_none());
+        assert!(UNMAPPED.unwrap().is_err());
+    }
+
+    #[test]
+    fn to_e_unmapped_is_unknown() {
+        assert_eq!(UNMAPPED.to_e(), E::UNKNOWN);
+        assert_eq!(SystemErrno::EUNKNOWN.to_e(), E::UNKNOWN);
+    }
+}


### PR DESCRIPTION
## Crash signature

```
panic: invalid enum value
threading/ThreadPool.zig:581  run
install/isolated_install/Installer.zig:1334  callback
install/isolated_install/Installer.zig:1024  run
install/isolated_install/Symlinker.zig:76  ensureSymlink
install/isolated_install/Symlinker.zig:8  symlink
sys/sys.zig:2758  symlinkOrJunction
sys/sys.zig:2808  symlinkW
```

Sentry BUN-2Q70 / BUN-2VC5, ~750 events across bun 1.3.10 through 1.3.14, Windows x86_64 only, all during `bun install --linker=isolated`.

## Status of the reported panic

The `@tagName(errno)` panic at `sys.zig:2795` **cannot occur on `main`**: the Zig source tree stopped compiling at 23427dbc12 (the Rust rewrite, 4 commits after `bun-v1.3.14`), and the Rust `Win32Error` is `#[repr(transparent)] struct Win32Error(pub u16)` with `#[derive(Debug)]`. Every `GetLastError()` value round-trips; there is no enum tag to be invalid. So the crash itself is fixed for any post-rewrite release with no code change.

## The carried-over behavior bug

Both the Zig `symlinkW` and its Rust port shared the same fall-through after the log line:

```rust
// src/sys/lib.rs, symlink_w, before this change
if rc == 0 {
    let win_err = windows::Win32Error::get();
    ...
    if let Some(sys_errno) = win_err.to_system_errno() {
        ...
        return Err(Error::from_code(e, Tag::symlink));
    }
    // Win32 error without an errno mapping: treat as success
}
return Ok(());
```

`SystemErrno::init_win32_error` only maps the ~90 libuv-relevant codes. `CreateSymbolicLinkW` can fail with many others: filter-driver status codes, network-redirector errors, ReFS limitations, or security software that hooks the call. When it does, `to_system_errno()` yields `None` and the function returns `Ok(())` even though no symlink was created.

On 1.3.x Zig builds the user never reached this branch because `@tagName(errno)` panicked first. On `main` the user *would* reach it: the isolated-install `Symlinker` sees success, `symlink_or_junction` skips its junction fallback, and `node_modules` is left with missing package links. The install exits 0 and module resolution fails at runtime.

## Fix

`symlink_w` now maps the Win32 error via `Win32ErrorExt::to_e()`, which falls back to `E::UNKNOWN` for unmapped codes. That sets the `has_failed_to_create_symlink` sticky bit (since `UNKNOWN` is not `NOENT`/`EXIST`) and returns an `Err`, so `symlink_or_junction` falls through to a junction and subsequent calls go straight to junctions. This matches every other `*_w` wrapper in the same module (`unlink_w`, `mkdir_w`, `link_w`), which all route through `windows::get_last_errno()` with the `EUNKNOWN` fallback.

`Win32ErrorUnwrap::unwrap` (used after `MoveFileExW` in `bun_resolver`) had the identical pattern: non-`SUCCESS` unmapped code returned `Ok(())`. It now returns `EUNKNOWN`.

## Verification

`cargo check -p bun_sys -p bun_resolver -p bun_install --target x86_64-pc-windows-msvc --tests` passes.

`#[cfg(all(windows, test))]` unit tests added in `src/sys/windows/mod.rs`:
- `Win32Error::SUCCESS.unwrap()` is `Ok`
- `Win32Error::FILE_NOT_FOUND.unwrap()` is `Err`
- `Win32Error(0xFFFE).unwrap()` is `Err` (was `Ok` before this change)
- `Win32Error(0xFFFE).to_e()` is `E::UNKNOWN`

### Why no integration test

Reproducing requires `CreateSymbolicLinkW` to return 0 with `GetLastError()` set to a code outside the ~90-entry `init_win32_error` table. The common failure modes on a clean Windows CI runner all map: `ERROR_PRIVILEGE_NOT_HELD` (1314) maps to `EPERM`, `ERROR_NOT_SUPPORTED` (50) on FAT32 maps to `ENOTSUP`, `ERROR_ALREADY_EXISTS` (183) maps to `EEXIST`, etc. The unmapped codes observed in the field come from the user's filter-driver / AV / network-redirector stack, which CI does not have. On Linux the code path does not compile (`#[cfg(windows)]`), so the gate's stash-src fail-before check has nothing to run; the Rust unit tests above run only under `cargo test --target x86_64-pc-windows-msvc`.