### PR TITLE
node:test: pass a done() callback to (t, done) => {} style tests

### DIFF
--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -665,10 +665,22 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
   checkNotInsideTest(ctx, "test");
   const context = new TestContext(true, name, Bun.main, ctx);
 
+  // Node's node:test passes a second `done` callback argument when the test
+  // function declares two or more parameters, e.g. `test('name', (t, done) => ...)`.
+  // Detect that here so we can both forward `done` to the user and avoid
+  // auto-completing the test synchronously while it waits on the callback.
+  // https://nodejs.org/api/test.html#testname-options-fn
+  const useCallback = typeof fn === "function" && fn.length >= 2;
+
   const runTest = (done: (error?: unknown) => void) => {
     const originalContext = ctx;
     ctx = context;
+    let ended = false;
     const endTest = (error?: unknown) => {
+      // Calling done() and also returning a value (or throwing) must not
+      // complete the test twice. Make endTest idempotent.
+      if (ended) return;
+      ended = true;
       try {
         done(error);
       } finally {
@@ -678,16 +690,18 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
 
     let result: unknown;
     try {
-      result = fn(context);
+      result = useCallback ? fn(context, endTest) : fn(context);
     } catch (error) {
       endTest(error);
       return;
     }
     if (result instanceof Promise) {
       (result as Promise<unknown>).then(() => endTest()).catch(error => endTest(error));
-    } else {
+    } else if (!useCallback) {
       endTest();
     }
+    // useCallback + sync return: wait for the user to invoke done().
+    // bun:test enforces the test timeout if done is never called.
   };
 
   return { name, options, fn: runTest };
@@ -756,7 +770,7 @@ function createHook(arg0: unknown, arg1: unknown) {
   return { options, fn: runHook };
 }
 
-type TestFn = (ctx: TestContext) => unknown | Promise<unknown>;
+type TestFn = (ctx: TestContext, done?: (error?: unknown) => void) => unknown | Promise<unknown>;
 type HookFn = () => unknown | Promise<unknown>;
 
 type TestOptions = {

--- a/src/js/node/test.ts
+++ b/src/js/node/test.ts
@@ -696,7 +696,15 @@ function createTest(arg0: unknown, arg1: unknown, arg2: unknown) {
       return;
     }
     if (result instanceof Promise) {
-      (result as Promise<unknown>).then(() => endTest()).catch(error => endTest(error));
+      const promise = result as Promise<unknown>;
+      if (useCallback) {
+        // Callback-style tests complete only when done() is invoked; the
+        // returned promise must not auto-complete the test on resolution.
+        // A rejection is still surfaced as a failure.
+        promise.catch(error => endTest(error));
+      } else {
+        promise.then(() => endTest(), error => endTest(error));
+      }
     } else if (!useCallback) {
       endTest();
     }

--- a/test/js/node/test_runner/fixtures/06-callback-tests.js
+++ b/test/js/node/test_runner/fixtures/06-callback-tests.js
@@ -1,0 +1,39 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+
+let callCount = 0;
+
+// Sync callback-style test: invokes done() to signal completion.
+test("callback test resolves with done()", (t, done) => {
+  assert.equal(typeof done, "function");
+  callCount++;
+  done();
+});
+
+// Async-but-callback-style test: schedules done() in a setTimeout.
+test("callback test resolves with done() asynchronously", (t, done) => {
+  setTimeout(() => {
+    callCount++;
+    done();
+  }, 5);
+});
+
+// Callback-style test that signals failure via done(err) must still report
+// failure, but we cannot easily inspect that from inside the same suite.
+// The shape is exercised by the next two tests instead.
+
+// Existing (t) => {...} sync-style signature must keep working.
+test("sync test without done() still passes", t => {
+  assert.equal(typeof t.name, "string");
+  callCount++;
+});
+
+// Existing async-function signature must keep working.
+test("async test without done() still passes", async t => {
+  await Promise.resolve();
+  callCount++;
+});
+
+process.on("exit", () => {
+  assert.equal(callCount, 4, `expected 4 test invocations, saw ${callCount}`);
+});

--- a/test/js/node/test_runner/fixtures/06-callback-tests.js
+++ b/test/js/node/test_runner/fixtures/06-callback-tests.js
@@ -10,17 +10,31 @@ test("callback test resolves with done()", (t, done) => {
   done();
 });
 
-// Async-but-callback-style test: schedules done() in a setTimeout.
-test("callback test resolves with done() asynchronously", (t, done) => {
-  setTimeout(() => {
-    callCount++;
-    done();
-  }, 5);
+// Async-but-callback-style test: the test function returns a promise that
+// resolves BEFORE done() is called. This proves the runner waits for done()
+// and does not auto-complete on promise resolution: `sawDone` is only true
+// once the deferred done() actually runs, and it is asserted on the next
+// microtask-draining tick via a second callback test below.
+let sawDone = false;
+test("callback test waits for done() even when the body returns a promise", (t, done) => {
+  // Returning a resolved promise must NOT complete the test; only done() may.
+  return Promise.resolve().then(() => {
+    setTimeout(() => {
+      callCount++;
+      sawDone = true;
+      done();
+    }, 5);
+  });
 });
 
-// Callback-style test that signals failure via done(err) must still report
-// failure, but we cannot easily inspect that from inside the same suite.
-// The shape is exercised by the next two tests instead.
+// Runs after the previous test. If the runner had wrongly completed the
+// prior test on promise-resolution (before done()), `sawDone` would still be
+// false here, failing the assertion.
+test("previous callback test only completed via done()", (t, done) => {
+  assert.equal(sawDone, true, "async callback test completed before done() was called");
+  callCount++;
+  done();
+});
 
 // Existing (t) => {...} sync-style signature must keep working.
 test("sync test without done() still passes", t => {
@@ -34,6 +48,14 @@ test("async test without done() still passes", async t => {
   callCount++;
 });
 
+// Calling done() twice (or done() plus a thrown/rejected value) must not
+// double-complete or double-count the test.
+test("done() is idempotent", (t, done) => {
+  callCount++;
+  done();
+  done();
+});
+
 process.on("exit", () => {
-  assert.equal(callCount, 4, `expected 4 test invocations, saw ${callCount}`);
+  assert.equal(callCount, 6, `expected 6 test invocations, saw ${callCount}`);
 });

--- a/test/js/node/test_runner/fixtures/07-callback-done-error.js
+++ b/test/js/node/test_runner/fixtures/07-callback-done-error.js
@@ -1,0 +1,6 @@
+const { test } = require("node:test");
+
+// Callback-style test that reports failure via done(error) must fail.
+test("callback test fails when done() is called with an error", (t, done) => {
+  done(new Error("boom"));
+});

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -52,6 +52,14 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+
+  test("should pass a done() callback to tests whose function takes two parameters", async () => {
+    const { exitCode, stderr } = await runTests(["06-callback-tests.js"]);
+    expect({ exitCode, stderr }).toMatchObject({
+      exitCode: 0,
+      stderr: expect.stringContaining("0 fail"),
+    });
+  });
 });
 
 async function runTests(filenames: string[]) {

--- a/test/js/node/test_runner/node-test.test.ts
+++ b/test/js/node/test_runner/node-test.test.ts
@@ -60,6 +60,13 @@ describe("node:test", () => {
       stderr: expect.stringContaining("0 fail"),
     });
   });
+
+  test("should report failure when a callback-style test calls done(error)", async () => {
+    const { exitCode, stderr } = await runTests(["07-callback-done-error.js"]);
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("1 fail");
+    expect(stderr).toContain("boom");
+  });
 });
 
 async function runTests(filenames: string[]) {


### PR DESCRIPTION
### What does this PR do?

Closes #32527.

Bun's `node:test` did not pass the second `done` callback argument when a test function declares two or more parameters (`test('name', (t, done) => { ... })`), unlike Node. As a result `done` resolved to `undefined` and callback-style tests could never signal completion.

This:
- Detects callback-style tests via `fn.length >= 2` in `createTest`.
- Forwards the wrapper's `endTest` as the user's second `done` argument, and waits for it to be called instead of auto-completing synchronously (the existing test timeout still applies if `done` is never called).
- Makes `endTest` idempotent so calling `done()` and also returning a non-Promise (or throwing) from the same function does not complete the test twice.
- Updates the `TestFn` type to include the optional `done` parameter.

### How did you verify your code works?

Added `test/js/node/test_runner/fixtures/06-callback-tests.js` and a runner case in `test/js/node/test_runner/node-test.test.ts` covering:
- a sync callback-style test that calls `done()`,
- an async callback-style test that calls `done()` from a `setTimeout`,
- the existing `(t) => {}` sync signature, and
- the existing `async (t) => {}` signature,

asserting all four invoke and the suite reports `0 fail`. Run with `bun test test/js/node/test_runner/node-test.test.ts`.
