### PR TITLE
parser: avoid O(n^2) arena blowup in comma-expression simplification

### DIFF
--- a/src/js_parser/visit/visit_binary.rs
+++ b/src/js_parser/visit/visit_binary.rs
@@ -207,7 +207,22 @@ impl BinaryExpressionVisitor {
                 // "(0, this.fn)" => "this.fn"
                 // "(0, this.fn)()" => "(0, this.fn)()"
                 if p.options.features.minify_syntax {
-                    if let Some(simplified_left) = SideEffects::simplify_unused_expr(p, e_.left) {
+                    // If e_.left is itself a comma, its .left was already simplified
+                    // by the previous unwind step; only simplify its .right to avoid
+                    // re-walking/reallocating the whole chain (O(n^2) arena blowup).
+                    let simplified_left = match e_.left.data {
+                        ExprData::EBinary(mut inner) if inner.op == Op::Code::BinComma => {
+                            match SideEffects::simplify_unused_expr(p, inner.right) {
+                                None => Some(inner.left),
+                                Some(simplified_right) => {
+                                    inner.right = simplified_right;
+                                    Some(e_.left)
+                                }
+                            }
+                        }
+                        _ => SideEffects::simplify_unused_expr(p, e_.left),
+                    };
+                    if let Some(simplified_left) = simplified_left {
                         if simplified_left.is_empty() {
                             return e_.right;
                         }

--- a/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
@@ -1,0 +1,64 @@
+// bun-fuzz: js parser OOM on long comma chains with target:"bun".
+// minify_syntax (enabled for target:"bun") calls simplify_unused_expr on the
+// left operand at every level of the comma chain; the simplifier rebuilds the
+// whole chain with fresh arena allocations each time, giving O(n^2) time and
+// memory. 66KB of "a,b,c,..." drove RSS past 2GB.
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+test("long comma expression does not blow up memory with target: bun", async () => {
+  const fixture = `
+    const n = 4000;
+    const input = Array(n).fill("a").join(",");
+    const expected = Array(n).fill("a").join(", ") + ";\\n";
+    const before = process.memoryUsage().rss;
+    const out = new Bun.Transpiler({ target: "bun" }).transformSync(input);
+    const after = process.memoryUsage().rss;
+    if (out !== expected) {
+      throw new Error("wrong output: " + JSON.stringify(out.slice(0, 80)));
+    }
+    console.log(JSON.stringify({ delta_mb: (after - before) / 1024 / 1024 }));
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    proc.stdout.text(),
+    proc.stderr.text(),
+    proc.exited,
+  ]);
+
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
+    stdout: expect.stringMatching(/^\{"delta_mb":/),
+    exitCode: 0,
+  });
+  const { delta_mb } = JSON.parse(stdout);
+  // Before the fix: ~280 MB in release, ~370 MB in debug+ASAN for n=4000.
+  expect(delta_mb).toBeLessThan(100);
+}, 60_000);
+
+test("comma simplification output is unchanged", () => {
+  const t = new Bun.Transpiler({ target: "bun" });
+  const cases: Record<string, string> = {
+    "1,2,3": "",
+    "a,b,c": "a, b, c;\n",
+    "(0,a)()": "a();\n",
+    "(a,0)()": "(a, 0)();\n",
+    "a,1,b,2,c": "a, b, c;\n",
+    "1,2,a,3,4": "a;\n",
+    "x(),1,2,y()": "x(), y();\n",
+    "a===b,c,d": "a, b, c, d;\n",
+    "(1,2,3,a)": "a;\n",
+    "a,(b,c),d": "a, b, c, d;\n",
+    "1,a,1,b,1,c,1": "a, b, c;\n",
+  };
+  const got: Record<string, string> = {};
+  for (const input of Object.keys(cases)) {
+    got[input] = t.transformSync(input);
+  }
+  expect(got).toEqual(cases);
+});

--- a/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
+++ b/test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts
@@ -26,11 +26,7 @@ test("long comma expression does not blow up memory with target: bun", async () 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    proc.stdout.text(),
-    proc.stderr.text(),
-    proc.exited,
-  ]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect({ stdout: stdout.trim(), stderr, exitCode }).toMatchObject({
     stdout: expect.stringMatching(/^\{"delta_mb":/),


### PR DESCRIPTION
## Repro

```js
new Bun.Transpiler({ target: "bun" }).transformSync(Array(10000).fill("a").join(","));
```

On current main this drives RSS past 2 GB and OOMs (found by the js fuzzer with `oom:js:mi_os_prim_alloc(...)|_mi_os_alloc_aligned(...)`). The original fuzzer input was 66 KB of repeated `thro ,hro ,hro`, which parses to a single ~9400-operand comma expression.

## Cause

`target: "bun"` enables `minify_syntax`. The iterative binary-expression visitor in [`visit_expr.rs::e_binary`](https://github.com/oven-sh/bun/blob/main/src/js_parser/visit/visit_expr.rs#L807-L886) descends to the leftmost leaf of a left-nested comma chain, then unwinds upward calling `visit_right_and_finish` once per node.

For `BinComma` with `minify_syntax`, [`visit_right_and_finish`](https://github.com/oven-sh/bun/blob/main/src/js_parser/visit/visit_binary.rs#L204-L228) calls `SideEffects::simplify_unused_expr(e_.left)`. At unwind level *k*, `e_.left` is already a comma chain of length *k-1*, so [`simplify_unused_binary_comma_expr`](https://github.com/oven-sh/bun/blob/main/src/js_parser/scan/scan_side_effects.rs#L516-L567) walks all *k-1* nodes and rebuilds the chain via `Expr::join_with_comma`, allocating *k-1* fresh `E::Binary` nodes in the AST arena. Summed over all levels, that is ~n²/2 arena allocations that survive until the arena resets. At n=9400, ~44M nodes × ~40 B ≈ 1.8 GB.

esbuild has the same algorithm, but its allocations go through the Go GC so the intermediate chains are collected as they become unreachable. Bun uses a bump arena, so nothing is freed.

## Fix

When `e_.left` is itself a `BinComma`, its own `.left` was already fully simplified by the previous unwind step; only its `.right` (the previous step's `e_.right`, which was visited but never passed through `simplify_unused_expr`) still needs simplifying. Simplify just that operand and either mutate the node in place or drop it. Each unwind step becomes O(1) and allocates nothing.

| n=4000, target:"bun" | before | after |
| :-- | --: | --: |
| release RSS delta | ~370 MB | ~4 MB |
| debug+ASAN RSS delta | ~377 MB | ~12 MB |
| debug+ASAN time | ~16.7 s | ~0.08 s |

Output is byte-identical on every minification test case (the second test in the new file asserts this for a matrix of comma shapes).

## Verification

```
bun bd test test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts   # passes
USE_SYSTEM_BUN=1 bun test test/js/bun/transpiler/transpiler-comma-chain-oom.test.ts   # fails (369 MB)
```

Also re-ran `test/bundler/transpiler/transpiler.test.js`, `test/bundler/esbuild/dce.test.ts`, and `test/bundler/bundler_minify.test.ts` with no regressions.