### PR TITLE
js_parser: handle AllocatedName default_name refs in export default visit

### DIFF
--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -455,7 +455,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                     }
                 }
 
-                if data.default_name.ref_.is_source_contents_slice() {
+                if !data.default_name.ref_.is_symbol() {
                     data.default_name = p.create_default_name(expr.loc).expect("unreachable");
                 }
 
@@ -611,7 +611,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             return Ok(());
                         }
 
-                        if data.default_name.ref_.is_source_contents_slice() {
+                        if !data.default_name.ref_.is_symbol() {
                             data.default_name =
                                 p.create_default_name(stmt.loc).expect("unreachable");
                         }
@@ -806,7 +806,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                             }
                         }
 
-                        if data.default_name.ref_.is_source_contents_slice() {
+                        if !data.default_name.ref_.is_symbol() {
                             data.default_name =
                                 p.create_default_name(stmt.loc).expect("unreachable");
                         }

--- a/src/js_parser/visit/visit_stmt.rs
+++ b/src/js_parser/visit/visit_stmt.rs
@@ -369,11 +369,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         data: &mut S::ExportDefault,
     ) -> Result<(), Error> {
         // scopeguard can't borrow `p` across the body; restructured to a tail
-        // closure invoked at every return site below.
+        // closure invoked at every return site below. Guard on `is_symbol()`
+        // because early returns can reach this before the parse-time name
+        // ref (SourceContentsSlice/AllocatedName) has been rewritten.
         macro_rules! record_on_exit {
             () => {
-                if let Some(ref_) = data.default_name.ref_.to_nullable() {
-                    p.record_declared_symbol(ref_);
+                if data.default_name.ref_.is_symbol() {
+                    p.record_declared_symbol(data.default_name.ref_);
                 }
             };
         }

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -279,6 +279,14 @@ describe("Bun.Transpiler", () => {
       const js = new Bun.Transpiler({ loader: "js" });
       expect(js.transformSync("export default \\u{66}")).toBe("export default f;\n");
       expect(js.transformSync("export default \\u0066oo")).toBe("export default foo;\n");
+
+      // exports.eliminate marks the default export dead and returns early before
+      // the default_name ref is rewritten to a symbol. record_on_exit must not
+      // feed that parse-time ref to record_declared_symbol.
+      const elim = new Bun.Transpiler({ loader: "ts", exports: { eliminate: ["default"] } });
+      expect(elim.transformSync("export default foo")).toBe("");
+      expect(elim.transformSync("export default \\u{66}")).toBe("");
+      expect(elim.transformSync("export default \\u{66}oo")).toBe("");
     });
 
     it("rejects export clauses inside a non-declare namespace", () => {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -270,6 +270,8 @@ describe("Bun.Transpiler", () => {
       exp("const \\u{66} = 1; export default \\u{66};", "const f = 1;\nexport default f;\n");
       exp("export default (function \\u{66}() {})", "export default (function f() {})");
       exp("export default (class \\u{66} {})", "export default (class f {\n})");
+      exp("export default function \\u{66}() {}", "export default function f() {}");
+      exp("export default class \\u{66} {}", "export default class f {\n}");
 
       // The exact fuzz repro used the ts loader with target:"node".
       const node = new Bun.Transpiler({ loader: "ts", target: "node" });

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -258,6 +258,29 @@ describe("Bun.Transpiler", () => {
       exp("export default interface Foo { bar(): void }\nexport const x = 1;", "export const x = 1;\n");
     });
 
+    it("export default of an identifier written with unicode escapes does not crash", () => {
+      // `\u{66}` decodes to `f`, but the decoded buffer lives outside the source
+      // contents, so the parse-time Ref is tagged AllocatedName rather than
+      // SourceContentsSlice. The visit pass must still replace it with a real
+      // symbol before calling record_declared_symbol.
+      const exp = ts.expectPrinted_;
+      exp("export default \\u{66}", "export default f");
+      exp("export default \\u0066", "export default f");
+      exp("export default \\u{66}oo", "export default foo");
+      exp("const \\u{66} = 1; export default \\u{66};", "const f = 1;\nexport default f;\n");
+      exp("export default (function \\u{66}() {})", "export default (function f() {})");
+      exp("export default (class \\u{66} {})", "export default (class f {\n})");
+
+      // The exact fuzz repro used the ts loader with target:"node".
+      const node = new Bun.Transpiler({ loader: "ts", target: "node" });
+      expect(node.transformSync("export default \\u{66}")).toBe("export default f;\n");
+
+      // The same shape through the plain JavaScript loader.
+      const js = new Bun.Transpiler({ loader: "js" });
+      expect(js.transformSync("export default \\u{66}")).toBe("export default f;\n");
+      expect(js.transformSync("export default \\u0066oo")).toBe("export default foo;\n");
+    });
+
     it("rejects export clauses inside a non-declare namespace", () => {
       const exp = ts.expectPrinted_;
       const err = ts.expectParseError;


### PR DESCRIPTION
## Reproduction

```js
new Bun.Transpiler({ loader: "ts", target: "node" }).transformSync("export default \\u{66}")
```

Debug/ASAN builds panic with:

```
panic: assertion failed: r#ref.is_symbol()
    at record_declared_symbol (src/js_parser/visit/mod.rs:77)
    at s_export_default (src/js_parser/visit/visit_stmt.rs:376)
```

## Cause

When the default-exported expression is a bare identifier, `default_name_for_expr` stores the identifier's parse-time `Ref` in `S::ExportDefault::default_name`. That ref comes from `store_name_in_ref`, which returns one of two non-symbol tags:

- `SourceContentsSlice` when the identifier text is a direct slice of the source (`export default foo`)
- `AllocatedName` when the lexer had to decode escapes into an arena buffer (`export default \u{66}` decodes to `f`, which does not live inside the source contents)

The visit pass rewrites `default_name` to a real symbol before calling `record_declared_symbol`, but the guard only checked `is_source_contents_slice()`. An `AllocatedName` ref passed straight through to `record_declared_symbol`, tripping its `debug_assert!(r#ref.is_symbol())`.

Separately, the `is_control_flow_dead` early return (reachable via `exports.eliminate: ["default"]`) runs `record_on_exit!()` before any rewrite happens at all, so even a plain `export default foo` hit the same assertion on that configuration.

Both were present in the Zig parser and carried over unchanged in the Rust rewrite.

## Fix

- Check `!is_symbol()` instead of `is_source_contents_slice()` at the three rewrite sites in `s_export_default` so both non-symbol ref kinds produced by `store_name_in_ref` are replaced with a proper default-name symbol.
- Guard `record_on_exit!()` on `is_symbol()` (the exact invariant `record_declared_symbol` asserts) instead of `to_nullable()`, so early returns that fire before the rewrite cannot feed a parse-time name ref into `record_declared_symbol`.

## Verification

Added coverage to `test/bundler/transpiler/transpiler.test.js` for escaped-identifier default exports through the `ts`, `js`, and `target: "node"` configurations (including function/class expression variants) and for `exports.eliminate: ["default"]` with both plain and escaped identifiers. The new test panics on the unfixed debug build and passes with this change; the rest of `transpiler.test.js`, `es-decorators.test.ts`, `decorators.test.ts`, and `esbuild/default.test.ts` continue to pass.
