### PR TITLE
parser: skip scope-order debug assert once a parse error is logged

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3605,8 +3605,10 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
 
         if cfg!(debug_assertions) {
             // Enforce that scope locations are strictly increasing to help catch bugs
-            // where the pushed scopes are mismatched between the first and second passes
-            if !self.scopes_in_order.is_empty() {
+            // where the pushed scopes are mismatched between the first and second passes.
+            // Skip once a parse error exists: error recovery past a soft-failing expect()
+            // can push two scopes at one loc, and the visit pass won't run anyway.
+            if self.log().errors == 0 && !self.scopes_in_order.is_empty() {
                 let mut last_i = self.scopes_in_order.len() - 1;
                 while self.scopes_in_order[last_i].is_none() && last_i > 0 {
                     last_i -= 1;

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -3604,10 +3604,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         }
 
         if cfg!(debug_assertions) {
-            // Enforce that scope locations are strictly increasing to help catch bugs
-            // where the pushed scopes are mismatched between the first and second passes.
-            // Skip once a parse error exists: error recovery past a soft-failing expect()
-            // can push two scopes at one loc, and the visit pass won't run anyway.
+            // Enforce strictly increasing scope locations to catch parse/visit pass
+            // mismatches. Skip once a parse error is logged: error recovery can push
+            // two scopes at one loc and the visit pass won't run anyway.
             if self.log().errors == 0 && !self.scopes_in_order.is_empty() {
                 let mut last_i = self.scopes_in_order.len() - 1;
                 while self.scopes_in_order[last_i].is_none() && last_i > 0 {

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -305,11 +305,9 @@ describe("Bun.Transpiler", () => {
     });
 
     it("reports a parse error for a truncated class-in-extends without tripping the scope-order assert", async () => {
-      // lexer.expect() logs and continues on a token mismatch, so an unterminated
-      // class expression in the extends clause and the outer class both push a
-      // ClassBody scope at the same EOF location during error recovery. Run in a
-      // subprocess so the debug-only scope-order assert surfaces as a test failure
-      // instead of taking down the runner.
+      // An unterminated class-in-extends pushes two ClassBody scopes at the same
+      // EOF loc during error recovery. Run in a subprocess so the debug-only
+      // scope-order assert surfaces as a test failure instead of killing the runner.
       const cases = {
         "class o extends class": 'Expected "{" but found end of file',
         "(class extends class": 'Expected "{" but found end of file',

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -304,6 +304,48 @@ describe("Bun.Transpiler", () => {
       exp("f<T>`ok`", "f`ok`;\n");
     });
 
+    it("reports a parse error for a truncated class-in-extends without tripping the scope-order assert", async () => {
+      // lexer.expect() logs and continues on a token mismatch, so an unterminated
+      // class expression in the extends clause and the outer class both push a
+      // ClassBody scope at the same EOF location during error recovery. Run in a
+      // subprocess so the debug-only scope-order assert surfaces as a test failure
+      // instead of taking down the runner.
+      const cases = {
+        "class o extends class": 'Expected "{" but found end of file',
+        "(class extends class": 'Expected "{" but found end of file',
+        "class o extends (class": 'Expected "{" but found end of file',
+        "class o extends class extends class": 'Expected "{" but found end of file',
+      };
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const t = new Bun.Transpiler({ loader: "tsx", target: "bun" });
+            const out = [];
+            for (const input of ${JSON.stringify(Object.keys(cases))}) {
+              try {
+                t.transformSync(input);
+                out.push("<no error>");
+              } catch (e) {
+                out.push((e instanceof AggregateError ? e.errors[0] : e).message);
+              }
+            }
+            process.stdout.write(JSON.stringify(out));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout && JSON.parse(stdout), stderr, exitCode }).toEqual({
+        stdout: Object.values(cases),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
     it("should parse infer extends ternary correctly #9959", () => {
       ts.expectPrinted_("type Foo<T> = T extends infer U ? U : never;", "");
       ts.expectPrinted_("var foo: Foo extends string | infer Foo extends string ? Foo : never", "var foo");


### PR DESCRIPTION
Fuzz-found debug-only panic in `push_scope_for_parse_pass`.

### Repro

```
bun -e 'new Bun.Transpiler({loader:"tsx", target:"bun"}).transformSync("class o extends class")'
```

Debug build:
```
panic: Scope location must be greater than previous
21 must be greater than 21
```

Release just throws `Expected "{" but found end of file` as expected.

### Cause

Unlike esbuild (whose `lexer.Expected()` panics and unwinds), Bun's `lexer.expect()` logs the error and continues so it can report multiple errors. For `class o extends class`:

1. The inner class expression's `parse_class` captures `body_loc` at EOF (21), `expect(TOpenBrace)` soft-fails and logs, and a `ClassBody` scope is pushed at loc 21.
2. Control returns to the outer class's `parse_class`, which captures `body_loc` at the same EOF (21), `expect(TOpenBrace)` soft-fails again (deduped by `prev_error_loc`), and it tries to push another `ClassBody` scope at loc 21.

The debug-only assert in `push_scope_for_parse_pass` (`prev_loc.start >= loc.start`) fires. In release the assert is compiled out and the parse halts normally at the `log.errors > orig_error_count` check in `_parse` before the visit pass.

### Fix

Gate the assert on `self.log().errors == 0`. Its purpose is to catch scope mismatches between the parse and visit passes; once a parse error has been logged the visit pass never runs, so colliding scope locations from error recovery are harmless and the assert is a false positive. The assert still fires on valid input.

### Test

Added a subprocess test to `test/bundler/transpiler/transpiler.test.js` covering the fuzz repro plus three variants (`(class extends class`, `class o extends (class`, triple nesting). Without the fix the subprocess panics on the first input under `bun bd`; with the fix all four throw the expected parse error and the subprocess exits 0. Release builds already throw the parse error so the test passes there unchanged.