### PR TITLE
patch: guard against crafted patches that panic the applier

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -154,13 +154,19 @@ impl<'a> PatchFile<'a> {
                     let Some(hunk) = &file_creation.hunk else {
                         continue;
                     };
+                    // A crafted `@@ -0,0 +0,0 @@` header with no body parses to a
+                    // hunk with zero parts; treat it as an empty file rather than
+                    // indexing `parts[0]`.
+                    let Some(first_part) = hunk.parts.first() else {
+                        continue;
+                    };
 
-                    let last_line = hunk.parts[0].lines.len().saturating_sub(1);
-                    let no_newline_at_end_of_file = hunk.parts[0].no_newline_at_end_of_file;
+                    let last_line = first_part.lines.len().saturating_sub(1);
+                    let no_newline_at_end_of_file = first_part.no_newline_at_end_of_file;
 
                     let count = {
                         let mut total: usize = 0;
-                        for (i, line) in hunk.parts[0].lines.iter().enumerate() {
+                        for (i, line) in first_part.lines.iter().enumerate() {
                             total += line.len();
                             total += (i < last_line) as usize;
                         }
@@ -175,7 +181,7 @@ impl<'a> PatchFile<'a> {
                     let file_contents: Vec<u8> = {
                         let mut contents = vec![0u8; count];
                         let mut i: usize = 0;
-                        for (idx, line) in hunk.parts[0].lines.iter().enumerate() {
+                        for (idx, line) in first_part.lines.iter().enumerate() {
                             contents[i..i + line.len()].copy_from_slice(line);
                             i += line.len();
                             if idx < last_line || !no_newline_at_end_of_file {
@@ -306,22 +312,24 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         }
         file_line_count = count;
 
-        // Adjust to account for the changes
+        // Adjust to account for the changes. This is only a capacity hint for
+        // `lines` below; saturate so a header that claims more deletions than
+        // the file has cannot panic (bounds are enforced during the splice).
         for hunk in &patch.hunks {
-            count = usize::try_from(
-                i64::try_from(count).expect("int cast") + i64::from(hunk.header.patched.len)
-                    - i64::from(hunk.header.original.len),
-            )
-            .unwrap();
+            count = count
+                .saturating_add(hunk.header.patched.len as usize)
+                .saturating_sub(hunk.header.original.len as usize);
             for part in &hunk.parts {
                 let part: &PatchMutationPart = part;
                 match part.ty {
                     PartType::Deletion => {
                         // deleting the no newline pragma so we are actually adding a line
-                        count += if part.no_newline_at_end_of_file { 1 } else { 0 };
+                        count = count
+                            .saturating_add(part.no_newline_at_end_of_file as usize);
                     }
                     PartType::Insertion => {
-                        count -= if part.no_newline_at_end_of_file { 1 } else { 0 };
+                        count = count
+                            .saturating_sub(part.no_newline_at_end_of_file as usize);
                     }
                     PartType::Context => {}
                 }

--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -324,12 +324,10 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
                 match part.ty {
                     PartType::Deletion => {
                         // deleting the no newline pragma so we are actually adding a line
-                        count = count
-                            .saturating_add(part.no_newline_at_end_of_file as usize);
+                        count = count.saturating_add(part.no_newline_at_end_of_file as usize);
                     }
                     PartType::Insertion => {
-                        count = count
-                            .saturating_sub(part.no_newline_at_end_of_file as usize);
+                        count = count.saturating_sub(part.no_newline_at_end_of_file as usize);
                     }
                     PartType::Context => {}
                 }

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -537,6 +537,85 @@ describe("apply", () => {
     ]);
     expect(exitCode).toBe(0);
   });
+
+  // A crafted patch from an untrusted source must never panic the process. Both
+  // cases below used to crash `bun install` when applying patchedDependencies.
+  describe.concurrent("malformed patches do not crash", () => {
+    test("file creation hunk with empty parts creates an empty file", async () => {
+      const dir = tempDirWithFiles("patch-empty-parts", { ".keep": "" });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           import { readFileSync } from "node:fs";
+           const patch = [
+             "diff --git a/newfile.txt b/newfile.txt",
+             "new file mode 100644",
+             "--- /dev/null",
+             "+++ b/newfile.txt",
+             "@@ -0,0 +0,0 @@",
+             "",
+           ].join("\\n");
+           try {
+             const ok = patchInternals.apply(patch, ${JSON.stringify(dir)});
+             console.log("ok=" + ok + " contents=" + JSON.stringify(readFileSync(${JSON.stringify(dir)} + "/newfile.txt", "utf8")));
+           } catch (e) {
+             console.log("threw: " + e.code + " " + e.message);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: 'ok=true contents=""',
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test("header deleting more lines than the target file has returns EINVAL", async () => {
+      const dir = tempDirWithFiles("patch-underflow", { "target.txt": "only line\n" });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           const body = [" only line"];
+           for (let i = 0; i < 9; i++) body.push("-deleted " + i);
+           const patch = [
+             "diff --git a/target.txt b/target.txt",
+             "--- a/target.txt",
+             "+++ b/target.txt",
+             "@@ -1,10 +1,1 @@",
+             ...body,
+             "",
+           ].join("\\n");
+           try {
+             patchInternals.apply(patch, ${JSON.stringify(dir)});
+             console.log("no-error");
+           } catch (e) {
+             console.log("caught: " + e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "caught: EINVAL",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
 });
 
 describe("parse", () => {


### PR DESCRIPTION
## Repro

Two inputs crash `bun install` (and `patchInternals.apply`) on current canary:

```js
// 1) file-creation hunk with an empty body
const patch = [
  "diff --git a/newfile.txt b/newfile.txt",
  "new file mode 100644",
  "--- /dev/null",
  "+++ b/newfile.txt",
  "@@ -0,0 +0,0 @@",
  "",
].join("\n");
patchInternals.apply(patch, dir);
// panic: index out of bounds: the len is 0 but the index is 0

// 2) header claims more deletions than the target file has
// target.txt = "only line\n"
const patch = [
  "diff --git a/target.txt b/target.txt",
  "--- a/target.txt",
  "+++ b/target.txt",
  "@@ -1,10 +1,1 @@",
  " only line",
  "-x","-x","-x","-x","-x","-x","-x","-x","-x",
  "",
].join("\n");
patchInternals.apply(patch, dir);
// panic: called `Result::unwrap()` on an `Err` value: TryFromIntError(NegOverflow)
```

Both patches parse successfully (they pass `verify_integrity`), so they reach `PatchFile::apply`. A malicious `patchedDependencies` entry can crash `bun install` this way.

## Cause

- `PatchFile::apply` for `FileCreation` indexed `hunk.parts[0]` unconditionally. A header like `@@ -0,0 +0,0 @@` with no body produces a hunk whose `parts` vec is empty (the integrity check passes because both lengths are 0).
- `apply_patch` precomputed the capacity for the `lines` vec as `usize::try_from(i64(count) + patched_len - original_len).unwrap()`. When the header's `original.len` exceeds the actual file's line count, that goes negative and the `usize` conversion panics before the real per-part bounds checks run.

## Fix

- Use `hunk.parts.first()` and treat an empty parts vec the same as `hunk: None`: the newly-created file stays empty.
- The `lines_count` value is only a `Vec::with_capacity` hint; switch to saturating arithmetic so a lying header clamps to 0 instead of panicking. The existing bounds checks during the splice then surface the mismatch as a catchable `EINVAL`.

## Verification

`bun bd test test/js/bun/patch/patch.test.ts`: 25 pass, including the two new `apply > malformed patches do not crash > ...` cases. Both new tests fail with `exitCode: 132` / panic output under `USE_SYSTEM_BUN=1`. `test/regression/issue/patch-bounds-check.test.ts` still passes (3/3).

Fixes #21932 (crash in `PatchFile.apply` during `bun install` when a `patchedDependencies` entry targets a package version whose files no longer match the hunk headers).