### PR TITLE
http: bounds-check HTTPClient::header_str to stop slice panic in build_request

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2102,7 +2102,20 @@ impl<'a> HTTPClient<'a> {
     pub fn header_str(&self, ptr: StringPointer) -> &'a [u8] {
         // Reborrow at `'a` so the returned slice doesn't tie up `&self`.
         let buf: &'a [u8] = self.header_buf;
-        &buf[ptr.offset as usize..][..ptr.length as usize]
+        let end = (ptr.offset as usize).wrapping_add(ptr.length as usize);
+        // Match `Headers::as_str`: return empty on a desynced `header_entries`
+        // / `header_buf` rather than slice-panicking on the HTTP thread.
+        debug_assert!(
+            end <= buf.len() && ptr.offset as usize <= end,
+            "HTTPClient::header_str: StringPointer {{ offset: {}, length: {} }} out of range for header_buf of length {}",
+            ptr.offset,
+            ptr.length,
+            buf.len(),
+        );
+        if end > buf.len() || ptr.offset as usize > end {
+            return b"";
+        }
+        &buf[ptr.offset as usize..end]
     }
 
     pub fn build_request(&mut self, body_len: usize) -> picohttp::Request<'static> {

--- a/src/http_jsc/headers_jsc.rs
+++ b/src/http_jsc/headers_jsc.rs
@@ -71,6 +71,13 @@ pub fn from_fetch_headers(
     let names_ptr: *mut api::StringPointer = sliced.items_raw::<"name", api::StringPointer>();
     // SAFETY: same `items_raw` contract as above; `value` column is a disjoint allocation.
     let values_ptr: *mut api::StringPointer = sliced.items_raw::<"value", api::StringPointer>();
+    // Zero-init so any slot `copy_to` fails to write (iterator skip, count
+    // desync) reads as `{0, 0}` — a valid empty slice — rather than garbage.
+    // SAFETY: both columns hold exactly `header_count` `StringPointer` slots.
+    unsafe {
+        core::ptr::write_bytes(names_ptr, 0, header_count as usize);
+        core::ptr::write_bytes(values_ptr, 0, header_count as usize);
+    }
     if let Some(h) = h_ptr {
         // SAFETY: `h` is a valid `&FetchHeaders` for the call; columns sized by `count` above.
         unsafe { (*h).copy_to(names_ptr, values_ptr, headers.buf.as_mut_ptr()) };

--- a/test/js/web/fetch/fetch-header-str-bounds.test.ts
+++ b/test/js/web/fetch/fetch-header-str-bounds.test.ts
@@ -1,0 +1,85 @@
+import { test, expect } from "bun:test";
+import { bunEnv, bunExe, tls as tlsCert } from "harness";
+
+// Regression probe for the "range start index N out of range for slice of
+// length M" panic in HTTPClient::header_str. The StringPointer offsets in
+// header_entries can desync from header_buf when the (bitwise-shared)
+// MultiArrayList backing is freed or reused while the TLS handshake is still
+// in flight. Run many concurrent HTTPS requests with varying header shapes
+// and abort a subset mid-handshake to maximise allocation churn on the HTTP
+// thread; the child must not panic.
+test("header_str does not panic on header_entries / header_buf desync under concurrent TLS load", async () => {
+  const fixture = /* js */ `
+    const tls = ${JSON.stringify(tlsCert)};
+
+    // h1-only TLS server so build_request runs for every connection.
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls,
+      async fetch(req) {
+        // Echo one request header so the whole pipeline is exercised.
+        return new Response(req.headers.get("x-echo-0") ?? "");
+      },
+    });
+
+    const url = \`https://127.0.0.1:\${server.port}/\`;
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+    const ITER = 8;
+    const FAN = 24;
+
+    for (let iter = 0; iter < ITER; iter++) {
+      const jobs = [];
+      const controllers = [];
+      for (let i = 0; i < FAN; i++) {
+        // Vary header count/length so the MultiArrayList allocation size
+        // differs between requests (encourages reuse of freed slots).
+        const headers = {};
+        const n = 1 + ((iter + i) % 9);
+        for (let h = 0; h < n; h++) {
+          headers["x-echo-" + h] = Buffer.alloc(8 + ((iter * 7 + i + h) % 40), 97 + (h % 26)).toString();
+        }
+        const ac = new AbortController();
+        controllers.push(ac);
+        jobs.push(
+          fetch(url, {
+            headers,
+            signal: ac.signal,
+            tls: { rejectUnauthorized: false },
+          })
+            .then(r => r.text())
+            .catch(() => {}),
+        );
+      }
+      // Abort ~a third of the requests immediately so some hit the handshake
+      // window with a freed/aborted sibling churning the allocator.
+      for (let i = 0; i < FAN; i += 3) controllers[i].abort();
+      await Promise.all(jobs);
+      Bun.gc(true);
+    }
+
+    server.stop(true);
+    console.log("OK");
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: { ...bunEnv, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "OK",
+    stderr,
+    exitCode: 0,
+    signalCode: null,
+  });
+});

--- a/test/js/web/fetch/fetch-header-str-bounds.test.ts
+++ b/test/js/web/fetch/fetch-header-str-bounds.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as tlsCert } from "harness";
 
 // Regression probe for the "range start index N out of range for slice of
@@ -70,11 +70,7 @@ test("header_str does not panic on header_entries / header_buf desync under conc
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: "OK",

--- a/test/js/web/fetch/fetch-header-str-bounds.test.ts
+++ b/test/js/web/fetch/fetch-header-str-bounds.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as tlsCert } from "harness";
 
+// https://github.com/oven-sh/bun/issues/23092
 // Regression probe for the "range start index N out of range for slice of
 // length M" panic in HTTPClient::header_str. The StringPointer offsets in
 // header_entries can desync from header_buf when the (bitwise-shared)
@@ -28,10 +29,13 @@ test("header_str does not panic on header_entries / header_buf desync under conc
 
     const ITER = 8;
     const FAN = 24;
+    let totalOk = 0;
 
     for (let iter = 0; iter < ITER; iter++) {
       const jobs = [];
       const controllers = [];
+      const expected = [];
+      let successes = 0;
       for (let i = 0; i < FAN; i++) {
         // Vary header count/length so the MultiArrayList allocation size
         // differs between requests (encourages reuse of freed slots).
@@ -40,27 +44,42 @@ test("header_str does not panic on header_entries / header_buf desync under conc
         for (let h = 0; h < n; h++) {
           headers["x-echo-" + h] = Buffer.alloc(8 + ((iter * 7 + i + h) % 40), 97 + (h % 26)).toString();
         }
+        expected.push(headers["x-echo-0"]);
         const ac = new AbortController();
         controllers.push(ac);
+        const idx = i;
         jobs.push(
           fetch(url, {
             headers,
             signal: ac.signal,
             tls: { rejectUnauthorized: false },
           })
-            .then(r => r.text())
-            .catch(() => {}),
+            .then(async r => {
+              const text = await r.text();
+              if (text !== expected[idx]) {
+                throw new Error(\`echo mismatch: got \${JSON.stringify(text)} want \${JSON.stringify(expected[idx])}\`);
+              }
+              successes++;
+            })
+            .catch(e => {
+              // Only aborted requests may fail; anything else is a real error.
+              if (e?.name !== "AbortError") throw e;
+            }),
         );
       }
       // Abort ~a third of the requests immediately so some hit the handshake
       // window with a freed/aborted sibling churning the allocator.
       for (let i = 0; i < FAN; i += 3) controllers[i].abort();
       await Promise.all(jobs);
+      if (successes === 0) {
+        throw new Error("expected at least one non-aborted fetch to succeed in iteration " + iter);
+      }
+      totalOk += successes;
       Bun.gc(true);
     }
 
     server.stop(true);
-    console.log("OK");
+    console.log("OK " + totalOk);
   `;
 
   await using proc = Bun.spawn({
@@ -73,9 +92,14 @@ test("header_str does not panic on header_entries / header_buf desync under conc
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-    stdout: "OK",
-    stderr,
+    stdout: expect.stringMatching(/^OK \d+$/),
+    stderr: expect.any(String),
     exitCode: 0,
     signalCode: null,
   });
+  // Two thirds of FAN are never aborted; all of those must round-trip with
+  // the correct echoed header value. Aborted ones may also succeed if the
+  // response beats the abort, so the count is in [128, 192].
+  const totalOk = Number(stdout.trim().slice("OK ".length));
+  expect(totalOk).toBeGreaterThanOrEqual(8 * (24 - Math.ceil(24 / 3)));
 });


### PR DESCRIPTION
Fixes #23092

## Crash

```
Panic: range start index 102904832 out of range for slice of length 224
core::slice::index::slice_index_fail
header_str                                  src/http/lib.rs:2102
<bun_http::HTTPClient>::build_request       src/http/lib.rs
send_initial_request_payload<true,false>    src/http/lib.rs
on_writable<true,true>                      src/http/lib.rs
first_call<true>                            src/http/lib.rs
on_handshake<true>                          src/http/HTTPContext.rs:1186
```

Fires on the HTTP thread the moment a TLS socket becomes writable after the handshake. The message embeds the offset and buffer length, so the same bug fragments into hundreds of distinct single-event crash-report groups; real volume is much higher than any one group suggests. #23092 is the same crash from the pre-Rust era (`headerStr` → `sendInitialRequestPayload` → `onWritable` → `firstCall` → handshake callback, `index 1864152300, len 1835`, Windows x64), so this predates the port.

## Cause

`HTTPClient::header_str` indexes `header_buf` with `StringPointer` offsets read out of `header_entries` with no range check:

```rust
&buf[ptr.offset as usize..][..ptr.length as usize]
```

`header_buf` is a borrowed `&'a [u8]` (a fat pointer: its `len` is copied into the struct and never changes), while `header_entries` is a `MultiArrayList<HeaderEntry>` whose backing allocation is heap-owned. `M` in the panic is therefore always the true header-buffer length; `N` is a garbage offset read out of the `header_entries` column.

Two independent paths can put a garbage `StringPointer` into `header_entries`:

1. **Bitwise-shared `MultiArrayList` allocation.** `start_queued_task` creates the HTTP-thread clone of `AsyncHTTP` via `core::ptr::read`, so the clone and the JS-thread original share the same `header_entries` allocation by pointer. The clone's teardown raw-deallocates without running `Drop` (the original is the sole owner), but if the owner drops the original early, the clone reads recycled heap bytes as `StringPointer`s while its copied `header_buf.len()` is still correct. I audited the `FetchTasklet` refcount protocol and could not find a path that drops the original early, but the crash reports (spanning Zig and Rust builds, macOS/Linux/Windows) confirm it happens.

2. **Uninitialised column slots.** `from_fetch_headers` reserves capacity, `set_len(header_count)` on the `MultiArrayList`, then relies on `WebCore__FetchHeaders__copyTo` to fully populate every slot. `count()` reports `headers->size()` but `copyTo`'s iterator can skip an entry whenever `HTTPHeaderMap::get(key)` returns null (`FetchHeaders::Iterator::next()` line 386-388). Any slot `copyTo` skips keeps whatever bytes the allocator handed back.

## Fix

* `HTTPClient::header_str` now performs the same bounds check as `Headers::as_str` (which already guards the identical indexing pattern in `bun_http_types::ETag`): if `offset + length` exceeds `header_buf.len()` or wraps, return an empty slice instead of slice-panicking on the HTTP thread. A `debug_assert!` keeps the failure loud in debug/ASAN builds so the underlying owner-lifetime question can be chased when it fires there.
* `from_fetch_headers` zero-initialises both `StringPointer` columns before `copy_to`, so any slot the iterator does not write is `{ offset: 0, length: 0 }` (a valid empty slice) rather than uninitialised heap.

## Verification

* `bun bd test test/js/web/fetch/fetch-header-str-bounds.test.ts` passes (128+ non-aborted TLS fetches per run, each echoed header body verified, non-`AbortError` failures rethrown).
* `bun bd test test/js/web/fetch/headers-case.test.ts test/js/web/fetch/fetch_headers.test.js test/js/web/fetch/fetch-connection-header.test.ts` all pass unchanged.

**Note on the gate:** this is a non-deterministic race; the stress test did not reproduce the panic on either the system bun or a stashed-src debug build. It exercises the exact `on_handshake → first_call → build_request → header_str` path the crash reports name and asserts every non-aborted request round-trips the correct header value, but the fail-before leg is expected to pass. A Rust `#[cfg(test)]` unit test that hands `header_str` a desynced `StringPointer` would gate the bounds check directly, but the gate stashes `src/` for fail-before and `bun bd test` does not run `cargo test`, so that route does not help the gate either. The fix is defensive parity with `Headers::as_str` plus elimination of uninitialised column bytes; merge is on the strength of the analysis above rather than a deterministic repro.
