### PR TITLE
Fix `bun:internal-for-testing` failing to load: $newZigFunction no longer exists

### DIFF
--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -300,17 +300,17 @@ export type SocketFaultRule = {
 
 export const socketFaultInjection = {
   /** True when the current binary was built with `--socket-fault-injection=on` (defaults to on for ASan builds). */
-  available: $newZigFunction(
-    "runtime/socket/socket.zig",
+  available: $newRustFunction(
+    "runtime/socket/socket.rs",
     "TestingAPIs.jsSocketFaultInjectionAvailable",
     0,
   ) as () => boolean,
   /** Arm a process-wide fault rule for one usockets bsd_* syscall. */
-  set: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsSetSocketFault", 1) as (
+  set: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsSetSocketFault", 1) as (
     rule: SocketFaultRule,
   ) => boolean,
   /** Disarm all fault rules. */
-  clear: $newZigFunction("runtime/socket/socket.zig", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
+  clear: $newRustFunction("runtime/socket/socket.rs", "TestingAPIs.jsClearSocketFaults", 0) as () => void,
 };
 type SerializationContext = "worker" | "window" | "postMessage" | "default";
 export const structuredCloneAdvanced: (


### PR DESCRIPTION
### What does this PR do?

`require("bun:internal-for-testing")` is broken on `main` since #32681 landed: it aborts on assertion-enabled builds (`ASSERTION FAILED: Private symbol not found: newZigFunction(...)` in `JSC::Lexer::parseIdentifier`) and throws a `SyntaxError` at module parse on release builds. Because `test/harness.ts` requires the module at module scope (`isASAN`), a debug `bun bd test <any file>` aborts immediately.

#32681 branched before #32621 removed the `$newZigFunction` JS→native binding macro (the `$zig`→`$rust` rename), so the merge brought back three `$newZigFunction("runtime/socket/socket.zig", …)` call sites in `src/js/internal-for-testing.ts`. The bundler's replacement pass only knows `$newRustFunction`/`$newCppFunction` (`src/codegen/replacements.ts`), so the unknown macro passed straight through into the bundled module as a `@newZigFunction` private name, which JSC rejects the moment the module is parsed.

This renames the three call sites to `$newRustFunction("runtime/socket/socket.rs", …)`. Everything else from #32681 was already wired for that spelling: the `"runtime/socket/socket.rs"` entry in `rustIdentifierPaths`, `pub use testing_apis as testing_ap_is` in `socket_body.rs`, and the `crate::socket::socket` re-export in `mod.rs` — only the macro name and file extension were stale.

`grep -rn newZigFunction src/` is now empty.

### How did you verify your code works?

On `main`:

```
$ bun bd -e 'require("bun:internal-for-testing")'
ASSERTION FAILED: Private symbol not found: newZigFunction(…)
SIGABRT
```

With this PR:

```
$ bun bd -e 'const m = require("bun:internal-for-testing"); console.log(m.socketFaultInjection.available())'
true

$ bun bd test test/js/bun/util/socket-fault-injection.test.ts
14 pass, 2 skip, 0 fail
```

Note: `bun run typecheck` also flags this class of mistake (`error TS2304: Cannot find name '$newZigFunction'` — the macro is no longer declared in `src/js/private.d.ts`).