### PR TITLE
Fix panic when require.resolve options.paths contains non-absolute paths

### DIFF
--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -2091,12 +2091,21 @@ impl<'a> Resolver<'a> {
                 bun_core::hint::cold();
                 for custom_path in custom_paths {
                     let custom_utf8 = custom_path.to_utf8_without_ref();
-                    match self.check_package_path(
-                        custom_utf8.slice(),
-                        import_path,
-                        kind,
-                        global_cache,
-                    ) {
+                    let mut abs_buf;
+                    let custom_slice = if bun_paths::is_absolute(custom_utf8.slice()) {
+                        custom_utf8.slice()
+                    } else {
+                        // Node.js resolves relative entries in `options.paths` against cwd.
+                        abs_buf = bun_paths::path_buffer_pool::get();
+                        match self
+                            .fs_ref()
+                            .abs_buf_checked(&[custom_utf8.slice()], &mut *abs_buf)
+                        {
+                            Some(p) => p,
+                            None => continue,
+                        }
+                    };
+                    match self.check_package_path(custom_slice, import_path, kind, global_cache) {
                         ResultUnion::Success(res) => return ResultUnion::Success(res),
                         ResultUnion::Pending(p) => return ResultUnion::Pending(p),
                         ResultUnion::Failure(p) => return ResultUnion::Failure(p),

--- a/test/js/node/module/module-resolve-filename-paths.test.js
+++ b/test/js/node/module/module-resolve-filename-paths.test.js
@@ -199,3 +199,48 @@ test("Module._resolveFilename throws ERR_INVALID_ARG_TYPE if options.paths is no
     Module._resolveFilename("path", __filename, false, { paths: { 0: "/some/path" } });
   }).toThrow();
 });
+
+test("require.resolve resolves relative entries in options.paths against cwd", () => {
+  const { path: dir, cleanup } = createTempDir("require-resolve-relative-paths", {
+    "sub/node_modules/rel-path-pkg/package.json": JSON.stringify({ name: "rel-path-pkg", main: "index.js" }),
+    "sub/node_modules/rel-path-pkg/index.js": "module.exports = 'ok';",
+  });
+
+  const prevCwd = process.cwd();
+  try {
+    process.chdir(dir);
+    const resolved = require.resolve("rel-path-pkg", { paths: ["./sub"] });
+    expect(resolved).toBe(resolve(dir, "sub/node_modules/rel-path-pkg/index.js"));
+  } finally {
+    process.chdir(prevCwd);
+    cleanup();
+  }
+});
+
+test("require.resolve with non-absolute options.paths does not crash", () => {
+  let err;
+  try {
+    require.resolve("this-package-does-not-exist-anywhere", { paths: ["not-absolute-dir", ""] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+
+  // Non-string entries: Node throws ERR_INVALID_ARG_TYPE, Bun coerces to string.
+  // Either way this must throw, not crash the process.
+  expect(() => {
+    require.resolve("this-package-does-not-exist-anywhere", { paths: [Int16Array] });
+  }).toThrow();
+});
+
+test("Module._resolveFilename with non-absolute options.paths does not crash", () => {
+  let err;
+  try {
+    Module._resolveFilename("this-package-does-not-exist-anywhere", null, false, { paths: ["not-absolute-dir"] });
+  } catch (e) {
+    err = e;
+  }
+  expect(err).toBeDefined();
+  expect(err.code).toBe("MODULE_NOT_FOUND");
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a panic in the resolver when `require.resolve()`, `require()`, or `Module._resolveFilename()` is called with `options.paths` containing a non-absolute path.

```js
require.resolve("pkg", { paths: ["./relative"] })
// panic: cannot resolve DirInfo for non-absolute path: ./relative
```

The resolver passed these user-supplied paths directly to `dir_info_cached`, which asserts the input is absolute. Since `options.paths` comes from userland, any relative string (or any non-string value that coerces to a non-absolute string) crashed the process.

Relative entries are now resolved against the top-level dir before lookup, which matches Node.js behavior (Node routes each entry through `path.resolve()` via `Module._nodeModulePaths`).

## How did you verify your code works?

Added regression tests in `test/js/node/module/module-resolve-filename-paths.test.js` covering `require.resolve` and `Module._resolveFilename` with relative string entries, empty strings, and non-string values. Tests pass in both Bun and Node.js, and crash the unpatched Bun.