### PR TITLE
Keep the watcher alive when process.exit() is called in --watch

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -326,6 +326,11 @@ impl JSGlobalObject {
     }
 
     #[inline]
+    pub fn request_termination(&self) {
+        JSGlobalObject__requestTermination(self)
+    }
+
+    #[inline]
     pub fn clear_termination_exception(&self) {
         JSGlobalObject__clearTerminationException(self)
     }
@@ -1580,6 +1585,7 @@ unsafe extern "C" {
     safe fn JSGlobalObject__clearExceptionExceptTermination(this: &JSGlobalObject) -> bool;
     safe fn JSGlobalObject__clearTerminationException(this: &JSGlobalObject);
     safe fn JSGlobalObject__hasException(this: &JSGlobalObject) -> bool;
+    safe fn JSGlobalObject__requestTermination(this: &JSGlobalObject);
     safe fn JSGlobalObject__setTimeZone(this: &JSGlobalObject, time_zone: &EncodedSlice) -> bool;
     safe fn JSGlobalObject__tryTakeException(this: &JSGlobalObject) -> JSValue;
 

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -183,10 +183,11 @@ pub fn is_emitting_watch_kill_signal() -> bool {
     IS_EMITTING_WATCH_KILL_SIGNAL.load(Ordering::Relaxed)
 }
 
-/// Whether a user-delivered kill-intent signal (Ctrl+C and friends) has
-/// reached JS handlers. Latched, never cleared: once the user has asked to
-/// stop, any later `process.exit()` under `--watch` is a real exit however
-/// the handler defers it (node's watcher dies with the child on Ctrl+C).
+/// Whether a kill-intent signal (Ctrl+C and friends) has reached JS
+/// handlers. Latched, never cleared, and the sender is indistinguishable
+/// (a self-sent `process.kill` counts too): any later `process.exit()`
+/// under `--watch` is a real exit however the handler defers it (node's
+/// watcher dies with the child on such signals).
 pub fn user_kill_signal_delivered() -> bool {
     USER_KILL_SIGNAL_DELIVERED.load(Ordering::Relaxed)
 }

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -194,9 +194,10 @@ pub fn user_kill_signal_delivered() -> bool {
 static USER_KILL_SIGNAL_DELIVERED: AtomicBool = AtomicBool::new(false);
 
 /// SIGHUP/SIGINT/SIGQUIT/SIGTERM on every supported platform, plus the
-/// Windows CRT's SIGBREAK.
+/// Windows CRT's SIGBREAK (21 is SIGTTIN on POSIX, which is job control,
+/// not kill intent).
 fn is_kill_intent_signal(number: i32) -> bool {
-    matches!(number, 1 | 2 | 3 | 15 | 21)
+    matches!(number, 1 | 2 | 3 | 15) || (cfg!(windows) && number == 21)
 }
 
 /// Both signal-delivery paths note the signal before emitting: POSIX in
@@ -234,6 +235,17 @@ impl PosixSignalTask {
         {
             bun_core::Output::flush();
             bun_core::Global::exit(0);
+        }
+        // A kill signal while the watcher is parked after a watch exit: the
+        // run is over and nothing deferred from the handler may fire there,
+        // so end the watcher now with the completed run's exit code.
+        if user_kill_signal_delivered() {
+            let vm = global_object.bun_vm().as_mut();
+            if vm.watch_exit_requested {
+                bun_core::Output::flush();
+                vm.on_exit();
+                vm.global_exit();
+            }
         }
     }
 }

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -210,6 +210,21 @@ pub extern "C" fn Bun__noteUserSignalDelivered(number: i32) {
     }
 }
 
+/// Shared tail of both signal-delivery paths (same pair as above): a kill
+/// signal while the watcher is parked after a watch exit ends the watcher,
+/// since nothing deferred from the handler may fire there.
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__endParkedWatcherOnKillSignal(global_object: &JSGlobalObject) {
+    if user_kill_signal_delivered() {
+        let vm = global_object.bun_vm().as_mut();
+        if vm.watch_exit_requested {
+            bun_core::Output::flush();
+            vm.on_exit();
+            vm.global_exit();
+        }
+    }
+}
+
 /// Runs the JS handlers of the configured `--watch-kill-signal` synchronously,
 /// mirroring node delivering that signal to the watched child before restart.
 /// SIGKILL/SIGSTOP are uncatchable in node, so nothing is emitted for them.
@@ -236,17 +251,7 @@ impl PosixSignalTask {
             bun_core::Output::flush();
             bun_core::Global::exit(0);
         }
-        // A kill signal while the watcher is parked after a watch exit: the
-        // run is over and nothing deferred from the handler may fire there,
-        // so end the watcher now with the completed run's exit code.
-        if user_kill_signal_delivered() {
-            let vm = global_object.bun_vm().as_mut();
-            if vm.watch_exit_requested {
-                bun_core::Output::flush();
-                vm.on_exit();
-                vm.global_exit();
-            }
-        }
+        Bun__endParkedWatcherOnKillSignal(global_object);
     }
 }
 

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -183,6 +183,16 @@ pub fn is_emitting_watch_kill_signal() -> bool {
     IS_EMITTING_WATCH_KILL_SIGNAL.load(Ordering::Relaxed)
 }
 
+/// Whether a user-delivered signal's JS handlers are running right now.
+/// `process.exit()` in such a handler must really exit even under `--watch`
+/// (node's watcher dies with the child on Ctrl+C), so the keepalive branch
+/// consults this.
+pub fn is_emitting_signal_for_js() -> bool {
+    IS_EMITTING_SIGNAL_FOR_JS.load(Ordering::Relaxed)
+}
+
+static IS_EMITTING_SIGNAL_FOR_JS: AtomicBool = AtomicBool::new(false);
+
 /// Runs the JS handlers of the configured `--watch-kill-signal` synchronously,
 /// mirroring node delivering that signal to the watched child before restart.
 /// SIGKILL/SIGSTOP are uncatchable in node, so nothing is emitted for them.
@@ -200,7 +210,9 @@ pub(crate) fn emit_watch_kill_signal_before_reload(global_object: &JSGlobalObjec
 
 impl PosixSignalTask {
     pub fn run_from_js_thread(number: u8, global_object: &JSGlobalObject) {
+        IS_EMITTING_SIGNAL_FOR_JS.store(true, Ordering::Relaxed);
         let fired = Bun__onSignalForJS(i32::from(number), global_object);
+        IS_EMITTING_SIGNAL_FOR_JS.store(false, Ordering::Relaxed);
         // Node parity: in watch mode the watcher exits 0 on SIGINT when the
         // script has no handler for it (see `enable_watch_mode_signals`).
         if !fired && number == SIGINT_NUMBER && WATCH_MODE_KILL_SIGNAL.load(Ordering::Relaxed) != 0

--- a/src/jsc/PosixSignalHandle.rs
+++ b/src/jsc/PosixSignalHandle.rs
@@ -183,15 +183,31 @@ pub fn is_emitting_watch_kill_signal() -> bool {
     IS_EMITTING_WATCH_KILL_SIGNAL.load(Ordering::Relaxed)
 }
 
-/// Whether a user-delivered signal's JS handlers are running right now.
-/// `process.exit()` in such a handler must really exit even under `--watch`
-/// (node's watcher dies with the child on Ctrl+C), so the keepalive branch
-/// consults this.
-pub fn is_emitting_signal_for_js() -> bool {
-    IS_EMITTING_SIGNAL_FOR_JS.load(Ordering::Relaxed)
+/// Whether a user-delivered kill-intent signal (Ctrl+C and friends) has
+/// reached JS handlers. Latched, never cleared: once the user has asked to
+/// stop, any later `process.exit()` under `--watch` is a real exit however
+/// the handler defers it (node's watcher dies with the child on Ctrl+C).
+pub fn user_kill_signal_delivered() -> bool {
+    USER_KILL_SIGNAL_DELIVERED.load(Ordering::Relaxed)
 }
 
-static IS_EMITTING_SIGNAL_FOR_JS: AtomicBool = AtomicBool::new(false);
+static USER_KILL_SIGNAL_DELIVERED: AtomicBool = AtomicBool::new(false);
+
+/// SIGHUP/SIGINT/SIGQUIT/SIGTERM on every supported platform, plus the
+/// Windows CRT's SIGBREAK.
+fn is_kill_intent_signal(number: i32) -> bool {
+    matches!(number, 1 | 2 | 3 | 15 | 21)
+}
+
+/// Both signal-delivery paths note the signal before emitting: POSIX in
+/// [`PosixSignalTask::run_from_js_thread`], Windows in `signalHandler`'s
+/// posted task (BunProcess.cpp).
+#[unsafe(no_mangle)]
+pub extern "C" fn Bun__noteUserSignalDelivered(number: i32) {
+    if is_kill_intent_signal(number) {
+        USER_KILL_SIGNAL_DELIVERED.store(true, Ordering::Relaxed);
+    }
+}
 
 /// Runs the JS handlers of the configured `--watch-kill-signal` synchronously,
 /// mirroring node delivering that signal to the watched child before restart.
@@ -210,9 +226,8 @@ pub(crate) fn emit_watch_kill_signal_before_reload(global_object: &JSGlobalObjec
 
 impl PosixSignalTask {
     pub fn run_from_js_thread(number: u8, global_object: &JSGlobalObject) {
-        IS_EMITTING_SIGNAL_FOR_JS.store(true, Ordering::Relaxed);
+        Bun__noteUserSignalDelivered(i32::from(number));
         let fired = Bun__onSignalForJS(i32::from(number), global_object);
-        IS_EMITTING_SIGNAL_FOR_JS.store(false, Ordering::Relaxed);
         // Node parity: in watch mode the watcher exits 0 on SIGINT when the
         // script has no handler for it (see `enable_watch_mode_signals`).
         if !fired && number == SIGINT_NUMBER && WATCH_MODE_KILL_SIGNAL.load(Ordering::Relaxed) != 0

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1372,9 +1372,6 @@ impl VirtualMachine {
             || !el.next_immediate_tasks.is_empty()
     }
 
-    /// Clears the sticky termination exception a `--watch` `process.exit()`
-    /// left pending, so the event loop can keep ticking while the watcher
-    /// waits. `watch_exit_requested` stays set until the re-exec.
     /// `process.exit()` under [`Self::watch_exit_keepalive`]: unwind the run
     /// via a JSC termination and leave the watcher alive. Inverse:
     /// [`Self::clear_watch_exit_termination`].
@@ -1386,6 +1383,9 @@ impl VirtualMachine {
         self.jsc_vm().notify_need_termination();
     }
 
+    /// Clears the sticky termination exception a `--watch` `process.exit()`
+    /// left pending, so the event loop can keep ticking while the watcher
+    /// waits. `watch_exit_requested` stays set until the re-exec.
     pub fn clear_watch_exit_termination(&mut self) {
         if self.watch_exit_requested {
             self.global().clear_termination_exception();

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -301,6 +301,14 @@ pub struct VirtualMachine {
     pub pending_internal_promise_is_protected: bool,
     pub pending_internal_promise_reported_at: u32,
     pub(crate) hot_reload_deferred: bool,
+    /// `bun run --watch` only: `process.exit()` keeps the watcher alive
+    /// instead of exiting. `--hot` (in-process re-eval, where one-shot exit
+    /// state would persist across runs) and `bun test --watch` leave it unset.
+    pub watch_exit_keepalive: bool,
+    /// `process.exit()` was called under [`Self::watch_exit_keepalive`]: the
+    /// run was unwound via a JSC termination exception and the event loop
+    /// stays quiet until the watcher re-execs on the next file change.
+    pub watch_exit_requested: bool,
     pub entry_point_result: EntryPointResult,
 
     pub on_unhandled_rejection: OnUnhandledRejection,
@@ -1292,7 +1300,11 @@ impl VirtualMachine {
 
     /// Exported to C++ as `Bun__VM__scriptExecutionStatus` via virtual_machine_exports.rs.
     pub fn script_execution_status(&self) -> crate::ScriptExecutionStatus {
-        if self.is_shutting_down || !self.script_allowed() {
+        // `watch_exit_requested`: callbacks queued before a `--watch`
+        // `process.exit()` must not resume. On Windows libuv fires JS timers
+        // inside `tick_possibly_forever` after the termination is cleared, so
+        // this status check is what stops them.
+        if self.is_shutting_down || self.watch_exit_requested || !self.script_allowed() {
             crate::ScriptExecutionStatus::Stopped
         } else {
             crate::ScriptExecutionStatus::Running
@@ -1330,6 +1342,11 @@ impl VirtualMachine {
     }
 
     pub fn is_event_loop_alive_excluding_immediates(&self) -> bool {
+        // A `--watch` `process.exit()` ends the run, like an uncaught
+        // exception does via `unhandled_error_counter` below.
+        if self.watch_exit_requested {
+            return false;
+        }
         let el = self.event_loop_shared();
         let active = self
             .platform_loop_opt()
@@ -1346,10 +1363,33 @@ impl VirtualMachine {
     }
 
     pub fn is_event_loop_alive(&self) -> bool {
+        if self.watch_exit_requested {
+            return false;
+        }
         let el = self.event_loop_shared();
         self.is_event_loop_alive_excluding_immediates()
             || !el.immediate_tasks.is_empty()
             || !el.next_immediate_tasks.is_empty()
+    }
+
+    /// Clears the sticky termination exception a `--watch` `process.exit()`
+    /// left pending, so the event loop can keep ticking while the watcher
+    /// waits. `watch_exit_requested` stays set until the re-exec.
+    /// `process.exit()` under [`Self::watch_exit_keepalive`]: unwind the run
+    /// via a JSC termination and leave the watcher alive. Inverse:
+    /// [`Self::clear_watch_exit_termination`].
+    pub fn request_watch_exit_termination(&mut self) {
+        self.watch_exit_requested = true;
+        // The main thread builds the termination-exception singleton lazily
+        // (workers build it at startup), so create it before firing the trap.
+        self.global().request_termination();
+        self.jsc_vm().notify_need_termination();
+    }
+
+    pub fn clear_watch_exit_termination(&mut self) {
+        if self.watch_exit_requested {
+            self.global().clear_termination_exception();
+        }
     }
 
     pub fn wakeup(&mut self) {
@@ -1681,8 +1721,14 @@ impl VirtualMachine {
             }
             self.run_error_handler(err, None);
             // SAFETY: `global_object` is the live VM global; `process_exit` is
-            // `bun_runtime::node::process::exit` (main-thread `noreturn`).
+            // `bun_runtime::node::process::exit`, normally `noreturn` on the
+            // main thread.
             unsafe { (hooks.process_exit)(global_object.as_ptr(), 7) };
+            // Under `--watch`, `process_exit` returns after requesting
+            // termination; let that unwind instead of panicking.
+            if self.watch_exit_requested {
+                return true;
+            }
             panic!("Uncaught exception while handling uncaught exception");
         }
         self.is_handling_uncaught_exception = true;
@@ -1699,12 +1745,17 @@ impl VirtualMachine {
             // worker falls through and exits 1 below (e.g. a beforeExit throw).
             if self.exit_on_uncaught_exception && self.is_main_thread() {
                 self.run_error_handler(err, None);
-                // `process_exit` emits `exit`, re-entering here if a listener
-                // throws. No handler is running, so drop the recursion guard or
-                // that re-entry exits 7 ("handler threw") instead of 1.
+                // Outside `--watch`, `process_exit` emits `exit`, re-entering
+                // here if a listener throws. No handler is running, so drop
+                // the recursion guard or that re-entry exits 7 ("handler
+                // threw") instead of 1.
                 self.is_handling_uncaught_exception = false;
                 // SAFETY: see above.
                 unsafe { (hooks.process_exit)(global_object.as_ptr(), 1) };
+                // As above: `process_exit` may return under `--watch`.
+                if self.watch_exit_requested {
+                    return true;
+                }
                 panic!("made it past process.exit()");
             }
             // TODO maybe we want a separate code path for uncaught exceptions
@@ -1712,13 +1763,10 @@ impl VirtualMachine {
             self.exit_handler.exit_code = 1;
             (self.on_unhandled_rejection)(self, global_object, err);
         }
-        // Note: this reset must cover BOTH the FFI call and the
-        // `onUnhandledRejection` callback above. The flag must stay raised
-        // while that callback runs so a re-entrant `uncaught_exception` from
-        // a user handler trips the recursion guard and hard-exits with code 7
-        // instead of recursing. Neither the FFI call nor the fn-pointer
-        // callback unwind past this frame (re-entry hits `process_exit` →
-        // `panic!`, which never returns), so a linear reset here suffices.
+        // The flag must stay raised through the FFI call AND the
+        // `onUnhandledRejection` callback so re-entry trips the recursion
+        // guard above. That guard never re-enters this frame (it diverges or
+        // returns `true`), so a linear reset suffices.
         self.is_handling_uncaught_exception = false;
         handled
     }
@@ -1752,17 +1800,23 @@ impl VirtualMachine {
                     return;
                 }
                 self.tick();
-                if !self.script_allowed() {
+                // Also a watch exit during this tick: run no more JS.
+                if !self.script_allowed() || self.watch_exit_requested {
                     return;
                 }
                 self.auto_tick_active();
                 dispatch = true;
             }
 
-            // Same guards as on entry: a fatal throw or a stop requested during
-            // the inner drain must not re-dispatch. The main-thread case already
+            // Same guards as on entry: a fatal throw, a stop request, or a
+            // watch exit (possible inside `auto_tick_active`) during the
+            // inner drain must not re-dispatch. The main-thread case already
             // hard-exits via `exit_on_uncaught_exception`; this covers workers.
-            if dispatch && self.unhandled_error_counter == 0 && self.script_allowed() {
+            if dispatch
+                && self.unhandled_error_counter == 0
+                && self.script_allowed()
+                && !self.watch_exit_requested
+            {
                 ExitHandler::dispatch_on_before_exit(self);
                 dispatch = false;
 
@@ -2276,10 +2330,11 @@ pub struct RuntimeHooks {
     /// `ResolveMessage` arms in `Macro::Run::coerce`.
     pub body_mixin_get_blob:
         fn(value: JSValue, global: &JSGlobalObject) -> JsResult<Option<JSValue>>,
-    /// `process.exit(global, code)`. Main-thread is `noreturn`; in a worker
-    /// it returns and the caller `panic!`s. Lives in `bun_runtime::node`
-    /// (forward-dep cycle), so [`uncaught_exception`] reaches it through this
-    /// slot instead of the linker.
+    /// `process.exit(global, code)`. `noreturn` on the main thread EXCEPT
+    /// under `bun run --watch` and in a worker, where it returns after
+    /// requesting termination — callers must handle the returning case.
+    /// Lives in `bun_runtime::node` (forward-dep cycle), so
+    /// [`uncaught_exception`] reaches it through this slot.
     pub process_exit: unsafe fn(global: *mut JSGlobalObject, code: u8),
     /// `onBeforePrint()` for the `bun:test` runner, which lives in `bun_runtime`;
     /// `console.log` calls this so the test reporter can flush its line state
@@ -2996,6 +3051,11 @@ impl VirtualMachine {
         // pending_internal_promise can change if hot module reloading is enabled
         if self.is_watcher_enabled() {
             loop {
+                // A watch exit leaves the entry promise pending forever; stop
+                // spinning and let the watcher loop take over.
+                if self.watch_exit_requested {
+                    break;
+                }
                 let Some(p) = self.pending_internal_promise else {
                     break;
                 };
@@ -4939,6 +4999,14 @@ impl VirtualMachine {
         }
         let str = bun_core::EncodedSlice::latin1(MAIN_FILE_NAME);
         self.global().delete_module_registry_entry(&str)
+    }
+
+    /// `node:vm` consults this before mapping a main-thread termination onto
+    /// its SIGINT/timeout errors: a `--watch` `process.exit()` termination
+    /// must propagate to the top of the run instead.
+    #[unsafe(export_name = "Bun__VM__isWatchExitRequested")]
+    pub extern "C" fn is_watch_exit_requested(&self) -> bool {
+        self.watch_exit_requested
     }
 
     /// Whether the per-test-isolation source provider cache is active.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1377,6 +1377,10 @@ impl VirtualMachine {
     /// [`Self::clear_watch_exit_termination`].
     pub fn request_watch_exit_termination(&mut self) {
         self.watch_exit_requested = true;
+        // A termination that escapes script implies a closed gate
+        // (`takeTerminationOutsideScript` asserts it), and no more JS may
+        // enter before the re-exec anyway.
+        self.forbid_script();
         // The main thread builds the termination-exception singleton lazily
         // (workers build it at startup), so create it before firing the trap.
         self.global().request_termination();

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1375,6 +1375,9 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
         (void)call(lexicalGlobalObject, capture, args, "uncaughtExceptionCaptureCallback"_s);
         if (auto ex = scope.exception()) {
             (void)scope.tryClearException();
+            // A termination (a `--watch` process.exit() in the callback, a
+            // worker being stopped) is not a throw: it stays pending and
+            // keeps unwinding; we fall through to `return true`.
             if (vm.hasPendingTerminationException()) [[unlikely]]
                 return true;
             // if an exception is thrown in the uncaughtException handler, we abort
@@ -3746,9 +3749,9 @@ JSC_DEFINE_HOST_FUNCTION(Process_functionReallyExit, (JSGlobalObject * globalObj
     // while native shutdown (profiles, cleanup hooks, SQLite close) still runs.
     zigGlobal->processObject()->m_isExiting = true;
     Bun__Process__exit(zigGlobal, exitCode);
-    // Main-thread Bun__Process__exit is noreturn. In a worker it returns; the
-    // WebWorker exit path it called requests JSC termination (guarded so it's a
-    // no-op when re-entered from a process.on('exit') handler).
+    // Main-thread Bun__Process__exit is noreturn, except under
+    // `bun run --watch` and in a worker, where it returns after requesting
+    // JSC termination (which then unwinds JS at the next safepoint).
     throwScope.release();
     return JSC::JSValue::encode(jsUndefined());
 }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1345,8 +1345,9 @@ extern "C" int Bun__handleUncaughtException(JSC::JSGlobalObject* lexicalGlobalOb
                 return true;
         } else if (!fatalException.isCallable()) {
             Bun__Process__exit(globalObject, 6);
-            // Bun__Process__exit returns in a worker (only requests termination); don't
-            // fall through to the emit logic and report handled so exit code is preserved.
+            // Bun__Process__exit returns in a worker and under `bun run --watch` (only
+            // requests termination); don't fall through to the emit logic and report
+            // handled so exit code is preserved.
             return true;
         }
     }

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1313,6 +1313,7 @@ void signalHandler(uv_signal_t* signal, int signalNumber)
     // uv_signal_t callbacks fire on the uv_run thread (JS thread), but defer to avoid
     // re-entering JS from inside the libuv poll loop
     context->postTaskConcurrently([signalNumber](ScriptExecutionContext& context) {
+        Bun__noteUserSignalDelivered(signalNumber);
         Bun__onSignalForJS(signalNumber, uncheckedDowncast<Zig::GlobalObject>(context.jsGlobalObject()));
     });
 #else

--- a/src/jsc/bindings/BunProcess.cpp
+++ b/src/jsc/bindings/BunProcess.cpp
@@ -1313,8 +1313,10 @@ void signalHandler(uv_signal_t* signal, int signalNumber)
     // uv_signal_t callbacks fire on the uv_run thread (JS thread), but defer to avoid
     // re-entering JS from inside the libuv poll loop
     context->postTaskConcurrently([signalNumber](ScriptExecutionContext& context) {
+        auto* globalObject = uncheckedDowncast<Zig::GlobalObject>(context.jsGlobalObject());
         Bun__noteUserSignalDelivered(signalNumber);
-        Bun__onSignalForJS(signalNumber, uncheckedDowncast<Zig::GlobalObject>(context.jsGlobalObject()));
+        Bun__onSignalForJS(signalNumber, globalObject);
+        Bun__endParkedWatcherOnKillSignal(globalObject);
     });
 #else
 

--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -3001,6 +3001,13 @@ extern "C" [[ZIG_EXPORT(nothrow)]] double JSC__JSGlobalObject__jsDateNow(JSC::JS
 uint8_t GlobalObject::drainMicrotasks()
 {
     auto& vm = this->vm();
+
+    // A `--watch` process.exit() ended this run: callbacks queued before it
+    // (process.nextTick in particular has no other gate) must not resume
+    // while the watcher waits for the next change.
+    if (Bun__VM__isWatchExitRequested(bunVM())) [[unlikely]]
+        return 1;
+
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     // A stopped VM has no checkpoint to run: whether or not its termination is still pending here (the
@@ -3212,6 +3219,15 @@ extern "C" bool JSGlobalObject__setTimeZone(JSC::JSGlobalObject* globalObject, c
     }
 
     return false;
+}
+
+extern "C" void JSGlobalObject__requestTermination(JSC::JSGlobalObject* globalObject)
+{
+    auto& vm = JSC::getVM(globalObject);
+    // The main thread builds the termination-exception singleton lazily
+    // (workers build it at startup), so create it before requesting.
+    vm.ensureTerminationException();
+    vm.setHasTerminationRequest();
 }
 
 extern "C" void JSGlobalObject__clearTerminationException(JSC::JSGlobalObject* globalObject)

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -403,6 +403,7 @@ extern "C" bool Bun__resolveAndFetchBuiltinModule(
     const BunString* specifier,
     ErrorableResolvedSource* result);
 extern "C" bool Bun__VM__useIsolationSourceProviderCache(void* bunVM);
+extern "C" bool Bun__VM__isWatchExitRequested(void* bunVM);
 
 // Used in process.version
 extern "C" const char* Bun__version;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -404,6 +404,7 @@ extern "C" bool Bun__resolveAndFetchBuiltinModule(
     ErrorableResolvedSource* result);
 extern "C" bool Bun__VM__useIsolationSourceProviderCache(void* bunVM);
 extern "C" bool Bun__VM__isWatchExitRequested(void* bunVM);
+extern "C" void Bun__noteUserSignalDelivered(int signalNumber);
 
 // Used in process.version
 extern "C" const char* Bun__version;

--- a/src/jsc/bindings/headers-handwritten.h
+++ b/src/jsc/bindings/headers-handwritten.h
@@ -405,6 +405,7 @@ extern "C" bool Bun__resolveAndFetchBuiltinModule(
 extern "C" bool Bun__VM__useIsolationSourceProviderCache(void* bunVM);
 extern "C" bool Bun__VM__isWatchExitRequested(void* bunVM);
 extern "C" void Bun__noteUserSignalDelivered(int signalNumber);
+extern "C" void Bun__endParkedWatcherOnKillSignal(JSC::JSGlobalObject* globalObject);
 
 // Used in process.version
 extern "C" const char* Bun__version;

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1397,6 +1397,8 @@ impl Run<'_> {
                 }
             }
             cli::command::HotReload::Watch => {
+                // `--watch` only; see the field doc for why `--hot` opts out.
+                vm.watch_exit_keepalive = true;
                 // SAFETY: `vm` is the boxed-and-leaked main-thread VM
                 // (process-lifetime); it outlives the leaked reloader.
                 unsafe {
@@ -1422,6 +1424,9 @@ impl Run<'_> {
         }
 
         match vm.load_entry_point(entry) {
+            // A watch exit already unwound the run; fall through to the
+            // watcher loop.
+            _ if vm.watch_exit_requested => {}
             Ok(promise) => {
                 // SAFETY: `promise` is a live GC cell returned by the module loader.
                 let promise = unsafe { &mut *promise };
@@ -1466,7 +1471,9 @@ impl Run<'_> {
         // Drop what transpiling and linking the entry graph left behind before settling into the event loop. A
         // standalone executable has no transpiler garbage, and its unlinked code blocks came from the embedded bytecode
         // cache — deleting them here only means decoding them again on first call — so leave its heap to the collector.
+        // On a watch exit the termination exception is still pending, so don't tick here either.
         if vm.standalone_module_graph.is_none()
+            && !vm.watch_exit_requested
             && (vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0)
         {
             vm.global().vm().release_weak_refs();
@@ -1490,10 +1497,23 @@ impl Run<'_> {
             loop {
                 while vm.is_event_loop_alive() {
                     vm.tick();
+                    // Watch exit during this tick: its termination exception
+                    // is pending, so run no more JS.
+                    if vm.watch_exit_requested {
+                        break;
+                    }
                     vm.report_exception_in_hot_reloaded_module_if_needed();
                     vm.auto_tick_active();
                 }
-                vm.on_before_exit();
+                // Node does not fire `beforeExit` after `process.exit()`.
+                if !vm.watch_exit_requested {
+                    vm.on_before_exit();
+                }
+                // Re-checked after `on_before_exit`: a `beforeExit` handler
+                // may itself call `process.exit()`.
+                if vm.watch_exit_requested {
+                    vm.clear_watch_exit_termination();
+                }
                 vm.report_exception_in_hot_reloaded_module_if_needed();
                 // SAFETY: `event_loop` is a self-pointer into this VM; uniquely
                 // accessed here. Watcher arm keeps the process alive across

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -904,10 +904,11 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
         if unsafe { &*promise }.status() == PromiseStatus::Rejected {
             return Ok(promise);
         }
-        // A stop was requested (worker terminate()/exit) while it loaded: the
-        // caller checks the same and shuts down; load nothing more.
+        // A stop was requested (worker terminate()/exit) or a `--watch`
+        // process.exit() unwound this preload while it loaded: the caller
+        // checks the same and shuts down; load nothing more.
         // SAFETY: per fn contract.
-        if !unsafe { &*vm }.script_allowed() {
+        if !unsafe { &*vm }.script_allowed() || unsafe { &*vm }.watch_exit_requested {
             return Ok(core::ptr::null_mut());
         }
         // `_protected` drops here → unprotect.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1370,8 +1370,9 @@ fn body_mixin_get_blob(
     Ok(None)
 }
 
-/// `process.exit(code)`. Main-thread is `noreturn`; in a
-/// worker it returns and the caller `panic!`s.
+/// `process.exit(code)`. `noreturn` on the main thread except under
+/// `bun run --watch` and in a worker, where it returns after requesting
+/// termination.
 ///
 /// # Safety
 /// `global` is the live VM global.

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -866,6 +866,12 @@ unsafe fn load_preloads(vm: *mut VirtualMachine) -> bun_jsc::CrateResult<*mut JS
                 // SAFETY: `el` is the live per-thread event loop.
                 let el = unsafe { &*vm }.event_loop();
                 loop {
+                    // A watch exit leaves the preload promise pending forever;
+                    // stop spinning and let the watcher loop take over.
+                    // SAFETY: per fn contract — `vm` is the live per-thread VM.
+                    if unsafe { &*vm }.watch_exit_requested {
+                        break;
+                    }
                     // SAFETY: `pending_internal_promise` was set just above (or
                     // swapped by HMR to another live cell); `status()` is a
                     // read-only FFI call on a live JSC heap cell.

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -73,6 +73,17 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         // @190n: we may need to use requestTerminate or throwTerminationException
         // instead to terminate the worker sooner
         worker.exit();
+    } else if vm.watch_exit_keepalive
+        && !bun_jsc::posix_signal_handle::is_emitting_watch_kill_signal()
+    {
+        // `bun run --watch`: a real exit would kill the in-process watcher.
+        // Unwind the run via a JSC termination instead, like a thrown error
+        // does. JS `process.exit()` already ran `exit` handlers in
+        // `Process_functionExit`; the internal error-exit callers skip them
+        // here, matching an uncaught error under `--watch`. During a
+        // kill-signal emit a reload is already underway, so the
+        // replace-process path below applies instead.
+        vm.request_watch_exit_termination();
     } else {
         // A watch-reload kill-signal handler may call process.exit; node restarts the child
         // regardless. `process.exit()` must never return control to JS, so replace the process

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -75,7 +75,7 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         worker.exit();
     } else if vm.watch_exit_keepalive
         && !bun_jsc::posix_signal_handle::is_emitting_watch_kill_signal()
-        && !bun_jsc::posix_signal_handle::is_emitting_signal_for_js()
+        && !bun_jsc::posix_signal_handle::user_kill_signal_delivered()
     {
         // `bun run --watch`: a real exit would kill the in-process watcher.
         // Unwind the run via a JSC termination instead, like a thrown error
@@ -83,8 +83,8 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         // `Process_functionExit`; the internal error-exit callers skip them
         // here, matching an uncaught error under `--watch`. Exceptions: during
         // a kill-signal emit a reload is already underway (the replace-process
-        // path below applies), and an exit from a user-delivered signal
-        // handler must really exit: node's watcher dies with the child.
+        // path below applies), and any exit after the user delivered a kill
+        // signal must really exit: node's watcher dies with the child.
         vm.request_watch_exit_termination();
     } else {
         // A watch-reload kill-signal handler may call process.exit; node restarts the child

--- a/src/runtime/node/node_process.rs
+++ b/src/runtime/node/node_process.rs
@@ -75,14 +75,16 @@ pub(crate) extern "C" fn exit(global_object: &JSGlobalObject, code: u8) {
         worker.exit();
     } else if vm.watch_exit_keepalive
         && !bun_jsc::posix_signal_handle::is_emitting_watch_kill_signal()
+        && !bun_jsc::posix_signal_handle::is_emitting_signal_for_js()
     {
         // `bun run --watch`: a real exit would kill the in-process watcher.
         // Unwind the run via a JSC termination instead, like a thrown error
         // does. JS `process.exit()` already ran `exit` handlers in
         // `Process_functionExit`; the internal error-exit callers skip them
-        // here, matching an uncaught error under `--watch`. During a
-        // kill-signal emit a reload is already underway, so the
-        // replace-process path below applies instead.
+        // here, matching an uncaught error under `--watch`. Exceptions: during
+        // a kill-signal emit a reload is already underway (the replace-process
+        // path below applies), and an exit from a user-delivered signal
+        // handler must really exit: node's watcher dies with the child.
         vm.request_watch_exit_termination();
     } else {
         // A watch-reload kill-signal handler may call process.exit; node restarts the child

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -374,8 +374,9 @@ for (const [variant, handler] of [
 }
 
 // SIGINT while the watcher is parked after a watch exit: the handler's
-// deferred continuation can never fire there, so the watcher ends with the
-// completed run's exit code instead of trapping Ctrl+C forever.
+// run's handlers can never run there (the run is over and its script gate is
+// closed), so the watcher ends like the no-handler case instead of trapping
+// Ctrl+C forever.
 it.skipIf(isWindows)("--watch: SIGINT after a watch exit ends the parked watcher", async () => {
   using dir = tempDir("watch-sigint-parked", {
     "index.ts": `process.on("SIGINT", () => { setTimeout(() => process.exit(7), 10); });\nconsole.log("READY");\nprocess.exit(3);\n`,
@@ -401,7 +402,7 @@ it.skipIf(isWindows)("--watch: SIGINT after a watch exit ends the parked watcher
   expect(proc.exitCode).toBeNull();
 
   proc.kill("SIGINT");
-  expect(await proc.exited).toBe(3);
+  expect(await proc.exited).toBe(0);
   await waiter.cancel();
   expect(await stderrText).toBe("");
 });

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -296,9 +296,42 @@ test("--hot: process.exit() exits the process (no keepalive)", async () => {
 
   expect(stdout).toContain("HOT_RAN");
   expect(stdout).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+  expect(stderr).toBe("");
   // Exited on its own with the given code instead of staying alive as a watcher.
-  if (exitCode !== 3) console.error(stderr);
   expect(exitCode).toBe(3);
+});
+
+// Ctrl+C must still stop the watcher: process.exit() from a user's signal
+// handler is a real exit, not a keepalive unwind.
+it.skipIf(isWindows)("--watch: process.exit() in a SIGINT handler exits the watcher", async () => {
+  using dir = tempDir("watch-sigint-exit", {
+    "index.ts": `process.on("SIGINT", () => { process.exit(7); });\nconsole.log("READY");\nsetInterval(() => {}, 1000);\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--watch", "--no-clear-screen", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const stderrText = proc.stderr.text();
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (!out.includes("READY")) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
+    out += decoder.decode(value, { stream: true });
+  }
+
+  proc.kill("SIGINT");
+  // The handler's exit code is honored and the watcher is gone.
+  expect(await proc.exited).toBe(7);
+  await reader.cancel();
+  expect(await stderrText).toBe("");
 });
 
 // Watcher::start() must propagate a failed thread spawn as an Err through its

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -394,6 +394,12 @@ it.skipIf(isWindows)("--watch: SIGINT after a watch exit ends the parked watcher
   const waiter = stdoutWaiter(proc);
   await waiter.waitFor("READY", out => `watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
 
+  // Sit through at least one of the parked loop's ~1s idle wakeups: those
+  // tick with the watch exit's termination already cleared, which used to
+  // trip a debug assert. The time itself is the condition here.
+  await Bun.sleep(1500);
+  expect(proc.exitCode).toBeNull();
+
   proc.kill("SIGINT");
   expect(await proc.exited).toBe(3);
   await waiter.cancel();

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -340,6 +340,39 @@ for (const [variant, handler] of [
   });
 }
 
+// SIGINT while the watcher is parked after a watch exit: the handler's
+// deferred continuation can never fire there, so the watcher ends with the
+// completed run's exit code instead of trapping Ctrl+C forever.
+it.skipIf(isWindows)("--watch: SIGINT after a watch exit ends the parked watcher", async () => {
+  using dir = tempDir("watch-sigint-parked", {
+    "index.ts": `process.on("SIGINT", () => { setTimeout(() => process.exit(7), 10); });\nconsole.log("READY");\nprocess.exit(3);\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--watch", "--no-clear-screen", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const stderrText = proc.stderr.text();
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (!out.includes("READY")) {
+    const { done, value } = await reader.read();
+    if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
+    out += decoder.decode(value, { stream: true });
+  }
+
+  proc.kill("SIGINT");
+  expect(await proc.exited).toBe(3);
+  await reader.cancel();
+  expect(await stderrText).toBe("");
+});
+
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An
 // LD_PRELOAD shim arms on inotify_init1 (which Watcher::init() calls on Linux

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -301,38 +301,44 @@ test("--hot: process.exit() exits the process (no keepalive)", async () => {
   expect(exitCode).toBe(3);
 });
 
-// Ctrl+C must still stop the watcher: process.exit() from a user's signal
-// handler is a real exit, not a keepalive unwind.
-it.skipIf(isWindows)("--watch: process.exit() in a SIGINT handler exits the watcher", async () => {
-  using dir = tempDir("watch-sigint-exit", {
-    "index.ts": `process.on("SIGINT", () => { process.exit(7); });\nconsole.log("READY");\nsetInterval(() => {}, 1000);\n`,
+// Ctrl+C must still stop the watcher: once a kill signal is delivered,
+// process.exit() is a real exit, not a keepalive unwind, even when the
+// handler defers the exit past the synchronous emit.
+for (const [variant, handler] of [
+  ["direct", `process.exit(7);`],
+  ["deferred", `setTimeout(() => process.exit(7), 10);`],
+] as const) {
+  it.skipIf(isWindows)(`--watch: process.exit() in a SIGINT handler exits the watcher (${variant})`, async () => {
+    using dir = tempDir("watch-sigint-exit", {
+      "index.ts": `process.on("SIGINT", () => { ${handler} });\nconsole.log("READY");\nsetInterval(() => {}, 1000);\n`,
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    const stderrText = proc.stderr.text();
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let out = "";
+    while (!out.includes("READY")) {
+      const { done, value } = await reader.read();
+      if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
+      out += decoder.decode(value, { stream: true });
+    }
+
+    proc.kill("SIGINT");
+    // The handler's exit code is honored and the watcher is gone.
+    expect(await proc.exited).toBe(7);
+    await reader.cancel();
+    expect(await stderrText).toBe("");
   });
-
-  await using proc = spawn({
-    cmd: [bunExe(), "--watch", "--no-clear-screen", "index.ts"],
-    cwd: String(dir),
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-    stdin: "ignore",
-  });
-
-  const stderrText = proc.stderr.text();
-  const reader = proc.stdout.getReader();
-  const decoder = new TextDecoder();
-  let out = "";
-  while (!out.includes("READY")) {
-    const { done, value } = await reader.read();
-    if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
-    out += decoder.decode(value, { stream: true });
-  }
-
-  proc.kill("SIGINT");
-  // The handler's exit code is honored and the watcher is gone.
-  expect(await proc.exited).toBe(7);
-  await reader.cancel();
-  expect(await stderrText).toBe("");
-});
+}
 
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -276,6 +276,58 @@ for (const [scenario, fixture] of Object.entries(exitScenarios)) {
   });
 }
 
+// process.exit() in a --preload script unwinds inside load_preloads' own
+// promise-spin loop, which must bail like load_entry_point's does.
+test("--watch: process.exit() in a --preload script keeps the watcher alive", async () => {
+  const fixture = (n: number) =>
+    `console.log("MARK:${n}");\nprocess.exit(1);\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`;
+  using dir = tempDir("watch-preload-exit", {
+    "preload.ts": fixture(0),
+    "index.ts": `console.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
+  });
+  const path = join(String(dir), "preload.ts");
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--watch", "--no-clear-screen", "--preload=./preload.ts", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const stderrText = proc.stderr.text();
+  const decoder = new TextDecoder();
+  const reader = proc.stdout.getReader();
+  let out = "";
+  const waitForMark = async (n: number) => {
+    const marker = `MARK:${n}`;
+    while (!out.includes(marker)) {
+      const { done, value } = await reader.read();
+      if (done) {
+        throw new Error(
+          `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
+        );
+      }
+      out += decoder.decode(value, { stream: true });
+    }
+  };
+
+  await waitForMark(0);
+  for (let n = 1; n <= 2; n++) {
+    await writeFile(path, fixture(n));
+    await waitForMark(n);
+  }
+
+  // Neither the statement after exit nor the entry point may run.
+  expect(out).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+  expect(proc.exitCode).toBeNull();
+
+  await reader.cancel();
+  proc.kill();
+  expect(await stderrText).toBe("");
+});
+
 // The keepalive is scoped to --watch (it re-execs on change). --hot
 // re-evaluates in place, so process.exit() there still exits the process.
 test("--hot: process.exit() exits the process (no keepalive)", async () => {

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -1,8 +1,9 @@
 import type { Subprocess } from "bun";
 import { spawn } from "bun";
-import { afterEach, expect, it } from "bun:test";
+import { afterEach, expect, it, test } from "bun:test";
 import { bunEnv, bunExe, isBroken, isLinux, isWindows, tempDir, tmpdirSync } from "harness";
 import { readdirSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 let watchee: Subprocess;
@@ -185,6 +186,120 @@ for (;;) spawnThreadsForTesting(1000, fd, 2);
   },
   30000,
 );
+
+// process.exit() used to tear down the whole process in --watch mode, killing
+// the watcher itself. It should instead end the current run (like a thrown
+// error does) and keep the watcher waiting for the next change.
+// https://github.com/oven-sh/bun/issues/32648
+const exitScenarios = {
+  // process.exit() during top-level evaluation.
+  direct: (n: number) => `console.log("MARK:${n}");\nprocess.exit(1);\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
+  // Callbacks queued before process.exit() must not resume while the watcher
+  // waits for the next change.
+  "pending callbacks": (n: number) =>
+    `console.log("MARK:${n}");\nprocess.nextTick(() => console.log("AFTER_EXIT_SHOULD_NOT_PRINT"));\nsetImmediate(() => console.log("AFTER_EXIT_SHOULD_NOT_PRINT"));\nsetTimeout(() => console.log("AFTER_EXIT_SHOULD_NOT_PRINT"), 0);\nprocess.exit(1);\n`,
+  // process.exit() from a beforeExit handler: the run ends normally, then the
+  // handler calls process.exit() while the watcher loop is dispatching
+  // beforeExit.
+  "beforeExit handler": (n: number) =>
+    `console.log("MARK:${n}");\nprocess.on("beforeExit", () => { process.exit(1); console.log("AFTER_EXIT_SHOULD_NOT_PRINT"); });\n`,
+  // A beforeExit handler that defers process.exit() to a timer: the exit fires
+  // inside on_before_exit's own drain loop, which must not re-dispatch
+  // beforeExit or run more JS.
+  "deferred exit in beforeExit": (n: number) =>
+    `console.log("MARK:${n}");\nprocess.on("beforeExit", () => setTimeout(() => { process.exit(1); console.log("AFTER_EXIT_SHOULD_NOT_PRINT"); }, 0));\n`,
+  // process.exit() inside a node:vm script: node:vm converts terminations to
+  // SIGINT/timeout errors (and aborts on any other source), so the watch-exit
+  // termination must propagate through it instead.
+  "node:vm script": (n: number) =>
+    `console.log("MARK:${n}");\nrequire("node:vm").runInThisContext("process.exit(1)");\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
+  // process.exit() inside an uncaughtExceptionCaptureCallback: the termination
+  // unwinding the callback must not be logged as if the callback threw.
+  "capture callback": (n: number) =>
+    `console.log("MARK:${n}");\nprocess.setUncaughtExceptionCaptureCallback(() => { process.exit(1); console.log("AFTER_EXIT_SHOULD_NOT_PRINT"); });\nthrow new Error("handled by capture callback");\n`,
+} as const;
+
+for (const [scenario, fixture] of Object.entries(exitScenarios)) {
+  test(`--watch: process.exit() (${scenario}) keeps the watcher alive`, async () => {
+    using dir = tempDir("watch-process-exit", { "index.ts": fixture(0) });
+    const path = join(String(dir), "index.ts");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--watch", "--no-clear-screen", "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+
+    // Drain stderr so a full pipe never blocks the child.
+    const stderrText = proc.stderr.text();
+
+    const decoder = new TextDecoder();
+    const reader = proc.stdout.getReader();
+    let out = "";
+    const waitForMark = async (n: number) => {
+      const marker = `MARK:${n}`;
+      while (!out.includes(marker)) {
+        const { done, value } = await reader.read();
+        if (done) {
+          throw new Error(
+            `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
+          );
+        }
+        out += decoder.decode(value, { stream: true });
+      }
+    };
+
+    // First run executes and calls process.exit().
+    await waitForMark(0);
+
+    // Each edit must reload, proving the watcher survived the previous
+    // process.exit().
+    for (let n = 1; n <= 2; n++) {
+      await writeFile(path, fixture(n));
+      await waitForMark(n);
+    }
+
+    // process.exit() stops execution: the statement after it never runs.
+    expect(out).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+    // The watcher is still running (we reloaded twice after process.exit()).
+    expect(proc.exitCode).toBeNull();
+
+    await reader.cancel();
+    proc.kill();
+    // Every scenario's error is consumed before it becomes unhandled, so
+    // nothing (like a rendering of the internal termination exception) may
+    // reach stderr.
+    expect(await stderrText).toBe("");
+  });
+}
+
+// The keepalive is scoped to --watch (it re-execs on change). --hot
+// re-evaluates in place, so process.exit() there still exits the process.
+test("--hot: process.exit() exits the process (no keepalive)", async () => {
+  using dir = tempDir("hot-process-exit", {
+    "index.ts": `console.log("HOT_RAN");\nprocess.exit(3);\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "--hot", "--no-clear-screen", "index.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toContain("HOT_RAN");
+  expect(stdout).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+  // Exited on its own with the given code instead of staying alive as a watcher.
+  if (exitCode !== 3) console.error(stderr);
+  expect(exitCode).toBe(3);
+});
 
 // Watcher::start() must propagate a failed thread spawn as an Err through its
 // Result return instead of aborting inside start() with `.expect()`. An

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -277,18 +277,20 @@ for (const [scenario, fixture] of Object.entries(exitScenarios)) {
 }
 
 // process.exit() in a --preload script unwinds inside load_preloads' own
-// promise-spin loop, which must bail like load_entry_point's does.
+// promise-spin loop, which must bail like load_entry_point's does, and must
+// not go on to load the remaining preloads or the entry point.
 test("--watch: process.exit() in a --preload script keeps the watcher alive", async () => {
   const fixture = (n: number) =>
     `console.log("MARK:${n}");\nprocess.exit(1);\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`;
   using dir = tempDir("watch-preload-exit", {
     "preload.ts": fixture(0),
+    "preload2.ts": `console.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
     "index.ts": `console.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`,
   });
   const path = join(String(dir), "preload.ts");
 
   await using proc = spawn({
-    cmd: [bunExe(), "--watch", "--no-clear-screen", "--preload=./preload.ts", "index.ts"],
+    cmd: [bunExe(), "--watch", "--no-clear-screen", "--preload=./preload.ts", "--preload=./preload2.ts", "index.ts"],
     cwd: String(dir),
     env: bunEnv,
     stdout: "pipe",

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -13,15 +13,18 @@ function stdoutWaiter(proc: Subprocess<"ignore", "pipe", any>) {
   const decoder = new TextDecoder();
   let output = "";
   return {
-    waitFor: async (needle: string) => {
+    waitFor: async (needle: string, closedMessage?: (output: string) => string) => {
       while (!output.includes(needle)) {
         const { value, done } = await reader.read();
-        if (done) throw new Error(`stream closed, output so far: ${JSON.stringify(output)}`);
+        if (done) {
+          throw new Error(closedMessage?.(output) ?? `stream closed, output so far: ${JSON.stringify(output)}`);
+        }
         output += decoder.decode(value, { stream: true });
       }
     },
-    release: () => reader.releaseLock(),
     output: () => output,
+    release: () => reader.releaseLock(),
+    cancel: () => reader.cancel(),
   };
 }
 
@@ -236,21 +239,12 @@ for (const [scenario, fixture] of Object.entries(exitScenarios)) {
     // Drain stderr so a full pipe never blocks the child.
     const stderrText = proc.stderr.text();
 
-    const decoder = new TextDecoder();
-    const reader = proc.stdout.getReader();
-    let out = "";
-    const waitForMark = async (n: number) => {
-      const marker = `MARK:${n}`;
-      while (!out.includes(marker)) {
-        const { done, value } = await reader.read();
-        if (done) {
-          throw new Error(
-            `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
-          );
-        }
-        out += decoder.decode(value, { stream: true });
-      }
-    };
+    const waiter = stdoutWaiter(proc);
+    const waitForMark = (n: number) =>
+      waiter.waitFor(
+        `MARK:${n}`,
+        out => `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
+      );
 
     // First run executes and calls process.exit().
     await waitForMark(0);
@@ -263,11 +257,11 @@ for (const [scenario, fixture] of Object.entries(exitScenarios)) {
     }
 
     // process.exit() stops execution: the statement after it never runs.
-    expect(out).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+    expect(waiter.output()).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
     // The watcher is still running (we reloaded twice after process.exit()).
     expect(proc.exitCode).toBeNull();
 
-    await reader.cancel();
+    await waiter.cancel();
     proc.kill();
     // Every scenario's error is consumed before it becomes unhandled, so
     // nothing (like a rendering of the internal termination exception) may
@@ -299,21 +293,12 @@ test("--watch: process.exit() in a --preload script keeps the watcher alive", as
   });
 
   const stderrText = proc.stderr.text();
-  const decoder = new TextDecoder();
-  const reader = proc.stdout.getReader();
-  let out = "";
-  const waitForMark = async (n: number) => {
-    const marker = `MARK:${n}`;
-    while (!out.includes(marker)) {
-      const { done, value } = await reader.read();
-      if (done) {
-        throw new Error(
-          `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
-        );
-      }
-      out += decoder.decode(value, { stream: true });
-    }
-  };
+  const waiter = stdoutWaiter(proc);
+  const waitForMark = (n: number) =>
+    waiter.waitFor(
+      `MARK:${n}`,
+      out => `watcher exited before reload ${n} (process.exit() killed it). stdout so far: ${JSON.stringify(out)}`,
+    );
 
   await waitForMark(0);
   for (let n = 1; n <= 2; n++) {
@@ -322,10 +307,10 @@ test("--watch: process.exit() in a --preload script keeps the watcher alive", as
   }
 
   // Neither the statement after exit nor the entry point may run.
-  expect(out).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+  expect(waiter.output()).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
   expect(proc.exitCode).toBeNull();
 
-  await reader.cancel();
+  await waiter.cancel();
   proc.kill();
   expect(await stderrText).toBe("");
 });
@@ -377,19 +362,13 @@ for (const [variant, handler] of [
     });
 
     const stderrText = proc.stderr.text();
-    const reader = proc.stdout.getReader();
-    const decoder = new TextDecoder();
-    let out = "";
-    while (!out.includes("READY")) {
-      const { done, value } = await reader.read();
-      if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
-      out += decoder.decode(value, { stream: true });
-    }
+    const waiter = stdoutWaiter(proc);
+    await waiter.waitFor("READY", out => `watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
 
     proc.kill("SIGINT");
     // The handler's exit code is honored and the watcher is gone.
     expect(await proc.exited).toBe(7);
-    await reader.cancel();
+    await waiter.cancel();
     expect(await stderrText).toBe("");
   });
 }
@@ -412,18 +391,12 @@ it.skipIf(isWindows)("--watch: SIGINT after a watch exit ends the parked watcher
   });
 
   const stderrText = proc.stderr.text();
-  const reader = proc.stdout.getReader();
-  const decoder = new TextDecoder();
-  let out = "";
-  while (!out.includes("READY")) {
-    const { done, value } = await reader.read();
-    if (done) throw new Error(`watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
-    out += decoder.decode(value, { stream: true });
-  }
+  const waiter = stdoutWaiter(proc);
+  await waiter.waitFor("READY", out => `watcher exited before READY. stdout so far: ${JSON.stringify(out)}`);
 
   proc.kill("SIGINT");
   expect(await proc.exited).toBe(3);
-  await reader.cancel();
+  await waiter.cancel();
   expect(await stderrText).toBe("");
 });
 

--- a/test/cli/watch/watch.test.ts
+++ b/test/cli/watch/watch.test.ts
@@ -222,8 +222,10 @@ const exitScenarios = {
     `console.log("MARK:${n}");\nprocess.setUncaughtExceptionCaptureCallback(() => { process.exit(1); console.log("AFTER_EXIT_SHOULD_NOT_PRINT"); });\nthrow new Error("handled by capture callback");\n`,
 } as const;
 
+// The reload-on-edit these rely on is what `should watch files` marks
+// expected-broken on Windows CI above; same gate here.
 for (const [scenario, fixture] of Object.entries(exitScenarios)) {
-  test(`--watch: process.exit() (${scenario}) keeps the watcher alive`, async () => {
+  it.todoIf(isBroken && isWindows)(`--watch: process.exit() (${scenario}) keeps the watcher alive`, async () => {
     using dir = tempDir("watch-process-exit", { "index.ts": fixture(0) });
     const path = join(String(dir), "index.ts");
 
@@ -273,7 +275,7 @@ for (const [scenario, fixture] of Object.entries(exitScenarios)) {
 // process.exit() in a --preload script unwinds inside load_preloads' own
 // promise-spin loop, which must bail like load_entry_point's does, and must
 // not go on to load the remaining preloads or the entry point.
-test("--watch: process.exit() in a --preload script keeps the watcher alive", async () => {
+it.todoIf(isBroken && isWindows)("--watch: process.exit() in a --preload script keeps the watcher alive", async () => {
   const fixture = (n: number) =>
     `console.log("MARK:${n}");\nprocess.exit(1);\nconsole.log("AFTER_EXIT_SHOULD_NOT_PRINT");\n`;
   using dir = tempDir("watch-preload-exit", {

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import {
   compileFunction,
   constants,
@@ -1974,3 +1974,42 @@ describe("node:vm lineOffset/columnOffset at the edge of int32", () => {
     expect(position).toBeLessThanOrEqual(INT32_MAX);
   });
 });
+
+// process.exit() in a Worker raises a JSC termination that is neither SIGINT
+// nor the watchdog firing; node:vm must let it propagate (and must not
+// misreport it as ERR_SCRIPT_EXECUTION_TIMEOUT when a timeout is armed)
+// so the worker can exit.
+for (const [variant, options] of [
+  ["no options", ""],
+  ["armed timeout", ", { timeout: 60_000 }"],
+] as const) {
+  test(`process.exit() inside vm.runInThisContext in a Worker exits only the worker (${variant})`, async () => {
+    using dir = tempDir("vm-worker-exit", {
+      "main.js": `
+        const { Worker } = require("node:worker_threads");
+        const { join } = require("node:path");
+        const w = new Worker(join(__dirname, "w.js"));
+        w.on("exit", code => console.log("WORKER_EXIT " + code));
+      `,
+      "w.js": `
+        require("node:vm").runInThisContext("process.exit(7)"${options});
+        console.log("AFTER_EXIT_SHOULD_NOT_PRINT");
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("WORKER_EXIT 7");
+    expect(stdout).not.toContain("AFTER_EXIT_SHOULD_NOT_PRINT");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+}


### PR DESCRIPTION
Fixes #32648

### Problem

In `--watch` mode the file watcher runs in the same process that runs the user's code. Calling `process.exit()` tore down the whole process via `global_exit`, which killed the watcher too, so file changes no longer triggered a reload and the user had to restart manually.

Every other way a run ends already keeps the watcher alive and reloads on the next change:

- script finishes normally -> watcher alive
- uncaught exception (`throw`) -> watcher alive
- `process.exit()` -> **watcher died** (this PR)

Node's `--watch` keeps the runner alive in all of these cases.

```ts
// index.ts
console.log("shall not pass");
process.exit(1);
console.log("pass"); // should not run
```

`bun --watch index.ts`, then edit the file: before this change the process was already gone, so the edit did nothing.

### Cause

On the main thread, `Bun__Process__exit` (`src/runtime/node/node_process.rs`) unconditionally ran `vm.on_exit()` + `vm.global_exit()` (a diverging full teardown). There was no watch branch, so the watcher thread went down with the process.

### Fix

In `--watch`, `process.exit()` on the main thread now stops the current run the same way a thrown error does, instead of exiting:

- Raise a JSC termination exception to unwind the run, so statements after `process.exit()` do not execute (matches Node).
- Set a `watch_exit_keepalive`-gated `watch_exit_requested` flag so the event loop reports as finished, mirroring how an uncaught exception lets the watcher loop fall through to waiting for the next change.
- The watcher re-execs the process on the next file change, as it already does for a normal run.

`process.exit()` outside `--watch` is unchanged (still exits with the given code).

**Scope: `--watch` only.** `--hot` re-evaluates in the same process, where process-exit state that is one-shot for a process lifetime (the `process.on('exit')` dispatch guard, `process._exiting`, ...) would persist across runs. `--watch` re-execs, so every run starts clean and none of that applies. `--hot` keeps exiting the process as before; the linked issue is about `--watch`.

Because `Bun__Process__exit` now returns on the main thread under `--watch`, `VirtualMachine::uncaught_exception` no longer assumes it diverges: it re-checks `watch_exit_requested` after `process_exit` and lets the termination unwind instead of panicking on the re-entrant / exit-on-uncaught paths.

### Verification

New tests in `test/cli/watch/watch.test.ts` for `--watch`: `process.exit()` during top-level evaluation and from a `beforeExit` handler. Each spawns the watcher, asserts the post-`exit` line never runs, edits the file, and asserts it reloads (proving the watcher survived).

- Fail on the released binary (`USE_SYSTEM_BUN=1`): `watcher exited before reload 1 (process.exit() killed it)`.
- Pass on the debug build.
- Manually verified: a re-entrant `uncaughtException` no longer panics the watcher; `--hot` and `bun test --watch` exit cleanly as before; full `watch.test.ts` passes.


---

### Merge with main (resolved)

Merged latest `main` (branch was ~235 commits behind). One conflict, in `src/jsc/VirtualMachine.rs::uncaught_exception`: `main` restructured the function, moving the `exit_on_uncaught_exception` handling out of its old spot (before the recursion guard) into the `if !handled` block after `Bun__handleUncaughtException`. I took `main`'s new structure and re-applied this PR's fix there: after `process_exit(1)`, return instead of `panic!` when `watch_exit_requested` or the VM is a worker (since `process_exit` now returns in those cases). The recursion-guard branch already carried the same check via the auto-merge. Rebuilt and re-ran `test/cli/watch/watch.test.ts` (6 pass) plus a re-entrant `uncaughtException` spot check (watcher survives, no panic).

### Hardening from review (same termination mechanism)

- `node:vm`: the classification sites (`checkForTermination` in `NodeVMScript.cpp`, two in `NodeVMModule.cpp`) mapped every termination to SIGINT/timeout errors and release-asserted on any other source ("vm.Script terminated due neither to SIGINT nor to timeout"). The watch-exit termination hit that assert, and so did the pre-existing case of `process.exit()` (or `terminate()`) in a Worker running `node:vm`, which aborted the whole process on released builds too. Terminations node:vm doesn't own now stay pending and unwind; the asserts are gone. Worker test added to `test/js/node/vm/vm.test.ts`.
- `uncaughtExceptionCaptureCallback`: a `process.exit()` inside the callback was logged as if the callback threw (the internal termination sentinel rendered to stderr) and re-entered exit with code 1; now guarded with `isTerminationException`.
- `process.nextTick`: callbacks queued before the exit ran once the watcher wait cleared the termination, because the nextTick drain in `GlobalObject::drainMicrotasks` has no execution-status gate; the drain now returns early on a watch exit.
- `on_before_exit`: a `beforeExit` handler deferring `process.exit()` to a timer could tick once more and re-dispatch `beforeExit`; the drain loop now stops on the flag.

Watch test scenarios grew to cover each of these (direct, pending callbacks including nextTick, beforeExit, deferred beforeExit exit, node:vm, capture callback), all failing on the released binary and passing on the debug build, with stderr asserted empty.

### Rebases (resolved)

- Fourth rebase: trivial. Main added a `standalone_module_graph` condition on the post-entry GC/tick block in `run_command.rs` at the same spot this PR adds `!watch_exit_requested`; both conditions combined. A new pthread test landed at the same insertion point in `watch.test.ts`; both kept.
- Third rebase: main redesigned node:vm termination (`NodeVMRunTermination`), which subsumes this PR's node:vm guards (dropped; the worker tests are kept), and added `takeTerminationOutsideScript`, which asserts that a termination escaping script implies a closed script gate. The watch exit now closes the gate via `forbid_script` (no JS may enter before the re-exec anyway); a kill signal delivered to the parked watcher therefore ends it like the no-handler case (exit 0) instead of running the dead run's handlers.
- Rebased onto current main twice before that on maintainer/harness request. The only recurring conflict is `VirtualMachine.rs`: main independently added `script_allowed()` guards at the same spots this PR guards with `watch_exit_requested` (`script_execution_status`, `on_before_exit`'s drain loop); resolved by combining both conditions. Main's `VmHandle::script_allowed` mechanism also replaced this PR's earlier worker-specific node:vm guards. Full `watch.test.ts` (19) and `vm.test.ts` (314) re-run after each rebase.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 18 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/vm/vm.test.ts, test/cli/watch/watch.test.ts

<!-- robobun:evidence:end -->



