### PR TITLE
test(napi): split napi_is_arraybuffer output on /\r?\n/ for Windows

### DIFF
--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -961,7 +961,8 @@ describe.skipIf(!canBuildNodeAddons())("cleanup hooks", () => {
         "test_is_arraybuffer",
         "[new ArrayBuffer(8), new SharedArrayBuffer(8), new Uint8Array(8)]",
       );
-      expect(output.split("\n")).toEqual([
+      // printf() via the Windows CRT emits \r\n, so split on either ending.
+      expect(output.split(/\r?\n/)).toEqual([
         "napi_is_arraybuffer=true napi_get_arraybuffer_info=0",
         "napi_is_arraybuffer=false napi_get_arraybuffer_info=0",
         "napi_is_arraybuffer=false napi_get_arraybuffer_info=1",


### PR DESCRIPTION
Follow-up to #32629.

### What

`test/napi/napi.test.ts` was failing on every Windows lane with:

```
expect(received).toEqual(expected)
  [
-   "napi_is_arraybuffer=true napi_get_arraybuffer_info=0",
-   "napi_is_arraybuffer=false napi_get_arraybuffer_info=0",
+   "napi_is_arraybuffer=true napi_get_arraybuffer_info=0\r",
+   "napi_is_arraybuffer=false napi_get_arraybuffer_info=0\r",
    "napi_is_arraybuffer=false napi_get_arraybuffer_info=1",
  ]
```

### Why

The native addon writes its output with `printf()`, which on Windows goes through the CRT in text mode and emits `\r\n`. `checkSameOutput()` trims the trailing `\r\n` off the whole string, but splitting the remaining output on `"\n"` leaves a stray `\r` at the end of every non-final line, so the array `toEqual` never matches.

### Fix

Split on `/\r?\n/` instead, the same way the re-entrant `napi_module_register` test a few hundred lines up already does. The assertion still pins the exact three output lines, so the regression guard for #32624 is unchanged.