### PR TITLE
paths: keep PathName base in sync while stripping trailing separators

### DIFF
--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -752,6 +752,7 @@ pub mod fs {
 
                 // Ignore trailing slashes
                 path = &path[0..i];
+                base = path;
             }
 
             // Strip off the extension

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2205,9 +2205,6 @@ console.log(<div {...obj} key="after" />);`),
     });
 
     it("import with separator-only or trailing-separator path", () => {
-      // PathName::init used to leave the full input in `base` when the path was
-      // entirely separators (or had only trailing separators after the basename),
-      // tripping a debug assertion when deriving the namespace symbol name.
       expectPrinted_(`import "/"`, `import"/"`);
       expectPrinted_(`import "//"`, `import"//"`);
       expectPrinted_(`import "///"`, `import"///"`);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2204,6 +2204,20 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`import { name } from '".ts';`, `import { name } from '".ts'`);
     });
 
+    it("import with separator-only or trailing-separator path", () => {
+      // PathName::init used to leave the full input in `base` when the path was
+      // entirely separators (or had only trailing separators after the basename),
+      // tripping a debug assertion when deriving the namespace symbol name.
+      expectPrinted_(`import "/"`, `import"/"`);
+      expectPrinted_(`import "//"`, `import"//"`);
+      expectPrinted_(`import "///"`, `import"///"`);
+      expectPrinted_(`import "foo//"`, `import"foo//"`);
+      expectPrinted_(`import "foo///"`, `import"foo///"`);
+      expectPrinted_(`export * from "/"`, `export * from "/"`);
+      expectPrinted_(`export * from "foo//"`, `export * from "foo//"`);
+      expectPrinted_(`export { a } from "/"`, `export { a } from "/"`);
+    });
+
     it("string quote selection", () => {
       expectPrinted_(`console.log("\\n")`, "console.log(`\n`)");
       expectPrinted_(`console.log("\\"")`, `console.log('"')`);


### PR DESCRIPTION
## Repro

```sh
bun -e 'new Bun.Transpiler({loader:"ts"}).transformSync("import\"/\"")'
```

On any build with `debug_assertions` (debug, release-asan):

```
panic: assertion failed: !self.base.contains(&b'/')
```

The same assertion fires for `import "//"`, `import "foo//"`, `export * from "/"`, and any other import/export specifier that is entirely separators or has only trailing separators after the basename.

## Cause

`PathName::init` seeds `base` with the full input and then walks separators from the end. When the last separator is trailing, it shortens `path` but leaves `base` untouched, so when the loop exits without ever finding a non-trailing separator (the path was all slashes, or `foo///` etc.) `base` is still the original input. The one-shot trailing-separator strip afterwards removes at most one, leaving `b"/"` or `b"foo/"` in `base`.

The parser then calls `non_unique_name_string_base()` on the import specifier to derive a namespace symbol name, which asserts `!self.base.contains(&b'/')`.

## Fix

Keep `base` in sync with `path` each time a trailing separator is stripped. If the loop later finds a non-trailing separator it overwrites `base` with the real basename as before; if it doesn't, `base` ends up as the fully stripped slice (empty for `/`, `foo` for `foo///`).

## Verification

New test in `test/bundler/transpiler/transpiler.test.js` covers `import "/"`, `//`, `///`, `foo//`, `foo///`, `export * from "/"`, `export * from "foo//"`, and `export { a } from "/"`.

- Without the fix: `bun bd test test/bundler/transpiler/transpiler.test.js -t separator-only` panics with the assertion above.
- With the fix: the full file passes (168 pass, 1 skip, 21 todo, 0 fail).
- `cargo test -p bun_paths`: 12 pass.