### PR TITLE
patch: reject paths with embedded NUL in is_safe_patch_path

### DIFF
--- a/src/patch/lib.rs
+++ b/src/patch/lib.rs
@@ -1051,7 +1051,10 @@ fn parse_file_mode(mode: &[u8]) -> Option<FileMode> {
 }
 
 fn is_safe_patch_path(path: &[u8]) -> bool {
+    // An embedded NUL would truncate the C-string view at the syscall
+    // boundary, addressing a different file than the patch claims to target.
     !path.is_empty()
+        && !path.contains(&0)
         && !paths::is_absolute_loose(path)
         && !path
             .split(|&c| c == b'/' || c == b'\\')

--- a/test/js/bun/patch/patch.test.ts
+++ b/test/js/bun/patch/patch.test.ts
@@ -615,6 +615,47 @@ describe("apply", () => {
         exitCode: 0,
       });
     });
+
+    test("path with embedded NUL is rejected, not truncated", async () => {
+      // A file named "x" exists; the patch targets "x\0ignored". Release builds
+      // used to truncate at the NUL and silently patch "x"; debug builds panicked
+      // in ZStr::as_cstr. The applier must reject the path and leave "x" alone.
+      const dir = tempDirWithFiles("patch-nul-path", { "x": "original\n" });
+
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `import { patchInternals } from "bun:internal-for-testing";
+           import { readFileSync } from "node:fs";
+           const patch = [
+             "diff --git a/x\\0ignored b/x\\0ignored",
+             "--- a/x\\0ignored",
+             "+++ b/x\\0ignored",
+             "@@ -1,1 +1,1 @@",
+             "-original",
+             "+modified",
+             "",
+           ].join("\\n");
+           try {
+             patchInternals.apply(patch, ${JSON.stringify(dir)});
+             console.log("no-error contents=" + JSON.stringify(readFileSync(${JSON.stringify(dir)} + "/x", "utf8")));
+           } catch (e) {
+             console.log("caught: " + e.code + " contents=" + JSON.stringify(readFileSync(${JSON.stringify(dir)} + "/x", "utf8")));
+           }`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: 'caught: EINVAL contents="original\\n"',
+        stderr: "",
+        exitCode: 0,
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Repro

```js
import { patchInternals } from "bun:internal-for-testing";
import { writeFileSync, readFileSync, mkdtempSync } from "node:fs";

const dir = mkdtempSync("/tmp/nul-");
writeFileSync(dir + "/x", "original\n");

const patch = [
  "diff --git a/x\0ignored b/x\0ignored",
  "--- a/x\0ignored",
  "+++ b/x\0ignored",
  "@@ -1,1 +1,1 @@",
  "-original",
  "+modified",
  "",
].join("\n");

patchInternals.apply(patch, dir);
console.log(readFileSync(dir + "/x", "utf8"));
```

Release build on `main`: prints `modified` (the file `x` was rewritten even though the patch targets `x\0ignored`).

Debug build on `main`:

```
panic: ZStr::as_cstr: interior NUL would truncate the C view
    at bun_sys::linux_syscall::fstatat
    at bun_patch::apply_patch (src/patch/lib.rs:271)
    at <bun_patch::PatchFile>::apply (src/patch/lib.rs:208)
```

This surfaced while investigating a bun-fuzz `index out of bounds` report against the patch applier; the minimized corpus input contains a `+++ b/file\0.txt` header that reaches the same path. The specific `index out of bounds` panic in that report is the `hunk.parts[0]` case already fixed by #32668.

## Cause

`is_safe_patch_path` checks for empty, absolute, and `..` components but not for embedded NUL. The path passes validation, gets wrapped in a `ZStr`, and is handed to `openat`/`fstatat`/`fchmodat`/`renameat`/`unlinkat`. Those all go through the C-string view, which truncates at the first NUL, so the syscall operates on whatever the prefix happens to name. The debug `ZStr::as_cstr` assertion catches this, release builds do not.

This is reachable from `bun install` via a crafted `patchedDependencies` entry.

## Fix

Reject any embedded NUL in `is_safe_patch_path`, alongside the existing checks, so every operation type (`FilePatch`, `FileCreation`, `FileDeletion`, `FileRename`, `FileModeChange`) returns `EINVAL` before touching the filesystem.

## Verification

`bun bd test test/js/bun/patch/patch.test.ts`: 26 pass, including the new `apply > malformed patches do not crash > path with embedded NUL is rejected, not truncated` case which asserts both the error code and that the bystander file `x` is untouched. `test/regression/issue/patch-bounds-check.test.ts`: 3 pass.

Without the `src/` change the new test fails under `bun bd test` (the spawned debug build aborts on the `ZStr::as_cstr` assertion).