### PR TITLE
bundler: allow relative FileMap keys without tripping absolute-path debug asserts

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1774,10 +1774,12 @@ impl<'a> LinkerContext<'a> {
                                 .path_with_pretty_initialized(&source.path, arena)
                                 .expect("OOM");
                         }
-                        // Note: `Path::assert_pretty_is_valid` lives on the
-                        // resolver-side `Path<'a>`; the logger `Path` has no
-                        // such debug hook yet.
-                        debug_assert!(source.path.text.as_ptr() != source.path.pretty.as_ptr());
+                        // FileMap keys may be relative; when the computed pretty
+                        // equals text, `dupe_alloc` aliases them and that's fine.
+                        debug_assert!(
+                            source.path.text.as_ptr() != source.path.pretty.as_ptr()
+                                || !bun_paths::is_absolute(source.path.text)
+                        );
 
                         break 'brk source.path.pretty;
                     } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2583,7 +2583,13 @@ pub mod bv2_impl {
                 None => return Ok(None),
             };
 
-            path.assert_file_path_is_absolute();
+            // FileMap keys are user-supplied and may be relative; they are lookup
+            // identities, not real fs paths, so the absolute invariant does not apply.
+            if bun_core::Environment::CI_ASSERT
+                && !self.file_map.is_some_and(|fm| fm.contains(path.text))
+            {
+                path.assert_file_path_is_absolute();
+            }
             // borrowck: get-then-put instead of a single get-or-put.
             if self
                 .path_to_source_index_map(target)

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -614,11 +614,7 @@ describe("bundler files option", () => {
         stdout: "pipe",
         stderr: "pipe",
       });
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
         stdout: "ok",
         stderr: "",
@@ -643,11 +639,7 @@ describe("bundler files option", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, stderr, exitCode] = await Promise.all([
-      proc.stdout.text(),
-      proc.stderr.text(),
-      proc.exited,
-    ]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
       stdout: JSON.stringify({ success: false, logs: 1 }),
       stderr: "",

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -585,7 +585,7 @@ describe("bundler files option", () => {
 
   // FileMap keys are user-supplied identities and may be relative; run in a
   // subprocess so an assertion panic fails the test instead of killing the runner.
-  test.each(["./e.js", "e.js", "./src/e.js"])(
+  test.concurrent.each(["./e.js", "e.js", "./src/e.js"])(
     "relative key %j as entry point does not trip the absolute-path assertion",
     async key => {
       const script = `
@@ -621,7 +621,7 @@ describe("bundler files option", () => {
     },
   );
 
-  test("relative key as entry point surfaces parse errors without crashing", async () => {
+  test.concurrent("relative key as entry point surfaces parse errors without crashing", async () => {
     const script = `
       const r = await Bun.build({
         entrypoints: ["./e.js"],

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 describe("bundler files option", () => {
   test("basic in-memory file bundling", async () => {
@@ -581,5 +581,77 @@ describe("bundler files option", () => {
 
     const output = await result.outputs[0].text();
     expect(output).toContain("injected by plugin");
+  });
+
+  // The debug assertion that file-namespace paths are absolute does not apply
+  // to FileMap keys, which are user-supplied lookup identities and may be
+  // relative. Run in a subprocess so a regression (assertion panic in the
+  // bundle thread) fails this test instead of taking down the runner.
+  test.each(["./e.js", "e.js", "./src/e.js"])(
+    "relative key %j as entry point does not trip the absolute-path assertion",
+    async key => {
+      const script = `
+        const r = await Bun.build({
+          entrypoints: [${JSON.stringify(key)}],
+          files: { ${JSON.stringify(key)}: 'console.log("from relative key")' },
+          target: "bun",
+          throw: false,
+        });
+        if (!r.success) {
+          for (const l of r.logs) console.error(l.message ?? l);
+          process.exit(1);
+        }
+        const out = await r.outputs[0].text();
+        if (!out.includes("from relative key")) {
+          console.error("missing content:", out);
+          process.exit(1);
+        }
+        console.log("ok");
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: "ok",
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+
+  test("relative key as entry point surfaces parse errors without crashing", async () => {
+    const script = `
+      const r = await Bun.build({
+        entrypoints: ["./e.js"],
+        files: { "./e.js": ")" },
+        target: "bun",
+        throw: false,
+      });
+      console.log(JSON.stringify({ success: r.success, logs: r.logs.length }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      proc.stdout.text(),
+      proc.stderr.text(),
+      proc.exited,
+    ]);
+    expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      stdout: JSON.stringify({ success: false, logs: 1 }),
+      stderr: "",
+      exitCode: 0,
+    });
   });
 });

--- a/test/bundler/bundler_files.test.ts
+++ b/test/bundler/bundler_files.test.ts
@@ -583,10 +583,8 @@ describe("bundler files option", () => {
     expect(output).toContain("injected by plugin");
   });
 
-  // The debug assertion that file-namespace paths are absolute does not apply
-  // to FileMap keys, which are user-supplied lookup identities and may be
-  // relative. Run in a subprocess so a regression (assertion panic in the
-  // bundle thread) fails this test instead of taking down the runner.
+  // FileMap keys are user-supplied identities and may be relative; run in a
+  // subprocess so an assertion panic fails the test instead of killing the runner.
   test.each(["./e.js", "e.js", "./src/e.js"])(
     "relative key %j as entry point does not trip the absolute-path assertion",
     async key => {


### PR DESCRIPTION
## Repro

```js
await Bun.build({
  entrypoints: ["./e.js"],
  files: { "./e.js": ")" },
  target: "bun",
  throw: false,
});
```

Under a debug/ASAN build:

```
panic: assertion failed: crate::is_absolute(self.text)
<bun_paths::fs::Path>::assert_file_path_is_absolute  src/paths/lib.rs:961
<bun_bundler::bundle_v2::BundleV2>::enqueue_entry_item  src/bundler/bundle_v2.rs:2586
<bun_bundler::bundle_v2::BundleV2>::enqueue_entry_points_normal  src/bundler/bundle_v2.rs:2949
```

The invalid JS is incidental; any relative key used as an entry point panics. A second assertion in `generate_isolated_hash` (LinkerContext.rs:1780) fires for bare keys like `"e.js"` once the first one is past. Release builds are unaffected since both are `debug_assert!`.

## Cause

`Bun.build`'s `files` option stores user-supplied keys verbatim. The docs show relative keys as valid (`"./src/generated.ts"`), and release builds handle them correctly. Two CI-only assertions were too strict:

- `enqueue_entry_item` asserts every `file:`-namespace path is absolute. `FileMap::resolve` returns the raw key in the `file` namespace, so relative keys trip it. The other two `FileMap::resolve` call sites (`run_resolver`, `resolve_import_records`) bypass `enqueue_entry_item` and never hit this.
- `generate_isolated_hash` asserts `pretty.ptr != text.ptr` after `path_with_pretty_initialized`. For a bare relative key like `"e.js"`, `relative(top_level_dir, "e.js")` yields `"e.js"` again, and `dupe_alloc`'s `index_of` optimization re-aliases `pretty` to `text` at offset 0.

## Fix

- Skip `assert_file_path_is_absolute` in `enqueue_entry_item` when the path is a FileMap key (gated on `CI_ASSERT` so the `contains` lookup costs nothing in release).
- Relax the `generate_isolated_hash` assertion to allow `pretty.ptr == text.ptr` for non-absolute `text`; absolute paths keep the original invariant.

## Verification

`bun bd test test/bundler/bundler_files.test.ts`: 27 pass (4 new subprocess tests covering `"./e.js"`, `"e.js"`, `"./src/e.js"`, and the fuzzer's parse-error input). With `src/` reverted, all 4 new tests fail on the panic.