### PR TITLE
transpiler: fix garbage output for decorated fields with non-ASCII string keys

### DIFF
--- a/src/js_parser/lower/lower_decorators.rs
+++ b/src/js_parser/lower/lower_decorators.rs
@@ -311,15 +311,20 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             );
         }
         if let js_ast::ExprData::EString(s) = &key_expr.data {
-            return self.new_expr(
-                E::Dot {
-                    target: target_expr,
-                    name: s.data,
-                    name_loc: key_expr.loc,
-                    ..Default::default()
-                },
-                key_expr.loc,
-            );
+            // `E::Dot.name` is a UTF-8 `Str`; a UTF-16 `EString.data` stores
+            // u16-count bytes that are garbage as UTF-8. Fall through to
+            // `E::Index` for UTF-16 keys so the printer emits `["…"]`.
+            if s.is_utf8() {
+                return self.new_expr(
+                    E::Dot {
+                        target: target_expr,
+                        name: s.data,
+                        name_loc: key_expr.loc,
+                        ..Default::default()
+                    },
+                    key_expr.loc,
+                );
+            }
         }
         self.new_expr(
             E::Index {
@@ -1534,7 +1539,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 if prop.kind == PropertyKind::AutoAccessor {
                     let accessor_name: &'a [u8] = 'brk: {
                         if let Some(k) = prop.key {
-                            if let js_ast::ExprData::EString(s) = &k.data {
+                            if let js_ast::ExprData::EString(s) = &k.data
+                                && s.is_utf8()
+                            {
                                 break 'brk p.bump_name2(b"_", &s.data);
                             }
                         }
@@ -1781,7 +1788,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             } else if k == 4 {
                 // Decorated public auto-accessor → WeakMap
                 let accessor_name: &'a [u8] = 'brk: {
-                    if let js_ast::ExprData::EString(s) = &key_expr.data {
+                    if let js_ast::ExprData::EString(s) = &key_expr.data
+                        && s.is_utf8()
+                    {
                         break 'brk p.bump_name2(b"_", &s.data);
                     }
                     let name = p.bump_name(b"_accessor_storage", Some(accessor_storage_counter));

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -6979,37 +6979,31 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             );
                         }
 
-                        if prop.flags.contains(Flags::Property::IsComputed)
-                            || matches!(
-                                prop.key.expect("infallible: prop has key").data,
-                                js_ast::ExprData::ENumber(_)
-                            )
-                        {
-                            target = self.new_expr(
+                        let key = prop.key.expect("infallible: prop has key");
+                        target = match &key.data {
+                            js_ast::ExprData::EString(s)
+                                if s.is_utf8()
+                                    && !prop.flags.contains(Flags::Property::IsComputed) =>
+                            {
+                                self.new_expr(
+                                    E::Dot {
+                                        target,
+                                        name: s.data,
+                                        name_loc: key.loc,
+                                        ..Default::default()
+                                    },
+                                    key.loc,
+                                )
+                            }
+                            _ => self.new_expr(
                                 E::Index {
                                     target,
-                                    index: prop.key.expect("infallible: prop has key"),
+                                    index: key,
                                     optional_chain: None,
                                 },
-                                prop.key.expect("infallible: prop has key").loc,
-                            );
-                        } else {
-                            target = self.new_expr(
-                                E::Dot {
-                                    target,
-                                    name: prop
-                                        .key
-                                        .expect("infallible: prop has key")
-                                        .data
-                                        .e_string()
-                                        .expect("infallible: variant checked")
-                                        .data,
-                                    name_loc: prop.key.expect("infallible: prop has key").loc,
-                                    ..Default::default()
-                                },
-                                prop.key.expect("infallible: prop has key").loc,
-                            );
-                        }
+                                key.loc,
+                            ),
+                        };
 
                         // remove fields with decorators from class body. Move static members outside of class.
                         if prop.flags.contains(Flags::Property::IsStatic) {

--- a/src/js_parser/visit/visit_expr.rs
+++ b/src/js_parser/visit/visit_expr.rs
@@ -1685,9 +1685,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                         .data
                         .e_string()
                         .expect("infallible: variant checked")
-                        .data
-                        == b"__proto__"
-                // __proto__ is utf8, assume it lives in refs
+                        .eql_comptime(b"__proto__")
                 {
                     if has_proto {
                         let r = js_lexer::range_of_identifier(p.source, key.loc);

--- a/test/bundler/transpiler/decorators.test.ts
+++ b/test/bundler/transpiler/decorators.test.ts
@@ -1019,6 +1019,24 @@ test("export default class works (anonymous name)", () => {
   expect(new DecoratedAnonClass()["methoddecorated"]).toBe(true);
 });
 
+test("field with supra-BMP string-literal key and initializer is assigned under the correct key", () => {
+  function dec(_t: any, _k: any) {}
+  class Foo {
+    @dec "\u{20BB7}\u{91BB6}": number = 42;
+    @dec static "\u{20BB7}\u{91BB6}": number = 7;
+  }
+  const f = new Foo();
+  expect({
+    instance: f["\u{20BB7}\u{91BB6}"],
+    instanceKeys: Object.getOwnPropertyNames(f),
+    staticVal: Foo["\u{20BB7}\u{91BB6}"],
+  }).toEqual({
+    instance: 42,
+    instanceKeys: ["\u{20BB7}\u{91BB6}"],
+    staticVal: 7,
+  });
+});
+
 test("decorator and declare", () => {
   let counter = 0;
   function d1() {

--- a/test/bundler/transpiler/es-decorators.test.ts
+++ b/test/bundler/transpiler/es-decorators.test.ts
@@ -244,6 +244,87 @@ describe("ES Decorators", () => {
     });
   });
 
+  describe("non-ASCII string-literal keys", () => {
+    // Supra-BMP code points are stored as UTF-16 in the AST; the lowering must
+    // not reinterpret those bytes as UTF-8 when it builds `this[key]`.
+    const key = "\u{20BB7}\u{91BB6}";
+
+    test("Bun.Transpiler output preserves the key", () => {
+      const t = new Bun.Transpiler({ loader: "js", target: "node", minifyWhitespace: true });
+      const out = t.transformSync(`class A{@(() => {})\n"\\u{20BB7}\\u{91BB6}"\n}`);
+      // The key appears twice in the lowered output (constructor assignment and
+      // __decorateElement call) and must be the same string both times, either
+      // as literal UTF-8 or as \uXXXX escapes of the correct surrogate pair.
+      const normalized = out.replace(/\\uD842\\uDFB7\\uDA06\\uDFB6/gi, key);
+      expect(normalized.split(key).length - 1).toBe(2);
+      expect(() => new Bun.Transpiler({ loader: "js" }).transformSync(out)).not.toThrow();
+    });
+
+    test("decorated instance field with supra-BMP key is assigned correctly", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) {
+          console.log(ctx.kind, JSON.stringify(ctx.name));
+          return (init) => init * 2;
+        }
+        class Foo {
+          @dec "\\u{20BB7}\\u{91BB6}" = 21;
+        }
+        const f = new Foo();
+        console.log(f[${JSON.stringify(key)}]);
+        console.log(Object.getOwnPropertyNames(f).map(n => JSON.stringify(n)).join(","));
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`field ${JSON.stringify(key)}\n42\n${JSON.stringify(key)}\n`);
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated static field with supra-BMP key is assigned correctly", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(value, ctx) { return (init) => init + 1; }
+        class Foo {
+          @dec static "\\u{20BB7}\\u{91BB6}" = 9;
+        }
+        console.log(Foo[${JSON.stringify(key)}]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("10\n");
+      expect(exitCode).toBe(0);
+    });
+
+    test("decorated accessor with supra-BMP key works", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(target, ctx) {
+          console.log(ctx.kind, JSON.stringify(ctx.name));
+          return target;
+        }
+        class Foo {
+          @dec accessor "\\u{20BB7}\\u{91BB6}" = 7;
+        }
+        const f = new Foo();
+        console.log(f[${JSON.stringify(key)}]);
+        f[${JSON.stringify(key)}] = 99;
+        console.log(f[${JSON.stringify(key)}]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe(`accessor ${JSON.stringify(key)}\n7\n99\n`);
+      expect(exitCode).toBe(0);
+    });
+
+    test("undecorated accessor with supra-BMP key in a decorated class works", async () => {
+      const { stdout, stderr, exitCode } = await runDecorator(`
+        function dec(cls, ctx) { return cls; }
+        @dec class Foo {
+          accessor "\\u{20BB7}\\u{91BB6}" = 3;
+        }
+        const f = new Foo();
+        console.log(f[${JSON.stringify(key)}]);
+      `);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("3\n");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   describe("decorator ordering", () => {
     test("decorators on different elements evaluate in source order", async () => {
       const { stdout, stderr, exitCode } = await runDecorator(`


### PR DESCRIPTION
## What

Fixes a fuzzer panic `assertion failed: is_valid_wtf8(str)` in the printer when lowering decorators on a class field whose key is a string literal containing non-ASCII characters.

## Repro

```sh
bun -e 'new Bun.Transpiler({loader:"js", target:"node", minifyWhitespace:true}).transformSync("class A{@(() => {})\n\"\\u{20BB7}\\u{91BB6}\"\n}")'
```

Debug build: panics with `assertion failed: is_valid_wtf8(str)` in `print_string_literal_utf8`.

Release build: silently emits the wrong property name:

```js
class A{constructor(){this["Bط\x00"]=__runInitializers(...)}}
//                         ^^^^^^^^ garbage; should be "\uD842\uDFB7\uDA06\uDFB6"
```

so at runtime the decorated field lands on a garbage key and `instance["\u{20BB7}\u{91BB6}"]` is `undefined`.

## Cause

`EString.data` is a `Str` byte slice. When `is_utf16` is set, that slice stores a `*const u16` reinterpreted as `*const u8` with **length = u16 element count**, not bytes. Three places in the decorator lowerings (and one in the TS experimental decorator path in `p.rs`) read `s.data` directly and either:

- stuff it into `E::Dot.name` (a UTF-8 `Str`), or
- use it as the raw bytes of a generated accessor storage symbol name,

without checking `is_utf16`. The printer then treats the bytes as UTF-8.

## Fix

Guard each site on `s.is_utf8()`:

- `member_target` (standard decorators) and the equivalent branch in `write_class` (TS experimental decorators) fall through to `E::Index` for UTF-16 keys so the printer emits `["…"]` via its UTF-16 path.
- The two accessor-storage-name sites fall through to the generic `_accessor_storageN` name for UTF-16 keys instead of building a symbol name from raw UTF-16 bytes.
- Switched the duplicate `__proto__` check to the encoding-aware `eql_comptime` helper for consistency with the rest of the file.

## Tests

- `test/bundler/transpiler/es-decorators.test.ts`: new `non-ASCII string-literal keys` describe covering the transpiler output, instance field, static field, decorated accessor, and undecorated accessor in a decorated class.
- `test/bundler/transpiler/decorators.test.ts`: new test for the TS experimental decorator path.

All six new tests fail on `main` (wrong key / SyntaxError) and pass with this change. Full `es-decorators.test.ts`, `decorators.test.ts`, `es-decorators-esbuild.test.ts`, and `property.test.ts` suites pass.