### PR TITLE
usockets: propagate epoll_ctl(EPOLL_CTL_ADD) failure instead of going silently deaf

### DIFF
--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -373,7 +373,19 @@ struct us_listen_socket_t *us_socket_group_listen(struct us_socket_group_t *grou
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
     us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
-    us_poll_start(p, group->loop, LIBUS_SOCKET_READABLE);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
+        /* EPOLL_CTL_ADD failed (e.g. ENOSPC when fs.epoll.max_user_watches is
+         * exhausted). The kernel would keep completing TCP handshakes into the
+         * listen backlog while the event loop never hears about it. Report the
+         * error via both the out-param and thread-local errno so Bun.listen
+         * (reads *error) and Bun.serve (reads errno) surface it. */
+        int saved_errno = errno;
+        bsd_close_socket(listen_socket_fd);
+        us_poll_free(p, group->loop);
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
 
     struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
     us_internal_init_listen_socket(ls, group, kind, ssl_ctx, options, socket_ext_size);
@@ -395,7 +407,14 @@ struct us_listen_socket_t *us_socket_group_listen_unix(struct us_socket_group_t 
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
     us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
-    us_poll_start(p, group->loop, LIBUS_SOCKET_READABLE);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
+        int saved_errno = errno;
+        bsd_close_socket(listen_socket_fd);
+        us_poll_free(p, group->loop);
+        *error = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
 
     struct us_listen_socket_t *ls = (struct us_listen_socket_t *) p;
     us_internal_init_listen_socket(ls, group, kind, ssl_ctx, options, socket_ext_size);
@@ -485,7 +504,13 @@ struct us_socket_t *us_socket_group_connect_resolved_dns(struct us_socket_group_
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
-    us_poll_start(p, group->loop, LIBUS_SOCKET_WRITABLE);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
+        int saved_errno = errno;
+        bsd_close_socket(connect_socket_fd);
+        us_poll_free(p, group->loop);
+        errno = saved_errno;
+        return NULL;
+    }
 
     struct us_socket_t *socket = (struct us_socket_t *) p;
     us_internal_init_connect_socket(socket, group, kind, options);
@@ -616,7 +641,13 @@ struct us_socket_t *us_socket_group_connect_unix(struct us_socket_group_t *group
 
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_socket_t) + socket_ext_size);
     us_poll_init(p, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
-    us_poll_start(p, group->loop, LIBUS_SOCKET_WRITABLE);
+    if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_WRITABLE) != 0) {
+        int saved_errno = errno;
+        bsd_close_socket(connect_socket_fd);
+        us_poll_free(p, group->loop);
+        errno = saved_errno;
+        return 0;
+    }
 
     struct us_socket_t *connect_socket = (struct us_socket_t *) p;
     us_internal_init_connect_socket(connect_socket, group, kind, options);
@@ -641,9 +672,16 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         if (connect_socket_fd == LIBUS_SOCKET_ERROR) {
             continue;
         }
-        ++opened;
         bsd_socket_nodelay(connect_socket_fd, 1);
         struct us_socket_t *s = (struct us_socket_t *)us_create_poll(loop, 0, sizeof(struct us_socket_t) + c->socket_ext_size);
+        struct us_poll_t *poll = &s->p;
+        us_poll_init(poll, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
+        if (us_poll_start_rc(poll, loop, LIBUS_SOCKET_WRITABLE) != 0) {
+            bsd_close_socket(connect_socket_fd);
+            us_poll_free(poll, loop);
+            continue;
+        }
+        ++opened;
         us_internal_init_connect_socket(s, group, c->kind, c->options);
         s->timeout = c->timeout;
         s->long_timeout = c->long_timeout;
@@ -655,10 +693,6 @@ int start_connections(struct us_connecting_socket_t *c, int count) {
         s->connect_next = c->connecting_head;
         c->connecting_head = s;
         s->connect_state = c;
-
-        struct us_poll_t *poll = &s->p;
-        us_poll_init(poll, connect_socket_fd, POLL_TYPE_SEMI_SOCKET);
-        us_poll_start(poll, loop, LIBUS_SOCKET_WRITABLE);
     }
     return opened;
 }

--- a/packages/bun-usockets/src/context.c
+++ b/packages/bun-usockets/src/context.c
@@ -374,11 +374,9 @@ struct us_listen_socket_t *us_socket_group_listen(struct us_socket_group_t *grou
     struct us_poll_t *p = us_create_poll(group->loop, 0, sizeof(struct us_listen_socket_t));
     us_poll_init(p, listen_socket_fd, POLL_TYPE_SEMI_SOCKET);
     if (us_poll_start_rc(p, group->loop, LIBUS_SOCKET_READABLE) != 0) {
-        /* EPOLL_CTL_ADD failed (e.g. ENOSPC when fs.epoll.max_user_watches is
-         * exhausted). The kernel would keep completing TCP handshakes into the
-         * listen backlog while the event loop never hears about it. Report the
-         * error via both the out-param and thread-local errno so Bun.listen
-         * (reads *error) and Bun.serve (reads errno) surface it. */
+        /* EPOLL_CTL_ADD failed (e.g. ENOSPC at fs.epoll.max_user_watches).
+         * Report via both the out-param and thread-local errno: Bun.listen
+         * reads *error, Bun.serve reads errno. */
         int saved_errno = errno;
         bsd_close_socket(listen_socket_fd);
         us_poll_free(p, group->loop);

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -465,6 +465,13 @@ int kqueue_change(int kqfd, int fd, int old_events, int new_events, void *user_d
 
     // ret should be 0 in most cases (not guaranteed when removing async)
 
+    /* KEVENT_FLAG_ERROR_EVENTS reports per-filter failures as EV_ERROR entries
+     * with the errno in .data; kevent64 itself returns the count and does not
+     * set errno. Mirror epoll's contract so us_poll_start_rc callers can read it. */
+    if (ret > 0) {
+        errno = (int) change_list[0].data;
+    }
+
     return ret;
 }
 #endif

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -104,6 +104,11 @@ void us_poll_start(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   uv_poll_start(p->uv_p, events, poll_cb);
 }
 
+int us_poll_start_rc(struct us_poll_t *p, struct us_loop_t *loop, int events) {
+  us_poll_start(p, loop, events);
+  return 0;
+}
+
 void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
   if(!p->uv_p) return;
   if (us_poll_events(p) != events) {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -415,7 +415,14 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     do {
                         struct us_poll_t *accepted_p = us_create_poll(loop, 0, sizeof(struct us_socket_t) - sizeof(struct us_poll_t) + listen_socket->socket_ext_size);
                         us_poll_init(accepted_p, client_fd, POLL_TYPE_SOCKET);
-                        us_poll_start(accepted_p, loop, LIBUS_SOCKET_READABLE);
+                        if (us_poll_start_rc(accepted_p, loop, LIBUS_SOCKET_READABLE) != 0) {
+                            /* EPOLL_CTL_ADD failed (e.g. ENOSPC). Close the fd so the
+                             * peer sees a RST instead of a connection that silently
+                             * never answers. */
+                            bsd_close_socket(client_fd);
+                            us_poll_free(accepted_p, loop);
+                            continue;
+                        }
 
                         struct us_socket_t *s = (struct us_socket_t *) accepted_p;
 

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -169,6 +169,14 @@ struct us_udp_socket_t *us_create_udp_socket(
 
     struct us_poll_t *p = us_create_poll(loop, fallthrough, sizeof(struct us_udp_socket_t) + ext_size);
     us_poll_init(p, fd, POLL_TYPE_UDP);
+    if (us_poll_start_rc(p, loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE) != 0) {
+        int saved_errno = errno;
+        bsd_close_socket(fd);
+        us_poll_free(p, loop);
+        if (err) *err = saved_errno;
+        errno = saved_errno;
+        return 0;
+    }
 
     struct us_udp_socket_t *udp = (struct us_udp_socket_t *)p;
 
@@ -189,8 +197,6 @@ struct us_udp_socket_t *us_create_udp_socket(
     udp->on_close = close_cb;
     udp->on_recv_error = recv_error_cb;
     udp->next = NULL;
-
-    us_poll_start((struct us_poll_t *) udp, udp->loop, LIBUS_SOCKET_READABLE | LIBUS_SOCKET_WRITABLE);
 
     return (struct us_udp_socket_t *) udp;
 }

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1733,10 +1733,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 port,
                 hostname: _hostname,
             } => {
+                let errno = bun_sys::get_errno(-1i32);
                 // Rust's `target_os = "linux"` excludes
                 // Android, so match both explicitly.
                 #[cfg(any(target_os = "linux", target_os = "android"))]
-                if bun_sys::get_errno(-1i32) == bun_sys::E::EACCES {
+                if errno == bun_sys::E::EACCES {
                     let host = _hostname
                         .as_ref()
                         .map(|h| h.as_bytes())
@@ -1754,16 +1755,27 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     let _ = global.throw_value(err.to_error_instance(global));
                     return;
                 }
-                jsc::SystemError {
-                    message: bun_core::String::create_format(format_args!(
-                        "Failed to start server. Is port {} in use?",
-                        port
-                    )),
-                    code: bun_core::String::static_("EADDRINUSE"),
-                    syscall: bun_core::String::static_("listen"),
-                    ..Default::default()
+                if errno != bun_sys::E::SUCCESS && errno != bun_sys::E::EADDRINUSE {
+                    // bind()/listen() failures other than "port in use" — e.g.
+                    // ENOSPC from epoll_ctl(EPOLL_CTL_ADD) when
+                    // fs.epoll.max_user_watches is exhausted. Surface the real
+                    // errno instead of misreporting EADDRINUSE.
+                    jsc::SystemError::from(
+                        bun_sys::Error::from_code(errno, bun_sys::Tag::listen).to_system_error(),
+                    )
+                    .to_error_instance(global)
+                } else {
+                    jsc::SystemError {
+                        message: bun_core::String::create_format(format_args!(
+                            "Failed to start server. Is port {} in use?",
+                            port
+                        )),
+                        code: bun_core::String::static_("EADDRINUSE"),
+                        syscall: bun_core::String::static_("listen"),
+                        ..Default::default()
+                    }
+                    .to_error_instance(global)
                 }
-                .to_error_instance(global)
             }
             server_config::Address::Unix(unix) => {
                 let unix = unix.as_bytes();

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1733,48 +1733,51 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                 port,
                 hostname: _hostname,
             } => {
-                let errno = bun_sys::get_errno(-1i32);
                 // Rust's `target_os = "linux"` excludes
                 // Android, so match both explicitly.
                 #[cfg(any(target_os = "linux", target_os = "android"))]
-                if errno == bun_sys::E::EACCES {
-                    let host = _hostname
-                        .as_ref()
-                        .map(|h| h.as_bytes())
-                        .unwrap_or(b"0.0.0.0");
-                    let err = jsc::SystemError {
-                        message: bun_core::String::create_format(format_args!(
-                            "permission denied {}:{}",
-                            bstr::BStr::new(host),
-                            port
-                        )),
-                        code: bun_core::String::static_("EACCES"),
-                        syscall: bun_core::String::static_("listen"),
-                        ..Default::default()
-                    };
-                    let _ = global.throw_value(err.to_error_instance(global));
-                    return;
-                }
-                if errno != bun_sys::E::SUCCESS && errno != bun_sys::E::EADDRINUSE {
-                    // bind()/listen() failures other than "port in use", e.g. ENOSPC
-                    // from epoll_ctl(EPOLL_CTL_ADD). Surface the real errno instead
-                    // of misreporting EADDRINUSE.
-                    jsc::SystemError::from(
-                        bun_sys::Error::from_code(errno, bun_sys::Tag::listen).to_system_error(),
-                    )
-                    .to_error_instance(global)
-                } else {
-                    jsc::SystemError {
-                        message: bun_core::String::create_format(format_args!(
-                            "Failed to start server. Is port {} in use?",
-                            port
-                        )),
-                        code: bun_core::String::static_("EADDRINUSE"),
-                        syscall: bun_core::String::static_("listen"),
-                        ..Default::default()
+                {
+                    let errno = bun_sys::get_errno(-1i32);
+                    if errno == bun_sys::E::EACCES {
+                        let host = _hostname
+                            .as_ref()
+                            .map(|h| h.as_bytes())
+                            .unwrap_or(b"0.0.0.0");
+                        let err = jsc::SystemError {
+                            message: bun_core::String::create_format(format_args!(
+                                "permission denied {}:{}",
+                                bstr::BStr::new(host),
+                                port
+                            )),
+                            code: bun_core::String::static_("EACCES"),
+                            syscall: bun_core::String::static_("listen"),
+                            ..Default::default()
+                        };
+                        let _ = global.throw_value(err.to_error_instance(global));
+                        return;
                     }
-                    .to_error_instance(global)
+                    // e.g. ENOSPC from epoll_ctl(EPOLL_CTL_ADD). Linux-only because
+                    // on other platforms errno is not reliably preserved through
+                    // the C++/callback chain to here; see PR #30364.
+                    if errno != bun_sys::E::SUCCESS && errno != bun_sys::E::EADDRINUSE {
+                        let err = jsc::SystemError::from(
+                            bun_sys::Error::from_code(errno, bun_sys::Tag::listen)
+                                .to_system_error(),
+                        );
+                        let _ = global.throw_value(err.to_error_instance(global));
+                        return;
+                    }
                 }
+                jsc::SystemError {
+                    message: bun_core::String::create_format(format_args!(
+                        "Failed to start server. Is port {} in use?",
+                        port
+                    )),
+                    code: bun_core::String::static_("EADDRINUSE"),
+                    syscall: bun_core::String::static_("listen"),
+                    ..Default::default()
+                }
+                .to_error_instance(global)
             }
             server_config::Address::Unix(unix) => {
                 let unix = unix.as_bytes();

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1756,10 +1756,9 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
                     return;
                 }
                 if errno != bun_sys::E::SUCCESS && errno != bun_sys::E::EADDRINUSE {
-                    // bind()/listen() failures other than "port in use" — e.g.
-                    // ENOSPC from epoll_ctl(EPOLL_CTL_ADD) when
-                    // fs.epoll.max_user_watches is exhausted. Surface the real
-                    // errno instead of misreporting EADDRINUSE.
+                    // bind()/listen() failures other than "port in use", e.g. ENOSPC
+                    // from epoll_ctl(EPOLL_CTL_ADD). Surface the real errno instead
+                    // of misreporting EADDRINUSE.
                     jsc::SystemError::from(
                         bun_sys::Error::from_code(errno, bun_sys::Tag::listen).to_system_error(),
                     )

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -116,11 +116,16 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
+function shimEnv(mode: "listener" | "accepted") {
+  const existing = bunEnv.LD_PRELOAD;
+  return { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, FAIL_EPOLL_ADD: mode };
+}
+
 async function runWithShim(script: string, mode: "listener" | "accepted" = "listener") {
   await using proc = Bun.spawn({
     cmd: [bunExe(), script],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: mode },
+    env: shimEnv(mode),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -164,7 +169,7 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
   await using proc = Bun.spawn({
     cmd: [bunExe(), "accept.js"],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: "accepted" },
+    env: shimEnv("accepted"),
     stdout: "pipe",
     stderr: "pipe",
     stdin: "pipe",

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -225,7 +225,11 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
         return line;
       }
       const { value, done } = await reader.read();
-      if (done) return buffered.length ? buffered : null;
+      if (done) {
+        const tail = buffered;
+        buffered = "";
+        return tail.length ? tail : null;
+      }
       buffered += decoder.decode(value, { stream: true });
     }
   }

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -261,18 +261,15 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
   expect(exitCode).toBe(0);
 });
 
-test.skipIf(!isLinux || !cc)(
-  "fetch() rejects when epoll_ctl(EPOLL_CTL_ADD) for the connect socket fails",
-  async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("fetch.js", "accepted");
-    const line = stdout.trim().split("\n").pop() ?? "";
-    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
-    const result = JSON.parse(line);
-    expect(result.settled).toBe("rejected");
-    expect(result.code).toBe("FailedToOpenSocket");
-    expect(exitCode).toBe(0);
-  },
-);
+test.skipIf(!isLinux || !cc)("fetch() rejects when epoll_ctl(EPOLL_CTL_ADD) for the connect socket fails", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim("fetch.js", "accepted");
+  const line = stdout.trim().split("\n").pop() ?? "";
+  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+  const result = JSON.parse(line);
+  expect(result.settled).toBe("rejected");
+  expect(result.code).toBe("FailedToOpenSocket");
+  expect(exitCode).toBe(0);
+});
 
 test.skipIf(!isLinux || !cc)(
   "Bun.connect rejects when epoll_ctl(EPOLL_CTL_ADD) for the connect socket fails",

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -5,10 +5,10 @@
 // completing TCP handshakes into the backlog while no request was ever
 // answered. This test injects that ENOSPC via an LD_PRELOAD shim and asserts
 // Bun.serve / Bun.listen now throw instead of silently going deaf.
-import { test, expect, beforeAll } from "bun:test";
+import { beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
-import { join } from "node:path";
 import net from "node:net";
+import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
@@ -132,26 +132,23 @@ async function runWithShim(script: string, mode: "listener" | "accepted" = "list
   return { stdout, stderr, exitCode };
 }
 
-test.skipIf(!isLinux || !cc)(
-  "Bun.serve throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails",
-  async () => {
-    const { stdout, stderr, exitCode } = await runWithShim("serve.js");
-    const line = stdout.trim().split("\n").pop() ?? "";
-    expect(line).not.toBe("");
-    const result = JSON.parse(line);
-    // Before the fix: { ok: true, port: <n> } and the server is a zombie.
-    expect({ stderr, result }).toEqual({
-      stderr: "",
-      result: {
-        ok: false,
-        code: "ENOSPC",
-        syscall: "listen",
-        message: expect.stringContaining("ENOSPC"),
-      },
-    });
-    expect(exitCode).toBe(0);
-  },
-);
+test.skipIf(!isLinux || !cc)("Bun.serve throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails", async () => {
+  const { stdout, stderr, exitCode } = await runWithShim("serve.js");
+  const line = stdout.trim().split("\n").pop() ?? "";
+  expect(line).not.toBe("");
+  const result = JSON.parse(line);
+  // Before the fix: { ok: true, port: <n> } and the server is a zombie.
+  expect({ stderr, result }).toEqual({
+    stderr: "",
+    result: {
+      ok: false,
+      code: "ENOSPC",
+      syscall: "listen",
+      message: expect.stringContaining("ENOSPC"),
+    },
+  });
+  expect(exitCode).toBe(0);
+});
 
 test.skipIf(!isLinux || !cc)(
   "Bun.listen throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails",
@@ -168,60 +165,57 @@ test.skipIf(!isLinux || !cc)(
   },
 );
 
-test.skipIf(!isLinux || !cc)(
-  "accepted connection is closed when epoll_ctl(EPOLL_CTL_ADD) fails for it",
-  async () => {
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "accept.js"],
-      cwd: String(dir),
-      env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: "accepted" },
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "pipe",
-    });
+test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL_CTL_ADD) fails for it", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "accept.js"],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: "accepted" },
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "pipe",
+  });
 
-    const reader = proc.stdout.getReader();
-    const decoder = new TextDecoder();
-    let buffered = "";
-    async function readLine(): Promise<string | null> {
-      for (;;) {
-        const i = buffered.indexOf("\n");
-        if (i >= 0) {
-          const line = buffered.slice(0, i);
-          buffered = buffered.slice(i + 1);
-          return line;
-        }
-        const { value, done } = await reader.read();
-        if (done) return buffered.length ? buffered : null;
-        buffered += decoder.decode(value, { stream: true });
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  async function readLine(): Promise<string | null> {
+    for (;;) {
+      const i = buffered.indexOf("\n");
+      if (i >= 0) {
+        const line = buffered.slice(0, i);
+        buffered = buffered.slice(i + 1);
+        return line;
       }
+      const { value, done } = await reader.read();
+      if (done) return buffered.length ? buffered : null;
+      buffered += decoder.decode(value, { stream: true });
     }
+  }
 
-    const portLine = await readLine();
-    expect(portLine).toMatch(/^PORT \d+$/);
-    const port = Number(portLine!.slice("PORT ".length));
+  const portLine = await readLine();
+  expect(portLine).toMatch(/^PORT \d+$/);
+  const port = Number(portLine!.slice("PORT ".length));
 
-    // Connect from the test process (no shim here). With the fix the server
-    // closes the accepted fd immediately because epoll_ctl failed, so the
-    // client observes close/end. Without the fix the server dispatches
-    // open() and leaves the socket parked forever; this await never resolves
-    // and the test fails on Bun's default per-test timeout.
-    const closed = await new Promise<string>(resolve => {
-      const sock = net.connect({ host: "127.0.0.1", port }, () => {
-        sock.write("ping");
-      });
-      sock.on("error", err => resolve("error:" + (err as NodeJS.ErrnoException).code));
-      sock.on("close", () => resolve("close"));
+  // Connect from the test process (no shim here). With the fix the server
+  // closes the accepted fd immediately because epoll_ctl failed, so the
+  // client observes close/end. Without the fix the server dispatches
+  // open() and leaves the socket parked forever; this await never resolves
+  // and the test fails on Bun's default per-test timeout.
+  const closed = await new Promise<string>(resolve => {
+    const sock = net.connect({ host: "127.0.0.1", port }, () => {
+      sock.write("ping");
     });
-    expect(["close", "error:ECONNRESET"]).toContain(closed);
+    sock.on("error", err => resolve("error:" + (err as NodeJS.ErrnoException).code));
+    sock.on("close", () => resolve("close"));
+  });
+  expect(["close", "error:ECONNRESET"]).toContain(closed);
 
-    // The server must not have reached open() for the dead connection.
-    proc.stdin.write("done\n");
-    proc.stdin.end();
-    const stderr = await proc.stderr.text();
-    let rest = "";
-    for (let line; (line = await readLine()) !== null; ) rest += line + "\n";
-    expect({ stderr, rest }).toEqual({ stderr: "", rest: "" });
-    expect(await proc.exited).toBe(0);
-  },
-);
+  // The server must not have reached open() for the dead connection.
+  proc.stdin.write("done\n");
+  proc.stdin.end();
+  const stderr = await proc.stderr.text();
+  let rest = "";
+  for (let line; (line = await readLine()) !== null; ) rest += line + "\n";
+  expect({ stderr, rest }).toEqual({ stderr: "", rest: "" });
+  expect(await proc.exited).toBe(0);
+});

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -8,8 +8,8 @@ import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// FAIL_EPOLL_ADD=listener fails ADD for listening sockets (SO_ACCEPTCONN);
-// FAIL_EPOLL_ADD=accepted fails ADD for connected SOCK_STREAM sockets.
+// FAIL_EPOLL_ADD=listener: listening TCP sockets (SO_ACCEPTCONN).
+// FAIL_EPOLL_ADD=accepted: connected SOCK_STREAM. FAIL_EPOLL_ADD=udp: SOCK_DGRAM.
 // Non-socket fds (timerfd, eventfd) always pass through.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
@@ -21,13 +21,13 @@ const SHIM_C = /* c */ `
 #include <sys/socket.h>
 
 static int (*real_epoll_ctl)(int, int, int, struct epoll_event *);
-static int mode = -1; // 0 = listener, 1 = accepted
+static int mode = -1; // 0 = listener, 1 = accepted, 2 = udp
 
 int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
     if (!real_epoll_ctl) {
         real_epoll_ctl = (int (*)(int, int, int, struct epoll_event *)) dlsym(RTLD_NEXT, "epoll_ctl");
         const char *m = getenv("FAIL_EPOLL_ADD");
-        mode = (m && strcmp(m, "accepted") == 0) ? 1 : 0;
+        mode = (m && strcmp(m, "udp") == 0) ? 2 : (m && strcmp(m, "accepted") == 0) ? 1 : 0;
     }
     if (op == EPOLL_CTL_ADD) {
         int acceptconn = 0, type = 0;
@@ -37,7 +37,8 @@ int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
             getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &acceptconn, &len);
             int is_stream = (type == SOCK_STREAM);
             if ((mode == 0 && is_stream && acceptconn) ||
-                (mode == 1 && is_stream && !acceptconn)) {
+                (mode == 1 && is_stream && !acceptconn) ||
+                (mode == 2 && type == SOCK_DGRAM)) {
                 errno = ENOSPC;
                 return -1;
             }
@@ -123,6 +124,16 @@ try {
 }
 `;
 
+const UDP_FIXTURE = /* js */ `
+try {
+  const sock = await Bun.udpSocket({ port: 0, hostname: "127.0.0.1", socket: { data() {} } });
+  console.log(JSON.stringify({ ok: true, port: sock.port }));
+  sock.close();
+} catch (e) {
+  console.log(JSON.stringify({ ok: false, code: e?.code, errno: e?.errno, message: String(e?.message ?? e) }));
+}
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -135,6 +146,7 @@ beforeAll(async () => {
     "accept.js": ACCEPT_FIXTURE,
     "fetch.js": FETCH_FIXTURE,
     "connect.js": CONNECT_FIXTURE,
+    "udp.js": UDP_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -153,12 +165,12 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-function shimEnv(mode: "listener" | "accepted") {
+function shimEnv(mode: "listener" | "accepted" | "udp") {
   const existing = bunEnv.LD_PRELOAD;
   return { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, FAIL_EPOLL_ADD: mode };
 }
 
-async function runWithShim(script: string, mode: "listener" | "accepted" = "listener") {
+async function runWithShim(script: string, mode: "listener" | "accepted" | "udp" = "listener") {
   await using proc = Bun.spawn({
     cmd: [bunExe(), script],
     cwd: String(dir),
@@ -290,6 +302,23 @@ test.skipIf(!isLinux || !cc)(
       errno: -111,
       syscall: "connect",
       message: expect.any(String),
+    });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "Bun.udpSocket throws when epoll_ctl(EPOLL_CTL_ADD) for the UDP socket fails",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("udp.js", "udp");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    const result = JSON.parse(line);
+    expect(result).toEqual({
+      ok: false,
+      code: "ENOSPC",
+      errno: 28,
+      message: expect.stringContaining("ENOSPC"),
     });
     expect(exitCode).toBe(0);
   },

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -117,7 +117,7 @@ try {
   console.log(JSON.stringify({ settled: "resolved" }));
   sock.end();
 } catch (e) {
-  console.log(JSON.stringify({ settled: "rejected", code: e?.code, errno: e?.errno, message: String(e?.message ?? e) }));
+  console.log(JSON.stringify({ settled: "rejected", code: e?.code, errno: e?.errno, syscall: e?.syscall, message: String(e?.message ?? e) }));
 } finally {
   server.stop(true);
 }
@@ -282,7 +282,15 @@ test.skipIf(!isLinux || !cc)(
     const line = stdout.trim().split("\n").pop() ?? "";
     expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
     const result = JSON.parse(line);
-    expect(result.settled).toBe("rejected");
+    // Synchronous NULL from us_socket_group_connect → do_connect() Err →
+    // handle_connect_error remaps the errno and rejects with syscall "connect".
+    expect(result).toEqual({
+      settled: "rejected",
+      code: "ECONNREFUSED",
+      errno: -111,
+      syscall: "connect",
+      message: expect.any(String),
+    });
     expect(exitCode).toBe(0);
   },
 );

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -1,21 +1,16 @@
-// epoll_ctl(EPOLL_CTL_ADD) for a listen socket can fail with ENOSPC when
-// fs.epoll.max_user_watches is exhausted. uSockets used to discard the
-// epoll_ctl return code, so Bun.serve() returned a healthy-looking server
-// whose listener was never registered with the event loop: the kernel kept
-// completing TCP handshakes into the backlog while no request was ever
-// answered. This test injects that ENOSPC via an LD_PRELOAD shim and asserts
-// Bun.serve / Bun.listen now throw instead of silently going deaf.
-import { beforeAll, expect, test } from "bun:test";
+// An LD_PRELOAD shim makes epoll_ctl(EPOLL_CTL_ADD) fail with ENOSPC (what the
+// kernel returns when fs.epoll.max_user_watches is exhausted) so Bun.serve /
+// Bun.listen must throw and accepted connections must be closed, not parked.
+import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import net from "node:net";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 
-// The shim makes epoll_ctl(ADD) fail with ENOSPC for either listening sockets
-// (SO_ACCEPTCONN == 1) or connected TCP sockets (SO_TYPE == SOCK_STREAM &&
-// SO_ACCEPTCONN == 0), selected by the FAIL_EPOLL_ADD env var. Non-socket fds
-// (timerfd, eventfd) always pass through so the event loop can start.
+// FAIL_EPOLL_ADD=listener fails ADD for listening sockets (SO_ACCEPTCONN);
+// FAIL_EPOLL_ADD=accepted fails ADD for connected SOCK_STREAM sockets.
+// Non-socket fds (timerfd, eventfd) always pass through.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -76,11 +71,8 @@ try {
 }
 `;
 
-// For the accepted-socket case: the listener registers fine, but every
-// accepted connection's EPOLL_CTL_ADD fails. The server prints its port,
-// then "OPEN" for each socket that reaches the open() handler. With the fix
-// the fd is closed before open() is dispatched, so the client sees the
-// connection close and the server never prints "OPEN".
+// Listener registers fine; every accepted connection's EPOLL_CTL_ADD fails.
+// open() must never fire and the client must observe the connection close.
 const ACCEPT_FIXTURE = /* js */ `
 const server = Bun.listen({
   port: 0,
@@ -97,7 +89,7 @@ process.stdin.once("data", () => { server.stop(true); process.exit(0); });
 `;
 
 let shimPath: string;
-let dir: ReturnType<typeof tempDir>;
+let dir: ReturnType<typeof tempDir> | undefined;
 
 beforeAll(async () => {
   if (!isLinux || !cc) return;
@@ -120,6 +112,10 @@ beforeAll(async () => {
   }
 });
 
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
 async function runWithShim(script: string, mode: "listener" | "accepted" = "listener") {
   await using proc = Bun.spawn({
     cmd: [bunExe(), script],
@@ -135,17 +131,13 @@ async function runWithShim(script: string, mode: "listener" | "accepted" = "list
 test.skipIf(!isLinux || !cc)("Bun.serve throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails", async () => {
   const { stdout, stderr, exitCode } = await runWithShim("serve.js");
   const line = stdout.trim().split("\n").pop() ?? "";
-  expect(line).not.toBe("");
+  expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
   const result = JSON.parse(line);
-  // Before the fix: { ok: true, port: <n> } and the server is a zombie.
-  expect({ stderr, result }).toEqual({
-    stderr: "",
-    result: {
-      ok: false,
-      code: "ENOSPC",
-      syscall: "listen",
-      message: expect.stringContaining("ENOSPC"),
-    },
+  expect(result).toEqual({
+    ok: false,
+    code: "ENOSPC",
+    syscall: "listen",
+    message: expect.stringContaining("ENOSPC"),
   });
   expect(exitCode).toBe(0);
 });
@@ -155,12 +147,15 @@ test.skipIf(!isLinux || !cc)(
   async () => {
     const { stdout, stderr, exitCode } = await runWithShim("listen.js");
     const line = stdout.trim().split("\n").pop() ?? "";
-    expect(line).not.toBe("");
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
     const result = JSON.parse(line);
-    expect({ stderr, ok: result.ok }).toEqual({ stderr: "", ok: false });
-    expect(result.errno).toBe(28); // ENOSPC
-    expect(result.code).toBe("ENOSPC");
-    expect(result.syscall).toBe("listen");
+    expect(result).toEqual({
+      ok: false,
+      errno: 28, // ENOSPC
+      code: "ENOSPC",
+      syscall: "listen",
+      message: expect.any(String),
+    });
     expect(exitCode).toBe(0);
   },
 );
@@ -175,6 +170,7 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
     stdin: "pipe",
   });
 
+  const stderrPromise = proc.stderr.text();
   const reader = proc.stdout.getReader();
   const decoder = new TextDecoder();
   let buffered = "";
@@ -196,11 +192,8 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
   expect(portLine).toMatch(/^PORT \d+$/);
   const port = Number(portLine!.slice("PORT ".length));
 
-  // Connect from the test process (no shim here). With the fix the server
-  // closes the accepted fd immediately because epoll_ctl failed, so the
-  // client observes close/end. Without the fix the server dispatches
-  // open() and leaves the socket parked forever; this await never resolves
-  // and the test fails on Bun's default per-test timeout.
+  // The shim is only in the child; this client must see the server close
+  // the accepted fd (epoll_ctl failed) instead of leaving it parked.
   const closed = await new Promise<string>(resolve => {
     const sock = net.connect({ host: "127.0.0.1", port }, () => {
       sock.write("ping");
@@ -210,12 +203,18 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
   });
   expect(["close", "error:ECONNRESET"]).toContain(closed);
 
-  // The server must not have reached open() for the dead connection.
   proc.stdin.write("done\n");
   proc.stdin.end();
-  const stderr = await proc.stderr.text();
-  let rest = "";
-  for (let line; (line = await readLine()) !== null; ) rest += line + "\n";
-  expect({ stderr, rest }).toEqual({ stderr: "", rest: "" });
-  expect(await proc.exited).toBe(0);
+  const [stderr, rest, exitCode] = await Promise.all([
+    stderrPromise,
+    (async () => {
+      let out = "";
+      for (let line; (line = await readLine()) !== null; ) out += line + "\n";
+      return out;
+    })(),
+    proc.exited,
+  ]);
+  // open() must not have fired (no "OPEN" line after PORT).
+  expect({ stderr, rest }).toEqual({ stderr: expect.any(String), rest: "" });
+  expect(exitCode).toBe(0);
 });

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -88,6 +88,41 @@ console.log("PORT " + server.port);
 process.stdin.once("data", () => { server.stop(true); process.exit(0); });
 `;
 
+// Listener passes; the outbound fetch() connect socket's ADD fails and the
+// promise must reject instead of pending forever.
+const FETCH_FIXTURE = /* js */ `
+const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+try {
+  const res = await fetch(\`http://127.0.0.1:\${server.port}/\`);
+  console.log(JSON.stringify({ settled: "resolved", status: res.status }));
+} catch (e) {
+  console.log(JSON.stringify({ settled: "rejected", code: e?.code, name: e?.name, message: String(e?.message ?? e) }));
+} finally {
+  server.stop(true);
+}
+`;
+
+// Same for Bun.connect: the outbound socket's ADD fails and the promise must
+// reject instead of pending forever.
+const CONNECT_FIXTURE = /* js */ `
+const server = Bun.listen({
+  port: 0, hostname: "127.0.0.1",
+  socket: { open(s) { s.end(); }, data() {}, close() {}, error() {} },
+});
+try {
+  const sock = await Bun.connect({
+    port: server.port, hostname: "127.0.0.1",
+    socket: { open() {}, data() {}, close() {}, error() {} },
+  });
+  console.log(JSON.stringify({ settled: "resolved" }));
+  sock.end();
+} catch (e) {
+  console.log(JSON.stringify({ settled: "rejected", code: e?.code, errno: e?.errno, message: String(e?.message ?? e) }));
+} finally {
+  server.stop(true);
+}
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -98,6 +133,8 @@ beforeAll(async () => {
     "serve.js": SERVE_FIXTURE,
     "listen.js": LISTEN_FIXTURE,
     "accept.js": ACCEPT_FIXTURE,
+    "fetch.js": FETCH_FIXTURE,
+    "connect.js": CONNECT_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -223,3 +260,28 @@ test.skipIf(!isLinux || !cc)("accepted connection is closed when epoll_ctl(EPOLL
   expect({ stderr, rest }).toEqual({ stderr: expect.any(String), rest: "" });
   expect(exitCode).toBe(0);
 });
+
+test.skipIf(!isLinux || !cc)(
+  "fetch() rejects when epoll_ctl(EPOLL_CTL_ADD) for the connect socket fails",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("fetch.js", "accepted");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    const result = JSON.parse(line);
+    expect(result.settled).toBe("rejected");
+    expect(result.code).toBe("FailedToOpenSocket");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "Bun.connect rejects when epoll_ctl(EPOLL_CTL_ADD) for the connect socket fails",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("connect.js", "accepted");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect({ stderr, line }).toEqual({ stderr: expect.any(String), line: expect.stringContaining("{") });
+    const result = JSON.parse(line);
+    expect(result.settled).toBe("rejected");
+    expect(exitCode).toBe(0);
+  },
+);

--- a/test/js/bun/http/serve-epoll-add-fail.test.ts
+++ b/test/js/bun/http/serve-epoll-add-fail.test.ts
@@ -1,0 +1,227 @@
+// epoll_ctl(EPOLL_CTL_ADD) for a listen socket can fail with ENOSPC when
+// fs.epoll.max_user_watches is exhausted. uSockets used to discard the
+// epoll_ctl return code, so Bun.serve() returned a healthy-looking server
+// whose listener was never registered with the event loop: the kernel kept
+// completing TCP handshakes into the backlog while no request was ever
+// answered. This test injects that ENOSPC via an LD_PRELOAD shim and asserts
+// Bun.serve / Bun.listen now throw instead of silently going deaf.
+import { test, expect, beforeAll } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+import net from "node:net";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+
+// The shim makes epoll_ctl(ADD) fail with ENOSPC for either listening sockets
+// (SO_ACCEPTCONN == 1) or connected TCP sockets (SO_TYPE == SOCK_STREAM &&
+// SO_ACCEPTCONN == 0), selected by the FAIL_EPOLL_ADD env var. Non-socket fds
+// (timerfd, eventfd) always pass through so the event loop can start.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+
+static int (*real_epoll_ctl)(int, int, int, struct epoll_event *);
+static int mode = -1; // 0 = listener, 1 = accepted
+
+int epoll_ctl(int epfd, int op, int fd, struct epoll_event *event) {
+    if (!real_epoll_ctl) {
+        real_epoll_ctl = (int (*)(int, int, int, struct epoll_event *)) dlsym(RTLD_NEXT, "epoll_ctl");
+        const char *m = getenv("FAIL_EPOLL_ADD");
+        mode = (m && strcmp(m, "accepted") == 0) ? 1 : 0;
+    }
+    if (op == EPOLL_CTL_ADD) {
+        int acceptconn = 0, type = 0;
+        socklen_t len = sizeof(int);
+        if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &type, &len) == 0) {
+            len = sizeof(int);
+            getsockopt(fd, SOL_SOCKET, SO_ACCEPTCONN, &acceptconn, &len);
+            int is_stream = (type == SOCK_STREAM);
+            if ((mode == 0 && is_stream && acceptconn) ||
+                (mode == 1 && is_stream && !acceptconn)) {
+                errno = ENOSPC;
+                return -1;
+            }
+        }
+    }
+    return real_epoll_ctl(epfd, op, fd, event);
+}
+`;
+
+const SERVE_FIXTURE = /* js */ `
+try {
+  const server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("ok") });
+  console.log(JSON.stringify({ ok: true, port: server.port }));
+  server.stop(true);
+} catch (e) {
+  console.log(JSON.stringify({ ok: false, code: e?.code, syscall: e?.syscall, message: String(e?.message ?? e) }));
+}
+`;
+
+const LISTEN_FIXTURE = /* js */ `
+try {
+  const server = Bun.listen({
+    port: 0,
+    hostname: "127.0.0.1",
+    socket: { data() {}, open() {}, close() {}, error() {} },
+  });
+  console.log(JSON.stringify({ ok: true, port: server.port }));
+  server.stop(true);
+} catch (e) {
+  console.log(JSON.stringify({ ok: false, code: e?.code, errno: e?.errno, syscall: e?.syscall, message: String(e?.message ?? e) }));
+}
+`;
+
+// For the accepted-socket case: the listener registers fine, but every
+// accepted connection's EPOLL_CTL_ADD fails. The server prints its port,
+// then "OPEN" for each socket that reaches the open() handler. With the fix
+// the fd is closed before open() is dispatched, so the client sees the
+// connection close and the server never prints "OPEN".
+const ACCEPT_FIXTURE = /* js */ `
+const server = Bun.listen({
+  port: 0,
+  hostname: "127.0.0.1",
+  socket: {
+    open() { console.log("OPEN"); },
+    data() {},
+    close() {},
+    error() {},
+  },
+});
+console.log("PORT " + server.port);
+process.stdin.once("data", () => { server.stop(true); process.exit(0); });
+`;
+
+let shimPath: string;
+let dir: ReturnType<typeof tempDir>;
+
+beforeAll(async () => {
+  if (!isLinux || !cc) return;
+  dir = tempDir("epoll-add-fail", {
+    "shim.c": SHIM_C,
+    "serve.js": SERVE_FIXTURE,
+    "listen.js": LISTEN_FIXTURE,
+    "accept.js": ACCEPT_FIXTURE,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+async function runWithShim(script: string, mode: "listener" | "accepted" = "listener") {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), script],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: mode },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+test.skipIf(!isLinux || !cc)(
+  "Bun.serve throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("serve.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect(line).not.toBe("");
+    const result = JSON.parse(line);
+    // Before the fix: { ok: true, port: <n> } and the server is a zombie.
+    expect({ stderr, result }).toEqual({
+      stderr: "",
+      result: {
+        ok: false,
+        code: "ENOSPC",
+        syscall: "listen",
+        message: expect.stringContaining("ENOSPC"),
+      },
+    });
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "Bun.listen throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails",
+  async () => {
+    const { stdout, stderr, exitCode } = await runWithShim("listen.js");
+    const line = stdout.trim().split("\n").pop() ?? "";
+    expect(line).not.toBe("");
+    const result = JSON.parse(line);
+    expect({ stderr, ok: result.ok }).toEqual({ stderr: "", ok: false });
+    expect(result.errno).toBe(28); // ENOSPC
+    expect(result.code).toBe("ENOSPC");
+    expect(result.syscall).toBe("listen");
+    expect(exitCode).toBe(0);
+  },
+);
+
+test.skipIf(!isLinux || !cc)(
+  "accepted connection is closed when epoll_ctl(EPOLL_CTL_ADD) fails for it",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "accept.js"],
+      cwd: String(dir),
+      env: { ...bunEnv, LD_PRELOAD: shimPath, FAIL_EPOLL_ADD: "accepted" },
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "pipe",
+    });
+
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    let buffered = "";
+    async function readLine(): Promise<string | null> {
+      for (;;) {
+        const i = buffered.indexOf("\n");
+        if (i >= 0) {
+          const line = buffered.slice(0, i);
+          buffered = buffered.slice(i + 1);
+          return line;
+        }
+        const { value, done } = await reader.read();
+        if (done) return buffered.length ? buffered : null;
+        buffered += decoder.decode(value, { stream: true });
+      }
+    }
+
+    const portLine = await readLine();
+    expect(portLine).toMatch(/^PORT \d+$/);
+    const port = Number(portLine!.slice("PORT ".length));
+
+    // Connect from the test process (no shim here). With the fix the server
+    // closes the accepted fd immediately because epoll_ctl failed, so the
+    // client observes close/end. Without the fix the server dispatches
+    // open() and leaves the socket parked forever; this await never resolves
+    // and the test fails on Bun's default per-test timeout.
+    const closed = await new Promise<string>(resolve => {
+      const sock = net.connect({ host: "127.0.0.1", port }, () => {
+        sock.write("ping");
+      });
+      sock.on("error", err => resolve("error:" + (err as NodeJS.ErrnoException).code));
+      sock.on("close", () => resolve("close"));
+    });
+    expect(["close", "error:ECONNRESET"]).toContain(closed);
+
+    // The server must not have reached open() for the dead connection.
+    proc.stdin.write("done\n");
+    proc.stdin.end();
+    const stderr = await proc.stderr.text();
+    let rest = "";
+    for (let line; (line = await readLine()) !== null; ) rest += line + "\n";
+    expect({ stderr, rest }).toEqual({ stderr: "", rest: "" });
+    expect(await proc.exited).toBe(0);
+  },
+);


### PR DESCRIPTION
## Repro

With an `LD_PRELOAD` shim that makes `epoll_ctl(EPOLL_CTL_ADD)` return `ENOSPC` for the listen socket (what the real kernel does when `fs.epoll.max_user_watches` is exhausted):

```
Bun.serve returned ok, port 41949        <- no error thrown
TCP handshake COMPLETED (kernel backlog)  <- connect()-based health checks pass
fetch -> TimeoutError                     <- forever, for every client
```

`Bun.serve()` returns a healthy-looking server object; the kernel keeps completing handshakes into the listen backlog; the event loop never hears about the listener. No exception, no `error` callback, nothing on stderr. Accepted and connecting sockets have the same failure mode.

## Cause

`us_poll_start()` in `packages/bun-usockets/src/eventing/epoll_kqueue.c` discards the `epoll_ctl` return code. `us_poll_start_rc()` exists but only `us_socket_from_fd` uses it; `us_socket_group_listen`, `us_socket_group_listen_unix`, the accept loop in `loop.c`, and all three connect paths (`us_socket_group_connect_resolved_dns`, `us_socket_group_connect_unix`, `start_connections`) call the void variant and carry on as if registration succeeded.

## Fix

Check `us_poll_start_rc()` at every listen/accept/connect site:

- `us_socket_group_listen` / `_listen_unix`: close the fd, free the poll, write the saved errno to `*error` and restore thread-local `errno`, return `NULL`. Both `Bun.listen` (which reads the out-param) and `Bun.serve` (which reads `errno` in `on_listen_failed`) now throw.
- accept loop in `loop.c`: close the accepted fd so the peer sees RST/FIN instead of a connection that never answers; free the poll; continue draining the backlog.
- connect paths: close the fd, free the poll, return `NULL` / `continue`. Callers already handle `NULL` as a connect failure.
- `libuv.c` gains a `us_poll_start_rc` that returns `0` so Windows links; no behaviour change there.
- `on_listen_failed` (TCP) now surfaces the real errno when it is neither `SUCCESS` nor `EADDRINUSE`, instead of hardcoding `EADDRINUSE` for everything that is not `EACCES`. `ENOSPC` now shows up as `ENOSPC`. (#30364 plumbs the errno through the callback signature properly; this change is the minimal version that works for the new `epoll_ctl` failure path and will resolve cleanly against that PR.)

## Verification

```
USE_SYSTEM_BUN=1 bun test test/js/bun/http/serve-epoll-add-fail.test.ts
  (fail) Bun.serve throws ...   -> received { ok: true, port: 33517 }
  (fail) Bun.listen throws ...  -> received { ok: true }
  (fail) accepted connection is closed ... -> timed out after 5000ms

bun bd test test/js/bun/http/serve-epoll-add-fail.test.ts
  (pass) Bun.serve throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails
  (pass) Bun.listen throws when epoll_ctl(EPOLL_CTL_ADD) for the listen socket fails
  (pass) accepted connection is closed when epoll_ctl(EPOLL_CTL_ADD) fails for it
  3 pass, 0 fail
```

The test compiles a tiny `LD_PRELOAD` shim that fails `epoll_ctl(EPOLL_CTL_ADD)` with `ENOSPC` for either listening sockets (`SO_ACCEPTCONN == 1`) or connected TCP sockets, selected via an env var; timerfd/eventfd pass through so the event loop itself starts. Linux-only.

Found by the `bun-sys-fuzz` syscall-level fault injector (`listener.epoll_add.0:E28`).