### PR TITLE
Fix assertion failure constructing jest.fn() via Reflect.construct

### DIFF
--- a/src/jsc/bindings/JSMockFunction.cpp
+++ b/src/jsc/bindings/JSMockFunction.cpp
@@ -86,6 +86,7 @@ inline To tryJSDynamicCast(JSC::WriteBarrier<WriteBarrierT>& from)
 }
 
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionCall);
+JSC_DECLARE_HOST_FUNCTION(jsMockFunctionConstruct);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_protoImpl);
 JSC_DECLARE_CUSTOM_GETTER(jsMockFunctionGetter_mock);
 JSC_DECLARE_HOST_FUNCTION(jsMockFunctionGetter_mockGetLastCall);
@@ -462,7 +463,7 @@ public:
     }
 
     JSMockFunction(JSC::VM& vm, JSC::Structure* structure, CallbackKind wrapKind)
-        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionCall)
+        : Base(vm, structure, jsMockFunctionCall, jsMockFunctionConstruct)
     {
         initMock();
     }
@@ -979,6 +980,28 @@ JSC_DEFINE_HOST_FUNCTION(jsMockFunctionCall, (JSGlobalObject * lexicalGlobalObje
 
     setReturnValue(createMockResult(vm, globalObject, "return"_s, jsUndefined()));
     return JSValue::encode(jsUndefined());
+}
+
+JSC_DEFINE_HOST_FUNCTION(jsMockFunctionConstruct, (JSGlobalObject * lexicalGlobalObject, CallFrame* callframe))
+{
+    auto& vm = JSC::getVM(lexicalGlobalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* newTarget = asObject(callframe->newTarget());
+    JSGlobalObject* functionGlobalObject = getFunctionRealm(lexicalGlobalObject, newTarget);
+    RETURN_IF_EXCEPTION(scope, {});
+    Structure* structure = InternalFunction::createSubclassStructure(lexicalGlobalObject, newTarget, functionGlobalObject->objectStructureForObjectConstructor());
+    RETURN_IF_EXCEPTION(scope, {});
+    JSObject* thisObject = constructEmptyObject(vm, structure);
+    callframe->setThisValue(thisObject);
+
+    EncodedJSValue encodedResult = jsMockFunctionCall(lexicalGlobalObject, callframe);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    JSValue result = JSValue::decode(encodedResult);
+    if (result.isObject())
+        return encodedResult;
+    return JSValue::encode(thisObject);
 }
 
 void JSMockFunctionPrototype::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)

--- a/test/js/bun/test/mock-fn.test.js
+++ b/test/js/bun/test/mock-fn.test.js
@@ -794,6 +794,28 @@ describe("mock()", () => {
 
     expect(bar()()).toBe(true);
   });
+
+  it("Reflect.construct returns an object when the implementation does not", () => {
+    const noImpl = jest.fn();
+    expect(typeof Reflect.construct(noImpl, [])).toBe("object");
+    expect(typeof new noImpl()).toBe("object");
+
+    const primitiveImpl = jest.fn(() => 42);
+    expect(typeof Reflect.construct(primitiveImpl, [])).toBe("object");
+    expect(typeof new primitiveImpl()).toBe("object");
+
+    const returnsPrimitive = jest.fn().mockReturnValue(42);
+    expect(typeof Reflect.construct(returnsPrimitive, [])).toBe("object");
+    expect(typeof new returnsPrimitive()).toBe("object");
+
+    const sentinel = {};
+    const objectImpl = jest.fn(() => sentinel);
+    expect(Reflect.construct(objectImpl, [])).toBe(sentinel);
+    expect(new objectImpl()).toBe(sentinel);
+
+    expect(noImpl()).toBeUndefined();
+    expect(primitiveImpl()).toBe(42);
+  });
 });
 
 describe("spyOn", () => {


### PR DESCRIPTION
## What

`JSMockFunction` used `jsMockFunctionCall` as both its call and construct native function. When the mock has no implementation (or the implementation returns a primitive), the function returns `jsUndefined()`. JSC's `Interpreter::executeConstruct` then calls `asObject()` on that result and hits `ASSERTION FAILED: cell->isObjectSlow()` in debug builds (the `Reflect.construct` path goes through `executeConstruct`).

Minimal repro:
```js
const fn = Bun.jest("a.js").mock();
Reflect.construct(fn, []);
Bun.gc(true);
```

## Fix

Add a dedicated `jsMockFunctionConstruct` that:
1. Allocates a `this` object based on `newTarget` via `InternalFunction::createSubclassStructure`
2. Sets it on the call frame and runs the shared call logic
3. Returns the implementation's result if it's an object, otherwise returns the allocated `this`

This matches standard `[[Construct]]` semantics (and what Jest does) where a constructor that returns a non-object yields the newly created instance.

This also fixes `new jest.fn()()` and `new jest.fn(() => 42)()` previously returning `undefined`/`42` instead of an object on the bytecode path.

Found by Fuzzilli.