### PR TITLE
parser: drop bogus no-clobber assert on enum ref_to_ts_namespace_member insert

### DIFF
--- a/src/js_parser/parse/parse_typescript.rs
+++ b/src/js_parser/parse/parse_typescript.rs
@@ -557,12 +557,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             name.ref_ = p.declare_symbol(SymbolKind::TsEnum, name_loc, name_text)?;
             let _ = p.push_scope_for_parse_pass(ScopeKind::Entry, loc)?;
             p.current_scope_mut().ts_namespace = Some(ts_namespace);
-            // debug-assert no prior entry.
-            let prev = p.ref_to_ts_namespace_member.insert(
+            // Overwrite allowed: on a forbidden redeclaration `declare_symbol` returns
+            // the existing ref for every colliding enum, so the key repeats; the value
+            // is the same map `get_or_create_exported_namespace_members` already reused.
+            p.ref_to_ts_namespace_member.insert(
                 name.ref_,
                 TSNamespaceMemberData::Namespace(exported_members),
             );
-            debug_assert!(prev.is_none());
         }
 
         p.lexer.expect(T::TOpenBrace)?;

--- a/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
+++ b/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
@@ -47,10 +47,10 @@ describe("enum redeclared after a non-mergeable symbol reports an error instead 
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
-      stdout: expect.stringMatching(/^OK \d+$/),
-      stderr: "",
-      exitCode: 0,
-    });
+    if (exitCode !== 0) {
+      expect(stderr).toBe("");
+    }
+    expect(stdout.trim()).toMatch(/^OK \d+$/);
+    expect(exitCode).toBe(0);
   });
 });

--- a/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
+++ b/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
@@ -1,14 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe } from "harness";
 
-// When an `enum` redeclares a name whose merge result is `Forbidden` (e.g. it
-// was already declared as a function/class/let/const), `declare_symbol`
-// returns the existing symbol's `Ref`. A second colliding `enum` therefore
-// returns the same `Ref` again, so the enum parser's insert into
-// `ref_to_ts_namespace_member` sees the key it inserted for the first enum.
-// That insert used to debug_assert the key was fresh, which turned a
-// user-facing "already declared" parse error into a panic in builds with
-// debug assertions enabled.
+// A forbidden redeclaration makes `declare_symbol` return the existing Ref for
+// every colliding enum, so `ref_to_ts_namespace_member` sees a repeat key.
+// https://github.com/oven-sh/bun/pull/32711
 describe("enum redeclared after a non-mergeable symbol reports an error instead of asserting", () => {
   const cases: [label: string, source: string][] = [
     ["function then enum x2", "function X() {}\nenum X {}\nenum X {}\n"],

--- a/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
+++ b/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// When an `enum` redeclares a name whose merge result is `Forbidden` (e.g. it
+// was already declared as a function/class/let/const), `declare_symbol`
+// returns the existing symbol's `Ref`. A second colliding `enum` therefore
+// returns the same `Ref` again, so the enum parser's insert into
+// `ref_to_ts_namespace_member` sees the key it inserted for the first enum.
+// That insert used to debug_assert the key was fresh, which turned a
+// user-facing "already declared" parse error into a panic in builds with
+// debug assertions enabled.
+describe("enum redeclared after a non-mergeable symbol reports an error instead of asserting", () => {
+  const cases: [label: string, source: string][] = [
+    ["function then enum x2", "function X() {}\nenum X {}\nenum X {}\n"],
+    ["class then enum x2", "class X {}\nenum X {}\nenum X {}\n"],
+    ["let then enum x2", "let X = 1;\nenum X {}\nenum X {}\n"],
+    ["const then enum x2", "const X = 1;\nenum X {}\nenum X {}\n"],
+    ["function then enum x3", "function X() {}\nenum X {}\nenum X {}\nenum X {}\n"],
+    ["fuzz repro (CRLF)", "function Reflect() {} // only)\r\nenum Reflect {} // collision\r\nenum Reflect {} // collision\r\n"],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_label, source) => {
+    const script = `
+      let threw;
+      try {
+        new Bun.Transpiler({ loader: "tsx", target: "node" }).transformSync(${JSON.stringify(source)});
+      } catch (e) {
+        threw = e;
+      }
+      if (!threw) throw new Error("expected a parse error");
+      const errors = threw.errors ?? [threw];
+      if (!errors.some(e => String(e.message).includes("has already been declared"))) {
+        throw new Error("expected 'already declared', got: " + errors.map(e => e.message).join(" | "));
+      }
+      console.log("OK " + errors.length);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: expect.stringMatching(/^OK \d+$/),
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});

--- a/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
+++ b/test/bundler/transpiler/ts-enum-redecl-panic.test.ts
@@ -16,7 +16,10 @@ describe("enum redeclared after a non-mergeable symbol reports an error instead 
     ["let then enum x2", "let X = 1;\nenum X {}\nenum X {}\n"],
     ["const then enum x2", "const X = 1;\nenum X {}\nenum X {}\n"],
     ["function then enum x3", "function X() {}\nenum X {}\nenum X {}\nenum X {}\n"],
-    ["fuzz repro (CRLF)", "function Reflect() {} // only)\r\nenum Reflect {} // collision\r\nenum Reflect {} // collision\r\n"],
+    [
+      "fuzz repro (CRLF)",
+      "function Reflect() {} // only)\r\nenum Reflect {} // collision\r\nenum Reflect {} // collision\r\n",
+    ],
   ];
 
   test.concurrent.each(cases)("%s", async (_label, source) => {


### PR DESCRIPTION
Fuzzer hit:

```
panic: assertion failed: prev.is_none()
  at parse_typescript_enum_stmt (src/js_parser/parse/parse_typescript.rs)
```

Repro:

```js
new Bun.Transpiler({ loader: "tsx" }).transformSync(
  "function X() {}\nenum X {}\nenum X {}\n"
);
```

### Cause

`declare_symbol(SymbolKind::TsEnum, ..., "X")` on a name that already has a non-mergeable declaration (function/class/let/const) returns `SymbolMergeResult::Forbidden`, which hands back the *existing* symbol's `Ref`. A second colliding `enum X` therefore gets the same `Ref` again, so when the enum parser inserts into `ref_to_ts_namespace_member` it sees the key it inserted for the first enum. The insert carried a `debug_assert!(prev.is_none())` (ported from the original Zig `putNoClobber`), so builds with debug assertions (debug, release-asan) panicked instead of reporting the "already declared" parse error.

### Fix

Drop the assert and use a plain overwriting insert. The overwrite is idempotent: `get_or_create_exported_namespace_members` already looked up `ref_to_ts_namespace_member[existing_ref]` and reused the same `exported_members` map, so the value being re-inserted is the same one already present. The sibling `namespace` path and the `arg_ref` insert in the same function already use a plain `.insert()` without the assert.

### Verification

New `test/bundler/transpiler/ts-enum-redecl-panic.test.ts` spawns the transpiler on function/class/let/const + repeated-enum variants and the original fuzzer input, and asserts the subprocess exits 0 with the caught `AggregateError` reporting "has already been declared". Without the fix the subprocess panics with `assertion failed: prev.is_none()` and the test fails.