### PR TITLE
tls: don't truncate the stream when destroy() follows a large write

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1306,6 +1306,7 @@ void us_internal_ssl_attach(struct us_socket_t *s, SSL_CTX *ctx,
   s->ssl_fatal_error = 0;
   s->ssl_raw_tap = 0;
   s->ssl_shutdown_after_spill = 0;
+  s->ssl_close_after_spill = 0;
   s->ssl_in_use = 0;
   s->ssl_pending_detach = 0;
   s->ssl_pending_close_code = 0;
@@ -1549,17 +1550,30 @@ static int ssl_handle_shutdown(struct us_socket_t *s, int force_fast_shutdown) {
 }
 
 struct us_socket_t *us_internal_ssl_close(struct us_socket_t *s, int code, void *reason) {
-  ssl_release_spill(s->group->loop, s);
   if (s->ssl && s->ssl_in_use) {
     /* A JS callback running from inside SSL_do_handshake/SSL_read (ALPN, SNI,
      * keylog, ...) destroyed this socket. Reaching ssl_set_loop_data /
      * SSL_do_handshake here would re-enter BoringSSL on the same SSL* while
      * the outer ssl_run_handshake is still on the stack; defer to the SSL
-     * driver's epilogue (the same protocol close_raw and ssl_detach honor). */
+     * driver's epilogue (the same protocol close_raw and ssl_detach honor),
+     * releasing the spill now so the re-issued close cannot itself defer. */
+    ssl_release_spill(s->group->loop, s);
     s->ssl_pending_detach = 1;
     s->ssl_pending_close_code = (unsigned char) code;
     return s;
   }
+  /* node's `_handle.close()` (FAST_SHUTDOWN, no reason) must not cut off spilled
+   * ciphertext already reported as written: SSL sealed it, so it can only be
+   * delivered, never re-sent. Mirror ssl_shutdown_after_spill; defer at most once. */
+  if (code == LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN && !reason
+      && !s->ssl_close_after_spill && !s->ssl_fatal_error && !us_socket_is_closed(s)) {
+    struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
+    if (loop_ssl_data && !ssl_drain_spill(loop_ssl_data, s)) {
+      s->ssl_close_after_spill = 1;
+      return s;
+    }
+  }
+  ssl_release_spill(s->group->loop, s);
   /* SEMI_SOCKET never connected — SSL was attached eagerly on the fast-path
    * connect, but no bytes were ever exchanged. Firing on_handshake(0) here
    * lands in JS after onConnectError already tore down `this`/its handlers. */
@@ -1721,6 +1735,10 @@ struct us_socket_t *us_internal_ssl_on_writable(struct us_socket_t *s) {
       s->ssl_shutdown_after_spill = 0;
       us_internal_ssl_shutdown(s);
       if (ssl_gone(s)) return s;
+    }
+    if (s->ssl_close_after_spill) {
+      s->ssl_close_after_spill = 0;
+      return us_internal_ssl_close(s, LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN, NULL);
     }
   }
   ssl_update_handshake(s);

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -271,6 +271,9 @@ struct us_socket_t {
    * spilled (see ssl_flush_write_batch); the shutdown re-runs once the
    * spill drains so those records are not cut off by our FIN/close_notify. */
   unsigned char ssl_shutdown_after_spill : 1;
+  /* Same as ssl_shutdown_after_spill but for us_internal_ssl_close: the
+   * close re-runs from the writable event once the spill drains. */
+  unsigned char ssl_close_after_spill : 1;
   /* Set while SSL_do_handshake/SSL_read is on the stack: JS run from inside
    * those calls (ALPN/SNI/keylog callbacks) may destroy the socket, and the
    * SSL must not be freed under BoringSSL's feet - the detach is deferred to

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -2975,7 +2975,9 @@ impl<const SSL: bool> NewSocket<SSL> {
         // synchronously (with `.normal` the SSL layer defers waiting for the peer, but we
         // detach + unref immediately below, orphaning the `us_socket_t`). NOT `.failure`:
         // that arms SO_LINGER{1,0} → RST and drops any data still in the kernel send
-        // buffer, which `destroy()` after `write()` must not do.
+        // buffer, which `destroy()` after `write()` must not do. The SSL layer may
+        // briefly defer this close behind its own ciphertext write spill
+        // (`ssl_close_after_spill`); that waits only on our fd, not the peer.
         socket.close(uws::CloseCode::FastShutdown);
         this.socket.set(SocketHandler::<SSL>::DETACHED);
         let _ = global;

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1248,8 +1248,8 @@ describe("tls.Server socket destroySoon", () => {
         const c = connect({ port: (server.address() as AddressInfo).port, rejectUnauthorized: false }, () => {
           let bytesRead = 0;
           c.on("readable", () => {
-            const d = c.read();
-            if (d) bytesRead += d.length;
+            let d;
+            while ((d = c.read()) !== null) bytesRead += d.length;
           });
           c.on("end", () => resolve(bytesRead));
         });

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1228,3 +1228,40 @@ it("an asynchronous SNICallback resolving cb(null, null) still honors addContext
   server.close();
   await once(server, "close");
 });
+
+describe("tls.Server socket destroySoon", () => {
+  // destroySoon() after end(big) must deliver every byte even when the TLS write
+  // batcher's final flush spills (#31584). The spill/kernel-buffer race hits ~4% of
+  // connections at this payload, so loop (mirrors test-tls-client-destroy-soon.js).
+  it("delivers the whole stream when destroySoon follows end", async () => {
+    const big = Buffer.alloc(2 * 1024 * 1024, "Y");
+    for (let i = 0; i < 64; i++) {
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      const server = createServer(COMMON_CERT, socket => {
+        socket.on("error", reject);
+        socket.end(big);
+        socket.destroySoon();
+      });
+      server.on("error", reject);
+      let client: TLSSocket | undefined;
+      server.listen(0, () => {
+        const c = connect({ port: (server.address() as AddressInfo).port, rejectUnauthorized: false }, () => {
+          let bytesRead = 0;
+          c.on("readable", () => {
+            const d = c.read();
+            if (d) bytesRead += d.length;
+          });
+          c.on("end", () => resolve(bytesRead));
+        });
+        c.on("error", reject);
+        client = c;
+      });
+      try {
+        expect({ iteration: i, bytesRead: await promise }).toEqual({ iteration: i, bytesRead: big.length });
+      } finally {
+        client?.destroy();
+        server.close();
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes silent data truncation on TLS sockets: after `socket.end(big)` (or any large write), `socket.destroySoon()` / `socket.destroy()` could drop the tail of the stream while still sending the peer a **clean** `close_notify` + FIN — so the receiver got a short read with no error. This is what makes `test/js/node/test/parallel/test-tls-client-destroy-soon.js` flaky on macOS (`bytesRead 2048000` instead of `2097152`, i.e. exactly 3 max-size TLS records missing).

### Mechanism

`us_internal_ssl_write` seals plaintext into a per-loop batch and flushes it every 128 KiB. If a flush can't fully reach the kernel, the leftover ciphertext is parked in a per-loop **spill** slot — but the call still reports every byte as written (by design: "honest up to one bounded spill"). On the *final* `us_internal_ssl_write` of a large payload, the closing flush can spill while `total == length` is returned, so:

1. node:net fires `'finish'` (the data is "fully written").
2. `destroySoon()` honors its contract and calls `destroy()` → `_handle.close()` → `socket.close(FastShutdown)`.
3. `us_internal_ssl_close`'s **first statement** was `ssl_release_spill`: one best-effort drain into a kernel send buffer that the same write burst just filled (so it deterministically fails), then `us_free` of up to 8 already-counted TLS records.
4. The close path then sends a clean `close_notify` + FIN. The peer sees an orderly EOF, short by exactly the spilled records.

The spilled records cannot be recovered any other way: BoringSSL already sealed them and advanced its write sequence numbers, so the caller cannot resubmit that plaintext (it would produce duplicate data with mismatched sequence numbers). The **only** sound action is to deliver the spilled ciphertext — which `us_internal_ssl_shutdown` already does correctly via `ssl_shutdown_after_spill`. The close path was the missing sibling.

### The fix

`us_internal_ssl_close` now mirrors `us_internal_ssl_shutdown`: if this socket owns an undrained spill, it defers the close and re-runs from the writable event once the spill drains (resumed right next to the existing deferred-shutdown resumption in `us_internal_ssl_on_writable`). It defers **at most once**.

The deferral is deliberately scoped to the **one route that can hit the bug**: `code == LIBUS_SOCKET_CLOSE_CODE_FAST_SHUTDOWN && reason == NULL`, which is exactly node's `_handle.close()` destroy path and nothing else. That keeps every other teardown byte-for-byte identical to `main`:

- `CONNECTION_RESET` (`terminate()`, GC finalize) stays abortive — it is *meant* to drop unflushed data.
- `code == 0` (graceful close, `on_end`, `ZERO_RETURN`) keeps its own existing wait-for-peer deferral and **cannot** enter the new one, so the resumed close is always fast-shutdown and always reaches `close_raw` — there is no path where the resumption itself waits forever for a peer.
- uWS WebSocket `forceClose` (the only caller passing a non-NULL `reason`) is excluded.

This precision isn't defensiveness — it is the contract. The `CloseCode` enum's own doc for `fast_shutdown` reads "**already-written data must still drain**", and the Rust call site's comment says `destroy()` after `write()` "must not" drop pending data; both stated the intent the implementation was missing.

Also: the `ssl_in_use` (re-entrant close from inside an SSL callback) branch now releases the spill itself, preserving that path's exact pre-change ordering.

### Intentionally NOT changed

- **Peer-initiated teardown** (the peer's `close_notify`/FIN arriving while *we* own a spill) keeps `main`'s behavior. Extending the deferral there requires solving an unbounded wait-for-peer on the `on_end` route and has no failing test; it is a separate piece of work.
- If the destroying socket is the **last handle keeping the event loop alive**, the process can still exit before the spill's writable event — but that data was equally lost before this change, so it is not a regression. Closing it needs the destroy path's `poll_ref.unref` to move to `on_close`, a much broader change.
- `endNT` in `net.ts` still fires `_final`'s callback before a deferred native shutdown completes (a pre-existing `'finish'`-timing fidelity gap vs Node). With this fix it can no longer cause data loss; it is noted as a separate follow-up.

### A pre-existing bug found during review (separate follow-up)

`us_socket_adopt`'s realloc path (`context.c`) can free a spill-owning `us_socket_t` **without** running `ssl_close` or `ssl_detach`, leaving the per-loop `ssl_spill_owner` dangling at the freed address. That permanently disables loop-wide write batching, and a later socket allocated at the recycled address would be matched as the owner and have a dead connection's TLS records written onto it. Concretely reachable from a WSS upgrade whose `101 Switching Protocols` response partially flushes right before the adopt. This exists on `main` independent of this change and needs its own fix.

## How did you verify your code works?

The race is a kernel-timing artifact (it needs the *last* `send()` of the burst to land while the loopback pipe is almost exactly full), so it cannot be made deterministic from JS; the regression test loops 64 connections, which catches it within the first few iterations on the unfixed build.

| | unfixed (`main`) | fixed |
|---|---|---|
| standalone repro of the CI pattern (`end(2MiB)` + `destroySoon`) | **17 / 400 fail** | **0 / 600** and **0 / 400 fail** |
| same pattern without `destroySoon` (control) | 0 / 400 | 0 / 200 |
| new regression test (`bun bd test node-tls-server.test.ts -t "delivers the whole stream"`) | **fails 15 / 15 runs**, with the exact CI byte counts | passes, 1.4 s for 64 iterations |
| full existing `node-tls-server.test.ts` | — | 39 / 39 pass |
| `test/js/node/test/parallel/test-tls-client-destroy-soon.js` × 60 | ~4 % per run | **0 / 60 fail** |

The new test **cannot** be validated with `USE_SYSTEM_BUN=1`: the spill mechanism that regressed this only exists since the batched write path landed, which is newer than the released bun (the system bun shows 0/450 at every payload size). It was instead proven against an unfixed build of `main`.

One unrelated, pre-existing test in `node-tls-server.test.ts` (`SNICallback rejecting with a non-Error value drops the connection`) flakes ~3% of runs on `main` (client reports `WRONG_VERSION_NUMBER`). It is structurally unaffected by this change (an SNI-rejected connection dies mid-handshake and can never own a write spill) and is being fixed in a separate PR.