### PR TITLE
node:http: fix panic when drain fires with cleared onWritable slot

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2977,14 +2977,15 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
     }
 
 #if ASSERT_ENABLED
-    JSC::Integrity::auditCellFully(vm, jsObject.asCell());
+    if (jsObject.isCell())
+        JSC::Integrity::auditCellFully(vm, jsObject.asCell());
 #endif
 
     auto callData = getCallData(jsObject);
 
-    ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
-    ASSERT(callData.type != JSC::CallData::Type::None);
     if (callData.type == JSC::CallData::Type::None) [[unlikely]] {
+        if (asyncContextData)
+            asyncContextData->putInternalField(vm, 0, restoreAsyncContext);
         throwException(globalObject, scope, createNotAFunctionError(globalObject, jsObject));
         return {};
     }

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2984,8 +2984,10 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
 
     ASSERT_WITH_MESSAGE(jsObject.isCallable(), "Function passed to .call must be callable.");
     ASSERT(callData.type != JSC::CallData::Type::None);
-    if (callData.type == JSC::CallData::Type::None)
+    if (callData.type == JSC::CallData::Type::None) [[unlikely]] {
+        throwException(globalObject, scope, createNotAFunctionError(globalObject, jsObject));
         return {};
+    }
 
     auto result = JSC::profiledCall(globalObject, ProfilingReason::API, jsObject, callData, jsThisObject, argList);
 

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -1339,9 +1339,13 @@ impl NodeHTTPResponse {
             self.deref();
             return;
         };
+        if on_writable.is_undefined() {
+            self.deref();
+            return;
+        }
         let vm = vm_get();
         let global_this = vm.global();
-        js::on_writable_set_cached(this_value, global_this, JSValue::UNDEFINED); // TODO(@heimskr): is this necessary?
+        js::on_writable_set_cached(this_value, global_this, JSValue::ZERO);
 
         vm.event_loop_ref().run_callback(
             on_writable,

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -107,44 +107,4 @@ describe("backpressure", () => {
 
     expect(totalBytes).toBe(totalSize + smallPayloadSize);
   }, 30_000);
-
-  it("does not crash when drain fires after the onWritable slot was cleared", async () => {
-    const src = /* js */ `
-      import http from "node:http";
-      import net from "node:net";
-      import { once } from "node:events";
-
-      const server = http.createServer(async (req, res) => {
-        res.writeHead(200, { "Content-Type": "application/octet-stream" });
-        res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
-        const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
-        const handle = res[sym];
-        handle.onwritable = undefined;
-        while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
-        res.end();
-      });
-      await once(server.listen(0), "listening");
-
-      const sock = net.connect(server.address().port, "127.0.0.1");
-      await once(sock, "connect");
-      sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
-      let received = 0;
-      sock.on("data", d => (received += d.length));
-      await once(sock, "close");
-      console.log(JSON.stringify({ received }));
-      server.close();
-    `;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", src],
-      env: bunEnv,
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
-      stdout: { received: expect.any(Number) },
-      stderr: "",
-      exitCode: 0,
-    });
-    expect(JSON.parse(stdout).received).toBeGreaterThan(8 * 1024 * 1024);
-  });
 });

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -5,7 +5,6 @@
  *
  * A handful of older tests do not run in Node in this file. These tests should be updated to run in Node, or deleted.
  */
-import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -8,6 +8,7 @@
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
+import { bunEnv, bunExe } from "harness";
 
 describe("backpressure", () => {
   // Writes `total` bytes to `res` in `chunk`-sized pieces, waiting for "drain"
@@ -106,4 +107,44 @@ describe("backpressure", () => {
 
     expect(totalBytes).toBe(totalSize + smallPayloadSize);
   }, 30_000);
+
+  it("does not crash when drain fires after the onWritable slot was cleared", async () => {
+    const src = /* js */ `
+      import http from "node:http";
+      import net from "node:net";
+      import { once } from "node:events";
+
+      const server = http.createServer(async (req, res) => {
+        res.writeHead(200, { "Content-Type": "application/octet-stream" });
+        res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
+        const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
+        const handle = res[sym];
+        handle.onwritable = undefined;
+        while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
+        res.end();
+      });
+      await once(server.listen(0), "listening");
+
+      const sock = net.connect(server.address().port, "127.0.0.1");
+      await once(sock, "connect");
+      sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+      let received = 0;
+      sock.on("data", d => (received += d.length));
+      await once(sock, "close");
+      console.log(JSON.stringify({ received }));
+      server.close();
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+      stdout: { received: expect.any(Number) },
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(JSON.parse(stdout).received).toBeGreaterThan(8 * 1024 * 1024);
+  });
 });

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -5,10 +5,10 @@
  *
  * A handful of older tests do not run in Node in this file. These tests should be updated to run in Node, or deleted.
  */
+import { bunEnv, bunExe } from "harness";
 import { once } from "node:events";
 import http from "node:http";
 import type { AddressInfo } from "node:net";
-import { bunEnv, bunExe } from "harness";
 
 describe("backpressure", () => {
   // Writes `total` bytes to `res` in `chunk`-sized pieces, waiting for "drain"

--- a/test/js/node/http/node-http-uaf.test.ts
+++ b/test/js/node/http/node-http-uaf.test.ts
@@ -21,3 +21,43 @@ function uafTest(fixture, iterations = 2) {
     }
   });
 }
+
+test("should not crash when drain fires after the onWritable slot was cleared", async () => {
+  const src = /* js */ `
+    import http from "node:http";
+    import net from "node:net";
+    import { once } from "node:events";
+
+    const server = http.createServer(async (req, res) => {
+      res.writeHead(200, { "Content-Type": "application/octet-stream" });
+      res.write(Buffer.alloc(8 * 1024 * 1024, "a"));
+      const sym = Object.getOwnPropertySymbols(res).find(s => s.description === "handle");
+      const handle = res[sym];
+      handle.onwritable = undefined;
+      while (handle.bufferedAmount > 0) await new Promise(r => setImmediate(r));
+      res.end();
+    });
+    await once(server.listen(0), "listening");
+
+    const sock = net.connect(server.address().port, "127.0.0.1");
+    await once(sock, "connect");
+    sock.write("GET / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\n\\r\\n");
+    let received = 0;
+    sock.on("data", d => (received += d.length));
+    await once(sock, "close");
+    console.log(JSON.stringify({ received }));
+    server.close();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: JSON.parse(stdout || "null"), stderr, exitCode }).toEqual({
+    stdout: { received: expect.any(Number) },
+    stderr: "",
+    exitCode: 0,
+  });
+  expect(JSON.parse(stdout).received).toBeGreaterThan(8 * 1024 * 1024);
+});


### PR DESCRIPTION
Fixes a release-build panic: `A JavaScript exception was thrown, but it was cleared before it could be read.`

`NodeHTTPResponse::on_drain_corked` clears the cached `onWritable` slot to `UNDEFINED` after each drain. The codegen `on_writable_get_cached` only returns `None` for an empty `WriteBarrier`, so a subsequent drain on the same response reads `Some(UNDEFINED)` and passes it to `run_callback`. `Bun__JSValue__call` then hit its non-callable fallback and returned `{}` **without throwing**, which the Rust `zero_is_throw` wrapper mapped to `Err(JsError::Thrown)`; `take_exception` then panicked because no exception was pending.

Two changes:
- `on_drain_corked` now early-returns on an `undefined` callback (matching the existing `on_data` guard) and clears the slot with `JSValue::ZERO` so it round-trips to `None`.
- `Bun__JSValue__call` throws a `TypeError` (via `createNotAFunctionError`) when handed a non-callable instead of silently returning `{}`, so any future caller hitting this state surfaces an uncaught exception instead of a process panic. The async-context swap is restored before the early return.

The new test reproduces the production state by setting `handle.onwritable = undefined` while the uWS writable handler is still registered, then draining; it panics on current `main` and passes with the fix.

Supersedes #28455 (same C++ contract fix; this PR also fixes the `node:http` caller and adds a regression test).
The C++ change also turns the #29145 RedisClient `onclose = null` panic into a catchable `TypeError`.