### PR TITLE
Fix use-after-free for reference-link href/title in Bun.markdown.react()/render()

### DIFF
--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -202,28 +202,6 @@ impl<'a> Default for SpanDetail<'a> {
     }
 }
 
-impl<'a> SpanDetail<'a> {
-    /// Widen `href`/`title` to `'static` for storage on the renderer stack.
-    /// Field-by-field reconstruction (no bitwise reinterpret).
-    ///
-    /// # Safety
-    /// Caller guarantees the source text the slices borrow outlives every
-    /// read through the returned value.
-    #[inline]
-    pub unsafe fn detach_lifetime(self) -> SpanDetail<'static> {
-        SpanDetail {
-            // SAFETY: caller contract.
-            href: unsafe { &*core::ptr::from_ref::<[u8]>(self.href) },
-            // SAFETY: caller contract.
-            title: unsafe { &*core::ptr::from_ref::<[u8]>(self.title) },
-            autolink: self.autolink,
-            autolink_email: self.autolink_email,
-            permissive_autolink: self.permissive_autolink,
-            autolink_www: self.autolink_www,
-        }
-    }
-}
-
 /// An attribute is a string that may contain embedded entities.
 /// The text is split into substrings, each with a type (normal or entity).
 /// The substr slices borrow from parser-owned buffers.

--- a/src/md/types.rs
+++ b/src/md/types.rs
@@ -174,7 +174,8 @@ impl<'a> Renderer<'a> {
 }
 
 /// Detail data for span events (links, images, wikilinks).
-/// `href`/`title` borrow from the source text.
+/// `href`/`title` are valid only for the duration of `enter_span`;
+/// renderers that retain them past that call must copy.
 #[derive(Copy, Clone)]
 pub struct SpanDetail<'a> {
     pub href: &'a [u8],

--- a/src/runtime/api/MarkdownObject.rs
+++ b/src/runtime/api/MarkdownObject.rs
@@ -475,11 +475,10 @@ struct ParseStackEntry {
     children: JSValue,
     data: u32,
     flags: u32,
-    // Note: `SpanDetail` borrows from `src_text`; the `RendererImpl`
-    // trait erases that lifetime, so we extend it to `'static` at the
-    // `enter_span` boundary (see SAFETY note there). Entries are popped
-    // and consumed strictly before `src_text` is dropped.
-    detail: md::SpanDetail<'static>,
+    // Owned copies of the span detail: reference-style links hand us
+    // slices into temporaries that drop before `leave_span` runs.
+    href: Box<[u8]>,
+    title: Box<[u8]>,
 }
 
 impl Default for ParseStackEntry {
@@ -488,7 +487,8 @@ impl Default for ParseStackEntry {
             children: JSValue::ZERO,
             data: 0,
             flags: 0,
-            detail: md::SpanDetail::default(),
+            href: Box::default(),
+            title: Box::default(),
         }
     }
 }
@@ -820,17 +820,12 @@ impl<'a> ParseRenderer<'a> {
             return Err(self.global_object.throw_stack_overflow());
         }
 
-        // SAFETY: `detail.href`/`.title` borrow from `self.src_text`, which
-        // outlives this renderer; the `RendererImpl` trait erases that
-        // lifetime so we extend it here. The entry is popped (and the slices
-        // consumed) in `leave_span_impl` before `src_text` is dropped.
-        let detail: md::SpanDetail<'static> = unsafe { detail.detach_lifetime() };
-
         let array = JSValue::create_empty_array(self.global_object, 0)?;
         self.marked_args.append(array);
         self.stack.push(ParseStackEntry {
             children: array,
-            detail,
+            href: Box::from(detail.href),
+            title: Box::from(detail.title),
             ..Default::default()
         });
         Ok(())
@@ -854,13 +849,13 @@ impl<'a> ParseRenderer<'a> {
         match span_type {
             md::SpanType::A => {
                 props_count += 1; // href
-                if !entry.detail.title.is_empty() {
+                if !entry.title.is_empty() {
                     props_count += 1;
                 }
             }
             md::SpanType::Img => {
                 props_count += 1; // src
-                if !entry.detail.title.is_empty() {
+                if !entry.title.is_empty() {
                     props_count += 1;
                 }
             }
@@ -883,19 +878,19 @@ impl<'a> ParseRenderer<'a> {
         // Set metadata props
         match span_type {
             md::SpanType::A => {
-                props.put(g, b"href", create_utf8_for_js(g, entry.detail.href)?);
-                if !entry.detail.title.is_empty() {
-                    props.put(g, b"title", create_utf8_for_js(g, entry.detail.title)?);
+                props.put(g, b"href", create_utf8_for_js(g, &entry.href)?);
+                if !entry.title.is_empty() {
+                    props.put(g, b"title", create_utf8_for_js(g, &entry.title)?);
                 }
             }
             md::SpanType::Img => {
-                props.put(g, b"src", create_utf8_for_js(g, entry.detail.href)?);
-                if !entry.detail.title.is_empty() {
-                    props.put(g, b"title", create_utf8_for_js(g, entry.detail.title)?);
+                props.put(g, b"src", create_utf8_for_js(g, &entry.href)?);
+                if !entry.title.is_empty() {
+                    props.put(g, b"title", create_utf8_for_js(g, &entry.title)?);
                 }
             }
             md::SpanType::Wikilink => {
-                props.put(g, b"target", create_utf8_for_js(g, entry.detail.href)?);
+                props.put(g, b"target", create_utf8_for_js(g, &entry.href)?);
             }
             md::SpanType::LatexmathDisplay => {
                 props.put(g, b"display", JSValue::TRUE);
@@ -1048,11 +1043,10 @@ struct CallbackStackEntry {
     /// For ul/ol: number of li children seen so far (next li's index).
     /// For li: this item's 0-based index within its parent list.
     child_index: u32,
-    // Note: `SpanDetail` borrows from `src_text`; the `RendererImpl`
-    // trait erases that lifetime, so we extend it to `'static` at the
-    // `enter_span` boundary (see SAFETY note there). Entries are popped
-    // and consumed strictly before `src_text` is dropped.
-    detail: md::SpanDetail<'static>,
+    // Owned copies of the span detail: reference-style links hand us
+    // slices into temporaries that drop before `leave_span` runs.
+    href: Box<[u8]>,
+    title: Box<[u8]>,
 }
 
 impl Default for CallbackStackEntry {
@@ -1063,7 +1057,8 @@ impl Default for CallbackStackEntry {
             data: 0,
             flags: 0,
             child_index: 0,
-            detail: md::SpanDetail::default(),
+            href: Box::default(),
+            title: Box::default(),
         }
     }
 }
@@ -1268,12 +1263,11 @@ impl<'a> JsCallbackRenderer<'a> {
         // Note: reshaped for borrowck — clone the saved entry (cheap; buffer not used) instead of holding a borrow across method calls.
         let saved = if self.stack.len() > 1 {
             CallbackStackEntry {
-                buffer: Vec::new(),
                 block_type: self.stack.last().unwrap().block_type,
                 data: self.stack.last().unwrap().data,
                 flags: self.stack.last().unwrap().flags,
                 child_index: self.stack.last().unwrap().child_index,
-                detail: self.stack.last().unwrap().detail,
+                ..Default::default()
             }
         } else {
             CallbackStackEntry::default()
@@ -1291,14 +1285,9 @@ impl<'a> JsCallbackRenderer<'a> {
         if !self.stack_check.is_safe_to_recurse() {
             return Err(self.global_object.throw_stack_overflow());
         }
-        // SAFETY: `detail` borrows from `src_text`, which outlives every
-        // `CallbackStackEntry` (the stack is fully drained before `src_text`
-        // is dropped). The `RendererImpl` trait erases the concrete lifetime,
-        // so we widen it to `'static` for storage on the stack — same pattern
-        // as `ParseStackEntry` above.
-        let detail: md::SpanDetail<'static> = unsafe { detail.detach_lifetime() };
         self.stack.push(CallbackStackEntry {
-            detail,
+            href: Box::from(detail.href),
+            title: Box::from(detail.title),
             ..Default::default()
         });
         Ok(())
@@ -1310,12 +1299,13 @@ impl<'a> JsCallbackRenderer<'a> {
         }
 
         let callback = self.get_span_callback(span_type);
-        let detail = if self.stack.len() > 1 {
-            self.stack.last().unwrap().detail
+        let (href, title): (&[u8], &[u8]) = if self.stack.len() > 1 {
+            let top = self.stack.last().unwrap();
+            (&top.href, &top.title)
         } else {
-            md::SpanDetail::default()
+            (b"", b"")
         };
-        let meta = self.create_span_meta(span_type, &detail)?;
+        let meta = self.create_span_meta(span_type, href, title)?;
         self.pop_and_callback(callback, meta)?;
         Ok(())
     }
@@ -1553,14 +1543,15 @@ impl<'a> JsCallbackRenderer<'a> {
     fn create_span_meta(
         &self,
         span_type: md::SpanType,
-        detail: &md::SpanDetail<'_>,
+        href: &[u8],
+        title: &[u8],
     ) -> JsResult<Option<JSValue>> {
         let g = self.global_object;
         match span_type {
             md::SpanType::A => {
-                let href = create_utf8_for_js(g, detail.href)?;
-                let title = if !detail.title.is_empty() {
-                    create_utf8_for_js(g, detail.title)?
+                let href = create_utf8_for_js(g, href)?;
+                let title = if !title.is_empty() {
+                    create_utf8_for_js(g, title)?
                 } else {
                     JSValue::UNDEFINED
                 };
@@ -1573,9 +1564,9 @@ impl<'a> JsCallbackRenderer<'a> {
                 // second slot, so just fall back to the generic path here —
                 // images are rare enough that it doesn't matter.
                 let obj = JSValue::create_empty_object(g, 2);
-                obj.put(g, b"src", create_utf8_for_js(g, detail.href)?);
-                if !detail.title.is_empty() {
-                    obj.put(g, b"title", create_utf8_for_js(g, detail.title)?);
+                obj.put(g, b"src", create_utf8_for_js(g, href)?);
+                if !title.is_empty() {
+                    obj.put(g, b"title", create_utf8_for_js(g, title)?);
                 }
                 Ok(Some(obj))
             }

--- a/test/js/bun/md/md-react.test.ts
+++ b/test/js/bun/md/md-react.test.ts
@@ -88,6 +88,45 @@ describe("Bun.markdown.react", () => {
     expect(img.props.children).toBeUndefined();
   });
 
+  test("reference-style link has href/title in props", () => {
+    const md = '[click here][ref]\n\n[ref]: https://example.com/path "the title"\n';
+    const link = children(md)[0].props.children[0];
+    expect(link.type).toBe("a");
+    expect({ href: link.props.href, title: link.props.title, children: link.props.children }).toEqual({
+      href: "https://example.com/path",
+      title: "the title",
+      children: ["click here"],
+    });
+  });
+
+  test("shortcut reference link has href/title in props", () => {
+    const md = '[ref]\n\n[ref]: https://example.com/path "the title"\n';
+    const link = children(md)[0].props.children[0];
+    expect(link.type).toBe("a");
+    expect({ href: link.props.href, title: link.props.title }).toEqual({
+      href: "https://example.com/path",
+      title: "the title",
+    });
+  });
+
+  test("collapsed reference link has href in props", () => {
+    const md = "[ref][]\n\n[ref]: https://example.com/path\n";
+    const link = children(md)[0].props.children[0];
+    expect(link.type).toBe("a");
+    expect(link.props.href).toBe("https://example.com/path");
+  });
+
+  test("reference-style image has src/title in props", () => {
+    const md = '![alt text][ref]\n\n[ref]: https://example.com/img.png "the title"\n';
+    const img = children(md)[0].props.children[0];
+    expect(img.type).toBe("img");
+    expect({ src: img.props.src, title: img.props.title, alt: img.props.alt }).toEqual({
+      src: "https://example.com/img.png",
+      title: "the title",
+      alt: "alt text",
+    });
+  });
+
   test("code block with language", () => {
     const pre = children("```ts\nconst x = 1;\n```\n")[0];
     expect(pre.$$typeof).toBe(REACT_TRANSITIONAL_SYMBOL);

--- a/test/js/bun/md/md-render-callback.test.ts
+++ b/test/js/bun/md/md-render-callback.test.ts
@@ -84,6 +84,33 @@ describe("Bun.markdown.render", () => {
     expect(result).toBe('<img src="image.png" alt="alt text" />');
   });
 
+  test("link callback with href/title from reference-style link", () => {
+    const md = '[click here][ref]\n\n[ref]: https://example.com/path "the title"\n';
+    const result = Markdown.render(md, {
+      link: (children: string, { href, title }: any) => `<a href="${href}" title="${title}">${children}</a>`,
+      paragraph: (children: string) => children,
+    });
+    expect(result).toBe('<a href="https://example.com/path" title="the title">click here</a>');
+  });
+
+  test("link callback with href from shortcut reference link", () => {
+    const md = "[ref]\n\n[ref]: https://example.com/path\n";
+    const result = Markdown.render(md, {
+      link: (children: string, { href }: any) => `<a href="${href}">${children}</a>`,
+      paragraph: (children: string) => children,
+    });
+    expect(result).toBe('<a href="https://example.com/path">ref</a>');
+  });
+
+  test("image callback with src/title from reference-style image", () => {
+    const md = '![alt text][ref]\n\n[ref]: https://example.com/img.png "the title"\n';
+    const result = Markdown.render(md, {
+      image: (children: string, { src, title }: any) => `<img src="${src}" title="${title}" alt="${children}" />`,
+      paragraph: (children: string) => children,
+    });
+    expect(result).toBe('<img src="https://example.com/img.png" title="the title" alt="alt text" />');
+  });
+
   test("code block callback with language metadata", () => {
     const result = Markdown.render("```js\nconsole.log('hi');\n```\n", {
       code: (children: string, meta: any) => `<pre lang="${meta?.language}">${children}</pre>`,


### PR DESCRIPTION
### Reproduction

```js
const md = '[x][y]\n\n[y]: http://example.com/path "the title"\n';
const a = Bun.markdown.react(md).props.children[0].props.children[0];
console.log(a.props.href, a.props.title);
// �\u001a#��\u0005\u0000\u0000xample.com/path  \u0000\t1��\u0005\u0000\u0000e
```

The first 8 bytes of both `href` and `title` are overwritten with allocator free-list data. Under ASAN this is a heap-use-after-free. Full/collapsed/shortcut reference links and reference images are all affected, in both `Bun.markdown.react()` and `Bun.markdown.render()`.

### Cause

For reference-style links, `process_link()` copies the definition's dest/title into a local `Box<[u8]>` (`src/md/links.rs:539,571`) and passes borrows of those boxes into `enter_span`. The react/render span renderers stored those borrows on their stack via `unsafe { detail.detach_lifetime() }` under a SAFETY comment asserting the slices always borrow from `src_text`:

```rust
// SAFETY: `detail.href`/`.title` borrow from `self.src_text`, which
// outlives this renderer; ...
let detail: md::SpanDetail<'static> = unsafe { detail.detach_lifetime() };
```

That holds for inline links and autolinks but not for reference links, where the boxes drop when `process_link` returns and `leave_span_impl` later reads freed memory.

### Fix

Store owned `Box<[u8]>` copies of `href`/`title` on `ParseStackEntry` and `CallbackStackEntry` instead of widening the borrow, matching what the HTML and ANSI renderers already do when they retain span detail across calls. This removes both `unsafe` blocks and the now-unused `SpanDetail::detach_lifetime()`. An empty `Box<[u8]>` does not allocate, so only link/image/wikilink spans pay for a copy.

### Verification

New tests in `test/js/bun/md/md-react.test.ts` and `md-render-callback.test.ts` cover full, collapsed, and shortcut reference links plus reference images in both renderers. They fail on the current build with corrupted href/title values and pass with this change; the full `test/js/bun/md/` suite (1062 tests) passes.