### PR TITLE
Fix crash when Bun.sql/Bun.$ lazy init throws near stack limit

### DIFF
--- a/src/jsc/bindings/BunObject+exports.h
+++ b/src/jsc/bindings/BunObject+exports.h
@@ -94,7 +94,8 @@ FOR_EACH_GETTER(DECLARE_ZIG_BUN_OBJECT_GETTER);
 
 // definition of the C++ wrapper to call the Rust function
 #define DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER(name) static JSC::JSValue BunObject_lazyPropCb_wrap_##name(JSC::VM &vm, JSC::JSObject *object) { \
-    return JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    JSC::JSValue result = JSC::JSValue::decode(BunObject_lazyPropCb_##name(object->globalObject(), object)); \
+    return result ? result : JSC::jsUndefined(); \
 } \
 
 FOR_EACH_GETTER(DEFINE_ZIG_BUN_OBJECT_GETTER_WRAPPER);

--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -318,11 +318,13 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    JSObject* sqlObject = sqlValue.getObject();
+    if (!sqlObject) [[unlikely]]
+        return jsUndefined();
+    JSValue result = sqlObject->get(globalObject, vm.propertyNames->defaultKeyword);
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    return result;
 }
 
 static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
@@ -330,12 +332,14 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    JSObject* sqlObject = sqlValue.getObject();
+    if (!sqlObject) [[unlikely]]
+        return jsUndefined();
     auto clientData = WebCore::clientData(vm);
-    RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));
+    JSValue result = sqlObject->get(globalObject, clientData->builtinNames().SQLPublicName());
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
+    return result;
 }
 
 extern "C" JSC::EncodedJSValue JSPasswordObject__create(JSGlobalObject*);
@@ -368,20 +372,20 @@ static JSValue constructBunShell(VM& vm, JSObject* bunObject)
     args.append(createShellInterpreterFunction);
     args.append(createParsedShellScript);
     JSC::JSValue shell = JSC::call(globalObject, createShellFn, args, "BunShell"_s);
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
 
     if (!shell.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell constructor did not return an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     auto* bunShell = shell.getObject();
 
     auto ShellError = bunShell->get(globalObject, JSC::Identifier::fromString(vm, "ShellError"_s));
-    RETURN_IF_EXCEPTION(scope, {});
+    RETURN_IF_EXCEPTION(scope, jsUndefined());
     if (!ShellError.isObject()) [[unlikely]] {
         throwTypeError(globalObject, scope, "Internal error: BunShell.ShellError is not an object"_s);
-        return {};
+        return jsUndefined();
     }
 
     bunShell->putDirectNativeFunction(vm, globalObject, Identifier::fromString(vm, "braces"_s), 1, Generated::BunObject::jsBraces, ImplementationVisibility::Public, NoIntrinsic, JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly | 0);

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -10,19 +10,14 @@ for (const expr of ["Bun.postgres", "Bun.sql", "Bun.SQL", "Bun.$"]) {
       cmd: [
         bunExe(),
         "-e",
-        `function F(){try{new this.constructor()}catch(e){}void ${expr}}` +
-          `try{new F()}catch(e){}console.log("OK")`,
+        `function F(){try{new this.constructor()}catch(e){}void ${expr}}` + `try{new F()}catch(e){}console.log("OK")`,
       ],
       env: bunEnv,
       stderr: "pipe",
       stdout: "pipe",
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
       stdout: "OK\n",

--- a/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
+++ b/test/js/bun/bun-object/lazy-property-stack-overflow.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// Accessing a lazily-initialized Bun.* property for the first time while the
+// stack is nearly exhausted must surface a catchable JS error instead of
+// crashing inside reifyStaticProperty.
+for (const expr of ["Bun.postgres", "Bun.sql", "Bun.SQL", "Bun.$"]) {
+  test(`lazy ${expr} access near stack exhaustion does not crash`, async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `function F(){try{new this.constructor()}catch(e){}void ${expr}}` +
+          `try{new F()}catch(e){}console.log("OK")`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+
+    expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "OK\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+}


### PR DESCRIPTION
Fuzzilli found a crash (fingerprint `7072f2e414da4c72`) triggered by accessing `Bun.postgres` for the first time while the call stack is nearly exhausted.

### Root cause

`Bun.sql`, `Bun.postgres`, `Bun.SQL` and `Bun.$` are `PropertyCallback` entries in the BunObject hash table. When accessed, JSC's `reifyStaticProperty` invokes the callback and passes the return value directly to `JSObject::putDirect` without checking for exceptions:

```cpp
JSValue result = value.lazyPropertyCallback()(vm, &thisObj);
thisObj.putDirect(vm, propertyName, result, ...);
```

The SQL/shell callbacks load an internal JS module via `requireId`, which can throw (stack overflow near the limit). On exception they returned `{}` (empty JSValue). `putDirect` then calls `value.isGetterSetter()` → `asCell()->isGetterSetter()` on a null cell, which segfaults in release and trips UBSan in debug.

Additionally in debug builds, a `#if BUN_DEBUG` block called `reportUncaughtExceptionAtEventLoop` before the exception check. That ran the unhandled error handler, which cleared the pending exception, so `RETURN_IF_EXCEPTION` fell through to `sqlValue.getObject()->get(...)` on an empty value.

### Fix

- Return `jsUndefined()` instead of `{}` from `PropertyCallback` lazy initializers on exception, so `putDirect` receives a valid JSValue while the pending exception still propagates to the caller.
- Remove the debug-only `reportUncaughtExceptionAtEventLoop` call in the SQL getters; the exception already propagates normally.
- Guard the shared Rust→C++ getter wrapper macro the same way.

### Test

Added a regression test that recurses to stack exhaustion, catches the error, then touches each of `Bun.postgres` / `Bun.sql` / `Bun.SQL` / `Bun.$` and verifies the process exits cleanly instead of crashing. Fails on main (segfault at 0x5 in release, UBSan null deref in debug), passes with this change.