### PR TITLE
usockets: drain + back off on accept() EMFILE instead of spinning

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -377,6 +377,7 @@ static void us_internal_init_listen_socket(struct us_listen_socket_t *ls,
     ls->on_server_name = NULL;
     ls->socket_ext_size = socket_ext_size;
     ls->deferred_accept = 0;
+    ls->emfile_paused = 0;
 
     /* Link into the group so close_all() / test-isolation can find it. */
     ls->next = group->head_listen_sockets;
@@ -446,6 +447,12 @@ void us_listen_socket_close(struct us_listen_socket_t *ls) {
     if (!us_socket_is_closed(s)) {
         struct us_socket_group_t *group = ls->accept_group;
         struct us_loop_t *loop = s->group->loop;
+#ifdef LIBUS_USE_LIBUV
+        if (ls->emfile_paused) {
+            ls->emfile_paused = 0;
+            us_internal_disable_sweep_timer(loop);
+        }
+#endif
         us_poll_stop((struct us_poll_t *) s, loop);
         bsd_close_socket(us_poll_fd((struct us_poll_t *) s));
 

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -412,6 +412,7 @@ void us_loop_run(struct us_loop_t *loop) {
 
         us_internal_dispatch_ready_polls(loop);
         us_internal_drain_ready_polls(loop);
+        us_internal_accept_rearm_if_due(loop);
         us_internal_sweep_if_due(loop);
 
         /* Emit post callback */
@@ -497,6 +498,7 @@ void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout
 
     us_internal_dispatch_ready_polls(loop);
     us_internal_drain_ready_polls(loop);
+    us_internal_accept_rearm_if_due(loop);
     us_internal_sweep_if_due(loop);
 
     /* Emit post callback */

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -155,7 +155,9 @@ void us_internal_disable_sweep_timer(struct us_loop_t *loop);
 uint64_t us_internal_monotonic_ns(void);
 long long us_internal_sweep_timeout_ns(struct us_loop_t *loop);
 void us_internal_sweep_if_due(struct us_loop_t *loop);
+void us_internal_accept_rearm_if_due(struct us_loop_t *loop);
 #endif
+void us_internal_accept_emfile(struct us_listen_socket_t *ls, struct us_loop_t *loop);
 void us_internal_free_closed_sockets(us_loop_r loop);
 void us_internal_loop_link_group(struct us_loop_t *loop, struct us_socket_group_t *group);
 void us_internal_loop_unlink_group(struct us_loop_t *loop, struct us_socket_group_t *group);
@@ -446,6 +448,10 @@ struct us_listen_socket_t {
   unsigned char accept_kind;
   /* Set when TCP_DEFER_ACCEPT/SO_ACCEPTFILTER was successfully applied. */
   unsigned char deferred_accept;
+  /* accept() hit EMFILE/ENFILE and the reserve-fd drain could not clear the
+   * backlog: the listener poll is watching no events (a level-triggered
+   * readable would spin the loop). Cleared when the backoff re-arms it. */
+  unsigned char emfile_paused;
 };
 
 void us_internal_socket_group_link_connecting_socket(us_socket_group_r group, struct us_connecting_socket_t *c);

--- a/packages/bun-usockets/src/internal/loop_data.h
+++ b/packages/bun-usockets/src/internal/loop_data.h
@@ -43,6 +43,13 @@ struct us_internal_loop_data_t {
     /* Absolute monotonic ns of the next sweep, or -1. Folded into the poll
      * timeout — no timerfd, no EVFILT_TIMER. */
     long long sweep_next_tick_ns;
+    /* Absolute monotonic ns at which to re-arm listeners paused on EMFILE, or
+     * -1. Folded into the poll timeout like sweep_next_tick_ns. */
+    long long accept_rearm_next_tick_ns;
+    /* Spare fd (open("/dev/null")) the accept path borrows under EMFILE: close,
+     * accept()+close() to drain the backlog so the level-triggered readable
+     * clears, reopen. -1 if the open failed or the reopen lost the race. */
+    int accept_reserve_fd;
 #endif
     int sweep_timer_count;
 #ifdef LIBUS_USE_LIBUV

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -24,6 +24,8 @@
 #include <time.h>
 #ifndef WIN32
 #include <sys/ioctl.h>
+#include <fcntl.h>
+#include <unistd.h>
 #endif
 #ifdef __linux__
 #include <netinet/in.h>
@@ -45,6 +47,34 @@ extern const size_t Bun__lock__size;
 #endif
 
 extern void Bun__internal_ensureDateHeaderTimerIsEnabled(struct us_loop_t *loop);
+extern void Bun__warnAcceptEMFILE(int err);
+
+/* accept() returned an error that means "out of file descriptors" (per-process
+ * or system-wide). The listener poll is level-triggered, so leaving it armed
+ * would spin the loop re-failing accept() at full speed. */
+static int us_internal_is_emfile(int err) {
+#ifdef _WIN32
+    return err == WSAEMFILE || err == WSAENOBUFS;
+#else
+    return err == EMFILE || err == ENFILE;
+#endif
+}
+
+/* Re-arm every listener that was paused on EMFILE. Runs from the backoff
+ * deadline (POSIX) or the sweep timer (libuv). Returns how many were resumed. */
+static int us_internal_resume_emfile_paused_listeners(struct us_loop_t *loop) {
+    int resumed = 0;
+    for (struct us_socket_group_t *g = loop->data.head; g; g = g->next) {
+        for (struct us_listen_socket_t *ls = g->head_listen_sockets; ls; ls = ls->next) {
+            if (ls->emfile_paused) {
+                ls->emfile_paused = 0;
+                us_poll_change((struct us_poll_t *) ls, loop, LIBUS_SOCKET_READABLE);
+                resumed++;
+            }
+        }
+    }
+    return resumed;
+}
 
 #ifdef LIBUS_USE_LIBUV
 
@@ -66,6 +96,21 @@ void us_internal_disable_sweep_timer(struct us_loop_t *loop) {
     if (loop->data.sweep_timer_count == 0) {
         us_timer_set(loop->data.sweep_timer, (void (*)(struct us_timer_t *)) sweep_timer_noop, 0, 0);
     }
+}
+
+/* Windows: no reserve-fd trick (sockets are a separate table from file
+ * handles). Pause the listener poll and let the sweep timer re-arm it. */
+void us_internal_accept_emfile(struct us_listen_socket_t *ls, struct us_loop_t *loop) {
+    Bun__warnAcceptEMFILE(LIBUS_ERR);
+    if (ls->emfile_paused) return;
+    us_poll_change((struct us_poll_t *) ls, loop, 0);
+    ls->emfile_paused = 1;
+    us_internal_enable_sweep_timer(loop);
+}
+
+static void us_internal_accept_rearm_libuv(struct us_loop_t *loop) {
+    int resumed = us_internal_resume_emfile_paused_listeners(loop);
+    while (resumed--) us_internal_disable_sweep_timer(loop);
 }
 
 #else
@@ -94,12 +139,17 @@ void us_internal_disable_sweep_timer(struct us_loop_t *loop) {
 }
 
 long long us_internal_sweep_timeout_ns(struct us_loop_t *loop) {
-    if (loop->data.sweep_next_tick_ns < 0) {
+    long long deadline = loop->data.sweep_next_tick_ns;
+    long long rearm = loop->data.accept_rearm_next_tick_ns;
+    if (rearm >= 0 && (deadline < 0 || rearm < deadline)) {
+        deadline = rearm;
+    }
+    if (deadline < 0) {
         return -1;
     }
     /* Its own reading, deliberately: this bounds the poll so the sweep is not
      * starved, and a caller's older reading would round the deadline up. */
-    long long diff = loop->data.sweep_next_tick_ns - (long long) us_internal_monotonic_ns();
+    long long diff = deadline - (long long) us_internal_monotonic_ns();
     return diff > 0 ? diff : 0;
 }
 
@@ -116,6 +166,67 @@ void us_internal_sweep_if_due(struct us_loop_t *loop) {
     us_internal_timer_sweep(loop);
 }
 
+#define LIBUS_ACCEPT_REARM_NS (200LL * 1000000LL)
+
+static int us_internal_open_accept_reserve_fd(void) {
+    int fd;
+    do {
+        fd = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    } while (fd == -1 && errno == EINTR);
+    return fd;
+}
+
+/* accept() hit EMFILE/ENFILE. First try the libuv uv__emfile_trick: close the
+ * reserved fd, accept() as many queued connections as that one slot allows and
+ * close each immediately so the peer sees a clean refusal instead of a
+ * connection that never answers. Draining the backlog clears the
+ * level-triggered readable. If the drain exhausts before the backlog does (or
+ * the reserve is spent), fall back to unpolling the listener and scheduling a
+ * re-arm via accept_rearm_next_tick_ns so the loop idles instead of spinning. */
+void us_internal_accept_emfile(struct us_listen_socket_t *ls, struct us_loop_t *loop) {
+    int err = LIBUS_ERR;
+    Bun__warnAcceptEMFILE(err);
+
+    if (err == EMFILE && loop->data.accept_reserve_fd != -1) {
+        close(loop->data.accept_reserve_fd);
+        loop->data.accept_reserve_fd = -1;
+        struct bsd_addr_t addr;
+        LIBUS_SOCKET_DESCRIPTOR fd;
+        while ((fd = bsd_accept_socket(us_poll_fd((struct us_poll_t *) ls), &addr)) != LIBUS_SOCKET_ERROR) {
+            bsd_close_socket(fd);
+        }
+        int drain_err = LIBUS_ERR;
+        loop->data.accept_reserve_fd = us_internal_open_accept_reserve_fd();
+        if (!us_internal_is_emfile(drain_err)) {
+            /* Backlog drained to EAGAIN (or some other terminal error); the
+             * level-triggered readable is clear, no backoff needed. */
+            return;
+        }
+    }
+
+    if (ls->emfile_paused) return;
+    us_poll_change((struct us_poll_t *) ls, loop, 0);
+    ls->emfile_paused = 1;
+    long long deadline = (long long) us_internal_monotonic_ns() + LIBUS_ACCEPT_REARM_NS;
+    if (loop->data.accept_rearm_next_tick_ns < 0 || deadline < loop->data.accept_rearm_next_tick_ns) {
+        loop->data.accept_rearm_next_tick_ns = deadline;
+    }
+}
+
+void us_internal_accept_rearm_if_due(struct us_loop_t *loop) {
+    if (loop->data.accept_rearm_next_tick_ns < 0) {
+        return;
+    }
+    if ((long long) us_internal_monotonic_ns() < loop->data.accept_rearm_next_tick_ns) {
+        return;
+    }
+    loop->data.accept_rearm_next_tick_ns = -1;
+    if (loop->data.accept_reserve_fd == -1) {
+        loop->data.accept_reserve_fd = us_internal_open_accept_reserve_fd();
+    }
+    us_internal_resume_emfile_paused_listeners(loop);
+}
+
 #endif
 
 
@@ -126,6 +237,8 @@ void us_internal_loop_data_init(struct us_loop_t *loop, void (*wakeup_cb)(struct
     loop->data.sweep_timer = us_create_timer(loop, 1, 0);
 #else
     loop->data.sweep_next_tick_ns = -1;
+    loop->data.accept_rearm_next_tick_ns = -1;
+    loop->data.accept_reserve_fd = us_internal_open_accept_reserve_fd();
 #endif
     loop->data.sweep_timer_count = 0;
     loop->data.recv_buf = us_malloc(LIBUS_RECV_BUFFER_LENGTH + LIBUS_RECV_BUFFER_PADDING * 2);
@@ -155,6 +268,11 @@ void us_internal_loop_data_free(struct us_loop_t *loop) {
 #ifdef LIBUS_USE_LIBUV
     us_timer_close(loop->data.sweep_timer, 0);
     if (loop->data.quic_timer) us_timer_close(loop->data.quic_timer, 0);
+#else
+    if (loop->data.accept_reserve_fd != -1) {
+        close(loop->data.accept_reserve_fd);
+        loop->data.accept_reserve_fd = -1;
+    }
 #endif
     us_internal_async_close(loop->data.wakeup_async);
 }
@@ -386,6 +504,7 @@ void us_internal_free_closed_sockets(struct us_loop_t *loop) {
 
 #ifdef LIBUS_USE_LIBUV
 void sweep_timer_cb(struct us_internal_callback_t *cb) {
+    us_internal_accept_rearm_libuv(cb->loop);
     us_internal_timer_sweep(cb->loop);
     /* Escalate paused sockets whose peer FIN was deferred behind buffered
      * data and whose peer has since reset (poll_cb consumed the only
@@ -501,13 +620,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                 struct bsd_addr_t addr;
 
                 LIBUS_SOCKET_DESCRIPTOR client_fd = bsd_accept_socket(us_poll_fd(p), &addr);
-                if (client_fd == LIBUS_SOCKET_ERROR) {
-                    /* Todo: start timer here */
-
-                } else {
-
-                    /* Todo: stop timer if any */
-
+                if (client_fd != LIBUS_SOCKET_ERROR) {
                     do {
                         struct us_poll_t *accepted_p = us_create_poll(loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + listen_socket->socket_ext_size);
                         us_poll_init(accepted_p, client_fd, POLL_TYPE_SOCKET);
@@ -568,6 +681,14 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         }
 
                     } while ((client_fd = bsd_accept_socket(us_poll_fd(p), &addr)) != LIBUS_SOCKET_ERROR);
+                }
+                /* EAGAIN is normal (backlog drained). EMFILE/ENFILE with a
+                 * connection still pending would spin the level-triggered
+                 * poll; drain it with the reserve fd and/or back off. */
+                if (client_fd == LIBUS_SOCKET_ERROR
+                    && !us_socket_is_closed(&listen_socket->s)
+                    && us_internal_is_emfile(LIBUS_ERR)) {
+                    us_internal_accept_emfile(listen_socket, loop);
                 }
             }
         break;

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3708,9 +3708,7 @@ bun_jsc::impl_js_class_via_generated!(DebugHTTPSServer => crate::generated_class
 
 // ─── Exported fns ────────────────────────────────────────────────────────────
 
-/// Called from `us_internal_accept_emfile` in bun-usockets when `accept()` fails
-/// with `EMFILE`/`ENFILE`. The accept loop drains the backlog with a reserve fd
-/// and backs off instead of spinning; this surfaces the condition once.
+/// One-shot stderr warning from bun-usockets `us_internal_accept_emfile`.
 #[unsafe(no_mangle)]
 pub(super) extern "C" fn Bun__warnAcceptEMFILE(err: c_int) {
     static WARNED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3707,6 +3707,29 @@ bun_jsc::impl_js_class_via_generated!(DebugHTTPServer => crate::generated_classe
 bun_jsc::impl_js_class_via_generated!(DebugHTTPSServer => crate::generated_classes::js_DebugHTTPSServer, no_constructor);
 
 // ─── Exported fns ────────────────────────────────────────────────────────────
+
+/// Called from `us_internal_accept_emfile` in bun-usockets when `accept()` fails
+/// with `EMFILE`/`ENFILE`. The accept loop drains the backlog with a reserve fd
+/// and backs off instead of spinning; this surfaces the condition once.
+#[unsafe(no_mangle)]
+pub(super) extern "C" fn Bun__warnAcceptEMFILE(err: c_int) {
+    static WARNED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if WARNED.swap(true, core::sync::atomic::Ordering::Relaxed) {
+        return;
+    }
+    if crate::cli::Command::get().debug.silent {
+        return;
+    }
+    let name = bun_errno::SystemErrno::init(i64::from(err))
+        .map(<&'static str>::from)
+        .unwrap_or("EMFILE");
+    bun_core::pretty_errorln!(
+        "<r><yellow>warn<r><d>:<r> accept() failed with <b>{}<r>; out of file descriptors, refusing queued connections. Raise <d><cyan>`ulimit -n`<r> if this is unexpected.",
+        name,
+    );
+    Output::flush();
+}
+
 #[unsafe(no_mangle)]
 extern "C" fn Server__setIdleTimeout(server: JSValue, seconds: JSValue, global: &JSGlobalObject) {
     match server_set_idle_timeout(server, seconds, global) {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3721,8 +3721,14 @@ pub(super) extern "C" fn Bun__warnAcceptEMFILE(err: c_int) {
     let name = bun_errno::SystemErrno::init(i64::from(err))
         .map(<&'static str>::from)
         .unwrap_or("EMFILE");
+    #[cfg(not(windows))]
     bun_core::pretty_errorln!(
         "<r><yellow>warn<r><d>:<r> accept() failed with <b>{}<r>; out of file descriptors, refusing queued connections. Raise <d><cyan>`ulimit -n`<r> if this is unexpected.",
+        name,
+    );
+    #[cfg(windows)]
+    bun_core::pretty_errorln!(
+        "<r><yellow>warn<r><d>:<r> accept() failed with <b>{}<r>; out of socket handles, refusing queued connections.",
         name,
     );
     Output::flush();

--- a/src/uws_sys/InternalLoopData.rs
+++ b/src/uws_sys/InternalLoopData.rs
@@ -28,6 +28,10 @@ pub struct InternalLoopData {
     pub sweep_timer: *mut Timer,
     #[cfg(not(windows))]
     pub sweep_next_tick_ns: i64,
+    #[cfg(not(windows))]
+    pub accept_rearm_next_tick_ns: i64,
+    #[cfg(not(windows))]
+    pub accept_reserve_fd: c_int,
     pub sweep_timer_count: i32,
     pub wakeup_async: *mut us_internal_async,
     pub head: *mut SocketGroup,

--- a/test/js/bun/http/serve-listen-emfile.test.ts
+++ b/test/js/bun/http/serve-listen-emfile.test.ts
@@ -1,0 +1,124 @@
+import { expect, test } from "bun:test";
+import { once } from "events";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { connect } from "net";
+
+// When the process is at its fd limit and a connection is waiting in the
+// listen backlog, accept() returns EMFILE. The listener poll is
+// level-triggered, so before the fix the loop woke immediately again, failed
+// accept() again, and pegged a core. With the fix the loop borrows a reserved
+// fd to accept()+close() the queued connection (so the client sees a clean
+// refusal and the readable clears), falling back to unpolling the listener
+// with a timed re-arm if the drain cannot make progress.
+// https://github.com/oven-sh/bun/issues/3271
+test.skipIf(!isPosix)("Bun.serve does not spin at 100% CPU when accept() fails with EMFILE", async () => {
+  using dir = tempDir("serve-emfile", {
+    "server.ts": /* ts */ `
+      import { openSync, closeSync, readSync, writeSync } from "fs";
+
+      const server = Bun.serve({
+        port: 0,
+        fetch() { return new Response("ok"); },
+      });
+
+      // Exhaust file descriptors so the next accept() returns EMFILE.
+      const held: number[] = [];
+      while (true) {
+        try {
+          held.push(openSync("/dev/null", "r"));
+        } catch (e: any) {
+          if (e?.code !== "EMFILE" && e?.code !== "ENFILE") throw e;
+          break;
+        }
+      }
+
+      // process.stdout lazily allocates an fd on first use, which would fail
+      // now; write to the existing fd 1 directly.
+      writeSync(1, JSON.stringify({ port: server.port, held: held.length }) + "\\n");
+
+      // Wait for the parent to tell us a connection is in the backlog.
+      // (Blocking read on fd 0; parent writes a single byte after connecting.)
+      readSync(0, Buffer.alloc(1));
+
+      // Sample CPU time over a fixed window. A spinning accept loop consumes
+      // ~100% of a core; a correctly paused listener consumes ~0.
+      const wallMs = 800;
+      const before = process.cpuUsage();
+      await Bun.sleep(wallMs);
+      const used = process.cpuUsage(before);
+      const cpuMs = (used.user + used.system) / 1000;
+
+      writeSync(1, JSON.stringify({ cpuMs, wallMs }) + "\\n");
+
+      for (const fd of held) closeSync(fd);
+      server.stop(true);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    // Lower both soft and hard RLIMIT_NOFILE so adjust_ulimit() cannot raise
+    // it back, and the child exhausts fds quickly.
+    cmd: ["/bin/sh", "-c", `ulimit -n 128 && exec "$@"`, "sh", bunExe(), "server.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stderrPromise = proc.stderr.text();
+  const reader = proc.stdout.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  const readLine = async () => {
+    while (true) {
+      const nl = buf.indexOf("\n");
+      if (nl !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(nl + 1);
+        return line;
+      }
+      const { value, done } = await reader.read();
+      if (done) {
+        const stderr = await stderrPromise;
+        throw new Error(`child exited before producing a line; stderr:\n${stderr}\nstdout so far:\n${buf}`);
+      }
+      buf += dec.decode(value, { stream: true });
+    }
+  };
+
+  const ready = JSON.parse(await readLine()) as { port: number; held: number };
+  expect(ready.port).toBeGreaterThan(0);
+  expect(ready.held).toBeGreaterThan(0);
+
+  // Put a connection in the listen backlog and send a request so
+  // TCP_DEFER_ACCEPT lets the listener poll fire. In the child, accept()
+  // now fails with EMFILE.
+  const sock = connect({ port: ready.port, host: "127.0.0.1" });
+  await once(sock, "connect");
+  await new Promise<void>((resolve, reject) => {
+    sock.once("error", reject);
+    sock.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n", err => (err ? reject(err) : resolve()));
+  });
+  sock.on("error", () => {});
+
+  proc.stdin.write("go\n");
+
+  const sample = JSON.parse(await readLine()) as { cpuMs: number; wallMs: number };
+  sock.destroy();
+  await proc.stdin.end();
+
+  const [stderr, exitCode] = await Promise.all([stderrPromise, proc.exited]);
+
+  // A spinning loop burns roughly wallMs of CPU. The fixed loop either drains
+  // the backlog with its reserve fd or idles in epoll_wait waiting for the
+  // re-arm deadline, consuming ~0. stderr should carry the one-shot warning;
+  // other lanes may add their own noise so match loosely.
+  expect({ ...sample, spin: sample.cpuMs > sample.wallMs / 2, stderr }).toEqual({
+    cpuMs: expect.any(Number),
+    wallMs: 800,
+    spin: false,
+    stderr: expect.stringContaining("accept() failed with EMFILE"),
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
## Problem

When `Bun.serve` (or any usockets listener) is at the process fd limit and a connection is waiting in the listen backlog, `accept()` returns `EMFILE`. The listener poll is level-triggered, so the event loop wakes immediately, fails `accept()` again, and repeats: the process pegs a core for as long as the fd limit is hit, serves nothing, and surfaces no error.

strace on the spin (Bun.serve under `prlimit --nofile=64`, 200 held connections; ~98k `EMFILE` returns in ~10s, ~80% of a core):

```
accept4(8, ..., SOCK_CLOEXEC|SOCK_NONBLOCK) = -1 EMFILE (Too many open files)
epoll_pwait2(3, [{events=EPOLLIN, data={...}}], 1024, {tv_sec=0, tv_nsec=98981071}, [], 8) = 1
accept4(8, ..., SOCK_CLOEXEC|SOCK_NONBLOCK) = -1 EMFILE (Too many open files)
epoll_pwait2(3, [{events=EPOLLIN, data={...}}], 1024, {tv_sec=0, tv_nsec=98930609}, [], 8) = 1
accept4(8, ..., SOCK_CLOEXEC|SOCK_NONBLOCK) = -1 EMFILE (Too many open files)
```

The backoff was a literal todo in `packages/bun-usockets/src/loop.c`:

```c
LIBUS_SOCKET_DESCRIPTOR client_fd = bsd_accept_socket(us_poll_fd(p), &addr);
if (client_fd == LIBUS_SOCKET_ERROR) {
    /* Todo: start timer here */
}
```

## Fix

**(a) Reserve-fd drain (POSIX):** hold one spare fd (`open("/dev/null", O_RDONLY|O_CLOEXEC)`) per loop. On `EMFILE`, close it, `accept()`+`close()` each queued connection so the peer sees a clean refusal instead of a connection that never answers, then reopen the reserve. Draining the backlog clears the level-triggered readable so the loop returns to idle without touching the listener poll. Same trick as libuv's `uv__emfile_trick`.

**(b) Timed backoff fallback:** if the drain cannot make progress (`ENFILE`, reserve spent, or a concurrent thread stole the freed slot), `us_poll_change(listener, loop, 0)` and schedule a re-arm ~200 ms later via a new `accept_rearm_next_tick_ns` deadline on `us_internal_loop_data_t`, folded into the `epoll_pwait2`/`kevent` timeout the same way `sweep_next_tick_ns` is (no timerfd). On Windows/libuv there is no reserve-fd path (sockets are a separate table from file handles), so `WSAEMFILE`/`WSAENOBUFS` goes straight to backoff via the sweep timer.

A one-shot warning is written to stderr so the condition is no longer silent:

```
warn: accept() failed with EMFILE; out of file descriptors, refusing queued connections. Raise `ulimit -n` if this is unexpected.
```

## Verification

`test/js/bun/http/serve-listen-emfile.test.ts` spawns a child under `ulimit -n 128`, starts `Bun.serve`, exhausts the remaining fds by opening `/dev/null` until `EMFILE`, then the parent puts a connection in the backlog (sending a request so `TCP_DEFER_ACCEPT` lets the listener poll fire). The child samples `process.cpuUsage()` across an 800 ms window.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve-listen-emfile.test.ts
  -> FAIL  { cpuMs: 803.51, wallMs: 800, spin: true, stderr: "" }

bun bd test test/js/bun/http/serve-listen-emfile.test.ts
  -> PASS  { spin: false, stderr: "...accept() failed with EMFILE..." }
```

POSIX-only test (needs `/bin/sh`, `ulimit`, `/dev/null`); the Windows path goes through the same `us_internal_dispatch_ready_poll` branch.

Closes #3271.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 8 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-listen-emfile.test.ts
bun test v1.4.0 (7ce30daf4)

test/js/bun/http/serve-listen-emfile.test.ts:
112 | 
113 |   // A spinning loop burns roughly wallMs of CPU. The fixed loop either drains
114 |   // the backlog with its reserve fd or idles in epoll_wait waiting for the
115 |   // re-arm deadline, consuming ~0. stderr should carry the one-shot warning;
116 |   // other lanes may add their own noise so match loosely.
117 |   expect({ ...sample, spin: sample.cpuMs > sample.wallMs / 2, stderr }).toEqual({
                                                                              ^
error: expect(received).toEqual(expected)

  {
-   "cpuMs": Any<Number>,
-   "spin": false,
-   "stderr": StringContaining "accept() failed with EMFILE",
+   "cpuMs": 910.325,
+   "spin": true,
+   "stderr": "",
    "wallMs": 800,
  }

- Expected  - 3
+ Received  + 3

      at <anonymous> (/workspace/bun/test/js/bun/http/serve-listen-emfile.test.ts:117:73)
(fail) Bun.serve does not spin at 100% CPU when accept() fails with EMFILE [2332.
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (c2218741b)

test/js/bun/http/serve-listen-emfile.test.ts:
(pass) Bun.serve does not spin at 100% CPU when accept() fails with EMFILE [843.77ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [1004.00ms]
__F:0:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/serve-listen-emfile.test.ts
bun test v1.4.0 (7ce30daf4)

test/js/bun/http/serve-listen-emfile.test.ts:
(pass) Bun.serve does not spin at 100% CPU when accept() fails with EMFILE [2400.24ms]

 1 pass
 0 fail
 4 expect() calls
Ran 1 test across 1 file. [4.57s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 700ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/25] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/25] cc obj/packages/bun-usockets/src/context.c.o
[3/25] cc obj/packages/bun-usockets/src/bsd.c.o
[4/25] cc obj/packages/bun-usockets/src/eventing/libuv.c.o
[5/25] cc obj/packages/bun-usockets/src/fault_inject.c.o
[6/25] cc obj/packages/bun-usockets/src/loop.c.o
[7/25] cc obj/packages/bun-usockets/src/eventing/epoll_kqueue.c.o
[8/25] cc obj/packages/bun-usockets/src/node_quic_shim.c.o
[9/25] cc obj/packages/bun-usockets/src/socket.c.o
[10/25] cc obj/packages/bun-usockets/src/quic.c.o
[11/25] cc obj/packages/bun-usockets/src/udp.c.o
[12/25] cxx obj/unified/UnifiedSource-packages_bun_usockets_src_crypto-0.cpp.o
[13/25] cxx obj/unified/UnifiedSource-src_jsc_bindings_node-0.cpp.o
[14/25] cxx obj/unified/UnifiedSource-src_uws_sys-0.cpp.o
[15/25] cxx obj/src/jsc/bindings/bindings.cpp.o
[16/25] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[17/25] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[18/25] cxx obj/unified/UnifiedSource-src_j
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
packages/bun-usockets/src/context.c               |   7 ++
 packages/bun-usockets/src/eventing/epoll_kqueue.c |   2 +
 packages/bun-usockets/src/internal/internal.h     |   6 +
 packages/bun-usockets/src/internal/loop_data.h    |   7 ++
 packages/bun-usockets/src/loop.c                  | 139 ++++++++++++++++++++--
 src/runtime/server/server_body.rs                 |  27 +++++
 src/uws_sys/InternalLoopData.rs                   |   4 +
 test/js/bun/http/serve-listen-emfile.test.ts      | 124 +++++++++++++++++++
 8 files changed, 307 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
packages/bun-usockets/src/context.c                    1      2      9
packages/bun-usockets/src/eventing/epoll_kqueue.c      1      0      9
packages/bun-usockets/src/internal/internal.h          2      3      9
packages/bun-usockets/src/internal/loop_data.h         1      0      9
packages/bun-usockets/src/loop.c                       6      6      9
src/runtime/server/server_body.rs                      2      2      9
src/uws_sys/InternalLoopData.rs                        1      0      9
test/js/bun/http/serve-listen-emfile.test.ts           3      5      9
```

</details>

<!-- robobun:evidence:end -->