### PR TITLE
markdown: cache scan_bracket_close walk to avoid O(n^2) rescans on link-tail desync

### DIFF
--- a/src/md/inlines.rs
+++ b/src/md/inlines.rs
@@ -192,6 +192,9 @@ impl Parser<'_> {
         // recycled via self.bracket_pairs.
         let bracket_storage = core::mem::take(&mut self.bracket_pairs);
         let brackets = self.compute_bracket_matches(content, bracket_storage);
+        // The Unknown-opener fallback describes one slice; a previous
+        // block's entries in the recycled buffer must not answer this one.
+        self.bracket_fallback.clear();
 
         // A link/image/wikilink label is rendered as inline content of its
         // own: emphasis pairs within the label, and nested constructs inside

--- a/src/md/links.rs
+++ b/src/md/links.rs
@@ -231,7 +231,7 @@ impl Parser<'_> {
     /// when `content` is a link-label sub-slice). Falls back to a forward scan
     /// when the opener is unknown to the map.
     fn match_bracket(
-        &self,
+        &mut self,
         content: &[u8],
         start: usize,
         brackets: &BracketMatches,
@@ -245,61 +245,100 @@ impl Parser<'_> {
                 })
             }
             BracketLookup::Unmatched => None,
-            _ => self.scan_bracket_close(content, start),
+            _ => self.scan_bracket_close(content, start, base),
         }
     }
 
     /// Forward scan for the `]` matching the `[` at `start`, skipping code
-    /// spans, HTML tags/autolinks and backslash escapes. Only used when the
-    /// opener is missing from the precomputed bracket map.
-    fn scan_bracket_close(&self, content: &[u8], start: usize) -> Option<BracketScan> {
+    /// spans, HTML tags/autolinks and backslash escapes. Only reached when
+    /// the opener is missing from the precomputed bracket map because the
+    /// inline processor and the map's single pass disagree on tokenization
+    /// (typically a backtick inside a link destination that the map treated
+    /// as a code-span opener). The walk records every `[` it visits and its
+    /// match into `self.bracket_fallback`, so later calls for openers in the
+    /// walked range are answered by lookup instead of rescanning; without
+    /// that cache a run of N unknown openers costs N walks to the end, which
+    /// is quadratic on inputs like "[x](`y)" + "[".repeat(n) + "`".
+    fn scan_bracket_close(
+        &mut self,
+        content: &[u8],
+        start: usize,
+        base: usize,
+    ) -> Option<BracketScan> {
+        let abs = (base + start) as OFF;
+        let end = (base + content.len()) as OFF;
+        let answer = |fb: &[(OFF, OFF)], i: usize| match fb[i].1 {
+            BracketMatches::UNMATCHED => None,
+            // A closer past `end` belongs to an enclosing label frame and
+            // is not a match in this sub-slice.
+            close if close < end => Some(BracketScan {
+                close: close as usize - base,
+                has_inner_bracket: fb.get(i + 1).is_some_and(|&(o, _)| o < close),
+            }),
+            _ => None,
+        };
+        let mut fb = core::mem::take(&mut self.bracket_fallback);
+        // The cache's first entry is the opener its walk started on. If
+        // `abs` falls in the recorded range and the walk visited it, answer
+        // from the cache; otherwise (different slice, past the recorded
+        // range, or inside a span the previous walk skipped) rebuild below.
+        if fb.first().is_some_and(|&(o, _)| o <= abs) {
+            if let Ok(i) = fb.binary_search_by_key(&abs, |&(o, _)| o) {
+                let scan = answer(&fb, i);
+                self.bracket_fallback = fb;
+                return scan;
+            }
+        }
+
+        fb.clear();
+        fb.push((abs, BracketMatches::UNMATCHED));
+        let mut top: usize = 0;
         let mut pos = start + 1;
-        let mut bracket_depth: u32 = 1;
-        let mut has_inner_bracket = false;
-        while pos < content.len() && bracket_depth > 0 {
-            if content[pos] == b'\\' && pos + 1 < content.len() {
-                pos += 2;
-                continue;
-            }
-            // Skip code spans — they take precedence over brackets (CommonMark §6.3)
-            if content[pos] == b'`' {
-                let count = inlines::count_backticks(content, pos);
-                if let Some(end_pos) = self.find_code_span_end(content, pos + count, count) {
-                    pos = end_pos + count;
-                } else {
-                    pos += count;
+        'walk: while pos < content.len() {
+            match content[pos] {
+                b'\\' if pos + 1 < content.len() => pos += 2,
+                // Code spans take precedence over brackets (CommonMark §6.3)
+                b'`' => {
+                    let count = inlines::count_backticks(content, pos);
+                    match self.find_code_span_end(content, pos + count, count) {
+                        Some(end_pos) => pos = end_pos + count,
+                        None => pos += count,
+                    }
                 }
-                continue;
-            }
-            // Skip HTML tags and autolinks — they take precedence over brackets
-            if content[pos] == b'<' && !self.flags.no_html_spans {
-                if let Some(tag_end) = self.find_html_tag(content, pos) {
-                    pos = tag_end;
-                    continue;
+                // HTML tags and autolinks take precedence over brackets
+                b'<' if !self.flags.no_html_spans => {
+                    if let Some(tag_end) = self.find_html_tag(content, pos) {
+                        pos = tag_end;
+                    } else if let Some(autolink) = self.find_autolink(content, pos) {
+                        pos = autolink.end_pos;
+                    } else {
+                        pos += 1;
+                    }
                 }
-                if let Some(autolink) = self.find_autolink(content, pos) {
-                    pos = autolink.end_pos;
-                    continue;
+                b'[' => {
+                    fb.push(((base + pos) as OFF, top as OFF));
+                    top = fb.len() - 1;
+                    pos += 1;
                 }
-            }
-            if content[pos] == b'[' {
-                bracket_depth += 1;
-                has_inner_bracket = true;
-            }
-            if content[pos] == b']' {
-                bracket_depth -= 1;
-            }
-            if bracket_depth > 0 {
-                pos += 1;
+                b']' => {
+                    let close = (base + pos) as OFF;
+                    if top == 0 {
+                        fb[0].1 = close;
+                        break 'walk;
+                    }
+                    top = core::mem::replace(&mut fb[top].1, close) as usize;
+                    pos += 1;
+                }
+                _ => pos += 1,
             }
         }
-        if bracket_depth != 0 {
-            return None;
+        // Openers still on the threaded stack have no matching `]`.
+        while top != 0 {
+            top = core::mem::replace(&mut fb[top].1, BracketMatches::UNMATCHED) as usize;
         }
-        Some(BracketScan {
-            close: pos,
-            has_inner_bracket,
-        })
+        let scan = answer(&fb, 0);
+        self.bracket_fallback = fb;
+        scan
     }
 
     /// Emit the opening span for a link/image whose label is about to be

--- a/src/md/parser.rs
+++ b/src/md/parser.rs
@@ -62,6 +62,10 @@ pub struct Parser<'a> {
     // Scratch storage recycled by compute_bracket_matches (links.rs) so inline
     // processing does not allocate a bracket-pair map per block.
     pub bracket_pairs: Vec<(OFF, OFF)>,
+    // Cache populated by scan_bracket_close (links.rs) on the rare path
+    // where an opener is missing from `bracket_pairs`; recycled across
+    // blocks so that path costs one allocation per Parser.
+    pub bracket_fallback: Vec<(OFF, OFF)>,
     // Label-frame stack recycled by process_inline_content (inlines.rs) so
     // blocks with links do not allocate a frame stack per block.
     pub label_frames: Vec<crate::inlines::LabelFrame>,
@@ -196,6 +200,7 @@ impl<'a> Parser<'a> {
             buffer: Vec::new(),
             emph_delims: Vec::new(),
             bracket_pairs: Vec::new(),
+            bracket_fallback: Vec::new(),
             label_frames: Vec::new(),
             html_scan_memo: Cell::new(HtmlScanMemo::EMPTY),
             n_containers: 0,

--- a/test/js/bun/md/md-edge-cases.test.ts
+++ b/test/js/bun/md/md-edge-cases.test.ts
@@ -726,6 +726,65 @@ describe("pathological bracket inputs", () => {
     expect(Markdown.ansi("[[target|wiki *label*]]", { colors: false })).toBe("[[wiki label]]\n");
   });
 
+  // The single-pass bracket map tokenizes a backtick inside an inline link
+  // destination / title / reference label as a code-span opener, while the
+  // inline processor consumes the whole link. With a matching backtick later
+  // in the paragraph, every subsequent `[` is absent from the map and falls
+  // through to scan_bracket_close: without a cache that was one walk to the
+  // end per opener, O(n²) on inputs like "[x](`y)" + "[".repeat(n) + "`"
+  // (found by fuzzing: a ~111 KB paragraph hung the ansi renderer).
+  test("bracket floods after a link whose tail contains a backtick render in linear time", async () => {
+    await expectRendersQuickly(`
+        const fill = (n, unit) => Buffer.alloc(n * unit.length, unit).toString();
+        const brackets = fill(120000, "[");
+        const cases = [
+          ["backtick in destination", "[x](\`y)" + brackets + "\`", out => out.includes('<a href="%60y">x</a>[[[')],
+          ["backtick in title", '[x](u "a\`b")' + brackets + "\`", out => out.includes('title="a\`b">x</a>[[[')],
+          ["backtick in full ref label", "[r\`]: /u\\n\\n[x][r\`]" + brackets + "\`", out => out.includes('<a href="/u">x</a>[[[')],
+          ["PI opener in destination", "[x](a<?b)" + brackets + "?>", out => out.includes('<a href="a%3C?b">x</a>[[[')],
+          ["interleaved links and brackets", fill(10000, "[x](\`y)[[[[[") + "\`", out => out.includes('<a href="%60y">x</a>[[[')],
+          // Bracket flood inside a rejected outer link's destination: must
+          // stay linear (these openers are in the primary map, not the
+          // fallback).
+          ["rejected outer link, brackets in destination", "[[a](u)](" + brackets + ")", out => out.includes('[<a href="u">a</a>]([[[')],
+        ];
+        for (const [name, input, check] of cases) {
+          const out = Bun.markdown.html(input);
+          if (!check(out)) throw new Error("unexpected output for " + name + ": " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK " + name);
+        }
+        {
+          const out = Bun.markdown.ansi("[x](\`y)" + brackets + "\`", { colors: false });
+          if (!out.includes("[[[[[[")) throw new Error("unexpected ansi output: " + JSON.stringify(out.slice(0, 200)));
+          console.log("OK ansi");
+        }
+        console.log("DONE");
+      `);
+  }, 90_000);
+
+  test("a backtick inside a link tail does not start a code span", () => {
+    // Matches commonmark.js / markdown-it: the link forms and the trailing
+    // lone backtick has no closer.
+    expect(Markdown.html("[x](`y)a`\n")).toBe('<p><a href="%60y">x</a>a`</p>\n');
+    expect(Markdown.html("[x](a`b)c`d\n")).toBe('<p><a href="a%60b">x</a>c`d</p>\n');
+    expect(Markdown.html('[x](u "a`b")c`d\n')).toBe('<p><a href="u" title="a`b">x</a>c`d</p>\n');
+    expect(Markdown.html("[r`]: /u\n\n[x][r`]a`\n")).toBe('<p><a href="/u">x</a>a`</p>\n');
+    // A backtick in the *text* label is a code-span opener when a closer
+    // exists later; without a closer the label forms and the collapsed ref
+    // resolves (commonmark.js agrees on both).
+    expect(Markdown.html("[r`]: /u\n\n[r`][]a`\n")).toBe("<p>[r<code>][]a</code></p>\n");
+    expect(Markdown.html("[r`]: /u\n\n[r`][]\n")).toBe('<p><a href="/u">r`</a></p>\n');
+    // Undefined reference: the backtick is a code-span opener (commonmark.js).
+    expect(Markdown.html("[x][r`ef]a`\n")).toBe("<p>[x][r<code>ef]a</code></p>\n");
+    // A backtick seen before `[` still opens a code span covering the link
+    // syntax (commonmark.js example 341).
+    expect(Markdown.html("`[x](`y)\n")).toBe("<p><code>[x](</code>y)</p>\n");
+    // Brackets inside the skipped tail stay literal; a later `]` is text.
+    expect(Markdown.html("[x](`[y)z]\n")).toBe('<p><a href="%60%5By">x</a>z]</p>\n');
+    // Skipping the tail does not pair brackets across an emphasis boundary.
+    expect(Markdown.html("*[x](`y)*[a]\n")).toBe('<p><em><a href="%60y">x</a></em>[a]</p>\n');
+  });
+
   test("link-validity lookahead agrees with the link parser", () => {
     // [foo][x] with x undefined is not a link: the full reference fails and
     // the shortcut form may not be followed by '['. The lookahead used by


### PR DESCRIPTION
## Repro

Found by bun-fuzz. Hang signature: `hang:markdown:_RNvMs0_NtC6bun_md7inlinesNtNtB7_6parser6Parser13find_html_tag|_RNvMs_NtC6bun_md5linksNtNtB6_6parser6Parse`

Minimal:

```js
Bun.markdown.ansi("[x](`y)" + Buffer.alloc(120000, "[").toString() + "`");
```

Before: hangs (quadratic). After: <15ms.

The same applies with the backtick in the link title or in a defined reference-link label, and to `<?` / `<!` openers in the destination.

## Cause

`compute_bracket_matches` builds a bracket-pair map for the inline slice in one pass so later `[` lookups are O(log n). That pass tokenizes `` ` `` as a code-span opener.

The inline processor parses ``[x](`y)`` as a link: the backtick is part of the destination (commonmark.js and markdown-it agree, rendering `<a href="%60y">x</a>`). So the map's single pass starts a code-span scan at the backtick, jumps to the closing backtick at the end of the paragraph, and records none of the 120k `[` in between. Every one of them returns `BracketLookup::Unknown` and falls back to `scan_bracket_close`, which walks to the end of the slice on each call.

## Fix

`scan_bracket_close` now records every `[` it walks past (and its matching `]`, or unmatched) into a recycled side vec using the same threaded-stack trick as the primary map. A later call for an opener the walk already visited is answered by binary search instead of rescanning. The primary map build and the map-hit path in `match_bracket` are unchanged, so documents where the map and the inline processor agree (no backtick/HTML-opener inside a link tail) do no extra work beyond one `Vec::clear` per block.

Benchmarked release build against main (median of 5, us/iter):

|input|main|this PR|
|-|-|-|
|1000 inline links|386|387|
|1000 reference links|309|312|
|1000 shortcut refs|247|250|
|readme-style mixed|419|417|
|plain-text paragraphs|204|198|
|60k balanced brackets|7207|7064|
|`[x](` `` ` `` `y)` + 120k `[` + `` ` ``|(hang)|11|

## Verification

```
bun bd test test/js/bun/md/   -> 1064 pass, 0 fail
```