### PR TITLE
yaml: fix stringify emitting \L/\P for U+00A8/U+00A9 instead of U+2028/U+2029

### DIFF
--- a/src/runtime/api/YAMLObject.rs
+++ b/src/runtime/api/YAMLObject.rs
@@ -641,16 +641,16 @@ impl Stringifier {
                 0x7f => self.builder.append_latin1(b"\\x7f"), // delete
                 0x85 => self.builder.append_latin1(b"\\N"),  // next line
                 0xa0 => self.builder.append_latin1(b"\\_"),  // non-breaking space
-                0xa8 => self.builder.append_latin1(b"\\L"),  // line separator
-                0xa9 => self.builder.append_latin1(b"\\P"),  // paragraph separator
+                0x2028 => self.builder.append_latin1(b"\\L"), // line separator
+                0x2029 => self.builder.append_latin1(b"\\P"), // paragraph separator
 
                 0x20..=0x21
                 | 0x23..=0x5b
                 | 0x5d..=0x7e
                 | 0x80..=0x84
                 | 0x86..=0x9f
-                | 0xa1..=0xa7
-                | 0xaa..=u16::MAX => self.builder.append_uchar(c),
+                | 0xa1..=0x2027
+                | 0x202a..=u16::MAX => self.builder.append_uchar(c),
             }
         }
 
@@ -883,8 +883,8 @@ fn string_needs_quotes(str: &BunString) -> bool {
             | 0x7f
             | 0x85
             | 0xa0
-            | 0xa8
-            | 0xa9 => return true,
+            | 0x2028
+            | 0x2029 => return true,
 
             _ => {
                 i += 1;

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2662,6 +2662,43 @@ config:
         expect(YAML.parse(YAML.stringify("with\rcarriage"))).toBe("with\rcarriage");
       });
 
+      test("round-trips U+00A8/U+00A9 and escapes U+2028/U+2029 as \\L/\\P", () => {
+        // U+00A8 (DIAERESIS) and U+00A9 (COPYRIGHT SIGN) are ordinary printable
+        // characters; only U+2028/U+2029 map to the YAML \L and \P escapes.
+        expect(YAML.parse(YAML.stringify("\u00a8"))).toBe("\u00a8");
+        expect(YAML.parse(YAML.stringify("\u00a9"))).toBe("\u00a9");
+        expect(YAML.parse(YAML.stringify("x\u00a8y"))).toBe("x\u00a8y");
+        expect(YAML.parse(YAML.stringify("x\u00a9y"))).toBe("x\u00a9y");
+        expect(YAML.parse(YAML.stringify({ k: "a\u00a8b\u00a9c" }))).toEqual({ k: "a\u00a8b\u00a9c" });
+
+        expect(YAML.stringify("\u00a8")).not.toContain("\\L");
+        expect(YAML.stringify("\u00a9")).not.toContain("\\P");
+        expect(YAML.stringify("\u2028")).toBe('"\\L"');
+        expect(YAML.stringify("\u2029")).toBe('"\\P"');
+        expect(YAML.parse(YAML.stringify("\u2028"))).toBe("\u2028");
+        expect(YAML.parse(YAML.stringify("\u2029"))).toBe("\u2029");
+        expect(YAML.parse(YAML.stringify("a\u2028b\u2029c"))).toBe("a\u2028b\u2029c");
+      });
+
+      test("round-trips every non-surrogate BMP code point", () => {
+        let all = "";
+        for (let cp = 0; cp <= 0xffff; cp++) {
+          if (cp >= 0xd800 && cp <= 0xdfff) continue;
+          all += String.fromCharCode(cp);
+        }
+        const back = YAML.parse(YAML.stringify(all));
+        expect(typeof back).toBe("string");
+        expect(back.length).toBe(all.length);
+        for (let i = 0; i < all.length; i++) {
+          if (back.charCodeAt(i) !== all.charCodeAt(i)) {
+            throw new Error(
+              `U+${all.charCodeAt(i).toString(16).padStart(4, "0")} did not round-trip: ` +
+                `got U+${back.charCodeAt(i).toString(16).padStart(4, "0")}`,
+            );
+          }
+        }
+      });
+
       test("round-trips arrays", () => {
         expect(YAML.parse(YAML.stringify([]))).toEqual([]);
         expect(YAML.parse(YAML.stringify([1, 2, 3]))).toEqual([1, 2, 3]);


### PR DESCRIPTION
## Problem

`YAML.stringify` output does not round-trip through `YAML.parse` when the value contains U+00A8 (DIAERESIS, `¨`) or U+00A9 (COPYRIGHT SIGN, `©`):

```js
Bun.YAML.parse(Bun.YAML.stringify("\u00a8"))
// => "\u2028"  (LINE SEPARATOR, wrong)

Bun.YAML.stringify("\u00a8")
// => '"\\L"'  (wrong escape)
```

Found via fuzzing (signature `invariant:yaml:YAML.stringify output does not reparse`).

## Cause

`append_double_quoted_string` in `src/runtime/api/YAMLObject.rs` mapped `0xa8 => \"\\L\"` and `0xa9 => \"\\P\"`. The YAML escapes `\\L` and `\\P` represent U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, not U+00A8/U+00A9. 0xA8 and 0xA9 happen to be the final bytes of the UTF-8 encodings of U+2028 (`E2 80 A8`) and U+2029 (`E2 80 A9`); the table used those trailing bytes in place of the code points.

The actual U+2028/U+2029 fell through the catch-all range and were emitted raw, and `string_needs_quotes` only forced quoting for `0xa8 | 0xa9`, so a bare U+2028/U+2029 value was emitted without quotes.

## Fix

- `append_double_quoted_string`: escape `0x2028`/`0x2029` as `\\L`/`\\P`; emit `0xa8`/`0xa9` raw (they are ordinary c-printable characters).
- `string_needs_quotes`: force quoting for `0x2028 | 0x2029` instead of `0xa8 | 0xa9`.

After:
```js
Bun.YAML.stringify("\u00a8")      // => "¨"
Bun.YAML.stringify("\u2028")      // => '"\\L"'
Bun.YAML.parse(Bun.YAML.stringify("\u00a8")) === "\u00a8"   // true
```

This matches js-yaml's behaviour for the same code points.

## Verification

- New targeted test asserts round-trip and exact output for U+00A8, U+00A9, U+2028, U+2029.
- New test round-trips every non-surrogate BMP code point through `stringify`/`parse` in a single string.
- Both tests fail on main and pass with this change.
- Full `test/js/bun/yaml/yaml.test.ts` suite passes (607 pass, 23 pre-existing todo).