### PR TITLE
Add tokenmaxxing to default trusted dependencies

### DIFF
--- a/src/install/default-trusted-dependencies.txt
+++ b/src/install/default-trusted-dependencies.txt
@@ -1,3 +1,4 @@
+@851-labs/tokenmaxxing
 @airbnb/node-memwatch
 @anthropic-ai/claude-code
 @apollo/protobufjs


### PR DESCRIPTION
## Summary
- add `@851-labs/tokenmaxxing` to Bun's default trusted dependency list

## Context
`@851-labs/tokenmaxxing` publishes a native CLI through platform optional packages and uses postinstall to link/copy the matching native binary, similar to `opencode-ai`. Without default trust, `bun add -g @851-labs/tokenmaxxing` leaves users with a blocked postinstall path unless they know to pass `--trust`.

## Testing
- Verified locally with Bun 1.3.14 that `bun add --trust` runs postinstall and installs the native binary.
- Verified the package also has a fallback launcher for blocked-script installs.