### PR TITLE
node:http2: cap inbound SETTINGS frame length at SETTINGS_MAX_FRAME_SIZE

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -4708,7 +4708,10 @@ impl H2FrameParser {
 
         let setting_byte_size = SettingsPayloadUnit::BYTE_SIZE;
         if frame.length > 0 {
-            if is_ack || !(frame.length as usize).is_multiple_of(setting_byte_size) {
+            if is_ack
+                || frame.length > self.local_settings.get().max_frame_size
+                || !(frame.length as usize).is_multiple_of(setting_byte_size)
+            {
                 bun_output::scoped_log!(H2FrameParser, "invalid settings frame size");
                 self.send_go_away(
                     frame.stream_identifier,

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -417,6 +417,19 @@ describe("frame size limit (checklist §4.2)", () => {
     expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
     c.destroy();
   });
+
+  test("a SETTINGS frame exceeding SETTINGS_MAX_FRAME_SIZE is a FRAME_SIZE_ERROR", async () => {
+    const c = await RawH2.connect(port);
+    c.sendPreface();
+    c.sendEmptySettings();
+    // 16386 is a multiple of 6 so the §6.5 length check passes; the §4.2 cap must still
+    // reject it before any payload is buffered.
+    const oversized = Buffer.alloc(16386, 0);
+    c.sendFrame(FrameType.SETTINGS, 0, 0, oversized);
+    const goaway = await c.waitForGoaway();
+    expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+    c.destroy();
+  });
 });
 
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`


### PR DESCRIPTION
## Finding

`src/runtime/api/bun/h2_frame_parser.rs:4710-4724` (`handle_settings_frame`) validates an inbound SETTINGS frame length only as a multiple of 6, without the RFC 9113 §4.2 cap against `SETTINGS_MAX_FRAME_SIZE` that the sibling handlers (DATA at 3851, CONTINUATION at 4456, HEADERS at 4570) already apply.

## Analysis

The flagged function sits on the **legacy inbound dispatch path** (`read_bytes` → `dispatch_frame` → `handle_settings_frame`), which is dead: both inbound entry points (`on_native_read` and the JS `read()` host fn) route exclusively through `rewrite_read` → `h2::connection::Connection::receive()`. That engine already enforces the §4.2 cap centrally at [h2/connection.rs:363](https://github.com/oven-sh/bun/blob/main/src/runtime/api/bun/h2/connection.rs#L360-L373), rejecting any frame header whose declared length exceeds `local_settings.max_frame_size` before a single payload byte is buffered. So no oversized SETTINGS payload is accumulated in practice.

## Change

- Add `frame.length > self.local_settings.get().max_frame_size` to the existing FRAME_SIZE_ERROR branch in the legacy `handle_settings_frame`, bringing it in line with its siblings. This has no runtime effect today (the path is dead per the file header) but closes the audit finding and keeps the handler correct should anything ever route through it before the legacy half is deleted.
- Add a wire-level conformance test in `test/js/node/http2/h2-conformance.test.ts` that sends a SETTINGS frame of length 16386 (a multiple of 6, one step past the 16384 default max) and asserts `GOAWAY(FRAME_SIZE_ERROR)`. This exercises and locks in the live engine's centralized check.

## Verification

```
bun bd test test/js/node/http2/h2-conformance.test.ts
 24 pass
 0 fail
```