### PR TITLE
Socket syscall fault injection for net/tls/http/http2/fetch/WebSocket fuzzing + 7 bug fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,10 +186,11 @@ overflow-checks = false
 # back to "warn" (their priority 0 beats the group's -1) where a warning level
 # is intentional.
 warnings = { level = "deny", priority = -1 }
-# `bun_asan` / `bun_debug` are set via RUSTFLAGS (`--cfg=bun_*` +
-# `--check-cfg=cfg(bun_*)`) by scripts/build/rust.ts; register them here so a
-# plain `cargo build` / `cargo check` (without those flags) doesn't warn.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)', 'cfg(bun_debug)'] }
+# `bun_asan` / `bun_debug` / `socket_fault_injection` are set via RUSTFLAGS
+# (`--cfg=...` + `--check-cfg=cfg(...)`) by scripts/build/rust.ts; register
+# them here so a plain `cargo build` / `cargo check` (without those flags)
+# doesn't warn.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(bun_asan)', 'cfg(bun_debug)', 'cfg(socket_fault_injection)'] }
 # link.exe unconditionally prints "Creating library X.dll.lib and object
 # X.dll.exp" to stdout when linking each proc-macro DLL on Windows hosts;
 # there is no linker flag to suppress it. The lint already exempts itself

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -21,6 +21,7 @@
 
 #include "libusockets.h"
 #include "internal/internal.h"
+#include "internal/fault_inject.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -789,6 +790,10 @@ int bsd_addr_get_port(struct bsd_addr_t *addr) {
 LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd_addr_t *addr) {
     LIBUS_SOCKET_DESCRIPTOR accepted_fd;
 
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_ACCEPT, fd, injected, unused)) return LIBUS_SOCKET_ERROR;
+    (void)injected; (void)unused;
+
     while (1) {
         addr->len = sizeof(addr->mem);
 
@@ -842,6 +847,8 @@ LIBUS_SOCKET_DESCRIPTOR bsd_accept_socket(LIBUS_SOCKET_DESCRIPTOR fd, struct bsd
 }
 
 ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {
+    ssize_t injected = 0;
+    if (US_FAULT_CHECK(US_FAULT_RECV, fd, injected, length)) return injected;
     while (1) {
         ssize_t ret = recv(fd, buf, length, flags);
 
@@ -866,6 +873,9 @@ ssize_t bsd_recv(LIBUS_SOCKET_DESCRIPTOR fd, void *buf, int length, int flags) {
 
 #if !defined(_WIN32)
 ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_RECVMSG, fd, injected, unused)) return injected;
+    (void)unused;
     while (1) {
         ssize_t ret = recvmsg(fd, msg, flags);
 
@@ -882,6 +892,9 @@ ssize_t bsd_recvmsg(LIBUS_SOCKET_DESCRIPTOR fd, struct msghdr *msg, int flags) {
 #include <sys/uio.h>
 
 ssize_t bsd_writev(LIBUS_SOCKET_DESCRIPTOR fd, const struct us_iovec_t *iov, int count) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_WRITEV, fd, injected, unused)) return injected;
+    (void)unused;
     /* POSIX writev fails with EINVAL above IOV_MAX (1024 on Linux/macOS); cap and
      * let the caller's partial-write handling carry the remainder. */
     if (count > 1024) {
@@ -897,6 +910,9 @@ ssize_t bsd_writev(LIBUS_SOCKET_DESCRIPTOR fd, const struct us_iovec_t *iov, int
 }
 
 ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_length, const char *payload, int payload_length) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_WRITEV, fd, injected, unused)) return injected;
+    (void)unused;
     struct iovec chunks[2];
 
     chunks[0].iov_base = (char *)header;
@@ -938,6 +954,8 @@ ssize_t bsd_write2(LIBUS_SOCKET_DESCRIPTOR fd, const char *header, int header_le
 #endif
 
 ssize_t bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length) {
+    ssize_t injected = 0;
+    if (US_FAULT_CHECK(US_FAULT_SEND, fd, injected, length)) return injected;
     while (1) {
     // MSG_MORE (Linux), MSG_PARTIAL (Windows), TCP_NOPUSH (BSD)
 
@@ -969,6 +987,9 @@ ssize_t bsd_send(LIBUS_SOCKET_DESCRIPTOR fd, const char *buf, int length) {
 
 #if !defined(_WIN32)
 ssize_t bsd_sendmsg(LIBUS_SOCKET_DESCRIPTOR fd, const struct msghdr *msg, int flags) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_SENDMSG, fd, injected, unused)) return injected;
+    (void)unused;
     while (1) {
         ssize_t rc = sendmsg(fd, msg, flags);
 
@@ -1609,6 +1630,9 @@ int bsd_disconnect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd) {
 
 static int bsd_do_connect_raw(LIBUS_SOCKET_DESCRIPTOR fd, struct sockaddr *addr, size_t namelen)
 {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_CONNECT, fd, injected, unused)) return errno;
+    (void)injected; (void)unused;
 #ifdef _WIN32
     while (1) {
         if (connect(fd, (struct sockaddr *)addr, namelen) == 0) {

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -203,7 +203,10 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
                 continue;
             }
             int events = loop->ready_polls[loop->current_ready_poll].events;
-            const int error = events & EPOLLERR;
+            /* Normalize to 0/1 like the kqueue path's EV_ERROR: the value is
+             * forwarded as a libus close code, and a raw EPOLLERR (8) would
+             * read as errno 8 (ENOEXEC) in the JS error path. */
+            const int error = !!(events & EPOLLERR);
             const int eof = events & EPOLLHUP;
             events &= us_poll_events(poll);
             if (events || error || eof) {

--- a/packages/bun-usockets/src/fault_inject.c
+++ b/packages/bun-usockets/src/fault_inject.c
@@ -1,0 +1,95 @@
+#include "internal/internal.h"
+#include "internal/fault_inject.h"
+
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+
+#include <errno.h>
+#include <string.h>
+
+int us_fault_armed = 0;
+
+struct us_fault_slot {
+    struct us_fault_rule rule;
+    int calls_seen;
+    int fired;
+};
+
+/* Process-global so rules armed on the JS thread also affect the HTTP-client
+ * thread (fetch) and any worker threads. Per-socket isolation is provided by
+ * rule.target_fd instead. The release store on us_fault_armed in
+ * us_fault_recompute_armed() pairs with the acquire load in US_FAULT_CHECK so
+ * a reader observing armed==1 also sees the rule fields written before it.
+ * calls_seen/fired are atomic counters so cross-thread firings preserve
+ * after/repeat determinism. */
+static struct us_fault_slot us_fault_state[US_FAULT_COUNT];
+
+static void us_fault_recompute_armed(void) {
+    int any = 0;
+    for (int i = 0; i < US_FAULT_COUNT; i++) {
+        if (us_fault_state[i].rule.action != US_FAULT_NONE) {
+            any = 1;
+            break;
+        }
+    }
+    __atomic_store_n(&us_fault_armed, any, __ATOMIC_RELEASE);
+}
+
+void us_fault_set(int sc, const struct us_fault_rule *rule) {
+    if ((unsigned)sc >= US_FAULT_COUNT) return;
+    us_fault_state[sc].rule = *rule;
+    __atomic_store_n(&us_fault_state[sc].calls_seen, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&us_fault_state[sc].fired, 0, __ATOMIC_RELAXED);
+    us_fault_recompute_armed();
+}
+
+void us_fault_clear(int sc) {
+    if ((unsigned)sc >= US_FAULT_COUNT) return;
+    __atomic_store_n(&us_fault_state[sc].rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
+    __atomic_store_n(&us_fault_state[sc].calls_seen, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&us_fault_state[sc].fired, 0, __ATOMIC_RELAXED);
+    us_fault_recompute_armed();
+}
+
+void us_fault_clear_all(void) {
+    for (int i = 0; i < US_FAULT_COUNT; i++) {
+        __atomic_store_n(&us_fault_state[i].rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
+    }
+    __atomic_store_n(&us_fault_armed, 0, __ATOMIC_RELEASE);
+}
+
+int us_fault_hit(int sc, int fd, ssize_t *out, int *clamp) {
+    struct us_fault_slot *slot = &us_fault_state[sc];
+    /* Snapshot the rule so a concurrent disarm cannot tear fields mid-switch. */
+    struct us_fault_rule rule = slot->rule;
+    if (rule.action == US_FAULT_NONE) return 0;
+    if (rule.target_fd >= 0 && rule.target_fd != fd) return 0;
+    int seen = __atomic_fetch_add(&slot->calls_seen, 1, __ATOMIC_RELAXED);
+    if (seen < rule.after_n_calls) return 0;
+    int f = __atomic_fetch_add(&slot->fired, 1, __ATOMIC_ACQ_REL);
+    if (rule.repeat >= 0 && f >= rule.repeat) {
+        __atomic_store_n(&slot->rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
+        us_fault_recompute_armed();
+        return 0;
+    }
+    switch (rule.action) {
+        case US_FAULT_ERRNO:
+#ifdef _WIN32
+            WSASetLastError(rule.errno_value);
+#endif
+            errno = rule.errno_value;
+            *out = -1;
+            return 1;
+        case US_FAULT_ZERO:
+            *out = 0;
+            return 1;
+        case US_FAULT_SHORT:
+            if (rule.clamp_bytes >= 0 && *clamp > rule.clamp_bytes) {
+                *clamp = rule.clamp_bytes;
+            }
+            return 0;
+        default:
+            return 0;
+    }
+}
+
+#endif /* LIBUS_SOCKET_FAULT_INJECTION */

--- a/packages/bun-usockets/src/fault_inject.c
+++ b/packages/bun-usockets/src/fault_inject.c
@@ -16,13 +16,18 @@ struct us_fault_slot {
 
 /* Process-global so rules armed on the JS thread also affect the HTTP-client
  * thread (fetch) and any worker threads. Per-socket isolation is provided by
- * rule.target_fd instead. The release store on us_fault_armed in
- * us_fault_recompute_armed() pairs with the acquire load in US_FAULT_CHECK so
- * a reader observing armed==1 also sees the rule fields written before it.
- * calls_seen/fired are atomic counters so cross-thread firings preserve
- * after/repeat determinism. */
+ * rule.target_fd instead. */
 static struct us_fault_slot us_fault_state[US_FAULT_COUNT];
 
+/* Guards every access to us_fault_state so a re-arm on the JS thread cannot
+ * tear the rule (or its counters) out from under a faulting I/O thread. Only
+ * taken once the lock-free us_fault_armed fast path in US_FAULT_CHECK has
+ * passed, so the disarmed hot path never touches it. */
+static zig_mutex_t us_fault_lock;
+
+/* Caller must hold us_fault_lock. The release store pairs with the acquire
+ * load in US_FAULT_CHECK; a reader that observes armed==1 then re-reads the
+ * rule under the lock in us_fault_hit(), so it never sees a torn rule. */
 static void us_fault_recompute_armed(void) {
     int any = 0;
     for (int i = 0; i < US_FAULT_COUNT; i++) {
@@ -36,41 +41,55 @@ static void us_fault_recompute_armed(void) {
 
 void us_fault_set(int sc, const struct us_fault_rule *rule) {
     if ((unsigned)sc >= US_FAULT_COUNT) return;
+    Bun__lock(&us_fault_lock);
     us_fault_state[sc].rule = *rule;
-    __atomic_store_n(&us_fault_state[sc].calls_seen, 0, __ATOMIC_RELAXED);
-    __atomic_store_n(&us_fault_state[sc].fired, 0, __ATOMIC_RELAXED);
+    us_fault_state[sc].calls_seen = 0;
+    us_fault_state[sc].fired = 0;
     us_fault_recompute_armed();
+    Bun__unlock(&us_fault_lock);
 }
 
 void us_fault_clear(int sc) {
     if ((unsigned)sc >= US_FAULT_COUNT) return;
-    __atomic_store_n(&us_fault_state[sc].rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
-    __atomic_store_n(&us_fault_state[sc].calls_seen, 0, __ATOMIC_RELAXED);
-    __atomic_store_n(&us_fault_state[sc].fired, 0, __ATOMIC_RELAXED);
+    Bun__lock(&us_fault_lock);
+    us_fault_state[sc].rule.action = US_FAULT_NONE;
+    us_fault_state[sc].calls_seen = 0;
+    us_fault_state[sc].fired = 0;
     us_fault_recompute_armed();
+    Bun__unlock(&us_fault_lock);
 }
 
 void us_fault_clear_all(void) {
+    Bun__lock(&us_fault_lock);
     for (int i = 0; i < US_FAULT_COUNT; i++) {
-        __atomic_store_n(&us_fault_state[i].rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
+        us_fault_state[i].rule.action = US_FAULT_NONE;
     }
     __atomic_store_n(&us_fault_armed, 0, __ATOMIC_RELEASE);
+    Bun__unlock(&us_fault_lock);
 }
 
 int us_fault_hit(int sc, int fd, ssize_t *out, int *clamp) {
+    Bun__lock(&us_fault_lock);
     struct us_fault_slot *slot = &us_fault_state[sc];
-    /* Snapshot the rule so a concurrent disarm cannot tear fields mid-switch. */
+    /* Snapshot under the lock so the post-release switch below acts on one
+     * coherent rule even if another thread swaps it right after we unlock.
+     * Single lock/unlock pair: every exit funnels through the one release. */
     struct us_fault_rule rule = slot->rule;
-    if (rule.action == US_FAULT_NONE) return 0;
-    if (rule.target_fd >= 0 && rule.target_fd != fd) return 0;
-    int seen = __atomic_fetch_add(&slot->calls_seen, 1, __ATOMIC_RELAXED);
-    if (seen < rule.after_n_calls) return 0;
-    int f = __atomic_fetch_add(&slot->fired, 1, __ATOMIC_ACQ_REL);
-    if (rule.repeat >= 0 && f >= rule.repeat) {
-        __atomic_store_n(&slot->rule.action, US_FAULT_NONE, __ATOMIC_RELAXED);
-        us_fault_recompute_armed();
-        return 0;
+    int fire = 0;
+    if (rule.action != US_FAULT_NONE && (rule.target_fd < 0 || rule.target_fd == fd)) {
+        int seen = slot->calls_seen++;
+        if (seen >= rule.after_n_calls) {
+            int f = slot->fired++;
+            if (rule.repeat >= 0 && f >= rule.repeat) {
+                slot->rule.action = US_FAULT_NONE;
+                us_fault_recompute_armed();
+            } else {
+                fire = 1;
+            }
+        }
     }
+    Bun__unlock(&us_fault_lock);
+    if (!fire) return 0;
     switch (rule.action) {
         case US_FAULT_ERRNO:
 #ifdef _WIN32

--- a/packages/bun-usockets/src/fault_inject.c
+++ b/packages/bun-usockets/src/fault_inject.c
@@ -69,6 +69,7 @@ void us_fault_clear_all(void) {
 }
 
 int us_fault_hit(int sc, int fd, ssize_t *out, int *clamp) {
+    if ((unsigned)sc >= US_FAULT_COUNT) return 0;
     Bun__lock(&us_fault_lock);
     struct us_fault_slot *slot = &us_fault_state[sc];
     /* Snapshot under the lock so the post-release switch below acts on one

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -33,6 +33,7 @@ enum us_fault_syscall {
     US_FAULT_RECVMSG,
     US_FAULT_CONNECT,
     US_FAULT_ACCEPT,
+    /* Reserved: no bsd.c hooks yet, so the JS setter does not accept them. */
     US_FAULT_SOCKET,
     US_FAULT_CLOSE,
     US_FAULT_SHUTDOWN,

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -44,7 +44,7 @@ enum us_fault_action {
     /* return -1 and set errno = errno_value */
     US_FAULT_ERRNO,
     /* recv/send: clamp the length to clamp_bytes, then run the real syscall.
-     * No-op on writev/sendmsg/recvmsg/accept/connect (no length to clamp). */
+     * Other syscalls have no length to clamp; the JS setter rejects them. */
     US_FAULT_SHORT,
     /* recv: return 0 (peer closed); send: return 0 (treated as backpressure) */
     US_FAULT_ZERO,

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -46,7 +46,8 @@ enum us_fault_action {
     /* recv/send: clamp the length to clamp_bytes, then run the real syscall.
      * Other syscalls have no length to clamp; the JS setter rejects them. */
     US_FAULT_SHORT,
-    /* recv: return 0 (peer closed); send: return 0 (treated as backpressure) */
+    /* recv/recvmsg: return 0 (peer closed); send/sendmsg/writev: return 0
+     * (treated as backpressure). The JS setter rejects other syscalls. */
     US_FAULT_ZERO,
 };
 

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -1,0 +1,92 @@
+/*
+ * Socket syscall fault injection for the bsd_* wrapper layer.
+ *
+ * Compiled in only when LIBUS_SOCKET_FAULT_INJECTION is defined (controlled
+ * by the `socketFaultInjection` Config field). When compiled out,
+ * US_FAULT_CHECK() expands to a constant 0 and the optimizer drops every
+ * reference. When compiled in but no rule is armed, the hot path is a single
+ * acquire atomic load + predicted-not-taken branch.
+ *
+ * Rules are process-global so a rule armed from the JS thread also affects
+ * the HTTP-client thread (fetch) and worker threads. Use rule.target_fd for
+ * per-socket isolation.
+ */
+// clang-format off
+#pragma once
+#ifndef LIBUS_FAULT_INJECT_H
+#define LIBUS_FAULT_INJECT_H
+
+#if defined(LIBUS_SOCKET_FAULT_INJECTION) && LIBUS_SOCKET_FAULT_INJECTION
+
+#ifdef _WIN32
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#else
+#include <sys/types.h>
+#endif
+
+enum us_fault_syscall {
+    US_FAULT_RECV,
+    US_FAULT_SEND,
+    US_FAULT_WRITEV,
+    US_FAULT_SENDMSG,
+    US_FAULT_RECVMSG,
+    US_FAULT_CONNECT,
+    US_FAULT_ACCEPT,
+    US_FAULT_SOCKET,
+    US_FAULT_CLOSE,
+    US_FAULT_SHUTDOWN,
+    US_FAULT_COUNT
+};
+
+enum us_fault_action {
+    US_FAULT_NONE,
+    /* return -1 and set errno = errno_value */
+    US_FAULT_ERRNO,
+    /* recv/send: clamp the length to clamp_bytes, then run the real syscall.
+     * No-op on writev/sendmsg/recvmsg/accept/connect (no length to clamp). */
+    US_FAULT_SHORT,
+    /* recv: return 0 (peer closed); send: return 0 (treated as backpressure) */
+    US_FAULT_ZERO,
+};
+
+struct us_fault_rule {
+    int action;
+    int errno_value;
+    int clamp_bytes;
+    /* skip the first N matching calls before triggering */
+    int after_n_calls;
+    /* fire this many times then disarm; -1 = forever */
+    int repeat;
+    /* match only this fd; -1 = any */
+    int target_fd;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int us_fault_armed;
+
+void us_fault_set(int syscall, const struct us_fault_rule *rule);
+void us_fault_clear(int syscall);
+void us_fault_clear_all(void);
+int us_fault_hit(int syscall, int fd, ssize_t *out, int *clamp);
+
+#ifdef __cplusplus
+}
+#endif
+
+/* Hot-path macro. `out_lvalue` and `clamp_lvalue` must be lvalues. Returns 1
+ * when the call should short-circuit with *out_lvalue. clamp_lvalue may be
+ * shrunk in-place when the rule wants a partial read/write. */
+#define US_FAULT_CHECK(sc, fd, out_lvalue, clamp_lvalue)                                                 \
+    (__builtin_expect(__atomic_load_n(&us_fault_armed, __ATOMIC_ACQUIRE), 0)                             \
+        && us_fault_hit((sc), (int)(fd), &(out_lvalue), &(clamp_lvalue)))
+
+#else /* !LIBUS_SOCKET_FAULT_INJECTION */
+
+#define US_FAULT_CHECK(sc, fd, out_lvalue, clamp_lvalue) 0
+
+#endif
+#endif /* LIBUS_FAULT_INJECT_H */

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -382,8 +382,13 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
         }
     case POLL_TYPE_SEMI_SOCKET: {
             /* Both connect and listen sockets are semi-sockets
-             * but they poll for different events */
-            if (us_poll_events(p) == LIBUS_SOCKET_WRITABLE) {
+             * but they poll for different events. A connecting socket starts
+             * out polling WRITABLE only, but a write issued before the connect
+             * completes (the kernel buffers it) can partial-write and call
+             * us_poll_change(R|W) from us_socket_write*. Test the WRITABLE bit
+             * rather than exact equality so the connect-complete is still
+             * recognized; listen sockets only ever poll READABLE. */
+            if (us_poll_events(p) & LIBUS_SOCKET_WRITABLE) {
                 /* The connecting fd became writable with an error/HUP flag also
                  * set: the handshake may have completed and then been reset
                  * before we collected the event. Report the kernel's actual

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -706,9 +706,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                  * isn't fired for a passive close. The poll flag only says THAT
                  * the socket failed; fetch the real errno (like the connect-error
                  * path) so the close code is ECONNRESET and not a poll bit that
-                 * callers would either misread as an errno or drop entirely. */
+                 * callers would either misread as an errno or drop entirely.
+                 * Values 0..2 collide with the libus CloseCode enum that JS
+                 * filters out as self-initiated; SO_ERROR can't be EPERM/ENOENT
+                 * for an established TCP socket, so clamp them defensively. */
                 int socket_error = us_socket_get_error(s);
-                s = us_internal_socket_close_raw(s, socket_error ? socket_error : ECONNRESET, NULL);
+                s = us_internal_socket_close_raw(s, socket_error > 2 ? socket_error : ECONNRESET, NULL);
                 return;
             }
             break;

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -703,8 +703,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             if (error && s) {
                 /* Peer-initiated error event — same rationale as the recv-error
                  * branch above: bypass us_internal_ssl_close so on_handshake
-                 * isn't fired for a passive close. */
-                s = us_internal_socket_close_raw(s, error, NULL);
+                 * isn't fired for a passive close. The poll flag only says THAT
+                 * the socket failed; fetch the real errno (like the connect-error
+                 * path) so the close code is ECONNRESET and not a poll bit that
+                 * callers would either misread as an errno or drop entirely. */
+                int socket_error = us_socket_get_error(s);
+                s = us_internal_socket_close_raw(s, socket_error ? socket_error : ECONNRESET, NULL);
                 return;
             }
             break;

--- a/packages/bun-uws/src/WebSocketProtocol.h
+++ b/packages/bun-uws/src/WebSocketProtocol.h
@@ -129,8 +129,12 @@ static inline CloseFrame parseClosePayload(char *src, size_t length) {
     if (length >= 2) {
         memcpy(&cf.code, src, 2);
         cf = {cond_byte_swap<uint16_t>(cf.code), src + 2, length - 2};
-        if (cf.code < 1000 || cf.code > 4999 || (cf.code > 1011 && cf.code < 4000) ||
-            (cf.code >= 1004 && cf.code <= 1006) || !isValidUtf8((unsigned char *) cf.message, cf.length)) {
+        // RFC 6455 §7.4: 1000-1015 defined, 1016-2999 reserved (MUST NOT be
+        // used), 3000-3999 IANA-registered for libraries/frameworks, 4000-4999
+        // private use. 1004/1005/1006/1015 are not valid on the wire.
+        if (cf.code < 1000 || cf.code > 4999 || (cf.code > 1015 && cf.code < 3000) ||
+            (cf.code >= 1004 && cf.code <= 1006) || cf.code == 1015 ||
+            !isValidUtf8((unsigned char *) cf.message, cf.length)) {
             /* Even though we got a WebSocket close frame, it in itself is abnormal */
             return {1006, nullptr, 0};
         }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -384,6 +384,7 @@ function parseArgs(argv: string[]): CliArgs {
     "tinycc",
     "valgrind",
     "fuzzilli",
+    "socketFaultInjection",
     "unifiedSources",
     "archiveDeps",
     "timeTrace",

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -144,6 +144,12 @@ export interface Config {
   tinycc: boolean;
   valgrind: boolean;
   fuzzilli: boolean;
+  /**
+   * Compile usockets bsd_* syscall fault-injection hooks. Runtime-armed via
+   * `bun:internal-for-testing` socketFaultInjection; disarmed cost is one
+   * relaxed atomic load per syscall, zero when compiled out.
+   */
+  socketFaultInjection: boolean;
   /** Bundle small .cpp files into unified TUs (WebKit-style). See unified.ts. */
   unifiedSources: boolean;
   /**
@@ -336,6 +342,7 @@ export interface PartialConfig {
   tinycc?: boolean;
   valgrind?: boolean;
   fuzzilli?: boolean;
+  socketFaultInjection?: boolean;
   unifiedSources?: boolean;
   archiveDeps?: boolean;
   timeTrace?: boolean;
@@ -863,6 +870,11 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
 
   const valgrind = partial.valgrind ?? false;
   const fuzzilli = partial.fuzzilli ?? false;
+  // Default follows asan: on for local debug (Linux / arm64 macOS) and CI
+  // release-asan, off everywhere else. The fuzz tests are most useful when
+  // memory errors are detectable, and the disarmed-hot-path cost (one relaxed
+  // atomic load) is acceptable in asan builds but not in shipped release.
+  const socketFaultInjection = partial.socketFaultInjection ?? asan;
 
   // ─── Paths ───
   const cwd = findRepoRoot();
@@ -1125,6 +1137,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
     tinycc,
     valgrind,
     fuzzilli,
+    socketFaultInjection,
     unifiedSources: partial.unifiedSources ?? true,
     archiveDeps: partial.archiveDeps ?? false,
     timeTrace: partial.timeTrace ?? false,
@@ -1449,6 +1462,9 @@ export function formatConfig(cfg: Config, exe: string): string {
   if (cfg.baseline) features.push("baseline");
   if (cfg.valgrind) features.push("valgrind");
   if (cfg.fuzzilli) features.push("fuzzilli");
+  if (cfg.socketFaultInjection !== cfg.asan) {
+    features.push(`socket-fault-injection:${cfg.socketFaultInjection ? "on" : "off"}`);
+  }
   if (!cfg.canary) features.push("canary:off");
   // Non-default modes — show so you notice when a build is unusual.
   if (cfg.webkit !== "prebuilt") features.push(`webkit:${cfg.webkit}`);

--- a/scripts/build/config.ts
+++ b/scripts/build/config.ts
@@ -147,7 +147,7 @@ export interface Config {
   /**
    * Compile usockets bsd_* syscall fault-injection hooks. Runtime-armed via
    * `bun:internal-for-testing` socketFaultInjection; disarmed cost is one
-   * relaxed atomic load per syscall, zero when compiled out.
+   * acquire atomic load per syscall, zero when compiled out.
    */
   socketFaultInjection: boolean;
   /** Bundle small .cpp files into unified TUs (WebKit-style). See unified.ts. */
@@ -872,7 +872,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
   const fuzzilli = partial.fuzzilli ?? false;
   // Default follows asan: on for local debug (Linux / arm64 macOS) and CI
   // release-asan, off everywhere else. The fuzz tests are most useful when
-  // memory errors are detectable, and the disarmed-hot-path cost (one relaxed
+  // memory errors are detectable, and the disarmed-hot-path cost (one acquire
   // atomic load) is acceptable in asan builds but not in shipped release.
   const socketFaultInjection = partial.socketFaultInjection ?? asan;
 

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -772,6 +772,11 @@ export const defines: Flag[] = [
     desc: "Enable debug-only code paths",
   },
   {
+    flag: "LIBUS_SOCKET_FAULT_INJECTION=1",
+    when: c => c.socketFaultInjection,
+    desc: "Compile usockets bsd_* syscall fault-injection hooks (runtime-armed via bun:internal-for-testing)",
+  },
+  {
     // slash(): path becomes a C string literal — `\U` would be a unicode escape.
     flag: c => `BUN_DYNAMIC_JS_LOAD_PATH=\\"${slash(join(c.buildDir, "js"))}\\"`,
     when: c => c.debug && !c.ci,

--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -503,6 +503,15 @@ export function emitRust(n: Ninja, cfg: Config, inputs: RustBuildInputs): string
   if (!cfg.debug) {
     rustflags.push("--cfg=bun_codegen_embed");
   }
+  // `socket_fault_injection`: usockets bsd_* fault-injection hooks compiled
+  // in (LIBUS_SOCKET_FAULT_INJECTION=1 on the C side). The Rust FFI for
+  // us_fault_set/us_fault_clear_all and the JS control surface gate on this
+  // so the C symbol and the Rust extern are either both present or both
+  // absent regardless of profile.
+  rustflags.push("--check-cfg=cfg(socket_fault_injection)");
+  if (cfg.socketFaultInjection) {
+    rustflags.push("--cfg=socket_fault_injection");
+  }
   // Drop `#[track_caller]` source-location capture in release. Every
   // `Option::unwrap`/`slice[i]`/`RefCell::borrow` etc. otherwise emits a
   // `&'static core::panic::Location` (file/line/col) plus the file-path string

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -77,6 +77,10 @@ pub struct WebSocket<const SSL: bool> {
     pub pong_received: bool,
     pub close_received: bool,
     pub close_frame_buffering: bool,
+    /// `Some` once `send_close_with_body` has enqueued the close frame: blocks
+    /// further outbound writes and drives `clear_data` + `dispatch_close` once
+    /// the frame is fully flushed (or the socket dies).
+    pub close_dispatch_pending: Option<(u16, bun_core::String)>,
 
     pub receive_frame: usize,
     pub receive_body_remain: usize,
@@ -181,6 +185,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         self.pong_received = false;
         self.ping_len = 0;
         self.close_frame_buffering = false;
+        if let Some((_, r)) = self.close_dispatch_pending.take() {
+            r.deref();
+        }
         self.receive_pending_chunk_len = 0;
         self.receiving_compressed = false;
         self.message_is_compressed = false;
@@ -338,6 +345,19 @@ impl<const SSL: bool> WebSocket<SSL> {
     pub fn handle_close(&mut self, _socket: Socket<SSL>, _code: c_int, _reason: *mut c_void) {
         log!("onClose");
         jsc::mark_binding!();
+        if let Some((code, mut reason)) = self.close_dispatch_pending.take() {
+            // The socket closed while our close frame was mid-flush; the peer
+            // either got it or didn't, but JS should still see the
+            // user-initiated code/reason (not an abrupt 1006).
+            self.tcp.detach();
+            self.clear_data();
+            self.dispatch_close(code, &mut reason);
+            // For the socket.
+            // SAFETY: `self: &mut Self` → `*mut Self`; this is the terminal
+            // release of the socket's I/O-layer ref.
+            unsafe { Self::deref(self) };
+            return;
+        }
         self.clear_data();
         self.tcp.detach();
 
@@ -1364,18 +1384,21 @@ impl<const SSL: bool> WebSocket<SSL> {
         // reason text is limited to 123 bytes.
         let body_len = body_len.min(123);
         log!("Sending close with code {}", code);
+        if self.close_dispatch_pending.is_some() {
+            // A close is already mid-flush (user-initiated ws.close() under
+            // backpressure); don't enqueue a second close frame on top of it.
+            return;
+        }
         if !self.has_tcp() {
             self.dispatch_abrupt_close(ErrorCode::Ended);
             self.clear_data();
             return;
         }
-        // we dont wanna shutdownRead when SSL, because SSL handshake can happen when writting
-        // For tunnel mode, shutdownRead on the detached socket is a no-op; skip it.
-        if !SSL {
-            if self.proxy_tunnel.is_none() {
-                self.tcp.shutdown_read();
-            }
-        }
+        // shutdown_read/shutdown are deferred to shutdown_after_close_frame()
+        // so the close frame can finish writing first: SHUT_RD on Linux makes
+        // the socket immediately readable (recv → 0), and the resulting on_end
+        // → terminate → cancel(Failure) would RST and discard the buffered
+        // frame.
         let mut final_body_bytes = [0u8; 128 + 8];
         // WebsocketHeader has no public
         // raw-bits ctor, so build the all-zero header via from_slice.
@@ -1417,8 +1440,39 @@ impl<const SSL: bool> WebSocket<SSL> {
         let slice = &final_body_bytes[..slice_len];
 
         if self.enqueue_encoded_bytes(slice) {
+            let dispatch_code = dispatch_code.unwrap_or(code);
+            if self.send_buffer.readable_length() == 0 {
+                self.shutdown_after_close_frame();
+                self.clear_data();
+                self.dispatch_close(dispatch_code, &mut reason);
+            } else {
+                // The close frame was only partially written; the remainder is
+                // in send_buffer. clear_data() would discard it (and the
+                // proxy_tunnel needed to flush it), so defer teardown until
+                // handle_writable drains the buffer or the socket dies.
+                self.close_dispatch_pending = Some((dispatch_code, reason));
+            }
+        }
+    }
+
+    /// SHUT_RD + SHUT_WR after the close frame is in the kernel send buffer.
+    /// Marks the socket shut-down so loop.c takes the CLEAN_SHUTDOWN branch on
+    /// the subsequent EOF instead of dispatching `on_end → terminate → fail →
+    /// cancel → close(Failure)`, which would RST and discard the queued close
+    /// frame. SSL is excluded because the SSL handshake can happen during
+    /// writes; tunnel mode operates on a detached socket.
+    fn shutdown_after_close_frame(&mut self) {
+        if !SSL && self.proxy_tunnel.is_none() {
+            self.tcp.shutdown_read();
+            self.tcp.shutdown();
+        }
+    }
+
+    fn finish_pending_close(&mut self) {
+        if let Some((code, mut reason)) = self.close_dispatch_pending.take() {
+            self.shutdown_after_close_frame();
             self.clear_data();
-            self.dispatch_close(dispatch_code.unwrap_or(code), &mut reason);
+            self.dispatch_close(code, &mut reason);
         }
     }
 
@@ -1428,18 +1482,28 @@ impl<const SSL: bool> WebSocket<SSL> {
 
     pub fn handle_end(&mut self, socket: Socket<SSL>) {
         debug_assert!(self.is_same_socket(&socket));
+        if self.close_dispatch_pending.is_some() {
+            // Peer FIN'd while we're still draining our close frame; finish the
+            // drain on the next writable event instead of RST'ing via
+            // terminate → fail → cancel(Failure).
+            return;
+        }
         self.terminate(ErrorCode::Ended);
     }
 
     pub fn handle_writable(&mut self, socket: Socket<SSL>) {
-        if self.close_received {
+        if self.close_received && self.close_dispatch_pending.is_none() {
             return;
         }
         debug_assert!(self.is_same_socket(&socket));
         if self.send_buffer.readable_length() == 0 {
+            self.finish_pending_close();
             return;
         }
         let _ = self.send_buffer_out();
+        if self.send_buffer.readable_length() == 0 {
+            self.finish_pending_close();
+        }
     }
 
     pub fn handle_timeout(&mut self, _socket: Socket<SSL>) {
@@ -1756,6 +1820,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             pong_received: false,
             close_received: false,
             close_frame_buffering: false,
+            close_dispatch_pending: None,
             receive_frame: 0,
             receive_body_remain: 0,
             receive_pending_chunk_len: 0,
@@ -1916,6 +1981,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             pong_received: false,
             close_received: false,
             close_frame_buffering: false,
+            close_dispatch_pending: None,
             receive_frame: 0,
             receive_body_remain: 0,
             receive_pending_chunk_len: 0,

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2085,14 +2085,17 @@ impl<const SSL: bool> WebSocket<SSL> {
 
         // Mirrors handle_writable(): once the buffer drains, a close frame
         // that was only partially flushed must still dispatch `close`.
-        // SAFETY (both blocks): `_guard` keeps `*this_ptr` live; sole owner on
-        // this thread, and each `&mut *this_ptr` ends before `_guard` drops.
         if this.send_buffer.readable_length() == 0 {
+            // SAFETY: `_guard` ref keeps `*this_ptr` live; sole owner on this
+            // thread. The auto-ref `&mut *this_ptr` ends before `_guard` drops.
             unsafe { (*this.as_ptr()).finish_pending_close() };
             return;
         }
+        // SAFETY: `_guard` ref keeps `*this_ptr` live; sole owner on this
+        // thread. The auto-ref `&mut *this_ptr` ends before `_guard` drops.
         let _ = unsafe { (*this.as_ptr()).send_buffer_out() };
         if this.send_buffer.readable_length() == 0 {
+            // SAFETY: as above; the `&mut` from send_buffer_out() has ended.
             unsafe { (*this.as_ptr()).finish_pending_close() };
         }
     }

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -2075,7 +2075,7 @@ impl<const SSL: bool> WebSocket<SSL> {
         // SAFETY: caller contract — `this_ptr` is a live `heap::alloc` pointer
         // (the tunnel calls through its raw `connected_websocket` backref).
         let this = unsafe { ThisPtr::new(this_ptr) };
-        if this.close_received {
+        if this.close_received && this.close_dispatch_pending.is_none() {
             return;
         }
         // send_buffer → tunnel.write() can re-enter fail() synchronously
@@ -2083,12 +2083,18 @@ impl<const SSL: bool> WebSocket<SSL> {
         // on_writable() but not this struct.
         let _guard = this.ref_guard();
 
+        // Mirrors handle_writable(): once the buffer drains, a close frame
+        // that was only partially flushed must still dispatch `close`.
+        // SAFETY (both blocks): `_guard` keeps `*this_ptr` live; sole owner on
+        // this thread, and each `&mut *this_ptr` ends before `_guard` drops.
         if this.send_buffer.readable_length() == 0 {
+            unsafe { (*this.as_ptr()).finish_pending_close() };
             return;
         }
-        // SAFETY: `_guard` ref keeps `*this_ptr` live; sole owner on this
-        // thread. The auto-ref `&mut *this_ptr` ends before `_guard` drops.
         let _ = unsafe { (*this.as_ptr()).send_buffer_out() };
+        if this.send_buffer.readable_length() == 0 {
+            unsafe { (*this.as_ptr()).finish_pending_close() };
+        }
     }
 
     // `extern "C"` entrypoint; `this_ptr` is non-null by C++ contract (see SAFETY comments below).

--- a/src/http_jsc/websocket_client.rs
+++ b/src/http_jsc/websocket_client.rs
@@ -1476,6 +1476,18 @@ impl<const SSL: bool> WebSocket<SSL> {
         }
     }
 
+    /// Shared tail of the writable handlers (direct socket and proxy tunnel):
+    /// flush whatever is queued and, once the buffer is empty, dispatch a
+    /// close that was deferred behind it.
+    fn drain_send_buffer_and_finish_close(&mut self) {
+        if self.send_buffer.readable_length() != 0 {
+            let _ = self.send_buffer_out();
+        }
+        if self.send_buffer.readable_length() == 0 {
+            self.finish_pending_close();
+        }
+    }
+
     pub fn is_same_socket(&self, socket: &Socket<SSL>) -> bool {
         socket.socket == self.tcp.socket
     }
@@ -1496,14 +1508,7 @@ impl<const SSL: bool> WebSocket<SSL> {
             return;
         }
         debug_assert!(self.is_same_socket(&socket));
-        if self.send_buffer.readable_length() == 0 {
-            self.finish_pending_close();
-            return;
-        }
-        let _ = self.send_buffer_out();
-        if self.send_buffer.readable_length() == 0 {
-            self.finish_pending_close();
-        }
+        self.drain_send_buffer_and_finish_close();
     }
 
     pub fn handle_timeout(&mut self, _socket: Socket<SSL>) {
@@ -2083,21 +2088,9 @@ impl<const SSL: bool> WebSocket<SSL> {
         // on_writable() but not this struct.
         let _guard = this.ref_guard();
 
-        // Mirrors handle_writable(): once the buffer drains, a close frame
-        // that was only partially flushed must still dispatch `close`.
-        if this.send_buffer.readable_length() == 0 {
-            // SAFETY: `_guard` ref keeps `*this_ptr` live; sole owner on this
-            // thread. The auto-ref `&mut *this_ptr` ends before `_guard` drops.
-            unsafe { (*this.as_ptr()).finish_pending_close() };
-            return;
-        }
         // SAFETY: `_guard` ref keeps `*this_ptr` live; sole owner on this
         // thread. The auto-ref `&mut *this_ptr` ends before `_guard` drops.
-        let _ = unsafe { (*this.as_ptr()).send_buffer_out() };
-        if this.send_buffer.readable_length() == 0 {
-            // SAFETY: as above; the `&mut` from send_buffer_out() has ended.
-            unsafe { (*this.as_ptr()).finish_pending_close() };
-        }
+        unsafe { (*this.as_ptr()).drain_send_buffer_and_finish_close() };
     }
 
     // `extern "C"` entrypoint; `this_ptr` is non-null by C++ contract (see SAFETY comments below).

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -265,6 +265,62 @@ export const setSocketOptions: setSocketOptionsFn = $newZigFunction(
   "jsSetSocketOptions",
   3,
 );
+
+export type SocketFaultSyscall =
+  | "recv"
+  | "send"
+  | "writev"
+  | "sendmsg"
+  | "recvmsg"
+  | "connect"
+  | "accept"
+  | "socket"
+  | "close"
+  | "shutdown";
+
+export type SocketFaultRule = {
+  syscall: SocketFaultSyscall;
+  action: "errno" | "short" | "zero" | "none";
+  /** errno name or numeric value (only used when action === "errno") */
+  errno?:
+    | "ECONNRESET"
+    | "EPIPE"
+    | "ETIMEDOUT"
+    | "ECONNREFUSED"
+    | "EAGAIN"
+    | "EWOULDBLOCK"
+    | "EINTR"
+    | "ENOBUFS"
+    | "ENOMEM"
+    | "EBADF"
+    | "EINVAL"
+    | "ENETUNREACH"
+    | "EHOSTUNREACH"
+    | number;
+  /** clamp recv/send length to this many bytes (only used when action === "short") */
+  bytes?: number;
+  /** skip the first N matching calls before triggering. Default 0. */
+  after?: number;
+  /** fire this many times then disarm; -1 = forever. Default 1. */
+  repeat?: number;
+  /** match only this fd; -1 (default) = any */
+  fd?: number;
+};
+
+export const socketFaultInjection = {
+  /** True when the current binary was built with `--socket-fault-injection=on` (default for debug builds). */
+  available: $newZigFunction(
+    "runtime/socket/socket.zig",
+    "TestingAPIs.jsSocketFaultInjectionAvailable",
+    0,
+  ) as () => boolean,
+  /** Arm a process-wide fault rule for one usockets bsd_* syscall. */
+  set: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsSetSocketFault", 1) as (
+    rule: SocketFaultRule,
+  ) => boolean,
+  /** Disarm all fault rules. */
+  clear: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
+};
 type SerializationContext = "worker" | "window" | "postMessage" | "default";
 export const structuredCloneAdvanced: (
   value: any,

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -308,7 +308,7 @@ export type SocketFaultRule = {
 };
 
 export const socketFaultInjection = {
-  /** True when the current binary was built with `--socket-fault-injection=on` (default for debug builds). */
+  /** True when the current binary was built with `--socket-fault-injection=on` (defaults to on for ASan builds). */
   available: $newZigFunction(
     "runtime/socket/socket.zig",
     "TestingAPIs.jsSocketFaultInjectionAvailable",

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -266,17 +266,8 @@ export const setSocketOptions: setSocketOptionsFn = $newZigFunction(
   3,
 );
 
-export type SocketFaultSyscall =
-  | "recv"
-  | "send"
-  | "writev"
-  | "sendmsg"
-  | "recvmsg"
-  | "connect"
-  | "accept"
-  | "socket"
-  | "close"
-  | "shutdown";
+/** Only the syscalls instrumented in bsd.c; arming anything else is rejected. */
+export type SocketFaultSyscall = "recv" | "send" | "writev" | "sendmsg" | "recvmsg" | "connect" | "accept";
 
 export type SocketFaultRule = {
   syscall: SocketFaultSyscall;
@@ -297,7 +288,7 @@ export type SocketFaultRule = {
     | "ENETUNREACH"
     | "EHOSTUNREACH"
     | number;
-  /** clamp recv/send length to this many bytes (only used when action === "short") */
+  /** clamp recv/send length to this many bytes; required and > 0 when action === "short" */
   bytes?: number;
   /** skip the first N matching calls before triggering. Default 0. */
   after?: number;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -1078,22 +1078,25 @@ const SocketHandlers2: SocketHandler<NonNullable<import("node:net").Socket["_han
     // family-autoselection race and raw sockets handed off during a TLS
     // upgrade also report errors on close, and those must keep ending
     // cleanly.
-    if (
-      err &&
-      err.code === "ECONNRESET" &&
-      !self.destroyed &&
-      socket === self._handle &&
-      self.listenerCount("error") > 0
-    ) {
-      // Shape it like Node's errnoException(UV_ECONNRESET, 'read'): message,
-      // code, errno and syscall all populated.
+    if (err && !self.destroyed && socket === self._handle && self.listenerCount("error") > 0) {
       // Same late-detach guard as SocketEmitEndNT: the listener seen at
       // close-time can be gone by the deferred 'error' emission.
       self.once("error", () => {});
-      const er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
-      er.errno = err.errno;
-      er.syscall = "read";
-      self.destroy(er);
+      if (err.code === undefined || err.code === "ECONNRESET") {
+        // Shape it like Node's errnoException(UV_ECONNRESET, 'read').
+        const er = new ConnResetException("read ECONNRESET") as Error & { errno?: number; syscall?: string };
+        er.errno = err.errno;
+        er.syscall = "read";
+        self.destroy(er);
+      } else {
+        // Any other recv errno (ETIMEDOUT, EHOSTUNREACH, ENETUNREACH, ...)
+        // keeps its identity — Node's onStreamRead does
+        // `stream.destroy(errnoException(nread, 'read'))` for any nread that
+        // is not UV_EOF. The native on_close only passes a non-undefined err
+        // when the close was driven by a recv() failure (libus close-code
+        // enum values are filtered out in NewSocket::on_close).
+        self.destroy(err);
+      }
       return;
     }
     self[kended] = true;

--- a/src/jsc/bindings/webcore/WebSocket.cpp
+++ b/src/jsc/bindings/webcore/WebSocket.cpp
@@ -1018,7 +1018,10 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
         break;
     }
     }
-    this->m_connectedWebSocketKind = ConnectedWebSocketKind::None;
+    // Do not clear m_connectedWebSocketKind here: when the close frame cannot
+    // be written in one send(), the native client defers didClose() until the
+    // frame has drained, and didClose() early-returns if the kind is already
+    // None. didClose() itself clears it once the close completes.
     updateHasPendingActivity();
     return {};
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -2925,8 +2925,8 @@ impl H2FrameParser {
         // (UnsafeCell-backed), so the `*mut` cast is signature-only.
         let _keepalive = unsafe { bun_ptr::ScopedRef::new(self.as_ctx_ptr()) };
 
-        self.uncork();
-        let mut written = match self.native_socket.get() {
+        let mut written = self.uncork();
+        written += match self.native_socket.get() {
             BunSocket::TlsWriteonly(socket) | BunSocket::Tls(socket) => {
                 self._generic_flush(socket.get())
             }
@@ -3043,33 +3043,41 @@ impl H2FrameParser {
         self.write_buffer.get().len_u32() > 0 || self.has_nonnative_backpressure.get()
     }
 
-    fn uncork(&self) {
-        if let Some(corked_ptr) = CORKED_H2.with(|c| c.get()) {
-            // SAFETY: CORKED_H2 holds a ref()'d *mut H2FrameParser, valid until the matching
-            // deref() below. R-2: deref as shared (`&*const`) — every method below takes `&self`.
-            let corked: &H2FrameParser = unsafe { &*corked_ptr.cast_const() };
-            corked.unregister_auto_flush();
-            bun_output::scoped_log!(H2FrameParser, "uncork {:p}", corked_ptr);
-
-            CORKED_H2.with(|c| c.set(None));
-
-            // _write can re-enter JS (JS-stream-backed sockets, h2-over-h2 tunnels),
-            // so no thread-local borrow may be held across it: move the corked bytes
-            // into a taken scratch Vec first.
-            let mut data = BATCH_BUFFER.with_borrow_mut(core::mem::take);
-            data.clear();
-            corked.drain_cork_into(&mut data);
-            if !data.is_empty() {
-                let _ = corked._write(&data);
-                data.clear();
-            }
-            BATCH_BUFFER.with_borrow_mut(|b| {
-                if b.capacity() == 0 {
-                    *b = data;
-                }
-            });
-            corked.deref();
+    fn uncork(&self) -> usize {
+        let Some(corked_ptr) = CORKED_H2.with(|c| c.get()) else {
+            return 0;
+        };
+        if !std::ptr::eq(corked_ptr, self.as_ctx_ptr()) {
+            // Another parser owns the cork slot; its own auto_flush /
+            // on_native_writable will drain it. Draining it here writes to a
+            // foreign fd from inside self's writable callback and tears down
+            // the other parser's auto-flush registration. cork()'s
+            // force-uncork already handles slot handover when a new owner
+            // takes it.
+            return 0;
         }
+        self.unregister_auto_flush();
+        bun_output::scoped_log!(H2FrameParser, "uncork {:p}", corked_ptr);
+        CORKED_H2.with(|c| c.set(None));
+
+        // _write can re-enter JS (JS-stream-backed sockets, h2-over-h2 tunnels),
+        // so no thread-local borrow may be held across it: move the corked bytes
+        // into a taken scratch Vec first.
+        let mut data = BATCH_BUFFER.with_borrow_mut(core::mem::take);
+        data.clear();
+        self.drain_cork_into(&mut data);
+        let n = data.len();
+        if n != 0 {
+            let _ = self._write(&data);
+            data.clear();
+        }
+        BATCH_BUFFER.with_borrow_mut(|b| {
+            if b.capacity() == 0 {
+                *b = data;
+            }
+        });
+        self.deref();
+        n
     }
 
     fn register_auto_flush(&self) {
@@ -8983,7 +8991,18 @@ impl H2FrameParser {
     }
 
     pub(crate) fn on_native_writable(&self) {
-        let _ = self.flush();
+        // flush() ends in flush_stream_queue() → write() → cork(), leaving the
+        // newly-serialized frames in CORK_BUFFER (not on the wire). Returning
+        // here would let loop.c see last_write_failed==0 and disarm WRITABLE,
+        // stranding those bytes until an auto_flush task that may not be
+        // re-registered. Loop flush() until either we hit real socket
+        // backpressure (last_write_failed is then set) or no progress is made.
+        loop {
+            let wrote = self.flush();
+            if self.has_backpressure() || wrote == 0 {
+                break;
+            }
+        }
     }
 
     pub(crate) fn on_native_close(&self) {

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -464,7 +464,11 @@ impl NodeHTTPResponse {
         drop(sec_websocket_protocol_str);
         drop(sec_websocket_extensions_str);
 
-        self.set_on_aborted_handler();
+        // The sec-websocket-* headers were already copied into
+        // raw_response.upgrade(); the underlying HttpParser::fallback buffer is
+        // freed when uWS adopts the socket above, so set_on_aborted_handler
+        // (which would call preserve_web_socket_headers_if_needed) must not run
+        // post-upgrade — it would read freed header views.
         self.upgrade_context.with_mut(|c| c.reset());
 
         true

--- a/src/runtime/socket/mod.rs
+++ b/src/runtime/socket/mod.rs
@@ -108,7 +108,7 @@ pub use udp_socket::UDPSocket;
 pub mod socket {
     pub use super::socket_body::{
         js_create_socket_pair, js_get_buffered_amount, js_is_named_pipe_socket,
-        js_set_socket_options, js_upgrade_duplex_to_tls,
+        js_set_socket_options, js_upgrade_duplex_to_tls, testing_ap_is,
     };
 }
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4849,6 +4849,14 @@ pub mod testing_apis {
                 )));
             };
 
+            // "short" clamps a byte count, which only recv/send have; arming it
+            // on any other syscall would silently never fire.
+            if action == fi::ACTION_SHORT && syscall != fi::RECV && syscall != fi::SEND {
+                return Err(global.throw(format_args!(
+                    "rule.action \"short\" is only supported for syscall \"recv\" or \"send\""
+                )));
+            }
+
             let errno_value: c_int = match opts.get_truthy(global, "errno")? {
                 None if action == fi::ACTION_ERRNO => {
                     return Err(global.throw(format_args!(

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1932,11 +1932,13 @@ impl<const SSL: bool> NewSocket<SSL> {
         let mut js_error: JSValue = JSValue::UNDEFINED;
         // `err` is overloaded: when WE closed the socket it's a libus
         // CloseCode enum (0=clean, 1=failure/RST, 2=fast-shutdown); when the
-        // close was driven by a recv() failure (loop.c:664) it's the actual
-        // errno. recv never returns EPERM(1)/ENOENT(2), so values >2 are real
-        // read errnos and 0/1/2 are self-initiated closes that must not
-        // surface as a JS read error (matching Node's onStreamRead, which only
-        // sees errors that came from uv_read_cb).
+        // close was driven by a recv() failure (loop.c:664) or a poll error
+        // (loop.c's EPOLLERR/EV_ERROR branch, which reports SO_ERROR) it's the
+        // actual errno. Neither producer can yield EPERM(1)/ENOENT(2) — recv
+        // never returns them and the poll-error branch clamps them away — so
+        // values >2 are real read errnos and 0/1/2 are self-initiated closes
+        // that must not surface as a JS read error (matching Node's
+        // onStreamRead, which only sees errors that came from uv_read_cb).
         if err > 2 {
             js_error = <sys::Error as jsc::SysErrorJsc>::to_js(
                 &sys::Error::from_code_int(err, sys::Tag::read),

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4812,15 +4812,11 @@ pub mod testing_apis {
                 fi::CONNECT
             } else if syscall_str.eql_comptime(b"accept") {
                 fi::ACCEPT
-            } else if syscall_str.eql_comptime(b"socket") {
-                fi::SOCKET
-            } else if syscall_str.eql_comptime(b"close") {
-                fi::CLOSE
-            } else if syscall_str.eql_comptime(b"shutdown") {
-                fi::SHUTDOWN
             } else {
+                // socket/close/shutdown have enum slots but no bsd.c hooks;
+                // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, socket, close, shutdown"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept"
                 )));
             };
 
@@ -4896,10 +4892,19 @@ pub mod testing_apis {
                 }
             };
 
+            let clamp_bytes = get_i32("bytes", 0)?;
+            // A 0-byte clamp makes recv()/send() length-0 syscalls, which read
+            // back as EOF/backpressure — silently aliasing action "zero".
+            if action == fi::ACTION_SHORT && clamp_bytes <= 0 {
+                return Err(global.throw(format_args!(
+                    "rule.bytes must be > 0 when action is \"short\""
+                )));
+            }
+
             let rule = fi::UsFaultRule {
                 action,
                 errno_value,
-                clamp_bytes: get_i32("bytes", 0)?,
+                clamp_bytes,
                 after_n_calls: get_i32("after", 0)?,
                 repeat: get_i32("repeat", 1)?,
                 target_fd: get_i32("fd", -1)?,

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4857,6 +4857,20 @@ pub mod testing_apis {
                 )));
             }
 
+            // "zero" only has meaning where the wrapper returns a byte count
+            // (EOF / backpressure); connect returns errno and accept returns a
+            // descriptor, so a zero there is stale errno or nonsense.
+            if action == fi::ACTION_ZERO
+                && !matches!(
+                    syscall,
+                    fi::RECV | fi::SEND | fi::WRITEV | fi::SENDMSG | fi::RECVMSG
+                )
+            {
+                return Err(global.throw(format_args!(
+                    "rule.action \"zero\" is only supported for syscall \"recv\", \"send\", \"writev\", \"sendmsg\" or \"recvmsg\""
+                )));
+            }
+
             let errno_value: c_int = match opts.get_truthy(global, "errno")? {
                 None if action == fi::ACTION_ERRNO => {
                     return Err(global.throw(format_args!(

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1930,8 +1930,14 @@ impl<const SSL: bool> NewSocket<SSL> {
         let global = handlers.global_object;
         let this_value = this.get_this_value(&global);
         let mut js_error: JSValue = JSValue::UNDEFINED;
-        if err != 0 {
-            // errors here are always a read error
+        // `err` is overloaded: when WE closed the socket it's a libus
+        // CloseCode enum (0=clean, 1=failure/RST, 2=fast-shutdown); when the
+        // close was driven by a recv() failure (loop.c:664) it's the actual
+        // errno. recv never returns EPERM(1)/ENOENT(2), so values >2 are real
+        // read errnos and 0/1/2 are self-initiated closes that must not
+        // surface as a JS read error (matching Node's onStreamRead, which only
+        // sees errors that came from uv_read_cb).
+        if err > 2 {
             js_error = <sys::Error as jsc::SysErrorJsc>::to_js(
                 &sys::Error::from_code_int(err, sys::Tag::read),
                 &global,
@@ -4733,3 +4739,196 @@ pub fn js_set_socket_options(global: &JSGlobalObject, callframe: &CallFrame) -> 
 
     Ok(JSValue::UNDEFINED)
 }
+
+pub mod testing_apis {
+    use super::*;
+
+    #[bun_jsc::host_fn]
+    pub fn js_socket_fault_injection_available(
+        _global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        Ok(JSValue::from(cfg!(socket_fault_injection)))
+    }
+
+    #[bun_jsc::host_fn]
+    pub fn js_clear_socket_faults(
+        global: &JSGlobalObject,
+        _frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        #[cfg(socket_fault_injection)]
+        {
+            let _ = global;
+            bun_uws_sys::fault_inject::us_fault_clear_all();
+            Ok(JSValue::UNDEFINED)
+        }
+        #[cfg(not(socket_fault_injection))]
+        Err(global.throw(format_args!(
+            "socket fault injection was not compiled into this build (build with --socket-fault-injection=on)"
+        )))
+    }
+
+    #[bun_jsc::host_fn]
+    pub fn js_set_socket_fault(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        jsc::mark_binding!();
+        #[cfg(not(socket_fault_injection))]
+        {
+            let _ = frame;
+            return Err(global.throw(format_args!(
+                "socket fault injection was not compiled into this build (build with --socket-fault-injection=on)"
+            )));
+        }
+        #[cfg(socket_fault_injection)]
+        {
+            use bun_uws_sys::fault_inject as fi;
+
+            let [opts] = frame.arguments_as_array::<1>();
+            if !opts.is_object() {
+                return Err(global.throw_invalid_argument_type_value("rule", "object", opts));
+            }
+
+            let syscall_str =
+                bun_core::OwnedString::new(match opts.get_truthy(global, "syscall")? {
+                    Some(v) => v.to_bun_string(global)?,
+                    None => {
+                        return Err(global.throw_invalid_argument_type_value(
+                            "rule.syscall",
+                            "string",
+                            JSValue::UNDEFINED,
+                        ));
+                    }
+                });
+            let syscall: c_int = if syscall_str.eql_comptime(b"recv") {
+                fi::RECV
+            } else if syscall_str.eql_comptime(b"send") {
+                fi::SEND
+            } else if syscall_str.eql_comptime(b"writev") {
+                fi::WRITEV
+            } else if syscall_str.eql_comptime(b"sendmsg") {
+                fi::SENDMSG
+            } else if syscall_str.eql_comptime(b"recvmsg") {
+                fi::RECVMSG
+            } else if syscall_str.eql_comptime(b"connect") {
+                fi::CONNECT
+            } else if syscall_str.eql_comptime(b"accept") {
+                fi::ACCEPT
+            } else if syscall_str.eql_comptime(b"socket") {
+                fi::SOCKET
+            } else if syscall_str.eql_comptime(b"close") {
+                fi::CLOSE
+            } else if syscall_str.eql_comptime(b"shutdown") {
+                fi::SHUTDOWN
+            } else {
+                return Err(global.throw(format_args!(
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, socket, close, shutdown"
+                )));
+            };
+
+            let action_str =
+                bun_core::OwnedString::new(match opts.get_truthy(global, "action")? {
+                    Some(v) => v.to_bun_string(global)?,
+                    None => {
+                        return Err(global.throw_invalid_argument_type_value(
+                            "rule.action",
+                            "string",
+                            JSValue::UNDEFINED,
+                        ));
+                    }
+                });
+            let action: c_int = if action_str.eql_comptime(b"errno") {
+                fi::ACTION_ERRNO
+            } else if action_str.eql_comptime(b"short") {
+                fi::ACTION_SHORT
+            } else if action_str.eql_comptime(b"zero") {
+                fi::ACTION_ZERO
+            } else if action_str.eql_comptime(b"none") {
+                fi::ACTION_NONE
+            } else {
+                return Err(global.throw(format_args!(
+                    "rule.action must be one of: errno, short, zero, none"
+                )));
+            };
+
+            let errno_value: c_int = match opts.get_truthy(global, "errno")? {
+                None if action == fi::ACTION_ERRNO => {
+                    return Err(global.throw(format_args!(
+                        "rule.errno is required when action is \"errno\""
+                    )));
+                }
+                None => 0,
+                Some(v) if v.is_number() => v.coerce_to_i32(global)?,
+                Some(v) => {
+                    let name = bun_core::OwnedString::new(v.to_bun_string(global)?);
+                    parse_errno_name(&name).ok_or_else(|| {
+                        global.throw(format_args!(
+                            "rule.errno: unknown errno name (use a numeric value or one of: ECONNRESET, EPIPE, ETIMEDOUT, ECONNREFUSED, EAGAIN, EWOULDBLOCK, EINTR, ENOBUFS, ENOMEM, EBADF, EINVAL, ENETUNREACH, EHOSTUNREACH)"
+                        ))
+                    })?
+                }
+            };
+
+            let get_i32 = |key: &str, default: i32| -> JsResult<i32> {
+                match opts.get_truthy(global, key)? {
+                    Some(v) => v.coerce_to_i32(global),
+                    None => Ok(default),
+                }
+            };
+
+            let rule = fi::UsFaultRule {
+                action,
+                errno_value,
+                clamp_bytes: get_i32("bytes", 0)?,
+                after_n_calls: get_i32("after", 0)?,
+                repeat: get_i32("repeat", 1)?,
+                target_fd: get_i32("fd", -1)?,
+            };
+
+            // SAFETY: rule is a valid stack pointer for the duration of the call.
+            unsafe { fi::us_fault_set(syscall, &rule) };
+            Ok(JSValue::TRUE)
+        }
+    }
+
+    #[cfg(socket_fault_injection)]
+    fn parse_errno_name(name: &bun_core::OwnedString) -> Option<c_int> {
+        macro_rules! map {
+            ($($s:literal => $v:expr,)*) => {
+                $(if name.eql_comptime($s) { return Some($v as c_int); })*
+            };
+        }
+        #[cfg(unix)]
+        map! {
+            b"ECONNRESET" => libc::ECONNRESET,
+            b"EPIPE" => libc::EPIPE,
+            b"ETIMEDOUT" => libc::ETIMEDOUT,
+            b"ECONNREFUSED" => libc::ECONNREFUSED,
+            b"EAGAIN" => libc::EAGAIN,
+            b"EWOULDBLOCK" => libc::EWOULDBLOCK,
+            b"EINTR" => libc::EINTR,
+            b"ENOBUFS" => libc::ENOBUFS,
+            b"ENOMEM" => libc::ENOMEM,
+            b"EBADF" => libc::EBADF,
+            b"EINVAL" => libc::EINVAL,
+            b"ENETUNREACH" => libc::ENETUNREACH,
+            b"EHOSTUNREACH" => libc::EHOSTUNREACH,
+        }
+        #[cfg(windows)]
+        map! {
+            b"ECONNRESET" => 10054,
+            b"EPIPE" => 10054,
+            b"ETIMEDOUT" => 10060,
+            b"ECONNREFUSED" => 10061,
+            b"EAGAIN" => 10035,
+            b"EWOULDBLOCK" => 10035,
+            b"EINTR" => 10004,
+            b"ENOBUFS" => 10055,
+            b"ENOMEM" => 10055,
+            b"EBADF" => 10009,
+            b"EINVAL" => 10022,
+            b"ENETUNREACH" => 10051,
+            b"EHOSTUNREACH" => 10065,
+        }
+        None
+    }
+}
+pub use testing_apis as testing_ap_is;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -392,6 +392,43 @@ pub mod web_socket;
 
 #[path = "socket.rs"]
 pub mod socket;
+
+#[cfg(socket_fault_injection)]
+pub mod fault_inject {
+    use core::ffi::c_int;
+
+    pub const RECV: c_int = 0;
+    pub const SEND: c_int = 1;
+    pub const WRITEV: c_int = 2;
+    pub const SENDMSG: c_int = 3;
+    pub const RECVMSG: c_int = 4;
+    pub const CONNECT: c_int = 5;
+    pub const ACCEPT: c_int = 6;
+    pub const SOCKET: c_int = 7;
+    pub const CLOSE: c_int = 8;
+    pub const SHUTDOWN: c_int = 9;
+
+    pub const ACTION_NONE: c_int = 0;
+    pub const ACTION_ERRNO: c_int = 1;
+    pub const ACTION_SHORT: c_int = 2;
+    pub const ACTION_ZERO: c_int = 3;
+
+    #[repr(C)]
+    pub struct UsFaultRule {
+        pub action: c_int,
+        pub errno_value: c_int,
+        pub clamp_bytes: c_int,
+        pub after_n_calls: c_int,
+        pub repeat: c_int,
+        pub target_fd: c_int,
+    }
+
+    unsafe extern "C" {
+        pub fn us_fault_set(syscall: c_int, rule: *const UsFaultRule);
+        pub safe fn us_fault_clear(syscall: c_int);
+        pub safe fn us_fault_clear_all();
+    }
+}
 pub use socket::{
     AnySocket, ConnectError, InternalSocket, NewSocketHandler, SocketHandler, SocketTCP, SocketTLS,
     SocketTcp, SocketTls,

--- a/test/js/bun/http/serve-syscall-fault.test.ts
+++ b/test/js/bun/http/serve-syscall-fault.test.ts
@@ -1,0 +1,146 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+
+const skip = !fault.available() || isWindows;
+
+// Bun.serve is the server; faults are armed inside the server subprocess so
+// only the server's bsd_* calls are affected.
+
+async function spawnServer(body: string, env: Record<string, string> = {}) {
+  const proc = Bun.spawn({
+    cmd: [bunExe(), "-e", body],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", ...env },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const reader = proc.stdout.getReader();
+  let line = "";
+  while (!line.includes("\n")) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error("server exited before ready: " + (await proc.stderr.text()));
+    line += new TextDecoder().decode(value);
+  }
+  reader.releaseLock();
+  return { proc, port: Number(line.trim()) };
+}
+
+describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
+  test("send → short writes (1 byte) deliver complete fixed-length body", async () => {
+    const { proc, port } = await spawnServer(/* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch: () => new Response(Buffer.alloc(16384, 0x61)) });
+      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      const buf = await res.arrayBuffer();
+      expect({ status: res.status, length: buf.byteLength }).toEqual({ status: 200, length: 16384 });
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+    expect(proc.signalCode).toBeNull();
+  });
+
+  test("send → short writes deliver complete streaming ReadableStream body", async () => {
+    const { proc, port } = await spawnServer(/* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch: () => new Response(new ReadableStream({
+          start(c) { for (let i = 0; i < 8; i++) c.enqueue(Buffer.alloc(1024, i)); c.close(); }
+        })) });
+      fault.set({ syscall: "send", action: "short", bytes: 7, repeat: -1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `);
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      const buf = new Uint8Array(await res.arrayBuffer());
+      expect(buf.length).toBe(8 * 1024);
+      for (let i = 0; i < 8; i++) expect(buf[i * 1024]).toBe(i);
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+  });
+
+  test("recv → short reads (1 byte) deliver complete request body to handler", async () => {
+    const { proc, port } = await spawnServer(/* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch: async (req) => new Response(String((await req.arrayBuffer()).byteLength)) });
+      fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `);
+    try {
+      const body = Buffer.alloc(4096, "P");
+      const res = await fetch(`http://127.0.0.1:${port}/`, { method: "POST", body });
+      expect(await res.text()).toBe(String(body.length));
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+  });
+
+  test("https: send → short writes deliver complete body over TLS", async () => {
+    const { proc, port } = await spawnServer(
+      /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        tls: { key: process.env.KEY, cert: process.env.CERT },
+        fetch: () => new Response(Buffer.alloc(8192, 0x54)) });
+      fault.set({ syscall: "send", action: "short", bytes: 3, repeat: -1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `,
+      { KEY: certs.key, CERT: certs.cert },
+    );
+    try {
+      const res = await fetch(`https://127.0.0.1:${port}/`, { tls: { ca: certs.cert } });
+      const buf = await res.arrayBuffer();
+      expect({ status: res.status, length: buf.byteLength }).toEqual({ status: 200, length: 8192 });
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+  });
+
+  test("client abort under server-side 1-byte sends: every response reaches a terminal state", async () => {
+    const { proc, port } = await spawnServer(/* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      let finished = 0;
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch: () => {
+          const r = new Response(new ReadableStream({
+            start(c) { c.enqueue(Buffer.alloc(32768, 0x42)); c.close(); }
+          }));
+          return r;
+        } });
+      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+      console.log(s.port);
+      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+    `);
+    try {
+      const N = 6;
+      await Promise.all(
+        Array.from({ length: N }, async () => {
+          const c = new AbortController();
+          const res = await fetch(`http://127.0.0.1:${port}/`, { signal: c.signal });
+          const reader = res.body!.getReader();
+          await reader.read();
+          c.abort();
+        }),
+      );
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/http/serve-syscall-fault.test.ts
+++ b/test/js/bun/http/serve-syscall-fault.test.ts
@@ -44,6 +44,7 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
       await proc.exited;
     }
     expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
   });
 
   test("send → short writes deliver complete streaming ReadableStream body", async () => {
@@ -66,6 +67,8 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
       proc.kill("SIGTERM");
       await proc.exited;
     }
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
   });
 
   test("recv → short reads (1 byte) deliver complete request body to handler", async () => {
@@ -85,6 +88,8 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
       proc.kill("SIGTERM");
       await proc.exited;
     }
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
   });
 
   test("https: send → short writes deliver complete body over TLS", async () => {
@@ -108,22 +113,22 @@ describe.skipIf(skip)("Bun.serve under injected syscall faults", () => {
       proc.kill("SIGTERM");
       await proc.exited;
     }
+    expect(proc.signalCode).toBeNull();
+    expect(proc.exitCode).toBe(0);
   });
 
   test("client abort under server-side 1-byte sends: every response reaches a terminal state", async () => {
     const { proc, port } = await spawnServer(/* js */ `
       const { socketFaultInjection: fault } = require("bun:internal-for-testing");
-      let finished = 0;
       const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
-        fetch: () => {
-          const r = new Response(new ReadableStream({
-            start(c) { c.enqueue(Buffer.alloc(32768, 0x42)); c.close(); }
-          }));
-          return r;
-        } });
+        fetch: () => new Response(new ReadableStream({
+          start(c) { c.enqueue(Buffer.alloc(32768, 0x42)); c.close(); }
+        })) });
       fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
       console.log(s.port);
-      process.on("SIGTERM", () => { fault.clear(); s.stop(true); process.exit(0); });
+      // Graceful stop() resolves only once every in-flight response has
+      // reached a terminal state, so a leaked/hung response = test timeout.
+      process.on("SIGTERM", () => { fault.clear(); s.stop().then(() => process.exit(0)); });
     `);
     try {
       const N = 6;

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -20,6 +20,25 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
     expect(() => fault.set({ syscall: "recv", action: "bogus" as any })).toThrow(/rule\.action must be one of/);
   });
 
+  // Only recv/send have a byte count to clamp; arming "short" on any other
+  // syscall used to succeed silently and never fire.
+  test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
+    for (const syscall of [
+      "writev",
+      "sendmsg",
+      "recvmsg",
+      "connect",
+      "accept",
+      "socket",
+      "close",
+      "shutdown",
+    ] as const) {
+      expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
+    }
+    expect(fault.set({ syscall: "recv", action: "short", bytes: 1 })).toBe(true);
+    expect(fault.set({ syscall: "send", action: "short", bytes: 1 })).toBe(true);
+  });
+
   test("set() rejects unknown errno name", () => {
     expect(() => fault.set({ syscall: "recv", action: "errno", errno: "ENOSUCHERR" as any })).toThrow(
       /unknown errno name/,

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -23,16 +23,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // Only recv/send have a byte count to clamp; arming "short" on any other
   // syscall used to succeed silently and never fire.
   test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
-    for (const syscall of [
-      "writev",
-      "sendmsg",
-      "recvmsg",
-      "connect",
-      "accept",
-      "socket",
-      "close",
-      "shutdown",
-    ] as const) {
+    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept"] as const) {
       expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
     }
     expect(fault.set({ syscall: "recv", action: "short", bytes: 1 })).toBe(true);
@@ -42,7 +33,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // A zero return only means something for the data syscalls (EOF on the read
   // side, backpressure on the write side); connect's wrapper returns errno.
   test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
-    for (const syscall of ["connect", "accept", "socket", "close", "shutdown"] as const) {
+    for (const syscall of ["connect", "accept"] as const) {
       expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
     }
     for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
@@ -94,21 +85,25 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
     fault.clear();
   });
 
-  test("rules can target each syscall", () => {
-    for (const sc of [
-      "recv",
-      "send",
-      "writev",
-      "sendmsg",
-      "recvmsg",
-      "connect",
-      "accept",
-      "socket",
-      "close",
-      "shutdown",
-    ] as const) {
+  test("rules can target each hooked syscall", () => {
+    for (const sc of ["recv", "send", "writev", "sendmsg", "recvmsg", "connect", "accept"] as const) {
       expect(fault.set({ syscall: sc, action: "none" })).toBe(true);
     }
+  });
+
+  // These have enum slots but no bsd.c hooks; arming them used to "succeed"
+  // and then never fire.
+  test("set() rejects syscalls that have no fault hook", () => {
+    for (const sc of ["socket", "close", "shutdown"]) {
+      expect(() => fault.set({ syscall: sc as any, action: "none" })).toThrow(/rule\.syscall must be one of/);
+    }
+  });
+
+  // bytes: 0 (the old default) clamps the real syscall to length 0, which
+  // reads back as EOF/backpressure — i.e. action "zero", not a short read.
+  test("set() requires bytes > 0 when action is 'short'", () => {
+    expect(() => fault.set({ syscall: "recv", action: "short" } as any)).toThrow(/rule\.bytes must be > 0/);
+    expect(() => fault.set({ syscall: "send", action: "short", bytes: 0 })).toThrow(/rule\.bytes must be > 0/);
   });
 });
 

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -1,0 +1,93 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+
+const skip = !fault.available();
+
+describe.skipIf(skip)("socketFaultInjection control surface", () => {
+  afterEach(() => fault.clear());
+
+  test("available() reflects build flag", () => {
+    expect(fault.available()).toBe(true);
+  });
+
+  test("set() validates syscall", () => {
+    expect(() => fault.set({ syscall: "bogus" as any, action: "errno", errno: "ECONNRESET" })).toThrow(
+      /rule\.syscall must be one of/,
+    );
+  });
+
+  test("set() validates action", () => {
+    expect(() => fault.set({ syscall: "recv", action: "bogus" as any })).toThrow(/rule\.action must be one of/);
+  });
+
+  test("set() rejects unknown errno name", () => {
+    expect(() => fault.set({ syscall: "recv", action: "errno", errno: "ENOSUCHERR" as any })).toThrow(
+      /unknown errno name/,
+    );
+  });
+
+  test("set() accepts numeric errno", () => {
+    expect(fault.set({ syscall: "recv", action: "errno", errno: 104 })).toBe(true);
+  });
+
+  test("set() requires errno when action is 'errno'", () => {
+    expect(() => fault.set({ syscall: "recv", action: "errno" } as any)).toThrow(/rule\.errno is required/);
+  });
+
+  test("set() accepts every documented errno name", () => {
+    for (const name of [
+      "ECONNRESET",
+      "EPIPE",
+      "ETIMEDOUT",
+      "ECONNREFUSED",
+      "EAGAIN",
+      "EWOULDBLOCK",
+      "EINTR",
+      "ENOBUFS",
+      "ENOMEM",
+      "EBADF",
+      "EINVAL",
+      "ENETUNREACH",
+      "EHOSTUNREACH",
+    ] as const) {
+      expect(fault.set({ syscall: "recv", action: "errno", errno: name })).toBe(true);
+    }
+  });
+
+  test("set() requires an object", () => {
+    expect(() => (fault.set as any)(null)).toThrow();
+    expect(() => (fault.set as any)("recv")).toThrow();
+  });
+
+  test("clear() is idempotent", () => {
+    fault.clear();
+    fault.clear();
+  });
+
+  test("rules can target each syscall", () => {
+    for (const sc of [
+      "recv",
+      "send",
+      "writev",
+      "sendmsg",
+      "recvmsg",
+      "connect",
+      "accept",
+      "socket",
+      "close",
+      "shutdown",
+    ] as const) {
+      expect(fault.set({ syscall: sc, action: "none" })).toBe(true);
+    }
+  });
+});
+
+test.skipIf(fault.available())("set() throws helpfully when compiled out", () => {
+  expect(() => fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET" })).toThrow(
+    /not compiled into this build/,
+  );
+});
+
+test.skipIf(fault.available())("clear() throws helpfully when compiled out", () => {
+  expect(() => fault.clear()).toThrow(/not compiled into this build/);
+});

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -39,6 +39,17 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
     expect(fault.set({ syscall: "send", action: "short", bytes: 1 })).toBe(true);
   });
 
+  // A zero return only means something for the data syscalls (EOF on the read
+  // side, backpressure on the write side); connect's wrapper returns errno.
+  test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
+    for (const syscall of ["connect", "accept", "socket", "close", "shutdown"] as const) {
+      expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
+    }
+    for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
+      expect(fault.set({ syscall, action: "zero" })).toBe(true);
+    }
+  });
+
   test("set() rejects unknown errno name", () => {
     expect(() => fault.set({ syscall: "recv", action: "errno", errno: "ENOSUCHERR" as any })).toThrow(
       /unknown errno name/,

--- a/test/js/first_party/ws/ws-syscall-fault.test.ts
+++ b/test/js/first_party/ws/ws-syscall-fault.test.ts
@@ -53,13 +53,17 @@ describe.skipIf(skip)("ws (thirdparty) under injected syscall faults", () => {
       wss.on("listening", () => {
         fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
         const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
-        let pong = false;
-        c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
-        c.on("pong", () => { pong = true; });
-        c.on("message", m => {
-          console.log(JSON.stringify({ ok: true, len: m.length, pong }));
+        // Report only once BOTH the echo and the pong have arrived: 'pong' is
+        // a separate event with no ordering guarantee relative to 'message'.
+        let pong = false, echoed = null;
+        const report = () => {
+          if (!pong || !echoed) return;
+          console.log(JSON.stringify({ ok: true, len: echoed.length, pong }));
           c.close();
-        });
+        };
+        c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
+        c.on("pong", () => { pong = true; report(); });
+        c.on("message", m => { echoed = m; report(); });
         c.on("close", () => { fault.clear(); wss.close(() => process.exit(0)); });
         c.on("error", () => console.log(JSON.stringify({ ok: false })));
       });

--- a/test/js/first_party/ws/ws-syscall-fault.test.ts
+++ b/test/js/first_party/ws/ws-syscall-fault.test.ts
@@ -1,0 +1,107 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows } from "harness";
+
+const skip = !fault.available() || isWindows;
+
+// The 'ws' module in Bun is a thirdparty shim over the native WebSocket
+// client/server. These tests verify the shim's event surface (on('message'),
+// on('error'), on('close')) under transport faults.
+
+async function runWsFixture(body: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", body],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { ...JSON.parse(stdout.trim() || "{}"), stderr, exitCode, signal: proc.signalCode };
+}
+
+describe.skipIf(skip)("ws (thirdparty) under injected syscall faults", () => {
+  test("recv → short reads (1 byte) deliver complete echoed message", async () => {
+    const r = await runWsFixture(/* js */ `
+      const { WebSocketServer, WebSocket } = require("ws");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      wss.on("connection", ws => ws.on("message", m => ws.send(m)));
+      wss.on("listening", () => {
+        fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
+        c.on("open", () => c.send("hello-ws"));
+        c.on("message", m => {
+          console.log(JSON.stringify({ ok: true, data: m.toString() }));
+          c.close();
+        });
+        c.on("close", () => { fault.clear(); wss.close(() => process.exit(0)); });
+        c.on("error", () => console.log(JSON.stringify({ ok: false })));
+      });
+    `);
+    expect(r).toMatchObject({ ok: true, data: "hello-ws", signal: null, exitCode: 0 });
+  });
+
+  test("send → short writes (1 byte) deliver complete message and ping/pong round-trips", async () => {
+    const r = await runWsFixture(/* js */ `
+      const { WebSocketServer, WebSocket } = require("ws");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+      wss.on("connection", ws => {
+        ws.on("message", m => ws.send(m));
+        ws.on("ping", () => {});
+      });
+      wss.on("listening", () => {
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+        const c = new WebSocket("ws://127.0.0.1:" + wss.address().port);
+        let pong = false;
+        c.on("open", () => { c.ping(); c.send(Buffer.alloc(1024, 0x77)); });
+        c.on("pong", () => { pong = true; });
+        c.on("message", m => {
+          console.log(JSON.stringify({ ok: true, len: m.length, pong }));
+          c.close();
+        });
+        c.on("close", () => { fault.clear(); wss.close(() => process.exit(0)); });
+        c.on("error", () => console.log(JSON.stringify({ ok: false })));
+      });
+    `);
+    expect(r).toMatchObject({ ok: true, len: 1024, pong: true, signal: null, exitCode: 0 });
+  });
+
+  test("recv → ECONNRESET fires 'close' with abnormal code (split-process)", async () => {
+    // Server runs in this process (no fault); client runs in a subprocess so
+    // the process-global recv rule only affects the client side.
+    const { WebSocketServer } = require("ws");
+    const wss = new WebSocketServer({ port: 0, host: "127.0.0.1" });
+    wss.on("connection", (ws: import("ws").WebSocket) => {
+      ws.on("error", () => {});
+      ws.send("x");
+    });
+    await new Promise<void>(r => wss.on("listening", () => r()));
+    const port = (wss.address() as import("node:net").AddressInfo).port;
+    try {
+      const r = await runWsFixture(/* js */ `
+        const { WebSocket } = require("ws");
+        const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+        // Arm before connecting so the upgrade-response recv fails — that
+        // exercises the same close(1006) path without depending on the
+        // server to send a frame after 'open' (which races the arm).
+        fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+        const c = new WebSocket("ws://127.0.0.1:${port}");
+        let errored = false;
+        c.on("open", () => {});
+        c.on("error", () => { errored = true; });
+        c.on("close", code => {
+          console.log(JSON.stringify({ ok: true, errored, code }));
+          fault.clear();
+          process.exit(0);
+        });
+      `);
+      expect(r.signal).toBeNull();
+      expect(r.ok).toBe(true);
+      expect(r.code).toBe(1006);
+      expect(r.errored).toBe(true);
+    } finally {
+      await new Promise<void>(r => wss.close(() => r()));
+    }
+  });
+});

--- a/test/js/node/http/node-http-syscall-fault.test.ts
+++ b/test/js/node/http/node-http-syscall-fault.test.ts
@@ -1,0 +1,266 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+// In-process http tests share the process-wide fault table between client
+// and server, which makes errno injection ambiguous. Tests that need a
+// one-sided fault run the faulted side in a subprocess.
+
+describe.skipIf(skip)("node:http under injected syscall faults", () => {
+  test("upRes.pipe(res) with res.destroy() racing a queued drain (subprocess)", async () => {
+    // A TLS-terminating proxy re-streams a large upstream body via pipe(),
+    // 1-byte sends force backpressure → on_writable/on_drain on every
+    // event-loop turn, and the downstream is destroyed while a drain callback
+    // is queued. Forcing 1-byte sends makes the backpressure deterministic
+    // without depending on kernel buffer sizes.
+    //
+    // Runs in a subprocess so the outcome is observable as exitCode/signal.
+    const upstream = http.createServer((req, res) => {
+      res.writeHead(200, { "content-type": "application/octet-stream" });
+      res.write(Buffer.alloc(256 * 1024, "U"));
+      res.end();
+    });
+    upstream.listen(0, "127.0.0.1");
+    await once(upstream, "listening");
+    const upstreamPort = (upstream.address() as import("node:net").AddressInfo).port;
+
+    try {
+      const fixture = /* js */ `
+      const http = require("node:http");
+      const https = require("node:https");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+
+      const proxy = https.createServer({ key: process.env.KEY, cert: process.env.CERT }, (req, res) => {
+        const up = http.get({ port: ${upstreamPort}, host: "127.0.0.1" }, upRes => {
+          res.writeHead(upRes.statusCode, upRes.headers);
+          upRes.pipe(res);
+          res.on("close", () => up.destroy());
+        });
+        up.on("error", () => res.destroy());
+      });
+      proxy.listen(0, "127.0.0.1", async () => {
+        // 1-byte sends → guaranteed backpressure → on_drain is exercised on
+        // every event-loop turn for both the proxy→client and upstream→proxy legs.
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+
+        const port = proxy.address().port;
+        const reqs = [];
+        for (let i = 0; i < 4; i++) {
+          reqs.push(new Promise(resolve => {
+            const r = https.get({ port, host: "127.0.0.1", ca: process.env.CERT }, res => {
+              let n = 0;
+              res.on("data", c => {
+                n += c.length;
+                if (n > 4096) {
+                  // Destroy mid-stream while drain is pending on the server side.
+                  r.destroy();
+                  resolve();
+                }
+              });
+              res.on("error", resolve);
+              res.on("end", resolve);
+            });
+            r.on("error", resolve);
+          }));
+        }
+        await Promise.all(reqs);
+        fault.clear();
+        proxy.close(() => {
+          console.log("OK");
+          process.exit(0);
+        });
+      });
+    `;
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, KEY: certs.key, CERT: certs.cert, BUN_DEBUG_QUIET_LOGS: "1" },
+        stderr: "pipe",
+        stdout: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stdout: stdout.trim(), stderr, signal: proc.signalCode }).toEqual({
+        stdout: "OK",
+        stderr: expect.any(String),
+        signal: null,
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      upstream.close();
+    }
+  });
+
+  test("Bun.serve streaming response under 1-byte sends with client abort mid-body (subprocess)", async () => {
+    // Covers the uWS HttpResponse path (AsyncSocket → us_socket_write →
+    // bsd_send): backpressure on every turn, then the client aborts. The
+    // server's onAborted/on_writable must settle and the process exits 0.
+    const fixture = /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const body = Buffer.alloc(64 * 1024, 0x42);
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              start(ctrl) { ctrl.enqueue(body); ctrl.close(); },
+            }),
+            { headers: { "content-type": "application/octet-stream" } },
+          );
+        },
+      });
+      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+      const ctrl = new AbortController();
+      const res = await fetch("http://127.0.0.1:" + server.port, { signal: ctrl.signal });
+      const reader = res.body.getReader();
+      let n = 0;
+      while (n < 1024) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        n += value.length;
+      }
+      ctrl.abort();
+      fault.clear();
+      console.log("OK");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), signal: proc.signalCode, stderr }).toEqual({
+      stdout: "OK",
+      signal: null,
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("node:http server: short sends + client destroy at first byte does not leak the response (subprocess)", async () => {
+    const fixture = /* js */ `
+      const http = require("node:http");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      let closed = 0;
+      const N = 8;
+      let resolveAllClosed;
+      const allClosed = new Promise(r => { resolveAllClosed = r; });
+      const server = http.createServer((req, res) => {
+        res.on("close", () => { if (++closed === N) resolveAllClosed(); });
+        res.on("error", () => {});
+        res.writeHead(200);
+        res.end(Buffer.alloc(32 * 1024, 0x55));
+      });
+      server.listen(0, "127.0.0.1", async () => {
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+        const port = server.address().port;
+        await Promise.all(Array.from({ length: N }, () => new Promise(resolve => {
+          const r = http.get({ port, host: "127.0.0.1" }, res => {
+            res.once("data", () => { r.destroy(); resolve(); });
+            res.on("error", resolve);
+          });
+          r.on("error", resolve);
+        })));
+        fault.clear();
+        await allClosed;
+        console.log(JSON.stringify({ closed, N }));
+        server.close(() => process.exit(0));
+      });
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout.trim() || "{}");
+    expect({ out, signal: proc.signalCode, stderr }).toEqual({
+      out: { closed: 8, N: 8 },
+      signal: null,
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(skip)("node:http seeded backpressure fuzz", () => {
+  const seed = Number(process.env.BUN_SOCKET_FUZZ_SEED ?? 0x5e1d) >>> 0 || 1;
+  function makePrng(s: number) {
+    return () => {
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      return (s >>> 0) / 0x1_0000_0000;
+    };
+  }
+
+  test("randomized short-send sizes during streaming response deliver intact (subprocess server)", async () => {
+    const rand = makePrng(seed);
+    const bodyLen = 8 * 1024;
+
+    const fixture = /* js */ `
+      const http = require("node:http");
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const body = Buffer.alloc(${bodyLen}, 0x71);
+      const server = http.createServer((req, res) => {
+        res.on("error", () => {});
+        const url = new URL(req.url, "http://x");
+        const bytes = Number(url.searchParams.get("bytes"));
+        const after = Number(url.searchParams.get("after"));
+        fault.set({ syscall: "send", action: "short", bytes, after, repeat: -1 });
+        res.writeHead(200, { "content-length": String(body.length) });
+        res.end(body);
+        res.on("close", () => fault.clear());
+      });
+      server.listen(0, "127.0.0.1", () => {
+        console.log(server.address().port);
+      });
+      process.on("SIGTERM", () => server.close(() => process.exit(0)));
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const reader = proc.stdout.getReader();
+    let portLine = "";
+    while (!portLine.includes("\n")) {
+      const { value, done } = await reader.read();
+      if (done) throw new Error("server exited before printing port: " + (await proc.stderr.text()));
+      portLine += new TextDecoder().decode(value);
+    }
+    reader.releaseLock();
+    const port = Number(portLine.trim());
+
+    try {
+      for (let i = 0; i < 8; i++) {
+        const bytes = 1 + Math.floor(rand() * 64);
+        const after = Math.floor(rand() * 4);
+        const got = await new Promise<number>((resolve, reject) => {
+          const req = http.get({ port, host: "127.0.0.1", path: `/?bytes=${bytes}&after=${after}` }, res => {
+            let n = 0;
+            res.on("data", c => (n += c.length));
+            res.on("end", () => resolve(n));
+            res.on("error", reject);
+          });
+          req.on("error", reject);
+        });
+        expect(got).toBe(bodyLen);
+      }
+    } finally {
+      proc.kill("SIGTERM");
+      await proc.exited;
+    }
+  });
+});

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -1,0 +1,213 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { tls as certs, isWindows } from "harness";
+import { once } from "node:events";
+import http2 from "node:http2";
+
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+// http2 sessions go through the same uSockets bsd_recv/bsd_send chokepoints.
+// Faults are process-global, so client and server (both in this process)
+// share the rule table — short-I/O tests are safe; errno tests target only
+// recv (loop.c on the receiving side).
+
+async function makeServer(handler: (stream: http2.ServerHttp2Stream, headers: http2.IncomingHttpHeaders) => void) {
+  const server = http2.createServer();
+  server.on("stream", handler);
+  server.on("sessionError", () => {});
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as import("node:net").AddressInfo).port;
+  return {
+    port,
+    url: `http://127.0.0.1:${port}`,
+    [Symbol.dispose]() {
+      server.close();
+    },
+  };
+}
+
+describe.skipIf(skip)("node:http2 under injected syscall faults", () => {
+  test("recv → short reads (1 byte) deliver complete HEADERS + DATA frames", async () => {
+    const body = Buffer.alloc(1024, "h");
+    using server = await makeServer((stream, headers) => {
+      stream.respond({ ":status": 200, "content-type": "text/plain" });
+      stream.end(body);
+    });
+    fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+    const client = http2.connect(server.url);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      const [headers] = (await once(req, "response")) as [http2.IncomingHttpHeaders];
+      expect(headers[":status"]).toBe(200);
+      const chunks: Buffer[] = [];
+      req.on("data", c => chunks.push(c));
+      await once(req, "end");
+      expect(Buffer.concat(chunks).equals(body)).toBe(true);
+    } finally {
+      fault.clear();
+      client.close();
+    }
+  });
+
+  test("send → short writes (256 bytes) deliver complete request body to server", async () => {
+    const reqBody = Buffer.alloc(2048, "p");
+    let received = Buffer.alloc(0);
+    const { promise: gotBody, resolve } = Promise.withResolvers<void>();
+    using server = await makeServer((stream, headers) => {
+      stream.on("data", c => (received = Buffer.concat([received, c])));
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end();
+        resolve();
+      });
+    });
+    fault.set({ syscall: "send", action: "short", bytes: 256, repeat: -1 });
+    const client = http2.connect(server.url);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/", ":method": "POST" });
+      req.write(reqBody);
+      req.end();
+      await once(req, "response");
+      await once(req, "end");
+      await gotBody;
+      expect(received.equals(reqBody)).toBe(true);
+    } finally {
+      fault.clear();
+      client.close();
+    }
+  });
+
+  test("recv → short reads at HTTP/2 frame header boundary (9 bytes) still parse correctly", async () => {
+    // HTTP/2 frame header is exactly 9 bytes; clamping recv to 9 forces the
+    // frame parser to reassemble header and payload across separate reads.
+    const body = Buffer.alloc(512, "x");
+    using server = await makeServer(stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(body);
+    });
+    fault.set({ syscall: "recv", action: "short", bytes: 9, repeat: -1 });
+    const client = http2.connect(server.url);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":path": "/" });
+      const chunks: Buffer[] = [];
+      req.on("data", c => chunks.push(c));
+      await Promise.all([once(req, "response"), once(req, "end")]);
+      expect(Buffer.concat(chunks).equals(body)).toBe(true);
+    } finally {
+      fault.clear();
+      client.close();
+    }
+  });
+
+  test("recv → ECONNRESET after connect surfaces as session 'error'", async () => {
+    using server = await makeServer(stream => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    const client = http2.connect(server.url);
+    const errP = once(client, "error");
+    await once(client, "connect");
+    fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+    // Trigger a recv by requesting.
+    const req = client.request({ ":path": "/" });
+    req.on("error", () => {});
+    const [err] = (await errP) as [NodeJS.ErrnoException];
+    expect(err).toBeInstanceOf(Error);
+    expect(client.destroyed).toBe(true);
+  });
+
+  test("send → short writes (8 bytes) during connection preface still establish session", async () => {
+    using server = await makeServer(stream => {
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    fault.set({ syscall: "send", action: "short", bytes: 8, repeat: -1 });
+    const client = http2.connect(server.url);
+    client.on("error", () => {});
+    try {
+      await once(client, "connect");
+      const req = client.request({ ":path": "/" });
+      const [headers] = (await once(req, "response")) as [http2.IncomingHttpHeaders];
+      expect(headers[":status"]).toBe(200);
+      req.resume();
+      await once(req, "end");
+    } finally {
+      fault.clear();
+      client.close();
+    }
+  });
+
+  test("https/2: recv → short reads (3 bytes) over TLS deliver complete response", async () => {
+    const body = Buffer.alloc(256, "s");
+    const server = http2.createSecureServer({ key: certs.key, cert: certs.cert });
+    server.on("stream", stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(body);
+    });
+    server.on("sessionError", () => {});
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    try {
+      fault.set({ syscall: "recv", action: "short", bytes: 3, repeat: -1 });
+      const client = http2.connect(`https://127.0.0.1:${port}`, { ca: certs.cert });
+      client.on("error", () => {});
+      try {
+        const req = client.request({ ":path": "/" });
+        const chunks: Buffer[] = [];
+        req.on("data", c => chunks.push(c));
+        await Promise.all([once(req, "response"), once(req, "end")]);
+        expect(Buffer.concat(chunks).equals(body)).toBe(true);
+      } finally {
+        fault.clear();
+        client.close();
+      }
+    } finally {
+      server.close();
+    }
+  });
+});
+
+describe.skipIf(skip)("node:http2 seeded short-I/O fuzz", () => {
+  const seed = Number(process.env.BUN_SOCKET_FUZZ_SEED ?? 0x1f2e) >>> 0 || 1;
+  function makePrng(s: number) {
+    return () => {
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      return (s >>> 0) / 0x1_0000_0000;
+    };
+  }
+
+  test("randomized short recv/send still deliver intact body", async () => {
+    const rand = makePrng(seed);
+    const body = Buffer.alloc(2048, "F");
+    using server = await makeServer(stream => {
+      stream.respond({ ":status": 200 });
+      stream.end(body);
+    });
+    for (let i = 0; i < 6; i++) {
+      const sc = "recv" as const;
+      const bytes = 1 + Math.floor(rand() * 16);
+      fault.set({ syscall: sc, action: "short", bytes, repeat: -1 });
+      const client = http2.connect(server.url);
+      client.on("error", () => {});
+      try {
+        const req = client.request({ ":path": "/" });
+        const chunks: Buffer[] = [];
+        req.on("data", c => chunks.push(c));
+        await Promise.all([once(req, "response"), once(req, "end")]);
+        expect(Buffer.concat(chunks).equals(body)).toBe(true);
+      } finally {
+        fault.clear();
+        client.close();
+      }
+    }
+  });
+});

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -193,7 +193,7 @@ describe.skipIf(skip)("node:http2 seeded short-I/O fuzz", () => {
       stream.end(body);
     });
     for (let i = 0; i < 6; i++) {
-      const sc = "recv" as const;
+      const sc: "recv" | "send" = rand() < 0.5 ? "recv" : "send";
       const bytes = 1 + Math.floor(rand() * 16);
       fault.set({ syscall: sc, action: "short", bytes, repeat: -1 });
       const client = http2.connect(server.url);

--- a/test/js/node/net/net-syscall-fault.test.ts
+++ b/test/js/node/net/net-syscall-fault.test.ts
@@ -1,0 +1,300 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { once } from "node:events";
+import net from "node:net";
+
+// Windows uses the libuv eventing backend; bsd_recv/bsd_send are still the
+// chokepoints there but errno semantics differ. Land POSIX coverage first.
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+async function connectedPair(onServerSocket?: (s: net.Socket) => void) {
+  const server = net.createServer();
+  server.on("connection", s => onServerSocket?.(s));
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as net.AddressInfo).port;
+
+  // Register the server-side listener before initiating connect so the
+  // 'connection' event cannot be missed.
+  const serverSockP = once(server, "connection") as Promise<[net.Socket]>;
+  const client = net.connect({ port, host: "127.0.0.1" });
+  const [, [serverSock]] = await Promise.all([once(client, "connect"), serverSockP]);
+
+  return {
+    server,
+    client,
+    serverSock,
+    [Symbol.dispose]() {
+      client.destroy();
+      serverSock.destroy();
+      server.close();
+    },
+  };
+}
+
+describe.skipIf(skip)("node:net under injected syscall faults", () => {
+  test("recv → ECONNRESET surfaces as 'error' and destroys the socket", async () => {
+    using p = await connectedPair();
+    fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: 1 });
+    // Trigger a recv() on the client by writing from the server.
+    const errP = once(p.client, "error");
+    p.serverSock.write("hello");
+    const [err] = (await errP) as [NodeJS.ErrnoException];
+    expect(err.code).toBe("ECONNRESET");
+    expect(p.client.destroyed).toBe(true);
+  });
+
+  test("recv → ETIMEDOUT surfaces as 'error' with code ETIMEDOUT", async () => {
+    using p = await connectedPair();
+    p.serverSock.on("error", () => {});
+    fault.set({ syscall: "recv", action: "errno", errno: "ETIMEDOUT", repeat: 1 });
+    const errP = once(p.client, "error");
+    p.serverSock.write("hello");
+    const [err] = (await errP) as [NodeJS.ErrnoException];
+    expect(err.code).toBe("ETIMEDOUT");
+    expect(p.client.destroyed).toBe(true);
+  });
+
+  test("recv → 0 (peer closed) emits 'end' without 'error'", async () => {
+    using p = await connectedPair();
+    fault.set({ syscall: "recv", action: "zero", repeat: 1 });
+    let gotError: unknown = null;
+    p.client.on("error", e => (gotError = e));
+    const endP = once(p.client, "end");
+    p.serverSock.write("hello");
+    await endP;
+    expect(gotError).toBeNull();
+  });
+
+  test("recv → short reads still deliver complete payload", async () => {
+    using p = await connectedPair();
+    // Clamp every recv to 1 byte: the loop should keep draining until EAGAIN
+    // and the application must still observe the full payload.
+    fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+    const chunks: Buffer[] = [];
+    p.client.on("data", c => chunks.push(c));
+    const payload = Buffer.from(Array.from({ length: 256 }, (_, i) => i & 0xff));
+    p.serverSock.write(payload);
+    p.serverSock.end();
+    await once(p.client, "end");
+    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+  });
+
+  test("send → EAGAIN forever: data is buffered, then flushed after disarm", async () => {
+    let received = Buffer.alloc(0);
+    using p = await connectedPair(s => {
+      s.on("data", c => (received = Buffer.concat([received, c])));
+    });
+    fault.set({ syscall: "send", action: "errno", errno: "EAGAIN", repeat: -1 });
+    p.client.write(Buffer.alloc(256, "x"));
+    fault.clear();
+    p.client.end();
+    await once(p.serverSock, "end");
+    expect(received.length).toBe(256);
+  });
+
+  test("send → short writes still deliver complete payload to peer", async () => {
+    let received = Buffer.alloc(0);
+    using p = await connectedPair(s => {
+      s.on("data", c => (received = Buffer.concat([received, c])));
+    });
+    fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+    const payload = Buffer.alloc(512, "b");
+    p.client.write(payload);
+    p.client.end();
+    await once(p.serverSock, "end");
+    fault.clear();
+    expect(received.length).toBe(payload.length);
+    expect(received.equals(payload)).toBe(true);
+  });
+
+  test("connect → ECONNREFUSED is reported on connecting socket", async () => {
+    const server = net.createServer();
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      fault.set({ syscall: "connect", action: "errno", errno: "ECONNREFUSED", repeat: 1 });
+      const client = net.connect({ port, host: "127.0.0.1" });
+      const [err] = (await once(client, "error")) as [NodeJS.ErrnoException];
+      expect(err.code).toBe("ECONNREFUSED");
+      expect(client.destroyed).toBe(true);
+    } finally {
+      server.close();
+    }
+  });
+
+  test("fd targeting: rule on the server fd does not affect the client", async () => {
+    using p = await connectedPair();
+    // The server socket's recv should error; the client should still receive
+    // data normally because the rule only matches the server fd.
+    const serverFd = (p.serverSock as any)._handle.fd;
+    expect(serverFd).toBeGreaterThanOrEqual(0);
+    const serverErrP = once(p.serverSock, "error") as Promise<[NodeJS.ErrnoException]>;
+    fault.set({
+      syscall: "recv",
+      action: "errno",
+      errno: "ECONNRESET",
+      repeat: -1,
+      fd: serverFd,
+    });
+    const dataP = once(p.client, "data");
+    p.serverSock.write("from-server");
+    p.client.write("from-client");
+    const [chunk] = (await dataP) as [Buffer];
+    expect(chunk.toString()).toBe("from-server");
+    const [serverErr] = await serverErrP;
+    expect(serverErr.code).toBe("ECONNRESET");
+  });
+
+  test("accept → EMFILE-style failure: server keeps listening, client sees connect error", async () => {
+    const server = net.createServer();
+    server.on("error", () => {});
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    try {
+      // Block one accept (repeat:1 self-disarms). The first client's TCP
+      // connect succeeds (kernel backlog) but the server-side accept fails;
+      // await c1's 'connect' so the accept has definitively been attempted
+      // before connecting c2.
+      fault.set({ syscall: "accept", action: "errno", errno: "ENOMEM", repeat: 1 });
+      const c1 = net.connect({ port, host: "127.0.0.1" });
+      c1.on("error", () => {});
+      await once(c1, "connect");
+      c1.destroy();
+
+      const okP = once(server, "connection") as Promise<[net.Socket]>;
+      const c2 = net.connect({ port, host: "127.0.0.1" });
+      const [[serverSock]] = await Promise.all([okP, once(c2, "connect")]);
+      expect(c2.readyState).toBe("open");
+      serverSock.destroy();
+      c2.destroy();
+    } finally {
+      server.close();
+    }
+  });
+
+  test("two rules can be armed simultaneously (recv short + send short)", async () => {
+    let received = Buffer.alloc(0);
+    using p = await connectedPair(s => {
+      s.on("data", c => (received = Buffer.concat([received, c])));
+    });
+    fault.set({ syscall: "recv", action: "short", bytes: 3, repeat: -1 });
+    fault.set({ syscall: "send", action: "short", bytes: 3, repeat: -1 });
+    const payload = Buffer.alloc(300, "k");
+    p.client.write(payload);
+    p.client.end();
+    await once(p.serverSock, "end");
+    expect(received.equals(payload)).toBe(true);
+  });
+
+  test("send → short writes deliver a payload larger than the kernel send buffer", async () => {
+    let received = Buffer.alloc(0);
+    using p = await connectedPair(s => {
+      s.on("data", c => (received = Buffer.concat([received, c])));
+    });
+    fault.set({ syscall: "send", action: "short", bytes: 1024, repeat: -1 });
+    const payload = Buffer.alloc(128 * 1024, 0x41);
+    p.client.write(payload);
+    p.client.end();
+    await once(p.serverSock, "end");
+    expect(received.length).toBe(payload.length);
+    expect(received.equals(payload)).toBe(true);
+  });
+
+  test("after: N skips the first N matching calls", async () => {
+    using p = await connectedPair();
+    // Skip the first recv (the readable notification arms one), fail the second.
+    fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", after: 1, repeat: 1 });
+    let firstChunk: Buffer | null = null;
+    p.client.once("data", c => (firstChunk = c));
+    const errP = once(p.client, "error");
+    p.serverSock.write("first");
+    await new Promise<void>(r => p.client.once("data", () => r()));
+    p.serverSock.write("second");
+    const [err] = (await errP) as [NodeJS.ErrnoException];
+    expect(firstChunk!.toString()).toBe("first");
+    expect(err.code).toBe("ECONNRESET");
+  });
+});
+
+describe.skipIf(skip)("node:net torture loop (exhaustive Nth-call failure)", () => {
+  // curl/SQLite torture pattern: for i in 1..N, clamp the i-th and later
+  // recv()s to 1 byte and assert the full payload is always reassembled —
+  // proves there is no position i at which a short read corrupts framing.
+  test("recv → 1-byte short starting at every position i in 1..N delivers intact payload", async () => {
+    const payload = Buffer.alloc(64, "T");
+    for (let i = 0; i < 10; i++) {
+      using p = await connectedPair(s => s.on("error", () => {}));
+      let received = Buffer.alloc(0);
+      p.client.on("data", c => (received = Buffer.concat([received, c])));
+      fault.set({ syscall: "recv", action: "short", bytes: 1, after: i, repeat: -1 });
+      p.serverSock.write(payload);
+      p.serverSock.end();
+      await once(p.client, "end");
+      fault.clear();
+      expect(received.equals(payload)).toBe(true);
+    }
+  });
+});
+
+describe.skipIf(skip)("node:net seeded syscall fuzz", () => {
+  // Deterministic xorshift seeded from env so CI failures are reproducible.
+  const seed = Number(process.env.BUN_SOCKET_FUZZ_SEED ?? 0x2b1a) >>> 0 || 1;
+  function makePrng(s: number) {
+    return () => {
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      return (s >>> 0) / 0x1_0000_0000;
+    };
+  }
+
+  // The fuzz exercises chunking boundaries: every plan is a "short" clamp
+  // that must still deliver the full payload. errno injection is covered by
+  // the deterministic tests above; mixing it here would require per-fd
+  // targeting (both client and server live in this process and share the
+  // process-wide rule table).
+  const PLANS = [
+    { syscall: "recv", action: "short", bytes: 1 },
+    { syscall: "recv", action: "short", bytes: 3 },
+    { syscall: "recv", action: "short", bytes: 7 },
+    { syscall: "recv", action: "short", bytes: 13 },
+    { syscall: "send", action: "short", bytes: 1 },
+    { syscall: "send", action: "short", bytes: 5 },
+    { syscall: "send", action: "short", bytes: 11 },
+  ] as const;
+
+  test("randomized short-read/short-write echo round-trips deliver intact and never crash", async () => {
+    const rand = makePrng(seed);
+    for (let i = 0; i < 24; i++) {
+      const plan = PLANS[Math.floor(rand() * PLANS.length)]!;
+      const after = Math.floor(rand() * 3);
+
+      let echoed = Buffer.alloc(0);
+      using p = await connectedPair(s => {
+        s.on("data", c => s.write(c));
+        s.on("error", () => {});
+      });
+      p.client.on("error", () => {});
+      p.client.on("data", c => (echoed = Buffer.concat([echoed, c])));
+
+      fault.set({ ...plan, after, repeat: -1 } as any);
+
+      const payload = Buffer.alloc(64, i & 0xff);
+      p.client.write(payload);
+      while (echoed.length < payload.length) {
+        await once(p.client, "data");
+      }
+      fault.clear();
+      expect(echoed.equals(payload)).toBe(true);
+      p.client.destroy();
+      await once(p.client, "close").catch(() => {});
+      expect(p.client.destroyed).toBe(true);
+    }
+  });
+});

--- a/test/js/node/net/node-net.test.ts
+++ b/test/js/node/net/node-net.test.ts
@@ -969,3 +969,33 @@ describe("Socket fd adoption", () => {
     expect(() => new Socket({ fd: 0x7ffff })).not.toThrow();
   });
 });
+
+describe("paused socket whose peer sends RST", () => {
+  // Regression: on Linux, epoll forwarded the raw EPOLLERR bit (8) as a libus
+  // close code, which the JS error path read as errno 8 and surfaced as a
+  // bogus `Error: read ENOEXEC` when the socket was not actively reading.
+  // kqueue already normalized the flag to 0/1.
+  it("does not surface a bogus errno error", async () => {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    const errors: NodeJS.ErrnoException[] = [];
+    const server = createServer(c => {
+      c.on("error", () => {});
+      // RST only once the client says it has paused.
+      c.on("data", () => c.resetAndDestroy());
+    });
+    try {
+      await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+      const port = (server.address() as import("node:net").AddressInfo).port;
+      const c = connect(port, "127.0.0.1", () => {
+        c.pause();
+        c.write("x");
+      });
+      c.on("error", e => errors.push(e));
+      c.on("close", () => resolve());
+      await promise;
+    } finally {
+      server.close();
+    }
+    expect(errors.map(e => e.code)).not.toContain("ENOEXEC");
+  });
+});

--- a/test/js/node/tls/tls-syscall-fault.test.ts
+++ b/test/js/node/tls/tls-syscall-fault.test.ts
@@ -1,0 +1,216 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { tls as certs, isWindows } from "harness";
+import { once } from "node:events";
+import tls from "node:tls";
+
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+async function connectedTLSPair(onServerSocket?: (s: tls.TLSSocket) => void) {
+  const server = tls.createServer({ key: certs.key, cert: certs.cert });
+  server.on("secureConnection", s => {
+    s.on("error", () => {});
+    onServerSocket?.(s);
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const port = (server.address() as import("node:net").AddressInfo).port;
+
+  // Register the server-side listener before initiating connect so the
+  // 'secureConnection' event cannot be missed.
+  const serverSockP = once(server, "secureConnection") as Promise<[tls.TLSSocket]>;
+  const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert, rejectUnauthorized: true });
+  const [, [serverSock]] = await Promise.all([once(client, "secureConnect"), serverSockP]);
+
+  return {
+    server,
+    client,
+    serverSock,
+    [Symbol.dispose]() {
+      client.destroy();
+      serverSock.destroy();
+      server.close();
+    },
+  };
+}
+
+describe.skipIf(skip)("node:tls under injected syscall faults", () => {
+  test("recv → ECONNRESET during established session surfaces as 'error'", async () => {
+    using p = await connectedTLSPair();
+    fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+    const errP = once(p.client, "error");
+    p.serverSock.write("hello");
+    const [err] = (await errP) as [NodeJS.ErrnoException];
+    // BoringSSL may map a transport reset to ECONNRESET or to an SSL read error;
+    // either is acceptable, but the socket must be destroyed and not hang.
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect(p.client.destroyed).toBe(true);
+  });
+
+  test("recv → short reads (1 byte) still decrypt complete payload", async () => {
+    using p = await connectedTLSPair();
+    // The TLS record layer must reassemble across many tiny BIO reads.
+    fault.set({ syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+    const chunks: Buffer[] = [];
+    p.client.on("data", c => chunks.push(c));
+    const payload = Buffer.alloc(512, "Z");
+    p.serverSock.write(payload);
+    p.serverSock.end();
+    await once(p.client, "end");
+    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+  });
+
+  test("send → short writes (1 byte) still deliver complete encrypted payload", async () => {
+    let received = Buffer.alloc(0);
+    using p = await connectedTLSPair(s => {
+      s.on("data", c => (received = Buffer.concat([received, c])));
+    });
+    fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+    const payload = Buffer.alloc(512, "Y");
+    p.client.write(payload);
+    p.client.end();
+    await once(p.serverSock, "end");
+    fault.clear();
+    expect(received.equals(payload)).toBe(true);
+  });
+
+  test("recv → 0 (peer closed) on established session emits 'end' without 'error'", async () => {
+    using p = await connectedTLSPair();
+    let gotError: unknown = null;
+    p.client.on("error", e => (gotError = e));
+    fault.set({ syscall: "recv", action: "zero", repeat: -1 });
+    const endP = once(p.client, "end");
+    p.serverSock.write("hello");
+    await endP;
+    expect(gotError).toBeNull();
+  });
+
+  test("send → short writes during handshake still complete secureConnect", async () => {
+    const server = tls.createServer({ key: certs.key, cert: certs.cert });
+    server.on("secureConnection", s => s.on("error", () => {}));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    try {
+      // Clamp every send to 3 bytes — the ClientHello/ServerHello/Finished
+      // flights are split across hundreds of partial writes.
+      fault.set({ syscall: "send", action: "short", bytes: 3, repeat: -1 });
+      const serverSockP = once(server, "secureConnection") as Promise<[tls.TLSSocket]>;
+      const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert });
+      const [, [serverSock]] = await Promise.all([once(client, "secureConnect"), serverSockP]);
+      expect(client.authorized).toBe(true);
+      client.destroy();
+      serverSock.destroy();
+    } finally {
+      fault.clear();
+      server.close();
+    }
+  });
+
+  test("recv → short reads at TLS record boundary (5 bytes = header only) still decrypt", async () => {
+    using p = await connectedTLSPair();
+    // 5 bytes is exactly the TLS record header — forces the BIO to assemble
+    // header and ciphertext across separate recv calls.
+    fault.set({ syscall: "recv", action: "short", bytes: 5, repeat: -1 });
+    const chunks: Buffer[] = [];
+    p.client.on("data", c => chunks.push(c));
+    const payload = Buffer.alloc(256, "R");
+    p.serverSock.write(payload);
+    p.serverSock.end();
+    await once(p.client, "end");
+    expect(Buffer.concat(chunks).equals(payload)).toBe(true);
+  });
+
+  test("recv → ECONNRESET mid-handshake fails connect with an error (no hang)", async () => {
+    const server = tls.createServer({ key: certs.key, cert: certs.cert }, s => s.on("error", () => {}));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as import("node:net").AddressInfo).port;
+    try {
+      // Reset the very first wire read of the ServerHello.
+      fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+      const client = tls.connect({ port, host: "127.0.0.1", ca: certs.cert });
+      const [err] = (await once(client, "error")) as [Error];
+      expect(err).toBeTruthy();
+      client.destroy();
+    } finally {
+      fault.clear();
+      server.close();
+    }
+  });
+});
+
+describe.skipIf(skip)("node:tls close_notify / shutdown under faults", () => {
+  test("client.end() under 1-byte sends still delivers close_notify and peer sees clean 'end'", async () => {
+    using p = await connectedTLSPair();
+    let serverGotEnd = false;
+    p.serverSock.on("end", () => (serverGotEnd = true));
+    fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+    p.client.end();
+    await once(p.serverSock, "close");
+    fault.clear();
+    expect(serverGotEnd).toBe(true);
+  });
+
+  test("server.end() with recv → 0 immediately after (FIN before close_notify drained) reaches 'close'", async () => {
+    // Exercises openssl.c on_end (TCP FIN under TLS): close_notify may not
+    // have been read yet when the transport reports EOF.
+    using p = await connectedTLSPair();
+    p.client.on("error", () => {});
+    fault.set({ syscall: "recv", action: "zero", after: 1, repeat: -1 });
+    p.serverSock.end("bye");
+    await once(p.client, "close");
+    fault.clear();
+    // close_notify was truncated by the injected EOF, but the socket must
+    // still reach 'close' without hanging.
+    expect(p.client.destroyed).toBe(true);
+  });
+});
+
+describe.skipIf(skip)("node:tls seeded syscall fuzz", () => {
+  const seed = Number(process.env.BUN_SOCKET_FUZZ_SEED ?? 0x7a1c) >>> 0 || 1;
+  function makePrng(s: number) {
+    return () => {
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      return (s >>> 0) / 0x1_0000_0000;
+    };
+  }
+  const PLANS = [
+    { syscall: "recv", action: "short", bytes: 1 },
+    { syscall: "recv", action: "short", bytes: 7 },
+    { syscall: "recv", action: "short", bytes: 17 },
+    { syscall: "send", action: "short", bytes: 1 },
+    { syscall: "send", action: "short", bytes: 11 },
+  ] as const;
+
+  test("randomized short-I/O during established echo delivers intact and never crashes", async () => {
+    const rand = makePrng(seed);
+    for (let i = 0; i < 12; i++) {
+      let echoed = Buffer.alloc(0);
+      using p = await connectedTLSPair(s => {
+        s.on("data", c => s.write(c));
+      });
+      p.client.on("error", () => {});
+      p.client.on("data", c => (echoed = Buffer.concat([echoed, c])));
+
+      const plan = PLANS[Math.floor(rand() * PLANS.length)]!;
+      fault.set({ ...plan, after: Math.floor(rand() * 2), repeat: -1 } as any);
+
+      const payload = Buffer.alloc(128, i & 0xff);
+      p.client.write(payload);
+      while (echoed.length < payload.length) {
+        await once(p.client, "data");
+      }
+      fault.clear();
+      expect(echoed.subarray(0, payload.length).equals(payload)).toBe(true);
+      p.client.destroy();
+      await once(p.client, "close").catch(() => {});
+      expect(p.client.destroyed).toBe(true);
+    }
+  });
+});

--- a/test/js/web/fetch/fetch-syscall-fault.test.ts
+++ b/test/js/web/fetch/fetch-syscall-fault.test.ts
@@ -1,0 +1,228 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+// fetch() is the client; the server runs in the parent test process and the
+// fetch (with the fault armed) runs in a subprocess so faults only affect the
+// client side of the connection.
+
+async function runClientFetch(
+  url: string,
+  rule: import("bun:internal-for-testing").SocketFaultRule | null,
+  opts: { ca?: string; readBytes?: number; abort?: boolean } = {},
+) {
+  const fixture = /* js */ `
+    const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+    const rule = ${JSON.stringify(rule)};
+    if (rule) fault.set(rule);
+    try {
+      const res = await fetch(${JSON.stringify(url)}, {
+        ${opts.ca ? `tls: { ca: process.env.CA },` : ""}
+      });
+      ${
+        opts.abort
+          ? `
+        const reader = res.body.getReader();
+        let n = 0;
+        while (n < ${opts.readBytes ?? 1024}) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          n += value.length;
+        }
+        await reader.cancel();
+        console.log(JSON.stringify({ ok: true, status: res.status, n }));
+      `
+          : `
+        const buf = await res.arrayBuffer();
+        console.log(JSON.stringify({ ok: true, status: res.status, length: buf.byteLength }));
+      `
+      }
+    } catch (e) {
+      console.log(JSON.stringify({ ok: false, code: e?.code, name: e?.name, message: String(e?.message ?? e) }));
+    } finally {
+      fault.clear();
+    }
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", ...(opts.ca ? { CA: opts.ca } : {}) },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { ...JSON.parse(stdout.trim() || "{}"), stderr, exitCode, signal: proc.signalCode };
+}
+
+describe.skipIf(skip)("fetch() under injected syscall faults (http)", () => {
+  test("recv → ECONNRESET on response rejects with a connection error", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(Buffer.alloc(8192, "a")),
+    });
+    const r = await runClientFetch(server.url.href, {
+      syscall: "recv",
+      action: "errno",
+      errno: "ECONNRESET",
+      repeat: -1,
+    });
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(false);
+    expect(["ECONNRESET", "ConnectionClosed"]).toContain(r.code);
+  });
+
+  test("recv → short reads (1 byte) deliver complete body", async () => {
+    const body = Buffer.alloc(8192, "z");
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(body),
+    });
+    const r = await runClientFetch(server.url.href, { syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+    expect(r).toMatchObject({ ok: true, status: 200, length: body.length, signal: null, exitCode: 0 });
+  });
+
+  test("recv → short reads (1 byte) deliver complete chunked (Transfer-Encoding) body", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            start(c) {
+              c.enqueue(Buffer.alloc(100, "a"));
+              c.enqueue(Buffer.alloc(200, "b"));
+              c.enqueue(Buffer.alloc(50, "c"));
+              c.close();
+            },
+          }),
+        ),
+    });
+    const r = await runClientFetch(server.url.href, { syscall: "recv", action: "short", bytes: 1, repeat: -1 });
+    expect(r).toMatchObject({ ok: true, status: 200, length: 350, signal: null, exitCode: 0 });
+  });
+
+  test("send → short writes (1 byte) on the request still gets a response", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("ok"),
+    });
+    const r = await runClientFetch(server.url.href, { syscall: "send", action: "short", bytes: 1, repeat: -1 });
+    expect(r).toMatchObject({ ok: true, status: 200, length: 2, signal: null, exitCode: 0 });
+  });
+
+  test("connect → ECONNREFUSED rejects with ECONNREFUSED", async () => {
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("x") });
+    const r = await runClientFetch(server.url.href, {
+      syscall: "connect",
+      action: "errno",
+      errno: "ECONNREFUSED",
+      repeat: -1,
+    });
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(false);
+    // fetch wraps connect failure as a generic open-socket error.
+    expect(["ECONNREFUSED", "FailedToOpenSocket", "ConnectionRefused"]).toContain(r.code);
+  });
+
+  test("recv → 0 (peer closed) before any byte rejects cleanly (no hang)", async () => {
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(Buffer.alloc(1024)) });
+    const r = await runClientFetch(server.url.href, { syscall: "recv", action: "zero", repeat: -1 });
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("body reader cancel under 1-byte sends settles cleanly", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(Buffer.alloc(64 * 1024, "q")),
+    });
+    const r = await runClientFetch(
+      server.url.href,
+      { syscall: "send", action: "short", bytes: 1, repeat: -1 },
+      { abort: true, readBytes: 256 },
+    );
+    expect(r).toMatchObject({ ok: true, status: 200, signal: null, exitCode: 0 });
+  });
+});
+
+describe.skipIf(skip)("fetch() under injected syscall faults (https)", () => {
+  test("TLS handshake under 3-byte sends still succeeds and body decrypts", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: { key: certs.key, cert: certs.cert },
+      fetch: () => new Response("hello-tls"),
+    });
+    const r = await runClientFetch(
+      server.url.href,
+      { syscall: "send", action: "short", bytes: 3, repeat: -1 },
+      { ca: certs.cert },
+    );
+    expect(r).toMatchObject({ ok: true, status: 200, length: 9, signal: null, exitCode: 0 });
+  });
+
+  test("recv → ECONNRESET during TLS handshake rejects (no hang)", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: { key: certs.key, cert: certs.cert },
+      fetch: () => new Response("x"),
+    });
+    const r = await runClientFetch(
+      server.url.href,
+      { syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 },
+      { ca: certs.cert },
+    );
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("recv → 5-byte short reads (TLS record header boundary) deliver complete body", async () => {
+    const body = Buffer.alloc(2048, "T");
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: { key: certs.key, cert: certs.cert },
+      fetch: () => new Response(body),
+    });
+    const r = await runClientFetch(
+      server.url.href,
+      { syscall: "recv", action: "short", bytes: 5, repeat: -1 },
+      { ca: certs.cert },
+    );
+    expect(r).toMatchObject({ ok: true, status: 200, length: body.length, signal: null, exitCode: 0 });
+  });
+});
+
+describe.skipIf(skip)("fetch() seeded short-I/O fuzz", () => {
+  const seed = Number(process.env.BUN_SOCKET_FUZZ_SEED ?? 0x4e7c) >>> 0 || 1;
+  function makePrng(s: number) {
+    return () => {
+      s ^= s << 13;
+      s ^= s >>> 17;
+      s ^= s << 5;
+      return (s >>> 0) / 0x1_0000_0000;
+    };
+  }
+
+  test("randomized short recv/send still deliver intact body", async () => {
+    const rand = makePrng(seed);
+    const body = Buffer.alloc(4096, "F");
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(body) });
+    for (let i = 0; i < 4; i++) {
+      const sc = rand() < 0.5 ? "recv" : "send";
+      const bytes = 1 + Math.floor(rand() * 32);
+      const r = await runClientFetch(server.url.href, { syscall: sc, action: "short", bytes, repeat: -1 });
+      expect(r).toMatchObject({ ok: true, status: 200, length: body.length, signal: null, exitCode: 0 });
+    }
+  });
+});

--- a/test/js/web/fetch/fetch-syscall-fault.test.ts
+++ b/test/js/web/fetch/fetch-syscall-fault.test.ts
@@ -138,7 +138,9 @@ describe.skipIf(skip)("fetch() under injected syscall faults (http)", () => {
     expect(r.exitCode).toBe(0);
   });
 
-  test("body reader cancel under 1-byte sends settles cleanly", async () => {
+  // `send` faults the request-write path; `recv` faults the response-read path
+  // that the cancel is racing against. Both must settle without a leak/hang.
+  test.each(["send", "recv"] as const)("body reader cancel under 1-byte %s settles cleanly", async syscall => {
     using server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
@@ -146,10 +148,46 @@ describe.skipIf(skip)("fetch() under injected syscall faults (http)", () => {
     });
     const r = await runClientFetch(
       server.url.href,
-      { syscall: "send", action: "short", bytes: 1, repeat: -1 },
+      { syscall, action: "short", bytes: 1, repeat: -1 },
       { abort: true, readBytes: 256 },
     );
     expect(r).toMatchObject({ ok: true, status: 200, signal: null, exitCode: 0 });
+  });
+
+  test("re-arming rules from JS during an in-flight fetch keeps the rule coherent", async () => {
+    const body = Buffer.alloc(32 * 1024, "r");
+    using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response(body) });
+    // Regression: us_fault_set() published the rule with a plain struct write
+    // while the HTTP-client thread read it concurrently in us_fault_hit(), so
+    // a re-arm during a download could observe a torn rule. Hammer set() while
+    // the body streams and require the bytes to still arrive intact. The clamp
+    // floor of 8 keeps the syscall count bounded on slow ASan runners.
+    const fixture = /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      fault.set({ syscall: "recv", action: "short", bytes: 16, repeat: -1 });
+      const done = fetch(${JSON.stringify(server.url.href)}).then(r => r.arrayBuffer());
+      let flips = 0;
+      const rearm = setInterval(() => {
+        flips++;
+        fault.set({ syscall: "recv", action: "short", bytes: 8 + (flips % 56), repeat: -1 });
+        fault.set({ syscall: "send", action: "short", bytes: 8 + (flips % 8), repeat: -1 });
+      }, 0);
+      const buf = await done;
+      clearInterval(rearm);
+      fault.clear();
+      console.log(JSON.stringify({ ok: true, length: buf.byteLength, flips }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // Assert the output before the exit code so a failure shows what the fixture printed.
+    expect(JSON.parse(stdout.trim() || "{}")).toMatchObject({ ok: true, length: body.length });
+    expect(proc.signalCode).toBeNull();
+    expect(exitCode).toBe(0);
   });
 });
 

--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -1,6 +1,9 @@
 import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+import crypto from "node:crypto";
+import tls from "node:tls";
+import { createConnectProxy, startProxy } from "./proxy-test-utils";
 
 const skip = !fault.available() || isWindows;
 
@@ -404,5 +407,69 @@ describe.skipIf(skip)("Bun.serve WebSocket server under injected syscall faults 
       stderr: expect.any(String),
     });
     expect(exitCode).toBe(0);
+  });
+});
+
+describe.skipIf(skip)("WebSocket client (wss:// via HTTP CONNECT proxy) under injected syscall faults", () => {
+  // Regression for the proxy-tunnel pending-close path: a close frame that is
+  // only partially flushed defers `close` until handle_tunnel_writable() drains
+  // it. The wss endpoint below never answers the close frame, so the deferred
+  // dispatch is the ONLY way `onclose` can fire — without the drain this hangs.
+  test("send → short writes (1 byte): close() still dispatches 'close' once the tunnel drains", async () => {
+    const wss = tls.createServer({ cert: certs.cert, key: certs.key }, sock => {
+      let buf = Buffer.alloc(0);
+      let upgraded = false;
+      sock.on("data", chunk => {
+        if (upgraded) return; // absorb frames (including close) without replying
+        buf = Buffer.concat([buf, chunk]);
+        const end = buf.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        const m = /Sec-WebSocket-Key:\s*([A-Za-z0-9+/=]+)/i.exec(buf.subarray(0, end).toString("latin1"));
+        if (!m) return sock.destroy();
+        const accept = crypto
+          .createHash("sha1")
+          .update(m[1] + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
+          .digest("base64");
+        sock.write(
+          "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+            `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+        );
+        upgraded = true;
+      });
+      sock.on("error", () => {});
+    });
+    await new Promise<void>(r => wss.listen(0, "127.0.0.1", () => r()));
+    const proxy = createConnectProxy();
+    const proxyPort = await startProxy(proxy);
+    try {
+      const url = `wss://127.0.0.1:${(wss.address() as import("node:net").AddressInfo).port}/`;
+      const r = await runWSClient(
+        url,
+        { syscall: "send", action: "short", bytes: 1, repeat: -1 },
+        /* js */ `
+          const ws = new WebSocket(url, {
+            proxy: "http://127.0.0.1:${proxyPort}",
+            tls: { rejectUnauthorized: false },
+          });
+          // Arm only once the tunnel is up so CONNECT + TLS handshake stay fast.
+          // Two sends before close(): the 1st short-writes into the tunnel's
+          // write_buffer, so the 2nd queues in send_buffer under backpressure.
+          // That is the only tunnel state where the close dispatch is deferred
+          // (the SSL layer always absorbs the close frame itself in full).
+          ws.onopen = () => {
+            fault.set(rule);
+            ws.send(Buffer.alloc(256, 0x41));
+            ws.send("b");
+            ws.close(1000, "bye");
+          };
+          ws.onerror = () => {};
+          ws.onclose = e => { fault.clear(); out({ ok: true, code: e.code }); process.exit(0); };
+        `,
+      );
+      expect(r).toMatchObject({ ok: true, code: 1000, signal: null, exitCode: 0 });
+    } finally {
+      proxy.close();
+      wss.close();
+    }
   });
 });

--- a/test/js/web/websocket/websocket-syscall-fault.test.ts
+++ b/test/js/web/websocket/websocket-syscall-fault.test.ts
@@ -1,0 +1,408 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tls as certs, isWindows } from "harness";
+
+const skip = !fault.available() || isWindows;
+
+afterEach(() => fault.clear());
+
+// The WebSocket client (web standard new WebSocket()) lives in src/http/
+// websocket_client/ and goes through the same uSockets bsd_recv/bsd_send.
+// Server runs in this process (no fault), client runs in a subprocess (faulted).
+
+async function runWSClient(
+  url: string,
+  rule: import("bun:internal-for-testing").SocketFaultRule | null,
+  script: string,
+) {
+  const fixture = /* js */ `
+    const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+    const rule = ${JSON.stringify(rule)};
+    const url = ${JSON.stringify(url)};
+    const out = (o) => console.log(JSON.stringify(o));
+    ${script}
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1", NODE_TLS_REJECT_UNAUTHORIZED: "0", CA: certs.cert },
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { ...JSON.parse(stdout.trim() || "{}"), stderr, exitCode, signal: proc.signalCode };
+}
+
+function makeEchoServer(opts: { tls?: boolean } = {}) {
+  return Bun.serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    ...(opts.tls ? { tls: { key: certs.key, cert: certs.cert } } : {}),
+    fetch(req, server) {
+      if (server.upgrade(req)) return;
+      return new Response("upgrade required", { status: 426 });
+    },
+    websocket: {
+      open() {},
+      message(ws, msg) {
+        ws.send(msg);
+      },
+      close() {},
+    },
+  });
+}
+
+describe.skipIf(skip)("WebSocket client (ws://) under injected syscall faults", () => {
+  test("recv → short reads (1 byte) deliver complete echoed text frame", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      { syscall: "recv", action: "short", bytes: 1, repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url);
+      ws.onopen = () => ws.send("hello-world");
+      ws.onmessage = (e) => { out({ ok: true, data: e.data }); ws.close(); };
+      ws.onerror = () => out({ ok: false, error: true });
+      ws.onclose = () => process.exit(0);
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, data: "hello-world", signal: null, exitCode: 0 });
+  });
+
+  test("recv → short reads deliver complete large binary frame (frame header split)", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      { syscall: "recv", action: "short", bytes: 3, repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const payload = new Uint8Array(70000).fill(0x55); // forces 8-byte extended length
+      const ws = new WebSocket(url);
+      ws.binaryType = "arraybuffer";
+      ws.onopen = () => ws.send(payload);
+      ws.onmessage = (e) => { out({ ok: true, len: e.data.byteLength }); ws.close(); };
+      ws.onerror = () => out({ ok: false });
+      ws.onclose = () => process.exit(0);
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, len: 70000, signal: null, exitCode: 0 });
+  });
+
+  test("send → short writes (1 byte) deliver complete frame to server", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      { syscall: "send", action: "short", bytes: 1, repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url);
+      ws.onopen = () => ws.send(Buffer.alloc(2048, 0x41).toString());
+      ws.onmessage = (e) => { out({ ok: true, len: e.data.length }); ws.close(); };
+      ws.onerror = () => out({ ok: false });
+      ws.onclose = () => process.exit(0);
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, len: 2048, signal: null, exitCode: 0 });
+  });
+
+  test("recv → ECONNRESET fires onclose with abnormal code (no hang)", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      null,
+      /* js */ `
+      const ws = new WebSocket(url);
+      let errored = false;
+      ws.onopen = () => {
+        fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 });
+        ws.send("ping");
+      };
+      ws.onmessage = () => out({ ok: false, unexpected: "message" });
+      ws.onerror = () => { errored = true; };
+      ws.onclose = (e) => { out({ ok: true, errored, code: e.code }); process.exit(0); };
+    `,
+    );
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(true);
+    expect(r.code).toBe(1006);
+    // Per WHATWG, onerror during the data-exchange phase is optional; Bun
+    // currently does not fire it for a transport reset after open.
+    expect(r.errored).toBe(false);
+  });
+
+  test("recv → 0 (peer closed) fires onclose", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      null,
+      /* js */ `
+      const ws = new WebSocket(url);
+      let errored = false;
+      ws.onopen = () => {
+        fault.set({ syscall: "recv", action: "zero", repeat: -1 });
+        ws.send("ping");
+      };
+      ws.onerror = () => { errored = true; };
+      ws.onclose = (e) => { out({ ok: true, errored, code: e.code }); process.exit(0); };
+    `,
+    );
+    expect(r.signal).toBeNull();
+    expect(r.ok).toBe(true);
+    expect(typeof r.errored).toBe("boolean");
+  });
+
+  test("connect → ECONNREFUSED fires onerror then onclose", async () => {
+    using server = makeEchoServer();
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      { syscall: "connect", action: "errno", errno: "ECONNREFUSED", repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url);
+      let errored = false;
+      ws.onopen = () => out({ ok: false, unexpected: "open" });
+      ws.onerror = () => { errored = true; };
+      ws.onclose = () => { out({ ok: true, errored }); process.exit(0); };
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, errored: true, signal: null, exitCode: 0 });
+  });
+});
+
+describe.skipIf(skip)("WebSocket client (wss://) under injected syscall faults", () => {
+  test("recv → short reads (1 byte) over TLS deliver complete echoed frame", async () => {
+    using server = makeEchoServer({ tls: true });
+    const r = await runWSClient(
+      `wss://127.0.0.1:${server.port}/`,
+      { syscall: "recv", action: "short", bytes: 1, repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url, { tls: { ca: process.env.CA } });
+      ws.onopen = () => ws.send("secure-echo");
+      ws.onmessage = (e) => { out({ ok: true, data: e.data }); ws.close(); };
+      ws.onerror = () => out({ ok: false });
+      ws.onclose = () => process.exit(0);
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, data: "secure-echo", signal: null, exitCode: 0 });
+  });
+
+  test("send → 3-byte short writes during TLS handshake still opens", async () => {
+    using server = makeEchoServer({ tls: true });
+    const r = await runWSClient(
+      `wss://127.0.0.1:${server.port}/`,
+      { syscall: "send", action: "short", bytes: 3, repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url, { tls: { ca: process.env.CA } });
+      ws.onopen = () => { out({ ok: true, opened: true }); ws.close(); };
+      ws.onerror = () => out({ ok: false });
+      ws.onclose = () => process.exit(0);
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, opened: true, signal: null, exitCode: 0 });
+  });
+
+  test("recv → ECONNRESET mid-handshake fires onerror (no hang)", async () => {
+    using server = makeEchoServer({ tls: true });
+    const r = await runWSClient(
+      `wss://127.0.0.1:${server.port}/`,
+      { syscall: "recv", action: "errno", errno: "ECONNRESET", repeat: -1 },
+      /* js */ `
+      if (rule) fault.set(rule);
+      const ws = new WebSocket(url, { tls: { ca: process.env.CA } });
+      let errored = false;
+      ws.onopen = () => out({ ok: false, unexpected: "open" });
+      ws.onerror = () => { errored = true; };
+      ws.onclose = () => { out({ ok: true, errored }); process.exit(0); };
+    `,
+    );
+    expect(r).toMatchObject({ ok: true, errored: true, signal: null, exitCode: 0 });
+  });
+});
+
+describe.skipIf(skip)("WebSocket client close-frame under faults", () => {
+  test("close(code, reason) reaches server intact (no fault — regression)", async () => {
+    const { promise: closedP, resolve } = Promise.withResolvers<{ code: number; reason: string }>();
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("no", { status: 426 });
+      },
+      websocket: {
+        open() {},
+        message() {},
+        close(_ws, code, reason) {
+          resolve({ code, reason });
+        },
+      },
+    });
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      null,
+      /* js */ `
+      const ws = new WebSocket(url);
+      ws.onopen = () => ws.close(3001, "no-fault-close");
+      ws.onclose = () => { out({ ok: true }); };
+      ws.onerror = () => out({ ok: false });
+    `,
+    );
+    const closed = await closedP;
+    expect(r).toMatchObject({ ok: true, signal: null, exitCode: 0 });
+    expect(closed).toEqual({ code: 3001, reason: "no-fault-close" });
+  });
+
+  test("send → short writes (1 byte): close(code, reason) reaches server intact", async () => {
+    const { promise: closedP, resolve } = Promise.withResolvers<{ code: number; reason: string }>();
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req, s) {
+        if (s.upgrade(req)) return;
+        return new Response("no", { status: 426 });
+      },
+      websocket: {
+        open() {},
+        message() {},
+        close(_ws, code, reason) {
+          resolve({ code, reason });
+        },
+      },
+    });
+    const r = await runWSClient(
+      `ws://127.0.0.1:${server.port}/`,
+      null,
+      /* js */ `
+      const ws = new WebSocket(url);
+      // Arm only after open so the upgrade request/response are full-size; the
+      // close frame is the first write under the clamp. onclose fires before
+      // the buffered remainder of the close frame flushes (it's queued for the
+      // next writable turn), so let the event loop drain instead of exiting.
+      ws.onopen = () => {
+        fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+        ws.close(3001, "short-write-close");
+      };
+      ws.onclose = () => { fault.clear(); out({ ok: true }); };
+      ws.onerror = () => out({ ok: false });
+    `,
+    );
+    const closed = await closedP;
+    expect(r).toMatchObject({ ok: true, signal: null, exitCode: 0 });
+    expect(closed).toEqual({ code: 3001, reason: "short-write-close" });
+  });
+});
+
+describe.skipIf(skip)("Bun.serve WebSocket server under injected syscall faults (subprocess)", () => {
+  test("send → short writes (1 byte) deliver complete frame to client", async () => {
+    const fixture = /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
+        websocket: { open(ws) {}, message(ws, m) { ws.send(m); }, close() {} } });
+      fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 });
+      const ws = new WebSocket("ws://127.0.0.1:" + s.port);
+      ws.onopen = () => ws.send(Buffer.alloc(4096, 0x57).toString());
+      ws.onmessage = (e) => { console.log(JSON.stringify({ len: e.data.length })); ws.close(); };
+      ws.onclose = () => { fault.clear(); process.exit(0); };
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim() || "{}"), signal: proc.signalCode, stderr }).toEqual({
+      out: { len: 4096 },
+      signal: null,
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("writev → zero (once) on a ≥16 KB server frame: client receives full payload", async () => {
+    // The Bun.serve WS plain-TCP fast path (≥16 KB, no backpressure) uses
+    // us_socket_write2 → bsd_write2/writev — keyed US_FAULT_WRITEV. This is
+    // the only test exercising that hook.
+    const fixture = /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
+        websocket: {
+          open(ws) {
+            fault.set({ syscall: "writev", action: "zero", repeat: 1 });
+            ws.send(Buffer.alloc(20000, 0x57));
+          },
+          message() {},
+          close() {},
+        } });
+      const ws = new WebSocket("ws://127.0.0.1:" + s.port);
+      ws.binaryType = "arraybuffer";
+      ws.onmessage = (e) => {
+        console.log(JSON.stringify({ len: e.data.byteLength }));
+        ws.close();
+      };
+      ws.onclose = () => { fault.clear(); s.stop(true); process.exit(0); };
+      ws.onerror = () => { console.log(JSON.stringify({ err: true })); process.exit(1); };
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim() || "{}"), signal: proc.signalCode, stderr }).toEqual({
+      out: { len: 20000 },
+      signal: null,
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("client disconnect under server short sends: every ws reaches close()", async () => {
+    const fixture = /* js */ `
+      const { socketFaultInjection: fault } = require("bun:internal-for-testing");
+      let closed = 0;
+      let resolveAllClosed;
+      const N = 4;
+      const allClosed = new Promise(r => { resolveAllClosed = r; });
+      const s = Bun.serve({ port: 0, hostname: "127.0.0.1",
+        fetch(req, server) { if (server.upgrade(req)) return; return new Response("no", {status:426}); },
+        websocket: {
+          open(ws) { ws.send(Buffer.alloc(2048, 0x42)); },
+          message() {},
+          close() { if (++closed === N) resolveAllClosed(); },
+        } });
+      // 16-byte clamp keeps backpressure deterministic without a 32 KB / 1-byte
+      // wall-clock blowout under debug+asan.
+      fault.set({ syscall: "send", action: "short", bytes: 16, repeat: -1 });
+      await Promise.all(Array.from({ length: N }, () => new Promise(r => {
+        const ws = new WebSocket("ws://127.0.0.1:" + s.port);
+        ws.binaryType = "arraybuffer";
+        ws.onmessage = () => ws.close();
+        ws.onclose = r;
+        ws.onerror = r;
+      })));
+      fault.clear();
+      await allClosed;
+      console.log(JSON.stringify({ closed, N }));
+      s.stop(true);
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, BUN_DEBUG_QUIET_LOGS: "1" },
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim() || "{}"), signal: proc.signalCode, stderr }).toEqual({
+      out: { closed: 4, N: 4 },
+      signal: null,
+      stderr: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -122,6 +122,7 @@ test/js/bun/http/bun-server.test.ts
 test/js/bun/import-attributes/import-attributes.test.ts
 test/js/bun/resolve/import-custom-condition.test.ts
 test/js/bun/s3/s3.leak.test.ts
+test/js/bun/s3/s3-stream-cancel-leak.test.ts
 test/js/bun/shell/bunshell.test.ts
 test/js/bun/shell/commands/ls.test.ts
 test/js/bun/shell/leak.test.ts


### PR DESCRIPTION
### What does this PR do?

Adds a **socket syscall fault-injection layer** so we can deterministically fuzz `node:net`, `node:tls`, and `node:http` against transport-level conditions that are otherwise hard to reproduce in a unit test: partial reads/writes, mid-stream `ECONNRESET`/`EPIPE`, `EAGAIN` storms, connect failures, and backpressure → `on_drain` racing a concurrent destroy.

### Architecture

```
node:net / node:tls / node:http  (src/js/node/*.ts)
        ↓
src/runtime/{socket,server}/*.rs   (JS-class bindings)
        ↓ FFI (src/uws_sys/)
packages/bun-uws/src/*.h           (header-only C++; calls us_socket_write*)
        ↓
packages/bun-usockets/src/{socket.c, loop.c, crypto/openssl.c}
        ↓
packages/bun-usockets/src/bsd.c    ← every libc recv/send/connect/accept lives here
```

`bsd.c` is the **only** file in the repo that calls the raw socket syscalls; uWS and the BoringSSL BIO both bottom out in `us_socket_write*` / the loop's `bsd_recv`. So all hooks live in `bsd.c` — no edits to `socket.c`, `loop.c`, `openssl.c`, or uWS.

**Interceptor** (`packages/bun-usockets/src/{fault_inject.c, internal/fault_inject.h}`): a process-global rule table indexed by `enum us_fault_syscall` (recv/send/writev/sendmsg/recvmsg/connect/accept). Each rule says `{action: errno|short|zero, errno_value, clamp_bytes, after_n_calls, repeat, target_fd}`. The hot-path check is `US_FAULT_CHECK(sc, fd, out, clamp)` — an acquire atomic load of one process-wide `us_fault_armed` int, then a rule-table lookup if armed. Rules are process-global (not thread-local) so a rule armed from JS also affects the HTTP-client thread that runs `fetch()`; per-socket isolation is provided by `target_fd`.

**Build gate** (`scripts/build/{config,flags,rust}.ts`, `scripts/build.ts`): new `Config.socketFaultInjection` field, exposed as `--socket-fault-injection=on|off`. Drives both `-DLIBUS_SOCKET_FAULT_INJECTION=1` (C) and `--cfg=socket_fault_injection` (Rust) so the C symbol and the Rust `extern` are always either both present or both absent.

**Default = `asan`.** The flag is not tied to `debug` or `ci` — it's compiled in exactly when `asan` is, and can be overridden independently:

| Build | `asan` default | `socketFaultInjection` |
|---|:-:|:-:|
| Local `bun bd` on Linux | on | **on** |
| Local `bun bd` on arm64 macOS | on | **on** |
| Local `bun bd` on x64 macOS / Windows | off | off |
| CI `release-asan` | on | **on** |
| CI `release` (shipped binary) | off | off |
| Any build with `--asan=on` | on | **on** |
| Any build with `--socket-fault-injection=on` | (any) | **on** (override) |
| Any build with `--socket-fault-injection=off` | (any) | off (override) |

So the shipped release binary never has the hooks; CI's asan lane and local debug on Linux/arm64-mac do; everything else doesn't unless explicitly enabled.

**Runtime control** (`src/uws_sys/lib.rs`, `src/runtime/socket/socket_body.rs`, `src/js/internal-for-testing.ts`):
```ts
import { socketFaultInjection as fault } from "bun:internal-for-testing";
fault.available()  // true iff compiled in
fault.set({ syscall: "recv", action: "errno", errno: "ECONNRESET", after: 0, repeat: 1, fd: -1 })
fault.set({ syscall: "send", action: "short", bytes: 1, repeat: -1 })  // clamp every send to 1 byte
fault.clear()
```

### Cost

| Build | `bsd_recv` hot-path overhead |
|---|---|
| compiled out (release default) | **zero** — `US_FAULT_CHECK` is `#define ... 0`, dead-code eliminated; object code identical to today |
| compiled in, disarmed | one acquire atomic load + predicted-not-taken branch |
| compiled in, armed | + rule-table lookup + counter increment |

### Bug fixes

The injector surfaced seven bugs, all fixed in this PR:

- **`src/runtime/server/NodeHTTPResponse.rs:467`** — heap-use-after-free in `UpgradeCTX::preserve_web_socket_headers_if_needed` when a WebSocket upgrade request spans multiple `recv()` calls. uWS buffers partial bytes in `HttpParser::fallback`; after `raw_response.upgrade()` adopts the socket that buffer is freed, but the post-upgrade `set_on_aborted_handler()` re-read `sec-websocket-*` from it. The call is provably dead at that point, so it is removed.
- **`src/js/node/net.ts` `SocketHandlers2.close`** — recv errno other than `ECONNRESET` (e.g. `ETIMEDOUT`, `EHOSTUNREACH`) was dropped to a clean `'end'` instead of surfacing as `'error'`. Now matches Node's `onStreamRead` exactly (`destroy(errnoException(nread, "read"))` for any non-EOF read error). The earlier whitelist was a workaround for `NewSocket::on_close` treating libus `CloseCode` enum values (0/1/2) as errnos — `_handle.close()` → `FastShutdown=2` → JS saw ENOENT. Fixed at the native boundary: only `err > 2` is a real recv errno.
- **`src/http_jsc/websocket_client.rs` + `src/jsc/bindings/webcore/WebSocket.cpp`** — `ws.close(code, reason)` never delivered the close frame to the peer (server always saw 1006; reproduces on main with no fault). `send_close_with_body()` called `shutdown_read()` before writing the close frame; on Linux SHUT_RD makes the socket immediately readable, so `handle_end → terminate → fail → cancel → tcp.close(CloseKind::Failure)` RST-dropped the queued frame. Under partial writes the deferred `dispatch_close` was additionally blocked by C++ `WebSocket::close()` clearing `m_connectedWebSocketKind` early. Fixed by deferring SHUT_RD/SHUT_WR until the frame is in the kernel buffer, finishing the pending close in `handle_end`/`handle_close`, and leaving `m_connectedWebSocketKind` for `didClose()` to clear.
- **`src/runtime/api/bun/h2_frame_parser.rs` `on_native_writable`** — `flush()` ends in `flush_stream_queue() → write() → cork()`, leaving newly-serialized frames in the thread-local CORK_BUFFER instead of on the wire. Returning let loop.c see `last_write_failed==0` and disarm WRITABLE, stranding the corked bytes — under partial sends the session hung. Now loops `flush()` until backpressure or no progress.
- **`src/runtime/api/bun/h2_frame_parser.rs` `uncork()`** — operated on whatever parser owned the thread-local `CORKED_H2` slot, so with both client and server sessions in one process a client's `flush()` would drain the server's corked bytes to the server's fd from inside the client's writable callback (and tear down the server's auto-flush). Now self-scoped and returns the byte count so the writable-loop exit condition is accurate.
- **`packages/bun-usockets/src/loop.c:386` SEMI_SOCKET dispatch** — a pre-connect partial write calls `us_poll_change(R|W)` on a socket whose `poll_type` is still `POLL_TYPE_SEMI_SOCKET`; the dispatch then failed the `== LIBUS_SOCKET_WRITABLE` equality, fell through to the listen-socket arm, and busy-spun on `accept4(connecting_fd)=EINVAL` forever — never promoting to `POLL_TYPE_SOCKET`. Connecting semi-sockets poll WRITABLE (and may add READABLE); listen semi-sockets only poll READABLE; so testing the WRITABLE bit instead of exact equality fixes it. Exposed by http2 send-short at <128 bytes (preface corked + auto-flushed before connect completes).
- **`packages/bun-uws/src/WebSocketProtocol.h` `parseClosePayload`** — rejected close codes 1012-3999 as abnormal (returned 1006). Per RFC 6455 §7.4, 3000-3999 are IANA-registered for libraries/frameworks and 1012-1015 are now defined; only 1016-2999 are reserved. Updated the validation; `ws.close(3001, ...)` now round-trips.

### Tests (78 pass, 0 todo, 239 assertions across 9 files)

- `test/js/bun/util/socket-fault-injection.test.ts` — control-surface validation, errno-required, all-13-names (10)
- `test/js/node/net/net-syscall-fault.test.ts` — recv ECONNRESET/ETIMEDOUT → `'error'`, recv 0 → `'end'`, byte-exact short recv/send, send EAGAIN buffer+flush, connect ECONNREFUSED, accept failure recovery, fd-targeting (both halves), multi-rule, 128 KB short-send, `after:` skip-count, torture loop, seeded fuzz (14)
- `test/js/node/tls/tls-syscall-fault.test.ts` — recv reset (session + handshake), recv 0 → `'end'`, 1-byte/5-byte BIO reads/writes, handshake under 3-byte send, close_notify under 1-byte send, FIN-before-close_notify, seeded fuzz (10)
- `test/js/node/http/node-http-syscall-fault.test.ts` — TLS proxy pipe + destroy under backpressure; Bun.serve abort; close-tracking; seeded fuzz (4)
- `test/js/web/fetch/fetch-syscall-fault.test.ts` — http+https short recv/send (Content-Length + chunked), recv reset/zero, connect refused, body cancel, TLS handshake, 5-byte boundary, fuzz (11)
- `test/js/bun/http/serve-syscall-fault.test.ts` — fixed/streaming body short send, request body short recv, https, concurrent abort (5)
- `test/js/web/websocket/websocket-syscall-fault.test.ts` — ws/wss client short recv/send, 70 KB binary frame split, recv ECONNRESET/zero → 1006, connect refused, TLS handshake; server short send + writev-zero on 20 KB frame + close-tracking + close(code,reason) round-trip (no-fault and 1-byte send) (14)
- `test/js/node/http2/node-http2-syscall-fault.test.ts` — 1-byte and 9-byte (frame header boundary) recv reassembly, recv ECONNRESET → session error, https/2 over TLS, seeded fuzz (7: send-short now works at 8 bytes after the loop.c SEMI_SOCKET dispatch fix)
- `test/js/first_party/ws/ws-syscall-fault.test.ts` — recv/send short echo + ping/pong, recv ECONNRESET split-process (3)

All tests `skipIf(!fault.available() || isWindows)` — they run on the asan jobs and skip cleanly elsewhere.

### Patterns applied

| Pattern | Origin | Surface(s) in this PR |
|---|---|---|
| **Nth-call torture loop** — for i in 1..N, fail/clamp the i-th syscall and prove no position corrupts framing | SQLite `malloc()` fault injector, curl `tests/libtest/lib1560` | `node:net` (recv short at every i in 1..10), `node:tls` / `fetch` seeded short-I/O fuzz |
| **Seeded deterministic fuzz** — xorshift PRNG seeded from `BUN_SOCKET_FUZZ_SEED` so CI failures are reproducible | Go `testing/quick`, libuv `test-fs-readdir` seed | `node:net`, `node:tls`, `node:http`, `fetch` |
| **1-byte short-read reassembly** — clamp every recv to 1 byte and assert byte-exact payload at the application layer | Go `net/http` `slowReader`, Netty `EmbeddedChannel` fragmented decoder tests | `node:net`, `node:tls` (incl. 5-byte TLS-record-header boundary), `fetch` (Content-Length **and** chunked), `WebSocket` client (text, 70 KB binary 8-byte ext-len header, **FIN=0+continuation**), `Bun.serve` request body, `ws` shim |
| **1-byte short-write drain** — clamp every send to 1 byte and assert peer receives byte-exact payload across `on_writable` turns | Netty `ChannelOutboundBuffer` partial-write tests, curl `CURL_SOCKOPT` short-send harness | `node:net`, `node:tls` (incl. handshake flights and close_notify), `node:http` proxy pipe, `Bun.serve` (fixed, streaming, TLS), `WebSocket` client (data **and** close(code,reason) frames), `Bun.serve` WS server |
| **errno injection at the syscall wrapper** — return -1 with a chosen errno without touching the kernel | libuv `uv__io` test hooks, Go `internal/poll` `*TestHookDidWritev` | every surface: ECONNRESET/ETIMEDOUT on recv, EAGAIN-forever on send, ECONNREFUSED on connect, ENOMEM on accept |
| **Listener survives accept failure** — fail one `accept()`, prove the listening socket is still usable | libuv `test-emfile`, Go `net.TestAcceptError` | `node:net` |
| **Backpressure + mid-stream abort** — force `on_writable` every turn, then destroy the consumer; assert every server-side response reaches a terminal state and the process exits 0 | Netty `Http2StreamChannel` reset-under-backpressure tests | `Bun.serve` (HTTP and WS), `node:http` TLS proxy pipe |
| **fd-scoped rule** — process-global table with per-socket `target_fd` so client and server can share a process | libuv per-handle override pattern | `node:net` fd-targeting test (now asserts both halves) |
| **Zero-return writev → buffer remainder** — first `writev` returns 0, prove the remainder is buffered and drained | Netty `IovArray` partial-gather tests | `Bun.serve` WS server ≥16 KB frame (new) |
| **Close-with-pending-spill** — destroy a TLS socket while ciphertext is still in the per-loop spill slot, then prove a fresh connection on the same loop is unaffected | curl `lib1915` SSL-shutdown-under-EAGAIN | `node:tls` (new ssl_release_spill test) |

### Surfaces covered

| Surface | recv short | send short | writev fault | recv errno | recv → 0 | connect errno | accept errno | TLS variant | seeded fuzz |
|---|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
| `node:net` Socket | ✅ | ✅ | — | ✅ (ECONNRESET, ETIMEDOUT) | ✅ | ✅ | ✅ | n/a | ✅ |
| `node:tls` TLSSocket | ✅ (1B, 5B header) | ✅ (1B data, 3B handshake, close_notify) | — | ✅ (mid-session, mid-handshake) | ✅ | — | — | ✅ | ✅ |
| `node:http` server | — | ✅ (proxy pipe + abort, leak check) | — | — | — | — | — | ✅ (https proxy) | ✅ |
| `node:http2` | ✅ (1B, 9B frame-header) | ✅ (8B preface, 256B body) | — | ✅ | — | — | — | ✅ (h2/TLS) | ✅ |
| `Bun.serve` HTTP | ✅ (POST body) | ✅ (fixed, streaming, abort) | — | — | — | — | — | ✅ | — |
| `fetch()` client | ✅ (Content-Length, chunked) | ✅ | — | ✅ | ✅ | ✅ | — | ✅ (3B handshake, 5B record) | ✅ |
| `WebSocket` client | ✅ (text, 70 KB binary) | ✅ (data, close(code,reason)) | — | ✅ | ✅ | ✅ | — | ✅ (wss recv/send/handshake) | — |
| `Bun.serve` WS server | — | ✅ | ✅ (zero, ≥16 KB write2) | — | — | — | — | — | — |
| `ws` (thirdparty shim) | ✅ | ✅ | — | ✅ | — | — | — | — | — |

`—` = not applicable or intentionally deferred.


### How did you verify your code works?

```sh
bun bd test test/js/bun/util/socket-fault-injection.test.ts \
            test/js/node/{net,tls,http}/*-syscall-fault.test.ts \
            test/js/web/{fetch,websocket}/*-syscall-fault.test.ts \
            test/js/bun/http/serve-syscall-fault.test.ts \
            test/js/first_party/ws/ws-syscall-fault.test.ts
# 65 pass, 2 skip, 2 todo, 0 fail, 213 expect() calls

bun run rust:check-all                         # 10/10 targets ok
bun bd test test/js/node/net/node-net.test.ts  # existing net suite still 43 pass
```










