### PR TITLE
ini: treat stripped-empty quoted values as empty string, not shared object

### DIFF
--- a/src/ini/lib.rs
+++ b/src/ini/lib.rs
@@ -567,6 +567,12 @@ mod draft {
                         };
                         offset += 1;
                     }
+                    // JSON.parse("") would throw; json::parse_utf8 returns the
+                    // shared EMPTY_OBJECT static, which a later [section] write
+                    // could then mutate. Fall through to the string path instead.
+                    if val.is_empty() {
+                        break 'out;
+                    }
                     // `bun_parsers::json::parse_utf8_impl` returns the T2
                     // value-subset `bun_ast::Expr`; lift it into the T4
                     // `bun_ast::Expr` (via the `From` impl in

--- a/src/install_jsc/ini_jsc.rs
+++ b/src/install_jsc/ini_jsc.rs
@@ -190,7 +190,9 @@ impl IniTestingAPIs {
     }
 
     pub fn parse(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
+        use bun_ast::ToJSError;
         use bun_ini::Parser;
+        use bun_jsc::JsError;
 
         let arguments_ = frame.arguments_old::<1>();
         let arguments = arguments_.slice();
@@ -217,6 +219,9 @@ impl IniTestingAPIs {
 
         match bun_js_parser_jsc::expr_to_js(&parser.out, global) {
             Ok(v) => Ok(v),
+            Err(ToJSError::OutOfMemory) => Err(JsError::OutOfMemory),
+            Err(ToJSError::JSError) => Err(JsError::Thrown),
+            Err(ToJSError::JSTerminated) => Err(JsError::Terminated),
             Err(e) => Err(global.throw_error(e.into(), "failed to turn AST into JS")),
         }
     }

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -417,6 +417,42 @@ isbar = 'lol'
     });
   });
 
+  describe("empty single-quoted value", () => {
+    // A lone `'` (or `''`) strips to an empty string. JSON-parsing that
+    // used to return the JSON parser's shared static EMPTY_OBJECT, which a
+    // later `[section]` would then write into (mutating a process global
+    // and, with the right input, storing the object into itself).
+
+    test.each([
+      ["a='", { a: "" }],
+      ["a=''", { a: "" }],
+      ["'=x", { "": "x" }],
+      ["''=x", { "": "x" }],
+      ["[']\nx=1", { "": { x: "1" } }],
+      ["['']\nx=1", { "": { x: "1" } }],
+    ])("%s", (ini, expected) => {
+      expect(parse(ini)).toEqual(expected);
+    });
+
+    test("section over empty-quote value does not mutate shared state", () => {
+      expect(parse("a=''\n[a]\nhello=world")).toEqual({ a: "" });
+      // Previously the first parse wrote `hello` into the static empty
+      // object, and it leaked (with arena-freed key bytes) into this one.
+      expect(parse("x=''")).toEqual({ x: "" });
+    });
+
+    test("fuzz repro ='\\n[]\\n=' does not create a self-referential object", () => {
+      expect(parse("='\n[]\n='")).toEqual({ "": "" });
+    });
+
+    test.each([
+      ["a='\n[a]\nb='", { a: "" }],
+      ["a=''\n[a]\nb=''", { a: "" }],
+    ])("no infinite recursion for %j", (ini, expected) => {
+      expect(parse(ini)).toEqual(expected);
+    });
+  });
+
   describe("duplicate properties", () => {
     test("decode with duplicate properties", () => {
       const ini = /* ini */ `

--- a/test/js/bun/ini/ini.test.ts
+++ b/test/js/bun/ini/ini.test.ts
@@ -418,11 +418,6 @@ isbar = 'lol'
   });
 
   describe("empty single-quoted value", () => {
-    // A lone `'` (or `''`) strips to an empty string. JSON-parsing that
-    // used to return the JSON parser's shared static EMPTY_OBJECT, which a
-    // later `[section]` would then write into (mutating a process global
-    // and, with the right input, storing the object into itself).
-
     test.each([
       ["a='", { a: "" }],
       ["a=''", { a: "" }],
@@ -436,8 +431,6 @@ isbar = 'lol'
 
     test("section over empty-quote value does not mutate shared state", () => {
       expect(parse("a=''\n[a]\nhello=world")).toEqual({ a: "" });
-      // Previously the first parse wrote `hello` into the static empty
-      // object, and it leaked (with arena-freed key bytes) into this one.
       expect(parse("x=''")).toEqual({ x: "" });
     });
 


### PR DESCRIPTION
Fuzzer found a debug-build panic in the ini parser:

```
BUN_FEATURE_FLAG_INTERNAL_FOR_TESTING=1 bun -e 'require("bun:internal-for-testing").iniInternals.parse(atob("PScKW10KPSc="))'
```

Input (8 bytes):
```ini
='
[]
='
```

Debug build: `panic: assertion failed: err != bun_core::err!("JSError")` in `JSGlobalObject::throw_error`.
Release build: `RangeError: Maximum call stack size exceeded`.

## Cause

A lone `'` (or `''`) satisfies `is_quoted` and strips to an empty string before being handed to `json::parse_utf8_impl`. That function special-cases zero-length input and returns a `StoreRef` pointing at the process-global `EMPTY_OBJECT` static rather than a fresh arena allocation.

The ini parser stores that ref as the value, and when a subsequent `[section]` header resolves to the same key it adopts that object as the mutable `head` for later `key=value` writes. Two things go wrong:

1. The static gets mutated. Arena-freed key bytes from one parse leak into every later use of `empty_object_data()` in the process:
   ```js
   parse("a=''\n[a]\nhello=world"); // {"a":{"hello":"world"}}
   parse("x=''");                   // {"x":{" \u0000���":"world"}}
   ```
2. When another empty-quote value appears under the section, the static is stored into itself. `expr_to_js` then recurses until its `StackCheck` throws, and `IniTestingAPIs::parse` re-wrapped that `ToJSError::JSError` via `throw_error`, tripping the `err != JSError` assertion.

## Fix

Skip the JSON parse when the stripped value is empty and fall through to the plain-string path. This matches npm/ini, where `JSON.parse("")` throws and the catch keeps the stripped `""`. Applies to all three `Usage` arms (value/key/section), so `'`, `''`, `'=x`, `[']` etc. now agree with the reference implementation.

Also propagate `ToJSError::{JSError, JSTerminated, OutOfMemory}` directly in `IniTestingAPIs::parse` instead of routing them through `throw_error`, matching the existing `JSONCObject` handling.

## Verification

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/ini/ini.test.ts -t 'empty single-quoted'
 0 pass, 10 fail   (RangeError + wrong-shape objects)

$ bun bd test test/js/bun/ini/ini.test.ts
 62 pass, 0 fail
```