### PR TITLE
js_printer: allow empty string as import/export clause alias

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2476,8 +2476,6 @@ pub mod __gated_printer {
         }
 
         pub fn print_clause_alias(&mut self, alias: &[u8]) {
-            debug_assert!(!alias.is_empty());
-
             if !strings::contains_non_bmp_code_point_or_is_invalid_identifier(alias) {
                 self.print_space_before_identifier();
                 self.print_identifier(alias);

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -2204,6 +2204,16 @@ console.log(<div {...obj} key="after" />);`),
       expectPrinted_(`import { name } from '".ts';`, `import { name } from '".ts'`);
     });
 
+    it("empty string as import/export clause alias", () => {
+      // ModuleExportName may be any well-formed string literal, including "".
+      expectPrinted_(`import { "" as z } from "m"; z`, `import { "" as z } from "m";\nz`);
+      expectPrinted_(`let z = 1; export { z as "" }`, `let z = 1;\n\nexport { z as "" }`);
+      expectPrinted_(`export { "" as z } from "m"`, `export { "" as z } from "m"`);
+      expectPrinted_(`export { z as "" } from "m"`, `export { z as "" } from "m"`);
+      expectPrinted_(`export { "" as "" } from "m"`, `export { "" } from "m"`);
+      expectPrinted_(`export * as "" from "m"`, `export * as "" from "m"`);
+    });
+
     it("string quote selection", () => {
       expectPrinted_(`console.log("\\n")`, "console.log(`\n`)");
       expectPrinted_(`console.log("\\"")`, `console.log('"')`);


### PR DESCRIPTION
Fuzzer-found panic (signature: `panic:assertion failed: !alias.is_empty()`).

## Repro

```
bun -e 'new Bun.Transpiler({loader:"js", target:"browser"}).transformSync("import{\"\"as z\n} from \"ry\"")'
```

On a build with debug assertions:

```
panic: assertion failed: !alias.is_empty()
Crashed while printing input.js
...
<bun_js_printer::__gated_printer::Printer<...>>::print_clause_alias
/workspace/bun/src/js_printer/lib.rs:2479:13
```

## Cause

`print_clause_alias` has `debug_assert!(!alias.is_empty())`, but ECMAScript allows ModuleExportName to be any well-formed string literal, including the empty string:

```js
import { "" as z } from "m";
export { z as "" };
export { "" as z } from "m";
export * as "" from "m";
```

All of these are valid JavaScript and accepted by the parser. The printer body already handles empty correctly: `contains_non_bmp_code_point_or_is_invalid_identifier` returns `true` for empty input, so the alias is printed as a quoted `""`. Only the assertion is wrong.

esbuild (the reference implementation) prints all of these without issue.

## Fix

Remove the bogus assertion.

The separate `debug_assert!(!item.export_alias.is_empty())` in `src/bundler/Chunk.rs` guards a bundler-synthesized name from the renamer, not user input, so it stays.

## Verification

New test in `test/bundler/transpiler/transpiler.test.js` covering all five import/export shapes that can carry an empty-string alias, plus `export { "" as "" }` (which collapses to `export { "" }`).

Without the fix, `bun bd test` crashes on the first `expectPrinted_` at the assertion (exit 132). With the fix, all six assertions pass and the full `transpiler.test.js` suite is green (168 pass, 0 fail).