### PR TITLE
FileSystemRouter: fix slice panic in URLPath::parse on leading '?' or empty-decoding path

### DIFF
--- a/src/http_types/URLPath.rs
+++ b/src/http_types/URLPath.rs
@@ -74,6 +74,14 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         decoded_pathname = decoded_storage.as_deref().unwrap();
     }
 
+    // The slicing below assumes a non-empty pathname with a leading byte to
+    // skip. An empty input (or an input like "%PUBLIC_URL%" that the fault-
+    // tolerant decoder consumes entirely) would otherwise index out of bounds.
+    if decoded_pathname.is_empty() {
+        decoded_pathname = b"/";
+        decoded_storage = None;
+    }
+
     let mut question_mark_i: i32 = -1;
     let mut period_i: i32 = -1;
 
@@ -131,14 +139,19 @@ pub fn parse(possibly_encoded_pathname_: &[u8]) -> Result<URLPath, bun_url::Deco
         }
     };
 
-    let mut path: &[u8] = if question_mark_i < 0 {
-        &decoded_pathname[1..]
+    // `path` is the pathname without the leading byte and without the query
+    // string. When the input begins with '?' the end index is 0, so clamp the
+    // start to avoid a 1..0 slice.
+    let path_end: usize = if question_mark_i < 0 {
+        decoded_pathname.len()
     } else {
-        &decoded_pathname[1..usize::try_from(question_mark_i).expect("int cast")]
+        usize::try_from(question_mark_i).expect("int cast")
     };
+    let mut path: &[u8] = &decoded_pathname[1.min(path_end)..path_end];
 
-    let first_segment = &decoded_pathname
-        [1..(usize::try_from(first_segment_end).expect("int cast")).min(decoded_pathname.len())];
+    let first_segment_end_u: usize =
+        (usize::try_from(first_segment_end).expect("int cast")).min(decoded_pathname.len());
+    let first_segment = &decoded_pathname[1.min(first_segment_end_u)..first_segment_end_u];
     let is_source_map = extname == b"map";
     let mut backup_extname: &[u8] = extname;
     if is_source_map && path.len() > b".map".len() {

--- a/test/js/bun/util/filesystem_router.test.ts
+++ b/test/js/bun/util/filesystem_router.test.ts
@@ -692,3 +692,45 @@ it("does not match a dynamic route whose static segment merely collides on lengt
   // A different segment that only collides on (length, 32-bit hash) must not.
   expect(router.match(`/${attackSegment}/42`)).toBeNull();
 });
+
+it("match() does not panic on a leading '?' or a path that percent-decodes to empty", async () => {
+  // URLPath::parse assumed the decoded pathname was non-empty and had a leading
+  // byte to skip. A bare query string ("?", "?foo") makes the path slice end at 0
+  // while the start is hardcoded to 1, and "%PUBLIC_URL%" (which the fault-tolerant
+  // decoder consumes entirely) yields an empty decoded pathname; either case used
+  // to trigger a slice bounds panic. Run in a subprocess so a panic is observable
+  // as a nonzero exit / missing stdout instead of killing the test runner.
+  using dir = tempDir("fsr-degenerate-path", {
+    "pages/index.tsx": "export default 1;",
+  });
+
+  const code = /* ts */ `
+    const router = new Bun.FileSystemRouter({
+      dir: ${JSON.stringify(path.join(String(dir), "pages"))},
+      style: "nextjs",
+      fileExtensions: [".tsx"],
+    });
+    const out = {};
+    for (const input of ["?", "?foo=bar", "%PUBLIC_URL%", "%PUBLIC_URL%?x=1"]) {
+      const m = router.match(input);
+      out[input] = m ? { name: m.name, query: m.query } : null;
+    }
+    console.log(JSON.stringify(out));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", code],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout.trim())).toEqual({
+    "?": { name: "/", query: {} },
+    "?foo=bar": { name: "/", query: { foo: "bar" } },
+    "%PUBLIC_URL%": { name: "/", query: {} },
+    "%PUBLIC_URL%?x=1": { name: "/", query: { x: "1" } },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## What

`URLPath::parse` panics on two classes of input that `FileSystemRouter.match()` forwards from user code:

```js
router.match("?");            // panic: slice index starts at 1 but ends at 0
router.match("?foo=bar");     // same
router.match("%PUBLIC_URL%"); // panic: range start index 1 out of range for slice of length 0
```

Since applications pass request-derived strings to `router.match()`, this is a remote process-crash vector.

## Cause

`parse()` assumes the decoded pathname is non-empty and has a leading byte to strip:

```rust
let mut path = if question_mark_i < 0 {
    &decoded_pathname[1..]
} else {
    &decoded_pathname[1..question_mark_i as usize]
};
let first_segment = &decoded_pathname[1..first_segment_end.min(len)];
```

- A leading `?` gives `question_mark_i == 0`, so the path slice is `[1..0]`.
- `%PUBLIC_URL%` is consumed entirely by the fault-tolerant percent decoder (the create-react-app placeholder special case), leaving `decoded_pathname` empty, so `[1..]` on a zero-length slice panics.

The empty/`"/"` guard in `filesystem_router.rs` runs on the raw input before decoding and does not catch either shape.

## Fix

In `URLPath::parse`:
- Normalise an empty decoded pathname to `"/"` before scanning.
- Compute the path and first-segment slices with the start index clamped to the end index (`1.min(end)..end`) so a bare query string yields an empty path rather than a reversed range.

Both inputs now resolve to the index route with the query string preserved.

## Verification

New test in `test/js/bun/util/filesystem_router.test.ts` spawns a subprocess, calls `match()` with `"?"`, `"?foo=bar"`, `"%PUBLIC_URL%"`, and `"%PUBLIC_URL%?x=1"`, and asserts each returns the index route with the expected query. Before this change the subprocess aborts with the slice-bounds panic above; after, all four resolve cleanly.