### PR TITLE
node:http2: bound frame length in legacy dispatch_frame; add §4.2 conformance coverage

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5135,9 +5135,8 @@ impl H2FrameParser {
         add: usize,
     ) -> JsResult<usize> {
         // RFC 9113 §4.2: refuse any frame whose declared length exceeds
-        // SETTINGS_MAX_FRAME_SIZE before handle_incomming_payload buffers it.
-        // Bounds every handler (SETTINGS/ALTSVC/ORIGIN/unknown included), so a
-        // 9-byte header cannot pin up to 16 MiB of read_buffer per connection.
+        // SETTINGS_MAX_FRAME_SIZE before handle_incomming_payload can buffer it,
+        // so a 9-byte header cannot pin ~16 MiB of read_buffer per connection.
         if header.length > self.local_settings.get().max_frame_size {
             self.send_go_away(
                 header.stream_identifier,

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -5173,6 +5173,20 @@ impl H2FrameParser {
         stream: Option<*mut Stream>,
         add: usize,
     ) -> JsResult<usize> {
+        // RFC 9113 §4.2: refuse any frame whose declared length exceeds
+        // SETTINGS_MAX_FRAME_SIZE before handle_incomming_payload buffers it.
+        // Bounds every handler (SETTINGS/ALTSVC/ORIGIN/unknown included), so a
+        // 9-byte header cannot pin up to 16 MiB of read_buffer per connection.
+        if header.length > self.local_settings.get().max_frame_size {
+            self.send_go_away(
+                header.stream_identifier,
+                ErrorCode::FRAME_SIZE_ERROR,
+                b"frame exceeds SETTINGS_MAX_FRAME_SIZE",
+                self.last_stream_id.get(),
+                true,
+            );
+            return Ok(bytes.len() + add);
+        }
         // RFC 9113 §4.3 / §6.10: once a HEADERS frame without END_HEADERS has
         // been received, the only frame permitted on the connection is a
         // CONTINUATION for that same stream until the header block is complete.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3847,24 +3847,6 @@ impl H2FrameParser {
         // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
         let mut stream = unsafe { &mut *stream_ptr };
 
-        let max_frame_size = self.local_settings.get().max_frame_size;
-        if frame.length > max_frame_size {
-            bun_output::scoped_log!(
-                H2FrameParser,
-                "received data frame with length: {} and max frame size: {}",
-                frame.length,
-                max_frame_size
-            );
-            self.send_go_away(
-                frame.stream_identifier,
-                ErrorCode::FRAME_SIZE_ERROR,
-                b"Invalid dataframe frame size",
-                self.last_stream_id.get(),
-                true,
-            );
-            return data.len();
-        }
-
         let end: usize = (self.remaining_length.get() as usize).min(data.len());
         let mut payload = &data[0..end];
         // window size considering the full frame.length received so far
@@ -4019,7 +4001,7 @@ impl H2FrameParser {
             );
             return data.len();
         }
-        if frame.length < 8 || frame.length > self.local_settings.get().max_frame_size {
+        if frame.length < 8 {
             self.send_go_away(
                 frame.stream_identifier,
                 ErrorCode::FRAME_SIZE_ERROR,
@@ -4453,16 +4435,6 @@ impl H2FrameParser {
             );
             return Ok(data.len());
         }
-        if frame.length > self.local_settings.get().max_frame_size {
-            self.send_go_away(
-                frame.stream_identifier,
-                ErrorCode::FRAME_SIZE_ERROR,
-                b"invalid Continuation frame size",
-                self.last_stream_id.get(),
-                true,
-            );
-            return Ok(data.len());
-        }
         if let Some(content) = self.handle_incomming_payload(data, frame.stream_identifier) {
             let payload = content.data();
             let end = content.end;
@@ -4566,17 +4538,6 @@ impl H2FrameParser {
         };
         // SAFETY: stream_ptr is a *mut Stream stored in self.streams (heap::alloc); valid for the lifetime of the entry, exclusive access reshaped for borrowck
         let mut stream = unsafe { &mut *stream_ptr };
-
-        if frame.length > self.local_settings.get().max_frame_size {
-            self.send_go_away(
-                frame.stream_identifier,
-                ErrorCode::FRAME_SIZE_ERROR,
-                b"invalid Headers frame size",
-                self.last_stream_id.get(),
-                true,
-            );
-            return Ok(data.len());
-        }
 
         if stream.is_waiting_more_headers {
             self.send_go_away(

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -417,6 +417,43 @@ describe("frame size limit (checklist §4.2)", () => {
     expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
     c.destroy();
   });
+
+  // §4.2: the max-frame-size check applies to every frame type and is enforced from the
+  // header alone, before the payload is buffered. A 9-byte header declaring a ~16 MiB
+  // payload must be rejected immediately; otherwise a peer could pin up to 16 MiB of
+  // reassembly buffer per connection while dribbling the body.
+  function oversizedHeader(type: number, streamId: number, length: number): Buffer {
+    const b = Buffer.alloc(9);
+    b.writeUIntBE(length, 0, 3);
+    b.writeUInt8(type, 3);
+    b.writeUInt8(0, 4);
+    b.writeUInt32BE(streamId & 0x7fffffff, 5);
+    return b;
+  }
+
+  test.each([
+    // Use a multiple of 6 for SETTINGS so the §6.5 length rule cannot mask the §4.2 check.
+    ["SETTINGS", FrameType.SETTINGS, 0, 0xfffffc],
+    ["GOAWAY", FrameType.GOAWAY, 0, 0xffffff],
+    ["PUSH_PROMISE", FrameType.PUSH_PROMISE, 1, 0xffffff],
+    ["ALTSVC", 0x0a, 0, 0xffffff],
+    ["ORIGIN", 0x0c, 0, 0xffffff],
+    ["unknown (0xff)", 0xff, 0, 0xffffff],
+  ])(
+    "an oversized %s frame is rejected from the header alone (no buffering)",
+    async (_name, type, streamId, length) => {
+      const c = await RawH2.connect(port);
+      c.sendPreface();
+      c.sendEmptySettings();
+      // Header declaring a multi-MiB payload, followed by only a handful of payload bytes.
+      c.send(oversizedHeader(type, streamId, length));
+      c.send(Buffer.alloc(16, 0));
+      // GOAWAY must arrive even though the declared payload was never sent.
+      const goaway = await c.waitForGoaway();
+      expect(goawayErrorCode(goaway)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+      c.destroy();
+    },
+  );
 });
 
 // ── Client-side conformance: a raw byte-level HTTP/2 *server* drives a Bun `node:http2`

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -420,8 +420,7 @@ describe("frame size limit (checklist §4.2)", () => {
 
   // §4.2: the max-frame-size check applies to every frame type and is enforced from the
   // header alone, before the payload is buffered. A 9-byte header declaring a ~16 MiB
-  // payload must be rejected immediately; otherwise a peer could pin up to 16 MiB of
-  // reassembly buffer per connection while dribbling the body.
+  // payload must be rejected immediately.
   function oversizedHeader(type: number, streamId: number, length: number): Buffer {
     const b = Buffer.alloc(9);
     b.writeUIntBE(length, 0, 3);


### PR DESCRIPTION
## Summary

A report flagged `handle_incomming_payload` in `src/runtime/api/bun/h2_frame_parser.rs` as reachable from `handle_settings_frame` / `handle_unknown_frame` / `handle_origin_frame` / `handle_altsvc_frame` without first checking the 24-bit declared frame length against `local_settings.max_frame_size`, letting a 9-byte header grow `read_buffer` to ~16 MiB per connection.

## Investigation

Those handlers are part of the **legacy inbound dispatcher**, which has been unreachable since #31584 routed all inbound bytes through the rewrite engine (`rewrite_read` → `h2::connection::Connection::receive`). The file carries an explicit `#![allow(dead_code)]` noting this.

Both live inbound paths already enforce RFC 9113 §4.2 from the header alone, before any payload is buffered:

- `src/runtime/api/bun/h2/connection.rs` `receive()`: `if hdr.length > self.local_settings.max_frame_size { send_go_away(FrameSizeError); return fatal }`
- `src/http/h2_client/dispatch.rs` `parse_frames()`: `if length > wire::DEFAULT_MAX_FRAME_SIZE { fatal_error = HTTP2FrameSizeError }`

Verified empirically against a `node:http2` h2c server by sending the preface, an empty SETTINGS, then only a 9-byte frame header declaring a ~16 MiB payload (plus 16 bytes of body) for each of SETTINGS / GOAWAY / PUSH_PROMISE / ALTSVC / ORIGIN / unknown (0xff): the server replies `GOAWAY(FRAME_SIZE_ERROR)` immediately without waiting for the declared payload.

## Changes

- **`h2_frame_parser.rs` `dispatch_frame`**: add the §4.2 `header.length > local_settings.max_frame_size` check before dispatch, so the dead legacy path is also bounded should it ever be re-enabled or used as a reference for the outbound migration. One guard covers every handler (including SETTINGS/ALTSVC/ORIGIN/PUSH_PROMISE/unknown, which previously reached `handle_incomming_payload` unchecked).
- **`h2_frame_parser.rs` per-handler cleanup**: drop the now-redundant `frame.length > max_frame_size` checks from `handle_data_frame`, `handle_continuation_frame`, `handle_headers_frame`, and the upper half of the disjunction in `handle_go_away_frame` (its `< 8` lower bound stays). Each has exactly one call site inside `dispatch_frame`'s match, so the central guard subsumes them.
- **`h2-conformance.test.ts`**: add wire-level tests (`test.each` over the six frame types above) that send only the oversized header plus a sliver of payload and assert the `GOAWAY(FRAME_SIZE_ERROR)` arrives, proving the rejection happens without buffering.

## Verification

```
bun bd test test/js/node/http2/h2-conformance.test.ts   # 29 pass
bun bd test test/js/node/http2/node-http2.test.js       # 287 pass, 6 skip
```

The new tests also pass on the released binary (the live engine already enforces the bound); the src/ change is defense-in-depth on the transitional legacy path.
