### PR TITLE
patch: refuse symlink and hard link escapes when applying patches

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -44,211 +44,116 @@ pub struct PatchFile<'a> {
     pub(crate) parts: Vec<PatchFilePart<'a>>,
 }
 
-#[cfg_attr(unix, allow(dead_code))]
-struct ApplyState {
-    pathbuf: PathBuffer,
-    patch_dir_abs_path: Option<usize>,
-}
-
-impl ApplyState {
-    fn new() -> Self {
-        Self {
-            pathbuf: PathBuffer::uninit(),
-            patch_dir_abs_path: None,
-        }
-    }
-
-    #[cfg_attr(unix, allow(dead_code))]
-    fn patch_dir_abs_path(&mut self, fd: Fd) -> sys::Result<&ZStr> {
-        if let Some(len) = self.patch_dir_abs_path {
-            // pathbuf[len] == 0 was written below on a previous call.
-            return sys::Result::Ok(ZStr::from_buf(&self.pathbuf.0, len));
-        }
-        match sys::get_fd_path(fd, &mut self.pathbuf) {
-            sys::Result::Ok(p) => {
-                // reshaped for borrowck — capture len, drop `p`,
-                // then re-borrow `self.pathbuf` to write the sentinel.
-                let len = p.len();
-                // On Linux `readlink(2)` does not NUL-terminate, so write the
-                // sentinel explicitly (the buffer is zero-initialized but be
-                // defensive).
-                self.pathbuf.0[len] = 0;
-                self.patch_dir_abs_path = Some(len);
-                sys::Result::Ok(ZStr::from_buf(&self.pathbuf.0, len))
-            }
-            sys::Result::Err(e) => sys::Result::Err(e.with_fd(fd)),
-        }
-    }
-}
-
 impl<'a> PatchFile<'a> {
     pub fn apply(&self, patch_dir: Fd) -> Option<sys::Error> {
-        let mut state = ApplyState::new();
-
         for part in &self.parts {
-            match part {
-                PatchFilePart::FileDeletion(file_deletion) => {
-                    if !is_safe_patch_path(file_deletion.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::unlink));
-                    }
-                    let pathz = ZBox::from_vec_with_nul(file_deletion.path.to_vec());
-
-                    if let sys::Result::Err(e) = sys::unlinkat(patch_dir, &pathz) {
-                        return Some(e.without_path());
-                    }
+            let result = match part {
+                PatchFilePart::FileDeletion(d) => {
+                    delete_file(patch_dir, d.path).map_err(|e| e.with_path(d.path))
                 }
-                PatchFilePart::FileRename(file_rename) => {
-                    if !is_safe_patch_path(file_rename.from_path)
-                        || !is_safe_patch_path(file_rename.to_path)
-                    {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::rename));
-                    }
-                    let from_path = ZBox::from_vec_with_nul(file_rename.from_path.to_vec());
-                    let to_path = ZBox::from_vec_with_nul(file_rename.to_path.to_vec());
-
-                    let todir = paths::dirname_simple(to_path.as_bytes());
-                    if !todir.is_empty() {
-                        if let sys::Result::Err(e) =
-                            sys::mkdir_recursive_at_mode(patch_dir, todir, 0o755)
-                        {
-                            return Some(e.without_path());
-                        }
-                    }
-
-                    if let sys::Result::Err(e) =
-                        sys::renameat(patch_dir, &from_path, patch_dir, &to_path)
-                    {
-                        return Some(e.without_path());
-                    }
+                // `rename_file` attributes its own errors, since either side can fail.
+                PatchFilePart::FileRename(r) => rename_file(patch_dir, r),
+                PatchFilePart::FileCreation(c) => {
+                    create_file(patch_dir, c).map_err(|e| e.with_path(c.path))
                 }
-                PatchFilePart::FileCreation(file_creation) => {
-                    if !is_safe_patch_path(file_creation.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
-                    }
-                    let filepath_z = ZBox::from_vec_with_nul(file_creation.path.to_vec());
-                    let filedir = paths::dirname_simple(filepath_z.as_bytes());
-                    let mode = file_creation.mode;
-
-                    if !filedir.is_empty() {
-                        // Create the directory under `patch_dir` so the
-                        // subsequent `openat` against `patch_dir` succeeds
-                        // (resolving `filedir` against the process CWD would be
-                        // inconsistent when `patch_dir != cwd`).
-                        if let sys::Result::Err(e) =
-                            sys::mkdir_recursive_at_mode(patch_dir, filedir, mode.to_bun_mode())
-                        {
-                            return Some(e.without_path());
-                        }
-                    }
-
-                    let newfile_fd = match sys::openat(
-                        patch_dir,
-                        &filepath_z,
-                        sys::O::CREAT | sys::O::WRONLY | sys::O::TRUNC,
-                        mode.to_bun_mode(),
-                    ) {
-                        sys::Result::Ok(fd) => fd,
-                        sys::Result::Err(e) => return Some(e.without_path()),
-                    };
-                    let _close_newfile = scopeguard::guard(newfile_fd, |fd| fd.close());
-
-                    let Some(hunk) = &file_creation.hunk else {
-                        continue;
-                    };
-                    // A crafted `@@ -0,0 +0,0 @@` header with no body parses to a
-                    // hunk with zero parts; treat it as an empty file rather than
-                    // indexing `parts[0]`.
-                    let Some(first_part) = hunk.parts.first() else {
-                        continue;
-                    };
-
-                    let last_line = first_part.lines.len().saturating_sub(1);
-                    let no_newline_at_end_of_file = first_part.no_newline_at_end_of_file;
-
-                    let count = {
-                        let mut total: usize = 0;
-                        for (i, line) in first_part.lines.iter().enumerate() {
-                            total += line.len();
-                            total += (i < last_line) as usize;
-                        }
-                        total += (!no_newline_at_end_of_file) as usize;
-                        total
-                    };
-
-                    // TODO: this additional allocation is probably not necessary in all cases and should be avoided or use stack buffer
-                    let file_contents: Vec<u8> = {
-                        let mut contents = vec![0u8; count];
-                        let mut i: usize = 0;
-                        for (idx, line) in first_part.lines.iter().enumerate() {
-                            contents[i..i + line.len()].copy_from_slice(line);
-                            i += line.len();
-                            if idx < last_line || !no_newline_at_end_of_file {
-                                contents[i] = b'\n';
-                                i += 1;
-                            }
-                        }
-                        contents
-                    };
-
-                    let mut written: usize = 0;
-                    while written < file_contents.len() {
-                        match sys::write(newfile_fd, &file_contents[written..]) {
-                            sys::Result::Ok(bytes) => written += bytes,
-                            sys::Result::Err(e) => return Some(e.without_path()),
-                        }
-                    }
+                PatchFilePart::FilePatch(f) => {
+                    patch_file(patch_dir, f).map_err(|e| e.with_path(f.path))
                 }
-                PatchFilePart::FilePatch(file_patch) => {
-                    if !is_safe_patch_path(file_patch.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
-                    }
-                    // TODO: should we compute the hash of the original file and check it against the on in the patch?
-                    if let sys::Result::Err(e) = apply_patch(file_patch, patch_dir, &mut state) {
-                        return Some(e.without_path());
-                    }
+                PatchFilePart::FileModeChange(m) => {
+                    change_mode(patch_dir, m).map_err(|e| e.with_path(m.path))
                 }
-                PatchFilePart::FileModeChange(file_mode_change) => {
-                    if !is_safe_patch_path(file_mode_change.path) {
-                        return Some(sys::Error::from_code(sys::E::EINVAL, sys::Tag::fchmodat));
-                    }
-                    let newmode = file_mode_change.new_mode;
-                    let filepath = ZBox::from_vec_with_nul(file_mode_change.path.to_vec());
-                    #[cfg(unix)]
-                    {
-                        if let sys::Result::Err(e) =
-                            sys::fchmodat(patch_dir, &filepath, newmode.to_bun_mode(), 0)
-                        {
-                            return Some(e.without_path());
-                        }
-                    }
-
-                    #[cfg(windows)]
-                    {
-                        let absfilepath = match state.patch_dir_abs_path(patch_dir) {
-                            sys::Result::Ok(p) => p,
-                            sys::Result::Err(e) => return Some(e.without_path()),
-                        };
-                        let mut buf = PathBuffer::uninit();
-                        let joined_absfilepath =
-                            paths::resolve_path::join_z_buf::<paths::platform::Auto>(
-                                &mut buf[..],
-                                &[absfilepath.as_bytes(), filepath.as_bytes()],
-                            );
-                        let fd = match sys::open(&joined_absfilepath, sys::O::RDWR, 0) {
-                            sys::Result::Err(e) => return Some(e.without_path()),
-                            sys::Result::Ok(f) => f,
-                        };
-                        let _close = scopeguard::guard(fd, |fd| fd.close());
-                        if let sys::Result::Err(e) = sys::fchmod(fd, newmode.to_bun_mode()) {
-                            return Some(e.without_path());
-                        }
-                    }
-                }
+            };
+            if let Err(e) = result {
+                return Some(e);
             }
         }
-
         None
     }
+}
+
+fn delete_file(patch_dir: Fd, path: &[u8]) -> sys::Result<()> {
+    let (parent, base) = resolve_target(patch_dir, path, None)?;
+    sys::unlinkat(parent.fd, &base)
+}
+
+fn rename_file(patch_dir: Fd, rename: &FileRename<'_>) -> sys::Result<()> {
+    let (from_parent, from_base) = resolve_target(patch_dir, rename.from_path, None)
+        .map_err(|e| e.with_path(rename.from_path))?;
+    let (to_parent, to_base) = resolve_target(patch_dir, rename.to_path, Some(CREATED_DIR_MODE))
+        .map_err(|e| e.with_path(rename.to_path))?;
+    sys::renameat(from_parent.fd, &from_base, to_parent.fd, &to_base)
+        .map_err(|e| e.with_path_dest(rename.from_path, rename.to_path))
+}
+
+fn create_file(patch_dir: Fd, creation: &FileCreation<'_>) -> sys::Result<()> {
+    let (parent, base) = resolve_target(patch_dir, creation.path, Some(CREATED_DIR_MODE))?;
+    let (fd, _) = open_target_file(
+        parent.fd,
+        &base,
+        sys::O::CREAT | sys::O::RDWR,
+        creation.mode.to_bun_mode(),
+    )?;
+    let _close = scopeguard::guard(fd, |fd| fd.close());
+    // Truncation is deferred until after the target is verified (no
+    // `O_TRUNC`), so a rejected target is never destroyed.
+    sys::ftruncate(fd, 0)?;
+
+    // A crafted `@@ -0,0 +0,0 @@` header with no body parses to a hunk with
+    // zero parts; either way the file is left empty.
+    let Some(first_part) = creation.hunk.as_ref().and_then(|h| h.parts.first()) else {
+        return Ok(());
+    };
+
+    let last_line = first_part.lines.len().saturating_sub(1);
+    let no_newline_at_end_of_file = first_part.no_newline_at_end_of_file;
+
+    let count = {
+        let mut total: usize = 0;
+        for (i, line) in first_part.lines.iter().enumerate() {
+            total += line.len();
+            total += (i < last_line) as usize;
+        }
+        total += (!no_newline_at_end_of_file) as usize;
+        total
+    };
+
+    let file_contents: Vec<u8> = {
+        let mut contents = vec![0u8; count];
+        let mut i: usize = 0;
+        for (idx, line) in first_part.lines.iter().enumerate() {
+            contents[i..i + line.len()].copy_from_slice(line);
+            i += line.len();
+            if idx < last_line || !no_newline_at_end_of_file {
+                contents[i] = b'\n';
+                i += 1;
+            }
+        }
+        contents
+    };
+
+    let mut written: usize = 0;
+    while written < file_contents.len() {
+        written += sys::write(fd, &file_contents[written..])?;
+    }
+    Ok(())
+}
+
+fn patch_file(patch_dir: Fd, patch: &FilePatch<'_>) -> sys::Result<()> {
+    let (parent, base) = resolve_target(patch_dir, patch.path, None)?;
+    apply_patch(patch, parent.fd, &base)
+}
+
+fn change_mode(patch_dir: Fd, change: &FileModeChange<'_>) -> sys::Result<()> {
+    let (parent, base) = resolve_target(patch_dir, change.path, None)?;
+    let (fd, _) = open_target_file(parent.fd, &base, sys::O::RDONLY, 0)?;
+    // On Windows `fchmod` needs a CRT-backed fd, and closing that one also
+    // closes the underlying HANDLE; elsewhere the conversion is the identity.
+    let fd = fd.make_libuv_owned().map_err(|()| {
+        fd.close();
+        sys::Error::from_code(sys::E::EMFILE, sys::Tag::chmod)
+    })?;
+    let _close = scopeguard::guard(fd, |fd| fd.close());
+    sys::fchmod(fd, change.new_mode.to_bun_mode())
 }
 
 /// Invariants:
@@ -259,42 +164,20 @@ impl<'a> PatchFile<'a> {
 /// we can speed it up by:
 /// - If file size <= PAGE_SIZE, read the whole file into memory. memcpy/memmove the file contents around will be fast
 /// - If file size > PAGE_SIZE, rather than making a list of lines, make a list of chunks
-fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> sys::Result<()> {
-    let file_path = ZBox::from_vec_with_nul(patch.path.to_vec());
+fn apply_patch(patch: &FilePatch<'_>, parent: Fd, base: &ZStr) -> sys::Result<()> {
+    let invalid = |tag: sys::Tag| sys::Error::from_code(sys::E::EINVAL, tag);
 
-    // Need to get the mode of the original file
-    // And also get the size to read file into memory
-    let stat = {
-        #[cfg(unix)]
-        let r = sys::fstatat(patch_dir, &file_path);
-        #[cfg(not(unix))]
-        let r = {
-            let p = match state.patch_dir_abs_path(patch_dir) {
-                sys::Result::Ok(p) => paths::resolve_path::join_z::<paths::platform::Auto>(&[
-                    p.as_bytes(),
-                    file_path.as_bytes(),
-                ]),
-                sys::Result::Err(e) => return sys::Result::Err(e),
-            };
-            sys::stat(p)
-        };
-        match r {
-            sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
-            sys::Result::Ok(stat) => stat,
-        }
-    };
-    #[cfg(unix)]
-    let _ = state; // suppress unused on posix
+    // One fd is used for the read and the write-back, so nothing can be
+    // swapped in for the target in between them.
+    let (file_fd, stat) = open_target_file(parent, base, sys::O::RDWR, 0)?;
+    let _close_file = scopeguard::guard(file_fd, |fd| fd.close());
 
-    let filebuf: Vec<u8> = match read_file_alloc(patch_dir, &file_path, 1024 * 1024 * 1024 * 4) {
-        Ok(b) => b,
-        Err(_) => {
-            return sys::Result::Err(
-                sys::Error::from_code(sys::E::EINVAL, sys::Tag::read)
-                    .with_path(file_path.as_bytes()),
-            );
-        }
-    };
+    if stat.st_size as u64 > MAX_PATCH_TARGET_BYTES {
+        return Err(invalid(sys::Tag::read));
+    }
+    let filebuf: Vec<u8> = sys::File::borrow(&file_fd)
+        .read_to_end()
+        .map_err(|_| invalid(sys::Tag::read))?;
 
     let file_line_count: usize;
     let lines_count: usize = {
@@ -345,10 +228,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
 
         // Validate hunk start position is within bounds
         if line_cursor > lines.len() {
-            return sys::Result::Err(
-                sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                    .with_path(file_path.as_bytes()),
-            );
+            return Err(invalid(sys::Tag::fstatat));
         }
 
         for part in &hunk.parts {
@@ -359,10 +239,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
 
                     // Validate context lines exist
                     if line_cursor + part.lines.len() > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
+                        return Err(invalid(sys::Tag::fstatat));
                     }
 
                     line_cursor += part.lines.len();
@@ -370,10 +247,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
                 PartType::Insertion => {
                     // Validate insertion position is within bounds
                     if line_cursor > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
+                        return Err(invalid(sys::Tag::fstatat));
                     }
 
                     lines.splice(line_cursor..line_cursor, part.lines.iter().copied());
@@ -387,10 +261,7 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
 
                     // Validate deletion range is within bounds
                     if line_cursor + part.lines.len() > lines.len() {
-                        return sys::Result::Err(
-                            sys::Error::from_code(sys::E::EINVAL, sys::Tag::fstatat)
-                                .with_path(file_path.as_bytes()),
-                        );
+                        return Err(invalid(sys::Tag::fstatat));
                     }
 
                     lines.drain(line_cursor..line_cursor + part.lines.len());
@@ -403,42 +274,185 @@ fn apply_patch(patch: &FilePatch<'_>, patch_dir: Fd, state: &mut ApplyState) -> 
         }
     }
 
-    let file_fd = match sys::openat(
-        patch_dir,
-        &file_path,
-        sys::O::CREAT | sys::O::WRONLY | sys::O::TRUNC,
-        stat.st_mode as sys::Mode,
-    ) {
-        sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
-        sys::Result::Ok(fd) => fd,
-    };
-    let _close_file = scopeguard::guard(file_fd, |fd| fd.close());
+    sys::ftruncate(file_fd, 0)?;
+    // `read_to_end` advanced the cursor on Windows (POSIX reads use `pread`);
+    // rewind so the write lands at offset 0 instead of leaving a hole.
+    sys::set_file_offset(file_fd, 0)?;
 
     let contents = join_bytes(b"\n", &lines);
 
     let mut written: usize = 0;
     while written < contents.len() {
-        match sys::write(file_fd, &contents[written..]) {
-            sys::Result::Ok(w) => written += w,
-            sys::Result::Err(e) => return sys::Result::Err(e.with_path(file_path.as_bytes())),
-        }
+        written += sys::write(file_fd, &contents[written..])?;
     }
 
-    sys::Result::Ok(())
+    Ok(())
 }
 
-fn read_file_alloc(dir: Fd, path: &ZStr, max: usize) -> sys::Result<Vec<u8>> {
-    // Allocate `min(size, max)` and error past `max`, so a pathological
-    // multi-GiB target file errors instead of allocating unboundedly. (The
-    // too-big error would surface as `.INVAL` at the only call site anyway,
-    // so we map it to EINVAL here.)
-    let stat = sys::fstatat(dir, path)?;
-    if stat.st_size as u64 > max as u64 {
-        return sys::Result::Err(
-            sys::Error::from_code(sys::E::EINVAL, sys::Tag::read).with_path(path.as_bytes()),
-        );
+/// Cap on a patch target read into memory; a larger `st_size` is an error
+/// rather than an unbounded allocation.
+const MAX_PATCH_TARGET_BYTES: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Mode for directories a patch has to create. A new file's header mode
+/// describes only the file; a directory given 0o644 cannot be entered.
+const CREATED_DIR_MODE: sys::Mode = 0o755;
+
+/// Directory handle returned by [`open_parent_beneath`]: `patch_dir` itself
+/// for single-component paths (not closed), an owned fd otherwise.
+struct ParentDir {
+    fd: Fd,
+    owned: bool,
+}
+
+impl Drop for ParentDir {
+    fn drop(&mut self) {
+        if self.owned {
+            self.fd.close();
+        }
     }
-    sys::File::read_from(dir, path)
+}
+
+/// The separators [`paths::dirname_simple`] splits on, so the walk below and
+/// the basename it leaves behind always reassemble the original path.
+const PATH_SEPS: &[u8] = if cfg!(windows) { b"/\\" } else { b"/" };
+
+/// Validates a patch path and resolves it to the verified directory holding
+/// its final component plus that component as a NUL-terminated name, the
+/// pair every `*at` syscall in `apply` operates on.
+fn resolve_target(
+    patch_dir: Fd,
+    path: &[u8],
+    create_mode: Option<sys::Mode>,
+) -> sys::Result<(ParentDir, ZBox)> {
+    if !is_safe_patch_path(path) {
+        return Err(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
+    }
+    let parent = open_parent_beneath(patch_dir, path, create_mode)?;
+    let dir = paths::dirname_simple(path);
+    let base = if dir.is_empty() {
+        path
+    } else {
+        &path[dir.len() + 1..]
+    };
+    Ok((parent, ZBox::from_vec_with_nul(base.to_vec())))
+}
+
+/// Opens the parent directory of `path` one component at a time from
+/// `patch_dir`, refusing symlinks, creating missing components when
+/// `create_mode` is given. `path` must have passed [`is_safe_patch_path`],
+/// which is what rules out `..`.
+fn open_parent_beneath(
+    patch_dir: Fd,
+    path: &[u8],
+    create_mode: Option<sys::Mode>,
+) -> sys::Result<ParentDir> {
+    let mut cur = ParentDir {
+        fd: patch_dir,
+        owned: false,
+    };
+    for component in strings::split_any(paths::dirname_simple(path), PATH_SEPS) {
+        if component.is_empty() || component == b"." {
+            continue;
+        }
+        let component_z = ZBox::from_vec_with_nul(component.to_vec());
+        cur = ParentDir {
+            fd: open_dir_component(cur.fd, &component_z, create_mode)?,
+            owned: true,
+        };
+    }
+    Ok(cur)
+}
+
+/// On Windows `O_NOFOLLOW` opens a reparse point itself rather than failing,
+/// and `fstat` on that handle reports an ordinary file or directory, so the
+/// entry's own attributes are checked by name first (hence not atomic against
+/// a concurrent swap, unlike the POSIX path).
+#[cfg(windows)]
+fn reject_reparse_point(dir: Fd, name: &ZStr) -> sys::Result<()> {
+    match sys::get_file_attributes_at(dir, name) {
+        Ok(attrs) if attrs.is_reparse_point => {
+            Err(sys::Error::from_code(sys::E::ELOOP, sys::Tag::open))
+        }
+        // Nonexistent (about to be created) or unreadable: the open that
+        // follows reports the real error.
+        _ => Ok(()),
+    }
+}
+
+/// One step of the walk: opens `component` under `dir` as a directory
+/// without following a symlink, creating it first on ENOENT when
+/// `create_mode` is given.
+fn open_dir_component(
+    dir: Fd,
+    component: &ZStr,
+    create_mode: Option<sys::Mode>,
+) -> sys::Result<Fd> {
+    #[cfg(windows)]
+    reject_reparse_point(dir, component)?;
+    let flags = sys::O::RDONLY | sys::O::DIRECTORY | sys::O::NOFOLLOW;
+    let open_err = match sys::openat(dir, component, flags, 0) {
+        Ok(fd) => return Ok(fd),
+        Err(e) => e,
+    };
+    let Some(mode) = create_mode.filter(|_| open_err.get_errno() == sys::E::ENOENT) else {
+        return Err(symlink_component_err(dir, component, open_err));
+    };
+    match sys::mkdirat(dir, component, mode) {
+        Ok(()) => {}
+        // Lost a creation race; the open below verifies whatever is there now.
+        Err(e) if e.get_errno() == sys::E::EEXIST => {}
+        Err(e) => return Err(e),
+    }
+    sys::openat(dir, component, flags, 0).map_err(|e| symlink_component_err(dir, component, e))
+}
+
+/// `O_NOFOLLOW` on a symlink reports ENOTDIR or ELOOP on Linux, ELOOP on
+/// Darwin, and EMLINK on FreeBSD; report the symlink case as ELOOP everywhere.
+/// (Only the errno depends on this lstat, never whether the open was refused.)
+fn symlink_component_err(dir: Fd, component: &ZStr, e: sys::Error) -> sys::Error {
+    if matches!(
+        e.get_errno(),
+        sys::E::ENOTDIR | sys::E::ELOOP | sys::E::EMLINK
+    ) && let Ok(st) = sys::lstatat(dir, component)
+        && sys::S::ISLNK(st.st_mode as u32)
+    {
+        return sys::Error::from_code(sys::E::ELOOP, sys::Tag::open);
+    }
+    e
+}
+
+/// Opens `base` under a verified parent without following a symlink and
+/// requires a regular file with a single hard link: a second link means the
+/// same inode is also reachable from outside the patch dir.
+fn open_target_file(
+    parent: Fd,
+    base: &ZStr,
+    flags: i32,
+    mode: sys::Mode,
+) -> sys::Result<(Fd, sys::Stat)> {
+    #[cfg(windows)]
+    reject_reparse_point(parent, base)?;
+    // Without `O_NONBLOCK`, opening a FIFO blocks until a writer appears and
+    // the `!ISREG` rejection below is never reached.
+    let nonblock = if cfg!(windows) { 0 } else { sys::O::NONBLOCK };
+    let fd = sys::openat(parent, base, flags | sys::O::NOFOLLOW | nonblock, mode)
+        .map_err(|e| symlink_component_err(parent, base, e))?;
+    let stat = match sys::fstat(fd) {
+        Ok(st) => st,
+        Err(e) => {
+            fd.close();
+            return Err(e);
+        }
+    };
+    if !sys::S::ISREG(stat.st_mode as u32) {
+        fd.close();
+        return Err(sys::Error::from_code(sys::E::EINVAL, sys::Tag::open));
+    }
+    if stat.st_nlink > 1 {
+        fd.close();
+        return Err(sys::Error::from_code(sys::E::EMLINK, sys::Tag::open));
+    }
+    Ok((fd, stat))
 }
 
 /// Joins byte slices with a separator.
@@ -1040,6 +1054,10 @@ fn is_safe_patch_path(path: &[u8]) -> bool {
     !path.is_empty()
         && !strings::contains_char(path, 0)
         && !paths::is_absolute_loose(path)
+        // On Windows, openat strips a drive prefix from a relative component,
+        // so `"C:.."` (not byte-equal to `..` below) resolves a real `..`.
+        // `:` never occurs in a legitimate NTFS file name.
+        && !(cfg!(windows) && strings::contains_char(path, b':'))
         && !strings::split_any(path, b"/\\").any(|part| part == b"..")
 }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -7149,13 +7149,10 @@ pub enum ExistsAtType {
     File,
     Directory,
 }
-/// Windows tail — `NtQueryAttributesFile` against an
-/// OBJECT_ATTRIBUTES built from an already NT-prefixed wide path. Shared by the
-/// UTF-8 (`exists_at_type`) and UTF-16 (`exists_at_type_w`) entry points so the
-/// width dispatch does not
-/// duplicate the syscall body.
+/// `NtQueryAttributesFile` on an NT-prefixed wide path relative to `dir`.
+/// Like `GetFileAttributesW`, a final-component reparse point is not followed.
 #[cfg(windows)]
-fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
+fn nt_query_attributes_at(dir: Fd, mut path: &[u16]) -> Maybe<u32> {
     use bun_windows_sys::externs as w;
     // Trim leading `.\` — NtQueryAttributesFile expects relative paths
     // without it.
@@ -7196,16 +7193,34 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
             Tag::access,
         ));
     }
+    Ok(basic_info.FileAttributes)
+}
+/// Attributes of the entry `sub` itself (a reparse point is not followed).
+#[cfg(windows)]
+pub fn get_file_attributes_at(dir: Fd, sub: &ZStr) -> Maybe<WindowsFileAttributes> {
+    use bun_windows_sys::externs as w;
+    let mut wbuf = bun_paths::w_path_buffer_pool::get();
+    let path = bun_paths::string_paths::to_nt_path(&mut wbuf.0[..], sub.as_bytes()).as_slice();
+    let dword = nt_query_attributes_at(dir, path)?;
+    Ok(WindowsFileAttributes {
+        is_directory: (dword & w::FILE_ATTRIBUTE_DIRECTORY) != 0,
+        is_reparse_point: (dword & w::FILE_ATTRIBUTE_REPARSE_POINT) != 0,
+    })
+}
+/// Shared by the UTF-8 (`exists_at_type`) and UTF-16 (`exists_at_type_w`)
+/// entry points.
+#[cfg(windows)]
+fn exists_at_type_nt(dir: Fd, path: &[u16]) -> Maybe<ExistsAtType> {
+    use bun_windows_sys::externs as w;
+    let attrs = nt_query_attributes_at(dir, path)?;
     // `FILE_ATTRIBUTE_READONLY` on a directory is a folder-customization
     // marker (OneDrive sets it) and does not affect directory-ness; only
     // `FILE_ATTRIBUTE_DIRECTORY` decides the type.
-    Ok(
-        if (basic_info.FileAttributes & w::FILE_ATTRIBUTE_DIRECTORY) != 0 {
-            ExistsAtType::Directory
-        } else {
-            ExistsAtType::File
-        },
-    )
+    Ok(if (attrs & w::FILE_ATTRIBUTE_DIRECTORY) != 0 {
+        ExistsAtType::Directory
+    } else {
+        ExistsAtType::File
+    })
 }
 /// `fstatat` then `S_ISDIR`.
 pub fn exists_at_type(dir: Fd, sub: &ZStr) -> Maybe<ExistsAtType> {

--- a/test/cli/install/bun-install-patch.test.ts
+++ b/test/cli/install/bun-install-patch.test.ts
@@ -7,7 +7,6 @@ import { join } from "path";
 const normalizeBunSnapshot = (str: string) => {
   str = normalizeBunSnapshot_(str);
   str = str.replace(/.*Resolved, downloaded and extracted.*\n?/g, "");
-  str = str.replaceAll("fstatat()", "stat()");
   return str;
 };
 
@@ -563,7 +562,7 @@ index 832d92223a9ec491364ee10dcbe3ad495446ab80..7e079a817825de4b8c3d01898490dc7e
       expect(exitCode).toBe(1);
       expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
         "Resolving dependencies
-        error: failed applying patch file: ENOENT: No such file or directory (stat())
+        error: failed applying patch file: ENOENT: node_modules/is-even/index.js: No such file or directory (open())
         error: failed to apply patchfile (patches/is-even@1.0.0.patch)"
       `);
       expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);

--- a/test/internal/source-lints/dead-code-escape-limits.json
+++ b/test/internal/source-lints/dead-code-escape-limits.json
@@ -15,7 +15,6 @@
   "src/jsc/PosixSignalHandle.rs": 6,
   "src/jsc_macros/lib.rs": 2,
   "src/opaque/lib.rs": 4,
-  "src/patch/lib.rs": 2,
   "src/runtime/api/bun/Terminal.rs": 1,
   "src/runtime/cli/test/ChangedFilesFilter.rs": 1,
   "src/runtime/image/backend_coregraphics.rs": 14,

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -179,6 +179,30 @@ describe("apply", () => {
 
       expect(await $`cat ${join(afolder, "newfile.txt")}`.cwd(tempdir).text()).toBe(files["b/newfile.txt"]);
     });
+
+    // The header mode belongs to the file; directories the patch has to create
+    // must be traversable regardless, or the file cannot be created inside them.
+    test.if(process.platform !== "win32")("creates missing parent directories traversable", async () => {
+      await using tempdir = tempDir("patch-test", { "a/.keep": "" });
+      const afolder = join(tempdir, "a");
+
+      const patch =
+        "diff --git a/newdir/sub/new.txt b/newdir/sub/new.txt\n" +
+        "new file mode 100644\n" +
+        "--- /dev/null\n" +
+        "+++ b/newdir/sub/new.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+hello\n";
+
+      await apply(patch, afolder);
+      const dirMode = (await fs.stat(join(afolder, "newdir"))).mode;
+      const fileMode = (await fs.stat(join(afolder, "newdir", "sub", "new.txt"))).mode;
+      expect({
+        contents: await fs.readFile(join(afolder, "newdir", "sub", "new.txt"), "utf8"),
+        dirOwnerExec: (dirMode & 0o100) !== 0,
+        fileOwnerExec: (fileMode & 0o100) !== 0,
+      }).toEqual({ contents: "hello\n", dirOwnerExec: true, fileOwnerExec: false });
+    });
   });
 
   describe("rename", () => {
@@ -627,6 +651,590 @@ describe("apply", () => {
            ].join("\\n");
            try {
              patchInternals.apply(patch, ${JSON.stringify(dir)});
+             console.log("no-error");
+           } catch (e) {
+             console.log("caught: " + e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "caught: EINVAL",
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
+
+  function setupEscapeDirs() {
+    const root = tempDirWithFiles("patch-symlink", {
+      "pkg/real.txt": "SAFE\n",
+      "outside/target.txt": "SAFE\n",
+      "outside.txt": "SAFE\n",
+    });
+    const pkgDir = join(root, "pkg");
+    return { root, pkgDir };
+  }
+
+  function tryApply(patch: string, dir: string) {
+    try {
+      apply(patch, dir);
+      return undefined;
+    } catch (e) {
+      return e as NodeJS.ErrnoException;
+    }
+  }
+
+  describe.if(process.platform !== "win32")("refuses to follow symlinks", () => {
+    const setup = setupEscapeDirs;
+
+    test("file creation through a symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outside = join(root, "outside.txt");
+      await fs.symlink(outside, join(pkgDir, "link"));
+
+      const patch =
+        "diff --git a/link b/link\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/link\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(outside, "utf8") }).toEqual({
+        code: "ELOOP",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file patch through a symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outside = join(root, "outside.txt");
+      await fs.symlink(outside, join(pkgDir, "link"));
+
+      const patch =
+        "diff --git a/link b/link\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/link\n" +
+        "+++ b/link\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(outside, "utf8") }).toEqual({
+        code: "ELOOP",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file creation through an intermediate directory symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/evildir/target.txt b/evildir/target.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/evildir/target.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(join(outsideDir, "target.txt"), "utf8") }).toEqual({
+        code: "ELOOP",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file creation through an intermediate directory symlink does not create the file", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/evildir/newfile.txt b/evildir/newfile.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/evildir/newfile.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      const created = await fs.access(join(outsideDir, "newfile.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, created }).toEqual({ code: "ELOOP", created: false });
+    });
+
+    test("file patch through an intermediate directory symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/evildir/target.txt b/evildir/target.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/evildir/target.txt\n" +
+        "+++ b/evildir/target.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(join(outsideDir, "target.txt"), "utf8") }).toEqual({
+        code: "ELOOP",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file deletion through an intermediate directory symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/evildir/target.txt b/evildir/target.txt\n" +
+        "deleted file mode 100644\n" +
+        "index e69de29..0000000\n";
+
+      const err = tryApply(patch, pkgDir);
+      const exists = await fs.access(join(outsideDir, "target.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, exists }).toEqual({ code: "ELOOP", exists: true });
+    });
+
+    test("file rename into an intermediate directory symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/payload.txt b/payload.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/payload.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n" +
+        "diff --git a/payload.txt b/evildir/pwned.txt\n" +
+        "similarity index 100%\n" +
+        "rename from payload.txt\n" +
+        "rename to evildir/pwned.txt\n";
+
+      const err = tryApply(patch, pkgDir);
+      const created = await fs.access(join(outsideDir, "pwned.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, path: err?.path, created }).toEqual({
+        code: "ELOOP",
+        path: "evildir/pwned.txt",
+        created: false,
+      });
+    });
+
+    test("file rename out of an intermediate directory symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"));
+
+      const patch =
+        "diff --git a/evildir/target.txt b/stolen.txt\n" +
+        "similarity index 100%\n" +
+        "rename from evildir/target.txt\n" +
+        "rename to stolen.txt\n";
+
+      const err = tryApply(patch, pkgDir);
+      const exists = await fs.access(join(outsideDir, "target.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, path: err?.path, exists }).toEqual({
+        code: "ELOOP",
+        path: "evildir/target.txt",
+        exists: true,
+      });
+    });
+
+    test("mode change through a symlink is rejected", async () => {
+      const { root, pkgDir } = setup();
+      const outside = join(root, "outside.txt");
+      await fs.chmod(outside, 0o644);
+      await fs.symlink(outside, join(pkgDir, "link"));
+
+      const patch = "diff --git a/link b/link\n" + "old mode 100644\n" + "new mode 100755\n";
+
+      const err = tryApply(patch, pkgDir);
+      const st = await fs.stat(outside);
+      expect({ code: err?.code, mode: st.mode & 0o777 }).toEqual({
+        code: "ELOOP",
+        mode: 0o644,
+      });
+    });
+
+    test("still applies to regular files inside the patch dir", async () => {
+      const { pkgDir } = setup();
+
+      const patch =
+        "diff --git a/real.txt b/real.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/real.txt\n" +
+        "+++ b/real.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+OK\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "real.txt"), "utf8")).toBe("OK\n");
+    });
+
+    test("still creates new files in subdirectories inside the patch dir", async () => {
+      const { pkgDir } = setup();
+      await fs.mkdir(join(pkgDir, "sub"));
+
+      const patch =
+        "diff --git a/sub/new.txt b/sub/new.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/sub/new.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+hello\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "sub", "new.txt"), "utf8")).toBe("hello\n");
+    });
+
+    test("still applies paths with a ./ prefix", async () => {
+      const { pkgDir } = setup();
+
+      const patch =
+        "diff --git a/./real.txt b/./real.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/./real.txt\n" +
+        "+++ b/./real.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+OK\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "real.txt"), "utf8")).toBe("OK\n");
+    });
+  });
+
+  // Hard links are a symlink-free escape: `link` and an outside path name the
+  // same inode, so truncating/writing through the patch-dir name corrupts the
+  // outside file. Works on every platform (NTFS hard links need no privilege).
+  describe("refuses to write through hard links", () => {
+    async function setupHardlink() {
+      const { root, pkgDir } = setupEscapeDirs();
+      const outside = join(root, "outside.txt");
+      await fs.link(outside, join(pkgDir, "link.txt"));
+      return { root, pkgDir, outside };
+    }
+
+    test("file patch of a hard-linked file is rejected", async () => {
+      const { pkgDir, outside } = await setupHardlink();
+
+      const patch =
+        "diff --git a/link.txt b/link.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/link.txt\n" +
+        "+++ b/link.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(outside, "utf8") }).toEqual({
+        code: "EMLINK",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file creation over a hard-linked file is rejected without truncating it", async () => {
+      const { pkgDir, outside } = await setupHardlink();
+
+      const patch =
+        "diff --git a/link.txt b/link.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/link.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(outside, "utf8") }).toEqual({
+        code: "EMLINK",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("mode change of a hard-linked file is rejected", async () => {
+      const { pkgDir, outside } = await setupHardlink();
+
+      const patch = "diff --git a/link.txt b/link.txt\n" + "old mode 100644\n" + "new mode 100755\n";
+
+      // A chmod leaves the contents alone, so the mode is what an escape would change.
+      const modeBefore = (await fs.stat(outside)).mode;
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, mode: (await fs.stat(outside)).mode }).toEqual({
+        code: "EMLINK",
+        mode: modeBefore,
+      });
+    });
+
+    test("still patches a regular file sitting next to a hard link", async () => {
+      const { pkgDir } = await setupHardlink();
+
+      const patch =
+        "diff --git a/real.txt b/real.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/real.txt\n" +
+        "+++ b/real.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+OK\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "real.txt"), "utf8")).toBe("OK\n");
+    });
+  });
+
+  // On Windows `O_NOFOLLOW` opens a reparse point itself instead of failing and
+  // fstat on that handle reports a plain file, so containment there is an
+  // attribute check on every component. Junctions need no privilege to create.
+  describe.if(process.platform === "win32")("refuses to traverse junctions on Windows", () => {
+    async function setupJunction() {
+      const { root, pkgDir } = setupEscapeDirs();
+      const outsideDir = join(root, "outside");
+      await fs.symlink(outsideDir, join(pkgDir, "evildir"), "junction");
+      return { root, pkgDir, outsideDir };
+    }
+
+    test("file creation through an intermediate junction is rejected", async () => {
+      const { pkgDir, outsideDir } = await setupJunction();
+
+      const patch =
+        "diff --git a/evildir/newfile.txt b/evildir/newfile.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/evildir/newfile.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      const created = await fs.access(join(outsideDir, "newfile.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, created }).toEqual({ code: "ELOOP", created: false });
+    });
+
+    test("file patch through an intermediate junction is rejected", async () => {
+      const { pkgDir, outsideDir } = await setupJunction();
+
+      const patch =
+        "diff --git a/evildir/target.txt b/evildir/target.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/evildir/target.txt\n" +
+        "+++ b/evildir/target.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+PWNED\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect({ code: err?.code, outside: await fs.readFile(join(outsideDir, "target.txt"), "utf8") }).toEqual({
+        code: "ELOOP",
+        outside: "SAFE\n",
+      });
+    });
+
+    test("file deletion through an intermediate junction is rejected", async () => {
+      const { pkgDir, outsideDir } = await setupJunction();
+
+      const patch =
+        "diff --git a/evildir/target.txt b/evildir/target.txt\n" +
+        "deleted file mode 100644\n" +
+        "index e69de29..0000000\n";
+
+      const err = tryApply(patch, pkgDir);
+      const exists = await fs.access(join(outsideDir, "target.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, exists }).toEqual({ code: "ELOOP", exists: true });
+    });
+
+    test("mode change of a junction itself is rejected", async () => {
+      const { pkgDir } = await setupJunction();
+
+      const patch = "diff --git a/evildir b/evildir\n" + "old mode 100644\n" + "new mode 100755\n";
+
+      const err = tryApply(patch, pkgDir);
+      expect(err?.code).toBe("ELOOP");
+    });
+
+    test("still applies to regular files inside the patch dir", async () => {
+      const { pkgDir } = await setupJunction();
+
+      const patch =
+        "diff --git a/real.txt b/real.txt\n" +
+        "index 0000000..1111111 100644\n" +
+        "--- a/real.txt\n" +
+        "+++ b/real.txt\n" +
+        "@@ -1,1 +1,1 @@\n" +
+        "-SAFE\n" +
+        "+OK\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "real.txt"), "utf8")).toBe("OK\n");
+    });
+
+    test("still creates new files in a directory the patch itself creates", async () => {
+      const { pkgDir } = setupEscapeDirs();
+
+      const patch =
+        "diff --git a/newdir/new.txt b/newdir/new.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/newdir/new.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+hello\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "newdir", "new.txt"), "utf8")).toBe("hello\n");
+    });
+
+    test("still applies a mode change to a regular file", async () => {
+      const { pkgDir } = await setupJunction();
+
+      const patch = "diff --git a/real.txt b/real.txt\n" + "old mode 100644\n" + "new mode 100755\n";
+
+      await apply(patch, pkgDir);
+      expect(await fs.readFile(join(pkgDir, "real.txt"), "utf8")).toBe("SAFE\n");
+    });
+  });
+
+  // A drive-relative component (`Z:..`) is not byte-equal to `..`, but the
+  // Windows openat normalizer strips the `Z:` prefix from a relative component
+  // and then resolves a real `..`, which would ascend out of the patch dir.
+  describe.if(process.platform === "win32")("rejects drive-relative components on Windows", () => {
+    test("a `X:..` component cannot escape the patch dir", async () => {
+      const root = tempDirWithFiles("patch-drive-rel", {
+        "pkg/.keep": "",
+        "keep.txt": "SAFE\n",
+      });
+      const pkgDir = join(root, "pkg");
+
+      const patch =
+        "diff --git a/Z:../escaped.txt b/Z:../escaped.txt\n" +
+        "new file mode 100644\n" +
+        "index 0000000..e69de29\n" +
+        "--- /dev/null\n" +
+        "+++ b/Z:../escaped.txt\n" +
+        "@@ -0,0 +1,1 @@\n" +
+        "+PWNED\n";
+
+      let err: any;
+      try {
+        apply(patch, pkgDir);
+      } catch (e) {
+        err = e;
+      }
+      const escaped = await fs.access(join(root, "escaped.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ code: err?.code, escaped }).toEqual({ code: "EINVAL", escaped: false });
+    });
+  });
+
+  // A `..` component with a trailing NUL byte is not byte-equal to `..`, but the
+  // kernel reads each component as a NUL-terminated C string and resolves a real
+  // `..`. Run in a child process: the unfixed failure mode is a process abort.
+  describe("rejects NUL bytes in patch paths", () => {
+    test("a `..` component hidden behind a NUL cannot escape the patch dir", async () => {
+      const root = tempDirWithFiles("patch-nul", {
+        "outside/.keep": "",
+        "pkg/a/b/.keep": "",
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           const NUL = String.fromCharCode(0);
+           const P = ".." + NUL + "1/.." + NUL + "2/.." + NUL + "3/outside/escaped.txt";
+           const patch = [
+             "diff --git a/" + P + " b/" + P,
+             "new file mode 100644",
+             "--- /dev/null",
+             "+++ b/" + P,
+             "@@ -0,0 +1,1 @@",
+             "+PWNED",
+             "",
+           ].join("\\n");
+           try {
+             patchInternals.apply(patch, ${JSON.stringify(join(root, "pkg", "a", "b"))});
+             console.log("no-error");
+           } catch (e) {
+             console.log("caught: " + e.code);
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      const escaped = await fs.access(join(root, "outside", "escaped.txt")).then(
+        () => true,
+        () => false,
+      );
+      expect({ stdout: stdout.trim(), stderr, escaped, exitCode }).toEqual({
+        stdout: "caught: EINVAL",
+        stderr: "",
+        escaped: false,
+        exitCode: 0,
+      });
+    });
+  });
+
+  // `O_RDONLY` on a FIFO without `O_NONBLOCK` blocks until a writer appears, so
+  // the target open must use `O_NONBLOCK` for the `!ISREG` check to ever run.
+  // Run in a child process: the unfixed failure mode is an indefinite hang.
+  describe.if(process.platform !== "win32")("non-regular patch targets", () => {
+    test("mode change on a FIFO is rejected instead of hanging", async () => {
+      const root = tempDirWithFiles("patch-fifo", { "pkg/.keep": "" });
+      const pkgDir = join(root, "pkg");
+      await $`mkfifo ${join(pkgDir, "pipe")}`;
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           const patch = "diff --git a/pipe b/pipe\\nold mode 100644\\nnew mode 100755\\n";
+           try {
+             patchInternals.apply(patch, ${JSON.stringify(pkgDir)});
              console.log("no-error");
            } catch (e) {
              console.log("caught: " + e.code);

--- a/test/regression/issue/patch-bounds-check.test.ts
+++ b/test/regression/issue/patch-bounds-check.test.ts
@@ -44,7 +44,7 @@ test("patch application should handle out-of-bounds line numbers gracefully", as
   expect(exitCode).toBe(1);
   expect(normalizeBunSnapshot(stderr)).toMatchInlineSnapshot(`
     "Resolving dependencies
-    error: failed applying patch file: EINVAL: Invalid argument (stat())
+    error: failed applying patch file: EINVAL: index.js: Invalid argument (stat())
     error: failed to apply patchfile (patches/lodash+4.17.21.patch)"
   `);
   expect(normalizeBunSnapshot(stdout)).toMatchInlineSnapshot(`"bun install <version> (<revision>)"`);


### PR DESCRIPTION
### Problem

- `PatchFile::apply` resolved every target path (`openat`, `unlinkat`, `renameat`, `fchmodat`, and the read of the file being patched) relative to the package directory and let the kernel follow whatever it found. `is_safe_patch_path` is lexical (empty / absolute / `..` / NUL), so a symlink, junction, or hard link already present in the directory redirected the operation, and the patch's bytes were written to (or the unlink/rename/chmod applied to) the link target outside the directory. Reproduction with the internal testing API:

  ```js
  import { patchInternals } from "bun:internal-for-testing";
  fs.symlinkSync("/tmp/outside.txt", "pkg/link");
  patchInternals.apply(
    "diff --git a/link b/link\nnew file mode 100644\n--- /dev/null\n+++ b/link\n@@ -0,0 +1,1 @@\n+PWNED\n",
    "pkg",
  );
  // /tmp/outside.txt now contains "PWNED"
  ```

- Scope, to be precise about what this does and does not close: the only production caller is `patch_install.rs`, which copies the package into a fresh temporary directory (`InstallMethod::Copyfile`, `patch_install.rs:497`) and applies the patch there. That copy never contains symlinks or extra hard links, so none of this is reachable from `bun install` today. This PR makes the applier enforce containment itself instead of relying on that caller property, so the applier's contract holds for any directory it is pointed at (the testing API, or a future caller that applies in place).
- Separately, a pre-existing bug this PR also fixes: `FileCreation` used the new file's mode from the patch header as the mode for any parent directories it had to create, so `new file mode 100644` produced a `0644` directory and the file creation inside it failed with `EACCES` for a non-root user (`newdir/x.txt` in a patch reproduces this on main). It is in this PR because the rewrite replaces that line; it is listed here, and tested in `describe("creation")`, as a behavior change rather than as containment.

### Fix

- `resolve_target` validates the path and walks its parent directory one component at a time from the package directory fd, opening each component `O_RDONLY | O_DIRECTORY | O_NOFOLLOW` (creating it with `mkdirat` first when the operation is allowed to create directories). It returns the verified parent fd plus the final component, and every operation in `apply` is now an `*at` call against exactly that pair, so no path is ever re-resolved by the kernel after it has been checked. All five operations (delete, rename, create, patch, chmod) go through it; `apply` attaches the patch path to whatever error comes back, so a failing multi-file patch names the file.
- `open_target_file` opens the final component `O_NOFOLLOW` (plus `O_NONBLOCK` on POSIX so a FIFO cannot block the open) and then requires the opened inode to be a regular file with `st_nlink == 1`. A second link means the inode is reachable from outside the directory, so it is refused before anything is truncated; the file being patched is read and written back through this one fd, and creation defers truncation until after the check.
- Lexical additions: `:` is rejected on Windows, because the Windows `openat` strips a drive prefix from a relative component, turning `C:..` into `..`. (NUL rejection already landed on main in #36165.) Created parent directories are `0755`.
- Windows: `openat` with `O_NOFOLLOW` opens with `FILE_OPEN_REPARSE_POINT` since #36193, so the walk and the final open pass `O_NOFOLLOW` on every platform. On Windows that opens the reparse point itself rather than failing, and `fstat` on that handle reports a regular file, so `reject_reparse_point` additionally checks each component's own attributes (`NtQueryAttributesFile` via the new `bun_sys::get_file_attributes_at`) before opening it. That check is by name rather than by handle, so on Windows containment is not atomic against a concurrent swap; on POSIX it is.
- Error codes: a symlink or junction anywhere in the path is `ELOOP` on every platform (Linux reports `ENOTDIR`, Darwin `ELOOP`, FreeBSD `EMLINK` for the refused open; `symlink_component_err` normalizes them after confirming with `lstat`); a hard-linked target is `EMLINK`; a non-regular target or a rejected path is `EINVAL`.
- Verification: `test/js/bun/patch/patch.test.ts` adds suites for symlinks (final and intermediate component, all five operations), hard links, Windows junctions, the NUL `..` chain, the Windows drive-relative component, FIFO targets, and the directory mode; each rejection test fails on the unfixed applier. `bun-install-patch.test.ts` and `patch-bounds-check.test.ts` snapshots are updated for the error messages, which now include the file name. `byte-search` and `dead-code-escapes` source lints pass.

### Background

- `openat`-family syscalls take a directory fd and resolve the given path relative to it. With a single-component name and `O_NOFOLLOW`, the kernel refuses to go through a symlink at that name, and since the directory fd already pins the parent, the combination is the standard way to operate on "this entry, in this directory, and nothing else"; walking a multi-component path this way is what makes intermediate symlinks unreachable too.
- `st_nlink` is the number of directory entries pointing at an inode. A freshly copied package has exactly one for every file, so a count above one means a second name for the same data exists somewhere, and writing through either name writes the other.
- On Windows, symlinks and junctions are both "reparse points". `FILE_OPEN_REPARSE_POINT` makes an open return the reparse point itself instead of its target, which is why a successful open there has to be followed by an attribute check rather than treated as proof the entry is a plain file or directory.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 15 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-patch.test.ts test/js/bun/patch/patch.test.ts

<!-- robobun:evidence:end -->