### PR TITLE
fetch: hold FetchTasklet mutex through deref_from_thread so HTTP thread is never the final deref

### DIFF
--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2190,8 +2190,10 @@ impl FetchTasklet {
         let task_ref = Self::from_raw_mut(task);
 
         task_ref.mutex.lock();
-        // we need to unlock before task.deref();
-        // explicit unlock + deref at end instead of nested defers.
+        // The mutex stays held through deref_from_thread at every exit so the
+        // HTTP-side deref is never the 1→0 transition (on_progress_update
+        // needs this mutex to release the JS-side initial ref).
+        //
         // Sync HTTP-thread state back into the JS-side instance via an
         // explicit field-subset copy (`AsyncHTTP` is not `Copy`:
         // `HTTPClient: Drop`, owned Vecs); see `AsyncHTTP::sync_progress_from`

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -409,10 +409,9 @@ impl FetchTasklet {
             unsafe { FetchTasklet::dealloc_for_shutdown(this) };
             return;
         }
-        // this is really unlikely to happen, but can happen
-        // lets make sure that we always call deinit from main thread
-        // `from_callback` heap-allocates a fresh `ConcurrentTaskItem`; the queue
-        // takes ownership of it.
+        // Defensive fallback for release builds; unreachable per the
+        // is_shutting_down() assert above. Bounce deinit to the JS thread
+        // via a fresh heap `ConcurrentTaskItem` that the queue owns.
         Self::enqueue_concurrent(
             self_.javascript_vm,
             ConcurrentTask::from_callback(this, FetchTasklet::deinit_callback),

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -391,7 +391,15 @@ impl FetchTasklet {
         if !unsafe { bun_ptr::ThreadSafeRefCount::<Self>::release(this) } {
             return;
         }
+        // The 1→0 transition should only be reachable at shutdown. The
+        // `callback` paths that call this hold the tasklet mutex, which
+        // blocks on_progress_update from releasing the JS-side initial ref,
+        // so at least one other ref is always live there.
         let self_ = Self::from_raw_ref(this);
+        debug_assert!(
+            self_.javascript_vm.is_shutting_down(),
+            "FetchTasklet::deref_from_thread reached 1->0 outside shutdown",
+        );
         if self_.javascript_vm.is_shutting_down() {
             // SAFETY: last ref; exclusive access. `deinit()` would run
             // `clear_data()` + `Drop` for the JSC `Strong`/`Weak` fields, which
@@ -2261,11 +2269,8 @@ impl FetchTasklet {
             }
             if success && task_ref.result.has_more {
                 // we are ignoring the body so we should not receive more data, so will only signal when result.has_more = true
+                // `has_more` is true here so `is_done` is always false; unlock only.
                 task_ref.mutex.unlock();
-                if is_done {
-                    // SAFETY: `task` is the live heap tasklet; HTTP-thread ref held.
-                    FetchTasklet::deref_from_thread(task);
-                }
                 return;
             }
         } else {
@@ -2287,11 +2292,16 @@ impl FetchTasklet {
             Ordering::Relaxed,
         ) {
             if has_schedule_callback {
-                task_ref.mutex.unlock();
+                // Deref while still holding the mutex. on_progress_update
+                // (the only releaser of the JS-side initial ref) needs this
+                // mutex, so the initial ref is still held here and this
+                // deref is never the 1→0 transition.
                 if is_done {
                     // SAFETY: `task` is the live heap tasklet; HTTP-thread ref held.
                     FetchTasklet::deref_from_thread(task);
                 }
+                // SAFETY: `task` is still live (initial ref still held).
+                Self::from_raw_ref(task).mutex.unlock();
                 return;
             }
         }
@@ -2337,13 +2347,17 @@ impl FetchTasklet {
         // queue takes ownership of its `next` link.
         Self::enqueue_concurrent(task_ref.javascript_vm, ct);
 
-        task_ref.mutex.unlock();
-        // we are done with the http client so we can deref our side
-        // this is a atomic operation and will enqueue a task to deinit on the main thread
+        // Deref while still holding the mutex. on_progress_update (the only
+        // releaser of the JS-side initial ref) needs this mutex, so the
+        // initial ref is still held here and this deref is never the 1→0
+        // transition — deref_from_thread therefore never schedules
+        // deinit_callback from this path.
         if is_done {
             // SAFETY: `task` is the live heap tasklet; HTTP-thread ref held.
             FetchTasklet::deref_from_thread(task);
         }
+        // SAFETY: `task` is still live (initial ref still held).
+        Self::from_raw_ref(task).mutex.unlock();
     }
 }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -2189,9 +2189,12 @@ impl FetchTasklet {
         let task_ref = Self::from_raw_mut(task);
 
         task_ref.mutex.lock();
-        // The mutex stays held through deref_from_thread at every exit so the
-        // HTTP-side deref is never the 1→0 transition (on_progress_update
-        // needs this mutex to release the JS-side initial ref).
+        // The mutex stays held through deref_from_thread at every
+        // non-shutdown exit so the HTTP-side deref is never the 1→0
+        // transition there (on_progress_update needs this mutex to release
+        // the JS-side initial ref). The is_shutting_down branch below
+        // unlocks first and intentionally takes the 1→0 →
+        // dealloc_for_shutdown path.
         //
         // Sync HTTP-thread state back into the JS-side instance via an
         // explicit field-subset copy (`AsyncHTTP` is not `Copy`:

--- a/test/js/web/fetch/fetch-tasklet-deref-race-fixture.ts
+++ b/test/js/web/fetch/fetch-tasklet-deref-race-fixture.ts
@@ -22,28 +22,38 @@ using server = Bun.serve({
 
 const url = server.url.href;
 
-async function one() {
+let completed = 0;
+
+async function one(shouldAbort: boolean) {
   // A mix of straight fetches and aborted fetches: the abort path feeds
   // schedule_shutdown to the HTTP thread which is where the final callback
   // with has_more=false (the is_done deref) originates, and the completion
   // path exercises the normal enqueue-then-deref order.
   const controller = new AbortController();
-  const abort = Math.random() < 0.5;
-  if (abort) queueMicrotask(() => controller.abort());
+  if (shouldAbort) queueMicrotask(() => controller.abort());
   try {
     const res = await fetch(url, { signal: controller.signal });
     await res.arrayBuffer();
-  } catch {}
+    if (!shouldAbort) completed++;
+  } catch (error) {
+    if (!shouldAbort) throw error;
+  }
 }
 
 let done = 0;
 async function worker() {
-  while (done++ < iterations) {
-    await one();
+  while (true) {
+    const i = done++;
+    if (i >= iterations) break;
+    await one((i & 1) === 0);
   }
 }
 
 await Promise.all(Array.from({ length: concurrency }, worker));
+
+if (completed === 0) {
+  throw new Error("fixture never completed a non-aborted fetch");
+}
 
 // Force a collection so any queued deinit_callback tasks have a chance to
 // run against memory that has been recycled.

--- a/test/js/web/fetch/fetch-tasklet-deref-race-fixture.ts
+++ b/test/js/web/fetch/fetch-tasklet-deref-race-fixture.ts
@@ -1,0 +1,54 @@
+// Stress test for the FetchTasklet HTTP-thread deref ordering race.
+//
+// The HTTP thread's result callback used to release the tasklet mutex before
+// calling deref_from_thread. In the gap, the JS thread could run
+// on_progress_update (which needs the mutex) and drop the JS-side ref first,
+// so the HTTP-side deref became the 1->0 transition and enqueued a
+// deinit_callback task. By the time that task ran the refcount could be
+// nonzero (or the memory reused), tripping the assert_no_refs panic.
+//
+// The window is a handful of instructions, so this fixture runs many
+// iterations under contention to give it a chance to fire.
+
+const iterations = Number(process.env.ITERATIONS ?? "2000");
+const concurrency = Number(process.env.CONCURRENCY ?? "64");
+
+using server = Bun.serve({
+  port: 0,
+  fetch() {
+    return new Response("x");
+  },
+});
+
+const url = server.url.href;
+
+async function one() {
+  // A mix of straight fetches and aborted fetches: the abort path feeds
+  // schedule_shutdown to the HTTP thread which is where the final callback
+  // with has_more=false (the is_done deref) originates, and the completion
+  // path exercises the normal enqueue-then-deref order.
+  const controller = new AbortController();
+  const abort = Math.random() < 0.5;
+  if (abort) queueMicrotask(() => controller.abort());
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    await res.arrayBuffer();
+  } catch {}
+}
+
+let done = 0;
+async function worker() {
+  while (done++ < iterations) {
+    await one();
+  }
+}
+
+await Promise.all(Array.from({ length: concurrency }, worker));
+
+// Force a collection so any queued deinit_callback tasks have a chance to
+// run against memory that has been recycled.
+Bun.gc(true);
+await Bun.sleep(0);
+Bun.gc(true);
+
+console.log("ok");

--- a/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
+++ b/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
@@ -22,11 +22,7 @@ test("FetchTasklet HTTP-thread deref is never the final ref", async () => {
     stderr: "pipe",
   });
 
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   // Include stderr in the failure message for diagnostics without asserting
   // it is exactly empty (debug/ASAN builds may emit benign warnings).

--- a/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
+++ b/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// The HTTP thread's result callback must hold the tasklet mutex through its
+// deref_from_thread call so it is never the 1->0 transition. When it was
+// not, the deref could schedule a deinit_callback task that later observed
+// a nonzero refcount and panicked with
+// "assertion failed: self.raw_count.load(Ordering::SeqCst) == 0".
+//
+// The race window is a handful of instructions between mutex.unlock() and
+// deref_from_thread() on the HTTP thread, so this test is best-effort: it
+// exercises many concurrent fetch + abort cycles under load and asserts
+// the process completes. It does not deterministically reproduce the crash
+// on an unfixed build; a debug_assert in deref_from_thread documents the
+// invariant the mutex ordering enforces.
+test("FetchTasklet HTTP-thread deref is never the final ref", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), path.join(import.meta.dir, "fetch-tasklet-deref-race-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  // Include stderr in the failure message for diagnostics without asserting
+  // it is exactly empty (debug/ASAN builds may emit benign warnings).
+  expect({ stdout: stdout.trim(), exitCode, stderr }).toMatchObject({
+    stdout: "ok",
+    exitCode: 0,
+  });
+});

--- a/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
+++ b/test/js/web/fetch/fetch-tasklet-deref-race.test.ts
@@ -30,4 +30,4 @@ test("FetchTasklet HTTP-thread deref is never the final ref", async () => {
     stdout: "ok",
     exitCode: 0,
   });
-});
+}, 30_000);


### PR DESCRIPTION
### Crash

```
Panic: assertion failed: self.raw_count.load(Ordering::SeqCst) == 0   (macOS arm64, bun 1.4.0)
assert_no_refs<FetchTasklet>          src/ptr/ref_count.rs:603
<FetchTasklet>::deinit                src/runtime/webcore/fetch/FetchTasklet.rs:499
<FetchTasklet>::deinit_callback       src/runtime/webcore/fetch/FetchTasklet.rs:418
<ManagedTask>::run                    src/event_loop/ManagedTask.rs:33
bun_runtime::dispatch::run_task       src/runtime/dispatch.rs:264
tick_queue_with_count                 src/runtime/dispatch.rs:615
<EventLoop>::tick                     src/jsc/event_loop.rs:688
<Run>::start                          src/runtime/cli/run_command.rs:1582
```

`deinit_callback` is a `ManagedTask` enqueued by `deref_from_thread` on the HTTP thread when `release()` observes the 1→0 transition. By the time the JS thread runs it, the refcount is nonzero, so the `assert_no_refs` in `deinit` fires.

### Cause

`FetchTasklet::callback` runs on the HTTP thread and ends with

```rust
Self::enqueue_concurrent(vm, ct);   // enqueue on_progress_update
task_ref.mutex.unlock();
if is_done {
    FetchTasklet::deref_from_thread(task);
}
```

Between `mutex.unlock()` and `deref_from_thread()`, the JS thread can:

1. acquire the mutex (it was parked in `on_progress_update` at `self.mutex.lock()`),
2. run `on_progress_update` to completion with `is_done = true`,
3. reach `cleanup` which drops the JS-side initial ref (`FetchTasklet::deref(this)` → N→1).

The HTTP thread then resumes at `deref_from_thread` → 1→0, and since the VM is not shutting down it enqueues `deinit_callback`. That task is the only path to `deinit` that is not synchronous with the 1→0 transition, so anything that touches the refcount (or the allocation) before it runs trips the assert instead of being blocked by a live ref.

The CAS-fail early return has the same `unlock → deref_from_thread` ordering. The `ignore_data` early return had an `if is_done { deref_from_thread }` that is unreachable (it is inside `if has_more { .. }`).

### Fix

Move `deref_from_thread` before the unlock in both reachable paths. `on_progress_update` is the only releaser of the initial ref, and it needs the mutex, so while the HTTP thread holds the mutex the initial ref is guaranteed live and the HTTP-side deref is never the 1→0 transition. `release()` therefore always returns false from `callback`, and `deinit_callback` is never scheduled from this path. The only remaining 1→0 callers of `deref_from_thread` are the shutdown paths (`callback`'s `is_shutting_down` branch and `release_at_shutdown`), which route through `dealloc_for_shutdown` rather than `deinit_callback`.

A `debug_assert!(is_shutting_down())` in `deref_from_thread` after a 1→0 transition documents the invariant. The dead `ignore_data` deref is dropped.

After the deref, `task` is still live (the initial ref is still held), so the subsequent unlock is safe.

### Verification

`test/js/web/fetch/fetch-tasklet-deref-race.test.ts` runs a subprocess fixture with 2000 concurrent fetch/abort cycles against a local server. On the fixed debug+ASAN build: passes in ~4s, 5/5 runs, and the new `debug_assert` never fires.

Existing `fetch.test.ts`, `fetch-leak.test.ts`, `fetch-abort-stream-body.test.ts`, `fetch-abort-queued.test.ts`, `abort-signal-leak.test.ts` on the fixed debug build have identical pass/fail counts to an unfixed baseline build in the same container (the failures are pre-existing debug-timeout and RSS-threshold issues).

**Note on fail-before:** the race window is the handful of instructions between `mutex.unlock()` and `deref_from_thread()`. The JS thread has to acquire the mutex, run all of `on_progress_update`, and reach its final `deref` in that gap. A 10× run of the fixture at 5000 iterations against the unfixed release build did not hit the panic once; the same conclusion was reached in #29453 (Zig-era, ~500 attempts). The gate's fail-before check will not be satisfiable without instrumentation in `src/`. The fix is correct by construction: with the mutex held through `deref_from_thread`, the HTTP thread categorically cannot observe `count == 1`.

### Related

- #29453 is the Zig-era PR for the same ordering change; it never merged and now conflicts post-Rust-port. This PR is the Rust-port equivalent.
- #32704 guards the sibling `Option::unwrap() on None` crash at `task_ref.http.as_mut().unwrap()` in the same callback, which is the UAF side of this lifecycle race (tasklet already freed when a stale `callback` runs). That change and this one do not conflict.
- #32071 closes the cross-thread VM-lifetime hole for the worker-termination class of the same UAF.