### PR TITLE
test: regression coverage for Bun.build define values starting with . or /

### DIFF
--- a/test/regression/issue/32686.test.ts
+++ b/test/regression/issue/32686.test.ts
@@ -1,0 +1,36 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "path";
+
+// https://github.com/oven-sh/bun/issues/32686
+test.concurrent.each(["./src/worker.ts", "../src/worker.ts", "/abs/path", "/$bunfs/root/worker", ".", "/", "/=foo"])(
+  "define value %j is auto-quoted",
+  async value => {
+    using dir = tempDir("bun-build-define-32686", {
+      "entry.ts": `declare const X: string; console.log(X);`,
+    });
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "entry.ts")],
+      define: { X: value },
+    });
+    expect(result.success).toBe(true);
+    const out = await result.outputs[0].text();
+    expect(out).toContain(JSON.stringify(value));
+  },
+);
+
+test.concurrent("--define CLI auto-quotes a value starting with a dot", async () => {
+  using dir = tempDir("bun-build-define-32686-cli", {
+    "entry.ts": `declare const X: string; console.log(X);`,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "--define", "X=./src/worker.ts", "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+  expect(stdout).toContain(JSON.stringify("./src/worker.ts"));
+});


### PR DESCRIPTION
Regression coverage for #32686.

### Background

Bun 1.4 regressed on `Bun.build({ define })` (and `bun build --define`): a value beginning with a bare `.` or `/` (for example `"./src/worker.ts"` or a `/$bunfs/...` path produced when cross-compiling) was rejected at parse time instead of being auto-quoted and treated as a string literal, as Bun 1.3 did.

```
1 | ./src/worker.ts
    ^
error: Syntax Error
    at defines.json:1:1
```

### What changed

This PR originally fixed the issue in the old lexer-based JSON parser (`src/parsers/json_lexer.rs`). While it was open, #33032 rewrote the JSON parser around a SIMD structural index and removed `json_lexer.rs`. The new `parse_env_json` dispatches a define value by its first byte: JSON-like starts (`{ [ 0-9 " '`, or `-`/`.` that lead a number) go to the classic parser, `true`/`false`/`null`/`undefined` are keywords, and everything else, including values starting with `.` or `/`, goes through the auto-quote string path. That independently fixes the regression, so the original `json_lexer.rs` change is obsolete and has been dropped in the rebase.

The existing auto-quote test block in `test/bundler/bun-build-api.test.ts` covers `*`/`?`/`(`/`)` starts but not the `.`/`/` path-shaped values from this issue, and #33032 added JSONC tests rather than define-path coverage. This PR keeps the regression test so those cases stay guarded.

### Test

`test/regression/issue/32686.test.ts` asserts each value round-trips as a quoted string literal: `./src/worker.ts`, `../src/worker.ts`, `/abs/path`, `/$bunfs/root/worker`, `.`, `/`, `/=foo`, plus the `bun build --define` CLI entry point.

- `bun bd test test/regression/issue/32686.test.ts` on current main (27009bf0f): 8 pass.

Note: the fix already lives in main via #33032, so this is a test-only change. It does not carry its own `src/` diff.