### PR TITLE
patch: remove bogus debug_assert in parse_diff_hashes

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -1531,8 +1531,7 @@ fn parse_hunk_header_line<'a>(line_: &'a [u8]) -> Result<Hunk<'a>, ParseErr> {
 fn parse_diff_hashes(line: &[u8]) -> Option<(&[u8], &[u8])> {
     // index 2de83dd..842652c 100644
     //       ^
-    //       we expect that we are here
-    debug_assert!(!line.starts_with(b"index "));
+    //       the caller has already stripped the leading "index "
 
     // From @pnpm/patch-package the regex is this:
     // const match = line.match(/(\w+)\.\.(\w+)/)

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -893,6 +893,14 @@ describe("parse", () => {
     });
   });
 
+  // After stripping the "index " prefix the remainder can itself start with "index ",
+  // which used to trip a bogus debug assertion in parse_diff_hashes.
+  test("does not crash when an index line repeats the 'index ' prefix", () => {
+    for (const line of ["index index ", "index index \n", "index index 2de83dd..842652c 100644\n"]) {
+      expect(removeCapacity(JSON.parse(parse(line)))).toEqual({ parts: { items: [] } });
+    }
+  });
+
   // A `---`/`+++` header line can be shorter than "--- a/"/"+++ b/" (no path after the marker).
   // This used to crash the parser with an out-of-bounds slice.
   test("does not crash on truncated ---/+++ header lines", () => {


### PR DESCRIPTION
Fuzzer-found panic in the patch parser on debug/ASAN builds.

## Repro

```
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").patchInternals.parse("index index ")'
```

```
panic: assertion failed: !line.starts_with(b"index ")
```

## Cause

`parse_diff_hashes` is called with the remainder of an `index ...` header line after the caller strips the leading `"index "`. It carried a `debug_assert!(!line.starts_with(b"index "))` intended to document that the prefix was already stripped, but that check is not a real invariant: an input line of `"index index ..."` leaves `"index ..."` after stripping, which legitimately starts with `"index "` again. The function already handles arbitrary remainders by returning `None` when the `a..b` pattern is not found.

## Fix

Remove the assertion; keep the comment documenting the calling convention.

## Verification

Added a regression test in `test/js/bun/patch/patch.test.ts` covering the fuzzer input and two variants. Without the fix the test process crashes on the debug assertion; with the fix all 26 tests in the file pass.