### PR TITLE
bundler: error instead of panic when splitting is used with non-ESM format

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2791,6 +2791,19 @@ pub mod bv2_impl {
             this.linker.resolver = Some(bun_ptr::ParentRef::new(&this.transpiler.resolver));
             this.linker.graph.code_splitting = this.transpiler.options.code_splitting;
 
+            // Cross-chunk imports/exports are only generated for ESM (see
+            // computeCrossChunkDependencies). Reject other formats up front
+            // rather than panicking later. Matches esbuild.
+            if this.transpiler.options.code_splitting
+                && this.transpiler.options.output_format != options::Format::Esm
+            {
+                this.transpiler.log_mut().add_error(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    "Code splitting is currently only supported when format is set to \"esm\"",
+                );
+            }
+
             this.linker.options.minify_syntax = this.transpiler.options.minify_syntax;
             this.linker.options.minify_identifiers = this.transpiler.options.minify_identifiers;
             this.linker.options.minify_whitespace = this.transpiler.options.minify_whitespace;

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -632,4 +632,34 @@ describe("bundler", () => {
       stdout: "success",
     },
   });
+  // https://github.com/oven-sh/bun/issues/32395
+  // Previously this panicked with: called `Option::unwrap()` on a `None` value
+  for (const format of ["cjs", "iife"] as const) {
+    for (const backend of ["cli", "api"] as const) {
+      itBundled(`splitting/ErrorWithNonEsmFormat_${format}_${backend}`, {
+        files: {
+          "/shared.js": /* js */ `
+            export function sharedFn() { return "shared"; }
+            export const sharedConst = 42;
+          `,
+          "/a.js": /* js */ `
+            import { sharedFn, sharedConst } from "./shared";
+            export const a = sharedFn() + sharedConst;
+          `,
+          "/b.js": /* js */ `
+            import { sharedFn, sharedConst } from "./shared";
+            export const b = sharedFn() + sharedConst;
+          `,
+        },
+        entryPoints: ["/a.js", "/b.js"],
+        outdir: "/out",
+        splitting: true,
+        format,
+        backend,
+        bundleErrors: {
+          "<bun>": ['Code splitting is currently only supported when format is set to "esm"'],
+        },
+      });
+    }
+  }
 });

--- a/test/bundler/esbuild/splitting.test.ts
+++ b/test/bundler/esbuild/splitting.test.ts
@@ -633,7 +633,6 @@ describe("bundler", () => {
     },
   });
   // https://github.com/oven-sh/bun/issues/32395
-  // Previously this panicked with: called `Option::unwrap()` on a `None` value
   for (const format of ["cjs", "iife"] as const) {
     for (const backend of ["cli", "api"] as const) {
       itBundled(`splitting/ErrorWithNonEsmFormat_${format}_${backend}`, {


### PR DESCRIPTION
### What does this PR do?

Fixes #32395.
Fixes #15125.

### Reproduction

```ts
// shared.ts
export function sharedFn() { return "shared"; }
export const sharedConst = 42;

// a.ts / b.ts both:
import { sharedFn, sharedConst } from "./shared";
export const a = sharedFn() + sharedConst;
```

```console
$ bun build ./a.ts ./b.ts --outdir ./dist --format cjs --splitting
panic: called `Option::unwrap()` on a `None` value
```

Same via `Bun.build({ entrypoints: ["./a.ts", "./b.ts"], outdir: "./dist", format: "cjs", splitting: true })`. `--format iife` panics identically. `--format esm` works.

### Root cause

`CrossChunkImport::sorted_cross_chunk_imports` (`src/bundler/Chunk.rs:1548`) looks up each cross-chunk import in the target chunk's `exports_to_other_chunks` map:

```rust
item.export_alias = (*exports_to_other_chunks.get(&item.r#ref).unwrap()).into();
```

`exports_to_other_chunks` is only populated when `output_format == Esm` (`computeCrossChunkDependencies.rs`, the `match c.options.output_format { Esm => { ... } _ => {} }` arm), while `imports_from_other_chunks` is populated unconditionally earlier in the same function. So when CJS/IIFE + splitting produces a shared chunk, each entry chunk has import items whose refs are looked up in an always-empty map, and `None.unwrap()` panics.

### Fix

The linker has never implemented cross-chunk imports/exports for non-ESM formats (both `match output_format` arms are `_ => {}` for CJS/IIFE), so the combination has never produced working output. esbuild rejects it outright:

```
error: Splitting currently only works with the "esm" format
```

This PR adds the same validation in `BundleV2::init`, which both `bun build` (CLI) and `Bun.build` (JS API) go through, and which both follow with a `log().has_errors()` check that converts it into a build failure. The panic becomes a catchable build error:

```console
$ bun build ./a.ts ./b.ts --outdir ./dist --format cjs --splitting
error: Code splitting is currently only supported when format is set to "esm"
```

```js
try { await Bun.build({ ... }) } catch (e) {
  // AggregateError with errors[0].message = "Code splitting is currently only supported ..."
}
```

### Verification

New tests in `test/bundler/esbuild/splitting.test.ts` cover `cjs` and `iife` on both the `cli` and `api` backends (4 cases). On the unfixed build the CLI cases fail with `'bun build' subprocess killed by SIGILL` and the API case panics the test process; with the fix all four pass with the expected error message.

- `bun bd test test/bundler/esbuild/splitting.test.ts`: 26 pass, 2 todo (pre-existing)
- `bun bd test test/bundler/bundler_splitting.test.ts`: 10 pass
- `bun bd test test/bundler/bundler_cjs.test.ts`: 23 pass
