### PR TITLE
Replace $newZigFunction with $newRustFunction in socketFaultInjection

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -300,17 +300,17 @@ export type SocketFaultRule = {
 
 export const socketFaultInjection = {
   /** True when the current binary was built with `--socket-fault-injection=on` (defaults to on for ASan builds). */
-  available: $newZigFunction(
-    "runtime/socket/socket.zig",
+  available: $newRustFunction(
+    "runtime/socket/socket.rs",
     "TestingAPIs.jsSocketFaultInjectionAvailable",
     0,
   ) as () => boolean,
   /** Arm a process-wide fault rule for one usockets bsd_* syscall. */
-  set: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsSetSocketFault", 1) as (
+  set: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsSetSocketFault", 1) as (
     rule: SocketFaultRule,
   ) => boolean,
   /** Disarm all fault rules. */
-  clear: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
+  clear: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
 };
 type SerializationContext = "worker" | "window" | "postMessage" | "default";
 export const structuredCloneAdvanced: (


### PR DESCRIPTION
## Problem

`bun:internal-for-testing` currently cannot be loaded on `main`:

```
$ bun -e 'require("bun:internal-for-testing")'
vendor/WebKit/Source/JavaScriptCore/parser/Lexer.cpp(1025) : JSTokenType JSC::Lexer<unsigned char>::parseIdentifier(...)
SIGABRT
```

The `socketFaultInjection` export added in #32681 uses `$newZigFunction("runtime/socket/socket.zig", ...)`. `$newZigFunction` is not in the codegen `function_replacements` table (only `$newRustFunction` is), so it passes through as `@newZigFunction` into the bundled module, and JSC aborts in `parseIdentifier` on the unregistered private name. This takes down every test that imports from `bun:internal-for-testing`.

## Fix

`$newZigFunction` -> `$newRustFunction` and `"runtime/socket/socket.zig"` -> `"runtime/socket/socket.rs"` at the three call sites. The `runtime/socket/socket.rs` key is already registered in `rustIdentifierPaths`, and the Rust side is already wired (the `testing_ap_is` alias in `socket_body.rs`, re-exported through `crate::socket::socket` in `mod.rs`), so no native changes are needed.

## Verification

After:
```
$ bun bd -e 'const { socketFaultInjection } = require("bun:internal-for-testing"); console.log(socketFaultInjection.available())'
true
$ bun bd test test/js/bun/util/socket-fault-injection.test.ts
 14 pass, 2 skip
$ bun bd test test/js/web/fetch/fetch-syscall-fault.test.ts
 13 pass
```

Generated `build/debug/codegen/generated_js2native.rs` now emits thunks targeting `crate::socket::socket::testing_ap_is::{js_socket_fault_injection_available, js_set_socket_fault, js_clear_socket_faults}`, and `socketFaultInjection` appears in the bundled module exports.

## Related

#32723 carries the same three-line change as a drive-by inside a larger node:http fix; this PR isolates it so `bun:internal-for-testing` is usable on `main` independently. #32216 proposes a broader rename of the macro to `$newNativeFunction`.