### PR TITLE
valkey: skip non-callable onclose/onconnect handlers

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -1280,7 +1280,9 @@ impl JSValkeyClient {
             };
             Js::hello_set_cached(this_value, &global_object, hello_value);
             // Call onConnect callback if defined by the user
-            if let Some(on_connect) = Js::onconnect_get_cached(this_value) {
+            if let Some(on_connect) =
+                Js::onconnect_get_cached(this_value).filter(|v| v.is_callable())
+            {
                 let js_value = this_value;
                 js_value.ensure_still_alive();
                 global_object.queue_microtask(on_connect, &[js_value, hello_value]);
@@ -1445,7 +1447,7 @@ impl JSValkeyClient {
         }
 
         // Call onClose callback if it exists
-        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue) {
+        if let Some(on_close) = Js::onclose_get_cached(this_jsvalue).filter(|v| v.is_callable()) {
             if let Err(e) = on_close.call(&global_object, this_jsvalue, &[error_value]) {
                 global_object.report_active_exception_as_unhandled(e);
             }
@@ -1470,7 +1472,7 @@ impl JSValkeyClient {
             return;
         };
         let global_object = self.global_object;
-        if let Some(on_close) = Js::onclose_get_cached(this_value) {
+        if let Some(on_close) = Js::onclose_get_cached(this_value).filter(|v| v.is_callable()) {
             let _exit = self.vm().enter_event_loop_scope();
             if let Err(e) = on_close.call(&global_object, this_value, &[value]) {
                 global_object.report_active_exception_as_unhandled(e);

--- a/test/js/valkey/valkey-gc.test.ts
+++ b/test/js/valkey/valkey-gc.test.ts
@@ -131,6 +131,111 @@ test.concurrent("RedisClient survives GC across many short-lived instances", asy
   expect(exitCode).toBe(0);
 });
 
+// Fuzzer: onclose/onconnect are user-settable cached slots with no type
+// validation in the setter. When the connection later fails or succeeds,
+// the runtime used to pass the stored value straight to JSValue::call /
+// queueMicrotask, tripping isCallable() assertions in debug builds and
+// surfacing a spurious unhandled TypeError in release builds. Non-callable
+// values should just be skipped.
+test.concurrent("RedisClient ignores non-callable onclose/onconnect handlers", async () => {
+  const src = `
+    const net = require("node:net");
+
+    process.on("uncaughtException", err => {
+      console.error("uncaughtException: " + err);
+      process.exit(1);
+    });
+    process.on("unhandledRejection", err => {
+      console.error("unhandledRejection: " + err);
+      process.exit(1);
+    });
+
+    // onclose path: connect to a listener that hangs up before completing
+    // the HELLO handshake, so the close callback runs.
+    {
+      const { promise: closed, resolve: onServerClose } = Promise.withResolvers();
+      const server = net.createServer(socket => {
+        socket.on("error", () => {});
+        socket.destroy();
+      });
+      await new Promise((resolve, reject) => {
+        server.on("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const port = server.address().port;
+
+      for (const bad of [{}, 42, "nope", [1, 2, 3], null, true]) {
+        const client = new Bun.RedisClient("redis://127.0.0.1:" + port, {
+          connectionTimeout: 2000,
+          autoReconnect: false,
+        });
+        client.onclose = bad;
+        client.onconnect = bad;
+        if (client.onclose !== bad) throw new Error("onclose setter should accept any value");
+        let caught;
+        try { await client.connect(); } catch (e) { caught = e; }
+        if (!caught || !/connection closed|socket closed|failed to connect/i.test(caught.message)) {
+          throw new Error("expected a connection error, got: " + caught);
+        }
+        client.close();
+      }
+      server.close(onServerClose);
+      await closed;
+    }
+
+    // onconnect path: mock server accepts the HELLO handshake so onconnect
+    // would be queued as a microtask.
+    {
+      const server = net.createServer(socket => {
+        socket.on("data", data => {
+          if (data.includes("HELLO")) socket.write("+OK\\r\\n");
+        });
+        socket.on("error", () => {});
+      });
+      await new Promise((resolve, reject) => {
+        server.on("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      const port = server.address().port;
+
+      const client = new Bun.RedisClient("redis://127.0.0.1:" + port, {
+        connectionTimeout: 2000,
+        autoReconnect: false,
+      });
+      client.onconnect = { not: "callable" };
+      client.onclose = 123;
+      await client.connect();
+      if (!client.connected) throw new Error("expected client to be connected");
+      await 1;
+
+      // A callable handler assigned afterwards still fires.
+      let closeArg;
+      client.onclose = err => { closeArg = err; };
+      client.close();
+      await 1;
+      if (!(closeArg instanceof Error)) throw new Error("callable onclose should still be invoked");
+
+      server.close();
+    }
+
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", src],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).not.toContain("is not a function");
+  expect(stdout.trim()).toBe("OK");
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});
+
 // A RESP scalar line (simple string, error, integer, ...) must end with CRLF.
 // The reader bounds how many bytes it will accumulate while waiting for that
 // terminator (MAX_LINE_LEN = 512 KiB), so a server that streams an endless


### PR DESCRIPTION
Fuzzilli found a crash where `RedisClient.onclose` / `RedisClient.onconnect` had been set to a non-callable value and the connection then failed or completed.

These are user-settable cached value slots with no type validation in the setter. The stored value was passed straight to `JSValue::call` / `queueMicrotask`, which tripped `isCallable()` assertions in debug builds and surfaced a spurious unhandled "X is not a function" TypeError in release builds.

```js
const client = new Bun.RedisClient("redis://127.0.0.1:1", {
  connectionTimeout: 50,
  autoReconnect: false,
});
client.onclose = {};        // not callable
client.connect().catch(() => {});
```

Filter on `is_callable()` at the three call sites before invoking, matching how other callback slots (`ResumableSink`, `Terminal`) handle the same case. The setter still accepts any value so `client.onclose = null` continues to work for clearing the handler.

Added a subprocess regression test in `test/js/valkey/valkey-gc.test.ts` covering both the close path (server drops the connection before HELLO) and the connect path (mock server accepts HELLO), plus a check that a callable handler assigned afterwards still fires.